### PR TITLE
ci(classifier): close 4 routing gaps (incl. P1 ssr-ring) (rf2-mvugr + 3 beads)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -118,7 +118,18 @@ else
       examples/*)
         cljs_browser=true
         examples_browser=true
-      ;;
+        ;;
+      testbeds/*)
+        # rf2-7vsfm — Top-level testbeds/* is mounted by
+        # examples/scripts/serve-and-run-examples-tests.cjs (ssr_basic,
+        # ssr_hydration_mismatch, ssr_multi_frame, deliberate_throw,
+        # http_toggle, deep_machine, non_trivial_app_db,
+        # long_flow_w_failure, drain_depth_trigger, …) and consumed by
+        # `npm run test:examples` -> the examples-browser job. A
+        # testbed-only PR must trigger both surfaces.
+        cljs_browser=true
+        examples_browser=true
+        ;;
       tools/template/*)
         tools_jvm=true
         template_expensive=true

--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -107,6 +107,25 @@ else
         bundle_isolation=true
         examples_browser=true
         ;;
+      spec/conformance/fixtures/*)
+        # rf2-qmiiz — Fixtures under spec/conformance/fixtures/*.edn
+        # are consumed by:
+        #   - implementation/core/test/re_frame/conformance_test.clj
+        #     (JVM core job, always-on)
+        #   - implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+        #     (cljs job, always-on)
+        #   - per-artefact _conformance_test.clj under
+        #     implementation/{flows,ssr,machines,schemas,routing}/test/
+        #     (each gated behind implementation_jvm='true')
+        # A fixture-only PR (no impl/test change) would skip every
+        # per-artefact _conformance_test.clj. Fire implementation_jvm
+        # so the per-artefact corpus runners pick up new fixtures, and
+        # fire the CLJS surfaces so the cross-platform corpus runner
+        # in core does too.
+        implementation_jvm=true
+        cljs_browser=true
+        cljs_prod=true
+        ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
         cljs_browser=true
         cljs_prod=true

--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -100,7 +100,7 @@ else
         mcp_conformance=true
         mcp_live=true
         ;;
-      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/epoch/*|implementation/deps.edn)
+      implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/deps.edn)
         implementation_jvm=true
         cljs_browser=true
         cljs_prod=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -561,6 +561,61 @@ jobs:
       - name: Run JVM tests (ssr artefact)
         run: clojure -M:test
 
+  jvm-ssr-ring:
+    name: JVM ssr-ring (clojure -M:test)
+    needs: detect_changed_surfaces
+    if: needs.detect_changed_surfaces.outputs.implementation_jvm == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: implementation/ssr-ring
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@3fe9b3ae632c6758d0b7757b0838606ef4287b08  # 13.4
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-ssr-ring-${{ hashFiles('implementation/ssr-ring/deps.edn', 'implementation/ssr/deps.edn', 'implementation/core/deps.edn', 'implementation/schemas/deps.edn', 'implementation/flows/deps.edn', 'implementation/routing/deps.edn', 'implementation/machines/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-ssr-ring-
+            ${{ runner.os }}-clj-
+
+      # rf2-mvugr — Closes the gap surfaced by the 2026-05-16 routing
+      # audit: PR #1243 (rf2-gtgf9) added 5 JVM-only test namespaces
+      # under implementation/ssr-ring/test/ (ring_test, ring_streaming_test,
+      # ring_e2e_validator_test, ring/concurrency_stress_test,
+      # ring/streaming_robustness_test) and none ran in CI on that PR.
+      # The PR was rescued only because it also touched
+      # implementation/ssr/* (which fired jvm-ssr) — but jvm-ssr does
+      # not cover ssr-ring's distinct surface.
+      #
+      # The ssr-ring artefact is the Ring/Pedestal host adapter (Spec
+      # 011 §HTTP response contract). It materialises :response into a
+      # Ring map, including cookies (RFC 6265), redirects, and the
+      # per-request frame lifecycle. The JVM e2e validator spins up a
+      # real Jetty host on an ephemeral port and hits it with
+      # java.net.http to observe bytes on the wire. The cognitect
+      # test-runner returns non-zero on any failure; this gate
+      # surfaces an ssr-ring regression at the ssr-ring artefact's CI
+      # step rather than leaving it uncovered.
+      - name: Run JVM tests (ssr-ring artefact)
+        run: clojure -M:test
+
   jvm-epoch:
     name: JVM epoch (clojure -M:test)
     needs: detect_changed_surfaces

--- a/TESTING.md
+++ b/TESTING.md
@@ -99,3 +99,38 @@ The default placement rule is:
 | Fast nice-to-have signal | Usually every PR unless noisy or duplicative. |
 | Slow essential signal | Agent pre-checkin for relevant changes, changed-surface PR CI, nightly/manual, and release. |
 | Slow nice-to-have signal | Local, nightly/manual, or release; keep off the PR critical path unless the changed surface directly needs it. |
+
+## Spec-impl-pair convention (rf2-4zqn7)
+
+Top-level `spec/*.md` files have **no rule** in
+`.github/scripts/report-changed-surfaces.sh`. A spec-only PR runs only the
+always-on jobs (jvm-core, cljs, js-harness-self-tests, lockstep + skill/MCP
+drift, and — for `docs/**` PRs — the MkDocs build). Per-feature JVM artefact
+gates and the broad CLJS browser matrix do NOT fire.
+
+This is intentional. `spec/*` is the normative artefact; not every spec edit
+needs the full impl test matrix, and a blanket `spec/* → mark_all` rule would
+be a sledgehammer that re-runs the rigorous matrix on every typo fix.
+
+The expected pattern is the **spec-impl-pair convention**: a spec change
+ships in the same PR as the impl/test change that realises it, so the impl
+edit fires the relevant classifier rule and the spec edit rides along. The
+2026-05-16 routing audit confirmed every spec edit in a 16-PR sample was
+paired this way.
+
+Rules for spec-only PRs:
+
+- A spec-only PR is acceptable for pure normative refinements (clarifications,
+  prose-only fixes, cross-reference updates) where the spec text is the only
+  thing changing and no implementation behaviour is in scope.
+- If a spec change implies an implementation change — even a test — pair the
+  two in the same PR so the classifier picks the right surface.
+- If a spec-only PR is genuinely needed and reviewers want the rigorous
+  matrix run against it, push it through the nightly/manual
+  `expensive-tests.yml` workflow before merge.
+
+This is policy-by-convention, not by classifier. The audit's
+recommendation is to revisit only if a real spec-only PR slips through and
+causes a regression; first incident triggers a surgical per-spec-file rule
+(e.g. `spec/011-SSR.md → fire jvm-ssr + jvm-ssr-ring`) rather than a blanket
+rule.

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -15,6 +15,7 @@ artefacts=(
   implementation/flows
   implementation/http
   implementation/ssr
+  implementation/ssr-ring
   implementation/epoch
 )
 


### PR DESCRIPTION
## Summary

Closes four gaps in the CI test-routing classifier surfaced by the 2026-05-16 audit. Commits are ordered smallest -> biggest so the high-impact P1 lands with focused review.

- **rf2-4zqn7 (P3, doc-only)** — Document the spec-impl-pair convention in `TESTING.md`. Top-level `spec/*.md` has no classifier rule; every spec edit in a 16-PR sample was paired with an impl edit that fired the right rule. Codify the convention; do not add a blanket sledgehammer.
- **rf2-7vsfm (P2)** — Add `testbeds/*` rule -> `cljs_browser + examples_browser`. Top-level `testbeds/` is mounted by `examples/scripts/serve-and-run-examples-tests.cjs` and consumed by `npm run test:examples`; a testbed-only PR previously triggered nothing surface-conditional. Also cleans a cosmetic 6-space indent on the preceding `examples/*` rule.
- **rf2-qmiiz (P2)** — Add `spec/conformance/fixtures/*` rule -> `implementation_jvm + cljs_browser + cljs_prod`. A fixture-only PR would skip every per-artefact `_conformance_test.clj` under `implementation/{flows,ssr,machines,schemas,routing}/test/`.
- **rf2-mvugr (P1 BUG)** — Add `jvm-ssr-ring` job + classifier rule + `scripts/test-jvm-implementation.sh` entry. PR #1243 added 5 JVM-only test namespaces under `implementation/ssr-ring/test/` that NEVER ran in CI (rescued only because that PR also touched `implementation/ssr/*` which fired `jvm-ssr`). Three coordinated changes across `.github/scripts/report-changed-surfaces.sh`, `.github/workflows/test.yml`, and `scripts/test-jvm-implementation.sh`. Verified locally: `cd implementation/ssr-ring && clojure -M:test` -> 58 tests / 299 assertions / 0 failures.

## Test plan

- [x] `bash -n .github/scripts/report-changed-surfaces.sh` — passes
- [x] `bash -n scripts/test-jvm-implementation.sh` — passes
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — passes
- [x] Classifier smoke test `testbeds/http_toggle/core.cljs` -> fires `cljs_browser=true` + `examples_browser=true`
- [x] Classifier smoke test `spec/conformance/fixtures/flow-eval-exception.edn` -> fires `implementation_jvm=true` + `cljs_browser=true` + `cljs_prod=true`
- [x] Classifier smoke test `implementation/ssr-ring/src/...` + `implementation/ssr-ring/test/...` -> fires `implementation_jvm=true`
- [x] Inspect new `jvm-ssr-ring` job via PyYAML — working-directory, gate, and last step `clojure -M:test` correct
- [x] `cd implementation/ssr-ring && clojure -M:test` — 58 tests / 299 assertions / 0 failures
- [ ] CI run on this branch validates the new `jvm-ssr-ring` job + adjacent classifier outputs.