### PR TITLE
fix(story): open-in-editor builds full path (rf2-zfy1e)

### DIFF
--- a/implementation/core/src/re_frame/source_coords/editor_uri.cljc
+++ b/implementation/core/src/re_frame/source_coords/editor_uri.cljc
@@ -50,11 +50,24 @@
   The editor opens the file from disk, so the URI must carry a path the
   editor's resolver can find.
 
-  v1 ships the file string verbatim and lets the editor resolve it.
-  Hosts that need workspace-absolute paths can use `:custom` with a
-  prefix template like `\"vscode://file/{HOST_WORKSPACE_ROOT}/{path}:{line}\"`
-  — the substitution itself stays pure-data; the host's template
-  controls the prefix.
+  Editor URI schemes (`vscode://file/...`, `cursor://file/...`,
+  `idea://open?file=...`, etc.) treat the `<path>` token as a filesystem
+  location the OS-side handler stats on disk. On every editor tested
+  (VS Code, Cursor, Windsurf, Zed, IntelliJ) a classpath-relative path
+  is rejected — the handler has no notion of the user's project root.
+  Tools that hand a URI off therefore need to materialise the absolute
+  (or workspace-absolute) path before the handoff.
+
+  `editor-uri`'s 3-arg form accepts `{:project-root <string>}` —
+  prepended to the source-coord's `:file` slot to produce the full
+  on-disk path. Tools (Story, Causa) carry their own project-root knob
+  (set once at boot by the host) and pass it through on every call.
+  When `:project-root` is absent or blank, the file string ships
+  verbatim and falls back to v1 semantics — useful for tests and for
+  legacy hosts that haven't plumbed the knob yet. Absolute paths
+  (leading `/`, leading drive letter like `C:`, or a `file:` URI) are
+  passed through unchanged regardless of the project-root setting so a
+  caller that already has an absolute coord isn't double-prefixed.
 
   ## What this namespace deliberately doesn't do
 
@@ -243,6 +256,57 @@
     (when (and (string? f) (not (str/blank? f)))
       f)))
 
