### PR TITLE
feat(causa): inline host width resize contract (rf2-um813)

### DIFF
--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -6,7 +6,12 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -43,12 +43,17 @@ Minimal host markup:
 </div>
 ```
 
-Minimal layout:
+Minimal layout (the `var(...)` reading of `--rf-causa-inline-width`
+is the supported host-resize knob — see §Resizing the inline host
+below):
 
 ```css
 body { margin: 0; }
 .app-shell { display: flex; min-height: 100vh; }
-[data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 420px);
+  min-width: 320px;
+}
 #app { flex: 1; min-width: 0; }
 ```
 
@@ -59,6 +64,70 @@ the host. Hosts may override the selector before Causa opens:
 (require '[day8.re-frame2-causa.config :as causa-config])
 (causa-config/configure! {:layout/host-selector "#devtools-causa"})
 ```
+
+### Resizing the inline host
+
+Per `rf2-um813`, the recommended host snippet reads a single CSS
+custom property — `--rf-causa-inline-width` — for its `flex-basis`,
+so developers can resize the inline Causa panel without forking the
+host rule or falling back to overlay / body-padding dock modes.
+
+The contract is **JS-free** and **host-owned**: Causa itself does not
+read the property; the host's stylesheet does. The host's
+`[data-rf-causa-host]` rule uses the variable with a default fallback
+identical to the historical fixed-pixel default (420px):
+
+```css
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 420px);
+  min-width: 320px;
+}
+```
+
+To resize, override the property anywhere up the cascade — the closest
+declaration wins as usual:
+
+```css
+/* Global default — every page in the app */
+:root { --rf-causa-inline-width: 560px; }
+
+/* Per-route override (e.g. a debugging route that wants more room) */
+.debug-route { --rf-causa-inline-width: 720px; }
+
+/* Per-user override via a developer stylesheet */
+[data-rf-causa-host] { --rf-causa-inline-width: 380px; }
+```
+
+Sizing units are unrestricted (`px`, `rem`, `vw`, `min(...)`, `clamp(...)`,
+…) — the variable is plugged straight into `flex-basis`. The
+`min-width: 320px` floor in the recommended rule prevents the panel
+from collapsing past readability when the developer specifies a small
+value; remove the floor if you want truly unbounded shrink.
+
+App content to the right (`#app { flex: 1; min-width: 0 }`) stays in
+normal flow regardless of the inline width — Causa never overlays the
+app, never claims a hit-test region outside its host, and never
+mutates `body` padding in the default true-inline mode. This holds
+during resize as well: changing the property triggers a flex reflow,
+the host shrinks/grows, the app reflows to fill the remainder, and
+nothing in the page becomes unclickable.
+
+The property name and default are published as
+`day8.re-frame2-causa.config/default-layout-host-css-var` and
+`default-layout-host-width` so tooling, story-mode chrome, and the AI
+co-pilot's snippet helper can refer to them without forking the
+string. Causa MUST NOT introduce a runtime API that sets the property
+from CLJS — the host's stylesheet is the single source of truth for
+sizing; introducing a CLJS setter would split that source.
+
+A JS-driven draggable separator was considered and rejected at this
+phase (rf2-um813): the CSS-variable contract covers the "developers
+need to tweak the width" requirement at zero runtime surface, zero
+new failure modes, and a one-line override path. A draggable handle
+adds pointer-capture, hit-test priority, ARIA semantics, and reduced-
+motion handling for marginal benefit; if the user need surfaces, a
+later bead may add it ON TOP of the CSS contract (the handle would
+write the same property).
 
 If the selector cannot be found after the substrate adapter is ready,
 Causa MUST fail loudly but safely: `console.error` with the selector

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -35,11 +35,67 @@
 (def default-layout-host-selector
   "[data-rf-causa-host]")
 
