### PR TITLE
fix(noise): silence 8 shadow-cljs warnings (rf2-5069x)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/hot_reload_cljs_test.cljs
@@ -120,17 +120,21 @@
     ;; wrapped fn. Hot-reload semantics ride on the registrar swap, so
     ;; the macro form must respect the contract too.
     ;;
-    ;; Re-evaluating the same defn-shape form (same sym → same auto-id)
+    ;; Re-evaluating with the SAME `:rf/id` (via the metadata override)
     ;; is the canonical macro-side hot-reload path: the file changes,
-    ;; the ns reloads, the same form re-runs, and the registry slot is
-    ;; replaced.
+    ;; the ns reloads, the form re-runs, and the registry slot keyed by
+    ;; that id is replaced. Two different local syms (`banner-v1` /
+    ;; `banner-v2`) bound by the macro's auto-`def` keep us out of
+    ;; CLJS's `:redef-in-file` lane — what matters for the contract is
+    ;; the registry slot keyed on `:rf/id`, not the Clojure Var that
+    ;; happens to back the form.
     (let [observed (atom nil)]
-      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
+      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner-v1 [t]
         (reset! observed [:m1 t])
         [:h1.m1 t])
       ((rf/view :rf.hot-reload-test/banner) "hello")
       (is (= [:m1 "hello"] @observed))
-      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner [t]
+      (reg-view ^{:rf/id :rf.hot-reload-test/banner} banner-v2 [t]
         (reset! observed [:m2 t])
         [:h2.m2 t])
       ((rf/view :rf.hot-reload-test/banner) "world")

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_badges_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_badges_cljs_test.cljs
@@ -18,7 +18,7 @@
   (is (some? (badges/status-colour :error))))
 
 (deftest status-badge-renders
-  (is (vector? (badges/status-badge :fresh false))))
+  (is (vector? (badges/status-badge :fresh))))
 
 (deftest layer-pill-renders-with-the-layer-number
   (is (vector? (badges/layer-pill 1))))

--- a/tools/story/src/re_frame/story/ui/a11y.cljs
+++ b/tools/story/src/re_frame/story/ui/a11y.cljs
@@ -239,7 +239,7 @@
 
   The trace event piggybacks on the existing warning op-type per
   spec/009 §Trace bus."
-  [frame-id violation]
+  [frame-id ^js violation]
   (trace/emit!
     :warning
     :rf.story.a11y/violation
@@ -300,7 +300,7 @@
 
   Best-effort: if the selectors don't match (e.g. the DOM mutated
   since the run) the overlay simply doesn't appear."
-  [scope-el violation]
+  [scope-el ^js violation]
   (let [nodes (.-nodes violation)
         root  (or scope-el js/document)]
     (doseq [node (array-seq nodes)]
@@ -360,11 +360,11 @@
        (swap! run-state assoc frame-id :loading)
        (-> (ensure-axe-loaded!)
            (.then
-             (fn [axe]
+             (fn [^js axe]
                (swap! run-state assoc frame-id :running)
                (.run axe context)))
            (.then
-             (fn [results]
+             (fn [^js results]
                (let [vs        (.-violations results)
                      scope-el  (when (and (some? context)
                                           (some? (.-nodeType context)))


### PR DESCRIPTION
## Summary

CI builds were emitting 8 shadow-cljs warnings on every PR, drowning real signal. All three fixes are surgical and behaviour-preserving.

- `tools/story/src/re_frame/story/ui/a11y.cljs` (6x `:infer-warning`): added `^js` hints on the fn params shadow-cljs couldn't infer — `violation` in `emit-warning-for-violation` + `record-violation-overlay!`, plus `axe` / `results` in the `run-axe!` promise callbacks. Matches the file's existing `[^js v]` style on `violation-row`.
- `tools/causa/test/.../subscriptions_badges_cljs_test.cljs` (1x `:fn-arity`): `status-badge` takes `[status]`; the test was passing `(status-badge :fresh false)`. Dropped the extraneous arg.
- `implementation/adapters/reagent/test/.../hot_reload_cljs_test.cljs` (1x `:redef-in-file`): the `reg-view` macro hot-reload test re-evaluated the same `defn`-shape form, redef'ing the local `banner` Var. Renamed the two forms to `banner-v1` / `banner-v2` and kept `:rf/id` identical, so the test still validates registry-slot replacement under the same id (the actual hot-reload contract).

## Verification

- `shadow-cljs compile :node-test` → **0 warnings** (was 2)
- `shadow-cljs compile :examples/cart-total` (build that pulls a11y.cljs) → **0 warnings** (was 6)
- `npm run test:cljs` → **2245 tests / 6389 assertions / 0 failures**
- Same compiled-files count (636 node-test, 297 cart-total)
- No `*warn-on-reflection*` config changes

## Test plan

- [x] Baseline both builds confirms 2 + 6 = 8 warnings
- [x] Post-fix both builds compile to 0 warnings
- [x] `npm run test:cljs` green (no behaviour regression)
- [x] Same compiled-files count both builds