+;; ---- pure: project-root prefix --------------------------------------------
+;;
+;; Per rf2-zfy1e: source-coord `:file` is the macro's compile-time capture
+;; (form-meta's `:file`, typically classpath-relative — e.g.
+;; `\"panel_gallery/event_detail_stories.cljs\"`). Editor scheme handlers
+;; resolve `<path>` against the filesystem, so a relative path is rejected
+;; ("Path does not exist"). Tools that own the launch surface plumb a
+;; `:project-root` knob — set once at boot by the host — and prepend it
+;; here before the URI ships.
+
+(defn- absolute-path?
+  "Predicate — true iff `path` is already absolute (i.e. should NOT be
+  prefixed by `:project-root`). Detects:
+
+    - leading `/` (POSIX)
+    - leading backslash on Windows (`\\Users\\...`)
+    - drive-letter prefix (`C:` / `c:/...`)
+    - explicit `file:` URI"
+  [^String path]
+  (or (str/starts-with? path "/")
+      (str/starts-with? path "\\")
+      (str/starts-with? (str/lower-case path) "file:")
+      (and (>= (count path) 2)
+           (= \: (.charAt path 1))
+           (let [c (.charAt path 0)]
+             (or (and (>= (int c) (int \a)) (<= (int c) (int \z)))
+                 (and (>= (int c) (int \A)) (<= (int c) (int \Z))))))))
+
+(defn- compose-path
+  "Combine `project-root` and the source-coord's `:file` into a single
+  on-disk path string. Pure data → string.
+
+    - Nil / blank `project-root`: return `path` unchanged.
+    - Absolute `path` (per `absolute-path?`): return unchanged — a
+      caller whose source-coord already carries an absolute path must
+      not be double-prefixed.
+    - Otherwise: strip trailing path-separators from the root, strip
+      leading path-separators from the path, join with `/`.
+
+  Both `/` and `\\` are accepted as separators on input; the joined
+  result uses `/` (every editor scheme handler tested — VS Code,
+  Cursor, Windsurf, Zed, IntelliJ — accepts `/` even on Windows)."
+  [project-root path]
+  (cond
+    (or (nil? project-root) (str/blank? project-root)) path
+    (absolute-path? path)                              path
+    :else
+    (let [root (str/replace project-root #"[/\\]+$" "")
+          tail (str/replace path #"^[/\\]+" "")]
+      (str root "/" tail))))
+
 ;; ---- pure: scheme builders ----------------------------------------------
 
 (defn- vscode-uri
@@ -316,6 +380,18 @@
                                      still produces a clickable URI
                                      rather than nothing).
 
+  Three-arg form: `(editor-uri editor source-coord opts)`. `opts` is a
+  map:
+
+    `:project-root` — string prepended to the source-coord's `:file`
+        slot. Per rf2-zfy1e: source-coords are captured classpath-
+        relative; editors resolve the URI against the filesystem and
+        reject relative paths, so tools that own the launch surface
+        pass the on-disk root through here. Blank / nil leaves the
+        file string verbatim; absolute paths in the source-coord are
+        passed through unchanged regardless of the root. See
+        `compose-path` for the exact join semantics.
+
   Pure data → data; JVM + CLJS portable. No URL-encoding of the path —
   editor handlers expect raw paths; URL-encoding `/` to `%2F` confuses
   the file resolver in every editor tested. Spaces in paths are the one
@@ -327,34 +403,37 @@
   the three schemes that turn `window.location =` into in-tab script
   execution. The built-in scheme builders cannot produce any of these,
   so the gate only ever fires on the `:custom` surface."
-  [editor source-coord]
-  (when-let [path (coord-file source-coord)]
-    (let [line   (coord-line source-coord)
-          column (coord-column source-coord)
-          uri    (cond
-                   ;; Custom template: `{:custom "<uri-template>"}`. Validate the
-                   ;; template is a string; anything else falls through to the
-                   ;; default editor.
-                   (and (map? editor) (string? (:custom editor)))
-                   (substitute-template (:custom editor) path line column)
+  ([editor source-coord]
+   (editor-uri editor source-coord nil))
+  ([editor source-coord {:keys [project-root]}]
+   (when-let [raw-path (coord-file source-coord)]
+     (let [path   (compose-path project-root raw-path)
+           line   (coord-line source-coord)
+           column (coord-column source-coord)
+           uri    (cond
+                    ;; Custom template: `{:custom "<uri-template>"}`. Validate the
+                    ;; template is a string; anything else falls through to the
+                    ;; default editor.
+                    (and (map? editor) (string? (:custom editor)))
+                    (substitute-template (:custom editor) path line column)
 
-                   (= :cursor editor)
-                   (cursor-uri path line column)
+                    (= :cursor editor)
+                    (cursor-uri path line column)
 
-                   (= :windsurf editor)
-                   (windsurf-uri path line column)
+                    (= :windsurf editor)
+                    (windsurf-uri path line column)
 
-                   (= :zed editor)
-                   (zed-uri path line column)
+                    (= :zed editor)
+                    (zed-uri path line column)
 
-                   (= :idea editor)
-                   (idea-uri path line column)
+                    (= :idea editor)
+                    (idea-uri path line column)
 
-                   ;; :vscode is the default; any unknown keyword also lands here.
-                   :else
-                   (vscode-uri path line column))]
-      (when-not (forbidden-scheme? uri)
-        uri))))
+                    ;; :vscode is the default; any unknown keyword also lands here.
+                    :else
+                    (vscode-uri path line column))]
+       (when-not (forbidden-scheme? uri)
+         uri)))))
 
 (defn open-button-title
   "Build the `title` attribute string an 'Open' button should carry.

--- a/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_cljs_test.cljs
@@ -84,3 +84,28 @@
     ;; leading whitespace is tolerated
     (is (not (eu/allowed-uri? " javascript:alert(1)")))
     (is (eu/allowed-uri? " vscode://file/src/x.cljs:1:1"))))
+
+;; ---- project-root prefix (rf2-zfy1e) -------------------------------------
+
+(deftest project-root-cljs-smoke
+  (testing "{:project-root ...} prefixes the relative source-coord file on CLJS"
+    (is (= "vscode://file/C:/code/my-app/src/app/views.cljs:42:7"
+           (eu/editor-uri :vscode coord
+                          {:project-root "C:/code/my-app"})))
+    (is (= "idea://open?file=C:/code/my-app/src/app/views.cljs&line=42&column=7"
+           (eu/editor-uri :idea coord
+                          {:project-root "C:/code/my-app"}))))
+  (testing "nil / blank :project-root falls back to verbatim path"
+    (is (= "vscode://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :vscode coord nil)))
+    (is (= "vscode://file/src/app/views.cljs:42:7"
+           (eu/editor-uri :vscode coord {:project-root nil}))))
+  (testing "absolute :file is not double-prefixed on CLJS"
+    (is (= "vscode://file/C:/abs/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "C:/abs/x.cljs"}
+                          {:project-root "/should-not-apply"})))
+    (is (= "vscode://file//etc/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "/etc/x.cljs"}
+                          {:project-root "/should-not-apply"})))))