+;; ---- Inline-host resize contract (rf2-um813) ----------------------------
+;;
+;; The host page owns sizing for `[data-rf-causa-host]` (per
+;; spec/011-Launch-Modes.md §Layout host contract). To let developers
+;; tweak the width WITHOUT forking the layout rule or falling back to
+;; overlay/body-padding dock modes, the recommended host rule reads
+;; one CSS custom property — Causa documents the property name and
+;; default; the host's CSS uses it via `var(--rf-causa-inline-width,
+;; 420px)`. Overriding the property anywhere up the cascade (`:root`,
+;; an ancestor, the host itself, or a user stylesheet) resizes the
+;; panel. App content to the right (`#app { flex: 1; min-width: 0 }`)
+;; remains in normal flow — no hit-test occlusion, no overlay.
+;;
+;; The contract is intentionally JS-free: the host CSS is the single
+;; source of truth for sizing. Causa itself does NOT read the variable
+;; (the panel fills its host) — the variable is the host's knob.
+
+(def default-layout-host-css-var
+  "Name of the CSS custom property the recommended host snippet reads
+  for its `flex-basis`. Hosts that follow the recommended snippet can
+  resize the inline Causa panel by overriding this property in their
+  own stylesheet:
+
+      :root { --rf-causa-inline-width: 560px; }
+
+  Causa never reads this property — sizing is owned by the host's
+  layout rule (per spec/011-Launch-Modes.md §Layout host contract).
+  The constant is published so tooling (story-mode chrome, docs
+  generators, the AI co-pilot's snippet helper) can refer to the
+  exact spelling without forking the string."
+  "--rf-causa-inline-width")
+
+(def default-layout-host-width
+  "Default value Causa recommends for `--rf-causa-inline-width` when the
+  host does not override it. Matches the historical fixed-pixel default
+  from the pre-rf2-um813 testbed snippets so existing pages render
+  identically after adopting the variable."
+  "420px")
+
 (def default-layout-host-snippet
+  ;; CSS uses `var(--rf-causa-inline-width, 420px)` so a host that
+  ;; pastes the snippet verbatim gets:
+  ;;   - identical default geometry (420px flex-basis, 320px floor)
+  ;;   - a single one-line override path:
+  ;;       :root { --rf-causa-inline-width: 560px; }
+  ;;   - app content to the right stays in normal flex flow
+  ;;     (no overlay, no body padding, no JS resize handle).
   "<div class=\"app-shell\">
   <aside data-rf-causa-host></aside>
   <main id=\"app\"></main>
-</div>")
+</div>
+
+<style>
+  body { margin: 0; }
+  .app-shell { display: flex; min-height: 100vh; }
+  [data-rf-causa-host] {
+    flex: 0 0 var(--rf-causa-inline-width, 420px);
+    min-width: 320px;
+  }
+  #app { flex: 1; min-width: 0; }
+</style>")
 
 (defonce
   ^{:doc "Atom holding the CSS selector for the app-provided normal-flow

--- a/tools/causa/testbeds/cart_total/index.html
+++ b/tools/causa/testbeds/cart_total/index.html
@@ -6,7 +6,12 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/tools/causa/testbeds/inline_resize/spec.cjs
+++ b/tools/causa/testbeds/inline_resize/spec.cjs
@@ -1,0 +1,232 @@
+/*
+ * Causa inline-host resize contract — browser smoke (rf2-um813).
+ *
+ * Pins the developer-resize contract documented in
+ * tools/causa/spec/011-Launch-Modes.md §Resizing the inline host:
+ *
+ *   - The host's `[data-rf-causa-host]` rule reads
+ *     `flex-basis: var(--rf-causa-inline-width, 420px)`.
+ *   - Overriding the CSS custom property anywhere up the cascade
+ *     resizes the inline panel, with no JS, no overlay, no body
+ *     padding, and no fork of the host rule.
+ *   - App content to the right of the host remains clickable
+ *     (the flex flow reshapes `#app` to fill the remainder; the
+ *     panel never overlays).
+ *
+ * The spec drives the existing /counter/ example (whose index.html
+ * was updated under rf2-um813 to use `var(--rf-causa-inline-width,
+ * 420px)` in its host rule). Three contracts are exercised:
+ *
+ *   1. **Default geometry pinned.** Without an override, the host
+ *      renders at the documented default width (420px) — exact
+ *      bounding-rect width, not a tolerance — so a regression that
+ *      silently drops the fallback in the `var(...)` is loud.
+ *
+ *   2. **Cascade override takes effect.** Injecting
+ *      `:root { --rf-causa-inline-width: 600px; }` resizes the host
+ *      to 600px on the very next layout pass. We assert the
+ *      bounding-rect width and that the right edge of the host moved
+ *      rightward exactly as much as the width grew.
+ *
+ *   3. **No hit-test occlusion across the resize.** A host-side
+ *      `+` button sits to the right of Causa; we click it before
+ *      and after the resize, asserting the counter increments each
+ *      time. The click would silently miss if the panel grew an
+ *      overlay layer or trapped pointer events outside its rect.
+ *
+ * Why a separate spec rather than amending rigorous/spec.cjs:
+ *   - The rigorous spec is already thick (~500 lines covering shell
+ *     visibility, time-travel, co-pilot, trace bus). The resize
+ *     contract is a small, focused regression-target — co-locating
+ *     it with rigorous would bury it. A dedicated 80-line spec lets
+ *     a failure surface the contract by name (`causa-inline-resize`)
+ *     in the runner's summary line.
+ *   - The runner (examples/scripts/run-examples-tests.cjs) walks
+ *     `tools/<tool>/testbeds/<scenario>/spec.cjs` by convention
+ *     (rf2-p8f2s), so a new directory under tools/causa/testbeds/
+ *     is picked up with no orchestrator change.
+ */
+
+const { expectTextEquals, expectVisible } =
+  require('../../../../examples/scripts/spec-helpers.cjs');
+
+// The historical default the recommended host rule uses as the
+// `var(...)`'s fallback. Matches
+// `day8.re-frame2-causa.config/default-layout-host-width`.
+const DEFAULT_HOST_WIDTH_PX = 420;
+
+// The deliberate override the spec injects. Chosen to be (a) larger
+// than the default, so the right-edge delta is positive and visible;
+// (b) different enough that a stale snapshot reading the default
+// would fail loudly; (c) compatible with the standard headless
+// viewport (Chromium defaults to 1280×720, so 600 still leaves room
+// for `#app` to render its controls).
+const OVERRIDE_HOST_WIDTH_PX = 600;
+
+async function readHostGeometry(page) {
+  return page.evaluate(() => {
+    const host = document.querySelector('[data-rf-causa-host]');
+    const app = document.getElementById('app');
+    function rect(el) {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { left: r.left, right: r.right, width: r.width };
+    }
+    return {
+      host: rect(host),
+      app: rect(app),
+      flexBasisVar: host
+        ? getComputedStyle(host).getPropertyValue('--rf-causa-inline-width')
+        : null,
+    };
+  });
+}
+
+async function injectCustomPropertyOverride(page, pixels) {
+  await page.evaluate((px) => {
+    const style = document.createElement('style');
+    style.setAttribute('data-test', 'rf-causa-inline-width-override');
+    style.textContent = `:root { --rf-causa-inline-width: ${px}px; }`;
+    document.head.appendChild(style);
+  }, pixels);
+}
+
+module.exports = {
+  name: 'causa-inline-resize',
+  url: '/counter/',
+  run: async (page) => {
+    // ----------------------------------------------------------------
+    // 0. Wait for first paint of Causa + the host app.
+    // ----------------------------------------------------------------
+    await expectVisible(
+      page.locator('[data-testid="rf-causa-shell"]'),
+      10000,
+    );
+    const counterValue = page.locator('#app [data-testid="counter-value"]');
+    await expectVisible(counterValue, 10000);
+    const initialCounter = parseInt(
+      ((await counterValue.textContent()) || '0').trim(),
+      10,
+    );
+
+    // ----------------------------------------------------------------
+    // 1. Default geometry — the `var(...)` fallback is in force.
+    // ----------------------------------------------------------------
+    const before = await readHostGeometry(page);
+    if (!before.host || !before.app) {
+      throw new Error(
+        `Expected [data-rf-causa-host] + #app to render; got ${JSON.stringify(before)}`,
+      );
+    }
+    if (Math.round(before.host.width) !== DEFAULT_HOST_WIDTH_PX) {
+      throw new Error(
+        `Default inline-host width should be ${DEFAULT_HOST_WIDTH_PX}px ` +
+          `(the var() fallback); got ${before.host.width}px. ` +
+          'Did the recommended host CSS rule drop its fallback?',
+      );
+    }
+    if (before.app.left < before.host.right) {
+      throw new Error(
+        `App content should sit to the right of the host; got ${JSON.stringify(before)}`,
+      );
+    }
+
+    // ----------------------------------------------------------------
+    // 2. Host `+` button is clickable through the default-width layout.
+    // ----------------------------------------------------------------
+    const plusButton = page
+      .locator('#app button', { hasText: '+' })
+      .first();
+    await expectVisible(plusButton, 5000);
+    await plusButton.click();
+    await expectTextEquals(counterValue, String(initialCounter + 1), 5000);
+
+    // ----------------------------------------------------------------
+    // 3. Inject the override — `--rf-causa-inline-width: 600px`.
+    //
+    //    The override goes into `:root` so the cascade lookup at the
+    //    host element resolves to the new value. We assert the host's
+    //    bounding-rect width updates on the very next layout pass.
+    // ----------------------------------------------------------------
+    await injectCustomPropertyOverride(page, OVERRIDE_HOST_WIDTH_PX);
+
+    // Force a layout read; getBoundingClientRect already flushes, but
+    // we re-read until the width settles to guard against any async
+    // style-recalc the browser schedules.
+    const start = Date.now();
+    let after = null;
+    while (Date.now() - start < 5000) {
+      after = await readHostGeometry(page);
+      if (
+        after.host &&
+        Math.round(after.host.width) === OVERRIDE_HOST_WIDTH_PX
+      ) {
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!after || Math.round(after.host.width) !== OVERRIDE_HOST_WIDTH_PX) {
+      throw new Error(
+        `Override --rf-causa-inline-width: ${OVERRIDE_HOST_WIDTH_PX}px ` +
+          'did not propagate to the host element. ' +
+          `Last reading: ${JSON.stringify(after)}. ` +
+          'Did the host CSS stop reading the variable?',
+      );
+    }
+
+    // The app must reflow to keep its left edge >= the host's new
+    // right edge. Equality is the flex-layout outcome (no gap rule);
+    // a strict `<` would indicate the panel started overlaying.
+    if (after.app.left < after.host.right) {
+      throw new Error(
+        `App content was overlapped by the resized host; got ${JSON.stringify(after)}`,
+      );
+    }
+    const widthDelta = after.host.width - before.host.width;
+    const rightDelta = after.host.right - before.host.right;
+    if (Math.abs(widthDelta - rightDelta) > 1) {
+      // The host's left edge is pinned by `.rf2-testbed-shell`'s
+      // flex container, so `width` and `right` MUST move in lockstep.
+      // A mismatch means the override grew the box via padding/margin
+      // (which would NOT survive a real developer override) rather
+      // than `flex-basis`.
+      throw new Error(
+        `Host width grew by ${widthDelta}px but right edge moved by ` +
+          `${rightDelta}px — these should match. Got ${JSON.stringify({ before, after })}.`,
+      );
+    }
+
+    // ----------------------------------------------------------------
+    // 4. Host `+` button is STILL clickable after the resize.
+    //
+    //    The button moved to the right when the host grew (the app
+    //    reflowed); Playwright's locator re-resolves on click, so a
+    //    successful increment is the simplest end-to-end proof that
+    //    no overlay or hit-test trap was introduced by the resize.
+    // ----------------------------------------------------------------
+    await plusButton.click();
+    await expectTextEquals(counterValue, String(initialCounter + 2), 5000);
+
+    // ----------------------------------------------------------------
+    // 5. Removing the override snaps the host back to the default —
+    //    proves the contract is reversible and that the host rule is
+    //    a single, well-behaved source of truth.
+    // ----------------------------------------------------------------
+    await page.evaluate(() => {
+      const el = document.querySelector(
+        'style[data-test="rf-causa-inline-width-override"]',
+      );
+      if (el && el.parentNode) el.parentNode.removeChild(el);
+    });
+    const reset = await readHostGeometry(page);
+    if (
+      !reset.host ||
+      Math.round(reset.host.width) !== DEFAULT_HOST_WIDTH_PX
+    ) {
+      throw new Error(
+        `Removing the override should revert to ${DEFAULT_HOST_WIDTH_PX}px; ` +
+          `got ${JSON.stringify(reset)}.`,
+      );
+    }
+  },
+};

--- a/tools/causa/testbeds/perf_counter/index.html
+++ b/tools/causa/testbeds/perf_counter/index.html
@@ -6,7 +6,12 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>


### PR DESCRIPTION
## Summary

- Define a CSS-variable contract — `--rf-causa-inline-width` — that the recommended Causa layout host rule reads via `flex: 0 0 var(--rf-causa-inline-width, 420px)`. Developers resize the inline panel by overriding the property anywhere up the cascade; no JS, no overlay, no fork of the host rule.
- Publish `default-layout-host-css-var` + `default-layout-host-width` from `day8.re-frame2-causa.config` and expand `default-layout-host-snippet` so docs / story chrome / the AI co-pilot's snippet helper can refer to the contract without forking strings.
- Document the contract in `tools/causa/spec/011-Launch-Modes.md` §Resizing the inline host (override paths, sizing units, the `min-width: 320px` floor, deferred draggable-handle rationale).
- Update the three live host index.html files (cart_total, perf_counter, examples/reagent/counter) to use the variable with the recommended fallback. The new in-flight `panel_gallery` testbed is intentionally untouched.
- New Playwright smoke (`tools/causa/testbeds/inline_resize/spec.cjs`) pins: default 420px geometry, cascade override to 600px takes effect on next layout, app `+` button remains clickable across the resize, and removing the override snaps back to the default.

## Approach

Approach (A) — CSS custom property — chosen over (B) — JS draggable handle — because the variable covers the developer-resize requirement at zero runtime surface, zero new failure modes, and a one-line override path. The spec notes a future bead MAY add a draggable handle ON TOP of the CSS contract (the handle would write the same property).

## Developer experience

Before — fork the host rule:

```css
[data-rf-causa-host] { flex: 0 0 600px; }
```

After — override one variable:

```css
:root { --rf-causa-inline-width: 600px; }
```

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 2140 tests, 6121 assertions, 0 failures, 0 errors.
- [x] `clojure -M:test` from `tools/causa/` — 535 tests, 1521 assertions, 0 failures, 0 errors.
- [ ] CI `npm run test:browser` exercises the new `causa-inline-resize` Playwright spec end-to-end against the Chromium-served `/counter/` build.

Closes rf2-um813.