### PR TITLE
fix+test(story): UI bugs + testbed siblings (6 beads cluster)

### DIFF
--- a/tools/story/src/re_frame/story/qr.cljs
+++ b/tools/story/src/re_frame/story/qr.cljs
@@ -67,10 +67,20 @@
   - `cell-px`  — pixel size of each QR cell. The total square edge is
                  roughly `(module-count + 2*margin) * cell-px`.
 
-  Pure data → data; no network access, no DOM touched."
+  Pure data → data; no network access, no DOM touched.
+
+  Returns `nil` when the input exceeds QR capacity at the chosen
+  error-correction level (rf2-3y7l4 — `qrcode-generator` throws on
+  overlong inputs; the share popover must not crash on long
+  `:cell-overrides`). Callers must handle the `nil` return as a
+  degraded-state signal (e.g. render a 'URL too long for QR — copy
+  link instead' panel) rather than splicing `nil` into the DOM."
   ([text]         (qr-svg-string text 4))
   ([text cell-px]
-   (let [qr (qrcode default-type-number default-error-correction-level)]
-     (.addData qr text)
-     (.make qr)
-     (.createSvgTag qr cell-px default-margin))))
+   (try
+     (let [qr (qrcode default-type-number default-error-correction-level)]
+       (.addData qr text)
+       (.make qr)
+       (.createSvgTag qr cell-px default-margin))
+     (catch :default _
+       nil))))

--- a/tools/story/src/re_frame/story/save_variant.cljc
+++ b/tools/story/src/re_frame/story/save_variant.cljc
@@ -38,12 +38,13 @@
   The dialog ratom + button component live in
   `re-frame.story.ui.save-variant` (CLJS-only)."
   (:require [clojure.string :as str]
-            [re-frame.core                  :as rf]
-            [re-frame.story.args            :as args]
-            [re-frame.story.config          :as config]
-            [re-frame.story.predicates      :as pred]
-            [re-frame.story.review-dialog   :as review-dialog]
-            [re-frame.story.ui.state        :as state]))
+            [re-frame.core                       :as rf]
+            [re-frame.story.args                 :as args]
+            [re-frame.story.config               :as config]
+            [re-frame.story.predicates           :as pred]
+            [re-frame.story.review-dialog        :as review-dialog]
+            [re-frame.story.ui.schema-validation :as schema-validation]
+            [re-frame.story.ui.state             :as state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: args-snapshot helper
@@ -75,6 +76,20 @@
    (args/resolve-args variant-id
                       {:active-modes   (or active-modes [])
                        :cell-overrides (or cell-overrides {})})))
+
+(defn snapshot-violations
+  "Project `args-snapshot` against `schema` using the validator-fn pair.
+  Thin pass-through to `schema-validation/args-violations` exposed here
+  for the save-as-variant flow (rf2-lancu) — the save dialog reads the
+  result to render a non-blocking 'Args do not match the variant's
+  Spec 010 schema' hint above the snippet, so the user catches a
+  drifted-args paste before it hits source.
+
+  Pure data → vec; JVM-testable. Returns the empty vector when no
+  validator / no schema / no violations (per Spec 010 §Recommended
+  soft-pass)."
+  [args-snapshot schema validator-fns]
+  (schema-validation/args-violations args-snapshot schema validator-fns))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: code-gen — `(reg-variant ... :args {...})` snippet
@@ -169,14 +184,25 @@
   captured `args-snapshot`. `now-ms` seeds the default id. The args
   ride in the dialog state's `:context` slot (per the review-dialog
   contract); a top-level `:args` key is preserved so callers reading
