### PR TITLE
fix(story): controls repeater stable React keys (rf2-c8kfy, 4th rf2-kgn0c-class sibling)

### DIFF
--- a/tools/story/src/re_frame/story/ui/controls.cljs
+++ b/tools/story/src/re_frame/story/ui/controls.cljs
@@ -433,27 +433,65 @@
     :tuple    (mapv default-element-value (:positions widget-spec))
     nil))
 
+(defn- row-keys-for-entries
+  "Return the React-key vector for `entries` at `[variant-id path]`.
+  Reads the row-id vector from the shell-state, syncing it to the
+  current entry count (append fresh ids when short; truncate when
+  long). The sync mutation is done inside `swap-state!` so concurrent
+  renders observe a single authoritative state.
+
+  Per rf2-c8kfy — row keys MUST be a stable per-entry identity so
+  React reconciles surviving rows in place across a mid-list delete
+  (no focus / cursor leakage onto neighbouring rows). The previous
+  positional-key shape (`^{:key i}`) caused the focused input's DOM
+  node to be reused with the next entry's value after a delete; for
+  `:set`-kind repeaters every keystroke triggered a re-sort and the
+  bug fired on every keystroke. Same class of fix as rf2-kgn0c /
+  rf2-z4fza / rf2-c56hr."
+  [variant-id path n]
+  (let [path-v (vec path)
+        ids    (state/repeater-row-ids (state/get-state) variant-id path-v)]
+    (if (= n (count ids))
+      (mapv (fn [id] (str "r:" id)) ids)
+      (do
+        (state/swap-state! state/ensure-repeater-row-ids variant-id path-v n)
+        (mapv (fn [id] (str "r:" id))
+              (state/repeater-row-ids (state/get-state) variant-id path-v))))))
+
 (defn- repeater-widget
   "Render a `:vector` (or `:set`) repeater. Each entry gets a nested row
   + an inline `[-]` button. A trailing `[+]` button appends a fresh
-  default-valued entry."
+  default-valued entry.
+
+  Per rf2-c8kfy each row is keyed on a stable monotonic id from the
+  shell-state's `:rf.story/repeater-row-ids` slot — NOT on its index.
+  Add allocates a fresh id; delete drops the id at position i in
+  lockstep with the entry. This pins React-key stability across a
+  mid-list delete so focus / cursor on surviving rows is preserved
+  (the focused input visually moves with its edit intact)."
   [variant-id path value {:keys [element kind] :as widget-spec}]
-  (let [entries (vector-coerce value)
-        on-add  (fn []
-                  (on-change-at-path
-                    variant-id path
-                    (let [next-v (conj entries (default-element-value element))]
-                      (case kind
-                        :set (set next-v)
-                        next-v))))
-        on-del  (fn [i]
-                  (on-change-at-path
-                    variant-id path
-                    (let [v (vec (concat (subvec entries 0 i)
-                                         (subvec entries (inc i))))]
-                      (case kind
-                        :set (set v)
-                        v))))]
+  (let [entries  (vector-coerce value)
+        path-v   (vec path)
+        row-keys (row-keys-for-entries variant-id path-v (count entries))
+        on-add   (fn []
+                   (state/swap-state!
+                     state/append-repeater-row-id variant-id path-v)
+                   (on-change-at-path
+                     variant-id path
+                     (let [next-v (conj entries (default-element-value element))]
+                       (case kind
+                         :set (set next-v)
+                         next-v))))
+        on-del   (fn [i]
+                   (state/swap-state!
+                     state/remove-repeater-row-id variant-id path-v i)
+                   (on-change-at-path
+                     variant-id path
+                     (let [v (vec (concat (subvec entries 0 i)
+                                          (subvec entries (inc i))))]
+                       (case kind
+                         :set (set v)
+                         v))))]
     [:div
      [:div {:style (:group-h styles)
             :data-controls-group (str kind)}
@@ -464,10 +502,12 @@
        "[+]"]]
      (into [:div]
            (for [[i entry-value] (map-indexed vector entries)
-                 :let [child-path (conj (vec path) i)]]
-             ^{:key i}
+                 :let [child-path (conj (vec path) i)
+                       row-key    (nth row-keys i (str "r:?-" i))]]
+             ^{:key row-key}
              [:div {:style (:nested-row styles)
-                    :data-controls-index i}
+                    :data-controls-index i
+                    :data-controls-row-key row-key}
               [:span {:style (:sublabel styles)} (str "[" i "]")]
               [:div
                [arg-widget variant-id child-path entry-value element]
@@ -479,7 +519,13 @@
 (defn- tuple-widget
   "Render a `:tuple` — one row per positional element. The arity is
   fixed; no `[+]` / `[-]` affordance. Each position's path is
-  `[... i]`."
+  `[... i]`.
+
+  Per rf2-c8kfy each row is keyed `t:<i>`. Tuple arity is fixed
+  (no add / delete affordance) so positional identity IS stable
+  identity — the namespacing prefix is for discipline-consistency
+  with the repeater fix and the rf2-kgn0c sibling family, not to
+  fix a focus-leak (tuple slots can't reshuffle)."
   [variant-id path value {:keys [positions]}]
   (let [entries (vector-coerce value)]
     [:div
@@ -489,10 +535,12 @@
      (into [:div]
            (for [[i pos-widget] (map-indexed vector positions)
                  :let [child-path  (conj (vec path) i)
-                       child-value (get entries i)]]
-             ^{:key i}
+                       child-value (get entries i)
+                       row-key     (str "t:" i)]]
+             ^{:key row-key}
              [:div {:style (:nested-row styles)
-                    :data-controls-index i}
+                    :data-controls-index i
+                    :data-controls-row-key row-key}
               [:span {:style (:sublabel styles)} (str "[" i "]")]
               [arg-widget variant-id child-path child-value pos-widget]]))]))
 

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -108,6 +108,13 @@
    :tag-filter          #{}
    :active-modes        []
    :cell-overrides      {}
+   ;; rf2-c8kfy: stable monotonic ids for repeater rows so React keys
+   ;; survive mid-list deletes (no focus / cursor leakage onto the
+   ;; surviving rows). Counter allocates fresh ids; the row-ids map
+   ;; carries `{[variant-id path] → [id0 id1 ...]}` in lockstep with
+   ;; the entries vector at `:cell-overrides`.
+   :rf.story/repeater-id-counter 0
+   :rf.story/repeater-row-ids    {}
    :substrate           :reagent
    :hot-reload-tick     0
    :fingerprints        {}
@@ -131,6 +138,10 @@
 (def set-cell-override         state.transitions/set-cell-override)
 (def set-cell-override-scalar  state.transitions/set-cell-override-scalar)
 (def clear-cell-overrides      state.transitions/clear-cell-overrides)
+(def ensure-repeater-row-ids   state.transitions/ensure-repeater-row-ids)
+(def repeater-row-ids          state.transitions/repeater-row-ids)
+(def append-repeater-row-id    state.transitions/append-repeater-row-id)
+(def remove-repeater-row-id    state.transitions/remove-repeater-row-id)
 (def bump-hot-reload-tick      state.transitions/bump-hot-reload-tick)
 (def record-fingerprints       state.transitions/record-fingerprints)
 (def pin-snapshot              state.transitions/pin-snapshot)

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -133,9 +133,110 @@
   (set-cell-override state variant-id [arg-key] value))
 
 (defn clear-cell-overrides
-  "Drop every override for `variant-id`."
+  "Drop every override for `variant-id`. Also drops any repeater row-id
+  bookkeeping under the same variant (rf2-c8kfy) so the next render
+  re-syncs from scratch against the resolved entry count.
+
+  Row-id storage is keyed on `[variant-id path]` tuples (one entry per
+  repeater path within the variant), so the cleanup walks the row-ids
+  map and drops every entry whose first tuple element matches."
   [state variant-id]
-  (update state :cell-overrides dissoc variant-id))
+  (-> state
+      (update :cell-overrides dissoc variant-id)
+      (update :rf.story/repeater-row-ids
+              (fn [m]
+                (if (seq m)
+                  (into {}
+                        (remove (fn [[[v _path] _ids]]
+                                  (= v variant-id)))
+                        m)
+                  m)))))
+
+;; ---- repeater stable row-ids (rf2-c8kfy) ---------------------------------
+;;
+;; The controls-panel `repeater-widget` (vector / set) renders one DOM row
+;; per entry. Pre-fix it keyed rows positionally (`^{:key i}`), so a
+;; mid-list delete shifted every surviving row's key up by one. React's
+;; reconciler matched by key + component type and reused the DOM node at
+;; each position with the next entry's value — an input that had focus /
+;; selection at index i+1 displayed index i's value with the SAME focus
+;; state. For `:set`-kind repeaters `vector-coerce` re-sorts on every
+;; render, so editing any entry shuffled keys against values and the
+;; bug fired on every keystroke. Same focus-leak class as rf2-kgn0c
+;; (workspace cells) / rf2-z4fza (causa trace ribbon) / rf2-c56hr
+;; (story workspace cell re-init).
+;;
+;; The fix carries a parallel vector of monotonically-allocated ids
+;; alongside the entries vector, keyed by `[variant-id path]`. The
+;; renderer keys each row on `(str "r:" id)`; add appends a fresh id,
+;; delete drops the id at position i in lockstep with the entry. The
+;; counter is a single int held on the shell-state — pure data → data,
+;; JVM-testable. The ids are render-internal and never persisted to a
+;; variant or args slot.
+
+(defn- next-repeater-id
+  "Allocate the next monotonic repeater row id and return
+  `[state' id]`. The counter lives on `:rf.story/repeater-id-counter`."
+  [state]
+  (let [id (or (:rf.story/repeater-id-counter state) 0)]
+    [(assoc state :rf.story/repeater-id-counter (inc id)) id]))
+
+(defn- alloc-repeater-ids
+  "Allocate `n` fresh repeater row ids. Returns `[state' ids]`."
+  [state n]
+  (loop [state state ids (transient []) remaining n]
+    (if (zero? remaining)
+      [state (persistent! ids)]
+      (let [[s id] (next-repeater-id state)]
+        (recur s (conj! ids id) (dec remaining))))))
+
+(defn ensure-repeater-row-ids
+  "Ensure the row-id vector at `[variant-id path]` has exactly `n`
+  entries — append fresh ids when short; truncate when long. Used by
+  `repeater-widget` on render to keep ids in lockstep with the
+  resolved entries vector (e.g. on first render, after `:reset
+  overrides`, or when the underlying args change shape).
+
+  Returns the updated state. Pure data → data."
+  [state variant-id path n]
+  (let [k       [variant-id (vec path)]
+        current (get-in state [:rf.story/repeater-row-ids k] [])
+        have    (count current)]
+    (cond
+      (= have n) state
+      (< have n) (let [[s ids] (alloc-repeater-ids state (- n have))]
+                   (assoc-in s [:rf.story/repeater-row-ids k]
+                             (into current ids)))
+      :else      (assoc-in state [:rf.story/repeater-row-ids k]
+                           (subvec current 0 n)))))
+
+(defn repeater-row-ids
+  "Read the row-id vector at `[variant-id path]`. Returns `[]` when
+  unset. Pure data → data."
+  [state variant-id path]
+  (get-in state [:rf.story/repeater-row-ids [variant-id (vec path)]] []))
+
+(defn append-repeater-row-id
+  "Allocate a fresh id and append it to the row-id vector at
+  `[variant-id path]`. Called when the repeater's `[+]` button adds a
+  new entry. Returns the updated state."
+  [state variant-id path]
+  (let [[s id] (next-repeater-id state)
+        k      [variant-id (vec path)]]
+    (update-in s [:rf.story/repeater-row-ids k] (fnil conj []) id)))
+
+(defn remove-repeater-row-id
+  "Drop the row id at position `i` in the row-id vector at
+  `[variant-id path]`. Called when the repeater's `[-]` button deletes
+  entry `i`. Returns the updated state. Out-of-range `i` is a no-op."
+  [state variant-id path i]
+  (let [k       [variant-id (vec path)]
+        current (get-in state [:rf.story/repeater-row-ids k] [])]
+    (if (and (nat-int? i) (< i (count current)))
+      (assoc-in state [:rf.story/repeater-row-ids k]
+                (into (subvec current 0 i)
+                      (subvec current (inc i))))
+      state)))
 
 ;; ---- hot-reload + fingerprints + snapshots + panels ---------------------
 

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -504,6 +504,225 @@
           k0      (canvas/run-key shell-0 vid)
           k1      (canvas/run-key shell-1 vid)]
       (is (not= k0 k1)))))
