### PR TITLE
ci(docs): narrow docs.yml paths filter to actually-staged surfaces (rf2-8k7vm)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,11 +17,16 @@ name: docs
 on:
   push:
     branches: [main]
+    # Trigger only on paths that actually feed the staged docs site or the
+    # link-validator's own fixtures. `skills/**/*.md` and `tools/**/*.md`
+    # are deliberately NOT listed — neither tree is copied into docs_dir
+    # (see mkdocs_hooks.py: tools/ and skills/ internals are rewritten to
+    # GitHub blob URLs precisely because they don't exist in the staged
+    # site). The per-skill summary pages that DO render live at
+    # docs/skills/X.md and are already covered by `docs/**` (rf2-8k7vm).
     paths:
       - 'docs/**'
       - 'spec/**'
-      - 'skills/**/*.md'
-      - 'tools/**/*.md'
       - 'mkdocs.yml'
       - 'mkdocs_hooks.py'
       - 'TESTING.md'
@@ -34,8 +39,6 @@ on:
     paths:
       - 'docs/**'
       - 'spec/**'
-      - 'skills/**/*.md'
-      - 'tools/**/*.md'
       - 'mkdocs.yml'
       - 'mkdocs_hooks.py'
       - 'TESTING.md'


### PR DESCRIPTION
## Summary

Removes `tools/**/*.md` and `skills/**/*.md` from the `docs` workflow's
`push.paths` and `pull_request.paths` filters. Neither tree is copied
into the MkDocs `docs_dir` at build time, so changes to those files
trigger a ~3-minute MkDocs build that produces no different artefact.

## Evidence

- **tools/** is not staged. `mkdocs_hooks.py` rewrites every `../tools/...`
  ref to a GitHub blob URL *precisely because* those files don't exist
  in the staged site:
  - `mkdocs_hooks.py:31` — `# - tools/ (tool source + per-tool spec; not staged into docs/)`
  - `mkdocs_hooks.py:147` — same comment in the rewrite catalogue
  - The `tools/` rewrite rules at `mkdocs_hooks.py:151-154` emit
    `https://github.com/day8/re-frame2/blob/main/tools/<path>` URLs.
- **skills/** is partially staged: only the hand-authored summary pages
  at `docs/skills/X.md` render (see the `Skills:` nav block in
  `mkdocs.yml:125-132`). Skill internals (`SKILL.md`, `references/`,
  `tests/`) are not staged:
  - `mkdocs_hooks.py:32-34` documents this explicitly.
  - `mkdocs_hooks.py:155-163` rewrites `../skills/X/Y` refs to GitHub
    blob URLs for the same reason.
  - Diff sample: `docs/skills/re-frame2.md` is an independent file with
    different content from `skills/re-frame2/SKILL.md` (not a copy).

## Observed waste

PR #1262 touched `tools/story/spec/005-SOTA-Features.md` and triggered a
3-minute MkDocs build that had nothing to do with the changed file.

## Filter — before / after

```diff
   pull_request:
     branches: [main]
     paths:
       - 'docs/**'
       - 'spec/**'
-      - 'skills/**/*.md'
-      - 'tools/**/*.md'
       - 'mkdocs.yml'
       - 'mkdocs_hooks.py'
       - 'TESTING.md'
       - 'requirements.txt'
       - 'scripts/check_doc_slugs.py'
       - 'scripts/_test_fixtures/check_doc_slugs/**'
       - '.github/workflows/docs.yml'
```

(Same removal applied to `push.paths`.)

## Per-line decision

| Path                                              | Decision | Reason |
|---------------------------------------------------|----------|--------|
| `docs/**`                                         | kept     | docs_dir root; everything rendered lives here |
| `spec/**`                                         | kept     | staged into `docs/spec/` by the workflow's `Stage spec/ into docs/spec/` step |
| `skills/**/*.md`                                  | removed  | not staged; only hand-authored `docs/skills/X.md` summaries render |
| `tools/**/*.md`                                   | removed  | not staged; explicitly rewritten to GitHub blob URLs by mkdocs_hooks.py |
| `mkdocs.yml`                                      | kept     | build config |
| `mkdocs_hooks.py`                                 | kept     | build-time link rewriter |
| `TESTING.md`                                      | kept     | rewritten to blob URL but the rewriter's regex tests live here |
| `requirements.txt`                                | kept     | pip-installed for the build |
| `scripts/check_doc_slugs.py`                      | kept     | link validator step |
| `scripts/_test_fixtures/check_doc_slugs/**`       | kept     | validator self-test fixtures |
| `.github/workflows/docs.yml`                      | kept     | workflow self-edit |

## Test plan

- [x] `python -m mkdocs build` runs clean locally (4.66s baseline,
  3.92s after the change — build itself is unchanged; the filter only
  affects when CI fires).
- [x] `python scripts/check_doc_slugs.py --self-test --verbose` — all
  7 self-tests pass.
- [ ] Verify CI: this PR touches `.github/workflows/docs.yml`, which
  IS in the kept list, so the workflow will run on this PR and validate
  the change in situ.

Closes rf2-8k7vm.