### PR TITLE
test(causa): Story-on-Causa Phase 1b — app-db-diff + subscriptions gallery variants (rf2-5nvk2)

### DIFF
--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -58,81 +58,101 @@ function waitForReady(url, timeoutMs) {
     await waitForReady(`${BASE_URL}/index.html`, 5000);
     const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
     const browser = await chromium.launch();
-    const ctx = await browser.newContext();
-    const page = await ctx.newPage();
-    const consoleErrors = [];
-    page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(`console.error: ${msg.text()}`);
-    });
 
-    // 1. landing
-    await page.goto(`${BASE_URL}/index.html`, { waitUntil: 'load' });
-    await page.waitForSelector('h1', { timeout: 5000 });
-    const heading = await page.locator('h1').first().textContent();
-    if (!heading.includes('Causa panel gallery')) throw new Error(`landing heading wrong: ${heading}`);
-
-    // 2. shell
-    await page.goto(`${BASE_URL}/index.html#/stories`, { waitUntil: 'load' });
-    // Story shell mounts a sidebar; the sidebar always renders; variants
-    // mount after the user picks a story or a workspace.
-    await page.waitForTimeout(1500);
-
-    // Probe the page DOM to discover what Story has rendered.
-    const sidebarText = await page.locator('body').textContent({ timeout: 5000 });
-    const hasStoryShell = sidebarText.includes('story.causa.event-detail') ||
-                          sidebarText.includes('Workspace.causa.event-detail') ||
-                          sidebarText.includes('event-detail');
-    if (!hasStoryShell) throw new Error(`Story shell text not found; first 500: ${sidebarText.slice(0, 500)}`);
-
-    // Dismiss the welcome overlay if present.
-    const gotIt = page.locator('button:has-text("Got it")').first();
-    if ((await gotIt.count()) > 0) await gotIt.click({ timeout: 2000 }).catch(() => {});
-    await page.waitForTimeout(500);
-
-    // The sidebar lists every variant + workspace by name. Click the
-    // workspace-grid entry first; fall back to the first variant.
-    let variantRoots = 0;
-    const workspaceLine = page.locator('text=/Workspace.causa.event-detail\\/all/').first();
-    if ((await workspaceLine.count()) > 0) {
-      await workspaceLine.click({ timeout: 3000 }).catch(() => {});
-      await page.waitForTimeout(2000);
-      variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+    // 1. landing (single page)
+    {
+      const page = await (await browser.newContext()).newPage();
+      await page.goto(`${BASE_URL}/index.html`, { waitUntil: 'load' });
+      await page.waitForSelector('h1', { timeout: 5000 });
+      const heading = await page.locator('h1').first().textContent();
+      if (!heading.includes('Causa panel gallery')) {
+        throw new Error(`landing heading wrong: ${heading}`);
+      }
+      console.log('landing OK');
+      await page.close();
     }
-    if (variantRoots < 1) {
-      const variantLine = page.locator('text=/empty-buffer/').first();
-      if ((await variantLine.count()) > 0) {
-        await variantLine.click({ timeout: 3000 }).catch(() => {});
-        await page.waitForTimeout(1500);
-        variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+
+    // 2. per-panel workspace walkthrough on FRESH pages.
+    //
+    // Each panel registered by Phase 1a (event-detail) and Phase 1b
+    // (app-db-diff, subscriptions) gets its own browser context + page.
+    // Workspace teardown across substrates in a single session has been
+    // observed to surface stale reaction derefs (variants registered for
+    // an unmounted-but-still-cached cell), so a clean page per workspace
+    // is the conservative assertion of "every variant renders" without
+    // entangling with shell-state teardown semantics.
+    const panels = [
+      {
+        id:          'event-detail',
+        workspaceRe: /Workspace\.causa\.event-detail\/all/,
+        cardTestid:  'panel-gallery-event-detail-card',
+        expectedAtLeast: 12,
+      },
+      {
+        id:          'app-db-diff',
+        workspaceRe: /Workspace\.causa\.app-db-diff\/all/,
+        cardTestid:  'panel-gallery-app-db-diff-card',
+        expectedAtLeast: 11,
+      },
+      {
+        id:          'subscriptions',
+        workspaceRe: /Workspace\.causa\.subscriptions\/all/,
+        cardTestid:  'panel-gallery-subscriptions-card',
+        expectedAtLeast: 10,
+      },
+    ];
+
+    const results = [];
+    for (const panel of panels) {
+      const page = await (await browser.newContext()).newPage();
+      const errs = [];
+      page.on('pageerror', (e) => errs.push(`pageerror: ${e.message}`));
+      page.on('console', (m) => {
+        if (m.type() === 'error') errs.push(`console.error: ${m.text()}`);
+      });
+      await page.goto(`${BASE_URL}/index.html#/stories`, { waitUntil: 'load' });
+      await page.waitForTimeout(1500);
+      const gotIt = page.locator('button:has-text("Got it")').first();
+      if ((await gotIt.count()) > 0) await gotIt.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(500);
+
+      const workspaceLine = page.getByText(panel.workspaceRe).first();
+      if ((await workspaceLine.count()) === 0) {
+        results.push({ ...panel, variantRoots: 0, cards: 0, missingWorkspace: true, errs });
+        await page.close();
+        continue;
+      }
+      await workspaceLine.click({ timeout: 3000 }).catch(() => {});
+      await page.waitForTimeout(2500);
+      const variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+      const cards        = await page.locator(`[data-testid="${panel.cardTestid}"]`).count();
+      results.push({ ...panel, variantRoots, cards, missingWorkspace: false, errs });
+      await page.close();
+    }
+
+    let totalRoots = 0;
+    let totalCards = 0;
+    let totalExpected = 0;
+    let failed = false;
+    for (const r of results) {
+      console.log(`panel=${r.id} workspace=${r.missingWorkspace ? 'MISSING' : 'OK'} ` +
+                  `variant-roots=${r.variantRoots}/${r.expectedAtLeast} ` +
+                  `cards=${r.cards}/${r.expectedAtLeast} ` +
+                  `page-errors=${r.errs.length}`);
+      if (r.errs.length > 0) {
+        for (const e of r.errs.slice(0, 3)) console.log(`  ${e}`);
+      }
+      totalRoots    += r.variantRoots;
+      totalCards    += r.cards;
+      totalExpected += r.expectedAtLeast;
+      if (r.missingWorkspace || r.variantRoots < r.expectedAtLeast || r.cards < r.expectedAtLeast) {
+        failed = true;
       }
     }
-    const cards = await page.locator('[data-testid="panel-gallery-event-detail-card"]').count();
+    console.log(`TOTAL variant-roots=${totalRoots}/${totalExpected} cards=${totalCards}/${totalExpected}`);
 
-    console.log(`landing OK • shell text contains story keys • variant-roots=${variantRoots} cards=${cards}`);
-    if (consoleErrors.length) {
-      console.log('--- console errors ---');
-      for (const err of consoleErrors) console.log(err);
-      console.log('----------------------');
-    }
-    if (variantRoots < 1) {
-      // Debug — dump the visible body content so we can see what Story rendered.
-      const bodyText = await page.locator('body').textContent({ timeout: 2000 });
-      console.log('--- body text snippet ---');
-      console.log(bodyText.slice(0, 2000));
-      console.log('-------------------------');
-      // Dump links / clickable elements
-      const links = await page.evaluate(() => {
-        const out = [];
-        document.querySelectorAll('a,button,[role="button"],[data-testid]').forEach((el) => {
-          out.push(`${el.tagName} testid=${el.getAttribute('data-testid')} text=${(el.textContent || '').slice(0, 60)}`);
-        });
-        return out.slice(0, 40);
-      });
-      console.log('--- clickable elements ---');
-      console.log(links.join('\n'));
-      console.log('--------------------------');
-      throw new Error(`expected ≥1 variant root after navigation, got ${variantRoots}`);
+    if (failed) {
+      throw new Error('one or more panels failed the variant-root / card count assertion');
     }
     console.log('smoke OK');
     await browser.close();

--- a/tools/causa/testbeds/panel_gallery/app_db_diff_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/app_db_diff_fixtures.cljs
@@ -1,0 +1,229 @@
+(ns panel-gallery.app-db-diff-fixtures
+  "Pure fixture builders for the Causa app-db-diff panel gallery
+  (rf2-5nvk2, Phase 1b).
+
+  The app-db-diff panel reads four slots from the Causa frame:
+
+    - `:epoch-history`         — vector of `:rf/epoch-record` maps
+    - `:selected-epoch-id`     — optional, drives 'diff this epoch'
+    - `:pinned-slices-store`   — `{frame-id [path ...]}`
+    - `:focused-slice-path`    — optional, drives 'Show me when this
+                                 changed' result
+
+  The composite `:rf.causa/app-db-diff` projects these into the map the
+  facade view destructures (`:changed-non-reserved`, `:pinned-slices`,
+  `:changed-reserved`, `:focused-path`, `:focused-hits`,
+  `:history-empty?`, `:target-frame`).
+
+  ## Why seed via `:rf.causa/sync-epoch-history`
+
+  `:rf.causa/sync-epoch-history` is the canonical seed event used by
+  the trace-bus integration in production. The handler `assoc`s the
+  history vector into Causa's frame app-db — Story's `:rf.story/*`
+  runtime slots survive untouched per `tools/story/spec/002-Runtime.md`
+  §Coexistence with hosting application state. Direct app-db assoc via
+  variant fixtures would wipe Story's lifecycle slots and corrupt the
+  variant.
+
+  ## Epoch-record shape
+
+  Per `spec/004-AppDbDiff.md` an `:rf/epoch-record` is:
+
+      {:epoch-id      <opaque>          ; stable id, ring-buffer key
+       :frame         :rf/default
+       :committed-at  <ms>
+       :event-id      <kw>              ; first elem of trigger-event
+       :trigger-event <event-vec>
+       :db-before     <app-db-value>
+       :db-after      <app-db-value>
+       :trace-events  []}               ; per-epoch trace slice
+
+  The diff algorithm (`app-db-diff-helpers/diff-paths`) only reads
+  `:db-before` / `:db-after` and `:epoch-id` for the diff-cache key, so
+  these fixtures populate just enough for the panel to render.")
+
+;; ---- epoch-record builder ----------------------------------------------
+
+(defn epoch-record
+  "Minimal `:rf/epoch-record` for diff-render purposes. The diff
+  algorithm reads `:db-before` and `:db-after`; the panel's epoch-
+  selector logic reads `:epoch-id` and (for the 'Show me when this
+  changed' walker) `:trigger-event`."
+  [{:keys [epoch-id event db-before db-after]}]
+  {:epoch-id      epoch-id
+   :frame         :rf/default
+   :committed-at  (* 1000 epoch-id)
+   :event-id      (first event)
+   :trigger-event event
+   :db-before     db-before
+   :db-after      db-after
+   :trace-events  []})
+
+;; ---- single-epoch buffers -----------------------------------------------
+
+(defn empty-buffer
+  "No epochs — panel renders the `[empty]` state with the
+  pinned/reserved scaffolding only."
+  []
+  [])
+
+(defn single-key-change-buffer
+  "One epoch whose only mutation is a single top-level key. Panel
+  renders one changed-slice card."
+  []
+  [(epoch-record
+     {:epoch-id 1
+      :event    [:counter/inc]
+      :db-before {:counter 5    :user {:id 7}}
+      :db-after  {:counter 6    :user {:id 7}}})])
+
+(defn five-key-changes-buffer
+  "One epoch mutating five top-level keys: added, removed, modified
+  scalar, modified nested map, modified vector slice."
+  []
+  [(epoch-record
+     {:epoch-id 2
+      :event    [:checkout/submit {:order-id 42}]
+      :db-before {:counter   5
+                  :user      {:id 7 :name "Ada"}
+                  :cart      {:items [{:id :apple :qty 1}]}
+                  :session   {:expires-at 1000}
+                  :legacy-flag true}
+      :db-after  {:counter   6
+                  :user      {:id 7 :name "Ada Lovelace"}
+                  :cart      {:items [{:id :apple :qty 2}
+                                      {:id :pear  :qty 1}]}
+                  :session   {:expires-at 2000 :renewed? true}
+                  :flash     {:level :ok :text "Order placed"}}})])
+
+(defn nested-deep-buffer
+  "One epoch whose only change is six levels deep — exercises the
+  path-as-pr-str sort and the structural-sharing prefix walk."
+  []
+  (let [path  [:tenant :acme :department :eng :team :platform :project :causa :status]
+        deep  (fn [v] (assoc-in {} path v))]
+    [(epoch-record
+       {:epoch-id 3
+        :event    [:project/update-status :active]
+        :db-before (deep :idle)
+        :db-after  (deep :active)})]))
+
+(defn large-flat-buffer
+  "One epoch mutating ~100 top-level keys at once — exercises the
+  overflow / scroll behaviour of the changed-slices stack."
+  []
+  (let [keys-100 (mapv #(keyword (str "metric-" %)) (range 100))
+        before   (zipmap keys-100 (range 100))
+        after    (zipmap keys-100 (map inc (range 100)))]
+    [(epoch-record
+       {:epoch-id 4
+        :event    [:dashboard/recompute-all]
+        :db-before before
+        :db-after  after})]))
+
+(defn cyclic-buffer
+  "An epoch whose `:db-after` carries a structurally large *but acyclic*
+  nested shape — true Clojure cycles via atoms / mutable refs are not
+  representable in immutable maps, and the panel's renderer can't
+  legitimately receive one. The named axis exercises 'deep + wide,
+  print-bounded' which is the legitimate stress."
+  []
+  (let [tier (fn [depth]
+               (reduce (fn [m i]
+                         (assoc m (keyword (str "k-" i))
+                                (* depth i)))
+                       {} (range 8)))
+        wide (reduce (fn [m d]
+                       (assoc m (keyword (str "tier-" d))
+                              (tier d)))
+                     {} (range 12))]
+    [(epoch-record
+       {:epoch-id 5
+        :event    [:graph/rebuild]
+        :db-before wide
+        :db-after  (assoc wide :tier-6 (tier 999))})]))
+
+(defn redacted-buffer
+  "One epoch whose mutated slice contains `:rf/redacted` slots — the
+  panel's value renderer must surface the marker verbatim per
+  Spec 009 §Privacy."
+  []
+  [(epoch-record
+     {:epoch-id 6
+      :event    [:auth/sign-in {:email "ada@example.com"
+                                :password :rf/redacted}]
+      :db-before {:auth {:status :anonymous}}
+      :db-after  {:auth {:status   :authenticated
+                         :user     {:id 7 :name "Ada"}
+                         :password :rf/redacted
+                         :totp     :rf/redacted}}})])
+
+(defn loading-buffer
+  "A buffer present but with no `:selected-epoch-id` and a synthetic
+  in-flight marker on the `:auth` slot — the panel renders the changed-
+  slices stack with the marker visible."
+  []
+  [(epoch-record
+     {:epoch-id 7
+      :event    [:profile/fetch]
+      :db-before {:profile {:status :idle}}
+      :db-after  {:profile {:status :loading
+                            :request-id "req-42"
+                            :started-at 12345}}})])
+
+(defn error-buffer
+  "Epoch where the mutation set the `:errors` slot — fetch-errored
+  state surfaced as a slice card."
+  []
+  [(epoch-record
+     {:epoch-id 8
+      :event    [:profile/fetch-error]
+      :db-before {:profile {:status :loading}}
+      :db-after  {:profile {:status :error
+                            :error  {:type    :network
+                                     :message "Connection refused"
+                                     :status  500
+                                     :url     "/api/profile"}}}})])
+
+;; ---- panel-specific axes -----------------------------------------------
+;;
+;; Two extra axes the app-db-diff panel uniquely exercises:
+;;
+;;   A. Added vs modified vs removed mix in a single epoch — surfaces
+;;      every op-tag (`:added` / `:modified` / `:removed`) side-by-side
+;;      so the panel's op-colour ladder is visible at a glance.
+;;   B. Reserved-keys group — `:rf/machines`, `:rf/route` etc. mutated
+;;      in the same epoch; the panel's `[runtime]` group renders
+;;      separately from the user-key slices.
+
+(defn mixed-ops-buffer
+  "One epoch demonstrating all three diff ops: an :added key, a
+  :modified scalar, a :modified nested map, and a :removed key. The
+  axis exercises the op-colour ladder uniformly."
+  []
+  [(epoch-record
+     {:epoch-id 9
+      :event    [:cart/transition]
+      :db-before {:cart {:items [{:id :apple}]}
+                  :flash {:text "old"}
+                  :counter 5}
+      :db-after  {:cart {:items [{:id :apple} {:id :pear}]
+                         :discount-code "SAVE10"}
+                  :counter 6}})])
+
+(defn reserved-keys-buffer
+  "Epoch mutating reserved app-db keys (per Spec Conventions §Reserved
+  app-db keys: `:rf/machines`, `:rf/route`, `:rf/spawned`, `:rf/elision`).
+  Panel routes these into the `[runtime]` group via
+  `app-db-diff-helpers/partition-reserved` — the axis pins that branch."
+  []
+  [(epoch-record
+     {:epoch-id 10
+      :event    [:rf/route-change]
+      :db-before {:rf/route    {:path "/home"}
+                  :rf/machines {}
+                  :counter 5}
+      :db-after  {:rf/route    {:path "/cart" :query {:tab :items}}
+                  :rf/machines {:checkout {:state :idle}}
+                  :rf/spawned  {:worker/sync :alive}
+                  :counter 6}})])

--- a/tools/causa/testbeds/panel_gallery/app_db_diff_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/app_db_diff_stories.cljs
@@ -1,0 +1,184 @@
+(ns panel-gallery.app-db-diff-stories
+  "Story coverage for the Causa app-db-diff panel under gallery
+  framing (rf2-5nvk2, Phase 1b).
+
+  Ten variants, each one render of `app-db-diff-view` against a
+  variant frame whose `:epoch-history` (and optionally
+  `:selected-epoch-id`, `:pinned-slices-store`, `:focused-slice-path`)
+  has been seeded by REAL Causa init events fired into the variant
+  frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-epoch-history`,
+  `:rf.causa/focus-slice-path`, `:rf.causa/pin-slice`) write via
+  `(assoc db ...)` — so Story's `:rf.story/*` runtime slots survive
+  untouched. Direct app-db assoc would wipe the lifecycle / loaders-
+  complete / assertions slots and corrupt the variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]` (per `tools/story/src/re_frame/story/ui/canvas.cljs`).
+  Subscriptions inside the rendered tree resolve to the variant
+  frame. `:rf.causa/app-db-diff` reads from the current frame's
+  app-db — exactly the variant-frame slots the seed events wrote.
+  Each variant therefore observes its own bespoke epoch history in
+  isolation; no two variants share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.app-db-diff-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the app-db-diff Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-app-db-diff
+    {:axis :feature
+     :doc  "Causa app-db-diff panel — changed slices, pinned slices,
+            reserved-keys group, and the 'Show me when this changed'
+            walker."})
+
+  (story/reg-story :story.causa.app-db-diff
+    {:doc        "Visual gallery of the Causa app-db-diff panel under
+                 varying state magnitude. Each variant seeds its frame's
+                 :epoch-history via :rf.causa/sync-epoch-history; the
+                 rendered panel reads from the variant frame in
+                 isolation."
+     :component  :panel-gallery.app-db-diff/Panel
+     :tags       #{:dev :feature/causa-app-db-diff}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty db --------------------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/empty-db
+    {:doc        "No epochs in history. Panel renders the empty-state
+                 + pinned + reserved scaffolding only."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/empty-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. single-key change ----------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/single-key-change
+    {:doc        "One epoch with a single top-level key mutation
+                 (`:counter` from 5 → 6). Panel renders one
+                 changed-slice card."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/single-key-change-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. five-key changes -----------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/five-key-changes
+    {:doc        "One epoch mutating five top-level keys — scalar,
+                 nested map, vector slice, added flash, removed
+                 legacy flag. Mid-size diff fits one screen."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/five-key-changes-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. nested deep ----------------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/nested-deep
+    {:doc        "Six-level-deep nested path (`[:tenant :acme :department
+                 :eng :team :platform :project :causa :status]`).
+                 Exercises the path-pr-str sort and the path rendering
+                 in slice cards."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/nested-deep-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. large flat (100 keys) ------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/large-flat
+    {:doc        "One epoch mutating ~100 top-level keys at once.
+                 Exercises the overflow / scroll behaviour of the
+                 changed-slices stack under storm load."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/large-flat-buffer)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. cyclic (deep+wide acyclic stress) ------------------------
+  ;;
+  ;; True Clojure cycles via mutable refs are not representable in
+  ;; immutable maps and never reach the panel; the axis here is the
+  ;; legitimate 'deep + wide, print-bounded' stress.
+  (story/reg-variant :story.causa.app-db-diff/cyclic
+    {:doc        "Deep + wide acyclic structure — 12 tiers each with
+                 eight nested keys. The named 'cyclic' axis exercises
+                 the print-bounded stress; the diff and renderer
+                 must not loop forever on a one-tier replacement."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/cyclic-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. redacted -------------------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/redacted
+    {:doc        "Epoch whose mutated `:auth` slice carries
+                 `:rf/redacted` markers on `:password` and `:totp`
+                 slots. The slice renderer surfaces the marker
+                 verbatim per Spec 009 §Privacy."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/redacted-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. loading (in-flight marker) -------------------------------
+  (story/reg-variant :story.causa.app-db-diff/loading
+    {:doc        "Epoch whose `:profile` slice transitioned to
+                 `:loading` with an in-flight request id. The diff
+                 card shows the loader-state slot visibly."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/loading-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. error ----------------------------------------------------
+  (story/reg-variant :story.causa.app-db-diff/error
+    {:doc        "Epoch whose `:profile` slice transitioned to
+                 `:error` with a populated `:error` map. The slice
+                 card surfaces the error shape."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/error-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 10. mixed ops (panel-specific axis A) ----------------------
+  (story/reg-variant :story.causa.app-db-diff/mixed-ops
+    {:doc        "One epoch demonstrating every diff op
+                 (`:added` / `:modified` / `:removed`) side-by-side.
+                 Panel-specific axis: surfaces the op-colour ladder
+                 uniformly in a single card."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/mixed-ops-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 11. reserved keys (panel-specific axis B) ------------------
+  ;;
+  ;; Panel-specific axis: `app-db-diff` distinctly routes reserved-key
+  ;; diffs through `partition-reserved` into a separate `[runtime]`
+  ;; group. No other panel renders this split.
+  (story/reg-variant :story.causa.app-db-diff/reserved-keys
+    {:doc        "Epoch mutating reserved app-db keys (`:rf/route`,
+                 `:rf/machines`, `:rf/spawned`). Panel-specific axis:
+                 the `[runtime]` group surfaces these separately
+                 from user-key slices per Spec Conventions §Reserved
+                 app-db keys."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/reserved-keys-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.app-db-diff/all
+    {:doc      "All eleven app-db-diff variants in one auto-grid.
+                Scroll to see the panel's response across empty / one
+                key / five keys / deep nesting / 100 keys / wide
+                structure / redacted / loading / error / mixed-ops /
+                reserved-keys."
+     :layout   :variants-grid
+     :story    :story.causa.app-db-diff
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -57,7 +57,9 @@
             [panel-gallery.gallery-views :as gallery-views]
             ;; Side-effecting story registrations — namespaces fire
             ;; their `register-all!` at load time.
-            [panel-gallery.event-detail-stories]))
+            [panel-gallery.event-detail-stories]
+            [panel-gallery.app-db-diff-stories]
+            [panel-gallery.subscriptions-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)
@@ -110,6 +112,25 @@
       (mount-stories!)
       (mount-landing!))))
 
+(defn- register-testbed-seed-events!
+  "Register testbed-local seed events that don't exist on Causa's
+  public surface. Currently exposes ONE event,
+  `:panel-gallery/seed-sub-cache-and-errors`, used by the
+  subscriptions-stories `error` variant — Causa registers
+  `:rf.causa/set-sub-cache-override-for-test` for the cache half but
+  has no public init event for `:sub-error-cache` (the runtime fills
+  it from the trace bus). The testbed event seeds both slots in one
+  `assoc` so Story's lifecycle slots are preserved per
+  `tools/story/spec/002-Runtime.md` §Coexistence with hosting
+  application state. Lives here, not in any panel — ZERO source-side
+  changes to Causa panels per the rf2-5nvk2 contract."
+  []
+  (rf/reg-event-db :panel-gallery/seed-sub-cache-and-errors
+    (fn [db [_ sub-cache error-cache]]
+      (-> db
+          (assoc :sub-cache-override sub-cache)
+          (assoc :sub-error-cache    error-cache)))))
+
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
   ;; Causa's :rf.causa/* events / subs / fxs land on the registry once.
@@ -117,6 +138,7 @@
   ;; variant frame the Story canvas allocates becomes its own isolated
   ;; "Causa frame" for the duration of the variant render.
   (causa-registry/register-causa-handlers!)
+  (register-testbed-seed-events!)
   ;; Story's canonical vocabulary (seven reg-* macros / tags / modes /
   ;; canvas decorators) installed once at boot. Each
   ;; `<panel>_stories.cljs` namespace also calls

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -1,6 +1,6 @@
 (ns panel-gallery.gallery-views
   "Registered views referenced by Story variant `:component` slots in
-  the Causa panel gallery (rf2-1o7mp).
+  the Causa panel gallery (rf2-1o7mp, rf2-5nvk2).
 
   Story canvas resolves `:component` to a registered re-frame view via
   `(rf/view <id>)` (per `tools/story/src/re_frame/story/ui/canvas.cljs`).
@@ -11,9 +11,31 @@
   Each gallery component is a thin wrapper around a single Causa
   panel's root view — it absorbs the Story-supplied args map and
   renders the panel inside a card that sets a fixed-ish height so the
-  variants-grid layout stays visually uniform."
+  variants-grid layout stays visually uniform.
+
+  ## Facade-mount discipline (rf2-043uz)
+
+  Each gallery wrapper mounts the panel through its facade view —
+  `event-detail-view`, `app-db-diff-view`, `subscriptions-view`. All
+  three are registered via `reg-view`, so their `render-fn` is
+  wrapped with `:contextType frame-context` by
+  `re-frame.views/reg-view*`. The Reagent component-vector form
+  `[event-detail/event-detail-view]` is therefore safe here — React
+  resolves the wrapped class's `:contextType`, the facade body reads
+  `current-frame` correctly, and inside the facade body the per-
+  panel discipline (function-call for plain-fn leaves, vector for
+  reg-view leaves) takes over.
+
+  The rf2-043uz lesson — function-call for leaves — applies INSIDE
+  facade bodies (`(views/subscriptions-panel)` not
+  `[views/subscriptions-panel]`); it does NOT apply at the gallery
+  wrapper boundary, where every panel root we mount is itself a
+  `reg-view` registration that carries `:contextType` through
+  React."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
 
 (def ^:private card-style
@@ -41,6 +63,41 @@
          :data-testid "panel-gallery-event-detail-card"}
    [event-detail/event-detail-view]])
 
+(defn- app-db-diff-panel
+  "Embedded mount of the Causa app-db-diff panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/app-db-diff` reads to the variant frame's app-db, where
+  the seed events have written `:epoch-history`,
+  `:selected-epoch-id`, `:pinned-slices-store`, and
+  `:focused-slice-path`.
+
+  `app-db-diff/app-db-diff-view` is a `reg-view` registration whose
+  body composes `app-db-diff-sections/*` plain fns via Reagent
+  vectors — the facade is itself the frame-aware render boundary."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-app-db-diff-card"}
+   [app-db-diff/app-db-diff-view]])
+
+(defn- subscriptions-panel
+  "Embedded mount of the Causa subscriptions panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/subscriptions-data` reads to the variant frame's app-db,
+  where the seed events have written `:sub-cache-override`,
+  `:sub-error-cache`, `:selected-sub`, and `:sub-filters`.
+
+  `subscriptions/subscriptions-view` is a `reg-view` whose body
+  invokes `(subscriptions-views/subscriptions-panel)` via plain
+  function call (rf2-043uz) — that internal call form keeps the
+  leaf's subscribes inside the facade reg-view wrapper's render so
+  frame-context resolves correctly. The gallery wrapper mounts the
+  facade view as a Reagent vector — safe here because reg-view
+  threads `:contextType` through React."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-subscriptions-card"}
+   [subscriptions/subscriptions-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -51,5 +108,7 @@
   re-registering the same id replaces the handler; subsequent calls
   are silent at the registry."
   []
-  (rf/reg-view* :panel-gallery.event-detail/Panel event-detail-panel)
+  (rf/reg-view* :panel-gallery.event-detail/Panel  event-detail-panel)
+  (rf/reg-view* :panel-gallery.app-db-diff/Panel   app-db-diff-panel)
+  (rf/reg-view* :panel-gallery.subscriptions/Panel subscriptions-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/subscriptions_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/subscriptions_fixtures.cljs
@@ -1,0 +1,207 @@
+(ns panel-gallery.subscriptions-fixtures
+  "Pure fixture builders for the Causa subscriptions panel gallery
+  (rf2-5nvk2, Phase 1b).
+
+  The subscriptions panel reads its rows from
+  `:rf.causa/subscriptions-data`, a composite over:
+
+    - `:rf.causa/sub-cache`        — `{query-v cache-entry}` (live or
+                                     override via `:sub-cache-override`
+                                     on Causa's app-db)
+    - `:rf.causa/sub-error-cache`  — `{query-v error}` (live errors)
+    - `:rf.causa/selected-sub`     — focused query-v
+    - `:rf.causa/sub-filters`      — set of status keywords to keep
+    - `:rf.causa/sub-chain-open?`  — boolean for the chain side-panel
+
+  Each variant seeds via `:rf.causa/set-sub-cache-override-for-test`
+  (the canonical override event registered in
+  `subscriptions-events/install!`). The override coexists with Story's
+  `:rf.story/*` runtime slots because the handler `assoc`s rather than
+  replacing the whole db.
+
+  ## cache-entry shape
+
+  Per `subscriptions-projection/project-rows` the panel reads five
+  keys off each cache entry:
+
+      {:query-v     [<sub-id> <args>...]   ; optional; falls back to map key
+       :layer       <int>                  ; layer depth — colours the dot
+       :ref-count   <int>
+       :input-subs  [[<input-q-v>] ...]    ; chain edges
+       :rerunning?  <bool>
+       :invalidated? <bool>}
+
+  ## status taxonomy
+
+  Per `subscriptions-status/statuses`:
+
+      :error :re-running :invalidated :fresh :cached-no-watcher
+
+  The panel renders one badge / chip per status; tests pin the count.")
+
+;; ---- entry builders ---------------------------------------------------
+
+(defn- entry
+  "Build a single cache entry. `:layer 1` and `:ref-count 1` default
+  so the row renders as `:fresh` unless overridden."
+  ([] (entry {}))
+  ([{:keys [layer ref-count input-subs rerunning? invalidated? value]
+     :or   {layer      1
+            ref-count  1
+            input-subs []}}]
+   (cond-> {:layer      layer
+            :ref-count  ref-count
+            :input-subs input-subs}
+     (some? value)       (assoc :value value)
+     rerunning?          (assoc :rerunning? true)
+     invalidated?        (assoc :invalidated? true))))
+
+;; ---- 1. empty cache --------------------------------------------------
+
+(defn empty-cache
+  "No subs in the cache — panel renders the empty-state copy."
+  []
+  {})
+
+;; ---- 2. small fanout (5 subs) ----------------------------------------
+
+(defn small-cache
+  "Five subs across two layers; demonstrates the typical small-app
+  fanout (auth + nav + a couple of feature subs)."
+  []
+  {[:auth/user]         (entry {:layer 1 :ref-count 3})
+   [:route/active]      (entry {:layer 1 :ref-count 1})
+   [:counter/value]     (entry {:layer 1 :ref-count 1})
+   [:cart/items-count]  (entry {:layer 2 :ref-count 1
+                                :input-subs [[:auth/user]]})
+   [:ui/theme]          (entry {:layer 1 :ref-count 2})})
+
+;; ---- 3. medium fanout (50 subs) --------------------------------------
+
+(defn medium-cache
+  "Fifty subs across three layers — typical mid-sized app shape.
+  Demonstrates the rows component under normal load."
+  []
+  (let [base-subs (for [i (range 50)]
+                    [(keyword (str "feature-" (mod i 10))
+                              (str "row-" i))
+                     (entry {:layer    (inc (mod i 3))
+                             :ref-count (inc (mod i 4))})])]
+    (into {} base-subs)))
+
+;; ---- 4. large fanout (200 subs) --------------------------------------
+
+(defn large-cache
+  "Two hundred subs — exercises the overflow / virtualisation behaviour
+  of the rows list under storm load."
+  []
+  (let [bulk (for [i (range 200)]
+               [(keyword (str "perf-tier-" (mod i 8))
+                         (str "key-" i))
+                (entry {:layer    (inc (mod i 4))
+                        :ref-count (inc (mod i 5))})])]
+    (into {} bulk)))
+
+;; ---- 5. derived-chain (sub depending on 3 inputs) --------------------
+
+(defn derived-chain-cache
+  "Six subs forming a small derivation tree:
+
+      :cart/total (L3) ─┬─ :cart/subtotal (L2) ─ :cart/items (L1)
+                       ├─ :cart/discount (L2) ─ :promo/active (L1)
+                       └─ :cart/tax (L2) ─── :tax/rate (L1)
+
+  Three input-subs on `:cart/total` — the chain view's three-input
+  fanout is the axis."
+  []
+  {[:cart/items]    (entry {:layer 1 :ref-count 2})
+   [:promo/active]  (entry {:layer 1 :ref-count 1})
+   [:tax/rate]      (entry {:layer 1 :ref-count 1})
+   [:cart/subtotal] (entry {:layer 2 :ref-count 1
+                            :input-subs [[:cart/items]]})
+   [:cart/discount] (entry {:layer 2 :ref-count 1
+                            :input-subs [[:promo/active]]})
+   [:cart/tax]      (entry {:layer 2 :ref-count 1
+                            :input-subs [[:tax/rate]]})
+   [:cart/total]    (entry {:layer 3 :ref-count 1
+                            :input-subs [[:cart/subtotal]
+                                         [:cart/discount]
+                                         [:cart/tax]]})})
+
+;; ---- 6. redacted sub payload -----------------------------------------
+
+(defn redacted-cache
+  "One sub whose computed value carries the `:rf/redacted` marker —
+  the cache entry surfaces the marker per Spec 009 §Privacy."
+  []
+  {[:auth/credentials] (entry {:layer 2 :ref-count 1
+                               :input-subs [[:auth/user]]
+                               :value {:user-id 7
+                                       :password :rf/redacted
+                                       :totp     :rf/redacted}})
+   [:auth/user]        (entry {:layer 1 :ref-count 1})})
+
+;; ---- 7. re-running (in-flight) ---------------------------------------
+
+(defn rerunning-cache
+  "Three subs in `:re-running` status — exercises the in-flight badge
+  rendering. The remaining two are `:fresh` for contrast."
+  []
+  {[:profile/data]   (entry {:layer 2 :ref-count 1
+                             :rerunning? true
+                             :input-subs [[:auth/user]]})
+   [:perms/effective] (entry {:layer 2 :ref-count 1
+                              :rerunning? true
+                              :input-subs [[:auth/user]]})
+   [:audit/recent]   (entry {:layer 1 :ref-count 1
+                             :rerunning? true})
+   [:auth/user]      (entry {:layer 1 :ref-count 3})
+   [:ui/theme]       (entry {:layer 1 :ref-count 2})})
+
+;; ---- 8. errored ------------------------------------------------------
+
+(def errored-cache-entries
+  "Cache + error-cache for the errored variant. The status projection
+  marks an entry `:error` when its query-v has an error-cache hit; the
+  variant fires two events to seed both shapes."
+  {:cache  {[:profile/data]   (entry {:layer 2 :ref-count 1})
+            [:perms/effective] (entry {:layer 2 :ref-count 1})
+            [:auth/user]      (entry {:layer 1 :ref-count 3})}
+   :errors {[:profile/data] {:type :handler-throw
+                             :message "Sub computation threw: nil-pointer
+                                      at perm-set/decorate"}
+            [:perms/effective] {:type :input-missing
+                                :message "Required input
+                                         :perms/active-bundle absent"}}})
+
+;; ---- 9. invalidated mix ----------------------------------------------
+
+(defn invalidated-mix-cache
+  "Five subs spanning every status the panel renders: `:fresh`,
+  `:re-running`, `:invalidated`, `:cached-no-watcher`, plus an
+  `:error`-driver pair seeded via the error-cache variant. Pins all
+  the badge variants visible in one card."
+  []
+  {[:s/fresh-1]        (entry {:layer 1 :ref-count 1})
+   [:s/rerunning-1]    (entry {:layer 1 :ref-count 1 :rerunning? true})
+   [:s/invalidated-1]  (entry {:layer 1 :ref-count 1 :invalidated? true})
+   [:s/no-watcher-1]   (entry {:layer 1 :ref-count 0})
+   [:s/fresh-2]        (entry {:layer 2 :ref-count 1
+                               :input-subs [[:s/fresh-1]]})})
+
+;; ---- 10. high-layer chain (panel-specific axis) ----------------------
+
+(defn deep-chain-cache
+  "Five-layer derivation chain — exercises the panel's layer-dot
+  ladder (l1 / l2 / l3 / l4 / l5) in a single card. Panel-specific
+  axis: the layer dot is unique to the subscriptions panel."
+  []
+  {[:l1/source]      (entry {:layer 1 :ref-count 1})
+   [:l2/derived]     (entry {:layer 2 :ref-count 1
+                             :input-subs [[:l1/source]]})
+   [:l3/composite]   (entry {:layer 3 :ref-count 1
+                             :input-subs [[:l2/derived]]})
+   [:l4/projection]  (entry {:layer 4 :ref-count 1
+                             :input-subs [[:l3/composite]]})
+   [:l5/view-model]  (entry {:layer 5 :ref-count 1
+                             :input-subs [[:l4/projection]]})})

--- a/tools/causa/testbeds/panel_gallery/subscriptions_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/subscriptions_stories.cljs
@@ -1,0 +1,204 @@
+(ns panel-gallery.subscriptions-stories
+  "Story coverage for the Causa subscriptions panel under gallery
+  framing (rf2-5nvk2, Phase 1b).
+
+  Ten variants, each one render of `subscriptions-view` against a
+  variant frame whose `:sub-cache-override` (and optionally
+  `:sub-error-cache`, `:selected-sub`, `:sub-filters`,
+  `:sub-chain-open?`) has been seeded by REAL Causa init events
+  fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. The seed event
+  `:rf.causa/set-sub-cache-override-for-test` writes via
+  `(assoc db :sub-cache-override ov)` — Story's `:rf.story/*` runtime
+  slots survive untouched. Direct app-db assoc would wipe the
+  lifecycle / loaders-complete / assertions slots and corrupt the
+  variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. `:rf.causa/subscriptions-data` reads from the
+  current frame's app-db, picking up `:sub-cache-override` per
+  `subscriptions-subs/install!` line 12. Each variant therefore
+  observes its own bespoke sub-cache in isolation; no two variants
+  share state.
+
+  ## Why no live `sub-cache` for the panel-gallery testbed
+
+  The panel reads `(rf/sub-cache target)` when `:sub-cache-override`
+  is absent — that's the live runtime cache, which here would be the
+  variant frame's actual subs. The gallery's purpose is visual; the
+  override slot exists precisely to let tests / galleries inject a
+  representative cache shape without forcing the runtime to
+  subscribe-then-derefa-real-graph. We use the canonical override
+  surface."
+  (:require [re-frame.story :as story]
+            [panel-gallery.subscriptions-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the subscriptions Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-subscriptions
+    {:axis :feature
+     :doc  "Causa subscriptions panel — rows + chain + status badges
+            over the target frame's sub-cache."})
+
+  (story/reg-story :story.causa.subscriptions
+    {:doc        "Visual gallery of the Causa subscriptions panel under
+                 varying state magnitude. Each variant seeds its frame's
+                 :sub-cache-override via :rf.causa/set-sub-cache-override-
+                 for-test; the rendered panel reads from the variant
+                 frame in isolation."
+     :component  :panel-gallery.subscriptions/Panel
+     :tags       #{:dev :feature/causa-subscriptions}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. 0 subs (empty cache) -------------------------------------
+  (story/reg-variant :story.causa.subscriptions/zero-subs
+    {:doc        "Empty cache. Panel renders the empty-state message
+                 ('No subscriptions yet')."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/empty-cache)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. 5 subs (small fanout) ------------------------------------
+  (story/reg-variant :story.causa.subscriptions/five-subs
+    {:doc        "Five subs — typical small-app shape (auth / route /
+                 counter / cart-count / theme). Two layers, mixed
+                 ref-counts."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/small-cache)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. 50 subs (medium fanout) ----------------------------------
+  (story/reg-variant :story.causa.subscriptions/fifty-subs
+    {:doc        "Fifty subs across three layers — typical mid-sized
+                 app shape. Demonstrates the rows list under normal
+                 load."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/medium-cache)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. 200 subs (large / overflow) ------------------------------
+  (story/reg-variant :story.causa.subscriptions/two-hundred-subs
+    {:doc        "Two hundred subs across four layers — exercises the
+                 overflow / scroll behaviour of the rows list under
+                 storm load."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/large-cache)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. derived-chain (3-input chain view) -----------------------
+  (story/reg-variant :story.causa.subscriptions/derived-chain
+    {:doc        "Six subs forming a small derivation tree —
+                 `:cart/total` depends on three layer-2 subs each of
+                 which depends on its own layer-1 source. Opens the
+                 chain side-panel focused on `:cart/total` so the
+                 three-input fanout renders."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/derived-chain-cache)]
+                  [:rf.causa/show-invalidation-chain [:cart/total]]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. redacted sub payload -------------------------------------
+  (story/reg-variant :story.causa.subscriptions/redacted
+    {:doc        "One sub whose computed `:value` carries
+                 `:rf/redacted` markers on `:password` and `:totp`
+                 slots. Per Spec 009 §Privacy the panel surfaces the
+                 marker verbatim."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/redacted-cache)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. loading / re-running -------------------------------------
+  (story/reg-variant :story.causa.subscriptions/loading
+    {:doc        "Three subs in `:re-running` status (computation
+                 in-flight). The remaining two are `:fresh` for
+                 contrast — surfaces the in-flight badge alongside
+                 a stable baseline."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/rerunning-cache)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. errored --------------------------------------------------
+  ;;
+  ;; The error variant seeds both the cache and the error cache. The
+  ;; error cache is read directly off `:sub-error-cache` (no public
+  ;; init event exists — the runtime trace-bus writes it). For test
+  ;; purposes we register a tiny gallery-local event below that does
+  ;; the assoc. This is the ONLY testbed-side handler the gallery
+  ;; needs; the panels themselves stay untouched.
+  (story/reg-variant :story.causa.subscriptions/error
+    {:doc        "Two subs errored at the sub-cache level (handler
+                 throw / missing input); panel renders the error
+                 badge for each, with the message visible on hover."
+     :events     [[:panel-gallery/seed-sub-cache-and-errors
+                   (:cache  fixtures/errored-cache-entries)
+                   (:errors fixtures/errored-cache-entries)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. invalidated mix (panel-specific axis A) -----------------
+  ;;
+  ;; Panel-specific axis: the subscriptions panel uniquely renders a
+  ;; five-status filter header (`:error`, `:re-running`,
+  ;; `:invalidated`, `:fresh`, `:cached-no-watcher`). This variant
+  ;; surfaces every status chip in a single card so the badge ladder
+  ;; is visible at a glance.
+  (story/reg-variant :story.causa.subscriptions/invalidated-mix
+    {:doc        "Five subs spanning four statuses (`:fresh`,
+                 `:re-running`, `:invalidated`, `:cached-no-watcher`)
+                 plus a derived `:fresh` sub. Panel-specific axis:
+                 the status badge ladder is unique to this panel."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/invalidated-mix-cache)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 10. deep chain (panel-specific axis B) ---------------------
+  ;;
+  ;; Panel-specific axis: the subscriptions panel uniquely renders a
+  ;; per-row layer dot (l1 / l2 / l3 / l4 / l5 colour swatch). This
+  ;; variant exercises every layer in one card.
+  (story/reg-variant :story.causa.subscriptions/deep-chain
+    {:doc        "Five-layer derivation chain — exercises the layer-
+                 dot ladder (l1 / l2 / l3 / l4 / l5) in a single
+                 card. Panel-specific axis."
+     :events     [[:rf.causa/set-sub-cache-override-for-test
+                   (fixtures/deep-chain-cache)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.subscriptions/all
+    {:doc      "All ten subscriptions variants in one auto-grid.
+                Scroll to see the panel's response across 0 / 5 / 50
+                / 200 subs, the derived chain side-panel, redacted
+                value, in-flight + errored badges, and the layer
+                ladder."
+     :layout   :variants-grid
+     :story    :story.causa.subscriptions
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)


### PR DESCRIPTION
## Summary

Phase 1b lands the **app-db-diff** (11 variants) and **subscriptions** (10 variants) panels in the panel-gallery testbed under Story framing. Combined with Phase 1a's 12 event-detail variants, the gallery now exercises **33 variants across 3 Causa panels**.

The visual gallery is the strategic deliverable per the Story-on-Causa feasibility plan (`ai/findings/story-on-causa-feasibility-2026-05-16.md` v2): one workspace, scroll, every state of a Causa panel side-by-side.

### Variant coverage

**app-db-diff (11):** `empty-db`, `single-key-change`, `five-key-changes`, `nested-deep` (6-level path), `large-flat` (100 keys), `cyclic` (deep+wide acyclic stress), `redacted`, `loading`, `error`, plus panel-specific axes `mixed-ops` and `reserved-keys` (exercises the `[runtime]` group).

**subscriptions (10):** `zero-subs`, `five-subs`, `fifty-subs`, `two-hundred-subs` (overflow), `derived-chain` (3-input chain via `:rf.causa/show-invalidation-chain`), `redacted`, `loading` (re-running), `error` (cache + error-cache), plus panel-specific axes `invalidated-mix` (status badge ladder) and `deep-chain` (l1..l5 layer-dot ladder).

### Architecture confirmation

ZERO source-side changes to Causa panels. The facade `(views/foo)` discipline from rf2-043uz holds end-to-end: reg-view-wrapped facade views carry `:contextType frame-context` so the gallery wrappers mount them as Reagent vectors safely; the function-call discipline applies INSIDE facade bodies (which already follow it). All 33 variants render correctly under their variant frame's seeded state.

### Smoke gate

`_smoke.cjs` walks each workspace on a fresh browser page:
- panel=event-detail: 12/12 roots, 12/12 cards, 0 errors
- panel=app-db-diff: 11/11 roots, 11/11 cards, 0 errors
- panel=subscriptions: 10/10 roots, 10/10 cards, 0 errors
- TOTAL: 33/33 roots, 33/33 cards, 0 page errors

### Follow-on

Workspace-switch within a single browser session surfaces stale subscribe→nil derefs in the new workspace's variants. Tracked as **rf2-kgn0c** (P3). Not a blocker for the gallery deliverable (each panel renders perfectly on its own); the fresh-page-per-workspace smoke shape is the conservative isolation.

## Test plan

- [x] `npm run test:cljs` — 2154 tests / 6142 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `shadow-cljs compile testbeds/panel-gallery` — Build completed
- [x] `_smoke.cjs` — 33/33 variant roots + 33/33 panel cards + 0 page errors
- [x] Reviewer manual: `npx shadow-cljs watch testbeds/panel-gallery`, open in browser, click each of the three workspaces — visual gallery as designed