### PR TITLE
fix(causa): stable React keys for trace ribbon (rf2-z4fza, rf2-kgn0c sibling)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -232,13 +232,21 @@
      (format-axis-value value)]))
 
 (defn- trace-row
-  "One row in the trace ribbon."
+  "One row in the trace ribbon.
+
+  Per rf2-z4fza: the React `:key` is the row's stable trace `:id`
+  (via `h/row-key`). The earlier shape keyed on a tuple that mixed
+  in the row's positional index inside the visible viewport — every
+  new trace push shifted every visible row's index, so every key
+  changed, and React unmounted+remounted the entire viewport on
+  EVERY push. Same discipline class as rf2-kgn0c's `v:<variant-id>`
+  cell-keying in the story workspace."
   [{:keys [id time op-type operation source origin frame description
-           source-coord dispatch-id row-index]
-    :as _row}]
+           source-coord dispatch-id]
+    :as row}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
         dot-colour  (h/op-type-colour op-type)]
-    [:li {:key         [row-index frame id time op-type operation source-coord]
+    [:li {:key         (h/row-key row)
           :data-testid row-test-id
           :on-click    (fn []
                          (when dispatch-id

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -326,10 +326,17 @@
                   (update :rendered inc))
               state'')))
         result         (reduce accumulate init-state events)
-        sorted-display (mapv (fn [idx row]
-                                (assoc row :row-index idx))
-                              (range)
-                              (:rev-filtered result))
+        ;; Per rf2-z4fza: rows are returned as a plain newest-first
+        ;; vector. The earlier shape stamped a positional `:row-index`
+        ;; on every row so the view could mix it into the React key;
+        ;; that meant every trace push shifted every visible row's
+        ;; index and React unmounted+remounted the entire viewport on
+        ;; every push (audit `ai/findings/causa-story-ui-stress-audit-
+        ;; 2026-05-17.md` F1). The view now keys on the row's stable
+        ;; trace `:id` (via `row-key` below) so `:row-index` carries
+        ;; no information for any consumer and is gone — its mere
+        ;; presence on the row was a footgun inviting positional keys.
+        sorted-display (vec (:rev-filtered result))
         empty-kind  (cond
                       (zero? (:total result))    :no-events
                       (zero? (:rendered result)) :no-matches
@@ -342,6 +349,31 @@
      :filters      normalised
      :any-filter?  (boolean (seq normalised))
      :empty-kind   empty-kind}))
+
+;; ---- React keys ---------------------------------------------------------
+
+(defn row-key
+  "Stable React key for one projected trace row.
+
+  Per rf2-z4fza (sibling of rf2-kgn0c — same React-key discipline):
+  the trace ribbon's earlier shape keyed each `<li>` on a tuple that
+  included the row's positional index inside the visible viewport. A
+  new trace push shifts every visible row's index down by one, which
+  changes every key, which makes React's reconciler unmount the
+  entire viewport and remount it on EVERY push — the dominant frame
+  cost under burst event rate.
+
+  The framework's `re-frame.trace` allocates a monotonically-
+  increasing `:id` per emit (`next-id!`), and the same trace event
+  is never re-projected — so `:id` is a stable, unique identity for
+  the row across the panel's lifetime. We namespace it with `t:` to
+  mirror the rf2-kgn0c discipline (`v:<variant-id>` in the story
+  workspace) so future positional fallbacks can't silently collide
+  with these keys.
+
+  Pure data → string; JVM-testable."
+  [{:keys [id] :as _row}]
+  (str "t:" (pr-str id)))
 
 ;; ---- selection ----------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -165,12 +165,52 @@
     ;; emit `:event/dispatched` etc. back through the trace-cb fan-out,
     ;; the collector would see its own self-emit, and the cascade would
     ;; loop until `drain-depth-default` terminated it.
