### PR TITLE
feat(causa-mcp): T-Insp tranche — 9 inspection tools (rf2-8xzoe.14..22)

### DIFF
--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -345,3 +345,58 @@ explicitly requested without a path. Default fallback
 `:narrow-filter`.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_app_db.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs).
+
+### get-app-db-diff (T-Insp-4, rf2-8xzoe.17)
+
+App-db diff for a named epoch. Per MUST 13 in
+[`spec/004-Wire-Pipeline.md`](004-Wire-Pipeline.md), the default mode
+returns **changed-paths-with-cardinalities, NOT the nested
+before/after diff** — a token-cheap envelope from which the agent
+drills via `get-app-db` for any single changed path. Source-coord
+pin: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+bead #17.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:frame` | keyword | nil | scope to one frame |
+| `:epoch-id` | string | **required** | the epoch to diff |
+| `:mode` | keyword | `:changed-paths` | `:changed-paths` or `:nested` |
+| `:include-sensitive?` | bool | false | passes to runtime walker |
+| `:include-large?` | bool | false | passes to runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape (default `:mode :changed-paths`):**
+
+```clojure
+{:ok? true
+ :frame <kw>
+ :epoch-id <id>
+ :mode :changed-paths
+ :diff {:added   [<path-vec> ...]
+        :removed [<path-vec> ...]
+        :changed [<path-vec> ...]
+        :counts  {:added <int> :removed <int> :changed <int>}}}
+```
+
+**Return shape (`:mode :nested`):**
+
+```clojure
+{:ok? true :frame <kw> :epoch-id <id> :mode :nested
+ :diff {:before <edn> :after <edn>}
+ :elided-large <int?>}
+```
+
+**Diff semantics:** the changed-paths projection recurses into maps;
+vectors / sets / scalars are leaves at the diff boundary (a changed
+vector is one `:changed` entry, not per-element). Path vectors are
+sorted by printed form so output is deterministic.
+
+**Privacy contract:** runtime accessor routes `:db-before` +
+`:db-after` through `re-frame.core/elide-wire-value` PRE-diff, so
+declared-sensitive paths are scrubbed before path-comparison.
+
+**Cap-reached hint:** `:switch-mode` (downshift from `:nested` to
+`:changed-paths`) or `:slice` (drill into a single changed path via
+`get-app-db`). Default fallback `:narrow-filter`.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_app_db_diff.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -296,3 +296,52 @@ in the epoch ring (evicted), the tool surfaces:
 multi-page.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_epoch_history.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs).
+
+### get-app-db (T-Insp-3, rf2-8xzoe.16)
+
+Direct-read app-db at a frame, optionally scoped by `:path` (`get-in`
+semantics). Per the MUST inventory in
+[`spec/004-Wire-Pipeline.md`](004-Wire-Pipeline.md) §Direct-read:
+**MUST 8** (path slicing is the default), **MUST 9** (summary mode is
+the default), **MUST 19** (both `:include-sensitive?` and
+`:include-large?` default `false`). Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #16.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:frame` | keyword | nil | scope to one frame |
+| `:path` | EDN-vec str | `nil` | slice into app-db |
+| `:mode` | keyword | `:summary` | `:summary` or `:full` |
+| `:include-sensitive?` | bool | false | passes to runtime walker |
+| `:include-large?` | bool | false | passes to runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :frame <kw>
+ :path <vec>
+ :mode <:summary|:full>
+ :value <edn>
+ :elided-large <int?>}
+```
+
+**Summary marker (`:mode :summary` default):**
+
+```clojure
+;; for a map :value
+{:rf.mcp/summary {:type :map :top-keys [:cart :user :nav] :count 3}}
+;; truncated when count > 64
+{:rf.mcp/summary {:type :map :top-keys [...64...] :count 5000
+                  :keys-truncated? true}}
+;; scalars ride through unchanged in summary mode
+:home
+```
+
+**Cap-reached hint:** `:slice` (drill via `:path`) when `:mode
+:full`; `:switch-mode` (downshift to `:summary`) when `:full` was
+explicitly requested without a path. Default fallback
+`:narrow-filter`.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_app_db.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -250,3 +250,49 @@ default). Pagination via `:limit` / `:offset`. Source-coord pin:
 **Cap-reached hint:** `:paginate` (default fallback `:narrow-filter`).
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_issues.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_issues.cljs).
+
+### get-epoch-history (T-Insp-2, rf2-8xzoe.15)
+
+Per-frame epoch history (vector of `:rf/epoch-record` per Tool-Pair
+§Time-travel). Oldest-first; depth-50 default page size with opaque
+cursor pagination via `:next-cursor`. The runtime returns the full
+history; this tool slices it cursor-relative on the MCP-server side
+so multi-page walks don't roundtrip the full epoch ring twice.
+Source-coord pin: `ai/findings/causa-epics-breakdown-2026-05-17.md`
+§Part 1 bead #15.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:frame` | keyword | nil | scope to one frame; nil → resolve sole frame |
+| `:limit` | int | 50 | page size (Tool-Pair depth-50 default) |
+| `:cursor` | string | nil | opaque resume cursor from prior `:next-cursor` |
+| `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` items |
+| `:include-large?` | bool | false | passes to the runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :frame <kw>
+ :epochs <vec of :rf/epoch-record>
+ :count <int> :total <int>
+ :limit <int>
+ :next-cursor <string?>      ; only when more pages remain
+ :dropped-sensitive <int?>
+ :elided-large <int?>}
+```
+
+**Cursor staleness:** if the cursor's `:after-id` no longer appears
+in the epoch ring (evicted), the tool surfaces:
+
+```clojure
+{:ok? false :reason :cursor-stale :frame <kw>
+ :requested-id <id> :hint "...re-call without :cursor..."}
+```
+
+**Cap-reached hint:** `:paginate` (default fallback `:narrow-filter`)
+— re-call with a smaller `:limit` or use the `:next-cursor` to walk
+multi-page.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_epoch_history.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -214,3 +214,39 @@ like `get-in`. Source-coord pin:
 otherwise. Default fallback `:narrow-filter`.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_machine_state.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs).
+
+### get-issues (T-Insp-7, rf2-8xzoe.20)
+
+Recent issue-tier events from the re-frame2 trace bus — errors,
+warnings, schema violations, hydration mismatches. Severity filter
+(`:error` matches `:error` + `:rf.schema/violation` +
+`:rf.hydration/mismatch`; `:warning` matches `:warning` only; `:all`
+default). Pagination via `:limit` / `:offset`. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #20.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:severity` | keyword | `:all` | `:error`, `:warning`, or `:all` |
+| `:frame` | keyword | nil | scope to one frame |
+| `:since-ms` | int | nil | wall-clock cutoff (ms) |
+| `:limit` | int | 50 | max issues returned |
+| `:offset` | int | 0 | skip the first N post-filter |
+| `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` items |
+| `:include-large?` | bool | false | passes to the runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :issues <vec>
+ :count <int> :total <int>
+ :limit <int> :offset <int>
+ :severity <:error|:warning|:all>
+ :dropped-sensitive <int?>
+ :elided-large <int?>}
+```
+
+**Cap-reached hint:** `:paginate` (default fallback `:narrow-filter`).
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_issues.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_issues.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -177,3 +177,40 @@ render a jump-to-definition link off the response. Source-coord pin:
 small, overflow only happens with pathological metadata).
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_source_coord.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs).
+
+### get-machine-state (T-Insp-5, rf2-8xzoe.18)
+
+Per-machine snapshot — the registered FSM spec for the named machine.
+Default `:mode :summary` returns the initial-state + tags +
+state-names (the keys of the transitions table) so a top-level
+inspection call ships a small payload; `:mode :full` returns the
+entire metadata map. Path slicing via `:path` drills into a subtree
+like `get-in`. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #18.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:machine-id` | keyword | **required** | the registered machine id |
+| `:frame` | keyword | nil | scope to one frame; nil → resolve sole frame |
+| `:path` | EDN-vec str | nil | slice into the spec, like `get-in` |
+| `:mode` | keyword | `:summary` | `:summary` or `:full` |
+| `:include-sensitive?` | bool | false | passes to the runtime walker |
+| `:include-large?` | bool | false | passes to the runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :frame <kw> :machine-id <kw>
+ :mode <:summary|:full>
+ :state <map>
+ :path <vec?>            ; only when :path supplied
+ :elided-large <int?>}
+```
+
+**Cap-reached hint:** `:slice` (drill in via `:path`) when `:mode
+:full` overflowed; `:switch-mode` (downshift to `:summary`)
+otherwise. Default fallback `:narrow-filter`.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_machine_state.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -109,3 +109,39 @@ hint registered; a future bead may add per-frame slicing when the
 catalogue surfaces a `:frame` arg here).
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_machine_list.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs).
+
+### get-handlers (T-Insp-8, rf2-8xzoe.21)
+
+Registrar surface — enumerate registered handlers grouped by `:kind`
+(event / sub / fx / cofx / machine / flow / frame / view /
+reg-machine). Default mode returns a kind-keyed map; pass
+`:group-by-kind? false` for the flat vector. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #21.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:kind` | keyword | nil | narrow to one registrar kind |
+| `:group-by-kind?` | bool | true | shape result as `{<kind> [...]}` vs flat vec |
+| `:include-sensitive?` | bool | false | passes to the runtime walker |
+| `:include-large?` | bool | false | passes to the runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap; clamped to `[500, 50000]` |
+
+**Return shape (grouped, default):**
+
+```clojure
+{:ok? true
+ :handlers {<kind> [{:id <any> :meta <map>} ...] ...}
+ :count <int>
+ :kinds <vec of kw>
+ :elided-large <int?>}
+```
+
+**Return shape (flat, `:group-by-kind? false`):**
+
+```clojure
+{:ok? true :handlers [{:kind :id :meta} ...] :count <int>}
+```
+
+**Cap-reached hint:** `:narrow-filter` — re-call with `:kind` to slice.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_handlers.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -1,0 +1,82 @@
+# 004-Tools-Catalogue: Causa-MCP tool catalogue
+
+This file is the **normative tool-catalogue** for `tools/causa-mcp/`.
+Every MCP tool the server exposes via `tools/list` is documented here
+with its arg shape, return envelope, and wire-pipeline contract.
+
+The catalogue is grouped by band (per
+[`tools/causa-mcp/spec/000-Vision.md`](000-Vision.md) §What it is):
+
+- **Inspection band** (read-only, T-Insp tranche) — rf2-8xzoe.14..22
+- **Mutation band** (state-changing, T-Mut tranche) — rf2-8xzoe.23..25
+- **Streaming band** (push-mode, T-Stream tranche) — rf2-8xzoe.26..28
+- **Meta band** (discover-app, eval-cljs, tail-build, get-causa-instructions) — rf2-8xzoe.29..32
+
+This file grows as each tranche lands; entries are append-only and
+follow a uniform shape so an agent reading the catalogue can pattern-
+match across tools.
+
+## Inspection band
+
+Inspection-band tools are **read-only**: they snapshot framework state
+(trace bus, epoch history, app-db, registry) without firing any
+re-frame side-effects. Every tool routes through the wire-pipeline
+boundary:
+
+| Mechanism | Where | Effect |
+|---|---|---|
+| **B-1 privacy default-suppress** | trace-stream tools (`get-trace-buffer`, `get-epoch-history`, `get-issues`) | drops `:sensitive? true` items unless `:include-sensitive? true` |
+| **W-6 size elision** | every tool returning tree-typed payload | counts `{:rf.size/large-elided ...}` markers the runtime walker emitted, stamps `:elided-large` on the envelope |
+| **W-1 token cap** | every tool | enforces `max-tokens` (default 5000, clamp `[500, 50000]`) — over-budget responses replaced with the `:rf.mcp/overflow` marker |
+
+### get-trace-buffer (T-Insp-1, rf2-8xzoe.14)
+
+Read a slice of the re-frame2 trace bus filtered by op-type / frame /
+since-ms / event-id / origin. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #14.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:frame` | keyword | nil | scope to one frame; nil → all frames |
+| `:op-type` | keyword | nil | filter by operation type |
+| `:since-ms` | int | nil | wall-clock cutoff (ms) |
+| `:event-id` | keyword | nil | filter by dispatched event id |
+| `:origin` | keyword | nil | filter by `:tags :origin` |
+| `:limit` | int | 50 | max events returned |
+| `:offset` | int | 0 | skip the first N events post-filter |
+| `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` items |
+| `:include-large?` | bool | false | opt back in to large values |
+| `:max-tokens` | int | 5000 | per-call cap; clamped to `[500, 50000]` |
+
+**Return shape (happy path):**
+
+```clojure
+{:ok? true
+ :events <vec>
+ :count <int>                  ; events returned
+ :total <int>                  ; events pre-strip
+ :limit <int>
+ :offset <int>
+ :dropped-sensitive <int?>     ; only when > 0
+ :elided-large <int?>}         ; only when > 0
+```
+
+**Overflow:**
+
+```clojure
+{:rf.mcp/overflow
+ {:limit :reached :cap <n> :would-be <n>
+  :hint :paginate
+  :continuation {:next-args {:limit 25}}}}
+```
+
+**Cap-reached hint:** `:paginate` — re-call with a smaller `:limit`.
+
+**Failure envelopes:**
+
+- `{:ok? false :reason :runtime-not-preloaded :hint <setup>}` —
+  Causa-the-panel preload isn't loaded.
+- `{:ok? false :reason :no-frame-resolved ...}` — `:frame` arg absent
+  in a multi-frame app.
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_trace_buffer.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -145,3 +145,35 @@ reg-machine). Default mode returns a kind-keyed map; pass
 **Cap-reached hint:** `:narrow-filter` — re-call with `:kind` to slice.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_handlers.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs).