-  the legacy slot keep working."
-  [_state source-variant-id args-snapshot now-ms]
-  (let [base (review-dialog/open review-dialog/initial-state
-                                 source-variant-id
-                                 {:args args-snapshot}
-                                 now-ms
-                                 default-id-prefix)]
-    (assoc base :args args-snapshot)))
+  the legacy slot keep working.
+
+  3-arity arity preserved for back-compat callers that don't yet pass
+  violations; defaults to no violations. 4-arity stamps the violations
+  vector onto the dialog state so the save dialog can render the
+  rf2-lancu 'Args do not match the variant's Spec 010 schema' hint
+  pre-paste."
+  ([state source-variant-id args-snapshot now-ms]
+   (open state source-variant-id args-snapshot now-ms nil))
+  ([_state source-variant-id args-snapshot now-ms violations]
+   (let [base (review-dialog/open review-dialog/initial-state
+                                  source-variant-id
+                                  {:args       args-snapshot
+                                   :violations (vec violations)}
+                                  now-ms
+                                  default-id-prefix)]
+     (-> base
+         (assoc :args args-snapshot)
+         (assoc :violations (vec violations))))))
 
 (defn close
   "Close the dialog — returns the idle state."
@@ -213,8 +239,11 @@
 
 (defn set-open-dialog-fn!
   "Register the UI-layer dialog-open callback. The callback is invoked
-  as `(callback source-variant-id args-snapshot)`. Idempotent — calling
-  again replaces."
+  as `(callback source-variant-id args-snapshot now-ms violations)`
+  where `violations` is the vector returned by
+  `schema-validation/args-violations` against the live
+  component schema (rf2-lancu — may be empty/nil).
+  Idempotent — calling again replaces."
   [f]
   (reset! open-dialog-fn f))
 
@@ -250,15 +279,27 @@
            now-ms     (or now-ms #?(:clj  (System/currentTimeMillis)
                                     :cljs (.now js/Date)))]
        (when target
-         (let [snapshot (snapshot-args
-                          target
-                          {:active-modes   (:active-modes shell)
-                           :cell-overrides (get-in shell [:cell-overrides target])})
-               record   {:source-id target
-                         :args      snapshot
-                         :now-ms    now-ms}]
+         (let [snapshot   (snapshot-args
+                            target
+                            {:active-modes   (:active-modes shell)
+                             :cell-overrides (get-in shell [:cell-overrides target])})
+               ;; rf2-lancu — validate the snapshot against the variant's
+               ;; Spec 010 schema BEFORE opening the dialog so the user
+               ;; gets a non-blocking 'paste at your own risk' hint when
+               ;; the live args have drifted into a non-conforming state.
+               ;; Soft-pass when no schema / validator is registered
+               ;; (per Spec 010 §Recommended soft-pass).
+               violations #?(:cljs (snapshot-violations
+                                     snapshot
+                                     (schema-validation/resolve-component-schema target)
+                                     (schema-validation/validator-fns))
+                             :clj  [])
+               record     {:source-id  target
+                           :args       snapshot
+                           :violations violations
+                           :now-ms     now-ms}]
            (when-let [cb @open-dialog-fn]
-             (cb target snapshot now-ms))
+             (cb target snapshot now-ms violations))
            record))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -125,6 +125,30 @@
             (keep parse-override-entry)
             (str/split s #",")))))
 
+(defn parse-overrides-param*
+  "Like `parse-overrides-param` but also reports any entries that were
+  dropped (malformed token, unparseable EDN, etc.). Returns a map
+  `{:overrides ... :dropped [<entry-string> ...]}` — both keys always
+  present so callers can pattern-match without an else-branch.
+
+  Powers the share-import hint (rf2-9jthx): the share UI surfaces a
+  non-blocking note when N>0 overrides from a stale share URL no
+  longer apply (variant args refactored, renamed, removed). Pure;
+  JVM-testable. The legacy `parse-overrides-param` keeps its silent-
+  drop signature for the param-parsing call sites that don't care
+  about the dropped set."
+  [s]
+  (if (and (string? s) (seq (str/trim s)))
+    (let [entries  (str/split s #",")
+          parsed   (mapv (fn [e] [e (parse-override-entry e)]) entries)
+          kept     (into {} (keep (fn [[_ kv]] kv) parsed))
+          dropped  (->> parsed
+                        (remove (fn [[_ kv]] kv))
+                        (mapv first))]
+      {:overrides (not-empty kept)
+       :dropped   dropped})
+    {:overrides nil :dropped []}))
+
 (defn- ^:no-doc kv-pair
   "Build a `k=v` URL parameter fragment. `k` is a keyword;
   `v-encoded` is the already-percent-encoded value string."

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -283,6 +283,12 @@
       ;; Stage 6: per-variant share affordance (IMPL-SPEC §2.8.5).
       (when variant-id
         [share/share-button variant-id])]
+     ;; rf2-9jthx: share-import hint surfaces a non-blocking note when
+     ;; a hydrated share URL dropped one or more overrides (variant
+     ;; args refactored/renamed/removed). Renders nil when nothing
+     ;; dropped, so this is unconditional-safe.
+     (when variant-id
+       [share/share-import-hint variant-id])
      (cond
        (nil? variant-id)
        [:div {:style (:empty styles)} "no variant selected"]

--- a/tools/story/src/re_frame/story/ui/save_variant.cljs
+++ b/tools/story/src/re_frame/story/ui/save_variant.cljs
@@ -46,9 +46,17 @@
 
 (defn- open-dialog!
   "Open the dialog against `source-variant-id` with the captured
-  `args-snapshot`. `now-ms` seeds the default id."
-  [source-variant-id args-snapshot now-ms]
-  (swap! ui-dialog save-variant/open source-variant-id args-snapshot now-ms))
+  `args-snapshot`. `now-ms` seeds the default id. `violations` (rf2-
+  lancu) is the vector returned by
+  `schema-validation/args-violations` against the live component
+  schema — used by the dialog to render a non-blocking 'Args do not
+  match the variant's Spec 010 schema' hint when non-empty. May be
+  nil/empty (no schema registered, or all args conform)."
+  ([source-variant-id args-snapshot now-ms]
+   (open-dialog! source-variant-id args-snapshot now-ms nil))
+  ([source-variant-id args-snapshot now-ms violations]
+   (swap! ui-dialog save-variant/open
+          source-variant-id args-snapshot now-ms violations)))
 
 (defn- close-dialog! []
   (swap! ui-dialog save-variant/close))
@@ -137,28 +145,64 @@
 ;; written directly — same as the recorder's save-as-variant dialog.
 ;; ---------------------------------------------------------------------------
 
+(defn- violations-hint
+  "Render the rf2-lancu non-blocking violations note. Stripe and list
+  of violating keys, so the user catches a drifted-args paste before
+  it lands in source. nil when no violations."
+  [violations]
+  (when (seq violations)
+    [:div {:data-test "story-save-variant-violations-hint"
+           :data-violation-count (count violations)
+           :style {:padding "8px 10px"
+                   :margin "0 0 8px 0"
+                   :background "#3a2a1a"
+                   :color "#e0a060"
+                   :border "1px solid #a06030"
+                   :border-radius "3px"
+                   :font-family "monospace"
+                   :font-size "10px"
+                   :line-height "1.5"}}
+     [:div {:style {:font-weight "bold" :margin-bottom "4px"}}
+      "Args do not match the variant's Spec 010 schema — preview below; "
+      "paste at your own risk"]
+     [:ul {:style {:margin "4px 0 0 16px" :padding 0}}
+      (for [v violations]
+        ^{:key (str (:key v))}
+        [:li {:data-test "story-save-variant-violation-row"
+              :data-key  (str (:key v))}
+         (str (pr-str (:key v))
+              " = "
+              (pr-str (:value v)))])]]))
+
 (defn save-dialog
   "Render the save-variant modal. Visible iff `:open?` is true on the
   dialog ratom. The snippet re-generates on every keystroke as the user
   edits the new variant id; copy-to-clipboard surfaces the form for the
   user to paste into source.
 
+  rf2-lancu: when the captured snapshot violates the variant's Spec 010
+  schema, a non-blocking hint renders above the snippet listing the
+  violating keys. Non-blocking — the user can still paste; the snippet
+  carries the violating args as captured (paste at your own risk).
+
   Public so tests can render the dialog hiccup directly after seeding
   the dialog ratom."
   []
   (let [dialog @ui-dialog]
     (when (:open? dialog)
-      (let [{:keys [draft-id source-id args]} dialog
+      (let [{:keys [draft-id source-id args violations]} dialog
             snippet (save-variant/gen-variant-snippet
                       {:variant-id (or draft-id :story.saved/example)
                        :extends    source-id
                        :args       args})]
         (review-dialog/review-dialog dialog
           {:title             "Save current canvas state as new variant"
-           :hint              (str "Args snapshot captured from "
-                                   (pr-str source-id)
-                                   " — edit the new variant id and copy + paste into your "
-                                   "stories namespace. Source is never written directly.")
+           :hint              [:div
+                               [:div (str "Args snapshot captured from "
+                                          (pr-str source-id)
+                                          " — edit the new variant id and copy + paste into your "
+                                          "stories namespace. Source is never written directly.")]
+                               (violations-hint violations)]
            :snippet           snippet
            :placeholder-id    :story.saved/example
            :placeholder-input ":story.your-story/saved-flow"

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -125,11 +125,20 @@
   Toolbar modes hydrate in `re-frame.story.ui.toolbar`; this function
   owns the rest of the share URL contract: focused variant, per-variant
   cell overrides, and substrate. Invalid/stale variant ids are ignored
-  so old QR links degrade to the shell empty state instead of crashing."
+  so old QR links degrade to the shell empty state instead of crashing.
+
+  Surfaces the count of dropped overrides (rf2-9jthx) under
+  `[:rf.story/share-import-hint variant-id]` so the shell can render
+  a non-blocking hint when a recorded URL has drifted (variant args
+  refactored, removed, renamed). Returns nothing — side-effect only.
+  Pure helper exposed via `share/parse-overrides-param*` so tests can
+  assert per-axis without touching the ratom."
   []
   (when-let [params (current-url-params)]
     (let [variant-id (share/parse-keyword-token (.get params "variant"))
-          overrides  (share/parse-overrides-param (.get params "overrides"))
+          parsed     (share/parse-overrides-param* (.get params "overrides"))
+          overrides  (:overrides parsed)
+          dropped    (:dropped parsed)
           substrate  (share/parse-substrate-param (.get params "substrate"))
           valid?     (and variant-id (registrar/registered? :variant variant-id))]
       (state/swap-state!
@@ -139,10 +148,62 @@
                                  (state/select-variant variant-id)
                                  (state/select-workspace nil))
                        (seq overrides)
-                       (assoc-in [:cell-overrides variant-id] overrides))
+                       (assoc-in [:cell-overrides variant-id] overrides)
+                       (and valid? (seq dropped))
+                       (assoc-in [:rf.story/share-import-hint variant-id]
+                                 {:dropped-count (count dropped)
+                                  :dropped       (vec dropped)}))
                      s)]
             (cond-> s'
               substrate (assoc :substrate substrate))))))))
+
+(defn dismiss-share-import-hint!
+  "Clear the share-import hint for `variant-id` (rf2-9jthx). Called
+  from the hint's close affordance."
+  [variant-id]
+  (state/swap-state!
+    (fn [s] (update s :rf.story/share-import-hint dissoc variant-id))))
+
+(defn share-import-hint
+  "Render the share-import hint banner for `variant-id` when a hydrated
+  share URL dropped one or more overrides (rf2-9jthx). Non-blocking —
+  shows N + the dropped tokens, with a dismiss affordance.
+
+  Returns nil when nothing dropped, so callers can splice
+  unconditionally."
+  [variant-id]
+  (let [hint (get-in @state/shell-state-atom
+                     [:rf.story/share-import-hint variant-id])
+        n    (:dropped-count hint 0)]
+    (when (pos? n)
+      [:div {:role      "status"
+             :data-test "story-share-import-hint"
+             :data-dropped-count n
+             :style     {:padding "6px 10px"
+                         :margin "4px 0"
+                         :background "#3a2a1a"
+                         :color "#e0a060"
+                         :border "1px solid #a06030"
+                         :border-radius "3px"
+                         :font-family "monospace"
+                         :font-size "11px"
+                         :display "flex"
+                         :align-items "center"
+                         :justify-content "space-between"}}
+       [:span
+        (str n " override" (when (not= 1 n) "s")
+             " from this URL no longer apply — variant args refactored?")]
+       [:button {:style     {:padding "2px 8px"
+                             :background "#37373d"
+                             :color "#cccccc"
+                             :border "1px solid #555"
+                             :border-radius "3px"
+                             :cursor "pointer"
+                             :font-size "10px"
+                             :margin-left "10px"}
+                 :data-test "story-share-import-hint-dismiss"
+                 :on-click  (fn [_] (dismiss-share-import-hint! variant-id))}
+        "dismiss"]])))
 
 (defn- copy-to-clipboard!
   "Best-effort clipboard write. Uses the async clipboard API where

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -65,6 +65,18 @@
                :padding "6px"
                :border-radius "3px"
                :margin-bottom "8px"}
+   :qr-fallback {:display "flex"
+                 :align-items "center"
+                 :justify-content "center"
+                 :background "#3a2a1a"
+                 :color "#e0a060"
+                 :padding "10px"
+                 :border "1px dashed #a06030"
+                 :border-radius "3px"
+                 :margin-bottom "8px"
+                 :font-size "10px"
+                 :text-align "center"
+                 :line-height "1.4"}
    :copy-btn  {:padding "4px 10px"
                :background "#0e639c"
                :color "white"
@@ -172,12 +184,23 @@
             ;; safe here because the SVG markup comes from the
             ;; trusted vendored library — caller text only contributes
             ;; the encoded URL, never markup.
-            [:div {:style                   (:qr styles)
-                   :role                    "img"
-                   :aria-label              "QR code for variant URL"
-                   :data-test               "story-share-qr"
-                   :data-share-url          url
-                   :dangerouslySetInnerHTML {:__html (qr/qr-svg-string url 4)}}]
+            ;;
+            ;; rf2-3y7l4: when the URL exceeds QR capacity (long
+            ;; :cell-overrides etc.) `qr-svg-string` returns nil rather
+            ;; than throwing; we render a degraded panel and keep the
+            ;; copy-link affordance live below.
+            (if-let [svg (qr/qr-svg-string url 4)]
+              [:div {:style                   (:qr styles)
+                     :role                    "img"
+                     :aria-label              "QR code for variant URL"
+                     :data-test               "story-share-qr"
+                     :data-share-url          url
+                     :dangerouslySetInnerHTML {:__html svg}}]
+              [:div {:style          (:qr-fallback styles)
+                     :role           "note"
+                     :data-test      "story-share-qr-fallback"
+                     :data-share-url url}
+               "URL too long for QR — copy link instead"])
             [:button {:style    (:copy-btn styles)
                       :on-click (fn [_]
                                   (copy-to-clipboard! url)

--- a/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
+++ b/tools/story/src/re_frame/story/ui/test_mode/pure.cljc
@@ -65,12 +65,20 @@
       {:assertion :rf.assert/path-equals
        :status    :pass|:fail|:skip
        :label     \":rf.assert/path-equals [[:count] 7]\"
+       :row-key   \":rf.assert/path-equals [[:count] 7]\"
        :detail    {:expected ... :actual ... :reason ...
                    :source <{:file ... :line ...}|nil>}}
 
   `:detail` is always present so the renderer can read uniformly;
   the renderer decides whether to surface it (only failing rows
   expand by default). Pure data → data; JVM-testable.
+
+  `:row-key` is the stable identity the view uses to thread :expanded
+  state across re-runs (rf2-tistm): keying on positional index opened
+  the wrong row when a re-run reordered or inserted assertions. The
+  label string is the densest stable id available — it carries the
+  assertion id + payload shape together — and is JVM-testable so the
+  pure helpers can pin the contract.
 
   Source-coord stamping arrives on the record as either `:source` or
   `:source-coord` depending on the assertion path that built it
@@ -91,6 +99,7 @@
     {:assertion aid
      :status    status
      :label     label
+     :row-key   label
      :detail    {:expected (:expected rec)
                  :actual   (:actual rec)
                  :reason   (:reason rec)

--- a/tools/story/src/re_frame/story/ui/test_mode/state.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/state.cljs
@@ -97,7 +97,16 @@
   `idx` is a 0-based index into the variant's `:epoch-ids` vector.
   Pass nil to release — the canvas reverts to the post-play app-db
   (we restore against the last epoch-id in the slice, which is the
-  play-sequence's terminal state)."
+  play-sequence's terminal state).
+
+  No-ops while the slot's `:running?` is true (rf2-tistm). A
+  scrubber-tick during an in-flight `reset-variant` would race
+  `store-result!`: the restore would land against the frame being
+  reset, the new `:epoch-ids` would overwrite the slice, and
+  `:selected-step` would silently index a different epoch (or no
+  epoch at all). Better to drop the click than to corrupt the
+  scrubber state — the slot's epoch-ids may change shape under
+  it on resolve."
   [variant-id idx]
   (let [s          (get @results-atom variant-id)
         epoch-ids  (or (:epoch-ids s) [])
@@ -112,17 +121,22 @@
                      (peek epoch-ids)
 
                      :else nil)]
-    (swap! results-atom assoc-in [variant-id :selected-step] idx)
-    (when target-id
-      (epoch/restore-epoch variant-id target-id))))
+    (when-not (:running? s)
+      (swap! results-atom assoc-in [variant-id :selected-step] idx)
+      (when target-id
+        (epoch/restore-epoch variant-id target-id)))))
 
 (defn toggle-expanded!
-  [variant-id idx]
+  "Toggle the expand state of an assertion row, keyed by stable
+  identity (`row-key`, derived from `assertion-row :label`) rather
+  than positional index (rf2-tistm). A re-run that reorders or
+  inserts assertions would otherwise open the wrong row."
+  [variant-id row-key]
   (swap! results-atom update-in [variant-id :expanded]
          (fn [s] (let [s (or s #{})]
-                   (if (contains? s idx)
-                     (disj s idx)
-                     (conj s idx))))))
+                   (if (contains? s row-key)
+                     (disj s row-key)
+                     (conj s row-key))))))
 
 (defn run-variant-pane!
   "Drive a fresh `reset-variant` against the variant's frame and

--- a/tools/story/src/re_frame/story/ui/test_mode/view.cljs
+++ b/tools/story/src/re_frame/story/ui/test_mode/view.cljs
@@ -314,10 +314,17 @@
               [:th {:style (:th styles)} "assertion"]
               [:th {:style (:th styles)} "detail"]]]
             [:tbody
+             ;; rf2-tistm — :expanded is keyed by the row's stable
+             ;; identity (:row-key from assertion-row, the rendered
+             ;; label string) rather than positional index. A re-run
+             ;; that reorders or inserts assertions (e.g. a new :play
+             ;; step lands between two existing ones) would otherwise
+             ;; open the wrong row.
              (for [[i row] (map-indexed vector rows)]
-               (let [open? (contains? expanded i)
+               (let [rk    (:row-key row)
+                     open? (contains? expanded rk)
                      fail? (= :fail (:status row))]
-                 ^{:key i}
+                 ^{:key (str rk "#" i)}
                  [:tr {:data-test     "story-test-row"
                        :data-status   (name (:status row))
                        :data-assertion (str (:assertion row))
@@ -332,7 +339,7 @@
                      [:div
                       [:button
                        {:style    (:details-tog styles)
-                        :on-click (fn [_] (state/toggle-expanded! variant-id i))
+                        :on-click (fn [_] (state/toggle-expanded! variant-id rk))
                         :aria-expanded (if open? "true" "false")}
                        (if open? "hide detail" "show detail")]
                       (when open? (row-detail (:detail row)))]

--- a/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/save_variant_cljs_test.cljc
@@ -120,3 +120,96 @@
        (let [flat (str (ui-sv/save-dialog))]
          (is (str/includes? flat ":extends"))
          (is (str/includes? flat ":story.x/source"))))))
+
+;; ---- rf2-lancu: snapshot-violations + save-dialog pre-paste hint --------
+
+(deftest snapshot-violations-soft-passes-when-no-validator
+  (testing "rf2-lancu — snapshot-violations is a thin pass-through to
+            schema-validation/args-violations; soft-passes per Spec 010
+            when no validator / no schema (returns empty vec)"
+    (is (= [] (save-variant/snapshot-violations {:a 1} nil nil)))
+    (is (= [] (save-variant/snapshot-violations
+                {:a 1}
+                [:map [:a :int]]
+                nil))
+        "no validator-fns → soft-pass per Spec 010")
+    (is (= [] (save-variant/snapshot-violations
+                {:a 1}
+                [:map [:a :int]]
+                {:validate (fn [_ _] true)}))
+        "validator that always passes → no violations")))
+
+(deftest snapshot-violations-reports-non-conforming-keys
+  (testing "rf2-lancu — when args break the schema the violation list
+            names the offending keys + their values so the save dialog
+            can render the 'paste at your own risk' hint pre-paste"
+    (let [violations (save-variant/snapshot-violations
+                       {:a 1 :b "oops"}
+                       [:map [:a :int] [:b :int]]
+                       {:validate (fn [s v]
+                                    ;; trivial int-only validator for the test
+                                    (if (= :int s) (int? v) true))})]
+      (is (= 1 (count violations)))
+      (is (= :b (-> violations first :key)))
+      (is (= "oops" (-> violations first :value))))))
+
+(deftest open-stamps-violations-on-dialog-state
+  (testing "rf2-lancu — save-variant/open's 5-arity stamps the violations
+            vector on the dialog state so the save dialog can render the
+            non-blocking hint above the snippet"
+    (let [vs [{:key :b :value "oops" :schema :int :explain nil}]
+          s  (save-variant/open save-variant/initial-dialog-state
+                                :story.x/y {:a 1 :b "oops"} 0 vs)]
+      (is (true? (:open? s)))
+      (is (= vs (:violations s))
+          "violations ride the dialog state under :violations"))))
+
+(deftest open-3-arity-defaults-violations-to-empty-vec
+  (testing "rf2-lancu — back-compat: the legacy 3-arity (without
+            violations) stamps an empty vec so the dialog hint path
+            renders nothing"
+    (let [s (save-variant/open save-variant/initial-dialog-state
+                               :story.x/y {:a 1} 0)]
+      (is (= [] (:violations s))))))
+
+#?(:cljs
+   (deftest save-dialog-renders-no-violations-hint-when-empty
+     (testing "rf2-lancu — when the snapshot conforms (no violations) the
+               dialog renders the snippet without the violations hint"
+       (reset! ui-sv/ui-dialog
+               (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/source
+                                  {:label "hi"}
+                                  12345
+                                  []))
+       (let [flat (str (ui-sv/save-dialog))]
+         (is (not (str/includes? flat "story-save-variant-violations-hint"))
+             "no hint when violations is empty")
+         (is (not (str/includes? flat "paste at your own risk"))
+             "no scary hint text on a conforming snapshot")))))
+
+#?(:cljs
+   (deftest save-dialog-renders-violations-hint-when-non-empty
+     (testing "rf2-lancu — when the snapshot violates the schema the
+               dialog renders a non-blocking hint above the snippet
+               listing the offending keys. Non-blocking — the user can
+               still copy / paste; the snippet carries the violating
+               args as captured"
+       (reset! ui-sv/ui-dialog
+               (save-variant/open save-variant/initial-dialog-state
+                                  :story.x/source
+                                  {:label "hi" :count "not-an-int"}
+                                  12345
+                                  [{:key :count :value "not-an-int"
+                                    :schema :int :explain nil}]))
+       (let [flat (str (ui-sv/save-dialog))]
+         (is (str/includes? flat "story-save-variant-violations-hint")
+             "the hint container is present")
+         (is (str/includes? flat "paste at your own risk")
+             "the scary hint text is present")
+         (is (str/includes? flat "story-save-variant-violation-row")
+             "the violation list renders rows")
+         (is (str/includes? flat ":count")
+             "the offending key name appears in the hint")
+         (is (str/includes? flat "story-save-variant-snippet")
+             "the snippet still renders — the hint is non-blocking")))))

--- a/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/test_mode_state_cljs_test.cljs
@@ -1,0 +1,88 @@
+(ns re-frame.story.ui.test-mode-state-cljs-test
+  "Tests for the `:test` pane's local state surface (rf2-tistm).
+
+  Covers the rf2-tistm race-guard: `select-step!` must no-op while a
+  re-run is in flight (the variant frame is being reset; restoring
+  against it would land against transient state and the new
+  :epoch-ids slice would silently re-index :selected-step against a
+  different epoch on resolve).
+
+  Runs CLJS-only because `re-frame.story.ui.test-mode.state` is a
+  .cljs file (it derefs Reagent ratoms + calls into runtime). Cross-
+  platform pure assertions on `assertion-row :row-key` live in
+  `re-frame.story-ui-test` (JVM)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.epoch :as epoch]
+            [re-frame.story.ui.test-mode.state :as tm-state]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn reset-results! []
+  (reset! tm-state/results-atom {}))
+
+(use-fixtures :each {:before reset-results! :after reset-results!})
+
+;; ---- rf2-tistm: select-step! race guard ----------------------------------
+
+(deftest select-step-noops-while-running
+  (testing "rf2-tistm — select-step! must no-op when the variant's slot
+            carries :running? true. Concurrent restore against the
+            frame being reset by run-variant-pane! would corrupt the
+            scrubber state on resolve (store-result! writes a fresh
+            :epoch-ids slice; :selected-step would silently index a
+            different epoch)."
+    (let [variant-id :story.unit/race
+          epoch-ids  [:epoch/a :epoch/b :epoch/c]
+          restored   (atom [])]
+      (swap! tm-state/results-atom assoc variant-id
+             {:running?  true
+              :epoch-ids epoch-ids})
+      (with-redefs [epoch/restore-epoch (fn [vid eid]
+                                          (swap! restored conj [vid eid]))]
+        (tm-state/select-step! variant-id 1))
+      (is (= [] @restored)
+          "epoch/restore-epoch is not called while :running? is true")
+      (is (nil? (get-in @tm-state/results-atom [variant-id :selected-step]))
+          ":selected-step is NOT mutated while :running? is true — preserving
+           the prior scrubber position so the post-resolve render is
+           consistent"))))
+
+(deftest select-step-fires-when-not-running
+  (testing "rf2-tistm sanity: the guard is conditional on :running? — when
+            the slot is idle (:running? falsy), select-step! restores the
+            epoch and stamps :selected-step as before"
+    (let [variant-id :story.unit/idle
+          epoch-ids  [:epoch/a :epoch/b :epoch/c]
+          restored   (atom [])]
+      (swap! tm-state/results-atom assoc variant-id
+             {:running?  false
+              :epoch-ids epoch-ids})
+      (with-redefs [epoch/restore-epoch (fn [vid eid]
+                                          (swap! restored conj [vid eid]))]
+        (tm-state/select-step! variant-id 1))
+      (is (= [[variant-id :epoch/b]] @restored)
+          "the idle path still calls restore-epoch against the targeted slot")
+      (is (= 1 (get-in @tm-state/results-atom [variant-id :selected-step]))
+          ":selected-step is stamped to the requested index"))))
+
+;; ---- rf2-tistm: toggle-expanded! keyed by row-key ------------------------
+
+(deftest toggle-expanded-uses-row-key
+  (testing "rf2-tistm — toggle-expanded! threads its key (a string row-key
+            in normal use, but any value) straight into the :expanded set.
+            View consumers pass assertion-row's :row-key — see the JVM
+            test pinning row-key = :label in re-frame.story-ui-test."
+    (let [variant-id :story.unit/expand]
+      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
+      (is (= #{":rf.assert/path-equals [[:count] 1]"}
+             (get-in @tm-state/results-atom [variant-id :expanded]))
+          "first toggle inserts the row-key")
+      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 2]")
+      (is (= #{":rf.assert/path-equals [[:count] 1]"
+               ":rf.assert/path-equals [[:count] 2]"}
+             (get-in @tm-state/results-atom [variant-id :expanded]))
+          "second toggle with a different key adds to the set")
+      (tm-state/toggle-expanded! variant-id ":rf.assert/path-equals [[:count] 1]")
+      (is (= #{":rf.assert/path-equals [[:count] 2]"}
+             (get-in @tm-state/results-atom [variant-id :expanded]))
+          "toggling an already-present key removes it"))))

--- a/tools/story/test/re_frame/story_save_variant_test.clj
+++ b/tools/story/test/re_frame/story_save_variant_test.clj
@@ -209,7 +209,7 @@
     (state/swap-state! state/select-variant :story.snap/v)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _now-ms]
+        (fn [source-id args _now-ms _violations]
           (reset! captured {:source-id source-id :args args})))
       (let [result (save-variant/save-current-as-variant!)]
         (is (some? @captured) "the callback fired")
@@ -222,7 +222,7 @@
     (state/swap-state! state/select-variant nil)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [_ _ _] (reset! captured :fired)))
