### PR TITLE
fix(story): recorder save-dialog snapshots events at open (rf2-8x9nb)

### DIFF
--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -110,6 +110,7 @@
   (:require [clojure.string :as str]
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
+            [re-frame.story.review-dialog :as review-dialog]
             [re-frame.trace :as trace]))
 
 ;; ---------------------------------------------------------------------------
@@ -429,6 +430,58 @@
   cleared."
   [_state]
   initial-state)
+
+;; ---------------------------------------------------------------------------
+;; Pure: save-as-variant dialog open/close transitions (rf2-8x9nb)
+;;
+;; The dialog snapshots `{:variant-id :events}` from the recorder atom
+;; AT OPEN TIME so a subsequent `start-recording!` (which resets the
+;; recorder atom) can't clobber the in-flight dialog's snippet.
+;;
+;; Layered on `re-frame.story.review-dialog`:
+;;   - `:source-id` carries the recorded variant-id (rides into the
+;;     snippet's `:extends`).
+;;   - `:context {:events <captured-events>}` carries the captured event
+;;     vectors (the per-flow opaque slot per review-dialog contract).
+;;
+;; A top-level `:events` key is also stashed for ergonomics, mirroring
+;; the `:args` slot that `save-variant/open` stashes for the same
+;; reason — call sites that want the snapshot off the dialog state map
+;; can read it directly without unpacking `:context`.
+;; ---------------------------------------------------------------------------
+
+(def ^:const default-id-prefix
+  "Per-flow prefix for the auto-derived default new-variant id."
+  "recorded")
+
+(def initial-dialog-state
+  "Alias for `review-dialog/initial-state` — kept for call-site
+  ergonomics so the dialog ratom seeding form reads as
+  `recorder/initial-dialog-state`."
+  review-dialog/initial-state)
+
+(defn open-dialog
+  "Pure: return the dialog state for opening the save-as-variant modal
+  against the recorded `variant-id` with the captured `events`
+  snapshot. `now-ms` seeds the default-id derivation.
+
+  The snapshot is stored on the dialog state itself — NOT read live
+  off the recorder atom — so a fresh `start-recording!` after the
+  dialog opens does not mutate the dialog's snippet (rf2-8x9nb)."
+  [_state variant-id events now-ms]
+  (let [base (review-dialog/open review-dialog/initial-state
+                                 variant-id
+                                 {:events (vec events)}
+                                 now-ms
+                                 default-id-prefix)]
+    (assoc base :events (vec events))))
+
+(defn close-dialog
+  "Pure: return the dialog's idle state. Aliased to
+  `review-dialog/close` — the dialog has no recorder-specific close
+  behaviour."
+  [_state]
+  review-dialog/initial-state)
 
 ;; ---------------------------------------------------------------------------
 ;; Impure: write the state atom. Gated under config/enabled? so the

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -294,11 +294,15 @@
 ;; ---------------------------------------------------------------------------
 ;; Modal state — driven by `re-frame.story.review-dialog`. The shared
 ;; dialog state map carries `:open?` / `:draft-id` / `:source-id` /
-;; `:context`; the recorder's flow stashes the recorded source
-;; variant id in `:source-id` and reads the captured `:events` off
-;; `@ui-state` at render time (the recorder atom is the source of
-;; truth for events; the dialog is just the review-then-commit
-;; surface).
+;; `:context`; the recorder's flow stashes the recorded source variant
+;; id in `:source-id` and the captured `:events` snapshot in
+;; `:context` (with a top-level `:events` mirror for ergonomics).
+;;
+;; **Snapshot at open time** (rf2-8x9nb): the captured events ride on
+;; the dialog state itself — NOT read live off the recorder atom — so
+;; clicking REC again to start a fresh recording (which resets the
+;; recorder atom) cannot mutate the in-flight dialog's snippet. The
+;; user's 10-event capture stays intact until they close / discard.
 ;;
 ;; The dialog opens automatically when the user STOPS recording and
 ;; there are captured events; it can also be reopened from the toolbar
@@ -306,18 +310,20 @@
 ;; only — re-open is a v1.1 polish).
 ;; ---------------------------------------------------------------------------
 
-(def ^:const default-id-prefix
-  "Per-flow prefix for the auto-derived default new-variant id."
-  "recorded")
-
 (defonce ui-dialog
-  (review-dialog/make-dialog-atom))
+  (r/atom recorder/initial-dialog-state))
 
