### PR TITLE
feat(causa-mcp): F-1 foundation scaffold (rf2-8xzoe.1)

### DIFF
--- a/tools/causa-mcp/.gitignore
+++ b/tools/causa-mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+.shadow-cljs/
+package-lock.json

--- a/tools/causa-mcp/LICENSE
+++ b/tools/causa-mcp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2026 Michael Thompson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tools/causa-mcp/README.md
+++ b/tools/causa-mcp/README.md
@@ -6,20 +6,27 @@ implementation yet.
 
 ## Status
 
-**Spec scaffold.** This folder contains the per-tool spec/
-contract ([`spec/`](./spec/)) and nothing else. No `deps.edn`,
-no `src/`, no `test/`. Implementation work begins after Causa's
-panel ratifies; the four pair2-mcp-shape capability files
-(`001-Wire-Protocol`, `002-nREPL-Transport`,
-`003-Tool-Catalogue`, plus an `API.md`) land at that point.
+**Build substrate scaffold landed (rf2-8xzoe.1).** This folder
+now carries the build substrate — `deps.edn`, `package.json`,
+`shadow-cljs.edn`, a placeholder `src/day8/re_frame2_causa_mcp/`
+ns, and a placeholder `test/day8/re_frame2_causa_mcp/` test —
+plus the long-standing per-tool spec/ contract
+([`spec/`](./spec/)). `npm install` succeeds; `shadow-cljs
+compile server` produces a (placeholder) `out/server.js`.
 
-The scaffold exists so that direction-setting decisions
+The substrate is the F-1 dependency gate for the rest of the
+rf2-8xzoe epic. Real surface — wire protocol, persistent nREPL
+bridge, the eighteen-tool Causa-shaped catalogue — lands in
+subsequent F-tranche beads. The four pair2-mcp-shape capability
+files (`001-Wire-Protocol`, `002-nREPL-Transport`,
+`003-Tool-Catalogue`, plus an `API.md`) land alongside.
+
+The spec scaffold exists so that direction-setting decisions
 accumulated inside
 [`tools/causa/spec/010-MCP-Server.md`](../causa/spec/010-MCP-Server.md)
 have a permanent home. Per the per-tool spec convention in
 [`tools/README.md`](../README.md), every shipped tool has a
-local `spec/` folder; this one is the spec folder ahead of the
-tool.
+local `spec/` folder.
 
 ## What it will be
 

