### PR TITLE
fix+spec(privacy): rf2-lqmje (A) clear trace buffer on set-show-sensitive! false

### DIFF
--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1400,6 +1400,27 @@ User-side listeners (in-app recorders, dev panels, custom forwarders) have no fr
 
 The **user-controllable config knob** each consumer exposes for the default-suppress policy follows a fixed verb convention per [Conventions §Privacy config-knob naming](Conventions.md#privacy-config-knob-naming-on-box-ui-vs-off-box-wire-egress): on-box devtools UI consumers use the `show-sensitive?` verb under the `:trace/*` ns (e.g. `:trace/show-sensitive?` — UI visibility), while off-box wire-egress consumers (the MCP triplet, the pair2 preload) use the **unqualified** `include-sensitive?` verb (e.g. `{:rf.size/include-sensitive? false}` on the elision policy map — wire egress). Both default to suppress; the verb choice tells the reader which trust boundary the knob governs without re-deriving from context.
 
+#### Retroactive-scrub on `set-show-sensitive!` false
+
+Resolved per **rf2-lqmje**.
+
+The on-box `show-sensitive?` knob is **not a one-way trapdoor**. Each consumer's `(set-show-sensitive! v)` is gated at ingest time only — it decides whether the next emit lands in the consumer's ring buffer, not whether buffer reads see existing payloads. Without an explicit retroactive-scrub rule the toggle has a privacy hole:
+
+```text
+1. show-sensitive? = true     (engineer flips on to debug redaction policy)
+2. sensitive cascade emitted  (auth/login event lands in every consumer's buffer)
+3. show-sensitive? = false    (engineer flips back off, expecting privacy restored)
+4. panels keep showing the buffered :sensitive? payloads forever
+```
+
+The normative rule: every on-box `:trace/show-sensitive?` consumer (Causa's `trace-bus`, Story's per-variant `ui.trace` buffer, future devtools that hold a buffer downstream of the on-box flag) MUST clear its trace buffer on the `true → false` transition. `false → false`, `false → true`, and `true → true` MUST NOT clear (no buffered sensitive risk exists for those transitions, and clearing would discard legitimate non-sensitive history without cause).
+
+The clear MUST be **whole-buffer**, not selective. Non-sensitive history buffered alongside the sensitive cascade is intentionally lost. Selective scrubbing is unsafe because a single sensitive event can have caused later non-sensitive cascades — sub recomputes, render args, dispatched-from-fx events — whose payloads structurally reveal the redacted value via the shape of what they consumed. Clearing the whole buffer is the simplest correct semantic; any "smarter" filter risks reintroducing the leak through a derived event.
+
+The clear MUST also reset the per-consumer `[● REDACTED N]` suppressed-events counter so the indicator drops in lockstep with the buffer (the counter is conceptually "since last clear", not "since process start"). Per Causa's `trace-bus/clear-buffer!` and Story's `ui.trace/clear-buffer!` — both already cascade through to the suppressed-counter reset.
+
+Implementation note (non-normative): the reference implementation uses a callback-registry pattern (`config/register-toggle-off-callback!`) so the config layer can invoke the consumer's clear-buffer fn without taking a require dependency on it (the consumer requires the config; not vice versa). Callbacks run on every `true → false` transition; one callback's exception MUST NOT block the others (privacy is the load-bearing concern, and a partial clear is strictly better than no clear). Off-box wire-egress consumers (`include-sensitive?` knobs on the MCP triplet, pair2 preload) are out of scope for this rule — their flag governs wire emission, not a persistent buffer, so the transitions are stateless.
+
 #### Production-elision behaviour
 
 The `:sensitive?` mechanism is **dev-time only** — both pieces of it ride the trace surface and elide with it:

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -248,11 +248,91 @@
   show-sensitive?
   (atom false))
 