-(defn- open-dialog! [source-variant-id]
-  (review-dialog/swap-open-now! ui-dialog source-variant-id nil default-id-prefix))
+(defn- open-dialog!
+  "Open the save-as-variant dialog against `source-variant-id` with
+  the captured `events` snapshot. `now-ms` defaults to the current
+  wall-clock; tests pass an explicit stamp."
+  ([source-variant-id events]
+   (open-dialog! source-variant-id events (.now js/Date)))
+  ([source-variant-id events now-ms]
+   (swap! ui-dialog recorder/open-dialog source-variant-id events now-ms)))
 
 (defn- close-dialog! []
-  (review-dialog/swap-close! ui-dialog))
+  (swap! ui-dialog recorder/close-dialog))
 
 (defn- set-draft-id! [s]
   (review-dialog/swap-parse-and-set-draft-id! ui-dialog s))
@@ -357,7 +363,7 @@
                        rec?
                        (let [{:keys [variant-id events]} (recorder/stop-recording!)]
                          (when (seq events)
-                           (open-dialog! variant-id)))))]
+                           (open-dialog! variant-id events)))))]
     [:button
      {:style        (cond
                       (not enabled?) (:chip-disabled styles)
@@ -585,7 +591,7 @@
          :on-click (fn [_]
                      (let [{:keys [variant-id events]} (recorder/stop-recording!)]
                        (when (seq events)
-                         (open-dialog! variant-id))))}
+                         (open-dialog! variant-id events))))}
         "stop"]])))
 
 ;; ---------------------------------------------------------------------------
@@ -598,22 +604,26 @@
   and a 'copy to clipboard' affordance.
 
   The user edits the variant id inline; the snippet re-generates on
-  every keystroke. Discard / close drop the captured events."
+  every keystroke. Discard / close drop the captured events.
+
+  Reads `:events` + `:source-id` from the dialog state itself — the
+  snapshot was taken at `open-dialog!` time so a subsequent
+  `start-recording!` cannot mutate the visible snippet (rf2-8x9nb)."
   []
