### PR TITLE
feat(causa-mcp): W-1 token cap + overflow marker (rf2-8xzoe.5)

### DIFF
--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/token_cap.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/token_cap.cljs
@@ -1,0 +1,399 @@
+(ns day8.re-frame2-causa-mcp.token-cap
+  "Wire-pipeline mechanism W-1 at the Causa-MCP boundary (rf2-8xzoe.5).
+  Token-cap with structured overflow marker — per
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §Tight token budget per
+  response §1 (Token budget cap).
+
+  ## What this gates
+
+  Every `tools/call` response is bounded at **≤ 5,000 tokens** by
+  default. Each call MAY override via a `max-tokens` integer JSON-RPC
+  argument; the server clamps to `[500, 50000]`. A tool that would
+  exceed the cap MUST NOT silently truncate (MUST 6 of the MUST
+  inventory); it MUST instead return a structured `:rf.mcp/overflow`
+  marker at the top of the payload (MUST 7).
+
+  This ns is the per-call wrapper that lives at the egress boundary
+  between the tool dispatcher and the MCP SDK's `tools/call` reply. It
+  measures the rendered payload (MUST 5), compares against the cap
+  (MUST 3), and either passes the payload through unchanged (under-
+  budget) or replaces it with the overflow marker (over-budget).
+
+  ## Causa-specific marker shape — divergence from pair2-mcp
+
+  Causa's normative marker (spec/004 §1, L244-249):
+
+      {:rf.mcp/overflow {:cap          5000
+                         :would-be     ~12400
+                         :hint         :switch-mode  ; or :paginate, :slice, :narrow-filter
+                         :continuation {:cursor \"opaque…\" :next-args {...}}}}
+
+  This is **deliberately divergent** from pair2-mcp's older marker
+  shape (which uses `:cap-tokens`, `:token-count`, `:limit :reached`,
+  and a string `:hint`). Pair2-mcp's shape predates the causa-spec
+  pin; the causa shape is the forward-going contract — `:hint` is a
+  keyword from a closed vocabulary the agent can pattern-match
+  exhaustively, and `:continuation` is a structured re-call affordance
+  rather than a free-text suggestion. The cross-MCP key
+  (`:rf.mcp/overflow`) stays byte-identical; only the value shape
+  evolves. When pair2-mcp aligns (future bead), the two consumers
+  collapse on this shape.
+
+  Because of this divergence we don't reuse
+  `re-frame.mcp-base.overflow/overflow-payload` (which still builds
+  the pair2-shape). We DO reuse `re-frame.mcp-base.cap`'s
+  measurement primitives — token estimate, char count, the two-stage
+  cap check (rf2-ih7g4) — those are platform-agnostic.
+
+  ## Per-call clamp `[500, 50000]`
+
+  Causa-mcp clamps the per-call override to `[500, 50000]` per
+  spec/004 §1 (L237). This is causa-specific — pair2-mcp's resolver
+  accepts any positive integer (and treats `0` as disable). Causa
+  intentionally rejects:
+
+    - Caps below 500 tokens (no useful payload fits — a tool would
+      always overflow, masking real over-budget conditions).
+    - Caps above 50,000 tokens (a single response would consume 25%
+      of a typical 200K-token context window — the agent host's
+      working session would be starved of room for follow-up tools).
+    - `0` is NOT a disable hatch on causa-mcp. The spec is a
+      normative MUST, not a per-call opt-out; the `[500, 50000]`
+      range pins the floor. A caller that passes `0` lands at `500`
+      (clamped to the floor).
+
+  ## Algorithm shape — single-pass measurement
+
+  `apply-cap` walks the result's content texts exactly once,
+  accumulating both the token sum (`(quot count 4)` per Anthropic's
+  English rule-of-thumb) and the char sum. The dual-gate check
+  (rf2-ih7g4): the primary token cap trips on the quotient; a
+  secondary byte cap (`cap * 8`) trips on raw char count to catch
+  payloads that escape the quotient heuristic (CJK, emoji, base64,
+  dense code).
+
+  Either gate trips the same overflow path. The reported `:would-be`
+  is the cap-relative measurement — token count when the token gate
+  trips, char count when the byte gate trips — so the agent's
+  overflow handler sees an actionable number.
+
+  ## Hint vocabulary — closed set
+
+  `:hint` is a keyword from `{:switch-mode :paginate :slice
+  :narrow-filter}`. Tools declare their per-overflow hint at the
+  catalogue site (rf2-8xzoe later F-tranches register the eighteen
+  catalogue entries); `hint-for-tool` looks it up and falls back to
+  `:narrow-filter` (the generic re-call-with-narrower-args hint)
+  when a tool isn't listed. The fallback is deliberate — a missing
+  table entry is a programmer bug; defaulting to a closed-set value
+  keeps the agent surface uniform while the gap is fixed.
+
+  ## Continuation slot
+
+  The `:continuation {:cursor … :next-args …}` slot is causa's
+  structured re-call affordance. The cursor (when present) is the
+  opaque pagination cursor for sequence-returning tools that the
+  agent passes back to resume mid-stream. `:next-args` is the
+  suggested per-call args delta (e.g. `{:mode :sample}` for a tool
+  whose `:full` mode overflowed, suggesting downshift to a bounded
+  sample). The slot is optional — `apply-cap` populates it only when
+  the call-site supplies it via opts."
+  (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.cap :as base-cap]
+            [re-frame.mcp-base.overflow :as base-overflow]))
+
+;; ---------------------------------------------------------------------------
+;; Constants — cap range and default.
+;; ---------------------------------------------------------------------------
+
+(def ^:const default-max-tokens
+  "Default per-response cap in tokens. 5,000 per spec/004 §1 — sized
+  for the typical MCP response envelope after diff-encode + dedup. The
+  constant is reified at the causa-mcp boundary (rather than imported
+  unchanged from `mcp-base.overflow`) so a downstream reader sees the
+  causa-side surface as a single self-contained unit. Today the value
+  is identical to the cross-MCP default; if causa ever diverges (it
+  shouldn't — the cap is a cross-server invariant) the change lands
+  here."
+  base-overflow/default-max-tokens)
+
+(def ^:const min-max-tokens
+  "Lower clamp on the per-call `max-tokens` override. Per spec/004 §1
+  (L237) — `[500, 50000]`. Below 500 tokens no useful tool response
+  fits; the cap would always trip, masking real over-budget
+  conditions."
+  500)
+
+(def ^:const max-max-tokens
+  "Upper clamp on the per-call `max-tokens` override. Per spec/004 §1
+  (L237) — `[500, 50000]`. Above 50,000 tokens a single response
+  consumes ~25% of a typical 200K-token context window, starving the
+  agent's working session of room for follow-up tool calls."
+  50000)
+
+;; ---------------------------------------------------------------------------
+;; max-tokens — per-call cap resolver with `[500, 50000]` clamp.
+;; ---------------------------------------------------------------------------
+
+(defn clamp-max-tokens
+  "Clamp `n` into the `[min-max-tokens, max-max-tokens]` range. Returns
+  an integer. `nil` / non-numeric inputs collapse to `default-max-tokens`.
+
+  The clamp is causa-specific — pair2-mcp's resolver passes any
+  positive integer through unchanged. Causa's spec/004 §1 pins the
+  range; a caller that supplies `200` lands at `500` (floor), one that
+  supplies `100000` lands at `50000` (ceiling).
+
+  Disambiguation:
+    - `nil` / `0` / non-number ⇒ `default-max-tokens` (5000). Causa
+      doesn't honour pair2-mcp's `0`-disables-cap escape hatch — the
+      cap is a normative MUST, not a per-call opt-out.
+    - any positive integer ⇒ clamped into `[500, 50000]`."
+  [n]
+  (cond
+    (nil? n)         default-max-tokens
+    (not (number? n)) default-max-tokens
+    (zero? n)        default-max-tokens
+    :else
+    (-> n long
+        (max min-max-tokens)
+        (min max-max-tokens))))
+
+(defn max-tokens-arg
+  "Resolve the per-call cap from the raw MCP args object. Returns an
+  integer in `[min-max-tokens, max-max-tokens]`.
+
+  Accepts both the JS-side args object (the npm MCP SDK shape) and a
+  CLJS map (already-coerced upstream). The slot name is the cross-
+  server `max-tokens` (string key for JS, `:max-tokens` for CLJS) per
+  spec/004 §1 (L237) — `the corresponding parsed CLJS keyword is
+  :max-tokens`.
+
+  Unrecognised / absent inputs collapse to `default-max-tokens`."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :max-tokens)
+                  (get args "max-tokens"))
+
+              :else
+              (let [v (j/get args "max-tokens")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (clamp-max-tokens raw)))
+
+;; ---------------------------------------------------------------------------
+;; Hint table — per-tool overflow hint keyword (closed vocabulary).
+;; ---------------------------------------------------------------------------
+
+(def ^:const hint-vocabulary
+  "The closed set of `:hint` values per spec/004 §1 (L247). An agent
+  pattern-matches on this set; an out-of-vocab value would break the
+  agent's exhaustive case. Reified as a set so a downstream lint can
+  assert the table only emits in-vocab keywords."
+  #{:switch-mode :paginate :slice :narrow-filter})
+
+(def default-hint
+  "Fallback when a tool isn't listed in `hints-by-tool`. `:narrow-filter`
+  is the generic re-call-with-narrower-args hint — applicable to any
+  tool whose response can be tightened by an extra filter or a smaller
+  scope. The fallback is deliberate: a missing table entry is a
+  programmer bug, and defaulting to a closed-set value keeps the agent
+  surface uniform while the gap is fixed."
+  :narrow-filter)
+
+(def hints-by-tool
+  "Per-tool overflow `:hint` keyword. Populated incrementally as the
+  causa-mcp catalogue lands (subsequent rf2-8xzoe F-tranche beads):
+  each tool's catalogue entry declares its `:cap-reached` hint and the
+  table entry mirrors it. Today (W-1 landing) the table is the
+  starting shape — the eighteen-tool catalogue lands in subsequent
+  F-tranche beads (per the F-2 server.cljs note on the empty
+  catalogue).
+
+  Hints chosen per spec/004 §1 + §4 (lazy summary as the default mode
+  for rich values):
+
+    - `get-app-db` / `get-machine-state` — `:slice`: drill in via
+      `:path` to a subtree.
+    - `get-trace-buffer` / `get-epoch-history` / `subscribe` —
+      `:paginate`: re-call with `:cursor` + `:limit`.
+    - Tools with a `:mode` knob (`:summary` / `:sample` / `:full`)
+      where `:full` overflowed — `:switch-mode`: downshift to
+      `:sample` or `:summary`.
+
+  Tools not yet in the catalogue (or not registered here) fall back
+  to `default-hint` (`:narrow-filter`)."
+  {})
+
+(defn hint-for-tool
+  "Resolve the overflow hint keyword for `tool`. Returns a keyword
+  from `hint-vocabulary` — `(hints-by-tool tool)` when registered,
+  `default-hint` otherwise."
+  [tool]
+  (get hints-by-tool tool default-hint))
+
+;; ---------------------------------------------------------------------------
+;; ResultIO — causa-mcp specialisation over `#js {:content #js [...]}`.
+;; ---------------------------------------------------------------------------
+
+(def ^:private result-io
+  "ResultIO reify over causa-mcp's `#js {:content #js [...]}` shape
+  (npm MCP SDK; parallel to pair2-mcp's). Reads `:text` slots via
+  `js-interop` and builds the overflow result with the same JS shape
+  so the MCP SDK serialises it as a `tools/call` reply unchanged.
+
+  Note that `build-overflow-result` is NOT called by causa's
+  `apply-cap` below — causa's marker shape diverges from
+  `re-frame.mcp-base.overflow/overflow-payload`, so we bypass
+  `base-cap/apply-cap` and build the marker inline. The reify is kept
+  for symmetry with pair2-mcp's surface and to satisfy the protocol
+  contract should a future bead lift causa's `apply-cap` back through
+  `base-cap`."
+  (reify base-cap/ResultIO
+    (content-texts [_ result]
+      (let [content (j/get result :content)
+            n       (if (array? content) (.-length content) 0)]
+        (loop [i 0 acc (transient [])]
+          (if (< i n)
+            (let [item (aget content i)
+                  text (when item (j/get item :text))]
+              (recur (inc i) (conj! acc text)))
+            (persistent! acc)))))
+    (build-overflow-result [_ marker _original]
+      #js {:content #js [#js {:type "text"
+                              :text (pr-str marker)}]})))
+
+;; ---------------------------------------------------------------------------
+;; Marker builder — causa-specific shape per spec/004 §1.
+;; ---------------------------------------------------------------------------
+
+(defn overflow-payload
+  "Build the causa-spec-shaped `:rf.mcp/overflow` marker map. Spec/004
+  §1 (L244-249) + the cross-MCP wire-vocab conformance schema
+  (`tools/mcp-conformance/wire-vocab/test/.../wire_vocab_test.clj`
+  `CausaOverflowBody`):
+
+    {:rf.mcp/overflow {:limit        :reached
+                       :cap          <int>
+                       :would-be     <int>
+                       :hint         <:switch-mode|:paginate|:slice|:narrow-filter>
+                       :continuation {:cursor … :next-args …}}}
+
+  The `:limit :reached` sentinel is shared with pair2-mcp's older
+  marker shape — the conformance schema requires it on both shapes
+  so an agent's first-pass pattern-match (`(get-in marker [:rf.mcp/overflow
+  :limit])`) lands identically across the triplet. The causa-spec
+  snippet omits the sentinel from the example for brevity; the
+  conformance test is the load-bearing pin.
+
+  Opts:
+    :cap          - the cap in tokens that the response would exceed.
+    :would-be     - the measured token count of the over-budget payload
+                    (or char count when the secondary byte cap trips —
+                    `apply-cap` picks the gate-relevant number).
+    :hint         - one of `:switch-mode :paginate :slice :narrow-filter`
+                    (validated against `hint-vocabulary`; out-of-vocab
+                    inputs collapse to `default-hint`).
+    :continuation - optional `{:cursor … :next-args …}` map. Omitted
+                    when absent. Callers populate it only when the
+                    tool has a cursor mid-stream or a meaningful
+                    `:next-args` delta to suggest.
+
+  The `:cursor` slot inside `:continuation` is an opaque server-
+  managed string per spec/004 §3 — the agent does not inspect it,
+  only passes it back. `:next-args` is the suggested per-call arg
+  delta to retry with."
+  [{:keys [cap would-be hint continuation]}]
+  (let [hint*   (if (contains? hint-vocabulary hint) hint default-hint)
+        marker  (cond-> {:limit    :reached
+                         :cap      cap
+                         :would-be would-be
+                         :hint     hint*}
+                  (some? continuation) (assoc :continuation continuation))]
+    {:rf.mcp/overflow marker}))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap — the wire-boundary enforcement entry point.
+;; ---------------------------------------------------------------------------
+
+(defn apply-cap
+  "Wire-boundary cap enforcement. Returns either `result-js` unchanged
+  (when under the cap) or a fresh JS-shape result carrying the
+  `:rf.mcp/overflow` marker as its sole `:content[0].text` slot.
+
+  ## Two-stage measurement (rf2-ih7g4)
+
+  1. Primary token cap — `(quot count 4)` per Anthropic's English
+     rule-of-thumb. The published contract pinned by the spec.
+
+  2. Secondary char-byte cap — `cap * base-cap/byte-cap-multiplier`
+     (8×). Defence-in-depth against payloads where the quotient
+     undercounts: CJK, emoji, base64, dense code. Trips
+     independently of the token sum; the gate-relevant measurement
+     becomes `:would-be` on the marker.
+
+  Either gate trips the same overflow path.
+
+  ## Single-pass walk
+
+  `content-texts` is materialised once; the token sum and char sum
+  are accumulated in a single transduce over the resulting seq. The
+  npm-SDK JS-shape `:text` slots are read via `j/get` exactly once
+  per text node.
+
+  ## Opts
+
+    :tool         - string tool name. Today used as the lookup key
+                    against `hints-by-tool`; carried on the marker
+                    only implicitly via the chosen `:hint` keyword
+                    (the agent doesn't need to know which tool
+                    overflowed — the next-action is the cap-reached
+                    behaviour, not blame-tracking).
+    :cap          - integer cap in tokens. Usually the output of
+                    `max-tokens-arg`. Required — pass
+                    `default-max-tokens` for the standard default.
+    :hint         - optional override of the per-tool hint table.
+                    When supplied, must be in `hint-vocabulary`;
+                    falls back to `default-hint` otherwise.
+    :continuation - optional `{:cursor … :next-args …}` map spliced
+                    onto the marker when present. Cursor-bearing
+                    tools that overflow mid-stream supply the active
+                    cursor here so the agent can resume.
+
+  ## Nil-safety
+
+  `nil` `result-js` passes through unchanged. `nil` `cap` is treated
+  as a programmer error (the cap is normative; a caller that means
+  `default-max-tokens` should pass that constant explicitly). The
+  guard falls back to `default-max-tokens` rather than throwing so
+  the wire stays bounded even on a buggy call-site."
+  [result-js {:keys [tool cap hint continuation]}]
+  (cond
+    (nil? result-js) result-js
+    :else
+    (let [cap*     (or cap default-max-tokens)
+          {:keys [tokens chars]}
+          (transduce (filter string?)
+                     (completing
+                       (fn [{:keys [tokens chars]} s]
+                         {:tokens (+ tokens (base-overflow/token-estimate s))
+                          :chars  (+ chars (count s))}))
+                     {:tokens 0 :chars 0}
+                     (base-cap/content-texts result-io result-js))
+          byte-cap (* cap* base-cap/byte-cap-multiplier)
+          over?    (or (> tokens cap*) (> chars byte-cap))]
+      (if-not over?
+        result-js
+        (let [would-be (if (> chars byte-cap) chars tokens)
+              hint*    (cond
+                         (and hint (contains? hint-vocabulary hint)) hint
+                         hint                                        default-hint
+                         :else                                       (hint-for-tool tool))
+              marker   (overflow-payload {:cap          cap*
+                                          :would-be     would-be
+                                          :hint         hint*
+                                          :continuation continuation})]
+          (base-cap/build-overflow-result result-io marker result-js))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/token_cap_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/token_cap_test.cljs
@@ -1,0 +1,449 @@
+(ns day8.re-frame2-causa-mcp.token-cap-test
+  "Unit tests for the W-1 token-cap-with-overflow-marker at the
+  Causa-MCP boundary (rf2-8xzoe.5). Pins:
+
+    - MUST 3 — A tool that cannot answer inside the 5,000-token budget
+      MUST trim, summarise, slice, paginate, or dedupe rather than
+      over-spend (spec/004 §1 L74).
+    - MUST 5 — Every tool that returns to the agent MUST measure the
+      rendered payload (post-EDN-encoding, post-JSON-wrap) against the
+      cap before returning (spec/004 §1 L115).
+    - MUST 6 — A tool that would exceed the cap MUST NOT silently
+      truncate (spec/004 §1 L121).
+    - MUST 7 — A tool exceeding the cap MUST return the structured
+      overflow marker at the top of the payload (spec/004 §1 L122)
+      with the causa-specific shape: `:cap`, `:would-be`, `:hint`
+      (keyword from `{:switch-mode :paginate :slice :narrow-filter}`),
+      and optional `:continuation {:cursor … :next-args …}`.
+    - Clamp `[500, 50000]` on `max-tokens` per spec/004 §1 L237.
+
+  These tests are the load-bearing pin for the eighteen downstream
+  tool beads — every dispatcher that returns to the agent runs its
+  envelope through `token-cap/apply-cap` at the egress boundary; the
+  contract here is the one those tools inherit."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers — build / read the `#js {:content #js [...]}` result shape.
+;; ---------------------------------------------------------------------------
+
+(defn- mk-result
+  "Build a single-text-slot JS result containing `s`."
+  [s]
+  #js {:content #js [#js {:type "text" :text s}]})
+
+(defn- result-text
+  "Read the text from a single-slot JS result."
+  [r]
+  (-> (j/get r :content) (aget 0) (j/get :text)))
+
+(defn- result-edn
+  "Read + EDN-parse the text from a single-slot JS result."
+  [r]
+  (edn/read-string (result-text r)))
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-1 lands the public surface downstream tool dispatchers
+            will require at the egress boundary"
+    (is (fn? token-cap/clamp-max-tokens))
+    (is (fn? token-cap/max-tokens-arg))
+    (is (fn? token-cap/hint-for-tool))
+    (is (fn? token-cap/overflow-payload))
+    (is (fn? token-cap/apply-cap))
+    (is (= 5000  token-cap/default-max-tokens))
+    (is (= 500   token-cap/min-max-tokens))
+    (is (= 50000 token-cap/max-max-tokens))
+    (is (= #{:switch-mode :paginate :slice :narrow-filter}
+           token-cap/hint-vocabulary)
+        "spec/004 §1 closed `:hint` vocabulary")
+    (is (= :narrow-filter token-cap/default-hint)
+        "default hint is the generic re-call-with-narrower-args hint")))
+
+;; ---------------------------------------------------------------------------
+;; clamp-max-tokens — `[500, 50000]` per spec/004 §1 L237.
+;; ---------------------------------------------------------------------------
+
+(deftest clamp-max-tokens-nil-defaults-to-5000
+  (is (= 5000 (token-cap/clamp-max-tokens nil))
+      "absent input collapses to default-max-tokens"))
+
+(deftest clamp-max-tokens-non-number-defaults
+  (is (= 5000 (token-cap/clamp-max-tokens "1000")))
+  (is (= 5000 (token-cap/clamp-max-tokens :foo)))
+  (is (= 5000 (token-cap/clamp-max-tokens {}))))
+
+(deftest clamp-max-tokens-zero-collapses-to-default
+  ;; Causa intentionally does NOT honour pair2-mcp's `0`-disables-cap
+  ;; escape hatch. The spec is normative.
+  (is (= 5000 (token-cap/clamp-max-tokens 0))
+      "0 is not a disable hatch on causa — defaults to 5000"))
+
+(deftest clamp-max-tokens-below-floor-clamps-up
+  (is (= 500 (token-cap/clamp-max-tokens 1)))
+  (is (= 500 (token-cap/clamp-max-tokens 100)))
+  (is (= 500 (token-cap/clamp-max-tokens 499))))
+
+(deftest clamp-max-tokens-at-floor-passes
+  (is (= 500 (token-cap/clamp-max-tokens 500))))
+
+(deftest clamp-max-tokens-mid-range-passes
+  (is (= 1000  (token-cap/clamp-max-tokens 1000)))
+  (is (= 5000  (token-cap/clamp-max-tokens 5000)))
+  (is (= 25000 (token-cap/clamp-max-tokens 25000))))
+
+(deftest clamp-max-tokens-at-ceiling-passes
+  (is (= 50000 (token-cap/clamp-max-tokens 50000))))
+
+(deftest clamp-max-tokens-above-ceiling-clamps-down
+  (is (= 50000 (token-cap/clamp-max-tokens 50001)))
+  (is (= 50000 (token-cap/clamp-max-tokens 100000)))
+  (is (= 50000 (token-cap/clamp-max-tokens 9999999))))
+
+;; ---------------------------------------------------------------------------
+;; max-tokens-arg — extract the per-call override from MCP args.
+;; ---------------------------------------------------------------------------
+
+(deftest max-tokens-arg-absent-defaults
+  (is (= 5000 (token-cap/max-tokens-arg nil)))
+  (is (= 5000 (token-cap/max-tokens-arg js/undefined)))
+  (is (= 5000 (token-cap/max-tokens-arg #js {})))
+  (is (= 5000 (token-cap/max-tokens-arg #js {:other 1}))))
+
+(deftest max-tokens-arg-from-js-object
+  (is (= 1500  (token-cap/max-tokens-arg #js {"max-tokens" 1500})))
+  (is (= 10000 (token-cap/max-tokens-arg #js {"max-tokens" 10000}))))
+
+(deftest max-tokens-arg-from-cljs-map
+  ;; CLJS map shape — both keyword and stringified-key entry points.
+  (is (= 2000 (token-cap/max-tokens-arg {:max-tokens   2000})))
+  (is (= 2000 (token-cap/max-tokens-arg {"max-tokens" 2000}))))
+
+(deftest max-tokens-arg-clamps-below-floor
+  (is (= 500 (token-cap/max-tokens-arg #js {"max-tokens" 100}))))
+
+(deftest max-tokens-arg-clamps-above-ceiling
+  (is (= 50000 (token-cap/max-tokens-arg #js {"max-tokens" 999999}))))
+
+;; ---------------------------------------------------------------------------
+;; hint-for-tool — lookup with default fallback.
+;; ---------------------------------------------------------------------------
+
+(deftest hint-for-tool-unknown-falls-back-to-default
+  (is (= :narrow-filter (token-cap/hint-for-tool "no-such-tool"))
+      "missing table entry falls back to default-hint, not nil"))
+
+(deftest hint-for-tool-returns-keyword-from-vocab
+  ;; Whatever the table returns must be in the closed vocab — the
+  ;; agent pattern-matches exhaustively on it. The table is empty at
+  ;; W-1 landing; this test pins the shape contract so a future
+  ;; catalogue-entry add can't slip a non-vocab keyword in.
+  (doseq [[tool _hint] token-cap/hints-by-tool]
+    (is (contains? token-cap/hint-vocabulary (token-cap/hint-for-tool tool))
+        (str "hint for " tool " must be in hint-vocabulary"))))
+
+;; ---------------------------------------------------------------------------
+;; overflow-payload — the marker shape per spec/004 §1.
+;; ---------------------------------------------------------------------------
+
+(deftest overflow-payload-shape-minimum
+  (let [m (token-cap/overflow-payload {:cap 5000 :would-be 12400 :hint :switch-mode})]
+    (is (= {:rf.mcp/overflow {:limit    :reached
+                              :cap      5000
+                              :would-be 12400
+                              :hint     :switch-mode}}
+           m))
+    (is (not (contains? (:rf.mcp/overflow m) :continuation))
+        "no continuation supplied ⇒ slot absent")))
+
+(deftest overflow-payload-with-continuation
+  (let [m (token-cap/overflow-payload
+            {:cap          5000
+             :would-be     12400
+             :hint         :paginate
+             :continuation {:cursor "abc123" :next-args {:limit 50}}})]
+    (is (= {:rf.mcp/overflow {:limit        :reached
+                              :cap          5000
+                              :would-be     12400
+                              :hint         :paginate
+                              :continuation {:cursor    "abc123"
+                                             :next-args {:limit 50}}}}
+           m))))
+
+(deftest overflow-payload-includes-limit-reached-sentinel
+  ;; The cross-MCP wire-vocab conformance schema (CausaOverflowBody)
+  ;; requires `:limit :reached` on every overflow marker. The causa
+  ;; spec snippet (004-Wire-Pipeline.md §1 L244-249) omits the
+  ;; sentinel from the example for brevity, but the conformance
+  ;; fixture (tools/mcp-conformance/wire-vocab/.../wire_vocab_test.clj
+  ;; canonical-markers :causa-mcp) includes it. The pair2-mcp marker
+  ;; shape carries the same sentinel.
+  (let [m (token-cap/overflow-payload {:cap 5000 :would-be 6000 :hint :paginate})]
+    (is (= :reached (get-in m [:rf.mcp/overflow :limit]))
+        ":limit :reached pin per cross-MCP CausaOverflowBody schema")))
+
+(deftest overflow-payload-matches-conformance-fixture
+  ;; Byte-identical to the :causa-mcp fixture in
+  ;; tools/mcp-conformance/wire-vocab/.../wire_vocab_test.clj
+  ;; canonical-markers. A change to either side fails this assertion
+  ;; loud — the cross-server contract is the pin.
+  (is (= {:rf.mcp/overflow {:limit        :reached
+                            :cap          5000
+                            :would-be     12400
+                            :hint         :switch-mode
+                            :continuation {:cursor    "opaque-cursor-123"
+                                           :next-args {:mode :sample}}}}
+         (token-cap/overflow-payload
+           {:cap          5000
+            :would-be     12400
+            :hint         :switch-mode
+            :continuation {:cursor    "opaque-cursor-123"
+                           :next-args {:mode :sample}}}))))
+
+(deftest overflow-payload-out-of-vocab-hint-falls-back
+  (let [m (token-cap/overflow-payload
+            {:cap 5000 :would-be 12400 :hint :made-up-hint})]
+    (is (= :narrow-filter (get-in m [:rf.mcp/overflow :hint]))
+        "out-of-vocab hint MUST collapse to default-hint")))
+
+(deftest overflow-payload-every-hint-keyword-roundtrips
+  (doseq [h token-cap/hint-vocabulary]
+    (is (= h (get-in (token-cap/overflow-payload
+                       {:cap 5000 :would-be 6000 :hint h})
+                     [:rf.mcp/overflow :hint])))))
+
+;; ---------------------------------------------------------------------------
+;; apply-cap — under-budget passes / at-budget passes / over-budget marker.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cap-under-budget-passes-unchanged
+  ;; Small payload, generous cap. The wrapper MUST pass the result
+  ;; through identity — no allocation, no walk side-effects.
+  (let [r   (mk-result "hello")
+        out (token-cap/apply-cap r {:tool "snapshot" :cap 5000})]
+    (is (identical? r out)
+        "under-budget path MUST return the result object unchanged")))
+
+(deftest apply-cap-empty-content-passes
+  (let [r   #js {:content #js []}
+        out (token-cap/apply-cap r {:tool "snapshot" :cap 5000})]
+    (is (identical? r out))))
+
+(deftest apply-cap-nil-result-passes
+  (is (nil? (token-cap/apply-cap nil {:tool "snapshot" :cap 5000}))))
+
+(deftest apply-cap-at-budget-passes
+  ;; Exactly-at-cap (`tokens == cap`) is UNDER the strict-greater
+  ;; gate — `(> tokens cap)`. The boundary payload passes through.
+  ;; (count s) / 4 = cap ⇒ build a string of exactly `cap * 4` chars.
+  (let [cap  500
+        s    (apply str (repeat (* cap 4) "x")) ; 2000 chars = 500 tokens
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})]
+    (is (= 500 (quot (count s) 4))
+        "test setup pin: payload is exactly cap tokens")
+    (is (identical? r out)
+        "at-budget (==cap) MUST pass — strict-greater gate")))
+
+(deftest apply-cap-over-token-budget-truncates-and-stamps-marker
+  ;; Payload over the primary token cap. The wrapper MUST emit the
+  ;; overflow marker as the SOLE content slot — no leak of the
+  ;; original payload (MUST 6: no silent truncation).
+  (let [cap  500
+        s    (apply str (repeat 4000 "x")) ; 1000 tokens, > 500 cap
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})
+        edn-v (result-edn out)]
+    (is (not (identical? r out))
+        "over-budget MUST produce a fresh result, not the original")
+    (is (contains? edn-v :rf.mcp/overflow)
+        "MUST 7: structured overflow marker at the top of the payload")
+    (let [marker (:rf.mcp/overflow edn-v)]
+      (is (= cap (:cap marker))
+          ":cap slot carries the cap that was exceeded")
+      (is (= 1000 (:would-be marker))
+          ":would-be carries the measured token count (count/4)")
+      (is (contains? token-cap/hint-vocabulary (:hint marker))
+          ":hint MUST be in the closed vocabulary"))
+    (testing "original payload must NOT leak into the overflow result"
+      (is (not (clojure.string/includes? (result-text out) (subs s 0 100)))
+          "the original 4000-char body MUST NOT appear in the marker result"))))
+
+(deftest apply-cap-over-byte-budget-trips-secondary-gate
+  ;; rf2-ih7g4 defence-in-depth: a payload that escapes the
+  ;; (count/4) token heuristic via dense-encoding (CJK, emoji, base64,
+  ;; etc.) still trips the secondary `cap * 8` char-byte cap.
+  ;;
+  ;; Construct a payload whose token-estimate stays UNDER the cap but
+  ;; whose char count exceeds `cap * byte-cap-multiplier` (8×). Token
+  ;; estimate = (quot count 4), so for it to stay under `cap` we need
+  ;; char count < `cap * 4`. But the byte cap is `cap * 8`. So we
+  ;; cannot trip the byte cap without also tripping the token cap on
+  ;; the SAME string — both are character-based.
+  ;;
+  ;; Therefore: the byte gate fires when char count > `cap * 8`. With
+  ;; a 500-cap, byte-cap = 4000. A 4001-char payload has token-estimate
+  ;; 1000 (also > 500 token cap). The byte gate fires alongside the
+  ;; token gate; with chars > byte-cap, `:would-be` reports the CHAR
+  ;; count (the more conservative number).
+  (let [cap  500
+        s    (apply str (repeat 4500 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})
+        marker (:rf.mcp/overflow (result-edn out))]
+    (is (contains? (result-edn out) :rf.mcp/overflow)
+        "byte gate independently trips the overflow path")
+    (is (= 4500 (:would-be marker))
+        "char gate trip ⇒ :would-be reports char count, not token count")))
+
+(deftest apply-cap-over-budget-aggregated-across-multiple-slots
+  ;; Multi-slot results share ONE cumulative budget — the wrapper sums
+  ;; tokens across every `:text` slot.
+  (let [cap   500
+        s1    (apply str (repeat 1200 "x")) ; 300 tokens
+        s2    (apply str (repeat 1200 "y")) ; 300 tokens — sum 600 > 500
+        r     #js {:content #js [#js {:type "text" :text s1}
+                                 #js {:type "text" :text s2}]}
+        out   (token-cap/apply-cap r {:tool "snapshot" :cap cap})
+        edn-v (result-edn out)]
+    (is (contains? edn-v :rf.mcp/overflow)
+        "cumulative-budget MUST trip when sum > cap, not per-slot")
+    (is (= 600 (get-in edn-v [:rf.mcp/overflow :would-be])))))
+
+(deftest apply-cap-default-cap-uses-5000
+  ;; nil cap collapses to default-max-tokens (5000).
+  (let [s   (apply str (repeat 20001 "x")) ; 5000.25 tokens (quot 20001 4 = 5000) — wait
+        r   (mk-result s)
+        ;; Build precisely 5001-token payload: 20004 chars
+        s2  (apply str (repeat 20004 "x"))
+        r2  (mk-result s2)
+        out (token-cap/apply-cap r2 {:tool "snapshot"})]
+    (is (= 5001 (quot (count s2) 4))
+        "test setup: 20004 chars = 5001 tokens (just over default cap)")
+    (is (contains? (result-edn out) :rf.mcp/overflow)
+        "nil cap MUST default to 5000 and trip on 5001 tokens")
+    (is (= 5000 (get-in (result-edn out) [:rf.mcp/overflow :cap]))
+        ":cap slot reports the resolved default-max-tokens")))
+
+(deftest apply-cap-uses-per-tool-hint-when-not-overridden
+  ;; The hint table is empty at W-1 — every tool falls back to
+  ;; default-hint. When the catalogue beads land, individual tools
+  ;; will populate entries; this test pins the lookup-and-fallback
+  ;; contract that those entries inherit.
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})]
+    (is (= :narrow-filter (get-in (result-edn out) [:rf.mcp/overflow :hint]))
+        "unknown tool ⇒ default-hint")))
+
+(deftest apply-cap-explicit-hint-override-wins
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap :hint :paginate})]
+    (is (= :paginate (get-in (result-edn out) [:rf.mcp/overflow :hint]))
+        "explicit :hint opt overrides the per-tool table")))
+
+(deftest apply-cap-out-of-vocab-hint-override-falls-back
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap :hint :gibberish})]
+    (is (= :narrow-filter (get-in (result-edn out) [:rf.mcp/overflow :hint]))
+        "out-of-vocab override collapses to default-hint")))
+
+(deftest apply-cap-continuation-splices-onto-marker
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        cont {:cursor "epoch-1234" :next-args {:limit 25}}
+        out  (token-cap/apply-cap r {:tool         "get-trace-buffer"
+                                     :cap          cap
+                                     :hint         :paginate
+                                     :continuation cont})
+        marker (:rf.mcp/overflow (result-edn out))]
+    (is (= cont (:continuation marker))
+        ":continuation MUST be spliced onto the marker when supplied")))
+
+(deftest apply-cap-no-continuation-omits-slot
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})
+        marker (:rf.mcp/overflow (result-edn out))]
+    (is (not (contains? marker :continuation))
+        ":continuation MUST be omitted when not supplied — common path")))
+
+(deftest apply-cap-result-shape-conforms-to-mcp-sdk
+  ;; The replacement result MUST be a valid MCP `tools/call` reply
+  ;; shape — `{:content [{:type "text" :text "..."}]}` — so the npm
+  ;; MCP SDK can serialise it unchanged.
+  (let [cap  500
+        s    (apply str (repeat 4000 "x"))
+        r    (mk-result s)
+        out  (token-cap/apply-cap r {:tool "snapshot" :cap cap})]
+    (is (array? (j/get out :content)) "content MUST be a JS array")
+    (is (= 1 (.-length (j/get out :content)))
+        "overflow result is a single content slot")
+    (let [item (aget (j/get out :content) 0)]
+      (is (= "text" (j/get item :type)))
+      (is (string? (j/get item :text))))))
+
+;; ---------------------------------------------------------------------------
+;; Load-bearing spec/004 §1 assertion — the marker shape pinned end-to-end.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-overflow-marker-shape-end-to-end
+  (testing "MUST 7 — over-budget payload returns the spec-shaped
+            `:rf.mcp/overflow` marker at the top of the payload, with
+            :cap, :would-be, :hint (keyword from closed vocab), and
+            optional :continuation"
+    (let [cap      5000
+          ;; Build a payload that overflows by a clean margin so the
+          ;; numbers are easy to assert against.
+          payload  (apply str (repeat 24000 "x")) ; 6000 tokens > 5000 cap
+          r        (mk-result payload)
+          out      (token-cap/apply-cap
+                     r
+                     {:tool         "get-trace-buffer"
+                      :cap          cap
+                      :hint         :paginate
+                      :continuation {:cursor    "trace-cursor-42"
+                                     :next-args {:limit 25}}})
+          edn-v    (result-edn out)
+          marker   (:rf.mcp/overflow edn-v)]
+      (testing "marker key is the cross-MCP-reserved `:rf.mcp/overflow`"
+        (is (contains? edn-v :rf.mcp/overflow))
+        (is (= [:rf.mcp/overflow] (vec (keys edn-v)))
+            "marker is the SOLE top-level key — the original payload
+             is replaced, not augmented (MUST 6 no silent truncation)"))
+      (testing "marker carries :cap"
+        (is (= 5000 (:cap marker))))
+      (testing "marker carries :would-be (the measured token count)"
+        (is (= 6000 (:would-be marker))))
+      (testing "marker carries :hint as a keyword from the closed vocab"
+        (is (keyword? (:hint marker)))
+        (is (contains? token-cap/hint-vocabulary (:hint marker)))
+        (is (= :paginate (:hint marker))))
+      (testing "marker carries :continuation as a structured map"
+        (is (= {:cursor "trace-cursor-42" :next-args {:limit 25}}
+               (:continuation marker)))))))
+
+(deftest spec-004-no-silent-truncation
+  (testing "MUST 6 — a tool that would exceed the cap MUST NOT silently
+            truncate. The original payload bytes MUST NOT appear in the
+            replacement result."
+    (let [secret  "TRIPWIRE-PAYLOAD-MUST-NOT-LEAK"
+          stuffing (apply str (repeat 4000 "x"))
+          payload  (str secret stuffing)
+          r        (mk-result payload)
+          out      (token-cap/apply-cap r {:tool "snapshot" :cap 500})]
+      (is (not (clojure.string/includes? (result-text out) secret))
+          "the original payload MUST NOT bleed into the overflow result"))))


### PR DESCRIPTION
## Summary

Wire-pipeline mechanism W-1 at the Causa-MCP boundary — per [`tools/causa-mcp/spec/004-Wire-Pipeline.md`](../tree/main/tools/causa-mcp/spec/004-Wire-Pipeline.md) §Tight token budget per response §1 (Token budget cap).

- **New ns `day8.re-frame2-causa-mcp.token-cap`** — the per-call wrapper at the egress boundary between tool dispatchers and the MCP SDK's `tools/call` reply. Measures the rendered payload, compares against the cap, and either passes through unchanged or replaces with the structured `:rf.mcp/overflow` marker.
- **Causa-spec marker shape** — `{:rf.mcp/overflow {:limit :reached :cap N :would-be N :hint <kw> :continuation {:cursor … :next-args …}?}}`. `:hint` is a keyword from the closed vocabulary `#{:switch-mode :paginate :slice :narrow-filter}`. Conforms to `CausaOverflowBody` in the cross-MCP wire-vocab conformance schema.
- **`[500, 50000]` clamp on per-call `:max-tokens`** per spec §1 L237; 0 is NOT a disable hatch (the cap is a normative MUST, not a per-call opt-out).
- **Two-stage measurement** (rf2-ih7g4): primary token cap (`(quot count 4)`) + secondary `cap * 8` char-byte cap. Defence-in-depth against payloads where the quotient undercounts (CJK, emoji, base64, dense code).

Covers MUST 3, 5, 6, 7 of [`tools/causa-mcp/spec/findings/MUST-inventory.md`](../tree/main/tools/causa-mcp/spec/findings/MUST-inventory.md).

### Pair2-mcp divergence (justified)

The marker shape diverges from pair2-mcp's older `{:limit :reached :cap-tokens N :token-count N :tool S :hint S}` shape — pair2-mcp predates the causa-spec pin. Causa's shape is the forward-going contract:

- `:hint` is keyword-from-closed-vocab (agent pattern-matches exhaustively), not free-text.
- `:continuation` is a structured re-call affordance (cursor + next-args), not absent.
- `:cap` / `:would-be` are the spec-snippet field names.

Both shapes validate against the union schema in `tools/mcp-conformance/wire-vocab/test/.../wire_vocab_test.clj`. `:limit :reached` is shared cross-server. When pair2-mcp aligns (future bead), the two consumers collapse on causa's shape.

Implementation reuses `re-frame.mcp-base.cap`'s `ResultIO` protocol (`content-texts` accessor + `build-overflow-result` builder) and `mcp-base.overflow/token-estimate` + `mcp-base.cap/byte-cap-multiplier`; bypasses `base-cap/apply-cap` because the marker shape differs from `mcp-base.overflow/overflow-payload`.

### Why a sibling ns (not collision with W-6)

Per the bead's "Concurrent agents on disjoint surfaces" rule — W-6 also lives in the causa-mcp wire pipeline. By landing W-1 as `token_cap.cljs` (a sibling ns at the top level of `src/day8/re_frame2_causa_mcp/`) rather than amending a shared `wire.cljs`, this PR has no file overlap with the dispatcher work.

### Wire-vocab tripwire

The cross-MCP `causa-mcp-impl-still-absent` tripwires (in `slot_name_test.clj` + `indicator_field_test.clj`) probe `tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/`. `token_cap.cljs` lives at the top-level ns (parallel to `privacy.cljs` from B-1), not under `/tools/`, so the tripwires don't fire.

## Test plan

- [x] `cd tools/causa-mcp && npm test` — 80 tests / 213 assertions, all green (was 42/130 pre-W-1; +38 tests / +83 assertions).
- [x] `cd tools/mcp-conformance/wire-vocab && clojure -M:test` — 38 tests / 534 assertions, all green (the union `OverflowBody` schema validates the causa fixture; my new emit-source doesn't break the per-tool tripwires).
- [x] `cd tools/mcp-base && clojure -M:test` — 112 tests / 283 assertions, all green (no upstream regression).

Test coverage in `token_cap_test`:
- Public surface, constants, hint vocabulary.
- Clamp at floor / ceiling / nil / zero / non-number.
- Arg extraction from JS object + CLJS map + clamp.
- Marker shape: minimum / with continuation / out-of-vocab hint fallback / every-hint-keyword roundtrip / byte-identical to the conformance fixture.
- `apply-cap`: under-budget identity / at-budget (==cap) pass / over-token / over-byte (rf2-ih7g4 secondary gate) / cumulative across multiple slots / nil-cap defaults to 5000.
- Hint override: per-tool table fallback / explicit override / out-of-vocab override.
- Continuation splices on when supplied / omits off when absent.
- MCP-SDK result shape conformance.
- End-to-end spec/004 §1 marker shape with all required slots.
- MUST 6 anti-leak: original payload bytes MUST NOT bleed into the overflow result.