+;; ---- toggle-off callbacks (rf2-lqmje — retroactive scrub) ----------------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub on `set-show-sensitive!`
+;; false (rf2-lqmje), toggling the flag from true → false MUST clear
+;; the trace buffer — the flag is NOT a one-way trapdoor. The collector
+;; only gates at ingest time (`suppress-sensitive?`), so without this
+;; scrub a sensitive cascade emitted while the flag was true would
+;; remain visible in every panel after the user flipped the flag back
+;; to false expecting privacy to be restored.
+;;
+;; The cost: non-sensitive history that was buffered alongside the
+;; sensitive cascade is also lost. This is the documented trade-off —
+;; selective scrubbing is unsafe because a single sensitive event can
+;; have caused later non-sensitive cascades (subs, renders, fx) whose
+;; payloads structurally reveal the redacted value (per the Spec 009
+;; rationale block). Clearing the whole buffer is the simplest correct
+;; semantic.
+;;
+;; The hook design avoids a circular require — `trace-bus.cljc`
+;; depends on `config.cljc` to read the flag and bump the counter, so
+;; `config.cljc` cannot directly invoke `trace-bus/clear-buffer!`.
+;; Instead, `trace-bus.cljc` registers its clear-buffer fn into this
+;; atom at load time; `set-show-sensitive!` walks the atom on every
+;; true → false transition. CLJC-pure so the registration shape is
+;; testable under the JVM target.
+
+(defonce
+  ^{:doc "Atom holding `{id → (fn [] ...)}` callbacks invoked when
+         `set-show-sensitive!` transitions the flag from true → false.
+         `trace-bus.cljc` registers its `clear-buffer!` at load time.
+         Internal — host applications should not register here."}
+  toggle-off-callbacks
+  (atom {}))
+
+(defn register-toggle-off-callback!
+  "Register `f` (a zero-arg fn) under `id` to be invoked when
+  `set-show-sensitive!` transitions the flag from `true` → `false`.
+  Replaces any existing entry under the same id. Internal API — Causa
+  modules use it to wire their buffer-clear hooks; host applications
+  should NOT register here.
+
+  Returns `id`."
+  [id f]
+  (swap! toggle-off-callbacks assoc id f)
+  id)
+
+(defn unregister-toggle-off-callback!
+  "Remove the toggle-off callback registered under `id`. Idempotent."
+  [id]
+  (swap! toggle-off-callbacks dissoc id)
+  nil)
+
+(defn- run-toggle-off-callbacks!
+  "Invoke every registered toggle-off callback. Each callback's
+  exception is swallowed (logged via `tap>`) so one buggy hook does
+  not prevent the others from running — privacy is the load-bearing
+  concern, and a partial clear is strictly better than no clear."
+  []
+  (doseq [[id f] @toggle-off-callbacks]
+    (try
+      (f)
+      (catch #?(:clj Throwable :cljs :default) e
+        (tap> {:tag ::toggle-off-callback-failed :id id :error e})))))
+
 (defn set-show-sensitive!
   "Replace the `:trace/show-sensitive?` flag. Causa's `configure!`
-  calls this. `nil` resets to the default (`false`)."
+  calls this. `nil` resets to the default (`false`).
+
+  Per rf2-lqmje (Spec 009 §Privacy §Retroactive-scrub): when the call
+  transitions the flag from `true` → `false`, the trace buffer is
+  cleared by invoking every registered `toggle-off-callbacks` entry.
+  The trade-off — non-sensitive history buffered alongside the
+  sensitive cascade is also lost — is intentional: clearing the whole
+  buffer is the simplest correct semantic because a sensitive event
+  emitted while the flag was true can have caused later cascades whose
+  payloads structurally reveal the redacted value. The flag is NOT a
+  one-way trapdoor; toggling it false MUST restore privacy fully.
+  true → true and false → ANY transitions do NOT invoke the
+  callbacks."
   [v]
-  (reset! show-sensitive? (boolean v))
+  (let [prev @show-sensitive?
+        next (boolean v)]
+    (reset! show-sensitive? next)
+    (when (and prev (not next))
+      (run-toggle-off-callbacks!)))
   nil)
 
 (defn get-show-sensitive

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -344,3 +344,26 @@
     ;; the reactive slot reflects the same eviction the atom just took.
     #?(:cljs (mirror-into-causa! [:rf.causa/sync-trace-buffer @buffer-state])))
   nil)
+
+;; ---- retroactive scrub on set-show-sensitive! false (rf2-lqmje) ---------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub on `set-show-sensitive!`
+;; false: toggling the flag from true → false clears the trace buffer.
+;; The collector only gates at ingest (`collect-trace!` consults
+;; `config/suppress-sensitive?`), so without this hook a sensitive
+;; cascade emitted while the flag was true would remain visible in
+;; every panel after the user expected privacy to be restored.
+;;
+;; The clear cascades through `clear-buffer!`:
+;;   - empties the atom + mirrors `:rf.causa/clear-trace-buffer` into
+;;     `:rf/causa` so the reactive `:trace-buffer` sub drops in lockstep,
+;;   - calls `config/reset-suppressed-count!` so the `[● REDACTED N]`
+;;     hint resets (the bottom rail's counter is conceptually
+;;     "since-last-clear", not "since-process-start").
+;;
+;; The hook registers at load time via a top-level form (guarded by
+;; `interop/debug-enabled?` — production builds keep the registration
+;; out of the bundle alongside the rest of the trace-bus surface).
+
+(when interop/debug-enabled?
+  (config/register-toggle-off-callback! ::clear-on-toggle-off clear-buffer!))

--- a/tools/causa/test/day8/re_frame2_causa/sensitive_trace_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/sensitive_trace_cljs_test.cljc
@@ -219,3 +219,109 @@
        (trace-bus/clear-buffer!)
        (is (= 0 (config/suppressed-count))
            "clearing the buffer also drops the indicator state"))))
