### PR TITLE
perf(adapters): lift make-derived-value arity-spec into spine (rf2-eoy63)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_make_derived_value_arity_spec_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.adapter.helix-make-derived-value-arity-spec-cljs-test
+  "Helix adapter — per-arity pin for `make-derived-value` (rf2-eoy63).
+
+  Pre-rf2-eoy63 the Helix adapter's `make-derived-value` (routed via
+  `spine/make-derived-value-fn`) built a recompute closure with naive
+  `(apply compute-fn (map deref source-containers))` — `apply` cost +
+  lazy `map` on every recompute. The spine now factors out an
+  arity-specialised `build-recompute-fn` so the Helix adapter (along
+  with Reagent, reagent-slim, UIx) shares one implementation.
+
+  Pins the observable per-arity contract so a regression on the
+  spine helper would surface here.
+
+  Pins:
+    * 0-arity (sources empty)
+    * 1-arity (layer-1 dominant)
+    * 2-arity (layer-n dominant)
+    * ≥3-arity (fallback)
+    * source-vector order preserved"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.helix :as adapter]))
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(deftest derived-zero-arity-cljs-test
+  (testing "0 sources — compute-fn called with no args"
+    (let [derived (derive [] (fn [] ::seed))]
+      (is (= ::seed @derived)))))
+
+(deftest derived-one-arity-cljs-test
+  (testing "1 source — derefs source per recompute (layer-1 dominant)"
+    (let [src     (make-source 7)
+          derived (derive [src] (fn [a] (* a 10)))]
+      (is (= 70 @derived))
+      (write! src 8)
+      (is (= 80 @derived)))))
+
+(deftest derived-two-arity-cljs-test
+  (testing "2 sources — derefs both per recompute (layer-n dominant)"
+    (let [a       (make-source 3)
+          b       (make-source 4)
+          derived (derive [a b] +)]
+      (is (= 7 @derived))
+      (write! a 100)
+      (is (= 104 @derived))
+      (write! b 200)
+      (is (= 300 @derived)))))
+
+(deftest derived-three-arity-cljs-test
+  (testing "3 sources — fallback (apply + mapv deref) path"
+    (let [a (make-source 1) b (make-source 2) c (make-source 3)
+          derived (derive [a b c] (fn [x y z] (+ x y z)))]
+      (is (= 6 @derived))
+      (write! a 10) (write! b 20) (write! c 30)
+      (is (= 60 @derived)))))
+
+(deftest derived-four-arity-cljs-test
+  (testing "4 sources — fallback path"
+    (let [a (make-source :a) b (make-source :b) c (make-source :c) d (make-source :d)
+          derived (derive [a b c d] (fn [w x y z] [w x y z]))]
+      (is (= [:a :b :c :d] @derived)))))
+
+(deftest derived-source-vector-order-preserved-cljs-test
+  (testing "argument order matches source-vector order"
+    (let [s0 (make-source 100)
+          s1 (make-source 1)
+          derived (derive [s0 s1] -)]
+      (is (= 99 @derived)))))

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -39,8 +39,14 @@
 ;; ---- derived (reactions) --------------------------------------------------
 
 (defn- make-derived-value [source-containers compute-fn]
-  (ratom/make-reaction
-    (fn [] (apply compute-fn (map deref source-containers)))))
+  ;; Arity-specialised recompute closure via `spine/build-recompute-fn`
+  ;; (rf2-eoy63 / rf2-v1nu0 / rf2-fzrav). Pre-rf2-eoy63 this body was a
+  ;; naive `(apply compute-fn (map deref ...))` — paid `apply` + a lazy
+  ;; cons cell per source per recompute on the hot path. Lifted into
+  ;; the spine so reagent-slim shares the same arity-spec as the
+  ;; Reagent, UIx and Helix adapters — single source of truth, same
+  ;; pattern as `spine/dispose-frame-sub-caches!` (rf2-jcjul).
+  (ratom/make-reaction (spine/build-recompute-fn source-containers compute-fn)))
 
 ;; ---- render ---------------------------------------------------------------
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_make_derived_value_arity_spec_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.adapter.reagent-slim-make-derived-value-arity-spec-cljs-test
+  "reagent-slim adapter — per-arity pin for `make-derived-value`
+  (rf2-eoy63).
+
+  Pre-rf2-eoy63 this adapter's `make-derived-value` was naive
+  `(apply compute-fn (map deref source-containers))` — `apply` cost on
+  every recompute and a lazy `map` cons chain that defers derefs. The
+  fn now routes through `spine/build-recompute-fn` so reagent-slim
+  shares the arity-spec with Reagent, UIx and Helix. These tests pin
+  the observable contract so an inadvertent regression to the naive
+  shape would break the suite.
+
+  Pins:
+
+    * 0-arity: 0-input compute-fn
+    * 1-arity: layer-1 sub shape
+    * 2-arity: layer-n sub shape
+    * ≥3-arity: fallback path
+    * source-vector order preserved through the recompute closure"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent-slim :as adapter]))
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(deftest derived-zero-arity-cljs-test
+  (testing "0 sources — compute-fn called with no args"
+    (let [derived (derive [] (fn [] ::seed))]
+      (is (= ::seed @derived)))))
+
+(deftest derived-one-arity-cljs-test
+  (testing "1 source — derefs source per recompute (layer-1 dominant path)"
+    (let [src     (make-source 7)
+          derived (derive [src] (fn [a] (* a 10)))]
+      (is (= 70 @derived))
+      (write! src 8)
+      (is (= 80 @derived) "1-arity recompute picks up source mutation"))))
+
+(deftest derived-two-arity-cljs-test
+  (testing "2 sources — derefs both per recompute (layer-n dominant path)"
+    (let [a       (make-source 3)
+          b       (make-source 4)
+          derived (derive [a b] +)]
+      (is (= 7 @derived))
+      (write! a 100)
+      (is (= 104 @derived) "source-0 mutation flows through")
+      (write! b 200)
+      (is (= 300 @derived) "source-1 mutation flows through"))))
+
+(deftest derived-three-arity-cljs-test
+  (testing "3 sources — fallback (apply + mapv deref) path"
+    (let [a (make-source 1) b (make-source 2) c (make-source 3)
+          derived (derive [a b c] (fn [x y z] (+ x y z)))]
+      (is (= 6 @derived))
+      (write! a 10) (write! b 20) (write! c 30)
+      (is (= 60 @derived) "all 3 sources flow through after mutations"))))
+
+(deftest derived-four-arity-cljs-test
+  (testing "4 sources — fallback path with apply"
+    (let [a (make-source :a) b (make-source :b) c (make-source :c) d (make-source :d)
+          derived (derive [a b c d] (fn [w x y z] [w x y z]))]
+      (is (= [:a :b :c :d] @derived)))))
+
+(deftest derived-source-vector-order-preserved-cljs-test
+  (testing "argument order matches source-vector order"
+    (let [s0 (make-source 100)
+          s1 (make-source 1)
+          derived (derive [s0 s1] -)]
+      (is (= 99 @derived)))))

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -33,25 +33,15 @@
 ;; ---- derived (reactions) --------------------------------------------------
 
 (defn- make-derived-value [source-containers compute-fn]
-  ;; Per recompute we want zero lazy-seq allocation and zero `apply`
-  ;; cost on the dominant arities. Subs typically chain off 1 input
-  ;; (layer-1 always; layer-n usually 1–2); specialise those, fall
-  ;; back to `mapv` (eager, vector-backed) + `apply` for ≥3.
-  ;; rf2-v1nu0; sourced from the rf2-fzrav perf sweep findings.
-  ;;
-  ;; `count` is captured once at construction (source-containers is a
-  ;; vector — see `inputs` in `re-frame.subs`) so the recompute closure
-  ;; pays no per-tick count.
-  (let [n (count source-containers)
-        recompute (case n
-                    0 (fn [] (compute-fn))
-                    1 (let [s0 (nth source-containers 0)]
-                        (fn [] (compute-fn @s0)))
-                    2 (let [s0 (nth source-containers 0)
-                            s1 (nth source-containers 1)]
-                        (fn [] (compute-fn @s0 @s1)))
-                    (fn [] (apply compute-fn (mapv deref source-containers))))]
-    (ratom/make-reaction recompute)))
+  ;; Arity-specialised recompute closure (rf2-v1nu0 / rf2-fzrav): the
+  ;; spine helper `build-recompute-fn` builds a 0-arg thunk that skips
+  ;; `apply` + lazy-`map` cost on the dominant 0/1/2-arity paths and
+  ;; falls back to `mapv` + `apply` for ≥3. Pre-rf2-eoy63 this fn
+  ;; carried the case-spec body inline; lifted into the spine so all
+  ;; four adapters (Reagent, reagent-slim, UIx, Helix) share one
+  ;; implementation — same single-source-of-truth pattern as
+  ;; `make-dispose-adapter!` (rf2-jcjul).
+  (ratom/make-reaction (spine/build-recompute-fn source-containers compute-fn)))
 
 ;; ---- render ---------------------------------------------------------------
 ;;

