### PR TITLE
test(ssr): live browser-driven SSR smoke (rf2-j3dlc)

### DIFF
--- a/examples/reagent/ssr/deps.edn
+++ b/examples/reagent/ssr/deps.edn
@@ -1,0 +1,34 @@
+;; rf2-j3dlc — live-SSR browser smoke test harness.
+;;
+;; This deps.edn is consumed ONLY by examples/scripts/serve-and-run-examples-tests.cjs
+;; via `clojure -X:live-ssr-server` to spin up a real Jetty + ssr-handler
+;; for the browser-driven live-SSR Playwright spec (ssr-live.spec.cjs).
+;;
+;; Pulls in the SSR + ssr-ring artefacts via :local/root so the published-
+;; artefact coordinate graph (implementation/deps.edn) is untouched (that
+;; file is hot-zone per the dispatch rules). The example's ssr.core
+;; namespace is on the classpath via the `examples/reagent` :extra-path.
+;;
+;; Test-only — this file is NOT part of any published artefact.
+;; `:paths` carries just the server.clj source (this directory). The
+;; `ssr.core` namespace under `examples/reagent/` is brought in via the
+;; alias `:extra-paths` (Clojure deprecates externals in `:paths` but
+;; allows them in `:extra-paths`).
+{:paths   ["."]
+ :deps    {day8/re-frame2           {:local/root "../../../implementation/core"}
+           day8/re-frame2-schemas   {:local/root "../../../implementation/schemas"}
+           day8/re-frame2-http      {:local/root "../../../implementation/http"}
+           day8/re-frame2-ssr       {:local/root "../../../implementation/ssr"}
+           day8/re-frame2-ssr-ring  {:local/root "../../../implementation/ssr-ring"}
+           ;; ssr-ring's :test alias pins this version; reuse it so the
+           ;; live-SSR harness rides on a known-good combination.
+           ring/ring-jetty-adapter  {:mvn/version "1.12.1"}}
+
+ :aliases
+ {:live-ssr-server
+  {:extra-paths ["../../../examples/reagent"]
+   :exec-fn     ssr.server/-main
+   ;; Defaults; the orchestrator overrides on the CLI via
+   ;;   clojure -X:live-ssr-server :port 8031 :static-root "..."
+   :exec-args   {:port        8031
+                 :static-root "../../../implementation/out/examples/ssr"}}}}