+    ;;
+    ;; ## Seed-race dedup (rf2-z4fza follow-up)
+    ;;
+    ;; The mount-time seed path (`ensure-causa-frame!` in mount.cljs)
+    ;; runs in this order:
+    ;;
+    ;;   1. `(rf/reg-frame :rf/causa {})` — registers the frame AND
+    ;;      synchronously emits a `:frame/created` trace event for
+    ;;      `:rf/causa`. `collect-trace!` runs for that event:
+    ;;        a. atom push (synchronous);
+    ;;        b. `mirror-into-causa!` checks `(frame/frame :rf/causa)`
+    ;;           — the frame was just registered above, so it exists.
+    ;;           A `:rf.causa/note-trace-event` dispatch is QUEUED.
+    ;;   2. `(rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])`
+    ;;      — runs synchronously; seeds the slot with the atom snapshot
+    ;;      (which already contains the `:frame/created` event).
+    ;;
+    ;; When the queued note-trace-event from step 1b eventually drains,
+    ;; the seeded slot already carries that event — re-pushing produces
+    ;; a duplicate-`:id` pair inside the slot vector. The Trace panel
+    ;; keys its `<li>`s on `t:<id>` (rf2-z4fza) so duplicate ids become
+    ;; duplicate React keys: React warns AND leaves one extra stale
+    ;; `<li>` in the DOM that survives subsequent renders even after
+    ;; cap-eviction removes both copies from the data — pushing the
+    ;; rendered viewport over the 200-row budget by one indefinitely.
+    ;;
+    ;; The dedup: the framework's `next-event-id` is a process-wide
+    ;; monotonic counter, so `:id` is a true identity for the event.
+    ;; If the incoming event's `:id` is already present anywhere in the
+    ;; slot, the seed has already mirrored it — drop the push. The
+    ;; scan is `O(slot)` but the slot is bounded by the cap (1000 by
+    ;; default) and the seed window only fires once per session, so
+    ;; the steady-state cost is one walk per emit. A tail-only check
+    ;; would be cheaper but is incorrect: events arrive at the slot in
+    ;; arrival order via `mirror-into-causa!`, so the dup from the
+    ;; seed race lands SOMEWHERE in the seeded prefix, not always at
+    ;; the tail.
     (rf/reg-event-db :rf.causa/note-trace-event
       {:rf.trace/no-emit? true}
       (fn [db [_ event]]
         (let [buf   (get db :trace-buffer [])
-              depth (trace-bus/current-depth)]
-          (assoc db :trace-buffer (trace-bus/push buf depth event)))))
+              depth (trace-bus/current-depth)
+              ev-id (:id event)]
+          (if (and ev-id (some #(= ev-id (:id %)) buf))
+            db
+            (assoc db :trace-buffer (trace-bus/push buf depth event))))))
 
     ;; Clear the mirrored slot in lockstep with the trace-bus atom
     ;; (dispatched from `trace-bus/clear-buffer!` in CLJS). Per

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -387,3 +387,82 @@
       (is (contains? axes :event-id))
       (is (contains? axes :handler-id))
       (is (contains? axes :dispatch-id)))))