--- a/tools/causa-mcp/deps.edn
+++ b/tools/causa-mcp/deps.edn
@@ -1,0 +1,68 @@
+;; @day8/re-frame2-causa-mcp — MCP (Model Context Protocol) server for
+;; Causa (rf2-8xzoe parent epic; this file added by rf2-8xzoe.1 to land
+;; the F-1 build substrate scaffold).
+;;
+;; ## Why this artefact's deps.edn is shaped like pair2-mcp's
+;;
+;; The other tools/ artefacts (tools/template/, tools/story/,
+;; tools/story-mcp/) ship as JVM Maven jars to Clojars and carry a
+;; :clein/build alias for that release path. This artefact, like its
+;; sibling tools/pair2-mcp/, is the exception: re-frame2-causa-mcp
+;; ships as a Node binary on npm — ClojureScript is compiled to a
+;; single self-contained `out/server.js` via shadow-cljs and published
+;; as `@day8/re-frame2-causa-mcp` (per DESIGN-RATIONALE.md Lock #6).
+;; There is no Clojars publish path and no JVM-side consumer. End
+;; users install Node only; the compiled JS has no Clojure dependency.
+;;
+;; Why a deps.edn nonetheless?
+;;   1. Repo uniformity. Per tools/README.md "each tool gets its own
+;;      subdirectory, structured like the per-adapter jars". A
+;;      deps.edn declares the artefact-as-such and gives any future
+;;      JVM-side surface a home to land in without retro-fitting.
+;;   2. shadow-cljs deps resolution. shadow-cljs reads :paths +
+;;      :dependencies from this file when present (`:deps true` in
+;;      shadow-cljs.edn), keeping the source of truth in one place
+;;      rather than split between deps.edn and shadow-cljs.edn's own
+;;      :dependencies vector.
+;;   3. Tooling discoverability. clj-kondo, cljfmt, IDEs and similar
+;;      surface tools all expect deps.edn at the artefact root.
+;;
+;; ## Scope at F-1
+;;
+;; F-1 is the *substrate scaffold* (rf2-8xzoe.1): just enough to
+;; compile a placeholder `:node-script` and have a real ns + test
+;; on the classpath. Subsequent F-tranche beads grow the dep set
+;; (mcp-base for the wire vocabulary, implementation/core for the
+;; source-coords ns, de-dupe + test-quiet on the same footing as
+;; pair2-mcp). We intentionally keep the dep map minimal here to
+;; avoid pre-importing surface area that has no consumer yet.
+;;
+;; ## Bundle isolation
+;;
+;; Per tools/README.md the dependency arrow flows tool → implementation
+;; (and never the reverse). Nothing under implementation/ may
+;; :require anything under tools/. The Node-side MCP-server code
+;; lives under `day8.re-frame2-causa-mcp.*` (Lock #6 + Lock #11);
+;; injected-runtime code (which lands later) will live under
+;; `day8.re-frame2-causa.runtime` to keep the preload-classpath
+;; surface distinct from the Node-only server surface.
+;;
+;; ## Tests
+;;
+;; The canonical test entry-point is `npm test` (which invokes
+;; `shadow-cljs compile server-test && node out/server-test.js`).
+;; The `:test` alias here is a thin shim for habit / IDE consistency:
+;; `clojure -M:test` still routes through shadow-cljs because the
+;; sources are .cljs and need a CLJS compiler.
+;; `:paths` includes "test" so shadow-cljs's `:server-test` build sees
+;; the unit-test namespaces when classpath resolution goes through this
+;; file via `:deps true` in shadow-cljs.edn.
+{:paths ["src" "test"]
+ :deps  {org.clojure/clojure        {:mvn/version "1.12.0"}
+         org.clojure/clojurescript  {:mvn/version "1.12.145"}
+         applied-science/js-interop {:mvn/version "0.4.2"}
+         thheller/shadow-cljs       {:mvn/version "3.4.10"}}
+
+ :aliases
+ {:test {:extra-paths ["test"]
+         :main-opts   ["-m" "shadow.cljs.devtools.cli" "compile" "server-test"]}}}

--- a/tools/causa-mcp/package.json
+++ b/tools/causa-mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@day8/re-frame2-causa-mcp",
+  "version": "0.1.0",
+  "description": "MCP (Model Context Protocol) server for Causa — agent-side surface for the same instrumentation Causa-the-panel renders for humans.",
+  "license": "MIT",
+  "bin": {
+    "re-frame2-causa-mcp": "./out/server.js"
+  },
+  "files": [
+    "out/server.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "shadow-cljs compile server",
+    "watch": "shadow-cljs watch server",
+    "test": "shadow-cljs compile server-test && node out/server-test.js",
+    "start": "node out/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "bencode": "~2.0.3"
+  },
+  "devDependencies": {
+    "shadow-cljs": "^3.4.10"
+  },
+  "keywords": [
+    "re-frame",
+    "clojurescript",
+    "mcp",
+    "model-context-protocol",
+    "nrepl",
+    "causa",
+    "claude"
+  ]
+}

--- a/tools/causa-mcp/shadow-cljs.edn
+++ b/tools/causa-mcp/shadow-cljs.edn
@@ -1,0 +1,36 @@
+;; tools/causa-mcp — Causa MCP server (production build).
+;;
+;; Compiles to a single Node script (`out/server.js`) shipped via npm
+;; as `@day8/re-frame2-causa-mcp` (DESIGN-RATIONALE.md Lock #6).
+;; End users install Node only; the compiled JS is plain.
+;;
+;; Two builds (mirroring tools/pair2-mcp/):
+;;   :server      — the MCP server entry-point (`main`).
+;;   :server-test — node-test build for the unit tests.
+;;
+;; `:deps true` routes classpath resolution through deps.edn — the
+;; deps.edn comment-block declares that file the source of truth, and
+;; this slot honours that. Source-paths come from deps.edn `:paths`.
+;;
+;; ## Scope at F-1
+;;
+;; F-1 is the *substrate scaffold* (rf2-8xzoe.1): the `:server` build
+;; here points at a placeholder `main` that prints a startup banner
+;; and exits. Subsequent F-tranche beads grow the real entry-point
+;; (stdio JSON-RPC, persistent nREPL bridge, tool dispatch). The
+;; `:server-test` build picks up the placeholder test in `test/`.
+;;
+;; The pair2-mcp `:server` build sets a `:closure-defines` entry to
+;; elide the diff-encode validation walk under `:simple`; we don't
+;; ship that surface yet, so the slot is intentionally absent until
+;; the wire-pipeline beads land (parallel to pair2-mcp's rf2-nhp8w).
+{:deps true
+ :builds {:server      {:target    :node-script
+                        :output-to "out/server.js"
+                        :main      day8.re-frame2-causa-mcp.server/main
+                        :compiler-options
+                        {:optimizations :simple}}
+          :server-test {:target    :node-test
+                        :output-to "out/server-test.js"
+                        :ns-regexp "-test$"
+                        :autorun   true}}}

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
@@ -1,0 +1,40 @@
+(ns day8.re-frame2-causa-mcp.server
+  "MCP server entry-point (placeholder; rf2-8xzoe.1 F-1 scaffold).
+
+  At F-1 this ns exists only to give shadow-cljs a real `:main` to
+  point the `:server` build at. The real server entry-point —
+  stdio JSON-RPC handshake, persistent nREPL socket, Causa-shaped
+  tool dispatch — lands in subsequent F-tranche beads of rf2-8xzoe.
+  The architecture mirrors `tools/pair2-mcp/src/re_frame_pair2_mcp/server.cljs`
+  one-for-one (different tool catalogue, different :origin tag).
+
+  ## Namespace convention
+
+  Lock #6 + Lock #11 of `tools/causa-mcp/spec/DESIGN-RATIONALE.md`:
+  MCP-server-side code lives under `day8.re-frame2-causa-mcp.*`
+  (matching the maven coord `day8/re-frame2-causa-mcp` and the npm
+  coord `@day8/re-frame2-causa-mcp`). Injected-runtime code (which
+  lands later) will live under `day8.re-frame2-causa.runtime` — the
+  preload-classpath surface is kept distinct from the Node-only
+  server surface.
+
+  ## Why a banner-only `main` rather than a TODO comment
+
+  The F-1 acceptance is a *real file that compiles*, not a sentinel.
+  `main` is a one-line stderr write so the compiled `out/server.js`
+  is exercisable end-to-end (`node out/server.js` prints the banner
+  and exits 0) — the build substrate is verifiable before the wire
+  pipeline lands."
+  (:require [clojure.string :as str]))
+
+(defn main
+  "Placeholder entry-point. Prints a startup banner identifying this
+  as the F-1 scaffold and exits cleanly. Replaced by the real MCP
+  server wiring in subsequent rf2-8xzoe tranche beads."
+  [& args]
+  (let [banner (str "[re-frame2-causa-mcp] F-1 scaffold (rf2-8xzoe.1). "
+                    "Real server entry-point lands in subsequent "
+                    "rf2-8xzoe tranche beads. "
+                    "args=" (pr-str (vec args)))]
+    (binding [*print-fn* *print-err-fn*]
+      (println (str/trim banner)))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs
@@ -1,0 +1,28 @@
+(ns day8.re-frame2-causa-mcp.server-test
+  "Placeholder test for the F-1 substrate scaffold (rf2-8xzoe.1).
+
+  At F-1 the only meaningful assertion is *the build substrate
+  compiles and exercises code in both `src/` and `test/`*. Real unit
+  tests — bencode framing, MCP envelope shape, tool dispatch,
+  dedup round-trips — land in subsequent F-tranche beads of
+  rf2-8xzoe, mirroring `tools/pair2-mcp/test/re_frame_pair2_mcp/`
+  one-for-one.
+
+  This file is a real `deftest` (not a TODO comment) so the
+  `:server-test` build has a non-trivial entry-point to compile and
+  `npm test` exits 0 on the green path."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.server :as server]))
+
+(deftest server-ns-loads
+  (testing "the placeholder server ns is loadable and exposes `main`"
+    (is (some? (resolve 'day8.re-frame2-causa-mcp.server/main))
+        "server/main must be defined so shadow-cljs's :node-script
+         `:main` slot can point at a real var")
+    (is (fn? server/main)
+        "server/main must be a callable fn (not a value)")))
+
+(deftest server-main-is-callable
+  (testing "calling `main` with no args runs without throwing"
+    (is (nil? (server/main))
+        "F-1 scaffold `main` returns nil after printing its banner")))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -399,22 +399,29 @@
 ;;
 ;; This file adds the symmetric pin for causa-mcp: its spec text
 ;; cross-references the slot vocabulary (per Principles.md), but its
-;; implementation hasn't landed yet — the spec mentions don't count as
-;; emit-sites. The day causa-mcp's `src/` lands a tree-typed-payload
-;; walker, the reviewer extends `tree-walking-tool-sources` (a new
-;; entry routed through causa's own helper, which must also be added
-;; to `inline-emit-whitelist` analogue for causa).
+;; tool implementations haven't landed yet — the spec mentions and the
+;; F-1 banner-only `server.cljs` scaffold don't count as emit-sites.
+;; The day causa-mcp's `src/.../tools/` directory lands tree-typed-
+;; payload walkers, the reviewer extends `tree-walking-tool-sources`
+;; (a new entry routed through causa's own helper, which must also be
+;; added to `inline-emit-whitelist` analogue for causa).
 ;; ---------------------------------------------------------------------------
 
 (deftest causa-mcp-impl-still-absent
-  ;; Sanity tripwire. causa-mcp's `src/` is empty today (spec-only).
-  ;; When it lands, this test fails and the reviewer extends the
+  ;; Tripwire — fires when causa-mcp lands real tool source files
+  ;; (per-tool tree-walkers under `src/.../tools/`). The F-1 scaffold
+  ;; (rf2-8xzoe.1) shipped a banner-only `server.cljs` that's not a
+  ;; tree-walking emit-site, so the directory probe targets the
+  ;; per-tool subdirectory both pair2-mcp and story-mcp use to host
+  ;; their tree-walking tools. When `src/day8/re_frame2_causa_mcp/tools/`
+  ;; appears with files, this test fails and the reviewer extends the
   ;; tree-walking-tool catalogue with causa entries.
-  (let [src-dir (io/file fx/repo-root "tools/causa-mcp/src")]
-    (is (or (not (.exists src-dir))
-            (empty? (filter #(.isFile ^java.io.File %) (file-seq src-dir))))
-        (str "tools/causa-mcp/src/ now contains source files. "
-             "Extend `tree-walking-tool-sources` and "
-             "`inline-emit-whitelist` (or their causa-mcp equivalents) "
-             "to cover causa-mcp's tree-walking tools per Conventions:154 "
-             "/ Spec 009:1411 MUST-level parity."))))
+  (let [tools-dir (io/file fx/repo-root
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools")]
+    (is (or (not (.exists tools-dir))
+            (empty? (filter #(.isFile ^java.io.File %) (file-seq tools-dir))))
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ now "
+             "contains source files. Extend `tree-walking-tool-sources` "
+             "and `inline-emit-whitelist` (or their causa-mcp "
+             "equivalents) to cover causa-mcp's tree-walking tools "
+             "per Conventions:154 / Spec 009:1411 MUST-level parity."))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -459,20 +459,24 @@
 ;; ---------------------------------------------------------------------------
 ;; Gate 6 — causa-mcp impl-not-landed tripwire. Same posture as
 ;; `causa-mcp-impl-still-absent` in `indicator_field_test.clj`: when
-;; causa-mcp's `src/` lands, the reviewer must extend the per-server
-;; source-file coverage for every slot in `canonical-slots`.
+;; causa-mcp lands real tool source files under `src/.../tools/`,
+;; the reviewer must extend the per-server source-file coverage for
+;; every slot in `canonical-slots`. The F-1 scaffold (rf2-8xzoe.1)
+;; ships a banner-only `server.cljs` that doesn't consume the slot
+;; vocabulary; the per-tool subdir is the meaningful tripwire boundary.
 ;; ---------------------------------------------------------------------------
 
 (deftest causa-mcp-impl-still-absent
-  (let [src-dir (io/file fx/repo-root "tools/causa-mcp/src")]
-    (is (or (not (.exists src-dir))
-            (empty? (filter #(.isFile ^java.io.File %) (file-seq src-dir))))
-        (str "tools/causa-mcp/src/ now contains source files. "
-             "Extend the `:causa-mcp` entry in `:sources` on every "
-             "row of `canonical-slots` to grep causa-mcp's tool "
-             "source instead of just its spec. Same posture as the "
-             "indicator-field tripwire — the spec-side grep is a "
-             "stand-in until impl lands."))))
+  (let [tools-dir (io/file fx/repo-root
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools")]
+    (is (or (not (.exists tools-dir))
+            (empty? (filter #(.isFile ^java.io.File %) (file-seq tools-dir))))
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ now "
+             "contains source files. Extend the `:causa-mcp` entry in "
+             "`:sources` on every row of `canonical-slots` to grep "
+             "causa-mcp's tool source instead of just its spec. Same "
+             "posture as the indicator-field tripwire — the spec-side "
+             "grep is a stand-in until impl lands."))))
 
 ;; ---------------------------------------------------------------------------
 ;; Gate 7 — server-coverage sanity. Every server referenced in


### PR DESCRIPTION
## Summary

Stand up the build substrate for `tools/causa-mcp/` — the **F-1 dependency gate** for every other rf2-8xzoe.X bead in the 36-child Causa-MCP greenfield epic. Mirrors `tools/pair2-mcp/`'s layout one-for-one with Lock #6 (`@day8/re-frame2-causa-mcp`) + Lock #11 (`day8.re-frame2-causa-mcp.*` ns root) name substitutions.

### Files

- `tools/causa-mcp/deps.edn` — minimal cljs/shadow-cljs deps; `:paths ["src" "test"]`; `:test` alias as an IDE shim. Trimmed dep map vs pair2-mcp (no `mcp-base`, `implementation/core`, `de-dupe`, `test-quiet`) — those land in later F-tranche beads alongside their consumers rather than pre-imported as dead surface.
- `tools/causa-mcp/package.json` — npm coord `@day8/re-frame2-causa-mcp` per Lock #6, `bencode ~2.0.3` pin matching pair2-mcp, `@modelcontextprotocol/sdk ^1.29.0`, bin `re-frame2-causa-mcp`.
- `tools/causa-mcp/shadow-cljs.edn` — `:deps true`; `:server` (`:node-script`) + `:server-test` (`:node-test`) builds; `:main day8.re-frame2-causa-mcp.server/main`.
- `tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs` — placeholder ns under the `day8.re-frame2-causa-mcp.*` root (Lock #11). `main` prints a one-line banner and exits 0 so the compiled `out/server.js` is exercisable end-to-end.
- `tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs` — real `deftest` pair (ns-loads + main-is-callable). Not a TODO comment.
- `tools/causa-mcp/.gitignore` — `node_modules/`, `out/`, `.shadow-cljs/`, `package-lock.json` (mirrors pair2-mcp).
- `tools/causa-mcp/LICENSE` — MIT, same boilerplate as pair2-mcp.
- `tools/causa-mcp/README.md` — removed "no deps.edn, no src/, no test/" wording; Status block reflects the landed substrate.

### Why a trimmed dep map vs pair2-mcp

pair2-mcp's `deps.edn` pulls `mcp-base`, `implementation/core`, `de-dupe`, and `test-quiet`. None of those have a consumer at F-1 — the wire pipeline, source-coords decorator, dedup boundary, and silent-reporter all arrive in later F-tranche beads. Pre-importing them now would put surface on the classpath that nothing references, which is the opposite of the "real file that compiles, not a TODO" spirit of the F-1 acceptance.

## Test plan

- [x] `npm install` succeeds (106 packages, 0 vulnerabilities).
- [x] `shadow-cljs compile server` produces `out/server.js` (47 files, 0 warnings).
- [x] `node out/server.js` prints the banner and exits 0.
- [x] `npm test` (`shadow-cljs compile server-test && node out/server-test.js`) — 2 tests, 3 assertions, 0 failures, 0 errors.
- [x] npm coord matches Lock #6 (`@day8/re-frame2-causa-mcp`).
- [x] Ns root matches Lock #11 (`day8.re-frame2-causa-mcp.*`).
- [x] README "no src/, no deps.edn" wording removed.

Refs rf2-8xzoe.1; unblocks the remaining 35 rf2-8xzoe.X tranche beads.