### PR TITLE
fix(causa): impl-side LEFT->RIGHT flip — config + testbeds + panel comments (rf2-vbm7a)

### DIFF
--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -10,15 +10,16 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
+       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
+       give the user a browser-native drag handle on the host (rf2-e07yk). */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/deep_machine/index.html
+++ b/testbeds/deep_machine/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/deliberate_throw/index.html
+++ b/testbeds/deliberate_throw/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/drain_depth_trigger/index.html
+++ b/testbeds/drain_depth_trigger/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/http_toggle/index.html
+++ b/testbeds/http_toggle/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/large_dispatcher/index.html
+++ b/testbeds/large_dispatcher/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/long_flow_w_failure/index.html
+++ b/testbeds/long_flow_w_failure/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/multi_frame/index.html
+++ b/testbeds/multi_frame/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/non_trivial_app_db/index.html
+++ b/testbeds/non_trivial_app_db/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/schema_violation/index.html
+++ b/testbeds/schema_violation/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/sensitive_dispatcher/index.html
+++ b/testbeds/sensitive_dispatcher/index.html
@@ -6,14 +6,14 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/testbeds/ssr_hydration_mismatch/index.html
+++ b/testbeds/ssr_hydration_mismatch/index.html
@@ -6,14 +6,13 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1 { margin-top: 0; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
   <!--
     Server-rendered HTML — a placeholder shape. The pre-rendered
     `not-hydrated` marker is intentional: the post-hydrate render
@@ -31,6 +30,7 @@
       </div>
     </div>
   </div>
+    <aside data-rf-causa-host></aside>
   </div>
   <!--
     The payload bakes a deliberately-wrong :rf/render-hash. The

--- a/testbeds/ssr_multi_frame/index.html
+++ b/testbeds/ssr_multi_frame/index.html
@@ -6,7 +6,7 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1, h3 { margin: 0.25em 0; }
     p { margin: 0.25em 0; }
@@ -14,7 +14,6 @@
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
   <!--
     The pre-rendered HTML is a placeholder (`not-hydrated`); the
     interesting assertion is the per-frame `:rf/hydration` metadata
@@ -29,6 +28,7 @@
       <h1>ssr-multi-frame testbed (loading)</h1>
     </div>
   </div>
+    <aside data-rf-causa-host></aside>
   </div>
   <!--
     Per-frame payload bundle. The outer map carries one entry per

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -75,16 +75,21 @@
   "420px")
 
 (def default-layout-host-snippet
-  ;; CSS uses `var(--rf-causa-inline-width, 420px)` so a host that
-  ;; pastes the snippet verbatim gets:
+  ;; DOM order is `<main>` first, host `<aside>` second — flex flow
+  ;; lays the aside on the right of the app column (per spec/011-
+  ;; Launch-Modes.md §Layout host contract, rf2-e07yk). CSS uses
+  ;; `var(--rf-causa-inline-width, 420px)` so a host that pastes the
+  ;; snippet verbatim gets:
   ;;   - identical default geometry (420px flex-basis, 320px floor)
   ;;   - a single one-line override path:
   ;;       :root { --rf-causa-inline-width: 560px; }
-  ;;   - app content to the right stays in normal flex flow
-  ;;     (no overlay, no body padding, no JS resize handle).
+  ;;   - a user-draggable resize handle via the browser-native
+  ;;     `resize: horizontal` + `overflow: auto` on the host
+  ;;   - app content to the left stays in normal flex flow
+  ;;     (no overlay, no body padding).
   "<div class=\"app-shell\">
-  <aside data-rf-causa-host></aside>
   <main id=\"app\"></main>
+  <aside data-rf-causa-host></aside>
 </div>
 
 <style>
@@ -93,6 +98,9 @@
   [data-rf-causa-host] {
     flex: 0 0 var(--rf-causa-inline-width, 420px);
     min-width: 320px;
+    border-left: 1px solid #2a2a2a;
+    resize: horizontal;
+    overflow: auto;
   }
   #app { flex: 1; min-width: 0; }
 </style>")

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -5,8 +5,8 @@
   - The preload auto-opens the shell into the app-provided
     `[data-rf-causa-host]` layout host once the substrate adapter is
     ready. This is true inline layout: Causa participates in normal
-    flex/grid flow on the left, and the app stays visible/clickable to
-    the right.
+    flex/grid flow on the right, and the app stays visible/clickable to
+    the left.
   - Subsequent presses toggle the container's `display` between
     `block` and `none` (a CSS-only show/hide; per the spec a re-mount
     would discard internal state and miss the <80ms toggle target).
@@ -153,7 +153,7 @@
      :reason   :missing-layout-host
      :selector selector
      :message  (str "Causa default launch requires an app-provided true-inline "
-                    "layout host matching " selector ". Add a left-side host "
+                    "layout host matching " selector ". Add a right-side host "
                     "to your normal app layout, or configure "
                     ":layout/host-selector before the preload opens.")
      :snippet  config/default-layout-host-snippet}))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -372,7 +372,7 @@
   "The full Causa shell. Wraps every panel region in a `:rf/causa`
   frame-provider so descendant `subscribe` / `dispatch` resolve to
   the isolated frame. Default `:inline` mode renders in normal document
