### PR TITLE
perf+spec(core): elide :source-coord from prod reg-meta; keep in error-emit (rf2-3un2g, Mike "b")

### DIFF
--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -41,10 +41,25 @@
 
      The rf2-52gw helper: centralises the `(binding [...] (target ...))`
      skeleton that every reg-* macro emits, so each defmacro becomes a
-     one-line delegation rather than a 12-line repetition."
+     one-line delegation rather than a 12-line repetition.
+
+     Per rf2-3un2g §Production elision: the bound coord-map is emitted
+     under an `(if interop/debug-enabled? <dev> <prod>)` gate. Dev rides
+     the full [[source-coords/coords-form]] (with `:column`); prod rides
+     [[source-coords/prod-coords-form]] (no `:column`). Closure folds the
+     constant `interop/debug-enabled?` (alias of `goog.DEBUG`) under
+     `:advanced` + `goog.DEBUG=false` and DCEs the dev branch — only
+     the slim prod coords literal survives into the bundle. The bound
+     coords are STILL captured at runtime via `*pending-coords*` so
+     `registrar/register!`'s `remember-error-coords!` hook (always-on)
+     populates the parallel error-coord registry; only the public
+     registry-meta merge is suppressed in prod (see
+     [[source-coords/merge-coords]])."
      [form-meta file ns-sym body-form]
      `(binding [re-frame.source-coords/*pending-coords*
-                ~(source-coords/coords-form form-meta file ns-sym)]
+                (if re-frame.interop/debug-enabled?
+                  ~(source-coords/coords-form      form-meta file ns-sym)
+                  ~(source-coords/prod-coords-form form-meta file ns-sym))]
         ~body-form)))
 
 ;; ---- defreg-macro --------------------------------------------------------
@@ -126,8 +141,14 @@
                                           (:column coords) (assoc :column (:column coords)))])
                                      per-el-coords))
            machine-sym    (gensym "machine__")]
+       ;; Per rf2-3un2g §Production elision: the binding-value rides an
+       ;; outer `interop/debug-enabled?` gate so Closure DCEs the dev
+       ;; coords (with `:column`) under `:advanced + goog.DEBUG=false`.
+       ;; See [[with-coords-form]] for the rationale.
        `(binding [re-frame.source-coords/*pending-coords*
-                  ~(source-coords/coords-form form-meta file ns-sym)]
+                  (if re-frame.interop/debug-enabled?
+                    ~(source-coords/coords-form      form-meta file ns-sym)
+                    ~(source-coords/prod-coords-form form-meta file ns-sym))]
           ~(if (empty? per-el-coords)
              `(re-frame.core-machines/reg-machine ~machine-id ~machine)
              `(let [~machine-sym ~machine

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -118,9 +118,17 @@
          ;; macro returns its primary id. The trailing `~id` is load-
          ;; bearing — without it the `def` would be the last form and the
          ;; macro would return the Var, breaking the contract.
+         ;; Per rf2-3un2g §Production elision: the binding-value rides
+         ;; an outer `interop/debug-enabled?` gate so Closure DCEs the
+         ;; dev coords (with `:column`) under `:advanced + goog.DEBUG=false`.
+         ;; The bound coords are still captured at runtime via the
+         ;; parallel `error-coords-by-id` registry (see
+         ;; `re-frame.source-coords`).
          `(do
             (binding [re-frame.source-coords/*pending-coords*
-                      ~(source-coords/coords-form form-meta current-file current-ns-sym)]
+                      (if re-frame.interop/debug-enabled?
+                        ~(source-coords/coords-form      form-meta current-file current-ns-sym)
+                        ~(source-coords/prod-coords-form form-meta current-file current-ns-sym))]
               (re-frame.core/reg-view* ~id
                 ~full-slot-meta
                 ~fn-form))

--- a/implementation/core/src/re_frame/error_emit.cljc
+++ b/implementation/core/src/re_frame/error_emit.cljc
@@ -9,16 +9,24 @@
     1. Corpus-wide listener registry — every fn registered through
        [[register-error-emit-listener!]] receives a tight error-record:
 
-         {:error      <kw>       ;; e.g. :rf.error/handler-exception
-          :event      <vector>    ;; dispatched event vector (elided)
-          :event-id   <kw>
-          :frame      <kw>
-          :time       <millis>
-          :exception  <ex>
-          :elapsed-ms <int>}
+         {:error        <kw>     ;; e.g. :rf.error/handler-exception
+          :event        <vector> ;; dispatched event vector (elided)
+          :event-id     <kw>
+          :frame        <kw>
+          :time         <millis>
+          :exception    <ex>
+          :elapsed-ms   <int>
+          :source-coord {:ns :file :line}  ;; rf2-3un2g; absent if
+                                           ;; the failing handler was
+                                           ;; registered programmatically
+                                           ;; (no macro capture)
+          }
 
        For off-box observability shippers (Sentry, Honeybadger,
-       Rollbar).
+       Rollbar). Per rf2-3un2g the `:source-coord` slot rides the
+       always-on parallel `error-coords-by-id` registry so it survives
+       CLJS `:advanced` + `goog.DEBUG=false` builds where public
+       registry-meta has been stripped of coord-keys.
 
     2. Per-frame `:on-error` policy fn — the frame's `:on-error` slot,
        when present, receives a structured error event (`:operation` /
@@ -40,12 +48,13 @@
   unchanged (operators need them for triage); the event payload —
   which may carry credentials / PII — is scrubbed at the substrate
   boundary."
-  (:require [re-frame.elision       :as elision]
+  (:require [re-frame.elision        :as elision]
             [re-frame.emit-substrate :as emit]
-            [re-frame.frame         :as frame]
-            [re-frame.late-bind     :as late-bind]
-            [re-frame.privacy       :as privacy]
-            [re-frame.registrar     :as registrar]))
+            [re-frame.frame          :as frame]
+            [re-frame.late-bind      :as late-bind]
+            [re-frame.privacy        :as privacy]
+            [re-frame.registrar      :as registrar]
+            [re-frame.source-coords  :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -131,6 +140,16 @@
   [error-kw event event-id frame-id exception elapsed-ms time error-event]
   (let [handler-meta (when event-id (registrar/lookup :event event-id))
         sensitive?   (privacy/sensitive?-from-meta handler-meta)
+        ;; Per rf2-3un2g §Always-on error-coord registry: source-coords
+        ;; for the failing handler ride the always-on parallel registry
+        ;; (NOT the public registry-meta — which is stripped of coord-
+        ;; keys under CLJS `:advanced + goog.DEBUG=false`). The lookup
+        ;; here surfaces `{:ns :file :line}` for Sentry-style shippers
+        ;; and the per-frame `:on-error` policy fn in BOTH dev AND
+        ;; production. Returns nil for programmatic registrations that
+        ;; bypassed the macro path — that's fine; the slot is absent
+        ;; from the record / tags rather than nil.
+        source-coord (when event-id (source-coords/error-coords-for :event event-id))
         ;; Redact the event slot at the substrate boundary when the
         ;; failing handler is declared sensitive. Otherwise run the
         ;; wire-walker as before (paths flagged `:sensitive?` /
@@ -139,16 +158,27 @@
         elided-event (if sensitive?
                        privacy/redacted-sentinel
                        (elision/elide-wire-value event {:frame frame-id}))
-        record       {:error      error-kw
-                      :event      elided-event
-                      :event-id   event-id
-                      :frame      frame-id
-                      :time       time
-                      :exception  exception
-                      :elapsed-ms elapsed-ms}
-        policy-event (if sensitive?
-                       (redact-tags-event error-event)
-                       error-event)]
+        record       (cond-> {:error      error-kw
+                              :event      elided-event
+                              :event-id   event-id
+                              :frame      frame-id
+                              :time       time
+                              :exception  exception
+                              :elapsed-ms elapsed-ms}
+                       source-coord (assoc :source-coord source-coord))
+        ;; The structured policy-event's `:tags` get the same
+        ;; `:source-coord` slot (innermost-wins: caller-supplied
+        ;; `:source-coord` already on `:tags` would survive
+        ;; intentionally; we only `assoc-when-missing`).
+        policy-event (let [pe (if sensitive?
+                                (redact-tags-event error-event)
+                                error-event)]
+                       (if (and source-coord
+                                (map? pe)
+                                (map? (:tags pe))
+                                (not (contains? (:tags pe) :source-coord)))
+                         (update pe :tags assoc :source-coord source-coord)
+                         pe))]
     ((:fan-out registry) record)
     (fire-on-error-policy! frame-id policy-event))
   nil)

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -27,8 +27,9 @@
   that the late-bind lookup, the call into trace/emit!, and the small
   metadata map allocation all disappear from `:advanced` production
   bundles where `goog.DEBUG` is `false`."
-  (:require [re-frame.interop   :as interop]
-            [re-frame.late-bind :as late-bind]))
+  (:require [re-frame.interop       :as interop]
+            [re-frame.late-bind     :as late-bind]
+            [re-frame.source-coords :as source-coords]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -246,6 +247,18 @@
   (when-not (valid-kind? kind)
     (throw (ex-info (str "re-frame2: unknown registry kind: " kind)
                     {:kind kind :id id})))
+  ;; Always-on error-coord parallel registry (rf2-3un2g §Production
+  ;; elision). When a public reg-* macro is on the stack `*pending-coords*`
+  ;; carries the captured coord-map (slim in CLJS prod — no `:column`).
+  ;; The error-emit substrate looks coords up via
+  ;; `source-coords/error-coords-for` when assembling the tight error-
+  ;; record / policy-event, so Sentry-style shippers still see source-
+  ;; line info even when public registry-meta has been stripped of
+  ;; coord-keys under `goog.DEBUG=false`. Programmatic paths
+  ;; (`*pending-coords*` nil) no-op cleanly — `remember-error-coords!`
+  ;; itself guards against nil.
+  (when-let [pc source-coords/*pending-coords*]
+    (source-coords/remember-error-coords! kind id pc))
   ;; 2-level lookup as paired `get`s rather than `(get-in ... [kind id])` —
   ;; `get-in` allocates a path vector per call (rf2-mqv4m).
   (let [previous (-> @kind->id->metadata (get kind) (get id))]
@@ -349,6 +362,9 @@
   (reset! kind->id->metadata {})
   (reset! missing-doc-warned #{})
   (reset! collision-warned   #{})
+  ;; Also clear the always-on error-coord parallel registry (rf2-3un2g)
+  ;; so test cases start from a clean state on both surfaces.
+  (source-coords/forget-error-coords!)
   nil)
 
 ;; ---- lookup ---------------------------------------------------------------

--- a/implementation/core/src/re_frame/source_coords.cljc
+++ b/implementation/core/src/re_frame/source_coords.cljc
@@ -20,11 +20,32 @@
        synthesises registrations from another source can stamp the
        original coordinates).
 
-  The data itself is fine in production (static metadata on the
-  registry slot — bytes, not behaviour). The DOM-annotation hook
-  (per Tool-Pair §Source-mapping) is the dev-only piece, gated
-  separately. Source-coord capture itself stays unconditional — the
-  runtime cost is one map merge at registration time.")
+  ## Production elision (rf2-3un2g)
+
+  Source-coord capture has TWO sinks:
+
+    1. **Public registry-meta**: in dev the captured coords are merged
+       into the registrar slot's metadata via [[merge-coords]] —
+       `(rf/handler-meta kind id)` consumers (Causa Open-in-editor,
+       re-frame-pair, IDE jump-to-source) read them from there. In
+       CLJS production (`:advanced` + `goog.DEBUG=false`) [[merge-coords]]
+       returns `user-meta` unchanged — the coord keys are stripped from
+       the public meta. The `:column` literal in the macro-emitted
+       coords-form additionally DCEs (the slim prod coords-form omits
+       `:column` entirely).
+
+    2. **Always-on error-coord registry**: [[remember-error-coords!]]
+       populates [[error-coords-by-id]] at registration time. The
+       error-emit substrate (`re-frame.error-emit/dispatch-on-error!`)
+       looks up coords via [[error-coords-for]] when assembling the
+       tight error-record and the structured policy-event — so
+       Sentry/Honeybadger/Rollbar shippers still see source-line info
+       in production builds where the trace surface is gone. This
+       channel survives `goog.DEBUG=false` by construction.
+
+  The DOM-annotation hook (per Tool-Pair §Source-mapping) is the dev-only
+  piece, gated separately."
+  (:require [re-frame.interop :as interop]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -44,12 +65,76 @@
   "Merge `*pending-coords*` into `user-meta`. User-supplied :ns / :line
   / :file override auto-captured values per Spec 001. Returns user-meta
   unchanged when no coords are pending (programmatic registration,
-  REPL eval without the macro path)."
+  REPL eval without the macro path).
+
+  Per rf2-3un2g §Production elision: in CLJS `:advanced` +
+  `goog.DEBUG=false` builds (and JVM SSR with `re-frame.debug=false`)
+  this fn returns `user-meta` unchanged regardless of any pending
+  coords binding. Coord-keys are stripped from the public registry-meta
+  in production; the always-on `error-coords-by-id` parallel registry
+  (see [[remember-error-coords!]]) carries them through to the
+  error-emit substrate for Sentry-style observability."
   [user-meta]
-  (let [coords *pending-coords*]
-    (if coords
-      (merge coords (or user-meta {}))
-      (or user-meta {}))))
+  (if-not interop/debug-enabled?
+    ;; Production: strip the coord-keys from public meta. The always-on
+    ;; error-coords parallel registry retains them for error-emit
+    ;; observability — see [[remember-error-coords!]] / [[error-coords-for]].
+    (or user-meta {})
+    (let [coords *pending-coords*]
+      (if coords
+        (merge coords (or user-meta {}))
+        (or user-meta {})))))
+
+;; ---- always-on error-coord registry (rf2-3un2g) --------------------------
+;;
+;; The parallel registry that retains source-coords in production builds.
+;; Populated unconditionally at registration time via [[remember-error-
+;; coords!]]; the error-emit substrate reads it via [[error-coords-for]]
+;; when assembling the tight error-record passed to corpus-wide listener
+;; fans (Sentry / Honeybadger / Rollbar) and the per-frame `:on-error`
+;; policy event. Survives `:advanced` + `goog.DEBUG=false` — the
+;; namespace and the atom are unconditional; only the dev-side merge
+;; into public registry-meta is elided.
+
+(defonce
+  ^{:doc "kind → id → coords-map. Atomic. Per-process. Mirrors the
+          registrar shape so error-emit can pivot on `(kind, id)`. The
+          values are coord-maps (`:rf/source-coord-meta` per
+          Spec-Schemas — `:ns` / `:file` / `:line`; `:column` is dev-
+          only). Survives production elision so Sentry-style shippers
+          see source-line info even when the trace surface is gone."}
+  error-coords-by-id
+  (atom {}))
+
+(defn remember-error-coords!
+  "Store coord-map under `[kind id]` in the always-on parallel registry.
+  Called by `re-frame.registrar/register!` from any path where
+  `*pending-coords*` is bound (the public reg-* macro path). In CLJS
+  production builds the coord-map's `:column` slot is absent — the
+  prod-side macro emission omits it; only `:ns`/`:file`/`:line` ride
+  through. Returns the stored coord-map.
+
+  Per rf2-3un2g §Always-on error-coord registry."
+  [kind id coords]
+  (when (and kind id coords)
+    (swap! error-coords-by-id assoc-in [kind id] coords))
+  coords)
+
+(defn error-coords-for
+  "Look up the stored source-coord map for `[kind id]`. Returns nil when
+  no coords were captured for that pair (programmatic registration, REPL
+  eval that bypassed the macro path). The error-emit substrate uses this
+  to stamp `:source-coord` on the tight record + policy-event in BOTH
+  dev AND production. Per rf2-3un2g."
+  [kind id]
+  (get-in @error-coords-by-id [kind id]))
+
+(defn forget-error-coords!
+  "Clear the parallel registry. Test fixtures use this between cases.
+  Mirrors `registrar/clear-all!`. Per rf2-3un2g."
+  []
+  (reset! error-coords-by-id {})
+  nil)
 
 ;; ---- :file resolution at macro-expansion time (rf2-mdjp) ------------------
 ;;
@@ -102,13 +187,45 @@
   data the caller splices into its expansion.
 
   :file picks the form-meta value over `*file*` and rejects the
-  `\"NO_SOURCE_PATH\"` sentinel via `resolve-file`."
+  `\"NO_SOURCE_PATH\"` sentinel via `resolve-file`.
+
+  Per rf2-3un2g §Production elision: callers SHOULD wrap the dev
+  emission alongside [[prod-coords-form]] under
+  `(if interop/debug-enabled? <dev> <prod>)` so Closure DCEs the dev
+  shape (with `:column`) under `:advanced` + `goog.DEBUG=false`. The
+  `with-coords-form` / `expand-reg-machine` helpers do this internally;
+  per-element machine stamping and call-site stamping handle elision
+  through their own outer gates and call this fn directly."
   [form-meta file ns-sym]
   (let [chosen-file (resolve-file form-meta file)]
     `(cond-> {:ns '~ns-sym}
        ~chosen-file         (assoc :file ~chosen-file)
        ~(:line form-meta)   (assoc :line ~(:line form-meta))
        ~(:column form-meta) (assoc :column ~(:column form-meta)))))
+
+#?(:clj
+   (defn prod-coords-form
+     "Slim production-side variant of [[coords-form]]: omits `:column`.
+     Per rf2-3un2g — `:column` is dev-tooling-only (IDE jump-to-source
+     refinement); Sentry-style observability needs only `:ns`/`:file`/
+     `:line`. Emitting the slim form under the prod branch of an
+     `(if interop/debug-enabled? ...)` lets Closure DCE the dev coords
+     literal (with `:column`) under `:advanced` + `goog.DEBUG=false`,
+     so the bundle ships the slimmer payload only.
+
+     Caller wraps:
+
+         `(if re-frame.interop/debug-enabled?
+            ~(coords-form form-meta file ns-sym)
+            ~(prod-coords-form form-meta file ns-sym))
+
+     Both branches use `cond->` so absent keys (e.g. nil `:line` on a
+     programmatic synthesis) elide cleanly."
+     [form-meta file ns-sym]
+     (let [chosen-file (resolve-file form-meta file)]
+       `(cond-> {:ns '~ns-sym}
+          ~chosen-file       (assoc :file ~chosen-file)
+          ~(:line form-meta) (assoc :line ~(:line form-meta))))))
 
 ;; ---- per-element spec stamping -------------------------------------------
 ;;

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -181,6 +181,86 @@
 
 ;; ---- rf2-vnjfg :sensitive? redaction enforcement under prod -------------
 
+;; ---- rf2-3un2g :source-coord rides the prod error-emit substrate --------
+
+(deftest source-coord-rides-error-record-under-prod
+  (testing "Per rf2-3un2g Policy B: under `:advanced` + `goog.DEBUG=false`,
+            the tight error-record passed to corpus-wide listeners MUST
+            include `:source-coord` for handlers registered via the
+            public macro path. The coord rides the always-on parallel
+            `error-coords-by-id` registry — it survives prod elision so
+            Sentry-style shippers see source-line info even when the
+            trace surface is gone and registry-meta has been stripped
+            of coord-keys."
+    (let [listener-saw (atom nil)]
+      (rf/register-error-emit-listener!
+        :rf2-3un2g/sentry-recorder
+        (fn [record] (reset! listener-saw record)))
+      (rf/reg-event-db :rf2-3un2g/prod-coord-throw
+                       (fn [_db _]
+                         (throw (ex-info "boom" {}))))
+      (rf/dispatch-sync [:rf2-3un2g/prod-coord-throw])
+      (is (some? @listener-saw)
+          "listener fired under :advanced + goog.DEBUG=false")
+      (let [sc (:source-coord @listener-saw)]
+        (is (some? sc)
+            ":source-coord present on the prod-mode error-record")
+        ;; :ns is a symbol; :line is an integer; :file is a string.
+        ;; :column is absent under prod (the prod-coords-form omits it).
+        (is (symbol?  (:ns sc))
+            ":source-coord :ns is a symbol in prod")
+        (is (integer? (:line sc))
+            ":source-coord :line is an integer in prod")
+        (is (string?  (:file sc))
+            ":source-coord :file is a string in prod")
+        (is (not (contains? sc :column))
+            ":source-coord :column is ABSENT in prod (DCE'd from the
+             coords-form literal under :advanced + goog.DEBUG=false)")))))
+
+(deftest source-coord-rides-policy-event-tags-under-prod
+  (testing "Per rf2-3un2g Policy B: under `:advanced` + `goog.DEBUG=false`,
+            the structured `error-event` passed to the per-frame
+            `:on-error` policy fn MUST include `:source-coord` under
+            `:tags` for handlers registered via the public macro path.
+            In-app recovery surfaces get the same observability signal
+            as Sentry shippers."
+    (let [policy-saw (atom nil)]
+      (rf/reg-frame :rf/default
+                    {:on-error (fn [ev] (reset! policy-saw ev) nil)})
+      (rf/reg-event-db :rf2-3un2g/prod-policy-coord-throw
+                       (fn [_db _]
+                         (throw (ex-info "boom" {}))))
+      (rf/dispatch-sync [:rf2-3un2g/prod-policy-coord-throw])
+      (is (some? @policy-saw)
+          ":on-error policy fired under :advanced + goog.DEBUG=false")
+      (let [sc (get-in @policy-saw [:tags :source-coord])]
+        (is (some? sc)
+            ":source-coord rides :tags on the structured error-event in prod")
+        (is (symbol?  (:ns sc)))
+        (is (integer? (:line sc)))
+        (is (string?  (:file sc)))))))
+
+(deftest registry-meta-stripped-of-coord-keys-under-prod
+  (testing "Per rf2-3un2g Policy A: under `:advanced` + `goog.DEBUG=false`
+            the public `rf/handler-meta` MUST NOT carry `:ns` / `:file`
+            / `:line` / `:column` coord-keys. Causa Open-in-editor and
+            re-frame-pair are dev-only — production bundles strip the
+            coord-keys from the registry-meta surface; coords for
+            error-emit ride the always-on parallel registry instead."
+    (rf/reg-event-db :rf2-3un2g/prod-meta-strip
+                     {:doc "stripped"}
+                     (fn [db _] db))
+    (let [meta (rf/handler-meta :event :rf2-3un2g/prod-meta-strip)]
+      (is (some? meta))
+      (is (= "stripped" (:doc meta))
+          "user-supplied :doc is preserved — only coord-keys strip")
+      (is (not (contains? meta :ns))     ":ns absent in prod meta")
+      (is (not (contains? meta :file))   ":file absent in prod meta")
+      (is (not (contains? meta :line))   ":line absent in prod meta")
+      (is (not (contains? meta :column)) ":column absent in prod meta"))))
+
+;; ---- end rf2-3un2g block -------------------------------------------------
+
 (deftest sensitive-handler-error-record-redacted-under-prod
   (testing "Per rf2-vnjfg: under `:advanced` + `goog.DEBUG=false` the
             always-on error-emit substrate MUST still enforce

--- a/implementation/core/test/re_frame/on_error_test.cljc
+++ b/implementation/core/test/re_frame/on_error_test.cljc
@@ -123,7 +123,11 @@
   (testing "Per rf2-bacs4: a registered listener receives exactly one
             tight error-record per `:rf.error/handler-exception`. The
             record's shape is fixed: `:error :event :event-id :frame
-            :time :exception :elapsed-ms`."
+            :time :exception :elapsed-ms`, plus `:source-coord` when
+            the failing handler was registered via the public macro
+            path (per rf2-3un2g §Always-on error-coord registry —
+            programmatic registrations omit the slot rather than nil
+            it; the macro-path test below sees it present)."
     (let [seen (atom [])]
       (rf/register-error-emit-listener!
         :test/recorder
@@ -143,9 +147,20 @@
         (is (number? (:time r))              ":time is a wall-clock millis number")
         (is (integer? (:elapsed-ms r))       ":elapsed-ms is an integer ms count")
         (is (not (neg? (:elapsed-ms r)))     ":elapsed-ms is non-negative")
-        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms}
+        ;; Per rf2-3un2g: `:source-coord` rides the tight record when the
+        ;; failing handler was registered via the public macro path. The
+        ;; coord rides the always-on parallel `error-coords-by-id`
+        ;; registry, so this slot survives `goog.DEBUG=false` (Sentry-
+        ;; style observability preserved in production).
+        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms
+                 :source-coord}
                (set (keys r)))
-            "record carries ONLY the tight rf2-bacs4 keys — no trace-bus enrichment")))))
+            "record carries the tight rf2-bacs4 keys plus rf2-3un2g
+             :source-coord — no trace-bus enrichment beyond that")
+        (let [sc (:source-coord r)]
+          (is (symbol?  (:ns   sc)))
+          (is (integer? (:line sc)))
+          (is (string?  (:file sc))))))))
 
 (deftest error-listener-exception-is-swallowed
   (testing "Per the substrate contract: a buggy listener cannot break

--- a/implementation/core/test/re_frame/source_coord_prod_elision_test.clj
+++ b/implementation/core/test/re_frame/source_coord_prod_elision_test.clj
@@ -1,0 +1,181 @@
+(ns re-frame.source-coord-prod-elision-test
+  "Per rf2-3un2g: source-coord production-elision contract.
+
+  Two surfaces, two policies:
+
+    A. **Public registry-meta strip in prod**. Under the JVM debug gate
+       off posture (`interop/debug-enabled?` rebound to `false` —
+       semantically equivalent to CLJS `:advanced` + `goog.DEBUG=false`),
+       `(rf/handler-meta kind id)` MUST NOT carry `:ns` / `:file` /
+       `:line` / `:column` coord-keys. Causa Open-in-editor and
+       re-frame-pair are dev-only tools; they don't reach the registry
+       at all in production bundles.
+
+    B. **Error-emit substrate retains source-coord in prod**. The tight
+       record passed to corpus-wide listeners (Sentry / Honeybadger /
+       Rollbar shippers) AND the structured policy-event passed to the
+       per-frame `:on-error` fn MUST include `:source-coord` even under
+       the disabled debug gate. The coord rides the always-on parallel
+       `error-coords-by-id` registry — NOT the public registry-meta.
+
+  Naming convention: `_test.clj` (JVM-only) by design — the canonical
+  CLJS production-elision verification rides the bundle-presence
+  probes (`scripts/check-elision.cjs`, `scripts/check-perf-bundle.cjs`).
+  This file pins the SEMANTIC contract on the JVM where we can
+  `with-redefs` the gate; the bundle probes pin the CODE-PATH absence
+  in CLJS-prod by negative grep."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.source-coords :as source-coords]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; ---- Policy A: registry-meta stripped under disabled debug gate ---------
+
+(deftest registry-meta-strips-coord-keys-under-disabled-debug-gate
+  (testing "Per rf2-3un2g Policy A: under `:advanced + goog.DEBUG=false`
+            (modelled here as `with-redefs [interop/debug-enabled? false]`)
+            the public registry-meta returned by `rf/handler-meta` MUST
+            NOT carry `:ns` / `:file` / `:line` / `:column` coord-keys.
+            The macro path still runs at JVM expansion time; only the
+            `merge-coords` propagation into the public meta is
+            suppressed."
+    (with-redefs [interop/debug-enabled? false]
+      (rf/reg-event-db :rf2-3un2g/prod-elide-event
+                       {:doc "stripped"}
+                       (fn [db _] db))
+      (let [meta (rf/handler-meta :event :rf2-3un2g/prod-elide-event)]
+        (is (some? meta))
+        (is (= "stripped" (:doc meta))
+            "user-supplied :doc is preserved — only auto-captured
+             coord-keys are stripped")
+        (is (not (contains? meta :ns))     ":ns absent from registry-meta in prod")
+        (is (not (contains? meta :file))   ":file absent from registry-meta in prod")
+        (is (not (contains? meta :line))   ":line absent from registry-meta in prod")
+        (is (not (contains? meta :column)) ":column absent from registry-meta in prod")))))
+
+(deftest registry-meta-keeps-coord-keys-under-enabled-debug-gate
+  (testing "Per rf2-3un2g Policy A: the dev posture (default
+            `interop/debug-enabled?` = true) preserves the historical
+            behaviour — `(rf/handler-meta ...)` returns the full coord-
+            map for Causa / re-frame-pair / IDE jump-to-source."
+    (rf/reg-event-db :rf2-3un2g/dev-keep-event
+                     {:doc "kept"}
+                     (fn [db _] db))
+    (let [meta (rf/handler-meta :event :rf2-3un2g/dev-keep-event)]
+      (is (some? (:ns   meta)) ":ns present in registry-meta in dev")
+      (is (some? (:line meta)) ":line present in registry-meta in dev")
+      (is (some? (:file meta)) ":file present in registry-meta in dev"))))
+
+;; ---- Policy B: error-emit substrate retains source-coord in prod --------
+
+(deftest error-record-includes-source-coord-under-disabled-debug-gate
+  (testing "Per rf2-3un2g Policy B: under the disabled debug gate, the
+            tight error-record passed to corpus-wide listeners (the
+            Sentry/Honeybadger/Rollbar fan-out) MUST carry the failing
+            handler's `:source-coord`. The coord rides the always-on
+            parallel `error-coords-by-id` registry — NOT the public
+            registry-meta (which Policy A strips). This pins the
+            production observability contract."
+    ;; Register the handler in DEV (default gate) so the parallel
+    ;; registry gets populated by the macro expansion's `*pending-
+    ;; coords*` binding. Then re-bind the gate to false and dispatch
+    ;; — the public meta would carry coords either way under JVM
+    ;; (registrations happened in dev); the load-bearing assertion is
+    ;; that the error-emit substrate stamps `:source-coord` on the
+    ;; tight record FROM the parallel registry, not from registry-meta.
+    (rf/reg-event-db :rf2-3un2g/prod-error-handler
+                     (fn [_db _]
+                       (throw (ex-info "boom" {:cause :test}))))
+    (with-redefs [interop/debug-enabled? false]
+      (let [seen (atom nil)]
+        (rf/register-error-emit-listener!
+          :rf2-3un2g/recorder
+          (fn [record] (reset! seen record)))
+        (rf/dispatch-sync [:rf2-3un2g/prod-error-handler])
+        (is (some? @seen)
+            "error-emit listener fired under disabled debug gate")
+        (let [sc (:source-coord @seen)]
+          (is (some? sc)
+              "`:source-coord` rides the tight error-record under
+               disabled debug gate — Sentry-style shippers see it")
+          (is (symbol? (:ns sc))
+              ":source-coord :ns is a symbol")
+          (is (integer? (:line sc))
+              ":source-coord :line is an integer")
+          (is (string? (:file sc))
+              ":source-coord :file is a string"))))))
+
+(deftest policy-event-tags-include-source-coord-under-disabled-debug-gate
+  (testing "Per rf2-3un2g Policy B: under the disabled debug gate, the
+            structured `error-event` passed to the per-frame `:on-error`
+            policy fn MUST include `:source-coord` under `:tags`. In-app
+            recovery surfaces (custom error overlays, breadcrumb
+            recorders) get the same observability signal as the
+            corpus-wide listener."
+    (rf/reg-event-db :rf2-3un2g/policy-error-handler
+                     (fn [_db _]
+                       (throw (ex-info "boom" {:cause :test}))))
+    (with-redefs [interop/debug-enabled? false]
+      (let [seen (atom nil)]
+        (rf/reg-frame :rf/default
+                      {:on-error (fn [ev] (reset! seen ev) nil)})
+        (rf/dispatch-sync [:rf2-3un2g/policy-error-handler])
+        (is (some? @seen)
+            ":on-error policy fired under disabled debug gate")
+        (let [sc (get-in @seen [:tags :source-coord])]
+          (is (some? sc)
+              "`:source-coord` rides `:tags` on the structured error-event
+               under disabled debug gate")
+          (is (symbol? (:ns sc)))
+          (is (integer? (:line sc)))
+          (is (string? (:file sc))))))))
+
+;; ---- programmatic registrations bypass the parallel registry -----------
+
+(deftest programmatic-registration-no-source-coord-in-error-record
+  (testing "Per rf2-3un2g: programmatic registrations (HoF, runtime
+            registration via the fn aliases — bypassing the macro
+            path) leave `*pending-coords*` unbound, so the parallel
+            `error-coords-by-id` registry stays empty for that
+            `(kind, id)`. The error-record's `:source-coord` slot is
+            ABSENT (not nil) for those cases — `cond->` skips the
+            assoc. This mirrors the dev-side behaviour where
+            programmatic registrations carry no `:ns` / `:line` /
+            `:file` on `handler-meta`."
+    (with-redefs [interop/debug-enabled? false]
+      (let [reg-fn (requiring-resolve 're-frame.events/reg-event-db)]
+        (reg-fn :rf2-3un2g/programmatic
+                (fn [_db _]
+                  (throw (ex-info "boom" {})))))
+      (let [seen (atom nil)]
+        (rf/register-error-emit-listener!
+          :rf2-3un2g/programmatic-recorder
+          (fn [record] (reset! seen record)))
+        (rf/dispatch-sync [:rf2-3un2g/programmatic])
+        (is (some? @seen)
+            "error-emit listener fired even for programmatic registration")
+        (is (not (contains? @seen :source-coord))
+            "`:source-coord` slot absent when no macro coords were
+             captured at registration time")))))
+
+;; ---- error-coords-by-id atom semantics ----------------------------------
+
+(deftest error-coords-by-id-populated-on-registration
+  (testing "Per rf2-3un2g: every macro-driven registration populates the
+            parallel `error-coords-by-id` registry under `[:kind :id]`.
+            The atom is the single source of truth for error-emit
+            source-coord lookup."
+    (rf/reg-event-db :rf2-3un2g/parallel-reg
+                     (fn [db _] db))
+    (let [sc (source-coords/error-coords-for :event :rf2-3un2g/parallel-reg)]
+      (is (some? sc)
+          "parallel registry carries coords for the registered id")
+      (is (some? (:ns   sc)))
+      (is (some? (:line sc)))
+      (is (some? (:file sc))))))

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -305,9 +305,12 @@
              leak from CLJS performance.now())")
         (is (not (neg? (:elapsed-ms r)))
             ":elapsed-ms is non-negative")
-        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms}
+        (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms
+                 :source-coord}
                (set (keys r)))
-            "record carries ONLY the tight rf2-bacs4 keys")))))
+            "record carries the tight rf2-bacs4 keys plus rf2-3un2g
+             :source-coord (always-on parallel error-coord registry —
+             the failing handler was macro-registered above)")))))
 
 (deftest flow-eval-exception-fires-per-frame-on-error-policy
   (testing "Per rf2-hrt5c: a flow whose :output throws ALSO fires the

--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -146,6 +146,24 @@ This is a CLJS-implementation choice. Other in-scope JS-cross-compile language p
 
 Source coords are valuable for navigation (jump-to-source from a tool, navigate-from-error, AI-source-cite) but their absence does not violate conformance. Per [Principles.md §Optional capabilities](Principles.md), source-coord capture is opt-in.
 
+### Production elision contract (rf2-3un2g)
+
+Source-coord capture has TWO sinks; each obeys a different production-elision policy. The split lets dev tooling (Causa Open-in-editor, re-frame-pair, IDE jump-to-source) read coords from `(rf/handler-meta ...)` in dev while keeping the public registry-meta surface cheap in production AND retaining source-line info on the always-on error-emit substrate for off-box observability (Sentry, Honeybadger, Rollbar).
+
+1. **Public registry-meta — STRIPPED in production.** Under `:advanced` + `goog.DEBUG=false` (and JVM SSR with `-Dre-frame.debug=false`), `(rf/handler-meta kind id)` MUST NOT carry `:ns` / `:file` / `:line` / `:column` coord-keys. Causa Open-in-editor and re-frame-pair are dev-only tools shipped via preloads; they do not reach the registry in production bundles. The CLJS reference achieves this via [[re-frame.source-coords/merge-coords]] returning `user-meta` unchanged when `interop/debug-enabled?` is false. Additionally, the macro-emitted coords-form literal omits `:column` in the production branch — the Closure compiler folds `(if interop/debug-enabled? <dev-coords> <prod-coords>)` and the dev shape (with `:column`) DCEs from the bundle.
+
+2. **Always-on error-coord registry — RETAINED in production.** A parallel registry indexed by `[kind id] → {:ns :file :line}` is populated at registration time (CLJS reference: [[re-frame.source-coords/remember-error-coords!]], invoked from `registrar/register!` whenever `*pending-coords*` is bound). The error-emit substrate (`re-frame.error-emit/dispatch-on-error!`) looks coords up via [[re-frame.source-coords/error-coords-for]] when assembling the tight error-record passed to corpus-wide listeners AND the structured policy-event passed to the per-frame `:on-error` fn. Both surfaces carry `:source-coord` even under `:advanced` + `goog.DEBUG=false` — the production-observability contract pins source-line info into Sentry-style reports regardless of debug-gate posture.
+
+   The parallel registry is a separate channel by construction so that Policy A (strip from public meta) does not conflict with Policy B (retain for error-emit). Programmatic registrations (HoF, runtime registration via the fn aliases that bypass the macro path) leave `*pending-coords*` unbound; the parallel registry has no entry for those `(kind, id)` pairs and the error-emit substrate's `:source-coord` slot is ABSENT (not nil) for them.
+
+| Sink | Dev (`debug-enabled? true`) | Prod (`debug-enabled? false`) |
+|---|---|---|
+| `(rf/handler-meta kind id)` `:ns`/`:file`/`:line`/`:column` | Present (full coord-map) | Absent (stripped — public meta carries only user-supplied keys) |
+| Tight error-record `:source-coord` (Sentry shippers) | Present `{:ns :file :line :column}` | Present `{:ns :file :line}` (no `:column`) |
+| Structured policy-event `:tags :source-coord` (`:on-error` fn) | Present | Present |
+
+This contract is JS-cross-compile-language-agnostic in spirit: ports MAY choose to keep coords on the public meta in production if their host's bundle-elision story differs (TypeScript / squint paths have different DCE characteristics). The minimum bar is "source-line info survives to error-emit listeners under the host's production-build mode" — the public-meta strip is a CLJS-specific optimisation.
+
 ## The query API
 
 The registry is a public, queryable structure. Tools and agents read it without private-API spelunking. The CLJS reference exposes:


### PR DESCRIPTION
## Summary

Per Mike's decision 2026-05-17 (**"b"**): two surfaces, two policies for `:source-coord` capture.

- **Policy A — STRIP from public registry-meta in production.** Under `:advanced` + `goog.DEBUG=false` (and JVM SSR with `re-frame.debug=false`), `(rf/handler-meta kind id)` no longer carries `:ns` / `:file` / `:line` / `:column` coord-keys. Causa Open-in-editor and re-frame-pair are dev-only tools shipped via preloads; production bundles don't need the bytes. The macro emissions wrap the `*pending-coords*` binding-value under an `(if interop/debug-enabled? <full-coords> <prod-coords>)` gate so Closure DCEs the dev shape (with `:column`); the slim prod variant (no `:column`) survives.
- **Policy B — KEEP in the always-on error-emit substrate.** A new parallel registry (`source-coords/error-coords-by-id`) is populated at `register!` time from `*pending-coords*`. `error-emit/dispatch-on-error!` stamps `:source-coord` on the tight error-record (Sentry-style listener fan-out) and `:tags :source-coord` on the structured policy-event (per-frame `:on-error` fn). Survives `goog.DEBUG=false` by construction.

The split lets production observability (Sentry/Honeybadger/Rollbar) retain source-line info even when the dev trace surface and public registry-meta have been elided.

Spec 001 §Source-coordinate capture amended with the new §Production elision contract documenting both policies + the dev/prod table.

### Bundle deltas (vs `origin/main` b9d7e91c)

| Example | Raw delta | Gzipped delta |
|---|---:|---:|
| examples/realworld | **-2 667 B** | **-1 156 B** |
| examples/todomvc | -35 B | -66 B |
| examples/counter | +190 B | +55 B |

Savings scale with registration count. The counter app has too few regs to amortise the substrate-side additions (the parallel-registry hook + `:source-coord` assoc in error-emit); realworld is in the ~3 KB raw / ~1 KB gzipped ballpark the bead targeted for typical apps.

## Test plan

- [x] `clojure -M:test` (JVM core, 521 tests / 2704 assertions — includes 6 new tests for rf2-3un2g)
- [x] `scripts/test-jvm-implementation.sh` (all JVM artefacts PASS)
- [x] `npm run test:cljs` (2245 tests / 6389 assertions)
- [x] `npm run test:browser-prod-elision` (29 tests / 108 assertions including 3 new for rf2-3un2g)
- [x] `npm run test:elision` (31/31 absent + 31/31 control present)
- [x] `npm run test:perf-bundle` (PASS)
- [x] `npm run test:bundle-isolation` (PASS)
- [x] `mkdocs build --strict` (no new warnings)