+;; ---- controls repeater stable React keys (rf2-c8kfy) --------------------
+;;
+;; Pre-fix, `controls/repeater-widget` keyed each row positionally
+;; (`^{:key i}`). Deleting a middle entry shifted every surviving row's
+;; key up by one — React reused the original DOM node at each position
+;; with the next entry's value, so an input that had focus / cursor at
+;; index i+1 displayed index i's value with the SAME focus. For
+;; `:set`-kind repeaters `vector-coerce` re-sorts on every render so
+;; the bug fired on every keystroke.
+;;
+;; Fix (post-rf2-c8kfy): the shell-state carries a parallel
+;; `[id0 id1 ...]` vector at `[:rf.story/repeater-row-ids
+;; [variant-id path]]` synced in lockstep with the entries vector.
+;; `repeater-widget` keys each row on `(str "r:" id)`; add appends a
+;; fresh id, delete drops the id at position i. Surviving rows retain
+;; their original id → React reconciles them in place across a
+;; mid-list delete → focus + cursor are preserved.
+;;
+;; Same fix-class as rf2-kgn0c (workspace cells) / rf2-z4fza (causa
+;; trace ribbon) / rf2-c56hr (story workspace cell re-init). The
+;; namespacing-prefix discipline (`r:` for repeater, `t:` for tuple,
+;; `v:` for variant cells) is consistent across the family.
+
+(defn- expand-hiccup
+  "Materialize a Reagent hiccup form by invoking any vector whose head
+  is a fn — Reagent does this at render-time. The controls' top-level
+  `arg-widget` dispatches to a private fn (`repeater-widget`,
+  `tuple-widget`, etc.) by returning `[<fn> & args]`; tests need the
+  materialized hiccup to inspect the per-row `^{:key ...}` metadata
+  and the `:data-controls-row-key` slot we stamp alongside it."
+  [tree]
+  (cond
+    (vector? tree)
+    (if (fn? (first tree))
+      (let [expanded (apply (first tree) (rest tree))
+            meta'    (meta tree)]
+        ;; Preserve the outer ^{:key ...} meta (Reagent threads it onto
+        ;; the materialized child).
+        (with-meta (expand-hiccup expanded) (or (meta expanded) meta')))
+      (with-meta (mapv expand-hiccup tree) (meta tree)))
+
+    (seq? tree)
+    (map expand-hiccup tree)
+
+    :else
+    tree))
+
+(defn- collect-repeater-row-keys
+  "Materialize the controls hiccup tree and return the React-key vector
+  for every `:div` child marked `:data-controls-row-key`. Keys live in
+  `^{:key ...}` metadata on each row vector AND in the
+  `:data-controls-row-key` slot — we read the meta so we mirror what
+  React would actually observe."
+  [tree]
+  (->> (expand-hiccup tree)
+       (tree-seq coll? seq)
+       (filter (fn [node]
+                 (and (vector? node)
+                      (map?  (second node))
+                      (= :div (first node))
+                      (contains? (second node) :data-controls-row-key))))
+       (mapv (comp :key meta))))
+
+(deftest controls-repeater-rows-key-on-stable-id-rf2-c8kfy
+  (testing "repeater-widget keys each row on a stable monotonic id
+            (`r:<id>`) — NOT on its positional index. The keys MUST be
+            namespaced with the `r:` prefix to consistently shape with
+            rf2-kgn0c / rf2-z4fza / rf2-c56hr."
+    (state/swap-state! state/set-cell-override
+                       :story.c8kfy/v [:items] ["a" "b" "c"])
+    (let [tree (controls/arg-widget
+                 :story.c8kfy/v [:items]
+                 ["a" "b" "c"]
+                 {:widget :repeater :kind :vector
+                  :element {:widget :text}})
+          keys (collect-repeater-row-keys tree)]
+      (is (= 3 (count keys)))
+      (is (every? string? keys))
+      (is (every? #(re-matches #"r:\d+" %) keys)
+          (str "row keys MUST match the `r:<int>` shape; got " (pr-str keys)))
+      (is (apply distinct? keys)
+          "row keys MUST be distinct across the row set"))))
+
+(deftest controls-repeater-mid-list-delete-preserves-surviving-keys-rf2-c8kfy
+  (testing "the regression pinned by rf2-c8kfy: after deleting the
+            middle row of a 4-row repeater, the surviving rows MUST
+            carry the SAME React keys they had pre-delete. Position
+            shifts by one — identity does not. React then reconciles
+            the surviving inputs in place and focus / cursor are
+            preserved (rather than leaking from row [i+1] onto row [i]
+            with the old DOM node)."
+    ;; Initial render against a 4-entry repeater.
+    (state/swap-state! state/set-cell-override
+                       :story.c8kfy/v [:items] ["a" "b" "c" "d"])
+    (let [tree-before (controls/arg-widget
+                        :story.c8kfy/v [:items]
+                        ["a" "b" "c" "d"]
+                        {:widget :repeater :kind :vector
+                         :element {:widget :text}})
+          keys-before (collect-repeater-row-keys tree-before)]
+      (is (= 4 (count keys-before)))
+      ;; Simulate the user clicking [-] on row index 1 (the second
+      ;; entry). The widget calls `remove-repeater-row-id` then
+      ;; updates the entries vector via `on-change-at-path`.
+      (state/swap-state! state/remove-repeater-row-id
+                         :story.c8kfy/v [:items] 1)
+      (state/swap-state! state/set-cell-override
+                         :story.c8kfy/v [:items] ["a" "c" "d"])
+      (let [tree-after (controls/arg-widget
+                        :story.c8kfy/v [:items]
+                        ["a" "c" "d"]
+                        {:widget :repeater :kind :vector
+                         :element {:widget :text}})
+            keys-after (collect-repeater-row-keys tree-after)]
+        (is (= 3 (count keys-after)))
+        ;; The CRITICAL invariant. Surviving rows keep their ids.
+        (is (= [(nth keys-before 0)
+                (nth keys-before 2)
+                (nth keys-before 3)]
+               keys-after)
+            (str "post-delete surviving row keys MUST match the "
+                 "pre-delete keys at positions 0, 2, 3 (the survivors). "
+                 "before=" (pr-str keys-before)
+                 " after="  (pr-str keys-after)))))))
+
+(deftest controls-repeater-add-allocates-fresh-id-rf2-c8kfy
+  (testing "after appending an entry the new row carries a FRESH id
+            not seen on any pre-existing row — React mounts a fresh
+            DOM node rather than reusing a stale one"
+    (state/swap-state! state/set-cell-override
+                       :story.c8kfy.add/v [:items] ["a" "b"])
+    (let [tree-before (controls/arg-widget
+                        :story.c8kfy.add/v [:items]
+                        ["a" "b"]
+                        {:widget :repeater :kind :vector
+                         :element {:widget :text}})
+          keys-before (collect-repeater-row-keys tree-before)]
+      (is (= 2 (count keys-before)))
+      ;; Simulate [+]: append id + extend entries vector.
+      (state/swap-state! state/append-repeater-row-id
+                         :story.c8kfy.add/v [:items])
+      (state/swap-state! state/set-cell-override
+                         :story.c8kfy.add/v [:items] ["a" "b" ""])
+      (let [tree-after (controls/arg-widget
+                        :story.c8kfy.add/v [:items]
+                        ["a" "b" ""]
+                        {:widget :repeater :kind :vector
+                         :element {:widget :text}})
+            keys-after (collect-repeater-row-keys tree-after)]
+        (is (= 3 (count keys-after)))
+        (is (= (subvec keys-after 0 2) keys-before)
+            "the surviving prefix's keys are unchanged after append")
+        (is (not (contains? (set keys-before) (nth keys-after 2)))
+            (str "the new row's key MUST be fresh; before="
+                 (pr-str keys-before) " after=" (pr-str keys-after)))))))
+
+(deftest controls-repeater-set-edit-preserves-keys-rf2-c8kfy
+  (testing ":set-kind repeaters re-sort entries on every render via
+            `vector-coerce`. Pre-fix every keystroke shuffled
+            positional keys against values. Post-fix the row keys are
+            tied to the stored id vector — NOT to the visible sort
+            order — so the keys are stable across edits regardless of
+            re-sort."
+    ;; First render syncs 3 ids for a 3-element set.
+    (let [tree-1 (controls/arg-widget
+                   :story.c8kfy.set/v [:tags]
+                   #{"alpha" "beta" "gamma"}
+                   {:widget :repeater :kind :set
+                    :element {:widget :text}})
+          keys-1 (collect-repeater-row-keys tree-1)
+          ;; Second render against the same set — keys MUST match
+          ;; exactly (same count, same ids).
+          tree-2 (controls/arg-widget
+                   :story.c8kfy.set/v [:tags]
+                   #{"alpha" "beta" "gamma"}
+                   {:widget :repeater :kind :set
+                    :element {:widget :text}})
+          keys-2 (collect-repeater-row-keys tree-2)]
+      (is (= 3 (count keys-1)))
+      (is (= keys-1 keys-2)
+          "set repeater keys MUST be stable across re-renders"))))
+
+(deftest controls-tuple-rows-key-on-positional-prefix-rf2-c8kfy
+  (testing "tuple-widget rows key on `t:<i>` — tuple arity is fixed so
+            position IS stable identity; the namespacing-prefix is for
+            discipline-consistency with the repeater + sibling fixes.
+            (Tuple positions don't reshuffle — the focus-leak class
+            doesn't fire — but uniform key shape across the file pins
+            the convention.)"
+    (let [tree (controls/arg-widget
+                 :story.c8kfy.tup/v [:pair]
+                 ["x" 42]
+                 {:widget :tuple :kind :tuple
+                  :positions [{:widget :text} {:widget :number}]})
+          keys (collect-repeater-row-keys tree)]
+      (is (= 2 (count keys)))
+      (is (= ["t:0" "t:1"] keys)
+          (str "tuple row keys MUST be `t:<i>`; got " (pr-str keys))))))
+
+(deftest controls-repeater-keys-not-bare-ints-rf2-c8kfy
+  (testing "regression-guard: row keys MUST NOT be bare integers. The
+            pre-fix shape used `^{:key i}` which serialises to a raw
+            int in React's reconciler; the rf2-c8kfy fix requires the
+            `r:` / `t:` namespacing prefix so distinct UI surfaces
+            with the same int positions never collide."
+    (state/swap-state! state/set-cell-override
+                       :story.c8kfy.guard/v [:items] ["a" "b" "c"])
+    (let [tree (controls/arg-widget
+                 :story.c8kfy.guard/v [:items]
+                 ["a" "b" "c"]
+                 {:widget :repeater :kind :vector
+                  :element {:widget :text}})
+          keys (collect-repeater-row-keys tree)]
+      (is (every? string? keys)
+          (str "post-rf2-c8kfy row keys MUST be strings, never bare "
+               "ints; got " (pr-str (map type keys))))
+      (is (every? #(.startsWith % "r:") keys)
+          (str "row keys MUST carry the `r:` namespacing prefix; got "
+               (pr-str keys))))))
 
 ;; ---- trace six-domino projection ----------------------------------------
 

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -95,6 +95,133 @@
       (is (= 42 (get-in s1 [:cell-overrides :story.a/x :n])))
       (is (nil? (get-in s2 [:cell-overrides :story.a/x]))))))
 
+;; ---- repeater stable row-ids (rf2-c8kfy) --------------------------------
+;;
+;; Per rf2-c8kfy the controls-panel repeater MUST key each row on a
+;; stable per-entry id (not on its positional index). The shell-state
+;; carries a parallel `[id0 id1 ...]` vector at
+;; `[:rf.story/repeater-row-ids [variant-id path]]` synced in lockstep
+;; with the entries vector. JVM-side we test the pure transitions
+;; (`ensure-repeater-row-ids`, `append-repeater-row-id`,
+;; `remove-repeater-row-id`); the CLJS suite exercises the rendered
+;; hiccup keys end-to-end. Same fix-class as rf2-kgn0c / rf2-z4fza /
+;; rf2-c56hr.
+
+(deftest repeater-row-ids-default-empty-rf2-c8kfy
+  (testing "default state carries the counter + the empty row-ids map"
+    (let [s state/default-shell-state]
+      (is (= 0 (:rf.story/repeater-id-counter s)))
+      (is (= {} (:rf.story/repeater-row-ids s))))))
+
+(deftest repeater-row-ids-ensure-allocates-fresh-ids-rf2-c8kfy
+  (testing "ensure-repeater-row-ids appends fresh monotonic ids when the
+            stored vector is shorter than the entries count"
+    (let [s  state/default-shell-state
+          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 3)
+          ids (state/repeater-row-ids s1 :story.x/v [:items])]
+      (is (= 3 (count ids)))
+      (is (apply distinct? ids))
+      (is (= 3 (:rf.story/repeater-id-counter s1))))))
+
+(deftest repeater-row-ids-ensure-truncates-when-long-rf2-c8kfy
+  (testing "ensure-repeater-row-ids truncates from the right when the
+            stored vector is longer than the entries count — keeps the
+            surviving prefix's ids intact (no churn for visible rows)"
+    (let [s  state/default-shell-state
+          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 4)
+          before (state/repeater-row-ids s1 :story.x/v [:items])
+          s2 (state/ensure-repeater-row-ids s1 :story.x/v [:items] 2)
+          after  (state/repeater-row-ids s2 :story.x/v [:items])]
+      (is (= 2 (count after)))
+      (is (= (subvec before 0 2) after)
+          "the surviving prefix's ids are unchanged after truncation"))))
+
+(deftest repeater-row-ids-ensure-noop-when-equal-rf2-c8kfy
+  (testing "ensure-repeater-row-ids is a no-op when the count already
+            matches — no counter churn, no id reallocation"
+    (let [s  state/default-shell-state
+          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 3)
+          counter-after-init (:rf.story/repeater-id-counter s1)
+          s2 (state/ensure-repeater-row-ids s1 :story.x/v [:items] 3)]
+      (is (= counter-after-init (:rf.story/repeater-id-counter s2)))
+      (is (= (state/repeater-row-ids s1 :story.x/v [:items])
+             (state/repeater-row-ids s2 :story.x/v [:items]))))))
+
+(deftest repeater-row-ids-append-allocates-rf2-c8kfy
+  (testing "append-repeater-row-id allocates a fresh id and appends"
+    (let [s  state/default-shell-state
+          s1 (state/ensure-repeater-row-ids s :story.x/v [:items] 2)
+          s2 (state/append-repeater-row-id s1 :story.x/v [:items])
+          ids (state/repeater-row-ids s2 :story.x/v [:items])]
+      (is (= 3 (count ids)))
+      (is (apply distinct? ids))
+      (is (= 3 (:rf.story/repeater-id-counter s2))))))
+
+(deftest repeater-row-ids-remove-mid-list-rf2-c8kfy
+  (testing "remove-repeater-row-id drops the id at position i — surviving
+            ids retain their original identity. THIS is the regression
+            pinned by rf2-c8kfy: pre-fix the renderer keyed rows on
+            their index so the surviving ids' React keys shifted up by
+            one and React reused the original DOM nodes (focus + cursor
+            leakage onto neighbouring rows). Post-fix the row ids ARE
+            stable across the delete."
+    (let [s     state/default-shell-state
+          s1    (state/ensure-repeater-row-ids s :story.x/v [:items] 4)
+          before (state/repeater-row-ids s1 :story.x/v [:items])
+          ;; Delete the middle entry at i=1.
+          s2    (state/remove-repeater-row-id s1 :story.x/v [:items] 1)
+          after (state/repeater-row-ids s2 :story.x/v [:items])]
+      (is (= 4 (count before)))
+      (is (= 3 (count after)))
+      ;; The surviving ids are exactly before[0], before[2], before[3]
+      ;; — same identity, just shifted to fill the gap. No reallocation.
+      (is (= [(nth before 0) (nth before 2) (nth before 3)] after)))))
+
+(deftest repeater-row-ids-remove-out-of-range-noop-rf2-c8kfy
+  (testing "remove-repeater-row-id is a no-op for out-of-range / nil i —
+            the storage is unchanged"
+    (let [s   state/default-shell-state
+          s1  (state/ensure-repeater-row-ids s :story.x/v [:items] 2)
+          ids (state/repeater-row-ids s1 :story.x/v [:items])
+          s2  (state/remove-repeater-row-id s1 :story.x/v [:items] 5)
+          s3  (state/remove-repeater-row-id s1 :story.x/v [:items] -1)]
+      (is (= ids (state/repeater-row-ids s2 :story.x/v [:items])))
+      (is (= ids (state/repeater-row-ids s3 :story.x/v [:items]))))))
+
+(deftest repeater-row-ids-cleared-with-overrides-rf2-c8kfy
+  (testing "clear-cell-overrides drops the variant's repeater row-ids
+            too — the next render re-syncs from scratch against the
+            default entries"
+    (let [s  state/default-shell-state
+          s1 (-> s
+                 (state/set-cell-override :story.x/v [:items] [1 2 3])
+                 (state/ensure-repeater-row-ids :story.x/v [:items] 3))
+          s2 (state/clear-cell-overrides s1 :story.x/v)]
+      (is (seq (state/repeater-row-ids s1 :story.x/v [:items])))
+      (is (empty? (state/repeater-row-ids s2 :story.x/v [:items])))
+      (is (nil? (get-in s2 [:cell-overrides :story.x/v]))))))
+
+(deftest repeater-row-ids-isolated-by-variant-and-path-rf2-c8kfy
+  (testing "row-ids are keyed on [variant-id path] — two repeaters with
+            the same arg-key on different variants (or the same variant
+            with different paths) get independent id namespaces"
+    (let [s  state/default-shell-state
+          s1 (-> s
+                 (state/ensure-repeater-row-ids :story.a/v [:items] 2)
+                 (state/ensure-repeater-row-ids :story.b/v [:items] 2)
+                 (state/ensure-repeater-row-ids :story.a/v [:other] 2))]
+      ;; Three independent id vectors of length 2 each — 6 ids total.
+      (is (= 6 (:rf.story/repeater-id-counter s1)))
+      (is (= 2 (count (state/repeater-row-ids s1 :story.a/v [:items]))))
+      (is (= 2 (count (state/repeater-row-ids s1 :story.b/v [:items]))))
+      (is (= 2 (count (state/repeater-row-ids s1 :story.a/v [:other]))))
+      ;; The id vectors are disjoint (no shared id across keys).
+      (let [all-ids (concat
+                      (state/repeater-row-ids s1 :story.a/v [:items])
+                      (state/repeater-row-ids s1 :story.b/v [:items])
+                      (state/repeater-row-ids s1 :story.a/v [:other]))]
+        (is (apply distinct? all-ids))))))
+
 (deftest hot-reload-tick-monotonic
   (testing "bump-hot-reload-tick increments each call"
     (let [s state/default-shell-state]


### PR DESCRIPTION
## Summary

4th rf2-kgn0c-class sibling fix surfaced by the rf2-yb5xx audit (F10).

Pre-fix, `tools/story/src/re_frame/story/ui/controls.cljs`'s `repeater-widget` keyed each row positionally (`^{:key i}`). Deleting a middle entry shifted every surviving row's key up by one — React's reconciler matched by key + component type and reused the original DOM node at each position with the next entry's value. An input that had focus / cursor at index `i+1` displayed index `i`'s value with the SAME focus state. For `:set`-kind repeaters `vector-coerce`'s `sort-by str` re-shuffled on every render, so the bug fired on every keystroke.

Same focus-leak class as:
- rf2-kgn0c (PR #1259) — story workspace cells, `v:<variant-id>` keys
- rf2-z4fza (PR #1281) — causa trace ribbon, `t:<trace-id>` keys
- rf2-c56hr (PR #1283) — story workspace cell re-init, full run-key tuple

Per the rf2-yb5xx audit: *"rf2-kgn0c was not an isolated fix; it surfaced a discipline gap with siblings."* This is the 4th surface to land that discipline.

## Fix

The shell-state carries a parallel `[id0 id1 ...]` vector at `[:rf.story/repeater-row-ids [variant-id path]]` synced in lockstep with the entries vector under `:cell-overrides`. A monotonic counter on `:rf.story/repeater-id-counter` allocates fresh ids.

- `repeater-widget` keys each row on `(str "r:" id)`.
  - Initial render syncs the id vector to the entries count via `ensure-repeater-row-ids`.
  - `[+]` appends a fresh id via `append-repeater-row-id`.
  - `[-]` drops the id at position `i` via `remove-repeater-row-id` (in lockstep with the entry).
  - `clear-cell-overrides` drops the row-id bookkeeping for the variant so the next render re-syncs from scratch.

Surviving rows retain their original id → React reconciles them in place across a mid-list delete → focus + cursor are preserved.

- `tuple-widget` rows key on `t:<i>`. Tuple arity is fixed (no add / delete affordance) so positional identity IS stable identity; the `t:` prefix is for discipline-consistency with the repeater fix and the rf2-kgn0c sibling family, not to fix a focus-leak (tuple slots can't reshuffle).

## Test plan

- [x] `clojure -M:test` (tools/story) — **439 tests / 1369 assertions / 0 failures** (9 new JVM tests covering alloc / append / remove / clear / truncate / no-op / per-variant-and-path isolation).
- [x] `npm run test:cljs` — **2234 tests / 6345 assertions / 0 failures** (6 new CLJS tests pinning the rendered hiccup keys end-to-end via a Reagent-style tree-walker; includes the regression test for mid-list delete preserving surviving keys exactly).
- [x] Rebased on `origin/main` after rf2-c56hr (#1283) and rf2-8x9nb (#1284) merged.

## Files

- `tools/story/src/re_frame/story/ui/controls.cljs` — `repeater-widget` + `tuple-widget` use stable per-row keys; new `row-keys-for-entries` helper.
- `tools/story/src/re_frame/story/ui/state/transitions.cljc` — pure transitions for the row-id bookkeeping (`ensure-repeater-row-ids`, `append-repeater-row-id`, `remove-repeater-row-id`, `repeater-row-ids`); `clear-cell-overrides` also clears row-ids for the variant.
- `tools/story/src/re_frame/story/ui/state.cljc` — re-exports of the new transitions; default-shell-state seeds the counter + map slots.
- `tools/story/test/re_frame/story_ui_test.clj` — 9 JVM unit tests.
- `tools/story/test/re_frame/story_ui_cljs_test.cljs` — 6 CLJS render tests + the `expand-hiccup` test helper.