-  (let [dialog                    @ui-dialog
-        {:keys [variant-id events]} @ui-state]
+  (let [dialog                          @ui-dialog
+        {:keys [events source-id]}      dialog]
     (when (:open? dialog)
       (let [draft-id (:draft-id dialog)
             snippet  (recorder/gen-play-snippet
                        events
                        {:variant-id (or draft-id :story.recorded/example)
-                        :extends    variant-id})]
+                        :extends    source-id})]
         (review-dialog/review-dialog dialog
           {:title             "Test Codegen — save recording as variant"
            :hint              (str "EDN snippet generated from "
                                    (count events) " captured event"
                                    (when (not= 1 (count events)) "s")
-                                   " against " (pr-str variant-id)
+                                   " against " (pr-str source-id)
                                    ". Edit the variant id then "
                                    "copy + paste into your stories namespace.")
            :snippet           snippet

--- a/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_cljs_test.cljc
@@ -1,0 +1,148 @@
+(ns re-frame.story.ui.recorder-cljs-test
+  "Tests for the Test Codegen recorder UI surface — specifically the
+  save-as-variant dialog's snapshot-at-open contract (rf2-8x9nb).
+
+  Splits into two tiers:
+
+  - **JVM + CLJS** (pure machinery in `recorder.cljc`) — the
+    `open-dialog` / `close-dialog` transitions snapshot
+    `{:variant-id :events}` onto the dialog state map. The corpus runs
+    on both runtimes via `clojure -M:test` and the CLJS `:node-test`
+    target.
+
+  - **CLJS-only** (`ui/recorder.cljs` is CLJS-only — depends on
+    Reagent / DOM) — the dialog renders a snippet built from the
+    snapshot stored on `@ui-dialog`, NOT from `@recorder/state`. A
+    fresh `start-recording!` after the dialog opens does NOT mutate
+    the rendered snippet — that's the rf2-8x9nb regression."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.recorder :as recorder]
+            #?(:cljs [re-frame.story.ui.recorder :as ui-rec])))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-recorder! [f]
+  (recorder/clear!)
+  #?(:cljs (reset! ui-rec/ui-dialog recorder/initial-dialog-state))
+  (f))
+
+(use-fixtures :each reset-recorder!)
+
+;; ---- JVM + CLJS: dialog state machine ------------------------------------
+
+(deftest open-dialog-snapshots-events-onto-dialog-state
+  (testing "open-dialog stashes the captured events on the dialog state"
+    (let [events [[:counter/inc] [:counter/dec]]
+          opened (recorder/open-dialog recorder/initial-dialog-state
+                                       :story.x/y events 12345)]
+      (is (:open? opened))
+      (is (= :story.x/y (:source-id opened))
+          "the recorded variant-id rides into :source-id (used as :extends)")
+      (is (= events (:events opened))
+          "the captured events ride on a top-level :events slot for ergonomics")
+      (is (= events (get-in opened [:context :events]))
+          "the captured events also ride in :context per review-dialog contract")
+      (is (some? (:draft-id opened))
+          "the default draft-id is derived from variant-id + now-ms"))))
+
+(deftest open-dialog-snapshot-is-independent-of-source-vector
+  (testing "the snapshot is decoupled from the caller's events vector"
+    (let [events (vec [[:counter/inc]])
+          opened (recorder/open-dialog recorder/initial-dialog-state
+                                       :story.x/y events 0)]
+      (is (= [[:counter/inc]] (:events opened))
+          "the snapshot is a fresh vector, not a reference to a recorder atom"))))
+
+(deftest close-dialog-returns-idle-state
+  (testing "close-dialog clears the snapshot — next open starts fresh"
+    (let [opened (recorder/open-dialog recorder/initial-dialog-state
+                                       :story.x/y [[:counter/inc]] 0)
+          closed (recorder/close-dialog opened)]
+      (is (false? (:open? closed)))
+      (is (nil? (:source-id closed)))
+      (is (nil? (:events closed))))))
+
+(deftest initial-dialog-state-is-idle
+  (testing "the seed value for the dialog ratom is the idle state"
+    (is (false? (:open? recorder/initial-dialog-state)))
+    (is (nil? (:source-id recorder/initial-dialog-state)))
+    (is (nil? (:draft-id recorder/initial-dialog-state)))))
+
+;; ---- CLJS-only: dialog rendered hiccup -----------------------------------
+
+#?(:cljs
+   (deftest save-dialog-not-rendered-when-closed
+     (testing "the dialog renders nil when the ratom :open? is false"
+       (reset! ui-rec/ui-dialog recorder/initial-dialog-state)
+       (is (nil? (ui-rec/save-dialog))))))
+
+#?(:cljs
+   (deftest save-dialog-renders-snippet-from-snapshot
+     (testing "the rendered snippet is built from the dialog snapshot"
+       (reset! ui-rec/ui-dialog
+               (recorder/open-dialog recorder/initial-dialog-state
+                                     :story.x/source
+                                     [[:counter/inc] [:counter/dec]]
+                                     12345))
+       (let [flat (str (ui-rec/save-dialog))]
+         (is (str/includes? flat ":counter/inc")
+             "captured events appear in the snippet preview")
+         (is (str/includes? flat ":counter/dec"))
+         (is (str/includes? flat ":story.x/source")
+             "the recorded variant-id appears via :extends")))))
+
+;; ---- CLJS-only: rf2-8x9nb regression ------------------------------------
+
+#?(:cljs
+   (deftest save-dialog-survives-fresh-start-recording
+     (testing "rf2-8x9nb: starting a new recording while the dialog is open
+              does NOT mutate the dialog's snippet — the snapshot is taken
+              at open time, not read live off the recorder atom"
+       ;; Step 1: simulate stop-of-recording-A → open dialog with A's events.
+       (let [a-events [[:counter/inc] [:counter/inc] [:counter/dec]]]
+         (reset! ui-rec/ui-dialog
+                 (recorder/open-dialog recorder/initial-dialog-state
+                                       :story.a/source a-events 12345))
+         (let [snippet-before (str (ui-rec/save-dialog))]
+           (is (str/includes? snippet-before ":counter/inc"))
+           (is (str/includes? snippet-before ":story.a/source"))
+
+           ;; Step 2: user clicks REC again — starts a fresh recording
+           ;; targeting B. This resets `recorder/state` to an empty
+           ;; recording with a different variant-id.
+           (recorder/start-recording! :story.b/target 99999)
+           (is (recorder/recording?))
+           (is (= :story.b/target (recorder/recording-variant)))
+           (is (= [] (recorder/recorded-events))
+               "the recorder atom is now empty / aimed at B")
+
+           ;; Step 3: re-render the dialog. The snippet MUST still
+           ;; reflect A's events + A's variant id — NOT empty/B.
+           (let [snippet-after (str (ui-rec/save-dialog))]
+             (is (= snippet-before snippet-after)
+                 "the dialog snippet is unchanged after start-recording!")
+             (is (str/includes? snippet-after ":counter/inc")
+                 "A's events still appear in the snippet")
+             (is (str/includes? snippet-after ":story.a/source")
+                 "A's variant-id still rides into :extends")
+             (is (not (str/includes? snippet-after ":story.b/target"))
+                 "B's variant-id does not leak into the open A dialog")))))))
+
+#?(:cljs
+   (deftest save-dialog-survives-record-event-into-fresh-recording
+     (testing "rf2-8x9nb: events captured into a fresh recording after the
+              dialog opened do NOT appear in the open dialog's snippet"
+       (let [a-events [[:counter/inc]]]
+         (reset! ui-rec/ui-dialog
+                 (recorder/open-dialog recorder/initial-dialog-state
+                                       :story.a/source a-events 12345))
+         (recorder/start-recording! :story.b/target 99999)
+         (recorder/record-event! [:auth/login {:email "test@test"}])
+         (recorder/record-event! [:auth/logout])
+         (let [flat (str (ui-rec/save-dialog))]
+           (is (str/includes? flat ":counter/inc")
+               "A's original event remains in the snippet")
+           (is (not (str/includes? flat ":auth/login"))
+               "B's freshly-captured events do NOT bleed into the snippet")
+           (is (not (str/includes? flat ":auth/logout"))))))))


