### PR TITLE
fix(adapters): unify sub-cache dispose-walk across all 3 adapters (rf2-jcjul)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispose_adapter_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispose_adapter_cljs_test.cljs
@@ -21,6 +21,9 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.disposable :as rf-disposable]
+            [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -97,3 +100,49 @@
         "dispose-adapter! returns nil even when no roots are tracked")
     (is (nil? ((:dispose-adapter! helix-adapter/adapter)))
         "second dispose is idempotent — active-roots set was already drained")))
+
+;; ---- MUST (1) — cancel all in-flight reactive subscriptions ---------------
+;;
+;; rf2-jcjul pinned this MUST at every React-shaped adapter. The spine's
+;; `dispose-frame-sub-caches!` is the single implementation behind
+;; Reagent / reagent-slim / UIx / Helix dispose paths; pinning the
+;; user-facing slot here guards against a future refactor that
+;; accidentally drops the walk from the spine factory.
+
+(deftest dispose-clears-sub-caches-across-live-frames
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (1) (rf2-jcjul):
+            dispose-adapter! cancels in-flight reactive subscriptions by
+            walking every live frame's per-frame sub-cache and disposing
+            each cached Reaction. The spine derived-value is an
+            re-frame-owned IDisposable; the Helix adapter routes
+            `:adapter/dispose!` to rf-disposable's protocol fn (lines
+            172-173 of re-frame.adapter.helix). Materialise a sub through
+            `rf/subscribe`, then drive the adapter's dispose-adapter! and
+            assert the underlying IDisposable fired."
+    (rf/reg-frame :helix-walk/a {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed] {:frame :helix-walk/a})
+
+    (let [r-a (rf/subscribe :helix-walk/a [:n])]
+      (is (= 7 @r-a) "precondition: subscription is live and deref-able")
+
+      (let [cache (:sub-cache (frame/frame :helix-walk/a))
+            entries-before @cache]
+        (is (>= (count entries-before) 1)
+            "precondition: sub-cache holds at least the [:n] entry")
+        (let [disposed (atom #{})
+              reactions (for [[_ entry] entries-before
+                              :let [r (:reaction entry)]
+                              :when r]
+                          r)]
+          (doseq [r reactions]
+            (rf-disposable/-add-on-dispose r (fn [] (swap! disposed conj r))))
+
+          ((:dispose-adapter! helix-adapter/adapter))
+
+          (doseq [r reactions]
+            (is (contains? @disposed r)
+                "every cached reaction fired its dispose hook"))
+          (is (= {} @cache)
+              "the frame's sub-cache atom was reset to {} by the walk"))))))

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -16,6 +16,7 @@
             [re-frame.frame            :as frame]
             [re-frame.late-bind        :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.spine   :as spine]
             [re-frame.views            :as views]))
 
 ;; ---- container ------------------------------------------------------------
