### PR TITLE
fix(ssr-ring): EDN-compliant frame-id keyword via (gensym "f") (rf2-joibj)

### DIFF
--- a/examples/reagent/ssr/server.clj
+++ b/examples/reagent/ssr/server.clj
@@ -22,28 +22,6 @@
    until the orchestrator tears the process down (per
    examples/scripts/serve-and-run-examples-tests.cjs).
 
-   ## Frame-id workaround (rf2-j3dlc finding)
-
-   `re-frame.ssr.ring.pipeline/setup-request-frame!` builds the
-   per-request frame-id via
-       (keyword \"rf.frame\" (str (gensym \"\")))
-   which produces names like `:rf.frame/1234` — a digit-only LOCAL
-   part. Clojure's keyword constructor accepts that, but the EDN
-   spec (https://github.com/edn-format/edn) requires symbol names
-   (and keywords are identifier-shaped) to begin with a non-numeric
-   character. CLJS's `cljs.tools.reader.edn` enforces the spec and
-   throws `Invalid keyword: :rf.frame/1234.` when the client tries to
-   read the embedded `__rf_payload`.
-
-   This is a latent ssr-ring bug — until rf2-j3dlc the only browser-
-   driven SSR coverage was over PRE-BAKED HTML that didn't ship the
-   frame-id from `pipeline/setup-request-frame!`. The live-SSR smoke
-   surfaces it. Per the dispatch rules, `implementation/ssr-ring/` is
-   a sibling agent's hot zone (rf2-o6ndb) so the fix lives in a
-   follow-on bead; this server papers over it with a custom
-   `:html-shell` that rewrites the gensym-shaped frame-id to a
-   leading-letter form before the EDN reaches the wire.
-
    Boundaries:
    - JVM-side Ring/SSR e2e details (header round-trip, cookie wire,
      redirect, CRLF rejection) live in
@@ -53,7 +31,6 @@
    - The example's `:rf.http/managed` flow goes through canned-success
      via `:fx-overrides`; we do NOT make outbound HTTP calls."
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
@@ -120,47 +97,6 @@
   (when (= uri "/favicon.ico")
     {:status 204 :headers {} :body ""}))
 
-;; ---- custom html-shell ------------------------------------------------------
-;;
-;; Wrap `ssr-ring/default-html-shell` with a tiny payload-EDN rewrite
-;; that fixes the digit-only `:rf.frame/<gensym>` keyword surfaced by
-;; the live-SSR smoke (see ns docstring §Frame-id workaround).
-;;
-;; The shell receives `payload-edn` as a string (already pr-str'd by
-;; the pipeline). We read it back to data, replace `:rf/frame-id` with
-;; a leading-letter form (`:rf.frame/f<digits>`) — still unique per
-;; request, still namespaced, EDN-spec-compliant — then re-serialise
-;; and hand off to the default shell.
-
-(def ^:private digit-only-frame-id-pattern
-  "Match `:rf.frame/<digits>` keyword literals inline in the payload's
-   EDN string. The gensym-induced shape always carries pure digits
-   in the local-part — that's what makes it cljs-EDN-invalid and what
-   makes the regex unambiguous (no risk of matching a legitimate
-   keyword)."
-  #":rf\.frame/(\d+)")
-
-(defn- rewriting-html-shell
-  "Custom `:html-shell` — patches the payload's frame-id keyword in
-   the raw EDN string and delegates to `default-html-shell`.
-
-   Why regex-on-string rather than read/rewrite/pr-str: both
-   `clojure.edn/read-string` AND `cljs.tools.reader.edn/read-string`
-   refuse `:rf.frame/<digits>` (EDN spec — identifier names start
-   non-numeric). So reading the payload to data on the JVM side
-   would throw before we could rewrite it. A targeted text
-   substitution sidesteps the reader entirely.
-
-   The substitution rewrites `:rf.frame/<digits>` →
-   `:rf.frame/f<digits>` (still unique per request, still namespaced,
-   EDN-spec-compliant on both JVM and CLJS). Conservative — leaves
-   any other keyword shape alone."
-  [body-html payload-edn opts]
-  (let [patched-edn (str/replace payload-edn
-                                 digit-only-frame-id-pattern
-                                 ":rf.frame/f$1")]
-    (ssr-ring/default-html-shell body-html patched-edn opts)))
-
 ;; ---- on-error logger -------------------------------------------------------
 ;;
 ;; Default `:on-error` from `ssr-ring` emits a fixed 500 body and
@@ -198,7 +134,6 @@
               :root-view      [:app/root]
               :fx-overrides   {:rf.http/managed :ssr.http/canned-articles}
               :payload-policy :rf.ssr.payload/whole-app-db
-              :html-shell     rewriting-html-shell
               :on-error       logging-on-error})
         main-js (static-handler static-root "/main.js"
                                 "application/javascript; charset=utf-8")]

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -81,7 +81,20 @@
   frames` happens before `dispatch-sync`), so the best-effort destroy
   is required even though `reg-frame` threw."
   [{:keys [on-create fx-overrides ssr on-error]} request]
-  (let [fid (keyword "rf.frame" (str (gensym "")))]
+  ;; rf2-joibj: the gensym prefix MUST start with a non-numeric
+  ;; character. Per the EDN spec (https://github.com/edn-format/edn)
+  ;; symbol / keyword identifier names cannot begin with a digit, and
+  ;; spec-strict readers (`clojure.edn/read-string`,
+  ;; `cljs.tools.reader.edn/read-string`) reject `:rf.frame/<digits>`.
+  ;; The per-request frame-id rides into the wire payload (Spec 011
+  ;; §Hydration boot) where the browser's strict EDN reader pulls it
+  ;; back during hydration — a digit-only local-part would crash the
+  ;; first call to `cljs.reader/read-string` on the embedded payload.
+  ;; `(gensym "f")` keeps the id unique per request, still namespaced,
+  ;; AND spec-compliant. `clojure.core/keyword` does not validate, so
+  ;; the read-side enforcement is the only signal — this naming is
+  ;; load-bearing.
+  (let [fid (keyword "rf.frame" (str (gensym "f")))]
     (ssr/set-request! fid request)
     (try
       (rf/reg-frame fid

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1348,10 +1348,7 @@
 
         ;; The EDN reader on the client side must still recover the
         ;; original string from the escaped payload. Extract just the
-        ;; specific value's quoted literal and read it — the full
-        ;; payload contains a generated `:rf.frame/<numeric-gensym>`
-        ;; keyword that the strict EDN reader (correctly) rejects, and
-        ;; isn't what this test is about anyway. `<` must be
+        ;; specific value's quoted literal and read it. `<` must be
         ;; transparent to clojure.edn/read-string.
         (let [payload-edn (second
                            (re-find
@@ -1617,3 +1614,63 @@
           (rf/remove-trace-cb! ::rh-ok)))
       (is (zero? (count @traces))
           "success path must NOT emit the head-resolution-failed trace"))))
+
+;; ===========================================================================
+;; rf2-joibj — per-request frame-id keyword is EDN-spec-compliant
+;;
+;; `setup-request-frame!` builds the frame-id via
+;;     (keyword "rf.frame" (str (gensym "f")))
+;; The `"f"` prefix is load-bearing: per the EDN spec
+;; (https://github.com/edn-format/edn) identifier names cannot begin
+;; with a digit, and spec-strict readers (`clojure.edn/read-string`,
+;; `cljs.tools.reader.edn/read-string`) reject `:rf.frame/<digits>`.
+;; The frame-id ships into the wire payload (Spec 011 §Hydration boot)
+;; where the browser's strict EDN reader pulls it back during
+;; hydration — without the prefix, the very first call to
+;; `cljs.reader/read-string` on the embedded payload would crash.
+;; `clojure.core/keyword` does not validate, so a regression here is
+;; only observable through a round-trip — which is exactly what this
+;; test asserts.
+;; ===========================================================================
+
+(deftest hydration-payload-frame-id-keyword-is-edn-readable
+  (testing "rf2-joibj: the per-request `:rf.frame/<gensym>` keyword
+            embedded in the wire payload survives a round-trip through
+            the strict EDN reader. Pre-fix the gensym produced a
+            digit-only local-part (`:rf.frame/5401`) which the spec-
+            strict reader correctly rejects."
+    (register-articles-app! [{:id "a" :title "Article A"}])
+
+    (let [handler     (ssr-ring/ssr-handler
+                        {:on-create      [:rf/server-init]
+                         :root-view      [:pages/articles]
+                         :fx-overrides   {:http/get :http/get.canned}
+                         :payload-policy :rf.ssr.payload/whole-app-db})
+          response    (handler {:uri "/articles" :request-method :get})
+          body        (:body response)
+          payload-m   (re-find
+                        #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>"
+                        body)
+          payload-edn (when payload-m (second payload-m))]
+      (is (= 200 (:status response)))
+      (is (some? payload-edn)
+          "hydration payload script tag is present — observation
+           surface is the wire payload, not a pre-serialisation map")
+      ;; THE PIN: the full payload reads cleanly. Without the `"f"`
+      ;; prefix on the gensym, the EDN reader would throw
+      ;; `Invalid token: :rf.frame/<digits>` here.
+      (let [recovered (clojure.edn/read-string payload-edn)]
+        (is (map? recovered)
+            "rf2-joibj: payload-EDN round-trips through
+             clojure.edn/read-string — the per-request frame-id
+             keyword complies with the EDN identifier grammar")
+        ;; And the recovered frame-id is the right shape — namespaced,
+        ;; local-part starts with a letter.
+        (let [fid (:rf/frame-id recovered)]
+          (is (keyword? fid)
+              "the recovered :rf/frame-id is a keyword")
+          (is (= "rf.frame" (namespace fid))
+              "the per-request frame-id keeps its `rf.frame` namespace")
+          (is (re-matches #"[^\d].*" (name fid))
+              (str "the frame-id local-part starts with a non-numeric "
+                   "character (saw " (pr-str fid) ")")))))))


### PR DESCRIPTION
## Summary

- **Root cause**: `setup-request-frame!` built the per-request frame-id via `(keyword "rf.frame" (str (gensym "")))`, producing `:rf.frame/<digits>`. `clojure.core/keyword` does not validate, but per the EDN spec identifier names must not begin with a digit. Spec-strict readers (`clojure.edn/read-string`, `cljs.tools.reader.edn/read-string`) correctly reject `:rf.frame/<digits>` — and the frame-id rides into the wire hydration payload, so the browser's strict EDN reader crashed on the very first call against the embedded `__rf_payload`. Surfaced by the live-SSR browser smoke (rf2-j3dlc, PR #1256).
- **Fix**: change the gensym prefix from `""` to `"f"` in `implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj` — still unique per request, still namespaced, now EDN-spec-compliant on both JVM and CLJS.
- **Workaround removal**: `examples/reagent/ssr/server.clj` had a custom `:html-shell` doing regex substitution on the payload-EDN string to paper over this bug. With the root-cause fix in place that workaround is unnecessary; dropped cleanly (no compat shim — pre-alpha).
- **Regression test**: `hydration-payload-frame-id-keyword-is-edn-readable` in `implementation/ssr-ring/test/re_frame/ssr/ring_test.clj` round-trips the wire payload through `clojure.edn/read-string` and asserts the recovered `:rf/frame-id` keyword's local-part is non-numeric. Verified to fail (with `Invalid token: :rf.frame/<digits>`) when the fix is reverted.

## Test plan

- [x] `clojure -M:test` in `implementation/ssr-ring/` — 59 tests, 305 assertions, 0 failures
- [x] New regression test exercised against the unfixed pipeline.clj to confirm it surfaces the bug (`Invalid token: :rf.frame/9926`) and passes after the fix
- [x] `npm run test:examples` in `implementation/` — 40 example specs, 0 failures (live-SSR smoke `ssr-live.spec.cjs` passes without the server.clj workaround)