+
+;; ---- (6) retroactive scrub on toggle-off (rf2-lqmje) --------------------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub on `set-show-sensitive!`
+;; false: when the flag transitions true → false, the trace buffer is
+;; cleared. The flag is NOT a one-way trapdoor — flipping it false
+;; MUST restore the privacy guarantee for events already buffered
+;; while the flag was true. The trade-off (non-sensitive history also
+;; lost) is intentional and documented in Spec 009.
+
+(deftest set-show-sensitive!-false-runs-toggle-off-callbacks
+  (testing "true → false transition invokes registered callbacks"
+    (let [called?  (atom false)
+          token-id ::scrub-callback-test]
+      (config/register-toggle-off-callback! token-id #(reset! called? true))
+      (try
+        (config/set-show-sensitive! true)
+        (is (false? @called?)
+            "false → true must NOT invoke callbacks (no buffered sensitive risk)")
+        (config/set-show-sensitive! false)
+        (is (true? @called?)
+            "true → false must invoke every registered callback")
+        (finally
+          (config/unregister-toggle-off-callback! token-id))))))
+
+(deftest set-show-sensitive!-no-transition-no-callback
+  (testing "true → true and false → false are no-ops for the callbacks"
+    (let [calls    (atom 0)
+          token-id ::scrub-callback-no-transition]
+      (config/register-toggle-off-callback! token-id #(swap! calls inc))
+      (try
+        (config/set-show-sensitive! false) ; default → false, no transition
+        (is (= 0 @calls))
+        (config/set-show-sensitive! true)
+        (config/set-show-sensitive! true)  ; true → true
+        (is (= 0 @calls))
+        (config/set-show-sensitive! false) ; true → false, the only transition
+        (is (= 1 @calls))
+        (config/set-show-sensitive! false) ; false → false
+        (is (= 1 @calls))
+        (finally
+          (config/unregister-toggle-off-callback! token-id))))))
+
+(deftest set-show-sensitive!-callback-failure-isolated
+  (testing "one buggy callback does not prevent others from running"
+    (let [other-called? (atom false)
+          token-bad     ::scrub-callback-bad
+          token-good    ::scrub-callback-good]
+      (config/register-toggle-off-callback!
+        token-bad (fn [] (throw (ex-info "boom" {}))))
+      (config/register-toggle-off-callback!
+        token-good (fn [] (reset! other-called? true)))
+      (try
+        (config/set-show-sensitive! true)
+        (config/set-show-sensitive! false)
+        (is (true? @other-called?)
+            "the good callback must still run after the bad one throws")
+        (finally
+          (config/unregister-toggle-off-callback! token-bad)
+          (config/unregister-toggle-off-callback! token-good))))))
+
+#?(:cljs
+   (deftest toggle-off-clears-trace-buffer
+     (testing "true → false clears the trace buffer in lockstep with the flag"
+       ;; Scenario: flag on, sensitive cascade lands, flag flipped off.
+       (config/set-show-sensitive! true)
+       (trace-bus/collect-trace! (sensitive-event))
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (trace-bus/collect-trace! (sensitive-event))
+       (is (= 3 (count (trace-bus/buffer)))
+           "all three events landed while the flag was true")
+       ;; User flips off expecting privacy restored.
+       (config/set-show-sensitive! false)
+       (is (= 0 (count (trace-bus/buffer)))
+           "buffer must be empty — sensitive payloads cannot survive the toggle")
+       (is (= 0 (config/suppressed-count))
+           "suppressed counter also drops in lockstep with the buffer"))))
+
+#?(:cljs
+   (deftest toggle-off-also-drops-non-sensitive-history
+     (testing "the simplest correct semantic — clear EVERYTHING, not just sensitive"
+       ;; The Spec 009 §Retroactive-scrub trade-off: selective scrubbing
+       ;; is unsafe because non-sensitive events can structurally reveal
+       ;; the redacted value (sub recomputes, render args, etc). Document
+       ;; the intentional loss so a future refactor doesn't try to
+       ;; "improve" by filtering instead of clearing.
+       (config/set-show-sensitive! true)
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (is (= 2 (count (trace-bus/buffer))))
+       (config/set-show-sensitive! false)
+       (is (= 0 (count (trace-bus/buffer)))
+           "non-sensitive history is intentionally lost — see Spec 009 §Retroactive-scrub"))))
+
+#?(:cljs
+   (deftest toggle-off-no-clear-when-flag-was-already-false
+     (testing "false → false transition leaves the buffer alone"
+       ;; The flag started false, so no sensitive events ever landed.
+       ;; A redundant set-show-sensitive! false call must NOT throw away
+       ;; the buffered non-sensitive history.
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (trace-bus/collect-trace! (non-sensitive-event))
+       (is (= 2 (count (trace-bus/buffer))))
+       (config/set-show-sensitive! false) ; redundant; default is false
+       (is (= 2 (count (trace-bus/buffer)))
+           "redundant set-show-sensitive! false must not clear the buffer"))))

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -244,11 +244,91 @@
   show-sensitive?
   (atom false))
 
