### PR TITLE
fix(causa): open-in-editor :project-root config (mirror of rf2-zfy1e) (rf2-5m5n2)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -172,6 +172,55 @@
   []
   @editor)
 
+;; ---- *project-root* (rf2-5m5n2 — 'Open in editor' path prefix) ----------
+;;
+;; Per rf2-zfy1e (Story) / rf2-5m5n2 (Causa): source-coords stamped at
+;; registration time are classpath-relative (the form-meta `:file` slot,
+;; e.g. `"panel_gallery/event_detail_stories.cljs"`). Editor URI handlers
+;; (`vscode://file/<path>...`, `cursor://...`, `idea://...`, etc.) resolve
+;; `<path>` against the filesystem; a relative path fails with "Path does
+;; not exist". Causa's 'Open' chip + the `:rf.editor/open` reg-fx
+;; therefore need to know the on-disk root to prepend before the URI
+;; ships.
+;;
+;; The host application sets this once at boot via
+;; `(causa-config/configure! {:project-root "C:/Users/me/code/my-app/src"})`.
+;; Default is nil — when unset, the source-coord file ships verbatim and
+;; the Open chip behaves exactly as it did pre-rf2-5m5n2 (useful for hosts
+;; whose source-paths are already absolute, and for tests).
+;;
+;; Causa's project-root is **independent** of Story's. Hosts that run
+;; both tools may want different roots (e.g. an app-source root for
+;; Causa, a stories root for Story); two atoms, two `configure!` surfaces.
+;;
+;; The atom is plain data; production builds DCE the Causa shell that
+;; reads it, so the value is harmless if it survives into a release
+;; bundle.
+
+(defonce
+  ^{:doc "Atom holding the project-root prefix for Causa's 'Open in
+         editor'. Default `nil` (no prefix; ship the source-coord file
+         verbatim). Set by `day8.re-frame2-causa.config/configure!` via
+         the `:project-root` key. Read by `open-in-editor/resolve-uri`
+         — prepended to the source-coord's `:file` slot when building
+         the editor URI."}
+  project-root
+  (atom nil))
+
+(defn set-project-root!
+  "Replace the project-root prefix. Accepts a string (the on-disk root,
+  typically the directory above the classpath source-paths, joined to
+  source-coords via `/`), or `nil` (clears the prefix). Causa's
+  `configure!` calls this. Blank strings normalise to nil."
+  [p]
+  (reset! project-root (when (and (string? p) (seq p)) p))
+  nil)
+
+(defn get-project-root
+  "Return the current project-root string, or nil when unset."
+  []
+  @project-root)
+
 ;; ---- *show-sensitive?* (rf2-azls9 — :sensitive? trace-event policy) ------
 ;;
 ;; Per Spec 009 §Privacy (resolved by rf2-a32kd): framework-published
@@ -340,6 +389,11 @@
   "Top-level Causa configuration. Accepts:
 
     `{:editor <kw>}` — Causa's 'Open in editor' preference (rf2-evgf5).
+    `{:project-root <string>}` — on-disk root prepended to the source-
+       coord's classpath-relative `:file` slot before the editor URI
+       ships (rf2-5m5n2). Default `nil`. Nil / blank clears the slot;
+       an absent key leaves the current value untouched. Hosts whose
+       source-paths are already absolute can leave this unset.
     `{:layout/host-selector <css-selector>}` — app-provided true-inline
        layout host for the default shell. Defaults to
        `[data-rf-causa-host]`.
