### PR TITLE
fix(causa): runtime.cljs use re-frame.trace.tooling (rf2-ustmv)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/runtime.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/runtime.cljs
@@ -76,6 +76,14 @@
   attach later without the runtime needing to know."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            ;; rf2-qwm0a: trace-buffer (and the rest of the listener +
+            ;; ring-buffer surface) lives in re-frame.trace.tooling, not
+            ;; re-frame.trace. CLJS deliberately omits `rf/<name>` aliases
+            ;; for these so production counter bundles DCE the tooling
+            ;; sibling wholesale; Causa's runtime is dev-only (rides the
+            ;; panel's :devtools/preloads), so requiring the tooling ns
+            ;; directly here is bundle-isolation-safe.
+            [re-frame.trace.tooling :as trace-tooling]
             [re-frame.interop :as interop]))
 
 ;; ---------------------------------------------------------------------------
@@ -211,7 +219,7 @@
 
 (defn get-trace-buffer
   "Tool: `get-trace-buffer`. Return a slice of the trace stream by
-  filter; forwards to `(rf/trace-buffer opts)`. Filter keys are the
+  filter; forwards to `(trace-tooling/trace-buffer opts)`. Filter keys are the
   canonical Spec 009 filter vocabulary (`:operation`, `:op-type`,
   `:since`, `:frame`, `:severity`, `:event-id`, `:handler-id`,
   `:source`, `:origin`, `:dispatch-id`, `:since-ms`, `:between`,
@@ -224,7 +232,7 @@
   ([opts]
    (let [{:keys [include-sensitive? include-large?]} opts
          filter-opts (dissoc opts :include-sensitive? :include-large?)
-         events      (rf/trace-buffer filter-opts)
+         events      (trace-tooling/trace-buffer filter-opts)
          scrubbed    (mapv #(elide % {:include-sensitive? include-sensitive?
                                       :include-large?     include-large?})
                            events)]
@@ -377,7 +385,7 @@
          issue-op-types #{:error :warning
                           :rf.schema/violation
                           :rf.hydration/mismatch}
-         events  (rf/trace-buffer {})
+         events  (trace-tooling/trace-buffer {})
          issues  (filterv #(contains? issue-op-types (:op-type %)) events)
          scrubbed (mapv #(elide % {:include-sensitive? include-sensitive?
                                    :include-large?     include-large?})


### PR DESCRIPTION
## Summary

Follow-on to rf2-qwm0a (trace-tooling sibling-ns extraction, merged in #1305) and the parallel pair2-mcp fix (also folded into that PR). Causa's injected runtime ns (`tools/causa/src/day8/re_frame2_causa/runtime.cljs`) still called `rf/trace-buffer` at two sites — `get-trace-buffer` (L227) backing the MCP `get-trace-buffer` tool, and `get-issues` (L380) backing `get-issues`. Post-extraction the `re-frame.core/trace-buffer` alias is JVM-only (CLJS deliberately omits it so production counter bundles DCE the tooling sibling wholesale), so both CLJS call sites resolved to undefined → `TypeError: Cannot read properties of undefined (reading 'cljs$core$IFn$_invoke$arity$2')` once Causa-MCP fired either tool against the live preload. Likely root cause for Mike's testbed regressions at http://127.0.0.1:8767 (rf2-q8154 app-db panel white-on-white, rf2-drf32 diff empty, scrubber non-functional) — Causa's runtime accessors silently undefined leaves panels rendering broken data.

Switches both call sites to `re-frame.trace.tooling/trace-buffer` directly and adds the explicit require. Bundle-isolation-safe: Causa's runtime ns rides Causa-the-panel's `:devtools/preloads` (dev-only per `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides), so pulling the tooling sibling here adds nothing to production counter bundles. Same posture as the pair2-mcp preload fix in #1305.

Grepped the rest of `runtime.cljs` for `rf/*` calls against the full rf2-qwm0a extraction inventory (`register-trace-cb!`, `remove-trace-cb!`, `clear-trace-cbs!`, `trace-buffer`, `clear-trace-buffer!`, `configure-trace-buffer!`, `configure`); only the two `rf/trace-buffer` sites needed routing. All other `rf/*` calls in the file (`frame-ids`, `elide-wire-value`, `epoch-history`, `get-frame-db`, `machine-meta`, `machines`, `registrations`, `handler-meta`, `dispatch`, `dispatch-sync`, `with-frame`, `restore-epoch`, `reset-frame-db!`) survive on `re-frame.core` post extraction. The `(rf/configure :source-coords ...)` mention at L684 is inside a docstring, not a call.

## Test plan

- [x] `implementation/` `npm run test:cljs` — 2300 tests, 6535 assertions, 0 failures
- [x] `tools/causa/` `clojure -M:test` — 550 tests, 1565 assertions, 0 failures
- [ ] Manual verification on Mike's testbed (http://127.0.0.1:8767) once merged — Causa panels should render real data; rf2-q8154 / rf2-drf32 may resolve automatically (file follow-up only if they persist after this lands)