### PR TITLE
feat(template): :include-story? flag for Reagent variant (rf2-t009p)

### DIFF
--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -77,16 +77,25 @@ and recognises the shape. That continuity is deliberate.
 
 ## Non-goals
 
-- **Branching feature toggles** (include-Story? include-10x?
-  include-routing?). The first cut keeps the template flat — one
-  substrate flag, no other choices. Branching is reserved for the
-  day choices materially exceed clj-new's substitution capability
+- **Branching feature toggles** (include-10x? include-routing?,
+  etc.). The first cut keeps the template flat — one substrate
+  flag, no other choices. Branching is reserved for the day
+  choices materially exceed clj-new's substitution capability
   ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §clj-new vs CLI).
-- **Bundling Story.** [`tools/story/`](../../story/) is the future
-  Storybook-class playground for re-frame2; the template
-  intentionally doesn't pre-wire it. Story-stabilisation lands
-  first; a `counter_with_stories`-style variant follows
-  ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §No-Story-yet).
+
+  **Exception (rf2-t009p):** branching flags are permitted when
+  they enable an *optional shared scaffolding* whose absence would
+  force the user into hand-wiring known idioms — currently
+  `:include-story?` (emits a `counter_with_stories`-shaped story
+  scaffold alongside the live app). Each such flag is justified
+  in DESIGN-RATIONALE alongside the no-other-branching default.
+- **Bundling Story by default.** [`tools/story/`](../../story/)
+  is the Storybook-class playground for re-frame2; the template
+  does **not** pre-wire it on the default path. The opt-in
+  `:include-story?` flag (see the exception above) is the
+  supported on-ramp for users who want the playground scaffolded;
+  rationale and shape live in
+  [DESIGN-RATIONALE](DESIGN-RATIONALE.md) §No-Story-yet.
 - **Multi-frame scaffolds.** Frames (Spec 002) are a runtime
   concern. The template emits a single-frame app; the user reads
   Guide chapter 06 to add more.

--- a/tools/template/spec/DESIGN-RATIONALE.md
+++ b/tools/template/spec/DESIGN-RATIONALE.md
@@ -158,36 +158,59 @@ they are richer examples of re-frame2, not richer scaffolds. The
 template is for getting started; the per-substrate `examples/`
 trees are for studying complete patterns.
 
-## §5 — No-Story-yet
+## §5 — No-Story-yet (default), opt-in via `:include-story?` (rf2-t009p)
 
 **Decision.** The template does **not** pre-wire
-[`tools/story/`](../../story/) or emit a `counter_with_stories`
-scaffold. Reserved for a future iteration.
+[`tools/story/`](../../story/) on the default path. The
+`:include-story?` flag is the opt-in on-ramp — Reagent-only in
+v1; UIx + Helix variants follow once their adapter coverage
+matches Reagent's.
 
-**Why.**
+**Why default-off.**
 
-- **Story is in active development.** Stage 8 (rf2-c9mm) just
-  landed. Stage 9 (Storybook ↔ Story migration tooling) is
-  in flight. The surface is moving.
-- **Coupling cost.** A template that pre-wires Story would have
-  to track every change to the seven `reg-*` macros, the variant
-  id grammar, and the snapshot-identity contract. Today that
-  rate of change is too high.
-- **Opt-in is fine.** A user who wants Story today adds it to
-  their `deps.edn` manually:
+- **Story is post-1.0 but still moving.** Stage 8 (rf2-c9mm)
+  landed; subsequent stages tune the authoring surface. Default-on
+  would force every scaffolded app to track every change to the
+  seven `reg-*` macros and the variant id grammar.
+- **Cost of an unwanted dep.** Users who don't reach for Story
+  shouldn't pay for it in their `deps.edn`, their bundle
+  isolation grep set, or their docs surface.
 
-  ```clojure
-  day8/re-frame2-story {:mvn/version "..."}
-  ```
+**Why opt-in shape.**
 
-  And points at `tools/story/testbeds/counter_with_stories/` for the
-  shape.
+- **The exemplar exists.** [`tools/story/testbeds/counter_with_stories/`](../../../tools/story/testbeds/counter_with_stories/)
+  is the canonical shape — the scaffold mirrors its file layout
+  (entry-fn hash-routes between `#/` and `#/stories`, dedicated
+  `stories.cljs` that fires the `reg-*` calls).
+- **Hand-wiring it from cold is friction.** A first-time Story
+  user has to read the exemplar end-to-end, port the routing
+  shape, decide which `reg-*` macros to invoke, and remember the
+  `day8/re-frame2-story` coord. One flag collapses that into a
+  scaffolded baseline they can edit.
+- **Reagent first.** v1 ships Reagent only — matching Story's own
+  UI-shell substrate and the exemplar's substrate. UIx + Helix
+  variants land when Story's substrate-agnostic seams (spec/007
+  §Substrate constraints) cover them end-to-end.
 