@@ -360,18 +414,21 @@
   Hosts typically call this once at boot:
 
       (require '[day8.re-frame2-causa.config :as causa-config])
-      (causa-config/configure! {:editor :cursor
+      (causa-config/configure! {:editor       :cursor
+                                :project-root \"C:/Users/me/code/my-app\"
                                 :layout/host-selector \"#causa\"
                                 :launch/auto-open? true})
 
   Returns nothing."
-  [{:keys [editor]
+  [{:keys [editor project-root]
     host-selector-opt :layout/host-selector
     auto-open-opt :launch/auto-open?
     show-sensitive-opt :trace/show-sensitive?
     :as opts}]
   (when (some? editor)
     (set-editor! editor))
+  (when (contains? opts :project-root)
+    (set-project-root! project-root))
   (when (contains? opts :layout/host-selector)
     (set-layout-host-selector! host-selector-opt))
   (when (contains? opts :launch/auto-open?)
@@ -384,9 +441,11 @@
 
 (defn editor-uri
   "Build an 'Open in editor' URI for `source-coord` using Causa's
-  configured editor. Thin wrapper around
-  `re-frame.source-coords.editor-uri/editor-uri` that reads the current
-  preference from the atom. Returns a string URI, or nil when the
-  source-coord has no `:file`."
+  configured editor + configured project-root (rf2-5m5n2). Thin
+  wrapper around `re-frame.source-coords.editor-uri/editor-uri` that
+  reads the current preference from the atom AND threads the
+  configured project-root through the helper's 3-arg form. Returns a
+  string URI, or nil when the source-coord has no `:file`."
   [source-coord]
-  (editor-uri/editor-uri (get-editor) source-coord))
+  (editor-uri/editor-uri (get-editor) source-coord
+                         {:project-root (get-project-root)}))

--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -135,12 +135,21 @@
   is outside `editor-uri/allowed-editor-uri-schemes` (the shared
   positive allowlist per rf2-cm93v / rf2-p887o).
 
+  Per rf2-5m5n2: threads the configured project-root through
+  `editor-uri/editor-uri`'s 3-arg form so a classpath-relative source-
+  coord (the common case — macros capture the form-meta `:file` slot,
+  typically classpath-relative) resolves to an absolute on-disk path
+  the OS-side editor handler can find. The `:project-root` opt is
+  nil-tolerant — when unset, behaviour matches the v1 2-arg call (file
+  ships verbatim) so legacy hosts and tests aren't broken.
+
   The chip render path and the `:rf.editor/open` reg-fx both call this
   — one source of truth for the URI shape across the data path and the
   side-effect path."
   [source-coord]
   (when (editor-uri/has-source? source-coord)
-    (let [uri (editor-uri/editor-uri (config/get-editor) source-coord)]
+    (let [opts {:project-root (config/get-project-root)}
+          uri  (editor-uri/editor-uri (config/get-editor) source-coord opts)]
       (when (and uri (editor-uri/allowed-uri? uri))
         uri))))
 

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -7,9 +7,11 @@
 (defn reset-editor [test-fn]
   (config/set-editor! :vscode)
   (config/set-auto-open! true)
+  (config/set-project-root! nil)
   (test-fn)
   (config/set-editor! :vscode)
-  (config/set-auto-open! true))
+  (config/set-auto-open! true)
+  (config/set-project-root! nil))
 
 (use-fixtures :each reset-editor)
 
@@ -98,3 +100,87 @@
   (testing "config/editor-uri returns nil when coord has no :file"
     (is (nil? (config/editor-uri {:line 10})))
     (is (nil? (config/editor-uri nil)))))
+
+;; ---- project-root (rf2-5m5n2) -------------------------------------------
+;;
+;; Mirror of Story's rf2-zfy1e test matrix. Source-coords stamped at
+;; registration time are classpath-relative; editor schemes resolve
+;; against the filesystem and reject relative paths. The host plumbs an
+;; on-disk root via `configure! :project-root`; the Causa-side helpers
+;; prepend it before the URI ships.
+
+(deftest default-project-root-is-nil
+  (testing "Causa's default project-root is nil (preserves v1 behaviour
+            for hosts that haven't plumbed the knob yet)"
+    (is (nil? (config/get-project-root)))))
+
+(deftest set-project-root-round-trips
+  (testing "set-project-root! writes and get-project-root reads"
+    (config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (config/get-project-root)))
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (is (= "C:/Users/me/code/my-app" (config/get-project-root)))
+    (config/set-project-root! nil)
+    (is (nil? (config/get-project-root)))))
+
+(deftest set-project-root-normalises-blank-string-to-nil
+  (testing "blank strings normalise to nil so the helper behaves as if
+            unset (mirrors Story's rf2-zfy1e normalisation)"
+    (config/set-project-root! "")
+    (is (nil? (config/get-project-root)))
+    (config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (config/get-project-root)))
+    (config/set-project-root! "")
+    (is (nil? (config/get-project-root)))))
+
+(deftest configure-passes-project-root-through
+  (testing "configure! routes :project-root through set-project-root!"
+    (config/configure! {:project-root "C:/Users/me/code/my-app"})
+    (is (= "C:/Users/me/code/my-app" (config/get-project-root)))
+    (config/configure! {:project-root "/abs/code"})
+    (is (= "/abs/code" (config/get-project-root)))
+    (testing "explicit nil clears the slot"
+      (config/configure! {:project-root nil})
+      (is (nil? (config/get-project-root))))))
+
+(deftest configure-without-project-root-leaves-slot-untouched
+  (testing "configure! with no :project-root key leaves the slot unchanged
+            (lets hosts call configure! multiple times for unrelated
+            keys without clobbering the project-root)"
+    (config/set-project-root! "/abs/code")
+    (config/configure! {:editor :cursor})
+    (is (= "/abs/code" (config/get-project-root)))))
+
+(deftest editor-uri-prepends-project-root
+  (testing "config/editor-uri threads :project-root through the helper's
+            3-arg form so a relative coord resolves to an absolute on-
+            disk URI"
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+           (config/editor-uri {:file "src/app/views.cljs"
+                               :line 42
+                               :column 7})))))
+
+(deftest editor-uri-without-project-root-ships-file-verbatim
+  (testing "config/editor-uri preserves v1 behaviour when project-root
+            is unset — the file string ships verbatim"
+    (is (nil? (config/get-project-root)))
+    (is (= "vscode://file/src/app/views.cljs:1:1"
+           (config/editor-uri {:file "src/app/views.cljs"
+                               :line 1
+                               :column 1})))))
+
+(deftest editor-uri-project-root-regression-rf2-5m5n2
+  (testing "regression: the relative source-coord case the editor's
+            OS handler used to reject ('Path does not exist') now
+            resolves to an absolute on-disk URI when :project-root is
+            plumbed (mirror of Story's rf2-zfy1e regression)"
+    (config/set-project-root!
+      "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+    (is (= (str "vscode://file/"
+                "C:/Users/miket/code/re-frame2/tools/causa/testbeds/"
+                "panel_gallery/event_detail_stories.cljs:115:3")
+           (config/editor-uri
+             {:file "panel_gallery/event_detail_stories.cljs"
+              :line 115
+              :column 3})))))

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -32,7 +32,8 @@
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 (defn reset-editor! []
-  (config/set-editor! :vscode))
+  (config/set-editor! :vscode)
+  (config/set-project-root! nil))
 
 ;; Combined per-test fixture: resets the re-frame runtime (so each
 ;; rf2-g5q8d test below sees a clean registrar + frame table) AND the