### PR DESCRIPTION
## Summary

P1 BUG fix from rf2-yb5xx audit F4. The Test Codegen recorder's save-as-variant dialog was reading `:events` + `:variant-id` **live** off `@ui-state` (the recorder atom mirror). If the user stopped recording A — auto-opening the dialog with A's snippet — then clicked REC again to start recording B, `recorder/start-recording!` reset the recorder atom and the in-flight dialog re-rendered showing **0 events**. The captured recording was unrecoverable.

Snapshot `{:variant-id :events}` onto the dialog state at open time, mirroring the `save-variant` flow that already snapshots `{:args}` correctly.

## Dialog state shape change

The recorder's `ui-dialog` ratom now carries:
- `:source-id` — the recorded variant-id (rides into snippet's `:extends`)
- `:context {:events <captured>}` — per review-dialog contract (opaque per-flow slot)
- `:events` — top-level mirror for call-site ergonomics (matches save-variant's `:args` slot)

Two pure transitions land in `recorder.cljc`: `open-dialog` + `close-dialog`. The impure `open-dialog!` in `ui/recorder.cljs` now takes `(source-variant-id, events, ?now-ms)`; both call sites (rec-chip on-click, recording-overlay stop button) pass events from `(recorder/stop-recording!)`.

`save-dialog` reads `:events` + `:source-id` from `@ui-dialog`, NOT `@ui-state`.

Pre-alpha — no back-compat shim. `default-id-prefix` consolidated to `recorder.cljc`.

## Test plan

- [x] 4 JVM tests (pure machinery, runs on both JVM + CLJS):
  - `open-dialog-snapshots-events-onto-dialog-state`
  - `open-dialog-snapshot-is-independent-of-source-vector`
  - `close-dialog-returns-idle-state`
  - `initial-dialog-state-is-idle`
- [x] 4 CLJS-only DOM tests:
  - `save-dialog-not-rendered-when-closed`
  - `save-dialog-renders-snippet-from-snapshot`
  - **`save-dialog-survives-fresh-start-recording`** (rf2-8x9nb regression — exact repro from the bead)
  - **`save-dialog-survives-record-event-into-fresh-recording`** (rf2-8x9nb regression — B's events don't bleed into open A dialog)
- [x] Story JVM: `clojure -M:test` from `tools/story/` — 430 tests / 1344 assertions, 0 failures, 0 errors
- [x] CLJS: `npm run test:cljs` from `implementation/` — 2223 tests / 6322 assertions, 0 failures, 0 errors

## Repro verification

The regression test `save-dialog-survives-fresh-start-recording` follows the exact sequence from the bead:

1. `(recorder/open-dialog ... :story.a/source a-events ...)` — simulates stop-of-A
2. Capture `snippet-before` from rendered dialog
3. `(recorder/start-recording! :story.b/target ...)` — user clicks REC again
4. Capture `snippet-after`
5. Assert `(= snippet-before snippet-after)` AND `:counter/inc` (A's event) still in snippet AND `:story.b/target` NOT in snippet

Closes rf2-8x9nb.