### PR TITLE
docs(tools): :redact-fn posture for epoch consumers (rf2-wp70d.4)

### DIFF
--- a/docs/causa/03-time-travel.md
+++ b/docs/causa/03-time-travel.md
@@ -41,6 +41,10 @@ The default buffer depth is 50 epochs per frame. To deepen:
 
 Two-million epoch slots and you've got a memory leak; fifty is a comfortable default for the "I just want to scrub backwards through the last few minutes" workflow.
 
+## Redacted records
+
+If you've installed an `:epoch-history` `:redact-fn` to keep secrets out of recorded `:db-before` / `:db-after` (`(rf/configure :epoch-history {:redact-fn (fn [record] …)})`), Causa renders the **redacted** shape. The runtime invokes your fn once per epoch *before* the ring buffer is appended, so every panel — App-DB Diff, Event detail, the scrubber preview — sees the same redacted record. Slots your fn rewrote appear as the `:rf/redacted` sentinel (or whatever shape you substituted); there is no separate raw copy to recover from. One consequence for time-travel: a confirmed rewind to a record whose `:db-after` was redacted will land `app-db` in the redacted state — the rewind structurally succeeds but the resulting state is not what the user observed at record time. Apps that need restore fidelity should leave `:db-before` / `:db-after` alone in the fn and redact only `:trace-events` / `:trigger-event`.
+
 ## The six failure modes of `restore-epoch`
 
 Active rewind can fail. Six modes, each with a structured error trace event:

--- a/docs/guide/24-configuration-and-safety/01-framework-config.md
+++ b/docs/guide/24-configuration-and-safety/01-framework-config.md
@@ -16,11 +16,16 @@ There are four. Each is a plain-data setting that applies to the framework runti
 (rf/configure :epoch-history {:depth 50})        ;; the default
 (rf/configure :epoch-history {:depth 200})       ;; deeper history; more memory
 (rf/configure :epoch-history {:depth 0})         ;; disable