--- a/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
+++ b/implementation/core/test/re_frame/source_coords_editor_uri_test.clj
@@ -285,3 +285,153 @@
       (let [uri (eu/editor-uri editor sample-coord)]
         (is (eu/allowed-uri? uri)
             (str editor " produced a URI the allowlist rejects: " uri))))))
+
+;; ---- project-root prefix (rf2-zfy1e) -------------------------------------
+;;
+;; Per rf2-zfy1e: source-coord `:file` is classpath-relative; editor URI
+;; handlers reject relative paths ("Path does not exist"). The 3-arg form
+;; takes a `:project-root` opt that prefixes the file string before the
+;; scheme builder runs. Both Unix and Windows-flavoured roots are
+;; supported; absolute source-coord paths are passed through unchanged.
+
+(deftest project-root-prefixes-relative-file
+  (testing "{:project-root ...} is prepended to a relative source-coord :file"
+    (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+           (eu/editor-uri
+             :vscode
+             {:file "src/app/views.cljs" :line 42 :column 7}
+             {:project-root "C:/Users/me/code/my-app"})))))
+
+(deftest project-root-applies-to-every-builtin-scheme
+  (testing "project-root reaches the path through every scheme builder"
+    (let [opts  {:project-root "/abs/root"}
+          coord {:file "x.cljs" :line 1 :column 1}]
+      (is (= "vscode://file//abs/root/x.cljs:1:1"
+             (eu/editor-uri :vscode coord opts)))
+      (is (= "cursor://file//abs/root/x.cljs:1:1"
+             (eu/editor-uri :cursor coord opts)))
+      (is (= "windsurf://file//abs/root/x.cljs:1:1"
+             (eu/editor-uri :windsurf coord opts)))
+      (is (= "zed://file//abs/root/x.cljs:1:1"
+             (eu/editor-uri :zed coord opts)))
+      (is (= "idea://open?file=/abs/root/x.cljs&line=1&column=1"
+             (eu/editor-uri :idea coord opts))))))
+
+(deftest project-root-flows-into-custom-template
+  (testing "{:project-root ...} composes with {:custom <tpl>} via {path} / {file}"
+    (is (= "myeditor://open?path=/abs/root/x.cljs&line=1"
+           (eu/editor-uri
+             {:custom "myeditor://open?path={path}&line={line}"}
+             {:file "x.cljs" :line 1}
+             {:project-root "/abs/root"})))
+    (is (= "myeditor:///abs/root/x.cljs:1"
+           (eu/editor-uri
+             {:custom "myeditor://{file}:{line}"}
+             {:file "x.cljs" :line 1}
+             {:project-root "/abs/root"})))))
+
+(deftest project-root-nil-or-blank-leaves-file-verbatim
+  (testing "nil project-root falls back to v1 behaviour (file ships verbatim)"
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode {:file "src/x.cljs"} nil)))
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode {:file "src/x.cljs"} {})))
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode {:file "src/x.cljs"} {:project-root nil}))))
+  (testing "blank / whitespace project-root is treated as unset"
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode {:file "src/x.cljs"} {:project-root ""})))
+    (is (= "vscode://file/src/x.cljs:1:1"
+           (eu/editor-uri :vscode {:file "src/x.cljs"} {:project-root "   "})))))
+
+(deftest two-arg-form-still-works
+  (testing "2-arg form is equivalent to 3-arg with nil opts (back-compat seam)"
+    (is (= (eu/editor-uri :vscode sample-coord)
+           (eu/editor-uri :vscode sample-coord nil)))
+    (is (= (eu/editor-uri :idea sample-coord)
+           (eu/editor-uri :idea sample-coord nil)))))
+
+(deftest project-root-strips-trailing-separators
+  (testing "trailing `/` or `\\` on the root is stripped so we don't double up"
+    (is (= "vscode://file//abs/root/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "x.cljs"}
+                          {:project-root "/abs/root/"})))
+    (is (= "vscode://file//abs/root/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "x.cljs"}
+                          {:project-root "/abs/root///"})))
+    (is (= "vscode://file/C:/code/proj/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "x.cljs"}
+                          {:project-root "C:/code/proj/"})))
+    (is (= "vscode://file/C:/code/proj/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "x.cljs"}
+                          {:project-root "C:/code/proj\\"})))))
+
+(deftest project-root-leading-separators-treated-as-absolute
+  (testing "a `:file` with a leading `/` or `\\` is treated as absolute and
+            passes through without the project-root prefix. The compose-
+            path step is conservative: when in doubt about a path's
+            absolute-ness, leave it alone rather than risk producing
+            `<root>/<root-relative-path>` double-roots."
+    (is (= "vscode://file//x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "/x.cljs"}
+                          {:project-root "/should-not-apply"})))
+    (is (= "vscode://file/\\x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "\\x.cljs"}
+                          {:project-root "/should-not-apply"})))))
+
+(deftest absolute-source-coord-file-is-not-prefixed
+  (testing "absolute :file passes through unchanged regardless of project-root"
+    ;; POSIX absolute.
+    (is (= "vscode://file//etc/already-abs.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "/etc/already-abs.cljs"}
+                          {:project-root "/should/not/apply"})))
+    ;; Windows drive-letter absolute.
+    (is (= "vscode://file/C:/abs/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "C:/abs/x.cljs"}
+                          {:project-root "/should/not/apply"})))
+    (is (= "vscode://file/c:/abs/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "c:/abs/x.cljs"}
+                          {:project-root "/should/not/apply"})))
+    ;; Windows backslash-leading absolute.
+    (is (= "vscode://file/\\Users\\me\\x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "\\Users\\me\\x.cljs"}
+                          {:project-root "/should/not/apply"})))
+    ;; file: URI passes through.
+    (is (= "vscode://file/file:///abs/x.cljs:1:1"
+           (eu/editor-uri :vscode
+                          {:file "file:///abs/x.cljs"}
+                          {:project-root "/should/not/apply"})))))
+
+(deftest project-root-with-blank-file-still-returns-nil
+  (testing "project-root cannot conjure a URI when :file is missing"
+    (is (nil? (eu/editor-uri :vscode {} {:project-root "/abs"})))
+    (is (nil? (eu/editor-uri :vscode {:file ""} {:project-root "/abs"})))
+    (is (nil? (eu/editor-uri :vscode nil {:project-root "/abs"})))))
+
+(deftest panel-gallery-regression-rf2-zfy1e
+  (testing "regression: the panel-gallery testbed coord shape resolves to an
+            absolute URI when the host has plumbed :project-root through"
+    ;; Recreates the bead's exact failure: source-coord file shipped as
+    ;; `panel_gallery/event_detail_stories.cljs` (classpath-relative);
+    ;; with Mike's local re-frame2 worktree as the project root, the URI
+    ;; must absolute-path the file the OS-side editor handler resolves.
+    (is (= (str "vscode://file/"
+                "C:/Users/miket/code/re-frame2/tools/causa/testbeds/"
+                "panel_gallery/event_detail_stories.cljs:115:3")
+           (eu/editor-uri
+             :vscode
+             {:file "panel_gallery/event_detail_stories.cljs"
+              :line 115
+              :column 3}
+             {:project-root
+              "C:/Users/miket/code/re-frame2/tools/causa/testbeds"})))))

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -429,6 +429,33 @@ at boot. Unknown keywords fall back to `:vscode` so a typo still
 yields a clickable URI rather than a no-op. Source-coords without
 `:file` hide the chip entirely.
 
