### PR TITLE
feat(causa-mcp): W-6 size-elision walker (rf2-8xzoe.10, B-1 sibling)

### DIFF
--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs
@@ -1,0 +1,309 @@
+(ns day8.re-frame2-causa-mcp.elision
+  "Spec/004 §6 size-elision wire-marker integration at the Causa-MCP
+  boundary (W-6 of rf2-8xzoe; tranche bead rf2-8xzoe.10).
+
+  ## What this gates
+
+  Spec/004 §6 mandates that every tool emitting a tree-typed payload
+  routes the value through the framework's size-elision walker
+  (`re-frame.core/elide-wire-value`) before it crosses the MCP stdio
+  trust boundary. The walker substitutes over-threshold leaves with a
+  canonical `{:rf.size/large-elided {...}}` marker carrying a re-fetch
+  handle (`[:rf.elision/at <path>]`); the small siblings ride the wire
+  verbatim. A single 100KB base64 PDF on `[:user :uploaded-pdf]` then
+  costs marker-bytes, not payload-bytes.
+
+  ## Where the gate fires for causa-mcp
+
+  The tree-typed surface — direct-read tools and per-record epoch
+  slices — is the canonical set: `get-app-db`, `get-app-db-diff`,
+  `get-machine-state`, `get-epoch-history` (per-record `:db-before` /
+  `:db-after`), `subscribe` payloads carrying rich coeffect / effect
+  slots. Each tool inlines `elision-opts-edn` into the CLJS eval form
+  it ships over nREPL so the walker actually runs in the consumer
+  app's runtime (the `[:rf/elision]` registry lives in app-db; the
+  Node process can't reach it directly). The marker-count then rides
+  back on the same round-trip and `apply-to-result` stamps the
+  `:elided-large` envelope counter at the MCP boundary.
+
+  ## Sibling to `privacy.cljs` (B-1 of the same epic)
+
+  B-1 (rf2-8xzoe.11) lands the spec/009 default-suppress filter at
+  the same MCP egress codepath. W-6 here is the size-elision
+  counterpart. The two boundary wrappers share an envelope shape
+  (`apply-to-result` is the per-call site, indicator counters are
+  unqualified envelope slots — `:dropped-sensitive` and
+  `:elided-large` — and ride together so an agent reads both axes on
+  the same response). The composition cascade is normative
+  (spec/004 §6 — sensitive wins; `(and sensitive? large?) → ::drop`,
+  no marker emitted); the walker itself enforces it server-side, so
+  the MCP-boundary wrapper just counts whatever markers came back.
+
+  ## Cross-server arg vocabulary
+
+  The opt-in escape hatch is `:include-large?` — fixed cross-server
+  (pair2-mcp + story-mcp + causa-mcp), parallel to
+  `:include-sensitive?`. An agent learns the slot name once and
+  recognises it everywhere. `parse-include-large` centralises the
+  boolean parse so a string `\"true\"` / `\"yes\"` / `\"1\"` from
+  the MCP wire collapses to the same boolean the helper here
+  expects.
+
+  ## Why this ns delegates to `re-frame.mcp-base`
+
+  The base nss are the shared spec/004 + spec/009 primitives across
+  the MCP triplet:
+
+  - `re-frame.mcp-base.elision/count-elided-markers` — the canonical
+    walker that counts `{:rf.size/large-elided ...}` markers in a
+    wire-bound payload (rf2-9fz64; per Conventions §Cross-MCP
+    indicator-field vocabulary, MUST-level per rf2-2499j).
+  - `re-frame.mcp-base.vocab` — the constants catalogue: marker key
+    (`:rf.size/large-elided`), walker opts (`:rf.size/include-large?`,
+    `:rf.size/include-sensitive?`), envelope-slot key
+    (`:elided-large`).
+  - `re-frame.mcp-base.args/parse-boolean` — the cross-MCP
+    accept-shape contract (rf2-vw4sq).
+
+  Same call shapes the pair2-mcp + story-mcp sibling boundary
+  wrappers use; behaviour stays byte-identical across the triplet
+  per the cross-MCP conformance gate (rf2-zvv65).
+
+  ## MUSTs honoured
+
+  - MUST 15 — every tree-typed tool declares the `:include-large?`
+    slot and the `:elided-large` indicator field; the default
+    elision-policy is on. `apply-to-result` is the wrapper those
+    tools call when they land.
+  - MUST 17 — `re-frame.core/elide-wire-value` is the single
+    normative emission site; per-tool reimplementation prohibited.
+    This ns NEVER emits the marker itself — it inlines the walker
+    call into the eval form (`elision-opts-edn`) and downstream
+    only counts markers the walker produced.
+  - MUST 18 — sensitive-wins composition; the cascade lives in the
+    framework walker, this ns just ships the opts and counts the
+    resulting markers (no separate marker-emission path here).
+  - MUST 19, `:include-large?` half — the opt-in slot name is fixed
+    cross-MCP (parallel to `:include-sensitive?`)."
+  (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.elision :as base-elision]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Marker count — direct re-export of the base walker.
+;;
+;; The canonical tree-walk lives in `re-frame.mcp-base.elision` so the
+;; MCP triplet shares one implementation. Causa-mcp re-exports it
+;; under the local ns so per-tool dispatchers `:require` a single ns
+;; for elision concerns (matches the privacy.cljs `sensitive-event?` /
+;; `strip-sensitive` re-export pattern).
+;; ---------------------------------------------------------------------------
+
+(def count-elided-markers
+  "Walk `v` and count every `{:rf.size/large-elided ...}` marker it
+  contains. The walker is shallow at the marker boundary — once a
+  marker is found, its body is NOT recursed into (marker bodies are
+  scalar metadata, not tree-shaped). Returns an integer ≥ 0.
+
+  Direct re-export of `re-frame.mcp-base.elision/count-elided-markers`
+  — the cross-MCP single implementation per the marker-shape
+  contract (rf2-9fz64)."
+  base-elision/count-elided-markers)
+
+;; ---------------------------------------------------------------------------
+;; Argument parsing — `:include-large?` is the cross-MCP opt-in.
+;;
+;; Parallel to privacy.cljs's `parse-include-sensitive`. The two args
+;; ride together on every tree-typed tool's surface; the parsers share
+;; the `base-args/parse-boolean` core so accept-shapes (boolean,
+;; lower-case string, keyword) stay byte-identical across the slots.
+;; ---------------------------------------------------------------------------
+
+(def ^:const include-large-default
+  "Default posture for `:include-large?` is `false` — spec/004 §6
+  defaults markers ON so over-threshold leaves elide. The constant is
+  reified so the test corpus + downstream tool dispatchers reference
+  the same identity rather than re-typing the literal. Parallel to
+  `privacy/include-sensitive-default`."
+  false)
+
+(defn parse-include-large
+  "Resolve the cross-server `:include-large?` MCP arg from a raw
+  arguments object. Accepts:
+
+    - a JS args object (the MCP SDK shape) — looked up via
+      `(j/get args \"include-large?\")`.
+    - a CLJS map — looked up via `(get args :include-large?)` or
+      the stringified key (whichever the upstream dispatcher hands us).
+    - `nil` / `js/undefined`.
+
+  Recognised-value parsing (boolean passthrough, string `\"true\"` /
+  `\"false\"` / `\"yes\"` / `\"no\"` / `\"1\"` / `\"0\"`, keyword
+  `:true` / `:false`) delegates to
+  `re-frame.mcp-base.args/parse-boolean` — the cross-MCP accept-shape
+  contract (rf2-vw4sq).
+
+  Returns a boolean. Unrecognised / absent inputs collapse to the
+  spec/004 §6 default-on posture (`false`)."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :include-large?)
+                  (get args "include-large?"))
+
+              :else
+              ;; JS object from the MCP wire.
+              (j/get args "include-large?"))]
+    (base-args/parse-boolean raw include-large-default)))
+
+;; ---------------------------------------------------------------------------
+;; Eval-form composition — render walker opts as EDN for inlining.
+;;
+;; The walker runs in the consumer app's runtime (the `[:rf/elision]`
+;; registry lives in app-db). The MCP server inlines the opts map
+;; into the eval form it ships over nREPL. Two knobs:
+;;
+;;   - `:rf.size/include-large?`     — `false` ⇒ emit markers (default)
+;;   - `:rf.size/include-sensitive?` — `false` ⇒ redact sensitive
+;;
+;; The polarity is inverted from the MCP-arg booleans (the MCP arg is
+;; `:include-large? true` to PASS THROUGH; the walker opt is
+;; `:rf.size/include-large? true` for the same posture). The helper
+;; encodes the inversion so call-sites pass the agent-facing boolean
+;; without re-doing the flip.
+;;
+;; Cross-server identical to pair2-mcp's `tools/elision/elision-opts-edn`
+;; (rf2-urjnc). Same key names, same polarity, same EDN shape.
+;; ---------------------------------------------------------------------------
+
+(defn elision-opts-edn
+  "Render the walker's opts map as an EDN string for inlining into a
+  CLJS eval form sent over nREPL.
+
+  Arguments:
+
+  - `include-large?`      — the MCP-arg boolean. `false` ⇒ walker
+                            emits markers (the default; spec/004 §6
+                            posture). `true` ⇒ walker passes large
+                            values through unmodified.
+  - `include-sensitive?`  — the MCP-arg boolean. `false` ⇒ walker
+                            substitutes the `:rf/redacted` sentinel at
+                            declared-sensitive leaves (the default;
+                            spec/009 §Privacy posture). `true` ⇒
+                            walker passes sensitive values through.
+
+  Both args default off-box-safe per the Tool-Pair §Direct-read
+  privacy posture contract (`spec/004-Wire-Pipeline.md §Direct-read
+  privacy — normative MUST`).
+
+  Returns the EDN string of `{:rf.size/include-large? <bool>
+  :rf.size/include-sensitive? <bool>}` — ready to splice into the
+  walker call inside a server-side eval form. The keys are
+  cross-MCP normative (per `re-frame.mcp-base.vocab`).
+
+  Single-arity form preserves the off-box-safe default for
+  `include-sensitive?` so legacy call-sites don't need to spell it
+  out. Both-args form is the canonical surface."
+  ([include-large?]
+   (elision-opts-edn include-large? false))
+  ([include-large? include-sensitive?]
+   (pr-str {base-vocab/include-large-opt     (boolean include-large?)
+            base-vocab/include-sensitive-opt (boolean include-sensitive?)})))
+
+;; ---------------------------------------------------------------------------
+;; Result-envelope shape — `:elided-large` counter (cross-MCP).
+;;
+;; Parallel to `privacy/stamp-dropped-sensitive`. The slot is
+;; unqualified per Conventions §Cross-MCP indicator-field vocabulary;
+;; the counter is omitted when zero so the zero-elision common path
+;; stays minimal on the wire.
+;; ---------------------------------------------------------------------------
+
+(defn stamp-elided-large
+  "Splice the `:elided-large` counter onto `envelope` iff `elided` is
+  positive. Returns the envelope unchanged when nothing was elided —
+  the zero-elision common path carries no counter so the agent
+  surface stays minimal (a missing slot reads as zero, same
+  convention as `privacy/stamp-dropped-sensitive` and pair2-mcp's
+  `wire/stamp-indicator-fields`).
+
+  `envelope` is the per-call result map a tool dispatcher is about
+  to serialise to the MCP wire. `elided` is the integer return of
+  `count-elided-markers` (or the accumulated total across a
+  multi-slice call)."
+  [envelope elided]
+  (cond-> envelope
+    (and (number? elided) (pos? elided))
+    (assoc base-vocab/elided-large-key elided)))
+
+;; ---------------------------------------------------------------------------
+;; Per-tool boundary wrapper.
+;;
+;; Tree-typed tools call this once at the end of their body, with the
+;; already-walked value (the eval form ran the walker server-side and
+;; returned the post-elision payload) + the in-progress envelope. The
+;; helper counts markers, stamps the `:elided-large` counter when
+;; non-zero, and writes the value back into the envelope at
+;; `value-key`. Same cross-tool one-liner shape `privacy/apply-to-result`
+;; uses, so the boundary site reads uniformly across tools — `value-key`
+;; varies (`:db` for `get-app-db`, `:diff` for `get-app-db-diff`,
+;; `:state` for `get-machine-state`, etc.); the call shape doesn't.
+;;
+;; The walker already ran server-side, so the value carries markers in
+;; place. We do NOT re-walk to substitute — that would violate MUST 17
+;; (single normative emission site). We only COUNT markers for the
+;; envelope indicator.
+;;
+;; ## Optional `:server-elided` opt
+;;
+;; Sibling to pair2-mcp's rf2-e35a5 optimisation: when the eval form
+;; pre-counts markers server-side and ships the integer back on the
+;; same nREPL round-trip, the dispatcher passes `:server-elided <n>`
+;; and skips the local walk. Cheaper for large payloads where the
+;; walk dominates the wrapper cost. Zero is a valid server count
+;; (not a sentinel — `(some? n)` semantics).
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/004 §6 size-elision boundary stamp to `value` and
+  write the result back into `envelope` under `value-key`. Returns
+  the updated envelope with the `:elided-large` counter spliced in
+  when non-zero. The single call-site every tree-typed tool uses
+  before returning — MUST 15 of the causa-mcp inventory.
+
+  Arguments:
+    - `envelope`   — the per-call result map (will be updated).
+    - `value-key`  — the slot in `envelope` the post-walk value goes
+                     into (e.g. `:db` for `get-app-db`, `:diff` for
+                     `get-app-db-diff`, `:state` for
+                     `get-machine-state`, `:events` for `subscribe`
+                     drain batches).
+    - `value`      — the already-walked payload (the eval form ran
+                     `re-frame.core/elide-wire-value` server-side;
+                     the marker substitution is already in place).
+    - `opts`       — optional map. Recognised keys:
+                       `:server-elided` — integer; when supplied,
+                         used verbatim instead of re-walking
+                         `value` to count markers (rf2-e35a5 sibling
+                         optimisation). Zero is honoured, not
+                         treated as a fall-back trigger.
+
+  Returns the envelope with `value-key` set to `value` and
+  `:elided-large` stamped when at least one marker was present.
+
+  The zero-arity-opts shape `(apply-to-result envelope value-key
+  value)` falls back to walking `value` locally with
+  `count-elided-markers`."
+  ([envelope value-key value]
+   (apply-to-result envelope value-key value nil))
+  ([envelope value-key value {:keys [server-elided]}]
+   (let [elided (if (some? server-elided)
+                  server-elided
+                  (count-elided-markers value))]
+     (-> envelope
+         (assoc value-key value)
+         (stamp-elided-large elided)))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/elision_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/elision_test.cljs
@@ -1,0 +1,493 @@
+(ns day8.re-frame2-causa-mcp.elision-test
+  "Unit tests for the W-6 size-elision walker integration at the
+  Causa-MCP boundary (rf2-8xzoe.10). Pins:
+
+    - MUST 15 — every tree-typed tool declares the `:include-large?`
+      slot and the `:elided-large` indicator field. `apply-to-result`
+      is the boundary wrapper those tools call; the slot + counter
+      are pinned here.
+    - MUST 17 — `re-frame.core/elide-wire-value` is the single
+      normative emission site. This ns NEVER emits the marker — it
+      inlines the walker call into the eval form (via
+      `elision-opts-edn`) and downstream only counts markers the
+      walker produced. The wrapper's no-marker-emission posture is
+      pinned by the count-then-stamp-only contract.
+    - MUST 18 — sensitive-wins composition. The cascade itself lives
+      in the framework walker (we ship opts, not policy); we pin the
+      knob shapes both arms receive.
+    - MUST 19, `:include-large?` half — cross-MCP opt-in slot name
+      (parallel to `:include-sensitive?`).
+    - Result-envelope counter shape — `:elided-large` stamped iff
+      at least one marker is present; the zero-elision common path
+      carries no counter (cross-MCP indicator-field convention,
+      parallel to `:dropped-sensitive`).
+    - Interaction with B-1 (privacy filter) — `apply-to-result`'s
+      envelope is additive, so the two boundary wrappers compose;
+      `:dropped-sensitive` + `:elided-large` ride together on the
+      same envelope when both axes fired.
+
+  These tests are the load-bearing pin for the downstream
+  tree-typed tool beads — every dispatcher that emits a tree-typed
+  payload calls `elision/apply-to-result` once at the boundary; the
+  contract here is the one those tools inherit."
+  (:require [cljs.reader]
+            [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]))
+
+;; A canonical `:rf.size/large-elided` marker, as the framework's
+;; `elide-wire-value` walker would emit. Reused across the corpus so a
+;; vocabulary drift surfaces once.
+(def ^:private marker
+  {:rf.size/large-elided
+   {:path   [:user :uploaded-pdf]
+    :bytes  102400
+    :type   :string
+    :reason :declared
+    :handle [:rf.elision/at [:user :uploaded-pdf]]}})
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-6 lands the elision-boundary helpers downstream
+            tree-typed tool dispatchers will require"
+    (is (fn? elision/count-elided-markers))
+    (is (fn? elision/parse-include-large))
+    (is (fn? elision/elision-opts-edn))
+    (is (fn? elision/stamp-elided-large))
+    (is (fn? elision/apply-to-result))
+    (is (false? elision/include-large-default)
+        "spec/004 §6 default posture: include-large? defaults false ⇒ markers emit")))
+
+;; ---------------------------------------------------------------------------
+;; count-elided-markers — re-export of the cross-MCP base walker.
+;; ---------------------------------------------------------------------------
+
+(deftest count-elided-markers-re-export-walks-payload
+  ;; Cross-MCP re-export of `re-frame.mcp-base.elision/count-elided-markers`
+  ;; (rf2-9fz64). The full walker corpus lives in the base ns; here
+  ;; we pin that the re-export wires through and surfaces the same
+  ;; behaviour at every depth and shape.
+  (is (= 0 (elision/count-elided-markers nil)))
+  (is (= 0 (elision/count-elided-markers {})))
+  (is (= 0 (elision/count-elided-markers [])))
+  (is (= 0 (elision/count-elided-markers "string")))
+  (is (= 0 (elision/count-elided-markers 42)))
+  (is (= 0 (elision/count-elided-markers {:ok? true :payload {:a 1 :b [2 3]}})))
+  (is (= 1 (elision/count-elided-markers marker)))
+  (is (= 1 (elision/count-elided-markers {:value marker})))
+  (is (= 1 (elision/count-elided-markers [marker])))
+  (is (= 2 (elision/count-elided-markers {:a marker :b marker})))
+  (is (= 3 (elision/count-elided-markers
+            {:slice1 marker :slice2 {:nested marker} :slice3 [{:deep marker}]}))))
+
+(deftest count-elided-markers-marker-body-opaque
+  ;; The walker is shallow at the marker boundary — once a marker is
+  ;; found, its body is NOT recursed into. Pathological marker-shape
+  ;; lodged inside the body still counts the OUTER marker once.
+  (let [pathological {:rf.size/large-elided
+                      {:path   [:a :b]
+                       :bytes  100
+                       :type   :string
+                       :reason :declared
+                       :handle [:rf.elision/at [:a :b]]
+                       :extra  {:rf.size/large-elided {:bytes 1}}}}]
+    (is (= 1 (elision/count-elided-markers pathological)))))
+
+;; ---------------------------------------------------------------------------
+;; parse-include-large — cross-MCP fixed arg name (MUST 19 half).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-include-large-default-false-when-absent
+  ;; spec/004 §6 MUST: the default is markers-on. Every shape of "no
+  ;; input" collapses to the default-false posture.
+  (is (false? (elision/parse-include-large nil)))
+  (is (false? (elision/parse-include-large js/undefined)))
+  (is (false? (elision/parse-include-large {})))
+  (is (false? (elision/parse-include-large #js {})))
+  (is (false? (elision/parse-include-large #js {:other "value"}))))
+
+(deftest parse-include-large-true-from-js-args-object
+  ;; The MCP SDK hands the dispatcher a JS args object; the helper
+  ;; reads the cross-server slot `include-large?` from it. Accept-
+  ;; shapes mirror `parse-include-sensitive` so an agent sees the same
+  ;; permissive parsing on both args.
+  (is (true? (elision/parse-include-large #js {"include-large?" true})))
+  (is (true? (elision/parse-include-large #js {"include-large?" "true"})))
+  (is (true? (elision/parse-include-large #js {"include-large?" "yes"})))
+  (is (true? (elision/parse-include-large #js {"include-large?" "1"}))))
+
+(deftest parse-include-large-false-from-js-args-object
+  (is (false? (elision/parse-include-large #js {"include-large?" false})))
+  (is (false? (elision/parse-include-large #js {"include-large?" "false"})))
+  (is (false? (elision/parse-include-large #js {"include-large?" "no"})))
+  (is (false? (elision/parse-include-large #js {"include-large?" "0"}))))
+
+(deftest parse-include-large-from-cljs-map
+  ;; Some downstream paths may hand the helper a CLJS map (already
+  ;; coerced from the MCP wire). Both keyword and stringified keys
+  ;; resolve so the helper is robust across call shapes.
+  (is (true?  (elision/parse-include-large {:include-large? true})))
+  (is (true?  (elision/parse-include-large {"include-large?" true})))
+  (is (false? (elision/parse-include-large {:include-large? false}))))
+
+(deftest parse-include-large-unrecognised-value-defaults-suppress
+  ;; Unrecognised raw values (e.g. a number, a random keyword, an
+  ;; arbitrary object) collapse to the default-on posture per the
+  ;; cross-MCP parse-boolean contract.
+  (is (false? (elision/parse-include-large #js {"include-large?" "maybe"})))
+  (is (false? (elision/parse-include-large #js {"include-large?" 42})))
+  (is (false? (elision/parse-include-large {:include-large? :perhaps}))))
+
+;; ---------------------------------------------------------------------------
+;; elision-opts-edn — render walker opts as EDN for nREPL inline.
+;;
+;; The polarity is inverted from pair2-mcp's `elision-opts-edn` —
+;; pair2-mcp accepts `enabled?` (the high-level "is elision on?"
+;; boolean) and INVERTS it before rendering, because pair2-mcp's MCP
+;; arg is `:elision` (truthy = walk). Causa-mcp accepts the
+;; cross-server `:include-large?` boolean DIRECTLY (truthy = pass
+;; through) and renders it WITHOUT inversion — same key polarity as
+;; the walker's `:rf.size/include-large?` opt itself. This is a
+;; deliberate divergence: the cross-MCP arg vocabulary (per
+;; spec/004 §6) is `:include-large?`, not `:elision`, so causa-mcp's
+;; arg names match the walker opt names directly. One fewer flip on
+;; the call-site.
+;; ---------------------------------------------------------------------------
+
+(deftest elision-opts-edn-include-large-false-emits-markers
+  ;; The default off-box-safe posture: include-large? false ⇒ walker
+  ;; opt `:rf.size/include-large? false` ⇒ markers emit. Pins the
+  ;; pass-through-polarity contract.
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false))]
+    (is (false? (:rf.size/include-large? parsed))
+        "include-large? false ⇒ walker emits markers")))
+
+(deftest elision-opts-edn-include-large-true-bypasses-walker
+  ;; Opt-in: include-large? true ⇒ walker opt
+  ;; `:rf.size/include-large? true` ⇒ large values pass through. The
+  ;; documented escape hatch (per spec/004 §6 "Per-call opt-out").
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn true))]
+    (is (true? (:rf.size/include-large? parsed))
+        "include-large? true ⇒ walker passes large values through")))
+
+(deftest elision-opts-edn-round-trips
+  ;; The EDN we ship over nREPL must be readable on the other side.
+  ;; pr-str + read-string round-trips for the structure we emit.
+  (doseq [include-large? [true false]]
+    (let [edn    (elision/elision-opts-edn include-large?)
+          parsed (cljs.reader/read-string edn)]
+      (is (map? parsed))
+      (is (contains? parsed :rf.size/include-large?)))))
+
+(deftest elision-opts-edn-include-sensitive-defaults-false
+  ;; Single-arity legacy form preserves the off-box-safe default for
+  ;; the sibling sensitive knob. spec/Tool-Pair §Direct-read privacy
+  ;; posture: sensitive slots redact unless the caller opts in
+  ;; explicitly. (The arg parser is `privacy/parse-include-sensitive`;
+  ;; this knob is the walker-opt half of the same flag.)
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false))]
+    (is (false? (:rf.size/include-sensitive? parsed))
+        "single-arity ⇒ include-sensitive? false (default per Tool-Pair §Direct-read)")))
+
+(deftest elision-opts-edn-include-sensitive-true-opts-in
+  ;; The documented opt-in flow: `:include-sensitive? true` flows into
+  ;; the walker opt of the same shape. Sensitive slots then pass
+  ;; through unmodified.
+  (let [parsed (cljs.reader/read-string (elision/elision-opts-edn false true))]
+    (is (true? (:rf.size/include-sensitive? parsed))
+        "two-arity true ⇒ walker passes sensitive values through")))
+
+(deftest elision-opts-edn-two-knobs-orthogonal
+  ;; The two knobs compose orthogonally — include-large? false +
+  ;; include-sensitive? true is a valid combo (the agent wants raw
+  ;; sensitive values but still wants large leaves elided). Every
+  ;; combination round-trips with the polarity preserved.
+  (doseq [il? [true false]
+          is? [true false]]
+    (let [parsed (cljs.reader/read-string (elision/elision-opts-edn il? is?))]
+      (is (= il? (:rf.size/include-large? parsed)))
+      (is (= is? (:rf.size/include-sensitive? parsed))))))
+
+(deftest elision-opts-edn-cross-mcp-vocabulary
+  ;; Pin the cross-MCP walker-opt vocabulary verbatim. A rename in the
+  ;; framework surface needs a co-ordinated update; the test pins the
+  ;; literals so drift surfaces here.
+  (let [edn (elision/elision-opts-edn false false)]
+    ;; Both keys appear in the EDN text (the test pins the LITERAL
+    ;; keyword names, not just the parsed form, so a vocabulary
+    ;; rename surfaces at the source level).
+    (is (not= -1 (.indexOf edn ":rf.size/include-large?")))
+    (is (not= -1 (.indexOf edn ":rf.size/include-sensitive?")))))
+
+;; ---------------------------------------------------------------------------
+;; stamp-elided-large — counter shape on the envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest stamp-elided-large-omits-slot-when-zero
+  ;; Zero-elision common path carries no counter. A missing slot
+  ;; reads as zero per the cross-MCP indicator-field convention; this
+  ;; keeps the agent surface minimal on the hot path.
+  (is (= {:db {:k :v}}
+         (elision/stamp-elided-large {:db {:k :v}} 0)))
+  (is (not (contains? (elision/stamp-elided-large {:db {:k :v}} 0)
+                      :elided-large))))
+
+(deftest stamp-elided-large-adds-slot-when-positive
+  (is (= {:db {} :elided-large 2}
+         (elision/stamp-elided-large {:db {}} 2)))
+  (is (= {:db {:k :v} :elided-large 7}
+         (elision/stamp-elided-large {:db {:k :v}} 7))))
+
+(deftest stamp-elided-large-non-positive-no-stamp
+  ;; Defensive: negative or non-number inputs (shouldn't happen on the
+  ;; happy path; defensive against future refactors) leave the
+  ;; envelope untouched rather than stamping a nonsense value.
+  (is (not (contains? (elision/stamp-elided-large {:db {}} -1)
+                      :elided-large)))
+  (is (not (contains? (elision/stamp-elided-large {:db {}} nil)
+                      :elided-large))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — the per-tool boundary wrapper (the MUST 15 site).
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-counts-markers-and-stamps-counter
+  ;; MUST 15: the boundary wrapper counts markers in the already-
+  ;; walked payload and stamps the `:elided-large` envelope counter.
+  ;; The wrapper does NOT emit markers (MUST 17 — single normative
+  ;; emission site is the walker, which already ran server-side).
+  (let [payload {:user {:uploaded-pdf marker}
+                 :cart {:items [{:sku "abc"} {:sku "def"}]}}
+        out     (elision/apply-to-result {} :db payload)]
+    (is (= payload (:db out))
+        "the already-walked value rides verbatim under :db")
+    (is (= 1 (:elided-large out))
+        ":elided-large counter stamped when ≥1 marker present")))
+
+(deftest apply-to-result-no-markers-no-counter
+  ;; Counter is absent when zero markers present — the cross-MCP
+  ;; indicator-field convention (zero-elision common path is minimal).
+  (let [payload {:cart {:items [{:sku "abc"} {:sku "def"}]}}
+        out     (elision/apply-to-result {} :db payload)]
+    (is (= payload (:db out)))
+    (is (not (contains? out :elided-large))
+        "clean payload MUST NOT stamp the counter slot")))
+
+(deftest apply-to-result-multiple-markers-counted
+  ;; Markers at mixed depths all count. The walker's marker-body-
+  ;; opaque rule still holds (the OUTER marker counts once, nested
+  ;; marker-shape inside the body does not).
+  (let [payload {:slice1 marker
+                 :slice2 {:nested marker}
+                 :slice3 [{:deep marker}]}
+        out     (elision/apply-to-result {} :db payload)]
+    (is (= 3 (:elided-large out)))))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; The wrapper is additive — pre-existing slots on the envelope
+  ;; (cursor, next-cursor, mode, etc.) pass through. Same shape
+  ;; `privacy/apply-to-result` provides; downstream tools compose the
+  ;; two wrappers freely.
+  (let [out (elision/apply-to-result
+             {:next-cursor "abc" :remaining 42 :mode :summary}
+             :db {:user {:uploaded-pdf marker}})]
+    (is (= 1 (:elided-large out)))
+    (is (= "abc"    (:next-cursor out)))
+    (is (= 42       (:remaining out)))
+    (is (= :summary (:mode out)))))
+
+(deftest apply-to-result-server-elided-used-verbatim
+  ;; Sibling to pair2-mcp's rf2-e35a5 optimisation: when the eval
+  ;; form pre-counts markers server-side and ships the integer back
+  ;; on the same nREPL round-trip, the wrapper uses it verbatim and
+  ;; skips the local walk.
+  (let [payload {:db {:k :v}}                      ; no actual markers
+        out     (elision/apply-to-result {} :db payload {:server-elided 7})]
+    (is (= 7 (:elided-large out))
+        "server-side count flows through verbatim, no local re-walk")))
+
+(deftest apply-to-result-server-elided-zero-honoured
+  ;; A `0` server-side count must be honoured (not treated as
+  ;; "absent ⇒ walk"). Pin the `some?` semantics — zero is a valid
+  ;; count, not a sentinel. Same shape pair2-mcp's wire-pipeline
+  ;; pins (rf2-e35a5).
+  (let [payload {:user {:uploaded-pdf marker}}     ; has a marker
+        out     (elision/apply-to-result {} :db payload {:server-elided 0})]
+    (is (not (contains? out :elided-large))
+        "zero is a valid server-side count, not a fall-back trigger")))
+
+(deftest apply-to-result-missing-server-elided-falls-back-to-walk
+  ;; Defensive: when opts omits :server-elided, the wrapper walks the
+  ;; payload locally. The counter is correct either way; the
+  ;; optimisation is the only thing dropped.
+  (let [payload {:user {:uploaded-pdf marker}}
+        out     (elision/apply-to-result {} :db payload {})]
+    (is (= 1 (:elided-large out))
+        "missing :server-elided ⇒ local walk picks up the marker")))
+
+(deftest apply-to-result-shape-for-tree-typed-tools
+  ;; Pins the canonical shape every tree-typed tool uses:
+  ;;   `:db`    for `get-app-db`
+  ;;   `:diff`  for `get-app-db-diff`
+  ;;   `:state` for `get-machine-state`
+  ;;   `:events` for `subscribe` drain batches
+  ;; The same wrapper services all — uniform boundary site.
+  (testing "get-app-db-shape (:db)"
+    (let [out (elision/apply-to-result
+               {} :db {:user {:uploaded-pdf marker}})]
+      (is (contains? out :db))
+      (is (= 1 (:elided-large out)))))
+  (testing "get-app-db-diff-shape (:diff)"
+    (let [out (elision/apply-to-result
+               {} :diff {:added {:k marker} :removed {}})]
+      (is (contains? out :diff))
+      (is (= 1 (:elided-large out)))))
+  (testing "get-machine-state-shape (:state)"
+    (let [out (elision/apply-to-result
+               {} :state {:current :running :context {:huge marker}} {})]
+      (is (contains? out :state))
+      (is (= 1 (:elided-large out)))))
+  (testing "subscribe-drain-batch-shape (:events)"
+    (let [out (elision/apply-to-result
+               {:tick 17} :events
+               [{:op :a :payload marker} {:op :b}])]
+      (is (= [{:op :a :payload marker} {:op :b}] (:events out)))
+      (is (= 1 (:elided-large out)))
+      (is (= 17 (:tick out))))))
+
+(deftest apply-to-result-three-arity-omits-opts
+  ;; The three-arity convenience shape skips the opts map for the
+  ;; common case (no server-side count). Identical behaviour to
+  ;; `(apply-to-result envelope key value nil)`.
+  (let [payload {:user {:uploaded-pdf marker}}
+        out-3   (elision/apply-to-result {} :db payload)
+        out-4   (elision/apply-to-result {} :db payload nil)]
+    (is (= out-3 out-4))
+    (is (= 1 (:elided-large out-3)))))
+
+;; ---------------------------------------------------------------------------
+;; Composition with B-1 (privacy filter).
+;;
+;; The two boundary wrappers ride the same egress codepath. They are
+;; designed to compose: both produce additive envelopes, both use
+;; unqualified envelope-slot keys (`:dropped-sensitive` /
+;; `:elided-large`) per Conventions §Cross-MCP indicator-field
+;; vocabulary, and the cross-MCP convention is to surface BOTH counts
+;; on the same response when both axes fired. This block pins the
+;; interaction explicitly so a future refactor that splits the two
+;; surfaces accidentally surfaces here.
+;; ---------------------------------------------------------------------------
+
+(deftest both-wrappers-compose-on-same-envelope
+  ;; The canonical case: a `subscribe` drain batch containing both
+  ;; sensitive events (B-1 drops them) and tree-typed coeffect /
+  ;; effect slots with large values (W-6 substitutes markers
+  ;; server-side; we count them here). Both indicator counters
+  ;; surface on the same envelope.
+  (let [events  [{:op :a :payload marker}
+                 {:op :b :sensitive? true}
+                 {:op :c :payload marker}
+                 {:op :d :sensitive? true}]
+        ;; First apply B-1 (privacy strip), then W-6 (elision count).
+        ;; Order is the spec/004 §6 cascade — sensitive WINS, then
+        ;; the size walker runs on the survivors. In practice the
+        ;; walker ran server-side and the privacy strip happens at
+        ;; MCP boundary; here we test the wrapper composition order.
+        envelope (-> {:tick 17}
+                     (privacy/apply-to-result :events events false))
+        kept     (:events envelope)
+        out      (elision/apply-to-result envelope :events kept)]
+    (is (= 2 (:dropped-sensitive out))
+        "B-1 surfaces dropped-sensitive count")
+    (is (= 2 (:elided-large out))
+        "W-6 surfaces elided-large count for the survivors")
+    (is (= 17 (:tick out))
+        "pre-existing envelope slots survive both wrappers")
+    (is (= [{:op :a :payload marker} {:op :c :payload marker}]
+           (:events out))
+        "survivors are the non-sensitive events with markers in place")))
+
+(deftest both-counters-omitted-when-clean-batch
+  ;; Both wrappers omit their counter on the zero-drop / zero-elision
+  ;; common path. A clean batch through both produces a minimal
+  ;; envelope — no indicator slots at all.
+  (let [events  [{:op :a} {:op :b}]
+        envelope (-> {}
+                     (privacy/apply-to-result :events events false))
+        kept     (:events envelope)
+        out      (elision/apply-to-result envelope :events kept)]
+    (is (= events (:events out)))
+    (is (not (contains? out :dropped-sensitive))
+        "clean batch: no dropped-sensitive counter")
+    (is (not (contains? out :elided-large))
+        "clean batch: no elided-large counter")))
+
+(deftest only-elision-axis-fired
+  ;; W-6 surfaces its counter; B-1 omits its counter. The two slots
+  ;; are independent — a tool that walks markers but has no sensitive
+  ;; events stamps only `:elided-large`.
+  (let [events  [{:op :a :payload marker} {:op :b}]
+        envelope (-> {}
+                     (privacy/apply-to-result :events events false))
+        kept     (:events envelope)
+        out      (elision/apply-to-result envelope :events kept)]
+    (is (= 1 (:elided-large out)))
+    (is (not (contains? out :dropped-sensitive)))))
+
+(deftest only-privacy-axis-fired
+  ;; B-1 surfaces its counter; W-6 omits its counter. The two slots
+  ;; are independent — a trace-stream tool that drops sensitive
+  ;; events but carries no markers stamps only `:dropped-sensitive`.
+  (let [events  [{:op :a :sensitive? true} {:op :b}]
+        envelope (-> {}
+                     (privacy/apply-to-result :events events false))
+        kept     (:events envelope)
+        out      (elision/apply-to-result envelope :events kept)]
+    (is (= 1 (:dropped-sensitive out)))
+    (is (not (contains? out :elided-large)))))
+
+(deftest opt-in-on-both-axes-passes-everything-no-counters
+  ;; Both opt-in flags ON: B-1 passes sensitive events through, the
+  ;; walker (server-side) would pass large values through. Both
+  ;; counters absent. The agent has explicitly opted into the full
+  ;; payload on both axes.
+  (let [events  [{:op :a :sensitive? true} {:op :b}]
+        envelope (-> {}
+                     ;; B-1 with include-sensitive? true
+                     (privacy/apply-to-result :events events true))
+        kept     (:events envelope)
+        ;; W-6 sees no markers (walker would have been bypassed too)
+        out      (elision/apply-to-result envelope :events kept)]
+    (is (= events (:events out)))
+    (is (not (contains? out :dropped-sensitive)))
+    (is (not (contains? out :elided-large)))))
+
+;; ---------------------------------------------------------------------------
+;; The load-bearing spec/004 §6 assertion.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-default-posture-is-elision-on-at-mcp-boundary
+  (testing "default (no include-large? arg) emits markers at the
+            MCP boundary; the counter surfaces on the envelope"
+    (let [;; Default args: include-large? not supplied, walker emits markers.
+          ;; (The walker actually fires server-side inside the eval form;
+          ;; here we model the post-walk payload — the marker is in place.)
+          opts   (cljs.reader/read-string (elision/elision-opts-edn
+                                           (elision/parse-include-large nil)))
+          ;; Post-walk payload with a marker substituted at the elided slot.
+          walked {:user {:uploaded-pdf marker}}
+          out    (elision/apply-to-result {} :db walked)]
+      (is (false? (:rf.size/include-large? opts))
+          "default arg ⇒ walker opt false ⇒ markers emit")
+      (is (= 1 (:elided-large out))
+          "counter MUST surface the marker count")))
+  (testing "explicit `:include-large? true` is the documented
+            cross-MCP opt-in (MUST 19 half)"
+    (let [opts (cljs.reader/read-string
+                (elision/elision-opts-edn
+                 (elision/parse-include-large #js {"include-large?" true})))]
+      (is (true? (:rf.size/include-large? opts))
+          "opt-in path ⇒ walker passes large values through unchanged"))))


### PR DESCRIPTION
## Summary

W-6 of the rf2-8xzoe wire-pipeline tranche: size-elision walker integration at the Causa-MCP boundary. Sibling to B-1 (rf2-8xzoe.11, PR #1291) which lands the spec/009 default-suppress filter at the same egress codepath; the two boundary wrappers share an additive-envelope shape and cross-MCP indicator-field convention so `:dropped-sensitive` + `:elided-large` ride together on the same response when both axes fire.

The new `day8.re-frame2-causa-mcp.elision` ns provides:

- `elision-opts-edn` — render walker opts (`:rf.size/include-large?` + `:rf.size/include-sensitive?`) as EDN for inlining into the CLJS eval form shipped over nREPL. The walker runs server-side because the `[:rf/elision]` registry lives in app-db; the Node process can't reach it directly.
- `parse-include-large` — cross-MCP arg parser; mirrors `privacy/parse-include-sensitive`.
- `count-elided-markers` — re-export of `re-frame.mcp-base.elision/count-elided-markers` (single cross-MCP walker per rf2-9fz64).
- `stamp-elided-large` — envelope-counter stamp, omitted when zero (cross-MCP indicator-field convention).
- `apply-to-result` — per-tool boundary wrapper. Counts markers in the already-walked payload and stamps `:elided-large`. Optional `:server-elided` opt sources the count from the eval-form pre-count (sibling to pair2-mcp's rf2-e35a5 optimisation).

## MUSTs honoured

Per `tools/causa-mcp/spec/findings/MUST-inventory.md`:

- **MUST 15** — every tree-typed tool declares `:include-large?` slot + `:elided-large` indicator field.
- **MUST 17** — `re-frame.core/elide-wire-value` is the single normative emission site. This ns inlines the walker call into the eval form and only COUNTS markers downstream; it never emits the marker itself.
- **MUST 18** — sensitive-wins composition lives in the framework walker; this ns ships the opts (both knobs render together).
- **MUST 19**, `:include-large?` half — cross-MCP opt-in vocab parallel to `:include-sensitive?`.

## Pair2-mcp parity + one deliberate divergence

Walker opts (`:rf.size/include-large?`, `:rf.size/include-sensitive?`) and envelope slot (`:elided-large`) match pair2-mcp's `tools/elision.cljs` (rf2-urjnc) byte-for-byte.

**Deliberate divergence**: `elision-opts-edn` accepts the cross-server `:include-large?` boolean DIRECTLY (truthy = pass through) and renders without inversion. Pair2-mcp inverts because its MCP arg is `:elision` (truthy = walk). Causa-mcp's cross-server arg vocabulary (per spec/004 §6) is `:include-large?`, matching the walker opt name — one fewer flip on the call-site, less surface area for sign-error bugs in downstream tools.

## Test plan

- [x] `npm test` in `tools/causa-mcp/` — 75 tests / 231 assertions, 0 failures.
- [x] 33 new deftests in `elision_test.cljs` covering: public surface, `count-elided-markers` re-export + marker-body opacity, `parse-include-large` accept-shapes (JS args, CLJS map, nil, unrecognised), `elision-opts-edn` polarity + two-knob orthogonality + vocabulary pins, `stamp-elided-large` zero-omit / positive-stamp / defensive-non-positive, `apply-to-result` marker counting + envelope additivity + `:server-elided` opt (zero honoured / missing falls back / verbatim) + canonical tool-shape coverage (`:db` / `:diff` / `:state` / `:events`).
- [x] 5 of those tests pin the composition with B-1 (privacy filter): both wrappers on the same envelope, both axes fired, single-axis (only-elision / only-privacy), zero-clean common path, opt-in-on-both.
- [x] Wire-vocab tripwire: file landed at `src/day8/re_frame2_causa_mcp/elision.cljs`, NOT under `tools/` — tripwire (which probes `tools/causa-mcp/src/.../tools/`) does not fire.

## Bead

Closes rf2-8xzoe.10. Sibling to B-1 (PR #1291, merged).