### PR TITLE
perf(core): extract trace + subs tooling Vars to sibling ns (rf2-qwm0a + rf2-bmzq0)

### DIFF
--- a/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
@@ -18,6 +18,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.late-bind]
             [re-frame.routing]
@@ -33,11 +35,11 @@
 
 (defn- collect-traces [k]
   (let [traces (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- stop-traces [k]
-  (rf/remove-trace-cb! k))
+  (trace-tooling/remove-trace-cb! k))
 
 ;; --- Interaction 1 — Frame disposal with active machine instances ---------
 

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_dispatch_frame_capture_cljs_test.cljs
@@ -25,7 +25,9 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
@@ -49,7 +51,7 @@
   (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
     (clear!))
   (substrate-adapter/dispose-adapter!)
-  (trace/clear-trace-cbs!)
+  (trace-tooling/clear-trace-cbs!)
   (substrate-adapter/install-adapter! helix-adapter/adapter)
   (frame/ensure-default-frame!))
 

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_events_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_events_cljs_test.cljs
@@ -15,6 +15,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -27,7 +29,7 @@
   events and return the recording atom."
   [k]
   (let [a (atom [])]
-    (rf/register-trace-cb! k
+    (trace-tooling/register-trace-cb! k
       (fn [ev]
         (when (and (= :warning (:op-type ev))
                    (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
@@ -43,7 +45,7 @@
       (rf/reg-event-db :test.bbea.helix/db-bad
         {:doc "Wrongly-shaped." :interceptors [noop-icpt]}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::db-warn)
+      (trace-tooling/remove-trace-cb! ::db-warn)
       (is (= 1 (count @warns)))
       (let [t (:tags (first @warns))]
         (is (= "reg-event-db" (:reg-fn t)))
@@ -54,7 +56,7 @@
     (rf/reg-event-fx :test.bbea.helix/fx-bad
       {:interceptors [noop-icpt]}
       (fn [_ _] {:db {}}))
-    (rf/remove-trace-cb! ::fx-warn)
+    (trace-tooling/remove-trace-cb! ::fx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-fx" (:reg-fn (:tags (first @warns)))))))
 
@@ -63,7 +65,7 @@
     (rf/reg-event-ctx :test.bbea.helix/ctx-bad
       {:interceptors [noop-icpt]}
       (fn [ctx] ctx))
-    (rf/remove-trace-cb! ::ctx-warn)
+    (trace-tooling/remove-trace-cb! ::ctx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-ctx" (:reg-fn (:tags (first @warns)))))))
 
@@ -80,5 +82,5 @@
       (rf/reg-event-db :test.bbea.helix/quiet-3
         {:doc "metadata only, no positional interceptors"}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::quiet)
+      (trace-tooling/remove-trace-cb! ::quiet)
       (is (zero? (count @warns))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_frame_context_corrupted_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_frame_context_corrupted_cljs_test.cljs
@@ -27,6 +27,8 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.test-support :as test-support]))
@@ -39,7 +41,7 @@
 
 (defn- collect-traces [k]
   (let [traces (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- corruption-traces [traces]
@@ -84,7 +86,7 @@
             (is (= 42 (-> errs first :tags :received))
                 ":tags :received echoes the offending value")))
         (finally
-          (rf/remove-trace-cb! ::direct-helix)
+          (trace-tooling/remove-trace-cb! ::direct-helix)
           (set! (.-_currentValue ^js adapter-context/frame-context) original))))))
 
 ;; ---- adapter-routed parity -------------------------------------------------
@@ -111,5 +113,5 @@
           (is (= :empty-string (-> errs first :tags :type))
               ":tags :type distinguishes empty-string from a populated string"))
         (finally
-          (rf/remove-trace-cb! ::routed-helix)
+          (trace-tooling/remove-trace-cb! ::routed-helix)
           (set! (.-_currentValue ^js adapter-context/frame-context) original))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
@@ -25,6 +25,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.machines :as machines]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.test-support :as test-support])
@@ -157,11 +159,11 @@
         (count (.something items))))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
       (let [v (rf/subscribe-once [:items-count])]
         (is (nil? v)
             "the sub returns nil under :replaced-with-default recovery"))
-      (rf/remove-trace-cb! ::sub-err)
+      (trace-tooling/remove-trace-cb! ::sub-err)
       (is (some (fn [ev]
                   (= :rf.error/sub-exception (:operation ev)))
                 @traces)

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_write_after_destroy_cljs_test.cljs
@@ -17,6 +17,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.adapter.helix :as helix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -35,7 +37,7 @@
             does under plain-atom (the JVM-tier reproducer in
             frame-lifecycle-test)."
     (let [recorded (atom [])]
-      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (trace-tooling/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
       (is (nil? (substrate-adapter/replace-container! nil {:any :value}))
           "nil container is a documented no-op, not an exception")
       (let [warns (filterv (fn [ev]
@@ -45,7 +47,7 @@
                            @recorded)]
         (is (= 1 (count warns))
             "exactly one :rf.warning/write-after-destroy trace fired"))
-      (rf/remove-trace-cb! ::rec))))
+      (trace-tooling/remove-trace-cb! ::rec))))
 
 (deftest write-after-destroy-emits-warning-helix
   (testing "rf2-k2fs0: a write through a destroyed frame's nil container
@@ -54,7 +56,7 @@
             (frame-lifecycle-test) but with the Helix adapter installed —
             the contract is substrate-agnostic."
     (let [recorded (atom [])]
-      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (trace-tooling/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
       (rf/reg-frame :helix-rf2-k2fs0/race-frame
                     {:doc "rf2-k2fs0 Helix-side reproducer frame"})
       ;; Tear the frame down; subsequent frame/get-frame-db returns nil.
@@ -73,4 +75,4 @@
                            @recorded)]
         (is (pos? (count warns))
             ":rf.warning/write-after-destroy fired for the post-destroy write"))
-      (rf/remove-trace-cb! ::rec))))
+      (trace-tooling/remove-trace-cb! ::rec))))

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_cljs_test.cljs
@@ -25,6 +25,8 @@
             [reagent.dom.client :as rdc]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.late-bind]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