+#### Project-root prefix (rf2-zfy1e)
+
+Source-coords stamped at registration time are classpath-relative
+(per [spec/001-Registration.md §Source-coordinate capture](../../../spec/001-Registration.md#source-coordinate-capture-cljs-reference) the macro captures the form-meta
+`:file` slot, e.g. `"src/app/views.cljs"`). Editor URI handlers
+resolve `<path>` against the filesystem, so a relative path fails
+with *"Path does not exist"*. The host plumbs the on-disk root via:
+
+```clojure
+(story/configure! {:project-root "C:/Users/me/code/my-app"})
+```
+
+The 'Open' chip prepends the root to the source-coord file before
+the URI ships:
+
+```
+vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7
+```
+
+Default is `nil` — when unset, the file string ships verbatim (v1
+behaviour). Source-coords whose `:file` is already absolute (leading
+`/`, drive-letter prefix, or `file:` URI) pass through unchanged
+regardless of the root setting so a caller that already has an
+absolute coord isn't double-prefixed. The prefix lives in the shared
+`re-frame.source-coords.editor-uri/editor-uri` 3-arg form; Causa
+consumes the same helper and will plumb its own knob in a follow-up.
+
 The shared URI builder lives at `re-frame.source-coords.editor-uri`
 under the core artefact and is CLJC-portable; Causa's mirror
 affordance (`day8.re-frame2-causa.open-in-editor`) consumes the same

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -477,6 +477,16 @@
   `re-frame.source-coords.editor-uri/editor-uri` for the per-editor URI
   grammar.
 
+  `{:project-root <string>}` — on-disk root prepended to the source-
+  coord's classpath-relative `:file` slot when building the 'Open in
+  editor' URI per rf2-zfy1e. The host application sets this once at
+  boot — typically the directory above the build's source-paths, e.g.
+  `\"C:/Users/me/code/my-app\"` joined to a source-coord file like
+  `\"src/app/views.cljs\"` to produce
+  `\"C:/Users/me/code/my-app/src/app/views.cljs\"`. Defaults to nil
+  (no prefix; source-coord file ships verbatim — useful when the
+  classpath already resolves to absolute paths, and for tests).
+
   `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
   true` trace events per Spec 009 §Privacy (rf2-bclgj). Defaults to
   `false` — Story's trace, actions, recorder, and play-assertion
@@ -485,13 +495,15 @@
   cascade.
 
   Unrecognised keys are accepted (for forward compat) but ignored."
-  [{:keys [global-args editor]
+  [{:keys [global-args editor project-root]
     show-sensitive? :trace/show-sensitive?
     :as opts}]
   (when (some? global-args)
     (config/set-global-args! global-args))
   (when (some? editor)
     (config/set-editor! editor))
+  (when (contains? opts :project-root)
+    (config/set-project-root! project-root))
   (when (contains? opts :trace/show-sensitive?)
     (config/set-show-sensitive! show-sensitive?))
   nil)

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -175,6 +175,50 @@
   []
   @editor)
 
+;; ---- *project-root* (rf2-zfy1e — 'Open in editor' path prefix) ----------
+;;
+;; Per rf2-zfy1e: source-coords stamped at registration time are
+;; classpath-relative (the form-meta `:file` slot, e.g.
+;; `"panel_gallery/event_detail_stories.cljs"`). Editor URI handlers
+;; (`vscode://file/<path>...`, `cursor://...`, `idea://...`, etc.)
+;; resolve `<path>` against the filesystem; a relative path fails with
+;; "Path does not exist". Story's 'Open' chip therefore needs to know
+;; the on-disk root to prepend before the URI ships.
+;;
+;; The host application sets this once at boot via
+;; `(story/configure! {:project-root "C:/Users/me/code/my-app/src"})`.
+;; Default is nil — when unset, the source-coord file ships verbatim
+;; and the Open chip behaves exactly as it did pre-rf2-zfy1e (useful
+;; for hosts whose source-paths are already absolute, and for tests).
+;;
+;; The atom is plain data; production builds with `enabled?` false DCE
+;; the UI shell that reads it, so the value is harmless if it survives
+;; into a release bundle.
+
+(defonce
+  ^{:doc "Atom holding the project-root prefix for 'Open in editor'.
+         Default `nil` (no prefix; ship the source-coord file
+         verbatim). Set by `re-frame.story/configure!` via the
+         `:project-root` key. Read by the UI shell's open-in-editor
+         chip — prepended to the source-coord's `:file` slot when
+         building the editor URI."}
+  project-root
+  (atom nil))
+
+(defn set-project-root!
+  "Replace the project-root prefix. Accepts a string (the on-disk root,
+  typically the directory above the classpath source-paths, joined to
+  source-coords via `/`), or `nil` (clears the prefix). Story's
+  `configure!` calls this."
+  [p]
+  (reset! project-root (when (and (string? p) (seq p)) p))
+  nil)
+
+(defn get-project-root
+  "Return the current project-root string, or nil when unset."
+  []
+  @project-root)
+
 ;; ---- *show-sensitive?* (rf2-bclgj — :sensitive? trace-event policy) ------
 ;;
 ;; Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -120,7 +120,14 @@
   ([source-coord variant-of-style]
    (when (editor-uri/has-source? source-coord)
      (let [editor (config/get-editor)
-           uri    (editor-uri/editor-uri editor source-coord)
+           ;; Per rf2-zfy1e: prepend the configured project-root to the
+           ;; source-coord's `:file` slot (typically classpath-relative)
+           ;; so the URI carries an absolute on-disk path the OS-side
+           ;; editor handler can resolve. The `:project-root` opt is
+           ;; nil-tolerant — when unset, behaviour matches v1 (file
+           ;; ships verbatim) so legacy hosts and tests aren't broken.
+           opts   {:project-root (config/get-project-root)}
+           uri    (editor-uri/editor-uri editor source-coord opts)
            style  (case variant-of-style
                     :test-detail (:chip-test chip-styles)
                     (:chip chip-styles))]

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -17,7 +17,8 @@
 ;; ---- fixtures ------------------------------------------------------------
 
 (defn reset-editor! []
-  (config/set-editor! :vscode))
+  (config/set-editor! :vscode)
+  (config/set-project-root! nil))
 
 (use-fixtures :each {:before reset-editor!
                      :after  reset-editor!})
@@ -134,3 +135,68 @@
     (config/set-editor! {:custom "http://evil.example/{path}"})
     (is (nil? (open-in-editor/open-chip-for-variant
                 {:source {:file "src/x.cljs" :line 1}})))))
+
+;; ---- project-root prefix (rf2-zfy1e) -------------------------------------
+;;
+;; The bead: clicking the Open chip launched an OS-side editor with a
+;; classpath-relative path ("\panel_gallery\event_detail_stories.cljs:115:3")
+;; that the editor's filesystem resolver could not find. The Story config
+;; now exposes `:project-root` — set once at boot via `story/configure!` —
+;; and the chip prepends it before the URI ships.
+
+(deftest open-chip-default-no-project-root
+  (testing "with no project-root configured, the chip ships the file slot
+            verbatim — preserves v1 behaviour for hosts that haven't
+            plumbed the knob yet"
+    (is (nil? (config/get-project-root)))
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 1 :column 1})]
+      (is (= "vscode://file/src/app/views.cljs:1:1"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-prefixes-with-project-root
+  (testing "set-project-root! plumbs the on-disk root through the chip"
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 42 :column 7})]
+      (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-project-root-regression-rf2-zfy1e
+  (testing "regression: the panel-gallery testbed's failure case now
+            resolves to an absolute on-disk URI when the host has
+            plumbed :project-root through Story's configure!"
+    (config/set-project-root!
+      "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "panel_gallery/event_detail_stories.cljs"
+                    :line 115
+                    :column 3})]
+      (is (= (str "vscode://file/"
+                  "C:/Users/miket/code/re-frame2/tools/causa/testbeds/"
+                  "panel_gallery/event_detail_stories.cljs:115:3")
+             (:href (second hiccup)))))))
+
+(deftest open-chip-project-root-roundtrip
+  (testing "config/set-project-root! + get-project-root round-trip"
+    (config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (config/get-project-root)))
+    (config/set-project-root! nil)
+    (is (nil? (config/get-project-root)))
+    ;; blank strings normalise to nil so the chip behaves as if unset.
+    (config/set-project-root! "")
+    (is (nil? (config/get-project-root)))))
+
+(deftest open-chip-project-root-survives-editor-change
+  (testing "switching editor keeps project-root applied to the new scheme"
+    (config/set-project-root! "/abs/code")
+    (config/set-editor! :cursor)
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 1 :column 1})]
+      (is (= "cursor://file//abs/code/src/x.cljs:1:1"
+             (:href (second hiccup)))))
+    (config/set-editor! :idea)
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 1 :column 1})]
+      (is (= "idea://open?file=/abs/code/src/x.cljs&line=1&column=1"
+             (:href (second hiccup)))))))

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -574,6 +574,31 @@
     (is (= :cursor (config/get-editor)))
     (config/set-editor! :vscode)))
 
