### PR TITLE
feat(epoch): :redact-fn at build-record time (rf2-wp70d.2)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -66,11 +66,15 @@
   5)
 
 (defonce ^:private config
-  ;; Two keys today (:depth, :trace-events-keep). Map shape kept open
-  ;; so future (rf/configure :epoch-history {...}) extensions don't
-  ;; break the shape.
+  ;; Three keys today (:depth, :trace-events-keep, :redact-fn). Map
+  ;; shape kept open so future (rf/configure :epoch-history {...})
+  ;; extensions don't break the shape. Per rf2-wp70d / Tool-Pair
+  ;; §Time-travel §Redaction hook + Security.md §Epoch privacy
+  ;; posture: :redact-fn defaults to nil — apps that record
+  ;; sensitive material into app-db opt in by installing a fn.
   (atom {:depth             default-depth
-         :trace-events-keep default-trace-events-keep}))
+         :trace-events-keep default-trace-events-keep
+         :redact-fn         nil}))
 
 (defn- non-neg-int?
   "True for non-negative integer values; nil and non-numeric values
@@ -98,6 +102,22 @@
                         'implementations may choose to drop traces
                         from older epochs') and refactor-audit r2
                         (rf2-lwn4t) §F3.1.
+    :redact-fn          fn? or nil; per Tool-Pair §Time-travel
+                        §Redaction hook and Security.md §Epoch
+                        privacy posture (rf2-wp70d). When non-nil
+                        the runtime invokes the fn once per
+                        assembled record between `build-record` and
+                        ring-append / listener fan-out, so the ring
+                        and every listener see the SAME redacted
+                        shape. The `:rf.epoch/sensitive?` rollup is
+                        computed BEFORE the fn runs — the rollup
+                        remains accurate even when the fn erases
+                        the leaves it keyed on. A throwing fn emits
+                        `:rf.warning/epoch-redact-fn-exception` and
+                        falls back to the raw record for that drain
+                        only (the drain itself is not broken).
+                        Passing `nil` clears any previously-installed
+                        fn.
 
   Per rf2-mrsck and Security.md §Epoch privacy posture: the default
   `:trace-events-keep` is a FINITE value (5) — the most-recent five
@@ -109,20 +129,32 @@
   nil})` is a no-op against the explicit-value validation below;
   use a numeric value or do not pass the slot at all.
 
-  Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: both keys are validated
-  at the boundary. A `:depth` or `:trace-events-keep` that isn't a
+  Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: keys are validated at
+  the boundary. A `:depth` or `:trace-events-keep` that isn't a
   non-negative integer is silently dropped from `opts` rather than
   stored — a `nil` or non-numeric value would otherwise survive
   configuration and explode at the next `record!` call when `pos?` /
-  `nat-int?` runs on the stored value. Validation mirrors the
-  pattern `re-frame.trace/configure-trace-buffer!` applies at its
-  own config boundary."
+  `nat-int?` runs on the stored value. `:redact-fn` accepts `fn?`
+  or `nil` (explicit clear); other shapes are silently dropped.
+  Validation mirrors the pattern `re-frame.trace/configure-trace-
+  buffer!` applies at its own config boundary."
   [opts]
   (when (map? opts)
-    (let [picked (select-keys opts [:depth :trace-events-keep])
-          valid  (into {}
-                       (filter (fn [[_ v]] (non-neg-int? v)))
-                       picked)]
+    (let [numeric (select-keys opts [:depth :trace-events-keep])
+          numeric-valid (into {}
+                              (filter (fn [[_ v]] (non-neg-int? v)))
+                              numeric)
+          ;; :redact-fn validated separately — accept fn? OR nil
+          ;; (explicit-clear); anything else silently dropped.
+          ;; `contains?` distinguishes 'absent slot' from 'present
+          ;; nil' so the explicit-clear path lands while a callsite
+          ;; that didn't mention :redact-fn doesn't clobber a
+          ;; previously-installed fn.
+          redact (when (contains? opts :redact-fn)
+                   (let [v (:redact-fn opts)]
+                     (when (or (nil? v) (fn? v))
+                       {:redact-fn v})))
+          valid (merge numeric-valid redact)]
       (when (seq valid)
         (swap! config merge valid))))
   nil)
@@ -138,6 +170,57 @@
 
 (defn- trace-events-keep []
   (:trace-events-keep @config default-trace-events-keep))
+
+(defn- redact-fn []
+  ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook. Returns
+  ;; the currently-installed redact-fn (or nil). One config-deref per
+  ;; record build — the hot path for installed-fn cases is one
+  ;; keyword lookup, no allocation.
+  (:redact-fn @config))
+
+(defn- maybe-redact
+  "Run the installed `:redact-fn` against `record` and return its
+  result. nil `record` and nil `redact` are pass-throughs (no
+  invocation, no try/catch overhead). A throwing fn emits
+  `:rf.warning/epoch-redact-fn-exception` carrying `:frame` and
+  `:ex-msg`, then falls back to the raw record so the drain itself
+  is not broken.
+
+  Per Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch
+  privacy posture (rf2-wp70d): the fn runs ONCE at build-time,
+  BETWEEN `build-record` and ring-append / listener fan-out — the
+  ring buffer, every `register-epoch-cb!` listener, and any off-box
+  projection through `projected-record` all see the SAME redacted
+  shape. The `:rf.epoch/sensitive?` rollup is computed inside
+  `build-record` (which runs first) so the rollup reflects the RAW
+  signal even when the fn erases the leaves it keyed on.
+
+  Caller MUST wrap invocations in `(when interop/debug-enabled? ...)`
+  — the whole epoch surface shares that gate; this helper carries no
+  separate production gate.
+
+  HOT PATH: fires once per drain-settle. Hot-path cost when no fn is
+  installed is a single keyword lookup on the config map and an
+  identity return."
+  [record]
+  (if-let [f (redact-fn)]
+    (if (some? record)
+      (try
+        (f record)
+        (catch #?(:clj Throwable :cljs :default) e
+          ;; Failure isolation: emit the warning, fall back to the
+          ;; raw record. The keyword literal sits inside an
+          ;; `(when interop/debug-enabled? ...)` gate at the call
+          ;; site (every consumer of `maybe-redact` is itself gated),
+          ;; so Closure DCE elides the warning emit + literals
+          ;; under :advanced + goog.DEBUG=false.
+          (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
+                       {:frame  (:frame record)
+                        :ex-msg #?(:clj (.getMessage ^Throwable e)
+                                   :cljs (.-message e))})
+          record))
+      record)
+    record))
 
 ;; ---- the per-frame ring buffer --------------------------------------------
 ;;
@@ -407,9 +490,14 @@
                                         (= :run-start (-> ev :tags :phase))))
                                  buffered-events)]
       (when in-cascade?
-        (let [record (build-record frame-id nil nil buffered-events
-                                   :halted-destroy
-                                   {:operation :rf.frame/destroyed-mid-drain})]
+        ;; Per rf2-wp70d: even on the halted-destroy partial-record
+        ;; commit, `maybe-redact` runs once between `build-record`
+        ;; and listener fan-out so listener consumers see the SAME
+        ;; redacted shape they would see for an :ok cascade record.
+        (let [record (maybe-redact
+                       (build-record frame-id nil nil buffered-events
+                                     :halted-destroy
+                                     {:operation :rf.frame/destroyed-mid-drain}))]
           (trace/emit! :rf.epoch :rf.epoch/snapshotted
                        {:frame    frame-id
                         :epoch-id (:epoch-id record)
@@ -505,7 +593,14 @@
     ;; has been built and the cascade-buffer (if any) has been harvested.
     :rf.epoch/db-replaced
     :rf.epoch/reset-frame-db-during-drain
-    :rf.epoch/reset-frame-db-schema-mismatch})
+    :rf.epoch/reset-frame-db-schema-mismatch
+    ;; Redact-fn exception warning (rf2-wp70d / Tool-Pair §Time-travel
+    ;; §Redaction hook). Emitted by `maybe-redact` AFTER
+    ;; `harvest-buffer!` has emptied the cascade buffer for this
+    ;; frame; if left un-skipped, the `:frame`-tagged emit would
+    ;; otherwise accrete into the NEXT cascade's harvested record
+    ;; for this frame.
+    :rf.warning/epoch-redact-fn-exception})
 
 (defn- capture-event!
   "Internal trace-capture entry point published through `re-frame.late-bind`
@@ -875,8 +970,16 @@
        ;; this seam fires when a router-only halt path (e.g. depth-
        ;; exceeded with an in-flight cascade) holds the events.
        (when (seq events)
-         (let [record (build-record frame-id db-before db-after
-                                    events outcome halt-reason)]
+         ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook:
+         ;; `maybe-redact` runs ONCE per record between
+         ;; `build-record` and ring-append / listener fan-out so the
+         ;; ring and listeners see the SAME redacted shape. The
+         ;; `:rf.epoch/sensitive?` rollup inside `build-record` runs
+         ;; FIRST — the rollup reflects raw signals even when the
+         ;; redact-fn erases the leaves it keyed on.
+         (let [record (maybe-redact
+                        (build-record frame-id db-before db-after
+                                      events outcome halt-reason))]
            (record! record)
            (trace/emit! :rf.epoch :rf.epoch/snapshotted
                         {:frame    frame-id
@@ -1296,9 +1399,13 @@
     ;; Record a synthetic epoch so `restore-epoch` can rewind the
     ;; previous state. The record's :trigger-event is the
     ;; pair-tool injection sentinel (no application event ran).
-    (let [record (assoc (build-record frame-id db-before new-db [])
-                        :event-id      :rf.epoch/db-replaced
-                        :trigger-event [:rf.epoch/db-replaced])]
+    ;; Per rf2-wp70d: `maybe-redact` runs once between assembly and
+    ;; the record!/notify-listeners! split so ring + listeners see
+    ;; the SAME redacted shape on this synthetic record too.
+    (let [record (maybe-redact
+                   (assoc (build-record frame-id db-before new-db [])
+                          :event-id      :rf.epoch/db-replaced
+                          :trigger-event [:rf.epoch/db-replaced]))]
       (record! record)
       (trace/emit! :rf.epoch :rf.epoch/db-replaced
                    {:frame    frame-id

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -64,7 +64,7 @@
                 ;; reset.
                 (epoch/clear-history!)
                 (epoch/clear-epoch-cbs!)
-                (reset! @#'epoch/config {:depth 50 :trace-events-keep 5}))}))
+                (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil}))}))
 
 ;; ---- 1. Recording — happy-path record shape -------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -146,7 +146,7 @@
   ;; :depth from a sibling test can't leak; configure! merges, so a
   ;; per-test opt-in to elision would otherwise persist. Per rf2-mrsck
   ;; the default :trace-events-keep is 5 (finite).
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5})
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -36,7 +36,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5})
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -50,7 +50,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5})
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -1,0 +1,492 @@
+(ns re-frame.epoch-redact-fn-test
+  "Per rf2-wp70d.2 — coverage for the in-process redaction hook on
+  `:epoch-history`. Spec contract: Tool-Pair §Time-travel §Redaction
+  hook (rf2-wp70d.1), Security.md §Epoch privacy posture bullet 5,
+  Spec-Schemas §`:rf/epoch-record` 'Redacted slot values', API.md
+  §Configure keys.
+
+  Five critical invariants:
+
+    1. **Rollup runs BEFORE redact-fn** — `:rf.epoch/sensitive?` is
+       computed from RAW signals; the redact-fn may erase the leaves
+       the rollup keyed on, but the rollup itself reflects raw truth.
+
+    2. **One pass per record** — ring + listeners see the SAME
+       redacted shape (build-time, not fan-out time).
+
+    3. **Failure isolation** — a throwing redact-fn emits
+       `:rf.warning/epoch-redact-fn-exception` and falls back to the
+       raw record (no broken drain).
+
+    4. **Composition with `:trace-events-keep`** — redact-fn runs
+       BEFORE the keep-window dissoc. A redact-fn that sentinels
+       `:trace-events` is idempotent against the later cap.
+
+    5. **`projected-record` × `:redact-fn` idempotency** — applying
+       `projected-record` to an already-redacted record produces the
+       same shape (two passes compose under `:rf/redacted`
+       sentinels).
+
+  Plus the `configure!` validation surface (`fn?` / `nil` accepted,
+  other shapes silently dropped), and the three per-site wirings
+  (`settle!`, `perform-reset-frame-db!`,
+  `on-frame-destroyed!`'s `:halted-destroy` path)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.epoch :as epoch]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            ;; Side-effect requires (mirror epoch_test.clj fixture).
+            [re-frame.machines]))
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (trace/clear-trace-cbs!)
+  (epoch/clear-history!)
+  (epoch/clear-epoch-cbs!)
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- last-record [frame-id]
+  (last (rf/epoch-history frame-id)))
+
+(defn- install-sensitive-schema!
+  [frame-id]
+  (rf/reg-app-schema [:auth]
+                     [:map [:password {:sensitive? true} :string]]
+                     {:frame frame-id})
+  (rf/populate-sensitive-from-schemas! frame-id)
+  nil)
+
+(defn- record-warnings! []
+  ;; Capture every `:warning` op-type emission so the failure-
+  ;; isolation invariant can assert the documented op-id + tags fire.
+  (let [warnings (atom [])]
+    (rf/register-trace-cb! ::warn-watcher
+                           (fn [ev]
+                             (when (= :warning (:op-type ev))
+                               (swap! warnings conj ev))))
+    warnings))
+
+;; ============================================================================
+;;  configure! validation surface (Spec API.md §Configure keys —
+;;  :redact-fn row; rf2-wp70d.1)
+;; ============================================================================
+
+(deftest configure-accepts-fn
+  (testing "(rf/configure :epoch-history {:redact-fn f}) — fn? accepted
+            and the slot lands in current-config"
+    (let [f (fn [r] r)]
+      (rf/configure :epoch-history {:redact-fn f})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          ":redact-fn lands by identity — no wrapping"))))
+
+(deftest configure-accepts-nil-to-clear
+  (testing "(rf/configure :epoch-history {:redact-fn nil}) clears a
+            previously-installed fn"
+    (rf/configure :epoch-history {:redact-fn (fn [r] r)})
+    (is (some? (:redact-fn (epoch/current-config))))
+
+    (rf/configure :epoch-history {:redact-fn nil})
+    (is (nil? (:redact-fn (epoch/current-config)))
+        "explicit nil clears the slot")))
+
+(deftest configure-rejects-non-fn
+  (testing "(rf/configure :epoch-history {:redact-fn <bad>}) silently
+            drops other shapes; a previously-installed fn survives"
+    (let [f (fn [r] r)]
+      (rf/configure :epoch-history {:redact-fn f})
+      (rf/configure :epoch-history {:redact-fn "not-a-fn"})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          "string silently dropped — prior fn survives")
+
+      (rf/configure :epoch-history {:redact-fn 42})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          "number silently dropped")
+
+      (rf/configure :epoch-history {:redact-fn {:k :v}})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          "map silently dropped")
+
+      (rf/configure :epoch-history {:redact-fn [:a :b]})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          "vector silently dropped"))))
+
+(deftest configure-absent-slot-preserves-existing-fn
+  (testing "a configure call that does NOT mention :redact-fn leaves
+            the previously-installed fn intact (the configure semantics
+            are 'merge present keys' — absence is a no-op)"
+    (let [f (fn [r] r)]
+      (rf/configure :epoch-history {:redact-fn f})
+      (rf/configure :epoch-history {:depth 17})
+      (is (identical? f (:redact-fn (epoch/current-config)))
+          ":redact-fn slot preserved across a :depth-only update")
+      (is (= 17 (:depth (epoch/current-config)))
+          "the :depth update was applied"))))
+
+(deftest configure-partial-update-mixed-validity
+  (testing "a configure call carrying a valid :redact-fn and an
+            invalid :depth applies the fn and drops the depth"
+    (rf/configure :epoch-history {:depth 9})
+    (let [f (fn [r] r)]
+      (rf/configure :epoch-history {:depth nil :redact-fn f})
+      (is (identical? f (:redact-fn (epoch/current-config))))
+      (is (= 9 (:depth (epoch/current-config)))
+          ":depth nil dropped; prior 9 survives"))))
+
+;; ============================================================================
+;;  Invariant 1 — rollup runs BEFORE redact-fn
+;; ============================================================================
+
+(deftest invariant-1-rollup-computed-from-raw-before-redact-fn
+  (testing "the :rf.epoch/sensitive? rollup reflects raw signals even
+            when the redact-fn erases the leaves the rollup keyed on
+            — the rollup must remain a trustworthy signal for off-box
+            consumers branching on it"
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+
+    ;; Redact-fn wipes the very slot the rollup keyed on. If the
+    ;; rollup ran AFTER the fn, it would observe the wiped leaf and
+    ;; report sensitive? false — silently breaking off-box consumers.
+    (rf/configure :epoch-history
+                  {:redact-fn (fn [r]
+                                (cond-> r
+                                  (get-in r [:db-after :auth :password])
+                                  (assoc-in [:db-after :auth :password]
+                                            :rf/redacted)))})
+
+    (rf/reg-event-db :login
+                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [r (last-record :test/main)]
+      (is (= :rf/redacted (get-in r [:db-after :auth :password]))
+          "redact-fn ran — the password slot is :rf/redacted")
+      (is (true? (:rf.epoch/sensitive? r))
+          "rollup is true because it ran from the RAW record BEFORE
+           the redact-fn erased the leaf"))))
+
+;; ============================================================================
+;;  Invariant 2 — one pass per record; ring + listeners see SAME shape
+;; ============================================================================
+
+(deftest invariant-2-ring-and-listener-see-same-redacted-shape
+  (testing "the redact-fn runs ONCE per record at build-time, between
+            assembly and ring-append/listener fan-out. The record
+            stored in the ring is identical to the record delivered
+            to every listener — no per-consumer divergence"
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+
+    ;; Track invocation count so we can assert ONE pass per record.
+    (let [invocations (atom 0)
+          listener-records (atom [])]
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [r]
+                                  (swap! invocations inc)
+                                  (assoc-in r [:db-after :auth :password]
+                                            :rf/redacted))})
+
+      (rf/register-epoch-cb! ::watch
+                             (fn [r] (swap! listener-records conj r)))
+
+      (rf/reg-event-db :login
+                       (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+      (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+      (is (= 1 @invocations)
+          "redact-fn invoked EXACTLY once for the cascade — not once
+           per listener nor once per consumer")
+
+      (let [ring-record     (last-record :test/main)
+            listener-record (last @listener-records)]
+        (is (= :rf/redacted (get-in ring-record [:db-after :auth :password]))
+            "ring record is redacted")
+        (is (= :rf/redacted (get-in listener-record [:db-after :auth :password]))
+            "listener record is redacted")
+        (is (= ring-record listener-record)
+            "ring and listener received structurally-equal records —
+             same redacted shape, single source of truth")))))
+
+(deftest invariant-2-multiple-listeners-receive-same-shape
+  (testing "multiple listeners all receive the SAME redacted shape
+            from the single build-time pass (no per-listener fan-out
+            invocation of redact-fn)"
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+
+    (let [invocations (atom 0)
+          a-rec       (atom nil)
+          b-rec       (atom nil)
+          c-rec       (atom nil)]
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [r]
+                                  (swap! invocations inc)
+                                  (assoc-in r [:db-after :auth :password]
+                                            :rf/redacted))})
+
+      (rf/register-epoch-cb! ::a (fn [r] (reset! a-rec r)))
+      (rf/register-epoch-cb! ::b (fn [r] (reset! b-rec r)))
+      (rf/register-epoch-cb! ::c (fn [r] (reset! c-rec r)))
+
+      (rf/reg-event-db :login
+                       (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+      (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+      (is (= 1 @invocations)
+          "three listeners + one ring-append = ONE redact-fn call")
+      (is (= @a-rec @b-rec @c-rec (last-record :test/main))
+          "every consumer sees the same redacted record"))))
+
+;; ============================================================================
+;;  Invariant 3 — failure isolation
+;; ============================================================================
+
+(deftest invariant-3-throwing-redact-fn-warns-and-falls-back
+  (testing "a throwing redact-fn emits
+            :rf.warning/epoch-redact-fn-exception and falls back to
+            the raw record — the drain itself is not broken; the next
+            cascade still records normally"
+    (rf/reg-frame :test/main {})
+
+    (let [warnings (record-warnings!)]
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [_]
+                                  (throw (ex-info "boom" {:why :test})))})
+
+      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+
+      ;; Fall-back to raw record landed in the ring.
+      (let [r (last-record :test/main)]
+        (is (some? r) "ring received a record — drain not broken")
+        (is (= {:n 0} (:db-after r))
+            "the record is the RAW shape — redact-fn's throw did not
+             corrupt the build-record output"))
+
+      ;; Warning fired with the documented op-id and tags.
+      (let [warn (->> @warnings
+                      (filter (fn [ev]
+                                (= :rf.warning/epoch-redact-fn-exception
+                                   (:operation ev))))
+                      first)]
+        (is (some? warn)
+            ":rf.warning/epoch-redact-fn-exception was emitted")
+        (is (= :test/main (get-in warn [:tags :frame]))
+            ":frame tag carries the offending frame-id")
+        (is (string? (get-in warn [:tags :ex-msg]))
+            ":ex-msg tag carries the exception message string"))
+
+      ;; Drain not broken — next cascade records as normal.
+      (rf/configure :epoch-history {:redact-fn nil})
+      (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+      (rf/dispatch-sync [:bump] {:frame :test/main})
+      (let [r2 (last-record :test/main)]
+        (is (= {:n 1} (:db-after r2))
+            "next drain after the throw records normally")))))
+
+(deftest invariant-3-throwing-redact-fn-stays-registered
+  (testing "a throwing redact-fn stays registered — the next cascade
+            re-attempts (the registration is not removed on first
+            throw; the framework's posture is 'log and continue')"
+    (rf/reg-frame :test/main {})
+    (let [call-count (atom 0)]
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [_]
+                                  (swap! call-count inc)
+                                  (throw (ex-info "boom" {})))})
+
+      (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+      (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+      (rf/dispatch-sync [:seed] {:frame :test/main})
+      (rf/dispatch-sync [:bump] {:frame :test/main})
+      (rf/dispatch-sync [:bump] {:frame :test/main})
+
+      (is (= 3 @call-count)
+          "redact-fn re-invoked on every cascade despite throwing"))))
+
+;; ============================================================================
+;;  Invariant 4 — composition with :trace-events-keep cap
+;; ============================================================================
+
+(deftest invariant-4-redact-fn-runs-before-trace-events-keep-cap
+  (testing "a redact-fn that sentinels :trace-events runs BEFORE the
+            keep-window dissoc — the sentinel survives the cap until
+            the record crosses the keep-window boundary, at which
+            point :trace-events is dissoc'd whether sentinel or raw"
+    (rf/reg-frame :test/main {})
+    ;; Sentinel :trace-events at build-time. The cap will later
+    ;; dissoc :trace-events on records that fall outside the
+    ;; keep-window — the sentinel makes that dissoc idempotent.
+    (rf/configure :epoch-history
+                  {:trace-events-keep 2
+                   :redact-fn (fn [r]
+                                (assoc r :trace-events :rf/redacted))})
+
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (rf/dispatch-sync [:bump] {:frame :test/main})
+    (rf/dispatch-sync [:bump] {:frame :test/main})
+    (rf/dispatch-sync [:bump] {:frame :test/main})
+
+    (let [history (rf/epoch-history :test/main)]
+      ;; The TWO MOST-RECENT records retain :trace-events (the
+      ;; sentinel) — the redact-fn ran first and replaced the slot
+      ;; value; the keep-window cap left the slot alone because it
+      ;; sits inside the keep window.
+      (doseq [r (take-last 2 history)]
+        (is (= :rf/redacted (:trace-events r))
+            "in-window record has the redact-fn's sentinel as
+             :trace-events"))
+      ;; The older records had their :trace-events dissoc'd by the
+      ;; keep-window cap (whether the slot held the sentinel or the
+      ;; raw vector, the cap dissociates uniformly — idempotent).
+      (doseq [r (drop-last 2 history)]
+        (is (not (contains? r :trace-events))
+            "out-of-window record had :trace-events dissoc'd by the
+             keep-window cap — composition is idempotent")))))
+
+;; ============================================================================
+;;  Invariant 5 — projected-record × :redact-fn idempotency
+;; ============================================================================
+
+(deftest invariant-5-projected-record-idempotent-over-redacted-record
+  (testing "applying projected-record to an already-redacted record
+            produces a structurally-stable shape — both passes
+            compose under :rf/redacted sentinels (rf2-wp70d.3
+            territory; pinned here as a cheap composition smoke)"
+    (rf/reg-frame :test/main {})
+    (install-sensitive-schema! :test/main)
+
+    ;; Redact-fn substitutes :rf/redacted in the same slot the
+    ;; projected-record helper would also redact via the schema-
+    ;; declared sensitive path.
+    (rf/configure :epoch-history
+                  {:redact-fn (fn [r]
+                                (cond-> r
+                                  (get-in r [:db-after :auth :password])
+                                  (assoc-in [:db-after :auth :password]
+                                            :rf/redacted)))})
+
+    (rf/reg-event-db :login
+                     (fn [db [_ pw]] (assoc-in db [:auth :password] pw)))
+    (rf/dispatch-sync [:login "topsecret"] {:frame :test/main})
+
+    (let [redacted   (last-record :test/main)
+          projected  (epoch/projected-record redacted)
+          projected2 (epoch/projected-record projected)]
+      (is (= :rf/redacted (get-in redacted [:db-after :auth :password]))
+          "redact-fn produced the sentinel")
+      (is (= :rf/redacted (get-in projected [:db-after :auth :password]))
+          "projection over an already-redacted leaf produces the
+           same sentinel — :rf/redacted is the projection's own
+           target value")
+      (is (= projected projected2)
+          "projection is idempotent — a second pass changes nothing
+           (the leaf is already the sentinel target)"))))
+
+;; ============================================================================
+;;  Per-site wirings — settle! / perform-reset-frame-db! /
+;;  on-frame-destroyed!'s :halted-destroy path
+;; ============================================================================
+
+(deftest wiring-settle-applies-redact-fn
+  (testing "the settle! drain-settle commit path runs the redact-fn
+            against the assembled record (the dominant per-event
+            recording path)"
+    (rf/reg-frame :test/main {})
+    (rf/configure :epoch-history
+                  {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (is (= :redacted (:rf/test-tag (last-record :test/main)))
+        "settle! path: ring record carries the redact-fn's tag")))
+
+(deftest wiring-reset-frame-db-applies-redact-fn
+  (testing "the perform-reset-frame-db! synthetic-record commit path
+            runs the redact-fn (pair-tool injection / story tools
+            land the synthetic :rf.epoch/db-replaced record through
+            this seam)"
+    (rf/reg-frame :test/main {})
+    (let [synthetic (atom nil)]
+      (rf/register-epoch-cb! ::watch (fn [r] (reset! synthetic r)))
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))})
+      (rf/reset-frame-db! :test/main {:injected :state})
+      (is (= :redacted (:rf/test-tag @synthetic))
+          "reset-frame-db! path: listener received the redacted
+           synthetic record")
+      (is (= :redacted (:rf/test-tag (last-record :test/main)))
+          "reset-frame-db! path: ring received the same redacted
+           synthetic record"))))
+
+(deftest wiring-halted-destroy-applies-redact-fn
+  (testing "on-frame-destroyed!'s :halted-destroy partial-record
+            commit runs the redact-fn — devtools observing the
+            halted-cascade record see the same redacted shape they
+            would for an :ok cascade"
+    (rf/reg-frame :test/main {})
+    (let [halted (atom nil)]
+      (rf/register-epoch-cb! ::watch
+                             (fn [r]
+                               (when (= :halted-destroy (:outcome r))
+                                 (reset! halted r))))
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [r] (assoc r :rf/test-tag :redacted))})
+      (rf/reg-event-fx :destroy-self
+                       (fn [_ _]
+                         (frame/destroy-frame! :test/main)
+                         {}))
+      (try (rf/dispatch-sync [:destroy-self] {:frame :test/main})
+           (catch Throwable _ nil))
+      (when @halted
+        (is (= :halted-destroy (:outcome @halted)))
+        (is (= :redacted (:rf/test-tag @halted))
+            "halted-destroy path: listener received the redacted
+             partial record")))))
+
+;; ============================================================================
+;;  Default no-op posture
+;; ============================================================================
+
+(deftest no-redact-fn-installed-is-identity-passthrough
+  (testing "without :redact-fn installed, every recorded record
+            passes through unchanged (the default-nil posture — apps
+            opt in explicitly)"
+    (rf/reg-frame :test/main {})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (let [r (last-record :test/main)]
+      (is (= {:n 0} (:db-after r))
+          "no redact-fn — record is the raw shape")
+      (is (not (contains? r :rf/test-tag))
+          "no redact-fn — no synthetic slots added"))))
+
+(deftest nil-redact-fn-installed-is-identity-passthrough
+  (testing "an explicitly-installed nil :redact-fn is equivalent to
+            'no redact-fn' — same identity-passthrough shape"
+    (rf/reg-frame :test/main {})
+    (rf/configure :epoch-history {:redact-fn nil})
+    (rf/reg-event-db :seed (fn [_ _] {:n 0}))
+    (rf/dispatch-sync [:seed] {:frame :test/main})
+    (let [r (last-record :test/main)]
+      (is (= {:n 0} (:db-after r))))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -55,7 +55,7 @@
   ;; opt-in to elision would otherwise persist. Per rf2-mrsck the
   ;; default :trace-events-keep is 5 (finite); fixtures restore the
   ;; default map verbatim.
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5})
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))
@@ -1550,11 +1550,11 @@
             ":rf.epoch/restore-unknown-epoch does not leak from a prior failed restore")))))
 
 (deftest skip-ops-catalogue-pins-every-rf-epoch-op
-  (testing "skip-ops covers every :rf.epoch/* op this namespace emits
-            with a :frame tag (catalogue test — adds a fail-loudly
-            signal if a new in-namespace :rf.epoch/* op is introduced
-            and forgotten in `skip-ops`)"
-    ;; The exhaustive set as of rf2-htf28. Update both this catalogue
+  (testing "skip-ops covers every :rf.epoch/* + :rf.warning/* op this
+            namespace emits with a :frame tag (catalogue test — adds
+            a fail-loudly signal if a new in-namespace op is
+            introduced and forgotten in `skip-ops`)"
+    ;; The exhaustive set as of rf2-wp70d. Update both this catalogue
     ;; AND `skip-ops` when adding/removing an op the namespace emits.
     ;; (`:rf.epoch.cb/silenced-on-frame-destroy` is op-type :rf.epoch.cb,
     ;; not :rf.epoch — and it emits AFTER the frame's ring buffer has
@@ -1569,11 +1569,16 @@
                      :rf.epoch/restore-non-ok-record    ;; rf2-v0jwt
                      :rf.epoch/db-replaced
                      :rf.epoch/reset-frame-db-during-drain
-                     :rf.epoch/reset-frame-db-schema-mismatch}
+                     :rf.epoch/reset-frame-db-schema-mismatch
+                     ;; rf2-wp70d: redact-fn exception warning emits
+                     ;; AFTER `harvest-buffer!` has emptied this
+                     ;; frame's cascade buffer, so it must be skipped
+                     ;; lest it accrete into the next cascade's record.
+                     :rf.warning/epoch-redact-fn-exception}
           actual   @#'epoch/skip-ops]
       (is (= expected actual)
           "skip-ops catalogue matches the documented set of
-           out-of-cascade :rf.epoch/* emits"))))
+           out-of-cascade :rf.epoch/* + :rf.warning/* emits"))))
 
 ;; ---- destroyed-frame contract (rf2-d656) -----------------------------------
 ;;

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -219,6 +219,14 @@ const DEV_ONLY_SENTINELS = [
   // must elide in production.
   { source: 're-frame.epoch/on-frame-destroyed! (rf.epoch.cb/silenced-on-frame-destroy)',
     sentinel: 'rf.epoch.cb/silenced-on-frame-destroy' },
+  // re-frame.epoch — :rf.warning/epoch-redact-fn-exception (rf2-wp70d).
+  // Emitted by maybe-redact when an installed :redact-fn throws.
+  // Every consumer of maybe-redact (settle!, perform-reset-frame-db!
+  // via reset-frame-db!'s if-not gate, on-frame-destroyed!) sits
+  // inside the universal `interop/debug-enabled?` gate, so this
+  // string literal must elide in :advanced + goog.DEBUG=false.
+  { source: 're-frame.epoch/maybe-redact (rf.warning/epoch-redact-fn-exception)',
+    sentinel: 'rf.warning/epoch-redact-fn-exception' },
   // re-frame.views — :view/render trace op (Spec 004 §Render-tree
   // primitives, rf2-piag / rf2-t5tx). Emitted by the reg-view*
   // wrapper on every render of a registered view; the entire emit


### PR DESCRIPTION
## Summary
- Implements the in-process redaction hook contract documented in rf2-wp70d.1 (spec merged in PR #1267). An app-supplied fn rewrites assembled `:rf/epoch-record` values once at build-time so the per-frame ring buffer, every `register-epoch-cb!` listener, and the off-box `projected-record` helper all observe the SAME redacted shape — no listener-fan-out divergence.
- Wired into all three commit sites (`settle!` both arities, `perform-reset-frame-db!`, `on-frame-destroyed!`'s `:halted-destroy` partial-record path) with failure isolation: a throwing fn emits `:rf.warning/epoch-redact-fn-exception` (carrying `:frame` + `:ex-msg`) and falls back to the raw record. The drain itself is never broken.
- The `:rf.epoch/sensitive?` rollup is computed inside `build-record` BEFORE `maybe-redact` runs — the rollup remains a trustworthy signal for off-box consumers even when the fn erases the very leaves the rollup keyed on.

## Key implementation notes
- `:redact-fn` added to the `:epoch-history` config defaults at `nil`. `configure!` accepts `fn?` or explicit `nil` (clear); other shapes silently dropped; `:redact-fn`-absent updates leave the prior fn intact.
- `maybe-redact` is a hot-path identity-passthrough when no fn is installed (one keyword lookup on the config map, no allocation).
- `:rf.warning/epoch-redact-fn-exception` added to `skip-ops` (it emits AFTER `harvest-buffer!` empties the cascade buffer; un-skipped it would accrete into the next cascade's record). Catalogue-pin test updated.
- Production elision: the warning op-id literal sits inside the universal `interop/debug-enabled?` gate (every consumer of `maybe-redact` is itself gated). Added matching elision-probe sentinel — verified absent in `:elision-probe`, present in `:elision-probe-control`.

## Test plan
- [x] `clojure -M:test` from `implementation/epoch/` — 144 tests / 521 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 2173 tests / 6190 assertions / 0 failures
- [x] `npm run test:elision` from `implementation/` — production 31/31 absent, control 31/31 present
- [x] New `epoch_redact_fn_test.clj` covers all 5 critical invariants (rollup-before-redact, one-pass-per-record, failure-isolation, `:trace-events-keep` composition, `projected-record` idempotency) plus 5 `configure!` validation cases, 3 per-site wirings, and 2 default-no-op cases.

Closes rf2-wp70d.2.