### PR TITLE
ci(classifier): tighten tools/* over-firing rules (rf2-os0c1)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -150,16 +150,46 @@ else
         examples_browser=true
         ;;
       tools/template/*)
-        tools_jvm=true
+        # rf2-os0c1 — tools/template is a clj-new template that scaffolds
+        # new projects; it does not share runtime with causa/story/story-mcp/
+        # mcp-base. The template_expensive gate fires jvm-tools-template
+        # (its only PR-time job); tools_jvm would unnecessarily fire the
+        # four sibling jvm-tools-* probes.
         template_expensive=true
         ;;
-      tools/story/*|tools/story-mcp/*|tools/causa/*|tools/causa-mcp/*)
+      tools/story/*|tools/causa/*)
+        # rf2-os0c1 — Story / Causa runtime changes legitimately fan out
+        # to story-causa-browser (Playwright feature gates), tools_jvm
+        # (per-artefact JVM unit tests + sibling story-mcp consumer), and
+        # mcp_conformance (the MCP wrappers consume these artefacts).
         tools_jvm=true
         mcp_conformance=true
         story_causa_browser=true
         ;;
-      tools/pair2-mcp/*|tools/mcp-conformance/*|tools/mcp-base/*)
+      tools/story-mcp/*|tools/causa-mcp/*)
+        # rf2-os0c1 — MCP wrappers don't run in a browser; story-causa-browser
+        # exercises the Story/Causa CLJS runtimes via Playwright and is
+        # noise for an MCP-wrapper-only diff. tools_jvm + mcp_conformance
+        # cover the actual JVM probes (jvm-tools-story-mcp / wire-vocab) and
+        # node integration tests.
         tools_jvm=true
+        mcp_conformance=true
+        ;;
+      tools/pair2-mcp/*|tools/mcp-base/*)
+        # rf2-os0c1 — mcp-base is .cljc shared by every MCP server (rf2-vw4sq),
+        # and pair2-mcp ships as a Node binary plus a JVM mcp-base consumer.
+        # tools_jvm picks up jvm-tools-mcp-base; mcp_conformance fires the
+        # node + wire-vocab gates; mcp_live fires the pair2 live conformance.
+        tools_jvm=true
+        mcp_conformance=true
+        mcp_live=true
+        ;;
+      tools/mcp-conformance/*)
+        # rf2-os0c1 — mcp-conformance is JS test scripts plus the JVM
+        # wire-vocab subdir. The wire-vocab JVM tests already run under
+        # mcp-conformance-wire-vocab, which is gated by mcp_conformance.
+        # Setting tools_jvm here would needlessly fire four unrelated
+        # jvm-tools-* probes (causa/story/story-mcp/mcp-base).
         mcp_conformance=true
         mcp_live=true
         ;;

--- a/TESTING.md
+++ b/TESTING.md
@@ -110,11 +110,11 @@ boolean GitHub-Actions outputs per surface:
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
 | `examples_browser` | Examples surface changed. |
-| `tools_jvm` | Any tool artefact changed; gates the per-tool JVM jobs. |
+| `tools_jvm` | Story / Causa / Story-MCP / Causa-MCP / Pair2-MCP / MCP-base changed; gates the four per-tool JVM probes (`jvm-tools-{causa,story,story-mcp,mcp-base}`). Not set by `tools/template/*` or `tools/mcp-conformance/*` — those don't share runtime with the per-tool probes. |
 | `template_expensive` | `tools/template/*` changed; gates the template emitted-app smoke. |
 | `mcp_conformance` | Any MCP-server tool, `tools/mcp-base/*`, or `tools/mcp-conformance/*` changed. |
 | `mcp_live` | Pair2-mcp / mcp-base / mcp-conformance changed; gates the live MCP coverage. |
-| `story_causa_browser` | Story or Causa surface changed. |
+| `story_causa_browser` | `tools/story/*` or `tools/causa/*` runtime changed. Not set by the `-mcp` wrappers (they don't run in a browser). |
 | `skills_structural` | `skills/re-frame-pair2/*` or `skills/shared/*` changed. |
 
 A few "blast-radius" inputs force the full sweep:
@@ -143,6 +143,18 @@ before (e.g. `implementation/ssr-ring/*` was added without a
 matching classifier rule); when in doubt, prefer over-classifying
 ("fire `implementation_jvm` for the new directory") to under-
 classifying.
+
+When writing a new per-tool rule, set only the outputs whose jobs the
+artefact's tests *actually exercise*. Coarse rules push unrelated jobs
+into the matrix as `skipping` entries — runner-minute-free, but
+they consume API quota, force branch-protection bookkeeping, and
+clutter the PR-checks UI. rf2-os0c1 split four such over-firing rules:
+`tools/template/*` no longer fires `tools_jvm` (template doesn't share
+runtime with the per-tool JVM probes); `tools/story-mcp/*` and
+`tools/causa-mcp/*` no longer fire `story_causa_browser` (MCP wrappers
+don't run in a browser); `tools/mcp-conformance/*` no longer fires
+`tools_jvm` (its wire-vocab JVM tests already run under
+`mcp-conformance-wire-vocab`, which is gated by `mcp_conformance`).
 
 The script also has a `--all` flag (forces every output `true`) and
 accepts an explicit path list for local exploration:


### PR DESCRIPTION
## Summary

Inverse audit to rf2-mvugr (which fixed under-firing). Four per-tool case-branches in `.github/scripts/report-changed-surfaces.sh` were setting outputs whose jobs the artefact's tests don't actually exercise. This PR narrows them.

| Surface | Before | After | Saving |
|---|---|---|---|
| `tools/template/*` | 11 jobs (tools_jvm + template_expensive) | 7 (template_expensive only) | **−4** (drop tools_jvm — template doesn't share runtime with jvm-tools-{causa,story,story-mcp,mcp-base}) |
| `tools/story-mcp/*` | 16 (tools_jvm + mcp_conformance + story_causa_browser) | 15 | **−1** (drop story_causa_browser — MCP wrappers don't run in a browser; ~6 min Playwright job saved) |
| `tools/causa-mcp/*` | 16 (same) | 15 | **−1** (same) |
| `tools/mcp-conformance/*` | 16 (tools_jvm + mcp_conformance + mcp_live) | 12 | **−4** (drop tools_jvm — wire-vocab JVM tests already gated by mcp_conformance via mcp-conformance-wire-vocab job) |

Story / Causa / Pair2-MCP / MCP-base unchanged (their fanouts are already minimal — they legitimately need cross-artefact gates).

## What this PR does not do

- No `.github/workflows/*.yml` edits — workflow gates are correct as-is; the bug is the classifier feeding them coarsely.
- Does not split coarse shared gates (`tools_jvm`, `mcp_conformance`). Per-MCP-server gate splitting (so a pair2-only PR doesn't fire story-mcp jobs and vice versa) requires per-server output keys + workflow gate edits — filed for a follow-up bead.
- Does not add a rule for `tools/machines-viz/*` (currently no rule, no CI consumer either — under-firing follow-up).

## Note on "38 jobs"

The mayor's "PR #1290 fires 38 jobs" number is the **total matrix job count**, not the running set. `gh pr checks 1290` shows 16 running and 22 `skipping` (duration 0, no runner minutes). Skipped jobs still consume API quota, force branch-protection bookkeeping, and clutter the PR-checks UI — so the cleanup is worthwhile even though runner-minute savings are smaller than the headline number suggested.

## Test plan

Spot-checks against the tightened classifier (all green):

- `tools/template/src/x.clj` → only `template_expensive=true` (was also `tools_jvm`)
- `tools/story-mcp/src/x.clj` → `tools_jvm + mcp_conformance` (no `story_causa_browser`)
- `tools/causa-mcp/src/x.cljs` → same shape
- `tools/mcp-conformance/test/x.js` → `mcp_conformance + mcp_live` (no `tools_jvm`)
- `tools/story/src/x.cljc` → unchanged: `tools_jvm + mcp_conformance + story_causa_browser`
- `tools/causa/src/x.cljc` → unchanged: same
- `tools/pair2-mcp/src/x.cljs` → unchanged: `tools_jvm + mcp_conformance + mcp_live`
- `tools/mcp-base/src/x.cljc` → unchanged: same

Blast-radius rules still fire `--all` for `.github/workflows/test.yml`, `.github/scripts/report-changed-surfaces.sh`, `TESTING.md`, and `implementation/core/*` (this PR self-fires the full sweep because it edits both the classifier and TESTING.md — verified locally).

- [x] Findings doc at `ai/findings/ci-over-firing-2026-05-17.md` (local-only, gitignored)
- [x] Classifier diff verified per-surface with `bash .github/scripts/report-changed-surfaces.sh <path>`
- [x] TESTING.md §Changed-surface classifier updated (gate-table tightened, new paragraph on per-tool rule writing)
- [x] Worker worktree guard passed before edits (`scripts/assert-worker-worktree.ps1`)