### PR TITLE
feat(flows): teardown + production error contract (2 beads incl. rf2-0q0du + rf2-gmrks)

### DIFF
--- a/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/flow_eval_exception_elision_prod_test.cljs
@@ -1,0 +1,159 @@
+(ns re-frame.flow-eval-exception-elision-prod-test
+  "Per rf2-gmrks — pins that `:rf.error/flow-eval-exception` rides the
+  **always-on production error-emit substrate**, not the dev-only
+  trace surface. Under CLJS `:advanced` + `goog.DEBUG=false` the trace
+  surface compile-time elides, but the per-frame `:on-error` policy
+  fn and corpus-wide `register-error-emit-listener!` callbacks MUST
+  still fire when a flow's `:output` throws.
+
+  Pre-rf2-hrt5c, the cascade-level `:rf.error/flow-eval-exception`
+  rode the trace path only. `trace/emit-error!` is gated by
+  `interop/debug-enabled?` and DCEs to a no-op under `:advanced` +
+  `goog.DEBUG=false` — so a CLJS production build silently swallowed
+  flow-eval throws (no `:on-error` policy fire, no corpus-wide
+  listener record for off-box monitors). The fix routes the error
+  through `error-emit/dispatch-on-error!` (the always-on substrate)
+  in parallel with the dev-only trace emit. This file is the
+  prod-elision proof — rf2-0q0du pinned the contract in Spec 013
+  §Failure semantics rule 4 + Resolved decisions, and this test
+  exercises the genuine `:advanced` build.
+
+  Companion to:
+    - `re-frame.on-error-elision-prod-test` (rf2-hqbeh, handler-
+      exception path)
+    - `re-frame.trace-listener-elision-prod-test` (rf2-2zdu)
+    - `re-frame.source-coord-dom-elision-prod-test` (rf2-uwg5)
+
+  Shared runner: `re-frame.prod-elision-runner`. Shadow-cljs build:
+  `:browser-test-prod-elision` (`:advanced` + `{goog.DEBUG false}`).
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            ;; Loading `re-frame.flows` registers the late-bind hooks
+            ;; (`:flows/reg-flow`, `:flows/run-flows!`) the router
+            ;; reaches at dispatch time — keep the require even when
+            ;; the test ns doesn't reach `flows/...` directly through
+            ;; a public fn.
+            [re-frame.flows]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                ;; Per rf2-bacs4: clear the listener registry between
+                ;; tests — defonce means it would otherwise leak.
+                (error-emit/clear-error-emit-listeners!))}))
+
+;; ---- :on-error fires for flow-eval failures under prod -------------------
+
+(deftest on-error-fires-under-prod-when-flow-output-throws
+  (testing "Per rf2-0q0du / rf2-hrt5c: under `:advanced` +
+            `goog.DEBUG=false`, a frame's `:on-error` policy fn MUST
+            fire when a flow's `:output` throws. The trace surface is
+            gone, but the always-on error-emit substrate delivers
+            the structured `:rf.error/flow-eval-exception` event to the
+            policy fn so production monitoring integrations still
+            observe flow failures."
+    (let [seen (atom [])]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [error-event]
+                                 (swap! seen conj error-event)
+                                 nil)})
+      (rf/reg-event-db :prod/seed-bad-token
+                       (fn [_db _]
+                         {:token "this-is-a-string"}))
+      ;; The flow's :output calls `count` on :token. A string input is
+      ;; legal Clojure (count of a String is its length), but to make
+      ;; the throw deterministic we wrap in a fn that rejects strings.
+      (rf/reg-flow {:id     :tries
+                    :inputs [[:token]]
+                    :output (fn [token]
+                              (when (string? token)
+                                (throw (ex-info "no strings allowed" {})))
+                              (count token))
+                    :path   [:tries]})
+      (rf/dispatch-sync [:prod/seed-bad-token])
+      (is (= 1 (count @seen))
+          ":on-error fired exactly once for the thrown flow — prod-elision contract holds")
+      (let [ev (first @seen)]
+        (is (= :rf.error/flow-eval-exception (:operation ev))
+            ":on-error received the structured :operation discriminator")
+        (is (= :error (:op-type ev))
+            "and the :op-type :error discriminator")
+        (is (= :rf/default (get-in ev [:tags :frame]))
+            "and :frame identifying the policy's host frame")
+        (is (= :flow-eval (get-in ev [:tags :where]))
+            "and :where :flow-eval discriminating from handler-exception path")
+        (is (= :tries (get-in ev [:tags :flow-id]))
+            "and :flow-id attributing the failure to the specific flow")))))
+
+;; ---- corpus-wide listener fires for flow-eval failures under prod -------
+
+(deftest error-emit-listener-fires-under-prod-on-flow-eval-throw
+  (testing "Per rf2-0q0du / rf2-bacs4: under `:advanced` +
+            `goog.DEBUG=false`, a registered corpus-wide error-emit
+            listener MUST fire for every flow-eval throw — the trace
+            surface is gone but the always-on error-emit substrate
+            delivers the tight record so off-box observability shippers
+            (Sentry / Honeybadger / Rollbar) still see every flow
+            failure in production."
+    (let [seen (atom [])]
+      (rf/register-error-emit-listener!
+        :prod/flow-recorder
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod/flow-throw
+                       (fn [_db _] {:token "string-value"}))
+      (rf/reg-flow {:id     :str-len
+                    :inputs [[:token]]
+                    :output (fn [t]
+                              (when (string? t)
+                                (throw (ex-info "no strings allowed" {})))
+                              (count t))
+                    :path   [:str-len]})
+      (rf/dispatch-sync [:prod/flow-throw])
+      (is (= 1 (count @seen))
+          "listener fired exactly once — prod-elision contract holds")
+      (let [r (first @seen)]
+        (is (= :rf.error/flow-eval-exception (:error r)))
+        (is (= [:prod/flow-throw] (:event r)))
+        (is (= :prod/flow-throw   (:event-id r)))
+        (is (= :rf/default        (:frame r)))
+        (is (number? (:time r)))
+        (is (integer? (:elapsed-ms r))
+            ":elapsed-ms is an integer under :advanced + goog.DEBUG=false
+             — the substrate boundary rounds the CLJS float-precision
+             performance.now() value")))))
+
+;; ---- both paths fire independently under prod ---------------------------
+
+(deftest flow-eval-listener-and-policy-fire-independently-under-prod
+  (testing "Per rf2-0q0du / rf2-bacs4 §independent paths under prod:
+            when both a per-frame `:on-error` policy fn AND a
+            corpus-wide listener are registered, BOTH fire on a
+            flow-eval throw. Neither blocks the other under
+            `:advanced` + `goog.DEBUG=false`."
+    (let [listener-saw (atom nil)
+          policy-saw   (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/register-error-emit-listener!
+        :prod/dual-recorder
+        (fn [record] (reset! listener-saw record)))
+      (rf/reg-event-db :prod/dual-throw (fn [_db _] {:token "go"}))
+      (rf/reg-flow {:id     :dual
+                    :inputs [[:token]]
+                    :output (fn [_t] (throw (ex-info "always-throws" {})))
+                    :path   [:dual]})
+      (rf/dispatch-sync [:prod/dual-throw])
+      (is (some? @policy-saw)
+          "per-frame :on-error fired under prod for the flow throw")
+      (is (some? @listener-saw)
+          "corpus-wide listener fired under prod — both paths survive elision")
+      (is (= :rf.error/flow-eval-exception (:error @listener-saw)))
+      (is (= :prod/dual-throw              (:event-id @listener-saw)))
+      (is (= :rf.error/flow-eval-exception (:operation @policy-saw))))))

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -25,7 +25,13 @@
             [re-frame.adapter.uix-source-coord-dom-elision-prod-test]
             [re-frame.adapter.helix-source-coord-dom-elision-prod-test]
             [re-frame.on-error-elision-prod-test]
-            [re-frame.event-emit-elision-prod-test]))
+            [re-frame.event-emit-elision-prod-test]
+            ;; Per rf2-gmrks — `:rf.error/flow-eval-exception` rides
+            ;; the always-on error-emit substrate (Spec 013 §Failure
+            ;; semantics rule 4 + Resolved decisions, rf2-0q0du).
+            ;; This prod-elision test pins the production-survival
+            ;; contract under `:advanced` + `goog.DEBUG=false`.
+            [re-frame.flow-eval-exception-elision-prod-test]))
 
 (defn ^:export init []
   (-> (env/get-test-data)

--- a/implementation/flows/test/re_frame/flows_conformance_test.clj
+++ b/implementation/flows/test/re_frame/flows_conformance_test.clj
@@ -101,6 +101,7 @@
             [clojure.string :as str]
             [re-frame.conformance :as conformance]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
             [re-frame.flows :as flows]
             [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
@@ -124,6 +125,11 @@
   (reset! schemas/schemas-by-frame {})
   (when-let [li-var (resolve 're-frame.flows/last-inputs)]
     (reset! (deref li-var) {}))
+  ;; Per rf2-bacs4: the error-emit listener registry is a `defonce` atom
+  ;; that survives test re-runs. Clear before each test so a listener
+  ;; registered by one fixture (per rf2-gmrks `:error-emit-records`
+  ;; matcher) doesn't leak into the next.
+  (error-emit/clear-error-emit-listeners!)
   (rf/init! plain-atom/adapter)
   ;; Framework events / fx are registered at namespace-load time in
   ;; routing.cljc / ssr.cljc; clear-all! wiped them. Re-eval those
@@ -177,11 +183,14 @@
   "The flow surface plus the `:core/*` capabilities every flow fixture
   cross-cuts. `:core/sub` is in the set because several fixtures
   (recompute-on-input-change, multi-input-topo) assert `:sub-values`
-  against materialised flow outputs."
+  against materialised flow outputs. `:core/error` covers the
+  flow-eval-exception fixture (rf2-gmrks) which asserts both the
+  cascade-level error trace and the always-on error-emit substrate."
   #{:core/event-handler
     :core/sub
     :core/fx
     :core/trace
+    :core/error
     :flow/basic
     :flow/topo
     :flow/dirty-check
@@ -312,6 +321,28 @@
                               (fn [ev] (swap! traces conj ev)))
     traces))
 
+;; ---- error-emit capture (rf2-gmrks) -------------------------------------
+;;
+;; Per Spec 013 §Failure semantics rule 4 + §Resolved decisions
+;; §`:rf.error/flow-eval-exception` rides the always-on error substrate
+;; (rf2-0q0du): flow-eval failures fire on the always-on production
+;; error-emit substrate, which survives CLJS `:advanced` +
+;; `goog.DEBUG=false` elision. The `flow-eval-exception.edn` fixture's
+;; `:error-emit-records` matcher asserts the listener captured a record
+;; of the expected shape — the host-agnostic data-shape equivalent of
+;; the JVM-side `re-frame.flows-trace-test` /
+;; `re-frame.on-error-elision-prod-test` assertions.
+
+(defn- collect-error-emit-records
+  "Register a corpus-wide error-emit listener for the fixture's run;
+  returns the captured-records atom."
+  [fixture-id]
+  (let [records (atom [])]
+    (error-emit/register-error-emit-listener!
+      [::flows-conformance fixture-id]
+      (fn [r] (swap! records conj r)))
+    records))
+
 ;; ---- matchers ------------------------------------------------------------
 
 (defn- submap?
@@ -415,6 +446,22 @@
   ([frame-id]
    (into #{} (keys (get @flows/flows frame-id {})))))
 
+(defn- last-inputs-frame-set
+  "Per-flow set of frame-ids currently present in `last-inputs[flow-id]`.
+  Per Spec 013 §Frame-destroy teardown: after `destroy-frame!`, the
+  destroyed frame's row in every `last-inputs[flow-id]` MUST be dropped;
+  the whole flow-id key drops when no other frame still holds an entry."
+  [flow-id]
+  (into #{} (keys (get @flows/last-inputs flow-id {}))))
+
+(defn- registrar-has-flow?
+  "True iff the cross-kind `:flow` registrar slot for `flow-id` is
+  present. Per Spec 013 §Frame-destroy teardown: the slot drops when
+  the destroyed frame was the last owner of the id; it survives when
+  a sibling frame still registers the id."
+  [flow-id]
+  (some? (registrar/lookup :flow flow-id)))
+
 ;; ---- single-fixture execution -------------------------------------------
 
 (defn- run-fixture
@@ -424,6 +471,12 @@
   (try
     (let [fid          (:fixture/id fixture)
           traces       (collect-traces fid)
+          ;; Always register an error-emit listener so the
+          ;; `:error-emit-records` matcher (rf2-gmrks) has a captured
+          ;; stream to assert against. Listeners with no expectations
+          ;; cost nothing — the registry is cleared in `reset-runtime`
+          ;; between fixtures.
+          err-records  (collect-error-emit-records fid)
           frame-config (or (:fixture/frame-config fixture) {})
           frames-spec  (:fixture/frames fixture)
           ;; `reset-runtime` already created :rf/default WITHOUT an
@@ -453,13 +506,27 @@
                          (rf/reg-frame :rf/default frame-config))
           _            (realise-flows! fixture)
           dispatches   (or (:fixture/dispatches fixture) [])]
-      ;; Dispatches may be a bare event vector (single-frame default) or
-      ;; an envelope map `{:event [...] :frame <id> ...}` (multi-frame,
-      ;; mirrors core's runner per spec/conformance/fixtures/frame-multi-instance.edn).
+      ;; Dispatches may be:
+      ;;   - a bare event vector (single-frame default)
+      ;;   - an envelope map `{:event [...] :frame <id> ...}` (multi-frame,
+      ;;     mirrors core's runner per
+      ;;     spec/conformance/fixtures/frame-multi-instance.edn)
+      ;;   - a teardown step `{:destroy-frame <frame-id>}` (rf2-gmrks /
+      ;;     Spec 013 §Frame-destroy teardown). The runner calls
+      ;;     `frame/destroy-frame!` on the named frame; subsequent
+      ;;     dispatch / matcher checks see the post-teardown state.
       (doseq [ev dispatches]
-        (if (map? ev)
-          (let [{event :event :as opts} ev]
-            (rf/dispatch-sync event (dissoc opts :event)))
+        (cond
+          (map? ev)
+          (cond
+            (contains? ev :destroy-frame)
+            (frame/destroy-frame! (:destroy-frame ev))
+
+            :else
+            (let [{event :event :as opts} ev]
+              (rf/dispatch-sync event (dissoc opts :event))))
+
+          :else
           (rf/dispatch-sync ev)))
       ;; ---- assertion gathering -----------------------------------------
       (let [expect           (or (:fixture/expect fixture) {})
@@ -510,8 +577,40 @@
                                (into {}
                                      (for [[fid _] expected-after]
                                        [fid (flow-registry-ids fid)]))
-                               :else (flow-registry-ids))]
+                               :else (flow-registry-ids))
+            ;; `:flow-last-inputs-after` (rf2-gmrks) — `{flow-id
+            ;; #{frame-ids}}` strict match. Per Spec 013 §Frame-destroy
+            ;; teardown: after `destroy-frame!`, the destroyed frame's
+            ;; row in every `last-inputs[flow-id]` MUST be dropped; the
+            ;; whole flow-id key drops when no other frame still holds
+            ;; an entry.
+            expected-li      (:flow-last-inputs-after expect)
+            actual-li        (when expected-li
+                               (into {}
+                                     (for [[flow-id _] expected-li]
+                                       [flow-id (last-inputs-frame-set flow-id)])))
+            ;; `:registrar-flow-slots-after` (rf2-gmrks) — strict set
+            ;; match of `:flow` registrar ids that survive the fixture's
+            ;; teardown. Per Spec 013 §Frame-destroy teardown: the slot
+            ;; drops iff no surviving frame still owns the id.
+            expected-slots   (:registrar-flow-slots-after expect)
+            actual-slots     (when expected-slots
+                               (into #{}
+                                     (filter registrar-has-flow?
+                                             expected-slots)))
+            ;; `:error-emit-records` (rf2-gmrks) — order-preserving
+            ;; subset match against the captured always-on error-emit
+            ;; substrate stream. Per Spec 013 §Failure semantics rule 4
+            ;; + Resolved decisions §`:rf.error/flow-eval-exception`
+            ;; rides the always-on error substrate (rf2-0q0du): the
+            ;; substrate fires under CLJS `:advanced` + `goog.DEBUG=false`
+            ;; — this matcher is the host-agnostic data-shape equivalent
+            ;; of the JVM-side prod-elision proof.
+            expected-err     (:error-emit-records expect)
+            err-failures     (when expected-err
+                               (check-trace-stream @err-records expected-err))]
         (trace/clear-trace-cbs!)
+        (error-emit/clear-error-emit-listeners!)
         {:fixture-id        fid
          :passed?           (and (or (nil? expected-db)  (submap? expected-db final-db))
                                  (or (nil? expected-dbs) (every? (fn [[fid db]] (submap? db (get final-dbs fid)))
@@ -521,7 +620,10 @@
                                  (or (nil? emit-failures)   (empty? emit-failures))
                                  (or (nil? expected-counts) (= expected-counts actual-counts))
                                  (or (nil? expected-topo)   (= expected-topo actual-topo))
-                                 (or (nil? expected-after)  (= expected-after actual-after)))
+                                 (or (nil? expected-after)  (= expected-after actual-after))
+                                 (or (nil? expected-li)     (= expected-li actual-li))
+                                 (or (nil? expected-slots)  (= expected-slots actual-slots))
+                                 (or (nil? err-failures)    (empty? err-failures)))
          :final-db          final-db
          :expected-db       expected-db
          :final-dbs         final-dbs
@@ -534,7 +636,12 @@
          :expected-topo     expected-topo
          :actual-topo       actual-topo
          :expected-after    expected-after
-         :actual-after      actual-after}))
+         :actual-after      actual-after
+         :expected-li       expected-li
+         :actual-li         actual-li
+         :expected-slots    expected-slots
+         :actual-slots      actual-slots
+         :err-failures      err-failures}))
     (catch Throwable e
       {:fixture-id (:fixture/id fixture)
        :passed?    false
@@ -630,7 +737,17 @@
           (when (some? (:expected-after f))
             (when (not= (:expected-after f) (:actual-after f))
               (println "    registry-after expected:" (:expected-after f))
-              (println "    registry-after actual:  " (:actual-after f))))))
+              (println "    registry-after actual:  " (:actual-after f))))
+          (when (some? (:expected-li f))
+            (when (not= (:expected-li f) (:actual-li f))
+              (println "    last-inputs-after expected:" (:expected-li f))
+              (println "    last-inputs-after actual:  " (:actual-li f))))
+          (when (some? (:expected-slots f))
+            (when (not= (:expected-slots f) (:actual-slots f))
+              (println "    registrar-slots expected:" (:expected-slots f))
+              (println "    registrar-slots actual:  " (:actual-slots f))))
+          (doseq [ef (:err-failures f)]
+            (println "    error-emit:" ef))))
       (is (zero? (count failed))
           (str "All claim-runnable flow-*.edn conformance fixtures must pass; "
                (count failed) " failed.")))))

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -140,6 +140,7 @@ The framework stamps the dispatch envelope with the frame's id automatically —
 - Disposes the sub-cache (each cached reactive is torn down so nothing leaks listeners).
 - Stops the router.
 - Fires `:on-destroy` events before teardown if specified.