@@ -87,9 +88,22 @@
 ;; ---- disposal -------------------------------------------------------------
 
 (defn- dispose-adapter! []
-  ;; Reactions GC themselves when their owners (componentWillUnmount-
-  ;; disposed render Reactions) go away. Nothing per-adapter to do.
-  nil)
+  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
+  ;; rf2-jcjul). The component-unmount-driven path handles the
+  ;; mounted case (reagent2 reaps Reactions once their last watcher
+  ;; drops) — but `dispose-adapter!` MUST cover the headless /
+  ;; test-fixture path where no component unmount fires before the
+  ;; adapter goes away, and the SSR path where the rendered tree was
+  ;; string-serialised without ever being mounted. Without the walk,
+  ;; sequential `init! → dispose-adapter!` cycles in a long-lived
+  ;; process accumulate per-frame sub-cache entries closed over stale
+  ;; Reactions forever.
+  ;;
+  ;; Delegated to `spine/dispose-frame-sub-caches!` (rf2-jcjul): the
+  ;; same helper backs the Reagent adapter and the spine-built UIx /
+  ;; Helix adapters so all three substrates share one implementation
+  ;; — no three-way drift on the lifecycle MUST.
+  (spine/dispose-frame-sub-caches!))
 
 (def adapter
   "The reagent-slim adapter map. Pass to `(rf/init! ...)` to install:

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_dispose_sub_cache_walk_cljs_test.cljs
@@ -1,0 +1,153 @@
+(ns re-frame.adapter.reagent-slim-dispose-sub-cache-walk-cljs-test
+  "Pins the reagent-slim adapter's `dispose-adapter!` four-MUST list
+  item 1 (rf2-jcjul + Spec 006 §Adapter disposal lifecycle): cancel
+  all in-flight reactive subscriptions by walking every live frame's
+  per-frame sub-cache and disposing each cached Reaction.
+
+  Mirrors the Reagent adapter's
+  `re-frame.dispose-adapter-sub-cache-walk-cljs-test` so the cross-
+  adapter parity from rf2-jcjul stays pinned at all three substrates'
+  user-facing surfaces. The unit-tier coverage of the underlying
+  `spine/dispose-frame-sub-caches!` helper lives in
+  `re-frame.substrate.spine-dispose-cljs-test`; this file covers the
+  through-the-slim-adapter shape.
+
+  Pre-rf2-jcjul this adapter's `dispose-adapter!` was a no-op
+  (`nil` return; comment claimed 'Reactions GC themselves') — but
+  that's the headless / test-fixture path the spec calls out as the
+  exact reason for the walk: no component unmount fires before the
+  adapter goes away, so the per-frame sub-cache's Reactions stay
+  pinned at ref-count 1 forever and the adapter slot can't be reused
+  cleanly. The spine-backed walk now covers this.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent2.ratom :as ratom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.adapter.reagent-slim :as reagent-slim-adapter]))
+
+;; ---- fixture --------------------------------------------------------------
+;;
+;; Cold-start. The unit under test IS `dispose-adapter!`, so we install
+;; the slim adapter ourselves at the top of each test and let the test
+;; body call dispose-adapter! to drive the walk. Each test cleans up
+;; after itself so a re-run is idempotent.
+
+(defn fresh-slim [test-fn]
+  ;; Wipe lifecycle state — adapter slot + disposed breadcrumb +
+  ;; frame registry — so the test starts from a never-installed cold
+  ;; state. The `reset-lifecycle-state-for-tests!` seam exists for
+  ;; exactly this purpose (rf2-6wxys).
+  (adapter/reset-lifecycle-state-for-tests!)
+  (reset! frame/frames {})
+  (rf/init! reagent-slim-adapter/adapter)
+  (frame/ensure-default-frame!)
+  (test-fn)
+  ;; Best-effort post-clean: if the test body left the adapter
+  ;; installed, dispose it; if already disposed, the breadcrumb
+  ;; lookup makes this a no-op.
+  (when (adapter/current-adapter)
+    (adapter/dispose-adapter!))
+  (reset! frame/frames {})
+  (adapter/reset-lifecycle-state-for-tests!))
+
+(use-fixtures :each fresh-slim)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- cached-reactions-across-all-frames
+  "Return a seq of every cached `:reaction` across every live frame's
+  sub-cache. Walks `@frame/frames` the same way the adapter's
+  `dispose-adapter!` walk does."
+  []
+  (for [[_ frame-record] @frame/frames
+        :let  [cache (:sub-cache frame-record)]
+        :when cache
+        [_k entry] @cache
+        :let  [r (:reaction entry)]
+        :when r]
+    r))
+
+(defn- sub-cache-counts
+  "Return `{frame-id <entry-count>}` for every frame with a sub-cache."
+  []
+  (into {}
+        (for [[fid frame-record] @frame/frames
+              :let [cache (:sub-cache frame-record)]
+              :when cache]
+          [fid (count @cache)])))
+
+;; ---- tests ----------------------------------------------------------------
+
+(deftest dispose-adapter-walks-and-disposes-cached-reactions-across-every-frame
+  (testing "after dispose-adapter!, every cached Reaction across every
+  live frame is disposed AND every frame's sub-cache atom is empty"
+    ;; Set up two frames each with a cached subscription, mirroring the
+    ;; counter-with-stories shape (one frame per Story variant).
+    (rf/reg-frame :walk/a {})
+    (rf/reg-frame :walk/b {})
+    (rf/reg-event-db :seed (fn [_ [_ n]] {:n n}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+
+    (rf/dispatch-sync [:seed 1] {:frame :walk/a})
+    (rf/dispatch-sync [:seed 2] {:frame :walk/b})
+
+    ;; Materialise + deref so the sub cache holds live Reactions.
+    (let [r-a (rf/subscribe :walk/a [:n])
+          r-b (rf/subscribe :walk/b [:n])]
+      (is (= 1 @r-a))
+      (is (= 2 @r-b))
+
+      (let [precount (sub-cache-counts)]
+        (is (>= (get precount :walk/a 0) 1)
+            "precondition: walk/a's sub-cache holds the [:n] entry")
+        (is (>= (get precount :walk/b 0) 1)
+            "precondition: walk/b's sub-cache holds the [:n] entry"))
+
+      ;; Snapshot every Reaction across every frame BEFORE dispose so
+      ;; we can inspect their disposed? after the walk. (After the walk
+      ;; the caches are empty, so we couldn't reach the Reactions
+      ;; through the cache anymore.)
+      (let [reactions-before (vec (cached-reactions-across-all-frames))]
+        (is (>= (count reactions-before) 2)
+            "precondition: at least one Reaction per frame is cached")
+        (is (every? #(satisfies? ratom/IDisposable %) reactions-before)
+            "precondition: snapshotted handles satisfy reagent2's disposal contract")
+
+        (let [disposed (atom #{})]
+          (doseq [r reactions-before]
+            (ratom/add-on-dispose! r (fn [& _] (swap! disposed conj r))))
+
+          ;; Drive the walk.
+          (adapter/dispose-adapter!)
+
+          ;; Invariant 1: every previously-cached Reaction is now
+          ;; disposed. Assert through reagent2's public disposal callback
+          ;; surface.
+          (doseq [r reactions-before]
+            (is (contains? @disposed r)
+                (str "post-dispose: Reaction " (pr-str r)
+                     " on a frame's sub-cache fired its dispose hook")))))
+
+      ;; Invariant 2: every frame's sub-cache atom is empty.
+      (doseq [[fid frame-record] @frame/frames
+              :let [cache (:sub-cache frame-record)]
+              :when cache]
+        (is (= {} @cache)
+            (str "post-dispose: frame " (pr-str fid)
+                 "'s sub-cache atom is empty"))))))
+
+(deftest dispose-adapter-walk-tolerates-an-empty-frames-registry
+  (testing "dispose-adapter! on an installed slim adapter with no live
+  frames is a no-op (no throw)"
+    ;; Pre-dispose: drop every frame, then dispose. This is the post-
+    ;; reset-runtime-fixture shape: the fixture resets frames BEFORE
+    ;; calling dispose-adapter!, so dispose-adapter! sees an empty
+    ;; registry.
+    (reset! frame/frames {})
+    (is (nil? (adapter/dispose-adapter!))
+        "dispose-adapter! returns nil with an empty frames registry — no throw")
+    (is (true? (adapter/adapter-disposed?))
+        "the disposed-adapter breadcrumb is set after the no-op walk")))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -8,9 +8,9 @@
             [reagent.dom.client :as rdc]
             [re-frame.disposable :as rf-disposable]
             [re-frame.frame :as frame]
-            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.spine :as spine]
             [re-frame.views :as views]))
 
 ;; ---- container ------------------------------------------------------------
@@ -108,18 +108,23 @@
 ;; ---- disposal -------------------------------------------------------------
 
 (defn- dispose-adapter! []
-  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq). The
-  ;; four-MUST list:
+  ;; Spec 006 §Adapter disposal lifecycle (rf2-9fdkb, rf2-a47kq,
+  ;; rf2-jcjul). The four-MUST list:
   ;;
   ;;   1. Cancel all in-flight reactive subscriptions — walk every live
   ;;      frame's per-frame sub-cache and dispose each cached Reaction.
+  ;;      Delegated to `spine/dispose-frame-sub-caches!` (rf2-jcjul):
+  ;;      the same helper backs reagent-slim and the spine-built UIx /
+  ;;      Helix adapters so all three substrates share one
+  ;;      implementation — no three-way drift on the lifecycle MUST.
   ;;      Component-unmount-driven disposal handles the mounted case
   ;;      (Reagent reaps Reactions when their last watcher drops); the
   ;;      explicit walk covers the test-fixture / headless path where
   ;;      no component unmount fires before the adapter goes away.
-  ;;      `interop/dispose!` routes through `:adapter/dispose!` which is
-  ;;      still wired for this adapter at this point in the teardown
-  ;;      (substrate-adapter clears the install slot AFTER calling us).
+  ;;      `interop/dispose!` inside the walk routes through
+  ;;      `:adapter/dispose!` which is still wired for this adapter at
+  ;;      this point in the teardown (substrate-adapter clears the
+  ;;      install slot AFTER calling us).
   ;;
   ;;   2. Release host-specific resources — drain the active-roots set
   ;;      (React 18+ Roots; mounted-but-not-unmounted at process exit /
@@ -133,16 +138,7 @@
   ;;   4. Make subsequent calls return `:rf.error/adapter-disposed` —
   ;;      handled one level up by `substrate-adapter/dispose-adapter!`
   ;;      via the `disposed?` breadcrumb (rf2-6wxys).
-  (doseq [[_ frame-record] @frame/frames]
-    (when-let [cache (:sub-cache frame-record)]
-      (doseq [[_k entry] @cache]
-        (when-let [h (:pending-dispose entry)]
-          (try (interop/clear-timeout! h)
-               (catch :default _ nil)))
-        (when-let [r (:reaction entry)]
-          (try (interop/dispose! r)
-               (catch :default _ nil))))
-      (reset! cache {})))
+  (spine/dispose-frame-sub-caches!)
   (doseq [root @active-roots]
     (try (rdc/unmount root)
          (catch :default _ nil)))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispose_adapter_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispose_adapter_cljs_test.cljs
@@ -21,6 +21,9 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.disposable :as rf-disposable]
+            [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -97,3 +100,49 @@
         "dispose-adapter! returns nil even when no roots are tracked")
     (is (nil? ((:dispose-adapter! uix-adapter/adapter)))
         "second dispose is idempotent — active-roots set was already drained")))