+;; ---- toggle-off callbacks (rf2-lqmje — retroactive scrub) ----------------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub on `set-show-sensitive!`
+;; false (rf2-lqmje), toggling the flag from true → false MUST clear
+;; the per-variant trace buffers — the flag is NOT a one-way trapdoor.
+;; The Story trace listener (`re-frame.story.ui.trace`) only gates at
+;; ingest time via `suppress-sensitive?`, so without this scrub a
+;; sensitive cascade emitted while the flag was true would remain
+;; visible in every variant's trace + actions panels after the user
+;; flipped the flag back to false expecting privacy to be restored.
+;;
+;; The cost: non-sensitive history that was buffered alongside the
+;; sensitive cascade is also lost. This is the documented trade-off —
+;; selective scrubbing is unsafe because a single sensitive event can
+;; have caused later non-sensitive cascades (subs, renders, fx) whose
+;; payloads structurally reveal the redacted value. Clearing every
+;; per-variant buffer is the simplest correct semantic.
+;;
+;; The hook design avoids a circular require — `ui.trace` depends on
+;; `config` to read the flag and bump the counter, so `config` cannot
+;; directly invoke `ui.trace/clear-buffer!`. Instead, `ui.trace`
+;; registers its clear-buffer fn into this atom at load time;
+;; `set-show-sensitive!` walks the atom on every true → false
+;; transition. CLJC-pure so the registration shape is testable under
+;; the JVM target.
+
+(defonce
+  ^{:doc "Atom holding `{id → (fn [] ...)}` callbacks invoked when
+         `set-show-sensitive!` transitions the flag from true → false.
+         `ui.trace` registers its `clear-buffer!` at load time.
+         Internal — host applications should not register here."}
+  toggle-off-callbacks
+  (atom {}))
+
+(defn register-toggle-off-callback!
+  "Register `f` (a zero-arg fn) under `id` to be invoked when
+  `set-show-sensitive!` transitions the flag from `true` → `false`.
+  Replaces any existing entry under the same id. Internal API — Story
+  modules use it to wire their buffer-clear hooks; host applications
+  should NOT register here.
+
+  Returns `id`."
+  [id f]
+  (swap! toggle-off-callbacks assoc id f)
+  id)
+
+(defn unregister-toggle-off-callback!
+  "Remove the toggle-off callback registered under `id`. Idempotent."
+  [id]
+  (swap! toggle-off-callbacks dissoc id)
+  nil)
+
+(defn- run-toggle-off-callbacks!
+  "Invoke every registered toggle-off callback. Each callback's
+  exception is swallowed (logged via `tap>`) so one buggy hook does
+  not prevent the others from running — privacy is the load-bearing
+  concern, and a partial clear is strictly better than no clear."
+  []
+  (doseq [[id f] @toggle-off-callbacks]
+    (try
+      (f)
+      (catch #?(:clj Throwable :cljs :default) e
+        (tap> {:tag ::toggle-off-callback-failed :id id :error e})))))
+
 (defn set-show-sensitive!
   "Replace the `:trace/show-sensitive?` flag. Story's `configure!`
-  calls this. `nil` resets to the default (`false`)."
+  calls this. `nil` resets to the default (`false`).
+
+  Per rf2-lqmje (Spec 009 §Privacy §Retroactive-scrub): when the call
+  transitions the flag from `true` → `false`, every per-variant trace
+  buffer is cleared by invoking the registered
+  `toggle-off-callbacks`. The trade-off — non-sensitive history
+  buffered alongside the sensitive cascade is also lost — is
+  intentional: clearing the whole buffer is the simplest correct
+  semantic because a sensitive event emitted while the flag was true
+  can have caused later cascades whose payloads structurally reveal
+  the redacted value. The flag is NOT a one-way trapdoor; toggling it
+  false MUST restore privacy fully. true → true and false → ANY
+  transitions do NOT invoke the callbacks."
   [v]
-  (reset! show-sensitive? (boolean v))
+  (let [prev @show-sensitive?
+        next (boolean v)]
+    (reset! show-sensitive? next)
+    (when (and prev (not next))
+      (run-toggle-off-callbacks!)))
   nil)
 
 (defn get-show-sensitive

--- a/tools/story/src/re_frame/story/ui/trace.cljs
+++ b/tools/story/src/re_frame/story/ui/trace.cljs
@@ -97,6 +97,28 @@
    (config/reset-suppressed-count! variant-id)
    nil))
 
