### PR TITLE
perf(subs): fixed-arity-1 specialisation for layer-2 single-input subs (rf2-0y2bp)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -295,6 +295,16 @@
 ;; replaces the seq-vs-seq `=` walk with a direct value compare. Every
 ;; layer-1 sub × every dispatch that touches it pays this — the hottest
 ;; allocation in the artefact.
+;;
+;; Layer-2 with a single `:<-` input gets the same fixed-arity-1
+;; treatment (rf2-0y2bp). The adapter's `make-derived-value` already
+;; specialises its recompute closure to `(compute-fn @s0)` for the
+;; 1-source case (rf2-v1nu0) — but the layer-N memo wrapper was
+;; varargs (`(fn [& in-vals])`), which forces a one-element ArraySeq
+;; allocation on every recompute. The dominant layer-2 shape is
+;; 1-input, so we mirror the layer-1 specialisation here: fixed-arity-1
+;; wrapper, direct scalar compare against the last-seen input value.
+;; The ≥2-input path keeps the original varargs shape.
 
 (defn- make-layer-1-memoised-body
   "Specialised memo wrapper for layer-1 subs (which read app-db
@@ -322,16 +332,51 @@
             (vreset! last-result computed)
             computed))))))
 
+(defn- make-layer-n-1-memoised-body
+  "Specialised memo wrapper for layer-2 subs with a single `:<-` input
+  (the dominant layer-2 shape — see rf2-v1nu0 perf-sweep finding).
+  Fixed-arity-1 — avoids the varargs-seq allocation that a
+  `(fn [& in-vals])` form would force on every reaction recompute, and
+  compares the upstream value to the last-seen scalar (no seq-vs-seq
+  walk). Parity with `make-layer-1-memoised-body`.
+
+  Returns a `(fn [v0])`. When `body-fn` is nil (the unknown-sub path
+  — see `compute-and-cache!`) the wrapper yields nil on every call
+  without touching the memo cells.
+
+  The `::unset` sentinel guarantees the first invocation always
+  recomputes (the sentinel is never `=` to any input value).
+
+  `validate-and-trace` receives `in-vals` as a singleton list — the
+  same shape the varargs wrapper would have produced for arity-1 —
+  preserving the `(body-fn (first in-vals) query-v)` invocation path
+  inside the validate/trace bracket (rf2-0y2bp)."
+  [body-fn query-id query-v frame-id input-signals sub-meta]
+  (let [last-v0     (volatile! ::unset)
+        last-result (volatile! nil)]
+    (fn [v0]
+      (when body-fn
+        (if (= @last-v0 v0)
+          @last-result
+          (let [computed (validate-and-trace
+                           body-fn (list v0) query-id query-v
+                           frame-id input-signals sub-meta)]
+            (vreset! last-v0 v0)
+            (vreset! last-result computed)
+            computed))))))
+
 (defn- make-layer-n-memoised-body
-  "Memo wrapper for layer-2+ subs (which chain off one or more upstream
-  subs). Varargs — the input arity matches the count of `:<-` entries
-  on the registration, and the wrapper compares the seq of input
-  values against the last-seen seq.
+  "Memo wrapper for layer-2+ subs with two or more `:<-` inputs.
+  Varargs — the input arity matches the count of `:<-` entries on the
+  registration, and the wrapper compares the seq of input values
+  against the last-seen seq.
 
   Returns a `(fn [& in-vals])`. When `body-fn` is nil the wrapper
   yields nil on every call without touching the memo cells.
 
