### PR TITLE
fix(story): workspace cells re-run on full run-key (rf2-c56hr, rf2-kgn0c+rf2-z4fza sibling)

### DIFF
--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -190,12 +190,20 @@
     (runtime/run-variant variant-id opts)
     nil))
 
-(defn- run-key
+(defn run-key
   "The shell-state slice that should trigger a fresh runtime run for
-  the focused variant. Ordinary app-db updates inside the variant frame
-  must not re-dispatch the variant's static `:events`; otherwise user
+  `variant-id`. Ordinary app-db updates inside the variant frame must
+  not re-dispatch the variant's static `:events`; otherwise user
   interactions reset the canvas and the recorder captures fixture
-  initialisation events as if they were user actions."
+  initialisation events as if they were user actions.
+
+  Public so the workspace renderer (`ui/workspace.cljc`) can mirror the
+  canvas's trigger condition for its per-cell run loop (rf2-c56hr).
+  Both surfaces re-run when ANY of `:variant-id` / `:hot-reload-tick` /
+  `:active-modes` / `:cell-overrides` / `:substrate` changes — keeping
+  them lockstep prevents the workspace cell from rendering against
+  stale `:events-seeded` app-db when the controls panel writes a new
+  `:cell-overrides` entry or the user toggles a mode / substrate."
   [shell variant-id]
   {:variant-id       variant-id
    :hot-reload-tick  (:hot-reload-tick shell)

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -277,9 +277,10 @@
    (defn- variant-cell
      "Reagent component for one variant cell. Pre-allocates the
      variant's frame and dispatches its `:events` slot SYNCHRONOUSLY
-     before the first render, then re-runs on each
-     `:hot-reload-tick` bump so the cell stays in sync with fingerprint
-     drift.
+     before the first render, then re-runs whenever ANY component of
+     the canvas/workspace shared `run-key` advances — `:variant-id`,
+     `:hot-reload-tick`, `:active-modes`, `:cell-overrides`, or
+     `:substrate`.
 
      Per rf2-zme7: the pre-allocation must happen before any subscribe
      deref. A `:component-did-mount` hook fires AFTER React's first
@@ -299,20 +300,25 @@
      to hang off (one selection drives N variants), so the cell itself
      owns the pre-allocation.
 
-     The per-cell `last-tick` atom tracks the most-recent
-     `:hot-reload-tick` value seen by THIS cell: re-running
-     `run-variant` only when the tick advances avoids re-dispatching
-     the variant's `:events` on every re-render — which would otherwise
-     reset state on every user interaction (an inc click re-renders the
-     cell, an unconditional re-run of `:events` would clobber the
-     count back to its initial value)."
+     Per rf2-c56hr (sibling to rf2-kgn0c, rf2-z4fza): the per-cell
+     `last-run-key` atom tracks the most-recent `(canvas/run-key shell
+     variant-id)` value seen by THIS cell. The prior implementation
+     keyed only on `:hot-reload-tick`, so editing a control through
+     the controls panel — which writes through to `:cell-overrides`
+     — never re-seeded the cell's frame and the cell kept rendering
+     against its original `:events`-seeded app-db. Mirroring the
+     canvas's full run-key (`canvas.cljs` `run-key` + `run-if-needed!`)
+     also covers chrome-level `:active-modes` toggles and substrate
+     flips. Keying on the full tuple still skips re-runs on ordinary
+     intra-cell renders (an inc click bumps app-db but leaves the run-
+     key intact), so the variant's `:events` are NOT clobbered on user
+     interaction — same property the tick-only path preserved."
      [variant-id]
-     (r/with-let [_init     (run-variant-with-shell-opts! variant-id)
-                  last-tick (atom 0)]
+     (r/with-let [last-run-key (atom nil)]
        (let [shell @state/shell-state-atom
-             tick  (or (:hot-reload-tick shell) 0)]
-         (when (> tick @last-tick)
-           (reset! last-tick tick)
+             key   (canvas/run-key shell variant-id)]
+         (when (not= key @last-run-key)
+           (reset! last-run-key key)
            (run-variant-with-shell-opts! variant-id))
          [variant-cell-inner variant-id]))))
 

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -413,6 +413,98 @@
           (str "workspace-root key MUST embed the workspace id; got "
                (pr-str k))))))
 
