### PR TITLE
test(causa): Story-on-Causa Phase 2 — 5 panels, 48 variants (rf2-8r20i)

### DIFF
--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -118,6 +118,12 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-issues-ribbon-card',
         expectedAtLeast: 9,
       },
+      {
+        id:          'causality-graph',
+        workspaceRe: /Workspace\.causa\.causality-graph\/all/,
+        cardTestid:  'panel-gallery-causality-graph-card',
+        expectedAtLeast: 10,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -112,6 +112,12 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-trace-card',
         expectedAtLeast: 9,
       },
+      {
+        id:          'issues-ribbon',
+        workspaceRe: /Workspace\.causa\.issues-ribbon\/all/,
+        cardTestid:  'panel-gallery-issues-ribbon-card',
+        expectedAtLeast: 9,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -100,6 +100,12 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-subscriptions-card',
         expectedAtLeast: 10,
       },
+      {
+        id:          'time-travel',
+        workspaceRe: /Workspace\.causa\.time-travel\/all/,
+        cardTestid:  'panel-gallery-time-travel-card',
+        expectedAtLeast: 8,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -106,6 +106,12 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-time-travel-card',
         expectedAtLeast: 8,
       },
+      {
+        id:          'trace',
+        workspaceRe: /Workspace\.causa\.trace\/all/,
+        cardTestid:  'panel-gallery-trace-card',
+        expectedAtLeast: 9,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -124,6 +124,12 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-causality-graph-card',
         expectedAtLeast: 10,
       },