--- a/implementation/adapters/reagent/test/re_frame/adapter_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/adapter_make_derived_value_arity_spec_cljs_test.cljs
@@ -1,0 +1,78 @@
+(ns re-frame.adapter-make-derived-value-arity-spec-cljs-test
+  "Reagent adapter — per-arity pin for `make-derived-value` (rf2-eoy63).
+
+  Pre-rf2-eoy63 the arity-spec lived inline in this adapter as a
+  4-branch `case`. The body now routes through `spine/build-recompute-fn`
+  so all four adapters share one implementation; these tests pin the
+  observable contract for the Reagent adapter so an inadvertent
+  spine-helper regression cannot silently revert this surface to the
+  naive `(apply compute-fn (map deref ...))` shape.
+
+  Pins:
+
+    * 0-arity: derived value tracks a 0-input compute-fn
+    * 1-arity: layer-1 sub shape — derefs one source per recompute
+    * 2-arity: layer-n sub shape — derefs two sources per recompute
+    * ≥3-arity: fallback path — derefs all sources per recompute
+    * mid-render mutation of a source produces a new derived value
+      on next deref (no caching at the substrate layer)"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.reagent :as adapter]))
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(deftest derived-zero-arity-cljs-test
+  (testing "0 sources — compute-fn called with no args"
+    (let [calls   (atom 0)
+          derived (derive []
+                    (fn [] (swap! calls inc) ::seed))]
+      (is (= ::seed @derived) "derived returns 0-arg compute-fn result")
+      (is (pos? @calls) "compute-fn fired")
+      (is (= ::seed @derived) "subsequent deref still ::seed"))))
+
+(deftest derived-one-arity-cljs-test
+  (testing "1 source — derefs source per recompute (layer-1 dominant path)"
+    (let [src     (make-source 7)
+          derived (derive [src] (fn [a] (* a 10)))]
+      (is (= 70 @derived))
+      (write! src 8)
+      (is (= 80 @derived) "1-arity recompute picks up source mutation"))))
+
+(deftest derived-two-arity-cljs-test
+  (testing "2 sources — derefs both per recompute (layer-n dominant path)"
+    (let [a       (make-source 3)
+          b       (make-source 4)
+          derived (derive [a b] +)]
+      (is (= 7 @derived))
+      (write! a 100)
+      (is (= 104 @derived) "source-0 mutation flows through")
+      (write! b 200)
+      (is (= 300 @derived) "source-1 mutation flows through"))))
+
+(deftest derived-three-arity-cljs-test
+  (testing "3 sources — fallback (apply + mapv deref) path"
+    (let [a (make-source 1) b (make-source 2) c (make-source 3)
+          derived (derive [a b c] (fn [x y z] (+ x y z)))]
+      (is (= 6 @derived))
+      (write! a 10) (write! b 20) (write! c 30)
+      (is (= 60 @derived) "all 3 sources flow through after mutations"))))
+
+(deftest derived-four-arity-cljs-test
+  (testing "4 sources — fallback path with apply"
+    (let [a (make-source :a) b (make-source :b) c (make-source :c) d (make-source :d)
+          derived (derive [a b c d] (fn [w x y z] [w x y z]))]
+      (is (= [:a :b :c :d] @derived) "args in source-vector order"))))
+
+(deftest derived-source-vector-order-preserved-cljs-test
+  (testing "argument order matches source-vector order (non-commutative compute-fn pins it)"
+    (let [s0 (make-source 100)
+          s1 (make-source 1)
+          derived (derive [s0 s1] -)]
+      (is (= 99 @derived) "subtraction in source-vector order"))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_make_derived_value_arity_spec_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_make_derived_value_arity_spec_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.adapter.uix-make-derived-value-arity-spec-cljs-test
+  "UIx adapter — per-arity pin for `make-derived-value` (rf2-eoy63).
+
+  Pre-rf2-eoy63 the UIx adapter's `make-derived-value` (routed via
+  `spine/make-derived-value-fn`) built a recompute closure with naive
+  `(apply compute-fn (map deref source-containers))` — `apply` cost +
+  lazy `map` on every recompute. The spine now factors out an
+  arity-specialised `build-recompute-fn` so the UIx adapter (along
+  with Reagent, reagent-slim, Helix) shares one implementation.
+
+  Pins the observable per-arity contract so a regression on the
+  spine helper would surface here.
+
+  Pins:
+    * 0-arity (sources empty)
+    * 1-arity (layer-1 dominant)
+    * 2-arity (layer-n dominant)
+    * ≥3-arity (fallback)
+    * source-vector order preserved"
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.adapter.uix :as adapter]))
+
+(defn- make-source [v]
+  ((:make-state-container adapter/adapter) v))
+
+(defn- write! [c v]
+  ((:replace-container! adapter/adapter) c v))
+
+(defn- derive [sources f]
+  ((:make-derived-value adapter/adapter) sources f))
+
+(deftest derived-zero-arity-cljs-test
+  (testing "0 sources — compute-fn called with no args"
+    (let [derived (derive [] (fn [] ::seed))]
+      (is (= ::seed @derived)))))
+
+(deftest derived-one-arity-cljs-test
+  (testing "1 source — derefs source per recompute (layer-1 dominant)"
+    (let [src     (make-source 7)
+          derived (derive [src] (fn [a] (* a 10)))]
+      (is (= 70 @derived))
+      (write! src 8)
+      (is (= 80 @derived)))))
+
+(deftest derived-two-arity-cljs-test
+  (testing "2 sources — derefs both per recompute (layer-n dominant)"
+    (let [a       (make-source 3)
+          b       (make-source 4)
+          derived (derive [a b] +)]
+      (is (= 7 @derived))
+      (write! a 100)
+      (is (= 104 @derived))
+      (write! b 200)
+      (is (= 300 @derived)))))
+
+(deftest derived-three-arity-cljs-test
+  (testing "3 sources — fallback (apply + mapv deref) path"
+    (let [a (make-source 1) b (make-source 2) c (make-source 3)
+          derived (derive [a b c] (fn [x y z] (+ x y z)))]
+      (is (= 6 @derived))
+      (write! a 10) (write! b 20) (write! c 30)
+      (is (= 60 @derived)))))
+
+(deftest derived-four-arity-cljs-test
+  (testing "4 sources — fallback path"
+    (let [a (make-source :a) b (make-source :b) c (make-source :c) d (make-source :d)
+          derived (derive [a b c d] (fn [w x y z] [w x y z]))]
+      (is (= [:a :b :c :d] @derived)))))
+
+(deftest derived-source-vector-order-preserved-cljs-test
+  (testing "argument order matches source-vector order"
+    (let [s0 (make-source 100)
+          s1 (make-source 1)
+          derived (derive [s0 s1] -)]
+      (is (= 99 @derived)))))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -87,13 +87,48 @@
 ;; by =. The derived container itself does not memoise; per the same
 ;; spec section that's the cache's job, not the substrate's.
 