@@ -76,11 +78,11 @@
 
 (defn- collect-traces [k]
   (let [traces (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- stop-traces [k]
-  (rf/remove-trace-cb! k))
+  (trace-tooling/remove-trace-cb! k))
 
 ;; ---------------------------------------------------------------------------
 ;; Interaction 1 — Frame disposal with active machine instances

--- a/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/dispatch_frame_capture_cljs_test.cljs
@@ -33,7 +33,9 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
@@ -50,7 +52,7 @@
   (reset! registrar-snapshot (test-support/snapshot-registrar))
   (reset! frame/frames {})
   (substrate-adapter/dispose-adapter!)
-  (trace/clear-trace-cbs!)
+  (trace-tooling/clear-trace-cbs!)
   (substrate-adapter/install-adapter! reagent-adapter/adapter)
   (frame/ensure-default-frame!))
 

--- a/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/events_cljs_test.cljs
@@ -10,6 +10,8 @@
   ns ends in -cljs-test so shadow-cljs ':node-test' picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -22,7 +24,7 @@
   events and return the recording atom."
   [k]
   (let [a (atom [])]
-    (rf/register-trace-cb! k
+    (trace-tooling/register-trace-cb! k
       (fn [ev]
         (when (and (= :warning (:op-type ev))
                    (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
@@ -38,7 +40,7 @@
       (rf/reg-event-db :test.bbea.cljs/db-bad
         {:doc "Wrongly-shaped." :interceptors [noop-icpt]}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::db-warn)
+      (trace-tooling/remove-trace-cb! ::db-warn)
       (is (= 1 (count @warns)))
       (let [t (:tags (first @warns))]
         (is (= "reg-event-db" (:reg-fn t)))
@@ -49,7 +51,7 @@
     (rf/reg-event-fx :test.bbea.cljs/fx-bad
       {:interceptors [noop-icpt]}
       (fn [_ _] {:db {}}))
-    (rf/remove-trace-cb! ::fx-warn)
+    (trace-tooling/remove-trace-cb! ::fx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-fx" (:reg-fn (:tags (first @warns)))))))
 
@@ -58,7 +60,7 @@
     (rf/reg-event-ctx :test.bbea.cljs/ctx-bad
       {:interceptors [noop-icpt]}
       (fn [ctx] ctx))
-    (rf/remove-trace-cb! ::ctx-warn)
+    (trace-tooling/remove-trace-cb! ::ctx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-ctx" (:reg-fn (:tags (first @warns)))))))
 
@@ -75,5 +77,5 @@
       (rf/reg-event-db :test.bbea.cljs/quiet-3
         {:doc "metadata only, no positional interceptors"}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::quiet)
+      (trace-tooling/remove-trace-cb! ::quiet)
       (is (zero? (count @warns))))))

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_cljs_test.cljs
@@ -73,6 +73,8 @@
             ["react" :as React]
             ["react-dom" :as react-dom]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
@@ -206,7 +208,7 @@
 
 (defn- collect-traces [k]
   (let [traces (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- corruption-traces [traces]
@@ -290,7 +292,7 @@
           (is (= :empty-string (-> errs first :tags :type))
               ":tags :type identifies empty-string distinctly from string")))
       (finally
-        (rf/remove-trace-cb! ::scenario-3)
+        (trace-tooling/remove-trace-cb! ::scenario-3)
         (set! (.-_currentValue ^js adapter-context/frame-context) original)))))
 
 ;; ---- Scenario 4: cross-frame subscribe resolution -------------------------

--- a/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/render_key_cljs_test.cljs
@@ -18,6 +18,8 @@
     - The instance-counter monotonically increases."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
@@ -31,7 +33,7 @@
 
 (defn- record-render-traces! []
   (let [recorded (atom [])]
-    (rf/register-trace-cb! ::recorder
+    (trace-tooling/register-trace-cb! ::recorder
       (fn [ev]
         (when (= :view/render (:operation ev))
           (swap! recorded conj ev))))
@@ -108,7 +110,7 @@
           (is (= :rf.test/traced (first k1) (first k2)))
           (is (not= (second k1) (second k2))
               "tokens differ across instances")))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))
 
 ;; ---- monotonicity ---------------------------------------------------------
 
@@ -152,4 +154,4 @@
           (is (keyword? (first k)) "view-id slot is a keyword")
           (is (or (int? (second k)) (nil? (second k)))
               "instance-token slot is an int (or nil for anonymous)")))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -5,6 +5,8 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [reagent.core :as r]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
@@ -285,11 +287,11 @@
         (count (.something items))))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
       (let [v (rf/subscribe-once [:items-count])]
         (is (nil? v)
             "the sub returns nil under :replaced-with-default recovery"))
-      (rf/remove-trace-cb! ::sub-err)
+      (trace-tooling/remove-trace-cb! ::sub-err)
       (is (some (fn [ev]
                   (= :rf.error/sub-exception (:operation ev)))
                 @traces)
@@ -447,14 +449,14 @@
 (deftest dispatch-sync-in-handler-errors-cljs
   (testing "calling dispatch-sync from inside a handler raises a structured error"
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::dsih (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::dsih (fn [ev] (swap! traces conj ev)))
       (rf/reg-event-db :outer (fn [db _] (assoc db :ran? true)))
       (rf/reg-event-fx :nested
         (fn [_ _]
           (rf/dispatch-sync [:outer])
           {}))
       (rf/dispatch-sync [:nested])
-      (rf/remove-trace-cb! ::dsih)
+      (trace-tooling/remove-trace-cb! ::dsih)
       (is (some (fn [ev]
                   (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
                        (= :error (:op-type ev))))

--- a/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/runtime_cljs_test.cljs
@@ -7,6 +7,8 @@
             [re-frame.core :as rf]
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
+            ;; rf2-bmzq0: sub-cache-snapshot lives in re-frame.subs.tooling.
+            [re-frame.subs.tooling :as subs-tooling]
             [re-frame.frame :as frame]
             [re-frame.machines :as machines]
             ;; rf2-k682: routing ships in day8/re-frame2-routing.
@@ -473,12 +475,12 @@
     (rf/reg-sub :name* (fn [db _] (:name db)))
     (rf/dispatch-sync [:seed])
     ;; Empty cache is the {} baseline.
-    (is (= {} (rf/sub-cache :rf/default))
+    (is (= {} (subs-tooling/sub-cache-snapshot :rf/default))
         "no subs materialised yet → empty map")
     (let [r1 (rf/subscribe [:n])
           r2 (rf/subscribe [:n])
           r3 (rf/subscribe [:name*])
-          snapshot (rf/sub-cache :rf/default)]
+          snapshot (subs-tooling/sub-cache-snapshot :rf/default)]
       (is (= 2 (count snapshot))
           "snapshot contains one entry per materialised query-v")
       (is (= 7     (get-in snapshot [[:n]     :value])))
@@ -487,13 +489,13 @@
           "ref-count reflects two outstanding subscribes for [:n]")
       (is (= 1     (get-in snapshot [[:name*] :ref-count])))
       ;; Default no-arg form uses the active frame.
-      (is (= snapshot (rf/sub-cache))
+      (is (= snapshot (subs-tooling/sub-cache-snapshot (rf/current-frame)))
           "no-arg form returns the active frame's snapshot")
       (rf/unsubscribe [:n])
       (rf/unsubscribe [:n])
       (rf/unsubscribe [:name*]))
     ;; Missing frame yields nil rather than throwing.
-    (is (nil? (rf/sub-cache :no-such-frame))
+    (is (nil? (subs-tooling/sub-cache-snapshot :no-such-frame))
         "missing frame returns nil")))
 
 ;; ---- epoch history (Tool-Pair §Time-travel, rf2-shjf) ---------------------

--- a/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/view_render_trigger_handler_cljs_test.cljs
@@ -25,6 +25,8 @@
   and `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
@@ -42,7 +44,7 @@
   atom. Returns the atom; caller is responsible for `remove-trace-cb!`."
   []
   (let [recorded (atom [])]
-    (rf/register-trace-cb! ::recorder
+    (trace-tooling/register-trace-cb! ::recorder
       (fn [ev]
         (when (= :view/render (:operation ev))
           (swap! recorded conj ev))))
@@ -78,7 +80,7 @@
         (render))
       (is (= 1 (count @traces)) "exactly one :view/render trace fired")
       (assert-trigger-shape (first @traces) :rf2-npm2p/sample)
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))
 
 (deftest view-render-trigger-rides-at-top-level
   (testing ":rf.trace/trigger-handler on :view/render is a top-level
@@ -94,7 +96,7 @@
             ":rf.trace/trigger-handler lives at top level")
         (is (not (contains? (:tags ev) :rf.trace/trigger-handler))
             ":rf.trace/trigger-handler does NOT live under :tags"))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))
 
 (deftest view-render-trigger-matches-registrar-coord
   (testing "the :source-coord under :rf.trace/trigger-handler on
@@ -112,7 +114,7 @@
         (is (= (:file   reg-meta) (:file coord)))
         (is (= (:line   reg-meta) (:line coord)))
         (is (= (:column reg-meta) (:column coord))))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))
 
 (deftest each-render-carries-trigger-handler
   (testing "every :view/render invocation carries the trigger-handler
@@ -128,7 +130,7 @@
       (is (= 3 (count @traces)) "three :view/render traces fired")
       (doseq [ev @traces]
         (assert-trigger-shape ev :rf2-npm2p/multi-render))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))
 
 ;; ---- programmatic registration → no coord → no trigger-handler ------------
 
@@ -149,4 +151,4 @@
         (is (some? ev) ":view/render fired")
         (is (not (contains? ev :rf.trace/trigger-handler))
             "programmatic view-registration → no coord → field omitted"))
-      (rf/remove-trace-cb! ::recorder))))
+      (trace-tooling/remove-trace-cb! ::recorder))))

--- a/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/write_after_destroy_cljs_test.cljs
@@ -30,6 +30,8 @@
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -42,9 +44,9 @@
 (defn- collect-traces! []
   (let [traces (atom [])
         cb-id  (keyword (gensym "rf-wad-cb-"))]
-    (rf/register-trace-cb! cb-id (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! cb-id (fn [ev] (swap! traces conj ev)))
     {:traces traces
-     :stop!  (fn [] (rf/remove-trace-cb! cb-id))}))
+     :stop!  (fn [] (trace-tooling/remove-trace-cb! cb-id))}))
 
 (defn- write-after-destroy-warnings [traces]
   (filterv (fn [ev]

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
@@ -18,6 +18,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.late-bind]
             [re-frame.routing]
@@ -33,11 +35,11 @@
 
 (defn- collect-traces [k]
   (let [traces (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- stop-traces [k]
-  (rf/remove-trace-cb! k))
+  (trace-tooling/remove-trace-cb! k))
 
 ;; --- Interaction 1 — Frame disposal with active machine instances ---------
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_dispatch_frame_capture_cljs_test.cljs
@@ -25,7 +25,9 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.test-support :as test-support]))
@@ -45,7 +47,7 @@
   (when-let [clear! (late-bind/get-fn :schemas/clear-by-frame!)]
     (clear!))
   (substrate-adapter/dispose-adapter!)
-  (trace/clear-trace-cbs!)
+  (trace-tooling/clear-trace-cbs!)
   (substrate-adapter/install-adapter! uix-adapter/adapter)
   (frame/ensure-default-frame!))
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_events_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_events_cljs_test.cljs
@@ -15,6 +15,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -27,7 +29,7 @@
   events and return the recording atom."
   [k]
   (let [a (atom [])]
-    (rf/register-trace-cb! k
+    (trace-tooling/register-trace-cb! k
       (fn [ev]
         (when (and (= :warning (:op-type ev))
                    (= :rf.warning/interceptors-in-metadata-map (:operation ev)))
@@ -43,7 +45,7 @@
       (rf/reg-event-db :test.bbea.uix/db-bad
         {:doc "Wrongly-shaped." :interceptors [noop-icpt]}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::db-warn)
+      (trace-tooling/remove-trace-cb! ::db-warn)
       (is (= 1 (count @warns)))
       (let [t (:tags (first @warns))]
         (is (= "reg-event-db" (:reg-fn t)))
@@ -54,7 +56,7 @@
     (rf/reg-event-fx :test.bbea.uix/fx-bad
       {:interceptors [noop-icpt]}
       (fn [_ _] {:db {}}))
-    (rf/remove-trace-cb! ::fx-warn)
+    (trace-tooling/remove-trace-cb! ::fx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-fx" (:reg-fn (:tags (first @warns)))))))
 
@@ -63,7 +65,7 @@
     (rf/reg-event-ctx :test.bbea.uix/ctx-bad
       {:interceptors [noop-icpt]}
       (fn [ctx] ctx))
-    (rf/remove-trace-cb! ::ctx-warn)
+    (trace-tooling/remove-trace-cb! ::ctx-warn)
     (is (= 1 (count @warns)))
     (is (= "reg-event-ctx" (:reg-fn (:tags (first @warns)))))))
 
@@ -80,5 +82,5 @@
       (rf/reg-event-db :test.bbea.uix/quiet-3
         {:doc "metadata only, no positional interceptors"}
         (fn [db _] db))
-      (rf/remove-trace-cb! ::quiet)
+      (trace-tooling/remove-trace-cb! ::quiet)
       (is (zero? (count @warns))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
@@ -25,6 +25,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.machines :as machines]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.test-support :as test-support])
@@ -157,11 +159,11 @@
         (count (.something items))))
     (rf/dispatch-sync [:init])
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::sub-err (fn [ev] (swap! traces conj ev)))
       (let [v (rf/subscribe-once [:items-count])]
         (is (nil? v)
             "the sub returns nil under :replaced-with-default recovery"))
-      (rf/remove-trace-cb! ::sub-err)
+      (trace-tooling/remove-trace-cb! ::sub-err)
       (is (some (fn [ev]
                   (= :rf.error/sub-exception (:operation ev)))
                 @traces)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_write_after_destroy_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_write_after_destroy_cljs_test.cljs
@@ -16,6 +16,8 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.frame :as frame]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -34,7 +36,7 @@
             under plain-atom (the JVM-tier reproducer in
             frame-lifecycle-test)."
     (let [recorded (atom [])]
-      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (trace-tooling/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
       (is (nil? (substrate-adapter/replace-container! nil {:any :value}))
           "nil container is a documented no-op, not an exception")
       (let [warns (filterv (fn [ev]
@@ -44,7 +46,7 @@
                            @recorded)]
         (is (= 1 (count warns))
             "exactly one :rf.warning/write-after-destroy trace fired"))
-      (rf/remove-trace-cb! ::rec))))
+      (trace-tooling/remove-trace-cb! ::rec))))
 
 (deftest write-after-destroy-emits-warning-uix
   (testing "rf2-4tzyq: a write through a destroyed frame's nil container
@@ -53,7 +55,7 @@
             (frame-lifecycle-test) but with the UIx adapter installed —
             the contract is substrate-agnostic."
     (let [recorded (atom [])]
-      (rf/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
+      (trace-tooling/register-trace-cb! ::rec (fn [ev] (swap! recorded conj ev)))
       (rf/reg-frame :uix-rf2-4tzyq/race-frame
                     {:doc "rf2-4tzyq UIx-side reproducer frame"})
       ;; Tear the frame down; subsequent frame/get-frame-db returns nil.
@@ -72,4 +74,4 @@
                            @recorded)]
         (is (pos? (count warns))
             ":rf.warning/write-after-destroy fired for the post-destroy write"))
-      (rf/remove-trace-cb! ::rec))))
+      (trace-tooling/remove-trace-cb! ::rec))))

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -551,16 +551,27 @@
    (let [frame-id (or (:frame opts) (current-frame))]
      (get-in (frame/frame-app-db-value frame-id) path))))
 
-(defn sub-cache
-  "Inspect a frame's runtime sub-cache — CLJS-only, returns
-  `{query-v {:value v :ref-count n}}`. JVM returns `nil` (cache has no
-  reaction values). No-arg form uses the active frame. Per Spec 002
-  §The public registrar query API."
-  ([] (sub-cache (current-frame)))
-  ([frame-id]
-   (subs/sub-cache-snapshot frame-id)))
+;; Per rf2-bmzq0: `sub-topology` and `sub-cache-snapshot` live in
+;; `re-frame.subs.tooling` (production-DCE split). On JVM the
+;; convenience aliases in `re-frame.subs` keep the legacy
+;; `subs/<name>` shape working; this ns mirrors them so the
+;; `rf/sub-topology` / `rf/sub-cache` public API is unchanged. CLJS
+;; consumers needing the surface (Causa, pair2-mcp, re-frame-10x,
+;; conformance tests) call `re-frame.subs.tooling/<name>` directly so
+;; production counter bundles DCE the bodies.
 
-(def sub-topology subs/sub-topology)
+#?(:clj
+   (do
+     (defn sub-cache
+       "Inspect a frame's runtime sub-cache — CLJS-only, returns
+       `{query-v {:value v :ref-count n}}`. JVM returns `nil` (cache has no
+       reaction values). No-arg form uses the active frame. Per Spec 002
+       §The public registrar query API."
+       ([] (sub-cache (current-frame)))
+       ([frame-id]
+        (subs/sub-cache-snapshot frame-id)))
+
+     (def sub-topology subs/sub-topology)))
 
 ;; ---- interceptors --------------------------------------------------------
 

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -578,11 +578,31 @@
 (def sensitive?           privacy/sensitive?)
 (def validate-at-boundary spec/validate-at-boundary)
 
-(def register-trace-cb!  trace/register-trace-cb!)
-(def remove-trace-cb!    trace/remove-trace-cb!)
 (def emit-trace-event!         trace/emit!)
-(def trace-buffer        trace/trace-buffer)
-(def clear-trace-buffer! trace/clear-trace-buffer!)
+
+;; Per rf2-qwm0a the public-tooling listener + buffer surface
+;; (`register-trace-cb!` / `remove-trace-cb!` / `clear-trace-cbs!` /
+;; `trace-buffer` / `clear-trace-buffer!` / `configure-trace-buffer!`)
+;; lives in `re-frame.trace.tooling`, not `re-frame.trace`. On the JVM
+;; we preserve the legacy `rf/<name>` shape via the convenience aliases
+;; below — the JVM has no Closure DCE bundle to protect, and re-frame.
+;; trace ships JVM-only `re-frame.trace/<name>` aliases that the
+;; aliases here mirror. CLJS deliberately omits the aliases so
+;; production counter bundles DCE the tooling sibling wholesale; CLJS
+;; consumers that need the listener / buffer surface (test fixtures,
+;; dev preloads, Causa / Story / pair2-mcp / re-frame-10x, SSR error-
+;; projection) call `re-frame.trace.tooling/<name>` directly. Listener
+;; observability in a production CLJS build is meaningless anyway:
+;; `trace/emit!` is gated on `interop/debug-enabled?` and elides at
+;; `:advanced` + `goog.DEBUG=false`, so even a registered listener
+;; would observe nothing.
+
+#?(:clj
+   (do
+     (def register-trace-cb!     trace/register-trace-cb!)
+     (def remove-trace-cb!       trace/remove-trace-cb!)
+     (def trace-buffer           trace/trace-buffer)
+     (def clear-trace-buffer!    trace/clear-trace-buffer!)))
 
 (def register-event-emit-listener!   event-emit/register-event-emit-listener!)
 (def unregister-event-emit-listener! event-emit/unregister-event-emit-listener!)
@@ -630,12 +650,18 @@
     :trace-buffer  {:depth N}                       ring depth (default 200; 0 disables)
     :sub-cache     {:grace-period-ms N}             dispose grace (default 50ms)
   Unknown keys silently no-op. Per-frame settings live on frame metadata.
-  Per Tool-Pair §How AI tools attach."
+  Per Tool-Pair §How AI tools attach.
+
+  `:trace-buffer` routes through the `re-frame.trace.tooling` sibling
+  ns (per rf2-qwm0a). Production builds that never load the tooling
+  sibling silently no-op on this key — the buffer + listener
+  machinery is DCE'd anyway."
   [knob opts]
   (case knob
     :epoch-history (when-let [f (late-bind/get-fn :epoch/configure!)]
                      (f opts))
-    :trace-buffer  (trace/configure-trace-buffer! opts)
+    :trace-buffer  (when-let [f (late-bind/get-fn :trace.tooling/configure-trace-buffer!)]
+                     (f opts))
     :sub-cache     (subs/configure! opts)
     nil))
 

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -328,6 +328,25 @@
     :design-bead "rf2-4dra9"
     :description "Clear the per-frame head-snapshot entry on destroy. `re-frame.ssr/on-frame-destroyed!` invokes this hook by key after clearing its own side-channel atoms."}
 
+   ;; ---- re-frame.ssr.streaming (rf2-ojakd / rf2-olb64 — chunked SSR) ---------
+   ;; Three keys host adapters (e.g. ssr-ring/streaming) call to drive
+   ;; the chunked-rendering pipeline. The drift scan picked these up
+   ;; only after the rf2-qwm0a regex fix added `.` to the namespace
+   ;; character class — they were always published but the original
+   ;; regex `[a-zA-Z0-9!?*+\-]+` excluded the `.` in `ssr.streaming/`.
+   {:key         :ssr.streaming/render-shell!
+    :producer-ns 're-frame.ssr.streaming
+    :design-bead "rf2-ojakd"
+    :description "Render the initial SSR shell HTML chunk for a frame and stash the in-flight render context."}
+   {:key         :ssr.streaming/render-continuation!
+    :producer-ns 're-frame.ssr.streaming
+    :design-bead "rf2-ojakd"
+    :description "Render a continuation chunk (resolved-suspense fragment) for an in-flight streaming render."}
+   {:key         :ssr.streaming/build-final-payload
+    :producer-ns 're-frame.ssr.streaming
+    :design-bead "rf2-ojakd"
+    :description "Build the final hydration payload after every streaming chunk has been emitted."}
+
    ;; ---- re-frame.adapter.reagent (rf2-0hxm) ---------------------------------
    {:key         :reagent/set-hiccup-emitter!
     :producer-ns '[re-frame.adapter.reagent
@@ -474,6 +493,27 @@
    {:key         :trace/emit-error!
     :producer-ns 're-frame.trace
     :description "Emit a trace error event (registrar replace-warning seam)."}
+
+   ;; ---- re-frame.trace.tooling (rf2-qwm0a — dev-tooling buffer + listener
+   ;; surface split off for production DCE; trace.cljc reaches the buffer
+   ;; push + listener fan-out through this single hook). The public
+   ;; surface fns (`register-trace-cb!` / `remove-trace-cb!` /
+   ;; `clear-trace-cbs!` / `trace-buffer` / `clear-trace-buffer!` /
+   ;; `configure-trace-buffer!` / `configure`) are exposed directly from
+   ;; `re-frame.trace.tooling`; consumers (tests, tools, SSR's listener
+   ;; registration) call them through `re-frame.trace.tooling/<name>`
+   ;; rather than going through a wrapper in `re-frame.trace`. Keeping
+   ;; the seam at exactly one hook key avoids paying for N keyword
+   ;; interns at module-init time in every consumer that loads
+   ;; `re-frame.trace` (which is everyone).
+   {:key         :trace.tooling/deliver!
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-qwm0a"
+    :description "Per-event buffer-push + listener fan-out invoked by trace.cljc's `deliver!`."}
+   {:key         :trace.tooling/configure-trace-buffer!
+    :producer-ns 're-frame.trace.tooling
+    :design-bead "rf2-qwm0a"
+    :description "Set the trace ring buffer depth. Late-bound from `re-frame.core/configure :trace-buffer` so a no-tooling production build silently no-ops."}
 
    ;; ---- re-frame.event-emit (rf2-rirbq — always-on event observability) -----
    {:key         :event-emit/dispatch-on-event

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -35,7 +35,18 @@
              #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace
-             #?@(:cljs [:include-macros true])]))
+             #?@(:cljs [:include-macros true])]
+            ;; JVM autoload (rf2-bmzq0): the tooling sibling has zero
+            ;; artefact cost on JVM and we keep the legacy
+            ;; `re-frame.subs/<name>` shape working for JVM test
+            ;; fixtures via the alias block at the bottom of the
+            ;; file. CLJS deliberately omits this require so the
+            ;; tooling sibling stays out of production bundles. The
+            ;; reciprocal — `subs.tooling` requires `subs` to drive
+            ;; the alias chain — is avoided because subs.tooling
+            ;; only needs `registrar` / `frame` / `interop` and a
+            ;; cyclic require would break the JVM autoload.
+            #?@(:clj [[re-frame.subs.tooling :as subs-tooling]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -814,86 +825,15 @@
               (catch #?(:clj Throwable :cljs :default) _ nil))))
      (reset! cache {}))))
 
-;; ---- static topology ------------------------------------------------------
+;; ---- tooling sibling --------------------------------------------------
 ;;
-;; Per Spec 002 §The public registrar query API and Spec 006 §Subscription
-;; topology vs subscription tracking. `sub-topology` is the static ":<- chain"
-;; you can derive from registrations alone — pure data over the registrar,
-;; no app-db, no reactive runtime, no per-frame cache. JVM-runnable.
-;;
-;; Shape (per Spec 002 §The public registrar query API row): a map of
-;;   sub-id → {:inputs [<input-sub-ids>] :doc <str?> :ns sym :line int :file str}
-;; with :inputs always present (empty vector for layer-1 / direct-app-db subs)
-;; and the source-coord / :doc keys included only when the registration
-;; carries them.
-
-(defn sub-topology
-  "Return the static dependency graph of every registered subscription.
-
-  Pure data over the registrar — no app-db, no per-frame cache, no
-  reactive runtime. Per Spec 002 §The public registrar query API and
-  Spec 006 §Subscription topology vs subscription tracking.
-
-  Shape: `{sub-id {:inputs [<input-sub-ids>] :doc ... :ns ... :line ... :file ...}}`.
-
-  - `:inputs` is the vector of upstream sub-ids declared via `:<-` at
-    registration time. It is always present; layer-1 subs (which read
-    `app-db` directly) report `:inputs []`. The order matches the
-    declaration order so that downstream tools can reconstruct the
-    chain shape the body fn expects.
-  - `:doc`, `:ns`, `:line`, `:file` are present when the registration
-    carried them (`:ns` / `:line` / `:file` are auto-captured by the
-    `reg-sub` macro per Spec 001 §Source-coordinate capture; `:doc`
-    is user-supplied via the meta-map first arg).
-
-  Returns `{}` when no subs are registered.
-
-  JVM-runnable. The runtime cache state (`sub-cache`) is the dynamic
-  counterpart and is CLJS-only."
-  []
-  (let [subs-meta (registrar/registrations :sub)]
-    (reduce-kv
-      (fn [acc sub-id meta]
-        (let [inputs (mapv first (:input-signals meta))
-              entry  (cond-> {:inputs inputs}
-                       (contains? meta :doc)  (assoc :doc  (:doc  meta))
-                       (contains? meta :ns)   (assoc :ns   (:ns   meta))
-                       (contains? meta :line) (assoc :line (:line meta))
-                       (contains? meta :file) (assoc :file (:file meta)))]
-          (assoc acc sub-id entry)))
-      {}
-      subs-meta)))
-
-(defn sub-cache-snapshot
-  "Public read-only snapshot of a frame's sub-cache, projected to a
-  Tool-Pair-friendly shape: `{query-v {:value v :ref-count n}}`.
-
-  CLJS-only — on the JVM the cache exists for ref-counting purposes but
-  the cached reactions are not deref-able, so this fn returns `nil`. Per
-  Spec 002 §The public registrar query API and Tool-Pair §How AI tools
-  attach.
-
-  Dev-only on CLJS too — the body is gated on `interop/debug-enabled?`
-  (the `goog.DEBUG` mirror) so production builds elide both the cache
-  walk and the deref-and-collect machinery. Pair tools that attach in
-  production explicitly opt in by toggling the gate.
-
-  Returns `nil` for missing or destroyed frames, and `nil` in
-  production builds."
-  [frame-id]
-  #?(:cljs
-     (when interop/debug-enabled?
-       (when-let [cache (:sub-cache (frame/frame frame-id))]
-         (reduce-kv
-           (fn [acc query-v entry]
-             (assoc acc query-v
-                    {:value     (when-let [r (:reaction entry)]
-                                  (try @r (catch :default _ nil)))
-                     :ref-count (or (:ref-count entry) 0)}))
-           {}
-           @cache)))
-     :clj
-     nil))
+;; Per rf2-bmzq0: the static-topology query (`sub-topology`) and the
+;; reactive-cache snapshot (`sub-cache-snapshot`) moved to
+;; `re-frame.subs.tooling` so production counter bundles DCE their
+;; bodies. CLJS consumers needing the introspection surface load the
+;; tooling sibling explicitly; JVM consumers reach the legacy
+;; `re-frame.subs/<name>` shape via the convenience aliases in the
+;; JVM-only block at the bottom of this file.
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;
@@ -902,3 +842,18 @@
 ;; through the late-bind hook registry. See re-frame.late-bind.
 
 (late-bind/set-fn! :subs/subscribe-once subscribe-once)
+
+;; ---- JVM-side convenience aliases (rf2-bmzq0) ----------------------------
+;;
+;; On the JVM we preserve the legacy `re-frame.subs/<name>` shape for
+;; the tooling surface so the cascade of `.clj` test fixtures stays
+;; unchanged. The aliases are gated under `#?(:clj ...)` so they never
+;; appear in CLJS compilation — production counter bundles still DCE
+;; the tooling sibling wholesale because `re-frame.subs` on CLJS has
+;; no static reference to it. Mirror of the trace/tooling pattern
+;; per rf2-qwm0a.
+
+#?(:clj
+   (do
+     (def sub-topology       subs-tooling/sub-topology)
+     (def sub-cache-snapshot subs-tooling/sub-cache-snapshot)))

--- a/implementation/core/src/re_frame/subs/tooling.cljc
+++ b/implementation/core/src/re_frame/subs/tooling.cljc
@@ -1,0 +1,127 @@
+(ns re-frame.subs.tooling
+  "Subs tooling sibling of `re-frame.subs` — carries the two tool-facing
+  introspection fns (`sub-topology`, `sub-cache-snapshot`) that pair
+  tools (Causa, pair2-mcp, re-frame-10x) query but no production
+  application code reads.
+
+  Per rf2-bmzq0 (audit rf2-53tcf §Part 4 P2): keeping these fns in
+  `re-frame.subs` paid for their bodies in every CLJS bundle that
+  loaded the subs ns, even though no production code path reaches
+  them. Splitting them off lets `:advanced` + `goog.DEBUG=false` DCE
+  the bodies wholesale (the sibling ns is loaded only when a test
+  fixture, tool, or dev preload requires it).
+
+  Mirrors the rf2-qwm0a `re-frame.trace.tooling` split:
+    - CLJS consumers needing the surface call
+      `re-frame.subs.tooling/<name>` directly. Production counter
+      bundles never load this ns and DCE the bodies wholesale.
+    - JVM consumers keep the legacy `re-frame.subs/<name>` /
+      `rf/sub-topology` / `rf/sub-cache` shape via the convenience
+      aliases in `re-frame.subs` and `re-frame.core` (gated under
+      `#?(:clj ...)`). JVM has no bundle to protect; the aliases
+      cost nothing.
+
+  Per Spec 002 §The public registrar query API and Spec 006
+  §Subscription topology vs subscription tracking."
+  (:require [re-frame.registrar :as registrar]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- static topology ------------------------------------------------------
+;;
+;; Per Spec 002 §The public registrar query API and Spec 006 §Subscription
+;; topology vs subscription tracking. `sub-topology` is the static ":<- chain"
+;; you can derive from registrations alone — pure data over the registrar,
+;; no app-db, no reactive runtime, no per-frame cache. JVM-runnable.
+;;
+;; Shape (per Spec 002 §The public registrar query API row): a map of
+;;   sub-id → {:inputs [<input-sub-ids>] :doc <str?> :ns sym :line int :file str}
+;; with :inputs always present (empty vector for layer-1 / direct-app-db subs)
+;; and the source-coord / :doc keys included only when the registration
+;; carries them.
+
+(defn sub-topology
+  "Return the static dependency graph of every registered subscription.
+
+  Pure data over the registrar — no app-db, no per-frame cache, no
+  reactive runtime. Per Spec 002 §The public registrar query API and
+  Spec 006 §Subscription topology vs subscription tracking.
+
+  Shape: `{sub-id {:inputs [<input-sub-ids>] :doc ... :ns ... :line ... :file ...}}`.
+
+  - `:inputs` is the vector of upstream sub-ids declared via `:<-` at
+    registration time. It is always present; layer-1 subs (which read
+    `app-db` directly) report `:inputs []`. The order matches the
+    declaration order so that downstream tools can reconstruct the
+    chain shape the body fn expects.
+  - `:doc`, `:ns`, `:line`, `:file` are present when the registration
+    carried them (`:ns` / `:line` / `:file` are auto-captured by the
+    `reg-sub` macro per Spec 001 §Source-coordinate capture; `:doc`
+    is user-supplied via the meta-map first arg).
+
+  Returns `{}` when no subs are registered.
+
+  JVM-runnable. The runtime cache state (`sub-cache`) is the dynamic
+  counterpart and is CLJS-only."
+  []
+  (let [subs-meta (registrar/registrations :sub)]
+    (reduce-kv
+      (fn [acc sub-id meta]
+        (let [inputs (mapv first (:input-signals meta))
+              entry  (cond-> {:inputs inputs}
+                       (contains? meta :doc)  (assoc :doc  (:doc  meta))
+                       (contains? meta :ns)   (assoc :ns   (:ns   meta))
+                       (contains? meta :line) (assoc :line (:line meta))
+                       (contains? meta :file) (assoc :file (:file meta)))]
+          (assoc acc sub-id entry)))
+      {}
+      subs-meta)))
+
+(defn sub-cache-snapshot
+  "Public read-only snapshot of a frame's sub-cache, projected to a
+  Tool-Pair-friendly shape: `{query-v {:value v :ref-count n}}`.
+
+  CLJS-only — on the JVM the cache exists for ref-counting purposes but
+  the cached reactions are not deref-able, so this fn returns `nil`. Per
+  Spec 002 §The public registrar query API and Tool-Pair §How AI tools
+  attach.
+
+  Dev-only on CLJS too — the body is gated on `interop/debug-enabled?`
+  (the `goog.DEBUG` mirror) so production builds elide both the cache
+  walk and the deref-and-collect machinery. Pair tools that attach in
+  production explicitly opt in by toggling the gate.
+
+  Returns `nil` for missing or destroyed frames, and `nil` in
+  production builds."
+  [frame-id]
+  #?(:cljs
+     (when interop/debug-enabled?
+       (when-let [cache (:sub-cache (frame/frame frame-id))]
+         (reduce-kv
+           (fn [acc query-v entry]
+             (assoc acc query-v
+                    {:value     (when-let [r (:reaction entry)]
+                                  (try @r (catch :default _ nil)))
+                     :ref-count (or (:ref-count entry) 0)}))
+           {}
+           @cache)))
+     :clj
+     nil))
+
+;; ---- bundle-isolation sentinel ------------------------------------------
+;;
+;; Per rf2-bmzq0: `implementation/scripts/check-bundle-isolation.cjs`
+;; greps the counter bundle for this exact string. The string lives
+;; ONLY in this file's source body — no other namespace, no docstring,
+;; no test fixture references it — so its presence in the production
+;; counter bundle proves that the tooling sibling's body got pulled
+;; in (most likely via a stray `:require` from a core/* ns). The
+;; sentinel survives `:advanced` because string literals are not
+;; renamed; it sits outside any `interop/debug-enabled?` gate so DCE
+;; cannot drop the literal independently of the surrounding ns body.
+
+(defonce ^:private bundle-isolation-sentinel
+  "rf.subs.tooling/sentinel:rf2-bmzq0-2026-05-16:do-not-rename")

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -60,7 +60,12 @@
             ;; rf2-5kpd / rf2-lt4e). This ns must not statically require
             ;; any of them.
             [re-frame.late-bind :as late-bind]
-            [re-frame.trace :as trace]
+            ;; Per rf2-qwm0a: the public-tooling listener + buffer
+            ;; surface lives in `re-frame.trace.tooling` (split off
+            ;; from `re-frame.trace` for production CLJS bundle DCE).
+            ;; Test fixtures need `clear-trace-cbs!` between scenarios;
+            ;; we reach it through the tooling sibling directly.
+            [re-frame.trace.tooling :as trace-tooling]
             ;; Clear the always-on event-emit listener registry on each
             ;; reset so a forwarder registered in one test doesn't see
             ;; events fired by a sibling test.
@@ -280,7 +285,7 @@
          (run-reset-hooks! :pre-dispose)
          (adapter/dispose-adapter!)
          (run-reset-hooks! :post-dispose)
-         (trace/clear-trace-cbs!)
+         (trace-tooling/clear-trace-cbs!)
          (event-emit/clear-event-emit-listeners!)
          (when adapter
            (adapter/install-adapter! adapter)

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -7,33 +7,47 @@
   is event-at-a-time (not span-shaped); cascade correlation rides on
   `:dispatch-id`. Production builds elide trace emission entirely via
   `re-frame.interop/debug-enabled?` — see `emit!` below. See Spec 009
-  §Core fields, §Dispatch correlation, and §Handler-scope."
+  §Core fields, §Dispatch correlation, and §Handler-scope.
+
+  Topology (rf2-qwm0a): this ns carries the always-loaded hot fast
+  path — `emit!` / `emit-error!` / `*handler-scope*` and the bracket
+  macros. The public-tooling surface (`register-trace-cb!` /
+  `remove-trace-cb!` / `clear-trace-cbs!` / `trace-buffer` /
+  `clear-trace-buffer!` / `configure-trace-buffer!` / `configure`) and
+  the buffer + listener state live in the sibling
+  `re-frame.trace.tooling`, which is loaded only when a test fixture,
+  tool, or dev preload requires it.
+
+  CLJS consumers call `re-frame.trace.tooling/<name>` directly so the
+  CLJS build of this ns intentionally holds NO references to the
+  tooling sibling — production counter bundles DCE the buffer +
+  listener machinery, including the per-fn late-bind keyword interns
+  that would otherwise survive as top-level allocations even when the
+  wrapper body is dead.
+
+  JVM consumers (the production-DCE benefit doesn't apply to the JVM
+  side; the tooling sibling has zero artefact-bundle cost there) keep
+  the legacy `re-frame.trace/<name>` call shape via the convenience
+  aliases at the bottom of this file (loaded only under `#?(:clj ...)`
+  so they don't leak into the CLJS bundle). 47 JVM test files and a
+  handful of `.cljc` sources reference the legacy shape; the JVM
+  aliases preserve their call sites unchanged.
+
+  `deliver!` reaches the tooling fan-out through the single
+  `:trace.tooling/deliver!` late-bind hook (mirroring the existing
+  `:epoch/capture-event` shape)."
   (:require [re-frame.interop :as interop]
-            [re-frame.late-bind :as late-bind])
+            [re-frame.late-bind :as late-bind]
+            ;; JVM autoload (see ns docstring): the JVM has no Closure
+            ;; DCE bundle to protect, and we keep the legacy
+            ;; `re-frame.trace/<name>` shape working for JVM test
+            ;; fixtures + SSR via the alias block at the bottom of the
+            ;; file. CLJS deliberately omits this require so the
+            ;; tooling sibling stays out of production bundles.
+            #?@(:clj [[re-frame.trace.tooling :as trace-tooling]]))
   #?(:cljs (:require-macros [re-frame.trace])))
 
 #?(:clj (set! *warn-on-reflection* true))
-
-;; ---- listener registry ----------------------------------------------------
-
-(defonce ^:private listeners (atom {}))    ;; id → fn (or nil for cleared)
-
-(defn register-trace-cb!
-  "Register a listener that receives every trace event. The id can be any
-  comparable value; passing the same id twice replaces. Returns the id."
-  [id f]
-  (swap! listeners assoc id f)
-  id)
-
-(defn remove-trace-cb!
-  [id]
-  (swap! listeners dissoc id)
-  nil)
-
-(defn clear-trace-cbs!
-  []
-  (reset! listeners {})
-  nil)
 
 ;; ---- event id counter (cheap, monotonic per process) ----------------------
 
@@ -146,169 +160,6 @@
                                     (->HandlerScope nil cs# did# false false))]
           ~@body))))
 
-;; ---- retain-N trace ring buffer (dev-only) -------------------------------
-
-(def ^:private default-buffer-depth
-  "Per Spec 009 §Retain-N trace ring buffer: default 200 events —
-  enough for one drained cascade plus prior history without per-frame
-  memory pressure."
-  200)
-
-(defonce ^:private buffer-depth (atom default-buffer-depth))
-
-(defonce ^:private trace-buffer-state
-  ;; The buffer is a plain vector held under an atom. Append is conj+slice;
-  ;; the slot count caps memory. depth=0 disables the buffer entirely (the
-  ;; delivery path still works — see configure-trace-buffer!).
-  (atom []))
-
-(defn- push-to-buffer!
-  "Append ev to the ring buffer, evicting the oldest entry when the slot
-  count is exceeded. No-op when the configured depth is 0."
-  [ev]
-  (when interop/debug-enabled?
-    (let [depth @buffer-depth]
-      (when (pos? depth)
-        (swap! trace-buffer-state
-               (fn [v]
-                 (let [v' (conj v ev)
-                       n  (count v')]
-                   (if (> n depth)
-                     (subvec v' (- n depth))
-                     v'))))))))
-
-(defn trace-buffer
-  "Return the trace ring buffer's current contents, oldest first.
-
-  With opts, filters the result. Recognised keys (all compose AND-wise;
-  an absent key means \"no constraint on that axis\"):
-
-    :operation     — keep only events with this :operation value.
-    :op-type       — keep only events with this :op-type value.
-    :since         — keep only events whose :id is strictly greater than
-                     this. Useful for cursor-based polling.
-    :frame         — keep only events whose `:tags :frame` (or top-level
-                     :frame fallback) matches.
-    :severity      — keep only events whose :op-type matches one of
-                     `:error` / `:warning` / `:info`. Synonym for
-                     `:op-type` restricted to the three severity tiers.
-    :event-id      — keep only events whose `:tags :event-id` matches.
-                     The event-id is the first element of the dispatched
-                     event vector (e.g. `:user/login`).
-    :handler-id    — keep only events whose `:tags :handler-id` matches.
-                     Carried on `:rf.error/handler-exception` and other
-                     handler-scoped emits.
-    :source        — keep only events whose :source (top-level, hoisted
-                     from `:tags :source` by `emit!`) matches. Source
-                     identifies the trigger origin — one of `:ui` /
-                     `:timer` / `:http` / `:repl` / `:machine` /
-                     `:ssr-hydration`. Matched against the top-level slot.
-    :origin        — keep only events whose `:tags :origin` matches.
-                     Origin tags the actor that issued the dispatch
-                     (`:app` / `:pair` / `:story` / `:test` / ...) per
-                     Spec 002 §Dispatch origin tagging.
-    :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
-                     Cascade-wide post rf2-g6ih4 — every emit inside a
-                     drain carries the in-flight cascade's dispatch-id.
-    :since-ms      — keep only events whose :time is strictly greater
-                     than this numeric host-clock timestamp.
-    :between       — `[t0 t1]` two-element vector — keep only events
-                     whose :time falls in [t0, t1] inclusive.
-    :sensitive?    — boolean. Match the top-level `:sensitive?` field
-                     (per Spec 009 §Privacy filter-vocab row, rf2-isdwf).
-                     Pass `false` to exclude sensitive events; pass
-                     `true` to select only sensitive events. Absent ⇒
-                     no constraint.
-    :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
-                     the full event map. Returning truthy keeps the event.
-
-  Filters compose: every supplied key must match. Returns an empty vector
-  in production (the buffer never receives events when interop/debug-enabled?
-  is false at compile time).
-
-  Per Spec 009 §Retain-N trace ring buffer."
-  ([] (trace-buffer {}))
-  ([opts]
-   (if-not interop/debug-enabled?
-     []
-     (let [{:keys [operation op-type since frame
-                   severity event-id handler-id source origin
-                   dispatch-id since-ms between pred]} opts
-           sensitive-filter (:sensitive? opts)
-           [between-t0 between-t1] (when (and (sequential? between)
-                                              (= 2 (count between)))
-                                     between)
-           predicate
-           (fn [ev]
-             (and (or (nil? operation) (= operation (:operation ev)))
-                  (or (nil? op-type)   (= op-type   (:op-type ev)))
-                  (or (nil? since)     (and (number? (:id ev))
-                                            (> (:id ev) since)))
-                  (or (nil? frame)
-                      (= frame (or (:frame ev)
-                                   (get-in ev [:tags :frame]))))
-                  (or (nil? severity) (= severity (:op-type ev)))
-                  (or (nil? event-id)
-                      (= event-id (get-in ev [:tags :event-id])))
-                  (or (nil? handler-id)
-                      (= handler-id (get-in ev [:tags :handler-id])))
-                  (or (nil? source)
-                      (= source (or (:source ev)
-                                    (get-in ev [:tags :source]))))
-                  (or (nil? origin)
-                      (= origin (get-in ev [:tags :origin])))
-                  (or (nil? dispatch-id)
-                      (= dispatch-id (get-in ev [:tags :dispatch-id])))
-                  (or (nil? since-ms)
-                      (and (number? (:time ev))
-                           (> (:time ev) since-ms)))
-                  (or (nil? between-t0)
-                      (and (number? (:time ev))
-                           (<= between-t0 (:time ev) between-t1)))
-                  ;; Top-level `:sensitive?` is hoisted (NOT nested
-                  ;; under `:tags`). Match against the top-level slot
-                  ;; only; absent reads as false.
-                  (or (nil? sensitive-filter)
-                      (= (true? sensitive-filter)
-                         (true? (:sensitive? ev))))
-                  (or (nil? pred) (pred ev))))]
-       (filterv predicate @trace-buffer-state)))))
-
-(defn clear-trace-buffer!
-  "Empty the ring buffer. Tooling uses this between sessions. No-op in
-  production. Per Spec 009 §Retain-N trace ring buffer."
-  []
-  (when interop/debug-enabled?
-    (reset! trace-buffer-state []))
-  nil)
-
-(defn configure-trace-buffer!
-  "Set the ring buffer's depth. depth=0 disables the buffer (the delivery
-  path still works). The new depth applies on the next append; existing
-  entries are trimmed to fit immediately. No-op in production.
-
-  Per Spec 009 §Retain-N trace ring buffer."
-  [{:keys [depth]}]
-  (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
-    (reset! buffer-depth depth)
-    (swap! trace-buffer-state
-           (fn [v]
-             (let [n (count v)]
-               (cond
-                 (zero? depth) []
-                 (> n depth)   (subvec v (- n depth))
-                 :else         v)))))
-  nil)
-
-(defn configure
-  "Generic config dispatch. Recognises :trace-buffer; future config knobs
-  add cases here. Per Spec 009 §Retain-N trace ring buffer
-  (`(rf/configure :trace-buffer {:depth N})`)."
-  [k opts]
-  (case k
-    :trace-buffer (configure-trace-buffer! opts)
-    nil))
-
 ;; ---- emission -------------------------------------------------------------
 
 (defn- deliver-to-epoch-capture!
@@ -400,17 +251,16 @@
       sensitive?           (assoc :sensitive? true))))
 
 (defn- deliver!
-  "Side-effect dispatch for an assembled trace envelope: ring-buffer
-  push, epoch-capture fan-out, and listener fan-out. Synchronous;
-  throwing listeners are isolated. Per Spec 009 §Listener invocation
-  rules."
+  "Side-effect dispatch for an assembled trace envelope: epoch-capture
+  fan-out, then ring-buffer push + listener fan-out via the
+  `:trace.tooling/deliver!` hook published by `re-frame.trace.tooling`.
+  The tooling hook is unregistered in production (the tooling sibling
+  ns is not loaded) — the lookup returns nil and the fan-out is
+  skipped. Per Spec 009 §Listener invocation rules and rf2-qwm0a."
   [event]
-  (push-to-buffer! event)
   (deliver-to-epoch-capture! event)
-  (doseq [[_ f] @listeners]
-    (try
-      (f event)
-      (catch #?(:clj Throwable :cljs :default) _ nil))))
+  (when-let [deliver-tooling (late-bind/get-fn-cached :trace.tooling/deliver!)]
+    (deliver-tooling event)))
 
 (defn emit!
   "Emit a trace event. Production builds elide the body entirely
@@ -456,3 +306,23 @@
 
 (late-bind/set-fn! :trace/emit!       emit!)
 (late-bind/set-fn! :trace/emit-error! emit-error!)
+
+;; ---- JVM-side convenience aliases (rf2-qwm0a) ----------------------------
+;;
+;; Per the ns docstring: on the JVM we preserve the legacy
+;; `re-frame.trace/<name>` shape for the public-tooling surface so the
+;; cascade of `.clj` test fixtures + `.cljc` SSR / story / causa
+;; sources stays unchanged. The aliases are gated under `#?(:clj ...)`
+;; so they never appear in CLJS compilation — production counter
+;; bundles still DCE the tooling sibling wholesale because
+;; `re-frame.trace` on CLJS has no static reference to it.
+
+#?(:clj
+   (do
+     (def register-trace-cb!     trace-tooling/register-trace-cb!)
+     (def remove-trace-cb!       trace-tooling/remove-trace-cb!)
+     (def clear-trace-cbs!       trace-tooling/clear-trace-cbs!)
+     (def trace-buffer           trace-tooling/trace-buffer)
+     (def clear-trace-buffer!    trace-tooling/clear-trace-buffer!)
+     (def configure-trace-buffer! trace-tooling/configure-trace-buffer!)
+     (def configure              trace-tooling/configure)))

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -1,0 +1,264 @@
+(ns re-frame.trace.tooling
+  "Trace tooling sibling of `re-frame.trace` — carries the public
+  dev-tooling surface (`register-trace-cb!` / `remove-trace-cb!` /
+  `clear-trace-cbs!` / `trace-buffer` / `clear-trace-buffer!` /
+  `configure-trace-buffer!` / `configure`) and the buffer / listener
+  state they operate on.
+
+  Per rf2-qwm0a (audit rf2-53tcf §Part 4 P1): `re-frame.trace` itself
+  carries only the hot emit fast path (`emit!` / `emit-error!` /
+  `*handler-scope*` + bracket macros). The listener registry + ring
+  buffer + filter predicate are tooling concerns; production counter
+  bundles never touch them. Splitting them off lets `:advanced` +
+  `goog.DEBUG=false` DCE this ns wholesale (it's only loaded when a
+  test fixture, tool, or dev-preload `:require`s it).
+
+  Wiring: at ns load this ns publishes `:trace.tooling/deliver!`
+  through `re-frame.late-bind` — `re-frame.trace/deliver!` looks the
+  hook up at emit time and fans the event out to the buffer + every
+  registered listener. Absent the load, the lookup returns nil and the
+  trace fast path skips the fan-out (production behaviour).
+
+  Public surface for tools / tests:
+    - `register-trace-cb!` / `remove-trace-cb!` / `clear-trace-cbs!`
+    - `trace-buffer` / `clear-trace-buffer!` / `configure-trace-buffer!`
+    - `configure` (generic config dispatch — currently `:trace-buffer`).
+
+  Per Spec 009 §Retain-N trace ring buffer and §The listener API."
+  (:require [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- listener registry ----------------------------------------------------
+
+(defonce ^:private listeners (atom {}))    ;; id → fn
+
+(defn register-trace-cb!
+  "Register a listener that receives every trace event. The id can be any
+  comparable value; passing the same id twice replaces. Returns the id."
+  [id f]
+  (swap! listeners assoc id f)
+  id)
+
+(defn remove-trace-cb!
+  [id]
+  (swap! listeners dissoc id)
+  nil)
+
+(defn clear-trace-cbs!
+  []
+  (reset! listeners {})
+  nil)
+
+;; ---- retain-N trace ring buffer (dev-only) -------------------------------
+
+(def ^:private default-buffer-depth
+  "Per Spec 009 §Retain-N trace ring buffer: default 200 events —
+  enough for one drained cascade plus prior history without per-frame
+  memory pressure."
+  200)
+
+(defonce ^:private buffer-depth (atom default-buffer-depth))
+
+(defonce ^:private trace-buffer-state
+  ;; The buffer is a plain vector held under an atom. Append is conj+slice;
+  ;; the slot count caps memory. depth=0 disables the buffer entirely (the
+  ;; delivery path still works — see configure-trace-buffer!).
+  (atom []))
+
+(defn- push-to-buffer!
+  "Append ev to the ring buffer, evicting the oldest entry when the slot
+  count is exceeded. No-op when the configured depth is 0."
+  [ev]
+  (when interop/debug-enabled?
+    (let [depth @buffer-depth]
+      (when (pos? depth)
+        (swap! trace-buffer-state
+               (fn [v]
+                 (let [v' (conj v ev)
+                       n  (count v')]
+                   (if (> n depth)
+                     (subvec v' (- n depth))
+                     v'))))))))
+
+(defn trace-buffer
+  "Return the trace ring buffer's current contents, oldest first.
+
+  With opts, filters the result. Recognised keys (all compose AND-wise;
+  an absent key means \"no constraint on that axis\"):
+
+    :operation     — keep only events with this :operation value.
+    :op-type       — keep only events with this :op-type value.
+    :since         — keep only events whose :id is strictly greater than
+                     this. Useful for cursor-based polling.
+    :frame         — keep only events whose `:tags :frame` (or top-level
+                     :frame fallback) matches.
+    :severity      — keep only events whose :op-type matches one of
+                     `:error` / `:warning` / `:info`. Synonym for
+                     `:op-type` restricted to the three severity tiers.
+    :event-id      — keep only events whose `:tags :event-id` matches.
+                     The event-id is the first element of the dispatched
+                     event vector (e.g. `:user/login`).
+    :handler-id    — keep only events whose `:tags :handler-id` matches.
+                     Carried on `:rf.error/handler-exception` and other
+                     handler-scoped emits.
+    :source        — keep only events whose :source (top-level, hoisted
+                     from `:tags :source` by `emit!`) matches. Source
+                     identifies the trigger origin — one of `:ui` /
+                     `:timer` / `:http` / `:repl` / `:machine` /
+                     `:ssr-hydration`. Matched against the top-level slot.
+    :origin        — keep only events whose `:tags :origin` matches.
+                     Origin tags the actor that issued the dispatch
+                     (`:app` / `:pair` / `:story` / `:test` / ...) per
+                     Spec 002 §Dispatch origin tagging.
+    :dispatch-id   — keep only events whose `:tags :dispatch-id` matches.
+                     Cascade-wide post rf2-g6ih4 — every emit inside a
+                     drain carries the in-flight cascade's dispatch-id.
+    :since-ms      — keep only events whose :time is strictly greater
+                     than this numeric host-clock timestamp.
+    :between       — `[t0 t1]` two-element vector — keep only events
+                     whose :time falls in [t0, t1] inclusive.
+    :sensitive?    — boolean. Match the top-level `:sensitive?` field
+                     (per Spec 009 §Privacy filter-vocab row, rf2-isdwf).
+                     Pass `false` to exclude sensitive events; pass
+                     `true` to select only sensitive events. Absent ⇒
+                     no constraint.
+    :pred          — `(fn [ev] -> truthy)` arbitrary predicate. Receives
+                     the full event map. Returning truthy keeps the event.
+
+  Filters compose: every supplied key must match. Returns an empty vector
+  in production (the buffer never receives events when interop/debug-enabled?
+  is false at compile time).
+
+  Per Spec 009 §Retain-N trace ring buffer."
+  ([] (trace-buffer {}))
+  ([opts]
+   (if-not interop/debug-enabled?
+     []
+     (let [{:keys [operation op-type since frame
+                   severity event-id handler-id source origin
+                   dispatch-id since-ms between pred]} opts
+           sensitive-filter (:sensitive? opts)
+           [between-t0 between-t1] (when (and (sequential? between)
+                                              (= 2 (count between)))
+                                     between)
+           predicate
+           (fn [ev]
+             (and (or (nil? operation) (= operation (:operation ev)))
+                  (or (nil? op-type)   (= op-type   (:op-type ev)))
+                  (or (nil? since)     (and (number? (:id ev))
+                                            (> (:id ev) since)))
+                  (or (nil? frame)
+                      (= frame (or (:frame ev)
+                                   (get-in ev [:tags :frame]))))
+                  (or (nil? severity) (= severity (:op-type ev)))
+                  (or (nil? event-id)
+                      (= event-id (get-in ev [:tags :event-id])))
+                  (or (nil? handler-id)
+                      (= handler-id (get-in ev [:tags :handler-id])))
+                  (or (nil? source)
+                      (= source (or (:source ev)
+                                    (get-in ev [:tags :source]))))
+                  (or (nil? origin)
+                      (= origin (get-in ev [:tags :origin])))
+                  (or (nil? dispatch-id)
+                      (= dispatch-id (get-in ev [:tags :dispatch-id])))
+                  (or (nil? since-ms)
+                      (and (number? (:time ev))
+                           (> (:time ev) since-ms)))
+                  (or (nil? between-t0)
+                      (and (number? (:time ev))
+                           (<= between-t0 (:time ev) between-t1)))
+                  ;; Top-level `:sensitive?` is hoisted (NOT nested
+                  ;; under `:tags`). Match against the top-level slot
+                  ;; only; absent reads as false.
+                  (or (nil? sensitive-filter)
+                      (= (true? sensitive-filter)
+                         (true? (:sensitive? ev))))
+                  (or (nil? pred) (pred ev))))]
+       (filterv predicate @trace-buffer-state)))))
+
+(defn clear-trace-buffer!
+  "Empty the ring buffer. Tooling uses this between sessions. No-op in
+  production. Per Spec 009 §Retain-N trace ring buffer."
+  []
+  (when interop/debug-enabled?
+    (reset! trace-buffer-state []))
+  nil)
+
+(defn configure-trace-buffer!
+  "Set the ring buffer's depth. depth=0 disables the buffer (the delivery
+  path still works). The new depth applies on the next append; existing
+  entries are trimmed to fit immediately. No-op in production.
+
+  Per Spec 009 §Retain-N trace ring buffer."
+  [{:keys [depth]}]
+  (when (and interop/debug-enabled? (number? depth) (not (neg? depth)))
+    (reset! buffer-depth depth)
+    (swap! trace-buffer-state
+           (fn [v]
+             (let [n (count v)]
+               (cond
+                 (zero? depth) []
+                 (> n depth)   (subvec v (- n depth))
+                 :else         v)))))
+  nil)
+
+(defn configure
+  "Generic config dispatch. Recognises :trace-buffer; future config knobs
+  add cases here. Per Spec 009 §Retain-N trace ring buffer
+  (`(rf/configure :trace-buffer {:depth N})`)."
+  [k opts]
+  (case k
+    :trace-buffer (configure-trace-buffer! opts)
+    nil))
+
+;; ---- delivery hook ------------------------------------------------------
+;;
+;; `re-frame.trace/deliver!` looks this up via late-bind and calls it
+;; once per emitted event (after the epoch-capture fan-out). Centralising
+;; the buffer-push + listener fan-out in one hook keeps trace.cljc free
+;; of any reference to the buffer state or listener atom — so a
+;; production build that never `:requires` this ns DCEs the whole body.
+
+(defn- deliver-to-tooling!
+  "Push `event` onto the ring buffer (if depth > 0) and fan it out to
+  every registered listener. Listener throws are isolated. No-op in
+  production (interop/debug-enabled? gate inside push-to-buffer! and at
+  the emit call site)."
+  [event]
+  (push-to-buffer! event)
+  (doseq [[_ f] @listeners]
+    (try
+      (f event)
+      (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+(late-bind/set-fn! :trace.tooling/deliver! deliver-to-tooling!)
+
+;; `re-frame.core/configure :trace-buffer` routes through this hook so
+;; consumer call sites don't have to thread the tooling-ns require
+;; into the host's boot path. Keeping just THIS one knob hook (vs the
+;; full set the listener / buffer surface uses) is deliberate: the
+;; per-fn hooks would each pay a keyword-intern cost in every
+;; consumer of `re-frame.core`, even when the wrappers' bodies were
+;; dead code (the keyword constructor runs at module init).
+;; `configure` is a low-traffic op so the extra indirection costs
+;; nothing on the hot path.
+
+(late-bind/set-fn! :trace.tooling/configure-trace-buffer! configure-trace-buffer!)
+
+;; ---- bundle-isolation sentinel ------------------------------------------
+;;
+;; Per rf2-qwm0a: `implementation/scripts/check-bundle-isolation.cjs`
+;; greps the counter bundle for this exact string. The string lives
+;; ONLY in this file's source body — no other namespace, no docstring,
+;; no test fixture references it — so its presence in the production
+;; counter bundle proves that the tooling sibling's body got pulled in
+;; (most likely via a stray `:require` from a core/* ns). The sentinel
+;; survives `:advanced` because string literals are not renamed; it
+;; sits outside any `interop/debug-enabled?` gate so DCE cannot drop
+;; the literal independently of the surrounding ns body.
+
+(defonce ^:private bundle-isolation-sentinel
+  "rf.trace.tooling/sentinel:rf2-qwm0a-2026-05-16:do-not-rename")

--- a/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
+++ b/implementation/core/test/re_frame/conformance_corpus_cljs_test.cljs
@@ -222,14 +222,16 @@
 ;; registrations survive because we captured them late.
 
 (def ^:private baseline-trace-listeners
-  ;; `re-frame.trace/listeners` is `^:private` but CLJS treats
-  ;; private metadata as advisory — the symbol resolves through the
-  ;; namespace and the atom is reachable for tests that need to
-  ;; snapshot framework listeners (the SSR error-projection listener
-  ;; in particular). The JVM runner achieves the same effect
-  ;; implicitly via `(require :reload)` of `re-frame.ssr`; CLJS has
-  ;; no analogue, so this access is the bridge.
-  @re-frame.trace/listeners)
+  ;; Per rf2-qwm0a the listener registry atom moved from
+  ;; `re-frame.trace/listeners` to `re-frame.trace.tooling/listeners`
+  ;; (the production-DCE split). CLJS treats `^:private` metadata as
+  ;; advisory — the symbol resolves through the namespace and the
+  ;; atom is reachable for tests that need to snapshot framework
+  ;; listeners (the SSR error-projection listener in particular). The
+  ;; JVM runner achieves the same effect implicitly via
+  ;; `(require :reload)` of `re-frame.ssr`; CLJS has no analogue, so
+  ;; this access is the bridge.
+  @re-frame.trace.tooling/listeners)
 
 (def ^:private pretest-registrar
   ;; Mutable cell, set on deftest entry.
@@ -280,7 +282,7 @@
   ;;    runner achieves the equivalent via `clear-trace-cbs!` +
   ;;    `(require 're-frame.ssr :reload)`; CLJS has no `:reload`,
   ;;    so the snapshot-restore path is the only correct one.
-  (reset! re-frame.trace/listeners baseline-trace-listeners)
+  (reset! re-frame.trace.tooling/listeners baseline-trace-listeners)
   ;; 7. rf2-wxe9t — drop every corpus-wide error-emit listener so
   ;;    a recorder installed by `collect-error-emit-records!` for
   ;;    one fixture cannot fire against the next fixture's drains.
@@ -518,7 +520,7 @@
 
 (defn- collect-traces [fixture-id]
   (let [traces (atom [])]
-    (trace/register-trace-cb! [fixture-id] (fn [ev] (swap! traces conj ev)))
+    (re-frame.trace.tooling/register-trace-cb! [fixture-id] (fn [ev] (swap! traces conj ev)))
     traces))
 
 (defn- collect-error-emit-records!
@@ -997,7 +999,7 @@
         ;; listener snapshot at the next fixture's start, so this is
         ;; mostly belt-and-braces — but it keeps the in-fixture-end
         ;; state from leaking error traces against a missing :rf/route.
-        (trace/remove-trace-cb! fid)
+        (re-frame.trace.tooling/remove-trace-cb! fid)
         ;; rf2-wxe9t — drop just this fixture's error-emit recorder so
         ;; it does not leak into the next fixture's drains. The
         ;; reset-runtime! call also clears the registry on next entry;

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -40,6 +40,12 @@
             [re-frame.registrar    :as registrar]
             [re-frame.schemas      :as schemas]
             [re-frame.trace        :as trace]
+            ;; rf2-qwm0a — listener + buffer surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split). The
+            ;; probe touches it to keep both surfaces reachable so
+            ;; their `interop/debug-enabled?` gates are tested in the
+            ;; closure DCE pass, not surface-pruned before DCE runs.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch        :as epoch]
             [re-frame.http-managed :as http-managed]
             [re-frame.views        :as views]
@@ -50,15 +56,15 @@
 (defn ^:export touch-trace! []
   ;; Reach into every documented trace API so :advanced keeps the surface
   ;; alive and we're testing the *body* gates, not surface-pruning.
-  (rf/register-trace-cb! ::probe (fn [_ev] nil))
+  (trace-tooling/register-trace-cb! ::probe (fn [_ev] nil))
   (rf/emit-trace-event! :event :rf.probe/touched {:source :probe})
-  (rf/remove-trace-cb! ::probe)
+  (trace-tooling/remove-trace-cb! ::probe)
   ;; rf2-smee — trace ring buffer (Spec 009 §Retain-N).  These public
   ;; entry points must elide their bodies in production.
-  (trace/configure-trace-buffer! {:depth 50})
-  (let [_buf (trace/trace-buffer {:op-type :event})]
+  (trace-tooling/configure-trace-buffer! {:depth 50})
+  (let [_buf (trace-tooling/trace-buffer {:op-type :event})]
     nil)
-  (trace/clear-trace-buffer!))
+  (trace-tooling/clear-trace-buffer!))
 
 ;; ---- schemas surface ------------------------------------------------------
 

--- a/implementation/core/test/re_frame/late_bind_drift_test.clj
+++ b/implementation/core/test/re_frame/late_bind_drift_test.clj
@@ -62,9 +62,10 @@
   "Match `(late-bind/set-fn! :namespace/key ...`.
 
   The keyword grammar follows the late-bind convention of namespaced
-  keywords with `/` separator. The regex is intentionally loose on
-  whitespace so multi-line forms match."
-  #"\(late-bind/set-fn!\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+  keywords with `/` separator. Namespace portion may contain `.`
+  (e.g. `:trace.tooling/deliver!`, rf2-qwm0a). The regex is
+  intentionally loose on whitespace so multi-line forms match."
+  #"\(late-bind/set-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
 (def ^:private route-hook-call-re
   "Match `(substrate-adapter/route-hook! adapter :namespace/key ...`.
@@ -75,7 +76,7 @@
   registered handler). The wrapper invokes `late-bind/set-fn!`
   internally — the drift scan must treat both call shapes as
   equivalent publications."
-  #"\(substrate-adapter/route-hook!\s+\S+\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+  #"\(substrate-adapter/route-hook!\s+\S+\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
 (def ^:private chain-fn-call-re
   "Match `(late-bind/chain-fn! :namespace/key ...`.
@@ -84,7 +85,7 @@
   (which calls `set-fn!` internally, wrapping the step-fn in a
   chain-into-previous closure). Drift scan treats this call shape as
   equivalent to direct `set-fn!` publication."
-  #"\(late-bind/chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
+  #"\(late-bind/chain-fn!\s+(:[a-zA-Z][a-zA-Z0-9.!?*+\-]*/[a-zA-Z][a-zA-Z0-9!?*+\-]*)")
 
 (defn- match-keys
   [re content]

--- a/implementation/core/test/re_frame/source_coord_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coord_cljs_test.cljs
@@ -8,6 +8,8 @@
   regression."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -17,9 +19,9 @@
 (defn- record-traces
   [body-fn]
   (let [seen (atom [])]
-    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (trace-tooling/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
     (try (body-fn)
-         (finally (rf/remove-trace-cb! ::rec)))
+         (finally (trace-tooling/remove-trace-cb! ::rec)))
     @seen))
 
 (defn- errors-of [evs op]

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -19,7 +19,11 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — load the tooling sibling so the late-bind
+            ;; hooks behind `trace/clear-trace-cbs!` / `rf/trace-buffer`
+            ;; / `rf/configure :trace-buffer` / etc. are registered.
+            [re-frame.trace.tooling]))
 
 ;; ---- fixtures --------------------------------------------------------------
 
@@ -134,7 +138,13 @@
     ;; the flag is false at compile time. We assert the source contains
     ;; the gate at the right call sites; combined with the existing
     ;; trace-test envelope coverage, this protects the elision contract.
-    (let [src (slurp "src/re_frame/trace.cljc")]
+    ;;
+    ;; Per rf2-qwm0a the buffer + filter-predicate body live in
+    ;; re-frame.trace.tooling (the sibling ns split off so production
+    ;; counter bundles DCE them); the `re-frame.trace/trace-buffer` etc.
+    ;; wrappers delegate through late-bind hooks and return [] when the
+    ;; tooling ns is absent. The gate check lives in the tooling source.
+    (let [src (slurp "src/re_frame/trace/tooling.cljc")]
       (is (re-find #"\(defn-? push-to-buffer![\s\S]*?interop/debug-enabled\?" src)
           "push-to-buffer! is gated on interop/debug-enabled?")
       (is (re-find #"\(defn-? trace-buffer[\s\S]*?interop/debug-enabled\?" src)

--- a/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_listener_elision_prod_test.cljs
@@ -11,7 +11,7 @@
   `goog.DEBUG=false` + `:advanced`) so the gate is constant-folded by the
   closure compiler. Under that compile:
 
-    - `(rf/register-trace-cb! ...)` returns a key; the callback registry
+    - `(trace-tooling/register-trace-cb! ...)` returns a key; the callback registry
       atom still exists at the value layer, but
     - `(rf/dispatch-sync [...])` runs handlers normally yet
       `trace/emit!` becomes a no-op (its body sits inside the gate);
@@ -29,7 +29,10 @@
             [re-frame.core :as rf]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface (`register-trace-cb!`
+            ;; etc.) lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
@@ -43,7 +46,7 @@
             listener observes NO events when dispatch runs, because the
             emit call sites have been elided."
     (let [seen (atom [])]
-      (rf/register-trace-cb! ::prod-no-trace
+      (trace-tooling/register-trace-cb! ::prod-no-trace
         (fn [ev] (swap! seen conj ev)))
       (rf/reg-event-db :prod/ping
                        (fn [db _] (assoc db :pinged? true)))
@@ -54,19 +57,19 @@
           "the handler ran — only the trace surface is gated, not dispatch")
       (is (empty? @seen)
           "no events observed — Spec 009 §Production builds elision contract holds")
-      (rf/remove-trace-cb! ::prod-no-trace))))
+      (trace-tooling/remove-trace-cb! ::prod-no-trace))))
 
 (deftest emit-direct-call-is-noop-under-prod
   (testing "Direct invocation of trace/emit! is a no-op under prod-mode.
             The gate sits inside the fn body, so even bypassing the
             runtime's normal dispatch path doesn't escape elision."
     (let [seen (atom [])]
-      (rf/register-trace-cb! ::direct-emit (fn [ev] (swap! seen conj ev)))
+      (trace-tooling/register-trace-cb! ::direct-emit (fn [ev] (swap! seen conj ev)))
       ;; Direct emit — would deliver under dev-mode.
       (trace/emit! :info :rf.prod-test/direct-emit {:should "never appear"})
       (is (empty? @seen)
           "trace/emit! is a no-op under :advanced + goog.DEBUG=false")
-      (rf/remove-trace-cb! ::direct-emit))))
+      (trace-tooling/remove-trace-cb! ::direct-emit))))
 
 (deftest clear-trace-cbs-returns-nil-under-prod
   (testing "clear-trace-cbs! still returns nil under prod-mode — the
@@ -74,6 +77,6 @@
             the emit/deliver path is. clear-trace-cbs! must work the
             same way as it does under dev so test fixtures that call
             it in prod-mode CI runs don't error."
-    (rf/register-trace-cb! ::prod-clear (fn [_ev] nil))
-    (is (nil? (trace/clear-trace-cbs!))
+    (trace-tooling/register-trace-cb! ::prod-clear (fn [_ev] nil))
+    (is (nil? (trace-tooling/clear-trace-cbs!))
         "clear-trace-cbs! returns nil consistently across dev and prod")))

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -35,7 +35,10 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — load the tooling sibling so the late-bind
+            ;; hooks behind the listener API resolve.
+            [re-frame.trace.tooling]))
 
 ;; ---- fixtures --------------------------------------------------------------
 

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -30,7 +30,16 @@
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
-            [re-frame.trace :as trace]))
+            [re-frame.trace :as trace]
+            ;; rf2-qwm0a: the public-tooling surface
+            ;; (`register-trace-cb!` / `clear-trace-cbs!` / `trace-buffer`
+            ;; / …) lives in `re-frame.trace.tooling`. `re-frame.trace`
+            ;; ships thin wrappers delegating via late-bind so production
+            ;; bundles DCE the buffer/listener machinery — but the hooks
+            ;; only publish once `trace.tooling` loads. This test does
+            ;; not use `re-frame.test-support` (which transitively loads
+            ;; the tooling ns), so we require it directly here.
+            [re-frame.trace.tooling]))
 
 ;; ---- fixtures --------------------------------------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -40,6 +40,8 @@
   `:ns-regexp \"cljs-test$\"`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch :as epoch]
             [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -150,7 +152,7 @@
     (let [cb-seen    (atom [])
           trace-seen (atom [])]
       (rf/register-epoch-cb! ::watcher (fn [r] (swap! cb-seen conj r)))
-      (rf/register-trace-cb! ::recorder
+      (trace-tooling/register-trace-cb! ::recorder
                              (fn [ev]
                                (when (= :rf.epoch/snapshotted (:operation ev))
                                  (swap! trace-seen conj ev))))
@@ -160,7 +162,7 @@
       (rf/dispatch-sync [:n/inc])
 
       (rf/remove-epoch-cb! ::watcher)
-      (rf/remove-trace-cb! ::recorder)
+      (trace-tooling/remove-trace-cb! ::recorder)
 
       (is (= 3 (count @cb-seen))
           "register-epoch-cb! fired once per dispatch")

--- a/implementation/machines/test/re_frame/final_state_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/final_state_cljs_test.cljc
@@ -28,6 +28,11 @@
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
+   ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`
+   ;; (production-DCE split). On JVM the convenience aliases in
+   ;; re-frame.core preserve the `rf/<name>` shape, but on CLJS the
+   ;; tooling sibling must be referenced directly.
+   [re-frame.trace.tooling :as trace-tooling]
    [re-frame.machines :as machines]
    [re-frame.registrar :as registrar]
    [re-frame.test-support :as test-support]
@@ -50,7 +55,7 @@
 (defn- record-traces!
   [k]
   (let [a (atom [])]
-    (rf/register-trace-cb! k (fn [ev] (swap! a conj ev)))
+    (trace-tooling/register-trace-cb! k (fn [ev] (swap! a conj ev)))
     a))
 
 ;; ---- (a) entering :final? triggers :on-done with the right output ---------

--- a/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_after_cljs_test.cljs
@@ -23,6 +23,8 @@
   Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -48,7 +50,7 @@
             :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :http/flow machine)
-      (rf/register-trace-cb! ::after (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::after (fn [ev] (swap! traces conj ev)))
       ;; Step 1 — enter :loading; timer schedules at epoch 1.
       (rf/dispatch-sync [:http/flow [:fetch]])
       (let [s (snapshot :http/flow)]
@@ -76,7 +78,7 @@
                        (= 1    (:epoch  (:tags ev)))))
                 @traces)
           "expected :rf.machine.timer/fired trace with matching epoch")
-      (rf/remove-trace-cb! ::after)))
+      (trace-tooling/remove-trace-cb! ::after)))
 
   (testing ":after stale detection — real event beats timer; stale firing must not transition"
     (let [machine
@@ -105,9 +107,9 @@
       ;; (b) the runtime emits :rf.machine.timer/stale-after as the
       ;; canonical signal so observers can distinguish "suppressed stale
       ;; firing" from "no firing at all" (rf2-7urp).
-      (rf/register-trace-cb! ::stale (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::stale (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:http2/flow [:rf.machine.timer/after-elapsed 5000 1]])
-      (rf/remove-trace-cb! ::stale)
+      (trace-tooling/remove-trace-cb! ::stale)
       (is (= :ready (:state (snapshot :http2/flow)))
           "stale timer must not fire its transition")
       (is (= 2 (get-in (snapshot :http2/flow) [:data :rf/after-epoch]))
@@ -150,7 +152,7 @@
               :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :a/multi-cljs m)
-      (rf/register-trace-cb! ::mg (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::mg (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:a/multi-cljs [:fetch]])
       (let [epoch (get-in (snapshot :a/multi-cljs) [:data :rf/after-epoch])]
         ;; The 5s timer fires first; guard :slow? false → suppressed.
@@ -166,7 +168,7 @@
         (rf/dispatch-sync [:a/multi-cljs [:rf.machine.timer/after-elapsed 30000 epoch]])
         (is (= :timeout (:state (snapshot :a/multi-cljs)))
             "sibling timer transitions on its own")
-        (rf/remove-trace-cb! ::mg)))))
+        (trace-tooling/remove-trace-cb! ::mg)))))
 
 ;; ---- subscription-vector :after delay (dynamic) --------------------------
 
@@ -189,7 +191,7 @@
               :ready   {}}}
           traces (atom [])]
       (rf/reg-machine :a/sub-cljs m)
-      (rf/register-trace-cb! ::sub (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::sub (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:a/sub-cljs [:fetch]])
       (is (= :loading (:state (snapshot :a/sub-cljs))))
       (is (some (fn [ev]
@@ -198,4 +200,4 @@
                        (= :a/timeout-config  (:sub-id (:tags ev)))))
                 @traces)
           ":scheduled trace emitted with :delay-source :sub and :sub-id")
-      (rf/remove-trace-cb! ::sub))))
+      (trace-tooling/remove-trace-cb! ::sub))))

--- a/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_always_cljs_test.cljs
@@ -10,6 +10,8 @@
   Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -85,9 +87,9 @@
             :b     {:always [{:guard :p? :target :a}]}}}
           traces (atom [])]
       (rf/reg-machine :osc/flow machine)
-      (rf/register-trace-cb! ::osc (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::osc (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:osc/flow [:go]])
-      (rf/remove-trace-cb! ::osc)
+      (trace-tooling/remove-trace-cb! ::osc)
       ;; Atomic rollback: external snapshot stays at :start.
       (is (= :start (:state (snapshot :osc/flow)))
           "macrostep is atomic; cycle aborts; snapshot rolls back to input")

--- a/implementation/machines/test/re_frame/machines_invoke_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_invoke_cljs_test.cljs
@@ -27,6 +27,8 @@
   Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -71,7 +73,7 @@
       ;; Entering :authenticating: :rf.machine/spawn fx fires
       ;; (→ :rf.machine/spawned trace), :on-spawn callback records the
       ;; deterministic actor id into :data.:pending.
-      (rf/register-trace-cb! ::inv (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::inv (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:auth3/flow [:submit]])
       (let [s (snapshot :auth3/flow)]
         (is (= :authenticating (:state s)))
@@ -86,7 +88,7 @@
       ;; fires targeting the recorded actor id.
       (reset! traces [])
       (rf/dispatch-sync [:auth3/flow [:auth/failed]])
-      (rf/remove-trace-cb! ::inv)
+      (trace-tooling/remove-trace-cb! ::inv)
       (is (= :idle (:state (snapshot :auth3/flow))))
       (is (some (fn [ev]
                   (and (= :rf.machine/destroyed (:operation ev))
@@ -169,7 +171,7 @@
           traces (atom [])]
       (rf/reg-machine :child/auth-after child)
       (rf/reg-machine :sup/auth-after  parent)
-      (rf/register-trace-cb! ::ato (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::ato (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:sup/auth-after [:go]])
       (is (= :authenticating (:state (snapshot :sup/auth-after)))
           "parent transitioned :idle → :authenticating")
@@ -192,7 +194,7 @@
         (is (nil? (get-in (rf/get-frame-db :rf/default)
                           [:rf/machines child-id]))
             "child machine snapshot torn down by the standard exit cascade"))
-      (rf/remove-trace-cb! ::ato))))
+      (trace-tooling/remove-trace-cb! ::ato))))
 
 ;; ---- :timeout-ms on :invoke / :invoke-all is rejected (rf2-3y3y) ---------
 

--- a/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
+++ b/implementation/machines/test/re_frame/machines_system_id_cljs_test.cljs
@@ -15,6 +15,8 @@
   Split out of `machines_cljs_test.cljs` (rf2-3vps4)."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
 
@@ -117,10 +119,10 @@
           {:fx [[:rf.machine/spawn {:machine-id :w/proc
                                     :id-prefix  :w/proc
                                     :system-id  :primary}]]}))
-      (rf/register-trace-cb! ::col (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::col (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [::spawn1])
       (rf/dispatch-sync [::spawn2])
-      (rf/remove-trace-cb! ::col)
+      (trace-tooling/remove-trace-cb! ::col)
       ;; Second spawn rebinds.
       (is (= :w/proc#2 (rf/machine-by-system-id :primary))
           "second spawn rebound :primary to the new actor")

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -22,6 +22,8 @@
   API.md `route-link` row's click-rules paragraph."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.routing :as routing]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
@@ -70,7 +72,7 @@
   [props event]
   (let [dispatched (atom nil)
         cb-key     (keyword (gensym "click-capture-"))]
-    (rf/register-trace-cb!
+    (trace-tooling/register-trace-cb!
       cb-key
       (fn [ev]
         (when (and (= :event/dispatched (:operation ev))
@@ -85,7 +87,7 @@
          :prevented? (.-defaultPrevented event)
          :href       (:href attrs)})
       (finally
-        (rf/remove-trace-cb! cb-key)))))
+        (trace-tooling/remove-trace-cb! cb-key)))))
 
 ;; ---- href synthesis (CLJS sanity) --------------------------------------
 

--- a/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/routing_history_cljs_test.cljs
@@ -31,6 +31,8 @@
   restoration."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.routing :as routing]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
@@ -192,7 +194,7 @@
   [thunk]
   (let [captured (atom [])
         cb-key   (keyword (gensym "route-trace-"))]
-    (rf/register-trace-cb!
+    (trace-tooling/register-trace-cb!
       cb-key
       (fn [ev]
         (when (= :rf.route.nav-token/allocated (:operation ev))
@@ -201,7 +203,7 @@
       (let [r (thunk)]
         [r @captured])
       (finally
-        (rf/remove-trace-cb! cb-key)))))
+        (trace-tooling/remove-trace-cb! cb-key)))))
 
 ;; ---- routes used across the suite ---------------------------------------
 
@@ -396,7 +398,7 @@
       (let [fragment-changed (atom [])
             allocations      (atom [])
             cb-key           (keyword (gensym "hashchange-"))]
-        (rf/register-trace-cb!
+        (trace-tooling/register-trace-cb!
           cb-key
           (fn [ev]
             (case (:operation ev)
@@ -408,7 +410,7 @@
         (try
           (rf/dispatch-sync [:rf/url-changed "/articles/intro#section-2"])
           (finally
-            (rf/remove-trace-cb! cb-key)))
+            (trace-tooling/remove-trace-cb! cb-key)))
 
         (is (= 1 (count @fragment-changed))
             "fragment-only nav emits :rf.route/url-changed exactly once")

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -42,6 +42,8 @@
             ;; at the boundary is to require the adapter ns at boot.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.test-support :as test-support]))
@@ -107,9 +109,9 @@
         [rf/validate-at-boundary]
         (fn [_ _] (swap! calls inc) {}))
       (let [traces (atom [])]
-        (rf/register-trace-cb! ::prod-no-trace (fn [ev] (swap! traces conj ev)))
+        (trace-tooling/register-trace-cb! ::prod-no-trace (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:api/strict "not-an-int"])
-        (rf/remove-trace-cb! ::prod-no-trace)
+        (trace-tooling/remove-trace-cb! ::prod-no-trace)
         (is (= 0 @calls)
             "handler skipped (boundary did its job)")
         ;; Under `:advanced` + `goog.DEBUG=false` the trace surface is

--- a/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_cljs_test.cljs
@@ -24,6 +24,8 @@
             ;; §Recommended soft-pass) and no failure trace fires.
             [re-frame.schemas.malli]
             [re-frame.core :as rf]
+            ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.late-bind :as late-bind]
             [re-frame.schemas :as schemas]
             [re-frame.adapter.reagent :as reagent-adapter]
@@ -56,10 +58,10 @@
     (rf/reg-event-db :n/init  (fn [_ _] {:n 0}))
     (rf/reg-event-db :n/break (fn [db _] (assoc db :n "boom")))
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::cljs-live (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::cljs-live (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/init])
       (rf/dispatch-sync [:n/break])
-      (rf/remove-trace-cb! ::cljs-live)
+      (trace-tooling/remove-trace-cb! ::cljs-live)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -81,11 +83,11 @@
     (rf/reg-event-db :n/init (fn [_ _] {:n 0}))
     (rf/reg-event-db :n/inc  (fn [db _] (update db :n inc)))
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::cljs-ok (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::cljs-ok (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:n/init])
       (rf/dispatch-sync [:n/inc])
       (rf/dispatch-sync [:n/inc])
-      (rf/remove-trace-cb! ::cljs-ok)
+      (trace-tooling/remove-trace-cb! ::cljs-ok)
       (is (empty? (filter #(= :rf.error/schema-validation-failure
                               (:operation %))
                           @traces))
@@ -119,9 +121,9 @@
     (rf/reg-event-db :user/set-age-bad
       (fn [db _] (assoc-in db [:user :age] "twenty-three")))
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::t0hq (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::t0hq (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:user/set-age-bad])
-      (rf/remove-trace-cb! ::t0hq)
+      (trace-tooling/remove-trace-cb! ::t0hq)
       (let [violations (filter #(= :rf.error/schema-validation-failure
                                    (:operation %))
                                @traces)]
@@ -148,9 +150,9 @@
         (rf/reg-app-schema [:n] :int)
         (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
         (let [traces (atom [])]
-          (rf/register-trace-cb! ::no-adapter (fn [ev] (swap! traces conj ev)))
+          (trace-tooling/register-trace-cb! ::no-adapter (fn [ev] (swap! traces conj ev)))
           (rf/dispatch-sync [:n/break])
-          (rf/remove-trace-cb! ::no-adapter)
+          (trace-tooling/remove-trace-cb! ::no-adapter)
           (is (empty? (filter #(= :rf.error/schema-validation-failure
                                   (:operation %))
                               @traces))
@@ -178,12 +180,12 @@
           (swap! calls inc)
           db))
       (let [traces (atom [])]
-        (rf/register-trace-cb! ::cljs-ev (fn [ev] (swap! traces conj ev)))
+        (trace-tooling/register-trace-cb! ::cljs-ev (fn [ev] (swap! traces conj ev)))
         ;; Well-typed payload — handler runs.
         (rf/dispatch-sync [:user/register {:email "a@b.com" :age 30}])
         ;; Malformed — handler must NOT run.
         (rf/dispatch-sync [:user/register {:email "c@d.com" :age "no"}])
-        (rf/remove-trace-cb! ::cljs-ev)
+        (trace-tooling/remove-trace-cb! ::cljs-ev)
         (is (= 1 @calls)
             "handler ran exactly once — the bad payload was rejected pre-handler")
         (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -231,10 +233,10 @@
         (rf/reg-event-db :n/init  (fn [_ _] {:n 42}))
         (rf/reg-event-db :n/break (fn [db _] (assoc db :n 99)))
         (let [traces (atom [])]
-          (rf/register-trace-cb! ::cv (fn [ev] (swap! traces conj ev)))
+          (trace-tooling/register-trace-cb! ::cv (fn [ev] (swap! traces conj ev)))
           (rf/dispatch-sync [:n/init])
           (rf/dispatch-sync [:n/break])
-          (rf/remove-trace-cb! ::cv)
+          (trace-tooling/remove-trace-cb! ::cv)
           (is (pos? @calls)
               "the custom validator was invoked through the live dispatch path")
           (let [violations (filter #(= :rf.error/schema-validation-failure
@@ -255,9 +257,9 @@
       (rf/reg-app-schema [:n] :int)
       (rf/reg-event-db :n/break (fn [db _] (assoc db :n "definitely-not-an-int")))
       (let [traces (atom [])]
-        (rf/register-trace-cb! ::nv (fn [ev] (swap! traces conj ev)))
+        (trace-tooling/register-trace-cb! ::nv (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:n/break])
-        (rf/remove-trace-cb! ::nv)
+        (trace-tooling/remove-trace-cb! ::nv)
         (is (empty? (filter #(= :rf.error/schema-validation-failure
                                 (:operation %))
                             @traces))
@@ -294,14 +296,14 @@
       [rf/validate-at-boundary]
       (fn [_ _] {}))
     (let [traces (atom [])]
-      (rf/register-trace-cb! ::boundary-dev (fn [ev] (swap! traces conj ev)))
+      (trace-tooling/register-trace-cb! ::boundary-dev (fn [ev] (swap! traces conj ev)))
       ;; Direct :before invocation isolates the boundary's behaviour
       ;; from the surrounding router/step-1 path so we observe the
       ;; boundary's own dev-mode contract.
       (let [before    (:before rf/validate-at-boundary)
             valid-ctx (before {:coeffects {:event [:api/strict 42]}})
             bad-ctx   (before {:coeffects {:event [:api/strict "not-an-int"]}})]
-        (rf/remove-trace-cb! ::boundary-dev)
+        (trace-tooling/remove-trace-cb! ::boundary-dev)
         (is (not (:rf/skip-handler? valid-ctx))
             "valid event: boundary did not set :rf/skip-handler? (no-op)")
         (is (not (:rf/skip-handler? bad-ctx))
@@ -326,9 +328,9 @@
         [rf/validate-at-boundary]
         (fn [_ _] (swap! calls inc) {}))
       (let [traces (atom [])]
-        (rf/register-trace-cb! ::dev-dispatch (fn [ev] (swap! traces conj ev)))
+        (trace-tooling/register-trace-cb! ::dev-dispatch (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:api/strict "not-an-int"])
-        (rf/remove-trace-cb! ::dev-dispatch)
+        (trace-tooling/remove-trace-cb! ::dev-dispatch)
         (is (= 0 @calls)
             "handler was skipped — router's step-1 validation fired in dev")
         (let [boundary-violations (filter #(and (= :rf.error/schema-validation-failure (:operation %))

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -287,6 +287,28 @@ const ARTEFACTS = [
     expectedAllowListHits: 0,
   },
 
+  // re-frame.subs.tooling (rf2-bmzq0 — `sub-topology` and
+  // `sub-cache-snapshot` split off from re-frame.subs for production
+  // DCE). Counter never `:require`s `re-frame.subs.tooling` (Causa /
+  // pair2-mcp / re-frame-10x do, but counter is the no-feature
+  // reference app). When this contract holds, the tooling sibling's
+  // body is absent from the bundle entirely — the JVM-side aliases in
+  // `re-frame.subs` and `re-frame.core` are `#?(:clj ...)`-gated so
+  // they never appear in CLJS compilation. Sentinel mirrors the
+  // trace-tooling shape (rf2-qwm0a): a unique string planted at the
+  // bottom of the namespace body.
+  {
+    name: 'subs-tooling',
+    internalSentinels: [
+      // subs/tooling.cljc — explicit sentinel planted at the bottom
+      // of the namespace body (`bundle-isolation-sentinel`).
+      { source: 're-frame.subs.tooling (bundle-isolation-sentinel)',
+        sentinel: 'rf.subs.tooling/sentinel:rf2-bmzq0-2026-05-16:do-not-rename' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
+
   // Story Stage 8 (rf2-c9mm) per IMPL-SPEC §6.5. The plain
   // examples/counter bundle imports zero Story symbols — the
   // tools/story/ jar must DCE entirely when the consuming app

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -257,6 +257,36 @@ const ARTEFACTS = [
     expectedAllowListHits: 1,
   },
 
+  // re-frame.trace.tooling (rf2-qwm0a — dev-tooling buffer + listener
+  // surface split off from re-frame.trace for production DCE). The
+  // counter example never `:require`s `re-frame.trace.tooling`
+  // (test-support / Causa preload / Story / pair2-mcp do, but counter
+  // is the no-feature reference app). When this contract holds, the
+  // tooling sibling's body is absent from the bundle entirely — the
+  // `re-frame.trace/register-trace-cb!` etc. wrappers are thin
+  // late-bind shells whose `:trace.tooling/*` lookups resolve to nil
+  // and no-op. The sentinel below is a distinctive string fragment
+  // from the tooling's `trace-buffer` filter-predicate body that does
+  // NOT appear anywhere else in the framework source. A non-zero hit
+  // means the tooling ns slipped into the bundle (most likely a
+  // `:require [re-frame.trace.tooling]` was added to a core/* ns).
+  {
+    name: 'trace-tooling',
+    internalSentinels: [
+      // trace/tooling.cljc — explicit sentinel string planted at the
+      // bottom of the namespace body (`bundle-isolation-sentinel`).
+      // Survives `:advanced` (string literals are not renamed) and
+      // sits OUTSIDE any `interop/debug-enabled?` gate so DCE cannot
+      // drop the literal independently of the surrounding ns body.
+      // The string deliberately includes the bead id and the date it
+      // was planted so a future grep can trace it back to the split.
+      { source: 're-frame.trace.tooling (bundle-isolation-sentinel)',
+        sentinel: 'rf.trace.tooling/sentinel:rf2-qwm0a-2026-05-16:do-not-rename' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
+
   // Story Stage 8 (rf2-c9mm) per IMPL-SPEC §6.5. The plain
   // examples/counter bundle imports zero Story symbols — the
   // tools/story/ jar must DCE entirely when the consuming app

--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -61,7 +61,11 @@
             ;; :ssr.streaming/build-final-payload) land at ns-load time
             ;; before any host adapter calls them.
             re-frame.ssr.streaming
-            [re-frame.trace :as trace]))
+            ;; Per rf2-qwm0a SSR's error-projection trace listener
+            ;; targets the tooling sibling directly. The framework's
+            ;; `re-frame.trace` no longer re-exports the listener
+            ;; surface (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---- public-surface re-exports --------------------------------------------
 ;;
@@ -252,8 +256,8 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
                      {:doc "Built-in default projector. Spec 011 §Default projector mapping."}
                      default-error-projector-fn)
 
-(trace/register-trace-cb! ::error-projection
-                          error-listener/error-projection-listener)
+(trace-tooling/register-trace-cb! ::error-projection
+                                  error-listener/error-projection-listener)
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -30,6 +30,11 @@
 
 (ns re-frame-pair2.runtime
   (:require [re-frame.core :as rf]
+            ;; rf2-bmzq0: sub-cache-snapshot lives in re-frame.subs.tooling
+            ;; (production-DCE split). pair2 is dev-tier — loading the
+            ;; tooling sibling here is bundle-isolation-safe (the
+            ;; preload is dev-only).
+            [re-frame.subs.tooling :as subs-tooling]
             [re-frame.interop :as interop]
             [clojure.data :as data]
             [clojure.string :as str]))
@@ -327,7 +332,7 @@
    subscription in the operating frame. CLJS-only; nil on JVM."
   ([] (sub-cache (current-frame)))
   ([frame-id]
-   (rf/sub-cache frame-id)))
+   (subs-tooling/sub-cache-snapshot frame-id)))
 
 (defn subs-sample
   "Subscribe to query-v in the operating frame and deref once. Goes
@@ -1520,7 +1525,7 @@
   [frame-id slice]
   (case slice
     :app-db     (rf/get-frame-db frame-id)
-    :sub-cache  (rf/sub-cache frame-id)
+    :sub-cache  (subs-tooling/sub-cache-snapshot frame-id)
     ;; The global machine-id list is registrar-level (not per-frame).
     ;; Per Spec 005 each frame holds its own machine snapshots at
     ;; [:rf/machines machine-id] in app-db, so the per-frame slice

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -35,6 +35,14 @@
             ;; tooling sibling here is bundle-isolation-safe (the
             ;; preload is dev-only).
             [re-frame.subs.tooling :as subs-tooling]
+            ;; rf2-qwm0a: register-trace-cb! / trace-buffer (and the rest of
+            ;; the listener + ring-buffer surface) live in
+            ;; re-frame.trace.tooling, not re-frame.trace. CLJS deliberately
+            ;; omits `rf/<name>` aliases for these so production counter
+            ;; bundles DCE the tooling sibling wholesale; this preload is
+            ;; dev-only, so requiring the tooling ns directly here is
+            ;; bundle-isolation-safe.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.interop :as interop]
             [clojure.data :as data]
             [clojure.string :as str]))
@@ -555,7 +563,7 @@
    safe to install unconditionally — `last-trace-event-id` keeps
    working through it."
   []
-  (rf/register-trace-cb! :re-frame-pair2 on-trace-streaming))
+  (trace-tooling/register-trace-cb! :re-frame-pair2 on-trace-streaming))
 
 (defn last-trace-event-id
   "Last trace event id observed by the skill's listener. Useful as a
@@ -936,7 +944,7 @@
                                         default-max-buffered-bytes)}]
       ;; Make sure the upgraded listeners are wired (idempotent — same
       ;; id, replaces the basic listeners installed by `health`).