+- **Releases every per-feature artefact's frame-scoped state.** `destroy-frame!` is the single normative teardown boundary every per-feature artefact (flows, machines, schemas, SSR side-channels, epoch history, …) MUST hang its frame-scoped cleanup off. Each artefact publishes a teardown hook the core invokes during destroy; an artefact that holds frame-scoped state without publishing such a hook leaks definitions and cached state on every `destroy-frame!`. Per-artefact contracts: flows tear down per [013 §Frame-destroy teardown](013-Flows.md#frame-destroy-teardown); machines tear down per [005 §Cross-Spec Interactions §1](005-StateMachines.md); schemas, SSR, and epoch tear down per their respective specs.
 - Subsequent `(dispatch [...] {:frame :todo})` / `(subscribe [...] {:frame :todo})` to a destroyed frame throws a clear, machine-readable error: `{:reason :frame-destroyed :frame :todo}`.
 - Tool-Pair surfaces against the destroyed frame route off their own contract (read returns empty / `nil`; mutate raises `:rf.error/no-such-handler` (kind `:frame`); listener silencing emits a one-shot trace) — see [Tool-Pair §Surface behaviour against destroyed frames](Tool-Pair.md#surface-behaviour-against-destroyed-frames).
 
@@ -1278,3 +1279,4 @@ A pointer-only index of decisions taken in this Spec. Each entry's load-bearing 
 | Plain Reagent fns under a non-default frame fire a one-shot warning per `(component-id, frame-id)`, elided in production | [004-Views §Plain Reagent fns](004-Views.md#plain-reagent-fns-staged-adoption-with-a-loud-footgun-warning) |
 | Per-instance frames via anonymous `make-frame` for per-mount lifecycles | [§Per-instance frames — anonymous `make-frame`](#per-instance-frames--anonymous-make-frame) |
 | Per-frame and per-call overrides via `:fx-overrides`, `:interceptor-overrides`, `:interceptors` | [§Per-frame and per-call overrides](#per-frame-and-per-call-overrides) |
+| `destroy-frame!` is the single normative teardown boundary every per-feature artefact (flows, machines, schemas, SSR, epoch) hangs its frame-scoped cleanup off; each artefact publishes a teardown hook the core invokes during destroy | [§Destroy](#destroy), [013 §Frame-destroy teardown](013-Flows.md#frame-destroy-teardown) |

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -108,6 +108,20 @@ This asymmetry is **intentional for v1**: the runtime correctness (each frame's 
 
 Frame defaulting matches the rest of the API: a bare `(reg-flow flow)` resolves the frame via `(current-frame)`, picking up `with-frame` bindings or falling through to `:rf/default`. Tests and per-tenant runtimes that need an explicit frame pass `{:frame ...}` as the second arg.
 
+## Frame-destroy teardown
+
+Flows are frame-scoped, so `destroy-frame!` is the boundary at which every per-frame piece of flow state MUST clear. This is a **normative requirement** — the frame-isolation contract from [002 §Destroy](002-Frames.md#destroy) is only honoured if flow registrations, the dirty-check `last-inputs` cache, and any `:flow` registrar slot whose last owning frame was the destroyed one all release in lockstep with the frame. Without lockstep teardown a long-running JVM SSR host (per-request frame churn), a pair-tool time-travel cycle, or any `make-frame` ephemeral usage leaks flow definitions and cached input vectors indefinitely.
+
+Three teardown invariants apply on `(destroy-frame! frame-id)`:
+
+1. **Per-frame flow registry.** `(get @flows frame-id)` clears in full — every flow registered against `frame-id` is dropped. Sibling frames' slots are unaffected (per [§Frame-scoping](#frame-scoping)).
+2. **Dirty-check cache.** Every `last-inputs[flow-id][frame-id]` row for the destroyed frame is dissoc'd. The whole `last-inputs[flow-id]` key is dropped when no other frame still holds an entry. Sibling frames' rows for the same flow id are preserved (a flow id registered against frames `:left` and `:right`, with frame `:left` destroyed, keeps `last-inputs[flow-id][:right]` intact).
+3. **`:flow` registrar slot.** The cross-kind registrar entry for each flow id the destroyed frame owned is `unregister!`'d **iff no surviving frame still registers that id**. When a sibling frame still holds the same flow id, the registrar slot survives (other frames need it for hot-reload tracking).
+
+Teardown is idempotent against a frame the registry never recorded — a `destroy-frame!` on a freshly-`reg-frame`'d frame with no flows ever registered against it leaves the flow registry, `last-inputs`, and registrar entries unchanged.
+
+The teardown contract is symmetric with the machines artefact's `:machines/teardown-on-frame-destroy!` hook and the schemas artefact's `:schemas/on-frame-destroyed!` hook — every per-feature artefact that holds frame-scoped state hangs its cleanup off the single normative `destroy-frame!` teardown boundary documented at [002 §Destroy](002-Frames.md#destroy). A new feature artefact MUST add its hook to the destroy cascade; a feature that holds frame-scoped state without one leaks on every `destroy-frame!`.
+
 ## Drain integration
 
 Flow evaluation happens **after `:db` commits and before `:fx` walks** on every event drain. Per [002 §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode), the per-event drain inserts one step:
@@ -188,7 +202,7 @@ When a flow's `:output` fn throws during `run-flows!`, the runtime applies these
 1. **Prior-flow writes are preserved.** Flows scheduled earlier in the same drain that successfully computed and produced dirty writes have their outputs flushed to `app-db` (one `replace-container!` against the loop accumulator) BEFORE the exception propagates. Earlier flows' work is never silently lost.
 2. **The failing flow's own output is not written.** The exception happened during `:output`; there is no usable new-output to assoc-in. Its `last-inputs` slot is NOT advanced, so the flow re-attempts on the next drain.
 3. **The cascade halts at the failing flow.** Downstream flows scheduled later in topo order do NOT run on this drain. They re-attempt naturally on the next drain (with whatever inputs the prior flush left in `app-db`).
-4. **The exception surfaces at the router's outer catch** as `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). The per-flow `:rf.flow/failed` trace fires first with the flow-attributed detail; the cascade-level error trace fires when the router catches the propagated throw.
+4. **The exception surfaces at the router's outer catch** as `:rf.error/flow-eval-exception` (per [009 §Error contract](009-Instrumentation.md#error-contract)). The cascade-level error is emitted onto the **always-on production error-emit substrate** ([009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)) — the per-frame `:on-error` policy fn fires, every `register-error-emit-listener!` callback fires, and both fan-out paths are mutually isolated. The substrate is NOT gated by `re-frame.interop/debug-enabled?`, so `:rf.error/flow-eval-exception` survives CLJS `:advanced` + `goog.DEBUG=false` elision: a flow-eval failure in a production build reaches every registered off-box error monitor (Sentry / Honeybadger / Rollbar / hosted observability) at full fidelity. The per-flow `:rf.flow/failed` trace event ALSO fires first with the flow-attributed detail, but that trace rides the dev-only trace surface and DCEs in production — production attribution is preserved on the always-on path via `:flow-id` / `:flow` slots stamped onto the cascade-level error's `:tags`.
 
 Worked example. Three flows in topo order — `:A`, `:B`, `:C`. Inputs change for all three. `:B` throws. After the drain:
 
@@ -321,12 +335,22 @@ Per [§Open questions §Map-keyed `:inputs`](#map-keyed-inputs-instead-of-vector
 
 No opt-out. Stale derived values are confusing; vacating the slot is the natural toggle-off semantics. Apps that want to preserve the value should copy it elsewhere before clearing.
 
+### Frame-destroy teardown is mandatory (RESOLVED rf2-0q0du)
+
+`destroy-frame!` MUST release every per-frame piece of flow state — the per-frame flow-registry slot, all `last-inputs` rows for the destroyed frame, and every `:flow` registrar entry the destroyed frame was the last owner of. Sibling frames' rows and shared-id registrar slots are preserved. Per [§Frame-destroy teardown](#frame-destroy-teardown). Without this, long-running SSR JVM hosts (per-request frame churn), pair-tool time-travel, and `make-frame` ephemeral usage leak flow definitions and cached input vectors indefinitely. Symmetric with the machines / schemas / SSR teardown hooks the per-feature artefacts publish off the single normative `destroy-frame!` boundary at [002 §Destroy](002-Frames.md#destroy).
+
+### `:rf.error/flow-eval-exception` rides the always-on error substrate (RESOLVED rf2-0q0du)
+
+Flow evaluation failures MUST surface on the always-on production error-emit substrate (per [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code)), NOT on the dev-only trace surface alone. Both fan-out paths — the per-frame `:on-error` policy fn and the corpus-wide `register-error-emit-listener!` registry — fire under CLJS `:advanced` + `goog.DEBUG=false`. The per-flow `:rf.flow/failed` trace still fires first with full flow-attributed detail, but it rides the dev-only trace surface and DCEs in production; flow attribution survives on the always-on path via `:flow-id` / `:flow` slots stamped onto the cascade-level error's `:tags`. Without this routing, a production-build flow-eval failure was silently dropped — no `:on-error` fire, no off-box monitor record. Per [§Failure semantics](#failure-semantics) rule 4.
+
 ## Cross-references
 
 - [001-Registration](001-Registration.md) — registration grammar (`reg-flow` is a kind under `:flow`).
 - [002-Frames §Drain-loop pseudocode](002-Frames.md#drain-loop-pseudocode) — where the flow after-interceptor sits.
+- [002-Frames §Destroy](002-Frames.md#destroy) — the normative teardown boundary `:rf.flow/*` state hangs off; cross-referenced from [§Frame-destroy teardown](#frame-destroy-teardown).
 - [006-ReactiveSubstrate](006-ReactiveSubstrate.md) — sub-cache invalidation; flows trigger sub-cache invalidation when they write.
-- [009-Instrumentation §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/flow-cycle` namespace.
+- [009-Instrumentation §Error contract](009-Instrumentation.md#error-contract) — `:rf.error/flow-cycle` and `:rf.error/flow-eval-exception` namespaces.
+- [009-Instrumentation §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code) — the always-on error-emit substrate `:rf.error/flow-eval-exception` rides; cross-referenced from [§Failure semantics](#failure-semantics) rule 4.
 - [009-Instrumentation §Flow trace events](009-Instrumentation.md#flow-trace-events) — full taxonomy and payloads for the `:rf.flow/*` event vocabulary; cross-referenced from [§Flow tracing](#flow-tracing) above.
 - [009-Instrumentation §The `:sensitive?` registration metadata key](009-Instrumentation.md#the-sensitive-registration-metadata-key) — `:rf.flow/*` trace events inherit `:sensitive?` from the in-scope handler at drain time; cross-referenced from [§Flow tracing](#flow-tracing) above.
 - [Conventions](Conventions.md) — `:rf.fx/reg-flow` and `:rf.fx/clear-flow` reserved fx-ids.

--- a/spec/API.md
+++ b/spec/API.md
@@ -50,7 +50,7 @@
 | `clear-sub` | Fn | `(clear-sub)` / `(clear-sub id)` | v1 (preserved) |
 | `clear-fx` | Fn | `(clear-fx)` / `(clear-fx id)` | v1 (preserved) |
 | `clear-flow` | Fn | `(clear-flow id)` / `(clear-flow id opts)` | v1 |
-| `destroy-frame!` | Fn | `(destroy-frame! frame-id)` | v1 |
+| `destroy-frame!` | Fn | `(destroy-frame! frame-id)` — the normative teardown boundary. Per-feature artefacts (flows, machines, schemas, SSR, epoch) hang their frame-scoped cleanup off this call; flows release per [013 §Frame-destroy teardown](013-Flows.md#frame-destroy-teardown). | v1 |
 | `reset-frame!` | Fn | `(reset-frame! frame-id)` | v1 |
 | `clear-sub-cache!` | Fn | `(clear-sub-cache! frame-id?)` | v1 (preserved) |
 
@@ -569,6 +569,10 @@ Removed in v2 (see [MIGRATION §M-21](MIGRATION.md#m-21-drop-debug-trim-v-on-cha
 ### `reg-flow` / `clear-flow` (Spec 013)
 
 `reg-flow` is rowed canonically in [§Registration](#registration); required flow-map keys are `:id`, `:inputs`, `:output`, `:path`. Both surfaces take an optional opts map (`{:frame frame-id}`) selecting the owning frame: `(reg-flow flow)` / `(reg-flow flow opts)` and `(clear-flow id)` / `(clear-flow id opts)`. `clear-flow` is rowed canonically in [§Clearing registrations](#clearing-registrations); it deregisters the flow from the named frame and `dissoc-in`s its `:path` from that frame's `app-db` only (per Spec 013 §Frame-scoping).
+
+**Frame-destroy teardown.** `destroy-frame!` releases every per-frame piece of flow state (registry slot, `last-inputs` rows, registrar entries for ids the destroyed frame was last owner of) per [Spec 013 §Frame-destroy teardown](013-Flows.md#frame-destroy-teardown). Sibling frames' state is preserved.
+
+**Flow-eval failures in production.** A throw inside a flow's `:output` fn surfaces as `:rf.error/flow-eval-exception` on the **always-on error-emit substrate** — registered `:on-error` policy fns and `register-error-emit-listener!` callbacks fire under CLJS `:advanced` + `goog.DEBUG=false`. The error is NOT trace-only. Per [Spec 013 §Failure semantics](013-Flows.md#failure-semantics) rule 4 and [009 §Production builds](009-Instrumentation.md#production-builds-zero-overhead-zero-code).
 
 Reserved fx-ids for runtime flow management via `:fx`:
 

--- a/spec/conformance/fixtures/flow-eval-exception.edn
+++ b/spec/conformance/fixtures/flow-eval-exception.edn
@@ -1,0 +1,108 @@
+;; Conformance fixture: flow/eval-exception
+;; Per Spec 013 §Failure semantics — when a flow's :output fn throws:
+;;
+;;   1. Prior successful flows' writes are PRESERVED.
+;;   2. The failing flow's own output is NOT written; its last-inputs
+;;      is NOT advanced (re-attempts next drain).
+;;   3. Downstream flows scheduled later in topo order do NOT run.
+;;   4. The exception surfaces at the router's outer catch as
+;;      `:rf.error/flow-eval-exception` on BOTH the dev-only trace
+;;      surface AND the always-on error-emit substrate (per Spec 013
+;;      §Resolved decisions §`:rf.error/flow-eval-exception` rides the
+;;      always-on error substrate, rf2-0q0du).
+;;
+;; The fixture also asserts the cascade halt: an
+;; :fx [[:dispatch [:should-not-fire]]] entry on the failing handler
+;; does NOT run (because the flow walk throws AFTER :db commits but
+;; BEFORE :fx walks — per Spec 013 §Drain integration §rule 3 +
+;; rf2-fslx0).
+;;
+;; ONE flow keeps the topo order deterministic across hosts: the
+;; flow throws iff its input is a string. The conformance DSL's
+;; `:count` builtin already does this — see
+;; core/src/re_frame/conformance.cljc line 64; the error/sub-exception
+;; fixture uses the same trick.
+
+{:fixture/id           :flow/eval-exception
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx :core/error :core/trace :flow/basic :flow/trace}
+ :fixture/doc          "A flow's :output throws. The runtime halts the cascade at the failing flow, fires the per-flow :rf.flow/failed trace, and surfaces the cascade-level :rf.error/flow-eval-exception on the always-on production error-emit substrate (per Spec 013 §Failure semantics rule 4 / Resolved decisions §:rf.error/flow-eval-exception rides the always-on error substrate, rf2-0q0du). The failing handler's :fx [[:dispatch [:should-not-fire]]] entry MUST NOT run — Spec 013 §Drain integration rule 3 cascade halt."
+
+ :fixture/registry
+ {:event {:flow/init       {:doc "Seed :token to a non-string vector — first drain computes :tries without throwing."}
+          :flow/bad-input  {:doc "Replace :token with a string; the :tries flow's [:fn :count] throws. The handler ALSO emits :fx [:dispatch [:should-not-fire]] which Spec 013 §Drain integration rule 3 says must NOT run."}
+          :should-not-fire {:doc "If the cascade-halt contract holds, this never fires."}}
+  :flow  {:tries
+          {:doc    "Materialised :tries — counts :token. The conformance :count builtin throws if :token is a string."
+           :inputs [[:token]]
+           :path   [:tries]}}}
+
+ :fixture/handlers
+ {:event {:flow/init       [[:set [:token] [1 2 3]]
+                            [:set [:fired] []]]
+          :flow/bad-input  [[:set [:token] "this-is-a-string"]
+                            ;; Spec 013 §Drain integration rule 3:
+                            ;; this :fx MUST NOT run because the flow
+                            ;; walk halts the cascade.
+                            [:fx :dispatch [:should-not-fire]]]
+          :should-not-fire [[:update [:fired] [:fn :conj :should-not-fire]]]}}
+
+ :fixture/flow-bodies
+ ;; :count is the builtin that throws on string input — see
+ ;; conformance.cljc line 64-77.
+ {:tries [[:fn :count [:event-arg 0]]]}
+
+ :fixture/frame-config
+ {:on-create [:flow/init]}
+
+ ;; First dispatch drives a successful flow eval — :token is the seeded
+ ;; vector [1 2 3]; :tries computes (count [1 2 3]) = 3 and writes.
+ ;; Conformance runners register flows AFTER the on-create cascade
+ ;; (per the comment at run-fixture's `realise-flows!` call site;
+ ;; rf2-wbtjn), so the on-create drain itself doesn't trigger :tries.
+ ;; A bare no-op dispatch is enough to fire the drain on which :tries
+ ;; first-evals — we use :flow/init again because re-dispatching it is
+ ;; deterministic and re-seeds the same vector.
+ :fixture/dispatches
+ [[:flow/init]
+  [:flow/bad-input]]
+
+ :fixture/expect
+ ;; After the failing drain:
+ ;;   :token is "this-is-a-string"  (the :db commit landed)
+ ;;   :tries is 3                    (preserved from the first drain
+ ;;                                    when :token was [1 2 3]; the
+ ;;                                    failing :output left the slot
+ ;;                                    untouched — Spec 013 §Failure
+ ;;                                    semantics rule 2)
+ ;;   :fired is []                   (cascade halt — :should-not-fire
+ ;;                                    never ran)
+ {:final-app-db
+  {:token "this-is-a-string"
+   :tries 3
+   :fired []}
+
+  ;; Trace stream: per-flow :rf.flow/failed first (with flow
+  ;; attribution), then the cascade-level :rf.error/flow-eval-exception.
+  ;; The router emits the cascade-level trace with :frame / :event /
+  ;; :exception in tags (per router.cljc:577-578); :where :flow-eval
+  ;; rides on the always-on substrate record only (asserted via
+  ;; :error-emit-records below).
+  :trace-emissions
+  [{:op-type   :flow
+    :operation :rf.flow/failed
+    :tags      {:flow-id :tries
+                :frame   :rf/default}}
+   {:op-type   :error
+    :operation :rf.error/flow-eval-exception
+    :tags      {:frame :rf/default}}]
+
+  ;; Production-survivable always-on substrate (Spec 013 §Resolved
+  ;; decisions §`:rf.error/flow-eval-exception` rides the always-on
+  ;; error substrate, rf2-0q0du / rf2-hrt5c). The runner registers a
+  ;; corpus-wide error-emit listener at fixture-start; this matcher
+  ;; asserts the listener captured the cascade-level record.
+  :error-emit-records
+  [{:error    :rf.error/flow-eval-exception
+    :event-id :flow/bad-input
+    :frame    :rf/default}]}}

--- a/spec/conformance/fixtures/flow-frame-destroy-teardown.edn
+++ b/spec/conformance/fixtures/flow-frame-destroy-teardown.edn
@@ -1,0 +1,104 @@
+;; Conformance fixture: flow/frame-destroy-teardown
+;; Per Spec 013 §Frame-destroy teardown and Spec 002 §Destroy — flows are
+;; frame-scoped, so `destroy-frame!` MUST release every per-frame piece of
+;; flow state: the per-frame flow-registry slot, every `last-inputs` row
+;; for the destroyed frame, and any `:flow` registrar entry whose last
+;; owning frame was the destroyed one. Sibling frames' state is preserved.
+;;
+;; This is a normative requirement (rf2-0q0du / rf2-wbtjn): without
+;; lockstep teardown a long-running SSR JVM with per-request frame churn
+;; leaks flow definitions and cached input vectors indefinitely.
+;;
+;; The fixture registers the same flow id (`:area`) against two frames
+;; (`:fc/a` and `:fc/b`) via the `:rf.fx/reg-flow` runtime fx (which
+;; targets the dispatching frame, per Spec 013 §Dynamic toggle via fx).
+;; After driving a `:seed` dispatch into each frame to populate the
+;; dirty-check cache, it tears down `:fc/a` via the harness-level
+;; `{:destroy-frame :fc/a}` step and asserts:
+;;
+;;   - `:flow-registry-after`         — frame :fc/a's slot is empty;
+;;                                       :fc/b's slot still holds :area.
+;;   - `:flow-last-inputs-after`      — last-inputs for :area no longer
+;;                                       holds a :fc/a row; :fc/b's row
+;;                                       is preserved.
+;;   - `:registrar-flow-slots-after`  — the :flow registrar slot for
+;;                                       :area survives because :fc/b
+;;                                       still owns it.
+;;
+;; A second teardown destroys `:fc/scratch`, which is the sole owner of
+;; `:area-sole`. Its `:flow` registrar slot MUST drop (no surviving
+;; frame still registers it).
+
+{:fixture/id           :flow/frame-destroy-teardown
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:core/event-handler :core/fx :flow/basic :flow/toggle :flow/frame-scoped}
+ :fixture/doc          "destroy-frame! releases every per-frame piece of flow state (registry slot, last-inputs rows, registrar entries the destroyed frame was last owner of). Sibling frames' state is preserved. The teardown is normative — without it, long-running SSR JVM hosts with per-request frame churn leak flow definitions and cached input vectors indefinitely."
+
+ :fixture/registry
+ {:event {:reg-area      {:doc "Emit :rf.fx/reg-flow for :area against the dispatching frame."}
+          :reg-area-sole {:doc "Emit :rf.fx/reg-flow for :area-sole against the dispatching frame."}
+          :seed          {:doc "Seed :w/:h on the dispatching frame."}}
+  :fx    {:rf.fx/reg-flow {:doc "Reserved — register a flow at runtime."
+                           :platforms #{:client :server}}}}
+
+ :fixture/handlers
+ {:event {:reg-area      [[:fx :rf.fx/reg-flow
+                           {:id     :area
+                            :inputs [[:w] [:h]]
+                            :body   [[:fn :* [:event-arg 0] [:event-arg 1]]]
+                            :path   [:rect :area]}]]
+          :reg-area-sole [[:fx :rf.fx/reg-flow
+                           {:id     :area-sole
+                            :inputs [[:w] [:h]]
+                            :body   [[:fn :* [:event-arg 0] [:event-arg 1]]]
+                            :path   [:rect :area-sole]}]]
+          :seed          [[:set [:w] [:event-arg 1]]
+                          [:set [:h] [:event-arg 2]]]}}
+
+ ;; Three frames. :fc/a + :fc/b co-own :area; :fc/scratch solely owns
+ ;; :area-sole.
+ :fixture/frames
+ [{:id :fc/a}
+  {:id :fc/b}
+  {:id :fc/scratch}]
+
+ :fixture/dispatches
+ [;; Register :area against :fc/a; first drain seeds :w/:h there.
+  {:event [:reg-area]    :frame :fc/a}
+  {:event [:seed 3 4]    :frame :fc/a}
+  ;; Same again for :fc/b — different inputs to make the dirty-check
+  ;; rows distinct.
+  {:event [:reg-area]    :frame :fc/b}
+  {:event [:seed 7 9]    :frame :fc/b}
+  ;; Sole-owner :area-sole on :fc/scratch.
+  {:event [:reg-area-sole] :frame :fc/scratch}
+  {:event [:seed 11 13]    :frame :fc/scratch}
+  ;; Harness teardown step — destroy :fc/a. :area survives on :fc/b;
+  ;; registrar slot for :area is preserved.
+  {:destroy-frame :fc/a}
+  ;; Destroy :fc/scratch — sole owner of :area-sole; its registrar slot
+  ;; clears.
+  {:destroy-frame :fc/scratch}]
+
+ :fixture/expect
+ {:final-app-dbs
+  ;; :fc/b is the only surviving frame holding flow state.
+  {:fc/b {:w 7 :h 9 :rect {:area 63}}}
+
+  ;; Per-frame flow registry. :fc/a and :fc/scratch are gone.
+  ;; :fc/b retains :area.
+  :flow-registry-after
+  {:fc/b #{:area}}
+
+  ;; Per-flow, per-frame last-inputs map. After destroy:
+  ;;   :area on :fc/a — gone (destroyed)
+  ;;   :area on :fc/b — preserved
+  ;;   :area-sole on :fc/scratch — gone (destroyed; whole flow-id row drops)
+  :flow-last-inputs-after
+  {:area #{:fc/b}}
+
+  ;; :flow registrar slots after destroy.
+  ;;   :area      — still present (frame :fc/b is still an owner)
+  ;;   :area-sole — gone (the sole owner :fc/scratch was destroyed)
+  :registrar-flow-slots-after
+  #{:area}}}


### PR DESCRIPTION
## Summary

Pins two flow-related contracts that were implemented but not normative in the spec, then adds host-agnostic conformance coverage plus a CLJS advanced-build proof.

**rf2-0q0du — spec(flows): pin frame-destroy teardown and production error contract**

- spec/002-Frames §Destroy gains a normative bullet making `destroy-frame!` the single per-feature teardown boundary every artefact (flows, machines, schemas, SSR, epoch) hangs its frame-scoped cleanup off.
- spec/013-Flows gains a §Frame-destroy teardown section (three invariants: per-frame registry slot, last-inputs rows, registrar slots) and a strengthened §Failure semantics rule 4 requiring `:rf.error/flow-eval-exception` to ride the always-on production error-emit substrate (NOT trace-only). Two Resolved-decisions entries record the contracts.
- spec/API.md `destroy-frame!` row + `reg-flow`/`clear-flow` section get matching prose.
- No implementation changes — the contracts already hold in router.cljc (rf2-hrt5c) and flows/registry.cljc (rf2-wbtjn); this commit lifts them into normative spec text.

**rf2-gmrks — test(flows): add conformance and CLJS prod coverage**

- Two new host-agnostic conformance fixtures: `flow-frame-destroy-teardown.edn` and `flow-eval-exception.edn`.
- Extended the flows conformance runner with `{:destroy-frame frame-id}` step support and three new matchers: `:flow-last-inputs-after`, `:registrar-flow-slots-after`, `:error-emit-records`. A corpus-wide error-emit listener is registered at fixture-start so the always-on substrate's records are observable from EDN — the host-agnostic equivalent of the JVM-side prod assertions.
- New CLJS `:advanced` + `goog.DEBUG=false` test (`flow_eval_exception_elision_prod_test.cljs`, 3 deftests, registered in `prod-elision-runner`) proving the per-frame `:on-error` policy fn AND `register-error-emit-listener!` callbacks BOTH fire for flow-eval throws under production elision.

## Test plan

- [x] `npm run test:cljs` — 2140 tests / 0 failures
- [x] `clojure -M:test` in `implementation/flows/` — 78 tests / 0 failures (includes the two new fixtures via the flows conformance corpus)
- [x] `npm run test:browser-prod-elision` — 26 tests / 0 failures (the 3 new flow-eval-exception prod tests included)
- [x] `npm run test:elision` — production elision probe passes (30/30 sentinels absent in `:advanced` bundle)
- [x] `scripts/test-fast-pr.sh` — full fast-PR spine passes