+(rf/configure :epoch-history
+  {:redact-fn (fn [record]                       ;; scrub secrets before
+     (update record :db-after dissoc :auth))})   ;; the ring stores the record
 ```
 
 Every dispatched event's full cascade is recorded as an *epoch record* — `:db-before`, `:db-after`, `:sub-runs`, `:renders`, `:effects`, `:trace-events` — and stored in a ring buffer. That buffer is what powers [chapter 15](../../causa/)'s time-travel debugging, `restore-epoch`, `reset-frame-db!`, and the Tool-Pair surface.
 
 50 epochs is enough for a typical debug session (you almost never want to rewind further than 50 user actions). 200 is reasonable for long-running stress tests. 0 disables history entirely — useful in SSR production where you have no replayer attached and the per-cascade allocation is wasted work.
+
+`:redact-fn` is the build-time hook for apps that record sensitive material into `app-db`. The framework invokes it **once per assembled record** — between `build-record` and ring-append / listener fan-out — so the ring buffer, every `register-epoch-cb!` listener, and every off-box egressor (Causa, pair2-mcp) see the **same** redacted shape. The fn returns the record (potentially rewritten); any slot it overwrites can ride as the `:rf/redacted` sentinel or any app-chosen shape. A throwing fn does not break the drain — the framework catches the throw, emits `:rf.warning/epoch-redact-fn-exception`, and falls back to the raw record for that drain only. One caveat: `restore-epoch` rewinds `app-db` *to the recorded `:db-after`*, so if your fn redacted `:db-after`, the rewind lands `app-db` in the redacted state. Apps that need restore fidelity should leave `:db-before` / `:db-after` alone and redact only `:trace-events` / `:trigger-event`. The full posture lives at [Tool-Pair §Time-travel](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo) and [Security §Epoch privacy posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress).
 
 The setting is **dev-only** by status. Under `:advanced` + `goog.DEBUG=false`, the recording site DCEs and the buffer never allocates, regardless of what you configured.
 

--- a/tools/causa/spec/002-Time-Travel.md
+++ b/tools/causa/spec/002-Time-Travel.md
@@ -27,6 +27,36 @@ Causa consumes Tool-Pair's epoch-history surface (per
 No new instrumentation; the scrubber renders what the framework
 already records.
 
+### App-installed `:redact-fn`
+
+When the consuming app installs a `:redact-fn` on the epoch-history
+configure key (`(rf/configure :epoch-history {:redact-fn (fn [record] …)})`,
+per [Tool-Pair §Time-travel §Redaction hook](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)
+and [Security §Epoch privacy posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress)),
+the runtime invokes the fn once per assembled record at build-time
+— before the ring buffer is appended and before listener fan-out
+runs. The vector returned by `(rf/epoch-history frame-id)` carries
+whatever shape the fn produced; Causa renders **the redacted shape**
+in every history-driven panel (App-DB Diff, Event detail, the
+scrubber preview). Any leaf the fn rewrote ships as the reserved
+`:rf/redacted` sentinel or whatever app-chosen shape the fn
+substituted, per [Spec-Schemas §`:rf/epoch-record`](../../../spec/Spec-Schemas.md#rfepoch-record).
+
+This has one user-visible caveat for the scrubber: `(rf/restore-epoch
+frame-id epoch-id)` rewinds `app-db` *to the recorded `:db-after`*,
+and the runtime keeps no separate copy of the pre-redaction value.
+A confirmed rewind against a record whose `:db-after` the fn
+overwrote with `:rf/redacted` (or any non-restorable shape) will
+land `app-db` in the redacted state — the rewind is structurally a
+success (`restore-epoch` returns `true` and emits `:rf.epoch/restored`)
+but the resulting state is not what the user observed at record
+time. Apps that need restore fidelity should leave `:db-before` /
+`:db-after` alone in their `:redact-fn` and target only
+`:trace-events` / `:trigger-event` / the structured projections.
+Causa does not currently surface a separate "this record's
+`:db-after` was redacted" affordance — the asymmetry rides the
+user's knowledge of which fn they installed.
+
 ## UI shape
 
 The bottom rail (40px on cosy density):

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -101,6 +101,36 @@ vocabulary `[:rf.elision/at <path>]` are reserved per
 and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md);
 the shape is shared across pair2-mcp, story-mcp, and causa-mcp.
 
+## Universal: app-installed `:redact-fn` on epoch consumers
+
+Every tool that ships `:rf/epoch-record` values — `dispatch`
+(trace mode), `trace-window`, `watch-epochs`, `snapshot` (the
+`:epochs` slot of each frame), and `subscribe` (the `epoch`
+event-kind) — delivers whatever shape the framework's
+app-installed `:redact-fn` produced (per [Tool-Pair §Time-travel
+§Redaction hook](../../../spec/Tool-Pair.md#time-travel-epoch-snapshots-and-undo)
+and [Security §Epoch privacy posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress)).
+When the consuming app has called `(rf/configure :epoch-history
+{:redact-fn (fn [record] …)})`, the runtime invokes the fn
+**once per assembled record at build-time** (between
+`build-record` and ring-append / listener fan-out) — so the
+per-frame ring buffer, every `register-epoch-cb!` listener, and
+the records pair2-mcp egresses all see the same redacted shape.
+Tools cannot recover raw shapes from the wire: any slot the fn
+rewrote ships as `:rf/redacted` (the reserved sentinel, per
+[Spec-Schemas §`:rf/epoch-record`](../../../spec/Spec-Schemas.md#rfepoch-record))
+or whatever app-chosen shape the fn substituted. Agents that
+pattern-match on `:db-before` / `:db-after` / `:trigger-event` /
+`:trace-events` MUST tolerate `:rf/redacted` (and arbitrary
+app-supplied shapes) at every leaf.
+
+The `:rf.epoch/sensitive?` rollup is computed from the raw
+record's schema-declared sensitive leaves **before** the
+`:redact-fn` runs, so it remains an accurate signal even when
+the fn erases the leaves it keyed on — `--allow-raw-state OFF`
+strips records that carry the rollup regardless of what the fn
+did to the underlying slots.
+
 ## Universal: `:typicalTokens` on every tool descriptor
 
 Every MCP tool descriptor emitted by `tools/list` carries a


### PR DESCRIPTION
## Summary

Tool-side + user-guide additions that complete the rf2-wp70d cluster — the impl-side contract for the `:epoch-history` `:redact-fn` (already landed normatively by rf2-wp70d.1 / PR #1267 in `spec/Tool-Pair.md`, `spec/Security.md`, `spec/Spec-Schemas.md`, `spec/API.md`) is now mirrored on the four downstream surfaces that consume or expose epoch records:

- **`tools/pair2-mcp/spec/003-Tool-Catalogue.md`** — new `Universal: app-installed :redact-fn on epoch consumers` section alongside the other epoch-touching universals. Enumerates the consuming tools (`dispatch` trace mode, `trace-window`, `watch-epochs`, `snapshot` `:epochs`, `subscribe` `:epoch` event-kind), states that tools cannot recover raw shapes from the wire, and tells agents to tolerate `:rf/redacted` at every leaf of `:db-before` / `:db-after` / `:trigger-event` / `:trace-events`. Notes the `:rf.epoch/sensitive?` rollup is computed pre-redact so it remains an accurate signal.
- **`tools/causa/spec/002-Time-Travel.md`** — new `App-installed :redact-fn` subsection under `## Substrate`. Same wire-shape note plus the restore-against-redacted-`:db-after` caveat: a confirmed rewind to a record whose `:db-after` the fn overwrote lands `app-db` in the redacted state.
- **`docs/causa/03-time-travel.md`** — short user-facing `## Redacted records` section (5 sentences) after `## How the buffer fills`. Covers the same point in plain language.
- **`docs/guide/24-configuration-and-safety/01-framework-config.md`** — added `:redact-fn` to the `:epoch-history` configure reference with a code example, the build-time invocation contract, throw-isolation surface (`:rf.warning/epoch-redact-fn-exception`), the restore-against-redacted-`:db-after` caveat, and cross-links to `Tool-Pair §Time-travel` and `Security §Epoch privacy posture`.

Disjoint from rf2-wp70d.2 (implementation in `implementation/epoch/`, dispatched alongside this).

## Test plan

- [x] `python -m mkdocs build --strict` (with `spec/` staged into `docs/spec/` per the `docs.yml` workflow) builds clean — zero warnings, zero errors
- [x] Worker-worktree guard passed before edits
- [x] Mayor checkout untouched