### PR TITLE
fix(story): variant-id-keyed cells so workspace switch remounts cleanly (rf2-kgn0c)

### DIFF
--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/*
+ * Local-only single-page workspace-switch smoke for the panel-gallery
+ * testbed (rf2-kgn0c regression gate).
+ *
+ * The sibling `_smoke.cjs` uses a FRESH page per workspace — conservative
+ * isolation that side-steps the workspace-teardown bug. This script
+ * walks every panel-gallery workspace in ONE browser session, asserting
+ * zero pageerrors across the whole walk. Pre-rf2-kgn0c fix, switching
+ * between two `:variants-grid` workspaces let React's reconciler reuse
+ * the prior workspace's `variant-cell` components (cell keys were
+ * position-only); the cell's `r/with-let` initialiser ran with the OLD
+ * variant id, the NEW variant's frame was never allocated, and the
+ * rendered view's subscribe returned nil — `@nil` then threw
+ * `No protocol method IDeref.-deref defined for type null`, surfacing
+ * as the ~22 pageerrors observed in PR #1254's Phase 1b smoke when
+ * clicking from `event-detail/all` to `app-db-diff/all`.
+ *
+ * Not wired into CI (mirrors `_smoke.cjs`'s posture). Run manually
+ * post-compile to verify the fix end-to-end:
+ *
+ *   shadow-cljs compile testbeds/panel-gallery
+ *   cp tools/causa/testbeds/panel_gallery/index.html implementation/out/testbeds/panel-gallery/
+ *   node tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const http = require('http');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const OUT_DIR = path.join(IMPL_ROOT, 'out', 'testbeds', 'panel-gallery');
+const PORT = Number(process.env.PANEL_GALLERY_WS_SWITCH_PORT || 8767);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+  paths: [IMPL_ROOT],
+});
+
+function waitForReady(url, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function probe() {
+      const req = http.get(url, (res) => {
+        res.resume();
+        if (res.statusCode === 200) resolve();
+        else if (Date.now() - start > timeoutMs) {
+          reject(new Error(`bad status ${res.statusCode} after ${timeoutMs}ms`));
+        } else setTimeout(probe, 200);
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) reject(new Error(`server not ready in ${timeoutMs}ms`));
+        else setTimeout(probe, 200);
+      });
+    }
+    probe();
+  });
+}
+
+(async () => {
+  const server = spawn(process.execPath, [HTTP_SERVER_BIN, OUT_DIR, '-p', String(PORT), '-s'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let exitCode = 0;
+  try {
+    await waitForReady(`${BASE_URL}/index.html`, 5000);
+    const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+    const browser = await chromium.launch();
+
+    const page = await (await browser.newContext()).newPage();
+    const errs = [];
+    page.on('pageerror', (e) => errs.push(`pageerror: ${e.message}`));
+    page.on('console', (m) => {
+      if (m.type() === 'error') errs.push(`console.error: ${m.text()}`);
+    });
+
+    await page.goto(`${BASE_URL}/index.html#/stories`, { waitUntil: 'load' });
+    await page.waitForTimeout(1500);
+    const gotIt = page.locator('button:has-text("Got it")').first();
+    if ((await gotIt.count()) > 0) await gotIt.click({ timeout: 2000 }).catch(() => {});
+    await page.waitForTimeout(500);
+
+    // Walk every gallery workspace in one session. Round-trip too —
+    // the bug surfaces on the SECOND workspace's first render.
+    const walk = [
+      { name: 'Workspace.causa.event-detail/all',   expectedAtLeast: 12 },
+      { name: 'Workspace.causa.app-db-diff/all',    expectedAtLeast: 11 },
+      { name: 'Workspace.causa.subscriptions/all',  expectedAtLeast: 10 },
+      { name: 'Workspace.causa.event-detail/all',   expectedAtLeast: 12 }, // round-trip
+      { name: 'Workspace.causa.app-db-diff/all',    expectedAtLeast: 11 }, // round-trip
+    ];
+
+    const stepResults = [];
+    for (const step of walk) {
+      const errsBefore = errs.length;
+      const row = page.getByText(step.name, { exact: false }).first();
+      await row.waitFor({ state: 'visible', timeout: 10000 });
+      await row.click({ timeout: 5000 });
+      await page.waitForTimeout(2500);
+      const variantRoots = await page.locator('[data-rf-story-variant-root]').count();
+      const errsAfter    = errs.length;
+      stepResults.push({
+        name: step.name,
+        expectedAtLeast: step.expectedAtLeast,
+        variantRoots,
+        newErrors: errsAfter - errsBefore,
+      });
+    }
+
+    let failed = false;
+    for (const r of stepResults) {
+      const ok = r.variantRoots >= r.expectedAtLeast && r.newErrors === 0;
+      console.log(`step ${r.name}: variant-roots=${r.variantRoots}/${r.expectedAtLeast} ` +
+                  `new-page-errors=${r.newErrors} ${ok ? 'OK' : 'FAIL'}`);
+      if (!ok) failed = true;
+    }
+    console.log(`TOTAL page errors across single-session walk: ${errs.length}`);
+    if (errs.length > 0) {
+      for (const e of errs.slice(0, 10)) console.log(`  ${e}`);
+    }
+    if (failed || errs.length > 0) {
+      throw new Error('single-session workspace-switch walk surfaced page errors / missing variants');
+    }
+    console.log('workspace-switch smoke OK — zero stale subscribe→nil derefs');
+    await browser.close();
+  } catch (err) {
+    console.error('workspace-switch smoke FAILED:', err.message);
+    exitCode = 1;
+  } finally {
+    server.kill('SIGTERM');
+    setTimeout(() => process.exit(exitCode), 200);
+  }
+})();

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -323,8 +323,47 @@
       body]))
 
 #?(:cljs
+   (defn- cell-key
+     "React key for a workspace cell. Variant cells key on the variant
+     id so distinct variants get distinct React identities — non-variant
+     cells (prose, custom) fall back to a positional key prefixed by
+     their type so they don't collide with variant keys.
+
+     Per rf2-kgn0c — position-only keys (`(str \"v-\" i)`) caused
+     React's reconciler to reuse the prior workspace's `variant-cell`
+     components when the user clicked from one `:variants-grid`
+     workspace to another (same layout, same cell positions, same
+     component type → reconciler diffs props in place rather than
+     unmounting). The cell's `r/with-let` initialiser ran only once
+     with the OLD variant id, so the NEW variant's frame was never
+     allocated by `run-variant-with-shell-opts!`. Subscribes against
+     the un-allocated frame returned `nil`, and `@nil` threw
+     `No protocol method IDeref.-deref defined for type null` —
+     surfacing as the ~22 pageerrors on the second workspace's
+     `app-db-diff` / `subscriptions` variants observed in PR #1254's
+     Phase 1b smoke run.
+
+     Variant-id-keyed cells force React to unmount the stale cells and
+     mount fresh ones whenever the variant set differs across the
+     swap, so each new cell's `with-let` initialiser fires once
+     against the correct variant id."
+     [i cell]
+     (case (:type cell)
+       :variant (str "v:" (pr-str (:variant-id cell)))
+       :prose   (str "p-" i)
+       :custom  (str "c-" i)
+       (str "?-" i))))
+
+#?(:cljs
    (defn workspace-view
-     "Render a workspace. Resolves the cells and dispatches per layout."
+     "Render a workspace. Resolves the cells and dispatches per layout.
+
+     The root `<section>` is keyed on `workspace-id` (via Reagent meta)
+     so switching workspaces unmounts the whole subtree rather than
+     diffing cells in place. Belt-and-braces alongside the variant-id-
+     keyed cell strategy below — if a future refactor narrows the cell
+     keys, the workspace-level remount still guarantees frame setup
+     re-fires on swap. Per rf2-kgn0c."
      [workspace-id]
      (let [body (registrar/handler-meta :workspace workspace-id)]
        (cond
@@ -333,6 +372,7 @@
          ;; `tab-index "0"` + aria-label make it focusable and named so
          ;; axe-core's scrollable-region-focusable rule passes. The
          ;; `<section>` lives inside the shell's <main> landmark.
+         ^{:key (str "ws:" (pr-str workspace-id))}
          [:section {:style      (:wrap styles)
                     :aria-label "Workspace"
                     :tab-index  "0"}
@@ -341,6 +381,7 @@
 
          :else
          (let [cells (resolve-layout workspace-id body)]
+           ^{:key (str "ws:" (pr-str workspace-id))}
            [:section {:style      (:wrap styles)
                       :aria-label (str "Workspace " (pr-str workspace-id))
                       :tab-index  "0"}
@@ -357,10 +398,10 @@
                (for [[i cell] (map-indexed vector cells)]
                  (case (:type cell)
                    :prose
-                   ^{:key (str "p-" i)}
+                   ^{:key (cell-key i cell)}
                    [prose-block (:body cell)]
                    :variant
-                   ^{:key (str "v-" i)}
+                   ^{:key (cell-key i cell)}
                    [variant-cell (:variant-id cell)]))]
 
               :else
@@ -368,13 +409,13 @@
                (for [[i cell] (map-indexed vector cells)]
                  (case (:type cell)
                    :variant
-                   ^{:key (str "v-" i)}
+                   ^{:key (cell-key i cell)}
                    [variant-cell (:variant-id cell)]
                    :prose
-                   ^{:key (str "p-" i)}
+                   ^{:key (cell-key i cell)}
                    [prose-block (:body cell)]
                    :custom
-                   ^{:key (str "c-" i)}
+                   ^{:key (cell-key i cell)}
                    [:div {:style (:cell styles)}
                     "custom render: " (pr-str (:render cell))]
                    nil))])])))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -15,6 +15,7 @@
   the browser-test target (Stage 4 ships the smoke layer; Stage 8's
   examples integration covers end-to-end Playwright)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.set :as set]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -306,6 +307,111 @@
       (is (boolean (some #(and (string? %)
                                (re-find #"not registered" %))
                          (tree-seq coll? seq tree)))))))
+
+;; ---- workspace cell keys are variant-id-derived (rf2-kgn0c) -------------
+;;
+;; Position-only React keys (`(str "v-" i)`) let React reconcile the prior
+;; workspace's `variant-cell` components in place when the user switched
+;; to a different `:variants-grid` workspace — same layout / same cell
+;; positions / same component type. The cell's `r/with-let` initialiser
+;; only runs once per mount, so the NEW variant's frame was never
+;; allocated by `run-variant-with-shell-opts!`. Subscribes against the
+;; un-allocated frame returned nil and `@nil` threw
+;; `No protocol method IDeref.-deref defined for type null` —
+;; ~22 pageerrors on the second workspace's app-db-diff variants
+;; observed in PR #1254's Phase 1b smoke.
+;;
+;; Fix: cell keys derive from variant-id, and the workspace root carries
+;; a workspace-id key. Two distinct workspaces with overlapping cell
+;; positions therefore produce disjoint React keys and React unmounts
+;; the old cells / mounts fresh ones — `r/with-let` re-fires against
+;; the correct variant id.
+
+(defn- collect-cell-keys
+  "Walk the rendered workspace tree and return the set of React keys
+  carried by variant-cell child vectors `[variant-cell-fn variant-id]`.
+  Reagent stores `^{:key ...}` metadata directly on the hiccup vector.
+
+  We match the shape `[fn namespaced-keyword]` — variant-cell is a
+  private fn-value (no Var in CLJS), so we match structurally rather
+  than by symbol. Variant ids are always namespaced keywords."
+  [tree]
+  (->> (tree-seq coll? seq tree)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (= 2 (count node))
+                      (fn? (first node))
+                      (keyword? (second node))
+                      (some? (namespace (second node))))))
+       (map (comp :key meta))
+       (remove nil?)
+       set))
+
+(deftest workspace-grid-cells-key-on-variant-id-rf2-kgn0c
+  (testing ":grid layout cells use variant-id-derived React keys so
+            React mounts fresh cells when a workspace swap changes the
+            variant set (per rf2-kgn0c)"
+    (story/reg-variant :story.rf2-kgn0c.a/x {:events []})
+    (story/reg-variant :story.rf2-kgn0c.a/y {:events []})
+    (story/reg-variant :story.rf2-kgn0c.b/p {:events []})
+    (story/reg-variant :story.rf2-kgn0c.b/q {:events []})
+    (story/reg-workspace :Workspace.rf2-kgn0c.a/grid
+      {:layout   :grid
+       :variants [:story.rf2-kgn0c.a/x :story.rf2-kgn0c.a/y]})
+    (story/reg-workspace :Workspace.rf2-kgn0c.b/grid
+      {:layout   :grid
+       :variants [:story.rf2-kgn0c.b/p :story.rf2-kgn0c.b/q]})
+    (let [keys-a (collect-cell-keys
+                   (workspace/workspace-view :Workspace.rf2-kgn0c.a/grid))
+          keys-b (collect-cell-keys
+                   (workspace/workspace-view :Workspace.rf2-kgn0c.b/grid))]
+      (is (= 2 (count keys-a)) "workspace-a yields one key per cell")
+      (is (= 2 (count keys-b)) "workspace-b yields one key per cell")
+      (is (empty? (set/intersection keys-a keys-b))
+          (str "two workspaces with disjoint variant sets MUST have "
+               "disjoint cell-key sets — overlap means React would "
+               "reconcile cells in place on workspace switch and the "
+               "new variant's frame would never be allocated. "
+               "keys-a=" (pr-str keys-a) " keys-b=" (pr-str keys-b)))
+      (is (every? #(re-find #"rf2-kgn0c" %) keys-a)
+          (str "cell keys MUST embed the variant id so distinct "
+               "variants produce distinct keys; got " (pr-str keys-a))))))
+
+(deftest workspace-variants-grid-cells-key-on-variant-id-rf2-kgn0c
+  (testing ":variants-grid layout cells use variant-id-derived React
+            keys (the layout the Phase 1b smoke triggered the bug on)"
+    (story/reg-variant :story.rf2-kgn0c-vg.a/x {:events []})
+    (story/reg-variant :story.rf2-kgn0c-vg.a/y {:events []})
+    (story/reg-variant :story.rf2-kgn0c-vg.b/p {:events []})
+    (story/reg-workspace :Workspace.rf2-kgn0c-vg.a/all
+      {:layout :variants-grid})
+    (story/reg-workspace :Workspace.rf2-kgn0c-vg.b/all
+      {:layout :variants-grid})
+    (let [keys-a (collect-cell-keys
+                   (workspace/workspace-view :Workspace.rf2-kgn0c-vg.a/all))
+          keys-b (collect-cell-keys
+                   (workspace/workspace-view :Workspace.rf2-kgn0c-vg.b/all))]
+      (is (seq keys-a))
+      (is (seq keys-b))
+      (is (empty? (set/intersection keys-a keys-b))
+          (str "variants-grid cell keys MUST be disjoint across "
+               "workspaces with disjoint anchor stories. "
+               "keys-a=" (pr-str keys-a) " keys-b=" (pr-str keys-b))))))
+
+(deftest workspace-root-section-keys-on-workspace-id-rf2-kgn0c
+  (testing "the workspace's root <section> carries a workspace-id-derived
+            React key so any swap unmounts the whole subtree as a
+            belt-and-braces guard alongside per-cell keys"
+    (story/reg-variant :story.rf2-kgn0c-root/v {:events []})
+    (story/reg-workspace :Workspace.rf2-kgn0c-root/g
+      {:layout   :grid
+       :variants [:story.rf2-kgn0c-root/v]})
+    (let [tree (workspace/workspace-view :Workspace.rf2-kgn0c-root/g)
+          k    (:key (meta tree))]
+      (is (string? k))
+      (is (re-find #"rf2-kgn0c-root" k)
+          (str "workspace-root key MUST embed the workspace id; got "
+               (pr-str k))))))
 
 ;; ---- trace six-domino projection ----------------------------------------
 

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -547,5 +547,57 @@ module.exports = {
         );
       }
     });
+
+    await scenario(page, 'workspace-switch-no-stale-subscribe-derefs-rf2-kgn0c', async () => {
+      /*
+       * Regression gate for rf2-kgn0c. Pre-fix, clicking from one
+       * workspace to another within the same browser session let
+       * React's reconciler reuse the prior workspace's variant-cell
+       * components when keys collided (`(str "v-" i)` was position-
+       * only); the cell's `r/with-let` initialiser ran once with the
+       * OLD variant id, the NEW variant's frame was never allocated
+       * by `run-variant-with-shell-opts!`, and the rendered view's
+       * subscribe returned nil — `@nil` then threw
+       * `No protocol method IDeref.-deref defined for type null`.
+       *
+       * The fix keys variant cells on the variant id. This walkthrough
+       * clicks through every workspace in the counter testbed in a
+       * single browser session — NO fresh page per workspace. Any
+       * stale-subscribe-deref would surface as a pageerror, and the
+       * spec-level pageerror gate would fail the run.
+       *
+       * Last scenario in the file so the post-walk shell state (a
+       * selected workspace, no selected variant) does not bleed into
+       * the next scenario's preconditions.
+       */
+      await primeHelpDismissed(page);
+      await gotoStory(page, '/counter-with-stories/#/stories');
+
+      const workspaceNames = [
+        'Workspace.counter/all-states',
+        'Workspace.counter/auto-grid',
+        'Workspace.counter/tabs',
+        'Workspace.counter/all-states', // round-trip
+        'Workspace.counter/auto-grid',  // round-trip
+      ];
+
+      for (const name of workspaceNames) {
+        const row = page.getByRole('navigation').getByText(name, { exact: false }).first();
+        await row.waitFor({ state: 'visible', timeout: 10000 });
+        await row.click();
+        // Wait for the workspace's <section> landmark to land — its
+        // aria-label embeds the workspace id, so we anchor on that.
+        const ws = page.locator(`main section[aria-label="Workspace :${name}"]`);
+        await ws.waitFor({ state: 'visible', timeout: 10000 });
+        // Workspace MUST render at least one variant root after the
+        // swap. The bug pre-fix left the new workspace blank /
+        // partially rendered around the throw.
+        await waitForValue(
+          () => ws.locator('[data-rf-story-variant-root]').count(),
+          (count) => count >= 1,
+          { timeoutMs: 10000, description: `${name} mounts at least one variant root` },
+        );
+      }
+    });
   },
 };


