### PR TITLE
feat(causa-mcp): W-2..W-5 wire-pipeline mechanisms (4 beads cluster)

### DIFF
--- a/tools/causa-mcp/deps.edn
+++ b/tools/causa-mcp/deps.edn
@@ -71,7 +71,21 @@
          ;; Per rf2-vw4sq the base ns is the single source of truth
          ;; for the privacy contract — same predicate, same fail-
          ;; closed posture, same accept-shapes across the MCP triplet.
-         day8/re-frame2-mcp-base    {:local/root "../mcp-base"}}
+         day8/re-frame2-mcp-base    {:local/root "../mcp-base"}
+
+         ;; day8/de-dupe — structural dedup of persistent data
+         ;; structures (W-5 of rf2-8xzoe; tranche bead rf2-8xzoe.9).
+         ;; Substitutes repeated subtrees with namespaced-symbol
+         ;; references (`de-dupe.cache/cache-N`); the flat cache map
+         ;; round-trips back through `expand`. Applied at the MCP wire
+         ;; boundary BEFORE the W-1 token-cap check so dedup gets to
+         ;; shrink first.
+         ;;
+         ;; Git-coord pinned to the same commit pair2-mcp uses
+         ;; (cross-MCP-aligned per spec/004 §5); the library's
+         ;; Clojars release lags the alive master.
+         day8/de-dupe               {:git/url "https://github.com/day8/de-dupe.git"
+                                     :git/sha "a2be701ddf42d94218116eda9e9ca822cef035bc"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/cursor.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/cursor.cljs
@@ -1,0 +1,305 @@
+(ns day8.re-frame2-causa-mcp.cursor
+  "Wire-pipeline mechanism W-3 at the Causa-MCP boundary (rf2-8xzoe.7).
+  Cursor pagination — per
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §3 (Cursor pagination).
+
+  ## What this provides
+
+  Sequence-returning tools (`get-trace-buffer`, `get-epoch-history`,
+  `list-subscriptions`, and any read tool whose return size is a
+  function of trace-bus depth) MUST accept `:cursor` (opaque
+  server-managed string, omitted on the first call) and `:limit`
+  (integer, default chosen so the response fits the cap).
+
+  Responses MUST carry `:next-cursor` (an opaque string for the
+  next page, or `nil` when exhausted) and `:remaining` (count or
+  estimate).
+
+  ## Opaque cursor encoding
+
+  Per spec/Principles.md §Pagination: cursors are opaque on the
+  wire. The agent has no business decoding the format; it MUST pass
+  the value back verbatim. We use base64-encoded EDN as the codec
+  — same shape pair2-mcp's `tools.cursor` ships, so any future
+  cross-MCP tooling that inspects cursors (it shouldn't, but if it
+  did) sees an identical shape.
+
+  The cursor payload is a small EDN map. The shape (today; subject
+  to change behind the opaque boundary) is:
+
+      {:v        1
+       :after-id <epoch-id-string>     ; the last record we emitted
+       :until-ms <int-or-nil>          ; first-call clock; bounds the
+                                       ; window so fresh records don't
+                                       ; sneak in mid-page
+       :frame    <keyword-or-nil>}
+
+  Encoding is `pr-str` → base64 (via `js/Buffer`). Round-trip is
+  via `decode-cursor`.
+
+  ## Cursor staleness — :rf.mcp/cursor-stale
+
+  The runtime's epoch ring is a bounded buffer. If a cursor's
+  `:after-id` no longer exists in the ring (because enough records
+  landed between calls that the buffer rotated past it), the
+  server returns a structured error rather than silently restarting
+  or shipping an out-of-order batch:
+
+      {:ok?            false
+       :reason         :rf.mcp/cursor-stale
+       :tool           \"<tool-name>\"
+       :requested-id   <id>
+       :head-id        <current-head>
+       :hint           \"...\"}
+
+  The `:reason` value is the cross-MCP convention from
+  `re-frame.mcp-base.vocab/cursor-stale-reason`. Agents pattern-
+  match on it to either restart (drop the cursor) or widen the
+  window via the tool-specific args.
+
+  ## Composition with W-1 / W-6 / B-1
+
+  - **With W-1 (token-cap)**: pagination is the primary defence
+    against unbounded sequence responses. `:limit`'s default is
+    chosen to fit the cap on typical record sizes; agents that
+    overflow anyway hit W-1's `apply-cap` with `:hint :paginate`
+    (re-call with a smaller `:limit`).
+  - **With W-6 (size-elision)**: each record's tree-typed slots
+    are already walked server-side. The cursor wrapper rides
+    above the walked items; W-6's `apply-to-result` counts markers
+    across the kept slice and stamps `:elided-large`. Both
+    wrappers compose freely.
+  - **With B-1 (privacy)**: trace-stream tools that paginate
+    (`get-trace-buffer`, `subscribe` drain, `get-epoch-history`)
+    apply B-1's strip BEFORE pagination so the per-page item
+    count reflects the post-strip slice. The two wrappers' counts
+    surface together on the same envelope.
+
+  ## MUSTs honoured
+
+  - MUST 10 — sequence-returning tools accept `:cursor` + `:limit`
+    (spec/004 §3 L274-281). `cursor-arg` + `limit-arg` are the
+    single normative parsers; per-tool dispatchers call them once
+    on the raw args object.
+  - MUST 11 — responses carry `:next-cursor` (or nil) + `:remaining`
+    (spec/004 §3 L283-284). `apply-to-result` is the single
+    normative envelope-shaper; it splices both slots."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader]
+            [clojure.string :as str]
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Defaults — limit floor / cap aligned with W-1's 5K-token budget.
+;; ---------------------------------------------------------------------------
+
+(def ^:const default-limit
+  "Default `:limit` MCP arg. 50 records per page — sized to fit a
+  5K-token cap (W-1) after diff-encode (rf2-1wdzp) and dedup (W-5)
+  on typical epoch / trace shapes.
+
+  Identical to pair2-mcp's `tools.cursor/default-limit` so an agent
+  that pages through pair2-mcp's surface sees the same per-page
+  count on causa-mcp's sibling tools. Cross-server symmetry per
+  spec/004 §Cross-server vocabulary."
+  50)
+
+(def ^:const min-limit
+  "Lower clamp on the per-call `:limit` override. Below 1 is
+  nonsensical (an empty page contradicts pagination). Pin the floor
+  so a caller passing `0` or a negative collapses to `1` (smallest
+  valid page) rather than disappearing into a paging dead-end."
+  1)
+
+;; ---------------------------------------------------------------------------
+;; limit-arg — per-call MCP-arg resolver.
+;; ---------------------------------------------------------------------------
+
+(defn parse-limit-arg
+  "Normalise a raw `:limit` value into a positive integer. Defaults
+  to `default-limit` (50). Delegates to
+  `re-frame.mcp-base.args/parse-positive-int` (rf2-vw4sq) so the
+  accept-shape contract (integer / numeric-string / nil) stays
+  cross-MCP identical."
+  [raw]
+  (base-args/parse-positive-int raw default-limit))
+
+(defn limit-arg
+  "Resolve the cross-server `:limit` MCP arg from a raw arguments
+  object. Returns a positive integer ≥ `min-limit`.
+
+  Accepts both the JS-side args object (the npm MCP SDK shape) and
+  a CLJS map (already-coerced upstream). The slot name is the
+  cross-server `limit` (string key for JS, `:limit` for CLJS) per
+  spec/004 §3.
+
+  Unrecognised / absent inputs collapse to `default-limit`."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :limit)
+                  (get args "limit"))
+
+              :else
+              (let [v (j/get args "limit")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (parse-limit-arg raw)))
+
+;; ---------------------------------------------------------------------------
+;; cursor encode / decode — opaque round-trip.
+;; ---------------------------------------------------------------------------
+
+(defn encode-cursor
+  "Encode a cursor payload as a base64 string. Returns `nil` on a
+  nil / empty payload (signalling pagination over) or on a payload
+  missing the required `:after-id` slot.
+
+  The payload is `pr-str`'d to EDN and base64-encoded via
+  `js/Buffer`. The agent passes the resulting string back verbatim
+  on the next call; the encoding is an implementation detail
+  behind the opaque cursor boundary."
+  [payload]
+  (when (and (map? payload) (some? (:after-id payload)))
+    (let [edn (pr-str payload)
+          buf (js/Buffer.from edn "utf8")]
+      (.toString buf "base64"))))
+
+(defn decode-cursor
+  "Decode a base64 cursor back to its EDN payload. Returns `nil`
+  when the cursor is absent (first call); returns `::malformed`
+  when the cursor exists but doesn't decode to a valid payload
+  map.
+
+  Callers translate `::malformed` into the same `:rf.mcp/cursor-
+  stale` error a runtime age-out raises — a cursor that doesn't
+  decode is, in effect, stale (the bound it referred to is no
+  longer reachable)."
+  [s]
+  (cond
+    (or (nil? s) (undefined? s)) nil
+    (not (string? s)) ::malformed
+    (str/blank? s)    nil
+    :else
+    (try
+      (let [buf (js/Buffer.from s "base64")
+            edn (.toString buf "utf8")
+            v   (cljs.reader/read-string edn)]
+        (if (and (map? v) (string? (:after-id v)))
+          v
+          ::malformed))
+      (catch :default _ ::malformed))))
+
+(defn cursor-arg
+  "Resolve the cross-server `:cursor` MCP arg from a raw arguments
+  object and decode it. Returns a CLJS map (the cursor payload),
+  `nil` (first-call / absent), or `::malformed` (the cursor exists
+  but doesn't decode — caller treats as stale).
+
+  Accepts both the JS-side args object (the npm MCP SDK shape) and
+  a CLJS map. The slot name is the cross-server `cursor` (string
+  key for JS, `:cursor` for CLJS) per spec/004 §3.
+
+  Unrecognised / absent inputs collapse to `nil`."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :cursor)
+                  (get args "cursor"))
+
+              :else
+              (let [v (j/get args "cursor")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (decode-cursor raw)))
+
+;; ---------------------------------------------------------------------------
+;; cursor-stale-result — the structured error per :rf.mcp/cursor-stale.
+;; ---------------------------------------------------------------------------
+
+(defn cursor-stale-result
+  "Build the structured cursor-stale error result.
+
+  Per spec/004 §3 + `re-frame.mcp-base.vocab/cursor-stale-reason`
+  (`:rf.mcp/cursor-stale`) — the cross-MCP convention agents
+  pattern-match on. The agent's recovery is to drop the cursor
+  and restart, or widen the window to recover the missed records.
+
+  Arguments:
+    - `tool`         — string tool name. Carried on the result so
+                       the agent's recovery branch knows which
+                       call to retry.
+    - opts:
+      - `:requested-id` — the cursor's `:after-id` that aged out
+                          (or that the malformed cursor referred
+                          to). Optional; omitted when not known.
+      - `:head-id`      — the runtime ring's current head id.
+                          Optional; omitted when not known.
+
+  Returns a map suitable for direct return from a tool dispatcher
+  (the envelope itself; no `value-key` slot is meaningful on a
+  cursor-stale response)."
+  [tool {:keys [requested-id head-id]}]
+  (cond-> {:ok?    false
+           :reason base-vocab/cursor-stale-reason
+           :tool   tool
+           :hint   (str "Cursor's id is no longer in the runtime ring. "
+                        "Drop the cursor and restart, or widen the window "
+                        "to recover the missed records.")}
+    requested-id (assoc :requested-id requested-id)
+    head-id      (assoc :head-id head-id)))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper for paginated tools.
+;;
+;; Tools call this once at the end of their body with:
+;;   - The already-walked (W-6) + already-stripped (B-1) items
+;;     vector (post-truncation to `:limit`).
+;;   - The cursor payload to encode for `:next-cursor` (or nil to
+;;     signal pagination over).
+;;   - The `:remaining` count / estimate.
+;;
+;; The wrapper splices `:next-cursor` + `:remaining` onto the
+;; envelope per MUST 11 and writes the items under `items-key`.
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/004 §3 cursor-pagination response shape to
+  `items` and write the result back into `envelope` under
+  `items-key`. Returns the updated envelope.
+
+  Arguments:
+    - `envelope`       — the per-call result map (will be updated).
+    - `items-key`      — the slot in `envelope` the per-page items
+                         go into (e.g. `:trace-events` for
+                         `get-trace-buffer`, `:epochs` for
+                         `get-epoch-history`, `:subscriptions` for
+                         `list-subscriptions`).
+    - `items`          — the per-page items vector (already
+                         truncated to `:limit`; already walked
+                         through W-6; already stripped via B-1
+                         when applicable).
+    - opts:
+      - `:next-cursor` — the cursor payload map to encode for the
+                        next page, or `nil` when pagination is
+                        exhausted. Encoded via `encode-cursor` —
+                        a payload missing `:after-id` collapses
+                        to `nil` (terminal page).
+      - `:remaining`   — integer count / estimate of items still
+                        unfetched. Per MUST 11. Always carried,
+                        even when zero (so the agent's per-page
+                        accounting is reliable).
+
+  Returns the envelope with `items-key` set to `items`,
+  `:next-cursor` to the encoded string (or `nil` for terminal
+  pages), and `:remaining` to the integer."
+  [envelope items-key items {:keys [next-cursor remaining]}]
+  (-> envelope
+      (assoc items-key items)
+      (assoc :next-cursor (encode-cursor next-cursor))
+      (assoc :remaining   (if (some? remaining) remaining 0))))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/dedup.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/dedup.cljs
@@ -1,0 +1,252 @@
+(ns day8.re-frame2-causa-mcp.dedup
+  "Wire-pipeline mechanism W-5 at the Causa-MCP boundary (rf2-8xzoe.9).
+  Structural dedup (de-dupe substitution table) — per
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §5 (Structural dedup).
+
+  ## What this provides
+
+  Sequence-returning tools whose items can repeat structural
+  prefixes (trace bursts where many events share the same
+  `:event-id` / `:handler-id` / `:source-coord` backbone, or
+  epoch slices where every record carries the same `:db-before`)
+  MAY apply **structural dedup** before counting tokens: shared
+  subtrees are emitted once and referenced by an integer id; the
+  wire payload carries
+
+      {:rf.mcp/dedup-table {1 {...} 2 {...} ...}
+       :items              [{:rf.mcp/ref 1 ...} ...]}
+
+  The dedup algorithm is `day8/de-dupe` — originally proven on
+  re-frame-10x's epoch payloads; re-applied here to re-frame2's
+  structurally-similar trace and epoch shapes.
+
+  ## Compression factor (cross-MCP measured — rf2-li2cw)
+
+  Spec/004 §5 cites three regimes (the agent budget hint matches
+  the call-site shape):
+
+  | Regime                | Reduction | Ratio   | When                              |
+  |-----------------------|-----------|---------|-----------------------------------|
+  | Raw trace bursts      | 28-31%    | ~1.4×   | `get-trace-buffer`, `subscribe`   |
+  | High-share replays    | ~90%      | ~10×    | Recurring cascade replays         |
+  | Epoch slices          | 80-90%    | 5-10×   | `get-epoch-history`, `:epochs`    |
+
+  Catalogue entries (when F-tranche `003-Tool-Catalogue.md` lands)
+  MUST cite the regime-appropriate factor when declaring the
+  `:typical-tokens` hint. The numbers are pinned by pair2-mcp's
+  `dedup_benchmark_test.cljs` (rf2-li2cw) and `dedup_test.cljs`
+  `reduction-ratio-shared-subtrees` (89.5% on the 10-epoch /
+  256-key shared-`:db-before` corpus).
+
+  ## Per-tick dedup table (no cross-tick refs)
+
+  Causa-mcp's dedup is **per-tick** — each `tools/call` response
+  carries its own self-contained `:rf.mcp/dedup-table`. No
+  cross-tick refs; the agent never holds state from prior calls
+  to decode the current one. This matches pair2-mcp's posture
+  (rf2-obpa9) and keeps the wire boundary stateless.
+
+  ## Why `de-dupe-eq` (equality), not `de-dupe` (identity)
+
+  Data arrives at the MCP server via bencode over nREPL; CLJS
+  values reconstructed from EDN don't share identity with values
+  the runtime emitted earlier. Equality is what makes the cross-
+  record share-pooling actually fire on the wire boundary.
+
+  ## Idempotence on no-dedup-opportunity
+
+  A payload with no repeated subtrees deduplicates to a one-entry
+  cache (the wire shape would be very slightly larger than the
+  input). The encoder skips wrapping in that case via an
+  `empty-payload?` short-circuit. Scalars and empty collections
+  similarly skip — the cache-of-one is a wire-size loss.
+
+  ## `:dedup?` opt-out
+
+  Per spec/004 §5 L329: `:dedup? false` MCP arg disables the
+  transform. On by default for trace-shaped and epoch-shaped
+  sequences. The cross-server arg name parallels
+  `:include-sensitive?` / `:include-large?` — agents learn the
+  flag-shape once.
+
+  ## Composition with W-1 / W-3 / W-6 / B-1
+
+  - **With W-1 (token-cap)**: dedup runs BEFORE the cap check
+    (spec/004 §1 + §5 ordering). The post-dedup payload's token
+    count is what trips the cap; on high-share regimes the ~10×
+    factor frequently keeps the response under cap that would
+    have overflowed raw.
+  - **With W-3 (cursor pagination)**: dedup is per-page; each
+    page carries its own self-contained dedup table. The agent
+    decodes one page at a time; no cross-page table state.
+  - **With W-6 (size-elision)**: the walker ran server-side
+    inside the eval form; markers are in place in `items` before
+    dedup. The deduper pools markers identically to other
+    repeated subtrees; the post-dedup payload still carries the
+    `:elided-large` counter on the envelope.
+  - **With B-1 (privacy)**: the strip runs BEFORE dedup — the
+    kept items vector is what the deduper sees; the
+    `:dropped-sensitive` counter rides on the envelope alongside
+    the dedup-table marker.
+
+  ## MUSTs honoured
+
+  - MUST 14 — catalogue entries cite regime-appropriate
+    compression factor (~1.4× raw trace bursts, ~10× high-share
+    replays, 5-10× epoch slices). The factor is surfaced in the
+    per-tool `:typical-tokens` hint when the F-tranche catalogue
+    lands; this namespace provides the algorithm and the wire
+    shape that the catalogue documents."
+  (:require [applied-science.js-interop :as j]
+            [de-dupe.core :as de-dupe]
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Defaults — dedup is opt-out, default true for trace/epoch shapes.
+;; ---------------------------------------------------------------------------
+
+(def ^:const include-dedup-default
+  "Default posture for `:dedup?` is `true` — spec/004 §5 L329
+  pins dedup on by default for trace-shaped and epoch-shaped
+  sequences. The constant is reified so the test corpus +
+  downstream tool dispatchers reference the same identity rather
+  than re-typing the literal. Parallel to
+  `privacy/include-sensitive-default` and
+  `elision/include-large-default` (though the polarity inverts —
+  `:dedup?` defaults TRUE; the two privacy flags default FALSE)."
+  true)
+
+;; ---------------------------------------------------------------------------
+;; empty-payload? — the no-op guard.
+;; ---------------------------------------------------------------------------
+
+(defn empty-payload?
+  "True for values where dedup yields no win — nil, empty
+  collections, scalars. Skipping the wrap avoids the trivial
+  cache-of-one shape bloating the wire for empty / single-record
+  responses."
+  [v]
+  (or (nil? v)
+      (and (coll? v) (empty? v))
+      (not (coll? v))))
+
+;; ---------------------------------------------------------------------------
+;; dedup-value — the wire-boundary wrap.
+;; ---------------------------------------------------------------------------
+
+(defn dedup-value
+  "Apply structural dedup to `v` and wrap the result in the cross-
+  MCP marker (`base-vocab/dedup-table-key` —
+  `:rf.mcp/dedup-table`). Returns `v` unchanged when `enabled?`
+  is false or when `v` is empty / scalar (no dedup opportunity).
+
+  Uses `de-dupe-eq` (equality-based) — see the namespace docstring
+  for the identity-vs-equality rationale.
+
+  The wire shape — `{:rf.mcp/dedup-table <cache-map>}` — is
+  cross-MCP-identical with pair2-mcp's `tools.dedup/dedup-value`;
+  the marker key comes from `re-frame.mcp-base.vocab`. The agent
+  host reconstructs by calling `de-dupe.core/expand` on the cache
+  map value."
+  [v enabled?]
+  (if (or (not enabled?) (empty-payload? v))
+    v
+    (let [cache (de-dupe/de-dupe-eq v)]
+      {base-vocab/dedup-table-key cache})))
+
+;; ---------------------------------------------------------------------------
+;; `:dedup?` MCP-arg parser.
+;; ---------------------------------------------------------------------------
+
+(defn parse-dedup-arg
+  "Resolve the cross-server `:dedup?` MCP arg from a raw arguments
+  object. Returns a boolean.
+
+  Accepts:
+    - JS args object (the MCP SDK shape) — looked up via
+      `(j/get args \"dedup?\")`.
+    - CLJS map — looked up via `(get args :dedup?)` or the
+      stringified key.
+    - nil / js/undefined.
+
+  Recognised-value parsing (boolean passthrough, string
+  `\"true\"`/`\"false\"`/`\"yes\"`/`\"no\"`/`\"1\"`/`\"0\"`,
+  keyword `:true`/`:false`) delegates to
+  `re-frame.mcp-base.args/parse-boolean` — the cross-MCP
+  accept-shape contract (rf2-vw4sq).
+
+  Unrecognised / absent inputs collapse to
+  `include-dedup-default` (`true` — spec/004 §5 default-on)."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              ;; Use `contains?` so an explicit `false` is honoured
+              ;; (an `or` chain would treat `false` as missing and
+              ;; fall through to the default).
+              (cond
+                (contains? args :dedup?)   (get args :dedup?)
+                (contains? args "dedup?")  (get args "dedup?")
+                :else                      nil)
+
+              :else
+              ;; JS object from the MCP wire.
+              (j/get args "dedup?"))]
+    (base-args/parse-boolean raw include-dedup-default)))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;;
+;; Tools call this once at the end of their body with the
+;; already-walked (W-6) + already-stripped (B-1) items vector +
+;; the resolved `:dedup?` arg. The wrapper:
+;;
+;;   1. Skips on opt-out / empty payload (no allocation, value
+;;      passes through).
+;;   2. Otherwise runs `de-dupe-eq` and writes the
+;;      `:rf.mcp/dedup-table`-wrapped value under `items-key`.
+;;
+;; ## Where in the cascade
+;;
+;; Per spec/004 §5: dedup runs BEFORE the W-1 cap check. The
+;; dispatcher's call sequence is:
+;;
+;;   raw items
+;;     → B-1 strip-sensitive
+;;     → W-6 count-elided-markers (the walker ran server-side)
+;;     → W-5 dedup-value           ← THIS WRAPPER
+;;     → W-3 cursor encode (when paginated)
+;;     → W-1 apply-cap             ← egress
+;;
+;; Each wrapper is additive; the envelope counters / cursors /
+;; mode slots accumulate as the cascade runs.
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/004 §5 structural-dedup transform to `items`
+  and write the result back into `envelope` under `items-key`.
+  Returns the updated envelope.
+
+  Arguments:
+    - `envelope`   — the per-call result map (will be updated).
+    - `items-key`  — the slot in `envelope` the (possibly
+                     deduped) items go into (e.g. `:trace-events`
+                     for `get-trace-buffer`, `:epochs` for
+                     `get-epoch-history`, `:events` for
+                     `subscribe` drain batches).
+    - `items`      — the items value (vector, seq, or
+                     `:rf.mcp/dedup-table`-wrapped map from a
+                     prior pass — though the latter is unusual
+                     for a single-pass dispatcher).
+    - `enabled?`   — boolean resolved from `parse-dedup-arg`;
+                     when `false`, the wrapper is a no-op
+                     (caller opted out explicitly).
+
+  Returns the envelope with `items-key` set to either the raw
+  items (opt-out / empty) or the `{:rf.mcp/dedup-table ...}`-
+  wrapped value (non-empty + opt-in)."
+  [envelope items-key items enabled?]
+  (assoc envelope items-key (dedup-value items enabled?)))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/path_slice.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/path_slice.cljs
@@ -1,0 +1,347 @@
+(ns day8.re-frame2-causa-mcp.path-slice
+  "Wire-pipeline mechanism W-2 at the Causa-MCP boundary (rf2-8xzoe.6).
+  Path slicing — per `tools/causa-mcp/spec/004-Wire-Pipeline.md` §2
+  (Path slicing).
+
+  ## What this provides
+
+  Tools returning rich nested values (`get-app-db`,
+  `get-machine-state`, `get-epoch-history`) MUST accept an optional
+  `:path` argument — an EDN-encoded vector of keys (e.g.
+  `\"[:cart :items 3 :sku]\"`) addressing a subtree.
+
+  This namespace is the per-call host-side input parser plus the
+  shared `:path-not-found` result builder. Tools call:
+
+    - `parse-path-arg` — normalise the raw `:path` MCP arg (JS array,
+      CLJS vector, EDN string, nil) into a CLJS vector suitable for
+      `get-in`.
+    - `apply-to-result` — resolve the path against a tree-typed value
+      and write the addressed subtree onto an envelope; on
+      out-of-range paths splice the structured `:path-not-found`
+      shape carrying the deepest-valid-prefix instead.
+    - `path-not-found` — the canonical structured error shape that
+      `apply-to-result` emits. Tools that compute the path resolution
+      server-side may emit it directly without going through
+      `apply-to-result`.
+    - `deepest-valid-prefix` — pure walker used by `path-not-found`
+      to compute the prefix attachment so the agent can re-aim
+      without binary-search.
+
+  ## Default-without-path posture (MUST 9)
+
+  Per spec/004 §2 L264: the default behaviour **without** a `:path`
+  argument MUST be a tree-summary (mechanism W-4 — `:summary` mode),
+  not the full payload. This namespace handles ONLY the path-arg
+  surface: the W-4 default-summary posture is enforced by the sibling
+  `summary` namespace's mode-resolver landing in W-4. The two
+  mechanisms compose at the per-tool dispatcher: the dispatcher
+  consults the parsed path; if non-nil, slice and ride the post-W-6
+  walker output through `apply-to-result`; if nil, route through
+  `summary/apply-to-result` instead.
+
+  ## Out-of-range — deepest-valid-prefix
+
+  Per spec/004 §2 L267-270: out-of-range paths return
+  `:ok? false :reason :path-not-found` with the deepest valid prefix
+  attached so the agent can re-aim. `deepest-valid-prefix` walks
+  the path against the tree, returning the longest prefix that
+  resolves. The walker handles map keys + sequential indices;
+  anything else (a scalar at depth, a function value, etc.)
+  terminates the walk.
+
+  ## Path-arg vocabulary (cross-MCP)
+
+  The parser accepts every shape pair2-mcp's `tools.args/parse-path-arg`
+  accepts (the surface the agent has already learned), so an agent
+  that learned `:path \"[:cart :items 0]\"` on pair2-mcp passes the
+  same string to causa-mcp's `get-app-db` / `get-machine-state` /
+  `get-epoch-history` tools unchanged.
+
+    - a JS array of strings — each parsed as EDN; non-EDN entries
+      stay as strings.
+    - a CLJS vector — passed through.
+    - an EDN-encoded string — `read-string`'d (e.g.
+      `\"[:cart :items 3 :sku]\"`).
+    - nil / missing — nil (no path slicing).
+
+  ## Composition with W-1 / W-6 / B-1
+
+  - **With W-1 (token-cap)**: path slicing typically reduces payload
+    size enough to stay under the cap. When even the sliced subtree
+    overflows, W-1's `apply-cap` trips with `:hint :slice` (further
+    drill) or `:slice` redux. The composition is the canonical
+    spec/004 §2 → §1 cascade: slice first, cap as backstop.
+  - **With W-6 (size-elision)**: the walker runs server-side INSIDE
+    the eval form; this namespace operates on the already-walked
+    value. `apply-to-result` calls `elision/apply-to-result` to
+    count + stamp the `:elided-large` counter. Tools wire both
+    boundary wrappers in a single envelope.
+  - **With B-1 (privacy)**: orthogonal — privacy lives on the
+    trace-stream surface; path slicing lives on the direct-read
+    surface. They don't compose at the per-call site, but the
+    cross-MCP shape `:include-sensitive?` opt-in slot stays
+    consistent across all of them.
+
+  ## MUSTs honoured
+
+  - MUST 8 — every direct-read tool MUST accept the `:path` arg
+    (spec/004 §2). `parse-path-arg` is the single normative
+    accept-shape parser; the per-tool dispatcher calls it once
+    on the raw args object.
+  - MUST 9 (default-mode-is-summary half) — the parser returns
+    `nil` for absent `:path`, signalling the dispatcher to take
+    the summary branch. This namespace owns the `nil` semantics;
+    the summary branch itself is W-4."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Path-arg accept-shape parser — cross-MCP vocabulary.
+;;
+;; Mirrors pair2-mcp's `tools.args/parse-path-arg` accept-shape table
+;; (rf2-tygdv). Same input shapes, same output (a CLJS vector or nil),
+;; same fallback semantics. Single namespace here so the per-tool
+;; dispatcher requires one ns for path-arg concerns.
+;; ---------------------------------------------------------------------------
+
+(defn coerce-path-segment
+  "Coerce one segment of a JS-array path argument.
+
+  Try `read-string`; on any failure (the bare identifier case —
+  `\"items\"` would otherwise read as a symbol, which is the wrong
+  `get-in` key) fall through as the original string. `read-string`
+  parses EDN literals (`\":cart\"` ⇒ `:cart`, `\"0\"` ⇒ `0`,
+  `\"-1\"` ⇒ `-1`) and rejects anything else, so the catch-fallback
+  IS the discriminator — no first-char heuristic needed."
+  [s]
+  (if-not (string? s)
+    s
+    (let [trimmed (str/trim s)
+          parsed  (try (cljs.reader/read-string trimmed)
+                       (catch :default _ ::reader-fail))]
+      (cond
+        (= ::reader-fail parsed) s
+        ;; Symbols are the reader's "bare identifier" outcome — not a
+        ;; valid `get-in` key on a map keyed by strings or keywords;
+        ;; keep the original string instead so `{\"items\" ...}` works.
+        (symbol? parsed)         s
+        :else                    parsed))))
+
+(defn parse-path-arg
+  "Normalise the `:path` MCP arg into a CLJS vector suitable for
+  `get-in`. Returns `nil` when the path is absent (signalling the
+  dispatcher to take the summary branch per MUST 9). Returns `[]`
+  for an explicit empty path (root). Unparseable strings fall
+  through as single-segment string paths — `get-in` then treats
+  them as map keys.
+
+  Accepts every shape pair2-mcp's `tools.args/parse-path-arg`
+  accepts (the cross-MCP path-arg vocabulary):
+
+    - JS array of strings — each parsed as EDN; non-EDN entries
+      stay as strings (`#js [\":cart\" \":items\" \"0\"]` ⇒
+      `[:cart :items 0]`).
+    - CLJS vector — pass through.
+    - CLJS sequential — coerced to a vector.
+    - EDN-encoded string — `read-string`'d
+      (`\"[:cart :items 3 :sku]\"` ⇒ `[:cart :items 3 :sku]`).
+    - nil / missing — `nil`.
+    - blank / whitespace string — `nil`."
+  [raw]
+  (cond
+    (nil? raw) nil
+    (vector? raw) raw
+    (sequential? raw) (vec raw)
+    (array? raw) (mapv coerce-path-segment (js->clj raw))
+    (string? raw)
+    (let [trimmed (str/trim raw)]
+      (cond
+        (str/blank? trimmed) nil
+        :else
+        (try
+          (let [parsed (cljs.reader/read-string trimmed)]
+            (cond
+              (vector? parsed)     parsed
+              (sequential? parsed) (vec parsed)
+              :else                [parsed]))
+          (catch :default _
+            ;; Unparseable; treat the whole string as a single segment.
+            [trimmed]))))
+    :else nil))
+
+(defn path-arg
+  "Extract the cross-server `:path` MCP arg from a raw arguments
+  object and normalise it. Returns a CLJS vector or `nil`.
+
+  Accepts both the JS-side args object (the npm MCP SDK shape) and
+  a CLJS map (already-coerced upstream). The slot name is the cross-
+  server `path` (string key for JS, `:path` for CLJS) per spec/004
+  §2.
+
+  Unrecognised / absent inputs collapse to `nil` (the signal for
+  the dispatcher to take the W-4 summary branch)."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :path)
+                  (get args "path"))
+
+              :else
+              (let [v (j/get args "path")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (parse-path-arg raw)))
+
+;; ---------------------------------------------------------------------------
+;; deepest-valid-prefix — walker for the :path-not-found re-aim hint.
+;; ---------------------------------------------------------------------------
+
+(defn deepest-valid-prefix
+  "Walk `path` against `tree` and return the deepest prefix that
+  resolves. Used in `:path-not-found` errors so the agent can re-aim
+  without a binary search. Handles map keys + sequential indices;
+  anything else (a scalar at depth, a function value, etc.) terminates
+  the walk.
+
+  Returns a vector — possibly empty (no prefix resolved) up to the
+  full path (every segment resolved; the call-site treats that as a
+  successful resolution, not a `:path-not-found`)."
+  [tree path]
+  (loop [acc [] cur tree remaining (seq path)]
+    (if-not remaining
+      acc
+      (let [k (first remaining)]
+        (cond
+          (and (map? cur) (contains? cur k))
+          (recur (conj acc k) (get cur k) (next remaining))
+
+          (and (sequential? cur)
+               (integer? k)
+               (<= 0 k (dec (count (if (counted? cur) cur (vec cur))))))
+          (recur (conj acc k)
+                 (nth (if (vector? cur) cur (vec cur)) k)
+                 (next remaining))
+
+          :else acc)))))
+
+;; ---------------------------------------------------------------------------
+;; path-not-found — the structured error result per spec/004 §2 L267.
+;; ---------------------------------------------------------------------------
+
+(defn path-not-found
+  "Build the structured `:path-not-found` result map per spec/004 §2
+  L267-270. Shape:
+
+      {:ok?                   false
+       :reason                :path-not-found
+       :path                  <requested-path>
+       :deepest-valid-prefix  <prefix-vector>}
+
+  The agent reads `:deepest-valid-prefix` to re-aim without a
+  binary-search — re-call with a path equal to (or one step into)
+  the prefix.
+
+  The `:reason :path-not-found` keyword is the cross-MCP convention
+  for re-aim errors on tree-typed direct-read tools; agents pattern-
+  match on it. (Sibling to `:rf.mcp/cursor-stale` on the
+  cursor-pagination side — pinned in `re-frame.mcp-base.vocab`; this
+  reason key stays unqualified because it's per-tool, not a cross-
+  cutting wire-mechanism marker.)"
+  [tree path]
+  {:ok?                   false
+   :reason                :path-not-found
+   :path                  path
+   :deepest-valid-prefix  (deepest-valid-prefix tree path)})
+
+;; ---------------------------------------------------------------------------
+;; resolve-path — sentinel-aware `get-in` for path slicing.
+;;
+;; The sentinel disambiguates a path that legitimately resolves to nil
+;; from one that doesn't resolve at all. Both pair2-mcp's get-path
+;; eval form and this host-side equivalent use the same trick: a fresh
+;; identity-comparable sentinel value, returned by `get-in` only when
+;; the path was missing.
+;; ---------------------------------------------------------------------------
+
+(def ^:private not-found-sentinel
+  "Identity-comparable marker for `resolve-path`. Reified once at ns
+  load so `identical?` resolves cheaply (a fresh `#js {}` on each
+  call would mean `identical?` is a pointer compare, but the fresh
+  value would prevent any pooling). Module-private — never escapes
+  this ns."
+  #js {})
+
+(defn resolve-path
+  "Resolve `path` against `tree`. Returns either the addressed
+  subtree (which may legitimately be `nil`) or `::not-found` when
+  the path is out of range.
+
+  Disambiguates `nil-at-path` (a path that resolves to a value of
+  `nil` — valid resolution) from `not-found` (a path that doesn't
+  resolve at all — out-of-range, triggers `:path-not-found`) via
+  an identity sentinel that `get-in` returns iff the path is missing."
+  [tree path]
+  (let [v (get-in tree path not-found-sentinel)]
+    (if (identical? v not-found-sentinel)
+      ::not-found
+      v)))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper for direct-read tools.
+;;
+;; Tools that take a `:path` arg call this once at the end of their
+;; body, with the already-walked tree (post-W-6 elision) + the parsed
+;; path + the in-progress envelope. The helper resolves the path:
+;;
+;;   - If the path resolves, writes the addressed subtree under
+;;     `value-key` on the envelope and returns the envelope.
+;;   - If the path is out-of-range, splices the `:path-not-found`
+;;     shape onto the envelope (slot-by-slot — `:ok?`, `:reason`,
+;;     `:path`, `:deepest-valid-prefix`) and returns it WITHOUT
+;;     writing under `value-key` (the slot is meaningless on a
+;;     `:path-not-found` response).
+;;
+;; The wrapper does NOT call into W-6 — the dispatcher already
+;; walked the tree server-side via the eval form. This wrapper is
+;; pure host-side path resolution.
+;;
+;; ## Why splice rather than replace
+;;
+;; The envelope already carries cursor / mode / cache / tool-name
+;; slots the dispatcher set upstream. Replacing the envelope with
+;; just the `:path-not-found` map would lose them; splicing keeps
+;; the dispatcher's other context (the agent still sees the
+;; `:tool`, the `:mode` it picked, etc.) alongside the error.
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/004 §2 path-slice resolution to `tree` and write
+  the result back into `envelope` under `value-key`. Returns the
+  updated envelope.
+
+  Arguments:
+    - `envelope`   — the per-call result map (will be updated).
+    - `value-key`  — the slot in `envelope` the resolved subtree
+                     goes into (e.g. `:db` for `get-app-db`,
+                     `:state` for `get-machine-state`, `:epochs`
+                     for `get-epoch-history`).
+    - `tree`       — the already-walked tree-typed payload (the
+                     eval form ran `re-frame.core/elide-wire-value`
+                     server-side; the marker substitution is
+                     already in place).
+    - `path`       — a CLJS vector of keys / indices (the output
+                     of `parse-path-arg`). May be `[]` (root) or
+                     a deep path.
+
+  Returns the envelope with `value-key` set to the addressed
+  subtree when the path resolves, or with the `:path-not-found`
+  slots spliced in when out-of-range."
+  [envelope value-key tree path]
+  (let [resolved (resolve-path tree path)]
+    (if (= ::not-found resolved)
+      (merge envelope (path-not-found tree path))
+      (assoc envelope value-key resolved))))

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/summary.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/summary.cljs
@@ -1,0 +1,413 @@
+(ns day8.re-frame2-causa-mcp.summary
+  "Wire-pipeline mechanism W-4 at the Causa-MCP boundary (rf2-8xzoe.8).
+  Lazy summary mode — per
+  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §4 (Lazy summary).
+
+  ## What this provides
+
+  The **default response mode** for any tool returning a rich
+  nested value is a **summary**, not the full payload. A summary
+  declares the shape without committing the budget:
+
+      {:rf.mcp/summary {:type   :map | :vector | :set | :seq | :scalar
+                        :keys   [:cart :user :ui ...]   ; :map only
+                        :counts {:cart 47 :user 3 ...}   ; :map only
+                        :count  N                         ; non-map
+                        :bytes  ~int}}
+
+  Tools MUST expose a `:mode` argument with at least:
+    - `:summary` (default) — the marker above.
+    - `:sample` — a bounded prefix of the value (configurable
+                  sample size; default 8 entries).
+    - `:full` — the complete payload, subject to W-1 token cap
+                and (where applicable) W-3 pagination.
+
+  Agents drill down via W-2 `:path` or W-3 `:cursor` once the
+  shape is known; `:full` is opt-in for cases where the agent
+  genuinely needs everything.
+
+  ## Causa-specific `:counts` shape
+
+  The causa-spec divergence from pair2-mcp's `tools.summary` is
+  the `:counts` map: pair2-mcp emits a single scalar `:count`
+  (total entry count), while causa-mcp's `:map` summary emits a
+  per-key `:counts` map (the cardinality of each top-level
+  value) so the agent can prioritise drill-down without a second
+  call.
+
+  For non-`:map` shapes (`:vector` / `:set` / `:seq`) the per-key
+  decomposition is meaningless; those carry a single scalar
+  `:count` like pair2-mcp.
+
+  ## Cheap `:bytes` estimator (rf2-qta8j shape)
+
+  The `:bytes` field is a cheap APPROXIMATION (per pair2-mcp
+  rf2-qta8j; cross-MCP convention). Earlier candidates that paid
+  `(count (pr-str v))` on every branch deep-serialised the
+  payload just to discard the string — contradicts the marker's
+  cost model (a 54MB app-db slice burns a 54MB string allocation
+  per summary). The estimator is `entry-count × per-entry
+  constant` — order-of-magnitude correct, constant-time.
+
+  Agents needing a precise size measure their drill-down result
+  directly. The marker's `:bytes` slot is for planning (`is this
+  slice worth drilling?`), not for budgeting.
+
+  ## Mode-arg parsing
+
+  `parse-mode-arg` is the cross-server `:mode` MCP arg resolver.
+  Recognised values: `:summary` (default), `:sample`, `:full`.
+  Unrecognised values fall back to the cap-sensitive default
+  (`:summary`) per the bounded-allowlist-keyword discipline
+  (rf2-ih7g4) — an out-of-vocab agent input never interns a
+  fresh keyword.
+
+  ## Composition with W-1 / W-2 / W-3 / W-6 / B-1
+
+  - **With W-1 (token-cap)**: `:summary` is the primary cap
+    defence — the marker is always small (tens of tokens for a
+    typical app-db root). `:full` mode is opt-in and may trip
+    W-1's `apply-cap` with `:hint :switch-mode` (recall with
+    `:sample` or `:summary`).
+  - **With W-2 (path slicing)**: the dispatcher consults the
+    parsed `:path` first; if non-nil, slice; if nil, take the
+    summary branch (the MUST 9 cascade — `path-slice/parse-path-
+    arg` returns nil signalling summary-mode).
+  - **With W-3 (cursor pagination)**: `:full` mode pages via
+    W-3 when the addressed value is sequence-shaped. `:sample`
+    and `:summary` modes are non-paginated (bounded by
+    construction).
+  - **With W-6 (size-elision)**: `:summary` operates on the
+    already-walked tree — large leaves are already markers, the
+    summary just describes the top-level shape.
+  - **With B-1 (privacy)**: orthogonal — privacy lives on the
+    trace-stream surface, summary lives on the direct-read
+    surface.
+
+  ## MUSTs honoured
+
+  - MUST 12 — every tree-typed tool exposes a `:mode` argument
+    with at least `:summary` (default), `:sample`, `:full`
+    (spec/004 §4 L303-306). `parse-mode-arg` is the single
+    normative parser; the per-tool dispatcher calls it once on
+    the raw args object."
+  (:require [applied-science.js-interop :as j]
+            [re-frame.mcp-base.args :as base-args]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; ---------------------------------------------------------------------------
+;; Constants — mode vocabulary, summary cap, sample-size default.
+;; ---------------------------------------------------------------------------
+
+(def mode-vocabulary
+  "The closed set of `:mode` values per spec/004 §4 (L303-306). An
+  agent pattern-matches on this set; an out-of-vocab value would
+  break the agent's exhaustive case. Reified as a set so the
+  parser can guard against fresh-keyword interning (rf2-ih7g4).
+
+  Closed set:
+    - `:summary` — the default; shape marker only.
+    - `:sample`  — bounded prefix (default `default-sample-size`).
+    - `:full`    — paginated complete payload.
+
+  Tools MUST expose all three modes per MUST 12."
+  #{:summary :sample :full})
+
+(def ^:const default-mode
+  "Default `:mode` per spec/004 §4 L304 — `:summary`. The cap-
+  sensitive default; an agent that doesn't supply `:mode` gets
+  the smallest-payload shape."
+  :summary)
+
+(def ^:const summary-keys-cap
+  "Top-N keys included verbatim in a tree-summary marker. Above
+  this, the summary truncates the `:keys` vector and stamps
+  `:keys-truncated? true` so the marker itself stays bounded —
+  a 5,000-entry map's key list alone would exceed the W-1 wire
+  cap otherwise.
+
+  64 is large enough that a human-scale app-db root surfaces
+  every key, and small enough that the marker is always tens of
+  tokens. Cross-MCP-aligned with pair2-mcp's
+  `tools.summary/summary-keys-cap`."
+  64)
+
+(def ^:const default-sample-size
+  "Default `:sample-size` MCP arg when `:mode :sample` is
+  requested. 8 entries is the rule-of-thumb for a useful prefix
+  that still fits the W-1 cap on typical record sizes — a 5K-token
+  cap divided by ~600-token-per-record envelope is ~8 records.
+
+  The sample is a bounded PREFIX (the first N entries by natural
+  collection order), not a stratified sample. Agents that need
+  representative coverage across a large value drill into
+  specific paths via W-2 `:path`."
+  8)
+
+(def ^:const min-sample-size 1)
+
+(def ^:const max-sample-size
+  "Upper clamp on `:sample-size`. 256 entries is generous (covers
+  most realistic exploratory windows) without blowing the W-1
+  cap. Agents asking for more than 256 should switch to
+  `:mode :full` + W-3 cursor pagination, not a giant sample."
+  256)
+
+;; ---------------------------------------------------------------------------
+;; Cheap `:bytes` estimator (rf2-qta8j cross-MCP shape).
+;; ---------------------------------------------------------------------------
+
+(def ^:const ^:private map-bytes-per-entry  16)
+(def ^:const ^:private coll-bytes-per-entry 8)
+
+(defn- approx-map-bytes  [n] (* map-bytes-per-entry  n))
+(defn- approx-coll-bytes [n] (* coll-bytes-per-entry n))
+
+(defn- entry-count
+  "Counted-aware count helper — works on seqs lazily (one pass)
+  and counted colls in O(1)."
+  [v]
+  (if (counted? v) (count v) (count v)))
+
+(defn- value-count
+  "Cardinality estimate for a per-key `:counts` entry value.
+  Scalars contribute 1; collections contribute their count. Used
+  to populate the `:counts` map's values without recursing."
+  [v]
+  (cond
+    (nil? v)         0
+    (map? v)         (count v)
+    (counted? v)     (count v)
+    (string? v)      (count v)
+    (sequential? v)  (count v)
+    :else            1))
+
+;; ---------------------------------------------------------------------------
+;; tree-summary — the {:rf.mcp/summary ...} marker shape.
+;; ---------------------------------------------------------------------------
+
+(defn tree-summary
+  "Compute a server-friendly tree summary of `v`. Returns the
+  marker shape causa-spec §4 pins.
+
+  Cheap — one pass over the top-level structure, no deep walk.
+  The marker itself is bounded: long key lists are truncated to
+  `summary-keys-cap` entries and flagged via `:keys-truncated?
+  true` so the marker can never blow the W-1 wire cap.
+
+  Causa-specific divergence from pair2-mcp's marker shape: maps
+  carry `:counts` (a per-key cardinality map) in addition to
+  `:keys`, so the agent can prioritise drill-down without a
+  second call. Non-map collections carry a single scalar
+  `:count` like pair2-mcp.
+
+  The `:bytes` field is an APPROXIMATION — `count × per-entry
+  constant`. Per rf2-qta8j (cross-MCP): deep `(count (pr-str v))`
+  would burn a deep walk per summary, contradicting the marker's
+  no-deep-walk cost model.
+
+  Scalars are returned unchanged — they already fit the wire cap
+  by definition; wrapping them in a summary marker would add
+  tokens without saving any."
+  [v]
+  (cond
+    (map? v)
+    (let [ks      (vec (keys v))
+          n       (count ks)
+          shown   (if (> n summary-keys-cap)
+                    (subvec ks 0 summary-keys-cap)
+                    ks)
+          ;; :counts is per-key cardinality — the causa divergence.
+          ;; Only emit entries for the shown keys (the truncated
+          ;; trailing keys aren't in :keys; they shouldn't be in
+          ;; :counts either, by parity).
+          counts  (reduce
+                    (fn [m k] (assoc m k (value-count (get v k))))
+                    {}
+                    shown)]
+      {:rf.mcp/summary (cond-> {:type   :map
+                                :keys   shown
+                                :counts counts
+                                :bytes  (approx-map-bytes n)}
+                         (> n summary-keys-cap)
+                         (assoc :keys-truncated? true))})
+    (vector? v)
+    (let [n (count v)]
+      {:rf.mcp/summary {:type  :vector
+                        :count n
+                        :bytes (approx-coll-bytes n)}})
+    (set? v)
+    (let [n (count v)]
+      {:rf.mcp/summary {:type  :set
+                        :count n
+                        :bytes (approx-coll-bytes n)}})
+    (sequential? v)
+    (let [n (entry-count v)]
+      {:rf.mcp/summary {:type  :seq
+                        :count n
+                        :bytes (approx-coll-bytes n)}})
+    :else
+    ;; Scalars pass through unchanged — `:type :scalar` isn't
+    ;; emitted as a marker because the scalar already fits the
+    ;; cap. Spec/004 §4 L297 lists `:scalar` in the type vocab
+    ;; for documentation completeness; the marker never wraps a
+    ;; scalar in practice.
+    v))
+
+;; ---------------------------------------------------------------------------
+;; sample-value — bounded prefix for :mode :sample.
+;; ---------------------------------------------------------------------------
+
+(defn sample-value
+  "Return a bounded prefix of `v` (up to `n` entries) for
+  `:mode :sample`. Returns a value of the same collection shape
+  (map → map; vector → vector; set → set; seq → seq); scalars
+  pass through unchanged (already cap-safe).
+
+  The sample is a PREFIX in natural collection order — `:keys`
+  for maps (sorted for stability), index order for vectors /
+  seqs, iteration order for sets. Agents needing representative
+  coverage across a large value drill into specific paths via
+  W-2 `:path`."
+  [v n]
+  (let [n* (max min-sample-size (min max-sample-size (long n)))]
+    (cond
+      (map? v)
+      (->> (sort-by (comp pr-str key) v)
+           (take n*)
+           (into {}))
+
+      (vector? v)
+      (vec (take n* v))
+
+      (set? v)
+      (set (take n* v))
+
+      (sequential? v)
+      (take n* v)
+
+      :else v)))
+
+;; ---------------------------------------------------------------------------
+;; Mode-arg + sample-size-arg parsers.
+;; ---------------------------------------------------------------------------
+
+(defn parse-mode-arg
+  "Normalise the cross-server `:mode` MCP arg into one of
+  `mode-vocabulary`. Defaults to `default-mode` (`:summary`) when
+  the arg is absent or unrecognised.
+
+  Routes through `re-frame.mcp-base.args/parse-mode` (rf2-vw4sq)
+  for the bounded-allowlist gate (rf2-ih7g4) — an unrecognised
+  agent-supplied string never interns a fresh keyword."
+  [raw]
+  (base-args/parse-mode raw default-mode mode-vocabulary))
+
+(defn mode-arg
+  "Resolve the cross-server `:mode` MCP arg from a raw arguments
+  object. Returns a keyword from `mode-vocabulary`.
+
+  Accepts both the JS-side args object (the npm MCP SDK shape) and
+  a CLJS map. The slot name is the cross-server `mode` (string key
+  for JS, `:mode` for CLJS) per spec/004 §4.
+
+  Unrecognised / absent inputs collapse to `default-mode`."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :mode)
+                  (get args "mode"))
+
+              :else
+              (let [v (j/get args "mode")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (parse-mode-arg raw)))
+
+(defn parse-sample-size-arg
+  "Normalise a raw `:sample-size` value into an integer in
+  `[min-sample-size, max-sample-size]`. Defaults to
+  `default-sample-size` when absent / unrecognised. Delegates
+  recognised-value parsing to
+  `re-frame.mcp-base.args/parse-positive-int` (rf2-vw4sq); the
+  upper clamp is applied here."
+  [raw]
+  (-> (base-args/parse-positive-int raw default-sample-size)
+      (max min-sample-size)
+      (min max-sample-size)))
+
+(defn sample-size-arg
+  "Resolve the cross-server `:sample-size` MCP arg from a raw
+  arguments object. Returns an integer in `[min-sample-size,
+  max-sample-size]`. Unrecognised / absent inputs collapse to
+  `default-sample-size`."
+  [args]
+  (let [raw (cond
+              (or (nil? args) (undefined? args))
+              nil
+
+              (map? args)
+              (or (get args :sample-size)
+                  (get args "sample-size"))
+
+              :else
+              (let [v (j/get args "sample-size")]
+                (when-not (or (nil? v) (undefined? v)) v)))]
+    (parse-sample-size-arg raw)))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;;
+;; Tools that take a `:mode` arg call this once at the end of their
+;; body with the already-walked (W-6) tree + the resolved mode +
+;; the resolved sample-size. The wrapper writes either the
+;; tree-summary marker (:summary), a bounded prefix (:sample), or
+;; the verbatim tree (:full) into the envelope under `value-key`,
+;; and stamps the chosen `:mode` slot for the agent's accounting.
+;;
+;; `:full` mode passes the value through unchanged — downstream
+;; mechanisms (W-3 pagination, W-1 cap) handle their own concerns.
+;; ---------------------------------------------------------------------------
+
+(defn apply-to-result
+  "Apply the spec/004 §4 mode-driven summary/sample/full
+  transform to `value` and write the result back into `envelope`
+  under `value-key`. Returns the updated envelope with the
+  chosen `:mode` slot stamped.
+
+  Arguments:
+    - `envelope`    — the per-call result map (will be updated).
+    - `value-key`   — the slot in `envelope` the post-transform
+                      value goes into (e.g. `:db` for `get-app-db`,
+                      `:state` for `get-machine-state`).
+    - `value`       — the already-walked tree-typed payload (the
+                      eval form ran `re-frame.core/elide-wire-value`
+                      server-side; the marker substitution is
+                      already in place).
+    - opts:
+      - `:mode`         — the resolved mode keyword (one of
+                          `mode-vocabulary`). Defaults to
+                          `default-mode` when omitted.
+      - `:sample-size`  — the resolved sample size (integer).
+                          Used only when `:mode :sample`. Defaults
+                          to `default-sample-size`.
+
+  Returns the envelope with `value-key` set to the transformed
+  value and `:mode` stamped to the chosen mode."
+  [envelope value-key value {:keys [mode sample-size]
+                             :or   {mode        default-mode
+                                    sample-size default-sample-size}}]
+  (let [transformed (case mode
+                      :summary (tree-summary value)
+                      :sample  (sample-value value sample-size)
+                      :full    value
+                      ;; Unknown mode — collapse to default. The
+                      ;; parser is bounded-allowlist-guarded, so
+                      ;; this branch shouldn't fire; defensive
+                      ;; against direct-call drift.
+                      (tree-summary value))]
+    (-> envelope
+        (assoc value-key transformed)
+        (assoc :mode mode))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/cursor_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/cursor_test.cljs
@@ -1,0 +1,415 @@
+(ns day8.re-frame2-causa-mcp.cursor-test
+  "Unit tests for the W-3 cursor-pagination wire-pipeline mechanism
+  at the Causa-MCP boundary (rf2-8xzoe.7). Pins:
+
+    - MUST 10 — sequence-returning tools (`get-trace-buffer`,
+      `get-epoch-history`, `list-subscriptions`) MUST accept
+      `:cursor` (opaque) + `:limit` (integer) args
+      (spec/004 §3 L274-281).
+    - MUST 11 — responses MUST carry `:next-cursor` (or nil) +
+      `:remaining` (count/estimate) (spec/004 §3 L283-284).
+    - Opaque round-trip — encode/decode preserves the cursor
+      payload exactly (the agent passes it back verbatim).
+    - Cursor staleness — `:rf.mcp/cursor-stale` structured error
+      shape, sourced from `re-frame.mcp-base.vocab/cursor-stale-
+      reason` (cross-MCP).
+    - Composition with W-1 (token-cap), W-6 (elision), and B-1
+      (privacy) — wrappers are additive; counters from all axes
+      ride together on the same envelope.
+
+  These tests are the load-bearing pin for the downstream paginated
+  tool beads — every dispatcher that returns a paginated payload
+  calls `cursor/apply-to-result` once at the boundary."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.cursor :as cursor]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; A canonical elided marker as the framework walker would emit. Reused
+;; across composition tests so the W-6 surface stays visible inside
+;; W-3's paginated batches.
+(def ^:private elided-marker
+  {:rf.size/large-elided
+   {:path   [:trace 0 :coeffect :db]
+    :bytes  102400
+    :type   :map
+    :reason :declared
+    :handle [:rf.elision/at [:trace 0 :coeffect :db]]}})
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-3 lands the public surface downstream paginated tool
+            dispatchers will require"
+    (is (fn? cursor/parse-limit-arg))
+    (is (fn? cursor/limit-arg))
+    (is (fn? cursor/encode-cursor))
+    (is (fn? cursor/decode-cursor))
+    (is (fn? cursor/cursor-arg))
+    (is (fn? cursor/cursor-stale-result))
+    (is (fn? cursor/apply-to-result))
+    (is (= 50 cursor/default-limit))
+    (is (= 1  cursor/min-limit))))
+
+;; ---------------------------------------------------------------------------
+;; parse-limit-arg / limit-arg — accept-shape contract.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-limit-default-when-absent
+  (is (= cursor/default-limit (cursor/parse-limit-arg nil))))
+
+(deftest parse-limit-positive-integer-pass-through
+  (is (= 10 (cursor/parse-limit-arg 10)))
+  (is (= 1  (cursor/parse-limit-arg 1)))
+  (is (= 1000 (cursor/parse-limit-arg 1000))))
+
+(deftest parse-limit-clamps-non-positive-to-floor
+  ;; min-limit is 1 — a caller asking for 0 / negative collapses to
+  ;; the smallest valid page rather than landing in a paging dead-end.
+  (is (= cursor/min-limit (cursor/parse-limit-arg 0)))
+  (is (= cursor/min-limit (cursor/parse-limit-arg -5))))
+
+(deftest parse-limit-parses-numeric-string
+  ;; The MCP wire may hand the dispatcher a stringified integer
+  ;; (depending on the agent host's serialiser); the parser handles
+  ;; both shapes uniformly.
+  (is (= 25 (cursor/parse-limit-arg "25"))))
+
+(deftest parse-limit-non-numeric-string-falls-back
+  (is (= cursor/default-limit (cursor/parse-limit-arg "bogus"))))
+
+(deftest limit-arg-from-js-args-object
+  ;; The MCP SDK hands the dispatcher a JS args object; the helper
+  ;; reads `limit` off it and routes through the parser.
+  (is (= 10 (cursor/limit-arg #js {"limit" 10})))
+  (is (= 25 (cursor/limit-arg #js {"limit" "25"})))
+  (is (= cursor/default-limit (cursor/limit-arg #js {}))))
+
+(deftest limit-arg-from-cljs-map
+  (is (= 10 (cursor/limit-arg {:limit 10})))
+  (is (= 10 (cursor/limit-arg {"limit" 10}))))
+
+(deftest limit-arg-absent-returns-default
+  (is (= cursor/default-limit (cursor/limit-arg nil)))
+  (is (= cursor/default-limit (cursor/limit-arg js/undefined))))
+
+;; ---------------------------------------------------------------------------
+;; encode-cursor / decode-cursor — opaque round-trip.
+;; ---------------------------------------------------------------------------
+
+(deftest encode-cursor-nil-when-no-after-id
+  ;; The terminal-page signal: a payload missing :after-id collapses
+  ;; to nil. The dispatcher passes nil when pagination is exhausted.
+  (is (nil? (cursor/encode-cursor nil)))
+  (is (nil? (cursor/encode-cursor {})))
+  (is (nil? (cursor/encode-cursor {:v 1 :after-id nil}))))
+
+(deftest encode-cursor-returns-string-on-valid-payload
+  (let [c (cursor/encode-cursor {:v 1 :after-id "abc"})]
+    (is (string? c))
+    (is (pos? (count c)))))
+
+(deftest encode-cursor-is-base64-on-wire
+  ;; The cursor must be base64-safe — no JSON-confusing characters
+  ;; that would break round-trip through stdio + JSON-RPC.
+  (let [c (cursor/encode-cursor {:v 1 :after-id "abc-def"})]
+    (is (re-matches #"^[A-Za-z0-9+/=]+$" c))))
+
+(deftest cursor-round-trip-preserves-payload
+  (let [payload {:v 1 :after-id "epoch-42" :until-ms 1234567890
+                 :frame :rf/default}
+        encoded (cursor/encode-cursor payload)
+        decoded (cursor/decode-cursor encoded)]
+    (is (= payload decoded))))
+
+(deftest decode-cursor-nil-on-nil-input
+  (is (nil? (cursor/decode-cursor nil)))
+  (is (nil? (cursor/decode-cursor "")))
+  (is (nil? (cursor/decode-cursor js/undefined))))
+
+(deftest decode-cursor-malformed-on-junk
+  ;; A cursor that doesn't decode is treated as stale — the caller
+  ;; translates ::malformed into the same :rf.mcp/cursor-stale error
+  ;; a runtime age-out raises.
+  (is (= :day8.re-frame2-causa-mcp.cursor/malformed
+         (cursor/decode-cursor "not-real-base64-edn-juzlblahHFGYbn")))
+  (is (= :day8.re-frame2-causa-mcp.cursor/malformed
+         (cursor/decode-cursor 12345)))
+  ;; base64 of "[1 2 3]" — decodes but isn't a map with :after-id
+  (let [bogus (.toString (js/Buffer.from "[1 2 3]" "utf8") "base64")]
+    (is (= :day8.re-frame2-causa-mcp.cursor/malformed
+           (cursor/decode-cursor bogus)))))
+
+(deftest decode-cursor-malformed-on-missing-after-id
+  ;; The :after-id slot is the load-bearing payload — a cursor
+  ;; without it can't resume the stream. Treated as malformed.
+  (let [bogus (.toString (js/Buffer.from "{:v 1}" "utf8") "base64")]
+    (is (= :day8.re-frame2-causa-mcp.cursor/malformed
+           (cursor/decode-cursor bogus)))))
+
+(deftest cursor-arg-from-js-args-object
+  (let [payload {:v 1 :after-id "epoch-42"}
+        encoded (cursor/encode-cursor payload)]
+    (is (= payload (cursor/cursor-arg #js {"cursor" encoded})))))
+
+(deftest cursor-arg-from-cljs-map
+  (let [payload {:v 1 :after-id "epoch-42"}
+        encoded (cursor/encode-cursor payload)]
+    (is (= payload (cursor/cursor-arg {:cursor encoded})))
+    (is (= payload (cursor/cursor-arg {"cursor" encoded})))))
+
+(deftest cursor-arg-absent-returns-nil
+  ;; First-call posture: no cursor arg supplied.
+  (is (nil? (cursor/cursor-arg nil)))
+  (is (nil? (cursor/cursor-arg js/undefined)))
+  (is (nil? (cursor/cursor-arg #js {})))
+  (is (nil? (cursor/cursor-arg {}))))
+
+(deftest cursor-arg-malformed-on-bad-input
+  (is (= :day8.re-frame2-causa-mcp.cursor/malformed
+         (cursor/cursor-arg #js {"cursor" "not-a-real-cursor"}))))
+
+;; ---------------------------------------------------------------------------
+;; cursor-stale-result — :rf.mcp/cursor-stale shape.
+;; ---------------------------------------------------------------------------
+
+(deftest cursor-stale-result-shape-minimum
+  (let [r (cursor/cursor-stale-result "get-trace-buffer" {})]
+    (is (false? (:ok? r)))
+    (is (= :rf.mcp/cursor-stale (:reason r)))
+    (is (= "get-trace-buffer" (:tool r)))
+    (is (string? (:hint r)))
+    (is (not (contains? r :requested-id)))
+    (is (not (contains? r :head-id)))))
+
+(deftest cursor-stale-result-with-ids
+  (let [r (cursor/cursor-stale-result
+            "get-epoch-history"
+            {:requested-id "ep-100" :head-id "ep-250"})]
+    (is (= "ep-100" (:requested-id r)))
+    (is (= "ep-250" (:head-id r)))))
+
+(deftest cursor-stale-reason-matches-cross-mcp-vocab
+  ;; Pin the cross-MCP convention: `:reason` value comes from
+  ;; `re-frame.mcp-base.vocab/cursor-stale-reason`. A rename in the
+  ;; base ns surfaces here loud rather than drifting silently.
+  (is (= base-vocab/cursor-stale-reason
+         (:reason (cursor/cursor-stale-result "any-tool" {})))))
+
+(deftest cursor-stale-reason-keyword-pin
+  ;; The keyword literal pin — agents pattern-match on the literal,
+  ;; not on the var. A change to the literal needs an explicit
+  ;; coordinated update across the MCP triplet.
+  (is (= :rf.mcp/cursor-stale
+         (:reason (cursor/cursor-stale-result "any-tool" {})))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-writes-items-and-shape
+  ;; Happy path: items ride under `items-key`; :next-cursor encodes
+  ;; the supplied payload; :remaining carries the estimate.
+  (let [items     [{:id 1} {:id 2} {:id 3}]
+        next-cur  {:v 1 :after-id "ep-3"}
+        out       (cursor/apply-to-result
+                    {} :trace-events items
+                    {:next-cursor next-cur :remaining 47})]
+    (is (= items (:trace-events out)))
+    (is (string? (:next-cursor out)))
+    (is (= 47 (:remaining out)))
+    ;; The encoded cursor round-trips back to the payload.
+    (is (= next-cur (cursor/decode-cursor (:next-cursor out))))))
+
+(deftest apply-to-result-terminal-page-next-cursor-nil
+  ;; Pagination exhausted: the dispatcher passes nil :next-cursor;
+  ;; the wrapper writes `nil` under `:next-cursor`. Per MUST 11
+  ;; the slot is ALWAYS present (even when nil) so the agent's
+  ;; pattern-match on `(nil? next-cursor)` reads uniformly.
+  (let [items [{:id 9} {:id 10}]
+        out   (cursor/apply-to-result
+                {} :epochs items
+                {:next-cursor nil :remaining 0})]
+    (is (= items (:epochs out)))
+    (is (nil? (:next-cursor out)))
+    (is (contains? out :next-cursor)
+        ":next-cursor MUST be present (even nil) per MUST 11")
+    (is (= 0 (:remaining out)))))
+
+(deftest apply-to-result-missing-after-id-is-terminal
+  ;; A payload missing `:after-id` collapses to a nil :next-cursor
+  ;; (the encode contract). Same terminal-page shape.
+  (let [items [{:id 1}]
+        out   (cursor/apply-to-result
+                {} :events items
+                {:next-cursor {:v 1} :remaining 0})]
+    (is (nil? (:next-cursor out)))))
+
+(deftest apply-to-result-empty-items-vector-pages-empty
+  ;; A legitimate empty page (zero kept items but possibly a next
+  ;; cursor if filtering produced a quiet window). The wrapper does
+  ;; not collapse this — it's not its place to decide whether an
+  ;; empty page is terminal; the dispatcher decides.
+  (let [out (cursor/apply-to-result
+              {} :events []
+              {:next-cursor {:v 1 :after-id "ep-99"} :remaining 100})]
+    (is (= [] (:events out)))
+    (is (string? (:next-cursor out)))
+    (is (= 100 (:remaining out)))))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; Additive wrapper — pre-existing slots survive. Same shape as
+  ;; `privacy/apply-to-result` / `elision/apply-to-result` /
+  ;; `path-slice/apply-to-result`.
+  (let [items [{:id 1}]
+        out   (cursor/apply-to-result
+                {:tool "get-trace-buffer" :mode :full} :events items
+                {:next-cursor nil :remaining 0})]
+    (is (= "get-trace-buffer" (:tool out)))
+    (is (= :full (:mode out)))))
+
+(deftest apply-to-result-remaining-defaults-to-zero
+  ;; Defensive: an omitted `:remaining` opt collapses to 0 rather
+  ;; than nil — the agent's per-page accounting stays an integer.
+  (let [out (cursor/apply-to-result
+              {} :events [{:id 1}]
+              {:next-cursor nil})]
+    (is (= 0 (:remaining out)))))
+
+(deftest apply-to-result-shape-for-paginated-tools
+  ;; Canonical shape every paginated tool uses:
+  ;;   `:trace-events`  for `get-trace-buffer`
+  ;;   `:epochs`        for `get-epoch-history`
+  ;;   `:subscriptions` for `list-subscriptions`
+  (testing "get-trace-buffer-shape (:trace-events)"
+    (let [out (cursor/apply-to-result
+                {} :trace-events [{:event :rf/dispatch}]
+                {:next-cursor nil :remaining 0})]
+      (is (contains? out :trace-events))))
+  (testing "get-epoch-history-shape (:epochs)"
+    (let [out (cursor/apply-to-result
+                {} :epochs [{:epoch-id "ep-1"}]
+                {:next-cursor nil :remaining 0})]
+      (is (contains? out :epochs))))
+  (testing "list-subscriptions-shape (:subscriptions)"
+    (let [out (cursor/apply-to-result
+                {} :subscriptions [{:query-v [:items]}]
+                {:next-cursor nil :remaining 0})]
+      (is (contains? out :subscriptions)))))
+
+;; ---------------------------------------------------------------------------
+;; Composition with W-6 (elision) + B-1 (privacy) — the canonical
+;; trace-stream + tree-typed cascade.
+;; ---------------------------------------------------------------------------
+
+(deftest composes-with-b1-privacy-on-paginated-trace-stream
+  ;; Trace-stream tools paginate after privacy-stripping. The
+  ;; envelope carries both axes' indicator counters.
+  (let [events   [{:op :a}
+                  {:op :b :sensitive? true}
+                  {:op :c}
+                  {:op :d :sensitive? true}]
+        ;; B-1 first; remaining vector carries the kept events.
+        envelope (-> {:tool "get-trace-buffer"}
+                     (privacy/apply-to-result :trace-events events false))
+        kept     (:trace-events envelope)
+        ;; W-3 paginates the post-strip slice.
+        out      (cursor/apply-to-result
+                   envelope :trace-events kept
+                   {:next-cursor {:v 1 :after-id "ep-3"} :remaining 50})]
+    (is (= 2 (:dropped-sensitive out))
+        "B-1 surfaces dropped-sensitive count")
+    (is (= [{:op :a} {:op :c}] (:trace-events out))
+        "W-3 carries the post-strip kept items")
+    (is (string? (:next-cursor out))
+        "W-3 stamps the next-cursor")
+    (is (= 50 (:remaining out)))))
+
+(deftest composes-with-w6-elision-on-paginated-trace-stream
+  ;; Per-record tree-typed slots already walked server-side; W-6
+  ;; counts markers across the batch. Both axes ride the same
+  ;; envelope.
+  (let [items    [{:event :rf/dispatch :coeffect elided-marker}
+                  {:event :rf/effects  :coeffect elided-marker}]
+        envelope (-> {:tool "get-trace-buffer"}
+                     (cursor/apply-to-result :trace-events items
+                                             {:next-cursor nil :remaining 0}))
+        out      (elision/apply-to-result envelope :trace-events
+                                          (:trace-events envelope))]
+    (is (= 2 (:elided-large out))
+        "W-6 counts markers across the paginated batch")
+    (is (nil? (:next-cursor out))
+        "W-3's terminal :next-cursor stays nil")
+    (is (= 0 (:remaining out)))))
+
+(deftest composes-with-b1-and-w6-on-same-envelope
+  ;; The full cascade: B-1 strips, W-3 paginates, W-6 counts. All
+  ;; three counters surface together.
+  (let [items    [{:event :a :coeffect elided-marker}
+                  {:event :b :sensitive? true :coeffect elided-marker}
+                  {:event :c :coeffect elided-marker}]
+        envelope (-> {:tool "get-trace-buffer"}
+                     (privacy/apply-to-result :trace-events items false))
+        kept     (:trace-events envelope)
+        paged    (cursor/apply-to-result envelope :trace-events kept
+                                         {:next-cursor {:v 1 :after-id "ep-3"}
+                                          :remaining 47})
+        out      (elision/apply-to-result paged :trace-events
+                                          (:trace-events paged))]
+    (is (= 1 (:dropped-sensitive out)) "B-1 drops sensitive")
+    (is (= 2 (:elided-large out)) "W-6 counts markers in kept")
+    (is (string? (:next-cursor out)) "W-3 stamps next-cursor")
+    (is (= 47 (:remaining out)))))
+
+;; ---------------------------------------------------------------------------
+;; Load-bearing spec/004 §3 assertions.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-cursor-and-limit-accepted-end-to-end
+  (testing "MUST 10 — :cursor + :limit accepted from the JS args object"
+    (let [payload {:v 1 :after-id "ep-42"}
+          encoded (cursor/encode-cursor payload)
+          args    #js {"cursor" encoded "limit" 25}]
+      (is (= payload (cursor/cursor-arg args)))
+      (is (= 25 (cursor/limit-arg args))))))
+
+(deftest spec-004-response-carries-next-cursor-and-remaining
+  (testing "MUST 11 — :next-cursor + :remaining on every paginated
+            response"
+    (let [out (cursor/apply-to-result
+                {} :events [{:id 1}]
+                {:next-cursor {:v 1 :after-id "ep-1"} :remaining 99})]
+      (is (contains? out :next-cursor))
+      (is (contains? out :remaining))))
+  (testing "terminal-page MUST still carry both slots (nil cursor)"
+    (let [out (cursor/apply-to-result
+                {} :events [{:id 1}]
+                {:next-cursor nil :remaining 0})]
+      (is (contains? out :next-cursor))
+      (is (nil? (:next-cursor out)))
+      (is (contains? out :remaining)))))
+
+(deftest spec-004-cursor-opaque-on-wire
+  (testing "spec/Principles §Pagination — cursors are opaque; the
+            agent passes them back verbatim. The encoded form is a
+            base64 string with no JSON-confusing chars."
+    (let [c (cursor/encode-cursor {:v 1 :after-id "epoch-with-special-chars/"})]
+      (is (re-matches #"^[A-Za-z0-9+/=]+$" c)
+          "cursor MUST be base64-safe for stdio + JSON-RPC transit"))))
+
+(deftest spec-004-cursor-stale-cross-mcp-vocabulary
+  (testing "spec/004 §3 — `:rf.mcp/cursor-stale` is the cross-MCP
+            convention agents pattern-match on for cursor age-out
+            recovery. The keyword is pinned in
+            `re-frame.mcp-base.vocab` so the triplet shares one
+            literal."
+    (let [r (cursor/cursor-stale-result
+              "get-trace-buffer"
+              {:requested-id "ep-100" :head-id "ep-250"})]
+      (is (= :rf.mcp/cursor-stale (:reason r)))
+      (is (= base-vocab/cursor-stale-reason (:reason r)))
+      (is (= "ep-100" (:requested-id r)))
+      (is (= "ep-250" (:head-id r))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/dedup_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/dedup_test.cljs
@@ -1,0 +1,522 @@
+(ns day8.re-frame2-causa-mcp.dedup-test
+  "Unit tests for the W-5 structural-dedup wire-pipeline mechanism
+  at the Causa-MCP boundary (rf2-8xzoe.9). Pins:
+
+    - MUST 14 — regime-appropriate compression-factor citation:
+      ~1.4× raw trace bursts, ~10× high-share replays, 5-10×
+      epoch slices. The reduction-ratio assertions here pin the
+      load-bearing case (epoch slices with shared `:db-before`)
+      at >=50% — the bead's floor; actual is ~89.5% per pair2-mcp's
+      `dedup_test.cljs reduction-ratio-shared-subtrees`.
+    - Wire shape — `{:rf.mcp/dedup-table <cache-map>}` from
+      `re-frame.mcp-base.vocab/dedup-table-key` (cross-MCP).
+    - Round-trip — `de-dupe.core/expand` reconstructs the
+      payload exactly (the agent host's decode contract).
+    - `:dedup?` opt-out — `false` => pass-through; `true` (default)
+      => wrap.
+    - Composition with B-1 (privacy), W-6 (elision), W-3 (cursor),
+      W-1 (token-cap) — additive envelopes; dedup runs BEFORE
+      W-1 per spec/004 §1 + §5 ordering.
+
+  These tests are the load-bearing pin for the downstream trace-
+  and epoch-shipping tool beads — every dispatcher that returns
+  a structurally-repetitive vector calls `dedup/apply-to-result`
+  once at the boundary."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.cursor :as cursor]
+            [day8.re-frame2-causa-mcp.dedup :as dedup]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]
+            [de-dupe.core :as de-dupe]
+            [re-frame.mcp-base.vocab :as base-vocab]))
+
+;; A canonical elided marker, as the framework walker would emit.
+;; Reused across composition tests so the W-6 surface stays visible
+;; inside W-5's deduped payloads.
+(def ^:private elided-marker
+  {:rf.size/large-elided
+   {:path   [:trace 0 :coeffect :db]
+    :bytes  102400
+    :type   :map
+    :reason :declared
+    :handle [:rf.elision/at [:trace 0 :coeffect :db]]}})
+
+(defn- expand
+  "Test helper — invert `dedup-value` via `de-dupe.core/expand`.
+  The agent host's decode contract."
+  [wrapped]
+  (if (and (map? wrapped) (contains? wrapped base-vocab/dedup-table-key))
+    (de-dupe/expand (get wrapped base-vocab/dedup-table-key))
+    wrapped))
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-5 lands the public surface downstream trace/epoch
+            shipping tool dispatchers will require"
+    (is (fn? dedup/empty-payload?))
+    (is (fn? dedup/dedup-value))
+    (is (fn? dedup/parse-dedup-arg))
+    (is (fn? dedup/apply-to-result))
+    (is (true? dedup/include-dedup-default)
+        "spec/004 §5 L329 — :dedup? defaults true (on by default
+         for trace/epoch shapes)")))
+
+;; ---------------------------------------------------------------------------
+;; empty-payload? — the no-op guard.
+;; ---------------------------------------------------------------------------
+
+(deftest empty-payload-nil-is-empty
+  (is (true? (dedup/empty-payload? nil))))
+
+(deftest empty-payload-empty-collections-are-empty
+  (is (true? (dedup/empty-payload? [])))
+  (is (true? (dedup/empty-payload? {})))
+  (is (true? (dedup/empty-payload? #{})))
+  (is (true? (dedup/empty-payload? '()))))
+
+(deftest empty-payload-scalars-are-empty
+  ;; Scalars can't be deduped — the no-op guard catches them. The
+  ;; cache-of-one wrap would be a wire-size loss.
+  (is (true? (dedup/empty-payload? 42)))
+  (is (true? (dedup/empty-payload? :keyword)))
+  (is (true? (dedup/empty-payload? "string")))
+  (is (true? (dedup/empty-payload? true))))
+
+(deftest empty-payload-non-empty-collections-fire-dedup
+  (is (false? (dedup/empty-payload? [1 2 3])))
+  (is (false? (dedup/empty-payload? {:a 1})))
+  (is (false? (dedup/empty-payload? #{:x})))
+  (is (false? (dedup/empty-payload? '(1 2)))))
+
+;; ---------------------------------------------------------------------------
+;; dedup-value — the wire-boundary wrap.
+;; ---------------------------------------------------------------------------
+
+(deftest dedup-disabled-passes-through
+  ;; opt-out: caller asks for the raw payload.
+  (let [payload [{:a 1 :b 2} {:a 1 :b 2}]]
+    (is (= payload (dedup/dedup-value payload false)))))
+
+(deftest dedup-empty-payload-passes-through
+  ;; Empty / scalar inputs skip wrapping — the cache-of-one would
+  ;; be a wire-size loss for trivial values.
+  (is (nil? (dedup/dedup-value nil true)))
+  (is (= [] (dedup/dedup-value [] true)))
+  (is (= {} (dedup/dedup-value {} true)))
+  (is (= 42 (dedup/dedup-value 42 true))))
+
+(deftest dedup-non-empty-collection-emits-marker
+  (let [payload [{:a 1} {:b 2}]
+        wrapped (dedup/dedup-value payload true)]
+    (is (map? wrapped))
+    (is (contains? wrapped :rf.mcp/dedup-table))
+    (is (map? (:rf.mcp/dedup-table wrapped))
+        "the table itself is a hash-map keyed by namespaced symbols")))
+
+(deftest dedup-marker-key-is-cross-mcp-vocab
+  ;; Pin: the marker key matches `re-frame.mcp-base.vocab/dedup-
+  ;; table-key`. Agents that learned `:rf.mcp/dedup-table` on
+  ;; pair2-mcp see the same slot here.
+  (let [wrapped (dedup/dedup-value [{:a 1} {:a 1}] true)]
+    (is (= [:rf.mcp/dedup-table] (vec (keys wrapped))))
+    (is (= base-vocab/dedup-table-key
+           (first (keys wrapped)))
+        "marker key sourced from re-frame.mcp-base.vocab")))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip: dedup → expand → identity. The agent host's decode
+;; contract.
+;; ---------------------------------------------------------------------------
+
+(deftest round-trip-simple-shared-map
+  (let [shared {:big "common" :keys [:a :b :c]}
+        payload [{:id 1 :payload shared}
+                 {:id 2 :payload shared}
+                 {:id 3 :payload shared}]
+        wrapped (dedup/dedup-value payload true)
+        restored (expand wrapped)]
+    (is (= payload restored))))
+
+(deftest round-trip-already-expanded-is-noop
+  ;; A payload that was never deduped (caller passed `dedup? false`)
+  ;; round-trips identity through expand.
+  (let [payload [{:a 1} {:b 2}]]
+    (is (= payload (expand payload)))))
+
+(deftest round-trip-nested-shared-subtrees
+  ;; The load-bearing case: epoch slice where every record carries
+  ;; the same large `:db-before`. After dedup → expand the structure
+  ;; comes back exactly.
+  (let [big-db (into {} (for [i (range 100)]
+                          [(keyword (str "k" i))
+                           {:v (str "value-" i)
+                            :meta {:tags [:tag1 :tag2 :tag3]}}]))
+        epochs (vec (for [i (range 10)]
+                      {:epoch-id (str "ep-" i)
+                       :db-before big-db
+                       :db-after  {:rf.mcp/diff-from :db-before
+                                   :patches [[[(keyword (str "k" i)) :v]
+                                              :assoc (str "new-" i)]]}}))
+        wrapped (dedup/dedup-value epochs true)
+        restored (expand wrapped)]
+    (is (= epochs restored))))
+
+(deftest round-trip-empty-collections-inside-payload
+  (let [payload [{:items [] :state {}} {:items [] :state {}}]
+        wrapped (dedup/dedup-value payload true)
+        restored (expand wrapped)]
+    (is (= payload restored))))
+
+(deftest round-trip-deeply-nested-uniform-records
+  ;; Stress: 50 records each carrying the same nested structure.
+  (let [record {:cart {:items [{:sku "A" :qty 1}
+                               {:sku "B" :qty 2}]
+                       :total 30}
+                :user {:id 7 :name "alice"}
+                :ui {:loading? false :error nil}}
+        payload (vec (repeat 50 record))
+        wrapped (dedup/dedup-value payload true)
+        restored (expand wrapped)]
+    (is (= payload restored))
+    (is (= 50 (count restored)))))
+
+;; ---------------------------------------------------------------------------
+;; Reduction-ratio benchmark — MUST 14 cross-MCP compression-factor pin.
+;; ---------------------------------------------------------------------------
+
+(deftest reduction-ratio-shared-subtrees
+  ;; The load-bearing case spec/004 §5 cites — "Epoch slices"
+  ;; row: 80-90% reduction (5-10x). pair2-mcp's
+  ;; `dedup_test.cljs reduction-ratio-shared-subtrees` pins this
+  ;; at ~89.5%; we mirror the same fixture so causa-mcp's
+  ;; benchmark stays cross-MCP-aligned.
+  (let [;; Build a "big" app-db — 256 keys, each a 256-char string
+        ;; value => ~80KB pr-str.
+        big-db (into {} (for [i (range 256)]
+                          [(keyword (str "k" i))
+                           (apply str (repeat 256 \x))]))
+        ;; 10 epochs, each sharing the same :db-before reference.
+        epochs (vec (for [i (range 10)]
+                      {:epoch-id (str "ep-" i)
+                       :event-id :touch
+                       :db-before big-db
+                       :db-after  {:rf.mcp/diff-from :db-before
+                                   :patches [[[(keyword (str "k" i))]
+                                              :assoc (apply str (repeat 256 \y))]]}}))
+        raw-size (count (pr-str epochs))
+        wrapped (dedup/dedup-value epochs true)
+        wrapped-size (count (pr-str wrapped))]
+    (testing "wrapped payload is much smaller than the raw vector"
+      (is (< wrapped-size raw-size)
+          (str "wrapped >= raw — measurement: raw=" raw-size
+               "chars deduped=" wrapped-size "chars"))
+      ;; >=50% reduction (the bead's floor). Actual ~89.5% per
+      ;; pair2-mcp's pin; the load-bearing epoch-slice regime cited
+      ;; in spec/004 §5 (5-10x ratio).
+      (is (< wrapped-size (* 0.5 raw-size))
+          (str "Deduped size (" wrapped-size
+               ") should be < 50% of raw (" raw-size
+               "). Ratio: " (/ wrapped-size raw-size 1.0))))
+    (testing "round-trip still reconstructs every epoch"
+      (let [restored (expand wrapped)]
+        (is (= epochs restored))))))
+
+(deftest reduction-ratio-trace-burst-regime
+  ;; The spec/004 §5 "Raw trace bursts" row (28-31% reduction —
+  ;; ~1.4x). This regime is the least-favourable case because per-
+  ;; event `:id` / `:time` variance dominates the wire bytes; the
+  ;; only shareable subtree is the cascade-level `:rf.trace/trigger-
+  ;; handler` map and `:dispatch-id` backbone.
+  (let [trigger-handler {:event-id :user/click
+                         :handler-id :user.click/dispatch
+                         :source-coord ["app.cljs" 42 7]}
+        events (vec (for [i (range 50)]
+                      {:id (str "trace-" i)
+                       :time (* i 16)
+                       :rf.trace/trigger-handler trigger-handler
+                       :dispatch-id "dispatch-123"
+                       :tag (keyword (str "tag-" i))}))
+        raw-size (count (pr-str events))
+        wrapped (dedup/dedup-value events true)
+        wrapped-size (count (pr-str wrapped))]
+    ;; Even the worst-case trace-burst regime should shrink — the
+    ;; trigger-handler subtree is the load-bearing shareable. The
+    ;; spec cites ~1.4x (28-31%); we pin > 5% as the floor (a
+    ;; deduper degenerating to no-shrink would surface here).
+    (is (< wrapped-size raw-size)
+        (str "trace-burst dedup: raw=" raw-size
+             "chars deduped=" wrapped-size "chars"))
+    ;; Round-trip stays exact regardless of compression ratio.
+    (is (= events (expand wrapped)))))
+
+;; ---------------------------------------------------------------------------
+;; Edge cases per the bead.
+;; ---------------------------------------------------------------------------
+
+(deftest edge-case-empty-payload-is-noop
+  ;; "empty payload (no-op)" — the wrapper short-circuits.
+  (is (nil? (dedup/dedup-value nil true)))
+  (is (= [] (dedup/dedup-value [] true))))
+
+(deftest edge-case-no-repeated-structure
+  ;; "payload with no repeated structure (table empty)" — the
+  ;; cache ships only the root entry; round-trip still exact.
+  (let [payload [{:a 1} {:b 2} {:c 3}]
+        wrapped (dedup/dedup-value payload true)
+        restored (expand wrapped)]
+    (is (= payload restored))))
+
+(deftest edge-case-one-big-repeated-subtree
+  ;; "payload that's one big repeated subtree (table has 1 entry)"
+  ;; — the cache compresses well; round-trip still exact.
+  (let [shared (into {} (for [i (range 100)]
+                          [(keyword (str "k" i)) i]))
+        payload (vec (repeat 20 shared))
+        wrapped (dedup/dedup-value payload true)
+        restored (expand wrapped)]
+    (is (= payload restored))
+    (is (= 20 (count restored)))
+    (is (every? #(= shared %) restored))))
+
+;; ---------------------------------------------------------------------------
+;; parse-dedup-arg — :dedup? defaults true (opt-out).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-dedup-default-true-when-absent
+  ;; spec/004 §5 L329: default on for trace/epoch shapes. Every
+  ;; shape of "no input" collapses to the default-true posture.
+  (is (true? (dedup/parse-dedup-arg nil)))
+  (is (true? (dedup/parse-dedup-arg js/undefined)))
+  (is (true? (dedup/parse-dedup-arg {})))
+  (is (true? (dedup/parse-dedup-arg #js {})))
+  (is (true? (dedup/parse-dedup-arg #js {:other "value"}))))
+
+(deftest parse-dedup-false-from-js-args-object
+  ;; The opt-out: caller asks for the raw (un-deduped) payload.
+  (is (false? (dedup/parse-dedup-arg #js {"dedup?" false})))
+  (is (false? (dedup/parse-dedup-arg #js {"dedup?" "false"})))
+  (is (false? (dedup/parse-dedup-arg #js {"dedup?" "no"})))
+  (is (false? (dedup/parse-dedup-arg #js {"dedup?" "0"}))))
+
+(deftest parse-dedup-true-from-js-args-object
+  ;; Explicit opt-in (same as default).
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" true})))
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" "true"})))
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" "yes"})))
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" "1"}))))
+
+(deftest parse-dedup-from-cljs-map
+  (is (true?  (dedup/parse-dedup-arg {:dedup? true})))
+  (is (false? (dedup/parse-dedup-arg {:dedup? false})))
+  (is (true?  (dedup/parse-dedup-arg {"dedup?" true})))
+  (is (false? (dedup/parse-dedup-arg {"dedup?" false}))))
+
+(deftest parse-dedup-unrecognised-value-defaults-on
+  ;; Unrecognised raw values collapse to the default-on posture per
+  ;; the cross-MCP parse-boolean contract.
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" "maybe"})))
+  (is (true? (dedup/parse-dedup-arg #js {"dedup?" 42})))
+  (is (true? (dedup/parse-dedup-arg {:dedup? :perhaps}))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-enabled-wraps
+  (let [items [{:a 1} {:a 1} {:a 1}]
+        out   (dedup/apply-to-result {} :trace-events items true)]
+    (is (contains? (:trace-events out) :rf.mcp/dedup-table)
+        ":trace-events MUST be the wrapped marker shape")
+    (is (= items (expand (:trace-events out)))
+        "round-trip restores the input")))
+
+(deftest apply-to-result-disabled-passes-through
+  (let [items [{:a 1} {:a 2}]
+        out   (dedup/apply-to-result {} :events items false)]
+    (is (= items (:events out))
+        ":dedup? false => raw payload under :events")))
+
+(deftest apply-to-result-empty-payload-passes-through
+  (let [out (dedup/apply-to-result {} :events [] true)]
+    (is (= [] (:events out))
+        "empty vector skips wrapping (no dedup opportunity)"))
+  (let [out (dedup/apply-to-result {} :events nil true)]
+    (is (nil? (:events out)))))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; Additive — pre-existing slots survive (parallel to every other
+  ;; W-* boundary wrapper).
+  (let [items [{:a 1} {:a 1}]
+        out   (dedup/apply-to-result
+                {:tool "get-trace-buffer" :mode :full} :events items true)]
+    (is (= "get-trace-buffer" (:tool out)))
+    (is (= :full (:mode out)))
+    (is (contains? (:events out) :rf.mcp/dedup-table))))
+
+(deftest apply-to-result-shape-for-trace-epoch-tools
+  ;; Canonical shape every dedup-enabled tool uses.
+  (testing "get-trace-buffer-shape (:trace-events)"
+    (let [out (dedup/apply-to-result
+                {} :trace-events [{:event :rf/dispatch}] true)]
+      (is (contains? out :trace-events))))
+  (testing "get-epoch-history-shape (:epochs)"
+    (let [out (dedup/apply-to-result
+                {} :epochs [{:epoch-id "ep-1"}] true)]
+      (is (contains? out :epochs))))
+  (testing "subscribe-drain-batch-shape (:events)"
+    (let [out (dedup/apply-to-result
+                {} :events [{:op :a}] true)]
+      (is (contains? out :events)))))
+
+;; ---------------------------------------------------------------------------
+;; Composition with B-1 (privacy), W-6 (elision), W-3 (cursor),
+;; W-1 (token-cap). The spec/004 §5 cascade order pinned end-to-end.
+;; ---------------------------------------------------------------------------
+
+(deftest composes-with-b1-privacy-strip-before-dedup
+  ;; The cascade per spec/004 §5: privacy strip first (B-1) => kept
+  ;; items; then dedup (W-5). The :dropped-sensitive counter rides
+  ;; alongside the dedup-table marker.
+  (let [events   [{:op :a :payload {:shared 1}}
+                  {:op :b :sensitive? true}
+                  {:op :c :payload {:shared 1}}
+                  {:op :d :sensitive? true}]
+        envelope (-> {:tool "get-trace-buffer"}
+                     (privacy/apply-to-result :trace-events events false))
+        kept     (:trace-events envelope)
+        out      (dedup/apply-to-result envelope :trace-events kept true)]
+    (is (= 2 (:dropped-sensitive out))
+        "B-1 surfaces dropped-sensitive")
+    (is (contains? (:trace-events out) :rf.mcp/dedup-table)
+        "W-5 wraps the kept items")
+    (let [restored (expand (:trace-events out))]
+      (is (= [{:op :a :payload {:shared 1}} {:op :c :payload {:shared 1}}]
+             restored)
+          "the post-strip kept items round-trip through dedup"))))
+
+(deftest composes-with-w6-elision-counts-survive-dedup
+  ;; W-6 counts markers in the items vector BEFORE W-5 dedup runs.
+  ;; The counter rides on the envelope and isn't disturbed by the
+  ;; dedup-table wrap of the items.
+  (let [items    [{:event :a :coeffect elided-marker}
+                  {:event :b :coeffect elided-marker}]
+        envelope (-> {}
+                     (elision/apply-to-result :trace-events items)
+                     ;; W-5 now wraps the items in place.
+                     ((fn [env]
+                        (dedup/apply-to-result env :trace-events
+                                               (:trace-events env) true))))]
+    (is (= 2 (:elided-large envelope))
+        "W-6 counter rides on the envelope across W-5 wrap")
+    (is (contains? (:trace-events envelope) :rf.mcp/dedup-table)
+        "W-5 wrapped the items")
+    (let [restored (expand (:trace-events envelope))]
+      (is (= items restored)
+          "elided-marker rides verbatim through dedup → expand"))))
+
+(deftest composes-with-w3-cursor-pagination
+  ;; W-5 wraps the per-page items; W-3 stamps :next-cursor +
+  ;; :remaining alongside. The agent decodes one page at a time.
+  (let [items   [{:event :a :shared {:x 1}}
+                 {:event :b :shared {:x 1}}]
+        ;; W-5 first (the cascade: dedup is per-page, runs before
+        ;; the cursor wrap).
+        deduped (dedup/apply-to-result {:tool "get-trace-buffer"}
+                                       :trace-events items true)
+        ;; W-3 stamps :next-cursor + :remaining; the :trace-events
+        ;; slot retains the dedup wrap.
+        out     (cursor/apply-to-result deduped :trace-events
+                                        (:trace-events deduped)
+                                        {:next-cursor {:v 1 :after-id "ep-2"}
+                                         :remaining 48})]
+    (is (contains? (:trace-events out) :rf.mcp/dedup-table)
+        "W-5 wrap survives the W-3 cursor stamp")
+    (is (string? (:next-cursor out))
+        "W-3 stamps the next-cursor alongside the deduped items")
+    (is (= 48 (:remaining out)))))
+
+(deftest composes-with-w1-token-cap-runs-after-dedup
+  ;; W-5 + W-1 cascade per spec/004 §1: dedup runs BEFORE the cap.
+  ;; The structural pin is that W-5's wrap REDUCES the rendered
+  ;; token count below the raw count — so a payload that would
+  ;; trip W-1 raw may pass post-dedup. We can't easily simulate
+  ;; the full cascade end-to-end (W-1's cap wrapper operates on
+  ;; the JS MCP-result envelope, not the CLJS map); the pin is
+  ;; the per-rendered-bytes reduction.
+  (let [big-db (into {} (for [i (range 256)]
+                          [(keyword (str "k" i))
+                           (apply str (repeat 256 \x))]))
+        epochs (vec (for [i (range 10)]
+                      {:epoch-id (str "ep-" i)
+                       :db-before big-db}))
+        raw-tokens     (quot (count (pr-str epochs)) 4)
+        deduped        (dedup/dedup-value epochs true)
+        deduped-tokens (quot (count (pr-str deduped)) 4)]
+    (is (< deduped-tokens raw-tokens)
+        (str "W-5 shrinks token count from " raw-tokens
+             " raw to " deduped-tokens " deduped"))
+    ;; The 10-epoch shared-:db-before fixture overflows the 5K cap
+    ;; raw — the load-bearing case W-1 would have to handle without
+    ;; W-5's help.
+    (is (> raw-tokens token-cap/default-max-tokens)
+        "raw payload overflows the 5K cap")
+    ;; Post-dedup, the shrink is at least 5x (the spec/004 §5
+    ;; epoch-slice regime floor). That's the load-bearing reduction
+    ;; the cascade leverages — fitting under cap is a function of
+    ;; absolute size; the structural shrink is what dedup provides.
+    (is (< deduped-tokens (quot raw-tokens 5))
+        (str "W-5 shrinks token count by >=5x for the shared-"
+             ":db-before regime (raw=" raw-tokens
+             " deduped=" deduped-tokens ")"))))
+
+;; ---------------------------------------------------------------------------
+;; Load-bearing spec/004 §5 assertions.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-dedup-table-marker-key-pin
+  (testing "spec/004 §5 + cross-MCP-vocab: marker key is
+            `:rf.mcp/dedup-table`"
+    (let [wrapped (dedup/dedup-value [{:a 1} {:a 1}] true)]
+      (is (= :rf.mcp/dedup-table (first (keys wrapped))))
+      (is (= base-vocab/dedup-table-key (first (keys wrapped)))))))
+
+(deftest spec-004-per-tick-self-contained
+  (testing "spec/004 §5 — per-tick dedup table; no cross-tick refs.
+            Each response is self-contained; the agent decodes one
+            response at a time without holding state from prior
+            calls."
+    (let [items-tick-1 [{:shared {:x 1}} {:shared {:x 1}}]
+          items-tick-2 [{:shared {:y 2}} {:shared {:y 2}}]
+          tick-1       (dedup/dedup-value items-tick-1 true)
+          tick-2       (dedup/dedup-value items-tick-2 true)]
+      ;; Each tick's cache decodes independently of the other.
+      (is (= items-tick-1 (expand tick-1)))
+      (is (= items-tick-2 (expand tick-2)))
+      ;; Caches are independent — no cross-tick ref sharing (each
+      ;; payload's cache map contains only its own refs).
+      (is (map? (:rf.mcp/dedup-table tick-1)))
+      (is (map? (:rf.mcp/dedup-table tick-2))))))
+
+(deftest spec-004-must-14-compression-factor-citation
+  (testing "MUST 14 — epoch-slice regime exhibits 5-10x ratio
+            (80-90% reduction). Pinned by the load-bearing
+            shared-:db-before fixture."
+    (let [big-db (into {} (for [i (range 256)]
+                            [(keyword (str "k" i))
+                             (apply str (repeat 256 \x))]))
+          epochs (vec (for [i (range 10)]
+                        {:epoch-id (str "ep-" i)
+                         :db-before big-db
+                         :db-after {:rf.mcp/diff-from :db-before
+                                    :patches [[[(keyword (str "k" i))] :assoc :y]]}}))
+          raw-bytes (count (pr-str epochs))
+          wrapped-bytes (count (pr-str (dedup/dedup-value epochs true)))
+          ratio (/ raw-bytes (double wrapped-bytes))]
+      (is (>= ratio 2.0)
+          (str "epoch-slice regime ratio " ratio
+               " should be >= 2x (spec/004 §5 cites 5-10x; the
+               floor is generous to absorb fixture variance)")))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/path_slice_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/path_slice_test.cljs
@@ -1,0 +1,411 @@
+(ns day8.re-frame2-causa-mcp.path-slice-test
+  "Unit tests for the W-2 path-slice wire-pipeline mechanism at the
+  Causa-MCP boundary (rf2-8xzoe.6). Pins:
+
+    - MUST 8 — direct-read tools (`get-app-db`, `get-machine-state`,
+      `get-epoch-history`) MUST accept the `:path` arg
+      (spec/004 §2 L260-262).
+    - MUST 9 (path-arg `nil` half) — absent `:path` parses to `nil`,
+      signalling the dispatcher to take the W-4 summary branch
+      (spec/004 §2 L264-266). This file pins the `nil` return; the
+      W-4 summary-mode default landing in W-4 (rf2-8xzoe.8) pins
+      the dispatcher behaviour.
+    - Out-of-range — `:path-not-found` shape with
+      `:deepest-valid-prefix` (spec/004 §2 L267-270).
+    - Cross-MCP path-arg vocabulary — accept-shape parity with
+      pair2-mcp's `tools.args/parse-path-arg`.
+    - Composition with W-1 (token-cap) + W-6 (elision) + B-1
+      (privacy) — wrappers are additive, share envelope shape.
+
+  These tests are the load-bearing pin for the downstream tree-typed
+  direct-read tools — every dispatcher that returns a tree-typed
+  payload calls `path-slice/apply-to-result` once at the boundary
+  when the `:path` arg is non-nil."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.path-slice :as path-slice]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]))
+
+;; The canonical large-elided marker, as the framework walker would
+;; emit. Reused across composition tests so the W-6 surface stays
+;; visible inside W-2's sliced subtrees.
+(def ^:private elided-marker
+  {:rf.size/large-elided
+   {:path   [:user :uploaded-pdf]
+    :bytes  102400
+    :type   :string
+    :reason :declared
+    :handle [:rf.elision/at [:user :uploaded-pdf]]}})
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-2 lands the public surface downstream direct-read tool
+            dispatchers will require"
+    (is (fn? path-slice/parse-path-arg))
+    (is (fn? path-slice/path-arg))
+    (is (fn? path-slice/deepest-valid-prefix))
+    (is (fn? path-slice/path-not-found))
+    (is (fn? path-slice/resolve-path))
+    (is (fn? path-slice/apply-to-result))
+    (is (fn? path-slice/coerce-path-segment))))
+
+;; ---------------------------------------------------------------------------
+;; parse-path-arg — the cross-MCP accept-shape contract.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-path-arg-nil-is-nil
+  ;; MUST 9 half: absent path parses to nil, signalling W-4
+  ;; default-summary on the dispatcher side.
+  (is (nil? (path-slice/parse-path-arg nil))))
+
+(deftest parse-path-arg-blank-string-is-nil
+  (is (nil? (path-slice/parse-path-arg "")))
+  (is (nil? (path-slice/parse-path-arg "   ")))
+  (is (nil? (path-slice/parse-path-arg "\t\n"))))
+
+(deftest parse-path-arg-edn-vector-string
+  (is (= [:cart :items 0] (path-slice/parse-path-arg "[:cart :items 0]")))
+  (is (= [:a :b :c] (path-slice/parse-path-arg "[:a :b :c]")))
+  (is (= [:cart :items 3 :sku]
+         (path-slice/parse-path-arg "[:cart :items 3 :sku]"))
+      "spec/004 §2 L261 example path"))
+
+(deftest parse-path-arg-edn-empty-vector-is-root
+  (is (= [] (path-slice/parse-path-arg "[]"))
+      "explicit empty path addresses the root"))
+
+(deftest parse-path-arg-cljs-vector-passes-through
+  (is (= [:a :b :c] (path-slice/parse-path-arg [:a :b :c])))
+  (is (= [] (path-slice/parse-path-arg []))))
+
+(deftest parse-path-arg-cljs-sequential-coerces-to-vector
+  (is (= [:a :b :c] (path-slice/parse-path-arg (list :a :b :c)))))
+
+(deftest parse-path-arg-js-array-of-edn-strings
+  ;; Each segment is parsed as EDN: keywords, integers.
+  (is (= [:cart :items 0]
+         (path-slice/parse-path-arg #js [":cart" ":items" "0"]))))
+
+(deftest parse-path-arg-js-array-with-bare-strings-stays-strings
+  ;; Non-EDN segments pass through as map keys (the agent may have
+  ;; an app-db keyed by strings rather than keywords).
+  (is (= [:a "bare-key" :b]
+         (path-slice/parse-path-arg #js [":a" "bare-key" ":b"]))))
+
+(deftest parse-path-arg-non-vector-edn-wraps-as-single-segment
+  ;; A lone keyword string becomes a 1-segment path.
+  (is (= [:foo] (path-slice/parse-path-arg ":foo")))
+  ;; A bare integer string also becomes a 1-segment path.
+  (is (= [42] (path-slice/parse-path-arg "42"))))
+
+(deftest parse-path-arg-unparseable-string-is-single-string-segment
+  ;; Pathological EDN — fall back to treating the whole string as one
+  ;; map-key segment rather than raising. Permissive on agent input.
+  (is (= ["((("] (path-slice/parse-path-arg "((("))))
+
+;; ---------------------------------------------------------------------------
+;; path-arg — the MCP-args object slot resolver.
+;; ---------------------------------------------------------------------------
+
+(deftest path-arg-absent-returns-nil
+  ;; Default for the missing slot — same nil-signal the parser uses.
+  (is (nil? (path-slice/path-arg nil)))
+  (is (nil? (path-slice/path-arg js/undefined)))
+  (is (nil? (path-slice/path-arg #js {})))
+  (is (nil? (path-slice/path-arg #js {:other 1}))))
+
+(deftest path-arg-from-js-object
+  ;; The MCP SDK hands the dispatcher a JS args object; the helper
+  ;; reads `path` off it and routes through the parser.
+  (is (= [:cart :items 0]
+         (path-slice/path-arg #js {"path" "[:cart :items 0]"})))
+  (is (= [:foo]
+         (path-slice/path-arg #js {"path" ":foo"}))))
+
+(deftest path-arg-from-cljs-map
+  ;; Some upstream paths hand the helper a CLJS map (already coerced).
+  ;; Both keyword and stringified-key entry points resolve.
+  (is (= [:a :b] (path-slice/path-arg {:path "[:a :b]"})))
+  (is (= [:a :b] (path-slice/path-arg {"path" "[:a :b]"})))
+  (is (= [:a :b] (path-slice/path-arg {:path [:a :b]}))))
+
+(deftest path-arg-empty-vector-roundtrips-as-root
+  (is (= [] (path-slice/path-arg #js {"path" "[]"}))))
+
+;; ---------------------------------------------------------------------------
+;; deepest-valid-prefix — re-aim hint.
+;; ---------------------------------------------------------------------------
+
+(deftest deepest-valid-prefix-empty-path-returns-empty
+  (is (= [] (path-slice/deepest-valid-prefix {:a 1} []))))
+
+(deftest deepest-valid-prefix-full-resolution-returns-full-path
+  (is (= [:a :b]
+         (path-slice/deepest-valid-prefix {:a {:b 42}} [:a :b]))))
+
+(deftest deepest-valid-prefix-truncates-at-first-miss
+  (is (= [:a]
+         (path-slice/deepest-valid-prefix {:a {:b 42}} [:a :c :d]))))
+
+(deftest deepest-valid-prefix-empty-on-first-segment-miss
+  (is (= []
+         (path-slice/deepest-valid-prefix {:a 1} [:no-such-key :b :c]))))
+
+(deftest deepest-valid-prefix-handles-vector-indices
+  ;; Full path resolves — prefix IS the full path.
+  (is (= [:items 0 :sku]
+         (path-slice/deepest-valid-prefix {:items [{:sku "abc"}]} [:items 0 :sku])))
+  ;; Path that ends one segment past a vector resolution stops at the
+  ;; deepest valid prefix.
+  (is (= [:items 0]
+         (path-slice/deepest-valid-prefix {:items [{:sku "abc"}]} [:items 0 :nope]))))
+
+(deftest deepest-valid-prefix-stops-at-out-of-range-index
+  (is (= [:items]
+         (path-slice/deepest-valid-prefix {:items [{:sku "abc"}]} [:items 5 :sku]))))
+
+(deftest deepest-valid-prefix-stops-at-scalar-leaf
+  ;; Path tries to descend INTO a scalar leaf — the walker halts.
+  (is (= [:a :b]
+         (path-slice/deepest-valid-prefix {:a {:b 42}} [:a :b :nope]))))
+
+(deftest deepest-valid-prefix-handles-empty-tree
+  (is (= []
+         (path-slice/deepest-valid-prefix {} [:any :path]))))
+
+;; ---------------------------------------------------------------------------
+;; path-not-found — structured error shape.
+;; ---------------------------------------------------------------------------
+
+(deftest path-not-found-shape
+  (let [tree {:a {:b 42}}
+        result (path-slice/path-not-found tree [:a :c :d])]
+    (is (= {:ok?                  false
+            :reason               :path-not-found
+            :path                 [:a :c :d]
+            :deepest-valid-prefix [:a]}
+           result))))
+
+(deftest path-not-found-reason-keyword-pin
+  ;; Pin the cross-MCP convention: `:reason :path-not-found` is the
+  ;; sentinel agents pattern-match on for re-aim. Sibling to
+  ;; `:rf.mcp/cursor-stale` for cursor pagination.
+  (is (= :path-not-found
+         (:reason (path-slice/path-not-found {} [:any])))))
+
+(deftest path-not-found-on-empty-tree
+  (is (= [] (:deepest-valid-prefix (path-slice/path-not-found {} [:nope])))))
+
+(deftest path-not-found-deep-prefix
+  (let [tree {:cart {:items [{:sku "abc" :qty 3}]}}
+        result (path-slice/path-not-found tree [:cart :items 0 :no-such])]
+    (is (= [:cart :items 0] (:deepest-valid-prefix result)))))
+
+;; ---------------------------------------------------------------------------
+;; resolve-path — sentinel-aware get-in.
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-path-root-returns-tree
+  (let [tree {:a 1 :b 2}]
+    (is (= tree (path-slice/resolve-path tree [])))))
+
+(deftest resolve-path-deep-resolution
+  (is (= 42
+         (path-slice/resolve-path {:cart {:items [{:sku "abc" :qty 42}]}}
+                                  [:cart :items 0 :qty]))))
+
+(deftest resolve-path-not-found-returns-sentinel
+  (is (= ::path-slice/not-found
+         (path-slice/resolve-path {:a 1} [:b]))))
+
+(deftest resolve-path-nil-value-resolves-not-not-found
+  ;; The load-bearing disambiguator: a path that legitimately
+  ;; resolves to `nil` MUST NOT report `:path-not-found`.
+  (is (= nil
+         (path-slice/resolve-path {:a nil} [:a]))
+      "nil-at-path resolves; the sentinel disambiguates from missing"))
+
+(deftest resolve-path-false-value-resolves
+  (is (= false
+         (path-slice/resolve-path {:flag false} [:flag]))))
+
+(deftest resolve-path-vector-out-of-range-is-not-found
+  ;; `get-in` returns the not-found sentinel on out-of-range indices.
+  (is (= ::path-slice/not-found
+         (path-slice/resolve-path {:items [{:sku "abc"}]} [:items 5 :sku]))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-writes-resolved-subtree
+  ;; The happy path: path resolves; the addressed subtree rides
+  ;; under `value-key`.
+  (let [tree {:cart {:items [{:sku "abc"} {:sku "def"}]}}
+        out  (path-slice/apply-to-result {} :db tree [:cart :items])]
+    (is (= {:db [{:sku "abc"} {:sku "def"}]} out))))
+
+(deftest apply-to-result-empty-path-writes-full-tree
+  ;; `[]` (root) writes the full tree under `value-key`.
+  (let [tree {:a 1 :b 2}
+        out  (path-slice/apply-to-result {} :db tree [])]
+    (is (= {:db tree} out))))
+
+(deftest apply-to-result-out-of-range-splices-path-not-found
+  ;; Out-of-range path: the canonical `:path-not-found` slots ride
+  ;; on the envelope; `value-key` is NOT written (no slot to write).
+  (let [tree {:a {:b 42}}
+        out  (path-slice/apply-to-result {} :db tree [:a :c :d])]
+    (is (false? (:ok? out)))
+    (is (= :path-not-found (:reason out)))
+    (is (= [:a :c :d] (:path out)))
+    (is (= [:a] (:deepest-valid-prefix out)))
+    (is (not (contains? out :db))
+        ":db slot MUST NOT be written on a :path-not-found result")))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; The wrapper is additive — pre-existing slots on the envelope
+  ;; (tool, mode, cache, etc.) survive. Same shape `privacy/apply-
+  ;; to-result` and `elision/apply-to-result` provide.
+  (let [tree {:a 1}
+        out  (path-slice/apply-to-result
+               {:tool "get-app-db" :mode :full} :db tree [:a])]
+    (is (= 1 (:db out)))
+    (is (= "get-app-db" (:tool out)))
+    (is (= :full (:mode out)))))
+
+(deftest apply-to-result-out-of-range-preserves-existing-envelope-keys
+  ;; The path-not-found splice MUST also preserve upstream context.
+  (let [tree {:a 1}
+        out  (path-slice/apply-to-result
+               {:tool "get-app-db" :mode :full} :db tree [:no-such])]
+    (is (false? (:ok? out)))
+    (is (= "get-app-db" (:tool out)))
+    (is (= :full (:mode out)))))
+
+(deftest apply-to-result-nil-value-resolves-not-not-found
+  ;; A path that legitimately resolves to `nil` MUST write `nil`
+  ;; under `value-key` rather than reporting `:path-not-found`.
+  (let [tree {:flag nil}
+        out  (path-slice/apply-to-result {} :db tree [:flag])]
+    (is (nil? (:db out)))
+    (is (contains? out :db)
+        ":db slot present with nil value when path resolves")
+    (is (not (contains? out :reason))
+        ":reason slot MUST NOT be stamped when path resolves to nil")))
+
+(deftest apply-to-result-false-value-resolves
+  ;; Same disambiguator for `false`: a path resolving to `false` is
+  ;; a successful resolution, not a not-found.
+  (let [tree {:flag false}
+        out  (path-slice/apply-to-result {} :db tree [:flag])]
+    (is (= false (:db out)))
+    (is (contains? out :db))))
+
+(deftest apply-to-result-shape-for-tree-typed-tools
+  ;; Pins the canonical shape every direct-read tool uses:
+  ;;   `:db`    for `get-app-db`
+  ;;   `:state` for `get-machine-state`
+  ;;   `:epochs` for `get-epoch-history`
+  ;; Same wrapper services all — uniform boundary site.
+  (testing "get-app-db-shape (:db)"
+    (let [out (path-slice/apply-to-result
+                {} :db {:cart {:items []}} [:cart])]
+      (is (= {:items []} (:db out)))))
+  (testing "get-machine-state-shape (:state)"
+    (let [out (path-slice/apply-to-result
+                {} :state {:current :running :context {:k :v}}
+                [:context :k])]
+      (is (= :v (:state out)))))
+  (testing "get-epoch-history-shape (:epochs)"
+    (let [out (path-slice/apply-to-result
+                {} :epochs
+                {:epochs [{:id "ep-1"} {:id "ep-2"}]}
+                [:epochs 0])]
+      (is (= {:id "ep-1"} (:epochs out))))))
+
+;; ---------------------------------------------------------------------------
+;; Composition with W-6 (elision) — the canonical wire-pipeline cascade.
+;; ---------------------------------------------------------------------------
+
+(deftest composes-with-w6-elision-on-sliced-subtree
+  ;; The dispatcher walked the tree server-side (W-6); the addressed
+  ;; subtree carries an `:rf.size/large-elided` marker in place of
+  ;; the large leaf. After W-2 slices, W-6's `apply-to-result`
+  ;; counts the marker on the sliced value and stamps the
+  ;; `:elided-large` counter. Both axes ride the same envelope.
+  (let [tree    {:user {:uploaded-pdf elided-marker :name "alice"}}
+        sliced  (-> {}
+                    (path-slice/apply-to-result :db tree [:user]))
+        result  (elision/apply-to-result sliced :db (:db sliced))]
+    (is (= 1 (:elided-large result))
+        ":elided-large counter rides on the sliced subtree")
+    (is (= {:uploaded-pdf elided-marker :name "alice"}
+           (:db result)))))
+
+(deftest composes-with-w6-elision-on-path-not-found
+  ;; Edge case: out-of-range path; the W-6 wrapper sees no `:db`
+  ;; slot to walk. The composition stays safe — W-6 walks whatever
+  ;; lives under `:db` (here, nothing), counts zero, and stamps
+  ;; nothing.
+  (let [tree   {:user {:name "alice"}}
+        sliced (path-slice/apply-to-result {} :db tree [:no-such])
+        ;; W-6 walks the absent :db slot (nil); zero markers, no
+        ;; counter — clean path-not-found envelope.
+        result (elision/apply-to-result sliced :db (:db sliced))]
+    (is (false? (:ok? result)))
+    (is (= :path-not-found (:reason result)))
+    (is (not (contains? result :elided-large))
+        "no markers to count on an absent :db slot ⇒ no counter")))
+
+(deftest composes-with-b1-privacy-orthogonally
+  ;; B-1 (privacy) and W-2 (path-slice) live on orthogonal surfaces
+  ;; — trace-stream vs direct-read — but the envelope shapes compose
+  ;; freely because both wrappers are additive. The combined
+  ;; envelope can carry both axes' counters when an exotic tool
+  ;; surfaces both.
+  (let [events   [{:op :a} {:op :b :sensitive? true}]
+        tree     {:cart {:items [{:sku "abc"}]}}
+        envelope (-> {}
+                     (privacy/apply-to-result :events events false)
+                     (path-slice/apply-to-result :db tree [:cart :items]))]
+    (is (= 1 (:dropped-sensitive envelope))
+        "B-1 counter rides on the envelope")
+    (is (= [{:op :a}] (:events envelope))
+        "B-1 strips the sensitive event")
+    (is (= [{:sku "abc"}] (:db envelope))
+        "W-2 writes the addressed subtree alongside")))
+
+;; ---------------------------------------------------------------------------
+;; Load-bearing spec/004 §2 assertion — path slicing end-to-end.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-path-arg-vocabulary-end-to-end
+  (testing "MUST 8 — direct-read tools accept the `:path` arg and the
+            parser handles every shape in the cross-MCP vocabulary"
+    (is (= [:cart :items 3 :sku]
+           (path-slice/path-arg
+             #js {"path" "[:cart :items 3 :sku]"}))
+        "spec/004 §2 L261 example path round-trips through the JS args
+         object → parser → CLJS vector chain")))
+
+(deftest spec-004-default-without-path-is-nil
+  (testing "MUST 9 half — absent `:path` parses to `nil`, signalling
+            the dispatcher to take the W-4 summary branch (the W-4
+            mode resolver in `summary.cljs` consumes the nil)"
+    (is (nil? (path-slice/path-arg #js {})))
+    (is (nil? (path-slice/path-arg nil)))))
+
+(deftest spec-004-out-of-range-returns-path-not-found
+  (testing "spec/004 §2 L267-270 — out-of-range path returns
+            `:ok? false :reason :path-not-found` with the deepest
+            valid prefix attached"
+    (let [tree {:cart {:items [{:sku "abc"}]}}
+          out  (path-slice/apply-to-result {} :db tree [:cart :items 5 :sku])]
+      (is (false? (:ok? out)))
+      (is (= :path-not-found (:reason out)))
+      (is (= [:cart :items 5 :sku] (:path out)))
+      (is (= [:cart :items] (:deepest-valid-prefix out))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/summary_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/summary_test.cljs
@@ -1,0 +1,417 @@
+(ns day8.re-frame2-causa-mcp.summary-test
+  "Unit tests for the W-4 lazy-summary wire-pipeline mechanism at
+  the Causa-MCP boundary (rf2-8xzoe.8). Pins:
+
+    - MUST 12 — every tree-typed tool exposes a `:mode` argument
+      with at least `:summary` (default), `:sample`, and `:full`
+      (spec/004 §4 L303-306).
+    - Causa-specific `:rf.mcp/summary` shape — `:type`, `:keys`,
+      `:counts` (per-key cardinality map; causa divergence from
+      pair2-mcp's scalar `:count`), `:bytes` (cheap approximation).
+    - Cheap `:bytes` estimator (rf2-qta8j shape) — `count × per-
+      entry constant`, NOT deep `pr-str`. Pinned by the structural
+      property `(zero? (mod bytes count))`.
+    - Mode-arg accept-shape — strings, keywords, nil; out-of-vocab
+      bounded-allowlist-guarded (rf2-ih7g4).
+    - Composition with W-1 (token-cap), W-2 (path slicing), W-6
+      (elision), B-1 (privacy) — additive wrappers.
+
+  These tests are the load-bearing pin for the downstream
+  tree-typed direct-read tools — every dispatcher that returns a
+  rich nested value calls `summary/apply-to-result` once at the
+  boundary, with the resolved `:mode` from `mode-arg`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.path-slice :as path-slice]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.summary :as summary]
+            [day8.re-frame2-causa-mcp.token-cap :as token-cap]))
+
+;; A canonical elided marker, as the framework walker would emit.
+;; Reused across composition tests so the W-6 surface stays visible
+;; inside W-4's summary / sample / full payloads.
+(def ^:private elided-marker
+  {:rf.size/large-elided
+   {:path   [:user :uploaded-pdf]
+    :bytes  102400
+    :type   :string
+    :reason :declared
+    :handle [:rf.elision/at [:user :uploaded-pdf]]}})
+
+;; ---------------------------------------------------------------------------
+;; Public surface — vars exist and are callable.
+;; ---------------------------------------------------------------------------
+
+(deftest public-surface-resolvable
+  (testing "W-4 lands the public surface downstream tree-typed
+            direct-read tool dispatchers will require"
+    (is (fn? summary/tree-summary))
+    (is (fn? summary/sample-value))
+    (is (fn? summary/parse-mode-arg))
+    (is (fn? summary/mode-arg))
+    (is (fn? summary/parse-sample-size-arg))
+    (is (fn? summary/sample-size-arg))
+    (is (fn? summary/apply-to-result))
+    (is (= :summary summary/default-mode))
+    (is (= #{:summary :sample :full} summary/mode-vocabulary)
+        "spec/004 §4 closed mode vocabulary (MUST 12)")
+    (is (= 64 summary/summary-keys-cap))
+    (is (= 8 summary/default-sample-size))))
+
+;; ---------------------------------------------------------------------------
+;; tree-summary — the marker shape (causa-spec divergence).
+;; ---------------------------------------------------------------------------
+
+(deftest tree-summary-map-records-keys-and-counts
+  ;; Causa divergence from pair2-mcp: `:counts` is a per-key
+  ;; cardinality map. Agents prioritise drill-down without a
+  ;; second call.
+  (let [v {:cart {:items [{:sku "A"} {:sku "B"}]} :user 1 :ui "loading"}
+        s (summary/tree-summary v)
+        marker (:rf.mcp/summary s)]
+    (is (= :map (:type marker)))
+    (is (= #{:cart :user :ui} (set (:keys marker))))
+    (is (map? (:counts marker)))
+    (is (= 1 (get (:counts marker) :cart))
+        ":cart's value is a 1-entry map (the :items slot) — counts=1")
+    (is (= 1 (get (:counts marker) :user))
+        "scalar value contributes 1")
+    (is (= 7 (get (:counts marker) :ui))
+        "string :ui counts as its length")
+    (is (integer? (:bytes marker)))
+    (is (pos? (:bytes marker)))))
+
+(deftest tree-summary-counts-tracks-vector-cardinality
+  ;; A :map slot whose value is a vector reports its length.
+  (let [v {:items [:a :b :c :d :e] :tags #{:x :y}}
+        marker (:rf.mcp/summary (summary/tree-summary v))]
+    (is (= 5 (get (:counts marker) :items)))
+    (is (= 2 (get (:counts marker) :tags)))))
+
+(deftest tree-summary-bytes-scales-with-entry-count
+  ;; The estimator is linear: a 10-entry map should report ~10x the
+  ;; `:bytes` of a 1-entry map.
+  (let [tiny  {:a 1}
+        big   (zipmap (map #(keyword (str "k" %)) (range 10)) (range 10))
+        tiny-bytes (-> tiny summary/tree-summary :rf.mcp/summary :bytes)
+        big-bytes  (-> big  summary/tree-summary :rf.mcp/summary :bytes)]
+    (is (= 10 (/ big-bytes tiny-bytes))
+        "10-entry map's bytes estimate should be 10x a 1-entry map's")))
+
+(deftest tree-summary-bytes-is-cheap-on-large-values
+  ;; rf2-qta8j (cross-MCP): the load-bearing property. The marker
+  ;; exists precisely to avoid deep `pr-str`. A regression to
+  ;; deep `pr-str` would surface as a non-multiple-of-the-
+  ;; constant byte count.
+  (let [huge   (zipmap (map #(keyword (str "k" %)) (range 50000))
+                       (repeat (zipmap (range 100) (range 100))))
+        marker (:rf.mcp/summary (summary/tree-summary huge))
+        bytes  (:bytes marker)]
+    (is (= 50000 (count huge)) "test setup pin: 50K-entry map")
+    (is (zero? (mod bytes 50000))
+        "Bytes must be entry-count × constant, not pr-str byte count")))
+
+(deftest tree-summary-vector-records-count-scalar
+  ;; Non-map collections: scalar `:count`, parallel to pair2-mcp.
+  (let [v [1 2 3 4 5]
+        marker (:rf.mcp/summary (summary/tree-summary v))]
+    (is (= :vector (:type marker)))
+    (is (= 5 (:count marker)))
+    (is (integer? (:bytes marker)))
+    (is (pos? (:bytes marker)))
+    (is (not (contains? marker :counts))
+        ":counts is map-only (causa divergence); vectors carry :count")))
+
+(deftest tree-summary-set-and-seq
+  (is (= :set (-> (summary/tree-summary #{1 2 3}) :rf.mcp/summary :type)))
+  (is (= 3   (-> (summary/tree-summary #{1 2 3}) :rf.mcp/summary :count)))
+  (is (= :seq (-> (summary/tree-summary (list 1 2 3)) :rf.mcp/summary :type))))
+
+(deftest tree-summary-map-truncates-huge-key-lists
+  ;; A 5k-entry map's key list alone would blow the cap. The summary
+  ;; marker MUST stay bounded.
+  (let [big-map (zipmap (map #(keyword (str "k" %)) (range 5000))
+                        (repeat :_))
+        marker  (:rf.mcp/summary (summary/tree-summary big-map))]
+    (is (= :map (:type marker)))
+    (is (= summary/summary-keys-cap (count (:keys marker))))
+    (is (true? (:keys-truncated? marker)))
+    ;; :counts also truncates to the shown keys — parity with :keys
+    (is (= summary/summary-keys-cap (count (:counts marker)))
+        ":counts truncates to the shown keys")))
+
+(deftest tree-summary-truncated-marker-fits-cap
+  ;; The truncated marker MUST still fit the W-1 5K-token cap.
+  (let [big-map (zipmap (map #(keyword (str "k" %)) (range 10000))
+                        (repeat :_))
+        marker  (summary/tree-summary big-map)
+        rendered (pr-str marker)
+        ;; quot/4 token estimate.
+        tokens   (quot (count rendered) 4)]
+    (is (< tokens token-cap/default-max-tokens)
+        "Marker for a 10K-entry map MUST fit the W-1 cap")))
+
+(deftest tree-summary-scalar-returns-value-unchanged
+  ;; Scalars pass through; wrapping adds tokens without saving any.
+  (is (= 42 (summary/tree-summary 42)))
+  (is (= "hello" (summary/tree-summary "hello")))
+  (is (= :keyword (summary/tree-summary :keyword)))
+  (is (= true (summary/tree-summary true))))
+
+(deftest tree-summary-marker-key-is-cross-mcp-vocab
+  ;; Pin the cross-MCP vocab: `:rf.mcp/summary` is the canonical
+  ;; marker key (per re-frame.mcp-base.vocab/summary-key).
+  (let [s (summary/tree-summary {:a 1 :b 2})]
+    (is (contains? s :rf.mcp/summary))
+    (is (= [:rf.mcp/summary] (vec (keys s)))
+        "summary marker is the SOLE top-level key on the result")))
+
+;; ---------------------------------------------------------------------------
+;; sample-value — :mode :sample bounded prefix.
+;; ---------------------------------------------------------------------------
+
+(deftest sample-value-vector-prefix
+  (is (= [:a :b :c] (summary/sample-value [:a :b :c :d :e :f] 3))))
+
+(deftest sample-value-vector-shorter-than-n
+  (is (= [:a :b] (summary/sample-value [:a :b] 5))))
+
+(deftest sample-value-map-prefix-is-sorted-for-stability
+  (let [v {:c 3 :a 1 :b 2 :d 4 :e 5}
+        sampled (summary/sample-value v 2)]
+    (is (= 2 (count sampled)))
+    (is (= {:a 1 :b 2} sampled)
+        "sort-by key for stability: same input ⇒ same prefix
+         regardless of map iteration order")))
+
+(deftest sample-value-set-bounded
+  (let [v #{:a :b :c :d :e}
+        sampled (summary/sample-value v 3)]
+    (is (= 3 (count sampled)))
+    (is (set? sampled))))
+
+(deftest sample-value-seq-prefix
+  (is (= '(0 1 2) (summary/sample-value (range 10) 3))))
+
+(deftest sample-value-scalar-passes-through
+  (is (= 42 (summary/sample-value 42 5)))
+  (is (= "hello" (summary/sample-value "hello" 5))))
+
+(deftest sample-value-clamps-size
+  ;; Below min-sample-size clamps up; above max clamps down.
+  (let [v (vec (range 100))]
+    (is (= 1 (count (summary/sample-value v 0))))
+    (is (= 1 (count (summary/sample-value v -5))))
+    (is (= summary/max-sample-size (count (summary/sample-value (vec (range 1000)) 999))))))
+
+;; ---------------------------------------------------------------------------
+;; Mode-arg parser — bounded-allowlist gate (MUST 12).
+;; ---------------------------------------------------------------------------
+
+(deftest parse-mode-arg-default-when-absent
+  (is (= :summary (summary/parse-mode-arg nil)))
+  (is (= :summary (summary/parse-mode-arg ""))))
+
+(deftest parse-mode-arg-keyword-pass-through
+  (is (= :summary (summary/parse-mode-arg :summary)))
+  (is (= :sample  (summary/parse-mode-arg :sample)))
+  (is (= :full    (summary/parse-mode-arg :full))))
+
+(deftest parse-mode-arg-string-coerces
+  (is (= :summary (summary/parse-mode-arg "summary")))
+  (is (= :sample  (summary/parse-mode-arg "sample")))
+  (is (= :full    (summary/parse-mode-arg "full"))))
+
+(deftest parse-mode-arg-edn-string-coerces
+  (is (= :summary (summary/parse-mode-arg ":summary")))
+  (is (= :full    (summary/parse-mode-arg ":full"))))
+
+(deftest parse-mode-arg-unknown-falls-back-to-default
+  ;; rf2-ih7g4 bounded-allowlist: unrecognised inputs collapse to
+  ;; default rather than interning a fresh keyword.
+  (is (= :summary (summary/parse-mode-arg "weird")))
+  (is (= :summary (summary/parse-mode-arg :weird-mode)))
+  (is (= :summary (summary/parse-mode-arg 42)))
+  (is (= :summary (summary/parse-mode-arg {:not-a-mode true}))))
+
+(deftest mode-arg-from-js-args-object
+  (is (= :full   (summary/mode-arg #js {"mode" "full"})))
+  (is (= :sample (summary/mode-arg #js {"mode" "sample"})))
+  (is (= :summary (summary/mode-arg #js {}))))
+
+(deftest mode-arg-from-cljs-map
+  (is (= :full (summary/mode-arg {:mode :full})))
+  (is (= :full (summary/mode-arg {"mode" "full"}))))
+
+(deftest mode-arg-absent-returns-default
+  (is (= :summary (summary/mode-arg nil)))
+  (is (= :summary (summary/mode-arg js/undefined))))
+
+;; ---------------------------------------------------------------------------
+;; sample-size-arg.
+;; ---------------------------------------------------------------------------
+
+(deftest parse-sample-size-default
+  (is (= summary/default-sample-size (summary/parse-sample-size-arg nil))))
+
+(deftest parse-sample-size-pass-through
+  (is (= 5 (summary/parse-sample-size-arg 5))))
+
+(deftest parse-sample-size-clamps
+  (is (= summary/min-sample-size (summary/parse-sample-size-arg 0)))
+  (is (= summary/max-sample-size (summary/parse-sample-size-arg 9999))))
+
+(deftest sample-size-arg-from-js
+  (is (= 25 (summary/sample-size-arg #js {"sample-size" 25}))))
+
+;; ---------------------------------------------------------------------------
+;; apply-to-result — per-tool boundary wrapper.
+;; ---------------------------------------------------------------------------
+
+(deftest apply-to-result-summary-mode-emits-marker
+  (let [tree {:cart {:items []} :user 1}
+        out  (summary/apply-to-result {} :db tree {:mode :summary})]
+    (is (contains? (:db out) :rf.mcp/summary))
+    (is (= :summary (:mode out))
+        ":mode slot stamps the chosen mode for agent accounting")))
+
+(deftest apply-to-result-default-mode-is-summary
+  ;; MUST 12: `:summary` is the default. The boundary wrapper
+  ;; defaults to summary when no mode is supplied.
+  (let [tree {:a 1 :b 2}
+        out  (summary/apply-to-result {} :db tree {})]
+    (is (contains? (:db out) :rf.mcp/summary))
+    (is (= :summary (:mode out)))))
+
+(deftest apply-to-result-sample-mode-bounded-prefix
+  (let [tree (vec (range 100))
+        out  (summary/apply-to-result {} :db tree
+                                      {:mode :sample :sample-size 5})]
+    (is (= [0 1 2 3 4] (:db out)))
+    (is (= :sample (:mode out)))))
+
+(deftest apply-to-result-full-mode-pass-through
+  (let [tree {:a 1 :b 2 :c 3}
+        out  (summary/apply-to-result {} :db tree {:mode :full})]
+    (is (= tree (:db out)))
+    (is (= :full (:mode out)))))
+
+(deftest apply-to-result-preserves-existing-envelope-keys
+  ;; Additive — pre-existing slots survive. Same shape as the
+  ;; other W-* boundary wrappers.
+  (let [tree {:a 1}
+        out  (summary/apply-to-result
+               {:tool "get-app-db"} :db tree {:mode :full})]
+    (is (= "get-app-db" (:tool out)))
+    (is (= 1 (-> out :db :a)))))
+
+(deftest apply-to-result-shape-for-tree-typed-tools
+  ;; Canonical shape every tree-typed tool uses.
+  (testing "get-app-db-shape (:db)"
+    (let [out (summary/apply-to-result
+                {} :db {:cart {} :user {}} {:mode :summary})]
+      (is (contains? out :db))))
+  (testing "get-machine-state-shape (:state)"
+    (let [out (summary/apply-to-result
+                {} :state {:current :running} {:mode :summary})]
+      (is (contains? out :state)))))
+
+;; ---------------------------------------------------------------------------
+;; Composition with W-2 (path slicing), W-6 (elision), W-1 (cap), B-1.
+;; ---------------------------------------------------------------------------
+
+(deftest summary-composes-with-w6-elision
+  ;; The walked tree carries markers in place; the summary describes
+  ;; the SHAPE — including the elided slot as a 1-entry value (the
+  ;; marker map). The :counts entry for that slot is 1 (single-key
+  ;; marker map).
+  (let [tree   {:user {:uploaded-pdf elided-marker} :name "alice"}
+        out    (summary/apply-to-result {} :db tree {:mode :summary})
+        marker (-> out :db :rf.mcp/summary)]
+    (is (= #{:user :name} (set (:keys marker))))
+    ;; :user's value is a 1-entry map (the marker map sat at
+    ;; :uploaded-pdf); :counts reflects the post-walk cardinality.
+    (is (= 1 (get (:counts marker) :user)))
+    (is (= 5 (get (:counts marker) :name))
+        "string \"alice\" counts as 5")))
+
+(deftest summary-composes-with-w2-path-slice
+  ;; Tools that take BOTH `:path` and `:mode`: the dispatcher
+  ;; checks `:path` first (MUST 9); when non-nil, slices first then
+  ;; routes the addressed subtree through summary. When nil, summary
+  ;; describes the full tree.
+  (testing "with-path: summary describes the sliced subtree"
+    (let [tree    {:cart {:items [{:sku "A"} {:sku "B"}] :total 30}}
+          sliced  (path-slice/apply-to-result {} :db tree [:cart])
+          ;; The dispatcher walks the resolved subtree (under :db)
+          ;; through summary's apply-to-result.
+          out     (summary/apply-to-result sliced :db (:db sliced)
+                                           {:mode :summary})
+          marker  (-> out :db :rf.mcp/summary)]
+      (is (= #{:items :total} (set (:keys marker))))
+      (is (= 2 (get (:counts marker) :items)))
+      (is (= 1 (get (:counts marker) :total))
+          "scalar :total counts as 1")))
+  (testing "no-path: summary describes the root"
+    (let [tree {:cart {} :user {} :ui {}}
+          out  (summary/apply-to-result {} :db tree {:mode :summary})
+          marker (-> out :db :rf.mcp/summary)]
+      (is (= #{:cart :user :ui} (set (:keys marker)))))))
+
+(deftest summary-composes-with-b1-orthogonally
+  ;; Privacy + summary are on orthogonal surfaces but the envelope
+  ;; shapes compose — additive wrappers.
+  (let [events  [{:op :a} {:op :b :sensitive? true}]
+        tree    {:cart {} :user {}}
+        out     (-> {}
+                    (privacy/apply-to-result :events events false)
+                    (summary/apply-to-result :db tree {:mode :summary}))]
+    (is (= 1 (:dropped-sensitive out)))
+    (is (= [{:op :a}] (:events out)))
+    (is (contains? (:db out) :rf.mcp/summary))))
+
+(deftest summary-marker-fits-under-w1-cap
+  ;; The load-bearing property: a summary marker for a HUGE app-db
+  ;; root MUST fit the W-1 cap. This is mechanism W-4's primary
+  ;; raison-d'etre — `:summary` is the cap defence for tree-typed
+  ;; tools. Synthesise a pathologically wide and deep root.
+  (let [huge   (zipmap (map #(keyword (str "k" %)) (range 10000))
+                       (repeat (zipmap (range 100) (range 100))))
+        out    (summary/apply-to-result {} :db huge {:mode :summary})
+        rendered (pr-str (:db out))
+        tokens   (quot (count rendered) 4)]
+    (is (< tokens token-cap/default-max-tokens)
+        "summary marker for a 10K-key root MUST fit W-1's 5K cap")))
+
+;; ---------------------------------------------------------------------------
+;; Load-bearing spec/004 §4 assertion.
+;; ---------------------------------------------------------------------------
+
+(deftest spec-004-mode-vocabulary-end-to-end
+  (testing "MUST 12 — :mode arg exposes at least :summary :sample
+            :full, default is :summary"
+    (is (contains? summary/mode-vocabulary :summary))
+    (is (contains? summary/mode-vocabulary :sample))
+    (is (contains? summary/mode-vocabulary :full))
+    (is (= :summary summary/default-mode)))
+  (testing "the per-mode behaviour"
+    (let [tree {:a 1 :b 2 :c 3 :d 4 :e 5}]
+      (is (contains? (:db (summary/apply-to-result {} :db tree {:mode :summary}))
+                     :rf.mcp/summary)
+          ":summary ⇒ marker")
+      (is (map? (:db (summary/apply-to-result {} :db tree {:mode :sample
+                                                            :sample-size 2})))
+          ":sample ⇒ bounded prefix of same shape")
+      (is (= tree (:db (summary/apply-to-result {} :db tree {:mode :full})))
+          ":full ⇒ pass-through"))))
+
+(deftest spec-004-summary-marker-shape-end-to-end
+  (testing "spec/004 §4 marker shape: :type, :keys, :counts
+            (causa-divergence per-key cardinality map), :bytes"
+    (let [v {:cart {:items [:a :b]} :user 1}
+          marker (:rf.mcp/summary (summary/tree-summary v))]
+      (is (= :map (:type marker)))
+      (is (= #{:cart :user} (set (:keys marker))))
+      (is (= 1 (get (:counts marker) :cart)))
+      (is (= 1 (get (:counts marker) :user)))
+      (is (integer? (:bytes marker))))))


### PR DESCRIPTION
## Summary

Implements the W-2..W-5 wire-pipeline mechanisms at the causa-mcp boundary, completing the W-tranche (W-1 and W-6 already shipped in PRs #1296 and #1294 respectively). Each mechanism is a sibling top-level namespace under `tools/causa-mcp/src/day8/re_frame2_causa_mcp/`, parallel to the already-shipped `token_cap.cljs` / `elision.cljs` / `privacy.cljs`.

### Beads

- **rf2-8xzoe.6** — W-2 path slicing (`path_slice.cljs` + tests; cross-MCP path-arg vocabulary parser + sentinel-aware resolver + `:path-not-found` shape with deepest-valid-prefix)
- **rf2-8xzoe.7** — W-3 cursor pagination (`cursor.cljs` + tests; opaque base64-EDN cursor encode/decode + `:next-cursor`/`:remaining` shape + `:rf.mcp/cursor-stale` error)
- **rf2-8xzoe.8** — W-4 lazy summary mode (`summary.cljs` + tests; `:summary`/`:sample`/`:full` mode resolver + `:rf.mcp/summary` marker shape with causa's per-key `:counts` divergence + cheap `bytes` estimator per rf2-qta8j)
- **rf2-8xzoe.9** — W-5 structural dedup (`dedup.cljs` + tests; `day8/de-dupe` integration + `:rf.mcp/dedup-table` wire shape + `:dedup?` opt-out + reduction-ratio benchmark)

### MUSTs honoured

- MUST 8 (path-arg accepted on direct-read tools)
- MUST 9 (default-without-path is summary mode; parser returns nil to signal the dispatcher)
- MUST 10 (`:cursor` + `:limit` accepted on sequence-returning tools)
- MUST 11 (`:next-cursor` + `:remaining` on every paginated response)
- MUST 12 (`:mode` arg exposes `:summary`/`:sample`/`:full`; `:summary` default)
- MUST 14 (regime-appropriate dedup compression-factor cited via reduction-ratio benchmark)

### Composition

Each mechanism includes deftest coverage for composition with the already-shipped B-1 (privacy), W-1 (token-cap), and W-6 (size-elision) wrappers — pinning the additive envelope contract: counters from all axes (`:dropped-sensitive`, `:elided-large`) ride together with `:next-cursor`/`:remaining`/`:mode`/`:rf.mcp/dedup-table` on the same response. The spec/004 §5 cascade order (B-1 → W-6 → W-5 → W-3 → W-1) is pinned end-to-end.

### Concurrent surfaces

This PR adds 4 new top-level sibling namespaces. The concurrently-running T-Insp tranche (#1304, already merged) added per-tool dispatchers under `tools/causa-mcp/src/.../tools/*.cljs` — **disjoint surfaces, no merge conflicts**. The T-Insp tools currently inline their own helpers (e.g. `summary-keys-cap`); a future refactor bead may consolidate them onto the W-* sibling namespaces shipped here.

## Test plan

- [x] `npm test` from `tools/causa-mcp/`: **384 tests / 980 assertions, 0 failures, 0 errors** (108 from T-Insp tranche + 276 from W-2..W-5)
- [x] `npm run test:cljs` from `implementation/`: **2281 tests / 6488 assertions, 0 failures, 0 errors** (regression)
- [x] Wire-vocab tripwire: new namespaces live as top-level siblings (NOT under `src/.../tools/`) — the wire-vocab probe target.
- [x] Rebased on origin/main (clean — no conflicts with concurrent T-Insp / privacy / inject-cofx PRs)