+
+;; ---- (13) row-key — rf2-z4fza (sibling of rf2-kgn0c) -------------------
+;;
+;; Per rf2-z4fza: the trace ribbon's React `:key` must be a stable
+;; per-trace-event identity (the framework's monotonic `:id`). The
+;; earlier shape mixed in the row's positional index inside the
+;; visible viewport, so every new trace push shifted every key and
+;; React remounted the entire viewport — the dominant frame cost
+;; under burst event rate. Same discipline class as rf2-kgn0c's
+;; `v:<variant-id>` keys in the story workspace.
+
+(deftest project-feed-rows-carry-no-row-index-slot
+  (testing "rf2-z4fza acceptance: rows MUST NOT carry a :row-index
+            slot — its mere presence on the row was a footgun
+            inviting positional React keys"
+    (let [feed (h/project-feed (events-fixture) {})]
+      (doseq [row (:rows feed)]
+        (is (not (contains? row :row-index))
+            (str "row " (:id row) " must not carry :row-index"))))))
+
+(deftest row-key-uses-stable-trace-id
+  (testing "row-key reads only :id — the framework's monotonic trace
+            id is stable per emit, so the key is stable across pushes"
+    (is (= "t:7" (h/row-key {:id 7})))
+    (is (= "t:42" (h/row-key {:id 42}))))
+  (testing "row-key is unique per distinct trace id"
+    (let [ids   (range 1 200)
+          keys  (mapv #(h/row-key {:id %}) ids)]
+      (is (= (count ids) (count (distinct keys)))
+          "every trace id maps to a unique React key"))))
+
+(deftest row-key-ignores-row-index-and-position
+  (testing "rf2-z4fza acceptance: row-key MUST NOT consume :row-index
+            (the slot is gone from rows; any future regression that
+            re-adds it would silently destabilise keys)"
+    (let [row-a (h/project-row {:id 5 :op-type :event :operation :event/dispatched
+                                :time 100})
+          row-b (assoc row-a :row-index 0)
+          row-c (assoc row-a :row-index 99)]
+      (is (= (h/row-key row-a) (h/row-key row-b))
+          "row-key with :row-index 0 equals row-key without :row-index")
+      (is (= (h/row-key row-a) (h/row-key row-c))
+          "row-key with :row-index 99 equals row-key without :row-index"))))
+
+(deftest row-keys-are-stable-across-trace-pushes
+  (testing "rf2-z4fza headline guarantee: appending a new trace event
+            does NOT change the React key of any previously-existing
+            row — same input row → same key. This is the property
+            React's reconciler needs to reuse DOM nodes across pushes
+            instead of unmounting+remounting the viewport on every push."
+    (let [events-1 (events-fixture)
+          ;; Simulate a burst — append three new events to the buffer.
+          new-evs  [(ev {:id 6 :op-type :event :operation :event/dispatched
+                         :time 600 :source :ui :origin :app
+                         :frame :rf/default})
+                    (ev {:id 7 :op-type :fx :operation :rf.fx/handled
+                         :time 700 :source :ui :origin :app
+                         :frame :rf/default})
+                    (ev {:id 8 :op-type :error :operation :rf.error/handler-threw
+                         :time 800 :source :ui :origin :app
+                         :frame :rf/default})]
+          events-2 (vec (concat events-1 new-evs))
+          feed-1   (h/project-feed events-1 {})
+          feed-2   (h/project-feed events-2 {})
+          keys-1   (into {} (map (juxt :id h/row-key) (:rows feed-1)))
+          keys-2   (into {} (map (juxt :id h/row-key) (:rows feed-2)))]
+      (doseq [[id k1] keys-1]
+        (is (= k1 (get keys-2 id))
+            (str "row id " id ": key must be stable across pushes "
+                 "(pre-push=" (pr-str k1) ", post-push=" (pr-str (get keys-2 id))
+                 "). rf2-z4fza: positional :row-index in the key would shift "
+                 "this on every append and re-mount the entire viewport.")))
+      (testing "all post-push keys are unique"
+        (let [all-keys (vals keys-2)]
+          (is (= (count all-keys) (count (distinct all-keys))))))
+      (testing "new events get fresh keys, not collisions"
+        (doseq [id [6 7 8]]
+          (is (some? (get keys-2 id)))
+          (is (not (contains? keys-1 id))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -415,3 +415,112 @@
           "filter map lands on Causa")
       (is (nil? (:trace-filters default-db))
           "filter map did NOT leak into :rf/default"))))
+
+;; ---- (8) React-key stability across trace pushes — rf2-z4fza -----------
+;;
+;; Sibling of rf2-kgn0c (same React-key discipline class). The earlier
+;; trace row shape keyed `<li>` on a tuple that included the row's
+;; positional index inside the visible viewport. Every trace push
+;; shifted every visible row's index → every key changed → React
+;; unmounted + remounted the entire viewport on EVERY push — the
+;; dominant frame cost under burst event rate (animation frames,
+;; polling). This test pins the fix: the rendered `<li>` for any row
+;; that survives a push has the SAME `:key` before and after.
+
+(defn- row-li-by-id
+  "Walk the rendered tree and return the `<li>` whose data-testid is
+  `rf-causa-trace-row-<id>`. Returns nil when the row isn't rendered."
+  [tree id]
+  (let [testid (str "rf-causa-trace-row-" id)]
+    (some (fn [node]
+            (when (and (vector? node)
+                       (= :li (first node))
+                       (map? (second node))
+                       (= testid (:data-testid (second node))))
+              node))
+          (hiccup-seq tree))))
+
+(defn- sync-push!
+  "Push a trace event AND synchronously flush the `:rf.causa/note-
+  trace-event` mirror into `:rf/causa`'s app-db. The production
+  `collect-trace!` mirror dispatches async (`rf/dispatch`); the
+  layer-1 `:rf.causa/trace-buffer` sub falls back to the atom when
+  the db slot is nil, which lets the first read succeed in tests.
+  But once the sub has materialised, subsequent atom-only pushes
+  are invisible to the cached sub. `dispatch-sync` of the note
+  event forces the db update so the sub re-fires."
+  [ev]
+  (push-trace! ev)
+  (rf/dispatch-sync [:rf.causa/note-trace-event ev]))
+
+(deftest trace-row-react-keys-are-stable-across-pushes
+  (testing "rf2-z4fza — appending a new trace event must NOT change the
+            :key of any previously-rendered <li>. Same input row → same
+            React key → React's reconciler reuses the DOM node instead
+            of unmounting + remounting it. Mirrors rf2-kgn0c's
+            v:<variant-id> discipline in the story workspace."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Seed three rows.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                             :time 200 :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
+                             :time 300 :dispatch-id 1}))
+      (let [tree-1   (trace/trace-view)
+            keys-1   {1 (:key (second (row-li-by-id tree-1 1)))
+                      2 (:key (second (row-li-by-id tree-1 2)))
+                      3 (:key (second (row-li-by-id tree-1 3)))}]
+        (is (every? some? (vals keys-1))
+            "every initial row carries a React :key")
+        (is (= 3 (count (distinct (vals keys-1))))
+            "initial row keys are distinct")
+        ;; Push three more events — under the broken positional-key
+        ;; shape, this would shift every existing key.
+        (sync-push! (mk-trace {:id 4 :op-type :event :operation :event/dispatched
+                               :time 400 :dispatch-id 2}))
+        (sync-push! (mk-trace {:id 5 :op-type :fx    :operation :rf.fx/handled
+                               :time 500 :dispatch-id 2}))
+        (sync-push! (mk-trace {:id 6 :op-type :error :operation :rf.error/handler-threw
+                               :time 600 :dispatch-id 2}))
+        (let [tree-2 (trace/trace-view)
+              keys-2 {1 (:key (second (row-li-by-id tree-2 1)))
+                      2 (:key (second (row-li-by-id tree-2 2)))
+                      3 (:key (second (row-li-by-id tree-2 3)))
+                      4 (:key (second (row-li-by-id tree-2 4)))
+                      5 (:key (second (row-li-by-id tree-2 5)))
+                      6 (:key (second (row-li-by-id tree-2 6)))}]
+          (doseq [id [1 2 3]]
+            (is (= (get keys-1 id) (get keys-2 id))
+                (str "row id " id ": React :key must be identical before "
+                     "and after the burst push (pre=" (pr-str (get keys-1 id))
+                     " post=" (pr-str (get keys-2 id)) "). "
+                     "If this fails, the trace ribbon is re-mounting the "
+                     "viewport on every push — the rf2-z4fza regression.")))
+          (is (every? some? (vals keys-2))
+              "every row in the post-push tree carries a React :key")
+          (is (= 6 (count (distinct (vals keys-2))))
+              "all six row keys remain distinct after the burst push"))))))
+
+(deftest trace-row-react-keys-have-no-positional-component
+  (testing "rf2-z4fza acceptance: the rendered <li> :key contains only
+            the stable trace id, NOT a positional row-index. Pins the
+            key shape so a future regression that re-introduces a
+            positional component would fail loudly here."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 11 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 1}))
+      (sync-push! (mk-trace {:id 22 :op-type :fx    :operation :rf.fx/handled
+                             :time 200 :dispatch-id 1}))
+      (let [tree (trace/trace-view)
+            k11  (:key (second (row-li-by-id tree 11)))
+            k22  (:key (second (row-li-by-id tree 22)))]
+        (is (= "t:11" k11)
+            "row 11 keyed on stable trace id alone (no positional prefix)")
+        (is (= "t:22" k22)
+            "row 22 keyed on stable trace id alone (no positional prefix)")
+        (is (string? k11)
+            "key is a string (not the positional-tuple from the
+             pre-rf2-z4fza shape)")))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -454,6 +454,56 @@
         (is (= [{:id 200 :tags {}}] @(rf/subscribe [:rf.causa/trace-buffer]))
             "second sync wholly replaces the slot (no merge)")))))
 
+(deftest sub-trace-buffer-note-event-dedupes-on-id
+  (testing "rf2-z4fza follow-up: `:rf.causa/note-trace-event` skips the
+            push when the incoming event's `:id` already exists in the
+            slot. The mount seed-race window — where the `:frame/created`
+            trace for `:rf/causa` lands in both the atom snapshot the
+            seed reads AND a queued mirror dispatch — would otherwise
+            land the same event id twice, producing a duplicate React
+            `t:<id>` key in the Trace panel and one extra `<li>` past
+            the 200-row budget that survives reconciliation."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Simulate the seed-race directly: seed lands the event id 42 in
+      ;; the slot wholesale, then a `:rf.causa/note-trace-event` for the
+      ;; same id arrives from a queued mirror dispatch.
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer
+                         [{:id 42 :op-type :frame :operation :frame/created
+                           :tags {:frame :rf/causa}}]])
+      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer]))))
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 42 :op-type :frame :operation :frame/created
+                          :tags {:frame :rf/causa}}])
+      (is (= 1 (count @(rf/subscribe [:rf.causa/trace-buffer])))
+          "duplicate-id push is a no-op — slot length unchanged")
+      (is (= [42] (mapv :id @(rf/subscribe [:rf.causa/trace-buffer])))
+          "only the seeded entry remains; the duplicate mirror push was
+           skipped")
+      ;; Distinct ids still push normally — dedup is per-id, not blanket
+      ;; deduplication-by-anything.
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:id 43 :op-type :event :operation :rf.test/y
+                          :tags {}}])
+      (is (= [42 43] (mapv :id @(rf/subscribe [:rf.causa/trace-buffer])))
+          "fresh ids still append — dedup is :id-keyed, not push-blocking"))))
+
+(deftest sub-trace-buffer-note-event-allows-events-without-id
+  (testing "rf2-z4fza follow-up: the dedup gate predicates on `:id`
+            being present (the framework's `next-event-id` stamp). An
+            event without `:id` is still pushed — defensive against
+            synthetic/test events that omit the slot."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:op-type :event :operation :rf.test/no-id
+                          :tags {}}])
+      (rf/dispatch-sync [:rf.causa/note-trace-event
+                         {:op-type :event :operation :rf.test/also-no-id
+                          :tags {}}])
+      (is (= 2 (count @(rf/subscribe [:rf.causa/trace-buffer])))
+          "events without :id are not deduped — both push lands"))))
+
 (deftest sub-trace-buffer-evicts-on-overflow
   (testing "trace-bus enforces the eviction-on-overflow algebra against
             `current-depth`. We shrink the depth to 3 then push 5


### PR DESCRIPTION
## Summary

- **Bug class.** Same React-key discipline as just-fixed rf2-kgn0c. The trace ribbon's `<li>` `:key` was a tuple containing the row's positional index inside the visible viewport. Every trace push shifted every existing row's index → every key changed → React unmounted+remounted the entire viewport (capped 200) on EVERY push. Dominant frame cost on the highest-rate Causa panel under burst event rate. Audit F1 in `ai/findings/causa-story-ui-stress-audit-2026-05-17.md`.
- **Fix.** Use the trace event's monotonic `:id` (`re-frame.trace/next-id!`) as the React key, namespaced `t:<id>` — mirrors rf2-kgn0c's `v:<variant-id>` discipline so future positional fallbacks can't silently collide. `project-feed` no longer stamps `:row-index` on rows (the slot's only consumer was the key; its presence was a footgun).
- **Tests.** 4 new tests in `trace_helpers_cljs_test.cljc` (JVM+CLJS) pinning row-key shape, stability across pushes, AC that `:row-index` is gone, and AC that `row-key` does not consume `:row-index` even if added. 2 new tests in `trace_view_cljs_test.cljs` pinning the actual rendered `<li>` `:key` is stable across a 3+3 burst push and has no positional component.

## Cross-ref

rf2-kgn0c — same React-key discipline class in the story workspace; this PR adopts the same `v:` / `t:` namespacing convention.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 547 tests / 1558 assertions, 0 failures.
- [x] `npm run test:cljs` from `implementation/` — 2189 tests / 6263 assertions, 0 failures.
- [x] All 4 new helpers tests pass under both JVM and CLJS runners.
- [x] Worktree-isolated edits; mayor checkout untouched.