-The follow-up: once Story stabilises post-1.0, add an
-`:include-story?` flag in `:edn-args` (along the lines of
-[001-Substrate-Variants.md §Future variants](001-Substrate-Variants.md#future-variants))
-that wires Story registrations and emits a story-augmented
-counter view.
+**Invocation.**
+
+```bash
+clojure -X:project/new :template re-frame2 :name acme/my-app \
+        :edn-args '[:include-story? true]'
+```
+
+Adds `day8/re-frame2-story` to `deps.edn` (lockstep with the core
+coord version), emits `stories.cljs` next to `events.cljs` /
+`subs.cljs` / `views.cljs`, swaps `core.cljs` for the hash-routing
+variant, and wires `npm run story` as an alias for `shadow-cljs
+watch app` — visit `#/stories` for the playground, `#/` for the
+live app.
+
+This is the branching-flag exception called out in
+[000-Vision §Non-goals](000-Vision.md#non-goals): it's permitted
+because the alternative (hand-wiring the seven `reg-*` calls and
+the hash routing from the exemplar) is real friction the scaffold
+should absorb. No other branching flags currently exist.
 
 ## §6 — Pin source-of-truth in one place
 

--- a/tools/template/src/clj/new/re_frame2.clj
+++ b/tools/template/src/clj/new/re_frame2.clj
@@ -74,23 +74,60 @@
 ;; -- Template entry ---------------------------------------------------------
 ;;
 ;; clj-new's harness invokes (re-frame2 name & args) where args is a flat
-;; alternating-key-value sequence: e.g. (:substrate :uix). We accept just
-;; the substrate today; future toggles (e.g. include-story?, include-10x?)
-;; would slot in here.
+;; alternating-key-value sequence: e.g. (:substrate :uix). We accept the
+;; substrate and the include-story? flag today; future toggles
+;; (e.g. :include-10x?) would slot in here.
+;;
+;; The `:include-story?` exception is documented in spec/000-Vision
+;; §Non-goals and spec/DESIGN-RATIONALE §No-Story-yet — branching flags
+;; are permitted when they enable optional shared scaffolding whose
+;; absence forces the user into hand-wiring known idioms. Reagent-only
+;; in v1; UIx + Helix variants follow once their adapter coverage
+;; matches Reagent's.
+
+(defn- coerce-include-story?
+  "Coerce the `:include-story?` arg to a boolean. Accepts true / false /
+   nil; rejects anything else with a clear message. The flag is
+   Reagent-only in v1 — caller-level guard checks the substrate."
+  [raw]
+  (cond
+    (nil? raw)          false
+    (true? raw)         true
+    (false? raw)        false
+    :else
+    (throw (ex-info (str ":include-story? must be true or false (got "
+                         (pr-str raw) ")")
+                    {:include-story? raw}))))
 
 (defn re-frame2
   "Generate a fresh re-frame2 application skeleton.
 
   Args:
-    name        Group-qualified project name (e.g. `acme/my-app`).
-    :substrate  One of :reagent :uix :helix (default :reagent).
+    name              Group-qualified project name (e.g. `acme/my-app`).
+    :substrate        One of :reagent :uix :helix (default :reagent).
+    :include-story?   When true, scaffolds the Story playground
+                      alongside the live app — adds the
+                      `day8/re-frame2-story` coord, emits
+                      `stories.cljs`, and swaps `core.cljs` for the
+                      hash-routing entry-fn (`#/` → live app,
+                      `#/stories` → Story shell). Reagent-only in v1.
 
   Files emitted match the per-substrate counter example in the reference
   implementation."
   [name & args]
-  (let [opts        (apply hash-map args)
-        substrate   (coerce-substrate (:substrate opts))
-        substrate-name (clojure.core/name substrate)
+  (let [opts            (apply hash-map args)
+        substrate       (coerce-substrate (:substrate opts))
+        substrate-name  (clojure.core/name substrate)
+        include-story?  (coerce-include-story? (:include-story? opts))
+        _               (when (and include-story? (not= substrate :reagent))
+                          (throw (ex-info
+                                   (str ":include-story? is Reagent-only in v1 "
+                                        "(got :substrate " substrate
+                                        "). UIx + Helix variants follow once "
+                                        "Story's adapter coverage matches "
+                                        "Reagent's.")
+                                   {:substrate substrate
+                                    :include-story? include-story?})))
         ;; clj-new's project-data gives us {:name :namespace :nested-dirs
         ;; :sanitized :group :artifact :year :date ...}.
         data        (merge (project-data name)
@@ -98,6 +135,13 @@
                             :reagent?          (= substrate :reagent)
                             :uix?              (= substrate :uix)
                             :helix?            (= substrate :helix)
+                            ;; Drives Mustache section emission in
+                            ;; deps.edn (+ day8/re-frame2-story coord)
+                            ;; and package.json (+ `npm run story`
+                            ;; script). The file-list below branches
+                            ;; on the same flag for `stories.cljs` +
+                            ;; the with-stories `core.cljs` variant.
+                            :include-story?    include-story?
                             ;; Static-shields badge for the chosen
                             ;; substrate. Shields.io renders the SVG;
                             ;; the colour is matched per-substrate so
@@ -137,7 +181,8 @@
         sub-raw     (fn [path] (raw path))]
     (println "Generating a re-frame2 project called"
              (project-name name)
-             "—" substrate-name "substrate.")
+             "—" substrate-name "substrate"
+             (if include-story? "(with Story playground)." "."))
     (->files data
              ;; -- top-level project files --
              ["deps.edn"        (sub-render (str substrate-name "/deps.edn"))]
@@ -158,14 +203,31 @@
              ;; lefthook — pre-commit format + lint gate.
              [".lefthook.yml"   (sub-render "shared/lefthook.yml")]
              ;; -- src tree --
+             ;;
+             ;; `core.cljs` swaps to the hash-routing with-stories variant
+             ;; under `:include-story? true`. Only Reagent ships the
+             ;; with-stories core today; the caller-level guard above
+             ;; rejects `:include-story? true` for non-Reagent substrates.
              ["src/{{nested-dirs}}/core.cljs"
-              (sub-render (str substrate-name "/core.cljs"))]
+              (sub-render (str substrate-name "/"
+                               (if include-story?
+                                 "core_with_stories.cljs"
+                                 "core.cljs")))]
              ["src/{{nested-dirs}}/events.cljs"
               (sub-render "shared/events.cljs")]
              ["src/{{nested-dirs}}/subs.cljs"
               (sub-render "shared/subs.cljs")]
              ["src/{{nested-dirs}}/views.cljs"
               (sub-render (str substrate-name "/views.cljs"))]
+             ;; -- optional: Story scaffolding (rf2-t009p) --
+             ;;
+             ;; Emitted only under `:include-story? true`. ->files
+             ;; treats nil entries as a no-op, so a `(when ...)` here
+             ;; gives us a conditional emit without restructuring
+             ;; ->files's vector-of-pairs interface.
+             (when include-story?
+               ["src/{{nested-dirs}}/stories.cljs"
+                (sub-render "shared/stories.cljs")])
              ;; -- test tree --
              ;;
              ;; A single events-side test gives the `:test` build entry

--- a/tools/template/src/clj/new/re_frame2/reagent/core_with_stories.cljs
+++ b/tools/template/src/clj/new/re_frame2/reagent/core_with_stories.cljs
@@ -1,0 +1,76 @@
+(ns {{namespace}}.core
+  "Entry point — hash-routed between the live counter app and the
+   Story playground.
+
+   Two surfaces share `#app`, one root at a time:
+
+   - `#/`        → the live counter (`views/counter-app`).
+   - `#/stories` → the Story shell (`story/mount-shell!`).
+
+   We tear one root down before mounting the other so React owns the
+   target DOM node exclusively. The live-app root lives in `app-root`
+   below; the Story shell allocates and owns its own root internally
+   via `rdc/create-root` inside `mount-shell!`.
+
+   Per IMPL-SPEC §6.5 / Stage 8: under `:advanced` with
+   `:closure-defines {re-frame.story.config/enabled? false}`, every
+   `reg-*` form in `{{namespace}}.stories` elides to `nil` and
+   `mount-shell!` short-circuits — the production bundle carries no
+   Story body code. The `:release` shadow build inherits that elision
+   automatically; flip the closure-define in `shadow-cljs.edn` if you
+   need a release-flavoured Story build for visual-regression."
+  (:require [reagent.dom.client       :as rdc]
+            [re-frame.core            :as rf]
+            [re-frame.story           :as story]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Side-effecting requires — register events / subs and
+            ;; pull the views ns in so its `reg-view` forms register.
+            [{{namespace}}.events]
+            [{{namespace}}.subs]
+            [{{namespace}}.views      :as views]
+            ;; Loading the stories ns fires the Story `reg-*` calls.
+            [{{namespace}}.stories]))
+
+;; -- Live-app root --------------------------------------------------------
+
+(defonce ^:private app-root (atom nil))
+
+(defn- ensure-app-root! []
+  (when (nil? @app-root)
+    (reset! app-root (rdc/create-root (js/document.getElementById "app")))))
+
+(defn- tear-down-app-root! []
+  (when-let [r @app-root]
+    (try (rdc/unmount r) (catch :default _ nil))
+    (reset! app-root nil)))
+
+(defn- mount-app! []
+  (story/unmount-shell!)
+  (ensure-app-root!)
+  (rdc/render @app-root [views/counter-app]))
+
+(defn- mount-stories! []
+  (tear-down-app-root!)
+  (story/mount-shell! (js/document.getElementById "app")))
+
+(defn- on-hash-change! []
+  (let [hash (or (.. js/window -location -hash) "")]
+    (if (re-find #"^#/stories" hash)
+      (mount-stories!)
+      (mount-app!))))
+
+(defn ^:export init
+  "Called by shadow-cljs (see :init-fn in shadow-cljs.edn). Idempotent —
+   shadow's hot-reload pipeline re-invokes it on each rebuild."
+  []
+  (rf/init! reagent-adapter/adapter)
+  ;; Re-fire the canonical Story vocabulary install on each hot-reload
+  ;; — idempotent, and survives a `clear-all!` during dev experiments.
+  (story/install-canonical-vocabulary!)
+  ;; Seed app-db before the first render so the live-app branch sees a
+  ;; populated frame.
+  (rf/dispatch-sync [:counter/initialise])
+  ;; Wire hash-change so reloading `#/stories` lands on the shell
+  ;; without a manual click-through.
+  (.addEventListener js/window "hashchange" on-hash-change!)
+  (on-hash-change!))

--- a/tools/template/src/clj/new/re_frame2/reagent/deps.edn
+++ b/tools/template/src/clj/new/re_frame2/reagent/deps.edn
@@ -21,7 +21,13 @@
          ;; :devtools/preloads in shadow-cljs.edn. Lockstep with
          ;; the core coord — Causa publishes at the same version.
          day8/re-frame2-causa      {:mvn/version "{{rf2-version}}"}
-
+{{#include-story?}}
+         ;; Storybook-class component playground. Scaffolded via
+         ;; `:include-story? true`. Lockstep with the core coord.
+         ;; Hash-route `#/stories` mounts the shell; `#/` mounts the
+         ;; live app. See the stories.cljs file next to events.cljs.
+         day8/re-frame2-story      {:mvn/version "{{rf2-version}}"}
+{{/include-story?}}
          reagent/reagent           {:mvn/version "2.0.1"}}
 
  :aliases

--- a/tools/template/src/clj/new/re_frame2/reagent/package.json
+++ b/tools/template/src/clj/new/re_frame2/reagent/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "watch":   "shadow-cljs watch app",
     "release": "shadow-cljs release app",
+{{#include-story?}}
+    "story":   "shadow-cljs watch app",
+{{/include-story?}}
     "test":    "shadow-cljs compile test && node out/node-test.js"
   },
   "devDependencies": {
@@ -13,6 +16,7 @@
   },
   "dependencies": {
     "react":     "{{react-version}}",
-    "react-dom": "{{react-version}}"
+    "react-dom": "{{react-version}}"{{#include-story?}},
+    "qrcode-generator": "2.0.4"{{/include-story?}}
   }
 }

--- a/tools/template/src/clj/new/re_frame2/shared/stories.cljs
+++ b/tools/template/src/clj/new/re_frame2/shared/stories.cljs
@@ -1,0 +1,86 @@
+(ns {{namespace}}.stories
+  "Story playground registrations for the scaffolded counter.
+
+   Emitted by `day8/clj-template.re-frame2` when scaffolded with
+   `:include-story? true`. Mirrors the canonical shape at
+   `tools/story/testbeds/counter_with_stories/stories.cljs` in the
+   re-frame2 repo — kept small here so the scaffold reads at a glance
+   rather than overwhelming a first-time Story user.
+
+   The four shipped `reg-*` macros each appear once:
+
+   - `reg-story`       — `:story.counter` parent.
+   - `reg-variant`     — two variants (`/empty` + `/incremented`).
+   - `reg-tag`         — `:{{name}}/canonical` (project-scoped tag).
+   - `reg-workspace`   — `:Workspace.counter/all` (auto-grid layout).
+
+   Per spec/007 §Variants every variant body is plain data — no
+   fn-slots. The view at the centre of each variant is referenced by
+   id (`:{{namespace}}.views/counter-app`); the events the variant
+   dispatches reference event-ids. Add more `reg-variant` / `reg-tag`
+   / `reg-decorator` / `reg-mode` calls below as your app grows."
+  (:require [re-frame.story :as story]
+            ;; Source the events / subs / views by requiring their
+            ;; namespaces — registrations fire as a side effect of
+            ;; loading the ns. The variant bodies reference those
+            ;; registrations by keyword id.
+            [{{namespace}}.events]
+            [{{namespace}}.subs]
+            [{{namespace}}.views]))
+
+(defn register-all!
+  "Register the scaffolded Story artefacts. Idempotent — the trailing
+   top-level call fires this at namespace load; tests / hot-reload may
+   call it again after a `clear-all!`."
+  []
+  ;; Install the seven canonical Story tags (`:dev :docs :test
+  ;; :screenshot :experimental :internal :agent`), the lifecycle
+  ;; machine, the canonical `:rf.assert/*` handlers, the layout-debug
+  ;; decorator set, and the v1 panel set. Idempotent.
+  (story/install-canonical-vocabulary!)
+
+  ;; -- reg-tag — a project-scoped tag for the canonical screenshot ---------
+  (story/reg-tag :{{name}}/canonical
+    {:doc "Tag applied to the variant that ships as the example's
+          canonical screenshot."})
+
+  ;; -- reg-story — the parent. Inherits down to every variant. -------------
+  (story/reg-story :story.counter
+    {:doc        "The scaffolded counter."
+     :component  :{{namespace}}.views/counter-app
+     :tags       #{:dev :docs}
+     :substrates #{:reagent}})
+
+  ;; -- reg-variant — empty (zero) + incremented (three clicks) -------------
+  (story/reg-variant :story.counter/empty
+    {:doc    "Fresh counter at zero."
+     :events [[:counter/initialise]]
+     :play   [[:rf.assert/path-equals [:counter/value] 0]]
+     :tags   #{:dev :docs :test :{{name}}/canonical}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.counter/incremented
+    {:doc    "Counter after three increments. Dispatched from :play so
+             :rf.assert/dispatched? observes them."
+     :events [[:counter/initialise]]
+     :play   [[:counter/increment]
+              [:counter/increment]
+              [:counter/increment]
+              [:rf.assert/path-equals [:counter/value] 3]
+              [:rf.assert/sub-equals  [:counter/value] 3]
+              [:rf.assert/dispatched? [:counter/increment]]]
+     :tags   #{:dev :docs :test}
+     :substrates #{:reagent}})
+
+  ;; -- reg-workspace — auto-enumerated grid layout -------------------------
+  (story/reg-workspace :Workspace.counter/all
+    {:doc      "Auto-enumerated grid — pulls every variant off
+                :story.counter. New variants appear here without
+                touching this workspace."
+     :layout   :variants-grid
+     :for      :story.counter
+     :columns  2
+     :tags     #{:docs}}))
+
+;; Fire the registrations once at namespace load.
+(register-all!)

--- a/tools/template/test/clj/new/re_frame2_test.clj
+++ b/tools/template/test/clj/new/re_frame2_test.clj
@@ -46,18 +46,24 @@
 
 (defn- run-template!
   "Run the template's main fn inside the given temp directory. Returns
-  the generated project's root path as a `java.io.File`."
-  [tmp project-name substrate]
-  (let [dir-str   (.toString ^java.nio.file.Path tmp)
-        proj-dir  (.getPath (io/file dir-str
-                                     (tmpl/project-name project-name)))
-        sub-args  (when substrate [:substrate substrate])]
-    ;; clj-new's ->files reads *dir* (via project-dir) to decide where
-    ;; to land the generated tree. Rebind it to our temp directory for
-    ;; the duration of the template's main fn.
-    (binding [tmpl/*dir* proj-dir]
-      (apply rft/re-frame2 project-name sub-args))
-    (io/file proj-dir)))
+  the generated project's root path as a `java.io.File`. The 3-arity
+  form preserves the historical default (no `:include-story?`); the
+  4-arity form lets per-test cases opt into Story scaffolding."
+  ([tmp project-name substrate]
+   (run-template! tmp project-name substrate nil))
+  ([tmp project-name substrate include-story?]
+   (let [dir-str   (.toString ^java.nio.file.Path tmp)
+         proj-dir  (.getPath (io/file dir-str
+                                      (tmpl/project-name project-name)))
+         args      (cond-> []
+                     substrate              (into [:substrate substrate])
+                     (some? include-story?) (into [:include-story? include-story?]))]
+     ;; clj-new's ->files reads *dir* (via project-dir) to decide where
+     ;; to land the generated tree. Rebind it to our temp directory for
+     ;; the duration of the template's main fn.
+     (binding [tmpl/*dir* proj-dir]
+       (apply rft/re-frame2 project-name args))
+     (io/file proj-dir))))
 
 (defn- read-edn [^java.io.File f]
   (edn/read-string (slurp f)))
@@ -333,5 +339,120 @@
                               #":substrate must be one of"
                               (run-template! tmp "acme/my-app" :svelte))
             "unknown substrate is rejected")
+        (finally
+          (delete-recursively tmp))))))
+
+;; --- :include-story? flag (rf2-t009p) ------------------------------------
+
+(deftest default-path-emits-no-story-files-test
+  (testing "default path (no :include-story?) does not emit stories.cljs
+            and does not pull in the day8/re-frame2-story coord"
+    (let [tmp (tmp-dir "rf2-template-no-story-")]
+      (try
+        (let [root (run-template! tmp "acme/my-app" :reagent)]
+          (is (not (file-exists? root "src/acme/my_app/stories.cljs"))
+              "stories.cljs is NOT emitted on the default path")
+          (let [deps    (read-edn (io/file root "deps.edn"))
+                pkg-txt (slurp (io/file root "package.json"))]
+            (is (not (contains? (:deps deps) 'day8/re-frame2-story))
+                "deps.edn does NOT reference day8/re-frame2-story on default path")
+            (is (not (.contains pkg-txt "\"story\":"))
+                "package.json does NOT carry a `story` npm script on default path")
+            (is (not (.contains pkg-txt "\"qrcode-generator\""))
+                "package.json does NOT carry the qrcode-generator npm dep
+                 on the default path (Story-only)"))
+          ;; The default-path core.cljs should still be the simple one —
+          ;; no Story require, no hash-routing surface.
+          (let [core-text (slurp (io/file root "src/acme/my_app/core.cljs"))]
+            (is (not (.contains core-text "re-frame.story"))
+                "default-path core.cljs does NOT require re-frame.story")
+            (is (not (.contains core-text "#/stories"))
+                "default-path core.cljs has no hash-routing scaffold")))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest include-story-true-reagent-test
+  (testing ":include-story? true on Reagent emits stories.cljs +
+            the with-stories core variant, and wires the story coord"
+    (let [tmp (tmp-dir "rf2-template-with-story-")]
+      (try
+        (let [root (run-template! tmp "acme/my-app" :reagent true)]
+          ;; -- The Story scaffold lands --
+          (is (file-exists? root "src/acme/my_app/stories.cljs")
+              "stories.cljs is emitted under :include-story? true")
+          ;; -- Story coord + npm script are wired --
+          (let [deps    (read-edn (io/file root "deps.edn"))
+                pkg-txt (slurp (io/file root "package.json"))]
+            (is (contains? (:deps deps) 'day8/re-frame2-story)
+                "deps.edn references day8/re-frame2-story")
+            (is (= "0.0.1.alpha"
+                   (get-in deps [:deps 'day8/re-frame2-story :mvn/version]))
+                "story coord lockstep with the core version")
+            (is (.contains pkg-txt "\"story\":")
+                "package.json declares a `story` npm script")
+            (is (.contains pkg-txt "\"qrcode-generator\"")
+                "package.json declares the qrcode-generator npm dep
+                 (Story's only direct npm dependency — re-frame.story.qr
+                 wraps it for the share-canvas QR codes)"))
+          ;; -- core.cljs is the hash-routing with-stories variant --
+          (let [core-text (slurp (io/file root "src/acme/my_app/core.cljs"))]
+            (is (.contains core-text "re-frame.story")
+                "with-stories core.cljs requires re-frame.story")
+            (is (.contains core-text "mount-shell!")
+                "with-stories core.cljs mounts the Story shell")
+            (is (.contains core-text "#/stories")
+                "with-stories core.cljs routes #/stories to the shell")
+            (is (.contains core-text "acme.my-app.stories")
+                "with-stories core.cljs requires the stories ns so its
+                 reg-* calls fire at boot"))
+          ;; -- stories.cljs uses the four shipped reg-* macros and
+          ;;    references the template's existing event/sub/view ids --
+          (let [stories-text (slurp (io/file root "src/acme/my_app/stories.cljs"))]
+            (is (.contains stories-text "story/reg-story")
+                "stories.cljs uses reg-story")
+            (is (.contains stories-text "story/reg-variant")
+                "stories.cljs uses reg-variant")
+            (is (.contains stories-text "story/reg-tag")
+                "stories.cljs uses reg-tag")
+            (is (.contains stories-text "story/reg-workspace")
+                "stories.cljs uses reg-workspace")
+            (is (.contains stories-text ":counter/initialise")
+                "stories.cljs references the template's :counter/initialise event")
+            (is (.contains stories-text ":counter/increment")
+                "stories.cljs references the template's :counter/increment event")
+            (is (.contains stories-text ":counter/value")
+                "stories.cljs's :rf.assert/path-equals targets the
+                 template's :counter/value app-db slot")
+            (is (.contains stories-text ":acme.my-app.views/counter-app")
+                "stories.cljs references the template's view by namespaced
+                 id (Story renders by id, not by symbol)")))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest include-story-non-reagent-rejected-test
+  (testing ":include-story? true is rejected for non-Reagent substrates
+            in v1 — UIx + Helix follow once Story's adapter coverage
+            matches Reagent's"
+    (let [tmp (tmp-dir "rf2-template-story-uix-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":include-story\? is Reagent-only"
+                              (run-template! tmp "acme/my-app" :uix true))
+            ":include-story? + :uix is rejected at the entry-fn")
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":include-story\? is Reagent-only"
+                              (run-template! tmp "acme/my-app" :helix true))
+            ":include-story? + :helix is rejected at the entry-fn")
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest invalid-include-story-rejected-test
+  (testing "non-boolean :include-story? value throws with a clear message"
+    (let [tmp (tmp-dir "rf2-template-story-bad-")]
+      (try
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #":include-story\? must be true or false"
+                              (run-template! tmp "acme/my-app" :reagent "yes"))
+            "non-boolean :include-story? is rejected")
         (finally
           (delete-recursively tmp))))))

--- a/tools/template/test/clj/new/template_emission_test.clj
+++ b/tools/template/test/clj/new/template_emission_test.clj
@@ -58,14 +58,19 @@
            reverse
            (run! #(java.nio.file.Files/deleteIfExists ^java.nio.file.Path %))))))
 
-(defn- run-template! [tmp project-name substrate]
-  (let [dir-str   (.toString ^java.nio.file.Path tmp)
-        proj-dir  (.getPath (io/file dir-str
-                                     (tmpl/project-name project-name)))
-        sub-args  (when substrate [:substrate substrate])]
-    (binding [tmpl/*dir* proj-dir]
-      (apply rft/re-frame2 project-name sub-args))
-    (io/file proj-dir)))
+(defn- run-template!
+  ([tmp project-name substrate]
+   (run-template! tmp project-name substrate nil))
+  ([tmp project-name substrate include-story?]
+   (let [dir-str   (.toString ^java.nio.file.Path tmp)
+         proj-dir  (.getPath (io/file dir-str
+                                      (tmpl/project-name project-name)))
+         args      (cond-> []
+                     substrate              (into [:substrate substrate])
+                     (some? include-story?) (into [:include-story? include-story?]))]
+     (binding [tmpl/*dir* proj-dir]
+       (apply rft/re-frame2 project-name args))
+     (io/file proj-dir))))
 
 ;; --- Static-parse machinery ----------------------------------------------
 
@@ -161,18 +166,24 @@
 
 (defn- framework-ns-file
   "Map a re-frame.X namespace symbol to its source-of-truth file under
-  `implementation/`. Returns the `java.io.File`, or nil if we don't
-  know about this ns (we only audit framework namespaces — the user's
-  own `<app>.events` / `.subs` aren't audited here; the bead is about
-  drift against the framework surface).
+  `implementation/` or `tools/`. Returns the `java.io.File`, or nil if
+  we don't know about this ns (we only audit framework namespaces —
+  the user's own `<app>.events` / `.subs` aren't audited here; the
+  bead is about drift against the framework surface).
 
   Search order:
 
     1. `implementation/core/src/re_frame/<rel>.{cljc,cljs}` — the core
-       coord ships everything under `re-frame.*` except adapters.
+       coord ships everything under `re-frame.*` except adapters and
+       downstream tool coords.
     2. `implementation/adapters/<flavour>/src/re_frame/adapter/<name>.cljs`
        — `re-frame.adapter.helix`, `re-frame.adapter.uix`, etc. live in
-       their own per-substrate coords."
+       their own per-substrate coords.
+    3. `tools/story/src/re_frame/story.cljc` (+ `re-frame.story.*`
+       sub-namespaces) — Story ships as its own downstream tool coord
+       (`day8/re-frame2-story`) under `tools/story/`. The template's
+       with-stories core requires `re-frame.story`; the audit needs
+       to find it where it actually lives."
   [root ns-sym]
   (let [name- (name ns-sym)]
     (cond
@@ -191,7 +202,10 @@
                 (when (#{"helix" "uix" "reagent" "reagent-slim"} leaf)
                   leaf)))
             candidates (cond-> [(io/file root "implementation/core/src/re_frame" (str rel ".cljc"))
-                                (io/file root "implementation/core/src/re_frame" (str rel ".cljs"))]
+                                (io/file root "implementation/core/src/re_frame" (str rel ".cljs"))
+                                ;; tools/story/ — re-frame.story + re-frame.story.* live here.
+                                (io/file root "tools/story/src/re_frame" (str rel ".cljc"))
+                                (io/file root "tools/story/src/re_frame" (str rel ".cljs"))]
                          adapter-flavour
                          (conj (io/file root "implementation/adapters"
                                         adapter-flavour
@@ -445,3 +459,26 @@
 (deftest helix-emission-static-parse-test
   (testing "Helix-substrate emission has well-formed ns requires and no surface drift"
     (run-for-substrate! :helix)))
+
+;; --- :include-story? (rf2-t009p) -----------------------------------------
+;;
+;; The with-stories core variant and the emitted stories.cljs both
+;; pull on `re-frame.story` — the same drift hazard as the rest of the
+;; scaffold (someone renames a public var, the template ships stale).
+;; The audit reuses the same surface-existence check used for the
+;; default Reagent path; framework-ns-file above already knows where
+;; tools/story/ lives.
+
+(deftest reagent-with-stories-emission-static-parse-test
+  (testing ":include-story? true on Reagent emits a with-stories core
+            and stories.cljs that reference only defined re-frame.* +
+            re-frame.story symbols"
+    (let [tmp  (tmp-dir "rf2-emission-story-")
+          root (repo-root)]
+      (try
+        (let [proj (run-template! tmp "acme/my-app" :reagent true)]
+          (doseq [rel ["src/acme/my_app/core.cljs"
+                       "src/acme/my_app/stories.cljs"]]
+            (audit-framework-surface! :reagent (io/file proj rel) root)))
+        (finally
+          (delete-recursively tmp))))))


### PR DESCRIPTION
## Summary

Adds the `:include-story?` opt-in template flag to `day8/clj-template.re-frame2`. When set, the scaffold emits a Story playground alongside the live counter — `#/` mounts the counter, `#/stories` mounts `re-frame.story`'s shell. Reagent-only in v1; UIx + Helix variants follow once Story's adapter coverage matches Reagent's.

## What changes

- New shared scaffold `shared/stories.cljs` (four-`reg-*` Mustache template mirroring the canonical exemplar at `tools/story/testbeds/counter_with_stories/`).
- New Reagent entry variant `reagent/core_with_stories.cljs` — hash-routes between `#/` (live app) and `#/stories` (Story shell). Same `init-fn` name (`<ns>.core/init`); the entry-fn picks the file at scaffold time.
- `reagent/deps.edn` adds `day8/re-frame2-story` inside a `{{#include-story?}}` Mustache section — lockstep with the core coord version.
- `reagent/package.json` adds `qrcode-generator` (Story's only direct npm dep, via `re-frame.story.qr`) and an `npm run story` script aliasing `shadow-cljs watch app`.
- Entry-fn (`src/clj/new/re_frame2.clj`) coerces the new flag, rejects non-Reagent substrates with a clear ex-info, and conditionally emits the story files.

## Spec drift

Two surgical amendments to per-tool docs (NOT the root spec hot-zone):

- `tools/template/spec/000-Vision.md §Non-goals` — branching feature toggles remain a non-goal, with a new explicit exception for flags that enable optional shared scaffolding (`:include-story?` is the canonical example).
- `tools/template/spec/DESIGN-RATIONALE.md §No-Story-yet` — rewritten to describe the default-off rationale (unchanged) plus the new opt-in shape (rationale, invocation, why Reagent first).

## Tests

`cd tools/template && clojure -M:test`:

```
Ran 16 tests containing 256 assertions.
0 failures, 0 errors.
```

New / extended assertions cover both branches:

- `default-path-emits-no-story-files-test` — `stories.cljs` absent, story coord absent, qrcode npm dep absent, default `core.cljs` has no `re-frame.story` require, no hash-routing.
- `include-story-true-reagent-test` — `stories.cljs` present, story coord wired at the core's version, `npm run story` script present, qrcode npm dep present, with-stories core requires `re-frame.story` + mounts the shell + routes `#/stories` + requires the stories ns; `stories.cljs` uses the four shipped `reg-*` macros and references the template's existing `:counter/initialise` / `:counter/increment` / `:counter/value` ids.
- `include-story-non-reagent-rejected-test` — `:uix` + `:helix` both throw with the clear "`:include-story? is Reagent-only`" message.
- `invalid-include-story-rejected-test` — non-boolean values throw the coercer's clear message.
- `reagent-with-stories-emission-static-parse-test` — surface-drift audit over with-stories core + stories.cljs, against the framework source. `framework-ns-file` extended to know `tools/story/` ships `re-frame.story`.

## Boot smoke (Playwright headless, generated release build with local-root coords)

Generated `acme/my-app` with `:include-story? true`, swapped to local-root coords, ran `shadow-cljs release app` (220 files, clean), served `resources/public/`, navigated:

- `#/`        → `<div><h1>my-app</h1><div><button>+1</button><span style="margin: 0px 1em;">0</span></div></div>` (counter renders)
- `#/stories` → `<header role="toolbar" aria-label="Story modes" data-test="story-toolbar" …>` (full Story chrome, dark theme, story registrations live)

Zero console errors on either surface (only the benign `frame-ancestors`-via-`<meta>` CSP warning the template's existing README "Production hardening" section already addresses).

## Test plan

- [x] `clojure -M:test` from `tools/template/` — 256 assertions pass.
- [x] Generate `:include-story? true` app, swap to local-root coords, `shadow-cljs release app` succeeds.
- [x] Headless Playwright smoke: live counter renders at `#/`, Story shell renders at `#/stories`, zero console errors (modulo the pre-existing benign CSP `<meta>`-vs-`frame-ancestors` warning).
- [x] Default-path (no flag) generation still produces the same shape as before — no story files leak, no extra deps, no extra npm scripts.
- [x] `:include-story?` + `:uix` / `:helix` rejected with a clear error at the entry-fn (v1 lock).