@@ -132,6 +133,89 @@
 
     (config/configure! {:editor {:custom "emacsclient://{path}"}})
     (is (some? (open-in-editor/open-chip {:file "src/x.cljs"})))))
+
+;; ---- project-root prefix (rf2-5m5n2) ------------------------------------
+;;
+;; The bead: clicking the Open chip on a Causa panel launched an OS-side
+;; editor with a classpath-relative path
+;; ("panel_gallery/event_detail_stories.cljs:115:3") that the editor's
+;; filesystem resolver could not find. The Causa config now exposes
+;; `:project-root` — set once at boot via `causa-config/configure!` — and
+;; `resolve-uri` (which both the chip and the `:rf.editor/open` fx share)
+;; prepends it before the URI ships. Mirror of Story's rf2-zfy1e matrix.
+
+(deftest open-chip-default-no-project-root
+  (testing "with no project-root configured, the chip ships the file slot
+            verbatim — preserves v1 behaviour for hosts that haven't
+            plumbed the knob yet"
+    (is (nil? (config/get-project-root)))
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 1 :column 1})]
+      (is (= "vscode://file/src/app/views.cljs:1:1"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-prefixes-with-project-root
+  (testing "set-project-root! plumbs the on-disk root through the chip"
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 42 :column 7})]
+      (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-project-root-regression-rf2-5m5n2
+  (testing "regression: the panel-gallery testbed's failure case now
+            resolves to an absolute on-disk URI when the host has
+            plumbed :project-root through causa-config/configure!"
+    (config/set-project-root!
+      "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "panel_gallery/event_detail_stories.cljs"
+                    :line 115
+                    :column 3})]
+      (is (= (str "vscode://file/"
+                  "C:/Users/miket/code/re-frame2/tools/causa/testbeds/"
+                  "panel_gallery/event_detail_stories.cljs:115:3")
+             (:href (second hiccup)))))))
+
+(deftest open-chip-project-root-roundtrip
+  (testing "config/set-project-root! + get-project-root round-trip on
+            the CLJS side"
+    (config/set-project-root! "/abs/code")
+    (is (= "/abs/code" (config/get-project-root)))
+    (config/set-project-root! nil)
+    (is (nil? (config/get-project-root)))
+    ;; blank strings normalise to nil so the chip behaves as if unset.
+    (config/set-project-root! "")
+    (is (nil? (config/get-project-root)))))
+
+(deftest open-chip-project-root-survives-editor-change
+  (testing "switching editor keeps project-root applied to the new scheme"
+    (config/set-project-root! "/abs/code")
+    (config/set-editor! :cursor)
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 1 :column 1})]
+      (is (= "cursor://file//abs/code/src/x.cljs:1:1"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-project-root-absolute-coord-not-double-prefixed
+  (testing "an already-absolute source-coord is NOT double-prefixed
+            (per editor-uri/compose-path's absolute-path? guard) — pins
+            that the Causa wiring respects the helper's contract"
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "/abs/already/here.cljs" :line 1 :column 1})]
+      (is (= "vscode://file//abs/already/here.cljs:1:1"
+             (:href (second hiccup)))))))
+
+(deftest open-chip-configure-passes-project-root-through
+  (testing "configure! routes :project-root through set-project-root!
+            on the CLJS side (mirror of Story's rf2-zfy1e config matrix)"
+    (config/configure! {:project-root "C:/Users/me/code/my-app"})
+    (is (= "C:/Users/me/code/my-app" (config/get-project-root)))
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/x.cljs" :line 1 :column 1})]
+      (is (= "vscode://file/C:/Users/me/code/my-app/src/x.cljs:1:1"
+             (:href (second hiccup)))))))
 
 ;; ---- rf2-g5q8d — :rf.causa/open-in-editor + :rf.editor/open ------------
 ;;