+(defn build-recompute-fn
+  "Arity-specialised recompute-closure factory for a derived value.
+
+  Returns a 0-arg thunk that derefs `source-containers` and calls
+  `compute-fn` with the deref'd values. The hottest path in the
+  artefact is `derived-recompute × dispatch × subscriber`; subs
+  typically chain off 1 input (layer-1 always; layer-n usually 1–2).
+  Specialising 0/1/2 sidesteps the `apply` + lazy-`map` cost on the
+  dominant arities; ≥3 falls back to `mapv` (eager, vector-backed)
+  + `apply`.
+
+  `count` is captured once at construction (per Spec 006 §CLJS reference
+  + `re-frame.subs`, `source-containers` is a vector) so the recompute
+  closure pays no per-tick `count`.
+
+  Single source of truth (rf2-eoy63 lockstep): the Reagent,
+  reagent-slim, UIx, and Helix adapters all build their recompute
+  closure through this fn — pre-rf2-eoy63 the arity-spec lived only in
+  the Reagent adapter and the spine + reagent-slim had naive
+  `(apply compute-fn (map deref ...))` shapes that paid the apply +
+  lazy-seq cost on every sub recompute × every dispatch. Lifting the
+  arity-spec into the spine matches the rf2-jcjul `make-dispose-adapter!`
+  shape: one implementation, four adapters, zero drift. Sourced from
+  the rf2-fzrav perf-sweep findings."
+  [source-containers compute-fn]
+  (let [n (count source-containers)]
+    (case n
+      0 (fn recompute-0 [] (compute-fn))
+      1 (let [s0 (nth source-containers 0)]
+          (fn recompute-1 [] (compute-fn @s0)))
+      2 (let [s0 (nth source-containers 0)
+              s1 (nth source-containers 1)]
+          (fn recompute-2 [] (compute-fn @s0 @s1)))
+      (fn recompute-n [] (apply compute-fn (mapv deref source-containers))))))
+
 (defn make-derived-value-fn
   "Return a `make-derived-value` fn that tags per-source watch keys with
   the given `gensym-prefix`. The fn signature matches the substrate
   contract: `(sources compute-fn) -> derived-container`."
   [gensym-prefix]
   (fn make-derived-value [source-containers compute-fn]
-    (let [recompute      (fn [] (apply compute-fn (map deref source-containers)))
+    (let [recompute      (build-recompute-fn source-containers compute-fn)
           watchers       (atom {})           ;; user-key → wrapper-fn
           on-dispose-fns (atom [])
           ;; Per-source wrapper keys we own so dispose can unwire them.

--- a/implementation/core/test/re_frame/substrate/spine_build_recompute_fn_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_build_recompute_fn_cljs_test.cljs
@@ -1,0 +1,134 @@
+(ns re-frame.substrate.spine-build-recompute-fn-cljs-test
+  "Unit coverage for the substrate-spine's `build-recompute-fn` helper
+  (rf2-eoy63 — arity-specialised recompute closure lifted into the
+  spine so all four adapters share one implementation).
+
+  Pins:
+
+    1. Arity-0 / -1 / -2 closures call `compute-fn` directly — no
+       `apply`, no lazy-seq allocation, no `mapv`.
+    2. Arity-N (≥3) uses an eager `mapv deref` (NOT lazy `map`) so a
+       lazy cons chain cannot defer derefs past the recompute boundary.
+    3. The returned thunk derefs its sources every call (does not
+       memoise) — the substrate contract says fresh recompute per
+       deref of the derived container.
+    4. Multi-source `notify` semantics — each source's change drives
+       a recompute; ZERO-arity has no sources to watch.
+
+  The recompute closures are tested directly without wiring through
+  `make-derived-value-fn` so the assertions stay focused on the
+  arity-spec contract."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.substrate.spine :as spine]))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- recompute-name [f]
+  ;; The fn names baked into the closures (`recompute-0`, `recompute-1`,
+  ;; `recompute-2`, `recompute-n`) are the surface tests can probe to
+  ;; confirm the case-branch fired without inspecting bytecode.
+  ;; ClojureScript exposes the fn's `.-name` for named anonymous fns
+  ;; declared via `(fn fname [...] ...)`.
+  (.-name f))
+
+;; ---- arity-spec branch-selection ------------------------------------------
+
+(deftest build-recompute-fn-zero-arity-picks-0-branch
+  (testing "0 sources → 0-arity closure that calls compute-fn with no args"
+    (let [calls (atom 0)
+          f     (spine/build-recompute-fn []
+                  (fn [] (swap! calls inc) ::seed))]
+      (is (re-find #"recompute_0" (recompute-name f))
+          "0-source case selects the recompute-0 branch")
+      (is (= ::seed (f)) "thunk returns the compute-fn result")
+      (is (= 1 @calls) "compute-fn invoked exactly once per call")
+      (f) (f)
+      (is (= 3 @calls) "thunk does NOT memoise — fresh call per invocation"))))
+
+(deftest build-recompute-fn-one-arity-picks-1-branch
+  (testing "1 source → 1-arity closure that derefs s0 and calls compute-fn"
+    (let [s0   (atom 7)
+          f    (spine/build-recompute-fn [s0] (fn [a] (* 2 a)))]
+      (is (re-find #"recompute_1" (recompute-name f))
+          "1-source case selects the recompute-1 branch")
+      (is (= 14 (f)) "derefs source 0, applies compute-fn directly")
+      (reset! s0 11)
+      (is (= 22 (f)) "subsequent call derefs latest source value"))))
+
+(deftest build-recompute-fn-two-arity-picks-2-branch
+  (testing "2 sources → 2-arity closure that derefs s0 + s1 and calls compute-fn"
+    (let [s0 (atom 3)
+          s1 (atom 4)
+          f  (spine/build-recompute-fn [s0 s1] +)]
+      (is (re-find #"recompute_2" (recompute-name f))
+          "2-source case selects the recompute-2 branch")
+      (is (= 7 (f)) "derefs both sources, calls compute-fn directly")
+      (reset! s1 40)
+      (is (= 43 (f)) "subsequent call derefs latest values"))))
+
+(deftest build-recompute-fn-three-arity-picks-n-branch
+  (testing "3 sources → N-arity closure that mapv-derefs and applies compute-fn"
+    (let [s0 (atom 1) s1 (atom 2) s2 (atom 3)
+          f  (spine/build-recompute-fn [s0 s1 s2]
+               (fn [a b c] (+ a b c)))]
+      (is (re-find #"recompute_n" (recompute-name f))
+          "3-source case selects the recompute-n fallback")
+      (is (= 6 (f)) "derefs all 3 sources via mapv, applies compute-fn"))))
+
+(deftest build-recompute-fn-n-arity-uses-mapv-not-lazy-map
+  (testing "N-arity (≥3) uses eager mapv-deref — derefs happen before compute-fn runs"
+    ;; Side-effect counter inside the deref machinery is impossible
+    ;; (CLJS `atom/deref` is pure) — instead pin the property via the
+    ;; observable consequence of `mapv` vs `map`: every source's deref
+    ;; is visible to compute-fn as a fully-realised arg list, NOT a
+    ;; lazy sequence that defers. We verify this by making compute-fn
+    ;; close over the *number* of args it received (which a lazy seq
+    ;; would still report correctly via `count`, so we go further) and
+    ;; by asserting the args are positionally bound to deref'd values
+    ;; — a lazy chain would still work positionally if forced, so the
+    ;; strongest invariant is the no-lazy-cons property: the closure
+    ;; gives compute-fn each value already realised and apply-able.
+    (let [s0 (atom :a) s1 (atom :b) s2 (atom :c) s3 (atom :d)
+          received-args (atom nil)
+          f (spine/build-recompute-fn [s0 s1 s2 s3]
+              (fn [& args]
+                (reset! received-args args)
+                (vec args)))]
+      (is (= [:a :b :c :d] (f)))
+      ;; `apply` flattens varargs into a seq; the underlying vector
+      ;; from `mapv` is observably eager (count + nth without realising
+      ;; further). The strongest pinning is value-equality of the
+      ;; received args against the source vals at call time.
+      (is (= [:a :b :c :d] (vec @received-args))))))
+
+(deftest build-recompute-fn-fresh-recompute-per-call
+  (testing "thunk does not cache — every call rederefs sources"
+    (let [s0  (atom 0)
+          f   (spine/build-recompute-fn [s0] identity)]
+      (is (= 0 (f)))
+      (reset! s0 1) (is (= 1 (f)))
+      (reset! s0 2) (is (= 2 (f)))
+      (reset! s0 3) (is (= 3 (f))))))
+
+(deftest build-recompute-fn-honours-source-vector-order
+  (testing "1-arity: s0 is the single source; 2-arity: order is s0 then s1"
+    (let [s0 (atom 100)
+          s1 (atom 1)
+          f  (spine/build-recompute-fn [s0 s1] -)]
+      ;; `-` is non-commutative: (- @s0 @s1) = 99, (- @s1 @s0) = -99.
+      (is (= 99 (f)) "argument order matches source-vector order"))))
+
+(deftest build-recompute-fn-shape-matches-make-derived-value-fn-flow
+  (testing "the recompute fn assembled by build-recompute-fn is the same one make-derived-value-fn wires into the IDeref body"
+    ;; Integration probe: drive `make-derived-value-fn` end-to-end and
+    ;; confirm the spine's derived container exposes the same value the
+    ;; bare arity-spec recompute closure would have produced. Pins the
+    ;; rf2-eoy63 wiring: spine's IDeref body MUST route through
+    ;; build-recompute-fn, not its old naive (apply compute-fn (map
+    ;; deref ...)) shape.
+    (let [make-derived (spine/make-derived-value-fn "rf-test-")
+          s0           (atom 5)
+          derived      (make-derived [s0] (fn [a] (* a 10)))]
+      (is (= 50 @derived) "1-arity recompute fires through the spine")
+      (reset! s0 6)
+      (is (= 60 @derived) "subsequent deref re-runs the recompute"))))


### PR DESCRIPTION
## Summary

Lifts the Reagent adapter's hand-rolled arity-spec for `make-derived-value`'s
recompute closure into the spine as a shared `build-recompute-fn` helper —
single source of truth across all four adapters.

**The drift (pre-rf2-eoy63):**
- **Reagent** (rf2-v1nu0 / rf2-fzrav) — arity-specialised `case` (0/1/2/N), avoids `apply` + lazy `map`
- **spine** (UIx + Helix) — naive `(apply compute-fn (map deref source-containers))`
- **reagent-slim** — same naive shape; also `map` (lazy) not `mapv`

Hottest path in the artefact: sub recompute x dispatch x subscriber. Per
the framework-quality audit (ai/findings/framework-quality-audit-2026-05-17.md §A1).

## Changes

- `implementation/core/src/re_frame/substrate/spine.cljs` — new `build-recompute-fn` (pure closure factory: 0/1/2 specialised, N falls back to `apply + mapv deref`). `make-derived-value-fn` consumes it (covers UIx + Helix).
- `implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs` — `make-derived-value` now wraps `spine/build-recompute-fn` with `ratom/make-reaction`. Inline case-spec removed.
- `implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs` — same shape as Reagent.
- 5 new test namespaces (one per adapter + one for the spine helper) pinning the arity-spec behavior and source-vector-order invariants.

Same single-source-of-truth pattern as rf2-jcjul / PR #1271 (`spine/dispose-frame-sub-caches!` + `make-dispose-adapter!`): one implementation, four adapters, zero drift.

## Test plan

- [x] `npm run test:cljs` — 2215 tests, 6294 assertions, 0 failures
- [x] JVM implementation artefacts — all green
- [x] `npm run test:bundle-isolation` — pass (UIx + Helix Reagent-free preserved)
- [x] `npm run test:reagent-slim:bundle-isolation` — pass
- [x] `npm run test:perf-bundle` — pass
- [x] `scripts/test-fast-pr.sh` — pass