### PR TITLE
feat(causa-mcp): B-1 privacy filter — sensitive default-drop (rf2-8xzoe.11)

### DIFF
--- a/tools/causa-mcp/deps.edn
+++ b/tools/causa-mcp/deps.edn
@@ -61,7 +61,17 @@
  :deps  {org.clojure/clojure        {:mvn/version "1.12.0"}
          org.clojure/clojurescript  {:mvn/version "1.12.145"}
          applied-science/js-interop {:mvn/version "0.4.2"}
-         thheller/shadow-cljs       {:mvn/version "3.4.10"}}
+         thheller/shadow-cljs       {:mvn/version "3.4.10"}
+
+         ;; Shared MCP primitives across the triplet (pair2-mcp,
+         ;; story-mcp, causa-mcp): wire vocabulary, the spec/009
+         ;; default-suppress filter, the cross-server arg parsers.
+         ;; Pulled in by rf2-8xzoe.11 (B-1 privacy filter) for
+         ;; `re-frame.mcp-base.sensitive` + `re-frame.mcp-base.args`.
+         ;; Per rf2-vw4sq the base ns is the single source of truth
+         ;; for the privacy contract — same predicate, same fail-
+         ;; closed posture, same accept-shapes across the MCP triplet.
+         day8/re-frame2-mcp-base    {:local/root "../mcp-base"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs
@@ -1,0 +1,203 @@
+(ns day8.re-frame2-causa-mcp.privacy
+  "Spec/009 §Privacy default-suppress filter at the Causa-MCP boundary
+  (B-1 of rf2-8xzoe; tranche bead rf2-8xzoe.11).
+
+  ## What this gates
+
+  Spec/009 mandates that framework-published forwarders — Sentry /
+  Honeybadger, pair2 server, story-mcp, causa-mcp — MUST default-drop
+  trace events whose registration declared `:sensitive? true`. The
+  runtime stamps the flag at the top level of every emitted trace
+  event inside such a registration's handler scope; the forwarder's
+  job is to gate egress on it before any data crosses the MCP stdio
+  trust boundary into the agent surface.
+
+  ## Where the gate fires for causa-mcp
+
+  The trace-stream surface is the four tools whose payloads carry raw
+  `:rf/trace-event` items or epoch-records:
+
+    - `get-trace-buffer`     — vector of trace events
+    - `subscribe`            — drain-batch over the trace bus
+    - `get-epoch-history`    — vector of epoch records
+
+  Every one of these MUST funnel its returned items through
+  `strip-sensitive` before the MCP wire-encode step. `apply-to-result`
+  is the per-call wrapper that does the strip and stamps the
+  `:dropped-sensitive` counter onto the envelope when non-zero. Direct
+  reads of live `app-db` / sub-cache / machine state go through the
+  `rf/elide-wire-value` walker instead (the §Direct-read MUST in
+  `spec/004-Wire-Pipeline.md`); that's a separate B-tranche surface
+  with its own normative MUST (row #19 of the MUST inventory).
+
+  ## Cross-server arg vocabulary
+
+  The opt-in escape hatch is `:include-sensitive? true` — fixed cross-
+  server (pair2-mcp + story-mcp + causa-mcp). An agent learns the slot
+  name once and recognises it everywhere. `parse-include-sensitive`
+  centralises the boolean parse so a string `\"true\"` / `\"yes\"` /
+  `\"1\"` from the MCP wire collapses to the same boolean the helper
+  here expects.
+
+  ## Why this ns delegates to `re-frame.mcp-base.sensitive`
+
+  The base ns (rf2-vw4sq) is the shared spec/009 default-suppress
+  primitive across the MCP triplet — same `sensitive-event?`
+  predicate, same fail-closed posture on non-boolean truthy stamps
+  (rf2-ih7g4), same `[kept dropped-count]` strip-fn contract. Causa-
+  mcp uses the trace-event-only filter (not the pair2-mcp union with
+  `sensitive-epoch?` — that's pair2-mcp-specific belt-and-braces over
+  its in-process epoch shape; the causa runtime returns epoch records
+  whose top-level `:sensitive?` rollup is computed at assembly time
+  per rf2-isdwf, and the per-event filter cascades through them via
+  the `:trace-events` slot from the same primitive).
+
+  ## MUSTs honoured
+
+  - MUST 1 — default-suppress at the MCP boundary (spec/004 L32).
+  - MUST 2 — every trace-stream-surface tool MUST apply the filter
+    before any data crosses (spec/004 L39). `apply-to-result` is the
+    wrapper those tools call when they land.
+  - MUST 19, `:include-sensitive?` half — the opt-in slot name is
+    fixed cross-MCP (spec/004 §Privacy + spec/Tool-Pair.md L569)."
+  (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.sensitive :as base-sensitive]))
+
+;; ---------------------------------------------------------------------------
+;; Predicate + strip — direct re-export of the base primitives.
+;;
+;; Causa-mcp uses the trace-event-only filter; the base helper handles
+;; epoch records correctly because the runtime stamps the rollup at
+;; assembly time (rf2-isdwf) and the per-event `:sensitive?` check
+;; fires on the same top-level slot whether the map is a trace event
+;; or an epoch record.
+;; ---------------------------------------------------------------------------
+
+(def sensitive-event?
+  "Does this map carry the spec/009 `:sensitive? true` stamp (or a
+  fail-closed malformed-truthy variant)? Delegates to
+  `re-frame.mcp-base.sensitive/sensitive-event?` — same predicate the
+  MCP triplet shares for byte-identical contract semantics."
+  base-sensitive/sensitive-event?)
+
+(def strip-sensitive
+  "Remove `:sensitive? true` items from `items` unless the caller opted
+  in. Returns `[kept dropped-count]`. Cheap on the common path
+  (no sensitive items ⇒ identical-vector return + zero drop count).
+
+  Two-arity `[items include?]` form delegates to
+  `re-frame.mcp-base.sensitive/strip-sensitive` — same fail-closed
+  fast-path the MCP triplet shares."
+  base-sensitive/strip-sensitive)
+
+;; ---------------------------------------------------------------------------
+;; Argument parsing — `:include-sensitive?` is the cross-MCP opt-in.
+;; ---------------------------------------------------------------------------
+
+(def ^:const include-sensitive-default
+  "Default posture for `:include-sensitive?` is `false` — spec/009
+  §Privacy MUST default-suppress. The constant is reified so the
+  test corpus + downstream tool dispatchers reference the same
+  identity rather than re-typing the literal."
+  false)
+
+(defn parse-include-sensitive
+  "Resolve the cross-server `:include-sensitive?` MCP arg from a raw
+  arguments object. Accepts:
+
+    - a JS args object (the MCP SDK shape) — looked up via
+      `(j/get args \"include-sensitive?\")`.
+    - a CLJS map — looked up via `(get args :include-sensitive?)` or
+      the stringified key (whichever the upstream dispatcher hands us).
+    - `nil` / `js/undefined`.
+
+  Recognised-value parsing (boolean passthrough, string `\"true\"` /
+  `\"false\"` / `\"yes\"` / `\"no\"` / `\"1\"` / `\"0\"`, keyword
+  `:true` / `:false`) delegates to
+  `re-frame.mcp-base.args/parse-boolean` — the cross-MCP accept-shape
+  contract (rf2-vw4sq).
+
+  Returns a boolean. Unrecognised / absent inputs collapse to the
+  spec/009 default-suppress posture (`false`)."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :include-sensitive?)
+                  (get args "include-sensitive?"))
+
+              :else
+              ;; JS object from the MCP wire.
+              (j/get args "include-sensitive?"))]
+    (base-args/parse-boolean raw include-sensitive-default)))
+
+;; ---------------------------------------------------------------------------
+;; Result-envelope shape — `:dropped-sensitive` counter (cross-MCP).
+;;
+;; The pair2-mcp wire emits `:dropped-sensitive <n>` only when the
+;; counter is positive. Story-mcp + causa-mcp follow the same shape so
+;; an agent reads one slot name and one polarity everywhere. The
+;; helper below stamps the slot only when non-zero — zero-drop calls
+;; carry no counter, keeping the common-path envelope minimal.
+;; ---------------------------------------------------------------------------
+
+(defn stamp-dropped-sensitive
+  "Splice the `:dropped-sensitive` counter onto `envelope` iff
+  `dropped` is positive. Returns the envelope unchanged when nothing
+  was dropped — the zero-drop common path carries no counter so the
+  agent surface stays minimal (a missing slot reads as zero, same
+  convention as pair2-mcp's `wire/stamp-indicator-fields`).
+
+  `envelope` is the per-call result map a tool dispatcher is about to
+  serialise to the MCP wire. `dropped` is the second return value of
+  `strip-sensitive` (or the accumulated total across a multi-slice
+  call)."
+  [envelope dropped]
+  (cond-> envelope
+    (and (number? dropped) (pos? dropped))
+    (assoc :dropped-sensitive dropped)))
+
+;; ---------------------------------------------------------------------------
+;; Per-tool boundary wrapper.
+;;
+;; Trace-stream-shaped tools call this once at the end of their body,
+;; with the raw items vector + the resolved `:include-sensitive?`
+;; arg + the in-progress envelope. The helper strips, accumulates the
+;; dropped count, stamps the counter when non-zero, and writes the
+;; kept items back into the envelope at `items-key`.
+;;
+;; Cross-tool one-liner shape so the gate is uniform across
+;; `get-trace-buffer`, `subscribe`, `get-epoch-history` — same call
+;; site, same envelope-mutation rule, same indicator slot.
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/009 default-suppress gate to `items` and write the
+  result back into `envelope` under `items-key`. Returns the updated
+  envelope with the `:dropped-sensitive` counter spliced in when non-
+  zero. The single call-site every trace-stream-shaped tool uses
+  before returning — MUST 2 of the causa-mcp inventory.
+
+  Arguments:
+    - `envelope`   — the per-call result map (will be updated).
+    - `items-key`  — the slot in `envelope` the kept items go into
+                     (e.g. `:events` for `subscribe`, `:trace-events`
+                     for `get-trace-buffer`, `:epochs` for
+                     `get-epoch-history`).
+    - `items`      — the vector of trace-event-shaped or epoch-record-
+                     shaped maps to filter.
+    - `include?`   — boolean resolved from `parse-include-sensitive`;
+                     when `true`, the gate is a no-op (caller opted
+                     in explicitly).
+
+  Returns the envelope with `items-key` set to the kept items (or the
+  original items unchanged when `include?` is true / nothing dropped)
+  and `:dropped-sensitive` stamped when at least one item was dropped."
+  [envelope items-key items include?]
+  (let [[kept dropped] (strip-sensitive items include?)]
+    (-> envelope
+        (assoc items-key kept)
+        (stamp-dropped-sensitive dropped))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/privacy_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/privacy_test.cljs
@@ -1,0 +1,292 @@
+(ns day8.re-frame2-causa-mcp.privacy-test
+  "Unit tests for the B-1 privacy filter at the Causa-MCP boundary
+  (rf2-8xzoe.11). Pins:
+
+    - MUST 1 / MUST 2 — default-suppress `:sensitive? true` events on
+      every trace-stream-shaped tool surface (`get-trace-buffer`,
+      `subscribe`, `get-epoch-history`).
+    - MUST 19 — the `:include-sensitive?` slot name is the cross-MCP
+      opt-in vocabulary (pair2-mcp + story-mcp + causa-mcp share the
+      identical arg).
+    - Result-envelope counter shape — `:dropped-sensitive` is stamped
+      iff the strip-step dropped at least one item; the zero-drop
+      common path carries no counter (cross-MCP convention).
+
+  These tests are the load-bearing pin for the 18 downstream tool
+  beads — every dispatcher that emits trace-stream-shaped payloads
+  calls `privacy/apply-to-result` once at the boundary; the contract
+  here is the one those tools inherit."
+  (:require [applied-science.js-interop :as j]
+            [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]))
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "B-1 lands the privacy boundary helpers downstream tool
+            dispatchers will require"
+    (is (fn? privacy/sensitive-event?))
+    (is (fn? privacy/strip-sensitive))
+    (is (fn? privacy/parse-include-sensitive))
+    (is (fn? privacy/stamp-dropped-sensitive))
+    (is (fn? privacy/apply-to-result))
+    (is (false? privacy/include-sensitive-default)
+        "spec/009 default-suppress posture: include-sensitive? defaults false")))
+
+;; ---------------------------------------------------------------------------
+;; sensitive-event? — the boolean predicate, delegated to mcp-base.
+;; ---------------------------------------------------------------------------
+
+(deftest sensitive-event?-true-stamp-detected
+  (is (privacy/sensitive-event? {:operation :event/dispatched :sensitive? true})))
+
+(deftest sensitive-event?-false-stamp-passes
+  (is (not (privacy/sensitive-event? {:operation :event/dispatched :sensitive? false}))))
+
+(deftest sensitive-event?-absent-stamp-passes
+  ;; Per spec/009: "Consumers treat absent as `false`."
+  (is (not (privacy/sensitive-event? {:operation :event/dispatched}))))
+
+(deftest sensitive-event?-non-map-input-passes
+  (is (not (privacy/sensitive-event? nil)))
+  (is (not (privacy/sensitive-event? [:sensitive? true])))
+  (is (not (privacy/sensitive-event? "anything"))))
+
+;; ---------------------------------------------------------------------------
+;; strip-sensitive — the per-batch default-suppress filter (MUST 1/2 spine).
+;; ---------------------------------------------------------------------------
+
+(deftest strip-sensitive-default-drops-true-stamps
+  (let [evts [{:id 1 :sensitive? false}
+              {:id 2 :sensitive? true}
+              {:id 3}
+              {:id 4 :sensitive? true}]
+        [kept dropped] (privacy/strip-sensitive evts false)]
+    (is (= [{:id 1 :sensitive? false} {:id 3}] kept))
+    (is (= 2 dropped))))
+
+(deftest strip-sensitive-include-opt-in-passes-everything
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? false}
+              {:id 3 :sensitive? true}]
+        [kept dropped] (privacy/strip-sensitive evts true)]
+    (is (= evts kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-empty-batch-zero-overhead
+  (let [[kept dropped] (privacy/strip-sensitive [] false)]
+    (is (= [] kept))
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-no-sensitive-events-zero-drop-identity-vector
+  ;; Fast-path (rf2-0q30r): when the scan finds no sensitive items the
+  ;; original vector is returned identity-equal and `dropped` is zero.
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        [kept dropped] (privacy/strip-sensitive evts false)]
+    (is (identical? evts kept)
+        "common-path optimisation: identical-vector return when nothing drops")
+    (is (zero? dropped))))
+
+(deftest strip-sensitive-on-epoch-records-via-top-level-stamp
+  ;; The causa runtime stamps the epoch-level `:sensitive?` rollup at
+  ;; assembly time (rf2-isdwf) — the per-event predicate fires on the
+  ;; same top-level slot whether the map is a trace event or an epoch
+  ;; record. No special-case helper needed.
+  (let [epochs [{:epoch-id 1 :event-id :cart/add}
+                {:epoch-id 2 :event-id :auth/sign-in :sensitive? true}
+                {:epoch-id 3 :event-id :nav/route}]
+        [kept dropped] (privacy/strip-sensitive epochs false)]
+    (is (= [{:epoch-id 1 :event-id :cart/add}
+            {:epoch-id 3 :event-id :nav/route}]
+           kept))
+    (is (= 1 dropped))))
+
+;; ---------------------------------------------------------------------------
+;; parse-include-sensitive — cross-MCP fixed arg name.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-include-sensitive-default-false-when-absent
+  ;; spec/009 MUST: the default is suppress. Every shape of "no input"
+  ;; collapses to the same default-false posture.
+  (is (false? (privacy/parse-include-sensitive nil)))
+  (is (false? (privacy/parse-include-sensitive js/undefined)))
+  (is (false? (privacy/parse-include-sensitive {})))
+  (is (false? (privacy/parse-include-sensitive #js {})))
+  (is (false? (privacy/parse-include-sensitive #js {:other "value"}))))
+
+(deftest parse-include-sensitive-true-from-js-args-object
+  ;; The MCP SDK hands the dispatcher a JS args object; the helper
+  ;; reads the cross-server slot `include-sensitive?` from it.
+  (is (true? (privacy/parse-include-sensitive #js {"include-sensitive?" true})))
+  (is (true? (privacy/parse-include-sensitive #js {"include-sensitive?" "true"})))
+  (is (true? (privacy/parse-include-sensitive #js {"include-sensitive?" "yes"})))
+  (is (true? (privacy/parse-include-sensitive #js {"include-sensitive?" "1"}))))
+
+(deftest parse-include-sensitive-false-from-js-args-object
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" false})))
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" "false"})))
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" "no"})))
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" "0"}))))
+
+(deftest parse-include-sensitive-from-cljs-map
+  ;; Some downstream paths may hand the helper a CLJS map (already
+  ;; coerced from the MCP wire). Both keyword and stringified keys
+  ;; resolve so the helper is robust across call shapes.
+  (is (true?  (privacy/parse-include-sensitive {:include-sensitive? true})))
+  (is (true?  (privacy/parse-include-sensitive {"include-sensitive?" true})))
+  (is (false? (privacy/parse-include-sensitive {:include-sensitive? false}))))
+
+(deftest parse-include-sensitive-unrecognised-value-defaults-suppress
+  ;; Unrecognised raw values (e.g. a number, a random keyword, an
+  ;; arbitrary object) collapse to the default-suppress posture per
+  ;; the cross-MCP parse-boolean contract.
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" "maybe"})))
+  (is (false? (privacy/parse-include-sensitive #js {"include-sensitive?" 42})))
+  (is (false? (privacy/parse-include-sensitive {:include-sensitive? :perhaps}))))
+
+;; ---------------------------------------------------------------------------
+;; stamp-dropped-sensitive — counter shape on the envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest stamp-dropped-sensitive-omits-slot-when-zero
+  ;; Zero-drop common path carries no counter. A missing slot reads
+  ;; as zero per the cross-MCP indicator-field convention; this keeps
+  ;; the agent surface minimal on the hot path.
+  (is (= {:events []}
+         (privacy/stamp-dropped-sensitive {:events []} 0)))
+  (is (= {:events [1 2 3]}
+         (privacy/stamp-dropped-sensitive {:events [1 2 3]} 0)))
+  (is (not (contains? (privacy/stamp-dropped-sensitive {:events []} 0)
+                      :dropped-sensitive))))
+
+(deftest stamp-dropped-sensitive-adds-slot-when-positive
+  (is (= {:events [] :dropped-sensitive 2}
+         (privacy/stamp-dropped-sensitive {:events []} 2)))
+  (is (= {:events [{:id 1}] :dropped-sensitive 7}
+         (privacy/stamp-dropped-sensitive {:events [{:id 1}]} 7))))
+
+(deftest stamp-dropped-sensitive-non-positive-no-stamp
+  ;; Defensive: negative or non-number inputs (shouldn't happen on the
+  ;; happy path; defensive against future refactors) leave the envelope
+  ;; untouched rather than stamping a nonsense value.
+  (is (not (contains? (privacy/stamp-dropped-sensitive {:events []} -1)
+                      :dropped-sensitive)))
+  (is (not (contains? (privacy/stamp-dropped-sensitive {:events []} nil)
+                      :dropped-sensitive))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — the per-tool boundary wrapper (the MUST 2 site).
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-default-strips-and-stamps-counter
+  ;; MUST 1 + MUST 2: default-suppress at the MCP boundary, and the
+  ;; counter surfaces in the envelope when at least one item drops.
+  (let [evts [{:id 1}
+              {:id 2 :sensitive? true}
+              {:id 3 :sensitive? true}
+              {:id 4}]
+        out (privacy/apply-to-result {} :events evts false)]
+    (is (= [{:id 1} {:id 4}] (:events out))
+        "sensitive events MUST be dropped at the MCP boundary by default")
+    (is (= 2 (:dropped-sensitive out))
+        ":dropped-sensitive counter stamped when non-zero")))
+
+(deftest apply-to-result-opt-in-passes-everything-no-stamp
+  ;; MUST 19 (`:include-sensitive?` half): the documented opt-in
+  ;; disables the gate. Counter is absent because nothing dropped.
+  (let [evts [{:id 1 :sensitive? true}
+              {:id 2 :sensitive? true}]
+        out (privacy/apply-to-result {} :events evts true)]
+    (is (= evts (:events out)) "opt-in MUST pass every item through")
+    (is (not (contains? out :dropped-sensitive))
+        "opt-in path adds no counter — nothing was dropped")))
+
+(deftest apply-to-result-clean-batch-no-counter
+  ;; Counter is absent when zero items dropped — the cross-MCP
+  ;; indicator-field convention (zero-drop common path is minimal).
+  (let [evts [{:id 1} {:id 2 :sensitive? false} {:id 3}]
+        out (privacy/apply-to-result {} :events evts false)]
+    (is (= evts (:events out)))
+    (is (not (contains? out :dropped-sensitive))
+        "clean batch MUST NOT stamp the counter slot")))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; The wrapper is additive — pre-existing slots on the envelope
+  ;; (cursor, next-cursor, remaining, mode, etc.) pass through.
+  (let [evts [{:id 1 :sensitive? true} {:id 2}]
+        out  (privacy/apply-to-result
+               {:next-cursor "abc" :remaining 42 :mode :summary}
+               :events evts false)]
+    (is (= [{:id 2}] (:events out)))
+    (is (= 1 (:dropped-sensitive out)))
+    (is (= "abc"    (:next-cursor out)))
+    (is (= 42       (:remaining out)))
+    (is (= :summary (:mode out)))))
+
+(deftest apply-to-result-empty-input
+  (let [out (privacy/apply-to-result {} :events [] false)]
+    (is (= [] (:events out)))
+    (is (not (contains? out :dropped-sensitive)))))
+
+(deftest apply-to-result-shape-for-trace-stream-tools
+  ;; Pins the canonical shape every trace-stream-shaped tool uses:
+  ;; `:trace-events` for `get-trace-buffer`, `:events` for
+  ;; `subscribe` drain batches, `:epochs` for `get-epoch-history`.
+  ;; The same wrapper services all three — uniform boundary site.
+  (testing "get-trace-buffer-shape (:trace-events)"
+    (let [out (privacy/apply-to-result
+                {} :trace-events
+                [{:op :a :sensitive? true} {:op :b}] false)]
+      (is (= [{:op :b}] (:trace-events out)))
+      (is (= 1 (:dropped-sensitive out)))))
+  (testing "subscribe-shape (:events)"
+    (let [out (privacy/apply-to-result
+                {:tick 17} :events
+                [{:op :a} {:op :b :sensitive? true}] false)]
+      (is (= [{:op :a}] (:events out)))
+      (is (= 1 (:dropped-sensitive out)))
+      (is (= 17 (:tick out)))))
+  (testing "get-epoch-history-shape (:epochs)"
+    (let [out (privacy/apply-to-result
+                {} :epochs
+                [{:epoch-id 1}
+                 {:epoch-id 2 :sensitive? true}
+                 {:epoch-id 3}]
+                false)]
+      (is (= [{:epoch-id 1} {:epoch-id 3}] (:epochs out)))
+      (is (= 1 (:dropped-sensitive out))))))
+
+;; ---------------------------------------------------------------------------
+;; The load-bearing spec/009 assertion.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-009-default-posture-is-suppress-at-mcp-boundary
+  (testing "default (no include-sensitive? arg) suppresses sensitive
+            events at the MCP boundary before crossing into the agent
+            surface (MUST 1 + MUST 2)"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          incl?           (privacy/parse-include-sensitive nil) ; absent arg
+          out             (privacy/apply-to-result {} :events sensitive-batch incl?)]
+      (is (false? incl?)
+          "parse-include-sensitive defaults to false (suppress)")
+      (is (= [] (:events out))
+          "sensitive event MUST NOT reach the agent surface by default")
+      (is (= 1 (:dropped-sensitive out))
+          "counter MUST surface the drop")))
+  (testing "explicit `:include-sensitive? true` is the documented
+            cross-MCP opt-in (MUST 19)"
+    (let [sensitive-batch [{:operation :event/dispatched
+                            :tags      {:event-id :auth/sign-in}
+                            :sensitive? true}]
+          incl?           (privacy/parse-include-sensitive
+                            #js {"include-sensitive?" true})
+          out             (privacy/apply-to-result {} :events sensitive-batch incl?)]
+      (is (true? incl?))
+      (is (= sensitive-batch (:events out))
+          "opt-in path MUST pass sensitive events through unchanged")
+      (is (not (contains? out :dropped-sensitive))
+          "opt-in path stamps no counter"))))


### PR DESCRIPTION
## Summary

- Ports the spec/009 §Privacy default-suppress filter from pair2-mcp to causa-mcp. New ns `day8.re-frame2-causa-mcp.privacy` exposes `sensitive-event?`, `strip-sensitive`, `parse-include-sensitive`, `stamp-dropped-sensitive`, and `apply-to-result` — the single boundary call-site every trace-stream-shaped tool dispatcher will reuse when the downstream F-tranche beads land.
- Delegates the predicate, fail-closed posture (rf2-ih7g4), and `[kept dropped-count]` strip contract to `re-frame.mcp-base.sensitive` (rf2-vw4sq) so the spec/009 contract stays byte-identical across the MCP triplet. Causa-mcp uses the trace-event-only filter (no pair2-mcp `sensitive-epoch?` union — the runtime stamps the epoch rollup at assembly time per rf2-isdwf, so the per-event predicate covers it).
- Cross-server arg vocabulary: `:include-sensitive? true` opt-in disables the gate per call; default is suppress. Counter `:dropped-sensitive` is stamped on the result envelope iff non-zero (zero-drop common path stays minimal, same convention as pair2-mcp's `wire/stamp-indicator-fields`).
- Gates 18 downstream tool beads — high leverage.

## MUST coverage (causa-mcp MUST-inventory)

- **MUST 1** — default-suppress at the MCP boundary.
- **MUST 2** — every trace-stream-shaped tool (`get-trace-buffer`, `subscribe`, `get-epoch-history`) MUST apply the filter at the boundary. `apply-to-result` is that single call-site.
- **MUST 19 (`:include-sensitive?` half)** — opt-in slot name fixed cross-MCP per `spec/Tool-Pair.md` L569.

## Wire-vocab tripwire

`privacy.cljs` sits at `src/day8/re_frame2_causa_mcp/privacy.cljs`, outside the `tools/` subdirectory that `tools/mcp-conformance/wire-vocab/` polices via `causa-mcp-impl-still-absent` (the tripwire fires the moment any file lands in `src/.../tools/`). Verified locally — wire-vocab tests pass (38 tests, 534 assertions, 0 failures).

## Test plan

- [x] `cd tools/causa-mcp && npm test` — 42 tests, 130 assertions, 0 failures.
- [x] `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — wire-vocab tripwire stays quiet (38/534).
- Test deltas (new): 22 tests across the public surface, `sensitive-event?`, `strip-sensitive` (incl. fast-path identity-vector), `parse-include-sensitive` (JS args, CLJS maps, opt-in/-out shapes, default-suppress on absent/unrecognised), `stamp-dropped-sensitive` (positive stamps; zero / negative / nil omit), `apply-to-result` (default strip + stamp; opt-in passes; clean batch no stamp; preserves envelope keys; canonical shapes for `:trace-events` / `:events` / `:epochs`), plus the load-bearing spec/009 default-posture assertion.

## Divergences from pair2-mcp (justified)

- No `sensitive-epoch?` union (pair2-mcp belt-and-braces for its in-process epoch shape). The base `strip-sensitive` fires on the top-level `:sensitive?` slot regardless of map identity, and the causa runtime computes the epoch rollup at assembly time (rf2-isdwf); the per-event predicate covers epochs without the extra walker. This matches the trace-event-only filter the base docstring recommends for story-mcp / causa-mcp consumers.
- `parse-include-sensitive` is a per-arg helper rather than a `bool-args` table — only one boolean arg lives at the privacy boundary; the table form would land later if/when `:dedup`, `:elision`, `:cache` join the surface (mirrored from pair2-mcp's `tools.args/bool-args`).
- `privacy.cljs` lives at the artefact root rather than under `src/.../tools/sensitive.cljs` (the pair2-mcp path) to keep the wire-vocab tripwire quiet until the downstream F-tranche tool beads land.

Closes rf2-8xzoe.11.