+;; ---- retroactive scrub on set-show-sensitive! false (rf2-lqmje) ---------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub on `set-show-sensitive!`
+;; false: toggling the flag from true → false clears every per-variant
+;; trace buffer. Each Story trace listener only gates at ingest via
+;; `config/suppress-sensitive?`, so without this hook a sensitive
+;; cascade emitted while the flag was true would remain visible in
+;; every variant's trace + actions panels after the user expected
+;; privacy to be restored.
+;;
+;; The clear cascades through `clear-buffer!` (zero-arg form):
+;;   - resets every per-variant ratom to `[]` (panels re-render empty),
+;;   - calls `config/reset-suppressed-count!` so each variant's
+;;     `[● REDACTED]` hint drops in lockstep with the buffer.
+;;
+;; The hook registers at load time, gated on `config/enabled?` —
+;; production builds (`enabled?` false via `:closure-defines`) elide
+;; Story entirely, including the registration form.
+
+(when config/enabled?
+  (config/register-toggle-off-callback! ::clear-on-toggle-off clear-buffer!))
+
 (defn drop-buffer!
   "Remove the buffer entry entirely. Called from shell unmount.
   Per rf2-bclgj: also clears the per-variant suppressed-events

--- a/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/sensitive_trace_cljs_test.cljc
@@ -304,3 +304,65 @@
       (is (= [[:counter/inc]] (recorder/recorded-events)))
       (is (zero? (config/suppressed-count :story.recorder/plain))))
     (recorder/clear!)))
