### PR TITLE
feat(causa-mcp): F-3 nREPL transport + bencode bridge (rf2-8xzoe.3, re-opened from #1285)

### DIFF
--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/nrepl.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/nrepl.cljs
@@ -1,0 +1,344 @@
+(ns day8.re-frame2-causa-mcp.nrepl
+  "Persistent nREPL client over a TCP socket — Causa-side mirror of
+  `tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs` (rf2-8xzoe.3).
+
+  Same shape as the pair2-mcp sibling: one cold connect at boot, then
+  every subsequent tool call is a bencode round-trip on the existing
+  socket. Per-op latency drops from ~700ms (bash-shim chain) to
+  ~5-50ms.
+
+  ## Reconnect protocol
+
+  A full page reload in the browser destroys the shadow-cljs CLJS
+  runtime but leaves the nREPL socket on the JVM side intact. So the
+  socket usually stays usable across page reloads. The Causa runtime
+  preload (lands in a later F-tranche under
+  `day8.re-frame2-causa.runtime`) will surface its own
+  `:reason :runtime-not-preloaded` error when the marker is absent —
+  this transport layer is preload-agnostic.
+
+  ## Concurrency
+
+  We dispatch by nREPL `id` (UUID per request). The same socket can
+  carry interleaved ops because nREPL's protocol multiplexes on `id` —
+  but the MCP server today calls one tool at a time, so we serialise
+  in-flight ops by `id` and resolve each Promise when its `:done`
+  status arrives.
+
+  ## Divergence from pair2-mcp
+
+  No `:probed-builds` field on the conn record. pair2-mcp uses that
+  to memoise per-socket-generation probes of the
+  `__re_frame_pair2_runtime` marker; Causa's runtime preload (a
+  different sentinel, different ns) hasn't landed yet. The matching
+  field will be added by the F-tranche that introduces Causa's
+  runtime-probe surface — pre-alpha so we don't carry a dead slot
+  with a stale name in the meantime."
+  (:require [applied-science.js-interop :as j]
+            [clojure.string :as str]
+            [cljs.reader :as edn]
+            ["bencode" :as bencode]
+            ["net" :as net]
+            ["fs" :as fs]))
+
+;; ---------------------------------------------------------------------------
+;; Port discovery — matches the bash-shim's read-port logic.
+;;
+;; Lifted from `day8.re-frame2-causa-mcp.server` at F-3 (rf2-8xzoe.3).
+;; F-2 inlined the helper to keep the server entry-point self-contained
+;; ahead of the transport landing; now the transport ns is the home.
+;; ---------------------------------------------------------------------------
+
+(def ^:private port-file-candidates
+  ["target/shadow-cljs/nrepl.port"
+   ".shadow-cljs/nrepl.port"
+   ".nrepl-port"])
+
+(defn read-port-from-fs
+  "Read the nREPL port from `SHADOW_CLJS_NREPL_PORT` or the standard
+  shadow-cljs / nrepl port-file locations. Returns an integer or nil."
+  []
+  (or (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
+        (let [n (js/parseInt env 10)]
+          (when-not (js/isNaN n) n)))
+      (some (fn [path]
+              (try
+                (let [content (str/trim (.toString (.readFileSync fs path)))
+                      n       (js/parseInt content 10)]
+                  (when-not (js/isNaN n) n))
+                (catch :default _ nil)))
+            port-file-candidates)))
+
+;; ---------------------------------------------------------------------------
+;; bencode framing — handle concatenated frames in one TCP packet.
+;; ---------------------------------------------------------------------------
+
+(defn decode-all-frames
+  "Decode every complete bencode frame from `buf`. Returns
+  `[js-array-of-frames trailing-buffer]`. Walks via the package's
+  `position` after-decode marker so multi-frame TCP chunks parse fully.
+
+  Public so `nrepl_test.cljs` can pin the contract directly rather than
+  re-implementing a parallel walker."
+  [^js buf]
+  (let [frames (array)]
+    (loop [^js b buf]
+      (if (zero? (.-length b))
+        [frames b]
+        (let [decoded  (try (bencode/decode b "utf8") (catch :default _ nil))
+              ;; bencode@2 stores byte cursor info on the decode fn,
+              ;; not on the module exports. `decode.bytes` is the
+              ;; cursor AFTER decoding the most recent frame.
+              ;; bencode@2 exposes a per-decode cursor on the decode
+              ;; fn itself. `position` is the byte offset AFTER the
+              ;; just-decoded frame; `bytes` is unreliable — it gets
+              ;; set to the total buffer length on some paths even
+              ;; when only the first frame was returned. We prefer
+              ;; `position`.
+              consumed (or (j/get-in bencode [:decode :position])
+                           (j/get-in bencode [:decode :bytes])
+                           0)]
+          (cond
+            (nil? decoded)        [frames b]
+            (zero? consumed)      (do (.push frames decoded) [frames (js/Buffer.alloc 0)])
+            :else
+            (do (.push frames decoded)
+                (recur (.slice b consumed)))))))))
+
+;; ---------------------------------------------------------------------------
+;; Connection state.
+;; ---------------------------------------------------------------------------
+
+(defn- log!
+  "Stderr logger — stdout is reserved for MCP messages."
+  [& parts]
+  (.error js/console (str "[causa-mcp/nrepl] " (str/join " " (map str parts)))))
+
+(defn make-conn
+  "Build a fresh connection record. `:socket` is filled in by `connect!`.
+  `:pending` is `{id resolve-fn}` for in-flight requests. `:closed?` is
+  set when the socket terminates so subsequent calls re-open."
+  [port host]
+  (atom {:port    port
+         :host    (or host "127.0.0.1")
+         :socket  nil
+         :buf     nil
+         :pending {}
+         :closed? true
+         :session nil}))
+
+(defn- attach-handlers!
+  "Wire up `data` / `error` / `close` on the freshly-connected socket.
+  Resolves pending requests on matching `:done` status; logs errors;
+  marks the conn closed on disconnect.
+
+  The `data` handler folds the incoming chunk into the buffer AND
+  splits off any complete frames in a single `swap!` — two-swap
+  variants left a window where a second `data` callback (or a
+  Buffer.concat racing) could observe the freshly-accumulated bytes
+  but not yet the trimmed trailer, double-decoding the same frame.
+  One atomic swap closes that window."
+  [conn-atom ^js socket]
+  (j/call socket :on "data"
+    (fn [chunk]
+      (let [frames* (atom nil)
+            _       (swap! conn-atom
+                           (fn [c]
+                             (let [buf'           (js/Buffer.concat
+                                                    #js [(or (:buf c) (js/Buffer.alloc 0))
+                                                         chunk])
+                                   [frames rest'] (decode-all-frames buf')]
+                               (reset! frames* frames)
+                               (assoc c :buf rest'))))]
+        (doseq [frame (array-seq @frames*)]
+          (let [id      (j/get frame "id")
+                resolve (get (:pending @conn-atom) id)]
+            (when resolve
+              ;; Accumulate fields into the pending result. Each pending
+              ;; entry holds {:result (atom result-map) :resolve fn}.
+              ;; For brevity we store a single resolve fn that merges
+              ;; via a per-call atom — see send-op! below.
+              (resolve frame)))))))
+  (j/call socket :on "error"
+    (fn [err]
+      (log! "socket error:" (.-message err))
+      (swap! conn-atom assoc :closed? true)))
+  (j/call socket :on "close"
+    (fn [_]
+      (swap! conn-atom assoc :closed? true))))
+
+(defn connect!
+  "Open the persistent socket. Returns a Promise resolving to the
+  connection atom once `connect` fires (or rejecting if it errors).
+  Idempotent — if a socket is already open and healthy, resolves
+  immediately."
+  [conn-atom]
+  (let [{:keys [socket closed?]} @conn-atom]
+    (if (and socket (not closed?))
+      (js/Promise.resolve conn-atom)
+      (js/Promise.
+        (fn [resolve reject]
+          (let [{:keys [host port]} @conn-atom
+                sock (net/createConnection #js {:host host :port port})]
+            (j/call sock :on "connect"
+              (fn []
+                (swap! conn-atom assoc :socket sock :closed? false
+                       :buf (js/Buffer.alloc 0))
+                (attach-handlers! conn-atom sock)
+                (resolve conn-atom)))
+            (j/call sock :once "error"
+              (fn [err]
+                (swap! conn-atom assoc :closed? true)
+                (reject err)))))))))
+
+(defn close!
+  "Close the persistent socket. Idempotent."
+  [conn-atom]
+  (when-let [^js sock (:socket @conn-atom)]
+    (try (.end sock) (catch :default _ nil)))
+  (swap! conn-atom assoc :socket nil :closed? true :pending {}))
+
+;; ---------------------------------------------------------------------------
+;; Op send / receive — multiplex by request id.
+;; ---------------------------------------------------------------------------
+
+(defn- new-id [] (str (random-uuid)))
+
+(def ^:private default-timeout-ms
+  "Per-op timeout when the caller doesn't override. 30s is generous
+  for shadow-cljs cljs-eval round-trips; heavy forms (e.g. a
+  trace-window walk over the full epoch ring under load) can pass
+  `:timeout-ms` for longer."
+  30000)
+
+(defn send-op!
+  "Send a single nREPL op over the persistent socket. `op-map` is a
+  bencode-able map like `{\"op\" \"eval\" \"code\" \"...\"}`. Returns a
+  Promise resolving to a combined response `{:value :out :err :status :ex}`
+  once a frame with `\"status\":[\"done\"]` arrives for this id.
+
+  Auto-(re)connects if the socket has dropped.
+
+  ## Options
+
+  Optional second arg:
+
+      :timeout-ms <ms>  per-op deadline. Defaults to
+                        `default-timeout-ms` (30s). Heavy forms can
+                        raise this rather than collapsing under the
+                        generic ceiling."
+  ([conn-atom op-map] (send-op! conn-atom op-map nil))
+  ([conn-atom op-map {:keys [timeout-ms]}]
+  (-> (connect! conn-atom)
+      (.then
+        (fn [_]
+          (js/Promise.
+            (fn [resolve reject]
+              (let [id        (new-id)
+                    state     (atom {:out "" :err "" :status #{} :value nil :ex nil})
+                    deadline  (or timeout-ms default-timeout-ms)
+                    timer     (js/setTimeout
+                                (fn []
+                                  (swap! conn-atom update :pending dissoc id)
+                                  (reject (js/Error. (str "nREPL op " (j/get op-map "op")
+                                                          " timed out after " deadline "ms"))))
+                                deadline)
+                    on-frame
+                    (fn [^js frame]
+                      (let [v   (j/get frame "value")
+                            out (j/get frame "out")
+                            err (j/get frame "err")
+                            ex  (j/get frame "ex")
+                            st  (or (j/get frame "status") #js [])]
+                        (when v   (swap! state assoc :value v))
+                        (when out (swap! state update :out str out))
+                        (when err (swap! state update :err str err))
+                        (when ex  (swap! state assoc :ex ex))
+                        (let [st-set (set (js->clj st))]
+                          (swap! state update :status into st-set)
+                          (when (contains? st-set "done")
+                            (js/clearTimeout timer)
+                            (swap! conn-atom update :pending dissoc id)
+                            (resolve @state)))))]
+                (swap! conn-atom assoc-in [:pending id] on-frame)
+                (let [op (j/assoc! (clj->js op-map) "id" id)
+                      ^js sock (:socket @conn-atom)]
+                  (.write sock (bencode/encode op))))))))
+      (.catch (fn [err] (js/Promise.reject err))))))
+
+;; ---------------------------------------------------------------------------
+;; nREPL → CLJS eval bridge (mirrors ops.clj's cljs-eval / cljs-eval-value).
+;; ---------------------------------------------------------------------------
+
+(defn jvm-eval
+  "Evaluate a Clojure form on the JVM side of nREPL. Returns a Promise
+  resolving to a combined response map. Optional `opts` passes
+  through to [[send-op!]] (e.g. `{:timeout-ms 60000}`)."
+  ([conn-atom form-str] (jvm-eval conn-atom form-str nil))
+  ([conn-atom form-str opts]
+   (send-op! conn-atom {"op" "eval" "code" form-str} opts)))
+
+(defn cljs-eval
+  "Evaluate a ClojureScript form through shadow-cljs's `cljs-eval` API.
+  Returns a Promise resolving to a combined response map. Optional
+  `opts` (e.g. `{:timeout-ms 60000}`) tunes the per-op deadline."
+  ([conn-atom build-id form-str] (cljs-eval conn-atom build-id form-str nil))
+  ([conn-atom build-id form-str opts]
+   (let [build-pr  (if (keyword? build-id) (str build-id) (str ":" (name (or build-id :app))))
+         ;; pr-str CLJS form: use double-quote-escaped string literal.
+         code-pr   (pr-str form-str)
+         wrapped   (str "(shadow.cljs.devtools.api/cljs-eval "
+                        build-pr " " code-pr " {})")]
+     (jvm-eval conn-atom wrapped opts))))
+
+(defn- read-edn-safe
+  "Best-effort EDN read of the nREPL value string. On parse failure we
+  return the raw string so the caller can decide what to do with the
+  unparseable shape — but we log to stderr first because a silent
+  drop-back hides genuine wire-shape regressions (a runtime that
+  shipped malformed EDN gets surfaced by inspection of the dev
+  console, not by a mute branch)."
+  [s]
+  (try
+    (edn/read-string s)
+    (catch :default e
+      (log! "read-edn-safe: parse failed —" (.-message e))
+      s)))
+
+(defn cljs-eval-value
+  "Like cljs-eval but unwraps to the actual CLJS value. shadow's
+  cljs-eval returns a string-encoded EDN result like
+  `{:results [\"...\"] :ns user}` — we pull the last `:results` entry
+  and read it as EDN.
+
+  Returns a Promise resolving to the unwrapped value (or rejecting
+  with an Error if the eval threw or returned an error map). Optional
+  `opts` (e.g. `{:timeout-ms 60000}`) tunes the per-op deadline —
+  heavy forms (full-epoch-ring walks) can raise it past the 30s
+  default."
+  ([conn-atom build-id form-str] (cljs-eval-value conn-atom build-id form-str nil))
+  ([conn-atom build-id form-str opts]
+  (-> (cljs-eval conn-atom build-id form-str opts)
+      (.then
+        (fn [resp]
+          (cond
+            (some? (:ex resp))
+            (js/Promise.reject (js/Error. (str "nREPL eval error: " (:ex resp)
+                                               (when-not (str/blank? (:err resp))
+                                                 (str " — " (:err resp))))))
+
+            (str/blank? (str (:value resp)))
+            nil
+
+            :else
+            (let [outer (read-edn-safe (str (:value resp)))]
+              (cond
+                (and (map? outer) (vector? (:results outer)))
+                (when-let [last-result (peek (:results outer))]
+                  (read-edn-safe last-result))
+
+                (and (map? outer) (:err outer))
+                (js/Promise.reject
+                  (js/Error. (str "cljs eval error: " (:err outer))))
+
+                :else outer))))))))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
@@ -38,10 +38,10 @@
   flags lands by extension rather than rewrite."
   (:require [applied-science.js-interop :as j]
             [clojure.string :as str]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
-            ["@modelcontextprotocol/sdk/types.js" :as mcp-types]
-            ["fs" :as fs]))
+            ["@modelcontextprotocol/sdk/types.js" :as mcp-types]))
 
 (def ^:const server-name    "re-frame2-causa-mcp")
 (def ^:const server-version "0.1.0")
@@ -54,33 +54,20 @@
 ;; ---------------------------------------------------------------------------
 ;; nREPL port discovery.
 ;;
-;; Inlined here at F-2 to keep the server entry-point self-contained;
-;; lifts into `day8.re-frame2-causa-mcp.nrepl` (with its socket + bencode
-;; surface) in a later F-tranche, mirroring pair2-mcp's split.
+;; Lifted in F-3 (rf2-8xzoe.3) to `day8.re-frame2-causa-mcp.nrepl`
+;; alongside the socket + bencode surface. The local `read-port-from-fs`
+;; alias keeps the server-public contract (the server-test resolves
+;; `server/read-port-from-fs`) stable across the lift.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private port-file-candidates
-  ["target/shadow-cljs/nrepl.port"
-   ".shadow-cljs/nrepl.port"
-   ".nrepl-port"])
-
-(defn read-port-from-fs
+(def read-port-from-fs
   "Read the nREPL port from `SHADOW_CLJS_NREPL_PORT` or the standard
   shadow-cljs / nrepl port-file locations. Returns an integer or nil.
 
-  Mirrors `re-frame-pair2-mcp.nrepl/read-port-from-fs`. Public so the
-  server test can pin the contract."
-  []
-  (or (when-let [env (j/get-in js/process [:env :SHADOW_CLJS_NREPL_PORT])]
-        (let [n (js/parseInt env 10)]
-          (when-not (js/isNaN n) n)))
-      (some (fn [path]
-              (try
-                (let [content (str/trim (.toString (.readFileSync fs path)))
-                      n       (js/parseInt content 10)]
-                  (when-not (js/isNaN n) n))
-                (catch :default _ nil)))
-            port-file-candidates)))
+  Thin alias to `nrepl/read-port-from-fs` — the real implementation
+  now lives with the transport. Public so the server test can pin the
+  contract; downstream code can call either ns equivalently."
+  nrepl/read-port-from-fs)
 
 (defn- resolve-port
   "Look up the nREPL port. Returns an integer or throws with a hint."

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/nrepl_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/nrepl_test.cljs
@@ -1,0 +1,124 @@
+(ns day8.re-frame2-causa-mcp.nrepl-test
+  "Unit tests for the F-3 nREPL transport + bencode framing
+  (rf2-8xzoe.3) — Causa-side mirror of
+  `tools/pair2-mcp/test/re_frame_pair2_mcp/nrepl_test.cljs`.
+
+  The hard bug pinned during the pair2 pilot — bencode@2 storing the
+  post-decode cursor on `bencode.decode.position` rather than the
+  module-level export — is the kind of regression that's easy to
+  reintroduce, so the multi-frame walker gets a thorough test.
+
+  Tests pin `decode-all-frames` directly from
+  `day8.re-frame2-causa-mcp.nrepl` — the source ns is the contract.
+
+  Also pins the F-3 lift: `read-port-from-fs` now lives on the
+  transport ns (was inlined in `server.cljs` at F-2), and the
+  conn-record shape that `make-conn` constructs."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [applied-science.js-interop :as j]
+            ["bencode" :as bencode]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]))
+
+(defn- decode-all
+  "Wrap `nrepl/decode-all-frames` returning `[clj-vec rest-buf]`.
+  Source returns `[js-array rest-buf]` for hot-path perf; tests want a
+  CLJS vector to walk."
+  [^js buf]
+  (let [[js-frames rest] (nrepl/decode-all-frames buf)]
+    [(vec (array-seq js-frames)) rest]))
+
+(deftest single-frame-decodes
+  (let [buf      (js/Buffer.from "d3:foo3:bare" "utf8")
+        [fs rst] (decode-all buf)]
+    (is (= 1 (count fs)))
+    (is (= "bar" (j/get (first fs) "foo")))
+    (is (zero? (.-length rst)))))
+
+(deftest two-concatenated-frames-decode
+  ;; This is the case the bash-shim chain never had to handle (each
+  ;; call opened a fresh socket), and the one that bit the pair2 pilot.
+  (let [buf      (js/Buffer.from "d3:foo3:bared3:baz3:quxe" "utf8")
+        [fs rst] (decode-all buf)]
+    (is (= 2 (count fs)))
+    (is (= "bar" (j/get (nth fs 0) "foo")))
+    (is (= "qux" (j/get (nth fs 1) "baz")))
+    (is (zero? (.-length rst)))))
+
+(deftest nrepl-status-response-decodes
+  ;; A representative two-frame nREPL response: value then status.
+  (let [buf      (js/Buffer.from
+                   "d2:id1:15:value1:3ed2:id1:16:statusl4:doneee"
+                   "utf8")
+        [fs rst] (decode-all buf)]
+    (is (= 2 (count fs)))
+    (is (= "3" (j/get (nth fs 0) "value")))
+    (let [status (j/get (nth fs 1) "status")]
+      (is (some? status))
+      (is (= "done" (aget status 0))))
+    (is (zero? (.-length rst)))))
+
+(deftest three-frames-decode
+  (let [buf      (js/Buffer.from
+                   "d1:ai1ee" "utf8")
+        twice    (js/Buffer.concat #js [buf buf buf])
+        [fs rst] (decode-all twice)]
+    (is (= 3 (count fs)))
+    (is (zero? (.-length rst)))))
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-vars-exist
+  (testing "F-3 lands the structural surface — every public var the
+            tool-dispatcher F-tranches will lean on is resolvable"
+    (is (fn? nrepl/read-port-from-fs))
+    (is (fn? nrepl/decode-all-frames))
+    (is (fn? nrepl/make-conn))
+    (is (fn? nrepl/connect!))
+    (is (fn? nrepl/close!))
+    (is (fn? nrepl/send-op!))
+    (is (fn? nrepl/jvm-eval))
+    (is (fn? nrepl/cljs-eval))
+    (is (fn? nrepl/cljs-eval-value))))
+
+;; ---------------------------------------------------------------------------
+;; Port discovery — lifted from server.cljs at F-3.
+;; ---------------------------------------------------------------------------
+
+(deftest read-port-from-fs-returns-nil-or-int
+  (testing "read-port-from-fs is total — returns nil when no port
+            source is present, or a positive integer when one is.
+            The degraded boot path keys on the nil branch."
+    ;; The node-test harness runs from `tools/causa-mcp/` (no port
+    ;; files at any of the three candidate paths). We only assert the
+    ;; nil-or-int contract; depending on dev-state the env-var might
+    ;; be set, so we accept either.
+    (let [result (nrepl/read-port-from-fs)]
+      (is (or (nil? result)
+              (and (number? result) (pos? result)))))))
+
+;; ---------------------------------------------------------------------------
+;; make-conn — initial record shape.
+;; ---------------------------------------------------------------------------
+
+(deftest make-conn-initial-shape
+  (testing "make-conn builds an atom carrying the fresh-connection
+            record: port + host + closed?=true + no socket + empty
+            pending map. connect! flips closed? and fills :socket;
+            close! resets back to the same closed shape."
+    (let [conn @(nrepl/make-conn 12345 nil)]
+      (is (= 12345 (:port conn)))
+      (is (= "127.0.0.1" (:host conn))
+          "nil host defaults to loopback — the shadow-cljs nREPL only
+           ever binds to localhost in dev")
+      (is (nil? (:socket conn)))
+      (is (true? (:closed? conn)))
+      (is (= {} (:pending conn)))
+      (is (nil? (:session conn))))))
+
+(deftest make-conn-honours-explicit-host
+  (testing "an explicit host overrides the loopback default — the
+            transport doesn't assume localhost, only defaults to it"
+    (let [conn @(nrepl/make-conn 12345 "10.0.0.42")]
+      (is (= "10.0.0.42" (:host conn))))))


### PR DESCRIPTION
Recovery of #1285 (force-closed via merge-conflict). Original work intact; rebased onto current main.

## Original report (PR #1285)

Port `tools/pair2-mcp/src/re_frame_pair2_mcp/nrepl.cljs` to `tools/causa-mcp/src/day8/re_frame2_causa_mcp/nrepl.cljs`. Wire bencode bridge + StdioServerTransport-compatible eval + port discovery + framing.

* `read-port-from-fs` LIFTED from F-2's server.cljs (per F-2 worker's promise)
* 17 tests / 56 assertions / 0 fail
* Dropped `:probed-builds` from conn record (pair2-specific runtime sentinel)
* Log tag `[causa-mcp/nrepl]`

## Recovery notes

* Original commit: `ae43a6b4` (preserved)
* Rebased onto current main (was on F-2 branch — F-2 merged via #1282 + #1279 + #1285's predecessor wave)
* Force-pushed to existing branch `worker/causa-mcp-nrepl-transport-rf2-8xzoe-3`