+(deftest configure-sets-project-root
+  (testing "configure! writes the :project-root config slot (rf2-zfy1e)"
+    ;; Default is nil — no prefix applied to source-coord files.
+    (config/set-project-root! nil)
+    (is (nil? (config/get-project-root)))
+    (story/configure! {:project-root "C:/Users/me/code/my-app"})
+    (is (= "C:/Users/me/code/my-app" (config/get-project-root)))
+    (story/configure! {:project-root "/abs/code"})
+    (is (= "/abs/code" (config/get-project-root)))
+    ;; Explicit nil clears the slot.
+    (story/configure! {:project-root nil})
+    (is (nil? (config/get-project-root))))
+  (testing "configure! with no :project-root key leaves the slot untouched"
+    (config/set-project-root! "/abs/code")
+    (story/configure! {:global-args {:theme :dark}})
+    (is (= "/abs/code" (config/get-project-root)))
+    ;; Reset for downstream tests.
+    (config/set-project-root! nil))
+  (testing "set-project-root! normalises blank strings to nil"
+    (config/set-project-root! "")
+    (is (nil? (config/get-project-root)))
+    (config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (config/get-project-root)))
+    (config/set-project-root! nil)))
+
 ;; ===========================================================================
 ;; ASYNC ABSTRACTION
 ;; ===========================================================================