+
+;; ---------------------------------------------------------------------------
+;; Retroactive scrub on set-show-sensitive! false (rf2-lqmje)
+;; ---------------------------------------------------------------------------
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub: toggling
+;; `:trace/show-sensitive?` from true → false MUST clear every
+;; per-variant trace buffer. The Story config layer exposes a generic
+;; callback registry that `ui.trace` (CLJS-only) hooks into; this
+;; pure-data shape is JVM-runnable so the algebra is covered here. The
+;; CLJS-only buffer-clear is covered in `re-frame.story-ui-cljs-test`.
+
+(deftest set-show-sensitive!-false-runs-toggle-off-callbacks-rf2-lqmje
+  (testing "true → false transition invokes registered callbacks"
+    (let [called?  (atom false)
+          token-id ::scrub-callback-test]
+      (config/register-toggle-off-callback! token-id #(reset! called? true))
+      (try
+        (config/set-show-sensitive! true)
+        (is (false? @called?)
+            "false → true must NOT invoke callbacks (no buffered sensitive risk)")
+        (config/set-show-sensitive! false)
+        (is (true? @called?)
+            "true → false must invoke every registered callback")
+        (finally
+          (config/unregister-toggle-off-callback! token-id))))))
+
+(deftest set-show-sensitive!-no-transition-no-callback-rf2-lqmje
+  (testing "true → true and false → false are no-ops for the callbacks"
+    (let [calls    (atom 0)
+          token-id ::scrub-callback-no-transition]
+      (config/register-toggle-off-callback! token-id #(swap! calls inc))
+      (try
+        (config/set-show-sensitive! false) ; default → false, no transition
+        (is (= 0 @calls))
+        (config/set-show-sensitive! true)
+        (config/set-show-sensitive! true)  ; true → true
+        (is (= 0 @calls))
+        (config/set-show-sensitive! false) ; true → false, the only transition
+        (is (= 1 @calls))
+        (config/set-show-sensitive! false) ; false → false
+        (is (= 1 @calls))
+        (finally
+          (config/unregister-toggle-off-callback! token-id))))))
+
+(deftest set-show-sensitive!-callback-failure-isolated-rf2-lqmje
+  (testing "one buggy callback does not prevent others from running"
+    (let [other-called? (atom false)
+          token-bad     ::scrub-callback-bad
+          token-good    ::scrub-callback-good]
+      (config/register-toggle-off-callback!
+        token-bad (fn [] (throw (ex-info "boom" {}))))
+      (config/register-toggle-off-callback!
+        token-good (fn [] (reset! other-called? true)))
+      (try
+        (config/set-show-sensitive! true)
+        (config/set-show-sensitive! false)
+        (is (true? @other-called?)
+            "the good callback must still run after the bad one throws")
+        (finally
+          (config/unregister-toggle-off-callback! token-bad)
+          (config/unregister-toggle-off-callback! token-good))))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -21,6 +21,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.story :as story]
+            [re-frame.story.config :as story-config]
             [re-frame.story.registrar :as story-registrar]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.command-palette :as command-palette]
@@ -799,6 +800,89 @@
         (is (nil? (scrubber/selected-epoch-id vid)))
         (finally
           (scrubber/drop-selection! vid))))))