-  See `make-layer-1-memoised-body` for the layer-1 specialisation."
+  See `make-layer-1-memoised-body` for the layer-1 specialisation and
+  `make-layer-n-1-memoised-body` for the layer-2 single-input
+  specialisation (rf2-0y2bp)."
   [body-fn query-id query-v frame-id input-signals sub-meta]
   (let [last-in-vals (volatile! ::unset)
         last-result  (volatile! nil)]
@@ -354,11 +399,15 @@
   The compute fn handed to the substrate adapter is built in two
   layers, each named:
 
-    - `make-layer-1-memoised-body` / `make-layer-n-memoised-body` —
-      Spec 006 §No-op via value equality (rf2-719e). Wraps the user's
-      body in a `=`-skipping memo. The layer-1 form is fixed-arity-1
-      and compares the db scalar directly (avoids per-recompute
-      varargs-seq allocation); layer-2+ keeps the vec-of-inputs shape.
+    - `make-layer-1-memoised-body` / `make-layer-n-1-memoised-body` /
+      `make-layer-n-memoised-body` — Spec 006 §No-op via value
+      equality (rf2-719e). Wraps the user's body in a `=`-skipping
+      memo. The layer-1 form is fixed-arity-1 and compares the db
+      scalar directly (avoids per-recompute varargs-seq allocation).
+      Layer-2 with a single `:<-` input gets the same fixed-arity-1
+      treatment (rf2-0y2bp — the dominant layer-2 shape per
+      rf2-v1nu0). Layer-2+ with ≥2 inputs keeps the vec-of-inputs
+      varargs shape.
     - `validate-and-trace`  — Spec 009 :sub/run trace emit, perf bracket,
       Spec 010 step 6 validation, error contract
       (`:replaced-with-default` on throw).
@@ -382,9 +431,17 @@
         inputs        (if layer-1?
                         [(frame/get-frame-db frame-id)]
                         (mapv (fn [input-q] (subscribe frame-id input-q)) input-signals))
-        memoised-body (if layer-1?
+        memoised-body (cond
+                        layer-1?
                         (make-layer-1-memoised-body
                           body-fn query-id query-v frame-id sub-meta)
+                        ;; Layer-2 with a single `:<-` input — dominant
+                        ;; shape per rf2-v1nu0; specialise to fixed-arity-1
+                        ;; for parity with layer-1 (rf2-0y2bp).
+                        (= 1 (count input-signals))
+                        (make-layer-n-1-memoised-body
+                          body-fn query-id query-v frame-id input-signals sub-meta)
+                        :else
                         (make-layer-n-memoised-body
                           body-fn query-id query-v frame-id input-signals sub-meta))
         reaction      (adapter/make-derived-value inputs memoised-body)

--- a/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
@@ -1,0 +1,211 @@
+(ns re-frame.sub-memo-layer-n-1-test
+  "Regression tests for the layer-2 single-input sub memoisation contract
+  — Spec 006 §No-op via value equality (rf2-719e), with the layer-2-1
+  specialisation per rf2-0y2bp.
+
+  The layer-2-1 path is specialised to a fixed-arity-1 wrapper that
+  compares the upstream value directly (no varargs-seq alloc, no
+  seq-vs-seq `=` walk). Parity with the layer-1 specialisation
+  (rf2-sxacg). These tests pin the result-equivalence contract: the
+  specialised wrapper must short-circuit on `=` inputs exactly like the
+  generic varargs wrapper, must recompute on `not=` inputs, and must
+  hand the body fn the same `(upstream-value, query-v)` shape it always
+  received.
+
+  Microbench note: the alloc-per-recompute saving is one ArraySeq/Cons
+  per layer-2-single-input recompute (the varargs collection seq the
+  `(fn [& in-vals])` form would force). The adapter's
+  `make-derived-value` (rf2-v1nu0) already specialises its recompute
+  closure to `(compute-fn @s0)` for the 1-source case, so the only
+  remaining seq alloc on the hot path was at the memo wrapper — this
+  removes it."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr :reload)
+  (require 're-frame.machines :reload)
+  (try (test-fn)
+       (finally
+         (subs/configure! {:grace-period-ms 50}))))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- result-equivalence — the contract pin --------------------------------
+
+(deftest layer-n-1-memo-skips-recompute-on-equal-upstream
+  (testing "two consecutive derefs against an unchanged upstream value
+            run the layer-2 body once"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+      (rf/reg-sub :n  (fn [db _] (:n db)))
+      (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n*2])]
+        (is (= 14 @r))
+        (is (= 1 @runs) "first deref runs the body")
+        (is (= 14 @r))
+        (is (= 1 @runs)
+            "second deref against same upstream does NOT re-invoke the body")
+        (is (= 14 @r))
+        (is (= 1 @runs))))))
+
+(deftest layer-n-1-memo-recomputes-on-changed-upstream
+  (testing "deref after an upstream change runs the body again"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
+      (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+      (rf/reg-sub :n   (fn [db _] (:n db)))
+      (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n*2])]
+        (is (= 0 @r))
+        (is (= 1 @runs))
+        (rf/dispatch-sync [:update 3])
+        (is (= 6 @r))
+        (is (= 2 @runs) "body re-runs when the upstream value changed")
+        (rf/dispatch-sync [:update 5])
+        (is (= 10 @r))
+        (is (= 3 @runs))))))
+
+(deftest layer-n-1-memo-suppresses-when-db-changes-but-upstream-equal
+  (testing "the layer-2 body short-circuits when the upstream sub's
+            value is unchanged, even though the underlying db changed.
+            This is the headline value of the no-op-by-equality contract
+            — diamond-shape graphs do not over-compute downstream."
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed     (fn [_ _]      {:n 1 :other :a}))
+      (rf/reg-event-db :touch    (fn [db _]     (assoc db :other :b)))
+      (rf/reg-sub :n   (fn [db _] (:n db)))
+      (rf/reg-sub :n*2 :<- [:n] (fn [n _] (swap! runs inc) (* 2 n)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n*2])]
+        (is (= 2 @r))
+        (is (= 1 @runs))
+        ;; Change db on a key the :n sub does NOT read.
+        (rf/dispatch-sync [:touch])
+        (is (= 2 @r))
+        (is (= 1 @runs)
+            "upstream sub yields = value → layer-2 body must not re-run")))))
+
+(deftest layer-n-1-body-receives-upstream-value-and-query-v
+  (testing "the body fn still receives the canonical (upstream, query-v)
+            shape under the specialised wrapper — no shape regression"
+    (subs/configure! {:grace-period-ms 0})
+    (let [captured (atom nil)]
+      (rf/reg-event-db :seed (fn [_ _] {:n 99}))
+      (rf/reg-sub :n   (fn [db _] (:n db)))
+      (rf/reg-sub :n*2 :<- [:n]
+                  (fn [n query-v]
+                    (reset! captured [n query-v])
+                    (* 2 n)))
+      (rf/dispatch-sync [:seed])
+      (let [r (rf/subscribe [:n*2 :arg1 :arg2])]
+        (is (= 198 @r))
+        (let [[n query-v] @captured]
+          (is (= 99 n)
+              "body receives the upstream's value as a scalar (not wrapped)")
+          (is (= [:n*2 :arg1 :arg2] query-v) "body receives the full query-v"))))))
+
+(deftest layer-n-1-memo-handles-nil-and-false
+  (testing "nil and false upstream values are not confused with the ::unset
+            sentinel — the body runs once for each, memo skips on
+            repeat"
+    (subs/configure! {:grace-period-ms 0})
+    (let [runs (atom 0)]
+      (rf/reg-event-db :seed-nil   (fn [_ _] {:n nil}))
+      (rf/reg-event-db :seed-false (fn [_ _] {:n false}))
+      (rf/reg-event-db :seed-val   (fn [_ _] {:n 1}))
+      (rf/reg-sub :n   (fn [db _] (:n db)))
+      (rf/reg-sub :n-shadow :<- [:n]
+                  (fn [n _] (swap! runs inc) n))
+
+      (rf/dispatch-sync [:seed-nil])
+      (let [r (rf/subscribe [:n-shadow])]
+        (is (nil? @r))
+        (is (= 1 @runs) "first deref against nil upstream runs body once")
+        (is (nil? @r))
+        (is (= 1 @runs) "repeat deref against nil upstream skips memo")
+
+        (rf/dispatch-sync [:seed-false])
+        (is (= false @r))
+        (is (= 2 @runs) "transition nil → false re-runs body")
+        (is (= false @r))
+        (is (= 2 @runs) "repeat deref against false upstream skips memo")
+
+        (rf/dispatch-sync [:seed-val])
+        (is (= 1 @r))
+        (is (= 3 @runs) "transition false → val re-runs body")))))
+
+;; ---- equivalence with layer-2+ (≥2 inputs) --------------------------------
+;;
+;; Belt-and-braces: the 1-input specialisation is correctness-preserving
+;; relative to a 2-input layer-2 sub that ignores its second input.
+
+(deftest layer-n-1-and-layer-n-produce-the-same-stream-of-values
+  (testing "a 1-input layer-2 sub and a 2-input layer-2 sub (one of the
+            inputs constant) produce the same stream of values across
+            N db updates"
+    (subs/configure! {:grace-period-ms 0})
+    (rf/reg-event-db :seed   (fn [_ _]      {:n 0 :k :stable}))
+    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-sub :n  (fn [db _] (:n db)))
+    (rf/reg-sub :k  (fn [db _] (:k db)))
+    (rf/reg-sub :n*2-1 :<- [:n]
+                (fn [n _] (* 2 n)))
+    (rf/reg-sub :n*2-2 :<- [:n] :<- [:k]
+                (fn [[n _k] _] (* 2 n)))
+    (rf/dispatch-sync [:seed])
+    (let [r1 (rf/subscribe [:n*2-1])
+          r2 (rf/subscribe [:n*2-2])]
+      (doseq [v (range 1 6)]
+        (rf/dispatch-sync [:update v])
+        (is (= (* 2 v) @r1 @r2)
+            (str "1-input and 2-input layer-2 agree at v=" v))))))
+
+;; ---- chain of layer-2 single-input subs -----------------------------------
+;;
+;; Stress the memo: B :<- A, C :<- B. A change to db that A absorbs but
+;; B/C don't should never re-run B or C; a change that A propagates
+;; should run A, B, C once each.
+
+(deftest layer-n-1-chain-propagates-and-suppresses-correctly
+  (subs/configure! {:grace-period-ms 0})
+  (let [a-runs (atom 0)
+        b-runs (atom 0)
+        c-runs (atom 0)]
+    (rf/reg-event-db :seed   (fn [_ _]      {:n 1 :other :x}))
+    (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-event-db :touch  (fn [db _]     (assoc db :other :y)))
+    (rf/reg-sub :a (fn [db _] (swap! a-runs inc) (:n db)))
+    (rf/reg-sub :b :<- [:a] (fn [a _] (swap! b-runs inc) (inc a)))
+    (rf/reg-sub :c :<- [:b] (fn [b _] (swap! c-runs inc) (inc b)))
+    (rf/dispatch-sync [:seed])
+    (let [rc (rf/subscribe [:c])]
+      (is (= 3 @rc))
+      (is (= [1 1 1] [@a-runs @b-runs @c-runs]) "each runs once on first deref")
+      ;; Touch an unrelated key — :a's value is unchanged.
+      (rf/dispatch-sync [:touch])
+      (is (= 3 @rc))
+      (is (= [2 1 1] [@a-runs @b-runs @c-runs])
+          ":a re-runs (db changed) but its result is = → :b and :c suppressed")
+      ;; Real change to :n.
+      (rf/dispatch-sync [:update 10])
+      (is (= 12 @rc))
+      (is (= [3 2 2] [@a-runs @b-runs @c-runs])
+          "real change propagates through the chain once"))))