--- a/examples/reagent/ssr/server.clj
+++ b/examples/reagent/ssr/server.clj
@@ -1,0 +1,250 @@
+(ns ssr.server
+  "Live SSR Ring server for the Playwright `ssr-live.spec.cjs` smoke
+   test (rf2-j3dlc).
+
+   Companion to the existing `ssr.spec.cjs` smoke. That spec exercises
+   the hydration path against PRE-BAKED server-shaped HTML staged from
+   `index.html`. This namespace stands up a REAL live SSR handler:
+
+   - Boot the SSR adapter (`re-frame.ssr/adapter`).
+   - Load `ssr.core` (registers events / views / fx).
+   - Register a per-request `:fx-overrides` redirect so
+     `:rf.http/managed` resolves to a canned-success stub serving the
+     example's two articles (mirrors the headless `ssr-tests` fn in
+     `ssr.core`).
+   - Wrap `re-frame.ssr.ring/ssr-handler` with a tiny dispatch handler
+     that also serves `/main.js` from the shadow-cljs output dir so the
+     browser can hydrate on the same origin (matches the `<script
+     src='/main.js'>` tag in the SSR-emitted HTML envelope).
+   - Run Jetty on the configured port, in this process.
+
+   Exec entrypoint: `clojure -X:live-ssr-server :port 8031`. Stays alive
+   until the orchestrator tears the process down (per
+   examples/scripts/serve-and-run-examples-tests.cjs).
+
+   ## Frame-id workaround (rf2-j3dlc finding)
+
+   `re-frame.ssr.ring.pipeline/setup-request-frame!` builds the
+   per-request frame-id via
+       (keyword \"rf.frame\" (str (gensym \"\")))
+   which produces names like `:rf.frame/1234` — a digit-only LOCAL
+   part. Clojure's keyword constructor accepts that, but the EDN
+   spec (https://github.com/edn-format/edn) requires symbol names
+   (and keywords are identifier-shaped) to begin with a non-numeric
+   character. CLJS's `cljs.tools.reader.edn` enforces the spec and
+   throws `Invalid keyword: :rf.frame/1234.` when the client tries to
+   read the embedded `__rf_payload`.
+
+   This is a latent ssr-ring bug — until rf2-j3dlc the only browser-
+   driven SSR coverage was over PRE-BAKED HTML that didn't ship the
+   frame-id from `pipeline/setup-request-frame!`. The live-SSR smoke
+   surfaces it. Per the dispatch rules, `implementation/ssr-ring/` is
+   a sibling agent's hot zone (rf2-o6ndb) so the fix lives in a
+   follow-on bead; this server papers over it with a custom
+   `:html-shell` that rewrites the gensym-shaped frame-id to a
+   leading-letter form before the EDN reaches the wire.
+
+   Boundaries:
+   - JVM-side Ring/SSR e2e details (header round-trip, cookie wire,
+     redirect, CRLF rejection) live in
+     `implementation/ssr-ring/test/.../ring_e2e_validator_test.clj`.
+     This server is intentionally minimal — it exists to give the
+     browser-driven smoke a real handler to talk to.
+   - The example's `:rf.http/managed` flow goes through canned-success
+     via `:fx-overrides`; we do NOT make outbound HTTP calls."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.ring :as ssr-ring]
+            [ring.adapter.jetty :as jetty])
+  (:import [java.io File]
+           [org.eclipse.jetty.server Server]))
+
+(set! *warn-on-reflection* true)
+
+;; ---- canned-articles fx (mirrors ssr.core/ssr-tests) ----------------------
+
+(defn- register-canned-articles-fx! []
+  ;; The example's `:rf.http/managed` call in `:rf/server-init` would
+  ;; otherwise hit the network. Per-frame `:fx-overrides` rewires it to
+  ;; this stub at request time. The stub delegates to the framework-
+  ;; shipped `:rf.http/managed-canned-success` (Spec 014 §Testing) with
+  ;; a fixed `:value` slice — same reply shape a live request would
+  ;; produce — so the drain settles synchronously inside `make-frame`
+  ;; on the server.
+  (rf/reg-fx :ssr.http/canned-articles
+    {:platforms #{:server :client}}
+    (fn [frame-ctx args-map]
+      (let [stub (registrar/handler :fx :rf.http/managed-canned-success)]
+        (stub frame-ctx
+              (assoc args-map
+                     :value [{:id "a" :title "Article A" :body "Body A"}
+                             {:id "b" :title "Article B" :body "Body B"}]))))))
+
+;; ---- static-asset handler --------------------------------------------------
+
+(defn- read-file-bytes ^bytes [^File f]
+  (with-open [in (io/input-stream f)
+              out (java.io.ByteArrayOutputStream.)]
+    (io/copy in out)
+    (.toByteArray out)))
+
+(defn- static-handler
+  "Serve a single static file (rooted in `static-root`) when the request
+   URI matches `match-uri`. Returns nil for any other request — caller
+   chains to the next handler.
+
+   Deliberately narrow: the live-SSR harness needs to serve `/main.js`
+   (and nothing else) so the browser can hydrate. Static-asset hosting
+   in the general case is the job of http-server / a real CDN; we don't
+   reinvent it here."
+  [static-root match-uri content-type]
+  (fn [{:keys [uri request-method]}]
+    (when (and (= uri match-uri) (= :get request-method))
+      (let [f (io/file static-root (subs match-uri 1))]
+        (when (.isFile f)
+          {:status  200
+           :headers {"Content-Type"  content-type
+                     "Cache-Control" "no-store"}
+           :body    (java.io.ByteArrayInputStream. (read-file-bytes f))})))))
+
+;; ---- request-method gate ---------------------------------------------------
+;;
+;; Browsers issue a HEAD favicon probe to discover the icon; with no
+;; favicon at the URL we return a fast 204 so the spec doesn't pick up
+;; a stray 404 in the console / pageerror stream.
+
+(defn- favicon-handler [{:keys [uri]}]
+  (when (= uri "/favicon.ico")
+    {:status 204 :headers {} :body ""}))
+
+;; ---- custom html-shell ------------------------------------------------------
+;;
+;; Wrap `ssr-ring/default-html-shell` with a tiny payload-EDN rewrite
+;; that fixes the digit-only `:rf.frame/<gensym>` keyword surfaced by
+;; the live-SSR smoke (see ns docstring §Frame-id workaround).
+;;
+;; The shell receives `payload-edn` as a string (already pr-str'd by
+;; the pipeline). We read it back to data, replace `:rf/frame-id` with
+;; a leading-letter form (`:rf.frame/f<digits>`) — still unique per
+;; request, still namespaced, EDN-spec-compliant — then re-serialise
+;; and hand off to the default shell.
+
+(def ^:private digit-only-frame-id-pattern
+  "Match `:rf.frame/<digits>` keyword literals inline in the payload's
+   EDN string. The gensym-induced shape always carries pure digits
+   in the local-part — that's what makes it cljs-EDN-invalid and what
+   makes the regex unambiguous (no risk of matching a legitimate
+   keyword)."
+  #":rf\.frame/(\d+)")
+
+(defn- rewriting-html-shell
+  "Custom `:html-shell` — patches the payload's frame-id keyword in
+   the raw EDN string and delegates to `default-html-shell`.
+
+   Why regex-on-string rather than read/rewrite/pr-str: both
+   `clojure.edn/read-string` AND `cljs.tools.reader.edn/read-string`
+   refuse `:rf.frame/<digits>` (EDN spec — identifier names start
+   non-numeric). So reading the payload to data on the JVM side
+   would throw before we could rewrite it. A targeted text
+   substitution sidesteps the reader entirely.
+
+   The substitution rewrites `:rf.frame/<digits>` →
+   `:rf.frame/f<digits>` (still unique per request, still namespaced,
+   EDN-spec-compliant on both JVM and CLJS). Conservative — leaves
+   any other keyword shape alone."
+  [body-html payload-edn opts]
+  (let [patched-edn (str/replace payload-edn
+                                 digit-only-frame-id-pattern
+                                 ":rf.frame/f$1")]
+    (ssr-ring/default-html-shell body-html patched-edn opts)))
+
+;; ---- on-error logger -------------------------------------------------------
+;;
+;; Default `:on-error` from `ssr-ring` emits a fixed 500 body and
+;; swallows the throwable per its no-topology-leak contract (rf2-kzvwq).
+;; That's the right production posture, but here in a test harness we
+;; want the stack trace on stderr so the live-SSR smoke can diagnose
+;; render-path failures without re-running through a debugger. The 500
+;; body stays identical so the production contract is honoured at the
+;; wire layer.
+
+(defn- logging-on-error
+  [_request ^Throwable t]
+  (binding [*out* *err*]
+    (println (str "ssr.server: render failed: " (.getMessage t)))
+    (.printStackTrace t))
+  {:status  500
+   :headers {"Content-Type" "text/plain; charset=utf-8"}
+   :body    "Internal error"})
+
+;; ---- top-level handler -----------------------------------------------------
+
+(defn make-handler
+  "Build the composite Ring handler for the live-SSR harness:
+
+      /main.js     → static bundle from `:static-root`
+      /favicon.ico → 204 no-content
+      anything else → ssr-handler (live SSR + hydration payload)
+
+   `static-root` must be the shadow-cljs `:output-dir` of the
+   `:examples/ssr` build (`implementation/out/examples/ssr` by
+   convention)."
+  [{:keys [static-root]}]
+  (let [ssr (ssr-ring/ssr-handler
+             {:on-create      [:rf/server-init]
+              :root-view      [:app/root]
+              :fx-overrides   {:rf.http/managed :ssr.http/canned-articles}
+              :payload-policy :rf.ssr.payload/whole-app-db
+              :html-shell     rewriting-html-shell
+              :on-error       logging-on-error})
+        main-js (static-handler static-root "/main.js"
+                                "application/javascript; charset=utf-8")]
+    (fn handler [request]
+      (or (main-js request)
+          (favicon-handler request)
+          (ssr request)))))
+
+;; ---- entry point -----------------------------------------------------------
+
+(defn -main
+  "`clojure -X:live-ssr-server :port 8031 :static-root \"...\"`.
+
+   Boots the SSR adapter, loads ssr.core (which registers events /
+   views / fx via its toplevel forms), registers the canned-articles
+   fx, and runs Jetty on `:port` (127.0.0.1 only, never a public
+   interface in CI). Blocks until killed."
+  [{:keys [port static-root] :or {port 8031}}]
+  (when-not static-root
+    (binding [*out* *err*]
+      (println "ssr.server: missing :static-root (path to shadow-cljs out/examples/ssr/ for main.js)"))
+    (System/exit 2))
+  (let [^File root-file (io/file static-root)]
+    (when-not (.isDirectory root-file)
+      (binding [*out* *err*]
+        (println (str "ssr.server: :static-root does not exist or is not a dir: "
+                      (.getAbsolutePath root-file))))
+      (System/exit 2)))
+  ;; Boot the SSR adapter (idempotent). Then load ssr.core so its
+  ;; toplevel reg-* forms run on the live registrar.
+  (rf/init! ssr/adapter)
+  (require 'ssr.core)
+  (register-canned-articles-fx!)
+  (let [handler (make-handler {:static-root static-root})
+        ^Server server (jetty/run-jetty handler
+                                        {:port                 (long port)
+                                         :host                 "127.0.0.1"
+                                         :join?                false
+                                         :send-server-version? false
+                                         :send-date-header?    false})]
+    ;; Print the bound URL on the line the orchestrator looks for
+    ;; (cross-platform parsing-friendly; matches the harness ready-probe).
+    (println (str "ssr.server: listening on http://127.0.0.1:" port "/"))
+    (flush)
+    ;; Stay alive until JVM teardown. The orchestrator kills this
+    ;; subprocess in its `finally` cleanup.
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. (fn [] (.stop server))))
+    @(promise)))

--- a/examples/reagent/ssr/ssr-live.spec.cjs
+++ b/examples/reagent/ssr/ssr-live.spec.cjs
@@ -1,0 +1,151 @@
+/*
+ * SSR + hydration — live server smoke test (rf2-j3dlc).
+ *
+ * Companion to ssr.spec.cjs (which exercises hydration against a
+ * PRE-BAKED server-shaped index.html). This spec hits a REAL live JVM
+ * Ring + Jetty server that runs the example's :clj `handle-request`
+ * shape end-to-end:
+ *
+ *   browser GET http://127.0.0.1:<LIVE_SSR_PORT>/
+ *     → re-frame.ssr.ring/ssr-handler
+ *       → per-request frame, :on-create dispatches :rf/server-init
+ *         → :fx-overrides redirects :rf.http/managed →
+ *           :ssr.http/canned-articles (synchronous canned reply)
+ *       → drain settles, app-db carries the articles slice
+ *       → render-to-string emits HTML + :rf/render-hash on the root
+ *       → builds the :rf/hydration-payload (whole-app-db policy)
+ *       → wraps in default-html-shell, returns Ring response
+ *
+ * What this asserts (in order):
+ *
+ *   1. **Server-rendered content present BEFORE hydration** — a raw
+ *      fetch() of the page from inside the browser observes the
+ *      article titles, the data-rf-render-hash marker, and the inline
+ *      __rf_payload script BEFORE any scripts execute. The
+ *      `<script src='/main.js'>` is the last child in <body> so the
+ *      raw HTML body is the server's authoritative pre-hydration
+ *      shape.
+ *
+ *   2. **Hydration completes and the client renders** — the
+ *      `Hide bodies` button + articles list are visible after navigate.
+ *
+ *   3. **Post-hydration interactivity** — the canonical "click the
+ *      button after hydration" check: clicking `toggle-bodies` removes
+ *      the body paragraphs (Reagent re-render fires the click through
+ *      the full re-frame dispatch loop).
+ *
+ *   4. **Articles survive hydration** — the titles remain after the
+ *      toggle (proves :rf/hydrate's replace-app-db policy seeded the
+ *      :articles slice into the client's app-db).
+ *
+ * Lower-level JVM SSR/Ring contract details (status codes, header
+ * round-trip, CRLF rejection, cookie wire shape, error projection) are
+ * covered exhaustively by the JVM-side tests at
+ * `implementation/ssr-ring/test/.../ring_e2e_validator_test.clj` and
+ * `ring_test.clj`. This spec does NOT duplicate that coverage — it
+ * narrowly proves the browser-side end-to-end path (live response →
+ * hydration → interactive) works through real bytes on the wire.
+ *
+ * Where the URL comes from: the orchestrator
+ * (examples/scripts/serve-and-run-examples-tests.cjs) launches the
+ * JVM Jetty harness in parallel with the static http-server and
+ * exposes its base URL via the EXAMPLES_LIVE_SSR_URL env var. We pin
+ * the full URL on `spec.url` so run-examples-tests.cjs uses it
+ * verbatim rather than prepending its default EXAMPLES_BASE_URL.
+ */
+
+const {
+  expectCount,
+  expectTextContains,
+  expectVisible,
+} = require('../../scripts/spec-helpers.cjs');
+
+const LIVE_SSR_URL = process.env.EXAMPLES_LIVE_SSR_URL;
+
+// When EXAMPLES_LIVE_SSR_URL is unset the spec emits SKIP rather than
+// failing module-load (the runner's `require(file)` happens for ALL
+// specs at startup; a throw here would crash the whole suite). The
+// orchestrator (examples/scripts/serve-and-run-examples-tests.cjs)
+// always sets it; the SKIP path covers manual `node run-examples-
+// tests.cjs` invocations.
+const SKIP_REASON = LIVE_SSR_URL
+  ? false
+  : 'EXAMPLES_LIVE_SSR_URL not set — run via examples/scripts/serve-and-run-examples-tests.cjs (which spins up the live JVM Jetty SSR harness on a side port).';
+
+module.exports = {
+  name: 'ssr-live (live JVM Ring handler)',
+  skip: SKIP_REASON,
+  // `url` is read for non-skipped runs only; when SKIP_REASON is truthy
+  // the runner short-circuits BEFORE `url` is consumed (see
+  // run-examples-tests.cjs `if (spec.skip)` block).
+  url: (LIVE_SSR_URL || 'http://invalid.local') + '/',
+  run: async (page) => {
+    // ---- (1) Server-rendered content present BEFORE hydration -----------
+    //
+    // Issue a SECOND HTTP GET from inside the browser context against
+    // the same origin and inspect the raw response body. This is the
+    // bytes-on-wire view — no client JS has touched it. Anchors:
+    //   - the article titles (server's authoritative slice)
+    //   - the data-rf-render-hash root-element marker
+    //   - the inline __rf_payload <script> with :rf/version 1
+    //
+    // Why this matters: if the SSR handler quietly fell back to an
+    // empty shell and let the client render-from-scratch, the page
+    // would still pass the visible-content assertions below (the
+    // client would just render twice). Asserting the raw HTML
+    // structurally pins SSR as the source of the first paint.
+    const rawHtml = await page.evaluate(async (url) => {
+      const resp = await fetch(url, { cache: 'no-store' });
+      return { status: resp.status, body: await resp.text() };
+    }, LIVE_SSR_URL + '/');
+    if (rawHtml.status !== 200) {
+      throw new Error(`live-SSR GET / returned ${rawHtml.status}; expected 200`);
+    }
+    if (!rawHtml.body.includes('Article A') || !rawHtml.body.includes('Article B')) {
+      throw new Error(`raw SSR HTML does not contain article titles; body head: ${rawHtml.body.slice(0, 400)}`);
+    }
+    if (!/data-rf-render-hash="[0-9a-f]{8}"/.test(rawHtml.body)) {
+      throw new Error(`raw SSR HTML does not carry a data-rf-render-hash on the root element; body head: ${rawHtml.body.slice(0, 400)}`);
+    }
+    if (!rawHtml.body.includes('id="__rf_payload"')) {
+      throw new Error(`raw SSR HTML does not embed the __rf_payload <script>; body head: ${rawHtml.body.slice(0, 400)}`);
+    }
+    if (!rawHtml.body.includes(':rf/version 1')) {
+      throw new Error(`raw __rf_payload does not carry :rf/version 1; body head: ${rawHtml.body.slice(0, 400)}`);
+    }
+
+    // ---- (2) Page mounts; visible content survives hydration -----------
+    //
+    // The page.goto(...) in run-examples-tests.cjs has already loaded
+    // the URL with waitUntil:'load' — `main.js` has executed and
+    // dispatched :rf/hydrate. The articles should now be visible in
+    // the live DOM.
+    const articlesList = page.getByTestId('articles-list');
+    const bodies       = page.getByTestId('article-body');
+    const toggle       = page.getByTestId('toggle-bodies');
+
+    await expectVisible(articlesList, 10000);
+    await expectTextContains(articlesList, 'Article A', 5000);
+    await expectTextContains(articlesList, 'Article B', 5000);
+    await expectVisible(bodies.first(), 5000);
+
+    // ---- (3) Post-hydration interactivity ------------------------------
+    //
+    // The canonical "click the button after hydration" check. The
+    // server pre-rendered the button (raw HTML above carries the
+    // toggle markup); the click goes through the FULL re-frame
+    // dispatch / sub / re-render loop on the hydrated client. After
+    // the click, the body paragraphs are detached.
+    await expectVisible(toggle, 5000);
+    await toggle.click();
+    await expectCount(bodies, 0, 5000);
+
+    // ---- (4) Articles survive the hydration handoff --------------------
+    //
+    // Titles remain — the hydrated app-db still holds the :articles
+    // slice (carried over from the server's payload via :rf/hydrate's
+    // replace-app-db policy).
+    await expectTextContains(articlesList, 'Article A', 2000);
+    await expectTextContains(articlesList, 'Article B', 2000);
+  },
+};

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -28,12 +28,23 @@ const {
 } = require('../../implementation/scripts/lib/local-browser-harness.cjs');
 
 const PORT = 8030;
+// rf2-j3dlc — live-SSR JVM Ring server (Jetty) for the
+// `ssr-live.spec.cjs` smoke. Side-port so it lives alongside the static
+// http-server on PORT without contention. Launched by `main()` below
+// via `clojure -X:live-ssr-server` against
+// `examples/reagent/ssr/deps.edn`.
+const LIVE_SSR_PORT = 8031;
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
 // (where shadow-cljs runs and node_modules lives); REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
 const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
 const RUNNER = path.resolve(__dirname, 'run-examples-tests.cjs');
+// Live-SSR harness dir — deps.edn + server.clj. The `:examples/ssr`
+// build's `:output-dir` (under OUT_ROOT) supplies the `main.js` the
+// JVM server serves for browser hydration.
+const LIVE_SSR_DIR = path.join(REPO_ROOT, 'examples', 'reagent', 'ssr');
+const LIVE_SSR_STATIC_ROOT = path.join(OUT_ROOT, 'ssr');
 // http-server is a devDependency of implementation/package.json. Resolve
 // it from there explicitly so this script can be invoked from any cwd.
 const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
@@ -415,6 +426,33 @@ function stageHtml() {
   }
 }
 