+
+;; ---- privacy: retroactive scrub on set-show-sensitive! false (rf2-lqmje)
+;;
+;; Per Spec 009 §Privacy §Retroactive-scrub: toggling
+;; `:trace/show-sensitive?` from true → false MUST clear every
+;; per-variant trace buffer. The Story trace listener only gates at
+;; ingest time, so without this scrub a sensitive cascade emitted
+;; while the flag was true would remain visible in every variant's
+;; trace + actions panels after the user expected privacy to be
+;; restored. The trade-off (non-sensitive history also lost) is the
+;; simplest correct semantic — see Spec 009 for the rationale.
+
+(deftest set-show-sensitive!-false-clears-every-variant-buffer-rf2-lqmje
+  (testing "true → false toggle clears every per-variant Story trace buffer"
+    (let [v-a       :story.priv-scrub/a
+          v-b       :story.priv-scrub/b
+          buf-a     (trace/ensure-buffer! v-a)
+          buf-b     (trace/ensure-buffer! v-b)
+          mk-ev     (fn [vid sensitive?]
+                      (cond-> {:op-type   :event
+                               :operation :event/dispatched
+                               :id        1
+                               :time      1700000000000
+                               :tags      {:dispatch-id 1
+                                           :frame       vid
+                                           :event-id    :foo
+                                           :event       [:foo]}}
+                        sensitive? (assoc :sensitive? true)))]
+      (try
+        ;; Engineer flips the flag on to investigate.
+        (story-config/set-show-sensitive! true)
+        ;; Simulate the per-variant listener body: with the flag on, the
+        ;; listener appends every event (no suppression).
+        (reset! buf-a [(mk-ev v-a true) (mk-ev v-a false)])
+        (reset! buf-b [(mk-ev v-b true)])
+        (story-config/note-suppressed! v-a) ; previously bumped before opt-in
+        (is (= 2 (count @buf-a)))
+        (is (= 1 (count @buf-b)))
+        (is (pos? (story-config/suppressed-count v-a)))
+
+        ;; Engineer flips the flag back off expecting privacy restored.
+        (story-config/set-show-sensitive! false)
+
+        (is (= 0 (count @buf-a))
+            "variant A's buffer must be empty — sensitive payloads cannot survive the toggle")
+        (is (= 0 (count @buf-b))
+            "variant B's buffer must be empty too — the clear is global")
+        (is (zero? (story-config/suppressed-count v-a))
+            "per-variant suppressed counter drops in lockstep with the buffer")
+        (finally
+          (trace/drop-buffer! v-a)
+          (trace/drop-buffer! v-b)
+          (story-config/set-show-sensitive! false)
+          (story-config/reset-suppressed-count!))))))
+
+(deftest set-show-sensitive!-no-clear-when-already-false-rf2-lqmje
+  (testing "false → false toggle leaves the buffers alone"
+    (let [vid :story.priv-scrub/idempotent
+          buf (trace/ensure-buffer! vid)]
+      (try
+        ;; The flag started false, so no sensitive events ever landed.
+        ;; A redundant set-show-sensitive! false call must NOT throw away
+        ;; the buffered non-sensitive history.
+        (reset! buf [{:op-type :event :tags {:frame vid}}])
+        (story-config/set-show-sensitive! false) ; redundant; default is false
+        (is (= 1 (count @buf))
+            "redundant set-show-sensitive! false must not clear the buffer")
+        (finally
+          (trace/drop-buffer! vid)
+          (story-config/set-show-sensitive! false))))))
+
+(deftest set-show-sensitive!-true-does-not-clear-rf2-lqmje
+  (testing "false → true toggle leaves the buffers alone (no buffered sensitive risk)"
+    (let [vid :story.priv-scrub/opt-in
+          buf (trace/ensure-buffer! vid)]
+      (try
+        (reset! buf [{:op-type :event :tags {:frame vid}}])
+        (story-config/set-show-sensitive! true)
+        (is (= 1 (count @buf))
+            "opting in must not clear pre-existing non-sensitive history")
+        (finally
+          (trace/drop-buffer! vid)
+          (story-config/set-show-sensitive! false))))))
 
 ;; ---- shell render smoke -------------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