+
+;; ---- MUST (1) — cancel all in-flight reactive subscriptions ---------------
+;;
+;; rf2-jcjul pinned this MUST at every React-shaped adapter. The spine's
+;; `dispose-frame-sub-caches!` is the single implementation behind
+;; Reagent / reagent-slim / UIx / Helix dispose paths; pinning the
+;; user-facing slot here guards against a future refactor that
+;; accidentally drops the walk from the spine factory.
+
+(deftest dispose-clears-sub-caches-across-live-frames
+  (testing "Spec 006 §Adapter disposal lifecycle MUST (1) (rf2-jcjul):
+            dispose-adapter! cancels in-flight reactive subscriptions by
+            walking every live frame's per-frame sub-cache and disposing
+            each cached Reaction. The spine derived-value is an
+            re-frame-owned IDisposable; the UIx adapter routes
+            `:adapter/dispose!` to rf-disposable's protocol fn (lines
+            172-173 of re-frame.adapter.uix). Materialise a sub through
+            `rf/subscribe`, then drive the adapter's dispose-adapter! and
+            assert the underlying IDisposable fired."
+    (rf/reg-frame :uix-walk/a {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 7}))
+    (rf/reg-sub :n (fn [db _] (:n db)))
+    (rf/dispatch-sync [:seed] {:frame :uix-walk/a})
+
+    (let [r-a (rf/subscribe :uix-walk/a [:n])]
+      (is (= 7 @r-a) "precondition: subscription is live and deref-able")
+
+      (let [cache (:sub-cache (frame/frame :uix-walk/a))
+            entries-before @cache]
+        (is (>= (count entries-before) 1)
+            "precondition: sub-cache holds at least the [:n] entry")
+        (let [disposed (atom #{})
+              reactions (for [[_ entry] entries-before
+                              :let [r (:reaction entry)]
+                              :when r]
+                          r)]
+          (doseq [r reactions]
+            (rf-disposable/-add-on-dispose r (fn [] (swap! disposed conj r))))
+
+          ((:dispose-adapter! uix-adapter/adapter))
+
+          (doseq [r reactions]
+            (is (contains? @disposed r)
+                "every cached reaction fired its dispose hook"))
+          (is (= {} @cache)
+              "the frame's sub-cache atom was reset to {} by the walk"))))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -34,6 +34,7 @@
   (:require ["react"             :as React]
             ["react-dom/client"  :as react-dom-client]
             [re-frame.disposable :as rf-disposable]
+            [re-frame.frame      :as frame]
             [re-frame.interop    :as interop]
             [re-frame.late-bind  :as late-bind]
             [re-frame.subs       :as subs]
@@ -201,22 +202,85 @@
         (swap! active-roots-cell disj root)
         (.unmount root)))))
 