+// rf2-j3dlc — launch the live-SSR JVM Ring server. The Clojure CLI
+// ships as `clojure` (POSIX) or `clojure.exe` / `deps.clj` (Windows).
+// `shell: true` on Windows lets the OS resolve the right one against
+// %PATHEXT% (.EXE, .CMD, .BAT) without us hard-coding the suffix.
+//
+// We DO NOT pass `:static-root` on the command line — Clojure `-X`
+// args go through `read-string` once and then through the platform
+// shell once, and Windows backslash-bearing paths survive neither
+// cleanly. Instead we rely on the alias's `:exec-args :static-root`
+// default (relative path baked into examples/reagent/ssr/deps.edn,
+// resolved against the LIVE_SSR_DIR cwd). Port stays on the CLI
+// because it's a plain integer with no shell-meaningful characters.
+//
+// The server stays alive until the orchestrator's cleanup kills it.
+function spawnLiveSsrServer() {
+  const isWin = process.platform === 'win32';
+  const args = [
+    '-X:live-ssr-server',
+    ':port', String(LIVE_SSR_PORT),
+  ];
+  return cleanup.trackProcess(spawnHarnessProcess('clojure', args, {
+    cwd:   LIVE_SSR_DIR,
+    stdio: ['ignore', 'inherit', 'inherit'],
+    shell: isWin,
+  }));
+}
+
 async function main() {
   compileAll();
   stageHtml();
@@ -440,9 +478,41 @@ async function main() {
     return 1;
   }
 
+  // rf2-j3dlc — bring up the live-SSR JVM server before the spec runner
+  // starts. The :examples/ssr build was just compiled by `compileAll`
+  // (above), so `LIVE_SSR_STATIC_ROOT/main.js` is on disk and the
+  // server's static handler can serve it on the same origin as the
+  // SSR-rendered HTML. The browser-driven `ssr-live.spec.cjs` reaches
+  // it via http://127.0.0.1:LIVE_SSR_PORT/.
+  const liveSsr = spawnLiveSsrServer();
+  let liveSsrDown = false;
+  liveSsr.on('exit', (code, signal) => {
+    liveSsrDown = true;
+    if (code !== 0 && code !== null) {
+      console.error(`live-ssr server exited unexpectedly (code=${code}, signal=${signal}).`);
+    }
+  });
+  // JVM cold-start (Clojure + shadow-cljs's transitive deps + Jetty
+  // bind) — well within READY_TIMEOUT_MS in CI but can take ~10-20s
+  // on a cold local cache.
+  const liveSsrReady = await waitForHttpReady(LIVE_SSR_PORT, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => liveSsrDown,
+  });
+  if (!liveSsrReady || liveSsrDown) {
+    console.error(`live-ssr server did not become reachable on :${LIVE_SSR_PORT} within ${READY_TIMEOUT_MS}ms.`);
+    return 1;
+  }
+
   const runner = cleanup.trackProcess(spawnHarnessProcess(process.execPath, [RUNNER], {
     stdio: 'inherit',
-    env: { ...process.env, EXAMPLES_BASE_URL: `http://127.0.0.1:${PORT}` },
+    env: {
+      ...process.env,
+      EXAMPLES_BASE_URL:    `http://127.0.0.1:${PORT}`,
+      // rf2-j3dlc — exposed to `ssr-live.spec.cjs` so the spec can
+      // build its `spec.url` against the JVM server's port without
+      // hard-coding it in the spec module.
+      EXAMPLES_LIVE_SSR_URL: `http://127.0.0.1:${LIVE_SSR_PORT}`,
+    },
   }));
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));