### PR DESCRIPTION
## Summary

- **Root cause**: Position-only React keys (`(str "v-" i)`) on workspace cells caused React's reconciler to reuse the prior workspace's `variant-cell` components on workspace switch. The cell's `r/with-let` initialiser ran once with the OLD variant id, the NEW variant's frame was never allocated, and `(rf/subscribe ...)` against the un-allocated frame returned nil → `@nil` threw `No protocol method IDeref.-deref defined for type null`.
- **Fix** (path A — surgical teardown): variant cells now key on `v:<variant-id>`; the workspace root `<section>` keys on the workspace id. Disjoint variant sets → disjoint keys → React unmounts stale cells and mounts fresh ones, so each new cell's `with-let` initialiser fires once against the correct variant id.
- **Phase 1b mitigation lifted**: the fresh-page-per-workspace shape in PR #1254's `_smoke.cjs` is no longer required. The new `_workspace_switch_smoke.cjs` walks all three gallery workspaces in a single browser session with zero pageerrors.

## Test plan

- [x] CLJS unit tests pin the variant-id-keyed cell + workspace-id-keyed root contract; all three fail without the workspace.cljc fix.
- [x] Playwright walkthrough in `story_browser_scenarios.cjs` clicks through 5 workspace selections in one session against `counter-with-stories`.
- [x] New `tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` walks event-detail → app-db-diff → subscriptions → event-detail → app-db-diff in one browser session. Pre-fix: shell crashes on switch to `subscriptions/all`. Post-fix: 56 variant roots, 0 pageerrors.
- [x] `npm run test:cljs` → 2159 tests / 6163 assertions / 0 failures.
- [x] `clojure -M:test` (tools/story) → 425 tests / 1325 assertions / 0 errors.
- [x] Original `tools/causa/testbeds/panel_gallery/_smoke.cjs` (fresh-page-per-workspace) → 33/33 variant roots + cards, 0 pageerrors.

Closes rf2-kgn0c.