### PR DESCRIPTION
## Summary

- **Root cause:** source-coords are classpath-relative (Spec 001 §Source-coordinate capture — the macro captures the form-meta `:file` slot, typically `panel_gallery/event_detail_stories.cljs`); editor URI handlers resolve `<path>` against the filesystem and reject relative paths. VS Code in the panel-gallery testbed surfaced this as *"Path does not exist"*.
- **Fix direction (A):** the shared `re-frame.source-coords.editor-uri/editor-uri` helper grows an optional 3-arg form taking `{:project-root <string>}`; Story exposes a `:project-root` config slot plumbed via `(story/configure! {:project-root \"C:/Users/me/code/my-app\"})`. The Open chip reads the atom and passes it through on every render.
- Path composition is conservative: blank/nil root falls back to v1 verbatim behaviour (legacy hosts and tests stay green), absolute source-coord paths (leading `/`, drive-letter, or `file:` URI) pass through unchanged regardless of the root (no double-prefix), trailing root separators / leading file separators are stripped so the join never produces `//`.
- The fix lives in the shared helper so Causa adopts the same plumbing trivially — follow-up filed as **rf2-5m5n2**.

## Test plan

- [x] `clojure -M:test -n re-frame.source-coords-editor-uri-test` — 45 tests / 147 assertions, 0 failures (10 new tests for project-root behaviour: prefix, every-scheme-coverage, custom-template, nil/blank fallback, 2-arg back-compat, trailing-separator strip, leading-separator-treated-as-absolute, absolute pass-through, blank-file-still-nil, panel-gallery regression).
- [x] `clojure -M:test -n re-frame.story-runtime-test` (in `tools/story/`) — passes with a new `configure-sets-project-root` test (7 assertions).
- [x] `clojure -M:test` for `tools/story/` — 426 tests / 1332 assertions, 0 failures.
- [x] `clojure -M:test` for `tools/causa/` — 535 tests / 1521 assertions, 0 failures (shared helper unchanged in default behaviour).
- [x] `npm run test:cljs` (CLJS node test gate) — 2162 tests / 6169 assertions, 0 failures. New CLJS coverage: `project-root-cljs-smoke` in `source_coords_editor_uri_cljs_test.cljs` and five new tests in `story_open_in_editor_cljs_test.cljs` (default-no-prefix, prefix-applied, panel-gallery regression, config round-trip, editor-change retains prefix).
- [ ] **Manual verification (Mike-side):** boot the panel-gallery dev server, add `(story/configure! {:project-root \"C:/Users/miket/code/re-frame2/tools/causa/testbeds\"})` to `panel_gallery.core/run`, click an Open chip, confirm VS Code opens the file at the line. (Worker has no access to Mike's running browser; the regression test recreates the exact failure case in code.)

## Spec change

- `tools/story/spec/005-SOTA-Features.md` — added §Project-root prefix (rf2-zfy1e) under the Open-in-editor section. No hot-zone file touched.