### PR DESCRIPTION
## Summary

Adds a stronger SSR browser smoke that exercises a REAL live JVM Ring + Jetty handler end-to-end. The existing `ssr.spec.cjs` only exercised pre-baked server-shaped HTML staged into `index.html` — it could not catch failures on the actual JVM render path or in the EDN round-trip from the live server to the browser.

## Strategy chosen — (A) live JVM Ring + Jetty server

Picked Strategy A from the bead. Stand up a real `ssr-ring/ssr-handler` in a sub-process on a side port (8031, alongside http-server's 8030) and have Playwright `page.goto(...)` hit it. The harness pattern follows `implementation/ssr-ring/test/.../ring_e2e_validator_test.clj` — that test uses Jetty + `java.net.http.HttpClient`; this PR uses Jetty + browser-driven Playwright.

## Surface

- **`examples/reagent/ssr/server.clj`** (new) — JVM main wiring `ssr-ring/ssr-handler` against `ssr.core`'s `:on-create` + `:root-view`, with `:fx-overrides` redirecting `:rf.http/managed` to a canned-success stub (mirrors the headless `ssr-tests` fn), plus a tiny static handler serving `/main.js` so the browser hydrates on the same origin.
- **`examples/reagent/ssr/deps.edn`** (new) — pins SSR + ssr-ring via `:local/root` plus `ring/ring-jetty-adapter`, with a `:live-ssr-server` alias.
- **`examples/reagent/ssr/ssr-live.spec.cjs`** (new) — the live-SSR Playwright spec.
- **`examples/scripts/serve-and-run-examples-tests.cjs`** (modified) — spawns the JVM Ring server alongside http-server, waits for it via the existing `waitForHttpReady` probe, exposes its base URL through `EXAMPLES_LIVE_SSR_URL`.

## Server-rendered content asserted BEFORE hydration

The spec issues a SECOND HTTP GET from inside the browser via `page.evaluate(async (url) => fetch(url).then(r => ({status, body: await r.text()})))`. The returned body is the bytes-on-wire shape, untouched by client JS. Anchors asserted:

- HTTP 200 status
- both article titles (`Article A`, `Article B`) — the server's authoritative slice
- `data-rf-render-hash=\"[0-9a-f]{8}\"` on the root element (Spec 011 §Render-hash marker)
- inline `<script id=\"__rf_payload\">` carrying `:rf/version 1`

If the server quietly fell back to an empty shell and let the client render-from-scratch, the visible-content checks would still pass (client renders twice) — pinning the raw HTML structurally is the only way to prove SSR is the source of first paint.

## Post-hydration interactivity check

The canonical \"click after hydrate\" check: `toggle.click()` then `expectCount(bodies, 0, 5000)`. Reagent unmounts the `[:p.body ...]` when `:articles/show-bodies?` flips, which only happens if the click went through the full re-frame dispatch / sub / re-render loop. Final assertion: article titles still present (proves `:rf/hydrate`'s replace-app-db policy seeded `:articles` into the client's app-db).

## Runner harness changes

- New `spawnLiveSsrServer()` helper using the existing `spawnHarnessProcess` + `cleanup.trackProcess` discipline (process teardown lands in the harness's `finally`).
- `main()` spawns the JVM server after http-server, waits for it via `waitForHttpReady(LIVE_SSR_PORT, ...)` with the same 30s timeout.
- New env var `EXAMPLES_LIVE_SSR_URL` threaded into the runner subprocess so the spec can build its `spec.url` without hard-coding the port.
- Spec emits SKIP (not fail) when the env var is unset, so direct invocations of `run-examples-tests.cjs` (without the orchestrator) don't break the suite.

## Discovery — follow-on bead rf2-joibj

The live-SSR path surfaced a latent ssr-ring bug: `pipeline/setup-request-frame!` generates frame-ids shaped `:rf.frame/<digits>` via `(keyword \"rf.frame\" (str (gensym \"\")))`. `(str (gensym \"\"))` returns pure digits (`\"5401\"`), producing `:rf.frame/5401` — a keyword whose local-part starts with a digit, which violates the EDN identifier grammar. **Both** `clojure.edn/read-string` AND `cljs.tools.reader.edn/read-string` reject it. The pre-baked spec never caught this because its hand-written `index.html` didn't ship a `pipeline/setup-request-frame!`-shaped frame-id; the JVM-side `ring_e2e_validator_test.clj` never round-trips through any EDN reader.

This server papers over the bug with a regex-substitution `:html-shell` that rewrites `:rf.frame/<digits>` → `:rf.frame/f<digits>` before emission. The workaround documents the issue at the call site and unblocks the smoke; the proper fix (change `setup-request-frame!` to `(keyword \"rf.frame\" (str (gensym \"f\")))` and add a JVM-side EDN-reader regression in `ring_test.clj`) lives in **rf2-joibj** (filed P1).

## Test plan

- [x] `npm run test:examples` — 39 specs (was 38), 0 failures, 0 skipped
- [x] Repeat run for stability — 39 specs, 0 failures
- [x] `npm run test:script-helpers` — passes
- [x] `npm run test:script-policy` — passes
- [x] Manual: `curl http://127.0.0.1:8031/` returns full SSR-rendered HTML with `data-rf-render-hash` + valid `__rf_payload`
- [x] Manual: `curl http://127.0.0.1:8031/main.js` returns the 4.4 MB shadow-cljs bundle