+        (fn [_ _ _ _] (reset! captured :fired)))
       (let [result (save-variant/save-current-as-variant!)]
         (is (nil? result) "no result without a focus")
         (is (nil? @captured) "callback never fires without a focus")))))
@@ -233,7 +233,7 @@
     (state/swap-state! state/select-variant nil)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _]
+        (fn [source-id args _ _]
           (reset! captured {:source-id source-id :args args})))
       (save-variant/save-current-as-variant! {:variant-id :story.snap/override})
       (is (= :story.snap/override (:source-id @captured)))
@@ -253,7 +253,7 @@
     (state/swap-state! state/select-variant :story.event/v)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _]
+        (fn [source-id args _ _]
           (reset! captured {:source-id source-id :args args})))
       (rf/dispatch-sync [save-variant/id-save-current-as-variant])
       (is (= :story.event/v (:source-id @captured)))
@@ -265,7 +265,7 @@
     (state/swap-state! state/select-variant nil)
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _]
+        (fn [source-id args _ _]
           (reset! captured {:source-id source-id :args args})))
       (rf/dispatch-sync [save-variant/id-save-current-as-variant
                          {:variant-id :story.event/explicit}])
@@ -284,7 +284,7 @@
     ;; Capture via the impure trigger; harvest snapshot from the callback.
     (let [captured (atom nil)]
       (save-variant/set-open-dialog-fn!
-        (fn [source-id args _]
+        (fn [source-id args _ _]
           (reset! captured {:source-id source-id :args args})))
       (save-variant/save-current-as-variant!)
       (let [snippet  (save-variant/gen-variant-snippet

--- a/tools/story/test/re_frame/story_share_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_share_cljs_test.cljs
@@ -87,3 +87,34 @@
     (let [svg (qr/qr-svg-string "https://example.test/" 4)]
       (is (not (str/includes? svg "api.qrserver.com")))
       (is (not (str/includes? svg "qrserver"))))))
+
+;; ---- rf2-3y7l4: overlong-URL guard --------------------------------------
+;;
+;; qrcode-generator at type-number 0 + ECC 'M' tops out around 2300
+;; alphanumeric chars (well under the 4296 absolute max for the largest
+;; type). A share URL carrying a fat :cell-overrides EDN map can blow
+;; past that. Pre-fix the throw propagated into Reagent render and
+;; blanked the share popover (taking the copy-link button with it).
+;; Post-fix the encoder returns nil — the popover renders a degraded
+;; panel and keeps copy-link reachable.
+
+(deftest qr-svg-string-overlong-returns-nil
+  (testing "qr-svg-string never throws into render — for a URL beyond
+            QR capacity it returns nil rather than propagating the
+            qrcode-generator exception (rf2-3y7l4)"
+    (let [pathological-overrides (apply str (repeat 10000 \X))
+          url (str "https://example.test/?variant=story.x/y&overrides="
+                   pathological-overrides)
+          result (qr/qr-svg-string url 4)]
+      (is (nil? result)
+          "encoder returns nil rather than throwing on an oversized payload"))))
+
+(deftest qr-svg-string-overlong-no-throw
+  (testing "the rf2-3y7l4 contract: qr-svg-string must NEVER throw,
+            regardless of input size — the share popover relies on
+            this to keep the copy-link button live when the QR cannot
+            be rendered"
+    (is (nil? (qr/qr-svg-string (apply str (repeat 50000 \A)) 4))
+        "50KB input returns nil without throwing")
+    (is (string? (qr/qr-svg-string "https://example.test/" 4))
+        "normal-sized input still produces an SVG string")))

--- a/tools/story/test/re_frame/story_share_test.clj
+++ b/tools/story/test/re_frame/story_share_test.clj
@@ -99,6 +99,62 @@
     (is (= {:label "Shared Label" :count 9}
            (share/parse-overrides-param "label:\"Shared Label\",count:9")))))
 
+;; ---- rf2-9jthx: parse-overrides-param* surfaces dropped entries ----------
+
+(deftest parse-overrides-param*-clean-input
+  (testing "rf2-9jthx — parse-overrides-param* returns the same :overrides
+            map as parse-overrides-param plus an empty :dropped vec for
+            clean input"
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param* "label:\"Hi\",count:9")]
+      (is (= {:label "Hi" :count 9} overrides))
+      (is (= [] dropped) "no entries dropped for a clean input"))))
+
+(deftest parse-overrides-param*-mixed-input
+  (testing "rf2-9jthx — parse-overrides-param* reports the SET of dropped
+            entries alongside the surviving overrides — the share-import
+            hint reads :dropped to count + name what failed.
+
+            'bogus' has no separator → no key/value split → dropped.
+            'count:[unclosed' has an unparseable EDN value → dropped.
+            'label:\"OK\"' and 'size:7' parse cleanly → kept."
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param*
+            "label:\"OK\",bogus,count:[unclosed,size:7")]
+      (is (= {:label "OK" :size 7} overrides)
+          "well-formed entries survive")
+      (is (= 2 (count dropped))
+          "two malformed entries — 'bogus' (no separator) and
+           'count:[unclosed' (bad EDN)")
+      (is (some #(= "bogus" %) dropped))
+      (is (some #(= "count:[unclosed" %) dropped)))))
+
+(deftest parse-overrides-param*-all-dropped
+  (testing "rf2-9jthx — when every entry is malformed :overrides is nil and
+            :dropped names them all"
+    (let [{:keys [overrides dropped]}
+          (share/parse-overrides-param* "bogus,also-bogus")]
+      (is (nil? overrides))
+      (is (= 2 (count dropped))))))
+
+(deftest parse-overrides-param*-blank-input
+  (testing "rf2-9jthx — blank/nil input returns the empty-shape map so
+            callers don't have to nil-check before destructuring"
+    (is (= {:overrides nil :dropped []}
+           (share/parse-overrides-param* nil)))
+    (is (= {:overrides nil :dropped []}
+           (share/parse-overrides-param* "")))
+    (is (= {:overrides nil :dropped []}
+           (share/parse-overrides-param* "   ")))))
+
+(deftest parse-overrides-param*-back-compat
+  (testing "rf2-9jthx — parse-overrides-param (legacy silent-drop) keeps
+            its signature. The share UI hydrator switches to
+            parse-overrides-param* so the dropped count surfaces; other
+            call sites that don't care about it keep working"
+    (is (= {:label "OK"}
+           (share/parse-overrides-param "label:\"OK\",bogus")))))
+
 (deftest variant-share-url-preserves-hash-route
   (testing "variant-share-url inserts params before # so the Story route survives"
     (let [url (share/variant-share-url

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -828,7 +828,22 @@
     (let [row (test-mode/assertion-row nil)]
       (is (= :fail (:status row))
           "nil record defaults to fail — a missing passed? slot can't be 'pass'")
-      (is (some? (:label row))))))
+      (is (some? (:label row)))))
+  (testing "assertion-row stamps :row-key = :label so the view can key
+            :expanded on stable identity instead of positional index (rf2-tistm).
+            A re-run that reorders or inserts assertions would otherwise open
+            the wrong row."
+    (let [a (test-mode/assertion-row
+              {:assertion :rf.assert/path-equals :payload [[:count] 1]
+               :passed? false :expected 1 :actual 0})
+          b (test-mode/assertion-row
+              {:assertion :rf.assert/path-equals :payload [[:count] 2]
+               :passed? false :expected 2 :actual 0})]
+      (is (= (:label a) (:row-key a)))
+      (is (= (:label b) (:row-key b)))
+      (is (not= (:row-key a) (:row-key b))
+          "different payloads produce distinct row-keys — keys do not collide
+           on a re-run that inserts a sibling path-equals on a different path"))))
 
 (deftest test-mode-format-elapsed-ms
   (testing "format-elapsed-ms switches at the 1s boundary"

--- a/tools/story/test/story_browser_scenarios.cjs
+++ b/tools/story/test/story_browser_scenarios.cjs
@@ -889,14 +889,16 @@ module.exports = {
        *     the toggle without mutating app state (panel visibility
        *     lives on shell state, not the variant frame's app-db).
        *
-       * Source-side follow-ons (filed separately): a dedicated
-       * panel registration whose :render points at an unregistered
-       * view id would let us assert the panel-host's "panel ... has
-       * no registered :render view" fallback branch (the broken-
-       * render path enumerated by the bead title). Adding that
-       * fixture would touch testbed source; per cluster discipline
-       * the broken-render rendering check stays as a P3 testbed
-       * bead.
+       * Broken-render fallback (rf2-76wo5): the testbed registers
+       * :Panel.counter-with-stories/broken-render whose :render
+       * points at the never-registered view id
+       * :counter-with-stories.views/not-registered. When the panel
+       * mounts (under any :story.counter/* variant, per the :for
+       * filter) the panel-host renders the fallback text:
+       *
+       *   panel <pid> has no registered :render view (<view-id>)
+       *
+       * Step (e) below anchors on that string.
        */
       await primeHelpDismissed(page);
       await gotoStory(page, '/counter-with-stories/#/stories');
@@ -1001,6 +1003,33 @@ module.exports = {
           timeoutMs: 5000,
           description: 'panel-visibility toggle restores the notes panel (parity-badge count >= 2)',
         },
+      );
+
+      // (e) rf2-76wo5 — broken-render fallback. The testbed
+      // registers :Panel.counter-with-stories/broken-render whose
+      // :render points at an unregistered view id. The panel-host
+      // renders the fallback text "panel ... has no registered
+      // :render view (...)" inside the right rail. We're back on
+      // /loaded (parent :story.counter) so the panel's :for filter
+      // passes; anchor on the substring + the absent view id.
+      const brokenAside = page.getByRole('complementary');
+      await expectVisible(
+        brokenAside.getByText(':Panel.counter-with-stories/broken-render', {
+          exact: false,
+        }).first(),
+        5000,
+      );
+      await expectVisible(
+        brokenAside.getByText('has no registered :render view', {
+          exact: false,
+        }).first(),
+        5000,
+      );
+      await expectVisible(
+        brokenAside.getByText(':counter-with-stories.views/not-registered', {
+          exact: false,
+        }).first(),
+        5000,
       );
     });
 

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -19,7 +19,11 @@
                         hiccup decorator alongside Story's canonical
                         `:rf.story/layout-debug.*` set).
   - `reg-story-panel` — `:Panel.counter-with-stories/notes` (a small
-                        project-custom panel in the right pane).
+                        project-custom panel in the right pane), and
+                        `:Panel.counter-with-stories/broken-render`
+                        (rf2-76wo5 testbed — :render points at an
+                        unregistered view to exercise the panel-host's
+                        broken-render fallback branch).
   - `reg-story`       — `:story.counter` parent (the four variants
                         below all inherit its decorators + args).
   - `reg-variant`     — four variants exercising every authoring shape.
@@ -179,6 +183,31 @@
      :title     "Notes"
      :placement :right
      :render    :counter-with-stories.views/parity-badge
+     :for       #{:story.counter}})
+
+  ;; -------------------------------------------------------------------------
+  ;; rf2-76wo5 — broken-render testbed panel
+  ;;
+  ;; A panel pointing at an :render view id that is NEVER registered.
+  ;; Exercises the panel-host's broken-render fallback branch in
+  ;; tools/story/src/re_frame/story/ui/panels.cljs:330-333:
+  ;;
+  ;;   "panel <pid> has no registered :render view (<view-id>)"
+  ;;
+  ;; The :for filter scopes the panel to :story.counter so test runs
+  ;; against /loaded surface the fallback without leaking it into
+  ;; every variant. Pure testbed — no source-side fix; the broken-
+  ;; render path is documented dev-time UX, not a defect.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-story-panel :Panel.counter-with-stories/broken-render
+    {:doc       "Testbed panel for rf2-76wo5 — :render points at an
+                unregistered view so the panel-host renders its
+                'no registered :render view' fallback. Asserted by
+                story_browser_scenarios.cjs."
+     :title     "Broken render (testbed)"
+     :placement :right
+     :render    :counter-with-stories.views/not-registered
      :for       #{:story.counter}})
 
   ;; -------------------------------------------------------------------------

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -509,6 +509,32 @@
      :tags      #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  ;; rf2-0uo4e — fx-stub-miss testbed variant. Source-side follow-on
+  ;; from rf2-6hauy. :play declares :rf.assert/effect-emitted against
+  ;; :never-stubbed WITHOUT a corresponding force-fx-stub decorator
+  ;; covering the id — the play-runner never observes the fx, so the
+  ;; assertion fails with the canonical reason:
+  ;;
+  ;;   "fx :never-stubbed was not emitted during play"
+  ;;
+  ;; Lets the test pane's failing-row reason-text surface be asserted
+  ;; directly without authoring a one-off probe. The variant is
+  ;; intentionally :test-tagged so the chrome test-widget picks it up
+  ;; and reports the failure.
+  (story/reg-variant :story.counter-matrix/fx-stub-miss
+    {:doc       "Deterministic fx-stub-miss failing assertion. :play
+                asserts :rf.assert/effect-emitted :never-stubbed with
+                NO force-fx-stub decorator covering it — the assertion
+                fails with the canonical 'fx <id> was not emitted
+                during play' reason. Pattern: :story.counter-
+                diagnostics/failing-play."
+     :args      {:label "fx-stub-miss"
+                 :settings {:title "fx-stub-miss" :enabled? true}}
+     :events    [[:counter/initialise 0]]
+     :play      [[:rf.assert/effect-emitted :never-stubbed]]
+     :tags      #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-workspace — two workspaces, one per layout the v1 ships
   ;;

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -134,9 +134,41 @@
                    :story.counter-matrix/isolation-b
                    :story.counter-matrix/recorder-redaction
                    :story.counter-matrix/a11y-known-good
-                   :story.counter-matrix/a11y-known-bad]]
+                   :story.counter-matrix/a11y-known-bad
+                   ;; rf2-0uo4e — fx-stub-miss testbed (parent story
+                   ;; :story.counter-matrix).
+                   :story.counter-matrix/fx-stub-miss]]
         (is (contains? vs vid) (str vid " registered")))
-      (is (= 13 (count vs))))))
+      (is (= 14 (count vs))))))
+
+(deftest fx-stub-miss-variant-fails-with-canonical-reason
+  (testing "rf2-0uo4e testbed — :story.counter-matrix/fx-stub-miss runs
+            and its :rf.assert/effect-emitted assertion FAILS with the
+            canonical reason text 'fx :never-stubbed was not emitted
+            during play'. This is the source-side fixture the test pane
+            renders in its failing-row reason-text surface."
+    (async done
+      (-> (story/run-variant :story.counter-matrix/fx-stub-miss)
+          (async-lib/then
+            (fn [result]
+              (let [assertions (:assertions result)
+                    miss       (first
+                                 (filter (fn [a]
+                                           (= :rf.assert/effect-emitted
+                                              (:assertion a)))
+                                         assertions))]
+                (is (= 1 (count assertions))
+                    "exactly one assertion declared on the variant")
+                (is (some? miss)
+                    ":rf.assert/effect-emitted record present")
+                (is (false? (:passed? miss))
+                    "the assertion FAILED — no force-fx-stub covers
+                     :never-stubbed so the play-runner never observed it")
+                (is (= "fx :never-stubbed was not emitted during play"
+                       (:reason miss))
+                    "the canonical reason text the test pane surfaces"))
+              (story/destroy-variant! :story.counter-matrix/fx-stub-miss)
+              (done)))))))
 
 (deftest example-workspaces-registered
   (testing "both workspaces registered"

--- a/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories_cljs_test.cljs
@@ -18,6 +18,7 @@
             [re-frame.core      :as rf]
             [re-frame.frame     :as frame]
             [re-frame.machines  :as machines]
+            [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story     :as story]
             [re-frame.story.async      :as async-lib]
@@ -81,6 +82,20 @@
 (deftest example-panel-registered
   (testing "the project's story-panel registered"
     (is (story/registered? :story-panel :Panel.counter-with-stories/notes))))
+
+(deftest example-broken-render-panel-registered
+  (testing "rf2-76wo5 testbed — the broken-render panel registered, and
+            its :render id is NOT registered as a view. Together those
+            two facts drive the panel-host into the broken-render
+            fallback branch (asserted live in story_browser_scenarios.cjs)."
+    (is (story/registered? :story-panel
+                           :Panel.counter-with-stories/broken-render)
+        "the testbed panel is registered")
+    (is (not (registrar/handler
+               :view :counter-with-stories.views/not-registered))
+        "the panel's :render view id is NOT registered — the panel-host
+         will hit the 'no registered :render view' fallback when it tries
+         to resolve it")))
 
 (deftest example-story-registered
   (testing "the parent story registered"


### PR DESCRIPTION
## Summary

Six-bead cluster across `tools/story/` — 4 bug/UX fixes + 2 testbed siblings.

### Bugs (P2/P3 fixes)
- **rf2-3y7l4** P2 — `qr-svg-string` returns `nil` on overlong URLs instead of throwing into render. Share popover renders a degraded panel ('URL too long for QR — copy link instead') and keeps the copy-link affordance live.
- **rf2-tistm** P2 — Test-pane scrubber `select-step!` no-ops when `:running?` true (drops scrubber-clicks during in-flight re-runs instead of corrupting state on resolve). `:expanded` set keys on a stable `:row-key` (= row's `:label`) rather than positional index, so a re-run that reorders/inserts assertions can no longer open the wrong row.
- **rf2-9jthx** P3 — `hydrate-from-url!` surfaces dropped overrides count via `[:rf.story/share-import-hint variant-id]`; canvas renders a non-blocking banner above the variant body. New pure helper `parse-overrides-param*` returns `{:overrides :dropped}` for per-axis testing; legacy parser keeps silent-drop signature.
- **rf2-lancu** P3 — `save-current-as-variant!` (CLJS) resolves the live Spec 010 schema + validator-fns and projects violations BEFORE opening the save dialog. Dialog renders a non-blocking 'Args do not match the variant's Spec 010 schema — paste at your own risk' hint with the offending keys. New `snapshot-violations` pure helper. `set-open-dialog-fn!` callback signature bumps to 4-arity (internal install surface).

### Testbed siblings (P3 — testbed-only deliverables)
- **rf2-76wo5** — `:Panel.counter-with-stories/broken-render` registered in the counter testbed with `:render` pointing at a never-registered view id. Drives the panel-host's broken-render fallback branch. Asserted in `story_browser_scenarios.cjs` + `stories_cljs_test.cljs`.
- **rf2-0uo4e** — `:story.counter-matrix/fx-stub-miss` variant whose `:play` declares `[:rf.assert/effect-emitted :never-stubbed]` without a covering `force-fx-stub` decorator. Exposes the canonical failing-row reason text 'fx :never-stubbed was not emitted during play'. CLJS test pins the exact reason string.

### Stability
- `npm run test:cljs` — 2281 tests, 6488 assertions, 0 failures.
- `clojure -M:test` (tools/story JVM) — 448 tests, 1393 assertions, 0 failures.

## Test plan
- [x] CLJS node-test full suite passes (2281/2281).
- [x] Story JVM tests pass (448/448).
- [x] Each fix carries either a new pinning test or extends an existing one (see commit bodies).
- [ ] Browser scenario (`story_browser_scenarios.cjs`) — rf2-76wo5 fallback assertion runs against the live shell (covered locally; CI gate validates on merge).