### PR TITLE
chore(small): 3 parked beads — router-perf + Mermaid + React-key conventions

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -169,6 +169,138 @@ always-on PR jobs; for the conditional surfaces, run the targeted
 commands from the [Local commands](#local-commands) tables matching
 whichever classifier outputs your diff trips.
 
+### Dependency diagram
+
+Two views of the same surface → output → jobs graph. The diagrams are
+hand-maintained against [`.github/scripts/report-changed-surfaces.sh`](.github/scripts/report-changed-surfaces.sh)
+(classifier rules) and [`.github/workflows/test.yml`](.github/workflows/test.yml)
+(`if:` gates); update both halves whenever a classifier rule or job-`if:`
+condition changes (per the **Adding a new artefact directory** rule above).
+
+**Surface → output** — read this to verify "did my PR fire the right
+classifier outputs?" Note the four hard-coded `mark_all` triggers in
+the top row light every output (defensive: a change to the matrix
+shape must re-run the matrix).
+
+```mermaid
+graph LR
+  classDef blast fill:#fdd,stroke:#a33;
+  classDef core fill:#fde,stroke:#a39;
+
+  S1[".github/workflows/test.yml<br/>.github/workflows/expensive-tests.yml<br/>report-changed-surfaces.sh<br/>TESTING.md"]:::blast --> ALL["(every output)"]:::blast
+
+  S2["implementation/core/*"]:::core --> impl_jvm
+  S2 --> adapter_diag
+  S2 --> cljs_br
+  S2 --> cljs_prod
+  S2 --> bundle_iso
+  S2 --> ex_br
+  S2 --> tools_jvm
+  S2 --> tpl_exp
+  S2 --> mcp_conf
+  S2 --> mcp_live
+  S2 --> story_causa_br
+
+  S3["implementation/adapters/reagent-slim/*<br/>examples/reagent/counter_slim_and_fast/*<br/>check-reagent-slim-bundle-isolation.cjs"] --> impl_jvm
+  S3 --> adapter_diag
+  S3 --> cljs_br
+  S3 --> cljs_prod
+  S3 --> reagent_slim
+  S3 --> ex_br
+
+  S4["implementation/adapters/* (other)"] --> impl_jvm
+  S4 --> adapter_diag
+  S4 --> cljs_br
+  S4 --> cljs_prod
+  S4 --> bundle_iso
+  S4 --> ex_br
+  S4 --> tools_jvm
+  S4 --> tpl_exp
+  S4 --> mcp_conf
+  S4 --> mcp_live
+
+  S5["implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*<br/>implementation/deps.edn"] --> impl_jvm
+  S5 --> cljs_br
+  S5 --> cljs_prod
+  S5 --> bundle_iso
+  S5 --> ex_br
+
+  S6["spec/conformance/fixtures/*"] --> impl_jvm
+  S6 --> cljs_br
+  S6 --> cljs_prod
+
+  S7["implementation/shadow-cljs.edn<br/>implementation/package.json<br/>implementation/package-lock.json<br/>implementation/scripts/*"] --> cljs_br
+  S7 --> cljs_prod
+  S7 --> bundle_iso
+  S7 --> reagent_slim
+  S7 --> ex_br
+  S7 --> story_causa_br
+
+  S8["examples/*"] --> cljs_br
+  S8 --> ex_br
+
+  S9["testbeds/*"] --> cljs_br
+  S9 --> ex_br
+
+  S10["tools/template/*"] --> tpl_exp
+
+  S11["tools/story/*<br/>tools/causa/*"] --> tools_jvm
+  S11 --> mcp_conf
+  S11 --> story_causa_br
+
+  S12["tools/story-mcp/*<br/>tools/causa-mcp/*"] --> tools_jvm
+  S12 --> mcp_conf
+
+  S13["tools/pair2-mcp/*<br/>tools/mcp-base/*"] --> tools_jvm
+  S13 --> mcp_conf
+  S13 --> mcp_live
+
+  S14["tools/mcp-conformance/*"] --> mcp_conf
+  S14 --> mcp_live
+
+  S15["skills/re-frame-pair2/tests/fixture/*"] --> skills_str
+  S15 --> mcp_conf
+  S15 --> mcp_live
+
+  S16["skills/re-frame-pair2/* (other)<br/>skills/shared/*"] --> skills_str
+
+  impl_jvm[implementation_jvm]
+  adapter_diag[adapter_diagnostic]
+  cljs_br[cljs_browser]
+  cljs_prod[cljs_prod]
+  bundle_iso[bundle_isolation]
+  reagent_slim[reagent_slim_bundle]
+  ex_br[examples_browser]
+  tools_jvm[tools_jvm]
+  tpl_exp[template_expensive]
+  mcp_conf[mcp_conformance]
+  mcp_live[mcp_live]
+  story_causa_br[story_causa_browser]
+  skills_str[skills_structural]
+```
+
+**Output → jobs** — read this to answer "if this output is `true`, what
+runs?" Job counts are grouped (the matrix expands to 30+ leaf jobs at
+PR time; one count per output here so the graph stays scannable).
+
+```mermaid
+graph LR
+  O1[implementation_jvm] --> J1["JVM artefact unit suites x9<br/>(jvm-core, jvm-flows, jvm-schemas,<br/> jvm-machines, jvm-routing, jvm-http,<br/> jvm-ssr, jvm-ssr-ring, jvm-epoch)"]
+  O2[adapter_diagnostic] --> J2["Adapter classpath probes x4<br/>(jvm-reagent, jvm-reagent-slim,<br/> jvm-uix, jvm-helix)"]
+  O3[cljs_browser] --> J3["node-test (consolidated CLJS<br/>unit + browser-test)"]
+  O4[cljs_prod] --> J4["Release-mode probes x3<br/>(browser-test-prod-elision,<br/> schemas boundary prod, etc.)"]
+  O5[bundle_isolation] --> J5["bundle-isolation"]
+  O6[reagent_slim_bundle] --> J6["reagent-slim-bundle-isolation"]
+  O7[examples_browser] --> J7["examples-browser (Playwright,<br/>testbeds + examples)"]
+  O8[story_causa_browser] --> J8["story-causa-browser<br/>(feature gates, Playwright)"]
+  O9[tools_jvm] --> J9["Per-tool JVM probes x4<br/>(jvm-tools-causa, jvm-tools-story,<br/> jvm-tools-story-mcp, jvm-tools-mcp-base)"]
+  O10[template_expensive] --> J10["jvm-tools-template<br/>(emitted-app smoke)"]
+  O11[mcp_conformance] --> J11["MCP conformance x5<br/>(mcp-conformance-{story,causa,<br/> pair2,wire-vocab,...})"]
+  O12[mcp_live] --> J12["mcp-conformance-pair2<br/>(live + hermetic)"]
+  O13[skills_structural] --> J13["skills-structural"]
+```
+
+
 ## Diagnostic / skip-ok gates
 
 Some checks intentionally exit 0 when their preconditions are absent. They are

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -155,10 +155,15 @@
   fell-through-to-default` warning is suppressed when this is false:
   single-frame apps cannot hit the footgun (the resolution chain has
   nowhere else to land), so emitting the warning would be noise rather
-  than signal. Per rf2-o8m0."
+  than signal. Per rf2-o8m0.
+
+  Body gated on `interop/debug-enabled?` (the sole caller is the dev-
+  only `emit-fallthrough-warning!`); production calls observe the
+  trivial `false` and the `frame/frame-ids` walk + transducer DCEs."
   []
-  (let [ids (frame/frame-ids)]
-    (boolean (some (fn [k] (not= :rf/default k)) ids))))
+  (when interop/debug-enabled?
+    (let [ids (frame/frame-ids)]
+      (boolean (some (fn [k] (not= :rf/default k)) ids)))))
 
 (defn- emit-fallthrough-warning!
   "Per rf2-o8m0: dispatch landed on `:rf/default` purely because the
@@ -183,39 +188,49 @@
   field is omitted — `dispatch` is a fn, not a macro, so the call site
   cannot be stamped without changing the public API. Documented
   limitation; tools that need call-site attribution capture it
-  externally."
+  externally.
+
+  Body gated on `interop/debug-enabled?` so the warning surface DCEs
+  wholesale under `:advanced` + `goog.DEBUG=false` (rf2-gaqwr): the
+  `:fell-through-to-default?` envelope key is only set in dev (per
+  `build-envelope` line 122) so the inner `(when ...)` is always
+  falsy in production, but without the outer compile-time gate the
+  reason-string allocation, the warning keyword's interned slot, the
+  `non-default-frame-registered?` call, and the helper-fn closure all
+  survive Closure DCE."
   [envelope]
-  (when (and (:fell-through-to-default? envelope)
-             (non-default-frame-registered?))
-    (let [event    (:event envelope)
-          event-id (first event)
-          reason   (str "Dispatch of `" event-id "` resolved to `:rf/default` "
-                        "because no `:frame` was supplied and `*current-frame*` "
-                        "was unbound, but no handler for that event is "
-                        "registered on `:rf/default`. The dispatch most "
-                        "likely originated from an async callback "
-                        "(`setTimeout`, `addEventListener`, "
-                        "`requestAnimationFrame`, `Promise.then`) attached "
-                        "from inside a view body — the surrounding "
-                        "frame-context binding does not survive the async "
-                        "escape (per Spec 002 §Dispatches issued from "
-                        "inside a handler body). Fixes (priority order): "
-                        "(a) use `:dispatch-later` or a registered `reg-fx` "
-                        "— both capture the frame in their closure; "
-                        "(b) capture `(rf/dispatcher)` inside the "
-                        "render and call it from the callback; "
-                        "(c) attach the listener from a Form-3 "
-                        "`:component-did-mount` / `use-effect` hook so "
-                        "the dispatcher is captured during render but "
-                        "the listener runs after commit.")]
-      (trace/emit! :warning
-                   :rf.warning/dispatch-from-async-callback-fell-through-to-default
-                   {:event        event
-                    :event-id     event-id
-                    :detected-at  (interop/now-ms)
-                    :routed-to    :rf/default
-                    :reason       reason
-                    :recovery     :no-recovery}))))
+  (when interop/debug-enabled?
+    (when (and (:fell-through-to-default? envelope)
+               (non-default-frame-registered?))
+      (let [event    (:event envelope)
+            event-id (first event)
+            reason   (str "Dispatch of `" event-id "` resolved to `:rf/default` "
+                          "because no `:frame` was supplied and `*current-frame*` "
+                          "was unbound, but no handler for that event is "
+                          "registered on `:rf/default`. The dispatch most "
+                          "likely originated from an async callback "
+                          "(`setTimeout`, `addEventListener`, "
+                          "`requestAnimationFrame`, `Promise.then`) attached "
+                          "from inside a view body — the surrounding "
+                          "frame-context binding does not survive the async "
+                          "escape (per Spec 002 §Dispatches issued from "
+                          "inside a handler body). Fixes (priority order): "
+                          "(a) use `:dispatch-later` or a registered `reg-fx` "
+                          "— both capture the frame in their closure; "
+                          "(b) capture `(rf/dispatcher)` inside the "
+                          "render and call it from the callback; "
+                          "(c) attach the listener from a Form-3 "
+                          "`:component-did-mount` / `use-effect` hook so "
+                          "the dispatcher is captured during render but "
+                          "the listener runs after commit.")]
+        (trace/emit! :warning
+                     :rf.warning/dispatch-from-async-callback-fell-through-to-default
+                     {:event        event
+                      :event-id     event-id
+                      :detected-at  (interop/now-ms)
+                      :routed-to    :rf/default
+                      :reason       reason
+                      :recovery     :no-recovery})))))
 
 (def ^:private empty-fx-overrides
   "Shared sentinel returned by `apply-overrides` on the no-override hot
@@ -294,14 +309,29 @@
 
   Returns truthy when the handler should run, falsy when it should be
   skipped. Defaults to true when the schemas namespace hasn't been
-  loaded."
+  loaded.
+
+  Body gated on `interop/debug-enabled?` (rf2-gaqwr). Spec 010
+  validate-*! is a dev-only validator surface — per
+  `re-frame.schemas.validate` §Production builds, every dev-time
+  `validate-*!` body sits inside its own `(if interop/debug-enabled?
+  ...)` gate and DCE-elides under :advanced+goog.DEBUG=false. The
+  validator therefore unconditionally returns true in production
+  whether or not the schemas artefact is loaded (the boundary-
+  validation seam `:schemas/validate-with-registered-fn` is the
+  production-side surface, not this one). Gating the router-side
+  caller collapses the late-bind lookup, the try/catch frame, and
+  the `:schemas/validate-event!` keyword's interned slot to a
+  constant `true` on the hot path."
   [event-id event handler-meta]
-  ;; Sticky hook (rf2-f72pd) — `:schemas/validate-event!` is published
-  ;; once at re-frame.schemas load and never withdrawn in production;
-  ;; this fires per-dispatch.
-  (if-let [validate! (late-bind/get-fn-cached :schemas/validate-event!)]
-    (try (validate! event-id event handler-meta)
-         (catch #?(:clj Throwable :cljs :default) _ true))
+  (if interop/debug-enabled?
+    ;; Sticky hook (rf2-f72pd) — `:schemas/validate-event!` is published
+    ;; once at re-frame.schemas load and never withdrawn in dev; fires
+    ;; per-dispatch.
+    (if-let [validate! (late-bind/get-fn-cached :schemas/validate-event!)]
+      (try (validate! event-id event handler-meta)
+           (catch #?(:clj Throwable :cljs :default) _ true))
+      true)
     true))
 
 (defn- assemble-initial-ctx

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -476,6 +476,49 @@ Render trees use Vars; runtime lookups use ids. `reg-view` bridges them — auto
 
 A bare `[:keyword args]` head in a render tree is an **HTML element** (Reagent's existing semantics) — the runtime does not intercept the keyword case to dispatch via the views registry. See [Spec 004 §Calling a registered view](004-Views.md#calling-a-registered-view) and [Cross-Spec-Interactions §21 Family asymmetry](Cross-Spec-Interactions.md#21-family-asymmetry--only-reg-view-has-a-macro-tier).
 
+## React keys: stable per-row identity, never positional, when rows can mutate
+
+When a re-frame2 view renders a collection of sibling rows whose membership or ordering can mutate at runtime (rows added, removed, reordered, filtered, or replaced), each sibling MUST be keyed on a value that follows row identity, not row position.
+
+This is a re-frame2 discipline because re-frame2 makes the mutable-collection case routine: a workspace lists every variant, a trace ribbon lists every captured trace, a controls repeater lists every entry the user has added. Whichever React substrate is mounted under the adapter port, React's reconciler uses `:key` to decide which DOM nodes (and which component instances, and which `r/with-let` brackets, and which `use-effect` cleanups) survive a re-render. A positional key (`(map-indexed (fn [i row] ^{:key i} [row-view row]))`) silently tells the reconciler that row `i` after the mutation IS row `i` before the mutation — even when the underlying row identity differs. The result is a class of bugs where a deletion leaks the deleted row's component state into the row that took its slot, an insertion mounts at the wrong index, and a `with-let` init body that should re-fire on identity change is silently retained.
+
+### Key naming
+
+Namespace the key value with a single-letter source prefix so a 10x / Causa inspector can read what "kind of row" a duplicate-key warning came from at a glance:
+
+| Prefix | Source                                                              | Example                       |
+|--------|---------------------------------------------------------------------|-------------------------------|
+| `v:`   | Variant cells (one row per registered variant)                      | `(str "v:" variant-id)`       |
+| `t:`   | Trace rows (one row per captured trace)                             | `(str "t:" trace-id)`         |
+| `r:`   | Mutable repeater rows (rows the user adds / removes / reorders)     | `(str "r:" row-id)`           |
+| `<i>`  | Bare positional, integer only                                        | `^{:key i} [field-view ...]`  |
+
+Bare positional `^{:key i}` is acceptable **only when the row collection has fixed arity** — a destructured 2-tuple, a 3-row form layout where the row count is a compile-time constant. The moment a row collection can grow, shrink, or reorder, the prefix-namespaced identity scheme above is required.
+
+### `r/with-let` init keys
+
+`r/with-let` (and any substrate equivalent that brackets first-render initialisation) re-fires its init body when the surrounding component remounts. When `:key` is the only signal that triggers a remount, the init body re-fires on key change but NOT on input change inside a single mounted instance. View bodies that read external inputs (variant id, run-key tuple, hot-reload tick) MUST include every relevant input in the `:key` tuple — otherwise the init body captures the first render's value and silently goes stale.
+
+```clojure
+;; WRONG — init captures the first run-key seen; subsequent changes to
+;; (run-key) are ignored inside the surviving with-let bracket.
+[^{:key (str "v:" variant-id)} [cell variant-id (run-key)]]
+
+;; RIGHT — every input that should re-init the cell rides the key tuple.
+[^{:key [(str "v:" variant-id) (run-key)]} [cell variant-id (run-key)]]
+```
+
+### Reference cases
+
+Four siblings of this discipline landed in one session and informed the rule above:
+
+- **Workspace cells**: PR [#1259](https://github.com/day8/re-frame2/pull/1259) (rf2-kgn0c) — variant cells switched from `^{:key i}` to `^{:key (str "v:" variant-id)}`.
+- **Causa trace ribbon**: PR [#1281](https://github.com/day8/re-frame2/pull/1281) (rf2-z4fza) — trace rows switched from `^{:key i}` to `^{:key (str "t:" trace-id)}`.
+- **Workspace cell re-init**: PR [#1283](https://github.com/day8/re-frame2/pull/1283) (rf2-c56hr) — `with-let` init keyed on the full run-key tuple, not just the hot-reload tick.
+- **Controls repeater**: PR [#1286](https://github.com/day8/re-frame2/pull/1286) (rf2-c8kfy) — repeater rows switched from `^{:key i}` to `^{:key (str "r:" row-id)}`; the inner tuple inside each row stayed `^{:key (str "t:" i)}` (fixed-arity tuple — positional legit).
+
+The discipline gap was surfaced by audit bead **rf2-yb5xx** (which found three siblings of rf2-kgn0c after the first fix landed).
+
 ## Packaging conventions
 
 re-frame2 ships as **multiple Maven artefacts**. A user picks the artefacts their app needs; bundle isolation is structural, not vigilance-based — the wrong feature or the wrong substrate is *absent from the classpath*, not eliminated by a hopeful pass of dead-code analysis.


### PR DESCRIPTION
Bundles three small, disjoint parked beads from prior triage rounds into one review pass.

## Commits

### 1. perf(router): gate emit-fallthrough-warning! + validate-event! bodies (rf2-gaqwr)

Per `ai/findings/implementation-bundle-size-2026-05-17.md` §Part 4 P3 (rf2-53tcf audit). Focused read pass on three surfaces in `implementation/core/src/re_frame/router.cljc`:

- **emit-fallthrough-warning! / non-default-frame-registered?**: wrapped the body in `(when interop/debug-enabled? ...)`. The inner `trace/emit!` already DCE'd via its own gate, but the `(:fell-through-to-default? envelope)` predicate read + the helper-fn closure + the per-call `frame/frame-ids` transducer walk survived. With the outer gate the helper itself DCEs.
- **validate-event!**: wrapped the late-bind lookup in `(if interop/debug-enabled? ... true)`. Per `re-frame.schemas.validate` §Production builds the dev-time validator returns `true` in production unconditionally; the router-side gate collapses the lookup, the try/catch, and the `:schemas/validate-event!` interned keyword to a constant `true`. (Bundle: `schemas/validate-event` literal disappears entirely after the fix.)
- **force-release-on-halt! / drain-emergency-release!**: no actionable change; runtime drain-lock release paths called on genuine production failures, bodies already minimal.

**Counter-bundle delta** (`examples/counter`, `:advanced` + `goog.DEBUG=false`): 369,321 → 368,951 raw (−370 B), 105,043 → 104,893 gzipped (−150 B). Below the original ~0.7 KB raw / 200 B gzipped speculation because the long reason string was already being DCE'd through the inner trace gate.

### 2. docs(testing): Mermaid dependency diagram for changed-surface classifier (rf2-2a174)

New §Dependency diagram sub-section under `TESTING.md` §Changed-surface classifier. Two `graph LR` Mermaid blocks (renders natively on GitHub):

- Surface → output — every classifier rule from `.github/scripts/report-changed-surfaces.sh`, with the four blast-radius triggers (`test.yml`, `expensive-tests.yml`, the script itself, `TESTING.md`) styled to stand out.
- Output → jobs — every classifier output paired with the jobs it gates in `.github/workflows/test.yml`, grouped by output (one count per gate so the graph stays scannable; matrix expands to 30+ leaf jobs at PR time).

Prose calls out that the diagrams are hand-maintained and ties updates to the existing two-sided "Adding a new artefact directory" checklist.

### 3. docs(conventions): codify React-key discipline (rf2-7gftq)

New §"React keys: stable per-row identity, never positional, when rows can mutate" in `spec/Conventions.md`, between §Render-tree shape and §Packaging conventions. Codifies the discipline behind the rf2-kgn0c sibling cluster:

- Single-letter source prefix scheme — `v:` (variants), `t:` (traces), `r:` (repeater rows); bare positional `^{:key i}` legitimate only for fixed-arity tuples.
- `r/with-let` init-key rule — every input that should re-init the bracket must ride the `:key` tuple; worked-example pair (wrong / right).
- Cross-links to the four landed PRs (#1259 / #1281 / #1283 / #1286) and the rf2-yb5xx audit.

## Test plan

- [x] `npm run test:perf-bundle` — PASS
- [x] `npm run test:elision` — PASS
- [x] `implementation/core` JVM tests — 522/2717/0/0
- [x] `npm run test:cljs` node-runtime — 2281/6488/0/0
- [x] `mkdocs build --strict` — exit 0
- [x] `python scripts/check_doc_slugs.py` — 321 files scanned, no broken links

Closes rf2-gaqwr, rf2-2a174, rf2-7gftq.