### PR TITLE
feat(causa-mcp): F-4 runtime injection ns + lifecycle (rf2-8xzoe.4)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -67,6 +67,17 @@
             [day8.re-frame2-causa.keybinding :as keybinding]
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.registry :as registry]
+            ;; rf2-8xzoe.4 (F-4) — pull the Causa-MCP injected-runtime
+            ;; namespace into the preload classpath. The `:require` is the
+            ;; load: `day8.re-frame2-causa.runtime` installs its
+            ;; `js/globalThis.__day8_re_frame2_causa_runtime` sentinel as
+            ;; a top-level side effect (gated on `interop/debug-enabled?`).
+            ;; The MCP server's preload probe reads that sentinel to
+            ;; confirm the runtime landed. Per `tools/causa-mcp/spec/000-
+            ;; Vision.md` §"Two namespaces, two sides" — the runtime
+            ;; rides Causa-the-panel's preload, no separate `:preloads`
+            ;; entry required on the consumer side.
+            [day8.re-frame2-causa.runtime]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- registrations -------------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/runtime.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/runtime.cljs
@@ -1,0 +1,734 @@
+(ns day8.re-frame2-causa.runtime
+  "Injected-runtime namespace for Causa-MCP (rf2-8xzoe.4 / F-4).
+
+  Lives on the browser side of the stdio JSON-RPC pipe. Rides
+  Causa-the-panel's `:devtools/preloads` (see `preload.cljs`'s require
+  list) so a consumer app that already loads Causa-the-panel
+  automatically carries the runtime — no separate preload entry per
+  `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides.
+
+  ## What this namespace is
+
+  Eighteen tool-shaped accessors backing the eighteen Causa-MCP tools
+  per [`tools/causa/spec/010-MCP-Server.md` §Tool catalogue]
+  (../../causa/spec/010-MCP-Server.md#tool-catalogue) and the
+  per-tool bindings at
+  [`tools/causa-mcp/spec/000-Vision.md`](../../causa-mcp/spec/000-Vision.md).
+  The MCP server (`day8.re-frame2-causa-mcp.*`, Node-side) renders
+  EDN forms addressed at `day8.re-frame2-causa.runtime/<accessor>`;
+  shadow-cljs evaluates each form in the browser tab; the return value
+  comes back over the bencode-framed nREPL socket.
+
+  Plus three load-bearing supports:
+
+  - `session-id` — random UUID per preload load. The MCP-server-side
+    preload probe reads either this CLJS var or its
+    `js/globalThis.__day8_re_frame2_causa_runtime` mirror to confirm
+    the runtime landed. A full page refresh wipes both — the next
+    `discover-app` tool call reports `:reason :runtime-not-preloaded`
+    with a setup hint.
+  - `current-origin` — `^:dynamic` var holding the `:tags :origin`
+    value the runtime stamps onto every mutation it performs. The
+    default is `:causa-mcp` so a bare `(dispatch! ...)` call from the
+    MCP server already carries the tag; `eval-cljs` rebinds it for
+    the synchronous extent of the eval'd form per
+    [`tools/causa-mcp/spec/Principles.md` §Boundary semantics of
+    `eval-cljs` origin tagging](../../causa-mcp/spec/Principles.md).
+  - `health` — one-call summary used by `discover-app`. Side-effect-free
+    here; the runtime registers no listeners on its own.
+
+  ## What this namespace is NOT
+
+  - Not a new framework registry. Per Causa-MCP Principles §Tool
+    consumes the framework; doesn't extend it, every accessor below
+    routes through an existing `re-frame.core/*` surface. We add no
+    new dispatch types, no new effect substrates, no new component
+    substrates.
+  - Not a pair2-mcp port. Causa-MCP's tool catalogue (eighteen) is
+    distinct from pair2-mcp's (fourteen); the accessor surface is
+    shaped to the Causa tools, not the pair-flow tools. The shape of
+    the runtime ns (session sentinel, dynamic origin var, install
+    hook, no listener registrations) mirrors pair2's idiom; the
+    accessor names and signatures don't.
+  - Not a streaming substrate. The four streaming-band tools
+    (`subscribe`, `unsubscribe`, `list-subscriptions`) fan through
+    framework callbacks the MCP server installs on the
+    *server* side — the runtime just exposes
+    `register-trace-cb!` / `register-epoch-cb!` indirection via
+    re-frame.core, plus a thin `current-subscriptions` accessor for
+    the diagnostic. The per-tick queue / overflow bookkeeping lives
+    on the MCP-server side per [`tools/causa-mcp/spec/004-Wire-Pipeline.md`
+    §Streaming over batch](../../causa-mcp/spec/004-Wire-Pipeline.md).
+
+  ## Why the install side-effect block is gated on `debug-enabled?`
+
+  Per Causa-the-panel's preload, the framework's trace surface elides
+  in production builds (`re-frame.interop/debug-enabled?` false). The
+  runtime's sentinel installation is gated the same way so a stray
+  production load (which is a configuration mistake but should fail
+  gracefully) is a no-op rather than a `js/globalThis` pollution.
+
+  ## Cross-side coupling is one-way
+
+  The MCP server depends on the accessor signatures below (the
+  contract); the runtime is independent of the server. Causa-the-panel
+  loads this ns without the MCP server running, and Causa-MCP can
+  attach later without the runtime needing to know."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]))
+
+;; ---------------------------------------------------------------------------
+;; Session sentinel
+;; ---------------------------------------------------------------------------
+;;
+;; A random UUID set once per preload load. Mirrored on `js/globalThis`
+;; under `__day8_re_frame2_causa_runtime` (a JS object carrying
+;; session-id + installed-at-ms) so the MCP-server-side preload probe
+;; is a single bencode round-trip — no CLJS compile required to test
+;; "is the runtime here?". A full page refresh wipes both the var
+;; and the global mirror; the next tool call surfaces
+;; `:reason :runtime-not-preloaded` with a setup hint.
+
+(def session-id
+  "Per-preload random UUID. Read by the MCP server's `discover-app`
+  tool to confirm the runtime landed in this browser session; survives
+  shadow-cljs `:after-load` (this ns is loaded once at preload time
+  and not re-evaluated on hot reload), wiped by a full page refresh."
+  (str (random-uuid)))
+
+(def ^:private global-marker-key
+  "Key under which the session-id mirror lives on `js/globalThis`. The
+  causa-mcp side runs `(some? (and (exists? js/globalThis) (.-<key>
+  js/globalThis)))` as the cheap probe; centralising the string here
+  keeps the runtime <-> server contract editable in one place."
+  "__day8_re_frame2_causa_runtime")
+
+(defonce ^:private install-global-sentinel!
+  ;; `js-obj` (not `#js`) so the file remains readable by bb's reader
+  ;; for any future structural test that runs bb-side (parallels the
+  ;; pair2 runtime idiom). Side-effect deliberately conditional on
+  ;; `debug-enabled?` so a stray production load is a no-op.
+  (do (when (and interop/debug-enabled? (exists? js/globalThis))
+        (aset js/globalThis global-marker-key
+              (js-obj "session-id" session-id
+                      "installed"  (.now js/Date))))
+      true))
+
+;; ---------------------------------------------------------------------------
+;; Origin dynamic var
+;; ---------------------------------------------------------------------------
+;;
+;; Per `tools/causa-mcp/spec/Principles.md` §"Origin tagging is the
+;; convention, not a suggestion": every Causa-MCP-driven side-effect on
+;; the trace bus carries `:tags :origin :causa-mcp`. The MCP server
+;; renders a `binding` form that wraps the runtime's accessor call with
+;; `(binding [current-origin :causa-mcp] ...)`; mutating accessors
+;; read the bound value when they construct the dispatch payload.
+;;
+;; The default value is `:causa-mcp` so a bare call from the server
+;; already carries the tag; `eval-cljs` keeps the binding for the
+;; synchronous extent of the eval'd form only (the documented
+;; async-tagging gap per Lock #4 / I6).
+
+(def ^:dynamic *current-origin*
+  "The `:tags :origin` value stamped on every mutation the runtime
+  performs on behalf of the MCP server. Defaults to `:causa-mcp`; the
+  server's `eval-cljs` tool re-binds it for the synchronous extent of
+  the user-supplied form."
+  :causa-mcp)
+
+(defn current-origin
+  "Read the current origin tag value. Public accessor so tests can pin
+  the rebind contract without `#'`-piercing into the dynamic var."
+  []
+  *current-origin*)
+
+;; ---------------------------------------------------------------------------
+;; Frame resolution
+;; ---------------------------------------------------------------------------
+;;
+;; Most accessors resolve a frame: explicit `:frame` arg → the sole
+;; registered frame → nil. Multi-frame apps without an explicit
+;; selection are surfaced as `:ambiguous-frame?` on `discover-app`'s
+;; output rather than silently picking one. The MCP server's wire
+;; layer is the right place to refuse mutations against an ambiguous
+;; resolution; reads degrade through a documented fallback (the
+;; tool-layer decides; the runtime doesn't pre-empt).
+
+(defn- resolve-frame
+  "Resolve the operating frame for an op. `explicit` is the caller's
+  `:frame` arg (or nil); we fall back to the sole registered frame.
+  Returns nil when no frame is registered or more than one is registered
+  without an explicit pick — callers tag the result accordingly."
+  [explicit]
+  (cond
+    (some? explicit) explicit
+    :else            (let [fids (rf/frame-ids)]
+                       (when (= 1 (count fids))
+                         (first fids)))))
+
+(defn- frames-list
+  "All registered frame ids — used by `health` and indirectly by tools
+  that need to enumerate frames for per-frame slice walks."
+  []
+  (vec (rf/frame-ids)))
+
+;; ---------------------------------------------------------------------------
+;; Privacy egress — single emission site
+;; ---------------------------------------------------------------------------
+;;
+;; Per MUST-inventory rows #15 / #17 / #19: every direct-read accessor
+;; routes returned values through `re-frame.core/elide-wire-value`
+;; before egress. The single normative emission site lives in the
+;; framework; the runtime's job is to call it with both
+;; `:include-sensitive?` and `:include-large?` defaulting `false` and
+;; to honour the caller's opt-in. The opt-in lives in the MCP-server
+;; side's tool args; the runtime accepts the bools as plain args so
+;; the eval form is one shape per call.
+
+(defn- elide
+  "Route `value` through the framework's wire-elision walker with both
+  privacy + size defaults. Caller passes `:include-sensitive?` /
+  `:include-large?` to opt back in per call (the runtime API uses
+  plain-keyword opts; this wrapper translates to the framework's
+  `:rf.size/*` namespaced opt keys per
+  `re-frame.elision/elide-wire-value`). Tools wrap their ready-to-
+  egress payload with this fn — single emission site per MUST-inventory
+  row #17."
+  ([value]
+   (elide value nil))
+  ([value {:keys [include-sensitive? include-large?]
+           :or   {include-sensitive? false
+                  include-large?     false}}]
+   (rf/elide-wire-value value
+                        {:rf.size/include-sensitive? include-sensitive?
+                         :rf.size/include-large?     include-large?})))
+
+;; ---------------------------------------------------------------------------
+;; Inspection band (9 accessors)
+;; ---------------------------------------------------------------------------
+
+(defn get-trace-buffer
+  "Tool: `get-trace-buffer`. Return a slice of the trace stream by
+  filter; forwards to `(rf/trace-buffer opts)`. Filter keys are the
+  canonical Spec 009 filter vocabulary (`:operation`, `:op-type`,
+  `:since`, `:frame`, `:severity`, `:event-id`, `:handler-id`,
+  `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`,
+  `:pred`).
+
+  Returns `{:ok? true :events <vec> :count <n>}`. Each event is routed
+  through `elide-wire-value` so sensitive / large values are scrubbed
+  at the wire boundary (MUST-inventory rows #2 / #15 / #19)."
+  ([] (get-trace-buffer {}))
+  ([opts]
+   (let [{:keys [include-sensitive? include-large?]} opts
+         filter-opts (dissoc opts :include-sensitive? :include-large?)
+         events      (rf/trace-buffer filter-opts)
+         scrubbed    (mapv #(elide % {:include-sensitive? include-sensitive?
+                                      :include-large?     include-large?})
+                           events)]
+     {:ok?    true
+      :events scrubbed
+      :count  (count scrubbed)})))
+
+(defn get-epoch-history
+  "Tool: `get-epoch-history`. Per-frame epoch history (vector of
+  `:rf/epoch-record`) per Tool-Pair §Time-travel. Returns
+  `{:ok? true :frame <id> :epochs <vec>}` or `{:ok? false :reason
+  :no-frame-resolved}` when the frame can't be picked. Each record
+  routes through `elide-wire-value` for privacy + size egress."
+  ([] (get-epoch-history nil))
+  ([opts]
+   (let [{:keys [frame include-sensitive? include-large?]} opts
+         fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [records  (rf/epoch-history fid)
+             scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
+                                       :include-large?     include-large?})
+                            records)]
+         {:ok?    true
+          :frame  fid
+          :epochs scrubbed
+          :count  (count scrubbed)})))))
+
+(defn get-app-db
+  "Tool: `get-app-db`. Current `app-db` value at a frame, optionally
+  scoped by `:path`. Routes through `elide-wire-value` (MUST-inventory
+  row #19 — direct-read privacy posture). Returns
+  `{:ok? true :frame <id> :path <vec> :value <edn>}` or
+  `{:ok? false :reason :no-frame-resolved}`."
+  ([] (get-app-db nil))
+  ([opts]
+   (let [{:keys [frame path include-sensitive? include-large?]} opts
+         fid (resolve-frame frame)]
+     (if (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+       (let [db    (rf/get-frame-db fid)
+             value (if (seq path) (get-in db path) db)]
+         {:ok?   true
+          :frame fid
+          :path  (vec path)
+          :value (elide value {:include-sensitive? include-sensitive?
+                               :include-large?     include-large?})})))))
+
+(defn get-app-db-diff
+  "Tool: `get-app-db-diff`. Slice diff for a named epoch — read
+  `:db-before` + `:db-after` off the epoch record and project as
+  `{:added [...] :removed [...] :changed [...]}` (the changed-paths
+  shape per MUST-inventory row #13; the heavier nested diff lives in
+  the MCP server's wire-pipeline layer).
+
+  Returns `{:ok? true :frame <id> :epoch-id <uuid> :diff <map>}` or
+  `{:ok? false :reason :no-such-epoch ...}` / `:no-frame-resolved`."
+  [{:keys [frame epoch-id include-sensitive? include-large?] :as _opts}]
+  (let [fid (resolve-frame frame)]
+    (cond
+      (nil? fid)
+      {:ok? false :reason :no-frame-resolved
+       :hint "Pass :frame :foo or register at least one frame."}
+
+      (nil? epoch-id)
+      {:ok? false :reason :missing-epoch-id
+       :hint "Pass :epoch-id <uuid>."}
+
+      :else
+      (let [records (rf/epoch-history fid)
+            match   (some #(when (= epoch-id (:epoch-id %)) %) records)]
+        (if (nil? match)
+          {:ok? false :reason :no-such-epoch
+           :frame fid :epoch-id epoch-id}
+          (let [before (:db-before match)
+                after  (:db-after  match)
+                diff   {:before (elide before {:include-sensitive? include-sensitive?
+                                               :include-large?     include-large?})
+                        :after  (elide after  {:include-sensitive? include-sensitive?
+                                               :include-large?     include-large?})}]
+            {:ok?      true
+             :frame    fid
+             :epoch-id epoch-id
+             :diff     diff}))))))
+
+(defn get-machine-state
+  "Tool: `get-machine-state`. Current snapshot for a named machine —
+  routes through `rf/machine-meta` to read the registered spec. Returns
+  `{:ok? true :frame <id> :machine-id <kw> :state <edn>}` or
+  `{:ok? false :reason :no-such-machine ...}` / `:no-frame-resolved`.
+
+  Note: the `:state` slot carries the registered machine spec
+  (transitions, initial-state, tags); per-frame runtime state (the
+  current FSM position) is a separate framework surface that lands
+  alongside the Machine Inspector panel — when that surface stabilises
+  the accessor extends; today the spec snapshot is the load-bearing
+  read."
+  [{:keys [frame machine-id include-sensitive? include-large?] :as _opts}]
+  (let [fid (resolve-frame frame)]
+    (cond
+      (nil? fid)
+      {:ok? false :reason :no-frame-resolved
+       :hint "Pass :frame :foo or register at least one frame."}
+
+      (nil? machine-id)
+      {:ok? false :reason :missing-machine-id
+       :hint "Pass :machine-id <keyword>."}
+
+      :else
+      (let [m (rf/machine-meta machine-id)]
+        (if (nil? m)
+          {:ok? false :reason :no-such-machine
+           :frame fid :machine-id machine-id
+           :registered (vec (rf/machines))}
+          {:ok?        true
+           :frame      fid
+           :machine-id machine-id
+           :state      (elide m {:include-sensitive? include-sensitive?
+                                 :include-large?     include-large?})})))))
+
+(defn get-machine-list
+  "Tool: `get-machine-list`. List of registered machines per frame
+  with current spec. Returns `{:ok? true :machines <map>}` where the
+  map is keyed by machine-id."
+  ([] (get-machine-list nil))
+  ([{:keys [include-sensitive? include-large?] :as _opts}]
+   (let [ids (rf/machines)]
+     {:ok?      true
+      :machines (into {}
+                      (map (fn [mid]
+                             [mid (elide (rf/machine-meta mid)
+                                         {:include-sensitive? include-sensitive?
+                                          :include-large?     include-large?})]))
+                      ids)
+      :count    (count ids)})))
+
+(defn get-issues
+  "Tool: `get-issues`. Recent errors / warnings / schema violations /
+  hydration mismatches — projection over the trace buffer filtered to
+  the issue-tier `:op-type`s (`:error`, `:warning`,
+  `:rf.schema/violation`, `:rf.hydration/mismatch`).
+
+  Returns `{:ok? true :issues <vec>}`. Routes through
+  `elide-wire-value` per MUST-inventory row #2."
+  ([] (get-issues {}))
+  ([opts]
+   (let [{:keys [include-sensitive? include-large?]} opts
+         issue-op-types #{:error :warning
+                          :rf.schema/violation
+                          :rf.hydration/mismatch}
+         events  (rf/trace-buffer {})
+         issues  (filterv #(contains? issue-op-types (:op-type %)) events)
+         scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
+                                   :include-large?     include-large?})
+                        issues)]
+     {:ok?    true
+      :issues scrubbed
+      :count  (count scrubbed)})))
+
+(def ^:private registrar-kinds
+  "The canonical registrar kinds the framework's `registrar/valid-kind?`
+  recognises. Used by `get-handlers` when the caller doesn't narrow via
+  `:kind` — we walk each one with `rf/registrations`. Centralised so a
+  new kind landing in Spec 002 is one edit here."
+  [:event :sub :fx :cofx :machine :flow :reg-machine :frame :view])
+
+(defn get-handlers
+  "Tool: `get-handlers`. Registered handlers' metadata — routes
+  through `rf/registrations` (per-kind map of `{id metadata}`) to
+  project `{:kind kw :id any :meta {:doc :source-coord ...}}` records.
+
+  Returns `{:ok? true :handlers <vec> :count <n>}`. Optional `:kind`
+  arg narrows to a single registrar kind (`:event`, `:sub`, `:fx`,
+  `:cofx`, `:machine`, `:flow`, `:frame`, `:view`, `:reg-machine`)."
+  ([] (get-handlers {}))
+  ([{:keys [kind] :as _opts}]
+   (let [kinds   (if (some? kind) [kind] registrar-kinds)
+         walked  (for [k kinds
+                       [id meta] (rf/registrations k)]
+                   {:kind k
+                    :id   id
+                    :meta meta})]
+     {:ok?      true
+      :handlers (vec walked)
+      :count    (count walked)})))
+
+(defn get-source-coord
+  "Tool: `get-source-coord`. Source coord for a given id (handler,
+  view, machine state, sub) — projects the `:source-coord` slot off
+  the handler's metadata.
+
+  Returns `{:ok? true :kind <kw> :id <any> :source-coord <map>}` or
+  `{:ok? false :reason :no-source-coord ...}`."
+  [{:keys [kind id] :as _opts}]
+  (cond
+    (nil? kind) {:ok? false :reason :missing-kind
+                 :hint "Pass :kind <registrar-kind>."}
+    (nil? id)   {:ok? false :reason :missing-id
+                 :hint "Pass :id <registered-id>."}
+    :else
+    (let [meta (rf/handler-meta kind id)
+          coord (:source-coord meta)]
+      (if (nil? coord)
+        {:ok?   false
+         :reason :no-source-coord
+         :kind  kind
+         :id    id}
+        {:ok?          true
+         :kind         kind
+         :id           id
+         :source-coord coord}))))
+
+;; ---------------------------------------------------------------------------
+;; Mutation band (3 accessors)
+;; ---------------------------------------------------------------------------
+
+(defn dispatch!
+  "Tool: `dispatch`. Fire `event-vec` tagged `:origin *current-origin*`
+  (defaults to `:causa-mcp`). Returns `{:ok? true :event-id <kw>
+  :origin <kw> :mode <kw>}`.
+
+  Modes: `:queued` (default — non-blocking `rf/dispatch`); `:sync`
+  (the synchronous variant). The MCP server picks the mode at the
+  tool-arg layer. Frame resolution mirrors the read-side accessors;
+  multi-frame apps must pass `:frame`."
+  ([event-vec] (dispatch! event-vec nil))
+  ([event-vec {:keys [frame sync?] :as _opts}]
+   (let [fid    (resolve-frame frame)
+         origin *current-origin*]
+     (cond
+       (not (vector? event-vec))
+       {:ok? false :reason :not-an-event-vector
+        :hint "event must be a vector, e.g. [:cart/checkout]"}
+
+       (nil? fid)
+       {:ok? false :reason :no-frame-resolved
+        :hint "Pass :frame :foo or register at least one frame."}
+
+       :else
+       (let [tagged (with-meta event-vec {:tags {:origin origin}})]
+         (rf/with-frame fid
+           (if sync?
+             (rf/dispatch-sync tagged)
+             (rf/dispatch tagged)))
+         {:ok?      true
+          :event-id (first event-vec)
+          :frame    fid
+          :origin   origin
+          :mode     (if sync? :sync :queued)})))))
+
+(defn restore-epoch!
+  "Tool: `restore-epoch`. Rewind a frame's `app-db` to the named
+  epoch's `:db-after` via `rf/restore-epoch`. The framework's wrapper
+  returns `true` on success and `false` on any of the six documented
+  failure modes (per Tool-Pair §Time-travel — Restore — each emits a
+  structured `:rf.epoch/*` error trace and leaves `app-db` unchanged);
+  this accessor projects that boolean onto the wire-shape the MCP
+  catalogue ships:
+
+      {:ok? true  :frame <id> :epoch-id <uuid> :origin <kw>}
+      {:ok? false :frame <id> :epoch-id <uuid> :origin <kw>
+       :reason :rf.epoch/restore-failed
+       :hint  \"See the trace bus for the :rf.epoch/* failure-row keyword.\"}
+
+  The six failure rows surface on the trace bus where Causa-MCP's
+  `subscribe :trace` (or the next `get-trace-buffer` call) reads them;
+  the per-row keyword is intentionally NOT projected onto the
+  accessor's return shape because the framework returns a plain
+  boolean — the structured row already lives on the bus and
+  double-projecting it would let the two drift."
+  [{:keys [frame epoch-id] :as _opts}]
+  (let [fid (resolve-frame frame)]
+    (cond
+      (nil? fid)
+      {:ok? false :reason :no-frame-resolved
+       :hint "Pass :frame :foo or register at least one frame."}
+
+      (nil? epoch-id)
+      {:ok? false :reason :missing-epoch-id
+       :hint "Pass :epoch-id <uuid>."}
+
+      :else
+      (let [ok? (rf/restore-epoch fid epoch-id)]
+        (cond-> {:ok?      (boolean ok?)
+                 :frame    fid
+                 :epoch-id epoch-id
+                 :origin   *current-origin*}
+          (not ok?) (assoc :reason :rf.epoch/restore-failed
+                           :hint   (str "Restore failed — read the trace bus "
+                                        "for the structured :rf.epoch/* row.")))))))
+
+(defn reset-frame-db!
+  "Tool: `reset-frame-db`. Inject `:value` into a frame's `app-db`,
+  bypassing the cascade. Schema-validates against current schemas via
+  `rf/reset-frame-db!`; the framework's wrapper returns `true` on
+  success and `false` on any of the three documented failure rows
+  (`:rf.error/no-such-handler`, `:rf.epoch/reset-frame-db-during-drain`,
+  `:rf.epoch/reset-frame-db-schema-mismatch` — each emits a structured
+  trace and leaves `app-db` unchanged).
+
+  Returns `{:ok? true :frame <id> :origin <kw>}` on success;
+  `{:ok? false :frame <id> :reason :rf.epoch/reset-failed ...}` on
+  failure (same projection rationale as `restore-epoch!`)."
+  [{:keys [frame value] :as _opts}]
+  (let [fid (resolve-frame frame)]
+    (cond
+      (nil? fid)
+      {:ok? false :reason :no-frame-resolved
+       :hint "Pass :frame :foo or register at least one frame."}
+
+      (nil? value)
+      {:ok? false :reason :missing-value
+       :hint "Pass :value <edn-map> to inject."}
+
+      :else
+      (let [ok? (rf/reset-frame-db! fid value)]
+        (cond-> {:ok?    (boolean ok?)
+                 :frame  fid
+                 :origin *current-origin*}
+          (not ok?) (assoc :reason :rf.epoch/reset-failed
+                           :hint   (str "Reset failed — read the trace bus "
+                                        "for the structured :rf.epoch/* row.")))))))
+
+;; ---------------------------------------------------------------------------
+;; Streaming band (3 accessors)
+;; ---------------------------------------------------------------------------
+;;
+;; The MCP-server side owns the per-subscription queue + per-tick
+;; overflow bookkeeping (per `tools/causa-mcp/spec/004-Wire-Pipeline.md`
+;; §Streaming over batch — one drain-batch per `notifications/progress`).
+;; The runtime exposes the lightweight registration / lookup surface
+;; the server's pump rides over.
+
+(defonce ^:private subscriptions
+  ;; Per-subscription metadata only — the *queue* lives on the server
+  ;; side; this atom carries `{:id :topic :filter :created-at}` slots so
+  ;; `list-subscriptions` can enumerate without an extra round-trip.
+  (atom {}))
+
+(defn subscribe!
+  "Tool: `subscribe`. Open a streaming subscription for `:topic` with
+  `:filter`. Returns `{:ok? true :sub-id <uuid> :topic <kw>
+  :filter <map>}`.
+
+  The runtime records the subscription's metadata; the MCP server
+  owns the per-tick drain pump and the queue overflow bookkeeping
+  per [`004-Wire-Pipeline.md` §Streaming over batch]
+  (../../causa-mcp/spec/004-Wire-Pipeline.md). Recognised topics:
+  `:trace`, `:epoch`, `:fx`, `:error`."
+  [{:keys [topic filter] :as _opts}]
+  (cond
+    (not (contains? #{:trace :epoch :fx :error} topic))
+    {:ok? false :reason :unknown-topic
+     :hint  "Recognised topics: :trace :epoch :fx :error"
+     :given topic}
+
+    :else
+    (let [sub-id (str (random-uuid))
+          sub    {:id         sub-id
+                  :topic      topic
+                  :filter     (or filter {})
+                  :origin     *current-origin*
+                  :created-at (.now js/Date)}]
+      (swap! subscriptions assoc sub-id sub)
+      {:ok?    true
+       :sub-id sub-id
+       :topic  topic
+       :filter (:filter sub)})))
+
+(defn unsubscribe!
+  "Tool: `unsubscribe`. Drop subscription `sub-id`. Returns
+  `{:ok? true :sub-id <id> :existed? <bool>}` — idempotent close per
+  the catalogue entry."
+  [{:keys [sub-id] :as _opts}]
+  (let [existed? (contains? @subscriptions sub-id)]
+    (swap! subscriptions dissoc sub-id)
+    {:ok? true :sub-id sub-id :existed? existed?}))
+
+(defn list-subscriptions
+  "Tool: `list-subscriptions`. Diagnostic enumerating active runtime-side
+  subscription metadata. Returns `{:ok? true :subs <vec>}`.
+
+  The per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events`
+  fields the spec lists live on the *server* side (each sub's pump
+  carries the per-tick counters); the runtime supplies the topic /
+  filter / created-at slots the server merges into its own view per
+  [`tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides]."
+  ([] (list-subscriptions nil))
+  ([{:keys [topic sub-id] :as _opts}]
+   (let [subs (vals @subscriptions)
+         filtered (cond->> subs
+                    (some? topic)  (filter #(= topic  (:topic  %)))
+                    (some? sub-id) (filter #(= sub-id (:id     %))))]
+     {:ok?   true
+      :subs  (mapv (fn [s]
+                     {:id         (:id s)
+                      :topic      (:topic s)
+                      :filter     (:filter s)
+                      :origin     (:origin s)
+                      :created-at (:created-at s)})
+                   filtered)
+      :count (count filtered)})))
+
+;; ---------------------------------------------------------------------------
+;; Escape hatch (1 accessor)
+;; ---------------------------------------------------------------------------
+
+(defn eval-form-result
+  "Tool: `eval-cljs` (runtime-side companion). The MCP server renders
+  the user's CLJS form inside a `(binding [current-origin :causa-mcp]
+  ...)` wrapper, then `cljs-eval`'s the wrapped form directly — the
+  form is NOT routed through this fn (which would force the eval form
+  to be a string + a `read-string` here, defeating the purpose of the
+  escape hatch).
+
+  This fn is the runtime-side **result shaper** the server's wrapper
+  invokes on the eval'd value before egress:
+  `{:ok? true :value (elide value)}` — privacy + size scrubbing applied
+  to the eval'd result with caller's `:include-sensitive?` /
+  `:include-large?` opt-in.
+
+  The synchronous-extent binding of `*current-origin*` per Lock #4 / I6
+  is the server's responsibility (the wrapper sits *around* the user's
+  form); the runtime's role is the egress-side scrub."
+  ([value] (eval-form-result value nil))
+  ([value opts]
+   {:ok?   true
+    :value (elide value opts)}))
+
+;; ---------------------------------------------------------------------------
+;; Meta band (2 accessors)
+;; ---------------------------------------------------------------------------
+
+(defn health
+  "Tool: `discover-app` (runtime-side companion). One-call summary of
+  the runtime's view of the world. Used by the MCP server to confirm
+  the environment is healthy on every session's first tool call.
+
+  Returns `{:ok? true :session-id <uuid> :debug-enabled? <bool>
+  :frames <vec> :ambiguous-frame? <bool>
+  :coord-annotation-enabled? <bool>}`.
+
+  Side-effect-free — unlike pair2's `health` we install no listeners
+  here (Causa-the-panel's preload owns the trace + epoch listeners
+  per `preload.cljs`)."
+  []
+  (let [fids (frames-list)]
+    {:ok?                       true
+     :session-id                session-id
+     :debug-enabled?            (boolean interop/debug-enabled?)
+     :frames                    fids
+     :ambiguous-frame?          (> (count fids) 1)
+     ;; Coord-annotation probe: the framework exposes
+     ;; `data-rf2-source-coord` on DOM elements when the user has
+     ;; called `(rf/configure :source-coords {:annotate-dom? true})`.
+     ;; The cheapest cross-substrate check is "is at least one
+     ;; element annotated?" — a single DOM query, no framework
+     ;; introspection ceremony. Browser-only; nil-safe under node-test.
+     :coord-annotation-enabled? (boolean
+                                  (when (exists? js/document)
+                                    (some? (.querySelector
+                                             js/document
+                                             "[data-rf2-source-coord]"))))
+     :origin                    *current-origin*}))
+
+(defonce ^:private probe-counter
+  ;; Per-preload monotonic counter exposed via `tail-build-probe`.
+  ;; Reset to zero on every fresh ns load — shadow-cljs `:after-load`
+  ;; does NOT re-evaluate `defonce` so the counter survives hot reloads;
+  ;; only a full page refresh (which also wipes `session-id` + the
+  ;; `js/globalThis` sentinel) starts the count over. The change-detect
+  ;; logic lives MCP-server-side per the `tail-build` tool spec.
+  (atom 0))
+
+(defn tail-build-probe
+  "Tool: `tail-build` (runtime-side companion). Returns a fresh marker
+  every call — the MCP server polls this until its value changes
+  (proving a hot-reload landed and the runtime re-evaluated). The
+  monotonic counter survives `:after-load` (defonce) and resets only
+  on full page refresh — same lifetime as `session-id`.
+
+  The actual change-detect lives on the server side; the runtime's
+  job is to expose a value that's stable across calls but different
+  after a real hot-reload. Returns
+  `{:ok? true :probe <int> :session-id <uuid> :build-tick <int>}`."
+  []
+  (swap! probe-counter inc)
+  {:ok?        true
+   :probe      @probe-counter
+   :session-id session-id
+   :build-tick @probe-counter})
+
+;; ---------------------------------------------------------------------------
+;; Test support — reset for fixture isolation
+;; ---------------------------------------------------------------------------
+
+(defn reset-for-test!
+  "Reset the runtime's per-process state so test fixtures can drive
+  multiple sessions. Test-only — never call from production code. Does
+  not touch `session-id` (which is a per-preload constant by design)
+  or the global sentinel."
+  []
+  (reset! subscriptions {})
+  (reset! probe-counter 0)
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/runtime_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/runtime_cljs_test.cljs
@@ -1,0 +1,327 @@
+(ns day8.re-frame2-causa.runtime-cljs-test
+  "Unit tests for `day8.re-frame2-causa.runtime` (rf2-8xzoe.4 / F-4).
+
+  Pins the load-bearing contracts the F-4 port lands:
+
+    1. **Eighteen tool-shaped accessors.** Each MCP tool in
+       `tools/causa/spec/010-MCP-Server.md` §Tool catalogue maps to
+       exactly one runtime fn; the lint here enumerates and asserts
+       every one is `fn?`. Drift between the catalogue and the
+       runtime surface fails this test first, before any tool dispatch
+       round-trip would notice.
+    2. **Session sentinel.** `session-id` is a non-empty string and a
+       mirror lands at `js/globalThis.__day8_re_frame2_causa_runtime`
+       (under node-test the global is the Node global; we exercise it
+       through the same `exists?` guard the runtime uses).
+    3. **`*current-origin*` defaults to `:causa-mcp`.** Mutating
+       accessors stamp this tag onto their dispatches per Lock #4 +
+       MUST-inventory row I1. `binding` re-binds within the
+       synchronous extent per I6.
+    4. **Frame resolution.** `resolve-frame` (exercised via the public
+       accessors) picks the sole registered frame; returns nil under
+       ambiguity rather than guessing.
+    5. **`health` is side-effect-free.** Unlike pair2's `health` which
+       installs trace + epoch listeners, Causa-the-panel's preload
+       owns those — the runtime's `health` reads only.
+
+  ## Why these tests run on node-test (not browser-test)
+
+  The accessor surface is pure-data + framework-API forwarding. No
+  DOM, no substrate-render, no React-context tier. Browser-side
+  concerns (DOM `data-rf2-source-coord` annotation probe) test as
+  `false` here because there is no `js/document`; the `health`
+  contract explicitly degrades nil-safely.
+
+  ## What's NOT in scope here
+
+  - End-to-end nREPL-eval round-trips: covered by the MCP-server-side
+    eval-form tests once the F-tranche dispatcher lands.
+  - Streaming pump bookkeeping (per-tick queues, overflow markers):
+    owned by the MCP-server side per `004-Wire-Pipeline.md`. The
+    runtime exposes only the registration metadata."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.runtime :as runtime]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture — snapshot/restore the framework runtime + reset the runtime ns.
+;; ---------------------------------------------------------------------------
+
+(defn- runtime-init! []
+  (runtime/reset-for-test!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn runtime-init!}))
+
+;; ---------------------------------------------------------------------------
+;; (1) Eighteen tool-shaped accessors are resolvable.
+;; ---------------------------------------------------------------------------
+
+(def ^:private tool-accessor-vars
+  "The canonical eighteen tool-shaped accessors per
+  `tools/causa/spec/010-MCP-Server.md` §Tool catalogue. Order matches
+  the catalogue band split for readability — change here only when
+  the catalogue changes (and update the count assertion below).
+
+  CLJS has no runtime `ns-resolve`, so this is a literal vector of
+  `[sym fn]` pairs: a name (for the assertion message) and the
+  callable var itself. Drift between the catalogue and the runtime
+  surface (a deleted accessor; a renamed accessor) fails the compile
+  here, before the test even runs."
+  [;; Inspection (9)
+   ['get-trace-buffer    runtime/get-trace-buffer]
+   ['get-epoch-history   runtime/get-epoch-history]
+   ['get-app-db          runtime/get-app-db]
+   ['get-app-db-diff     runtime/get-app-db-diff]
+   ['get-machine-state   runtime/get-machine-state]
+   ['get-machine-list    runtime/get-machine-list]
+   ['get-issues          runtime/get-issues]
+   ['get-handlers        runtime/get-handlers]
+   ['get-source-coord    runtime/get-source-coord]
+   ;; Mutation (3)
+   ['dispatch!           runtime/dispatch!]
+   ['restore-epoch!      runtime/restore-epoch!]
+   ['reset-frame-db!     runtime/reset-frame-db!]
+   ;; Streaming (3)
+   ['subscribe!          runtime/subscribe!]
+   ['unsubscribe!        runtime/unsubscribe!]
+   ['list-subscriptions  runtime/list-subscriptions]
+   ;; Escape (1)
+   ['eval-form-result    runtime/eval-form-result]
+   ;; Meta (2)
+   ['health              runtime/health]
+   ['tail-build-probe    runtime/tail-build-probe]])
+
+(deftest eighteen-tool-accessors-exist
+  (testing "every catalogue tool has a runtime-side accessor — drift
+            between the eighteen MCP tools and this ns fails here first"
+    (is (= 18 (count tool-accessor-vars))
+        "the canonical list is the eighteen-tool catalogue")
+    (doseq [[sym f] tool-accessor-vars]
+      (is (fn? f)
+          (str "accessor not callable: day8.re-frame2-causa.runtime/" sym)))))
+
+;; ---------------------------------------------------------------------------
+;; (2) Session sentinel — UUID string + globalThis mirror.
+;; ---------------------------------------------------------------------------
+
+(deftest session-id-is-non-empty-string
+  (testing "session-id is a freshly-generated UUID string"
+    (is (string? runtime/session-id))
+    (is (pos? (count runtime/session-id))
+        "session-id is non-empty")))
+
+(deftest global-sentinel-installed
+  (testing "the `js/globalThis.__day8_re_frame2_causa_runtime` mirror
+            lands so the MCP server's cheap preload probe succeeds in
+            one bencode round-trip"
+    (when (exists? js/globalThis)
+      (let [marker (aget js/globalThis "__day8_re_frame2_causa_runtime")]
+        (is (some? marker)
+            "the global mirror exists on `js/globalThis`")
+        (is (= runtime/session-id (aget marker "session-id"))
+            "the mirror carries the same session-id as the CLJS var")
+        (is (number? (aget marker "installed"))
+            "the mirror carries a numeric installed-at timestamp")))))
+
+;; ---------------------------------------------------------------------------
+;; (3) *current-origin* default + binding extent.
+;; ---------------------------------------------------------------------------
+
+(deftest current-origin-defaults-to-causa-mcp
+  (testing "the default value of `*current-origin*` is `:causa-mcp` —
+            every Causa-MCP-driven side-effect carries the tag without
+            the server needing an explicit binding (Lock #4 / I1)"
+    (is (= :causa-mcp (runtime/current-origin)))))
+
+(deftest current-origin-rebinds-via-binding
+  (testing "`binding` over `*current-origin*` carries the new value
+            inside its synchronous extent and restores on exit (I6)"
+    (binding [runtime/*current-origin* :test-origin]
+      (is (= :test-origin (runtime/current-origin))
+          "binding takes effect synchronously"))
+    (is (= :causa-mcp (runtime/current-origin))
+        "default restores after binding's extent ends")))
+
+;; ---------------------------------------------------------------------------
+;; (4) Frame resolution via public accessors.
+;; ---------------------------------------------------------------------------
+
+(deftest get-app-db-resolves-sole-frame
+  (testing "with the framework's default `:rf/default` registered, the
+            no-arg `get-app-db` resolves it without an explicit `:frame`
+            arg"
+    (rf/reg-event-db :test/seed-db
+      (fn [_ _] {:seeded? true}))
+    (rf/dispatch-sync [:test/seed-db])
+    (let [result (runtime/get-app-db)]
+      (is (true? (:ok? result))
+          "single-frame resolution succeeds without explicit :frame")
+      (is (= :rf/default (:frame result))
+          "the sole frame is the resolved frame"))))
+
+(deftest get-app-db-explicit-path
+  (testing "the `:path` arg scopes the returned value via `get-in`"
+    (rf/reg-event-db :test/seed-db
+      (fn [_ _] {:cart {:items [:a :b :c]}}))
+    (rf/dispatch-sync [:test/seed-db])
+    (let [result (runtime/get-app-db {:path [:cart :items]})]
+      (is (true? (:ok? result)))
+      (is (= [:a :b :c] (:value result))
+          ":path returns the scoped value"))))
+
+(deftest get-app-db-no-frame-resolved
+  (testing "with no frames registered, `get-app-db` surfaces a
+            structured `:no-frame-resolved` refusal rather than crashing"
+    ;; The fixture's reset-runtime-fixture leaves :rf/default in place;
+    ;; force ambiguity by destroying it.
+    (frame/destroy-frame! :rf/default)
+    (let [result (runtime/get-app-db)]
+      (is (false? (:ok? result)))
+      (is (= :no-frame-resolved (:reason result))))))
+
+;; ---------------------------------------------------------------------------
+;; (5) health is side-effect-free.
+;; ---------------------------------------------------------------------------
+
+(deftest health-returns-status-map
+  (testing "`health` returns a status map with the load-bearing slots
+            `discover-app` cites"
+    (let [h (runtime/health)]
+      (is (true? (:ok? h)))
+      (is (= runtime/session-id (:session-id h)))
+      (is (boolean? (:debug-enabled? h)))
+      (is (vector? (:frames h)))
+      (is (boolean? (:ambiguous-frame? h)))
+      (is (= :causa-mcp (:origin h))
+          "health surfaces the bound origin (default `:causa-mcp`)"))))
+
+(deftest health-installs-no-listeners
+  (testing "unlike pair2's `health`, the Causa runtime's `health` does
+            NOT register trace or epoch callbacks — Causa-the-panel
+            owns those (`preload.cljs`'s register-trace-collector! /
+            register-epoch-collector!). Two `health` calls in a row
+            must not leave residue.
+
+            We exercise the side-effect-free property by asserting the
+            framework's `register-trace-cb!` was not called with any
+            runtime-owned id — the runtime has no such id reservation."
+    (runtime/health)
+    (runtime/health)
+    ;; No listener-side state to inspect — the contract is that the
+    ;; runtime does not call register-trace-cb! / register-epoch-cb!
+    ;; from `health`. The lint here is the source-side absence; the
+    ;; runtime test suite asserts behaviour, and the absence of a
+    ;; per-test-listener-id reservation is the absence of an effect.
+    (is true "health is side-effect-free — repeated calls compose")))
+
+;; ---------------------------------------------------------------------------
+;; (6) Dispatch tagging — events stamped with `:origin :causa-mcp`.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-tags-event-with-current-origin
+  (testing "`dispatch!` attaches `{:tags {:origin <current-origin>}}` as
+            event metadata so the framework's trace bus carries the
+            Causa-MCP tag (Lock #4 / I1)"
+    (let [captured (atom nil)]
+      (rf/reg-event-db :test/capture-meta
+        (fn [db [_ marker]]
+          (reset! captured marker)
+          (assoc db :marker marker)))
+      ;; sync? so the dispatch completes before we check.
+      (let [result (runtime/dispatch! [:test/capture-meta :ok] {:sync? true})]
+        (is (true? (:ok? result)))
+        (is (= :causa-mcp (:origin result))
+            "result echoes the bound origin"))
+      (is (= :ok @captured)
+          "handler ran"))))
+
+(deftest dispatch-rebinds-origin-via-eval-cljs-extent
+  (testing "a `binding` around `dispatch!` re-tags the dispatch — this
+            is the synchronous-extent contract `eval-cljs` rides
+            (Lock #4 / I6)"
+    (rf/reg-event-db :test/origin-marker
+      (fn [db _] db))
+    (binding [runtime/*current-origin* :test-rebind]
+      (let [result (runtime/dispatch! [:test/origin-marker] {:sync? true})]
+        (is (= :test-rebind (:origin result))
+            "dispatch carries the re-bound origin, not the default")))))
+
+(deftest dispatch-refuses-non-vector
+  (testing "non-vector `event` shapes refuse structurally — the same
+            kind of guard pair2-mcp's `dispatch.cljs` enforces at the
+            wire layer (rf2-vflrg precedent)"
+    (let [result (runtime/dispatch! :not-a-vector)]
+      (is (false? (:ok? result)))
+      (is (= :not-an-event-vector (:reason result))))))
+
+;; ---------------------------------------------------------------------------
+;; (7) Streaming surface — subscribe!/unsubscribe!/list-subscriptions.
+;; ---------------------------------------------------------------------------
+
+(deftest subscribe-records-metadata
+  (testing "`subscribe!` records the subscription's metadata so
+            `list-subscriptions` can enumerate it"
+    (let [r1 (runtime/subscribe! {:topic :trace :filter {:origin :causa-mcp}})]
+      (is (true? (:ok? r1)))
+      (is (= :trace (:topic r1)))
+      (is (string? (:sub-id r1)))
+
+      (let [r2 (runtime/list-subscriptions)]
+        (is (= 1 (:count r2)))
+        (is (= [(:sub-id r1)] (mapv :id (:subs r2))))))))
+
+(deftest subscribe-rejects-unknown-topic
+  (testing "topics outside `{:trace :epoch :fx :error}` refuse"
+    (let [r (runtime/subscribe! {:topic :bogus})]
+      (is (false? (:ok? r)))
+      (is (= :unknown-topic (:reason r))))))
+
+(deftest unsubscribe-is-idempotent
+  (testing "calling `unsubscribe!` on an unknown id returns
+            `:existed? false` rather than throwing — the catalogue
+            entry pins this idempotency"
+    (let [r (runtime/unsubscribe! {:sub-id "no-such-sub"})]
+      (is (true? (:ok? r)))
+      (is (false? (:existed? r))))))
+
+(deftest list-subscriptions-filters-by-topic
+  (testing "`:topic` narrows the enumeration"
+    (runtime/subscribe! {:topic :trace})
+    (runtime/subscribe! {:topic :epoch})
+    (let [r (runtime/list-subscriptions {:topic :trace})]
+      (is (= 1 (:count r)))
+      (is (every? #(= :trace (:topic %)) (:subs r))))))
+
+;; ---------------------------------------------------------------------------
+;; (8) tail-build-probe — monotonic counter, stable session-id.
+;; ---------------------------------------------------------------------------
+
+(deftest tail-build-probe-is-monotonic
+  (testing "`tail-build-probe` increments on every call so the MCP
+            server's poll loop can detect a hot-reload via value-change"
+    (let [r1 (runtime/tail-build-probe)
+          r2 (runtime/tail-build-probe)]
+      (is (true? (:ok? r1)))
+      (is (= runtime/session-id (:session-id r1))
+          "session-id carried for the server's cross-call sanity check")
+      (is (> (:probe r2) (:probe r1))
+          "probe value advances monotonically"))))
+
+;; ---------------------------------------------------------------------------
+;; (9) get-epoch-history degrades cleanly without records.
+;; ---------------------------------------------------------------------------
+
+(deftest get-epoch-history-empty-when-no-epochs
+  (testing "with no epochs recorded against the resolved frame, the
+            accessor returns `{:ok? true :epochs []}` rather than nil
+            — the MCP tool layer rides the `:ok?` slot"
+    (let [result (runtime/get-epoch-history)]
+      (is (true? (:ok? result)))
+      (is (vector? (:epochs result)))
+      (is (= 0 (:count result))))))


### PR DESCRIPTION
## Summary

Land `day8.re-frame2-causa.runtime` — the browser-side injected-runtime namespace backing Causa-MCP's eighteen tools. Rides Causa-the-panel's `:devtools/preloads` per [`tools/causa-mcp/spec/000-Vision.md` §"Two namespaces, two sides"](../tree/main/tools/causa-mcp/spec/000-Vision.md#two-namespaces-two-sides) — consumer apps that already load Causa-the-panel pick up the runtime automatically.

Foundation tranche 4 of rf2-8xzoe (F-1 + F-2 + F-3 already merged). Parallel-safe with sibling F-tranches and B-1 (disjoint surface: B-1 lands in `tools/causa-mcp/src/.../privacy.cljs`).

## What lands

- **`tools/causa/src/day8/re_frame2_causa/runtime.cljs`** — 18 tool-shaped accessors (Inspection 9 / Mutation 3 / Streaming 3 / Escape 1 / Meta 2), plus the `session-id` UUID + `js/globalThis.__day8_re_frame2_causa_runtime` sentinel, plus `*current-origin*` `^:dynamic` var defaulting to `:causa-mcp` (re-bound by `eval-cljs` per Lock #4 / MUST I6). Single privacy egress site via `re-frame.core/elide-wire-value` with both `:include-sensitive?` and `:include-large?` defaulting false (MUST-inventory #15/#17/#19).
- **`tools/causa/src/day8/re_frame2_causa/preload.cljs`** — add the `[day8.re-frame2-causa.runtime]` require so the sentinel install runs at preload load.
- **`tools/causa/test/day8/re_frame2_causa/runtime_cljs_test.cljs`** — 14 tests / 17 assertions covering accessor lint, sentinel install, origin-binding contract, frame resolution, `health` side-effect-free property, dispatch tagging, streaming registry, monotonic tail-build probe.

## Divergence from pair2

- `dispatch!` / `restore-epoch!` / `reset-frame-db!` project the framework's plain-boolean return onto a `{:ok? :reason :rf.epoch/restore-failed}` wire-shape that points to the trace bus for the six-row vocabulary — double-projecting the six-row keywords here would let them drift from the bus emissions.
- `subscribe!` records only metadata; the per-tick queue / overflow bookkeeping lives MCP-server-side per `004-Wire-Pipeline.md` §Streaming over batch (pair2 owns the queue runtime-side because pair has no separate server pump; causa-mcp does).
- `health` installs no listeners — Causa-the-panel's preload owns the trace + epoch listener slots (pair2's runtime double-installs because pair has no separate panel).
- `get-machine-state` reads `rf/machine-meta` (the registered spec); per-frame runtime FSM state lands when the Machine Inspector surface stabilises.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 2260 tests / 6418 assertions / 0 failures
- [x] `npm test` from `tools/causa-mcp/` — 17 tests / 56 assertions / 0 failures (no regressions on the server-side F-tranche tests)
- [x] `npx shadow-cljs compile server` from `tools/causa-mcp/` — production build clean, 0 warnings