### PR TITLE
fix(core): delete redundant inject-cofx alias clobbering CLJ macro var (rf2-7imjx)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -569,7 +569,6 @@
 (def assoc-coeffect  interceptor/assoc-coeffect)
 (def get-effect      interceptor/get-effect)
 (def assoc-effect    interceptor/assoc-effect)
-(def inject-cofx     cofx/inject-cofx)
 (def path            std-interceptors/path)
 (def unwrap          std-interceptors/unwrap)
 

--- a/implementation/core/test/re_frame/source_coord_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_test.cljc
@@ -126,6 +126,11 @@
 
 ;; ---- inject-cofx / inject-cofx* -------------------------------------------
 
+(deftest inject-cofx-public-var-is-macro
+  #?(:clj
+     (testing "rf/inject-cofx in CLJ is a macro var (not clobbered by runtime alias)"
+       (is (true? (:macro (meta #'re-frame.core/inject-cofx)))))))
+
 (deftest inject-cofx-macro-stamps-call-site
   (testing ":rf.error/no-such-cofx carries the call site of inject-cofx (macro form)"
     (rf/reg-event-fx :rf2-ts1a/uses-missing-cofx


### PR DESCRIPTION
## Summary

P0 correctness fix discovered by `rf2-s60vj` audit probe.

`implementation/core/src/re_frame/core.cljc:572` held an **ungated** runtime alias `(def inject-cofx cofx/inject-cofx)` that clobbered the CLJ-guarded `defmacro inject-cofx` at line 405. In CLJ — where macros and fns share the var — top-to-bottom evaluation made the runtime def win, so JVM callers (SSR pipelines under `ssr/`, `ssr-ring/`, JVM tests) got the bare interceptor with **no `:rf.trace/call-site` source-coord stamping** on error events from inside cofx bodies.

CLJS users were unaffected: the macro lives in the JVM compile-time ns and CLJS user code resolves `rf/inject-cofx` to the macro via the `:require-macros` self-import at line 74. Hence the regression went undetected by `npm run test:cljs`.

`inject-cofx*` at line 342 remains the documented HoF / programmatic form. Line 572 was a redundant accidental copy — pure regression — and contradicted `spec/API.md:557` which already marks `inject-cofx` as `M` (macro). This PR **restores** the spec contract; no spec changes needed.

## Changes

- **Delete** the offending `(def inject-cofx cofx/inject-cofx)` line in `core.cljc`.
- **Add** a CLJ-only regression in `source_coord_test.cljc` asserting `(:macro (meta #'re-frame.core/inject-cofx))` is `true`.

```
 implementation/core/src/re_frame/core.cljc               | 1 -
 implementation/core/test/re_frame/source_coord_test.cljc | 5 +++++
```

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 523 tests / 2718 assertions, 0 failures, 0 errors. New `inject-cofx-public-var-is-macro` passes.
- [x] `npm run test:cljs` from `implementation/` — 2281 tests / 6488 assertions, 0 failures, 0 errors.
- [x] No consumer relied on the clobbered runtime alias (none could, since it was a silent regression of the macro's source-coord stamping).