+(defn dispose-frame-sub-caches!
+  "Walk every live frame's per-frame sub-cache and dispose each cached
+  Reaction (Spec 006 §Adapter disposal lifecycle MUST 1; rf2-9fdkb,
+  rf2-a47kq, rf2-jcjul).
+
+  Why the walk exists at all. Component-unmount-driven disposal handles
+  the mounted case — the reactive substrate reaps a derived value once
+  its last watcher drops. This walk covers the test-fixture / headless
+  path where no component unmount fires before the adapter goes away,
+  AND the SSR / server-render path where the rendered tree was string-
+  serialised without ever being mounted. Without the walk, a long-lived
+  process driving sequential `init! → dispose-adapter!` cycles (test
+  bundles, hot-reload, multi-adapter integration tests) accumulates
+  cached Reactions closed over stale frames forever.
+
+  Per-entry contract. For every `[k entry]` in every live frame's
+  `:sub-cache` atom:
+
+    1. If `entry` carries a `:pending-dispose` timer handle (the
+       sub-cache's grace-period reaper), cancel it via
+       `interop/clear-timeout!` — otherwise a fired timer would
+       attempt to touch a torn-down adapter slot.
+    2. Dispose the cached `:reaction` via `interop/dispose!`. This
+       routes through `:adapter/dispose!`, which is still wired at
+       this point in the teardown sequence (the substrate-adapter
+       clears the install slot AFTER calling the adapter's
+       `dispose-adapter!`).
+    3. After draining each frame's entries, `reset!` its sub-cache
+       atom to `{}`.
+
+  The walk is best-effort: a throwing per-entry dispose (e.g. a
+  misbehaving user `:on-dispose` hook, or a poison entry inserted by
+  tests) does NOT abort the rest of the walk — every other cached
+  Reaction in the same cache AND every cache in subsequent frames
+  still gets disposed and cleared. Per-entry throws are swallowed.
+
+  Used by every React-shaped adapter's `dispose-adapter!` — wired into
+  the `make-dispose-adapter!` factory for UIx / Helix and called
+  directly from the Reagent / reagent-slim adapters' dispose paths.
+  Centralising the walk here is the rf2-jcjul lockstep: one
+  implementation, three adapters, zero drift."
+  []
+  (doseq [[_ frame-record] @frame/frames]
+    (when-let [cache (:sub-cache frame-record)]
+      (doseq [[_k entry] @cache]
+        (when-let [h (:pending-dispose entry)]
+          (try (interop/clear-timeout! h)
+               (catch :default _ nil)))
+        (when-let [r (:reaction entry)]
+          (try (interop/dispose! r)
+               (catch :default _ nil))))
+      (reset! cache {}))))
+
 (defn make-dispose-adapter!
-  "Build a `dispose-adapter!` fn that drains `active-roots-cell` by
-  calling `.unmount` on every tracked React root and clears the
-  spine's per-adapter caches:
+  "Build a `dispose-adapter!` fn satisfying Spec 006 §Adapter disposal
+  lifecycle (rf2-9fdkb). The returned fn:
 
-    * the active-roots set is emptied (post-unmount),
-    * the warn-once cache is emptied (so a subsequent install does not
-      inherit stale warn-once state from a prior lifecycle),
-    * the hiccup-emitter cell is cleared.
+    1. Walks every live frame's per-frame sub-cache and disposes each
+       cached Reaction (`dispose-frame-sub-caches!`), satisfying MUST
+       (1): cancel all in-flight reactive subscriptions.
+    2. Drains `active-roots-cell` by calling `.unmount` on every
+       tracked React root, satisfying MUST (2): release host-specific
+       resources.
+    3. Clears the spine's per-adapter caches — `active-roots-cell`,
+       `warn-cache`, `emitter-cell` — satisfying MUST (3): discard
+       internal caches.
 
-  Per Spec 006 §Adapter disposal lifecycle (rf2-9fdkb). React's
-  `.unmount` is idempotent / no-op on already-unmounted roots; we
-  swallow any unmount throw so one misbehaving root does not strand
-  the rest of the drain."
+  MUST (4) (subsequent calls return `:rf.error/adapter-disposed`) is
+  enforced one level up by `substrate-adapter/dispose-adapter!` via
+  the `disposed?` breadcrumb (rf2-6wxys).
+
+  Best-effort drains. React's `.unmount` is idempotent / no-op on
+  already-unmounted roots; we swallow any unmount throw so one
+  misbehaving root does not strand the rest of the drain. The
+  sub-cache walk has its own per-entry try/catch (see
+  `dispose-frame-sub-caches!`)."
   [{:keys [active-roots-cell warn-cache emitter-cell]}]
   (fn dispose-adapter! []
+    (dispose-frame-sub-caches!)
     (doseq [root @active-roots-cell]
       (try (.unmount root)
            (catch :default _ nil)))

--- a/implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_dispose_cljs_test.cljs
@@ -11,7 +11,10 @@
   compatible (no JSDOM, no Playwright).
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
-  (:require [cljs.test :refer-macros [deftest is testing]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.disposable :as rf-disposable]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.substrate.spine :as spine]))
 
 (defn- fake-root
@@ -92,6 +95,173 @@
           "warn-cache cleared so a fresh install does not inherit stale warn-once state")
       (is (nil? @emitter-cell)
           "hiccup-emitter cell cleared so a fresh install starts from no emitter"))))