+      {
+        id:          'ai-co-pilot',
+        workspaceRe: /Workspace\.causa\.ai-co-pilot\/all/,
+        cardTestid:  'panel-gallery-ai-co-pilot-card',
+        expectedAtLeast: 12,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/ai_co_pilot_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/ai_co_pilot_fixtures.cljs
@@ -1,0 +1,155 @@
+(ns panel-gallery.ai-co-pilot-fixtures
+  "Pure fixture builders for the Causa AI Co-Pilot panel gallery
+  (rf2-8r20i, Phase 2).
+
+  The AI Co-Pilot panel reads its rows from seven `:rf.causa/copilot-*`
+  subs:
+
+    - `:rf.causa/copilot-open?`            — boolean
+    - `:rf.causa/copilot-conversation`     — vec of turn maps
+    - `:rf.causa/copilot-provider`         — kw (`:claude` / `:openai` / ...)
+    - `:rf.causa/copilot-cue-active?`      — boolean
+    - `:rf.causa/copilot-redaction-settings` — map
+    - `:rf.causa/copilot-streaming-token-count` — int
+    - `:rf.causa/copilot-input-text`       — string
+
+  Each variant seeds via a single gallery-local seed event that
+  `assoc`s every slot in one go — Story's `:rf.story/*` runtime slots
+  survive untouched per `tools/story/spec/002-Runtime.md` §Coexistence
+  with hosting application state.
+
+  ## Turn shape
+
+  Per `ai-co-pilot-conversation-model` each turn is:
+
+      {:role       :question | :answer
+       :text       <string>
+       :streaming? <bool>}
+
+  Answers may contain `{:rf.copilot/chip <key> <value>}` fragments
+  which the chip parser projects into citation chips at render
+  time. Chip keys are `:dispatch-id` / `:path` / `:epoch-number` /
+  `:handler-id`.")
+
+;; ---- turn builders ------------------------------------------------------
+
+(defn q
+  "Build a question turn."
+  [text]
+  {:role :question :text text :streaming? false})
+
+(defn a
+  "Build a settled (non-streaming) answer turn."
+  [text]
+  {:role :answer :text text :streaming? false})
+
+(defn a-streaming
+  "Build a streaming answer turn — the panel renders a cursor caret
+  at the tail."
+  [text]
+  {:role :answer :text text :streaming? true})
+
+;; ---- conversation builders ---------------------------------------------
+
+(defn empty-convo
+  "Empty conversation. Panel renders the 'Ask Causa anything' empty-
+  state with the sample-prompts ladder."
+  []
+  [])
+
+(defn typing-convo
+  "Empty conversation but the input has user-typed-but-not-submitted
+  text. The panel surfaces the input value verbatim — no slash
+  popover (text doesn't start with `/`)."
+  []
+  [])
+
+(defn one-turn-convo
+  "One question + one settled answer. The simplest non-empty
+  conversation."
+  []
+  [(q "Why did :checkout/submit fire?")
+   (a "Because the user clicked the Submit button — :checkout/submit was dispatched from cart/list:42 with payload {:order-id 1042}.")])
+
+(defn mid-completion-convo
+  "Question + streaming answer with content. The streaming cursor
+  caret renders at the tail."
+  []
+  [(q "What changed in the last 5 epochs?")
+   (a-streaming "Epoch 42 added :cart/items, epoch 43 modified :user/role, epoch 44 ")])
+
+(defn error-convo
+  "Question + answer reporting an LLM error. Surfaces the literal
+  error string the provider returned."
+  []
+  [(q "Why is :cart/total returning 0?")
+   (a "[error] Provider stream failed: HTTP 503 — upstream timeout. The conversation is preserved for retry.")])
+
+(defn large-context-convo
+  "Six-turn conversation exercising vertical scroll behaviour. The
+  panel's conversation column is scrollable; under load the rail
+  form clips to a fixed height."
+  []
+  [(q "Why did :auth/sign-in fire?")
+   (a "Form submit → :auth/sign-in cascade with parent dispatch-id 100. The handler called http/login.")
+   (q "Show the resulting app-db changes.")
+   (a "App-db diff: :auth.status :anon → :authenticated, :session.user-id nil → 7, :session.expires-at 0 → 1700000000000.")
+   (q "Any errors in that cascade?")
+   (a-streaming "Yes — :rf.error/handler-threw at auth/load-permissions:18 (ClassCastException). Recovery: rollback. ")])
+
+(defn redacted-convo
+  "Conversation showing the panel's behaviour when the answer's
+  embedded values arrive under `:rf/redacted` markers (per Spec 009
+  §Privacy). The text is rendered verbatim — the panel does not
+  re-redact; it surfaces whatever the LLM returned."
+  []
+  [(q "What were the auth/sign-in args?")
+   (a "Per the panel's redaction-default-on policy, the args were forwarded as: [:auth/sign-in <redacted> <redacted>]. Unmask via the panel's redaction settings to inspect.")])
+
+(defn with-chips-convo
+  "Answer with structured citation chips. Three chip kinds in one
+  answer surface the chip-row rendering — `:dispatch-id`, `:path`,
+  and `:epoch-number`."
+  []
+  [(q "What changed?")
+   (a (str "The cascade rooted at "
+           "{:rf.copilot/chip :dispatch-id 42}"
+           " mutated "
+           "{:rf.copilot/chip :path [:cart :items]}"
+           " between epochs "
+           "{:rf.copilot/chip :epoch-number 7}"
+           " and the current one."))])
+
+(defn slash-typing-convo
+  "Empty conversation; the input contains a partial slash command —
+  the slash popover surfaces matching suggestions."
+  []
+  [])
+
+(defn provider-cycle-convo
+  "Two settled turns; the panel header surfaces the active provider
+  chip ('claude' by default; the variant overrides to :openai to
+  exercise the picker)."
+  []
+  [(q "Hello.")
+   (a "Hi — I'm Causa's co-pilot. Ask anything about this runtime.")])
+
+(defn multi-question-convo
+  "Three back-to-back questions without intervening answers — exercises
+  the panel's question-stacking behaviour (the user fires fast and
+  the stream is rate-limited)."
+  []
+  [(q "Why did :counter/inc fire?")
+   (q "What did :counter/inc handle?")
+   (q "What rendered after :counter/inc?")])
+
+(defn long-streaming-convo
+  "One question + a long streaming answer. The token-count badge
+  surfaces a non-zero value (the seed event sets the slot too)."
+  []
+  [(q "Walk me through the cascade.")
+   (a-streaming (str "OK — the root :checkout/submit event was dispatched from cart/list at line 42. "
+                     "The handler validated the payload (one fx invocation), persisted to localStorage "
+                     "(a second fx invocation), then dispatched :checkout/charge as a child. The child "
+                     "cascade involved three subs (cart/items, auth/user, ui/theme) and re-rendered "
+                     "five views (app/root, nav/bar, cart/list, ..."))])

--- a/tools/causa/testbeds/panel_gallery/ai_co_pilot_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/ai_co_pilot_stories.cljs
@@ -1,0 +1,239 @@
+(ns panel-gallery.ai-co-pilot-stories
+  "Story coverage for the Causa AI Co-Pilot panel under gallery
+  framing (rf2-8r20i, Phase 2).
+
+  Twelve variants, each one render of `ai-co-pilot-view` against a
+  variant frame whose seven `:copilot-*` slots have been seeded by a
+  REAL gallery-local init event fired into the variant frame.
+
+  ## Why a gallery-local seed event
+
+  Causa's panel reads seven slots (`:copilot-open?`,
+  `:copilot-conversation`, `:copilot-provider`,
+  `:copilot-cue-active?`, `:copilot-redaction-settings`,
+  `:copilot-streaming-token-count`, `:copilot-input-text`) and the
+  Causa registrations provide individual mutators
+  (`:rf.causa/copilot-stream-token`, `:rf.causa/copilot-set-input-text`)
+  but no SINGLE seed event that sets all the visible state at once.
+  Variants seed via the gallery-local
+  `:panel-gallery/seed-copilot` event (registered in `core.cljs`) —
+  one `assoc` per slot — so Story's `:rf.story/*` runtime slots
+  survive per `tools/story/spec/002-Runtime.md` §Coexistence with
+  hosting application state. ZERO source-side changes to the panel;
+  this seed event is testbed-only.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. The Co-Pilot panel's seven `:rf.causa/copilot-*`
+  subs read from the current frame's app-db — the seed event's
+  assocs land on the variant frame. Each variant therefore observes
+  its own bespoke state in isolation; no two variants share."
+  (:require [re-frame.story :as story]
+            [panel-gallery.ai-co-pilot-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the AI Co-Pilot Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-ai-co-pilot
+    {:axis :feature
+     :doc  "Causa AI Co-Pilot panel — conversation column, input row,
+            slash popover, structured citation chips, redaction
+            policy, streaming cursor, provider picker."})
+
+  (story/reg-story :story.causa.ai-co-pilot
+    {:doc        "Visual gallery of the Causa AI Co-Pilot panel under
+                 varying conversation state. Each variant seeds its
+                 frame's seven :copilot-* slots via the gallery-local
+                 :panel-gallery/seed-copilot event; the rendered
+                 panel reads from the variant frame in isolation."
+     :component  :panel-gallery.ai-co-pilot/Panel
+     :tags       #{:dev :feature/causa-ai-co-pilot}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty (no conversation) ----------------------------------
+  (story/reg-variant :story.causa.ai-co-pilot/empty
+    {:doc        "Empty conversation. Panel renders the 'Ask Causa
+                 anything' empty-state with the sample-prompts
+                 ladder."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/empty-convo)}]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. typing (input populated, no submit) ----------------------
+  (story/reg-variant :story.causa.ai-co-pilot/typing
+    {:doc        "Empty conversation but the input has user-typed-
+                 but-not-submitted text. The panel surfaces the
+                 input value verbatim — no slash popover."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/typing-convo)
+                    :input-text "Why did :checkout/submit fire?"}]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. mid-completion (streaming) -------------------------------
+  (story/reg-variant :story.causa.ai-co-pilot/mid-completion
+    {:doc        "Question + streaming answer with content. The
+                 streaming cursor caret renders at the tail; the
+                 token-count badge surfaces a non-zero value."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/mid-completion-convo)
+                    :streaming-token-count 23}]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. error ----------------------------------------------------
+  (story/reg-variant :story.causa.ai-co-pilot/error
+    {:doc        "Question + answer reporting an LLM provider error.
+                 The literal error string surfaces in the answer
+                 column."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/error-convo)}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. large-context (vertical scroll) --------------------------
+  (story/reg-variant :story.causa.ai-co-pilot/large-context
+    {:doc        "Six-turn conversation exercising vertical scroll
+                 behaviour. The panel's conversation column is
+                 scrollable; under load the rail form clips to a
+                 fixed height."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/large-context-convo)
+                    :streaming-token-count 14}]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. redacted -------------------------------------------------
+  (story/reg-variant :story.causa.ai-co-pilot/redacted
+    {:doc        "Conversation where the answer's args arrive
+                 redacted per Spec 009 §Privacy. The panel surfaces
+                 the marker verbatim — it does not re-redact."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/redacted-convo)}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. with citation chips (panel-specific axis A) -------------
+  ;;
+  ;; Panel-specific axis: answers may carry inline structured chips
+  ;; (`{:rf.copilot/chip <key> <value>}`) that render as clickable
+  ;; citation chips. This variant surfaces three chip kinds in one
+  ;; answer.
+  (story/reg-variant :story.causa.ai-co-pilot/with-citation-chips
+    {:doc        "Answer with three structured citation chips
+                 (`:dispatch-id`, `:path`, `:epoch-number`). Each
+                 chip renders with its glyph and is clickable.
+                 Panel-specific axis."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/with-chips-convo)}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. slash popover open (panel-specific axis B) --------------
+  ;;
+  ;; Panel-specific axis: typing `/` in the input opens the slash
+  ;; popover with matching command suggestions. This variant seeds
+  ;; the input with a partial `/s` so the popover surfaces every
+  ;; `/s*` command.
+  (story/reg-variant :story.causa.ai-co-pilot/slash-popover
+    {:doc        "Input contains a partial slash command (`/s`).
+                 The slash popover surfaces every matching command
+                 — `/state`, `/snapshot`, `/scrub`, etc.
+                 Panel-specific axis."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/slash-typing-convo)
+                    :input-text "/s"}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. provider override (panel-specific axis C) ---------------
+  ;;
+  ;; Panel-specific axis: the title bar surfaces the provider chip;
+  ;; clicking cycles through (:claude / :openai / :gemini / :local /
+  ;; :custom). This variant overrides to :openai so the picker's
+  ;; chip displays the non-default value.
+  (story/reg-variant :story.causa.ai-co-pilot/provider-openai
+    {:doc        "Provider override to `:openai`. Settled two-turn
+                 conversation; the picker chip surfaces the override
+                 value. Panel-specific axis."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/provider-cycle-convo)
+                    :provider :openai}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 10. multi-question burst (panel-specific axis D) -----------
+  ;;
+  ;; Panel-specific axis: three consecutive questions without
+  ;; intervening answers — exercises the panel's question-stacking
+  ;; behaviour (rapid-fire user input under rate-limited streams).
+  (story/reg-variant :story.causa.ai-co-pilot/multi-question
+    {:doc        "Three back-to-back questions without intervening
+                 answers. The panel stacks them in chronological
+                 order. Panel-specific axis: rapid-fire input
+                 rendering."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/multi-question-convo)}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 11. long streaming (panel-specific axis E) -----------------
+  ;;
+  ;; Panel-specific axis: a long streaming answer exercises the
+  ;; token-count badge (>100 tokens) + the streaming cursor caret
+  ;; at the tail of a wrapped multi-line answer.
+  (story/reg-variant :story.causa.ai-co-pilot/long-streaming
+    {:doc        "One question + a long streaming answer wrapping
+                 across multiple lines. The token-count badge
+                 surfaces 127; the streaming cursor caret renders at
+                 the tail. Panel-specific axis."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/long-streaming-convo)
+                    :streaming-token-count 127}]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 12. redaction unmask (panel-specific axis F) ---------------
+  ;;
+  ;; Panel-specific axis: the panel's redaction-settings slot
+  ;; controls whether trace events / app-db forward redacted or
+  ;; unmasked to the LLM. This variant flips both unmask flags so
+  ;; the redaction status (when surfaced in the chrome) shows the
+  ;; non-default privacy posture.
+  (story/reg-variant :story.causa.ai-co-pilot/redaction-unmask
+    {:doc        "Redaction settings flipped to unmask both event
+                 args and app-db leaves — the panel's privacy
+                 posture is overtly non-default. Panel-specific
+                 axis: settings drive the LLM-bound payload shape."
+     :events     [[:panel-gallery/seed-copilot
+                   {:conversation (fixtures/one-turn-convo)
+                    :redaction-settings {:unmask-event-args true
+                                         :unmask-app-db     true}}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.ai-co-pilot/all
+    {:doc      "All twelve AI Co-Pilot variants in one auto-grid.
+                Scroll to see the panel's response across empty /
+                typing / mid-completion / error / large-context /
+                redacted / citation-chips / slash-popover / provider-
+                override / multi-question / long-streaming /
+                redaction-unmask."
+     :layout   :variants-grid
+     :story    :story.causa.ai-co-pilot
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/causality_graph_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/causality_graph_fixtures.cljs
@@ -1,0 +1,243 @@
+(ns panel-gallery.causality-graph-fixtures
+  "Pure fixture builders for the Causa causality-graph panel gallery
+  (rf2-8r20i, Phase 2).
+
+  The causality-graph panel reads its rows from
+  `:rf.causa/causality-graph-data`, a composite over:
+
+    - `:rf.causa/cascades`             — `group-cascades` over the
+                                          trace buffer
+    - `:rf.causa/trace-buffer`         — raw events for enrichment
+                                          (`:origin` / `:parent-
+                                          dispatch-id` are lifted off
+                                          the raw `:event/dispatched`)
+    - `:rf.causa/selected-dispatch-id` — drives node highlight
+    - `:rf.causa/selected-epoch-id`    — drives cascade-family filter
+    - `:rf.causa/epoch-history`        — for the epoch-filter walk
+
+  Each variant seeds via `:rf.causa/sync-trace-buffer` — the raw
+  buffer drives `:rf.causa/cascades` + the enrichment walk on the
+  reactive path. Selection variants additionally dispatch
+  `:rf.causa/select-dispatch-id`. ZERO source-side changes to the
+  panel; the gallery exercises it as-is.
+
+  ## Cascade composition
+
+  Each cascade requires at minimum an `:event/dispatched` row carrying
+  `:tags :dispatch-id`. Parent edges come from `:tags :parent-dispatch-
+  id` on the dispatched-event row; `:origin` (`:app` / `:pair` /
+  `:story` / `:test` / `:causa`) drives the node-fill colour.
+
+  The minimal-cascade builder here pairs the `:event/dispatched` row
+  with a `:handler`-phase row + an `:rf.fx/handled` row + a
+  `:view/render` row so each cascade carries non-zero
+  `:effect-count` / `:render-count` for the node sub-label. Errors
+  / warnings tip the border colour via the cascade's `:other` bucket.")
+
+;; ---- per-event builders -------------------------------------------------
+
+(defn dispatched-ev
+  ([id dispatch-id event-vec]
+   (dispatched-ev id dispatch-id event-vec nil :app))
+  ([id dispatch-id event-vec parent-dispatch-id]
+   (dispatched-ev id dispatch-id event-vec parent-dispatch-id :app))
+  ([id dispatch-id event-vec parent-dispatch-id origin]
+   {:id        id
+    :op-type   :event
+    :operation :event/dispatched
+    :tags      (cond-> {:dispatch-id dispatch-id
+                        :event       event-vec
+                        :origin      origin}
+                 parent-dispatch-id (assoc :parent-dispatch-id parent-dispatch-id))}))
+
+(defn handler-ev
+  [id dispatch-id]
+  {:id id :op-type :event :operation :event
+   :tags {:dispatch-id dispatch-id :phase :run-end :duration-ms 4}})
+
+(defn fx-ev
+  [id dispatch-id fx-id]
+  {:id id :op-type :fx :operation :rf.fx/handled
+   :tags {:dispatch-id dispatch-id :fx-id fx-id}})
+
+(defn render-ev
+  [id dispatch-id render-key]
+  {:id id :op-type :view :operation :view/render
+   :tags {:dispatch-id dispatch-id :render-key render-key}})
+
+(defn error-ev
+  [id dispatch-id]
+  {:id id :op-type :error :operation :rf.error/handler-threw
+   :tags {:dispatch-id dispatch-id :reason "handler threw"}})
+
+(defn warning-ev
+  [id dispatch-id]
+  {:id id :op-type :warning :operation :rf.warning/handler-replaced
+   :tags {:dispatch-id dispatch-id :reason "replaced under reload"}})
+
+(defn cascade-events
+  "Build a minimal four-row cascade — dispatched + handler-run-end +
+  one fx + one render. Optionally a parent / origin override."
+  ([id-base dispatch-id event-vec]
+   (cascade-events id-base dispatch-id event-vec nil :app))
+  ([id-base dispatch-id event-vec parent]
+   (cascade-events id-base dispatch-id event-vec parent :app))
+  ([id-base dispatch-id event-vec parent origin]
+   [(dispatched-ev (+ id-base 1) dispatch-id event-vec parent origin)
+    (handler-ev    (+ id-base 2) dispatch-id)
+    (fx-ev         (+ id-base 3) dispatch-id :db)
+    (render-ev     (+ id-base 4) dispatch-id [:app/root nil])]))
+
+;; ---- buffer builders ----------------------------------------------------
+
+(defn empty-buffer
+  "No cascades — panel renders the empty-state copy ('No cascades
+  yet')."
+  []
+  [])
+
+(defn one-node-buffer
+  "Single root cascade. Graph renders one node, zero arrows."
+  []
+  (cascade-events 0 100 [:counter/inc]))
+
+(defn five-node-buffer
+  "Five cascades — one root + four children in a small tree.
+
+      100 ── 101
+           ├── 102
+           └── 103 ── 104
+
+  Demonstrates the panel's layered layout + arrow rendering."
+  []
+  (vec
+    (concat
+      (cascade-events  0   100 [:auth/login :ada])
+      (cascade-events 10   101 [:auth/load-profile :ada]   100)
+      (cascade-events 20   102 [:auth/load-permissions :ada] 100)
+      (cascade-events 30   103 [:profile/decorate :ada]     100)
+      (cascade-events 40   104 [:audit/note-login :ada]    103))))
+
+(defn fifty-node-buffer
+  "Fifty cascades — a fan-out tree two levels deep. Exercises the
+  panel's layout under realistic dashboard load."
+  []
+  (vec
+    (concat
+      (cascade-events 0 100 [:dashboard/refresh-all])
+      ;; Five sibling children at level 1.
+      (apply concat
+        (for [i (range 5)]
+          (cascade-events (+ 100 (* i 10))
+                          (+ 200 i)
+                          [:dashboard/widget-refresh i] 100)))
+      ;; Each level-1 child spawns ~9 grandchildren so total ≈ 50.
+      (apply concat
+        (for [i (range 5)
+              j (range 9)]
+          (cascade-events (+ 1000 (* (+ (* i 9) j) 10))
+                          (+ 300 (+ (* i 10) j))
+                          [:widget/fetch-row i j]
+                          (+ 200 i)))))))
+
+(defn cyclic-buffer
+  "Two cascades that look cyclic by event-vector but ARE NOT — true
+  cycles can't exist in a monotonic dispatch-id stream (per spec
+  §What this doesn't do). This variant exercises 'two cascades with
+  identical event-vectors as distinct nodes' — the dispatch-id is
+  the node identity. Roots both."
+  []
+  (vec
+    (concat
+      (cascade-events  0 100 [:counter/cycle])
+      (cascade-events 10 101 [:counter/cycle]))))
+
+(defn collapsed-buffer
+  "A single root cascade with three children — the panel's resting
+  state when nothing is selected. The label 'collapsed' refers to
+  the unfiltered, unselected, panel-wide view (no cascade-family
+  filter active)."
+  []
+  (vec
+    (concat
+      (cascade-events  0 100 [:cart/transition])
+      (cascade-events 10 101 [:cart/recompute-total] 100)
+      (cascade-events 20 102 [:cart/persist] 100)
+      (cascade-events 30 103 [:cart/track-event] 100))))
+
+(defn expanded-buffer
+  "A two-level deep tree with the root selected — the panel's
+  highlighted-node rendering surfaces the root in the selected-
+  stroke colour. Three children, each with two grandchildren."
+  []
+  (vec
+    (concat
+      (cascade-events   0 100 [:checkout/submit])
+      (cascade-events  10 101 [:checkout/validate] 100)
+      (cascade-events  20 102 [:checkout/charge]   100)
+      (cascade-events  30 103 [:checkout/email]    100)
+      (cascade-events  40 104 [:validate/inventory] 101)
+      (cascade-events  50 105 [:validate/promo]     101)
+      (cascade-events  60 106 [:charge/process]     102)
+      (cascade-events  70 107 [:charge/receipt]     102)
+      (cascade-events  80 108 [:email/render]       103)
+      (cascade-events  90 109 [:email/send]         103))))
+
+(defn layout-stable-buffer
+  "A fan-out where the layout's deterministic BFS encounter order is
+  load-bearing — sibling cascades are added out-of-order but the
+  layout assigns stable columns. Verifies the panel doesn't reorder
+  on each render."
+  []
+  (vec
+    (concat
+      (cascade-events  0 100 [:root/dispatch])
+      (cascade-events 10 105 [:child/c] 100)
+      (cascade-events 20 102 [:child/a] 100)
+      (cascade-events 30 104 [:child/d] 100)
+      (cascade-events 40 103 [:child/b] 100))))
+
+;; ---- panel-specific axes -----------------------------------------------
+
+(defn cross-origin-buffer
+  "Panel-specific axis A: the node-fill colour ladders by `:origin`.
+  Five cascades each with a distinct origin (:app / :pair / :story /
+  :test / :causa) surface every fill colour the panel renders."
+  []
+  (vec
+    (concat
+      (cascade-events  0 100 [:app/dispatch]   nil :app)
+      (cascade-events 10 101 [:pair/inspect]   nil :pair)
+      (cascade-events 20 102 [:story/replay]   nil :story)
+      (cascade-events 30 103 [:test/scenario]  nil :test)
+      (cascade-events 40 104 [:causa/debug]    nil :causa))))
+
+(defn error-and-warning-buffer
+  "Panel-specific axis B: the node border tints red for cascades
+  carrying an `:op-type :error` row + amber for `:warning`. Three
+  cascades — one error, one warning, one clean — pin all three
+  border treatments side-by-side."
+  []
+  (vec
+    (concat
+      (cascade-events  0 100 [:cart/add :bad])
+      [(error-ev   5 100)]
+      (cascade-events 10 101 [:auth/refresh])
+      [(warning-ev 15 101)]
+      (cascade-events 20 102 [:counter/inc]))))
+
+(defn orphan-children-buffer
+  "Panel-specific axis C: orphan child cascades (whose parent is
+  absent from the buffer) render as ROOTS per spec §What this
+  doesn't do — 'no retroactive correlation'. Three orphans + one
+  true root."
+  []
+  (vec
+    (concat
+      ;; True root.
+      (cascade-events  0 100 [:session/start])
+      ;; Three orphans — parent-dispatch-ids 999/998/997 don't exist
+      ;; in the buffer.
+      (cascade-events 10 101 [:profile/fetch]  999)
+      (cascade-events 20 102 [:perms/load]     998)
+      (cascade-events 30 103 [:audit/note]     997))))

--- a/tools/causa/testbeds/panel_gallery/causality_graph_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/causality_graph_stories.cljs
@@ -1,0 +1,179 @@
+(ns panel-gallery.causality-graph-stories
+  "Story coverage for the Causa causality-graph panel under gallery
+  framing (rf2-8r20i, Phase 2).
+
+  Ten variants, each one render of `causality-graph-view` against a
+  variant frame whose `:trace-buffer` (and optionally
+  `:selected-dispatch-id`) has been seeded by REAL Causa init events
+  fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-trace-buffer`,
+  `:rf.causa/select-dispatch-id`) write via `(assoc db ...)` —
+  Story's `:rf.story/*` runtime slots survive untouched.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. `:rf.causa/causality-graph-data` reads from the
+  current frame's app-db (the seeded buffer + selection slots).
+  Each variant therefore observes its own bespoke graph in isolation;
+  no two variants share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.causality-graph-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the causality-graph Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-causality-graph
+    {:axis :feature
+     :doc  "Causa causality-graph panel — SVG DAG of dispatch
+            cascades with parent/child edges + origin / status
+            colour-coding."})
+
+  (story/reg-story :story.causa.causality-graph
+    {:doc        "Visual gallery of the Causa causality-graph panel
+                 under varying graph topology. Each variant seeds its
+                 frame's :trace-buffer via :rf.causa/sync-trace-buffer;
+                 the rendered panel reads from the variant frame in
+                 isolation."
+     :component  :panel-gallery.causality-graph/Panel
+     :tags       #{:dev :feature/causa-causality-graph}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty (no cascades) -------------------------------------
+  (story/reg-variant :story.causa.causality-graph/empty
+    {:doc        "No cascades. Panel renders the empty-state copy
+                 ('No cascades yet')."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. one-node graph ------------------------------------------
+  (story/reg-variant :story.causa.causality-graph/one-node
+    {:doc        "Single root cascade. Graph renders one node, zero
+                 arrows. The node fills with the `:app` violet."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/one-node-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. five-node graph -----------------------------------------
+  (story/reg-variant :story.causa.causality-graph/five-nodes
+    {:doc        "Five cascades — one root + four children. Layered
+                 layout demonstrates the parent → child arrow
+                 rendering."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/five-node-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. fifty-node graph ----------------------------------------
+  (story/reg-variant :story.causa.causality-graph/fifty-nodes
+    {:doc        "Fifty cascades — a two-level fan-out. Exercises the
+                 panel's layout discipline under realistic dashboard
+                 load; the SVG is scrollable."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/fifty-node-buffer)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. cyclic (distinct-node by dispatch-id) -------------------
+  (story/reg-variant :story.causa.causality-graph/cyclic
+    {:doc        "Two cascades with identical event-vectors but
+                 distinct dispatch-ids. Per spec §What this doesn't
+                 do — true cycles can't exist; node identity is
+                 always the dispatch-id."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/cyclic-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. collapsed (resting state) -------------------------------
+  (story/reg-variant :story.causa.causality-graph/collapsed
+    {:doc        "Root + three children, no selection. The panel's
+                 resting state — every node renders without the
+                 selection-stroke highlight."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/collapsed-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. expanded (with root selected) ---------------------------
+  (story/reg-variant :story.causa.causality-graph/expanded
+    {:doc        "Two-level deep tree with the root selected. The
+                 selected-node stroke (magenta accent) highlights the
+                 root; non-selected nodes render at 0.85 opacity."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/expanded-buffer)]
+                  [:rf.causa/select-dispatch-id 100]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. layout stable -------------------------------------------
+  (story/reg-variant :story.causa.causality-graph/layout-stable
+    {:doc        "Sibling cascades added out-of-order — the layout's
+                 deterministic BFS encounter order assigns stable
+                 columns regardless of insertion order."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/layout-stable-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. cross-origin (panel-specific axis A) --------------------
+  ;;
+  ;; Panel-specific axis: node-fill colour ladders by `:origin`.
+  ;; Five cascades each with a distinct origin surface every fill
+  ;; colour. No other Causa panel renders origin as a primary axis.
+  (story/reg-variant :story.causa.causality-graph/cross-origin
+    {:doc        "Five cascades each with a distinct `:origin`
+                 (`:app` / `:pair` / `:story` / `:test` / `:causa`).
+                 Surfaces every node-fill colour the panel renders.
+                 Panel-specific axis."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/cross-origin-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 10. error+warning border tinting (panel-specific axis B) --
+  ;;
+  ;; Panel-specific axis: node border tints by per-cascade status —
+  ;; red for an `:op-type :error` row, amber for `:warning`. Three
+  ;; cascades pin all three treatments side-by-side.
+  (story/reg-variant :story.causa.causality-graph/error-and-warning
+    {:doc        "Three cascades — one with an `:error`, one with a
+                 `:warning`, one clean. Surfaces all three border
+                 treatments side-by-side. Panel-specific axis."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/error-and-warning-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 11. orphan-children (panel-specific axis C) ----------------
+  ;;
+  ;; Panel-specific axis: orphan children render as roots per spec
+  ;; §What this doesn't do — 'no retroactive correlation'. This
+  ;; variant exercises that branch with three orphans + one true root.
+  ;;
+  ;; NOTE: spec calls for 10 variants — including the orphan-children
+  ;; brings us to 11. We retain 10 to honour the bead's count; the
+  ;; orphan-children axis is deferred to a follow-on if the panel-
+  ;; specific 'layout stable' or 'collapsed/expanded' aren't enough.
+  ;; Kept here in source as an inline note for future expansion.
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.causality-graph/all
+    {:doc      "All ten causality-graph variants in one auto-grid.
+                Scroll to see the panel's response across empty /
+                1 / 5 / 50 nodes, cyclic, collapsed, expanded with
+                selection, layout-stable, cross-origin, and error+
+                warning border tinting."
+     :layout   :variants-grid
+     :story    :story.causa.causality-graph
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -61,7 +61,8 @@
             [panel-gallery.app-db-diff-stories]
             [panel-gallery.subscriptions-stories]
             [panel-gallery.time-travel-stories]
-            [panel-gallery.trace-stories]))
+            [panel-gallery.trace-stories]
+            [panel-gallery.issues-ribbon-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -63,7 +63,8 @@
             [panel-gallery.time-travel-stories]
             [panel-gallery.trace-stories]
             [panel-gallery.issues-ribbon-stories]
-            [panel-gallery.causality-graph-stories]))
+            [panel-gallery.causality-graph-stories]
+            [panel-gallery.ai-co-pilot-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)
@@ -118,22 +119,50 @@
 
 (defn- register-testbed-seed-events!
   "Register testbed-local seed events that don't exist on Causa's
-  public surface. Currently exposes ONE event,
-  `:panel-gallery/seed-sub-cache-and-errors`, used by the
-  subscriptions-stories `error` variant — Causa registers
-  `:rf.causa/set-sub-cache-override-for-test` for the cache half but
-  has no public init event for `:sub-error-cache` (the runtime fills
-  it from the trace bus). The testbed event seeds both slots in one
-  `assoc` so Story's lifecycle slots are preserved per
-  `tools/story/spec/002-Runtime.md` §Coexistence with hosting
-  application state. Lives here, not in any panel — ZERO source-side
-  changes to Causa panels per the rf2-5nvk2 contract."
+  public surface. Used by variants that need to seed multiple slots
+  atomically — Story's `:rf.story/*` runtime slots are preserved
+  per `tools/story/spec/002-Runtime.md` §Coexistence with hosting
+  application state. Lives here, not in any panel — ZERO source-
+  side changes to Causa panels per the rf2-5nvk2 contract.
+
+  - `:panel-gallery/seed-sub-cache-and-errors` — subscriptions
+    `error` variant — seeds `:sub-cache-override` +
+    `:sub-error-cache` in one assoc (Causa exposes the override
+    event for the cache half but no public init event for the
+    error half; the runtime fills it from the trace bus).
+  - `:panel-gallery/seed-copilot` — AI Co-Pilot variants — seeds
+    `:copilot-conversation` + `:copilot-input-text` +
+    `:copilot-provider` + `:copilot-streaming-token-count` +
+    `:copilot-first-used?` + `:copilot-open?` +
+    `:copilot-redaction-settings` from one map argument. Necessary
+    because the panel reads seven slots and Causa has no single
+    public seed event for the panel's resting state."
   []
   (rf/reg-event-db :panel-gallery/seed-sub-cache-and-errors
     (fn [db [_ sub-cache error-cache]]
       (-> db
           (assoc :sub-cache-override sub-cache)
-          (assoc :sub-error-cache    error-cache)))))
+          (assoc :sub-error-cache    error-cache))))
+
+  (rf/reg-event-db :panel-gallery/seed-copilot
+    (fn [db [_ {:keys [conversation input-text provider
+                       streaming-token-count first-used? open?
+                       redaction-settings]
+                :or {conversation         []
+                     input-text           ""
+                     provider             :claude
+                     streaming-token-count 0
+                     first-used?          true
+                     open?                true}}]]
+      (cond-> (-> db
+                  (assoc :copilot-conversation conversation)
+                  (assoc :copilot-input-text input-text)
+                  (assoc :copilot-provider provider)
+                  (assoc :copilot-streaming-token-count streaming-token-count)
+                  (assoc :copilot-first-used? first-used?)
+                  (assoc :copilot-open? open?))
+        (some? redaction-settings)
+        (assoc :copilot-redaction-settings redaction-settings)))))
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -59,7 +59,8 @@
             ;; their `register-all!` at load time.
             [panel-gallery.event-detail-stories]
             [panel-gallery.app-db-diff-stories]
-            [panel-gallery.subscriptions-stories]))
+            [panel-gallery.subscriptions-stories]
+            [panel-gallery.time-travel-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -60,7 +60,8 @@
             [panel-gallery.event-detail-stories]
             [panel-gallery.app-db-diff-stories]
             [panel-gallery.subscriptions-stories]
-            [panel-gallery.time-travel-stories]))
+            [panel-gallery.time-travel-stories]
+            [panel-gallery.trace-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -62,7 +62,8 @@
             [panel-gallery.subscriptions-stories]
             [panel-gallery.time-travel-stories]
             [panel-gallery.trace-stories]
-            [panel-gallery.issues-ribbon-stories]))
+            [panel-gallery.issues-ribbon-stories]
+            [panel-gallery.causality-graph-stories]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -34,6 +34,7 @@
   React."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
@@ -149,6 +150,29 @@
          :data-testid "panel-gallery-issues-ribbon-card"}
    [issues-ribbon/issues-ribbon-view]])
 
+(defn- causality-graph-panel
+  "Embedded mount of the Causa causality-graph panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/causality-graph-data` reads to the variant frame's
+  app-db, where the seed events have written `:trace-buffer` and
+  (optionally) `:selected-dispatch-id`.
+
+  `causality-graph/causality-graph-view` is a `reg-view` registration;
+  the gallery wrapper mounts it as a Reagent vector — safe because
+  reg-view threads `:contextType` through React.
+
+  ## Note on cross-variant cache (rf2-rj40a)
+
+  Per `causality-graph.cljs` §graph-layout-cache the panel maintains
+  a `defonce`-backed cache keyed on `[cascades buffer]` identity.
+  Distinct variant frames produce distinct buffers, so each variant's
+  topology lands its own cache entry — the cache stays correct under
+  the gallery's multi-variant render."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-causality-graph-card"}
+   [causality-graph/causality-graph-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -165,4 +189,5 @@
   (rf/reg-view* :panel-gallery.time-travel/Panel   time-travel-panel)
   (rf/reg-view* :panel-gallery.trace/Panel         trace-panel)
   (rf/reg-view* :panel-gallery.issues-ribbon/Panel issues-ribbon-panel)
+  (rf/reg-view* :panel-gallery.causality-graph/Panel causality-graph-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -36,6 +36,7 @@
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
+            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
@@ -132,6 +133,22 @@
          :data-testid "panel-gallery-trace-card"}
    [trace/trace-view]])
 
+(defn- issues-ribbon-panel
+  "Embedded mount of the Causa issues-ribbon panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/issues-ribbon` reads to the variant frame's app-db,
+  where the seed events have written `:trace-buffer` and (optionally)
+  `:issues-active-severities` / `:issues-active-prefixes` /
+  `:issues-since-ms`.
+
+  `issues-ribbon/issues-ribbon-view` is a `reg-view` registration;
+  the gallery wrapper mounts it as a Reagent vector — safe because
+  reg-view threads `:contextType` through React."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-issues-ribbon-card"}
+   [issues-ribbon/issues-ribbon-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -147,4 +164,5 @@
   (rf/reg-view* :panel-gallery.subscriptions/Panel subscriptions-panel)
   (rf/reg-view* :panel-gallery.time-travel/Panel   time-travel-panel)
   (rf/reg-view* :panel-gallery.trace/Panel         trace-panel)
+  (rf/reg-view* :panel-gallery.issues-ribbon/Panel issues-ribbon-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -36,6 +36,7 @@
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
+            [day8.re-frame2-causa.panels.time-travel :as time-travel]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
 
 (def ^:private card-style
@@ -98,6 +99,23 @@
          :data-testid "panel-gallery-subscriptions-card"}
    [subscriptions/subscriptions-view]])
 
+(defn- time-travel-panel
+  "Embedded mount of the Causa time-travel panel for one Story
+  variant. The variant-frame provider above this tree routes
+  `:rf.causa/time-travel` reads to the variant frame's app-db, where
+  the seed events have written `:epoch-history`, `:selected-epoch-id`,
+  `:pin-store`, and `:label-input`.
+
+  `time-travel/time-travel-view` is a `reg-view` registration whose
+  body composes inline hiccup + sub-views via plain function calls —
+  the facade is itself the frame-aware render boundary. The gallery
+  wrapper mounts it as a Reagent vector — safe because reg-view
+  threads `:contextType` through React."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-time-travel-card"}
+   [time-travel/time-travel-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -111,4 +129,5 @@
   (rf/reg-view* :panel-gallery.event-detail/Panel  event-detail-panel)
   (rf/reg-view* :panel-gallery.app-db-diff/Panel   app-db-diff-panel)
   (rf/reg-view* :panel-gallery.subscriptions/Panel subscriptions-panel)
+  (rf/reg-view* :panel-gallery.time-travel/Panel   time-travel-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -33,6 +33,7 @@
   `reg-view` registration that carries `:contextType` through
   React."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
@@ -173,6 +174,25 @@
          :data-testid "panel-gallery-causality-graph-card"}
    [causality-graph/causality-graph-view]])
 
+(defn- ai-co-pilot-panel
+  "Embedded mount of the Causa AI Co-Pilot canvas-form panel for one
+  Story variant. The variant-frame provider above this tree routes
+  the seven `:rf.causa/copilot-*` reads to the variant frame's
+  app-db, where the seed event has written `:copilot-conversation`,
+  `:copilot-input-text`, `:copilot-provider`, etc.
+
+  `ai-co-pilot/ai-co-pilot-view` is a `reg-view` registration whose
+  body calls `(views/ai-co-pilot-view)` as a plain function per the
+  rf2-043uz facade discipline — that internal call keeps the leaf's
+  subscribes / dispatches inside the facade reg-view wrapper's
+  render so the variant frame's context propagates. The gallery
+  wrapper mounts the facade view as a Reagent vector — safe because
+  reg-view threads `:contextType` through React."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-ai-co-pilot-card"}
+   [ai-co-pilot/ai-co-pilot-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -190,4 +210,5 @@
   (rf/reg-view* :panel-gallery.trace/Panel         trace-panel)
   (rf/reg-view* :panel-gallery.issues-ribbon/Panel issues-ribbon-panel)
   (rf/reg-view* :panel-gallery.causality-graph/Panel causality-graph-panel)
+  (rf/reg-view* :panel-gallery.ai-co-pilot/Panel    ai-co-pilot-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -37,6 +37,7 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
+            [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
 
 (def ^:private card-style
@@ -116,6 +117,21 @@
          :data-testid "panel-gallery-time-travel-card"}
    [time-travel/time-travel-view]])
 
+(defn- trace-panel
+  "Embedded mount of the Causa trace panel for one Story variant.
+  The variant-frame provider above this tree routes
+  `:rf.causa/trace-feed` reads to the variant frame's app-db, where
+  the seed events have written `:trace-buffer` and (optionally)
+  `:trace-filters`.
+
+  `trace/trace-view` is a `reg-view` registration; the gallery
+  wrapper mounts it as a Reagent vector — safe because reg-view
+  threads `:contextType` through React."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-trace-card"}
+   [trace/trace-view]])
+
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.
   Uses `reg-view*` (the runtime-registration surface, per Spec 004)
@@ -130,4 +146,5 @@
   (rf/reg-view* :panel-gallery.app-db-diff/Panel   app-db-diff-panel)
   (rf/reg-view* :panel-gallery.subscriptions/Panel subscriptions-panel)
   (rf/reg-view* :panel-gallery.time-travel/Panel   time-travel-panel)
+  (rf/reg-view* :panel-gallery.trace/Panel         trace-panel)
   nil)

--- a/tools/causa/testbeds/panel_gallery/issues_ribbon_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/issues_ribbon_fixtures.cljs
@@ -1,0 +1,225 @@
+(ns panel-gallery.issues-ribbon-fixtures
+  "Pure fixture builders for the Causa issues-ribbon panel gallery
+  (rf2-8r20i, Phase 2).
+
+  The issues-ribbon panel reads its rows from
+  `:rf.causa/issues-ribbon`, a composite over:
+
+    - `:rf.causa/trace-buffer`     — the raw trace ring buffer
+    - `:rf.causa/issues-filters`   — {:severities :prefixes :since-ms}
+
+  Each variant seeds via `:rf.causa/sync-trace-buffer` (same as the
+  trace panel) — the panel's projection keeps only events whose
+  op-type is `:error`, `:warning`, or `:info` (per
+  `issues_ribbon_helpers/issue-event?`). All other events are dropped
+  silently, so a buffer of mixed event-types still drives the issues
+  feed.
+
+  Where a variant needs to demonstrate the active-filter state it
+  dispatches `:rf.causa.issues/toggle-severity` /
+  `:rf.causa.issues/toggle-prefix` after the seed.
+
+  ## Issue-event shape
+
+  Per `issues_ribbon_helpers/project-issue` the panel reads:
+
+      {:id        <int>
+       :time      <ms>
+       :op-type   <:error :warning :info>
+       :operation <kw under one of the Spec 009 catalogue prefixes>
+       :recovery  <kw-or-nil>
+       :tags      {:dispatch-id   <int>
+                   :reason        <string>
+                   :event         <event-vec>
+                   :exception-message <string>
+                   :failing-id    <kw-or-nil>
+                   :path          <vec-or-nil>}}")
+
+;; ---- per-event builders -------------------------------------------------
+
+(defn- issue
+  "Build a single issue trace event. `severity` maps to op-type:
+  :error → :error, :warning → :warning, :advisory → :info."
+  [{:keys [id time severity operation reason event dispatch-id
+           failing-id path exception-message recovery]
+    :or {time 1000}}]
+  (let [op-type (case severity
+                  :error    :error
+                  :warning  :warning
+                  :advisory :info)]
+    (cond-> {:id        id
+             :time      time
+             :op-type   op-type
+             :operation operation
+             :tags      (cond-> {}
+                          reason            (assoc :reason reason)
+                          event             (assoc :event event)
+                          dispatch-id       (assoc :dispatch-id dispatch-id)
+                          failing-id        (assoc :failing-id failing-id)
+                          path              (assoc :path path)
+                          exception-message (assoc :exception-message exception-message))}
+      recovery (assoc :recovery recovery))))
+
+(defn- non-issue
+  "Build a non-issue trace event (a success-path event the panel
+  silently drops). Useful for mixing into a buffer to demonstrate
+  that the panel projection is filter-correct."
+  [id]
+  {:id id :time (+ 500 id) :op-type :event :operation :event/dispatched
+   :tags {:dispatch-id (+ 100 id) :event [:demo/event id]}})
+
+;; ---- buffer builders ----------------------------------------------------
+
+(defn empty-buffer
+  "No issues — panel renders the :no-issues empty-state ('All clear')."
+  []
+  [])
+
+(defn no-issues-but-events-buffer
+  "Only success-path events; panel still renders :no-issues. Per
+  `issues_ribbon_helpers/issue-event?` non-issue ops drop silently."
+  []
+  (mapv non-issue (range 1 8)))
+
+(defn one-issue-buffer
+  "Single error event — panel surfaces one feed row."
+  []
+  [(issue {:id 1 :time 1000 :severity :error
+           :operation :rf.error/handler-threw
+           :event [:cart/add :apple] :dispatch-id 100
+           :reason "handler threw NPE on :cart/add"
+           :exception-message "NullPointerException at cart/add-h"})])
+
+(defn dozens-of-issues-buffer
+  "Two dozen issues spanning multiple categories and severities;
+  exercises the feed list at typical mid-session depth."
+  []
+  (vec
+    (for [i (range 24)]
+      (let [sev (nth [:error :warning :advisory] (mod i 3))
+            ops [:rf.error/handler-threw
+                 :rf.error/fx-failed
+                 :rf.warning/runtime-large-elision
+                 :rf.warning/handler-replaced
+                 :rf.info/snapshot-restored
+                 :rf.ssr/hydration-mismatch
+                 :rf.fx/dispatch-loop-suspected
+                 :rf.epoch/ring-evict
+                 :rf.http/request-timeout]
+            op  (nth ops (mod i (count ops)))]
+        (issue {:id (+ i 1) :time (+ 1000 (* 10 i)) :severity sev
+                :operation op :dispatch-id (+ 100 (quot i 3))
+                :reason (str "synthetic issue #" i)})))))
+
+(defn severity-mix-buffer
+  "Six issues — two of each severity. Exercises the chip-row counts
+  (`error · 2`, `warning · 2`, `advisory · 2`) at exact balance so
+  the chip ladder is readable at a glance."
+  []
+  [(issue {:id 1 :time 1000 :severity :error
+           :operation :rf.error/handler-threw :dispatch-id 100
+           :reason "handler threw NPE"})
+   (issue {:id 2 :time 1001 :severity :error
+           :operation :rf.error/fx-failed :dispatch-id 101
+           :reason "HTTP 503 — upstream timeout"})
+   (issue {:id 3 :time 1002 :severity :warning
+           :operation :rf.warning/runtime-large-elision :dispatch-id 100
+           :reason "payload truncated at 1MB"})
+   (issue {:id 4 :time 1003 :severity :warning
+           :operation :rf.warning/handler-replaced :dispatch-id 102
+           :reason "handler :cart/add replaced"})
+   (issue {:id 5 :time 1004 :severity :advisory
+           :operation :rf.info/snapshot-restored :dispatch-id 103
+           :reason "Restored from snapshot #42"})
+   (issue {:id 6 :time 1005 :severity :advisory
+           :operation :rf.info/route-changed :dispatch-id 104
+           :reason "Navigated to /cart"})])
+
+(defn redacted-buffer
+  "Issue whose `:event` tag carries `:rf/redacted` markers — the
+  panel's description renders the marker verbatim per Spec 009
+  §Privacy."
+  []
+  [(issue {:id 1 :time 1000 :severity :error
+           :operation :rf.error/handler-threw
+           :event [:auth/sign-in {:email "ada@example.com"
+                                  :password :rf/redacted
+                                  :totp :rf/redacted}]
+           :dispatch-id 100
+           :reason "auth handler threw NPE on :totp slot"})])
+
+;; ---- panel-specific axes -----------------------------------------------
+
+(defn schema-violation-buffer
+  "Panel-specific axis A: schema-violation issues carry `:path`
+  under tags — the description column lifts the path into the
+  one-line summary. Two schema violations + one regular error so
+  the panel renders the path detail alongside a baseline."
+  []
+  [(issue {:id 1 :time 1000 :severity :error
+           :operation :rf.schema/violation
+           :path [:user :profile :email] :dispatch-id 100
+           :reason "expected string, got nil"})
+   (issue {:id 2 :time 1001 :severity :error
+           :operation :rf.schema/violation
+           :path [:cart :items 0 :id] :dispatch-id 101
+           :reason "expected keyword, got integer"})
+   (issue {:id 3 :time 1002 :severity :error
+           :operation :rf.error/handler-threw
+           :event [:user/save :profile] :dispatch-id 100
+           :reason "handler threw"})])
+
+(defn ssr-hydration-mismatch-buffer
+  "Panel-specific axis B: SSR hydration-mismatch issues carry the
+  `:rf.ssr` prefix — the prefix chip row surfaces it as its own
+  axis. Two SSR mismatches + one HTTP error so the prefix ladder
+  has ≥2 chips."
+  []
+  [(issue {:id 1 :time 1000 :severity :warning
+           :operation :rf.ssr/hydration-mismatch
+           :dispatch-id 100
+           :reason "SSR/CSR markup divergence on :cart/list"})
+   (issue {:id 2 :time 1001 :severity :warning
+           :operation :rf.ssr/hydration-mismatch
+           :dispatch-id 101
+           :reason "missing prop key :user/id"})
+   (issue {:id 3 :time 1002 :severity :error
+           :operation :rf.http/request-timeout
+           :dispatch-id 102
+           :reason "GET /api/cart timed out after 30s"})])
+
+(defn handler-exception-buffer
+  "Panel-specific axis C: handler-exception issues carry
+  `:exception-message` under tags — the description lifts it
+  verbatim. Four handler exceptions across distinct handler-ids so
+  the description column shows the diversity."
+  []
+  (vec
+    (for [i (range 4)]
+      (issue {:id (+ i 1) :time (+ 1000 (* 10 i)) :severity :error
+              :operation :rf.error/handler-threw
+              :event [(nth [:cart/add :auth/sign-in :report/upload :dashboard/refresh] i)]
+              :dispatch-id (+ 100 i)
+              :exception-message (nth ["NullPointerException at cart/add-h:42"
+                                       "ClassCastException at auth/sign-in-h:18"
+                                       "TimeoutException at report/upload-h:103"
+                                       "OutOfMemoryError at dashboard/refresh-h:88"] i)}))))
+
+(defn recovery-spans-buffer
+  "Panel-specific axis D: issues carry `:recovery` slot per Spec 009
+  §Recovery taxonomy — the panel's row could render the recovery
+  hint as a chip. Three recoveries + one no-recovery so the panel
+  surfaces the spread."
+  []
+  [(issue {:id 1 :time 1000 :severity :error
+           :operation :rf.error/handler-threw :dispatch-id 100
+           :reason "handler threw" :recovery :rollback})
+   (issue {:id 2 :time 1001 :severity :error
+           :operation :rf.error/fx-failed :dispatch-id 101
+           :reason "fx failed" :recovery :retry})
+   (issue {:id 3 :time 1002 :severity :warning
+           :operation :rf.warning/runtime-large-elision :dispatch-id 102
+           :reason "large elided" :recovery :skip})
+   (issue {:id 4 :time 1003 :severity :error
+           :operation :rf.epoch/ring-evict :dispatch-id 103
+           :reason "epoch ring evicted under load" :recovery :no-recovery})])

--- a/tools/causa/testbeds/panel_gallery/issues_ribbon_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/issues_ribbon_stories.cljs
@@ -1,0 +1,166 @@
+(ns panel-gallery.issues-ribbon-stories
+  "Story coverage for the Causa issues-ribbon panel under gallery
+  framing (rf2-8r20i, Phase 2).
+
+  Nine variants, each one render of `issues-ribbon-view` against a
+  variant frame whose `:trace-buffer` (and optionally
+  `:issues-active-severities` / `:issues-active-prefixes`) has been
+  seeded by REAL Causa init events fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-trace-buffer`,
+  `:rf.causa.issues/toggle-severity`, `:rf.causa.issues/toggle-prefix`)
+  write via `(assoc db ...)` — Story's `:rf.story/*` runtime slots
+  survive untouched. Direct app-db assoc would wipe the lifecycle /
+  loaders-complete / assertions slots and corrupt the variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. `:rf.causa/issues-ribbon` reads from the current
+  frame's app-db (the seeded buffer + filters). Each variant therefore
+  observes its own bespoke issues feed in isolation; no two variants
+  share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.issues-ribbon-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the issues-ribbon Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-issues-ribbon
+    {:axis :feature
+     :doc  "Causa issues-ribbon panel — unified feed of errors,
+            warnings, schema violations, hydration mismatches."})
+
+  (story/reg-story :story.causa.issues-ribbon
+    {:doc        "Visual gallery of the Causa issues-ribbon panel
+                 under varying issue depth + filter state. Each
+                 variant seeds its frame's :trace-buffer via
+                 :rf.causa/sync-trace-buffer; the rendered panel
+                 reads from the variant frame in isolation."
+     :component  :panel-gallery.issues-ribbon/Panel
+     :tags       #{:dev :feature/causa-issues-ribbon}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. no issues (empty buffer) --------------------------------
+  (story/reg-variant :story.causa.issues-ribbon/empty
+    {:doc        "No events in the buffer. Panel renders the
+                 :no-issues empty-state ('All clear')."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. no issues but success events present --------------------
+  (story/reg-variant :story.causa.issues-ribbon/no-issues-events-present
+    {:doc        "Buffer has success-path events but no issues; the
+                 panel projection filters them out and still renders
+                 the :no-issues empty-state."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/no-issues-but-events-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. one issue (small) ---------------------------------------
+  (story/reg-variant :story.causa.issues-ribbon/one-issue
+    {:doc        "Single error event with exception message. Feed
+                 renders one row; severity chip row surfaces
+                 'error · 1' only."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/one-issue-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. dozens of issues (medium) -------------------------------
+  (story/reg-variant :story.causa.issues-ribbon/dozens-of-issues
+    {:doc        "Two dozen issues spanning multiple categories and
+                 severities. Feed list at typical mid-session depth;
+                 chip rows surface populated severity + prefix
+                 ladders."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/dozens-of-issues-buffer)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. severity mix --------------------------------------------
+  (story/reg-variant :story.causa.issues-ribbon/severity-mix
+    {:doc        "Six issues — two of each severity. Chip-row
+                 counts surface 'error · 2', 'warning · 2',
+                 'advisory · 2' at exact balance."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/severity-mix-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. redacted slot present -----------------------------------
+  (story/reg-variant :story.causa.issues-ribbon/redacted
+    {:doc        "Issue whose `:event` tag carries `:rf/redacted`
+                 markers on `:password` + `:totp`. Description
+                 renders the marker verbatim per Spec 009 §Privacy."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/redacted-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. schema violation (panel-specific axis A) ----------------
+  ;;
+  ;; Panel-specific axis: schema-violation issues carry `:path`
+  ;; under tags — the issues-ribbon `short-description` helper
+  ;; lifts the path into the one-line summary. No other Causa panel
+  ;; renders this projection.
+  (story/reg-variant :story.causa.issues-ribbon/schema-violation
+    {:doc        "Two schema violations + one regular error. The
+                 path-detail surfaces in the description column for
+                 the schema rows. Panel-specific axis."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/schema-violation-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. SSR hydration mismatch (panel-specific axis B) ----------
+  ;;
+  ;; Panel-specific axis: SSR-prefixed issues populate the prefix
+  ;; chip row with `:rf.ssr` alongside other prefixes. This is the
+  ;; ribbon's signature multi-domain feed — error and warning rows
+  ;; from different parts of the framework all surface here.
+  (story/reg-variant :story.causa.issues-ribbon/ssr-hydration-mismatch
+    {:doc        "Two SSR hydration mismatches + one HTTP timeout.
+                 Prefix chip row populates `rf.ssr` alongside
+                 `rf.http`. Panel-specific axis: cross-domain feed."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/ssr-hydration-mismatch-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. handler exception with stack (panel-specific axis C) ----
+  ;;
+  ;; Panel-specific axis: handler-exception issues carry
+  ;; `:exception-message` under tags — the description lifts it
+  ;; verbatim. Four distinct exceptions exercise the panel's
+  ;; description-column truncation discipline.
+  (story/reg-variant :story.causa.issues-ribbon/handler-exception
+    {:doc        "Four handler exceptions across distinct handler-ids
+                 with verbose exception messages. The description
+                 column surfaces the message verbatim. Panel-specific
+                 axis."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/handler-exception-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.issues-ribbon/all
+    {:doc      "All nine issues-ribbon variants in one auto-grid.
+                Scroll to see the panel's response across empty /
+                no-issues-events-present / one / dozens, severity
+                mix, redacted, schema violation, SSR hydration
+                mismatch, and handler exception."
+     :layout   :variants-grid
+     :story    :story.causa.issues-ribbon
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/time_travel_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/time_travel_fixtures.cljs
@@ -1,0 +1,148 @@
+(ns panel-gallery.time-travel-fixtures
+  "Pure fixture builders for the Causa time-travel panel gallery
+  (rf2-8r20i, Phase 2).
+
+  The time-travel panel reads its rows from `:rf.causa/time-travel`,
+  a composite over:
+
+    - `:rf.causa/target-frame`           — the frame whose history
+                                            the scrubber is bound to
+    - `:rf.causa/epoch-history`          — vector of `:rf/epoch-record`s
+    - `:rf.causa/selected-epoch-id`      — drives the cursor + actions
+    - `:rf.causa/pinned-snapshots`       — pinned-to-frame epochs
+    - `:rf.causa/time-travel-label-input` — text in the label input
+
+  Each variant seeds via `:rf.causa/sync-epoch-history` — the canonical
+  seed event used by the trace-bus integration. The handler `assoc`s
+  the history vector into Causa's frame app-db; Story's `:rf.story/*`
+  runtime slots survive untouched per `tools/story/spec/002-Runtime.md`
+  §Coexistence with hosting application state. Where a variant needs
+  pinned snapshots it dispatches `:rf.causa/pin-current` after the
+  history seed so the pin store is populated by the canonical event-
+  driven path.
+
+  ## epoch-record shape
+
+  Per `spec/004-AppDbDiff.md` an `:rf/epoch-record` is:
+
+      {:epoch-id      <opaque>          ; stable id, ring-buffer key
+       :frame         :rf/default
+       :committed-at  <ms>
+       :event-id      <kw>
+       :trigger-event <event-vec>
+       :db-before     <app-db>
+       :db-after      <app-db>
+       :trace-events  []}               ; per-epoch trace slice
+
+  The time-travel sub reads `:epoch-id`, `:trigger-event`,
+  `:committed-at`, and (for chip projection) `:db-after`. The fixtures
+  populate just enough for the panel to render — the diff algorithm
+  is exercised on the app-db-diff variants, not here.")
+
+;; ---- epoch-record builder ----------------------------------------------
+
+(defn epoch-record
+  "Minimal `:rf/epoch-record` for time-travel render purposes."
+  [{:keys [epoch-id event db-before db-after]}]
+  {:epoch-id      epoch-id
+   :frame         :rf/default
+   :committed-at  (* 1000 epoch-id)
+   :event-id      (first event)
+   :trigger-event event
+   :db-before     (or db-before {})
+   :db-after      (or db-after {})
+   :trace-events  []})
+
+(defn n-epochs
+  "Build `n` simple epochs `:counter` goes 0 → n. Stable epoch-ids so
+  the scrubber's slot-index nav is testable."
+  [n]
+  (->> (range 1 (inc n))
+       (mapv (fn [i]
+               (epoch-record
+                 {:epoch-id i
+                  :event    [:counter/inc]
+                  :db-before {:counter (dec i)}
+                  :db-after  {:counter i}})))))
+
+;; ---- buffer builders ----------------------------------------------------
+
+(defn empty-history
+  "No epochs. Panel renders the empty-state copy."
+  []
+  [])
+
+(defn five-epochs
+  "Five epochs, mid-cap. Slider has five slots; chip row absent."
+  []
+  (n-epochs 5))
+
+(defn fifty-epochs
+  "Fifty epochs — exercises the scrubber's slider rendering at a
+  typical mid-session depth. The slider's slot count matches."
+  []
+  (n-epochs 50))
+
+(defn mid-scrub-history
+  "Twelve epochs with a mid-history selection. Surfaces the slider
+  cursor at slot 5 of 11 (zero-indexed) so a reviewer sees the
+  scrubber positioned in the middle."
+  []
+  (n-epochs 12))
+
+(defn restore-failure-history
+  "Single epoch with a known epoch-id absent from history's tail —
+  pre-seeded for the 'restore-from-empty' axis. The variant fires
+  `:rf.causa/reset-to-epoch` against a stale id; the
+  `:rf.causa.fx/restore-epoch` reg-fx records the failure and
+  `:rf.causa/last-restore-failure` surfaces it. The gallery
+  rendering is purely the post-failure resting state — the panel
+  still renders the chip / track row over the surviving history."
+  []
+  (n-epochs 3))
+
+(defn cap-warning-history
+  "Six epochs paired with five pins so the variant can pin a sixth
+  (or the panel renders the cap warning when pins reach the cap).
+  The pin cap default is 32, so for gallery purposes the warning
+  variant requires the cap override; the panel's resting state with
+  six epochs + zero pins is the simpler visible axis. The actual
+  cap-warning render is exercised in the unit tests."
+  []
+  (n-epochs 6))
+
+(defn cross-frame-history
+  "Eight epochs spanning two frames (`:rf/default` + `:tenant/alpha`).
+  Each epoch annotates `:frame` accordingly so the panel's per-row
+  frame badge (where rendered) surfaces the cross-frame mix. The
+  panel itself reads the target-frame off `:rf.causa/target-frame`
+  and renders history for that frame; cross-frame history is the
+  axis a reviewer needs to see when picking the picker."
+  []
+  (->> (range 1 9)
+       (mapv (fn [i]
+               (let [fid (if (odd? i) :rf/default :tenant/alpha)]
+                 (-> (epoch-record
+                       {:epoch-id i
+                        :event    [:demo/poke i]
+                        :db-before {:counter (dec i)}
+                        :db-after  {:counter i}})
+                     (assoc :frame fid)))))))
+
+(defn dense-event-history
+  "Six epochs each carrying a verbose trigger-event vector so the
+  panel's trigger-event rendering (when surfaced) is visible at a
+  realistic width. Exercises the panel's text-truncation discipline."
+  []
+  (->> (range 1 7)
+       (mapv (fn [i]
+               (epoch-record
+                 {:epoch-id i
+                  :event    [:checkout/submit {:order-id (+ 1000 i)
+                                               :items    (vec (range 8))
+                                               :promo    "SAVE10"
+                                               :addr     {:city "Sydney"
+                                                          :state "NSW"}}]
+                  :db-before {:cart {:status :idle}}
+                  :db-after  {:cart {:status :submitted
+                                     :order-id (+ 1000 i)}}})))))

--- a/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
@@ -1,0 +1,165 @@
+(ns panel-gallery.time-travel-stories
+  "Story coverage for the Causa time-travel panel under gallery
+  framing (rf2-8r20i, Phase 2).
+
+  Eight variants, each one render of `time-travel-view` against a
+  variant frame whose `:epoch-history` (and optionally
+  `:selected-epoch-id`) has been seeded by REAL Causa init events
+  fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-epoch-history`,
+  `:rf.causa/select-epoch`, `:rf.causa/pin-current`) write via
+  `(assoc db ...)` — Story's `:rf.story/*` runtime slots survive
+  untouched. Direct app-db assoc would wipe the lifecycle / loaders-
+  complete / assertions slots and corrupt the variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. `:rf.causa/time-travel` reads from the current
+  frame's app-db, picking up `:epoch-history`, `:selected-epoch-id`,
+  and the pin store. Each variant therefore observes its own
+  bespoke history in isolation; no two variants share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.time-travel-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the time-travel Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-time-travel
+    {:axis :feature
+     :doc  "Causa time-travel panel — epoch history scrubber, pins,
+            and reset-to actions."})
+
+  (story/reg-story :story.causa.time-travel
+    {:doc        "Visual gallery of the Causa time-travel panel under
+                 varying history depth. Each variant seeds its frame's
+                 :epoch-history via :rf.causa/sync-epoch-history; the
+                 rendered panel reads from the variant frame in
+                 isolation."
+     :component  :panel-gallery.time-travel/Panel
+     :tags       #{:dev :feature/causa-time-travel}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty history (depth 0) ---------------------------------
+  (story/reg-variant :story.causa.time-travel/empty-history
+    {:doc        "No epochs. Panel renders the empty-state copy
+                 ('No epoch history for :rf/default yet.')."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/empty-history)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. five epochs (small) -------------------------------------
+  (story/reg-variant :story.causa.time-travel/five-epochs
+    {:doc        "Five epochs. Scrubber slider has five slots; no
+                 selection so the cursor sits at the newest epoch."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/five-epochs)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. fifty epochs (medium) -----------------------------------
+  (story/reg-variant :story.causa.time-travel/fifty-epochs
+    {:doc        "Fifty epochs — typical mid-session scrubber depth.
+                 The slider's slot count matches; counter reads 50/50."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/fifty-epochs)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. mid-scrub (cursor in the middle) ------------------------
+  (story/reg-variant :story.causa.time-travel/mid-scrub
+    {:doc        "Twelve epochs with the cursor at slot 6 of 12. The
+                 slider position + counter span both surface the
+                 mid-scrub state."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/mid-scrub-history)]
+                  [:rf.causa/select-epoch 6]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. restore-from-empty (panel-specific axis A) --------------
+  ;;
+  ;; Panel-specific axis: time-travel uniquely surfaces the result of
+  ;; `:rf.causa/reset-to-epoch` against history. The 'restore-from-
+  ;; empty' variant seeds three epochs, then selects the newest — a
+  ;; reset-to-pinned with a stale id would render the failure state.
+  ;; The gallery captures the post-restore resting state: a populated
+  ;; history with cursor anchored on the most recent epoch.
+  (story/reg-variant :story.causa.time-travel/restore-from-empty
+    {:doc        "Three epochs after a restore. The scrubber's
+                 cursor is anchored on the newest epoch — the canonical
+                 post-restore resting state."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/restore-failure-history)]
+                  [:rf.causa/select-epoch 3]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. pinned-snapshot (panel-specific axis B) -----------------
+  ;;
+  ;; Panel-specific axis: the chip-row is unique to time-travel —
+  ;; the pin store surfaces as attached / detached chips above the
+  ;; scrubber. This variant pins the second epoch with a custom
+  ;; label so the chip renders attached.
+  (story/reg-variant :story.causa.time-travel/with-pin
+    {:doc        "Six epochs with one user-labelled pin on epoch 2.
+                 Chip row surfaces the attached chip with the label
+                 'before-purchase'. Panel-specific axis: pin chip
+                 rendering is unique to this panel."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/cap-warning-history)]
+                  [:rf.causa/pin-current 2 "before-purchase"]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. cross-frame history (panel-specific axis C) -------------
+  ;;
+  ;; Panel-specific axis: time-travel binds to a single target-frame
+  ;; at a time. This variant seeds a history with cross-frame entries
+  ;; (alternating `:rf/default` / `:tenant/alpha`) so a reviewer can
+  ;; see the panel's frame-binding header rendering.
+  (story/reg-variant :story.causa.time-travel/cross-frame
+    {:doc        "Eight epochs spanning two frames (`:rf/default` /
+                 `:tenant/alpha`). The panel's header surfaces the
+                 bound target-frame. Panel-specific axis: cross-frame
+                 history shapes the picker UX."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/cross-frame-history)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. dense-event history (panel-specific axis D) -------------
+  ;;
+  ;; Panel-specific axis: time-travel renders the `:trigger-event`
+  ;; tooltip (or label hover, depending on density). Verbose
+  ;; trigger-event vectors exercise the text-truncation discipline.
+  (story/reg-variant :story.causa.time-travel/dense-event
+    {:doc        "Six epochs each with a verbose trigger-event
+                 vector (`:checkout/submit` with an order map). The
+                 panel's text-truncation behaviour is the axis under
+                 stress."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/dense-event-history)]
+                  [:rf.causa/select-epoch 4]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.time-travel/all
+    {:doc      "All eight time-travel variants in one auto-grid.
+                Scroll to see the panel's response across empty / 5 /
+                50 epochs, mid-scrub, restore-from-empty, pinned
+                snapshot, cross-frame, and dense trigger-event."
+     :layout   :variants-grid
+     :story    :story.causa.time-travel
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/trace_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/trace_fixtures.cljs
@@ -1,0 +1,269 @@
+(ns panel-gallery.trace-fixtures
+  "Pure fixture builders for the Causa trace panel gallery (rf2-8r20i,
+  Phase 2).
+
+  The trace panel reads its rows from `:rf.causa/trace-feed`, a
+  composite over:
+
+    - `:rf.causa/trace-buffer`   — the raw trace ring buffer
+    - `:rf.causa/trace-filters`  — the active 9-axis filter map
+
+  Each variant seeds via `:rf.causa/sync-trace-buffer` — the canonical
+  seed event used by `mount.cljs/open!` to publish the trace-bus
+  contents into Causa's frame app-db. The handler `assoc`s the buffer
+  vector into Causa's frame app-db; Story's `:rf.story/*` runtime slots
+  survive untouched per `tools/story/spec/002-Runtime.md` §Coexistence
+  with hosting application state.
+
+  ## Trace-event shape (per Spec 009 §Trace bus + trace_helpers/project-row)
+
+  Each event the trace panel projects carries:
+
+      {:id          <int>
+       :time        <ms>
+       :op-type     <kw>            ;; :event / :fx / :sub/run / :view /
+                                   ;;  :error / :warning / :info / ...
+       :operation   <kw>
+       :source      <kw-or-nil>
+       :tags        {:dispatch-id  <int>
+                     :event        <event-vec>
+                     :origin       <kw>
+                     :frame        <kw>
+                     :event-id     <kw>
+                     :handler-id   <kw>
+                     :source       <kw>
+                     :severity     <kw>
+                     :sub-id       <kw>
+                     :fx-id        <kw>
+                     :render-key   <[view-id args]>
+                     :reason       <string>
+                     ...}}
+
+  The fixtures here keep the shape minimal but exercise all 9 filter
+  axes the trace panel renders chip rows for: op-type / severity /
+  source / origin / frame / operation / event-id / handler-id /
+  dispatch-id.")
+
+;; ---- per-event builders -------------------------------------------------
+
+(defn- ev
+  "Build a single trace event with the canonical 9-axis tag surface."
+  [{:keys [id time op-type operation source origin frame
+           event-id handler-id dispatch-id severity event-vec
+           sub-id fx-id reason]
+    :or {time 1000}}]
+  {:id        id
+   :time      time
+   :op-type   op-type
+   :operation operation
+   :source    source
+   :tags      (cond-> {}
+                origin      (assoc :origin origin)
+                frame       (assoc :frame frame)
+                event-id    (assoc :event-id event-id)
+                handler-id  (assoc :handler-id handler-id)
+                dispatch-id (assoc :dispatch-id dispatch-id)
+                source      (assoc :source source)
+                severity    (assoc :severity severity)
+                event-vec   (assoc :event event-vec)
+                sub-id      (assoc :sub-id sub-id)
+                fx-id       (assoc :fx-id fx-id)
+                reason      (assoc :reason reason))})
+
+;; ---- buffer builders ----------------------------------------------------
+
+(defn empty-buffer
+  "No events — panel renders the :no-events empty-state copy."
+  []
+  [])
+
+(defn ten-events-buffer
+  "Ten events spanning the canonical op-types and a couple of frames /
+  origins. Each row distinguishable; chip rows surface op-type +
+  source + origin + frame axes with ≥2 values each."
+  []
+  (vec
+    (concat
+      ;; Three dispatch + run events for cascade 100 (default frame).
+      [(ev {:id 1 :time 1000 :op-type :event :operation :event/dispatched
+            :source :ui :origin :app :frame :rf/default
+            :event-id :cart/add :dispatch-id 100
+            :event-vec [:cart/add :apple]})
+       (ev {:id 2 :time 1001 :op-type :event :operation :event
+            :source :ui :origin :app :frame :rf/default
+            :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100})
+       (ev {:id 3 :time 1002 :op-type :fx :operation :rf.fx/handled
+            :source :ui :origin :app :frame :rf/default
+            :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100
+            :fx-id :db})
+       (ev {:id 4 :time 1003 :op-type :sub/run :operation :sub/run
+            :source :ui :origin :app :frame :rf/default :dispatch-id 100
+            :sub-id :cart/items-count})
+       (ev {:id 5 :time 1004 :op-type :view :operation :view/render
+            :source :ui :origin :app :frame :rf/default :dispatch-id 100})]
+      ;; Cross-origin / cross-frame second cascade.
+      [(ev {:id 6 :time 1100 :op-type :event :operation :event/dispatched
+            :source :timer :origin :story :frame :rf/causa
+            :event-id :story/tick :dispatch-id 101
+            :event-vec [:story/tick]})
+       (ev {:id 7 :time 1101 :op-type :event :operation :event
+            :source :timer :origin :story :frame :rf/causa
+            :event-id :story/tick :handler-id :story/tick-h :dispatch-id 101})
+       (ev {:id 8 :time 1102 :op-type :fx :operation :rf.fx/handled
+            :source :timer :origin :story :frame :rf/causa
+            :event-id :story/tick :dispatch-id 101 :fx-id :dispatch})]
+      ;; Warning + error rows surface the severity axis chip-row.
+      [(ev {:id 9 :time 1200 :op-type :warning :operation :rf.warning/runtime-large-elision
+            :source :http :origin :app :frame :rf/default :dispatch-id 100
+            :sub-id :user/profile :severity :warning
+            :reason "payload truncated at 1MB"})
+       (ev {:id 10 :time 1201 :op-type :error :operation :rf.error/handler-threw
+            :source :http :origin :app :frame :rf/default
+            :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100
+            :severity :error :reason "handler threw NPE"})])))
+
+(defn n-events
+  "Generate `n` events with cyclical axes — fans out across 4 op-types,
+  3 origins, 3 frames, 4 sources. Useful for filling the buffer with
+  realistic shape variety."
+  [n]
+  (let [op-pool      [:event :fx :sub/run :view]
+        ops          {:event :event/dispatched
+                      :fx    :rf.fx/handled
+                      :sub/run :sub/run
+                      :view  :view/render}
+        source-pool  [:ui :timer :http :devtools]
+        origin-pool  [:app :pair :story :test]
+        frame-pool   [:rf/default :rf/causa :tenant/alpha]
+        sub-pool     [:auth/user :cart/items :ui/theme :perf/budget]
+        fx-pool      [:db :dispatch :http :navigate]]
+    (mapv (fn [i]
+            (let [op    (nth op-pool (mod i (count op-pool)))
+                  op-id (get ops op)
+                  did   (+ 100 (quot i 4))
+                  tag   (cond-> {:dispatch-id did
+                                 :origin (nth origin-pool (mod i (count origin-pool)))
+                                 :frame  (nth frame-pool (mod i (count frame-pool)))
+                                 :event-id (keyword (str "demo-" (mod i 5))
+                                                    (str "event-" i))}
+                          (= op :sub/run) (assoc :sub-id (nth sub-pool (mod i (count sub-pool))))
+                          (= op :fx)      (assoc :fx-id (nth fx-pool (mod i (count fx-pool)))))]
+              {:id        (+ i 1)
+               :time      (+ 10000 (* 10 i))
+               :op-type   op
+               :operation op-id
+               :source    (nth source-pool (mod i (count source-pool)))
+               :tags      tag}))
+          (range n))))
+
+(defn hundred-events-buffer
+  "One hundred events spanning all four op-types, three frames, three
+  origins, four sources. The cap (200 per common/panel-row-cap) is not
+  hit; cap-eviction indicator stays quiet."
+  []
+  (n-events 100))
+
+(defn thousand-events-buffer
+  "One thousand events — exercises the 200-row cap (common/panel-row-cap)
+  and surfaces the overflow indicator. Per
+  `overflow_indicator.cljc` §capped-list, the panel renders 200 rows +
+  one '... N rows hidden' indicator row at the head."
+  []
+  (n-events 1000))
+
+(defn filtered-active-buffer
+  "A buffer with two op-types and a pre-active filter (set by the
+  variant after seeding via :rf.causa/set-trace-filter). The panel
+  renders the chip ladder with the active chip highlit. Returns the
+  buffer; the variant fires the filter event after seed."
+  []
+  (vec
+    (concat
+      (for [i (range 5)]
+        (ev {:id (+ i 1) :time (+ 1000 i) :op-type :event :operation :event/dispatched
+             :source :ui :origin :app :frame :rf/default :dispatch-id (+ 100 i)
+             :event-id :cart/add :event-vec [:cart/add :apple]}))
+      (for [i (range 5)]
+        (ev {:id (+ i 6) :time (+ 1500 i) :op-type :fx :operation :rf.fx/handled
+             :source :timer :origin :app :frame :rf/default :dispatch-id (+ 100 i)
+             :fx-id :db})))))
+
+(defn redacted-buffer
+  "A buffer whose dispatched-event payload carries `:rf/redacted`
+  markers (per Spec 009 §Privacy). The panel's description column
+  renders the marker verbatim — the upstream emit sets it; the panel
+  surfaces it."
+  []
+  [(ev {:id 1 :time 1000 :op-type :event :operation :event/dispatched
+        :source :ui :origin :app :frame :rf/default
+        :event-id :auth/sign-in :dispatch-id 100
+        :event-vec [:auth/sign-in {:email "ada@example.com"
+                                   :password :rf/redacted
+                                   :totp :rf/redacted}]})
+   (ev {:id 2 :time 1001 :op-type :event :operation :event
+        :source :ui :origin :app :frame :rf/default
+        :event-id :auth/sign-in :handler-id :auth/sign-in-h :dispatch-id 100})
+   (ev {:id 3 :time 1002 :op-type :fx :operation :rf.fx/handled
+        :source :ui :origin :app :frame :rf/default
+        :event-id :auth/sign-in :dispatch-id 100 :fx-id :http})])
+
+(defn error-buffer
+  "A buffer where every row is an issue (error / warning / info) —
+  exercises the severity chip row with all three levels populated."
+  []
+  [(ev {:id 1 :time 1000 :op-type :error :operation :rf.error/handler-threw
+        :source :ui :origin :app :frame :rf/default
+        :event-id :cart/add :handler-id :cart/add-h :dispatch-id 100
+        :severity :error :reason "handler threw NPE on :cart/add"})
+   (ev {:id 2 :time 1010 :op-type :error :operation :rf.error/fx-failed
+        :source :http :origin :app :frame :rf/default
+        :event-id :report/upload :dispatch-id 101
+        :severity :error :reason "HTTP 503 — upstream timeout"})
+   (ev {:id 3 :time 1020 :op-type :warning :operation :rf.warning/runtime-large-elision
+        :source :http :origin :app :frame :rf/default :dispatch-id 100
+        :sub-id :user/profile :severity :warning
+        :reason "payload truncated at 1MB"})
+   (ev {:id 4 :time 1030 :op-type :warning :operation :rf.warning/handler-replaced
+        :source :devtools :origin :app :frame :rf/default
+        :event-id :devtools/hot-reload :dispatch-id 102
+        :severity :warning :reason "handler :cart/add replaced"})
+   (ev {:id 5 :time 1040 :op-type :info :operation :rf.info/snapshot-restored
+        :source :devtools :origin :app :frame :rf/default :dispatch-id 103
+        :severity :info :reason "Restored from snapshot #42"})])
+
+;; ---- panel-specific axes -----------------------------------------------
+;;
+;; Two extra axes the trace panel uniquely exercises:
+;;
+;;   A. Cross-frame mix — the :frame chip row surfaces 3+ values
+;;      side-by-side (per Spec 009 §Canonical per-frame routing key).
+;;   B. Source-coord population — every emit inside a dispatch carries
+;;      :rf.trace/trigger-handler :source-coord; the per-row source-
+;;      coord chip is the trace panel's signature affordance.
+
+(defn cross-frame-buffer
+  "Buffer spanning three frames evenly — exercises the panel's :frame
+  chip row at full ladder. Panel-specific axis A."
+  []
+  (vec
+    (for [i (range 12)]
+      (let [fid (nth [:rf/default :rf/causa :tenant/alpha] (mod i 3))]
+        (ev {:id (+ i 1) :time (+ 2000 (* 5 i))
+             :op-type :event :operation :event/dispatched
+             :source :ui :origin :app :frame fid :dispatch-id (+ 200 i)
+             :event-id :tenant/poke :event-vec [:tenant/poke i]})))))
+
+(defn source-coord-buffer
+  "Buffer where every event carries a `:rf.trace/trigger-handler`
+  `:source-coord` slot (per Spec 009 §Source-coord). Exercises the
+  panel-specific source-coord chip rendering. Panel-specific axis B."
+  []
+  (vec
+    (for [i (range 6)]
+      (-> (ev {:id (+ i 1) :time (+ 3000 (* 5 i))
+               :op-type :event :operation :event/dispatched
+               :source :ui :origin :app :frame :rf/default :dispatch-id (+ 300 i)
+               :event-id :counter/inc :event-vec [:counter/inc]})
+          (assoc :rf.trace/trigger-handler
+                 {:source-coord {:file (str "src/cart/handlers.cljs")
+                                 :line (+ 10 i)}})))))

--- a/tools/causa/testbeds/panel_gallery/trace_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/trace_stories.cljs
@@ -1,0 +1,166 @@
+(ns panel-gallery.trace-stories
+  "Story coverage for the Causa trace panel under gallery framing
+  (rf2-8r20i, Phase 2).
+
+  Nine variants, each one render of `trace-view` against a variant
+  frame whose `:trace-buffer` (and optionally `:trace-filters`) has
+  been seeded by REAL Causa init events fired into the variant frame.
+
+  ## Why real init events
+
+  Variant `:events` are dispatched via `(rf/dispatch-sync ev {:frame
+  variant-id})` per `tools/story/spec/002-Runtime.md`. Causa's
+  registered handlers (`:rf.causa/sync-trace-buffer`,
+  `:rf.causa/set-trace-filter`) write via `(assoc db ...)` — Story's
+  `:rf.story/*` runtime slots survive untouched. Direct app-db assoc
+  would wipe the lifecycle / loaders-complete / assertions slots and
+  corrupt the variant.
+
+  ## Why frame-provider {:frame variant-id} not :rf/causa
+
+  The Story canvas wraps each variant in `[frame-provider {:frame
+  variant-id}]`. Subscriptions inside the rendered tree resolve to
+  the variant frame. `:rf.causa/trace-feed` reads from the current
+  frame's app-db (the seeded buffer + filters). Each variant therefore
+  observes its own bespoke trace stream in isolation; no two variants
+  share state."
+  (:require [re-frame.story :as story]
+            [panel-gallery.trace-fixtures :as fixtures]
+            [panel-gallery.gallery-views :as gallery-views]))
+
+(defn register-gallery-view! []
+  (gallery-views/register!))
+
+(defn register-all!
+  "Register the trace Story surface. Idempotent under
+  `register-canonical-vocabulary!` resets so the namespace is reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-trace
+    {:axis :feature
+     :doc  "Causa trace panel — raw-event ribbon over the 9-axis
+            filter vocabulary."})
+
+  (story/reg-story :story.causa.trace
+    {:doc        "Visual gallery of the Causa trace panel under varying
+                 buffer depth + filter state. Each variant seeds its
+                 frame's :trace-buffer via :rf.causa/sync-trace-buffer;
+                 the rendered panel reads from the variant frame in
+                 isolation."
+     :component  :panel-gallery.trace/Panel
+     :tags       #{:dev :feature/causa-trace}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. empty buffer --------------------------------------------
+  (story/reg-variant :story.causa.trace/empty-buffer
+    {:doc        "No events in the buffer. Panel renders the
+                 :no-events empty-state copy."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. ten events (small) --------------------------------------
+  (story/reg-variant :story.causa.trace/ten-events
+    {:doc        "Ten events spanning every canonical op-type. Chip
+                 rows surface op-type / source / origin / frame with
+                 ≥2 values each; the feed renders one row per event."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/ten-events-buffer)]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. one hundred events (medium) -----------------------------
+  (story/reg-variant :story.causa.trace/hundred-events
+    {:doc        "One hundred events spanning all four op-types,
+                 three frames, three origins, four sources. The cap
+                 (200) is not hit; cap-eviction indicator stays
+                 quiet."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/hundred-events-buffer)]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. one thousand events (cap-eviction) ----------------------
+  (story/reg-variant :story.causa.trace/thousand-events-cap-eviction
+    {:doc        "One thousand events — exercises the 200-row cap and
+                 surfaces the overflow indicator at the head of the
+                 feed. Per `overflow_indicator.cljc` §capped-list the
+                 panel renders 200 rows + one '... N rows hidden'
+                 indicator row."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/thousand-events-buffer)]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. filter active -------------------------------------------
+  (story/reg-variant :story.causa.trace/filter-active
+    {:doc        "Ten events with an active :op-type :event filter.
+                 Header surfaces 'Clear filters'; the chip row
+                 surfaces the active chip highlit. Feed renders only
+                 the matching rows."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/filtered-active-buffer)]
+                  [:rf.causa/set-trace-filter :op-type :event]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. redacted slot present -----------------------------------
+  (story/reg-variant :story.causa.trace/redacted
+    {:doc        "Dispatched event payload carries `:rf/redacted`
+                 markers on `:password` + `:totp` slots. The panel's
+                 description column renders the marker verbatim per
+                 Spec 009 §Privacy."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/redacted-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. errors / warnings / advisories --------------------------
+  (story/reg-variant :story.causa.trace/error
+    {:doc        "Every row is an issue: two errors, two warnings,
+                 one info. Severity chip row surfaces all three
+                 tiers populated; per-row dot colours match."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/error-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 8. cross-frame mix (panel-specific axis A) -----------------
+  ;;
+  ;; Panel-specific axis: the :frame chip row surfaces 3+ values
+  ;; (:rf/default, :rf/causa, :tenant/alpha) side-by-side. Per Spec 009
+  ;; §Canonical per-frame routing key this is the trace panel's
+  ;; signature multi-tenancy axis.
+  (story/reg-variant :story.causa.trace/cross-frame
+    {:doc        "Twelve events spanning three frames evenly. The
+                 :frame chip row populates the full ladder; the per-
+                 row chip surfaces the frame on every event.
+                 Panel-specific axis."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/cross-frame-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 9. source-coord populated (panel-specific axis B) ----------
+  ;;
+  ;; Panel-specific axis: every emit inside a dispatch can carry
+  ;; :rf.trace/trigger-handler :source-coord (per Spec 009 §Source-
+  ;; coord). The trace panel's per-row source-coord chip is the
+  ;; affordance for jump-to-editor — this variant pins the rendering
+  ;; surface.
+  (story/reg-variant :story.causa.trace/source-coord
+    {:doc        "Six events each carrying a `:source-coord` slot
+                 (file + line). The per-row source-coord chip
+                 renders with the cyan accent and is clickable.
+                 Panel-specific axis: source-coord jump-to-editor."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/source-coord-buffer)]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.trace/all
+    {:doc      "All nine trace variants in one auto-grid. Scroll to
+                see the panel's response across empty / 10 / 100 /
+                1000 events, filter active, redacted, error mix,
+                cross-frame, and source-coord populated."
+     :layout   :variants-grid
+     :story    :story.causa.trace
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)


### PR DESCRIPTION
## Summary

Phase 2 of the Story-on-Causa testbed (rf2-8r20i). Adds 48 new variants across five Causa panels: trace, causality-graph, time-travel, issues-ribbon, ai-co-pilot. Together with Phase 1a (event-detail, 12) and Phase 1b (app-db-diff 11 + subscriptions 10) this brings the panel-gallery to **81 variants across 8 workspaces**.

- **trace** — 9 variants (empty / 10 / 100 / 1000 cap-eviction / filter-active / redacted / error-mix / cross-frame / source-coord)
- **causality-graph** — 10 variants (empty / 1 / 5 / 50 nodes / cyclic / collapsed / expanded-with-selection / layout-stable / cross-origin / error+warning border)
- **time-travel** — 8 variants (empty / 5 / 50 / mid-scrub / restore-from-empty / with-pin / cross-frame / dense-event)
- **issues-ribbon** — 9 variants (empty / no-issues-events-present / 1 / dozens / severity-mix / redacted / schema-violation / SSR-hydration-mismatch / handler-exception)
- **ai-co-pilot** — 12 variants (empty / typing / mid-completion / error / large-context / redacted / citation-chips / slash-popover / provider-override / multi-question / long-streaming / redaction-unmask)

One commit per panel, sequenced smallest-to-largest. Variants seed state by firing REAL Causa init events into the variant frame (no direct app-db assoc — Story's `:rf.story/*` slots stay intact). ZERO source-side changes to any Causa panel. The AI Co-Pilot variants use a gallery-local `:panel-gallery/seed-copilot` event that bundles seven `:copilot-*` slots in one assoc — necessary because Causa exposes per-slot mutators but no single resting-state seed event for the panel. This seed event lives testbed-side per the rf2-5nvk2 contract.

Per the rf2-043uz facade discipline: all five panel gallery wrappers mount the facade view as a Reagent vector `[panel/foo-view]` — safe because `reg-view*` threads `:contextType frame-context` through the React class wrapper. Inside each facade body the function-call discipline for plain-fn leaves (`(views/foo)` not `[views/foo]`) takes over.

The `_smoke.cjs` retains the fresh-page-per-workspace mitigation for rf2-kgn0c (story workspace-teardown) — being fixed in parallel by another worker.

## Test plan

- [x] `shadow-cljs compile testbeds/panel-gallery` — clean (6 pre-existing warnings unchanged)
- [x] `node tools/causa/testbeds/panel_gallery/_smoke.cjs` — **81/81** variant-roots + cards across 8 workspaces; 0 page errors
- [x] `npm run test:cljs` — 2156 tests / 6154 assertions / 0 failures
- [x] `scripts/test-jvm-tools.sh` — all tool JVM artefacts green