Per Mike's decision on **rf2-lqmje (option A)**: the on-box `:trace/show-sensitive?` flag is not a one-way trapdoor. Toggling it `true → false` MUST clear the trace buffer so already-buffered sensitive payloads cannot survive a "flip back off" that the user expects to restore privacy.

The collector only gates at ingest, so before this PR:

1. `show-sensitive? = true` (engineer flips on to debug)
2. sensitive cascade emitted (`auth/login` lands in the buffer)
3. `show-sensitive? = false` (engineer flips back off)
4. panels keep showing the buffered `:sensitive?` payloads forever

The clear is whole-buffer, not selective — non-sensitive history buffered alongside the sensitive cascade is intentionally lost, because non-sensitive cascades (sub recomputes, render args, dispatched-from-fx events) can structurally reveal the redacted value via the shape of what they consumed. Clearing the whole buffer is the simplest correct semantic.

## Changes

**Causa**
- `tools/causa/src/day8/re_frame2_causa/config.cljc` — `set-show-sensitive!` detects `true → false` and invokes registered `toggle-off-callbacks`. Callback-registry pattern avoids a circular require (trace-bus depends on config, not vice versa). One callback exception MUST NOT block the others.
- `tools/causa/src/day8/re_frame2_causa/trace_bus.cljc` — registers `clear-buffer!` at load time (gated on `interop/debug-enabled?` so production elides it).

**Story**
- `tools/story/src/re_frame/story/config.cljc` — same `toggle-off-callbacks` shape mirrored across the parallel namespace.
- `tools/story/src/re_frame/story/ui/trace.cljs` — registers `clear-buffer!` (zero-arg form clears every per-variant buffer + drops the per-variant suppressed counters) at load time, gated on `config/enabled?`.

**Spec**
- `spec/009-Instrumentation.md` — new `#### Retroactive-scrub on set-show-sensitive! false` subsection under §Privacy. Pins the transitions (only `true → false` clears; other transitions are no-ops), requires whole-buffer clear with rationale, notes that off-box wire-egress consumers (`include-sensitive?` knobs on the MCP triplet / pair2 preload) are out of scope.

**Tests**
- `tools/causa/test/.../sensitive_trace_cljs_test.cljc` — five new deftests: callback-registry algebra (JVM + CLJS), callback isolation across exceptions, end-to-end buffer clear on toggle-off, intentional non-sensitive history loss, and the no-op `false → false` / `false → true` transitions.
- `tools/story/test/.../sensitive_trace_cljs_test.cljc` — three new deftests for the callback registry (JVM-runnable).
- `tools/story/test/.../story_ui_cljs_test.cljs` — three CLJS-only deftests asserting per-variant Story buffer clear on toggle-off + the no-op transitions.

## Gates

| Gate | Result |
|---|---|
| `clojure -M:test` (tools/causa) | 550 tests / 1565 assertions / 0F0E |
| `clojure -M:test` (tools/story) | 451 tests / 1400 assertions / 0F0E |
| `npm run test:cljs` | 2293 tests / 6517 assertions / 0F0E |
| `npm run test:elision` | PASS (31/31 absent in production; 31/31 present in control) |
| `npm run test:bundle-isolation` | PASS (24 internal sentinels absent; 3 allow-list budgets ok) |

## Test plan

- [x] Causa JVM tests (callback registry + isolation algebra)
- [x] Story JVM tests (callback registry algebra)
- [x] CLJS node tests (end-to-end buffer clear in both Causa + Story)
- [x] Production-elision probe (the callback hooks compile out of the production bundle)
- [x] Bundle-isolation (no Causa/Story internals leaked into examples bundles)

Unblocks rf2-44vzy + rf2-vu0mp (causa-trace-helpers cluster).