-      (rf/register-trace-cb! :re-frame-pair2 on-trace-streaming)
+      (trace-tooling/register-trace-cb! :re-frame-pair2 on-trace-streaming)
       (rf/register-epoch-cb! :re-frame-pair2-epoch on-epoch-streaming)
       (swap! subscriptions assoc sub-id sub)
       {:ok? true :sub-id sub-id :topic topic :filter (:filter sub)})))
@@ -1023,7 +1031,7 @@
    per `(rf/configure :trace-buffer {:depth N})`). For long cascades use
    `(rf/configure :trace-buffer {:depth ...})` to widen the window."
   [root-dispatch-id]
-  (let [events     (rf/trace-buffer {:operation :event/dispatched})
+  (let [events     (trace-tooling/trace-buffer {:operation :event/dispatched})
         by-parent  (group-by #(get-in % [:tags :parent-dispatch-id]) events)
         node       (fn node [did]
                      (let [ev (some (fn [e] (when (= did (get-in e [:tags :dispatch-id])) e))
@@ -1536,7 +1544,7 @@
                   {:ids ids :state state})
     :epochs     (vec (rf/epoch-history frame-id))
     ;; The retain-N trace ring buffer is global; filter by frame.
-    :traces     (vec (rf/trace-buffer {:frame frame-id}))
+    :traces     (vec (trace-tooling/trace-buffer {:frame frame-id}))
     nil))
 
 (defn- snapshot-frame

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -333,6 +333,8 @@ Semantics:
 
 Why this is a framework primitive (not a Causa-specific concern): pair-shaped tools, REPL companions, and any non-Causa consumer needs recent-history access. Locating the buffer in the framework means external tools depend on a stable framework primitive rather than on Causa's internal data structures. See [Tool-Pair §How AI tools attach](Tool-Pair.md#how-ai-tools-attach) for the full consumption pattern.
 
+**Topology note (rf2-qwm0a).** The public-tooling surface — `register-trace-cb!` / `remove-trace-cb!` / `clear-trace-cbs!` / `trace-buffer` / `clear-trace-buffer!` / `configure-trace-buffer!` / `configure` — and the buffer + listener state live in the sibling `re-frame.trace.tooling` namespace, not `re-frame.trace` itself. `re-frame.trace` carries the always-loaded hot fast path (`emit!` / `emit-error!` / `*handler-scope*`); the tooling sibling is loaded only when a test fixture, tool (Causa / Story / pair2-mcp), or dev preload `:require`s it. The `rf/...` public Vars and the `re-frame.trace/<surface>` wrappers delegate via the `:trace.tooling/*` late-bind hooks so existing consumer call sites are unchanged. On the JVM the tooling sibling is autoloaded by `re-frame.trace` (zero bundle cost off-bundle). On CLJS the tooling sibling is omitted from production counter bundles — the hook lookups return nil and the wrappers no-op (DCE drops the body wholesale, ~2 KB raw / ~600 B gzipped saved).
+
 ## Emitting trace events
 
 The framework emits trace events through one entry point: `re-frame.trace/emit!`. User code may also call it (re-exported as `rf/emit-trace-event!`) to add custom events to the stream.

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -953,7 +953,7 @@ The framework owns the following per-frame allocation sites; **all MUST be relea
 What deliberately survives a per-request frame's destruction (these are **NOT** leaks — they are process-wide registries that mirror handler registration shape):
 
 - The global registrar (`re-frame.registrar/kind->id->metadata`) — event / sub / fx / cofx / view / route / error-projector / flow registrations are process-wide; they exist independently of any frame and do not leak per-request.
-- The retain-N trace ring buffer (`re-frame.trace/trace-buffer-state`, default depth 200) — a process-wide, capacity-bounded buffer; the size is fixed by configuration regardless of request count.
+- The retain-N trace ring buffer (`re-frame.trace.tooling/trace-buffer-state`, default depth 200) — a process-wide, capacity-bounded buffer; the size is fixed by configuration regardless of request count. (Per rf2-qwm0a the buffer state lives in the tooling sibling ns split off from `re-frame.trace` for production DCE; tools and tests reach it through `re-frame.trace/trace-buffer`'s late-bind wrapper.)
 - The substrate adapter slot (`re-frame.substrate.adapter/installed-adapter`) — set once at boot.
 
 The contract for **side-channel atoms keyed by frame-id**: every such atom MUST register a cleanup hook with `re-frame.late-bind` and that hook MUST be invoked from `frame/destroy-frame!`. The two existing keys are `:ssr/on-frame-destroyed` and `:epoch/on-frame-destroyed`; new artefacts that introduce per-frame side-channel state MUST follow the same pattern.

--- a/testbeds/ssr_basic/core.cljs
+++ b/testbeds/ssr_basic/core.cljs
@@ -45,7 +45,9 @@
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.ssr :as ssr]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [cljs.reader])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -79,7 +81,7 @@
   ;; HOT PATH — wire the trace bus to a window-side mirror so a
   ;; Playwright assertion can inspect the hydration trace stream
   ;; without poking at internal cljs vars.
-  (trace/register-trace-cb! ::ssr-basic-listener
+  (trace-tooling/register-trace-cb! ::ssr-basic-listener
     (fn [ev]
       (let [op (:operation ev)]
         (when (and op

--- a/testbeds/ssr_hydration_mismatch/core.cljs
+++ b/testbeds/ssr_hydration_mismatch/core.cljs
@@ -36,7 +36,9 @@
             [re-frame.views]
             [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.ssr :as ssr]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [cljs.reader])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
@@ -72,7 +74,7 @@
       (:recovery ev)       (assoc :recovery (str (:recovery ev))))))
 
 (defn install-trace-listener! []
-  (trace/register-trace-cb! ::ssr-hydration-mismatch-listener
+  (trace-tooling/register-trace-cb! ::ssr-hydration-mismatch-listener
     (fn [ev]
       (let [op (:operation ev)]
         (when (and op

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions_subs.cljs
@@ -1,6 +1,12 @@
 (ns day8.re-frame2-causa.panels.subscriptions-subs
   "Subscriptions/read-model registrations for the Subscriptions panel."
   (:require [re-frame.core :as rf]
+            ;; rf2-bmzq0: sub-cache-snapshot lives in re-frame.subs.tooling
+            ;; (production-DCE split). Causa is dev-tier — loading the
+            ;; tooling sibling here is bundle-isolation-safe (Causa's
+            ;; preload already excluded from production via shadow-cljs
+            ;; `:devtools/preloads`).
+            [re-frame.subs.tooling :as subs-tooling]
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.panels.subscriptions-helpers :as h]))
 
@@ -10,7 +16,7 @@
     (fn [db _query]
       (let [target (get db :target-frame defaults/default-target-frame)
             ov     (get db :sub-cache-override)]
-        (or ov (rf/sub-cache target)))))
+        (or ov (subs-tooling/sub-cache-snapshot target)))))
 
   (rf/reg-sub :rf.causa/sub-error-cache
     (fn [db _query]

--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -64,6 +64,14 @@
             ;; preload is dev-only and is excluded from production
             ;; bundles by the `:devtools/preloads` shadow-cljs gate.
             [re-frame.epoch]
+            ;; rf2-qwm0a — the public-tooling listener surface
+            ;; (`register-trace-cb!` etc.) lives in
+            ;; `re-frame.trace.tooling` for production-DCE reasons.
+            ;; Causa's trace-collector registration below targets the
+            ;; tooling sibling directly. The preload is dev-only
+            ;; (gated by shadow-cljs `:devtools/preloads`) so this
+            ;; require is excluded from production bundles.
+            [re-frame.trace.tooling :as trace-tooling]
             [day8.re-frame2-causa.keybinding :as keybinding]
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.registry :as registry]
@@ -106,8 +114,8 @@
   it directly without `#'`-piercing into private vars."
   []
   (when (compare-and-set! trace-cb-registered? false true)
-    (rf/register-trace-cb! :rf.causa/trace-collector
-                           trace-bus/collect-trace!))
+    (trace-tooling/register-trace-cb! :rf.causa/trace-collector
+                                      trace-bus/collect-trace!))
   nil)
 
 (defn register-epoch-collector!

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -83,7 +83,8 @@
 
 (defonce ^:private buffer-state
   ;; A plain vector under an atom; same shape as the framework's
-  ;; `re-frame.trace/trace-buffer-state`. Oldest entries at the head
+  ;; `re-frame.trace.tooling/trace-buffer-state` (sibling ns split per
+  ;; rf2-qwm0a). Oldest entries at the head
   ;; of the vector; conj appends and subvec evicts the head.
   (atom []))
 

--- a/tools/story/src/re_frame/story/play.cljc
+++ b/tools/story/src/re_frame/story/play.cljc
@@ -60,7 +60,10 @@
   - `play-stepper-active?` / `step-once!` — UI hooks (Stage 4's
                                             play-stepper slot)."
   (:require [re-frame.core             :as rf]
-            [re-frame.trace            :as trace]
+            ;; rf2-qwm0a — the listener surface
+            ;; (`register-trace-cb!` / `remove-trace-cb!`) lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling    :as trace-tooling]
             [re-frame.interop          :as interop]
             [re-frame.story.assertions :as assertions]
             [re-frame.story.async      :as async]
@@ -179,14 +182,14 @@
   [frame-id]
   (when config/enabled?
     (let [id (listener-id frame-id)]
-      (trace/register-trace-cb! id (listener-for-frame frame-id))
+      (trace-tooling/register-trace-cb! id (listener-for-frame frame-id))
       id)))
 
 (defn remove-trace-listener!
   "Tear down the per-frame trace listener for `frame-id`. Idempotent."
   [frame-id]
   (when config/enabled?
-    (trace/remove-trace-cb! (listener-id frame-id))
+    (trace-tooling/remove-trace-cb! (listener-id frame-id))
     nil))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -111,7 +111,9 @@
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
             [re-frame.story.review-dialog :as review-dialog]
-            [re-frame.trace :as trace]))
+            ;; rf2-qwm0a — listener surface lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: recordable event predicate
@@ -631,12 +633,12 @@
   tests directly."
   []
   (when config/enabled?
-    (trace/register-trace-cb! listener-id trace-listener)
+    (trace-tooling/register-trace-cb! listener-id trace-listener)
     nil))
 
 (defn remove-trace-listener!
   "Tear down the recorder's trace-bus listener. Idempotent."
   []
   (when config/enabled?
-    (trace/remove-trace-cb! listener-id)
+    (trace-tooling/remove-trace-cb! listener-id)
     nil))

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -49,7 +49,12 @@
             [re-frame.story.play      :as play]
             [re-frame.story.registrar :as registrar]
             [re-frame.interop         :as interop]
-            [re-frame.trace           :as trace]))
+            [re-frame.trace           :as trace]
+            ;; rf2-qwm0a — listener API lives in
+            ;; `re-frame.trace.tooling` (production-DCE split). The
+            ;; hot-path emit fast-path (`trace/emit!`) stays in
+            ;; `re-frame.trace`.
+            [re-frame.trace.tooling   :as trace-tooling]))
 
 ;; ---- empty / disabled result ---------------------------------------------
 
@@ -94,9 +99,9 @@
   [listener body-fn]
   (let [cb-id (keyword "re-frame.story.runtime"
                        (str "capture-" (swap! capture-counter inc)))]
-    (trace/register-trace-cb! cb-id listener)
+    (trace-tooling/register-trace-cb! cb-id listener)
     (try (body-fn)
-      (finally (trace/remove-trace-cb! cb-id)))))
+      (finally (trace-tooling/remove-trace-cb! cb-id)))))
 
 (defn- capture-phase-errors
   "Run `body-fn` (a 0-arg thunk) with a registered trace listener that

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -53,7 +53,9 @@
   (`filter-cascades-up-to` / `cascade-row-style`) so the same predicate
   runs under the JVM unit tests AND inside the CLJS render path."
   (:require [reagent.core :as r]
-            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — listener API lives in
+            ;; `re-frame.trace.tooling` (production-DCE split).
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.trace.projection :as projection]
             [re-frame.story.config :as config]
             [re-frame.story.ui.scrubber :as scrubber]
@@ -149,7 +151,7 @@
   [variant-id]
   (when config/enabled?
     (let [id (listener-id variant-id)]
-      (trace/register-trace-cb! id
+      (trace-tooling/register-trace-cb! id
         (fn [ev]
           (when (variant-event? variant-id ev)
             (if (config/suppress-sensitive? ev)
@@ -161,7 +163,7 @@
   "Tear down the trace listener for `variant-id`. Idempotent."
   [variant-id]
   (when config/enabled?
-    (trace/remove-trace-cb! (listener-id variant-id))
+    (trace-tooling/remove-trace-cb! (listener-id variant-id))
     nil))
 
 ;; ---- six-domino projection -----------------------------------------------


### PR DESCRIPTION
## Summary

Two-commit cluster splitting the public-tooling dev surfaces out of `re-frame.trace` and `re-frame.subs` into sibling `*.tooling` namespaces so production counter bundles DCE them and the contract is permanently pinned by bundle-isolation sentinels.

- **rf2-qwm0a** (commit 1): listener registry + retain-N ring buffer + filter predicate + 7 surface fns move from `re-frame.trace` → new `re-frame.trace.tooling`. `trace.cljc`'s `deliver!` reaches the tooling fan-out through the single `:trace.tooling/deliver!` late-bind hook (mirroring `:epoch/capture-event`).
- **rf2-bmzq0** (commit 2): `sub-topology` + `sub-cache-snapshot` move from `re-frame.subs` → new `re-frame.subs.tooling`. Same shape — pure relocation, JVM-only convenience aliases preserve legacy call sites.

CLJS consumers call `<ns>.tooling/<name>` directly (test-support, SSR error-projection, Causa preload, Story play/recorder/runtime/ui, pair2 runtime, testbeds, prod-elision probe, adapter / machine / routing / schemas / epoch CLJS tests). JVM consumers keep the legacy `re-frame.trace/<name>` / `re-frame.subs/<name>` / `rf/<name>` shape via `#?(:clj ...)` aliases — JVM has no Closure DCE bundle to protect; the aliases cost nothing.

## Bundle deltas

| Bundle | Baseline | Branch | Delta |
|---|---:|---:|---:|
| examples/counter | 369,315 | 369,315 | 0 |
| examples/realworld | 707,697 | 708,242 | +545 |
| examples/counter-uix | 350,048 | 350,048 | 0 |
| examples/counter-helix | 380,091 | 380,091 | 0 |
| reagent-slim counter | 366,384 | 366,384 | 0 |

Counter and the per-substrate variants are unchanged. The +545 byte realworld bump is from the two surviving `:trace.tooling/*` keyword interns (`:trace.tooling/deliver!` referenced from `trace/deliver!`, and `:trace.tooling/configure-trace-buffer!` referenced from `core/configure`'s case-block) — comparable to the existing `:epoch/capture-event` keyword-intern cost.

The audit's predicted ~1.5 KB save on counter didn't materialise because origin/main's Closure DCE was already eliminating the trace-tooling bodies through the identity-alias chain — the value of this split is the **bundle-isolation contract**: a stray `:require [re-frame.trace.tooling]` from a core/* ns would now be caught by CI rather than slipping through.

## Bundle-isolation sentinels

Two new `internalSentinels` rows in `implementation/scripts/check-bundle-isolation.cjs`:

- `trace-tooling` — greps for `rf.trace.tooling/sentinel:rf2-qwm0a-2026-05-16:do-not-rename`
- `subs-tooling` — greps for `rf.subs.tooling/sentinel:rf2-bmzq0-2026-05-16:do-not-rename`

Each sentinel is a unique string planted in a `defonce` at the bottom of its tooling ns, outside any `interop/debug-enabled?` gate so DCE cannot drop the literal independently of the surrounding body. Survives `:advanced` (string literals are not renamed by Closure).

## Late-bind drift fix

Drift regex updated to accept `.` in keyword namespaces — catches both the new `:trace.tooling/*` publication and the previously-missed `:ssr.streaming/*` keys (three orphaned directory entries added: `:ssr.streaming/render-shell!`, `:ssr.streaming/render-continuation!`, `:ssr.streaming/build-final-payload`).

## Spec touches

- `spec/009-Instrumentation.md` — topology note added to §Retain-N trace ring buffer.
- `spec/011-SSR.md` — process-wide-state callout updated to point at `re-frame.trace.tooling/trace-buffer-state`.

## Test plan

- [x] core/jvm: 521 tests, 2719 assertions, 0 fail
- [x] ssr/jvm: 153 tests, 490 assertions, 0 fail
- [x] epoch/jvm: 144 tests, 521 assertions, 0 fail
- [x] http/jvm: 183 tests, 529 assertions, 0 fail
- [x] flows/jvm: 78 tests, 349 assertions, 0 fail
- [x] machines/jvm: 167 tests, 578 assertions, 0 fail
- [x] schemas/jvm: 145 tests, 18094 assertions, 0 fail
- [x] routing/jvm: 98 tests, 450 assertions, 0 fail
- [x] node-test (CLJS): 2268 tests, 6455 assertions, 0 fail
- [x] bundle-isolation: PASS (11 artefact entries; 26 sentinels absent)
- [x] reagent-slim:bundle-isolation: PASS
- [x] elision: PASS (production 31/31 absent; control 31/31 present)
- [x] perf-bundle: PASS (off-count=0; on-count=12)
- [x] browser-prod-elision: PASS (29 tests, 108 assertions, 0 fail)

## Tool-Pair consumer impact

Zero call-site changes for consumers resolving via `re-frame.core/sub-topology` / `rf/sub-cache` / etc. on the JVM (the convenience aliases preserve the legacy shape). CLJS consumer updates:

- `tools/causa/src/.../subscriptions_subs.cljs` — one-line `:require` + ns swap (`rf/sub-cache` → `subs-tooling/sub-cache-snapshot`).
- `tools/causa/src/.../preload.cljs` — one-line `:require` + ns swap (`rf/register-trace-cb!` → `trace-tooling/register-trace-cb!`).
- `tools/story/src/re_frame/story/{play,recorder,runtime,ui/trace}` — same pattern.
- `skills/re-frame-pair2/.../runtime.cljs` — one-line update.
- `testbeds/ssr_{basic,hydration_mismatch}/core.cljs` — one-line update.