### PR TITLE
spec+docs(causa): flip default-side LEFT->RIGHT + add user-draggable resize (rf2-e07yk)

### DIFF
--- a/docs/causa/01-installation.md
+++ b/docs/causa/01-installation.md
@@ -17,13 +17,14 @@ Once we publish to Clojars, the dev-deps coord will be `day8/re-frame2-causa {:m
 
 ## 2. Add the layout host
 
-Causa's default launch is true inline. Add a left-side host to your
-normal app layout:
+Causa's default launch is true inline. Add a right-side host to your
+normal app layout. Note the DOM order: `<main>` first, host `<aside>`
+second — flex flow puts the aside to the right of the app column:
 
 ```html
 <div class="app-shell">
-  <aside data-rf-causa-host></aside>
   <main id="app"></main>
+  <aside data-rf-causa-host></aside>
 </div>
 ```
 
@@ -32,16 +33,27 @@ normal app layout:
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
+  resize: horizontal;                /* user-draggable width */
+  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
 
-Resize the panel from anywhere up the cascade by overriding the
-`--rf-causa-inline-width` CSS custom property (per `rf2-um813` — JS-free, host-owned):
+Two complementary resize mechanisms — both browser-native, both
+JS-free — ship together:
 
-```css
-:root { --rf-causa-inline-width: 560px; }
-```
+- **CSS variable** (host-owned, fixed-point sizing). Override
+  `--rf-causa-inline-width` anywhere up the cascade to set the
+  initial width:
+  ```css
+  :root { --rf-causa-inline-width: 560px; }
+  ```
+- **Browser-native drag** (user-controlled). `resize: horizontal` +
+  `overflow: auto` give the host a drag-handle in the bottom corner;
+  the user drags to resize ad-hoc. The variable seeds the initial
+  size; a drag overrides it for the page lifetime; reload (or a
+  fresh cascade override) returns to the declared initial.
 
 If Causa cannot find the host, it logs an actionable `console.error`
 and exposes the same diagnostic through
@@ -62,11 +74,11 @@ A re-frame2 dev build with that preload, reloaded, is the precondition for the r
 
 ## 4. Launch
 
-Open your app in dev. The shell appears in the left inline host:
+Open your app in dev. The shell appears in the right inline host:
 
 ![The Causa shell, opened over the live app](../images/causa/02-shell-opened.png)
 
-The shell is a three-region layout:
+The shell is a three-region layout (inside the Causa panel itself):
 
 - **Sidebar** (left): the panel list.
 - **Canvas** (right): the selected panel.
@@ -91,7 +103,7 @@ The popout uses `window.opener` to reach the host's runtime — same listeners, 
 
 Tool-owned pages that deliberately do not reserve app real estate for
 Causa (for example a Story-only browser-test canvas, or an internal
-dev tool whose layout cannot accommodate a left column) can suppress
+dev tool whose layout cannot accommodate a right column) can suppress
 **only** the default page-load open while leaving the rest of the
 preload — collectors, browser API, keybinding — installed:
 
@@ -147,6 +159,6 @@ npx http-server -p 8080 out/examples/counter
 # then browser: http://localhost:8080
 ```
 
-The Causa shell should appear in the left inline host as soon as the counter app loads. Click the `+` button a few times and the Event-detail panel should paint the cascade your clicks produced. `Ctrl+Shift+C` hides/shows the mounted shell. That's the smoke test.
+The Causa shell should appear in the right inline host as soon as the counter app loads. Click the `+` button a few times and the Event-detail panel should paint the cascade your clicks produced. `Ctrl+Shift+C` hides/shows the mounted shell. That's the smoke test.
 
 When that works on your own app, you're ready for the [panel tour](02-panel-tour.md).

--- a/docs/causa/index.md
+++ b/docs/causa/index.md
@@ -2,7 +2,7 @@
 
 **The cascade you can see.**
 