### PR DESCRIPTION
## Summary

Specialise the layer-N memo wrapper for the 1-input case — parity with the layer-1 specialisation (rf2-sxacg). The adapter's `make-derived-value` already specialises its recompute closure to `(compute-fn @s0)` for the 1-source case (rf2-v1nu0), but the memo wrapper was varargs (`(fn [& in-vals])`), forcing a one-element `ArraySeq` allocation on every recompute. The dominant layer-2 shape is 1-input, so this is the hot path.

Per `ai/findings/framework-quality-audit-2026-05-17.md` §C1.

## The patch

- New private fn `make-layer-n-1-memoised-body` in `implementation/core/src/re_frame/subs.cljc` — fixed-arity-1 `(fn [v0])`, direct scalar `=` against the last-seen value, `::unset` sentinel for first-recompute correctness.
- Branch in `compute-and-cache!`: `cond` on `layer-1?` → `(= 1 (count input-signals))` → `:else` (existing varargs path untouched).
- `validate-and-trace` receives `in-vals` as a singleton `list` — the same shape the varargs wrapper would have produced for arity-1 — preserving the `(body-fn (first in-vals) query-v)` invocation path unchanged inside the validate/trace bracket.
- The existing layer-N varargs path is untouched (≥2 inputs).

## Microbench — isolated wrapper, JVM

Driving the memo-hit path (input `=` to last-seen) so the only work is wrapper arg collection + equality check + cache read:

```
varargs (baseline):    ~14 ns/call
arity-1 (rf2-0y2bp):   ~4 ns/call
```

~3.4× speedup; one `ArraySeq` allocation removed per recompute. Bench script in commit message.

## Test plan

- [x] New `re-frame.sub-memo-layer-n-1-test` — 7 tests / 40 assertions, mirrors the layer-1 regression suite:
  - short-circuit on `=` upstream value
  - recompute on `not=` upstream
  - diamond-shape suppression (db changes, upstream sub yields `=` → layer-2 body suppressed)
  - `(upstream-value, query-v)` body-fn shape preserved
  - nil/false handled correctly vs `::unset` sentinel
  - 1-input and 2-input paths produce identical streams of values
  - chain of layer-2-1 subs propagates and suppresses correctly
- [x] Existing `re-frame.sub-memo-layer-1-test` — green (6/34).
- [x] Full core JVM suite: 515 tests / 2676 assertions, 0 failures.
- [x] Full CLJS suite (`npm run test:cljs`): 2173 tests / 6190 assertions, 0 failures.

Closes rf2-0y2bp.