+
+;; ---- dispose-frame-sub-caches! (rf2-jcjul) -------------------------------
+;;
+;; The shared sub-cache walk lifted out of the Reagent adapter into the
+;; spine so all three React-shaped adapters (Reagent / reagent-slim /
+;; UIx / Helix) drive the same implementation of Spec 006 §Adapter
+;; disposal lifecycle MUST (1): cancel all in-flight reactive
+;; subscriptions.
+;;
+;; These tests exercise the helper in isolation by populating
+;; `frame/frames` directly with fake sub-cache entries — no adapter
+;; install, no real Reactions, no JSDOM. Each fake `:reaction` is a
+;; reified `rf-disposable/IDisposable` that records dispose calls; an
+;; integration test in `re-frame.dispose-adapter-sub-cache-walk-cljs-test`
+;; pins the through-the-Reagent-adapter shape.
+
+(defn- fake-reaction
+  "Build a stand-in for a cached Reaction that records every
+  `-dispose` call in a per-instance counter atom. The walk only
+  exercises the `IDisposable` `-dispose` slot, so this is enough."
+  []
+  (let [dispose-count (atom 0)]
+    {:reaction      (reify rf-disposable/IDisposable
+                      (-dispose [_]
+                        (swap! dispose-count inc))
+                      (-add-on-dispose [_ _f] nil))
+     :dispose-count dispose-count}))
+
+(defn- fake-frame
+  "Build a frame-record-shaped map carrying a `:sub-cache` atom seeded
+  with the supplied `cache-map`. The walk only reads `:sub-cache` off
+  the frame record, so this is enough."
+  [cache-map]
+  {:sub-cache (atom cache-map)})
+
+(defn frames-fixture
+  "Save and restore `frame/frames` + the `:adapter/dispose!` late-bind
+  hook so each test gets a clean slate and any other suite running in
+  the same JS heap sees the pre-existing globals."
+  [test-fn]
+  (let [saved-frames @frame/frames
+        saved-hook   (late-bind/get-fn-cached :adapter/dispose!)]
+    (reset! frame/frames {})
+    ;; Install a dispose hook that calls rf-disposable's protocol fn so
+    ;; the walk's `interop/dispose!` invocation actually fires the
+    ;; recording reify. Without this seed `interop/dispose!` no-ops
+    ;; (the hook is unbound in a cold-start test) and we can't tell
+    ;; the walk from a stub.
+    (late-bind/set-fn! :adapter/dispose! rf-disposable/-dispose)
+    (try (test-fn)
+         (finally
+           (reset! frame/frames saved-frames)
+           (when saved-hook
+             (late-bind/set-fn! :adapter/dispose! saved-hook))))))
+
+(use-fixtures :each frames-fixture)
+
+(deftest dispose-frame-sub-caches-walks-every-live-frame
+  (testing "every cached :reaction across every live frame is disposed
+  and every frame's sub-cache atom is reset to {}"
+    (let [r-a-x  (fake-reaction)
+          r-a-y  (fake-reaction)
+          r-b    (fake-reaction)
+          frm-a  (fake-frame {[:sub :x] (select-keys r-a-x [:reaction])
+                              [:sub :y] (select-keys r-a-y [:reaction])})
+          frm-b  (fake-frame {[:sub :z] (select-keys r-b   [:reaction])})]
+      (reset! frame/frames {:walk/a frm-a :walk/b frm-b})
+      ;; Preconditions: cache atoms populated, no dispose yet.
+      (is (= 2 (count @(:sub-cache frm-a))))
+      (is (= 1 (count @(:sub-cache frm-b))))
+      (is (zero? @(:dispose-count r-a-x)))
+      (is (zero? @(:dispose-count r-a-y)))
+      (is (zero? @(:dispose-count r-b)))
+
+      (spine/dispose-frame-sub-caches!)
+
+      (is (= 1 @(:dispose-count r-a-x))
+          "walk/a [:sub :x]'s reaction was disposed")
+      (is (= 1 @(:dispose-count r-a-y))
+          "walk/a [:sub :y]'s reaction was disposed")
+      (is (= 1 @(:dispose-count r-b))
+          "walk/b [:sub :z]'s reaction was disposed")
+      (is (= {} @(:sub-cache frm-a))
+          "walk/a's sub-cache atom was reset to {}")
+      (is (= {} @(:sub-cache frm-b))
+          "walk/b's sub-cache atom was reset to {}"))))
+
+(deftest dispose-frame-sub-caches-cancels-pending-dispose-timers
+  (testing "any :pending-dispose timer handle on a sub-cache entry is
+  clear-timeout!ed before the entry's reaction is disposed — otherwise
+  a fired timer would touch a torn-down adapter slot"
+    (let [timer-fired? (atom false)
+          ;; A real timer scheduled far enough in the future that the
+          ;; test's synchronous walk happens before fire. If the walk
+          ;; correctly calls clear-timeout! the flag stays false.
+          handle (js/setTimeout #(reset! timer-fired? true) 5000)
+          r      (fake-reaction)
+          frm    (fake-frame {[:sub :x] (assoc r :pending-dispose handle)})]
+      (reset! frame/frames {:walk/a frm})
+
+      (spine/dispose-frame-sub-caches!)
+
+      (is (= 1 @(:dispose-count r))
+          "the reaction was still disposed")
+      (is (false? @timer-fired?)
+          "the pending-dispose timer was cancelled (handle was clear-timeout!ed)"))))
+
+(deftest dispose-frame-sub-caches-is-best-effort
+  (testing "a throwing per-entry dispose does NOT abort the rest of the
+  walk — every other cached reaction in the same cache AND every cache
+  in subsequent frames still gets disposed and cleared"
+    (let [good-1 (fake-reaction)
+          good-2 (fake-reaction)
+          ;; Poison entry: an object that doesn't satisfy IDisposable so
+          ;; the seeded `:adapter/dispose!` hook (rf-disposable/-dispose)
+          ;; throws when invoked on it.
+          poison {:reaction (js-obj "not" "a reaction")}
+          frm-a  (fake-frame {[:sub :good-1] (select-keys good-1 [:reaction])
+                              [:sub :poison] poison})
+          frm-b  (fake-frame {[:sub :good-2] (select-keys good-2 [:reaction])})]
+      (reset! frame/frames {:walk/a frm-a :walk/b frm-b})
+
+      (spine/dispose-frame-sub-caches!)
+
+      (is (= 1 @(:dispose-count good-1))
+          "good-1 (same cache as the poison) was disposed despite the sibling throw")
+      (is (= 1 @(:dispose-count good-2))
+          "good-2 (different frame) was disposed despite the poison entry")
+      (is (= {} @(:sub-cache frm-a))
+          "walk/a's cache was still cleared despite the throw")
+      (is (= {} @(:sub-cache frm-b))
+          "walk/b's cache was still cleared after the throwing walk/a entry"))))
+
+(deftest dispose-frame-sub-caches-tolerates-empty-frames-registry
+  (testing "dispose-frame-sub-caches! on an empty frames registry is a no-op (no throw)"
+    (reset! frame/frames {})
+    (is (nil? (spine/dispose-frame-sub-caches!))
+        "returns nil with no live frames")))
+
+(deftest dispose-frame-sub-caches-tolerates-frame-without-sub-cache
+  (testing "a frame record lacking the :sub-cache key is skipped (no throw)"
+    (reset! frame/frames {:walk/no-cache {:other-key :value}})
+    (is (nil? (spine/dispose-frame-sub-caches!))
+        "returns nil; the cacheless frame is skipped")))
+
+(deftest make-dispose-adapter-invokes-sub-cache-walk
+  (testing "the spine's `make-dispose-adapter!` factory drives the
+  sub-cache walk as part of its build of MUST-1 + MUST-2 + MUST-3.
+  Pinning this through the factory protects the rf2-jcjul lockstep:
+  the UIx and Helix adapters wire their dispose-adapter! slot through
+  this factory only — if the factory ever stopped invoking the walk,
+  those adapters' dispose path would silently regress."
+    (let [r          (fake-reaction)
+          frm        (fake-frame {[:sub :x] (select-keys r [:reaction])})
+          _          (reset! frame/frames {:walk/a frm})
+          active     (spine/make-active-roots-cell)
+          warn-cache (spine/make-warn-once-cache)
+          emitter    (spine/make-hiccup-emitter-cell)
+          dispose-fn (spine/make-dispose-adapter!
+                       {:active-roots-cell active
+                        :warn-cache        warn-cache
+                        :emitter-cell      emitter})]
+      (dispose-fn)
+      (is (= 1 @(:dispose-count r))
+          "factory-built dispose-adapter! reached the cached reaction")
+      (is (= {} @(:sub-cache frm))
+          "factory-built dispose-adapter! cleared the sub-cache atom"))))
 
 (deftest unmount-thunk-removes-root-from-active-set
   (testing "the unmount thunk returned by `render` removes its root from the active-roots cell"


### PR DESCRIPTION
## Summary

Per Spec 006 §Adapter disposal lifecycle MUST (1) — *cancel all in-flight reactive subscriptions by walking every live frame's per-frame sub-cache and disposing each cached Reaction* — had drifted three ways:

- **Reagent** walked `frame/frames × :sub-cache` (correct, but in-adapter).
- **reagent-slim** returned `nil` with a comment claiming *Reactions GC themselves* — exactly the headless / test-fixture path the spec cites as the reason for the walk.
- **UIx + Helix** (via `spine/make-dispose-adapter!`) cleared `active-roots` + `warn-cache` + `emitter-cell` but did **not** walk sub-caches.

This PR lifts the walk into a single shared spine helper, `re-frame.substrate.spine/dispose-frame-sub-caches!`, wires it into the spine's `make-dispose-adapter!` factory (covers UIx + Helix), and calls it directly from the Reagent + reagent-slim adapter dispose paths. **One implementation, three substrates, zero drift.**

### What changed

- `implementation/core/src/re_frame/substrate/spine.cljs` — added `dispose-frame-sub-caches!` helper; wired into `make-dispose-adapter!`.
- `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` — replaced inline walk with `(spine/dispose-frame-sub-caches!)`.
- `implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs` — replaced `nil` no-op with `(spine/dispose-frame-sub-caches!)`; updated rationale comment to the actual reason for the walk (headless / test-fixture / SSR path).

### Test deltas

- `core/test/.../spine_dispose_cljs_test.cljs` — 6 new deftests: per-entry dispose, `:pending-dispose` timer cancellation, best-effort throw isolation, empty-frames tolerance, cacheless-frame tolerance, factory wiring.
- `adapters/reagent-slim/test/.../reagent_slim_dispose_sub_cache_walk_cljs_test.cljs` — new file, mirrors the existing Reagent integration test.
- `adapters/uix/test/.../uix_dispose_adapter_cljs_test.cljs` — added MUST (1) `testing` block.
- `adapters/helix/test/.../helix_dispose_adapter_cljs_test.cljs` — added MUST (1) `testing` block.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 2183 tests, 6231 assertions, 0 failures, 0 errors.
- [x] `clojure -M:test` from `implementation/core/` — 508 tests, 2636 assertions, 0 failures, 0 errors.
- [x] No spec drift — implementation now matches Spec 006 §Adapter disposal lifecycle MUST (1) for all three React-shaped adapters.

## Spec drift

None. Spec 006 was already correct; only the implementation had drifted away from it.

Closes rf2-jcjul.