-Causa is the in-app devtools panel for re-frame2. It auto-opens in a left-side `[data-rf-causa-host]` layout column in your dev build, toggles with `Ctrl+Shift+C`, and renders sixteen panels over a single observation surface — the framework's own trace bus and epoch buffer. No bespoke recorder, no shadow runtime, no second substrate. The runtime knows what happened; Causa is what knows knows.
+Causa is the in-app devtools panel for re-frame2. It auto-opens in a right-side `[data-rf-causa-host]` layout column in your dev build, toggles with `Ctrl+Shift+C`, and renders sixteen panels over a single observation surface — the framework's own trace bus and epoch buffer. No bespoke recorder, no shadow runtime, no second substrate. The runtime knows what happened; Causa is what knows knows.
 
 Where the v1-era [`re-frame-10x`](https://github.com/day8/re-frame-10x) was a sidecar with its own recorder, Causa is a *renderer* of an already-structured surface. Same panels — events, subs, renders, fxs, app-db diff, time-travel — different substrate. The framework moved the observation contract into the runtime; Causa moved with it.
 

--- a/skills/re-frame2-setup/reference/shadow-cljs.md
+++ b/skills/re-frame2-setup/reference/shadow-cljs.md
@@ -54,6 +54,9 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
     [data-rf-causa-host] {
       flex: 0 0 var(--rf-causa-inline-width, 420px);
       min-width: 320px;
+      border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
+      resize: horizontal;                /* user-draggable width */
+      overflow: auto;
     }
     #app { flex: 1; min-width: 0; }
     /* Resize from anywhere up the cascade: */
@@ -62,8 +65,8 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
 </head>
 <body>
   <div class="app-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="/js/main.js"></script>
 </body>
@@ -73,8 +76,8 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
 Four contractual bits:
 
 - **`<main id="app"></main>`** — the app mount point. Whatever id you use here, the entry ns must call `(js/document.getElementById "<same-id>")`. By convention it's `"app"`.
-- **`<aside data-rf-causa-host></aside>`** — Causa's default true-inline devtools host. Keep it as a left-side layout column beside `#app` when you enable `day8.re-frame2-causa.preload`; otherwise Causa logs an actionable missing-host diagnostic and exposes the same status through `window.day8.re_frame2_causa.status()`.
-- **`.app-shell` flex CSS** — the host app owns sizing and layout. The minimal contract is a left column (`flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0; }`). Override `--rf-causa-inline-width` anywhere up the cascade (e.g. `:root { --rf-causa-inline-width: 560px; }`) to resize the Causa panel — JS-free, host-owned (per `rf2-um813`).
+- **`<aside data-rf-causa-host></aside>`** — Causa's default true-inline devtools host. Keep it as a right-side layout column beside `#app` when you enable `day8.re-frame2-causa.preload` (DOM order: `<main>` first, `<aside>` second — flex flow puts the aside on the right); otherwise Causa logs an actionable missing-host diagnostic and exposes the same status through `window.day8.re_frame2_causa.status()`.
+- **`.app-shell` flex CSS** — the host app owns sizing and layout. The minimal contract is a right column (`flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0; }`). Two complementary resize mechanisms ship together — both browser-native, both JS-free: (1) **CSS variable** — override `--rf-causa-inline-width` anywhere up the cascade (e.g. `:root { --rf-causa-inline-width: 560px; }`) to set the initial width (host-owned, per `rf2-um813`); (2) **Browser-native drag** — `resize: horizontal` + `overflow: auto` paint a drag-handle in the host's bottom corner so the user can resize ad-hoc. The variable seeds the initial size; a drag overrides it for the page lifetime.
 - **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows.
 - **`/js/main.js` is an absolute path from site root.** That's correct for shadow-cljs's dev server.
 

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -14,7 +14,7 @@ surfaces as an issue you cannot miss.
 
 An in-app true-inline devtools panel for re-frame2 applications,
 preloaded into dev builds via `:preloads`. The host app provides a
-left-side `[data-rf-causa-host]` column in its normal layout; Causa
+right-side `[data-rf-causa-host]` column in its normal layout; Causa
 auto-opens there once the substrate adapter is ready. Production builds elide the entire surface
 through the universal `interop/debug-enabled?` gate — zero bytes
 shipped to consumers.
@@ -64,12 +64,13 @@ Once published, the dev-deps coord will be
 ### Add The Layout Host
 
 Causa's default launch mode is true inline, not an overlay. Add a
-left-side host to the app layout:
+right-side host to the app layout (DOM order: `<main>` first, host
+`<aside>` second — flex puts the aside on the right):
 
 ```html
 <div class="app-shell">
-  <aside data-rf-causa-host></aside>
   <main id="app"></main>
+  <aside data-rf-causa-host></aside>
 </div>
 ```
 
@@ -78,13 +79,24 @@ left-side host to the app layout:
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  border-left: 1px solid #2a2a2a;
+  resize: horizontal;
+  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
 
-Override `--rf-causa-inline-width` anywhere up the cascade (e.g.
-`:root { --rf-causa-inline-width: 560px; }`) to resize the inline
-panel — JS-free, host-owned (per `rf2-um813`).
+Two complementary resize mechanisms ship together — both
+browser-native, both JS-free:
+
+- **CSS variable** (host-owned). Override `--rf-causa-inline-width`
+  anywhere up the cascade (e.g.
+  `:root { --rf-causa-inline-width: 560px; }`) to set the initial
+  width.
+- **Browser-native drag** (user-controlled). `resize: horizontal` +
+  `overflow: auto` give the host a drag-handle in the bottom corner;
+  the variable seeds the initial size, a drag overrides it for the
+  page lifetime.
 
 If the host is missing, Causa logs an actionable `console.error` and
 exposes the same state through `window.day8.re_frame2_causa.status()`.

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -10,11 +10,11 @@ and [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md).
 
 ## Layout
 
-Causa fills a true-inline panel on the **left side** of the host app by
+Causa fills a true-inline panel on the **right side** of the host app by
 default. The host app provides `[data-rf-causa-host]` as a normal
 flex/grid column and Causa renders inside it. This is not an overlay
 and not a body-padding dock: the app remains visible and clickable to
-the right because normal layout owns the relationship.
+the left because normal layout owns the relationship.
 
 ### The five regions
 
@@ -65,7 +65,7 @@ explaining desktop-only.
 
 On page load after `rf/init!`, when `[data-rf-causa-host]` exists:
 
-- Causa auto-opens in the left inline host.
+- Causa auto-opens in the right inline host.
 - `Ctrl+Shift+C` hides/shows the already-mounted shell with a CSS-only
   display toggle.
 - **Active panel: Events**, showing the most-recent epoch's

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -4,9 +4,9 @@ Causa launches in two complementary ways:
 
 1. **In-app true-inline panel** — the default. Causa preloads into
    the dev build, waits for the substrate adapter, then mounts into an
-   app-provided left-side layout host (`[data-rf-causa-host]` by
+   app-provided right-side layout host (`[data-rf-causa-host]` by
    default). The panel participates in normal layout, so app controls
-   remain visible and clickable to the right.
+   remain visible and clickable to the left.
 
 2. **Standalone via MCP** — the remote-attach story. An AI agent
    running on the user's machine (or elsewhere) drives Causa-MCP
@@ -34,12 +34,14 @@ layout. Default selector:
 [data-rf-causa-host]
 ```
 
-Minimal host markup:
+Minimal host markup (note the DOM order: `<main>` first, host
+`<aside>` second — flex flow lays the aside to the right of the app
+column):
 
 ```html
 <div class="app-shell">
-  <aside data-rf-causa-host></aside>
   <main id="app"></main>
+  <aside data-rf-causa-host></aside>
 </div>
 ```
 
@@ -53,6 +55,9 @@ body { margin: 0; }
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  border-left: 1px solid #2a2a2a;     /* visual separator on the app side */
+  resize: horizontal;                  /* user-draggable width (see below) */
+  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
@@ -84,6 +89,9 @@ identical to the historical fixed-pixel default (420px):
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  border-left: 1px solid #2a2a2a;
+  resize: horizontal;
+  overflow: auto;
 }
 ```
 
@@ -107,7 +115,7 @@ Sizing units are unrestricted (`px`, `rem`, `vw`, `min(...)`, `clamp(...)`,
 from collapsing past readability when the developer specifies a small
 value; remove the floor if you want truly unbounded shrink.
 
-App content to the right (`#app { flex: 1; min-width: 0 }`) stays in
+App content to the left (`#app { flex: 1; min-width: 0 }`) stays in
 normal flow regardless of the inline width — Causa never overlays the
 app, never claims a hit-test region outside its host, and never
 mutates `body` padding in the default true-inline mode. This holds
@@ -123,14 +131,43 @@ string. Causa MUST NOT introduce a runtime API that sets the property
 from CLJS — the host's stylesheet is the single source of truth for
 sizing; introducing a CLJS setter would split that source.
 
-A JS-driven draggable separator was considered and rejected at this
-phase (rf2-um813): the CSS-variable contract covers the "developers
-need to tweak the width" requirement at zero runtime surface, zero
-new failure modes, and a one-line override path. A draggable handle
-adds pointer-capture, hit-test priority, ARIA semantics, and reduced-
-motion handling for marginal benefit; if the user need surfaces, a
-later bead may add it ON TOP of the CSS contract (the handle would
-write the same property).
+### User-draggable resize
+
+The recommended host snippet ships two complementary resize
+mechanisms — both browser-native, both JS-free, both writing the
+same `flex-basis` slot:
+
+1. **CSS variable** (host-owned, fixed-point sizing) — the
+   `--rf-causa-inline-width` property described above. The host's
+   stylesheet sets the *initial* width and any cascade-level
+   overrides (per-route, per-user, per-build). One declaration, no
+   pointer events, no runtime cost. This is the path for "the team
+   agreed Causa should default to 560px on the debug route."
+2. **Browser-native drag** (user-controlled, ad-hoc sizing) — the
+   `resize: horizontal` + `overflow: auto` pair on
+   `[data-rf-causa-host]`. The browser paints a drag-handle in the
+   bottom corner of the host (per
+   [CSS UI L3 §`resize`](https://drafts.csswg.org/css-ui-3/#resize)),
+   the user drags it, the host's *used* width updates, and flex
+   reflow shrinks `#app` to fill the remainder. No CLJS, no listener,
+   no Causa surface — the browser owns the interaction. This is the
+   path for "I want a bit more room for the event-detail panel right
+   now."
+
+The two cooperate cleanly. The variable establishes the initial
+size; a drag overrides it for the page lifetime; reload (or a fresh
+`--rf-causa-inline-width` override up the cascade) returns to the
+declared initial. The drag handle is the bottom-right corner of the
+host element (in LTR layouts) and is keyboard-accessible per the
+browser's standard `resize` semantics; no ARIA wiring is required.
+
+Causa MUST NOT introduce a JS-driven draggable separator — the
+`resize: horizontal` contract covers the user-drag requirement at
+zero runtime surface, zero new failure modes, and zero ARIA
+semantics for Causa to maintain. If a future use case demands
+pointer-capture beyond what the browser primitive provides, it MUST
+write to `--rf-causa-inline-width` (preserving cascade semantics);
+it MUST NOT introduce a parallel sizing channel.
 
 If the selector cannot be found after the substrate adapter is ready,
 Causa MUST fail loudly but safely: `console.error` with the selector
@@ -245,7 +282,7 @@ full-screen" use case.
 ### Animation
 
 Default inline launch is normal document layout: Causa renders inside
-the host's left column and the app remains visible to the right. The
+the host's right column and the app remains visible to the left. The
 default hide/show operation is a CSS display swap on the mount node
 and MUST respect `prefers-reduced-motion`.
 

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -142,7 +142,7 @@ cascade.
 ### `:layout/host-selector`
 
 The CSS selector Causa uses for its default true-inline shell mount.
-The host app owns the normal-flow left-side layout host; Causa renders
+The host app owns the normal-flow right-side layout host; Causa renders
 inside it after substrate readiness.
 
 | Value | Meaning |


### PR DESCRIPTION
## Summary

Two-axis change to Causa's default true-inline host contract.

**Axis 1 — Side flip (LEFT → RIGHT).** Every spec/docs/snippet reference flips. DOM order in install snippets becomes `<main id=\"app\">` first, `<aside data-rf-causa-host>` second; flex flow puts the aside on the right. App content stays on the left. Visual separator becomes `border-left` on the host (paints the rule on the app-facing edge).

**Axis 2 — User-draggable resize.** The recommended host snippet now adds `resize: horizontal` + `overflow: auto`, giving the user a browser-native drag-handle in the host's bottom corner. The existing `--rf-causa-inline-width` CSS variable (rf2-um813) keeps its role as the host-owned initial-width knob; the two mechanisms cooperate — variable seeds the initial size, drag overrides for the page lifetime. Replaces the previous \"JS-driven separator considered and rejected\" paragraph in `011-Launch-Modes.md` with a new **§User-draggable resize** subsection that documents both paths.

## Files

- `tools/causa/spec/011-Launch-Modes.md` — normative; main flip + new §User-draggable resize subsection
- `tools/causa/spec/007-UX-IA.md` — layout description flip
- `tools/causa/spec/015-Configuration.md` — one-line flip
- `tools/causa/README.md` — quick-start flip + resize blurb
- `docs/causa/01-installation.md` — install snippet flip + two-mechanism blurb
- `docs/causa/index.md` — welcome-page one-liner flip
- `skills/re-frame2-setup/reference/shadow-cljs.md` — `index.html` snippet flip

## Pre-alpha posture

Clean flip — no \"left also supported\" caveat, no deprecation aliases, no migration paths. CSS variable name (`--rf-causa-inline-width`) is unchanged; only the position semantics flip.

## Out of scope (follow-on)

The implementation surface still describes Causa as left-side in several spots — `tools/causa/src/day8/re_frame2_causa/config.cljc` (default-snippet docstring), the testbeds under `tools/causa/testbeds/`, and a few `panels/*` source comments. Those flip in the implementation bead, not this spec+docs flip.

## Test plan

- [x] `mkdocs build --strict` — 68 pre-existing warnings (unrelated, all in `guide/24-configuration-and-safety/*` + `skills/re-frame2-implementor.md`), zero new warnings from this change.
- [ ] Spec reviewers eyeball `011-Launch-Modes.md` §User-draggable resize for normative-language fit.