@@ -320,3 +404,17 @@
       (is (= (:href (second (open-in-editor/open-chip coord)))
              (:uri (first @captured-editor-fx)))
           "chip's :href ≡ fx's :uri"))))
+
+(deftest open-in-editor-event-applies-project-root-prefix
+  (testing "rf2-5m5n2 — the event-fx's URI reflects the configured
+            project-root (same source of truth as `open-chip`'s
+            `:href`), so the four panels' dispatch path resolves
+            relative source-coords to absolute on-disk URIs"
+    (setup!)
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-in-editor
+                         {:file "src/app/views.cljs" :line 42 :column 7}])
+      (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
+             (:uri (first @captured-editor-fx)))
+          "fx's :uri ≡ chip's :href once :project-root is configured"))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -64,7 +64,11 @@
   (preload/reset-for-test!)
   (registry/reset-for-test!)
   (trace-bus/clear-buffer!)
-  (config/reset-suppressed-count!))
+  (config/reset-suppressed-count!)
+  ;; rf2-5m5n2 — reset the project-root prefix atom so a sibling test
+  ;; that set it (e.g. `open_in_editor_cljs_test.cljs`) doesn't leak
+  ;; into the registry tests' URI assertions.
+  (config/set-project-root! nil))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture


### PR DESCRIPTION
## Summary

Mirror of Story's rf2-zfy1e plumbing for Causa.

Causa's `resolve-uri` / `:rf.editor/open` reg-fx / `config/editor-uri` pass-through now thread the configured `:project-root` through `editor-uri/editor-uri`'s 3-arg form. A classpath-relative source-coord (the common case — form-meta captures the file slot classpath-relative) resolves to an absolute on-disk URI the OS-side editor handler can find. Without this fix, clicking the Open chip on a Causa panel against a relative coord failed with 'Path does not exist'.

Per-file:
- `tools/causa/src/day8/re_frame2_causa/config.cljc` — add `project-root` atom + `set-project-root!` / `get-project-root` + `:project-root` key on `configure!`. Pass-through `config/editor-uri` helper now ships the 3-arg form so JVM consumers benefit too.
- `tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs` — `resolve-uri` threads `{:project-root (config/get-project-root)}` into the helper. The chip render path and the `:rf.editor/open` fx share this seam (one source of truth).
- `tools/causa/test/day8/re_frame2_causa/config_test.clj` — 7 new JVM deftests (default-nil, round-trip, blank-normalises-to-nil, configure! pass-through, configure! no-:project-root-leaves-slot, editor-uri prepend, regression for the panel-gallery testbed case).
- `tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs` — 7 new CLJS deftests covering the chip render path + 1 end-to-end deftest pinning the rf2-g5q8d fx's URI also reflects the configured project-root. Fixture resets the atom.
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — fixture also resets the project-root atom (defends against test-order leak from sibling open_in_editor tests).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 543 tests / 1536 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2173 tests / 6190 assertions, 0 failures
- [x] No mayor-checkout edits (worker worktree boundary verified)