### PR TITLE
fix(registrar): emit :rf.warning/missing-doc + :rf.warning/registration-collision per Spec 001 (rf2-45kaz)

### DIFF
--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -113,6 +113,122 @@
   (when-let [f (late-bind/get-fn-cached :trace/emit!)]
     (f :registry operation tags)))
 
+(defn- emit-warning!
+  "Invoke `:trace/emit!` with the `:warning` op-type. Sibling to
+  `emit!` (which uses `:registry`). Callers MUST wrap invocations in
+  `(when interop/debug-enabled? ...)` so Closure DCE elides the call
+  and its literal args under `:advanced + goog.DEBUG=false`."
+  [operation tags]
+  (when-let [f (late-bind/get-fn-cached :trace/emit!)]
+    (f :warning operation tags)))
+
+;; ---- warn-once caches (Spec 001 §`:doc` is dev-warned when absent,
+;;                        Spec 001 §Re-registration of a different
+;;                        function — collision warning) ---------------------
+;;
+;; `:rf.warning/missing-doc` fires at most once per `(kind, id)` pair
+;; within a runtime process. `:rf.warning/registration-collision`
+;; uses the same suppression discipline. Mirrors the warn-once cache
+;; pattern from re-frame.spec (boundary-without-spec) and
+;; re-frame.views (plain-fn-under-non-default-frame-once).
+;;
+;; Caches sit alongside the registry; production elision (Spec 009
+;; §Production builds) elides the consult+emit branches, but the
+;; atom allocation itself is process-load-time and harmless.
+
+(defonce ^:private missing-doc-warned
+  (atom #{}))
+
+(defonce ^:private collision-warned
+  (atom #{}))
+
+(defn clear-warning-caches!
+  "Reset the warn-once caches for `:rf.warning/missing-doc` and
+  `:rf.warning/registration-collision`. Tests use this between cases
+  so each case starts from a clean slate.
+
+  Per Spec 001 §`:doc` is dev-warned when absent: suppression is
+  per-process; the cache is process-local state, not registry state."
+  []
+  (reset! missing-doc-warned #{})
+  (reset! collision-warned   #{})
+  nil)
+
+(defn- source-coords
+  "Extract the source-coord subset of a registration metadata map.
+  Returns nil when no coord slot is present (programmatic / non-macro
+  path). Mirrors the `{:ns :line :file :column}` envelope per Spec 001
+  §Source-coordinate capture (CLJS reference)."
+  [meta]
+  (let [coords (select-keys meta [:ns :line :file :column])]
+    (when (seq coords) coords)))
+
+(defn- macro-path?
+  "Truthy when the metadata map carries the macro-path signature —
+  source coords merged in via `source-coords/merge-coords` (Spec 001
+  §Source-coordinate capture). Per Spec 001 §`:doc` is dev-warned
+  obligation 4, programmatic re-registrations through internal
+  helpers that bypass the public macro path are out of scope for
+  `:rf.warning/missing-doc`. The `:ns` slot is the canonical signal
+  the macro layer reached `register!`."
+  [meta]
+  (contains? meta :ns))
+
+(defn- missing-doc?
+  "True when `meta` has no usable `:doc` slot: absent, nil, or an
+  empty string (per Spec 001 §`:doc` obligation 1)."
+  [meta]
+  (let [d (:doc meta)]
+    (or (nil? d)
+        (and (string? d) (= "" d)))))
+
+(defn- maybe-emit-missing-doc!
+  "Emit `:rf.warning/missing-doc` once per `(kind, id)` when `meta`
+  came from the public macro path and carries no usable `:doc`.
+  Per Spec 001 §`:doc` is dev-warned when absent.
+
+  Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
+  so the production bundle DCEs the consult+emit branch (Spec 009
+  §Production builds). The keyword `:rf.warning/missing-doc` is a
+  literal arg at the call site — moving the gate inside this helper
+  would leave the literal reachable from the unconditional helper
+  call and defeat the elision sentinel."
+  [kind id meta]
+  (when (and (macro-path? meta) (missing-doc? meta))
+    (let [k [kind id]]
+      (when-not (contains? @missing-doc-warned k)
+        (swap! missing-doc-warned conj k)
+        (emit-warning! :rf.warning/missing-doc
+                       (cond-> {:kind kind :id id}
+                         (source-coords meta) (assoc :source-coords
+                                                     (source-coords meta))))))))
+
+(defn- maybe-emit-collision!
+  "Emit `:rf.warning/registration-collision` once per `(kind, id)`
+  when a re-registration swaps in a different handler-fn (different
+  in fn identity).
+
+  Per Spec 001 §Re-registration of a different function — collision
+  warning. The existing `:rf.registry/handler-replaced` trace stays
+  intact (with `:different-fn?` tag); this warning surface is the
+  separate dev-nudge that single-source-of-truth tools surface to
+  the developer. Same suppression discipline as missing-doc — fires
+  once per `(kind, id)` to keep the dev stream readable.
+
+  Callers MUST wrap invocations in `(when interop/debug-enabled? ...)`
+  for production elision (Spec 009 §Production builds)."
+  [kind id previous new-meta]
+  (when (not= (:handler-fn previous) (:handler-fn new-meta))
+    (let [k [kind id]]
+      (when-not (contains? @collision-warned k)
+        (swap! collision-warned conj k)
+        (emit-warning! :rf.warning/registration-collision
+                       (cond-> {:kind            kind
+                                :id              id
+                                :previous-coords (source-coords previous)}
+                         (source-coords new-meta) (assoc :source-coords
+                                                         (source-coords new-meta))))))))
+
 (defn register!
   "Register an id under kind with the given metadata. Re-registering the
   same id replaces the slot atomically (per Spec 001 §Hot-reload semantics
@@ -160,13 +276,29 @@
         ;; branch (per Spec 009 §Production builds).
         (when interop/debug-enabled?
           (emit! :rf.registry/handler-replaced
-                 {:kind kind :id id :different-fn? different?})))
+                 {:kind kind :id id :different-fn? different?})
+          ;; Per Spec 001 §Re-registration of a different function —
+          ;; collision warning (rf2-45kaz). Fires alongside
+          ;; handler-replaced when the fn-identity actually changed,
+          ;; with the same per-(kind, id) suppression discipline so
+          ;; the dev stream stays readable across hot-reload churn.
+          (maybe-emit-collision! kind id previous metadata)))
       ;; First-time registration — emit handler-registered per Spec 009
       ;; §:op-type vocabulary. Hot-reload tools (10x, re-frame-pair) use
       ;; this to track when fresh ids appear in the registry.
       :else
       (when interop/debug-enabled?
         (emit! :rf.registry/handler-registered {:kind kind :id id})))
+    ;; Per Spec 001 §`:doc` is dev-warned when absent (rf2-45kaz). Fires
+    ;; on every reg-* call whose final metadata-map carries no usable
+    ;; `:doc`, once per (kind, id) within the runtime process. Production
+    ;; elides via the outer `interop/debug-enabled?` gate (Spec 009
+    ;; §Production builds). Fires on BOTH first-time and re-registration
+    ;; — the consult+emit body is suppressed by the per-(kind, id) cache
+    ;; on subsequent calls; obligation 2 says re-registering the same id
+    ;; without `:doc` does NOT re-fire the warning.
+    (when interop/debug-enabled?
+      (maybe-emit-missing-doc! kind id metadata))
     ;; Always-on registration hooks (rf2-w50qm): fire on BOTH first-time
     ;; and re-registration so cross-id invariants (e.g. routing's
     ;; `:url-bound?` exclusivity per Spec 012 §Multi-frame routing) can
@@ -206,9 +338,17 @@
   nil)
 
 (defn clear-all!
-  "Remove every registration for every kind. Test fixtures use this."
+  "Remove every registration for every kind. Test fixtures use this.
+
+  Also resets the per-process warn-once caches for
+  `:rf.warning/missing-doc` and `:rf.warning/registration-collision`
+  so each test case starts from a clean diagnostic state — without
+  this, a test that re-registers an already-warned (kind, id) pair
+  would silently miss the warning under suppression."
   []
   (reset! kind->id->metadata {})
+  (reset! missing-doc-warned #{})
+  (reset! collision-warned   #{})
   nil)
 
 ;; ---- lookup ---------------------------------------------------------------

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -1,0 +1,260 @@
+(ns re-frame.registrar-warnings-test
+  "Per rf2-45kaz / Spec 001 §`:doc` is dev-warned when absent +
+  §Re-registration of a different function — collision warning.
+
+  Two warnings the registrar emits on the trace bus:
+
+    1. `:rf.warning/missing-doc` — every reg-* call whose final
+       metadata-map carries no usable `:doc` slot (absent, nil, or
+       empty string). Suppressed per `(kind, id)` within a runtime
+       process so the dev stream stays readable across hot-reload.
+       Emitted from the public macro path only — programmatic
+       internal helpers that bypass coord capture are out of scope.
+
+    2. `:rf.warning/registration-collision` — re-registration with a
+       different `:handler-fn`. Sits alongside the existing
+       `:rf.registry/handler-replaced` trace (which fires on EVERY
+       re-registration with a `:different-fn?` tag); the warning is
+       the separate dev-nudge surface that lifts the collision out
+       of the steady-state hot-reload stream. Same per-(kind, id)
+       suppression discipline.
+
+  Both warnings sit inside the registrar's outer
+  `(when interop/debug-enabled? ...)` gate so `:advanced +
+  goog.DEBUG=false` constant-folds the consult+emit branch to nil
+  (Spec 009 §Production builds). The CLJS elision-probe sentinels
+  pin the absence of `rf.warning/missing-doc` and
+  `rf.warning/registration-collision` in the production bundle."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.source-coords :as source-coords]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            [re-frame.core :as rf]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces!
+  "Attach a recording listener and return its atom."
+  [listener-id]
+  (let [a (atom [])]
+    (rf/register-trace-cb! listener-id (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- warnings-of
+  [recorded operation]
+  (filterv (fn [ev]
+             (and (= :warning (:op-type ev))
+                  (= operation (:operation ev))))
+           @recorded))
+
+(defn- with-stamped-coords
+  "Invoke `f` with `*pending-coords*` bound to a synthetic
+  macro-path coord map. Mirrors what every reg-* macro does at
+  expansion time — every entry that reaches `register!` via the
+  user-facing macro path carries the `:ns/:line/:file` envelope.
+
+  Tests use this to exercise the `:rf.warning/missing-doc` emission
+  gate, which only fires for metadata that came through the macro
+  path (Spec 001 §`:doc` obligation 4 carves out programmatic /
+  internal-helper paths)."
+  [f]
+  (binding [source-coords/*pending-coords*
+            {:ns 're-frame.registrar-warnings-test
+             :file "registrar_warnings_test.clj"
+             :line 1
+             :column 1}]
+    (f)))
+
+;; =============================================================================
+;; F1 — `:rf.warning/missing-doc`
+;; =============================================================================
+
+;; Obligation 1: emit on every reg-* whose final metadata-map carries no
+;; usable :doc (absent, nil, or empty string).
+
+(deftest missing-doc-fires-when-doc-absent
+  (testing "reg-* via the macro path with no :doc key emits :rf.warning/missing-doc"
+    (let [recorded (record-traces! ::missing-absent)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/no-doc (fn [db _] db))))
+      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+        (is (= 1 (count warns))
+            (str "expected exactly one missing-doc warning, got " (count warns)))
+        (let [t (:tags (first warns))]
+          (is (= :event (:kind t))
+              ":tags carries the registry :kind")
+          (is (= :ev/no-doc (:id t))
+              ":tags carries the registered :id")
+          (is (map? (:source-coords t))
+              ":tags carries the captured :source-coords envelope")
+          (is (= 're-frame.registrar-warnings-test (:ns (:source-coords t)))))))))
+
+(deftest missing-doc-fires-when-doc-nil
+  (testing ":doc explicitly nil is treated as missing"
+    (let [recorded (record-traces! ::missing-nil)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/nil-doc {:doc nil} (fn [db _] db))))
+      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))))))
+
+(deftest missing-doc-fires-when-doc-empty-string
+  (testing ":doc as the empty string is treated as missing"
+    (let [recorded (record-traces! ::missing-empty)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/empty-doc {:doc ""} (fn [db _] db))))
+      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))))))
+
+(deftest missing-doc-suppressed-when-doc-present
+  (testing "well-documented registration emits no warning"
+    (let [recorded (record-traces! ::doc-present)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/well-doc'd
+                           {:doc "a real description"}
+                           (fn [db _] db))))
+      (is (empty? (warnings-of recorded :rf.warning/missing-doc))))))
+
+;; Obligation 2: suppress per (kind, id) within a runtime process.
+
+(deftest missing-doc-suppressed-on-re-registration-same-id
+  (testing "re-registering the same (kind, id) with still-missing :doc does NOT re-emit"
+    (let [recorded (record-traces! ::suppress-rereg)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/same-id (fn [db _] db))
+          ;; Save-triggered re-eval — same id, still no :doc; warning is silent.
+          (rf/reg-event-db :ev/same-id (fn [db _] (assoc db :touched? true)))
+          (rf/reg-event-db :ev/same-id (fn [db _] db))))
+      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))
+          "exactly one warning across three registrations of the same id"))))
+
+(deftest missing-doc-fires-once-per-id-within-kind
+  (testing "different ids under the same kind each get their own warning"
+    (let [recorded (record-traces! ::per-id-within-kind)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :ev/alpha (fn [db _] db))
+          (rf/reg-event-db :ev/beta  (fn [db _] db))
+          (rf/reg-event-db :ev/gamma (fn [db _] db))))
+      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+        (is (= 3 (count warns)))
+        (is (= #{:ev/alpha :ev/beta :ev/gamma}
+               (into #{} (map #(get-in % [:tags :id])) warns)))))))
+
+(deftest missing-doc-fires-once-per-kind-for-same-id
+  (testing "the same id under different kinds each get their own warning"
+    (let [recorded (record-traces! ::per-kind-same-id)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :alias/shared (fn [db _] db))
+          (rf/reg-sub       :alias/shared (fn [db _] (:x db)))))
+      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+        (is (= 2 (count warns)))
+        (is (= #{:event :sub}
+               (into #{} (map #(get-in % [:tags :kind])) warns)))))))
+
+;; Obligation 4: kind coverage. Spot-check a representative slice across
+;; the canonical kinds (:event :sub :fx :cofx). The :doc check sits in
+;; the registrar chokepoint so every kind flows through the same gate;
+;; per-kind enumeration confirms the gate is independent of kind.
+
+(deftest missing-doc-fires-across-multiple-kinds
+  (testing "the gate is kind-agnostic — fires on :event, :sub, :fx, :cofx"
+    (let [recorded (record-traces! ::multi-kind)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :k/event-doc-missing (fn [db _] db))
+          (rf/reg-sub       :k/sub-doc-missing   (fn [db _] (:x db)))
+          (rf/reg-fx        :k/fx-doc-missing    (fn [_ _] nil))
+          (rf/reg-cofx      :k/cofx-doc-missing  (fn [cofx _] cofx))))
+      (let [warns (warnings-of recorded :rf.warning/missing-doc)
+            kinds (into #{} (map #(get-in % [:tags :kind])) warns)]
+        (is (= 4 (count warns))
+            "one warning per (kind, id) across four kinds")
+        (is (= #{:event :sub :fx :cofx} kinds))))))
+
+;; Obligation 4: programmatic registrations that bypass the macro path
+;; (no source coords merged in) are out of scope.
+
+(deftest missing-doc-silent-on-programmatic-path
+  (testing "register! called without macro-path source coords does NOT emit"
+    (let [recorded (record-traces! ::programmatic)]
+      ;; Note: NO with-stamped-coords wrapper — *pending-coords* is nil,
+      ;; mirroring an internal helper / REPL register! call.
+      (registrar/register! :event :internal/no-coords
+                           {:handler-fn (fn [db _] db)})
+      (is (empty? (warnings-of recorded :rf.warning/missing-doc))
+          "programmatic / internal-helper path is out of scope (Spec 001 obligation 4)"))))
+
+;; =============================================================================
+;; F2 — `:rf.warning/registration-collision`
+;; =============================================================================
+
+(deftest collision-fires-on-different-fn-re-registration
+  (testing "re-registering an id with a different handler-fn emits the warning"
+    (let [recorded (record-traces! ::collision-different)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :collide/id {:doc "first"}  (fn [db _] (assoc db :v 1)))
+          (rf/reg-event-db :collide/id {:doc "second"} (fn [db _] (assoc db :v 2)))))
+      (let [warns (warnings-of recorded :rf.warning/registration-collision)]
+        (is (= 1 (count warns))
+            "exactly one collision warning fires on the second registration")
+        (let [t (:tags (first warns))]
+          (is (= :event (:kind t)))
+          (is (= :collide/id (:id t)))
+          (is (map? (:source-coords t))
+              ":source-coords carries the NEW registration's coords")
+          ;; :previous-coords is the captured envelope of the prior reg;
+          ;; both registrations were stamped with the same coords here.
+          (is (map? (:previous-coords t))))))))
+
+(deftest collision-suppressed-on-third-re-registration
+  (testing "subsequent re-registrations of the same (kind, id) do NOT re-emit"
+    (let [recorded (record-traces! ::collision-suppressed)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :churn/id {:doc "a"} (fn [db _] (assoc db :v 1)))
+          (rf/reg-event-db :churn/id {:doc "b"} (fn [db _] (assoc db :v 2)))
+          (rf/reg-event-db :churn/id {:doc "c"} (fn [db _] (assoc db :v 3)))
+          (rf/reg-event-db :churn/id {:doc "d"} (fn [db _] (assoc db :v 4)))))
+      (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
+          "warn-once: only the first different-fn re-registration emits"))))
+
+;; The existing `:rf.registry/handler-replaced` trace must keep firing on
+;; EVERY re-registration (per Spec 001 §Hot-reload trace surface, rf2-6w7zn)
+;; — the collision warning is a SEPARATE surface, not a replacement.
+
+(deftest collision-warning-coexists-with-handler-replaced
+  (testing "handler-replaced still fires unconditionally; collision is the dev-nudge addition"
+    (let [recorded (record-traces! ::coexist)]
+      (with-stamped-coords
+        (fn []
+          (rf/reg-event-db :coex/id {:doc "1"} (fn [db _] (assoc db :v 1)))
+          (rf/reg-event-db :coex/id {:doc "2"} (fn [db _] (assoc db :v 2)))
+          (rf/reg-event-db :coex/id {:doc "3"} (fn [db _] (assoc db :v 3)))))
+      (let [replaced (filterv (fn [ev]
+                                (and (= :registry (:op-type ev))
+                                     (= :rf.registry/handler-replaced
+                                        (:operation ev))))
+                              @recorded)
+            collisions (warnings-of recorded :rf.warning/registration-collision)]
+        (is (= 2 (count replaced))
+            "handler-replaced fires on each of the two re-registrations")
+        (is (= 1 (count collisions))
+            "collision warning fires once and is then suppressed")))))

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -79,6 +79,24 @@ const DEV_ONLY_SENTINELS = [
   // re-frame.registrar — handler-cleared trace op.
   { source: 're-frame.registrar/unregister! / clear-kind! (handler-cleared)',
     sentinel: 'rf.registry/handler-cleared' },
+  // re-frame.registrar — :rf.warning/missing-doc trace op (Spec 001
+  // §`:doc` is dev-warned when absent, rf2-45kaz). Emitted from
+  // maybe-emit-missing-doc! when a public macro-path reg-* call
+  // carries no usable :doc. The emit call sits inside the outermost
+  // `(when interop/debug-enabled? ...)` gate in register!; under
+  // :advanced + goog.DEBUG=false the consult+emit branch and the
+  // operation keyword's string literal must elide.
+  { source: 're-frame.registrar/register! (rf.warning/missing-doc)',
+    sentinel: 'rf.warning/missing-doc' },
+  // re-frame.registrar — :rf.warning/registration-collision trace op
+  // (Spec 001 §Re-registration of a different function — collision
+  // warning, rf2-45kaz). Emitted from maybe-emit-collision! when a
+  // re-registration swaps in a different :handler-fn. Sits inside
+  // the same gated branch as handler-replaced; the operation
+  // keyword's string fragment must elide under :advanced +
+  // goog.DEBUG=false.
+  { source: 're-frame.registrar/register! (rf.warning/registration-collision)',
+    sentinel: 'rf.warning/registration-collision' },
   // re-frame.router — :event/dispatched trace op (rf2-smee dispatch-id
   // correlation).  Emitted via trace/emit! whose body is gated; the
   // operation keyword should not survive.


### PR DESCRIPTION
## Summary

Spec 001 normatively requires two registrar warnings the impl did not emit. Catch the impl up to the spec (parent finding: rf2-m84iv F1+F2).

- **`:rf.warning/missing-doc`** (Spec 001 §`:doc` is dev-warned when absent) — fires once per `(kind, id)` when a public macro-path `reg-*` carries no usable `:doc` (absent, nil, or empty string). The macro-path gate uses `(:ns metadata)` — the canonical signature `source-coords/merge-coords` leaves — so programmatic / internal-helper paths are out of scope (per obligation 4).
- **`:rf.warning/registration-collision`** (Spec 001 §Re-registration of a different function) — fires once per `(kind, id)` on a re-registration that swaps in a different `:handler-fn`, alongside the existing `:rf.registry/handler-replaced` trace (preserved unchanged as the unconditional hot-reload trace surface).

Both warnings sit inside `register!`'s existing outer `(when interop/debug-enabled? ...)` gate so `:advanced + goog.DEBUG=false` constant-folds the consult+emit branches. Two new sentinels in `check-elision.cjs` pin the production-elision contract.

Suppression mechanism: two `defonce` atoms (`missing-doc-warned`, `collision-warned`) keyed by `[kind id]`; `clear-all!` resets both so test fixtures start clean.

## Test plan

- [x] 12 new `deftest` cases in `implementation/core/test/re_frame/registrar_warnings_test.clj` covering all five `:rf.warning/missing-doc` obligations (absence / nil / empty / per-(kind,id) suppression / kind coverage across `:event :sub :fx :cofx`) plus the programmatic-path carve-out, and three `:rf.warning/registration-collision` cases (different-fn detection / suppression / coexistence with `handler-replaced`).
- [x] Full `clojure -M:test` core suite: **498 tests / 2606 assertions, 0 failures, 0 errors**.
- [x] `npm run test:cljs`: **2156 tests / 6154 assertions, 0 failures, 0 errors**.
- [x] `npm run test:elision`: **production 30/30 absent (326599 chars); control 30/30 present (368488 chars)** — both new sentinels confirmed present-in-control, absent-in-prod.
- [x] `scripts/test-fast-pr.sh`: **PASS fast PR spine**.

Closes rf2-45kaz.