+;; ---- workspace cells re-run on full run-key (rf2-c56hr) -----------------
+;;
+;; Sibling to rf2-kgn0c (variant-id-keyed React identity) and rf2-z4fza
+;; (Causa trace `t:<trace-id>` keying). The prior workspace `variant-cell`
+;; kept a `last-tick` atom and re-ran `run-variant-with-shell-opts!` ONLY
+;; when `:hot-reload-tick` advanced. Consequence in `:variants-grid` /
+;; `:grid` workspaces: editing a control through the controls panel
+;; wrote through to `:cell-overrides` but the cell's frame was never
+;; re-seeded → the cell kept rendering against its original `:events`-
+;; seeded app-db. Same hazard for chrome-level `:active-modes` toggles
+;; and substrate flips.
+;;
+;; Fix: lift the canvas's `run-key` into a shared public helper and key
+;; the workspace cell's re-run trigger on the FULL tuple
+;; `{:variant-id :hot-reload-tick :active-modes :cell-overrides
+;;   :substrate}` — same shape canvas's `run-if-needed!` uses. These
+;; tests pin both halves: the shared helper detects the three previously-
+;; missed transitions, AND ordinary intra-cell renders (app-db updates
+;; that DON'T touch the run-key slice) still skip the re-run so user
+;; interactions are not clobbered.
+
+(deftest run-key-detects-cell-overrides-change-rf2-c56hr
+  (testing "canvas/run-key flips when the shell's :cell-overrides for
+            the variant changes — the workspace cell's trigger MUST see
+            this transition (per rf2-c56hr; the prior :hot-reload-tick-
+            only key missed it)"
+    (let [vid     :story.rf2-c56hr.co/v
+          shell-0 {:hot-reload-tick 0
+                   :active-modes    []
+                   :cell-overrides  {}
+                   :substrate       :reagent}
+          shell-1 (assoc-in shell-0 [:cell-overrides vid :label] "edited")
+          k0      (canvas/run-key shell-0 vid)
+          k1      (canvas/run-key shell-1 vid)]
+      (is (not= k0 k1)
+          "writing a per-variant override MUST yield a distinct run-key")
+      (is (= "edited" (get-in k1 [:cell-overrides :label]))
+          "the override value is carried through the run-key slice"))))
+
+(deftest run-key-detects-active-modes-change-rf2-c56hr
+  (testing "canvas/run-key flips when chrome-level :active-modes change
+            — the workspace cell MUST re-seed on mode toggle"
+    (let [vid     :story.rf2-c56hr.am/v
+          shell-0 {:hot-reload-tick 0 :active-modes []
+                   :cell-overrides {} :substrate :reagent}
+          shell-1 (assoc shell-0 :active-modes [:Mode.x/dark])
+          k0      (canvas/run-key shell-0 vid)
+          k1      (canvas/run-key shell-1 vid)]
+      (is (not= k0 k1)))))
+
+(deftest run-key-detects-substrate-change-rf2-c56hr
+  (testing "canvas/run-key flips when the host substrate changes — the
+            workspace cell MUST re-seed on substrate flip"
+    (let [vid     :story.rf2-c56hr.sb/v
+          shell-0 {:hot-reload-tick 0 :active-modes []
+                   :cell-overrides {} :substrate :reagent}
+          shell-1 (assoc shell-0 :substrate :uix)
+          k0      (canvas/run-key shell-0 vid)
+          k1      (canvas/run-key shell-1 vid)]
+      (is (not= k0 k1)))))
+
+(deftest run-key-stable-across-ordinary-app-db-renders-rf2-c56hr
+  (testing "canvas/run-key stays equal when nothing in the watched slice
+            changes — guarantees an inc-click re-render does NOT clobber
+            the variant's :events-seeded state. Pins the rf2-c56hr fix
+            against an over-eager future change that would re-seed on
+            every render."
+    (let [vid     :story.rf2-c56hr.stable/v
+          shell-0 {:hot-reload-tick 0 :active-modes []
+                   :cell-overrides {} :substrate :reagent
+                   :other-unrelated-slot "anything"}
+          shell-1 (assoc shell-0 :other-unrelated-slot "changed")
+          k0      (canvas/run-key shell-0 vid)
+          k1      (canvas/run-key shell-1 vid)]
+      (is (= k0 k1)
+          (str "run-key MUST be stable when only non-watched shell "
+               "slots change; got k0=" (pr-str k0)
+               " k1=" (pr-str k1))))))
+
+(deftest run-key-detects-hot-reload-tick-change-rf2-c56hr
+  (testing "canvas/run-key still flips on :hot-reload-tick — the new
+            workspace cell trigger MUST preserve the legacy tick-driven
+            re-run path on top of the three previously-missed
+            transitions"
+    (let [vid     :story.rf2-c56hr.tick/v
+          shell-0 {:hot-reload-tick 0 :active-modes []
+                   :cell-overrides {} :substrate :reagent}
+          shell-1 (assoc shell-0 :hot-reload-tick 1)
+          k0      (canvas/run-key shell-0 vid)
+          k1      (canvas/run-key shell-1 vid)]
+      (is (not= k0 k1)))))
+
 ;; ---- trace six-domino projection ----------------------------------------
 
 (deftest trace-group-cascades-classifies


### PR DESCRIPTION
## Summary

Workspace `variant-cell` (`tools/story/src/re_frame/story/ui/workspace.cljc`) kept a `last-tick` atom and re-ran `run-variant-with-shell-opts!` ONLY when `:hot-reload-tick` advanced.

Consequence in `:variants-grid` / `:grid` workspaces: editing a control through the controls panel wrote through to `:cell-overrides` but the cell's frame was never re-seeded, so the cell kept rendering against its original `:events`-seeded app-db. Same hazard for chrome-level `:active-modes` toggles and substrate flips.

**Fix.** Lift the canvas's `run-key` into a shared public helper (`canvas/run-key`) and key the workspace cell's re-run trigger on the FULL tuple `{:variant-id :hot-reload-tick :active-modes :cell-overrides :substrate}` — same shape `canvas/run-if-needed!` uses. Both surfaces are now lockstep.

Sibling to **rf2-kgn0c** (variant-id-keyed React identity) and **rf2-z4fza** (Causa trace `t:<trace-id>` keying). Same class: `r/with-let` initialiser-once semantics + insufficient re-trigger keys.

## Before / after

```clj
;; before
(r/with-let [_init     (run-variant-with-shell-opts! variant-id)
             last-tick (atom 0)]
  (let [shell @state/shell-state-atom
        tick  (or (:hot-reload-tick shell) 0)]
    (when (> tick @last-tick)
      (reset! last-tick tick)
      (run-variant-with-shell-opts! variant-id))
    [variant-cell-inner variant-id]))

;; after
(r/with-let [last-run-key (atom nil)]
  (let [shell @state/shell-state-atom
        key   (canvas/run-key shell variant-id)]
    (when (not= key @last-run-key)
      (reset! last-run-key key)
      (run-variant-with-shell-opts! variant-id))
    [variant-cell-inner variant-id]))
```

The synchronous pre-allocation property the old `_init` binding provided is preserved: on first mount `last-run-key` is `nil`, the predicate fires, and `run-variant-with-shell-opts!` runs synchronously before `[variant-cell-inner ...]` is returned.

## Tests

Five new pinning tests under "workspace cells re-run on full run-key (rf2-c56hr)" in `tools/story/test/re_frame/story_ui_cljs_test.cljs`:

- `run-key-detects-cell-overrides-change-rf2-c56hr`
- `run-key-detects-active-modes-change-rf2-c56hr`
- `run-key-detects-substrate-change-rf2-c56hr`
- `run-key-stable-across-ordinary-app-db-renders-rf2-c56hr`
- `run-key-detects-hot-reload-tick-change-rf2-c56hr`

## Test plan

- [x] `clojure -M:test` from `tools/story/` — 426 tests / 1332 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 2220 tests / 6300 assertions / 0 failures
- [ ] Browser-level Playwright regression (per bead acceptance criteria) follow-up: open a `:variants-grid` workspace, edit a control via args-editor, assert the cell's rendered output reflects the new arg without requiring a hot-reload