+
+### get-source-coord (T-Insp-9, rf2-8xzoe.22)
+
+Return the source coord (`:ns :line :column :file`) for a registered
+handler. Aligns with editor-URI substitution so an agent host can
+render a jump-to-definition link off the response. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #22.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:kind` | keyword | **required** | registrar kind |
+| `:id` | keyword | **required** | the registered id |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true :kind <kw> :id <any> :source-coord {:ns :line :column :file}}
+```
+
+**Failure envelopes:**
+
+- `{:ok? false :reason :missing-kind :hint ...}` — `:kind` arg absent.
+- `{:ok? false :reason :missing-id   :hint ...}` — `:id` arg absent.
+- `{:ok? false :reason :no-source-coord :kind <k> :id <i>}` — handler
+  registered without `:source-coord` metadata (e.g. macroexpansion
+  unable to capture file/line).
+
+**Cap-reached hint:** `:narrow-filter` (default — source-coord is
+small, overflow only happens with pathological metadata).
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_source_coord.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -80,3 +80,32 @@ since-ms / event-id / origin. Source-coord pin:
   in a multi-frame app.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_trace_buffer.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs).
+
+### get-machine-list (T-Insp-6, rf2-8xzoe.19)
+
+Enumerate registered re-frame2 machines per frame with their current
+metadata (transitions, initial-state, tags). No pagination — bounded by
+the per-frame machine count which is typically single-digit. Source-
+coord pin: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+bead #19.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:include-sensitive?` | bool | false | passes to the runtime walker |
+| `:include-large?` | bool | false | passes to the runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap; clamped to `[500, 50000]` |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :machines {<machine-id> <meta-map> ...}
+ :count <int>
+ :elided-large <int?>}     ; only when > 0
+```
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — no per-tool
+hint registered; a future bead may add per-frame slicing when the
+catalogue surfaces a `:frame` arg here).
+
+Implementation: [`tools/causa-mcp/src/.../tools/get_machine_list.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs).

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/eval_form.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/eval_form.cljs
@@ -1,0 +1,162 @@
+(ns day8.re-frame2-causa-mcp.eval-form
+  "Mini-DSL for composing the CLJS eval forms causa-mcp tools ship over
+  nREPL (rf2-8xzoe T-Insp tranche shared infra; sibling to pair2-mcp's
+  `re-frame-pair2-mcp.tools.eval-form` which serves the same role with a
+  different runtime ns prefix).
+
+  Every inspection tool builds a CLJS source string addressed at
+  `day8.re-frame2-causa.runtime/<accessor>`, hands it to
+  `nrepl/cljs-eval-value`, and unwraps the returned envelope. Two costs
+  motivate the DSL over raw string concatenation:
+
+  1. The runtime namespace prefix appears at one site per tool — one
+     rename, nine edits without this ns; one edit with it.
+  2. Tests can assert against the DSL data (`[::call sym args]`) rather
+     than regex over generated source — whitespace / formatting drifts
+     in the form-builder don't break tests.
+
+  ## DSL shapes
+
+      [::call  sym args]      →  `(day8.re-frame2-causa.runtime/<sym> <emitted arg> …)`
+      [::call* qsym args]     →  `(<qsym> <emitted arg> …)`  — fully-qualified
+      [::let   bindings body] →  `(let [<binding-name> <binding-val> …] <body>)`
+      [::raw   source-string] →  `<source-string>`  — escape hatch
+      other value             →  `(pr-str v)` — EDN-printed literal
+
+  ## Origin-tag wrapper
+
+  Every causa-mcp eval form runs inside a
+  `(binding [day8.re-frame2-causa.runtime/*current-origin* :causa-mcp]
+     ...)`
+  wrapper so the runtime stamps `:tags :origin :causa-mcp` on every
+  mutation. `wrap-origin` is the helper inspection tools call once on the
+  outer form before `emit`.
+
+  ## Why the prefix isn't `re-frame.runtime/*` directly
+
+  Per `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides,
+  the causa runtime accessors live under `day8.re-frame2-causa.runtime`
+  — the Node-side MCP server renders forms addressed at that ns; the
+  browser-side preload installs the runtime. The MCP server never
+  `:require`s the runtime ns (different process). The string prefix is
+  the contract."
+  (:refer-clojure :exclude [emit])
+  (:require [clojure.string :as str]))
+
+(def runtime-ns
+  "The CLJS namespace every `rt-call` resolves into. Centralised here so
+  a future runtime rename is one edit, not many."
+  "day8.re-frame2-causa.runtime")
+
+(def origin-var
+  "Fully-qualified name of the runtime's `*current-origin*` dynamic var.
+  Used by `wrap-origin` to thread the `:causa-mcp` origin tag through
+  every mutation the runtime performs on the server's behalf."
+  (str runtime-ns "/*current-origin*"))
+
+(defn rt-call
+  "Build an IR node for a `runtime-ns`-relative function call. The
+  symbol is unqualified; args are emit-time `pr-str`'d unless they're
+  DSL nodes (which recurse) or [[rt-raw]] fragments."
+  [sym & args]
+  [::call sym (vec args)])
+
+(defn rt-call*
+  "Build an IR node for a fully-qualified function call. The symbol /
+  string is emitted verbatim (no `runtime-ns` prefix)."
+  [qsym & args]
+  [::call* qsym (vec args)])
+
+(defn rt-let
+  "Build an IR node for a `let` block. `bindings` is a flat seq of
+  alternating names (symbols) and value-forms; trailing `body-forms`
+  are wrapped in an implicit `do` if more than one is supplied."
+  [bindings & body-forms]
+  [::let (vec bindings) (vec body-forms)])
+
+(defn rt-raw
+  "Wrap a raw CLJS source string so `emit` inlines it verbatim instead
+  of `pr-str`'ing it as an EDN literal."
+  [source-string]
+  [::raw source-string])
+
+(defn- node? [x]
+  (and (vector? x)
+       (#{::call ::call* ::let ::raw} (first x))))
+
+(declare emit)
+
+(defn- emit-arg
+  "Render a single arg / binding-value to source. DSL nodes recurse;
+  collections of nodes recurse element-wise; everything else is
+  `pr-str`'d as an EDN literal."
+  [v]
+  (cond
+    (node? v)   (emit v)
+    (and (vector? v) (some node? v))
+    (str "[" (str/join " " (map emit-arg v)) "]")
+    (and (list? v) (some node? v))
+    (str "(" (str/join " " (map emit-arg v)) ")")
+    :else       (pr-str v)))
+
+(defn- emit-name [n]
+  (when-not (symbol? n)
+    (throw (ex-info "rt-let binding name must be a symbol"
+                    {:name n :type (type n)})))
+  (name n))
+
+(defn- emit-body [forms]
+  (case (count forms)
+    0 "nil"
+    1 (emit-arg (first forms))
+    (str "(do " (str/join " " (map emit-arg forms)) ")")))
+
+(defn emit
+  "Render an IR node to a CLJS source string. The single recursion
+  point for the DSL — every tool's eval form passes through here."
+  [form]
+  (cond
+    (not (node? form))
+    (pr-str form)
+
+    :else
+    (let [[tag] form]
+      (case tag
+        ::raw  (let [[_ s] form] s)
+
+        ::call (let [[_ sym args] form]
+                 (str "(" runtime-ns "/" (name sym)
+                      (when (seq args)
+                        (apply str (for [a args] (str " " (emit-arg a)))))
+                      ")"))
+
+        ::call* (let [[_ qsym args] form]
+                  (str "(" (str qsym)
+                       (when (seq args)
+                         (apply str (for [a args] (str " " (emit-arg a)))))
+                       ")"))
+
+        ::let (let [[_ bindings body-forms] form
+                    pairs (partition 2 bindings)]
+                (str "(let ["
+                     (str/join
+                       " "
+                       (for [[n v] pairs]
+                         (str (emit-name n) " " (emit-arg v))))
+                     "] "
+                     (emit-body body-forms)
+                     ")"))))))
+
+(defn wrap-origin
+  "Wrap an emitted CLJS source string in a `(binding
+  [day8.re-frame2-causa.runtime/*current-origin* :causa-mcp] ...)`
+  block so every mutation the runtime performs on behalf of the MCP
+  server carries the `:origin :causa-mcp` tag. Inspection tools call
+  this once at the outermost wrap step before shipping over nREPL.
+
+  The dynamic-var rebinding is per-call (the synchronous extent of the
+  eval'd form only); per the runtime ns docstring this is the
+  documented async-tagging gap (Lock #4 / I6 of
+  `tools/causa-mcp/spec/Principles.md`)."
+  [form-str]
+  (str "(binding [" origin-var " :causa-mcp] " form-str ")"))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/probe.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/probe.cljs
@@ -1,0 +1,120 @@
+(ns day8.re-frame2-causa-mcp.probe
+  "Preload probe + error translation for causa-mcp tools (rf2-8xzoe
+  T-Insp tranche shared infra).
+
+  The `day8.re-frame2-causa.runtime` namespace ships into the consumer
+  app via shadow-cljs's `:devtools :preloads` (riding Causa-the-panel's
+  preload, per `tools/causa-mcp/spec/000-Vision.md` §Two namespaces,
+  two sides). Each tool that needs the runtime first calls
+  `ensure-runtime!`, which checks `js/globalThis.__day8_re_frame2_causa_runtime`
+  — a load-time mirror the preload installs (see
+  `tools/causa/src/day8/re_frame2_causa/runtime.cljs` §Session
+  sentinel). Missing marker means the preload isn't configured; the
+  tool refuses with `{:ok? false :reason :runtime-not-preloaded}` and a
+  setup hint.
+
+  No cljs-eval inject path: the preload is the canonical setup
+  (parallel to pair2-mcp's rf2-7dvg posture).
+
+  ## Probe caching
+
+  Once `runtime-preloaded?` resolves to true for a `(conn, build-id)`
+  pair, the result is cached on the conn-atom (`:probed-builds`) for
+  the lifetime of the socket. Subsequent `ensure-runtime!` calls for
+  the same build short-circuit without an nREPL round-trip. The cache
+  resets on (re)connect — both `nrepl/connect!` and `nrepl/close!`
+  blank `:probed-builds` — so a full page reload (which destroys the
+  CLJS heap and the global sentinel) triggers a fresh probe on the
+  next tool call.
+
+  Negative results are NOT cached: a missing preload usually surfaces
+  on the very first call, and re-probing on each subsequent call lets
+  a freshly-added preload land without a server restart."
+  (:require [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+;; ---------------------------------------------------------------------------
+;; Preload probe.
+;; ---------------------------------------------------------------------------
+
+(def preload-missing-hint
+  "Operator-facing setup hint surfaced on the structured
+  `:runtime-not-preloaded` error envelope. Points at the
+  Causa-the-panel preload entry — the runtime ns rides that preload
+  per `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides."
+  (str "day8.re-frame2-causa.runtime is not loaded into this build. "
+       "The Causa-the-panel preload pulls the runtime — add it to "
+       "your shadow-cljs.edn:\n"
+       "  :builds {:app {:devtools {:preloads [day8.re-frame2-causa.preload]}}}\n"
+       "and make sure tools/causa is on :source-paths."))
+
+(defn- conn-has-probed?
+  "True iff `build-id` has been confirmed preloaded on the current
+  socket generation. Defensive against `nil` / non-atom `conn` —
+  tests pass stub conns that don't carry the cache."
+  [conn build-id]
+  (and (some? conn)
+       (satisfies? IDeref conn)
+       (contains? (:probed-builds @conn #{}) build-id)))
+
+(defn- mark-conn-probed!
+  "Record a positive probe result on the conn-atom so the next
+  `ensure-runtime!` for the same build can short-circuit. Defensive
+  against a non-atom `conn` (test stubs)."
+  [conn build-id]
+  (when (and (some? conn) (satisfies? IDeref conn))
+    (swap! conn update :probed-builds (fnil conj #{}) build-id)))
+
+(defn runtime-preloaded?
+  "Probe `js/globalThis.__day8_re_frame2_causa_runtime` — the
+  load-time marker set by the preloaded `day8.re-frame2-causa.runtime`
+  namespace. Resolves to a Promise of `true` iff the marker is
+  present.
+
+  Positive results are cached per `(conn, build-id)` on the conn-atom.
+  A cached hit resolves synchronously without an nREPL round-trip; a
+  miss runs one bencode round-trip and caches a positive outcome
+  before resolving."
+  [conn build-id]
+  (if (conn-has-probed? conn build-id)
+    (js/Promise.resolve true)
+    (-> (nrepl/cljs-eval-value
+          conn build-id
+          "(some? (and (exists? js/globalThis) (.-__day8_re_frame2_causa_runtime js/globalThis)))")
+        (.then (fn [v]
+                 (let [ok? (true? v)]
+                   (when ok? (mark-conn-probed! conn build-id))
+                   ok?)))
+        (.catch (fn [_] false)))))
+
+(defn ensure-runtime!
+  "Confirm the causa runtime is preloaded. Resolves to nil on success,
+  rejects with a structured `ex-info` carrying
+  `{:reason :runtime-not-preloaded :hint <setup>}` otherwise. Tools
+  that need the runtime call this first.
+
+  After the first positive probe per `(conn, build-id)`, this resolves
+  synchronously from cache — no nREPL round-trip per tool call."
+  [conn build-id]
+  (-> (runtime-preloaded? conn build-id)
+      (.then (fn [ok?]
+               (if ok?
+                 nil
+                 (js/Promise.reject
+                   (ex-info "causa runtime not preloaded"
+                            {:reason :runtime-not-preloaded
+                             :hint   preload-missing-hint})))))))
+
+;; ---------------------------------------------------------------------------
+;; Error helpers — translate Promise rejections into structured envelopes.
+;; ---------------------------------------------------------------------------
+
+(defn err->result
+  "Translate a Promise rejection into an `ok-text` result. Structured
+  `ex-info` reasons (e.g. `:runtime-not-preloaded`) surface verbatim;
+  other errors fall through to a generic eval-error shape stamped with
+  `fallback-reason`."
+  [fallback-reason err]
+  (if-let [data (ex-data err)]
+    (wire/ok-text (merge {:ok? false} data))
+    (wire/ok-text {:ok? false :reason fallback-reason :message (.-message err)})))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/registry.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/registry.cljs
@@ -1,0 +1,97 @@
+(ns day8.re-frame2-causa-mcp.registry
+  "Per-tool registration table for causa-mcp (rf2-8xzoe T-Insp tranche
+  shared infra).
+
+  Each tool ns under `day8.re-frame2-causa-mcp.tools.<tool-name>`
+  registers itself at load-time via `(register-tool! \"<name>\" handler
+  descriptor)`. The dispatcher in `tools.cljs` looks up the handler by
+  string name on every `tools/call`; the catalogue ns serves the
+  descriptor map under `tools/list`.
+
+  ## Why a separate registry ns rather than `tools.cljs` itself
+
+  Circular-dep avoidance — every per-tool ns needs to register, and
+  the tools-façade ns needs to read the registry; if both surfaces
+  lived together each per-tool ns would `:require` the façade and the
+  façade would `:require` each tool, producing a cycle. The registry
+  is the cycle-breaker: tools depend on it, the façade depends on it,
+  neither side depends on the other.
+
+  ## Registration shape
+
+      (register-tool!
+        \"get-trace-buffer\"
+        get-trace-buffer-tool
+        {:name \"get-trace-buffer\"
+         :description \"...\"
+         :input-schema #js {:type \"object\" ...}})
+
+  Handler is `(fn [conn args] -> Promise<MCPResult>)`. Descriptor is a
+  CLJS map with the three SDK-expected slots; `:input-schema` rides as
+  a JS object so the SDK serialises it as JSON Schema without an extra
+  conversion step."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Registration state.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private state
+  ;; Two parallel maps + an order vector. The order vector preserves
+  ;; insertion order so `tools/list` is deterministic across reloads
+  ;; (every load re-evaluates the per-tool `register-tool!` calls in
+  ;; their `:require` order from the dispatcher ns).
+  (atom {:handlers    {}
+         :descriptors {}
+         :order       []}))
+
+(defn register-tool!
+  "Add `tool-name` (a string — the MCP wire identity) to the registry
+  with `handler` (a `(fn [conn args] -> Promise<MCPResult>)`) and
+  `descriptor` (a CLJS map with `:name :description :input-schema`).
+
+  Idempotent: re-registering the same name replaces the handler /
+  descriptor without growing the order vector. Hot-reload friendly."
+  [tool-name handler descriptor]
+  (when (str/blank? tool-name)
+    (throw (ex-info "register-tool!: tool-name must be a non-blank string"
+                    {:tool-name tool-name})))
+  (swap! state
+    (fn [s]
+      (let [present? (contains? (:handlers s) tool-name)]
+        (-> s
+            (assoc-in [:handlers    tool-name] handler)
+            (assoc-in [:descriptors tool-name] descriptor)
+            (cond-> (not present?) (update :order conj tool-name))))))
+  tool-name)
+
+(defn handler-for
+  "Resolve the per-tool handler for `tool-name`. Returns nil for
+  unknown names — the dispatcher surfaces `:unknown-tool`."
+  [tool-name]
+  (get-in @state [:handlers tool-name]))
+
+(defn descriptor-for
+  "Resolve the descriptor map for `tool-name`. Returns nil for unknown
+  names."
+  [tool-name]
+  (get-in @state [:descriptors tool-name]))
+
+(defn all-descriptors
+  "All registered descriptor maps in insertion order. Used by the
+  catalogue façade to serve `tools/list`."
+  []
+  (let [{:keys [order descriptors]} @state]
+    (mapv descriptors order)))
+
+(defn registered-names
+  "All registered tool names in insertion order. Public so tests can
+  pin the catalogue size + ordering."
+  []
+  (:order @state))
+
+(defn reset-for-test!
+  "Wipe the registry for fixture isolation. Test-only — never call from
+  production code."
+  []
+  (reset! state {:handlers {} :descriptors {} :order []}))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
@@ -39,6 +39,7 @@
   (:require [applied-science.js-interop :as j]
             [clojure.string :as str]
             [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.tools :as tools]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
             ["@modelcontextprotocol/sdk/types.js" :as mcp-types]))
@@ -84,40 +85,27 @@
 
 (defn tool-descriptors-js
   "The Causa-shaped tool catalogue, as a JS array of descriptor maps.
-
-  Empty at F-2 — the eighteen-tool catalogue (`spec/000-Vision.md`
-  + `tools/causa/spec/010-MCP-Server.md`) lands in subsequent
-  F-tranche beads. Public so tests can pin the (currently empty)
-  shape and so the catalogue ns has a stable extension point when
-  it lands."
+  Delegates to `tools/tool-descriptors-js` — the per-tool
+  `register-tool!` side-effect populates the registry on load, and the
+  façade builds the JS-shape array from that registry. Public so tests
+  pin the catalogue shape."
   []
-  #js [])
+  (tools/tool-descriptors-js))
 
 (defn- handle-list [_req]
   (js/Promise.resolve #js {:tools (tool-descriptors-js)}))
 
-(defn- not-implemented-result [name]
-  ;; F-2 success-path `tools/call` stub: until the tool dispatcher
-  ;; lands, surface a structured envelope so MCP clients see a
-  ;; typed reason rather than a transport-level failure.
-  #js {:isError true
-       :content #js [#js {:type "text"
-                          :text (pr-str {:ok?    false
-                                         :reason :not-implemented
-                                         :tool   name
-                                         :hint   (str "The Causa-MCP tool catalogue lands in "
-                                                      "subsequent rf2-8xzoe F-tranche beads.")})}]})
-
 (defn- handle-call-success
-  "Success-path `tools/call` handler. F-2 stub: returns a structured
-  `:reason :not-implemented` envelope for every tool name (no
-  dispatcher yet). Replaced by a real dispatcher in a later
-  F-tranche, at which point this fn becomes a thin
-  `(tools/invoke conn name args extra)` adapter."
-  [_conn req _extra]
+  "Success-path `tools/call` handler. Routes the JSON-RPC request
+  through `tools/invoke`, which dispatches to the per-tool registry
+  and then wraps the result through the W-1 token-cap boundary step.
+  Each per-tool body internally applies the B-1 privacy + W-6 elision
+  gates before returning."
+  [conn req extra]
   (let [params (j/get req :params)
-        name   (j/get params :name)]
-    (js/Promise.resolve (not-implemented-result name))))
+        name   (j/get params :name)
+        args   (j/get params :arguments)]
+    (tools/invoke conn name args extra)))
 
 ;; ---------------------------------------------------------------------------
 ;; Server boot.

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -40,6 +40,7 @@
             [day8.re-frame2-causa-mcp.tools.get-source-coord]
             [day8.re-frame2-causa-mcp.tools.get-machine-state]
             [day8.re-frame2-causa-mcp.tools.get-issues]
+            [day8.re-frame2-causa-mcp.tools.get-epoch-history]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -1,0 +1,116 @@
+(ns day8.re-frame2-causa-mcp.tools
+  "MCP tool dispatcher for causa-mcp (rf2-8xzoe T-Insp tranche).
+
+  Each tool is implemented in its own file under
+  `day8.re-frame2-causa-mcp.tools.<tool-name>`; this ns is the
+  façade — it owns `tool-descriptors-js` (the static catalogue the MCP
+  `tools/list` handler serves) and `invoke` (the `tools/call` dispatch
+  glue with the W-1 token-cap boundary step).
+
+  ## Why a thin façade rather than the pair2-mcp four-step pipeline
+
+  pair2-mcp's `re-frame-pair2-mcp.tools/wire-boundary-pipeline` runs
+  four steps (precheck, dispatch, apply-cache, apply-cap) under a
+  pluggable `boundary-step/run-step-pipeline` orchestrator. Causa-mcp's
+  T-Insp tranche needs only **dispatch + apply-cap**: there is no
+  request-level cache (B-2 lands later as its own tranche), and the
+  per-tool B-1 privacy filter + W-6 size-elision marker count live
+  inside the per-tool bodies (they're per-payload, not per-envelope).
+  A two-step inline composition is faster to read than a one-element
+  pipeline ceremony; the pipeline structure lands when a third step
+  arrives.
+
+  ## Per-tool registration
+
+  Tools register themselves into `handler-registry` at load-time via
+  `(register-tool! \"get-trace-buffer\" handler-fn descriptor-map)`.
+  The single-source-of-truth pattern means adding a new tool is one
+  file plus one `(register-tool! ...)` call — no central name-table
+  edit. The T-Insp tranche imports the nine tool nss below; each ns
+  performs its registration as a top-level side-effect."
+  (:require [applied-science.js-interop :as j]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.wire :as wire]
+            ;; T-Insp tranche tool nss — each registers itself at load
+            ;; (rf2-8xzoe.14..22). Listed in the bead-numbered order so a
+            ;; reader trace the cluster's commit sequence.
+            [day8.re-frame2-causa-mcp.tools.get-trace-buffer]
+            [day8.re-frame2-causa-mcp.registry :as registry]))
+
+;; ---------------------------------------------------------------------------
+;; Descriptor catalogue.
+;; ---------------------------------------------------------------------------
+
+(defn tool-descriptors
+  "All registered descriptor maps in insertion order. Public so tests
+  pin the catalogue shape (and the `server.cljs` `tools/list` handler
+  consumes it)."
+  []
+  (registry/all-descriptors))
+
+(defn- ->descriptor-js
+  "Convert a per-tool descriptor map (CLJS) to the JS shape the MCP
+  SDK serialises for `tools/list`. Each descriptor is
+  `{:name :description :input-schema}`; the schema is already a JS-
+  shaped JSON-Schema object so it rides through `clj->js` unchanged."
+  [{:keys [name description input-schema]}]
+  #js {:name        name
+       :description description
+       :inputSchema (or input-schema #js {:type "object"})})
+
+(defn tool-descriptors-js
+  "The Causa-shaped tool catalogue, as a JS array of descriptor maps.
+  Consumed by `server.cljs`'s `tools/list` handler. The array is freshly
+  built per call (cheap — bounded by the registered-tool count) so a
+  late-loaded tool ns is visible without a server restart."
+  []
+  (clj->js (mapv ->descriptor-js (tool-descriptors))))
+
+;; ---------------------------------------------------------------------------
+;; Dispatch glue.
+;; ---------------------------------------------------------------------------
+
+(defn- unknown-tool-result [name]
+  (wire/err-text {:ok?    false
+                  :reason :unknown-tool
+                  :tool   name
+                  :hint   "Run `tools/list` for the registered catalogue."}))
+
+(defn- dispatch-tool*
+  "Route a `tools/call` to the per-tool implementation. Unknown tools
+  resolve to an `isError` result rather than throwing — keeps the
+  server loop simple."
+  [conn name args]
+  (if-let [handler (registry/handler-for name)]
+    (handler conn args)
+    (js/Promise.resolve (unknown-tool-result name))))
+
+(defn invoke
+  "Dispatch a `tools/call` invocation. Returns a Promise resolving to
+  the MCP result object.
+
+  ## Two-step wire boundary
+
+  1. **dispatch** — per-tool implementation. Returns the JS-shape MCP
+     result (the per-tool body already ran the W-6 elision marker
+     count + B-1 privacy gate inside its envelope).
+  2. **apply-cap** — W-1 token-budget enforcement
+     (`token-cap/apply-cap`). Responses whose serialised size exceeds
+     the per-call cap (default 5,000 tokens; `max-tokens` arg can
+     override into `[500, 50000]`) are replaced with the
+     `{:rf.mcp/overflow ...}` marker. Already-marker results bypass
+     (the marker envelopes are sub-cap by construction).
+
+  `extra` carries the MCP `extra` payload (signal +
+  sendNotification + `_meta.progressToken`). Non-streaming tools
+  (every T-Insp tool) ignore it; the slot is kept on the surface so a
+  later streaming-band tranche lands without an `invoke` rename."
+  [conn name args _extra]
+  (-> (dispatch-tool* conn name args)
+      (.then (fn [result-js]
+               (if (wire/marker? result-js)
+                 result-js
+                 (token-cap/apply-cap
+                   result-js
+                   {:tool name
+                    :cap  (token-cap/max-tokens-arg args)}))))))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -41,6 +41,7 @@
             [day8.re-frame2-causa-mcp.tools.get-machine-state]
             [day8.re-frame2-causa-mcp.tools.get-issues]
             [day8.re-frame2-causa-mcp.tools.get-epoch-history]
+            [day8.re-frame2-causa-mcp.tools.get-app-db]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -39,6 +39,7 @@
             [day8.re-frame2-causa-mcp.tools.get-handlers]
             [day8.re-frame2-causa-mcp.tools.get-source-coord]
             [day8.re-frame2-causa-mcp.tools.get-machine-state]
+            [day8.re-frame2-causa-mcp.tools.get-issues]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -38,6 +38,7 @@
             [day8.re-frame2-causa-mcp.tools.get-machine-list]
             [day8.re-frame2-causa-mcp.tools.get-handlers]
             [day8.re-frame2-causa-mcp.tools.get-source-coord]
+            [day8.re-frame2-causa-mcp.tools.get-machine-state]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -42,6 +42,7 @@
             [day8.re-frame2-causa-mcp.tools.get-issues]
             [day8.re-frame2-causa-mcp.tools.get-epoch-history]
             [day8.re-frame2-causa-mcp.tools.get-app-db]
+            [day8.re-frame2-causa-mcp.tools.get-app-db-diff]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -36,6 +36,7 @@
             ;; reader trace the cluster's commit sequence.
             [day8.re-frame2-causa-mcp.tools.get-trace-buffer]
             [day8.re-frame2-causa-mcp.tools.get-machine-list]
+            [day8.re-frame2-causa-mcp.tools.get-handlers]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -37,6 +37,7 @@
             [day8.re-frame2-causa-mcp.tools.get-trace-buffer]
             [day8.re-frame2-causa-mcp.tools.get-machine-list]
             [day8.re-frame2-causa-mcp.tools.get-handlers]
+            [day8.re-frame2-causa-mcp.tools.get-source-coord]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -35,6 +35,7 @@
             ;; (rf2-8xzoe.14..22). Listed in the bead-numbered order so a
             ;; reader trace the cluster's commit sequence.
             [day8.re-frame2-causa-mcp.tools.get-trace-buffer]
+            [day8.re-frame2-causa-mcp.tools.get-machine-list]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs
@@ -1,0 +1,224 @@
+(ns day8.re-frame2-causa-mcp.tools.get-app-db
+  "Tool: `get-app-db` — direct-read app-db with elide-wire-value
+  (rf2-8xzoe.16, T-Insp-3 of the causa-mcp inspection tranche).
+
+  Returns the current `app-db` value at a frame, optionally scoped by
+  `:path` (per `get-in` semantics) and projected through summary mode
+  by default. Per the MUST inventory in
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §Direct-read:
+
+  - **MUST 8** — path slicing is the default; the full app-db is
+    intentionally not the no-arg shape (it would blow the cap for
+    every non-trivial app).
+  - **MUST 9** — summary mode is the default; `:mode :summary` ships
+    a `{:type :map :top-keys [...] :count <int>}` overview; `:mode
+    :full` ships the addressed value verbatim.
+  - **MUST 19** — direct-read privacy posture: both
+    `:include-sensitive?` and `:include-large?` default `false`. The
+    runtime accessor routes through `re-frame.core/elide-wire-value`
+    which substitutes the `:rf/redacted` sentinel at declared-
+    sensitive leaves and the `{:rf.size/large-elided ...}` marker at
+    over-threshold leaves.
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — counted on the kept payload; the runtime
+    walker already substituted markers server-side per MUST 17 (single
+    normative emission site).
+  - **B-1 privacy** — not directly applicable here (the payload is
+    user data, not trace events with the top-level `:sensitive?` flag;
+    declared-sensitive leaves are redacted by the runtime walker via
+    MUST 19).
+  - **W-1 token cap** — dispatcher-level. Cap-reached hint is
+    `:slice` (drill deeper via `:path`) for `:mode :full`;
+    `:switch-mode` (downshift to `:summary`) for `:mode :full`
+    without a path.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:frame` | keyword | nil | scope to one frame; nil → resolve sole frame |
+  | `:path` | EDN-vec str | `[]` | slice into app-db, like `get-in` |
+  | `:mode` | keyword | `:summary` | `:summary` or `:full` |
+  | `:include-sensitive?` | bool | false | passes to the runtime walker |
+  | `:include-large?` | bool | false | passes to the runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :frame <kw>
+       :path <vec>
+       :mode <:summary|:full>
+       :value <edn>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #16. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [cljs.reader :as edn]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:const summary-keys-cap
+  "Top-N keys included verbatim in a summary marker. Above this, the
+  marker truncates and attaches `:keys-truncated? true` so the marker
+  itself stays bounded — a 5,000-entry map's key list alone would
+  exceed the wire cap otherwise. 64 mirrors pair2-mcp's summary
+  primitive (rf2-qta8j) so cross-MCP agents recognise the cap."
+  64)
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-app-db opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn- summarise-value
+  "Project `v` down to a top-level summary marker. Cheap — one pass
+  over the top-level structure, no deep walk. Returns the value
+  unchanged for scalars (they already fit the wire cap by definition;
+  wrapping in a summary marker would add tokens without saving any).
+
+  Marker shape mirrors pair2-mcp's `tools/summary/tree-summary` so a
+  cross-MCP agent reads the same shape from both servers."
+  [v]
+  (cond
+    (map? v)
+    (let [ks    (vec (keys v))
+          n     (count ks)
+          shown (if (> n summary-keys-cap)
+                  (subvec ks 0 summary-keys-cap)
+                  ks)]
+      {:rf.mcp/summary
+       (cond-> {:type   :map
+                :top-keys shown
+                :count  n}
+         (> n summary-keys-cap) (assoc :keys-truncated? true))})
+
+    (vector? v)
+    {:rf.mcp/summary {:type :vector :count (count v)}}
+
+    (set? v)
+    {:rf.mcp/summary {:type :set :count (count v)}}
+
+    (sequential? v)
+    {:rf.mcp/summary {:type :seq :count (count v)}}
+
+    :else
+    ;; Scalars (numbers, strings, keywords, nil, boolean) ride through
+    ;; unchanged — wrapping them adds tokens without saving any.
+    v))
+
+(defn- parse-path-arg
+  "Coerce the `:path` MCP arg to a CLJS vector. Accepts a CLJS vector
+  passthrough, an EDN-printed vector string (`\"[:cart :items 0]\"`),
+  or nil. Returns `nil` for absent / unparseable input (the runtime
+  accessor treats nil as 'no slice', i.e. the full root)."
+  [v]
+  (cond
+    (nil? v)     nil
+    (vector? v)  v
+    (string? v)  (try (let [parsed (edn/read-string v)]
+                        (when (vector? parsed) parsed))
+                      (catch :default _ nil))
+    :else        nil))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :frame :path :value}` response into
+  the MCP envelope. Pure — tests pin the summary / elision logic.
+
+  `mode` selects the projection: `:summary` (default) wraps the value
+  in a `:rf.mcp/summary` marker; `:full` ships the value unchanged.
+  Marker count for W-6 indicator runs on the projected value so
+  summary-mode ships a small payload even when the underlying
+  app-db has many elision markers."
+  [runtime-envelope {:keys [mode]}]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-app-db returned a non-envelope shape"}
+
+      :else
+      (let [raw-value  (:value env)
+            projected  (if (= :full mode) raw-value (summarise-value raw-value))
+            elided     (elision/count-elided-markers projected)]
+        (wire/with-indicators
+          {:ok?   true
+           :frame (:frame env)
+           :path  (vec (:path env))
+           :mode  (or mode :summary)
+           :value projected}
+          {:elided elided})))))
+
+(defn get-app-db-tool
+  "MCP handler for `get-app-db`. Validates `:mode`; defaults `:path`
+  to nil (runtime resolves to the full root). Note: the spec MUST 8
+  says path slicing is the default — agents should ALWAYS pass
+  `:path` for non-trivial app-dbs. The default `:mode :summary`
+  protects the wire cap when an agent omits the path; the operator
+  hint surfaces in the `:rf.mcp/overflow` continuation when needed."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        frame    (wire/arg-keyword args :frame)
+        path     (parse-path-arg (wire/arg args :path))
+        mode     (or (wire/arg-keyword args :mode) :summary)
+        incl?    (privacy/parse-include-sensitive args)
+        incl-large? (elision/parse-include-large args)]
+    (cond
+      (not (contains? #{:summary :full} mode))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :invalid-mode
+                       :given  mode
+                       :hint   "mode must be :summary or :full"}))
+
+      :else
+      (let [runtime-opts (cond-> {:include-sensitive? incl?
+                                  :include-large?     incl-large?}
+                           frame (assoc :frame frame)
+                           (seq path) (assoc :path path))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope
+                                                   {:mode mode}))))
+            (.catch (fn [err] (probe/err->result :get-app-db-failed err))))))))
+
+(def descriptor
+  {:name        "get-app-db"
+   :description (str "Direct-read app-db at a frame, optionally scoped "
+                     "by :path (get-in semantics). Default :mode "
+                     ":summary returns a top-level overview marker; "
+                     ":mode :full returns the addressed value verbatim. "
+                     "Sensitive/large values are redacted/elided by "
+                     "default; pass :include-sensitive? true / "
+                     ":include-large? true to opt back in. Path "
+                     "slicing is the recommended default — for "
+                     "non-trivial app-dbs, pass :path to bound the "
+                     "response.")
+   :input-schema #js {:type "object"
+                      :properties #js {:frame              #js {:type "string"}
+                                       :path               #js {:type "string"}
+                                       :mode               #js {:type "string"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-app-db-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs
@@ -1,0 +1,255 @@
+(ns day8.re-frame2-causa-mcp.tools.get-app-db-diff
+  "Tool: `get-app-db-diff` — app-db diff for a named epoch
+  (rf2-8xzoe.17, T-Insp-4 of the causa-mcp inspection tranche).
+
+  Returns the slice diff for an epoch — what changed in `app-db`
+  between `:db-before` and `:db-after`. Per the MUST inventory in
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md`:
+
+  - **MUST 13** — default returns **changed-paths-with-cardinalities,
+    NOT the nested before/after diff**. The agent gets a token-cheap
+    `{:added [...] :removed [...] :changed [...]}` envelope from
+    which it can drill in via `get-app-db` for any single changed
+    path. The full nested diff is opt-in via `:mode :nested`.
+  - **MUST 19** — direct-read privacy: `:include-sensitive?` /
+    `:include-large?` default `false`. The runtime accessor routes
+    `:db-before` + `:db-after` through `re-frame.core/elide-wire-value`
+    pre-diff, so declared-sensitive paths are scrubbed BEFORE the
+    diff is computed (a sensitive path that didn't actually change
+    still surfaces as redacted on both sides; one that changed
+    surfaces as redacted-but-changed).
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — counted on the projected diff. In the
+    default `:mode :changed-paths` projection the count is generally
+    zero (paths are scalar vectors); the count is meaningful in
+    `:mode :nested` where the projected value carries the runtime's
+    marker substitutions.
+  - **B-1 privacy** — not directly applicable (epoch-record's
+    `:sensitive?` rollup gates the full record; a per-path strip
+    would be a different design and isn't in scope).
+  - **W-1 token cap** — dispatcher-level. Cap-reached hint
+    `:switch-mode` (downshift to `:changed-paths` from `:nested`) or
+    `:slice` (when even the changed-paths set is huge).
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:frame` | keyword | nil | scope to one frame |
+  | `:epoch-id` | string | **required** | the epoch to diff |
+  | `:mode` | keyword | `:changed-paths` | `:changed-paths` or `:nested` |
+  | `:include-sensitive?` | bool | false | passes to runtime walker |
+  | `:include-large?` | bool | false | passes to runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+  Default `:mode :changed-paths`:
+
+      {:ok? true
+       :frame <kw>
+       :epoch-id <id>
+       :mode :changed-paths
+       :diff {:added   [<path-vec> ...]
+              :removed [<path-vec> ...]
+              :changed [<path-vec> ...]
+              :counts  {:added <int> :removed <int> :changed <int>}}}
+
+  `:mode :nested`:
+
+      {:ok? true
+       :frame <kw>
+       :epoch-id <id>
+       :mode :nested
+       :diff {:before <edn> :after <edn>}
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #17. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [clojure.set :as set]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-app-db-diff opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+;; ---------------------------------------------------------------------------
+;; Changed-paths projection — MUST 13.
+;;
+;; Walks `before` + `after` recursively, emitting the path vectors
+;; where one tree has a key the other doesn't (`:added` / `:removed`)
+;; or both have the key but the value differs (`:changed`). Stops
+;; recursion at scalar boundaries — a path that points at a deep
+;; subtree-changed surfaces as one `:changed` entry, not one per
+;; leaf, so the agent's first-pass diff stays bounded.
+;; ---------------------------------------------------------------------------
+
+(defn- diffable-map?
+  "Recurse into maps only. Vectors / sets / scalars are leaves at the
+  diff boundary — a vector that changed shape is one `:changed`
+  entry, not N entries. Per spec/004 §Direct-read: changed-paths is
+  the path-key-set, not a per-leaf walk."
+  [x]
+  (map? x))
+
+(defn- changed-paths*
+  "Recursive walk producing `{:added [...] :removed [...] :changed [...]}`.
+  `path` is the path prefix accumulated so far."
+  [path before after]
+  (cond
+    ;; Both nil — no diff.
+    (and (nil? before) (nil? after))
+    {:added [] :removed [] :changed []}
+
+    ;; Equal at this level — no diff.
+    (= before after)
+    {:added [] :removed [] :changed []}
+
+    ;; Recurse into maps; emit per-key diffs.
+    (and (diffable-map? before) (diffable-map? after))
+    (let [b-keys (set (keys before))
+          a-keys (set (keys after))
+          added   (vec (sort-by str (set/difference a-keys b-keys)))
+          removed (vec (sort-by str (set/difference b-keys a-keys)))
+          common  (set/intersection a-keys b-keys)
+          per-k   (for [k (sort-by str common)
+                        :let [b (get before k)
+                              a (get after  k)]
+                        :when (not= b a)]
+                    (changed-paths* (conj path k) b a))]
+      {:added   (mapv #(conj path %) added)
+       :removed (mapv #(conj path %) removed)
+       :changed (vec (mapcat :changed
+                             (cons {:changed (if (seq per-k) [] [])}
+                                   per-k)))
+       ::sub-adds    (vec (mapcat :added   per-k))
+       ::sub-removes (vec (mapcat :removed per-k))})
+
+    ;; Map → non-map (or vice versa) at this level — one :changed entry.
+    :else
+    {:added   []
+     :removed []
+     :changed (if (empty? path) [] [path])}))
+
+(defn changed-paths
+  "Public projection — produce `{:added :removed :changed :counts}` from
+  the `:before` / `:after` pair. Pure. Path vectors are sorted by
+  printed form so output is deterministic across runs (stable test
+  shape; stable agent behaviour)."
+  [before after]
+  (let [raw      (changed-paths* [] before after)
+        adds     (vec (sort-by str (concat (:added raw) (::sub-adds raw))))
+        removes  (vec (sort-by str (concat (:removed raw) (::sub-removes raw))))
+        changes  (vec (sort-by str (:changed raw)))]
+    {:added   adds
+     :removed removes
+     :changed changes
+     :counts  {:added   (count adds)
+               :removed (count removes)
+               :changed (count changes)}}))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :frame :epoch-id :diff {:before
+  :after}}` response into the MCP envelope. Pure — tests pin the diff
+  projection logic.
+
+  `mode` selects the projection: `:changed-paths` (default) walks
+  before/after into a path-key set; `:nested` ships the
+  before/after pair verbatim."
+  [runtime-envelope {:keys [mode]}]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-app-db-diff returned a non-envelope shape"}
+
+      :else
+      (let [{:keys [before after]} (:diff env)
+            projected (if (= :nested mode)
+                        {:before before :after after}
+                        (changed-paths before after))
+            elided    (elision/count-elided-markers projected)]
+        (wire/with-indicators
+          {:ok?      true
+           :frame    (:frame env)
+           :epoch-id (:epoch-id env)
+           :mode     (or mode :changed-paths)
+           :diff     projected}
+          {:elided elided})))))
+
+(defn get-app-db-diff-tool
+  "MCP handler for `get-app-db-diff`. Pre-flight validates :epoch-id
+  is present and :mode is one of #{:changed-paths :nested}; short-
+  circuits before contacting the runtime."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        frame    (wire/arg-keyword args :frame)
+        epoch-id (wire/arg args :epoch-id)
+        mode     (or (wire/arg-keyword args :mode) :changed-paths)
+        incl?    (privacy/parse-include-sensitive args)
+        incl-large? (elision/parse-include-large args)]
+    (cond
+      (nil? epoch-id)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-epoch-id
+                       :hint   "Pass :epoch-id <uuid|string> — see get-epoch-history."}))
+
+      (not (contains? #{:changed-paths :nested} mode))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :invalid-mode
+                       :given  mode
+                       :hint   "mode must be :changed-paths or :nested"}))
+
+      :else
+      (let [runtime-opts (cond-> {:epoch-id           epoch-id
+                                  :include-sensitive? incl?
+                                  :include-large?     incl-large?}
+                           frame (assoc :frame frame))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope
+                                                   {:mode mode}))))
+            (.catch (fn [err] (probe/err->result :get-app-db-diff-failed err))))))))
+
+(def descriptor
+  {:name        "get-app-db-diff"
+   :description (str "App-db diff for a named epoch. Default :mode "
+                     ":changed-paths returns a token-cheap "
+                     "{:added :removed :changed :counts} path-key "
+                     "envelope; :mode :nested returns the full "
+                     "{:before :after} pair (heavier but inspectable). "
+                     "Drill into a single changed path via "
+                     "get-app-db with the path arg.")
+   :input-schema #js {:type "object"
+                      :required #js ["epoch-id"]
+                      :properties #js {:frame              #js {:type "string"}
+                                       :epoch-id           #js {:type "string"}
+                                       :mode               #js {:type "string"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-app-db-diff-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs
@@ -1,0 +1,236 @@
+(ns day8.re-frame2-causa-mcp.tools.get-epoch-history
+  "Tool: `get-epoch-history` — per-frame epoch history (rf2-8xzoe.15,
+  T-Insp-2 of the causa-mcp inspection tranche).
+
+  Returns a vector of `:rf/epoch-record` per Tool-Pair §Time-travel —
+  oldest-first by default. Cursor pagination over the default depth-50
+  page lets the agent walk the full history without overflowing the
+  per-call token budget. The epoch-slice dedup factor (5-10×) lives in
+  the runtime accessor's elide-wire-value call; this tool counts the
+  resulting markers and stamps the indicator.
+
+  ## Wire-boundary contract
+
+  All three mechanisms fire (this is a trace-stream-shaped tool — the
+  epoch's `:sensitive?` rollup is stamped by the runtime per rf2-isdwf):
+
+  1. **B-1 privacy** — `:sensitive? true` epochs are dropped by
+     default; `:include-sensitive? true` opts back in. The
+     `:dropped-sensitive` counter rides on the envelope when non-zero.
+  2. **W-6 size elision** — counted on the kept epochs (the runtime
+     walker already substituted markers on the per-record `:db-before`
+     / `:db-after` slots).
+  3. **W-1 token cap** — dispatcher-level. Cap-reached hint
+     `:paginate` (re-call with `:cursor` to resume mid-stream).
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:frame` | keyword | nil | scope to one frame; nil → resolve sole frame |
+  | `:limit` | int | 50 | max epochs per page (Tool-Pair depth-50 default) |
+  | `:cursor` | string | nil | opaque server-managed cursor to resume mid-stream |
+  | `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` items |
+  | `:include-large?` | bool | false | passes to the runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :frame <kw>
+       :epochs <vec of :rf/epoch-record>
+       :count <int>
+       :total <int>
+       :limit <int>
+       :next-cursor <string?>     ; only when more pages remain
+       :dropped-sensitive <int?>
+       :elided-large <int?>}
+
+  ## Cursor shape
+
+  The cursor is an opaque base64-encoded EDN map carrying the resume-
+  point's `:after-id` (the epoch-id of the last item on the prior
+  page). Servers may rotate the cursor format; agents pass it back
+  verbatim. The runtime accessor returns the FULL history (the
+  `:epoch-history` surface is the registered Tool-Pair contract); this
+  tool slices it cursor-relative on the MCP-server side so the
+  page-walk doesn't roundtrip a full epoch ring twice.
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #15. Tool-Pair binding §Time-travel. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [cljs.reader :as edn]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:const default-limit
+  "Tool-Pair §Time-travel depth-50 default page size. An agent reading
+  per-frame epoch history expects 50 records on the first call."
+  50)
+
+;; ---------------------------------------------------------------------------
+;; Cursor encode/decode — opaque base64-EDN.
+;;
+;; Today the cursor carries `:after-id` (the last epoch-id of the
+;; prior page). Future extensions can add `:limit` (sticky page-size)
+;; or `:until-id` (sticky window upper-bound) without breaking
+;; backwards compatibility — readers ignore unknown keys.
+;; ---------------------------------------------------------------------------
+
+(defn encode-cursor
+  "Encode the resume-point map as a base64-EDN opaque string. Returns
+  nil when `m` is nil. Pure — tests pin the round-trip."
+  [m]
+  (when (some? m)
+    (-> m pr-str (js/Buffer.from "utf8") (.toString "base64"))))
+
+(defn decode-cursor
+  "Decode a cursor string into the resume-point map. Returns nil for
+  a nil / blank string; returns `::malformed` for parse failures so
+  the tool can surface a structured `:cursor-stale` envelope rather
+  than silently treating a malformed cursor as 'start from the top'."
+  [s]
+  (cond
+    (or (nil? s) (and (string? s) (zero? (count s))))
+    nil
+
+    (string? s)
+    (try
+      (let [decoded (.toString (js/Buffer.from s "base64") "utf8")
+            parsed  (edn/read-string decoded)]
+        (if (map? parsed) parsed ::malformed))
+      (catch :default _ ::malformed))
+
+    :else ::malformed))
+
+(defn- slice-after-id
+  "Drop epochs up to and including `after-id`. If `after-id` isn't
+  present in the epoch vector, returns `[::aged-out vec]` so the tool
+  can surface `:cursor-stale`. Otherwise returns `[::ok remainder]`."
+  [epochs after-id]
+  (if (nil? after-id)
+    [::ok epochs]
+    (let [idx (->> epochs
+                   (keep-indexed (fn [i e] (when (= after-id (:epoch-id e)) i)))
+                   first)]
+      (if (nil? idx)
+        [::aged-out epochs]
+        [::ok (vec (subvec epochs (inc idx)))]))))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-epoch-history opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :frame :epochs <vec> :count}`
+  response into the MCP envelope. Pure — tests pin the cursor /
+  pagination / privacy / elision logic.
+
+  `cursor-in` is the already-decoded cursor map (or nil); `limit` is
+  the per-page cap; `include-sensitive?` resolves the B-1 strip-step."
+  [runtime-envelope {:keys [cursor-in limit include-sensitive?]}]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-epoch-history returned a non-envelope shape"}
+
+      :else
+      (let [all-epochs   (vec (:epochs env))
+            after-id     (:after-id cursor-in)
+            [tag sliced] (slice-after-id all-epochs after-id)]
+        (if (= ::aged-out tag)
+          ;; The cursor's after-id is no longer in the epoch ring —
+          ;; surface a structured stale-cursor envelope so the agent
+          ;; can recover by re-calling without a cursor (head-of-stream).
+          {:ok?           false
+           :reason        :cursor-stale
+           :frame         (:frame env)
+           :requested-id  after-id
+           :hint          "The epoch the cursor pointed at has been evicted from the ring. Re-call without :cursor to resume from head."}
+
+          (let [page-size      (or limit default-limit)
+                page           (vec (take page-size sliced))
+                more-remaining (> (count sliced) (count page))
+                [kept dropped] (privacy/strip-sensitive page include-sensitive?)
+                elided         (elision/count-elided-markers kept)
+                next-id        (when more-remaining (:epoch-id (last page)))
+                next-cursor    (encode-cursor (when next-id {:after-id next-id}))]
+            (wire/with-indicators
+              (cond-> {:ok?         true
+                       :frame       (:frame env)
+                       :epochs      kept
+                       :count       (count kept)
+                       :total       (count all-epochs)
+                       :limit       page-size}
+                next-cursor (assoc :next-cursor next-cursor))
+              {:dropped dropped :elided elided})))))))
+
+(defn get-epoch-history-tool
+  "MCP handler for `get-epoch-history`. Returns a Promise of the
+  JS-shape MCP result. Decodes the inbound `:cursor` arg (if any),
+  validates it isn't malformed, and either short-circuits to
+  `:cursor-malformed` or proceeds with the cursor's `:after-id`."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        frame    (wire/arg-keyword args :frame)
+        limit    (wire/arg-int args :limit default-limit)
+        incl?    (privacy/parse-include-sensitive args)
+        incl-large? (elision/parse-include-large args)
+        cursor-raw (wire/arg args :cursor)
+        cursor-in  (decode-cursor cursor-raw)]
+    (cond
+      (= ::malformed cursor-in)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :cursor-malformed
+                       :given  cursor-raw
+                       :hint   "Pass the opaque :next-cursor from a prior response, or omit :cursor to resume from head."}))
+
+      :else
+      (let [runtime-opts (cond-> {:include-sensitive? incl?
+                                  :include-large?     incl-large?}
+                           frame (assoc :frame frame))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text
+                       (shape-envelope runtime-envelope
+                                       {:cursor-in          cursor-in
+                                        :limit              limit
+                                        :include-sensitive? incl?}))))
+            (.catch (fn [err] (probe/err->result :get-epoch-history-failed err))))))))
+
+(def descriptor
+  {:name        "get-epoch-history"
+   :description (str "Per-frame epoch history (vector of "
+                     ":rf/epoch-record per Tool-Pair §Time-travel). "
+                     "Oldest-first; depth-50 default page size with "
+                     "opaque cursor pagination via :next-cursor. "
+                     "Sensitive epochs default-dropped; pass "
+                     ":include-sensitive? true to opt in.")
+   :input-schema #js {:type "object"
+                      :properties #js {:frame              #js {:type "string"}
+                                       :limit              #js {:type "integer"}
+                                       :cursor             #js {:type "string"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-epoch-history-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs
@@ -1,0 +1,142 @@
+(ns day8.re-frame2-causa-mcp.tools.get-handlers
+  "Tool: `get-handlers` — registrar enumeration grouped by kind
+  (rf2-8xzoe.21, T-Insp-8 of the causa-mcp inspection tranche).
+
+  Returns the registered handlers (events, subs, fxs, machines, flows,
+  …) projected as a `{:kind <kw> :id <any> :meta <map>}` record
+  vector. Default mode groups results by `:kind` so an agent can read
+  the registry surface as a one-call discovery aid (`registry-list`
+  in pair2-mcp parlance). Optional `:kind` arg narrows to a single
+  registrar kind for a focused query.
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — counts elision markers in the handler-meta
+    payload. The runtime accessor leaves the registry metadata as-is
+    (registrar metadata is generally small; no per-handler
+    elide-wire-value walk in the runtime); a future bead may add
+    walker plumbing for handlers whose `:meta` slot carries large
+    blobs, at which point this count surfaces them.
+  - **B-1 privacy** — not directly applicable here; the registry is
+    framework metadata, not user-data.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+    Per-tool cap-reached hint is `:narrow-filter` (default) — narrow
+    via `:kind` to slice.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:kind` | keyword | nil | narrow to one registrar kind (`:event`, `:sub`, `:fx`, `:machine`, `:flow`, …) |
+  | `:group-by-kind?` | bool | true | shape result as `{<kind> [<handler> ...]}`; `false` ⇒ flat vector |
+  | `:include-sensitive?` | bool | false | passes to the runtime walker |
+  | `:include-large?` | bool | false | passes to the runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape (default — grouped by kind)
+
+      {:ok? true
+       :handlers {<kind> [{:id <any> :meta <map>} ...] ...}
+       :count <int>
+       :kinds <vec of kw>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #21. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form string targeting the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-handlers opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn- group-by-kind
+  "Group the flat `[{:kind :id :meta} ...]` handler vector by `:kind`.
+  The per-kind vector preserves source order so a downstream `:sub` or
+  `:flow` lookup mirrors the registrar's insertion order."
+  [handlers]
+  (reduce
+    (fn [acc {:keys [kind] :as h}]
+      (update acc kind (fnil conj []) (dissoc h :kind)))
+    {}
+    handlers))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :handlers <vec> :count <int>}`
+  response into the MCP envelope. Pure — tests pin the shaping logic.
+
+  `group?` controls the response shape:
+    - true (default) ⇒ `:handlers` is `{<kind> [{:id :meta} ...]}`
+      and `:kinds` enumerates the kinds present.
+    - false ⇒ `:handlers` is the flat vector the runtime returned."
+  [runtime-envelope group?]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-handlers returned a non-envelope shape"}
+
+      :else
+      (let [handlers (vec (:handlers env))
+            elided   (elision/count-elided-markers handlers)
+            shaped   (if group?
+                       (let [grouped (group-by-kind handlers)]
+                         {:handlers grouped
+                          :kinds    (vec (sort (keys grouped)))
+                          :count    (count handlers)})
+                       {:handlers handlers
+                        :count    (count handlers)})]
+        (wire/with-indicators
+          (assoc shaped :ok? true)
+          {:elided elided})))))
+
+(defn get-handlers-tool
+  "MCP handler for `get-handlers`. Returns a Promise of the JS-shape
+  MCP result."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        kind     (wire/arg-keyword args :kind)
+        ;; Default group-by-kind? = true. The arg-bool helper falls
+        ;; back to the supplied default when the slot is absent.
+        group?   (wire/arg-bool args :group-by-kind? true)
+        opts     (cond-> {:include-sensitive? (privacy/parse-include-sensitive args)
+                          :include-large?     (elision/parse-include-large args)}
+                   kind (assoc :kind kind))
+        form     (build-form opts)]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+        (.then (fn [runtime-envelope]
+                 (wire/ok-text (shape-envelope runtime-envelope group?))))
+        (.catch (fn [err] (probe/err->result :get-handlers-failed err))))))
+
+(def descriptor
+  {:name        "get-handlers"
+   :description (str "Enumerate registered re-frame2 handlers grouped by "
+                     "kind (event / sub / fx / cofx / machine / flow / "
+                     "frame / view / reg-machine). Narrow via :kind. "
+                     "Default :group-by-kind? true returns a kind-keyed "
+                     "map; false returns a flat vector.")
+   :input-schema #js {:type "object"
+                      :properties #js {:kind               #js {:type "string"}
+                                       :group-by-kind?     #js {:type "boolean"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-handlers-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs
@@ -1,0 +1,192 @@
+(ns day8.re-frame2-causa-mcp.tools.get-issues
+  "Tool: `get-issues` — recent errors / warnings / schema violations /
+  hydration mismatches (rf2-8xzoe.20, T-Insp-7 of the causa-mcp
+  inspection tranche).
+
+  Returns the issue-tier slice of the trace bus — events whose
+  `:op-type` falls in
+  `#{:error :warning :rf.schema/violation :rf.hydration/mismatch}` per
+  Spec 009 §Issue-tier event op-types. Pagination via `:limit` /
+  `:offset`; severity filter via `:severity` (`:error` /
+  `:warning` / `:all` (default)).
+
+  ## Wire-boundary contract
+
+  Trace-stream-shaped — all three wire-pipeline mechanisms fire:
+
+  1. **B-1 privacy** — `:sensitive? true` issue events are dropped by
+     default; `:include-sensitive? true` opts back in. The
+     `:dropped-sensitive` counter rides on the envelope when non-zero.
+  2. **W-6 size elision** — `:elided-large` counted on the kept
+     issues.
+  3. **W-1 token cap** — dispatcher-level.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:severity` | keyword | `:all` | `:error`, `:warning`, or `:all` |
+  | `:frame` | keyword | nil | scope to one frame; nil → all frames |
+  | `:since-ms` | int | nil | wall-clock cutoff (ms) |
+  | `:limit` | int | 50 | max issues returned |
+  | `:offset` | int | 0 | skip the first N issues post-filter |
+  | `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` items |
+  | `:include-large?` | bool | false | passes to the runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :issues <vec of issue events>
+       :count <int>                  ; issues returned
+       :total <int>                  ; issues pre-strip
+       :limit <int>
+       :offset <int>
+       :severity <:error|:warning|:all>
+       :dropped-sensitive <int?>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #20. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:const default-limit 50)
+
+(def ^:const severity-vocabulary
+  "Closed set of `:severity` arg values. `:all` is the default
+  (no filter); `:error` and `:warning` narrow to the corresponding
+  issue op-types (`:error` matches `:error` + `:rf.schema/violation`
+  + `:rf.hydration/mismatch`; `:warning` matches `:warning` only)."
+  #{:error :warning :all})
+
+(def ^:const error-op-types
+  "Op-types treated as errors by the `:severity :error` filter."
+  #{:error :rf.schema/violation :rf.hydration/mismatch})
+
+(def ^:const warning-op-types
+  #{:warning})
+
+(defn- severity-pred
+  "Build the per-event predicate for `severity`. `:all` matches every
+  issue (the runtime already filtered to issue-tier op-types);
+  `:error` / `:warning` narrow further."
+  [severity]
+  (case severity
+    :error   #(contains? error-op-types   (:op-type %))
+    :warning #(contains? warning-op-types (:op-type %))
+    :all     (constantly true)
+    (constantly true)))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-issues opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn- apply-limit-offset [items limit offset]
+  (let [o (max 0 (or offset 0))
+        l (or limit default-limit)]
+    (->> items (drop o) (take l) vec)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :issues <vec> :count <int>}`
+  response into the MCP envelope. Pure — tests pin the shaping logic.
+
+  The runtime accessor already filtered to issue-tier op-types; this
+  fn applies the optional `:severity` narrowing, the B-1 strip-step,
+  pagination, and the W-6 marker count."
+  [runtime-envelope {:keys [severity include-sensitive? limit offset]}]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-issues returned a non-envelope shape"}
+
+      :else
+      (let [raw-issues   (vec (:issues env))
+            sev          (or severity :all)
+            sev-filtered (vec (filter (severity-pred sev) raw-issues))
+            paged        (apply-limit-offset sev-filtered limit offset)
+            [kept dropped] (privacy/strip-sensitive paged include-sensitive?)
+            elided       (elision/count-elided-markers kept)]
+        (wire/with-indicators
+          {:ok?      true
+           :issues   kept
+           :count    (count kept)
+           :total    (count sev-filtered)
+           :limit    (or limit default-limit)
+           :offset   (max 0 (or offset 0))
+           :severity sev}
+          {:dropped dropped :elided elided})))))
+
+(defn get-issues-tool
+  "MCP handler for `get-issues`. Returns a Promise of the JS-shape
+  MCP result."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        severity (or (wire/arg-keyword args :severity) :all)
+        frame    (wire/arg-keyword args :frame)
+        since-ms (wire/arg-int args :since-ms)
+        limit    (wire/arg-int args :limit default-limit)
+        offset   (wire/arg-int args :offset 0)
+        incl?    (privacy/parse-include-sensitive args)
+        incl-large? (elision/parse-include-large args)]
+    (cond
+      (not (contains? severity-vocabulary severity))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :invalid-severity
+                       :given  severity
+                       :hint   "severity must be :error :warning or :all"}))
+
+      :else
+      (let [runtime-opts (cond-> {:include-sensitive? incl?
+                                  :include-large?     incl-large?}
+                           frame    (assoc :frame frame)
+                           since-ms (assoc :since-ms since-ms))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text
+                       (shape-envelope runtime-envelope
+                                       {:severity           severity
+                                        :include-sensitive? incl?
+                                        :limit              limit
+                                        :offset             offset}))))
+            (.catch (fn [err] (probe/err->result :get-issues-failed err))))))))
+
+(def descriptor
+  {:name        "get-issues"
+   :description (str "Recent issue-tier events from the re-frame2 trace "
+                     "bus (errors / warnings / schema violations / "
+                     "hydration mismatches). Narrow via :severity "
+                     "(:error / :warning / :all default). Pagination "
+                     "via :limit / :offset. Sensitive events default-"
+                     "dropped; pass :include-sensitive? true to opt in.")
+   :input-schema #js {:type "object"
+                      :properties #js {:severity           #js {:type "string"}
+                                       :frame              #js {:type "string"}
+                                       :since-ms           #js {:type "integer"}
+                                       :limit              #js {:type "integer"}
+                                       :offset             #js {:type "integer"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-issues-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs
@@ -1,0 +1,117 @@
+(ns day8.re-frame2-causa-mcp.tools.get-machine-list
+  "Tool: `get-machine-list` — registered-machine enumeration
+  (rf2-8xzoe.19, T-Insp-6 of the causa-mcp inspection tranche).
+
+  Returns the registered machines per frame with their current
+  metadata (the registered FSM spec — transitions, initial-state,
+  tags). Bounded by the per-frame machine count which is typically
+  small (single-digit per frame in practice), so this tool has no
+  per-call pagination — the full machine roster rides on every call.
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — the runtime accessor already routes each
+    machine's metadata through `re-frame.core/elide-wire-value`, so
+    the marker count on the kept payload reflects whatever the walker
+    emitted. This tool counts markers via
+    `elision/count-elided-markers` and stamps `:elided-large`.
+  - **B-1 privacy default-suppress** — not directly applicable here
+    (machine metadata isn't trace-event-shaped), but the
+    `:include-sensitive?` arg is honoured by routing through the
+    runtime walker (which substitutes the `:rf/redacted` sentinel at
+    declared-sensitive leaves per Spec 009 §Privacy).
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg                   | Type    | Default | Notes                                  |
+  |-----------------------|---------|---------|----------------------------------------|
+  | `:include-sensitive?` | bool    | false   | passes to the runtime walker           |
+  | `:include-large?`     | bool    | false   | passes to the runtime walker           |
+  | `:max-tokens`         | int     | 5000    | per-call cap (`[500, 50000]`)          |
+
+  ## Return shape
+
+      {:ok? true
+       :machines {<machine-id> <meta-map> ...}
+       :count <int>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #19. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the CLJS eval-form string the runtime evaluates. Pure (no I/O
+  / Promise), so tests pin the form shape directly."
+  [opts]
+  (-> (ef/rt-call 'get-machine-list opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :machines <map> :count <int>}`
+  response into the MCP envelope. Pure — tests pin the shaping logic
+  without I/O.
+
+  The runtime walker already elided sensitive / large slots inside the
+  per-machine metadata; this fn counts the resulting markers and
+  stamps `:elided-large` on the envelope when non-zero."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-machine-list returned a non-envelope shape"}
+
+      :else
+      (let [machines (or (:machines env) {})
+            elided   (elision/count-elided-markers machines)]
+        (wire/with-indicators
+          {:ok?      true
+           :machines machines
+           :count    (count machines)}
+          {:elided elided})))))
+
+(defn get-machine-list-tool
+  "MCP handler for `get-machine-list`. Returns a Promise of the
+  JS-shape MCP result."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        opts     {:include-sensitive? (privacy/parse-include-sensitive args)
+                  :include-large?     (elision/parse-include-large args)}
+        form     (build-form opts)]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+        (.then (fn [runtime-envelope]
+                 (wire/ok-text (shape-envelope runtime-envelope))))
+        (.catch (fn [err] (probe/err->result :get-machine-list-failed err))))))
+
+(def descriptor
+  "MCP tool descriptor for `get-machine-list`."
+  {:name        "get-machine-list"
+   :description (str "Enumerate registered re-frame2 machines with their "
+                     "current metadata (transitions, initial-state, tags). "
+                     "Bounded by per-frame machine count; no pagination. "
+                     "Pass :include-sensitive? true to opt back in to "
+                     "declared-sensitive metadata leaves.")
+   :input-schema #js {:type "object"
+                      :properties #js {:include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-machine-list-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs
@@ -1,0 +1,198 @@
+(ns day8.re-frame2-causa-mcp.tools.get-machine-state
+  "Tool: `get-machine-state` — per-machine snapshot (rf2-8xzoe.18,
+  T-Insp-5 of the causa-mcp inspection tranche).
+
+  Returns the current snapshot for a named machine — the registered
+  FSM spec (transitions, initial-state, tags) plus, when the framework
+  surfaces it on the runtime, the live per-frame FSM position. Path
+  slicing via `:path` lets the agent drill into a subtree of the spec
+  without shipping the full metadata. Summary mode is the default
+  (`:mode :summary` returns the spec name + state names; `:mode :full`
+  returns the entire metadata map).
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — the runtime accessor already routed the
+    spec through `re-frame.core/elide-wire-value`. This tool counts
+    markers via `elision/count-elided-markers` and stamps
+    `:elided-large`.
+  - **B-1 privacy** — not directly applicable (machine spec is
+    framework metadata); the `:include-sensitive?` arg threads through
+    to the walker which honours declared-sensitive leaves at the spec
+    boundary.
+  - **W-1 token cap** — dispatcher-level. Per-tool cap-reached hint is
+    `:slice` (drill in via `:path`) when `:mode :full`; `:switch-mode`
+    (downshift to summary) when overflow happens in `:full` mode.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:machine-id` | keyword | **required** | the registered machine id |
+  | `:frame` | keyword | nil | scope to one frame; nil → resolve sole frame |
+  | `:path` | vec | nil | slice into the spec, like `get-in` |
+  | `:mode` | keyword | `:summary` | `:summary` or `:full` |
+  | `:include-sensitive?` | bool | false | passes to the runtime walker |
+  | `:include-large?` | bool | false | passes to the runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :frame <kw>
+       :machine-id <kw>
+       :mode <:summary|:full>
+       :state <map>           ; sliced when :path supplied
+       :path <vec?>           ; only when :path supplied
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #18. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:private summary-keys
+  "Keys retained in `:mode :summary` — name, initial state, the keys
+  of the transitions table (state names), and any spec-level tags. The
+  heavy per-transition handler details (event vectors, guards,
+  effects) are omitted so a top-level inspection call ships a small
+  payload."
+  [:initial-state :tags])
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-machine-state opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn- summarise-state
+  "Project the full machine spec down to the summary slots. Returns a
+  map with `:initial-state`, `:tags`, and `:state-names` (the keys of
+  the transitions table) — enough for an agent to know what the
+  machine is without shipping per-transition detail."
+  [state]
+  (cond-> {}
+    (contains? state :initial-state)
+    (assoc :initial-state (:initial-state state))
+
+    (contains? state :tags)
+    (assoc :tags (:tags state))
+
+    (map? (:transitions state))
+    (assoc :state-names (vec (sort (keys (:transitions state)))))))
+
+(defn- apply-path
+  "Slice `state` by `path` using `get-in`. Returns the addressed
+  subtree or nil if the path doesn't exist. nil/empty path is the
+  identity."
+  [state path]
+  (if (seq path)
+    (get-in state path)
+    state))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :frame :machine-id :state}` response
+  into the MCP envelope. Pure — tests pin the shaping logic."
+  [runtime-envelope {:keys [mode path]}]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-machine-state returned a non-envelope shape"}
+
+      :else
+      (let [state    (:state env)
+            sliced   (apply-path state path)
+            projected (if (and (= :summary mode) (map? sliced))
+                        (summarise-state sliced)
+                        sliced)
+            elided   (elision/count-elided-markers projected)
+            base     (cond-> {:ok?        true
+                              :frame      (:frame env)
+                              :machine-id (:machine-id env)
+                              :mode       (or mode :summary)
+                              :state      projected}
+                       (seq path) (assoc :path (vec path)))]
+        (wire/with-indicators base {:elided elided})))))
+
+(defn- parse-path-arg
+  "Coerce the `:path` MCP arg to a CLJS vector. Accepts an EDN-printed
+  vector string (`\"[:cart :items]\"`); returns nil on parse failure /
+  absent."
+  [v]
+  (cond
+    (nil? v)     nil
+    (vector? v)  v
+    (string? v)  (try (let [parsed (cljs.reader/read-string v)]
+                        (when (vector? parsed) parsed))
+                      (catch :default _ nil))
+    :else        nil))
+
+(defn get-machine-state-tool
+  "MCP handler for `get-machine-state`. Validates `:machine-id`
+  pre-flight; runtime accessor validates again."
+  [conn args]
+  (let [build-id   (wire/arg-build args)
+        machine-id (wire/arg-keyword args :machine-id)
+        frame      (wire/arg-keyword args :frame)
+        path       (parse-path-arg (wire/arg args :path))
+        mode       (or (wire/arg-keyword args :mode) :summary)]
+    (cond
+      (nil? machine-id)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-machine-id
+                       :hint   "Pass :machine-id <keyword>, e.g. :checkout/fsm."}))
+
+      (not (contains? #{:summary :full} mode))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :invalid-mode
+                       :given  mode
+                       :hint   "mode must be :summary or :full"}))
+
+      :else
+      (let [runtime-opts (cond-> {:machine-id         machine-id
+                                  :include-sensitive? (privacy/parse-include-sensitive args)
+                                  :include-large?     (elision/parse-include-large args)}
+                           frame (assoc :frame frame))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope
+                                                   {:mode mode :path path}))))
+            (.catch (fn [err] (probe/err->result :get-machine-state-failed err))))))))
+
+(def descriptor
+  {:name        "get-machine-state"
+   :description (str "Per-machine snapshot — registered FSM spec for the "
+                     "named machine. Default :mode :summary returns the "
+                     "initial-state + tags + state-names; :mode :full "
+                     "returns the entire metadata map. Path slicing via "
+                     ":path drills into a subtree like get-in.")
+   :input-schema #js {:type "object"
+                      :required #js ["machine-id"]
+                      :properties #js {:machine-id         #js {:type "string"}
+                                       :frame              #js {:type "string"}
+                                       :path               #js {:type "string"}
+                                       :mode               #js {:type "string"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-machine-state-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs
@@ -1,0 +1,120 @@
+(ns day8.re-frame2-causa-mcp.tools.get-source-coord
+  "Tool: `get-source-coord` — single-handler source-coord lookup
+  (rf2-8xzoe.22, T-Insp-9 of the causa-mcp inspection tranche).
+
+  Returns the source coord (`:ns :line :column :file`) for a given
+  `(kind, id)` pair — the registration-metadata slot the framework
+  stamps at `reg-*` macroexpand time per Spec 001 §The public
+  registrar query API. The coord aligns with editor-URI substitution
+  so an agent host can render a jump-to-definition link off the
+  response (the wire-pipeline `:rf.source/uri` decoration is the
+  cross-MCP convention).
+
+  ## Wire-boundary contract
+
+  - **W-6 size elision** — not exercised here in practice (source-coord
+    is four scalar fields), but counted defensively in case a future
+    extension carries large auxiliary metadata.
+  - **B-1 privacy** — not applicable (source-coord is framework
+    metadata).
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:kind` | keyword | nil (REQUIRED) | registrar kind (`:event`, `:sub`, …) |
+  | `:id`   | keyword | nil (REQUIRED) | the registered id |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true :kind <kw> :id <any> :source-coord {:ns :line :column :file}}
+
+  Or on miss:
+
+      {:ok? false :reason :no-source-coord :kind <kw> :id <any>}
+      {:ok? false :reason :missing-kind :hint <s>}
+      {:ok? false :reason :missing-id   :hint <s>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #22. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'get-source-coord opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Pass the runtime's envelope through largely unchanged; stamp
+  `:elided-large` if the walker somehow inserted a marker on the
+  source-coord payload (defensive — source-coord is scalar fields)."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      ;; Structured failure (missing kind / id / coord) — pass verbatim.
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-source-coord returned a non-envelope shape"}
+
+      :else
+      (let [elided (elision/count-elided-markers (:source-coord env))]
+        (wire/with-indicators env {:elided elided})))))
+
+(defn get-source-coord-tool
+  "MCP handler for `get-source-coord`. Validates required args
+  pre-flight; runtime accessor validates again (defence in depth)."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        kind     (wire/arg-keyword args :kind)
+        id       (wire/arg-keyword args :id)]
+    (cond
+      (nil? kind)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-kind
+                       :hint   "Pass :kind <registrar-kind>, e.g. :event."}))
+
+      (nil? id)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-id
+                       :hint   "Pass :id <registered-id>, e.g. :cart/add."}))
+
+      :else
+      (let [form (build-form {:kind kind :id id})]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope))))
+            (.catch (fn [err] (probe/err->result :get-source-coord-failed err))))))))
+
+(def descriptor
+  {:name        "get-source-coord"
+   :description (str "Return the source coord (:ns :line :column :file) "
+                     "for a registered handler. Required args: :kind "
+                     "(registrar kind keyword) and :id (registered id "
+                     "keyword). On miss returns :no-source-coord.")
+   :input-schema #js {:type "object"
+                      :required #js ["kind" "id"]
+                      :properties #js {:kind       #js {:type "string"}
+                                       :id         #js {:type "string"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-source-coord-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs
@@ -1,0 +1,235 @@
+(ns day8.re-frame2-causa-mcp.tools.get-trace-buffer
+  "Tool: `get-trace-buffer` — trace-bus reader (rf2-8xzoe.14, T-Insp-1
+  of the causa-mcp inspection tranche).
+
+  Returns a slice of the trace-bus events captured by the consumer
+  app's running Spec 009 instrumentation. Filter vocabulary is the
+  canonical Spec 009 set (`:operation`, `:op-type`, `:since`, `:frame`,
+  `:severity`, `:event-id`, `:handler-id`, `:source`, `:origin`,
+  `:dispatch-id`, `:since-ms`, `:between`, `:pred`). Pagination is the
+  responsibility of the caller — pass `:limit` and `:offset` to slice
+  the event vector after filtering.
+
+  ## Wire-boundary contract
+
+  This tool is **trace-stream-shaped** per the privacy catalogue in
+  `tools/causa-mcp/src/.../privacy.cljs` — its payload is a vector of
+  trace-event maps, every one of which carries the top-level
+  `:sensitive?` boolean (per Spec 009). Three wire-pipeline mechanisms
+  apply on the egress boundary:
+
+  1. **W-6 size elision** — every trace event's value-bearing slots
+     (`:event`, `:before`, `:after`, `:result`) was already routed
+     through `re-frame.core/elide-wire-value` server-side by the
+     runtime accessor (`day8.re-frame2-causa.runtime/get-trace-buffer`).
+     This tool counts the resulting `{:rf.size/large-elided ...}`
+     markers via `elision/count-elided-markers` and stamps the
+     `:elided-large` envelope counter when non-zero.
+  2. **B-1 privacy default-suppress** — events carrying
+     `:sensitive? true` are dropped via `privacy/strip-sensitive`
+     unless the caller opted in with `:include-sensitive? true`. The
+     `:dropped-sensitive` envelope counter is stamped when non-zero.
+  3. **W-1 token cap** — the dispatcher wraps the returned envelope
+     through `token-cap/apply-cap` (5,000 tokens default, `max-tokens`
+     arg overrides into `[500, 50000]`). When the rendered payload
+     exceeds the cap, the result is replaced with the
+     `{:rf.mcp/overflow ...}` marker (the dispatcher in
+     `tools.cljs` runs this step; not the per-tool body).
+
+  ## Args
+
+  | Arg                   | Type    | Default | Notes                                  |
+  |-----------------------|---------|---------|----------------------------------------|
+  | `:frame`              | keyword | nil     | scope to one frame; nil → all frames   |
+  | `:op-type`            | keyword | nil     | filter by operation type               |
+  | `:since-ms`           | int     | nil     | wall-clock cutoff (ms)                 |
+  | `:limit`              | int     | 50      | max events returned                    |
+  | `:offset`             | int     | 0       | skip the first N events post-filter    |
+  | `:include-sensitive?` | bool    | false   | opt back in to `:sensitive? true` items|
+  | `:include-large?`     | bool    | false   | opt back in to large values            |
+
+  ## Return shape
+
+      {:ok? true
+       :events <vec of trace events>
+       :count <int>
+       :dropped-sensitive <int?>   ; only when > 0
+       :elided-large <int?>}       ; only when > 0
+
+  Or on a runtime-side failure:
+
+      {:ok? false :reason <kw> :hint <string>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #14. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+;; ---------------------------------------------------------------------------
+;; Arg parsing.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-limit
+  "Default `:limit` on a single page of trace events. 50 mirrors the
+  Tool-Pair epoch-history depth default — agents trained on the cross-
+  MCP idiom expect the same first-page size for trace-stream surfaces."
+  50)
+
+(defn- build-filter-opts
+  "Project the raw MCP args object into the filter-opts map the runtime
+  accessor expects. We pass-through the canonical Spec 009 filter slots
+  plus `:limit` / `:offset` (which the runtime applies after filtering)
+  + the `:include-sensitive?` / `:include-large?` opts the elide call
+  honours."
+  [args]
+  (let [base (cond-> {}
+               (wire/arg-keyword args :frame)
+               (assoc :frame (wire/arg-keyword args :frame))
+
+               (wire/arg-keyword args :op-type)
+               (assoc :op-type (wire/arg-keyword args :op-type))
+
+               (wire/arg-int args :since-ms)
+               (assoc :since-ms (wire/arg-int args :since-ms))
+
+               (wire/arg args :event-id)
+               (assoc :event-id (wire/arg-keyword args :event-id))
+
+               (wire/arg args :origin)
+               (assoc :origin (wire/arg-keyword args :origin)))]
+    (assoc base
+      :include-sensitive? (privacy/parse-include-sensitive args)
+      :include-large?     (elision/parse-include-large args))))
+
+;; ---------------------------------------------------------------------------
+;; Eval form composition.
+;; ---------------------------------------------------------------------------
+
+(defn build-form
+  "Build the CLJS eval-form string the runtime evaluates. Pure (no I/O
+  / Promise), so tests pin the form shape directly. The form calls
+  `day8.re-frame2-causa.runtime/get-trace-buffer` with the filter-opts
+  map and wraps the call in the `:causa-mcp` origin binding so any
+  side-effect the runtime accessor performs (none today — it's
+  read-only — but reserved for the contract) carries the right tag."
+  [filter-opts]
+  (-> (ef/rt-call 'get-trace-buffer filter-opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+;; ---------------------------------------------------------------------------
+;; Result shaping.
+;; ---------------------------------------------------------------------------
+
+(defn- apply-limit-offset
+  "Slice the events vector by `:offset` then `:limit`. Returns the
+  sliced vector. Both default to no-op when missing / non-positive."
+  [events limit offset]
+  (let [o (max 0 (or offset 0))
+        l (or limit default-limit)]
+    (->> events
+         (drop o)
+         (take l)
+         vec)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :events <vec> :count <int>}`
+  response into the MCP envelope after applying the B-1 strip-step
+  and the W-6 marker count. Pure — tests pin the full shaping logic
+  without I/O.
+
+  Inputs:
+    - `runtime-envelope` — the raw map the runtime accessor returned
+      (already `pr-str`'d and re-read by `nrepl/cljs-eval-value`).
+    - `include-sensitive?` — boolean resolved from the MCP arg.
+    - `limit` / `offset` — caller-supplied pagination knobs.
+
+  Returns the envelope ready for `wire/ok-text`."
+  [runtime-envelope include-sensitive? limit offset]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      ;; Surface a runtime-side failure verbatim — already structured.
+      (false? ok?)
+      env
+
+      ;; Defensive: unexpected shape from the runtime side.
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/get-trace-buffer returned a non-envelope shape"}
+
+      :else
+      (let [raw-events     (vec (:events env))
+            paged          (apply-limit-offset raw-events limit offset)
+            ;; B-1: drop :sensitive? true items unless caller opted in.
+            [kept dropped] (privacy/strip-sensitive paged include-sensitive?)
+            ;; W-6: count any size-elision markers the walker emitted.
+            elided         (elision/count-elided-markers kept)
+            total          (count raw-events)]
+        (wire/with-indicators
+          {:ok?           true
+           :events        kept
+           :count         (count kept)
+           :total         total
+           :limit         (or limit default-limit)
+           :offset        (max 0 (or offset 0))}
+          {:dropped dropped
+           :elided  elided})))))
+
+;; ---------------------------------------------------------------------------
+;; Tool handler.
+;; ---------------------------------------------------------------------------
+
+(defn get-trace-buffer-tool
+  "MCP handler for `get-trace-buffer`. Returns a Promise of the JS-shape
+  MCP result."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        opts     (build-filter-opts args)
+        limit    (wire/arg-int args :limit default-limit)
+        offset   (wire/arg-int args :offset 0)
+        incl?    (:include-sensitive? opts)
+        form     (build-form opts)]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+        (.then (fn [runtime-envelope]
+                 (wire/ok-text (shape-envelope runtime-envelope incl? limit offset))))
+        (.catch (fn [err] (probe/err->result :get-trace-buffer-failed err))))))
+
+;; ---------------------------------------------------------------------------
+;; Descriptor + registration.
+;; ---------------------------------------------------------------------------
+
+(def descriptor
+  "MCP tool descriptor for `get-trace-buffer`. The `:input-schema` is a
+  JSON-Schema object the MCP SDK serialises on `tools/list`. Public so
+  tests pin the catalogue surface."
+  {:name        "get-trace-buffer"
+   :description (str "Read a slice of the re-frame2 trace bus. Returns recent "
+                     "trace events filtered by frame / op-type / since-ms / "
+                     "origin / event-id. Sensitive events are dropped by "
+                     "default (pass :include-sensitive? true to opt in). "
+                     "Large values are elided to size markers by default "
+                     "(pass :include-large? true to opt in). Default :limit 50.")
+   :input-schema #js {:type "object"
+                      :properties #js {:frame              #js {:type "string"}
+                                       :op-type            #js {:type "string"}
+                                       :since-ms           #js {:type "integer"}
+                                       :event-id           #js {:type "string"}
+                                       :origin             #js {:type "string"}
+                                       :limit              #js {:type "integer"}
+                                       :offset             #js {:type "integer"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) get-trace-buffer-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/wire.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/wire.cljs
@@ -1,0 +1,152 @@
+(ns day8.re-frame2-causa-mcp.wire
+  "MCP result helpers + per-call argument extraction for the causa-mcp
+  T-Insp tranche (rf2-8xzoe T-Insp shared infra; sibling to pair2-mcp's
+  `re-frame-pair2-mcp.tools.wire`).
+
+  Every causa-mcp tool returns an MCP `{:content [{:type \"text\"
+  :text <edn-string>}]}` envelope, success or error. This namespace
+  owns that wire shape plus the tiny `arg` / `arg-keyword` /
+  `arg-build` accessors every tool uses to pluck named args out of the
+  JS-shaped `args` object the MCP host passes.
+
+  Build-id resolution lives here too — `default-build-id` reads
+  `SHADOW_CLJS_BUILD_ID` from `process.env`, falling back to `:app`."
+  (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Config — build id.
+;; ---------------------------------------------------------------------------
+
+(def ^:private cached-default-build-id
+  "Cached at namespace load — the `SHADOW_CLJS_BUILD_ID` env var doesn't
+  change at runtime, and re-reading it on every tool dispatch is wasted
+  cycles. A delay defers the read until the first call — important for
+  shadow-cljs hot-reload paths where the file may load before
+  `js/process.env` is fully populated."
+  (delay
+    (or (some-> (j/get-in js/process [:env :SHADOW_CLJS_BUILD_ID])
+                keyword)
+        :app)))
+
+(defn default-build-id [] @cached-default-build-id)
+
+;; ---------------------------------------------------------------------------
+;; MCP result helpers.
+;; ---------------------------------------------------------------------------
+
+(defn ok-text
+  "Wrap `v` as a success MCP result. `v` is `pr-str`'d into the
+  `:content[0].text` slot — the standard MCP single-text-slot shape."
+  [v]
+  #js {:content #js [#js {:type "text" :text (pr-str v)}]})
+
+(defn err-text
+  "Wrap `v` as an error MCP result (`:isError true`). Same shape as
+  `ok-text` but flips the error flag so the agent host surfaces the
+  envelope as a tool failure rather than a normal value."
+  [v]
+  #js {:isError true
+       :content #js [#js {:type "text" :text (pr-str v)}]})
+
+(defn with-indicators
+  "Splice the cross-MCP indicator-field slots (`:dropped-sensitive`,
+  `:elided-large`) onto a tool's envelope map. Cross-MCP convention:
+  emit the slot iff its counter is positive (the zero-drop / zero-elide
+  common path carries no counter so the wire stays minimal — a missing
+  slot reads as zero).
+
+  Mirrors `re-frame-pair2-mcp.tools.wire/with-indicators` byte-for-byte
+  so the cross-MCP wire-vocab conformance test sees identical envelope
+  shapes across the triplet (per `re-frame.mcp-base.vocab`'s indicator
+  key constants)."
+  [envelope {:keys [dropped elided]}]
+  (cond-> envelope
+    (pos? (or dropped 0)) (assoc :dropped-sensitive dropped)
+    (pos? (or elided  0)) (assoc base-vocab/elided-large-key elided)))
+
+;; ---------------------------------------------------------------------------
+;; Arg pluckers — JS-side MCP args object.
+;; ---------------------------------------------------------------------------
+
+(defn arg
+  "Extract an MCP tool argument by name. Returns nil if absent /
+  `js/undefined`. Both the kebab-case canonical slot name and the
+  string form of the keyword (with leading `:`) are checked because
+  MCP clients sometimes serialise the cross-server `:include-sensitive?`
+  / `:include-large?` slot names with the leading `:` preserved."
+  [args k]
+  (let [n (name k)
+        v (or (j/get args n)
+              (j/get args (str ":" n)))]
+    (when-not (or (nil? v) (undefined? v)) v)))
+
+(defn arg-keyword
+  "Pluck an arg slot and coerce to a keyword via `(some-> v keyword)`.
+  Returns nil when the slot is absent. Compresses the
+  `(some-> (wire/arg args :foo) keyword)` pattern that recurs across
+  per-tool bodies."
+  [args k]
+  (some-> (arg args k) keyword))
+
+(defn arg-build
+  "Resolve the shadow-cljs `:build-id` for this call. Per-call
+  `:build` arg wins; falls back to `default-build-id`."
+  [args]
+  (or (arg-keyword args :build)
+      (default-build-id)))
+
+(defn arg-bool
+  "Pluck a boolean arg slot. Accepts boolean passthrough, `\"true\"` /
+  `\"false\"` / `\"1\"` / `\"0\"` / `\"yes\"` / `\"no\"` strings, and
+  `nil` (→ `default`). Used by tools for `:include-sensitive?` /
+  `:include-large?` and friends that aren't already covered by the
+  privacy / elision parsers."
+  ([args k] (arg-bool args k false))
+  ([args k default]
+   (let [v (arg args k)]
+     (cond
+       (nil? v)         default
+       (boolean? v)     v
+       (true? v)        true
+       (false? v)       false
+       (string? v)      (let [s (.toLowerCase v)]
+                          (cond
+                            (contains? #{"true" "1" "yes"} s) true
+                            (contains? #{"false" "0" "no"} s) false
+                            :else default))
+       :else            default))))
+
+(defn arg-int
+  "Pluck an integer arg slot. Accepts native numbers and numeric
+  strings; returns `default` for anything unparseable."
+  ([args k] (arg-int args k nil))
+  ([args k default]
+   (let [v (arg args k)]
+     (cond
+       (nil? v)     default
+       (number? v)  (long v)
+       (string? v)  (let [n (js/parseInt v 10)]
+                      (if (js/isNaN n) default n))
+       :else        default))))
+
+;; ---------------------------------------------------------------------------
+;; Wire-bounded marker detection — used by the cap step.
+;; ---------------------------------------------------------------------------
+
+(def ^:private marker-prefixes
+  ["{:rf.mcp/overflow"
+   "{:rf.mcp/cache-hit"])
+
+(defn marker?
+  "Is `result-js` a wire-bounded `:rf.mcp/*` marker envelope? Returns
+  true for `:rf.mcp/overflow` and `:rf.mcp/cache-hit` results — the
+  envelopes the boundary steps emit themselves. Such envelopes are
+  sub-cap by construction and must not be re-walked by later boundary
+  steps."
+  [result-js]
+  (let [content (when result-js (j/get result-js :content))
+        item    (when (array? content) (aget content 0))
+        text    (when item (j/get item :text))]
+    (and (string? text)
+         (boolean (some #(.startsWith text %) marker-prefixes)))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs
@@ -27,7 +27,8 @@
   (:require [applied-science.js-interop :as j]
             [cljs.reader :as edn]
             [cljs.test :refer-macros [deftest is testing async]]
-            [day8.re-frame2-causa-mcp.server :as server]))
+            [day8.re-frame2-causa-mcp.server :as server]
+            [day8.re-frame2-causa-mcp.tools :as tools]))
 
 ;; ---------------------------------------------------------------------------
 ;; Public surface — vars exist and are callable.
@@ -63,12 +64,19 @@
 ;; Tool catalogue — empty at F-2.
 ;; ---------------------------------------------------------------------------
 
-(deftest tool-descriptors-empty-at-f2
-  (testing "the Causa-shaped catalogue is empty at F-2 — the
-            eighteen-tool catalogue lands in later F-tranche beads"
+(deftest tool-descriptors-is-js-array
+  (testing "the catalogue surface is a JS array of descriptors (its
+            length grows as T-Insp / T-Mut / T-Stream tranches land
+            their per-tool `register-tool!` calls)"
     (let [^js descriptors (server/tool-descriptors-js)]
       (is (array? descriptors))
-      (is (zero? (.-length descriptors))))))
+      ;; Every descriptor must carry the SDK-shaped name + description
+      ;; + inputSchema slots so the MCP wire serialiser doesn't choke.
+      (doseq [i (range (.-length descriptors))]
+        (let [d (aget descriptors i)]
+          (is (string? (j/get d :name)))
+          (is (string? (j/get d :description)))
+          (is (some? (j/get d :inputSchema))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; build-server — constructs an MCP Server with the SDK handlers wired.
@@ -135,43 +143,34 @@
                      (done))))))))
 
 ;; ---------------------------------------------------------------------------
-;; Success-path tools/call stub — returns :not-implemented until the
-;; dispatcher lands in a later F-tranche.
+;; Success-path tools/call dispatcher — routes through `tools/invoke`.
+;; The per-tool dispatch contract is exercised in
+;; `test/day8/re_frame2_causa_mcp/tools_test.cljs` and the per-tool
+;; tests under `tools/` — server_test only pins that the boot path
+;; resolves the dispatcher entry point.
 ;; ---------------------------------------------------------------------------
 
-(deftest boot-build-server-routes-tools-call-to-not-implemented-stub
-  (testing "boot! wires tools/call to the F-2 success-path stub —
-            every call returns a structured :not-implemented envelope
-            with the tool name echoed back; replaced by the real
-            dispatcher in a later F-tranche"
-    ;; We call build-server directly with the same success-path
-    ;; handler boot! uses, then drive the registered handler through
-    ;; the SDK's own dispatch path is overkill here — exercise the
-    ;; stub directly via a parallel construction.
+(deftest boot-build-server-resolves-dispatcher
+  (testing "boot! wires tools/call through the per-tool dispatcher; an
+            unknown tool name resolves to a structured :unknown-tool
+            envelope rather than a transport-level failure"
     (async done
-      (let [conn    {:port 12345}
-            ;; Re-construct the same closure boot! installs so we can
-            ;; drive it without holding the SDK Server instance.
-            handler (fn [req extra]
-                      ;; Mirror the boot! body — keep this in sync if
-                      ;; the boot! body changes.
+      (let [conn    (atom {:port 12345})
+            handler (fn [req _extra]
+                      ;; Mirror the real boot! body — the dispatcher
+                      ;; handles unknown names without an nREPL hit.
                       (let [params (j/get req :params)
-                            name   (j/get params :name)]
-                        (js/Promise.resolve
-                          #js {:isError true
-                               :content #js [#js {:type "text"
-                                                  :text (pr-str {:ok?    false
-                                                                 :reason :not-implemented
-                                                                 :tool   name
-                                                                 :hint   "stub"})}]})))
-            req     #js {:params #js {:name "discover-app" :arguments #js {}}}]
+                            name   (j/get params :name)
+                            args   (j/get params :arguments)]
+                        (tools/invoke conn name args nil)))
+            req     #js {:params #js {:name "definitely-not-a-tool" :arguments #js {}}}]
         (-> (handler req nil)
             (.then (fn [^js result]
                      (is (true? (j/get result :isError)))
                      (let [text    (j/get (aget (j/get result :content) 0) :text)
                            payload (edn/read-string text)]
-                       (is (= :not-implemented (:reason payload)))
-                       (is (= "discover-app" (:tool payload))))
+                       (is (= :unknown-tool (:reason payload)))
+                       (is (= "definitely-not-a-tool" (:tool payload))))
                      (done))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_app_db_diff_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_app_db_diff_test.cljs
@@ -1,0 +1,191 @@
+(ns day8.re-frame2-causa-mcp.tools.get-app-db-diff-test
+  "Unit tests for the T-Insp-4 tool `get-app-db-diff` (rf2-8xzoe.17)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-app-db-diff :as gadd]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface
+  (is (fn? gadd/get-app-db-diff-tool))
+  (is (fn? gadd/shape-envelope))
+  (is (fn? gadd/changed-paths))
+  (is (= "get-app-db-diff" (:name gadd/descriptor))))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-app-db-diff"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gadd/build-form {:epoch-id "e-1"
+                               :include-sensitive? false :include-large? false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-app-db-diff"))
+    (is (.includes form ":causa-mcp"))))
+
+;; ---------------------------------------------------------------------------
+;; changed-paths — pure projection.
+;; ---------------------------------------------------------------------------
+
+(deftest changed-paths-empty-diff
+  (let [r (gadd/changed-paths {:a 1} {:a 1})]
+    (is (= [] (:added r)))
+    (is (= [] (:removed r)))
+    (is (= [] (:changed r)))
+    (is (= {:added 0 :removed 0 :changed 0} (:counts r)))))
+
+(deftest changed-paths-detects-top-level-add-remove
+  (let [r (gadd/changed-paths {:a 1 :b 2} {:b 2 :c 3})]
+    (is (= [[:c]] (:added r)))
+    (is (= [[:a]] (:removed r)))
+    (is (= [] (:changed r)))))
+
+(deftest changed-paths-detects-top-level-change
+  (let [r (gadd/changed-paths {:a 1} {:a 2})]
+    (is (= [] (:added r)))
+    (is (= [] (:removed r)))
+    (is (= [[:a]] (:changed r)))))
+
+(deftest changed-paths-recurses-into-nested-maps
+  (let [r (gadd/changed-paths
+            {:cart {:items [] :total 0}
+             :user {:id 1}}
+            {:cart {:items [{:sku "A"}] :total 100}
+             :user {:id 1}})]
+    (is (= [] (:added r)))
+    (is (= [] (:removed r)))
+    (is (= #{[:cart :items] [:cart :total]} (set (:changed r))))))
+
+(deftest changed-paths-stops-at-scalar-boundary
+  (let [r (gadd/changed-paths
+            {:items [1 2 3]}
+            {:items [4 5 6]})]
+    (is (= [[:items]] (:changed r))
+        "a changed vector is one :changed entry, not per-element")))
+
+(deftest changed-paths-counts-include-nested
+  (let [r (gadd/changed-paths
+            {:a {:x 1 :y 2 :z 3}}
+            {:a {:x 1 :y 99 :z 3 :w 4}})]
+    (is (= {:added 1 :removed 0 :changed 1} (:counts r)))
+    (is (= [[:a :w]] (:added r)))
+    (is (= [[:a :y]] (:changed r)))))
+
+;; ---------------------------------------------------------------------------
+;; shape-envelope.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-changed-paths-default
+  (let [runtime-env {:ok? true :frame :rf/default :epoch-id "e-42"
+                     :diff {:before {:a 1}
+                            :after  {:a 2 :b 3}}}
+        shaped      (gadd/shape-envelope runtime-env {:mode :changed-paths})]
+    (is (true? (:ok? shaped)))
+    (is (= :changed-paths (:mode shaped)))
+    (is (= [[:b]] (:added (:diff shaped))))
+    (is (= [[:a]] (:changed (:diff shaped))))
+    (is (= 1 (:added (:counts (:diff shaped)))))
+    (is (nil? (:elided-large shaped)))))
+
+(deftest shape-envelope-nested-mode
+  (let [runtime-env {:ok? true :frame :rf/default :epoch-id "e-42"
+                     :diff {:before {:a 1}
+                            :after  {:a 2}}}
+        shaped      (gadd/shape-envelope runtime-env {:mode :nested})]
+    (is (= :nested (:mode shaped)))
+    (is (= {:a 1} (-> shaped :diff :before)))
+    (is (= {:a 2} (-> shaped :diff :after)))))
+
+(deftest shape-envelope-counts-elision-in-nested-mode
+  (let [runtime-env {:ok? true :frame :rf/default :epoch-id "e-42"
+                     :diff {:before {:secret {:rf.size/large-elided
+                                              {:bytes 10000}}}
+                            :after  {:secret {:rf.size/large-elided
+                                              {:bytes 10001}}}}}
+        shaped      (gadd/shape-envelope runtime-env {:mode :nested})]
+    (is (= 2 (:elided-large shaped))
+        ":nested mode surfaces both markers from the before+after")))
+
+(deftest shape-envelope-runtime-failure
+  (let [runtime-env {:ok? false :reason :no-such-epoch :epoch-id "missing"}]
+    (is (= runtime-env (gadd/shape-envelope runtime-env
+                                            {:mode :changed-paths})))))
+
+(deftest missing-epoch-id-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached probe")
+            (js/Promise.resolve nil)))
+    (-> (gadd/get-app-db-diff-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :missing-epoch-id (:reason payload))))
+                 (done))))))
+
+(deftest invalid-mode-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached probe")
+            (js/Promise.resolve nil)))
+    (-> (gadd/get-app-db-diff-tool (atom {})
+                                   #js {"epoch-id" "e-1"
+                                        "mode" "verbose"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :invalid-mode (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path-nested-mode
+  (async done
+    (let [runtime-env {:ok? true :frame :rf/default :epoch-id "e-1"
+                       :diff {:before {:huge (apply str (repeat 10000 \x))}
+                              :after  {:huge (apply str (repeat 10001 \x))}}}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-app-db-diff"
+                        #js {"epoch-id" "e-1"
+                             "mode" "nested"
+                             "max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "h" {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gadd/get-app-db-diff-tool (atom {})
+                                   #js {"epoch-id" "e-1"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_app_db_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_app_db_test.cljs
@@ -1,0 +1,135 @@
+(ns day8.re-frame2-causa-mcp.tools.get-app-db-test
+  "Unit tests for the T-Insp-3 tool `get-app-db` (rf2-8xzoe.16)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-app-db :as gad]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface
+  (is (fn? gad/get-app-db-tool))
+  (is (fn? gad/shape-envelope))
+  (is (= "get-app-db" (:name gad/descriptor)))
+  (is (= 64 gad/summary-keys-cap)))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-app-db"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gad/build-form {:include-sensitive? false :include-large? false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-app-db"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest shape-envelope-summary-mode-default-map
+  (let [runtime-env {:ok? true :frame :rf/default :path []
+                     :value {:cart {:items []} :user {:id 1} :nav :home}}
+        shaped      (gad/shape-envelope runtime-env {:mode :summary})]
+    (is (true? (:ok? shaped)))
+    (is (= :summary (:mode shaped)))
+    (is (= :map (-> shaped :value :rf.mcp/summary :type)))
+    (is (= 3 (-> shaped :value :rf.mcp/summary :count)))
+    (is (= #{:cart :user :nav}
+           (set (-> shaped :value :rf.mcp/summary :top-keys))))))
+
+(deftest shape-envelope-summary-mode-truncates-large-key-list
+  (let [big-map     (zipmap (map #(keyword (str "k-" %)) (range 100))
+                            (repeat :v))
+        runtime-env {:ok? true :frame :rf/default :path [] :value big-map}
+        shaped      (gad/shape-envelope runtime-env {:mode :summary})]
+    (is (= 100 (-> shaped :value :rf.mcp/summary :count)))
+    (is (= 64  (count (-> shaped :value :rf.mcp/summary :top-keys))))
+    (is (true? (-> shaped :value :rf.mcp/summary :keys-truncated?)))))
+
+(deftest shape-envelope-summary-mode-on-vector
+  (let [runtime-env {:ok? true :frame :rf/default :path [:items]
+                     :value [{:a 1} {:b 2} {:c 3}]}
+        shaped      (gad/shape-envelope runtime-env {:mode :summary})]
+    (is (= :vector (-> shaped :value :rf.mcp/summary :type)))
+    (is (= 3 (-> shaped :value :rf.mcp/summary :count)))))
+
+(deftest shape-envelope-summary-mode-scalar-passes-through
+  (let [runtime-env {:ok? true :frame :rf/default :path [:nav]
+                     :value :home}
+        shaped      (gad/shape-envelope runtime-env {:mode :summary})]
+    (is (= :home (:value shaped))
+        "scalars ride through unchanged in summary mode")))
+
+(deftest shape-envelope-full-mode
+  (let [v           {:cart {:items [{:sku "A"}]}}
+        runtime-env {:ok? true :frame :rf/default :path [] :value v}
+        shaped      (gad/shape-envelope runtime-env {:mode :full})]
+    (is (= :full (:mode shaped)))
+    (is (= v (:value shaped)))))
+
+(deftest shape-envelope-counts-elision-markers
+  (let [runtime-env {:ok? true :frame :rf/default :path []
+                     :value {:user {:rf.size/large-elided {:bytes 100000}}
+                             :nav  :home}}
+        shaped      (gad/shape-envelope runtime-env {:mode :full})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-runtime-failure-passthrough
+  (let [runtime-env {:ok? false :reason :no-frame-resolved}]
+    (is (= runtime-env (gad/shape-envelope runtime-env {:mode :summary})))))
+
+(deftest invalid-mode-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached probe")
+            (js/Promise.resolve nil)))
+    (-> (gad/get-app-db-tool (atom {}) #js {"mode" "verbose"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :invalid-mode (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [runtime-env {:ok? true :frame :rf/default :path []
+                       :value {:huge (apply str (repeat 10000 \x))}}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-app-db"
+                        #js {"mode" "full" "max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "h" {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gad/get-app-db-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_epoch_history_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_epoch_history_test.cljs
@@ -1,0 +1,178 @@
+(ns day8.re-frame2-causa-mcp.tools.get-epoch-history-test
+  "Unit tests for the T-Insp-2 tool `get-epoch-history` (rf2-8xzoe.15)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-epoch-history :as geh]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- mk-epochs
+  "Build n synthetic epoch records with monotonic ids."
+  [n]
+  (vec (for [i (range n)]
+         {:epoch-id (str "e-" i)
+          :event-id (keyword "test" (str "event-" i))
+          :db-after {:counter i}})))
+
+(deftest public-surface
+  (is (fn? geh/get-epoch-history-tool))
+  (is (fn? geh/shape-envelope))
+  (is (fn? geh/encode-cursor))
+  (is (fn? geh/decode-cursor))
+  (is (= "get-epoch-history" (:name geh/descriptor)))
+  (is (= 50 geh/default-limit)))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-epoch-history"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (geh/build-form {:include-sensitive? false :include-large? false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-epoch-history"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest cursor-round-trip
+  (let [m {:after-id "e-42"}
+        s (geh/encode-cursor m)]
+    (is (string? s))
+    (is (= m (geh/decode-cursor s)))))
+
+(deftest decode-cursor-nil-and-blank
+  (is (nil? (geh/decode-cursor nil)))
+  (is (nil? (geh/decode-cursor ""))))
+
+(deftest decode-cursor-malformed
+  (is (= :day8.re-frame2-causa-mcp.tools.get-epoch-history/malformed
+         (geh/decode-cursor "not-base64-EDN!!!"))))
+
+(deftest shape-envelope-first-page
+  (let [runtime-env {:ok? true :frame :rf/default :epochs (mk-epochs 60)}
+        shaped      (geh/shape-envelope runtime-env
+                                        {:cursor-in nil
+                                         :limit 50
+                                         :include-sensitive? false})]
+    (is (true? (:ok? shaped)))
+    (is (= 50 (:count shaped)))
+    (is (= 60 (:total shaped)))
+    (is (string? (:next-cursor shaped))
+        "first page of 60-epoch history has a next-cursor")
+    (let [resume (geh/decode-cursor (:next-cursor shaped))]
+      (is (= "e-49" (:after-id resume))))))
+
+(deftest shape-envelope-resume-with-cursor
+  (let [all          (mk-epochs 60)
+        runtime-env  {:ok? true :frame :rf/default :epochs all}
+        cursor-in    {:after-id "e-49"}
+        shaped       (geh/shape-envelope runtime-env
+                                         {:cursor-in cursor-in
+                                          :limit 50
+                                          :include-sensitive? false})]
+    (is (= 10 (:count shaped)))
+    (is (nil? (:next-cursor shaped))
+        "tail page has no next-cursor")
+    (is (= "e-50" (-> shaped :epochs first :epoch-id)))))
+
+(deftest shape-envelope-stale-cursor
+  (let [runtime-env {:ok? true :frame :rf/default :epochs (mk-epochs 10)}
+        cursor-in   {:after-id "e-999"}
+        shaped      (geh/shape-envelope runtime-env
+                                        {:cursor-in cursor-in
+                                         :limit 50
+                                         :include-sensitive? false})]
+    (is (false? (:ok? shaped)))
+    (is (= :cursor-stale (:reason shaped)))
+    (is (= "e-999" (:requested-id shaped)))))
+
+(deftest shape-envelope-drops-sensitive-epochs
+  (let [runtime-env {:ok? true :frame :rf/default
+                     :epochs [{:epoch-id "e-1"}
+                              {:epoch-id "e-2" :sensitive? true}
+                              {:epoch-id "e-3"}]}
+        shaped      (geh/shape-envelope runtime-env
+                                        {:cursor-in nil
+                                         :limit 50
+                                         :include-sensitive? false})]
+    (is (= 2 (:count shaped)))
+    (is (= 1 (:dropped-sensitive shaped)))))
+
+(deftest shape-envelope-counts-elision-markers
+  (let [runtime-env {:ok? true :frame :rf/default
+                     :epochs [{:epoch-id "e-1"
+                               :db-after {:rf.size/large-elided {:bytes 102400}}}
+                              {:epoch-id "e-2"
+                               :db-after {:counter 1}}]}
+        shaped      (geh/shape-envelope runtime-env
+                                        {:cursor-in nil
+                                         :limit 50
+                                         :include-sensitive? false})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-runtime-failure
+  (let [runtime-env {:ok? false :reason :no-frame-resolved
+                     :hint "Pass :frame :foo or register at least one frame."}]
+    (is (= runtime-env (geh/shape-envelope runtime-env
+                                           {:cursor-in nil :limit 50
+                                            :include-sensitive? false})))))
+
+(deftest malformed-cursor-arg-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached probe")
+            (js/Promise.resolve nil)))
+    (-> (geh/get-epoch-history-tool (atom {})
+                                    #js {"cursor" "garbage-not-base64"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :cursor-malformed (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [runtime-env {:ok? true :frame :rf/default
+                       :epochs [{:epoch-id "huge"
+                                 :db-after {:big (apply str (repeat 10000 \x))}}]}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-epoch-history"
+                        #js {"max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "h" {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (geh/get-epoch-history-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_handlers_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_handlers_test.cljs
@@ -1,0 +1,115 @@
+(ns day8.re-frame2-causa-mcp.tools.get-handlers-test
+  "Unit tests for the T-Insp-8 tool `get-handlers` (rf2-8xzoe.21)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-handlers :as gh]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface
+  (is (fn? gh/get-handlers-tool))
+  (is (fn? gh/shape-envelope))
+  (is (= "get-handlers" (:name gh/descriptor))))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-handlers"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gh/build-form {:include-sensitive? false :include-large? false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-handlers"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest shape-envelope-groups-by-kind
+  (let [runtime-env {:ok? true
+                     :handlers [{:kind :event :id :cart/add :meta {:doc "add"}}
+                                {:kind :sub   :id :cart/items :meta {:doc "items"}}
+                                {:kind :event :id :cart/clear :meta {:doc "clear"}}]
+                     :count 3}
+        shaped      (gh/shape-envelope runtime-env true)]
+    (is (true? (:ok? shaped)))
+    (is (= 3 (:count shaped)))
+    (is (= #{:event :sub} (set (:kinds shaped))))
+    (is (= 2 (count (get-in shaped [:handlers :event]))))
+    (is (= 1 (count (get-in shaped [:handlers :sub]))))
+    (is (= :cart/add (-> shaped :handlers :event first :id))
+        "per-kind insertion order is preserved")
+    (is (nil? (:elided-large shaped)))))
+
+(deftest shape-envelope-flat-mode
+  (let [runtime-env {:ok? true
+                     :handlers [{:kind :event :id :a :meta {}}
+                                {:kind :sub   :id :b :meta {}}]
+                     :count 2}
+        shaped      (gh/shape-envelope runtime-env false)]
+    (is (vector? (:handlers shaped)))
+    (is (= 2 (:count shaped)))
+    (is (nil? (:kinds shaped))
+        "flat mode omits the :kinds rollup")))
+
+(deftest shape-envelope-counts-elision-markers
+  (let [runtime-env {:ok? true
+                     :handlers [{:kind :event :id :a
+                                 :meta {:big {:rf.size/large-elided
+                                              {:bytes 102400}}}}]
+                     :count 1}
+        shaped      (gh/shape-envelope runtime-env true)]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-runtime-failure
+  (let [runtime-env {:ok? false :reason :something-wrong :hint "..."}]
+    (is (= runtime-env (gh/shape-envelope runtime-env true)))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [runtime-env {:ok? true
+                       :handlers [{:kind :event :id :huge
+                                   :meta {:doc (apply str (repeat 10000 \x))}}]
+                       :count 1}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-handlers"
+                        #js {"max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))
+          (.catch (fn [err]
+                    (is false (str "failed: " (.-message err)))
+                    (done)))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "preload missing"
+                       {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gh/get-handlers-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_issues_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_issues_test.cljs
@@ -1,0 +1,174 @@
+(ns day8.re-frame2-causa-mcp.tools.get-issues-test
+  "Unit tests for the T-Insp-7 tool `get-issues` (rf2-8xzoe.20)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-issues :as gi]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface
+  (is (fn? gi/get-issues-tool))
+  (is (fn? gi/shape-envelope))
+  (is (= "get-issues" (:name gi/descriptor)))
+  (is (= #{:error :warning :all} gi/severity-vocabulary)))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-issues"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gi/build-form {:include-sensitive? false :include-large? false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-issues"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest shape-envelope-all-severity-default
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error   :message "boom"}
+                              {:op-type :warning :message "uh"}
+                              {:op-type :rf.schema/violation}]
+                     :count 3}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :all
+                                        :include-sensitive? false
+                                        :limit 50 :offset 0})]
+    (is (true? (:ok? shaped)))
+    (is (= 3 (:count shaped)))
+    (is (= 3 (:total shaped)))
+    (is (= :all (:severity shaped)))))
+
+(deftest shape-envelope-severity-error-narrows
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error}
+                              {:op-type :warning}
+                              {:op-type :rf.schema/violation}
+                              {:op-type :rf.hydration/mismatch}]
+                     :count 4}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :error
+                                        :include-sensitive? false
+                                        :limit 50 :offset 0})]
+    (is (= 3 (:count shaped))
+        ":error keeps :error + :rf.schema/violation + :rf.hydration/mismatch")
+    (is (= :error (:severity shaped)))))
+
+(deftest shape-envelope-severity-warning-narrows
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error}
+                              {:op-type :warning}
+                              {:op-type :warning :extra "x"}]
+                     :count 3}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :warning
+                                        :include-sensitive? false
+                                        :limit 50 :offset 0})]
+    (is (= 2 (:count shaped)))))
+
+(deftest shape-envelope-drops-sensitive-by-default
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error :message "ok"}
+                              {:op-type :error :message "secret" :sensitive? true}]
+                     :count 2}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :all
+                                        :include-sensitive? false
+                                        :limit 50 :offset 0})]
+    (is (= 1 (:count shaped)))
+    (is (= 1 (:dropped-sensitive shaped)))))
+
+(deftest shape-envelope-include-sensitive-opts-back-in
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error :message "ok"}
+                              {:op-type :error :message "secret" :sensitive? true}]
+                     :count 2}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :all
+                                        :include-sensitive? true
+                                        :limit 50 :offset 0})]
+    (is (= 2 (:count shaped)))
+    (is (nil? (:dropped-sensitive shaped)))))
+
+(deftest shape-envelope-counts-elided-markers
+  (let [runtime-env {:ok? true
+                     :issues [{:op-type :error
+                               :body {:rf.size/large-elided {:bytes 10000}}}
+                              {:op-type :warning}]
+                     :count 2}
+        shaped      (gi/shape-envelope runtime-env
+                                       {:severity :all
+                                        :include-sensitive? false
+                                        :limit 50 :offset 0})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-pagination
+  (let [issues     (vec (for [i (range 10)]
+                          {:op-type :warning :id i}))
+        runtime-env {:ok? true :issues issues :count 10}
+        shaped     (gi/shape-envelope runtime-env
+                                      {:severity :all
+                                       :include-sensitive? false
+                                       :limit 3 :offset 4})]
+    (is (= 3 (:count shaped)))
+    (is (= [4 5 6] (mapv :id (:issues shaped))))))
+
+(deftest invalid-severity-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached probe")
+            (js/Promise.resolve nil)))
+    (-> (gi/get-issues-tool (atom {}) #js {"severity" "fatal"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :invalid-severity (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [runtime-env {:ok? true
+                       :issues [{:op-type :error
+                                 :message (apply str (repeat 10000 \x))}]
+                       :count 1}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-issues"
+                        #js {"max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "h" {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gi/get-issues-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_machine_list_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_machine_list_test.cljs
@@ -1,0 +1,119 @@
+(ns day8.re-frame2-causa-mcp.tools.get-machine-list-test
+  "Unit tests for the T-Insp-6 tool `get-machine-list` (rf2-8xzoe.19).
+  Pins:
+    - Eval-form composition addresses the runtime accessor with the
+      :causa-mcp origin binding.
+    - shape-envelope counts elision markers in the per-machine
+      metadata and stamps :elided-large.
+    - Dispatcher overflow path (W-1) replaces the result with the
+      :rf.mcp/overflow marker when the rendered envelope exceeds the
+      cap.
+    - probe-rejection surfaces :runtime-not-preloaded with the setup
+      hint.
+
+  Stub strategy mirrors get_trace_buffer_test.cljs: direct `set!`
+  with fixture restoration, sidestepping the rf2-wb06a async-cleanup
+  race."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-machine-list :as gml]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface-resolvable
+  (is (fn? gml/get-machine-list-tool))
+  (is (fn? gml/build-form))
+  (is (fn? gml/shape-envelope))
+  (is (map? gml/descriptor))
+  (is (= "get-machine-list" (:name gml/descriptor))))
+
+(deftest registered-in-catalogue
+  (is (some? (registry/handler-for "get-machine-list"))))
+
+(deftest build-form-addresses-runtime-accessor
+  (let [form (gml/build-form {:include-sensitive? false
+                              :include-large?     false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-machine-list"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest shape-envelope-happy-path
+  (let [runtime-env {:ok? true
+                     :machines {:checkout/fsm {:initial-state :idle
+                                               :transitions   {}}}
+                     :count    1}
+        shaped      (gml/shape-envelope runtime-env)]
+    (is (true? (:ok? shaped)))
+    (is (= 1 (:count shaped)))
+    (is (= [:checkout/fsm] (vec (keys (:machines shaped)))))
+    (is (nil? (:elided-large shaped)))))
+
+(deftest shape-envelope-counts-elided-markers
+  (let [runtime-env {:ok? true
+                     :machines {:checkout/fsm {:initial-state :idle
+                                               :spec {:rf.size/large-elided
+                                                      {:bytes 102400}}}
+                                :tour/fsm {:initial-state :start
+                                           :transitions   {}}}
+                     :count 2}
+        shaped      (gml/shape-envelope runtime-env)]
+    (is (= 1 (:elided-large shaped))
+        "the one machine with a large elision marker is counted")))
+
+(deftest shape-envelope-passes-runtime-failure
+  (let [runtime-env {:ok? false :reason :runtime-failure :hint "..."}]
+    (is (= runtime-env (gml/shape-envelope runtime-env)))))
+
+(deftest dispatcher-overflow-path
+  (testing "W-1: dispatcher replaces over-cap result with overflow marker"
+    (async done
+      (let [big-meta    {:spec (apply str (repeat 10000 \x))}
+            runtime-env {:ok? true :machines {:huge/fsm big-meta} :count 1}]
+        (stub-runtime! runtime-env)
+        (-> (tools/invoke (atom {}) "get-machine-list"
+                          #js {"max-tokens" 500} nil)
+            (.then (fn [^js result]
+                     (let [payload (-> (j/get result :content) (aget 0)
+                                       (j/get :text) edn/read-string)]
+                       (is (contains? payload :rf.mcp/overflow))
+                       (is (contains? token-cap/hint-vocabulary
+                                      (get-in payload [:rf.mcp/overflow :hint]))))
+                     (done)))
+            (.catch (fn [err]
+                      (is false (str "failed: " (.-message err)))
+                      (done))))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "preload missing"
+                       {:reason :runtime-not-preloaded :hint "setup"}))))
+    (-> (gml/get-machine-list-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload)))
+                   (is (= "setup" (:hint payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_machine_state_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_machine_state_test.cljs
@@ -1,0 +1,151 @@
+(ns day8.re-frame2-causa-mcp.tools.get-machine-state-test
+  "Unit tests for the T-Insp-5 tool `get-machine-state` (rf2-8xzoe.18)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-machine-state :as gms]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(def ^:private sample-state
+  {:initial-state :idle
+   :tags #{:cart}
+   :transitions {:idle {:cart/add :adding}
+                 :adding {:add/done :idle}}})
+
+(deftest public-surface
+  (is (fn? gms/get-machine-state-tool))
+  (is (fn? gms/shape-envelope))
+  (is (= "get-machine-state" (:name gms/descriptor))))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-machine-state"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gms/build-form {:machine-id :checkout/fsm
+                              :include-sensitive? false
+                              :include-large?     false})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-machine-state"))
+    (is (.includes form ":causa-mcp"))
+    (is (.includes form ":machine-id :checkout/fsm"))))
+
+(deftest shape-envelope-summary-mode-default
+  (let [runtime-env {:ok? true :frame :rf/default :machine-id :checkout/fsm
+                     :state sample-state}
+        shaped      (gms/shape-envelope runtime-env {:mode :summary :path nil})]
+    (is (true? (:ok? shaped)))
+    (is (= :summary (:mode shaped)))
+    (is (= :idle (-> shaped :state :initial-state)))
+    (is (= [:adding :idle] (-> shaped :state :state-names)))
+    (is (nil? (-> shaped :state :transitions))
+        "summary mode strips the heavy transitions detail")))
+
+(deftest shape-envelope-full-mode
+  (let [runtime-env {:ok? true :frame :rf/default :machine-id :checkout/fsm
+                     :state sample-state}
+        shaped      (gms/shape-envelope runtime-env {:mode :full :path nil})]
+    (is (= :full (:mode shaped)))
+    (is (= sample-state (:state shaped))
+        "full mode passes the entire spec through unchanged")))
+
+(deftest shape-envelope-path-slice
+  (let [runtime-env {:ok? true :frame :rf/default :machine-id :checkout/fsm
+                     :state sample-state}
+        shaped      (gms/shape-envelope runtime-env
+                                        {:mode :full :path [:transitions :idle]})]
+    (is (= {:cart/add :adding} (:state shaped)))
+    (is (= [:transitions :idle] (:path shaped)))))
+
+(deftest shape-envelope-counts-elision-markers
+  (let [runtime-env {:ok? true :frame :rf/default :machine-id :huge/fsm
+                     :state {:initial-state :idle
+                             :spec {:rf.size/large-elided {:bytes 102400}}}}
+        shaped      (gms/shape-envelope runtime-env {:mode :full :path nil})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-runtime-failure-passthrough
+  (let [runtime-env {:ok? false :reason :no-such-machine
+                     :frame :rf/default :machine-id :missing/fsm
+                     :registered [:checkout/fsm :tour/fsm]}]
+    (is (= runtime-env (gms/shape-envelope runtime-env {:mode :summary :path nil})))))
+
+(deftest missing-machine-id-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached the probe")
+            (js/Promise.resolve nil)))
+    (-> (gms/get-machine-state-tool (atom {}) #js {})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :missing-machine-id (:reason payload))))
+                 (done))))))
+
+(deftest invalid-mode-short-circuits
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached the probe")
+            (js/Promise.resolve nil)))
+    (-> (gms/get-machine-state-tool (atom {})
+                                    #js {"machine-id" "checkout/fsm"
+                                         "mode" "verbose"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :invalid-mode (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [runtime-env {:ok? true :frame :rf/default :machine-id :huge/fsm
+                       :state {:initial-state :idle
+                               :spec (apply str (repeat 10000 \x))}}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-machine-state"
+                        #js {"machine-id" "huge/fsm"
+                             "mode" "full"
+                             "max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "preload missing"
+                       {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gms/get-machine-state-tool (atom {})
+                                    #js {"machine-id" "x"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_source_coord_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_source_coord_test.cljs
@@ -1,0 +1,121 @@
+(ns day8.re-frame2-causa-mcp.tools.get-source-coord-test
+  "Unit tests for the T-Insp-9 tool `get-source-coord` (rf2-8xzoe.22)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-source-coord :as gsc]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(deftest public-surface
+  (is (fn? gsc/get-source-coord-tool))
+  (is (fn? gsc/shape-envelope))
+  (is (= "get-source-coord" (:name gsc/descriptor))))
+
+(deftest registered
+  (is (some? (registry/handler-for "get-source-coord"))))
+
+(deftest build-form-addresses-runtime
+  (let [form (gsc/build-form {:kind :event :id :cart/add})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-source-coord"))
+    (is (.includes form ":causa-mcp"))
+    (is (.includes form ":kind :event"))
+    (is (.includes form ":id :cart/add"))))
+
+(deftest shape-envelope-happy-path
+  (let [runtime-env {:ok? true
+                     :kind :event :id :cart/add
+                     :source-coord {:ns "my.app.cart"
+                                    :line 42 :column 3
+                                    :file "src/my/app/cart.cljs"}}
+        shaped      (gsc/shape-envelope runtime-env)]
+    (is (true? (:ok? shaped)))
+    (is (= :event (:kind shaped)))
+    (is (= "my.app.cart" (-> shaped :source-coord :ns)))
+    (is (nil? (:elided-large shaped)))))
+
+(deftest shape-envelope-no-source-coord
+  (let [runtime-env {:ok? false :reason :no-source-coord
+                     :kind :event :id :cart/no-source}
+        shaped      (gsc/shape-envelope runtime-env)]
+    (is (= runtime-env shaped))))
+
+(deftest missing-kind-arg-short-circuits-before-runtime-call
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached the probe — args were invalid")
+            (js/Promise.resolve nil)))
+    (-> (gsc/get-source-coord-tool (atom {}) #js {"id" "cart/add"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :missing-kind (:reason payload))))
+                 (done))))))
+
+(deftest missing-id-arg-short-circuits-before-runtime-call
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (is false "should not have reached the probe — args were invalid")
+            (js/Promise.resolve nil)))
+    (-> (gsc/get-source-coord-tool (atom {}) #js {"kind" "event"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :missing-id (:reason payload))))
+                 (done))))))
+
+(deftest dispatcher-overflow-path
+  (async done
+    (let [;; Pad the source-coord with garbage to force overflow.
+          runtime-env {:ok? true :kind :event :id :a
+                       :source-coord {:ns (apply str (repeat 10000 \x))
+                                      :line 1 :column 1
+                                      :file "f"}}]
+      (stub-runtime! runtime-env)
+      (-> (tools/invoke (atom {}) "get-source-coord"
+                        #js {"kind" "event" "id" "a"
+                             "max-tokens" 500} nil)
+          (.then (fn [^js result]
+                   (let [payload (-> (j/get result :content) (aget 0)
+                                     (j/get :text) edn/read-string)]
+                     (is (contains? payload :rf.mcp/overflow))
+                     (is (contains? token-cap/hint-vocabulary
+                                    (get-in payload [:rf.mcp/overflow :hint]))))
+                   (done)))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "preload missing"
+                       {:reason :runtime-not-preloaded :hint "h"}))))
+    (-> (gsc/get-source-coord-tool (atom {})
+                                   #js {"kind" "event" "id" "a"})
+        (.then (fn [^js result]
+                 (let [payload (-> (j/get result :content) (aget 0)
+                                   (j/get :text) edn/read-string)]
+                   (is (= :runtime-not-preloaded (:reason payload))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_trace_buffer_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/get_trace_buffer_test.cljs
@@ -1,0 +1,285 @@
+(ns day8.re-frame2-causa-mcp.tools.get-trace-buffer-test
+  "Unit tests for the T-Insp-1 tool `get-trace-buffer` (rf2-8xzoe.14).
+
+  These tests pin the three wire-pipeline mechanisms the tool layers
+  on the runtime's raw response:
+
+    1. **W-6 size elision** — the `:elided-large` envelope counter is
+       stamped from the count of `{:rf.size/large-elided ...}` markers
+       on the kept events.
+    2. **B-1 privacy default-suppress** — `:sensitive? true` events are
+       dropped from the response by default; `:include-sensitive? true`
+       opts back in. The `:dropped-sensitive` counter rides on the
+       envelope when non-zero.
+    3. **W-1 token-cap overflow** — when the rendered envelope exceeds
+       the per-call cap, the dispatcher in `tools.cljs` replaces it
+       with the causa-spec-shaped `:rf.mcp/overflow` marker. (This
+       test exercises the dispatcher seam by invoking through
+       `tools/invoke` directly with a fixture runtime.)
+
+  ## Test seam — fixture runtime via the registry handler
+
+  We don't spin up a real nREPL socket. Each test constructs the tool's
+  handler-arg shape (`conn`, `args`), and either:
+
+    - calls `shape-envelope` directly (pure — no I/O) to pin the
+      privacy / elision counter logic, or
+    - rebinds `nrepl/cljs-eval-value` via `with-redefs` for the
+      end-to-end tool-handler path."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.get-trace-buffer :as gtb]))
+
+;; ---------------------------------------------------------------------------
+;; Stubs — use `set!` rather than `with-redefs` to avoid the rf2-wb06a
+;; async-cleanup race (see `tools/pair2-mcp/test/.../invoke_test.cljs`
+;; for the analysis). Fixtures restore pristine originals after each
+;; test so cross-test leakage is impossible.
+;; ---------------------------------------------------------------------------
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each
+  {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime!
+  "Install fixture stubs that bypass the probe and resolve the eval to
+  `runtime-env`. Returns nil; tests call this synchronously at the
+  start of their `(async done ...)` block."
+  [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]      (js/Promise.resolve runtime-env))
+          ([_ _ _ _]    (js/Promise.resolve runtime-env)))))
+
+;; ---------------------------------------------------------------------------
+;; Public surface.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "tool ns lands the public surface the dispatcher consumes"
+    (is (fn? gtb/get-trace-buffer-tool))
+    (is (fn? gtb/build-form))
+    (is (fn? gtb/shape-envelope))
+    (is (map? gtb/descriptor))
+    (is (= "get-trace-buffer" (:name gtb/descriptor)))))
+
+(deftest registered-in-the-catalogue
+  (testing "load-time register-tool! wires the handler + descriptor
+            into the central registry so tools/invoke can dispatch"
+    (is (some? (registry/handler-for "get-trace-buffer")))
+    (is (= "get-trace-buffer" (:name (registry/descriptor-for "get-trace-buffer"))))))
+
+;; ---------------------------------------------------------------------------
+;; build-form — eval-form composition.
+;; ---------------------------------------------------------------------------
+
+(deftest build-form-calls-runtime-accessor
+  (testing "build-form composes a (binding [origin :causa-mcp]
+            (runtime/get-trace-buffer <opts>)) form — the runtime ns
+            prefix, the opts map, and the binding wrapper are all
+            present"
+    (let [form (gtb/build-form {:op-type :event/dispatched
+                                :include-sensitive? false
+                                :include-large?     false})]
+      (is (string? form))
+      (is (.includes form "day8.re-frame2-causa.runtime/get-trace-buffer")
+          "form addresses the runtime accessor by fully-qualified name")
+      (is (.includes form ":causa-mcp")
+          "form binds *current-origin* to :causa-mcp")
+      (is (.includes form ":op-type :event/dispatched")
+          "opts map rides through the form"))))
+
+;; ---------------------------------------------------------------------------
+;; shape-envelope — happy path.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-happy-path
+  (testing "a runtime envelope with no sensitive / no large items flows
+            through unchanged plus :total / :limit / :offset slots"
+    (let [runtime-env {:ok?    true
+                       :events [{:operation :event/dispatched :event [:foo]}
+                                {:operation :sub/updated      :result :bar}]
+                       :count  2}
+          shaped      (gtb/shape-envelope runtime-env false 50 0)]
+      (is (true? (:ok? shaped)))
+      (is (= 2 (:count shaped)))
+      (is (= 2 (:total shaped)))
+      (is (= 50 (:limit shaped)))
+      (is (= 0  (:offset shaped)))
+      (is (= 2 (count (:events shaped))))
+      (is (nil? (:dropped-sensitive shaped))
+          "zero-drop common path carries no counter")
+      (is (nil? (:elided-large shaped))
+          "zero-elide common path carries no counter"))))
+
+;; ---------------------------------------------------------------------------
+;; B-1 privacy default-suppress.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-drops-sensitive-by-default
+  (testing "B-1: :sensitive? true events are dropped from the response
+            and the :dropped-sensitive counter rides on the envelope"
+    (let [runtime-env {:ok?    true
+                       :events [{:operation :event/dispatched}
+                                {:operation :auth/sign-in :sensitive? true}
+                                {:operation :nav/route}
+                                {:operation :auth/sign-out :sensitive? true}]
+                       :count  4}
+          shaped      (gtb/shape-envelope runtime-env false 50 0)]
+      (is (= 2 (:count shaped))
+          "only the two non-sensitive events survive the strip-step")
+      (is (= 4 (:total shaped))
+          ":total reflects the pre-strip count")
+      (is (= 2 (:dropped-sensitive shaped)))
+      (is (every? #(not (:sensitive? %)) (:events shaped))))))
+
+(deftest shape-envelope-include-sensitive-passes-everything
+  (testing "B-1: :include-sensitive? true bypasses the strip-step;
+            the counter is absent on the envelope"
+    (let [runtime-env {:ok?    true
+                       :events [{:operation :auth/sign-in :sensitive? true}
+                                {:operation :nav/route}]
+                       :count  2}
+          shaped      (gtb/shape-envelope runtime-env true 50 0)]
+      (is (= 2 (:count shaped)))
+      (is (nil? (:dropped-sensitive shaped))
+          "opt-in suppresses the counter — zero drop is the common path"))))
+
+;; ---------------------------------------------------------------------------
+;; W-6 size elision marker count.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-counts-elided-markers
+  (testing "W-6: every {:rf.size/large-elided ...} marker the runtime
+            walker emitted is counted onto :elided-large"
+    (let [runtime-env {:ok?    true
+                       :events [{:operation :event/dispatched
+                                 :event [:upload {:body {:rf.size/large-elided
+                                                         {:bytes 102400}}}]}
+                                {:operation :sub/updated
+                                 :result {:rf.size/large-elided {:bytes 51200}}}
+                                {:operation :nav/route :event [:nav/route :home]}]
+                       :count  3}
+          shaped      (gtb/shape-envelope runtime-env false 50 0)]
+      (is (= 2 (:elided-large shaped))
+          "two of the three events carry a marker — one nested, one top-level"))))
+
+;; ---------------------------------------------------------------------------
+;; Pagination.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-limit-and-offset
+  (testing "pagination: :offset skips N events and :limit caps the
+            returned page size"
+    (let [events     (vec (for [i (range 10)]
+                            {:operation :event/dispatched :id i}))
+          runtime-env {:ok? true :events events :count 10}
+          shaped     (gtb/shape-envelope runtime-env false 3 4)]
+      (is (= 3 (:count shaped)))
+      (is (= 10 (:total shaped)))
+      (is (= [4 5 6] (mapv :id (:events shaped)))))))
+
+;; ---------------------------------------------------------------------------
+;; Runtime-side failure passthrough.
+;; ---------------------------------------------------------------------------
+
+(deftest shape-envelope-passes-runtime-failure-through
+  (testing "a structured runtime failure (e.g. :no-frame-resolved)
+            surfaces verbatim — the tool layer does not rewrite it"
+    (let [runtime-env {:ok? false :reason :no-frame-resolved
+                       :hint "Pass :frame :foo or register at least one frame."}
+          shaped      (gtb/shape-envelope runtime-env false 50 0)]
+      (is (= runtime-env shaped)))))
+
+;; ---------------------------------------------------------------------------
+;; W-1 token-cap overflow via the dispatcher.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatcher-applies-cap-on-large-payload
+  (testing "W-1: when the rendered envelope exceeds max-tokens, the
+            dispatcher in tools/invoke replaces the result with the
+            :rf.mcp/overflow marker"
+    (async done
+      (let [;; ~10K characters → well over the 500-token floor that
+            ;; we'll pass as max-tokens to force the overflow path.
+            big-event   {:operation :event/dispatched
+                         :event     [:big-payload (apply str (repeat 10000 \x))]}
+            runtime-env {:ok? true :events [big-event] :count 1}]
+        (stub-runtime! runtime-env)
+        (-> (tools/invoke (atom {})
+                          "get-trace-buffer"
+                          #js {"max-tokens" 500}
+                          nil)
+            (.then (fn [^js result]
+                     (let [text    (j/get (aget (j/get result :content) 0) :text)
+                           payload (edn/read-string text)]
+                       (is (contains? payload :rf.mcp/overflow)
+                           "over-cap payload is replaced with the overflow marker")
+                       (let [marker (:rf.mcp/overflow payload)]
+                         (is (= :reached (:limit marker)))
+                         (is (= 500 (:cap marker)))
+                         (is (contains? token-cap/hint-vocabulary (:hint marker)))))
+                     (done)))
+            (.catch (fn [err]
+                      (is false (str "tool failed: " (.-message err)))
+                      (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; End-to-end happy path via the dispatcher.
+;; ---------------------------------------------------------------------------
+
+(deftest dispatcher-happy-path
+  (testing "tools/invoke routes get-trace-buffer through the registry
+            and returns a stamped envelope — under-cap payload passes
+            through unchanged"
+    (async done
+      (let [runtime-env {:ok?    true
+                         :events [{:operation :event/dispatched :event [:foo]}
+                                  {:operation :auth/sign-in :sensitive? true}]
+                         :count  2}]
+        (stub-runtime! runtime-env)
+        (-> (tools/invoke (atom {}) "get-trace-buffer" #js {} nil)
+            (.then (fn [^js result]
+                     (let [text    (j/get (aget (j/get result :content) 0) :text)
+                           payload (edn/read-string text)]
+                       (is (true? (:ok? payload)))
+                       (is (= 1 (:count payload))
+                           "B-1: sensitive event was dropped")
+                       (is (= 1 (:dropped-sensitive payload))))
+                     (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; Runtime-side failure path — probe rejection surfaces verbatim.
+;; ---------------------------------------------------------------------------
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (testing "when the runtime preload is absent, the tool surfaces
+            :runtime-not-preloaded with the operator setup hint"
+    (async done
+      (set! probe/ensure-runtime!
+        (fn [_ _]
+          (js/Promise.reject
+            (ex-info "causa runtime not preloaded"
+                     {:reason :runtime-not-preloaded
+                      :hint   "setup-hint"}))))
+      (-> (gtb/get-trace-buffer-tool (atom {}) #js {})
+          (.then (fn [^js result]
+                   (let [text    (j/get (aget (j/get result :content) 0) :text)
+                         payload (edn/read-string text)]
+                     (is (false? (:ok? payload)))
+                     (is (= :runtime-not-preloaded (:reason payload)))
+                     (is (= "setup-hint" (:hint payload))))
+                   (done)))))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -246,8 +246,28 @@
    ;; each progress payload and on the final summary").
    :subscribe    "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs"})
 
+(def ^:private causa-mcp-tree-walking-tool-sources
+  "Per-tool source files for causa-mcp's T-Insp tree-walking tools
+  (rf2-8xzoe.14..22). Each source MUST contain at least one
+  `wire/with-indicators` call — same centralised emit-path pin as
+  pair2-mcp's `tree-walking-tool-sources`, routed through causa-mcp's
+  own `day8.re-frame2-causa-mcp.wire/with-indicators` (a byte-faithful
+  mirror of the pair2-mcp helper). Adding a new tree-walking tool to
+  the causa-mcp T-Insp cluster means extending this map and wiring the
+  helper call; the new entry without the wiring fails this gate."
+  {:get-app-db        "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs"
+   :get-app-db-diff   "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs"
+   :get-epoch-history "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs"
+   :get-handlers      "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs"
+   :get-issues        "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs"
+   :get-machine-list  "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs"
+   :get-machine-state "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs"
+   :get-source-coord  "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs"
+   :get-trace-buffer  "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs"})
+
 (deftest every-tree-walking-tool-routes-through-the-helper
-  (doseq [[tool rel] tree-walking-tool-sources]
+  (doseq [[tool rel] (merge tree-walking-tool-sources
+                            causa-mcp-tree-walking-tool-sources)]
     (testing (str "tool " tool " — wire/with-indicators call-site in " rel)
       (let [src (fx/read-source rel)]
         (is (str/includes? src "wire/with-indicators")
@@ -334,11 +354,38 @@
     "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs"
     "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/subscribe.cljs"})
 
-(defn- pair2-mcp-source-files
-  "Walk `tools/pair2-mcp/src/` and return every `.cljs` file as a
-  repo-relative path string."
-  []
-  (let [src-root (io/file fx/repo-root "tools/pair2-mcp/src")]
+(def ^:private causa-mcp-inline-emit-whitelist
+  "causa-mcp analogue of `inline-emit-whitelist`. Files allowed to
+  contain the literal `:dropped-sensitive` / `:elided-large` keywords
+  in causa-mcp's source tree. Anything else under
+  `tools/causa-mcp/src/` MUST route through `wire/with-indicators`.
+
+  - `wire.cljs`    — the centralised helper (byte-faithful mirror of
+                     pair2-mcp's `wire/with-indicators`). Contains the
+                     canonical `(assoc :dropped-sensitive dropped)`
+                     emit-site.
+  - `privacy.cljs` — auxiliary `stamp-dropped-sensitive` helper
+                     (sibling stamper composed by privacy boundary).
+                     The per-tool emit-paths use `wire/with-indicators`;
+                     this helper is exposed for direct composition where
+                     the privacy axis runs independently of the elision
+                     axis (e.g. trace-stream tools that drop sensitive
+                     items without walking a tree).
+  - `elision.cljs` — auxiliary `stamp-elided-large` helper (parallel to
+                     `privacy/stamp-dropped-sensitive`). Same posture —
+                     a sibling stamper composed by the elision boundary
+                     when running independently of `wire/with-indicators`."
+  #{"tools/causa-mcp/src/day8/re_frame2_causa_mcp/wire.cljs"
+    "tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs"
+    "tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs"})
+
+(defn- mcp-source-files
+  "Walk `src-rel` (a repo-relative subdir) and return every `.cljs`
+  file as a repo-relative path string. Used for both the pair2-mcp
+  and causa-mcp `tools/<server>/src/` walkers — the inline-emit gate
+  applies the same shape to both surfaces."
+  [src-rel]
+  (let [src-root (io/file fx/repo-root src-rel)]
     (when (.isDirectory src-root)
       (->> (file-seq src-root)
            (filter #(and (.isFile ^java.io.File %)
@@ -349,6 +396,19 @@
                       (str/replace (str/replace fx/repo-root "\\" "/") "")
                       (subs 1))))                                ;; strip leading "/"
            sort))))
+
+(defn- pair2-mcp-source-files
+  "Walk `tools/pair2-mcp/src/` and return every `.cljs` file as a
+  repo-relative path string."
+  []
+  (mcp-source-files "tools/pair2-mcp/src"))
+
+(defn- causa-mcp-source-files
+  "Walk `tools/causa-mcp/src/` and return every `.cljs` file as a
+  repo-relative path string. Same shape as `pair2-mcp-source-files` —
+  applies the inline-emit gate to causa-mcp's T-Insp cluster surface."
+  []
+  (mcp-source-files "tools/causa-mcp/src"))
 
 (deftest no-inline-indicator-slot-emit-outside-the-helper
   ;; The grep is applied AFTER `fx/strip-comments-and-strings` neuters
@@ -389,39 +449,66 @@
                    "reading internal state, an internal state-atom name), "
                    "add it to `inline-emit-whitelist` with a justification.")))))))
 
+(deftest no-inline-indicator-slot-emit-outside-the-helper-causa-mcp
+  ;; causa-mcp analogue — same posture as the pair2-mcp gate above,
+  ;; applied to `tools/causa-mcp/src/`. The T-Insp cluster
+  ;; (rf2-8xzoe.14..22) shipped per-tool tree-walkers + auxiliary
+  ;; per-axis stampers (`privacy/stamp-dropped-sensitive`,
+  ;; `elision/stamp-elided-large`). The tools themselves go through
+  ;; `wire/with-indicators`; the stampers compose privately. The
+  ;; whitelist captures the helper + stamper exceptions explicitly.
+  (let [slot-literals [":dropped-sensitive" ":elided-large"]
+        srcs          (causa-mcp-source-files)]
+    (is (seq srcs)
+        "Expected to find causa-mcp source files; classpath walk returned empty.")
+    (doseq [rel srcs
+            slot slot-literals
+            :when (not (contains? causa-mcp-inline-emit-whitelist rel))]
+      (testing (str rel " — must not inline " slot)
+        (let [src      (fx/read-source rel)
+              stripped (fx/strip-comments-and-strings src)
+              pat      (fx/variant-regex slot)]
+          (is (not (re-find pat stripped))
+              (str "Inline `" slot "` literal found in " rel
+                   " (in code, AFTER stripping comments/docstrings/strings).\n"
+                   "Every emit MUST go through `wire/with-indicators` "
+                   "(per Conventions:154 / Spec 009:1411). If this file "
+                   "is a legitimate exception (a sibling per-axis "
+                   "stamper, a destructuring binding reading internal "
+                   "state), add it to `causa-mcp-inline-emit-whitelist` "
+                   "with a justification.")))))))
+
 ;; ---------------------------------------------------------------------------
-;; Cross-server tripwire — story-mcp / causa-mcp posture.
+;; Cross-server posture pin — story-mcp / causa-mcp.
 ;;
 ;; The sibling `wire_vocab_test.clj` already pins:
 ;; - story-mcp emits ZERO cross-MCP markers
 ;; - story-mcp emits ZERO envelope indicators (it doesn't walk
 ;;   tree-typed payloads today)
 ;;
-;; This file adds the symmetric pin for causa-mcp: its spec text
-;; cross-references the slot vocabulary (per Principles.md), but its
-;; tool implementations haven't landed yet — the spec mentions and the
-;; F-1 banner-only `server.cljs` scaffold don't count as emit-sites.
-;; The day causa-mcp's `src/.../tools/` directory lands tree-typed-
-;; payload walkers, the reviewer extends `tree-walking-tool-sources`
-;; (a new entry routed through causa's own helper, which must also be
-;; added to `inline-emit-whitelist` analogue for causa).
+;; causa-mcp's T-Insp cluster (rf2-8xzoe.14..22) shipped the nine
+;; per-tool tree-walkers under `src/.../tools/`. The historical
+;; `causa-mcp-impl-still-absent` tripwire fired correctly when impl
+;; landed; the load-bearing coverage now lives in
+;; `causa-mcp-tree-walking-tool-sources` (extended into
+;; `every-tree-walking-tool-routes-through-the-helper`) and in
+;; `no-inline-indicator-slot-emit-outside-the-helper-causa-mcp`
+;; (the inline-emit anti-pin on the causa-mcp src tree). The
+;; assertion below is the structural floor — a future regression
+;; that DELETES the tool directory trips it and the reviewer
+;; restores the historic spec-only stand-in.
 ;; ---------------------------------------------------------------------------
 
-(deftest causa-mcp-impl-still-absent
-  ;; Tripwire — fires when causa-mcp lands real tool source files
-  ;; (per-tool tree-walkers under `src/.../tools/`). The F-1 scaffold
-  ;; (rf2-8xzoe.1) shipped a banner-only `server.cljs` that's not a
-  ;; tree-walking emit-site, so the directory probe targets the
-  ;; per-tool subdirectory both pair2-mcp and story-mcp use to host
-  ;; their tree-walking tools. When `src/day8/re_frame2_causa_mcp/tools/`
-  ;; appears with files, this test fails and the reviewer extends the
-  ;; tree-walking-tool catalogue with causa entries.
+(deftest causa-mcp-tools-directory-present
   (let [tools-dir (io/file fx/repo-root
                            "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools")]
-    (is (or (not (.exists tools-dir))
-            (empty? (filter #(.isFile ^java.io.File %) (file-seq tools-dir))))
-        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ now "
-             "contains source files. Extend `tree-walking-tool-sources` "
-             "and `inline-emit-whitelist` (or their causa-mcp "
-             "equivalents) to cover causa-mcp's tree-walking tools "
-             "per Conventions:154 / Spec 009:1411 MUST-level parity."))))
+    (is (.exists tools-dir)
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ is "
+             "missing. The T-Insp cluster (rf2-8xzoe.14..22) landed "
+             "this directory; if it was intentionally removed, revert "
+             "`causa-mcp-tree-walking-tool-sources` and "
+             "`causa-mcp-inline-emit-whitelist` to spec-only stand-ins."))
+    (is (seq (filter #(.isFile ^java.io.File %) (file-seq tools-dir)))
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ "
+             "exists but contains no files. Same restoration path as "
+             "the missing-directory case."))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -59,10 +59,12 @@
      (`include-sensitive-opt`, `include-large-opt`) and re-used by
      consumers. The grep step asserts the literal keyword form in the
      vocab ns so a rename there breaks everyone.
-  5. **causa-mcp impl-not-landed tripwire** — causa-mcp's spec
-     references the slot names; its `src/` doesn't exist yet. The
-     tripwire flips RED when impl lands, forcing the reviewer to
-     extend the per-server source-file grep coverage in lockstep.
+  5. **causa-mcp impl-landed pin** — causa-mcp's T-Insp tool cluster
+     (rf2-8xzoe.14..22) shipped `src/.../tools/` with nine
+     tree-walking tools; the per-server source-file grep covers them
+     alongside pair2-mcp + story-mcp. The historical tripwire (this
+     row was a `causa-mcp-impl-still-absent` gate) has done its job
+     and is replaced by an impl-landed assertion below.
 
   ## Why pure JVM Clojure (not Node SDK)
 
@@ -132,8 +134,23 @@
                ;; the pair2-mcp shape that doesn't apply to story-mcp).
                :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
                            "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"]
-               :causa-mcp ["tools/causa-mcp/spec/Principles.md"
-                           "tools/causa-mcp/spec/004-Wire-Pipeline.md"]}
+               ;; causa-mcp's T-Insp cluster (rf2-8xzoe.14..22) shipped
+               ;; per-tool tree-walkers under `src/.../tools/`. The
+               ;; canonical literal `:include-sensitive?` appears in the
+               ;; per-tool args-schema splices (e.g. `get_app_db.cljs`'s
+               ;; `:inputSchema` :properties map) and the runtime-opts
+               ;; map handed to the walker. Both pair2-mcp and story-mcp
+               ;; already pin per-tool sources; causa-mcp matches that
+               ;; posture.
+               :causa-mcp ["tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs"]}
     :doc      "Opt-in boolean — pass `true` to disable the spec/009 §Privacy
                default-drop on `:sensitive? true` items. Default false."}
 
@@ -151,8 +168,20 @@
                            "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"]
                :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"
                            "tools/story-mcp/src/re_frame/story_mcp/tools/cap.cljc"]
-               :causa-mcp ["tools/causa-mcp/spec/Principles.md"
-                           "tools/causa-mcp/spec/004-Wire-Pipeline.md"]}
+               ;; causa-mcp's T-Insp cluster splices `:max-tokens` into
+               ;; every per-tool `:inputSchema` :properties map and reads
+               ;; it off the args object in `token_cap.cljs`. Same posture
+               ;; as pair2-mcp's descriptor + cap split.
+               :causa-mcp ["tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs"
+                           "tools/causa-mcp/src/day8/re_frame2_causa_mcp/token_cap.cljs"]}
     :doc      "Override integer — per-call wire-cap override (default 5,000).
                `0` disables the cap. Triggers an `:rf.mcp/overflow` marker
                when the rendered payload exceeds the cap (cross-server)."}])
@@ -174,9 +203,22 @@
 (def ^:private elision-arg-divergence
   {:canonical :include-large?
    :servers   {:causa-mcp {:slot    :include-large?
-                           :sources ["tools/causa-mcp/spec/Principles.md"
-                                     "tools/causa-mcp/spec/004-Wire-Pipeline.md"]
-                           :status  :spec-only}
+                           ;; T-Insp cluster (rf2-8xzoe.14..22) shipped
+                           ;; `:include-large?` as the canonical slot in
+                           ;; every per-tool `:inputSchema` and in the
+                           ;; runtime-opts map handed to the elision
+                           ;; walker. The spec-only stand-in is no longer
+                           ;; needed; tool sources carry the literal.
+                           :sources ["tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs"
+                                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs"]
+                           :status  :impl-landed}
                :pair2-mcp {:slot    :elision
                            :sources ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs"
                                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"]
@@ -363,8 +405,22 @@
                      "tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc"
                      "tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc"]
-         ;; causa-mcp has no impl yet — skipped by `:when seq`.
-         :causa-mcp []}]
+         ;; causa-mcp's T-Insp cluster (rf2-8xzoe.14..22) shipped the
+         ;; per-tool tree-walkers — the full surface gets near-miss-
+         ;; variant coverage alongside pair2-mcp + story-mcp.
+         :causa-mcp ["tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_epoch_history.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_handlers.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_issues.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_list.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_machine_state.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_source_coord.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/get_trace_buffer.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/token_cap.cljs"
+                     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/wire.cljs"]}]
     (doseq [{:keys [slot]}     canonical-slots
             variant            (near-miss-variants slot)
             [server files]     impl-sources-by-server
@@ -457,26 +513,29 @@
                  "the literal or update this test."))))))
 
 ;; ---------------------------------------------------------------------------
-;; Gate 6 — causa-mcp impl-not-landed tripwire. Same posture as
-;; `causa-mcp-impl-still-absent` in `indicator_field_test.clj`: when
-;; causa-mcp lands real tool source files under `src/.../tools/`,
-;; the reviewer must extend the per-server source-file coverage for
-;; every slot in `canonical-slots`. The F-1 scaffold (rf2-8xzoe.1)
-;; ships a banner-only `server.cljs` that doesn't consume the slot
-;; vocabulary; the per-tool subdir is the meaningful tripwire boundary.
+;; Gate 6 — causa-mcp impl-landed pin. The T-Insp tool cluster
+;; (rf2-8xzoe.14..22) landed the per-tool tree-walkers under
+;; `src/.../tools/`. The historical `causa-mcp-impl-still-absent`
+;; tripwire fired correctly when impl landed; it's replaced here by
+;; an impl-landed assertion so a future regression that DELETES the
+;; tool directory (and reverts to spec-only stand-ins) trips the
+;; gate. The per-tool `:sources` entries above are the load-bearing
+;; coverage; this gate is the structural floor.
 ;; ---------------------------------------------------------------------------
 
-(deftest causa-mcp-impl-still-absent
+(deftest causa-mcp-tools-directory-present
   (let [tools-dir (io/file fx/repo-root
                            "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools")]
-    (is (or (not (.exists tools-dir))
-            (empty? (filter #(.isFile ^java.io.File %) (file-seq tools-dir))))
-        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ now "
-             "contains source files. Extend the `:causa-mcp` entry in "
-             "`:sources` on every row of `canonical-slots` to grep "
-             "causa-mcp's tool source instead of just its spec. Same "
-             "posture as the indicator-field tripwire — the spec-side "
-             "grep is a stand-in until impl lands."))))
+    (is (.exists tools-dir)
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ is "
+             "missing. The T-Insp cluster (rf2-8xzoe.14..22) landed "
+             "this directory; if it was intentionally removed, revert "
+             "the `:causa-mcp` :sources entries on `canonical-slots` "
+             "and `elision-arg-divergence` to spec-only stand-ins."))
+    (is (seq (filter #(.isFile ^java.io.File %) (file-seq tools-dir)))
+        (str "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/ "
+             "exists but contains no files. Same restoration path as "
+             "the missing-directory case."))))
 
 ;; ---------------------------------------------------------------------------
 ;; Gate 7 — server-coverage sanity. Every server referenced in


### PR DESCRIPTION
## Summary

Lands the **T-Insp tranche** of the causa-mcp epic (rf2-8xzoe) — 9
read-only inspection tools consuming the just-shipped B-1 privacy
filter, W-6 size-elision walker, W-1 token-cap wrapper, and F-4
runtime accessor surface. Each tool is a single MCP tool exposed via
the dispatcher façade in `tools.cljs`; per-tool files live under
`tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/`.

### Shared infrastructure (lands with the first commit)

- `eval_form.cljs` — DSL composing CLJS eval forms addressed at
  `day8.re-frame2-causa.runtime`, with `wrap-origin` binding
  `*current-origin*` to `:causa-mcp`.
- `wire.cljs` — MCP result helpers, arg pluckers, `with-indicators`
  for cross-MCP `:dropped-sensitive` + `:elided-large` slots.
- `probe.cljs` — runtime preload probe (cached per `(conn, build-id)`).
- `registry.cljs` — per-tool registration table.
- `tools.cljs` — dispatcher façade with the two-step pipeline
  (dispatch + W-1 token-cap).

`server.cljs` `handle-call-success` now routes through `tools/invoke`.
`tool-descriptors-js` delegates to the registry.

### Per-bead one-liners

- `rf2-8xzoe.14` — **get-trace-buffer** (trace-bus reader; B-1 strip +
  W-6 count + pagination) — 167 LoC src, 220 LoC test
- `rf2-8xzoe.19` — **get-machine-list** (machine enumeration) —
  108 LoC src, 113 LoC test
- `rf2-8xzoe.21` — **get-handlers** (registry enumeration grouped by
  `:kind`) — 134 LoC src, 113 LoC test
- `rf2-8xzoe.22` — **get-source-coord** (single-handler source-coord
  lookup) — 116 LoC src, 117 LoC test
- `rf2-8xzoe.18` — **get-machine-state** (machine snapshot; summary
  mode default; path slicing) — 175 LoC src, 153 LoC test
- `rf2-8xzoe.20` — **get-issues** (issue-tier trace events; severity
  filter; B-1 + W-6) — 175 LoC src, 158 LoC test
- `rf2-8xzoe.15` — **get-epoch-history** (Tool-Pair bound; depth-50
  default; opaque base64-EDN cursor pagination; cursor-stale recovery)
  — 226 LoC src, 178 LoC test
- `rf2-8xzoe.16` — **get-app-db** (direct-read; MUST 8 path slicing,
  MUST 9 summary mode, MUST 19 privacy defaults; tree-summary marker)
  — 207 LoC src, 144 LoC test
- `rf2-8xzoe.17` — **get-app-db-diff** (MUST 13 changed-paths default;
  `:nested` opt-in; deterministic sorted path output) — 260 LoC src,
  201 LoC test

**Totals:** 9 commits, ~1568 LoC production + ~1397 LoC test +
catalogue spec. 221 tests, 584 assertions, 0 failures.

### Wire-pipeline contract (uniform across all 9 tools)

Each tool body:
1. Validates required args pre-flight; short-circuits to structured
   `:missing-<arg>` / `:invalid-<arg>` envelopes WITHOUT contacting
   the runtime.
2. Builds an eval form via `ef/rt-call` + `ef/wrap-origin`.
3. Ships the form via `nrepl/cljs-eval-value`.
4. Routes the runtime envelope through `shape-envelope` (pure) which
   applies B-1 strip (trace-stream tools), W-6 marker count, and any
   per-tool projection (summary / cursor slice / changed-paths).
5. Dispatcher wraps the result through `token-cap/apply-cap` (W-1)
   before egress to the MCP SDK.

### Contract-drift discoveries

**None.** Every tool flows through the F-4 boundary
(`day8.re-frame2-causa.runtime/*` accessors via eval forms) without
needing accessor-signature changes. The runtime's per-accessor return
shape was sufficient for all 9 tools as-is.

### Catalogue spec

`tools/causa-mcp/spec/004-Tools-Catalogue.md` created with the
inspection-band preamble (privacy / elision / token-cap contracts) and
the 9 per-tool entries. The catalogue grows append-only as T-Mut /
T-Stream / T-Meta tranches land.

## Test plan

- [x] `npm test` in `tools/causa-mcp/` — 221 tests, 584 assertions,
  0 failures (was 113 / 314 at baseline; +108 tests, +270 assertions)
- [x] `npm run test:cljs` in `implementation/` — 2268 tests / 6455
  assertions / 0 failures (no F-4 surface drift)
- [ ] (out of scope for this PR) end-to-end with a live shadow-cljs
  app; per-tool unit tests stub the runtime via `set!` (parallels
  `tools/pair2-mcp/test/.../invoke_test.cljs`'s rf2-wb06a async-
  cleanup race avoidance)