-  flow inside the app-provided left layout host. `:overlay` and
+  flow inside the app-provided right layout host. `:overlay` and
   `:popout` remain available debug/manual modes.
 
   Per rf2-in6l2 `reg-view`-registered for parity with every other

--- a/tools/causa/testbeds/cart_total/index.html
+++ b/tools/causa/testbeds/cart_total/index.html
@@ -10,15 +10,16 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
+       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
+       give the user a browser-native drag handle on the host (rf2-e07yk). */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/tools/causa/testbeds/feature_matrix/README.md
+++ b/tools/causa/testbeds/feature_matrix/README.md
@@ -32,8 +32,8 @@ re-check. It now exercises the follow-up surfaces directly:
 - Open in Editor / Source Coordinates: trace and issues source chips are
   clicked in the browser. Failures include the panel, source coordinate,
   expected editor URI, observed bridge traces, network outcome, and screenshot.
-- Pop-out: the gate asserts that the inline shell leaves the left
-  host app clickable and that `popout!` renders a same-origin second-window
+- Pop-out: the gate asserts that the inline shell leaves the host app
+  (laid out to the left of Causa) clickable and that `popout!` renders a same-origin second-window
   Causa shell sharing the opener's runtime. (Per `rf2-sbfb7`, the dock /
   docked-overlay and `mount-inline-panel!` debug surfaces were removed;
   declarative embedding lands under 008-Embedding-Contract.)

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -371,8 +371,8 @@ async function assertDefaultInlineLaunchModes(page, state) {
   if (!defaultInline.hostPlus) {
     failWithDetails('Host app + button missing while Causa is open', { mode: 'inline', observed: defaultInline });
   }
-  if (defaultInline.hostPlus.left < defaultInline.shell.right) {
-    failWithDetails('Host app controls are not laid out to the right of Causa', { mode: 'inline', observed: defaultInline });
+  if (defaultInline.hostPlus.right > defaultInline.shell.left) {
+    failWithDetails('Host app controls are not laid out to the left of Causa', { mode: 'inline', observed: defaultInline });
   }
   if (defaultInline.topAtHostPlus && defaultInline.topAtHostPlus.inCausa) {
     failWithDetails('Causa chrome is topmost over the host-app + button', { mode: 'inline', observed: defaultInline });

--- a/tools/causa/testbeds/inline_resize/spec.cjs
+++ b/tools/causa/testbeds/inline_resize/spec.cjs
@@ -9,7 +9,7 @@
  *   - Overriding the CSS custom property anywhere up the cascade
  *     resizes the inline panel, with no JS, no overlay, no body
  *     padding, and no fork of the host rule.
- *   - App content to the right of the host remains clickable
+ *   - App content to the left of the host remains clickable
  *     (the flex flow reshapes `#app` to fill the remainder; the
  *     panel never overlays).
  *
@@ -25,11 +25,13 @@
  *   2. **Cascade override takes effect.** Injecting
  *      `:root { --rf-causa-inline-width: 600px; }` resizes the host
  *      to 600px on the very next layout pass. We assert the
- *      bounding-rect width and that the right edge of the host moved
- *      rightward exactly as much as the width grew.
+ *      bounding-rect width and that the left edge of the host moved
+ *      leftward exactly as much as the width grew (the host is pinned
+ *      to the shell's right edge, so growing the host extends its left
+ *      edge into the app column).
  *
  *   3. **No hit-test occlusion across the resize.** A host-side
- *      `+` button sits to the right of Causa; we click it before
+ *      `+` button sits to the left of Causa; we click it before
  *      and after the resize, asserting the counter increments each
  *      time. The click would silently miss if the panel grew an
  *      overlay layer or trapped pointer events outside its rect.
@@ -125,9 +127,9 @@ module.exports = {
           'Did the recommended host CSS rule drop its fallback?',
       );
     }
-    if (before.app.left < before.host.right) {
+    if (before.app.right > before.host.left) {
       throw new Error(
-        `App content should sit to the right of the host; got ${JSON.stringify(before)}`,
+        `App content should sit to the left of the host; got ${JSON.stringify(before)}`,
       );
     }
 
@@ -174,35 +176,38 @@ module.exports = {
       );
     }
 
-    // The app must reflow to keep its left edge >= the host's new
-    // right edge. Equality is the flex-layout outcome (no gap rule);
-    // a strict `<` would indicate the panel started overlaying.
-    if (after.app.left < after.host.right) {
+    // The app must reflow to keep its right edge <= the host's new
+    // left edge. Equality is the flex-layout outcome (no gap rule);
+    // a strict `>` would indicate the panel started overlaying.
+    if (after.app.right > after.host.left) {
       throw new Error(
         `App content was overlapped by the resized host; got ${JSON.stringify(after)}`,
       );
     }
     const widthDelta = after.host.width - before.host.width;
-    const rightDelta = after.host.right - before.host.right;
-    if (Math.abs(widthDelta - rightDelta) > 1) {
-      // The host's left edge is pinned by `.rf2-testbed-shell`'s
-      // flex container, so `width` and `right` MUST move in lockstep.
-      // A mismatch means the override grew the box via padding/margin
-      // (which would NOT survive a real developer override) rather
-      // than `flex-basis`.
+    const leftDelta = before.host.left - after.host.left;
+    if (Math.abs(widthDelta - leftDelta) > 1) {
+      // The host's right edge is pinned by `.rf2-testbed-shell`'s
+      // flex container, so `width` and `left` MUST move in lockstep
+      // (growing the host extends its left edge leftward into the app
+      // column). A mismatch means the override grew the box via
+      // padding/margin (which would NOT survive a real developer
+      // override) rather than `flex-basis`.
       throw new Error(
-        `Host width grew by ${widthDelta}px but right edge moved by ` +
-          `${rightDelta}px — these should match. Got ${JSON.stringify({ before, after })}.`,
+        `Host width grew by ${widthDelta}px but left edge moved by ` +
+          `${leftDelta}px — these should match. Got ${JSON.stringify({ before, after })}.`,
       );
     }
 
     // ----------------------------------------------------------------
     // 4. Host `+` button is STILL clickable after the resize.
     //
-    //    The button moved to the right when the host grew (the app
-    //    reflowed); Playwright's locator re-resolves on click, so a
-    //    successful increment is the simplest end-to-end proof that
-    //    no overlay or hit-test trap was introduced by the resize.
+    //    The button's position stays anchored in the app column on the
+    //    left (the host grew leftward, the app column compressed but
+    //    the button still sits in its #app subtree); Playwright's
+    //    locator re-resolves on click, so a successful increment is
+    //    the simplest end-to-end proof that no overlay or hit-test
+    //    trap was introduced by the resize.
     // ----------------------------------------------------------------
     await plusButton.click();
     await expectTextEquals(counterValue, String(initialCounter + 2), 5000);

--- a/tools/causa/testbeds/perf_counter/index.html
+++ b/tools/causa/testbeds/perf_counter/index.html
@@ -10,15 +10,16 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; }
+       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
+       give the user a browser-native drag handle on the host (rf2-e07yk). */
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>
 <body>
   <div class="rf2-testbed-shell">
-    <aside data-rf-causa-host></aside>
     <main id="app"></main>
+    <aside data-rf-causa-host></aside>
   </div>
   <script src="main.js"></script>
 </body>

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -204,8 +204,8 @@ module.exports = {
     if (inline.bodyPaddingLeft || inline.bodyPaddingRight) {
       throw new Error(`Expected inline Causa to avoid body-padding layout tricks; got ${JSON.stringify(inline)}`);
     }
-    if (!inline.shell || !inline.hostPlus || inline.hostPlus.left < inline.shell.right) {
-      throw new Error(`Expected host controls to be laid out to the right of Causa; got ${JSON.stringify(inline)}`);
+    if (!inline.shell || !inline.hostPlus || inline.hostPlus.right > inline.shell.left) {
+      throw new Error(`Expected host controls to be laid out to the left of Causa; got ${JSON.stringify(inline)}`);
     }
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-on to rf2-e07yk (#1310 — spec+docs flipped LEFT→RIGHT). Flips the remaining impl-side surface to match the new right-side default-host contract.

- `tools/causa/src/day8/re_frame2_causa/config.cljc` — `default-layout-host-snippet` now emits the canonical post-flip snippet (DOM order: `<main>` first, host `<aside>` second; CSS adds `border-left`, `resize: horizontal`, `overflow: auto` so the host gets a user-draggable handle out of the box). Snippet-comment updated to describe the right-side flow + two-mechanism resize.
- `tools/causa/src/day8/re_frame2_causa/mount.cljs` + `shell.cljs` — three docstring/comment refs to "left" flipped (auto-mount flow narrative, missing-host diagnostic's "add a right-side host" hint, shell-view's docstring for the default `:inline` mount target).
- `tools/causa/testbeds/inline_resize/spec.cjs` — assertion semantics flipped: `app.right <= host.left` is the no-overlap predicate; the resize-delta invariant uses `before.host.left - after.host.left` (host's right edge is pinned by the flex container; growth extends the left edge into the app column). Comments updated to match the new geometry.
- `tools/causa/testbeds/rigorous/spec.cjs` + `tools/causa/testbeds/feature_matrix/scenarios.cjs` — the inline-layout assertion that pinned the host `+` button to the right of Causa now pins it to the left (`hostPlus.right > shell.left` is the failure case). Error-message text flipped.
- `tools/causa/testbeds/feature_matrix/README.md` — pop-out blurb references the app's now-left layout.
- Testbed + counter-example index.html files (14 top-level testbeds + the reagent counter example used by `/counter/` + Causa's three internal testbed pages) — DOM order flipped to `<main>`-first, `<aside>`-second; host CSS picks up the new `border-left` + `resize: horizontal` + `overflow: auto` recipe so the recommended snippet works as-is.

## Runtime-mount verification

`mount.cljs` is side-agnostic — Causa appends into whatever host the page provides. The default mount position is determined entirely by where the host page places `[data-rf-causa-host]` in its DOM/CSS, and every shipped testbed/example HTML now puts the host `<aside>` after `<main id=\"app\">`. The post-flip rigorous + feature_matrix gates now assert `hostPlus.right > shell.left` is the failure case — i.e., they actively pin "host controls laid out to the LEFT of Causa" at runtime.

## Test plan

- [x] `clojure -M:test` from `tools/causa/`: 550 tests, 1565 assertions, 0 failures / 0 errors.
- [x] `npm run test:cljs` from `implementation/`: 2300 tests, 6535 assertions, 0 failures / 0 errors.
- [ ] CI: `tools/causa` browser testbeds (inline_resize / rigorous / feature_matrix scenarios) — the assertion-direction flip is load-bearing; CI is the place to verify the post-flip predicates against a real browser layout pass.