### PR TITLE
feat(causa-mcp): T-Mut+Stream+Eval+Meta tranche — 9 tools (rf2-8xzoe.23..31 cluster)

### DIFF
--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -545,3 +545,84 @@ bead #25.
 envelope is small).
 
 Implementation: [`tools/causa-mcp/src/.../tools/reset_frame_db.cljs`](../src/day8/re_frame2_causa_mcp/tools/reset_frame_db.cljs).
+
+## Streaming band
+
+Streaming-band tools surface push-mode data over an MCP `tools/call`
+that stays open across many polling ticks. The contract surface is
+**per-drain-batch port-pinning** (the cross-MCP wire-batching idiom):
+one `tools/call` ↔ one `progressToken` ↔ one stream of
+`notifications/progress` ticks ↔ one terminal summary on close. The
+agent reads ticks correlated by `progressToken` and pattern-matches
+on the terminal envelope's `:reason` slot to discover why the stream
+closed.
+
+### subscribe (T-Stream-1, rf2-8xzoe.26)
+
+Open a per-drain-batch streaming subscription on topic `:trace`,
+`:epoch`, `:fx`, or `:error`. The `tools/call` stays open until the
+client aborts, `:max-events` / `:max-ms` is reached, or `unsubscribe`
+is called. Each non-empty polling tick emits one
+`notifications/progress` notification carrying the batch's events;
+the terminal `tools/call` result is a summary with cumulative
+`:delivered` + `:ticks` + `:reason`. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #26.
+
+**Topic → trace-bus projection:**
+
+| Topic | Source |
+|---|---|
+| `:trace` | full trace buffer; `:op-type` filter optional |
+| `:epoch` | trace events with `:op-type :epoch/closed` |
+| `:fx` | trace events with `:op-type :fx/run` |
+| `:error` | issue-tier events (`:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`) |
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:topic` | keyword | **required** | one of `:trace :epoch :fx :error` |
+| `:filter` | map | nil | per-topic Spec 009 filter |
+| `:frame` | keyword | nil | scope to one frame |
+| `:poll-ms` | int | 100 | polling cadence |
+| `:max-events` | int | 0 | terminate after N events (0 = unbounded) |
+| `:max-ms` | int | 0 | terminate after N ms (0 = unbounded) |
+| `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` |
+| `:include-large?` | bool | false | passes to runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Per-tick `notifications/progress` payload:**
+
+```clojure
+;; progressToken correlated to the originating tools/call
+{:progressToken <token>
+ :progress      <tick-int>
+ :message       (pr-str {:sub-id <uuid>
+                         :events [<event> ...]
+                         :dropped-sensitive <int?>
+                         :elided-large <int?>})}
+```
+
+**Terminal `tools/call` result:**
+
+```clojure
+{:ok? true
+ :sub-id <uuid>
+ :topic <kw>
+ :delivered <int>
+ :ticks <int>
+ :reason <:aborted|:max-events-reached|:max-ms-reached|:unsubscribed>
+ :dropped-sensitive <int?>
+ :elided-large <int?>}
+```
+
+**Failure envelopes:**
+
+- `{:ok? false :reason :unknown-topic :given <s> :hint ...}` — topic
+  not in `{:trace :epoch :fx :error}`.
+- `{:ok? false :reason :runtime-not-preloaded :hint <setup>}` —
+  Causa-the-panel preload isn't loaded.
+
+**Cap-reached hint:** `:paginate` (default fallback `:narrow-filter`)
+— shorten the stream via `:max-events` / `:max-ms`, or narrow the
+`:filter`.
+
+Implementation: [`tools/causa-mcp/src/.../tools/subscribe.cljs`](../src/day8/re_frame2_causa_mcp/tools/subscribe.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -626,3 +626,35 @@ the terminal `tools/call` result is a summary with cumulative
 `:filter`.
 
 Implementation: [`tools/causa-mcp/src/.../tools/subscribe.cljs`](../src/day8/re_frame2_causa_mcp/tools/subscribe.cljs).
+
+### unsubscribe (T-Stream-2, rf2-8xzoe.27)
+
+Close a streaming subscription by `:sub-id`. Idempotent: re-calling
+for an already-closed sub-id returns `:existed? false`. An open
+`subscribe` `tools/call` observes the missing sub-id on its next
+polling tick and resolves with `:reason :unsubscribed`. Source-coord
+pin: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+bead #27.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:sub-id` | string | **required** | sub-id from a prior `subscribe` |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true :sub-id <uuid> :existed? <bool>}
+```
+
+**Failure envelopes:**
+
+- `{:ok? false :reason :missing-sub-id :hint ...}` — `:sub-id`
+  arg absent / blank (returned as `isError`).
+- `{:ok? false :reason :runtime-not-preloaded :hint <setup>}` —
+  Causa-the-panel preload isn't loaded.
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — ack
+envelope is small).
+
+Implementation: [`tools/causa-mcp/src/.../tools/unsubscribe.cljs`](../src/day8/re_frame2_causa_mcp/tools/unsubscribe.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -400,3 +400,54 @@ declared-sensitive paths are scrubbed before path-comparison.
 `get-app-db`). Default fallback `:narrow-filter`.
 
 Implementation: [`tools/causa-mcp/src/.../tools/get_app_db_diff.cljs`](../src/day8/re_frame2_causa_mcp/tools/get_app_db_diff.cljs).
+
+## Mutation band
+
+Mutation-band tools change framework state. Per `004-Wire-Pipeline.md`
+§Authority classes, **Class-1 named mutations** (`dispatch`,
+`restore-epoch`, `reset-frame-db`) carry **no per-call consent
+gate** — consent is the server-launch enable signal. Every mutation
+routes through the framework's normal dispatch / restore / reset
+cascade; the runtime stamps `:tags :origin :causa-mcp` on emitted
+traces via the `*current-origin*` dynamic binding (B-3 of the
+wire-pipeline tranche). Trace egress from a mutation's cascade is
+read via `subscribe :trace` (T-Stream-1) or the next
+`get-trace-buffer` call.
+
+### dispatch (T-Mut-1, rf2-8xzoe.23)
+
+Fire a re-frame event through the frame's normal dispatch cascade.
+Source-coord pin: `ai/findings/causa-epics-breakdown-2026-05-17.md`
+§Part 1 bead #23.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:event` | EDN-vec str | **required** | event vector, e.g. `"[:cart/add 42]"` |
+| `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+| `:sync?` | bool | false | `:sync` (true) vs `:queued` (false) |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :event-id <kw>
+ :frame    <kw>
+ :origin   :causa-mcp
+ :mode     <:queued|:sync>}
+```
+
+**Failure envelopes:**
+
+- `{:ok? false :reason :missing-event :hint ...}`
+- `{:ok? false :reason :event-malformed :given <s> :hint ...}`
+- `{:ok? false :reason :not-an-event-vector :hint ...}` — parsed
+  value isn't a vector.
+- `{:ok? false :reason :no-frame-resolved :hint ...}` — multi-frame
+  app without an explicit `:frame` arg.
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — the
+mutation envelope is small; overflow would only happen with
+pathological runtime auxiliary metadata).
+
+Implementation: [`tools/causa-mcp/src/.../tools/dispatch.cljs`](../src/day8/re_frame2_causa_mcp/tools/dispatch.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -500,3 +500,48 @@ on the bus). Source-coord pin:
 envelope is small).
 
 Implementation: [`tools/causa-mcp/src/.../tools/restore_epoch.cljs`](../src/day8/re_frame2_causa_mcp/tools/restore_epoch.cljs).
+
+### reset-frame-db (T-Mut-3, rf2-8xzoe.25)
+
+Re-inject a value into a frame's `app-db`, bypassing the dispatch
+cascade. Schema-validates against registered app-db schemas via
+`re-frame.core/reset-frame-db!`. Same projection rationale as
+`restore-epoch`: the framework wrapper returns a boolean, the per-row
+`:rf.epoch/*` keyword lives on the trace bus, this tool surfaces
+`:rf.epoch/reset-failed` and points at the bus. Every reset rides
+the restore-audit ring tagged `:origin :causa-mcp`. Source-coord
+pin: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+bead #25.
+
+**Three-row failure table** (read off the trace bus):
+
+| Row | Trace `:op-type` keyword |
+|---|---|
+| unknown frame | `:rf.error/no-such-handler` (kind `:frame`) |
+| reset during drain | `:rf.epoch/reset-frame-db-during-drain` |
+| schema mismatch | `:rf.epoch/reset-frame-db-schema-mismatch` |
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:value` | EDN-map str | **required** | the new `app-db` value |
+| `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape (success):**
+
+```clojure
+{:ok? true :frame <kw> :origin :causa-mcp}
+```
+
+**Return shape (failure):**
+
+```clojure
+{:ok? false :frame <kw> :origin :causa-mcp
+ :reason :rf.epoch/reset-failed
+ :hint "Reset failed — read the trace bus for the structured :rf.epoch/* row."}
+```
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — ack
+envelope is small).
+
+Implementation: [`tools/causa-mcp/src/.../tools/reset_frame_db.cljs`](../src/day8/re_frame2_causa_mcp/tools/reset_frame_db.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -738,3 +738,43 @@ The result routes through `re-frame.core/elide-wire-value`; privacy
 less data.
 
 Implementation: [`tools/causa-mcp/src/.../tools/eval_cljs.cljs`](../src/day8/re_frame2_causa_mcp/tools/eval_cljs.cljs).
+
+### discover-app (T-Meta-1, rf2-8xzoe.30)
+
+One-call summary of the runtime's view of the world — preload status,
+debug-enabled flag, registered frames (and ambiguity flag),
+source-coord annotation status, `--allow-eval` gate state. Use as
+the first call of every session to confirm the environment is
+healthy. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #30.
+
+**Warning ladder** (fail-loud-but-useful):
+
+1. `:debug-disabled` (production build; trace/epoch elided) — `:ok? false`.
+2. `:no-frames-registered` (call `rf/init!`) — `:ok? false`.
+3. `:ambiguous-frame` (multi-frame; mutating ops need `:frame`) — `:ok? true` with `:warning`.
+4. `:no-source-coord-annotation` (DOM coord annotation not enabled) — `:ok? true` with `:warning`.
+5. otherwise `:ok? true` with no warning.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape (healthy):**
+
+```clojure
+{:ok? true
+ :session-id <uuid>
+ :debug-enabled? <bool>
+ :frames <vec>
+ :ambiguous-frame? <bool>
+ :coord-annotation-enabled? <bool>
+ :origin :causa-mcp
+ :eval-cljs-enabled? <bool>
+ :build-id <kw>}
+```
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — health
+envelope is small).
+
+Implementation: [`tools/causa-mcp/src/.../tools/discover_app.cljs`](../src/day8/re_frame2_causa_mcp/tools/discover_app.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -778,3 +778,46 @@ healthy. Source-coord pin:
 envelope is small).
 
 Implementation: [`tools/causa-mcp/src/.../tools/discover_app.cljs`](../src/day8/re_frame2_causa_mcp/tools/discover_app.cljs).
+
+### tail-build (T-Meta-2, rf2-8xzoe.31)
+
+Wait for a shadow-cljs hot-reload to land. Two modes:
+
+- **Probe mode** (default when `:probe` supplied) — poll the user's
+  `:probe` form's value; resolve when it changes (signaling the
+  reload completed) or `:reason :timed-out` after `:wait-ms`. A
+  timeout typically means a compile error (the operator can look at
+  the shadow-cljs build log).
+- **Soft-delay mode** (no `:probe`) — resolve after a fixed 300ms
+  delay; gives the bundle-swap cycle a chance to complete without
+  instrumenting a probe.
+
+Source-coord pin: `ai/findings/causa-epics-breakdown-2026-05-17.md`
+§Part 1 bead #31.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:probe` | string | nil | CLJS source whose value-change signals reload |
+| `:wait-ms` | int | 5000 | timeout for probe-mode |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+;; probe mode — change detected
+{:ok? true :t <ms> :soft? false}
+
+;; probe mode — timeout
+{:ok? false :reason :timed-out :timed-out? true :note <s>}
+
+;; soft-delay mode
+{:ok? true :t <ms> :soft? true :note <s>}
+
+;; probe eval threw
+{:ok? false :reason :probe-failed :message <s>}
+```
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — ack
+envelope is tiny scalars).
+
+Implementation: [`tools/causa-mcp/src/.../tools/tail_build.cljs`](../src/day8/re_frame2_causa_mcp/tools/tail_build.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -451,3 +451,52 @@ mutation envelope is small; overflow would only happen with
 pathological runtime auxiliary metadata).
 
 Implementation: [`tools/causa-mcp/src/.../tools/dispatch.cljs`](../src/day8/re_frame2_causa_mcp/tools/dispatch.cljs).
+
+### restore-epoch (T-Mut-2, rf2-8xzoe.24)
+
+Rewind a frame's `app-db` to the named epoch's `:db-after` via
+`re-frame.core/restore-epoch`. Bound by the Tool-Pair §Time-travel
+restore contract: returns `:ok? true` on success, `:ok? false`
+with `:reason :rf.epoch/restore-failed` on any of the six
+documented failure rows. The per-row `:rf.epoch/*` keyword surfaces
+on the trace bus (read via `get-trace-buffer` or `subscribe :trace`)
+— the tool envelope intentionally does not double-project it (the
+framework wrapper returns a plain boolean; the row already lives
+on the bus). Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #24.
+
+**Six-row failure table** (read off the trace bus by `:op-type`):
+
+| Row | Trace `:op-type` keyword |
+|---|---|
+| unknown frame | `:rf.error/no-such-handler` (kind `:frame`) |
+| unknown epoch | `:rf.epoch/restore-unknown-epoch` |
+| schema mismatch | `:rf.epoch/restore-schema-mismatch` |
+| missing handler | `:rf.epoch/restore-missing-handler` |
+| version mismatch | `:rf.epoch/restore-version-mismatch` |
+| restore during drain | `:rf.epoch/restore-during-drain` |
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:epoch-id` | string | **required** | epoch-id from `get-epoch-history` |
+| `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape (success):**
+
+```clojure
+{:ok? true :frame <kw> :epoch-id <id> :origin :causa-mcp}
+```
+
+**Return shape (failure):**
+
+```clojure
+{:ok? false :frame <kw> :epoch-id <id> :origin :causa-mcp
+ :reason :rf.epoch/restore-failed
+ :hint "Restore failed — read the trace bus for the structured :rf.epoch/* row."}
+```
+
+**Cap-reached hint:** `:narrow-filter` (default fallback — ack
+envelope is small).
+
+Implementation: [`tools/causa-mcp/src/.../tools/restore_epoch.cljs`](../src/day8/re_frame2_causa_mcp/tools/restore_epoch.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -688,3 +688,53 @@ calls. Source-coord pin:
 enumeration to one topic.
 
 Implementation: [`tools/causa-mcp/src/.../tools/list_subscriptions.cljs`](../src/day8/re_frame2_causa_mcp/tools/list_subscriptions.cljs).
+
+## Meta band
+
+Meta-band tools serve the introspection / escape-hatch / build-time
+diagnostic surfaces — `discover-app` (health summary), `eval-cljs`
+(arbitrary CLJS evaluation, `--allow-eval` gated), `tail-build`
+(hot-reload landed signal).
+
+### eval-cljs (T-Eval-1, rf2-8xzoe.29)
+
+Evaluate an arbitrary CLJS form in the host runtime. **GATED behind
+`--allow-eval` at server launch** (sibling to pair2-mcp's
+`rf2-cxx5s` gate; default OFF in published builds). When the gate is
+OFF, the tool returns `:rf.error/eval-cljs-disabled` refusal
+envelope without touching the nREPL socket. When ON, the form runs
+inside a `(binding [*current-origin* :causa-mcp] ...)` wrapper so
+**synchronous-extent** mutations tag `:origin :causa-mcp` —
+async-extent handlers fired AFTER the user-form returns do NOT
+inherit the binding (the documented Lock #4 / I6 async-tagging gap).
+The result routes through `re-frame.core/elide-wire-value`; privacy
++ size scrub still apply unless `:include-sensitive?` /
+`:include-large?` opt out. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #29.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:form` | string | **required** | CLJS source string to eval |
+| `:include-sensitive?` | bool | false | passes to runtime walker |
+| `:include-large?` | bool | false | passes to runtime walker |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape (enabled):**
+
+```clojure
+{:ok? true :value <edn>
+ :elided-large <int?>}
+```
+
+**Refusal shape (default — gate OFF):**
+
+```clojure
+{:ok?    false
+ :reason :rf.error/eval-cljs-disabled
+ :hint   "eval-cljs is disabled by default for security; pass --allow-eval at server launch to opt in."}
+```
+
+**Cap-reached hint:** `:narrow-filter` — narrow the form to return
+less data.
+
+Implementation: [`tools/causa-mcp/src/.../tools/eval_cljs.cljs`](../src/day8/re_frame2_causa_mcp/tools/eval_cljs.cljs).

--- a/tools/causa-mcp/spec/004-Tools-Catalogue.md
+++ b/tools/causa-mcp/spec/004-Tools-Catalogue.md
@@ -658,3 +658,33 @@ bead #27.
 envelope is small).
 
 Implementation: [`tools/causa-mcp/src/.../tools/unsubscribe.cljs`](../src/day8/re_frame2_causa_mcp/tools/unsubscribe.cljs).
+
+### list-subscriptions (T-Stream-3, rf2-8xzoe.28)
+
+Diagnostic enumerating active streaming subscriptions. The
+**eighteenth** tool added by DESIGN-RATIONALE Lock #12 (rf2-3we2k).
+Useful when a streaming probe seems quiet (confirm the sub is still
+registered) or when pruning leaked subs across crashed `subscribe`
+calls. Source-coord pin:
+`ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1 bead #28.
+
+| Arg | Type | Default | Notes |
+|---|---|---|---|
+| `:topic` | keyword | nil | filter to one topic |
+| `:sub-id` | string | nil | filter to one sub-id |
+| `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+**Return shape:**
+
+```clojure
+{:ok? true
+ :subs [{:id <uuid> :topic <kw> :filter <map>
+         :origin <kw> :created-at <ms>} ...]
+ :count <int>
+ :elided-large <int?>}
+```
+
+**Cap-reached hint:** `:narrow-filter` — pass `:topic` to scope the
+enumeration to one topic.
+
+Implementation: [`tools/causa-mcp/src/.../tools/list_subscriptions.cljs`](../src/day8/re_frame2_causa_mcp/tools/list_subscriptions.cljs).

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/probe.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/probe.cljs
@@ -30,7 +30,8 @@
   Negative results are NOT cached: a missing preload usually surfaces
   on the very first call, and re-probing on each subsequent call lets
   a freshly-added preload land without a server restart."
-  (:require [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+  (:require [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
             [day8.re-frame2-causa-mcp.wire :as wire]))
 
 ;; ---------------------------------------------------------------------------
@@ -86,6 +87,19 @@
                    (when ok? (mark-conn-probed! conn build-id))
                    ok?)))
         (.catch (fn [_] false)))))
+
+(defn runtime-health!
+  "Call `(day8.re-frame2-causa.runtime/health)`. Caller must have
+  already confirmed the preload landed via `runtime-preloaded?` (or
+  `ensure-runtime!`). Returns a Promise resolving to the runtime's
+  health envelope (per the runtime ns docstring).
+
+  Sibling to pair2-mcp's `runtime-health!` — same one-call summary
+  surface so `discover-app` reads identically across the MCP triplet
+  (with the small caveat that causa's `:origin` slot is `:causa-mcp`
+  by default whereas pair2's is `:pair2-mcp`)."
+  [conn build-id]
+  (nrepl/cljs-eval-value conn build-id (ef/emit (ef/rt-call 'health))))
 
 (defn ensure-runtime!
   "Confirm the causa runtime is preloaded. Resolves to nil on success,

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
@@ -40,6 +40,7 @@
             [clojure.string :as str]
             [day8.re-frame2-causa-mcp.nrepl :as nrepl]
             [day8.re-frame2-causa-mcp.tools :as tools]
+            [day8.re-frame2-causa-mcp.tools.eval-cljs :as eval-cljs]
             ["@modelcontextprotocol/sdk/server/index.js" :as mcp-server]
             ["@modelcontextprotocol/sdk/server/stdio.js" :as mcp-stdio]
             ["@modelcontextprotocol/sdk/types.js" :as mcp-types]))
@@ -161,12 +162,38 @@
                                              :reason :nrepl-port-not-found
                                              :hint   (-> boot-error ex-data :hint)})}]})))
 
+(defn parse-launch-flags
+  "Pluck named boolean launch flags out of the raw process argv. One
+  flag today:
+
+    --allow-eval — opt-in to the `eval-cljs` tool (rf2-8xzoe.29; sibling
+                   to pair2-mcp's rf2-cxx5s gate). Default OFF in
+                   published builds; required to enable arbitrary CLJS
+                   evaluation in the host runtime.
+
+  Returns `{:allow-eval? bool}`. Unknown flags are ignored — node's
+  shadow-cljs entry passes its own argv prelude (script path), and
+  future flags can land here without breaking older invocations."
+  [argv]
+  {:allow-eval? (boolean (some #{"--allow-eval"} argv))})
+
+(defn- apply-launch-flags!
+  "Wire launch-flag state into the relevant tool gates. Called once
+  before the dispatcher accepts requests."
+  [{:keys [allow-eval?]}]
+  (eval-cljs/set-allow-eval! allow-eval?)
+  (log! "eval-cljs:" (if allow-eval?
+                       "ENABLED (--allow-eval)"
+                       "disabled (default; pass --allow-eval to opt in)")))
+
 (defn main
   "Entry-point. Resolves the nREPL port and boots the success-path
   server; on resolve failure (e.g. shadow-cljs not running) boots the
   degraded-mode server so the MCP client still gets a clean
   handshake and a typed error from the first `tools/call`."
-  [& _args]
+  [& args]
+  (let [argv (vec args)]
+    (apply-launch-flags! (parse-launch-flags argv)))
   (try
     (let [port   (resolve-port)
           _      (log! "nREPL port =" port)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -43,6 +43,8 @@
             [day8.re-frame2-causa-mcp.tools.get-epoch-history]
             [day8.re-frame2-causa-mcp.tools.get-app-db]
             [day8.re-frame2-causa-mcp.tools.get-app-db-diff]
+            ;; T-Mut tranche (rf2-8xzoe.23..25) — Class-1 named mutations.
+            [day8.re-frame2-causa-mcp.tools.dispatch]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -50,6 +50,7 @@
             ;; T-Stream tranche (rf2-8xzoe.26..28) — per-drain-batch streaming.
             [day8.re-frame2-causa-mcp.tools.subscribe]
             [day8.re-frame2-causa-mcp.tools.unsubscribe]
+            [day8.re-frame2-causa-mcp.tools.list-subscriptions]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -53,6 +53,8 @@
             [day8.re-frame2-causa-mcp.tools.list-subscriptions]
             ;; T-Eval tranche (rf2-8xzoe.29) — --allow-eval-gated escape hatch.
             [day8.re-frame2-causa-mcp.tools.eval-cljs]
+            ;; T-Meta tranche (rf2-8xzoe.30..31) — health + build-tail.
+            [day8.re-frame2-causa-mcp.tools.discover-app]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -47,6 +47,8 @@
             [day8.re-frame2-causa-mcp.tools.dispatch]
             [day8.re-frame2-causa-mcp.tools.restore-epoch]
             [day8.re-frame2-causa-mcp.tools.reset-frame-db]
+            ;; T-Stream tranche (rf2-8xzoe.26..28) — per-drain-batch streaming.
+            [day8.re-frame2-causa-mcp.tools.subscribe]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -49,6 +49,7 @@
             [day8.re-frame2-causa-mcp.tools.reset-frame-db]
             ;; T-Stream tranche (rf2-8xzoe.26..28) — per-drain-batch streaming.
             [day8.re-frame2-causa-mcp.tools.subscribe]
+            [day8.re-frame2-causa-mcp.tools.unsubscribe]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -45,6 +45,7 @@
             [day8.re-frame2-causa-mcp.tools.get-app-db-diff]
             ;; T-Mut tranche (rf2-8xzoe.23..25) — Class-1 named mutations.
             [day8.re-frame2-causa-mcp.tools.dispatch]
+            [day8.re-frame2-causa-mcp.tools.restore-epoch]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -55,6 +55,7 @@
             [day8.re-frame2-causa-mcp.tools.eval-cljs]
             ;; T-Meta tranche (rf2-8xzoe.30..31) — health + build-tail.
             [day8.re-frame2-causa-mcp.tools.discover-app]
+            [day8.re-frame2-causa-mcp.tools.tail-build]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -46,6 +46,7 @@
             ;; T-Mut tranche (rf2-8xzoe.23..25) — Class-1 named mutations.
             [day8.re-frame2-causa-mcp.tools.dispatch]
             [day8.re-frame2-causa-mcp.tools.restore-epoch]
+            [day8.re-frame2-causa-mcp.tools.reset-frame-db]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools.cljs
@@ -51,6 +51,8 @@
             [day8.re-frame2-causa-mcp.tools.subscribe]
             [day8.re-frame2-causa-mcp.tools.unsubscribe]
             [day8.re-frame2-causa-mcp.tools.list-subscriptions]
+            ;; T-Eval tranche (rf2-8xzoe.29) — --allow-eval-gated escape hatch.
+            [day8.re-frame2-causa-mcp.tools.eval-cljs]
             [day8.re-frame2-causa-mcp.registry :as registry]))
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/discover_app.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/discover_app.cljs
@@ -1,0 +1,150 @@
+(ns day8.re-frame2-causa-mcp.tools.discover-app
+  "Tool: `discover-app` — health summary for the host runtime
+  (rf2-8xzoe.30, T-Meta-1 of the causa-mcp meta tranche).
+
+  One-call summary of the runtime's view of the world. Used by an
+  agent to confirm the environment is healthy on every session's first
+  tool call — preload status, debug-enabled flag, registered frames
+  (and ambiguity flag), source-coord annotation status,
+  `eval-cljs` gate state, current `:origin` tag default.
+
+  Mirrors pair2-mcp's `discover-app` shape so cross-MCP agents read
+  the same warning posture from both servers; the structural
+  differences are intentional:
+
+    - `:eval-cljs-enabled?` reflects causa's `--allow-eval` gate
+      (sibling to pair2-mcp's same-named gate).
+    - `:build-id` is the shadow-cljs build the server probed
+      (resolved from `SHADOW_CLJS_BUILD_ID` env or `:app` default).
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — not applicable (health metadata, not
+    user data).
+  - **W-6 size elision** — counted defensively on the health payload.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      ;; healthy
+      {:ok? true
+       :session-id <uuid>
+       :debug-enabled? <bool>
+       :frames <vec>
+       :ambiguous-frame? <bool>
+       :coord-annotation-enabled? <bool>
+       :origin :causa-mcp
+       :eval-cljs-enabled? <bool>
+       :build-id <kw>}
+
+      ;; warnings — still :ok? true, but with :warning + :note
+      {... :ok? true :warning :ambiguous-frame :note <s> ...}
+
+      ;; failures
+      {:ok? false :reason :runtime-not-preloaded :hint <setup>}
+      {:ok? false :reason :debug-disabled :hint <prod-build-explanation>}
+      {:ok? false :reason :no-frames-registered :hint <init-explanation>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #30. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.eval-cljs :as eval-cljs]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn shape-envelope
+  "Project the runtime's `health` map onto the MCP envelope, adding
+  the server-side concerns (`:eval-cljs-enabled?`, `:build-id`) and
+  surfacing operator-actionable warnings. Pure — tests pin the
+  warning ladder.
+
+  The warning ladder is fail-loud-but-useful:
+
+    1. `:debug-disabled` → production build; trace/epoch surfaces are
+       elided. Returns `:ok? false` so agents short-circuit.
+    2. `:no-frames-registered` → app hasn't called `(rf/init!)`. Same.
+    3. `:ambiguous-frame` → multi-frame app; mutating ops require an
+       explicit `:frame` arg. `:ok? true` with `:warning`.
+    4. `:no-source-coord-annotation` → DOM coord annotation not
+       enabled. `:ok? true` with `:warning`.
+    5. otherwise `:ok? true` with no warning."
+  [health build-id eval-cljs-enabled?]
+  (let [base (merge {:eval-cljs-enabled? eval-cljs-enabled?
+                     :build-id           build-id}
+                    health)]
+    (cond
+      (not (:ok? health))
+      health
+
+      (not (:debug-enabled? health))
+      {:ok?    false
+       :reason :debug-disabled
+       :hint   (str "re-frame.interop/debug-enabled? is false. This is a "
+                    "production build (or goog.DEBUG was forced off). "
+                    "Trace and epoch surfaces are elided.")}
+
+      (empty? (:frames health))
+      {:ok?    false
+       :reason :no-frames-registered
+       :hint   "Call (rf/init!) to register :rf/default, or wait for app boot."}
+
+      (:ambiguous-frame? health)
+      (assoc base :warning :ambiguous-frame
+                  :note    (str "Multiple frames registered: "
+                                (vec (:frames health))
+                                ". Mutating ops require :frame :foo "
+                                "or run `frames/select` first."))
+
+      (not (:coord-annotation-enabled? health))
+      (assoc base :warning :no-source-coord-annotation
+                  :note    (str "Neither data-rf2-source-coord nor "
+                                "data-rc-src is on any element. "
+                                "DOM->source ops will degrade. Enable "
+                                "(rf/configure :source-coords {:annotate-dom? true}) "
+                                "or use re-com with :src (at)."))
+
+      :else
+      base)))
+
+(defn discover-app-tool
+  "MCP handler for `discover-app`. Probes preload, fetches health, and
+  shapes the envelope."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        eval-en? (eval-cljs/allow-eval-enabled?)]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (probe/runtime-health! conn build-id)))
+        (.then
+          (fn [health]
+            (let [shaped (shape-envelope health build-id eval-en?)
+                  elided (elision/count-elided-markers shaped)]
+              (wire/ok-text (wire/with-indicators shaped {:elided elided})))))
+        (.catch (fn [err] (probe/err->result :discover-failed err))))))
+
+(def descriptor
+  {:name        "discover-app"
+   :description (str "One-call summary of the runtime's view of the "
+                     "world — preload status, debug-enabled flag, "
+                     "registered frames (and ambiguity flag), "
+                     "source-coord annotation status, --allow-eval "
+                     "gate state. Use as the first call of every "
+                     "session to confirm the environment is healthy. "
+                     "Warnings (:ambiguous-frame, "
+                     ":no-source-coord-annotation) surface as :ok? "
+                     "true with :warning + :note; failures "
+                     "(:debug-disabled, :no-frames-registered, "
+                     ":runtime-not-preloaded) surface as :ok? false.")
+   :input-schema #js {:type "object"
+                      :properties #js {:max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) discover-app-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/dispatch.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/dispatch.cljs
@@ -1,0 +1,185 @@
+(ns day8.re-frame2-causa-mcp.tools.dispatch
+  "Tool: `dispatch` — Class-1 named mutation (rf2-8xzoe.23,
+  T-Mut-1 of the causa-mcp mutation tranche).
+
+  Routes a re-frame event vector through the frame's normal dispatch
+  cascade; the framework stamps `:tags :origin :causa-mcp` on the
+  emitted trace via the runtime's `*current-origin*` binding (B-3 of
+  the rf2-8xzoe wire-pipeline tranche). Per `004-Wire-Pipeline.md`
+  §Authority classes, Class-1 mutations carry **no per-call consent
+  gate** — consent is the server-launch enable signal — so this tool
+  fires without a confirmation handshake.
+
+  ## Wire-boundary contract
+
+  - **B-3 origin stamp** — `ef/wrap-origin` binds the runtime's
+    `*current-origin*` dynamic var to `:causa-mcp` for the synchronous
+    extent of the dispatched event so any trace event the cascade
+    emits carries `:tags :origin :causa-mcp` (Lock #4 / I6: async
+    handlers fired AFTER the synchronous extent do NOT inherit the
+    tag — that's the documented async-tagging gap).
+  - **B-1 privacy** — not applicable here (the response envelope is
+    structured ack metadata, not trace events).
+  - **W-6 size elision** — counted defensively on the runtime envelope
+    in case a future extension carries auxiliary metadata.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Modes
+
+  - `:queued` (default) — non-blocking `rf/dispatch`. Event is added to
+    the per-frame queue; the cascade runs asynchronously on the next
+    JS microtask tick. The tool resolves once the dispatch hand-off
+    completes; downstream cascade traces are surfaced through
+    `subscribe :trace` (T-Stream-1) rather than the mutation ack.
+  - `:sync` — `rf/dispatch-sync`. The full cascade (interceptor chain,
+    effect handlers, view re-render hand-off) runs synchronously
+    before this tool resolves. Use sparingly — sync dispatch defeats
+    the queue's batching guarantees and risks re-entrancy across
+    frames.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:event` | EDN-vec str | nil (REQUIRED) | event vector (e.g. `\"[:cart/add 42]\"`) |
+  | `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+  | `:sync?` | bool | false | `:sync` (true) vs `:queued` (false) |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :event-id <kw>
+       :frame    <kw>
+       :origin   :causa-mcp
+       :mode     <:queued|:sync>}
+
+  ## Failure envelopes
+
+  - `{:ok? false :reason :missing-event :hint ...}` — `:event` absent.
+  - `{:ok? false :reason :event-malformed :given <s> :hint ...}` —
+    `:event` couldn't be parsed as an EDN vector.
+  - `{:ok? false :reason :not-an-event-vector :hint ...}` — parsed
+    value isn't a vector.
+  - `{:ok? false :reason :no-frame-resolved :hint ...}` — multi-frame
+    app without an explicit `:frame` arg.
+  - `{:ok? false :reason :runtime-not-preloaded :hint <setup>}` —
+    Causa-the-panel preload isn't loaded.
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #23. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [cljs.reader :as edn]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn parse-event-arg
+  "Coerce the `:event` MCP arg to a CLJS vector. Accepts a CLJS vector
+  passthrough or an EDN-printed vector string. Returns `::malformed`
+  for unparseable input so the caller can surface a structured
+  envelope; returns `nil` for absent input."
+  [v]
+  (cond
+    (nil? v)    nil
+    (vector? v) v
+    (string? v) (try (let [parsed (edn/read-string v)]
+                       (if (vector? parsed) parsed ::malformed))
+                     (catch :default _ ::malformed))
+    :else       ::malformed))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure.
+
+  The runtime accessor is `dispatch!` (arity-2 with opts map); the
+  `wrap-origin` outer binding stamps `*current-origin* :causa-mcp` so
+  the framework's trace cascade tags the synchronous extent."
+  [event-vec opts]
+  (-> (ef/rt-call 'dispatch! event-vec opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :event-id :frame :origin :mode}`
+  response into the MCP envelope. Pure — tests pin the indicator
+  stamping logic."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?)
+      env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/dispatch! returned a non-envelope shape"}
+
+      :else
+      (let [elided (elision/count-elided-markers env)]
+        (wire/with-indicators env {:elided elided})))))
+
+(defn dispatch-tool
+  "MCP handler for `dispatch`. Validates `:event` pre-flight; runtime
+  accessor validates again (defence in depth)."
+  [conn args]
+  (let [build-id  (wire/arg-build args)
+        frame     (wire/arg-keyword args :frame)
+        sync?     (wire/arg-bool args :sync? false)
+        event-raw (wire/arg args :event)
+        event     (parse-event-arg event-raw)]
+    (cond
+      (nil? event)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-event
+                       :hint   "Pass :event \"[:foo/bar 42]\" (EDN-vec string)."}))
+
+      (= ::malformed event)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :event-malformed
+                       :given  event-raw
+                       :hint   "Could not parse :event as an EDN vector."}))
+
+      (not (vector? event))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :not-an-event-vector
+                       :given  event
+                       :hint   "Event must be a vector, e.g. [:cart/add 42]."}))
+
+      :else
+      (let [runtime-opts (cond-> {:sync? sync?}
+                           frame (assoc :frame frame))
+            form         (build-form event runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope))))
+            (.catch (fn [err] (probe/err->result :dispatch-failed err))))))))
+
+(def descriptor
+  {:name        "dispatch"
+   :description (str "Fire a re-frame event through the frame's normal "
+                     "dispatch cascade. Class-1 mutation: server-enable "
+                     "is the consent gate, no per-call confirmation. "
+                     "The event's trace is stamped :origin :causa-mcp. "
+                     ":sync? true uses dispatch-sync (the full cascade "
+                     "runs before this tool resolves); :sync? false "
+                     "(default) is the standard queued dispatch. Required "
+                     ":event arg is an EDN vector string, e.g. "
+                     "\"[:cart/add 42]\".")
+   :input-schema #js {:type "object"
+                      :required #js ["event"]
+                      :properties #js {:event      #js {:type "string"}
+                                       :frame      #js {:type "string"}
+                                       :sync?      #js {:type "boolean"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) dispatch-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/eval_cljs.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/eval_cljs.cljs
@@ -1,0 +1,213 @@
+(ns day8.re-frame2-causa-mcp.tools.eval-cljs
+  "Tool: `eval-cljs` — arbitrary CLJS evaluation in the host runtime,
+  gated by `--allow-eval` (rf2-8xzoe.29, T-Eval-1 of the causa-mcp
+  meta tranche).
+
+  ## Launch-flag gate
+
+  Arbitrary code execution is qualitatively different from named
+  mutations (`dispatch` / `restore-epoch` / `reset-frame-db`) — the
+  programmer must opt in explicitly at server launch. Published builds
+  default OFF; the operator passes `--allow-eval` on the causa-mcp
+  server command line to enable. When OFF, this tool returns the
+  structured refusal envelope `{:ok? false
+  :reason :rf.error/eval-cljs-disabled :hint <opt-in-instructions>}`
+  without touching the nREPL socket.
+
+  Mirrors pair2-mcp's `eval-cljs` posture (rf2-cxx5s cascade from
+  rf2-czv3p). The gate atom (`allow-eval?`) is set by
+  `server.cljs/main` from `process.argv` before the dispatcher starts
+  handling tools/call requests. Tests flip the atom directly via
+  `set-allow-eval!`.
+
+  ## Sync-extent origin tag (Lock #4 / I6)
+
+  When eval is enabled, the tool ships the user's form wrapped in a
+  `(binding [day8.re-frame2-causa.runtime/*current-origin* :causa-mcp]
+     <user-form>)`
+  block so any mutation the form performs during its synchronous
+  extent tags `:origin :causa-mcp`. **Async-extent handlers fired
+  AFTER the user-form returns do NOT inherit the binding** — this is
+  the documented async-tagging gap (Lock #4 / I6 of
+  `tools/causa-mcp/spec/Principles.md`), spec'd as known incomplete.
+  Agents that want stable async tagging should use the named-mutation
+  tools (`dispatch`, etc.) which carry the contract through the
+  framework's existing `:tags` plumbing.
+
+  ## Egress scrub
+
+  The eval'd value is shaped by the runtime's `eval-form-result` —
+  routes the value through `re-frame.core/elide-wire-value` with the
+  caller's `:include-sensitive?` / `:include-large?` opt-in. Privacy +
+  elision still apply on the result; bypass requires both
+  `--allow-eval` AND `:include-*` true.
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — runtime walker substitutes `:rf/redacted` at
+    declared-sensitive leaves; `:include-sensitive?` opt-in passes
+    through.
+  - **W-6 size elision** — runtime walker substitutes
+    `{:rf.size/large-elided ...}` at over-threshold leaves; counted
+    onto `:elided-large`.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:form` | string | nil (REQUIRED) | CLJS source string to eval |
+  | `:include-sensitive?` | bool | false | passes to runtime walker |
+  | `:include-large?` | bool | false | passes to runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape (enabled)
+
+      {:ok? true :value <edn>
+       :elided-large <int?>}
+
+  ## Refusal shape (default — gate OFF)
+
+      {:ok?    false
+       :reason :rf.error/eval-cljs-disabled
+       :hint   \"eval-cljs is disabled by default for security; pass
+                 --allow-eval at server launch to opt in.\"}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #29. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+;; ---------------------------------------------------------------------------
+;; Launch-flag gate
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private allow-eval?
+  ;; Default OFF in published builds. `server.cljs/main` flips this to
+  ;; `true` when `--allow-eval` is present in `process.argv`.
+  (atom false))
+
+(defn set-allow-eval!
+  "Set the `eval-cljs` launch-flag gate. Called once by
+  `server.cljs/main` during boot; called by tests to flip the gate.
+  `enabled?` is coerced to boolean."
+  [enabled?]
+  (reset! allow-eval? (boolean enabled?)))
+
+(defn allow-eval-enabled?
+  "Read the current gate state. Exposed for tests + server-side
+  logging."
+  []
+  @allow-eval?)
+
+;; ---------------------------------------------------------------------------
+;; Form composition
+;; ---------------------------------------------------------------------------
+
+(defn build-form
+  "Wrap the user's CLJS source string in the origin-binding + the
+  runtime's `eval-form-result` shaper. Pure — tests pin the structure.
+
+  The shape is
+
+      (binding [day8.re-frame2-causa.runtime/*current-origin* :causa-mcp]
+        (day8.re-frame2-causa.runtime/eval-form-result
+          <user-form> <opts-map>))
+
+  so any mutation the user-form performs during its synchronous extent
+  carries `:origin :causa-mcp`, and the returned value is routed
+  through `elide-wire-value` server-side before the result crosses the
+  nREPL wire."
+  [user-form opts]
+  (-> (ef/rt-call 'eval-form-result (ef/rt-raw user-form) opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Shape the runtime's `{:ok? true :value <edn>}` response. Pure —
+  tests pin the indicator stamping."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?) env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/eval-form-result returned a non-envelope shape"}
+
+      :else
+      (let [elided (elision/count-elided-markers (:value env))]
+        (wire/with-indicators env {:elided elided})))))
+
+;; ---------------------------------------------------------------------------
+;; Tool handler
+;; ---------------------------------------------------------------------------
+
+(def disabled-hint
+  "Operator-facing setup hint surfaced on the structured
+  `:rf.error/eval-cljs-disabled` refusal envelope."
+  (str "eval-cljs is disabled by default for security; pass "
+       "--allow-eval at server launch to opt in."))
+
+(defn eval-cljs-tool [conn args]
+  (let [build-id  (wire/arg-build args)
+        form      (wire/arg args :form)
+        incl?     (privacy/parse-include-sensitive args)
+        incl-large? (elision/parse-include-large args)]
+    (cond
+      (not @allow-eval?)
+      (js/Promise.resolve
+        (wire/err-text {:ok?    false
+                        :reason :rf.error/eval-cljs-disabled
+                        :hint   disabled-hint}))
+
+      (or (nil? form) (and (string? form) (str/blank? form)))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-form
+                       :hint   "Pass :form \"<cljs-source-string>\"."}))
+
+      :else
+      (let [opts        {:include-sensitive? incl?
+                         :include-large?     incl-large?}
+            wrapped     (build-form form opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id wrapped)))
+            (.then (fn [runtime-env]
+                     (wire/ok-text (shape-envelope runtime-env))))
+            (.catch (fn [err] (probe/err->result :eval-error err))))))))
+
+(def descriptor
+  {:name        "eval-cljs"
+   :description (str "Evaluate an arbitrary CLJS form in the host "
+                     "runtime. GATED behind --allow-eval at server "
+                     "launch; default OFF returns "
+                     ":rf.error/eval-cljs-disabled refusal envelope. "
+                     "When enabled, the form runs inside a "
+                     "(binding [*current-origin* :causa-mcp] ...) "
+                     "wrapper so synchronous-extent mutations tag "
+                     ":origin :causa-mcp (async-extent handlers do NOT "
+                     "inherit the binding — documented Lock #4 / I6 "
+                     "gap). The result routes through "
+                     "elide-wire-value (privacy + size scrub still "
+                     "apply; pass :include-sensitive? / "
+                     ":include-large? true to opt out).")
+   :input-schema #js {:type "object"
+                      :required #js ["form"]
+                      :properties #js {:form               #js {:type "string"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) eval-cljs-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/list_subscriptions.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/list_subscriptions.cljs
@@ -1,0 +1,114 @@
+(ns day8.re-frame2-causa-mcp.tools.list-subscriptions
+  "Tool: `list-subscriptions` — diagnostic enumerating active streaming
+  subscriptions (rf2-8xzoe.28, T-Stream-3 of the causa-mcp streaming
+  tranche).
+
+  The **eighteenth** tool added by DESIGN-RATIONALE Lock #12
+  (rf2-3we2k, 2026-05-14). Wraps the runtime's `list-subscriptions`
+  diagnostic so an agent doesn't need an `eval-cljs` round-trip to ask
+  \"what streams are currently open?\". Useful when a streaming probe
+  has gone quiet (confirm the sub is still registered) or when
+  pruning leaked subs across crashed `subscribe` calls.
+
+  Optional `:topic` / `:sub-id` filters narrow the enumeration. The
+  runtime accessor returns per-sub metadata (`:id`, `:topic`,
+  `:filter`, `:origin`, `:created-at`); the queue-depth / overflow
+  fields documented in the runtime ns docstring will arrive when the
+  server-side pump tranche grows them (per
+  `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides).
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — not applicable (subscription metadata is not
+    trace-event-shaped; `:filter` may contain user-supplied keywords
+    but doesn't carry user data).
+  - **W-6 size elision** — counted defensively on the runtime
+    envelope.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:topic` | keyword | nil | filter to one topic |
+  | `:sub-id` | string | nil | filter to one sub-id |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true
+       :subs [{:id <uuid> :topic <kw> :filter <map>
+               :origin <kw> :created-at <ms>} ...]
+       :count <int>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #28; DESIGN-RATIONALE.md Lock #12 (rf2-3we2k). Catalogue entry
+  lives in `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'list-subscriptions opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Pass the runtime's `{:ok? true :subs <vec> :count <int>}` through;
+  count defensive elision markers. Pure — tests pin the indicator
+  stamping."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (false? ok?) env
+
+      (not (true? ok?))
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/list-subscriptions returned a non-envelope shape"}
+
+      :else
+      (let [subs   (vec (or (:subs env) []))
+            elided (elision/count-elided-markers subs)]
+        (wire/with-indicators
+          {:ok?   true
+           :subs  subs
+           :count (count subs)}
+          {:elided elided})))))
+
+(defn list-subscriptions-tool [conn args]
+  (let [build-id (wire/arg-build args)
+        topic    (wire/arg-keyword args :topic)
+        sub-id   (wire/arg args :sub-id)
+        opts     (cond-> {}
+                   topic  (assoc :topic  topic)
+                   sub-id (assoc :sub-id sub-id))]
+    (-> (probe/ensure-runtime! conn build-id)
+        (.then (fn [_] (nrepl/cljs-eval-value conn build-id (build-form opts))))
+        (.then (fn [runtime-env] (wire/ok-text (shape-envelope runtime-env))))
+        (.catch (fn [err] (probe/err->result :list-subscriptions-failed err))))))
+
+(def descriptor
+  {:name        "list-subscriptions"
+   :description (str "Enumerate active streaming subscriptions. Returns "
+                     "per-sub metadata (id, topic, filter, origin, "
+                     "created-at). Optional :topic / :sub-id filters "
+                     "narrow the enumeration. Diagnostic — useful when "
+                     "a streaming probe seems quiet (confirm the sub "
+                     "is still registered) or when pruning leaked "
+                     "subs.")
+   :input-schema #js {:type "object"
+                      :properties #js {:topic      #js {:type "string"}
+                                       :sub-id     #js {:type "string"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) list-subscriptions-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/reset_frame_db.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/reset_frame_db.cljs
@@ -1,0 +1,159 @@
+(ns day8.re-frame2-causa-mcp.tools.reset-frame-db
+  "Tool: `reset-frame-db` — Class-1 named mutation (rf2-8xzoe.25,
+  T-Mut-3 of the causa-mcp mutation tranche).
+
+  Re-injects a value into a frame's `app-db`, bypassing the dispatch
+  cascade. Schema-validates against the registered app-db schemas via
+  the framework's `re-frame.core/reset-frame-db!`; the wrapper returns
+  a boolean (`true` on success; `false` on any of the three documented
+  failure rows — each emits a structured trace and leaves `app-db`
+  unchanged):
+
+  | Row | Trace `:op-type` keyword |
+  |---|---|
+  | unknown frame | `:rf.error/no-such-handler` (kind `:frame`) |
+  | reset during drain | `:rf.epoch/reset-frame-db-during-drain` |
+  | schema mismatch | `:rf.epoch/reset-frame-db-schema-mismatch` |
+
+  Same projection rationale as `restore-epoch`: the framework returns
+  a plain boolean, the per-row keyword lives on the trace bus, this
+  tool surfaces `:reason :rf.epoch/reset-failed` and points at the
+  bus.
+
+  ## Restore-audit trail
+
+  The framework's restore-audit ring captures every `reset-frame-db!`
+  call alongside `restore-epoch` calls (per Tool-Pair §Time-travel —
+  the restore-audit IS the audit of explicit-write operations). The
+  audit row's `:tags :origin` carries the binding-extent value, so
+  every reset this tool fires shows up tagged `:causa-mcp` in the
+  next `get-epoch-history` read.
+
+  ## Wire-boundary contract
+
+  - **B-3 origin stamp** — synchronous-extent `*current-origin*`
+    binding around the runtime call.
+  - **B-1 privacy** — not applicable (ack envelope, not trace
+    events).
+  - **W-6 size elision** — counted defensively on the runtime
+    envelope.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:value` | EDN-map str | nil (REQUIRED) | the new `app-db` value |
+  | `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      ;; success
+      {:ok? true  :frame <kw> :origin :causa-mcp}
+
+      ;; failure (one of the three rows; see trace bus for the
+      ;; structured :rf.epoch/* keyword)
+      {:ok? false :frame <kw> :origin :causa-mcp
+       :reason :rf.epoch/reset-failed
+       :hint   \"Reset failed — read the trace bus for the structured
+                :rf.epoch/* row.\"}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #25. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [cljs.reader :as edn]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn parse-value-arg
+  "Coerce the `:value` MCP arg to a CLJS value. Accepts a CLJS map
+  passthrough or an EDN-printed string. Returns `::malformed` for
+  unparseable input; returns `::absent` for nil so the caller can
+  distinguish 'absent' from 'parsed-to-nil' (a user could legitimately
+  pass `nil` as a fresh `app-db`)."
+  [v]
+  (cond
+    (nil? v)    ::absent
+    (string? v) (try (edn/read-string v)
+                     (catch :default _ ::malformed))
+    :else       v))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'reset-frame-db! opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Pass the runtime's reset ack through; count any defensive elision
+  markers. Pure — tests pin the indicator stamping logic."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      (or (true? ok?) (false? ok?))
+      (let [elided (elision/count-elided-markers env)]
+        (wire/with-indicators env {:elided elided}))
+
+      :else
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/reset-frame-db! returned a non-envelope shape"})))
+
+(defn reset-frame-db-tool
+  "MCP handler for `reset-frame-db`. Validates `:value` pre-flight."
+  [conn args]
+  (let [build-id  (wire/arg-build args)
+        frame     (wire/arg-keyword args :frame)
+        value-raw (wire/arg args :value)
+        value     (parse-value-arg value-raw)]
+    (cond
+      (= ::absent value)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-value
+                       :hint   "Pass :value <EDN-string> to inject (e.g. \"{:cart {}}\")."}))
+
+      (= ::malformed value)
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :value-malformed
+                       :given  value-raw
+                       :hint   "Could not parse :value as EDN."}))
+
+      :else
+      (let [runtime-opts (cond-> {:value value}
+                           frame (assoc :frame frame))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope))))
+            (.catch (fn [err] (probe/err->result :reset-frame-db-failed err))))))))
+
+(def descriptor
+  {:name        "reset-frame-db"
+   :description (str "Re-inject :value into a frame's app-db via "
+                     "re-frame.core/reset-frame-db! (bypasses dispatch "
+                     "cascade; schema-validates). Returns :ok? true on "
+                     "success; :ok? false :reason :rf.epoch/reset-failed "
+                     "on any of the three documented failure rows "
+                     "(unknown frame / reset during drain / schema "
+                     "mismatch). The structured per-row :rf.epoch/* "
+                     "keyword surfaces on the trace bus. Required "
+                     ":value is an EDN string, e.g. \"{:cart {}}\".")
+   :input-schema #js {:type "object"
+                      :required #js ["value"]
+                      :properties #js {:value      #js {:type "string"}
+                                       :frame      #js {:type "string"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) reset-frame-db-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/restore_epoch.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/restore_epoch.cljs
@@ -1,0 +1,141 @@
+(ns day8.re-frame2-causa-mcp.tools.restore-epoch
+  "Tool: `restore-epoch` — Class-1 named mutation (rf2-8xzoe.24,
+  T-Mut-2 of the causa-mcp mutation tranche).
+
+  Rewinds a frame's `app-db` to the named epoch's `:db-after` via the
+  framework's `re-frame.core/restore-epoch`. The framework wrapper
+  returns a boolean (`true` on success; `false` on any of the six
+  documented failure rows). This tool surfaces the six-row failure
+  table via the framework's emitted trace stream — `subscribe :trace`
+  or the next `get-trace-buffer` call reads the structured
+  `:rf.epoch/*` row that names which row tripped:
+
+  | Row | Trace `:op-type` keyword |
+  |---|---|
+  | unknown frame | `:rf.error/no-such-handler` (kind `:frame`) |
+  | unknown epoch | `:rf.epoch/restore-unknown-epoch` |
+  | schema mismatch | `:rf.epoch/restore-schema-mismatch` |
+  | missing handler | `:rf.epoch/restore-missing-handler` |
+  | version mismatch | `:rf.epoch/restore-version-mismatch` |
+  | restore during drain | `:rf.epoch/restore-during-drain` |
+
+  The accessor intentionally does NOT project the per-row keyword
+  onto its own return shape — the framework returns a plain boolean,
+  the row already lives on the bus, and double-projection would let
+  the two drift. The tool returns `:reason :rf.epoch/restore-failed`
+  with a hint pointing at the trace bus.
+
+  ## Wire-boundary contract
+
+  - **B-3 origin stamp** — synchronous-extent `*current-origin*`
+    binding around the runtime call so the framework's restore-emitted
+    traces tag `:origin :causa-mcp`.
+  - **B-1 privacy** — not applicable (the response envelope is
+    structured ack metadata, not trace events).
+  - **W-6 size elision** — counted defensively on the runtime
+    envelope.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:epoch-id` | string | nil (REQUIRED) | the epoch-id to restore |
+  | `:frame` | keyword | nil | scope to one frame; nil → sole frame |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      ;; success
+      {:ok? true  :frame <kw> :epoch-id <id> :origin :causa-mcp}
+
+      ;; failure (one of the six rows; see trace bus for the
+      ;; structured :rf.epoch/* keyword)
+      {:ok? false :frame <kw> :epoch-id <id> :origin :causa-mcp
+       :reason :rf.epoch/restore-failed
+       :hint   \"Restore failed — read the trace bus for the structured
+                :rf.epoch/* row.\"}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #24. Tool-Pair §Time-travel — Restore — the six-row failure
+  surface contract. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [opts]
+  (-> (ef/rt-call 'restore-epoch! opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Pass the runtime's restore ack through; count any defensive elision
+  markers. Pure — tests pin the indicator stamping logic."
+  [runtime-envelope]
+  (let [{:keys [ok?] :as env} (if (map? runtime-envelope) runtime-envelope {})]
+    (cond
+      ;; Both success (true) and failure (false) carry the same
+      ;; structural slots — flow through and stamp.
+      (or (true? ok?) (false? ok?))
+      (let [elided (elision/count-elided-markers env)]
+        (wire/with-indicators env {:elided elided}))
+
+      :else
+      {:ok?     false
+       :reason  :unexpected-shape
+       :runtime runtime-envelope
+       :hint    "runtime/restore-epoch! returned a non-envelope shape"})))
+
+(defn restore-epoch-tool
+  "MCP handler for `restore-epoch`. Validates `:epoch-id` pre-flight;
+  runtime accessor validates again (defence in depth)."
+  [conn args]
+  (let [build-id (wire/arg-build args)
+        frame    (wire/arg-keyword args :frame)
+        epoch-id (wire/arg args :epoch-id)]
+    (cond
+      (or (nil? epoch-id) (and (string? epoch-id) (str/blank? epoch-id)))
+      (js/Promise.resolve
+        (wire/ok-text {:ok?    false
+                       :reason :missing-epoch-id
+                       :hint   "Pass :epoch-id <uuid-string> from get-epoch-history."}))
+
+      :else
+      (let [runtime-opts (cond-> {:epoch-id epoch-id}
+                           frame (assoc :frame frame))
+            form         (build-form runtime-opts)]
+        (-> (probe/ensure-runtime! conn build-id)
+            (.then (fn [_] (nrepl/cljs-eval-value conn build-id form)))
+            (.then (fn [runtime-envelope]
+                     (wire/ok-text (shape-envelope runtime-envelope))))
+            (.catch (fn [err] (probe/err->result :restore-epoch-failed err))))))))
+
+(def descriptor
+  {:name        "restore-epoch"
+   :description (str "Rewind a frame's app-db to the named epoch's "
+                     ":db-after via re-frame.core/restore-epoch. Returns "
+                     ":ok? true on success; :ok? false :reason "
+                     ":rf.epoch/restore-failed on any of the six "
+                     "documented failure rows (unknown frame / unknown "
+                     "epoch / schema mismatch / missing handler / "
+                     "version mismatch / restore during drain). The "
+                     "structured per-row :rf.epoch/* keyword surfaces "
+                     "on the trace bus (read via get-trace-buffer or "
+                     "subscribe :trace). Required :epoch-id from "
+                     "get-epoch-history.")
+   :input-schema #js {:type "object"
+                      :required #js ["epoch-id"]
+                      :properties #js {:epoch-id   #js {:type "string"}
+                                       :frame      #js {:type "string"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) restore-epoch-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/subscribe.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/subscribe.cljs
@@ -1,0 +1,401 @@
+(ns day8.re-frame2-causa-mcp.tools.subscribe
+  "Tool: `subscribe` — per-drain-batch streaming over a topic
+  (rf2-8xzoe.26, T-Stream-1 of the causa-mcp streaming tranche).
+
+  The MCP `tools/call` runs until either (a) the client aborts via the
+  `extra.signal` AbortSignal, (b) an `unsubscribe` clears the sub-id
+  from the runtime, (c) `:max-events` / `:max-ms` is reached, or (d)
+  the runtime reports the sub is gone. While running, each polling
+  tick emits ONE `notifications/progress` notification per non-empty
+  batch correlated to the original `tools/call` via
+  `extra._meta.progressToken`. The terminal `tools/call` result is a
+  summary `{:ok? true :sub-id :topic :delivered N :ticks N :reason
+  <terminated-reason>}`.
+
+  ## Causa vs pair2-mcp model
+
+  pair2-mcp's runtime owns a per-subscription queue with a bounded
+  events/bytes budget; the server's drain-form pops events off the
+  queue per tick. Causa's runtime is lighter — `subscribe!` records
+  per-subscription metadata only; the events live on the central trace
+  bus. The server polls the trace bus filtered by topic + an
+  `:since-ms` cursor, yielding the events that landed in this tick's
+  window. Per-tick port-pinning (the MCP contract surface) is
+  preserved: one `progressToken`, one notification per tick, one
+  terminal summary on close.
+
+  Topic → trace projection:
+
+  | Topic | Source |
+  |---|---|
+  | `:trace` | full trace buffer; `:op-type` filter optional |
+  | `:epoch` | trace events with `:op-type :epoch/closed` |
+  | `:fx` | trace events with `:op-type :fx/run` |
+  | `:error` | issue-tier events (`:error` / `:warning` / `:rf.schema/violation` / `:rf.hydration/mismatch`) |
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — every per-tick batch routes through
+    `privacy/strip-sensitive` before egress; the cumulative
+    `:dropped-sensitive` counter rides on the final summary.
+  - **W-6 size elision** — the runtime accessor already routes each
+    event through `re-frame.core/elide-wire-value` server-side; the
+    per-tick batch's marker count accumulates onto the final summary's
+    `:elided-large` counter.
+  - **W-1 token cap** — applies to BOTH the per-tick progress payload
+    and the final summary. Per-tick over-cap payloads are NOT
+    dropped — the cap step runs on the final summary, not on
+    notifications (the MCP SDK strips overflow markers from
+    progress payloads without breaking the contract).
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:topic` | keyword | nil (REQUIRED) | `:trace`, `:epoch`, `:fx`, `:error` |
+  | `:filter` | map | nil | per-topic filter (e.g. `{:op-type :event/dispatched}`) |
+  | `:frame` | keyword | nil | scope to one frame |
+  | `:poll-ms` | int | 100 | polling cadence |
+  | `:max-events` | int | 0 | terminate after N events (0 = unbounded) |
+  | `:max-ms` | int | 0 | terminate after N ms (0 = unbounded) |
+  | `:include-sensitive?` | bool | false | opt back in to `:sensitive? true` |
+  | `:include-large?` | bool | false | passes to runtime walker |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape (terminal summary)
+
+      {:ok? true
+       :sub-id <uuid>
+       :topic <kw>
+       :delivered <int>
+       :ticks <int>
+       :reason <:aborted|:max-events-reached|:max-ms-reached|:sub-gone|:unsubscribed>
+       :dropped-sensitive <int?>
+       :elided-large <int?>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #26. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [applied-science.js-interop :as j]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.privacy :as privacy]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:const default-poll-ms 100)
+
+(def ^:const recognised-topics
+  "Closed set of topics the runtime accepts. Mirrors the runtime's
+  `subscribe!` validation; we duplicate it server-side so an unknown
+  topic short-circuits without an nREPL round-trip."
+  #{:trace :epoch :fx :error})
+
+(def ^:const initial-state
+  "Per-stream rolling accumulators. One atom per `subscribe-tool`
+  call; merged once per tick. Mirrors pair2-mcp's `initial-state` so
+  the cross-MCP final-summary shape is byte-identical (with the
+  exception of the queue-bound `:dropped-events`/`:dropped-bytes`
+  slots which causa's lighter model doesn't carry)."
+  {:tick              0
+   :delivered         0
+   :since-ms          0
+   :dropped-sensitive 0
+   :elided-large      0})
+
+(def ^:const issue-op-types
+  "The `:error` topic projects to this op-type set on the trace bus —
+  errors, warnings, schema violations, hydration mismatches."
+  #{:error :warning :rf.schema/violation :rf.hydration/mismatch})
+
+;; ---------------------------------------------------------------------------
+;; Topic → filter projection
+;; ---------------------------------------------------------------------------
+
+(defn topic->filter
+  "Project a `:topic` keyword onto the runtime's trace-buffer filter
+  vocabulary. Returns the filter map the runtime walker honours.
+  Pure — tests pin the projection table."
+  [topic user-filter frame since-ms]
+  (let [base (cond-> (or user-filter {})
+               frame              (assoc :frame frame)
+               (pos? (or since-ms 0)) (assoc :since-ms since-ms))]
+    (case topic
+      :trace base
+      :epoch (assoc base :op-type :epoch/closed)
+      :fx    (assoc base :op-type :fx/run)
+      :error base ;; :error topic post-filters by op-type set below
+      base)))
+
+(defn project-error-topic
+  "Post-filter `events` to the issue-tier op-types when `topic` is
+  `:error`. Pure — non-error topics pass through unchanged."
+  [topic events]
+  (if (= :error topic)
+    (filterv #(contains? issue-op-types (:op-type %)) events)
+    events))
+
+;; ---------------------------------------------------------------------------
+;; Eval form composition — drain a tick's worth of events
+;; ---------------------------------------------------------------------------
+
+(defn drain-form
+  "Build the eval form addressing `runtime/get-trace-buffer` with the
+  topic-projected filter. Pure — tests pin the form shape directly."
+  [filter-opts]
+  (-> (ef/rt-call 'get-trace-buffer filter-opts)
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn subscribe-form
+  "Build the eval form registering the subscription in the runtime's
+  metadata atom. The runtime returns `{:ok? true :sub-id :topic
+  :filter}` (or an `:unknown-topic` failure)."
+  [topic user-filter]
+  (-> (ef/rt-call 'subscribe! (cond-> {:topic topic}
+                                user-filter (assoc :filter user-filter)))
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn unsubscribe-form
+  "Build the eval form closing the subscription. Returns
+  `{:ok? true :sub-id :existed?}`."
+  [sub-id]
+  (-> (ef/rt-call 'unsubscribe! {:sub-id sub-id})
+      (ef/emit)
+      (ef/wrap-origin)))
+
+;; ---------------------------------------------------------------------------
+;; Per-tick batch accumulators
+;; ---------------------------------------------------------------------------
+
+(defn merge-tick
+  "Pure state update — fold one tick's contributions into the rolling
+  accumulators. Public so tests pin the contract directly."
+  [s {:keys [n dropped elided]}]
+  (cond-> s
+    (pos? (or n 0))       (-> (update :tick      inc)
+                              (update :delivered + n))
+    (pos? (or dropped 0)) (update :dropped-sensitive + dropped)
+    (pos? (or elided 0))  (update :elided-large      + elided)))
+
+(defn final-summary
+  "Build the terminal `ok-text` result emitted when the subscription
+  ends. Public so tests pin the shape; `wire/with-indicators` stamps
+  the cumulative `:dropped-sensitive` + `:elided-large` counters per
+  the cross-MCP indicator-field convention."
+  [{:keys [sub-id topic state reason]}]
+  (let [{:keys [tick delivered dropped-sensitive elided-large]} state]
+    (wire/ok-text
+      (wire/with-indicators
+        {:ok?       true
+         :sub-id    sub-id
+         :topic     topic
+         :delivered delivered
+         :ticks     tick
+         :reason    reason}
+        {:dropped dropped-sensitive
+         :elided  elided-large}))))
+
+;; ---------------------------------------------------------------------------
+;; Per-tick progress emission
+;; ---------------------------------------------------------------------------
+
+(defn progress-payload
+  "Build the JSON params payload for one `notifications/progress` tick.
+  Mirrors pair2-mcp's `progress-payload` shape so cross-MCP agents
+  decode the same envelope from both servers. Public so tests pin
+  the contract."
+  [progress-token tick events-edn]
+  #js {:progressToken progress-token
+       :progress      tick
+       :message       events-edn
+       :_meta         #js {}})
+
+(defn- emit-progress-tick!
+  "Ship one `notifications/progress` notification. Failures swallowed
+  — a flaky client must not collapse the stream."
+  [{:keys [send-note progress-tk sub-id]} tick events dropped elided]
+  (try
+    (send-note
+      #js {:method "notifications/progress"
+           :params (progress-payload
+                     progress-tk
+                     tick
+                     (pr-str (wire/with-indicators
+                               {:sub-id sub-id :events events}
+                               {:dropped dropped :elided elided})))})
+    (catch :default _ nil)))
+
+;; ---------------------------------------------------------------------------
+;; Stream controller — termination + poll loop
+;; ---------------------------------------------------------------------------
+
+(defn- parse-mcp-extra
+  "Pluck the three MCP-host slots the streaming loop needs out of the
+  JS `extra` object: the abort signal, the progress-notification
+  emitter, and the progress token correlating ticks to this
+  `tools/call`."
+  [extra]
+  {:signal      (some-> extra (j/get :signal))
+   :send-note   (some-> extra (j/get :sendNotification))
+   :progress-tk (some-> extra (j/get :_meta) (j/get :progressToken))})
+
+(defn- make-stream-controller
+  "Build the `terminate` + `poll` fns over a shared `state` atom. The
+  `terminate` issues the runtime-side `unsubscribe!` and resolves the
+  outer `tools/call` Promise with the final-summary envelope. `poll`
+  runs the drain → state-merge → progress-emit → reschedule cycle."
+  [{:keys [conn build-id sub-id topic resolve state signal send-note
+           progress-tk poll-ms max-events incl? frame user-filter]}]
+  (let [terminated? (atom false)
+        terminate
+        (fn terminate [reason]
+          (when (compare-and-set! terminated? false true)
+            (-> (nrepl/cljs-eval-value conn build-id (unsubscribe-form sub-id))
+                (.catch (fn [_] nil))
+                (.then (fn [_]
+                         (resolve
+                           (final-summary
+                             {:sub-id sub-id :topic topic
+                              :state  @state :reason reason})))))))
+        poll
+        (fn poll []
+          (cond
+            (and signal (.-aborted signal))
+            (terminate :aborted)
+
+            (and (pos? max-events)
+                 (>= (:delivered @state) max-events))
+            (terminate :max-events-reached)
+
+            :else
+            (let [since-ms     (:since-ms @state)
+                  filter-opts  (-> (topic->filter topic user-filter frame since-ms)
+                                   (assoc :include-sensitive? incl?))]
+              (-> (nrepl/cljs-eval-value conn build-id (drain-form filter-opts))
+                  (.then
+                    (fn [runtime-env]
+                      (let [raw-events     (vec (project-error-topic
+                                                  topic
+                                                  (or (:events runtime-env) [])))
+                            [kept dropped] (privacy/strip-sensitive raw-events incl?)
+                            elided         (elision/count-elided-markers kept)
+                            n              (count kept)
+                            now-ms         (.now js/Date)]
+                        ;; Always bump :since-ms to NOW so the next tick
+                        ;; reads only fresh events — even a zero-event
+                        ;; tick advances the cursor (otherwise we'd
+                        ;; re-poll the same window forever).
+                        (swap! state assoc :since-ms now-ms)
+                        (when (pos? n)
+                          (swap! state merge-tick
+                                 {:n n :dropped dropped :elided elided})
+                          (when (and send-note progress-tk)
+                            (emit-progress-tick!
+                              {:send-note send-note
+                               :progress-tk progress-tk
+                               :sub-id sub-id}
+                              (:tick @state) kept dropped elided)))
+                        (js/setTimeout poll poll-ms))))
+                  (.catch
+                    (fn [_err]
+                      ;; nREPL hiccup — back off and try again rather
+                      ;; than collapsing the stream.
+                      (js/setTimeout poll (* 2 poll-ms))))))))]
+    {:state state :terminate terminate :poll poll}))
+
+;; ---------------------------------------------------------------------------
+;; Tool handler
+;; ---------------------------------------------------------------------------
+
+(defn- run-acquired
+  "Drive the subscription lifecycle. Registers the sub via the runtime,
+  builds the controller, schedules max-ms watchdog, and starts the
+  poll loop. Returns a Promise resolving to the final-summary MCP
+  result."
+  [{:keys [conn build-id topic user-filter frame poll-ms max-ms max-events
+           incl? signal send-note progress-tk]}]
+  (-> (probe/ensure-runtime! conn build-id)
+      (.then (fn [_]
+               (nrepl/cljs-eval-value conn build-id
+                                      (subscribe-form topic user-filter))))
+      (.then
+        (fn [sub-env]
+          (if-not (:ok? sub-env)
+            (wire/ok-text sub-env)
+            (let [sub-id (:sub-id sub-env)]
+              (js/Promise.
+                (fn [resolve _reject]
+                  (let [{:keys [terminate poll]}
+                        (make-stream-controller
+                          {:conn conn :build-id build-id
+                           :sub-id sub-id :topic topic
+                           :resolve resolve
+                           :state (atom (assoc initial-state
+                                               :since-ms (.now js/Date)))
+                           :signal signal :send-note send-note
+                           :progress-tk progress-tk :poll-ms poll-ms
+                           :max-events max-events :incl? incl?
+                           :frame frame :user-filter user-filter})]
+                    (when (pos? max-ms)
+                      (js/setTimeout #(terminate :max-ms-reached) max-ms))
+                    (poll))))))))
+      (.catch (fn [err] (probe/err->result :subscribe-failed err)))))
+
+(defn subscribe-tool [conn raw-args extra]
+  (let [build-id    (wire/arg-build raw-args)
+        topic       (wire/arg-keyword raw-args :topic)
+        frame       (wire/arg-keyword raw-args :frame)
+        user-filter (wire/arg raw-args :filter)
+        poll-ms     (or (wire/arg-int raw-args :poll-ms) default-poll-ms)
+        max-ms      (or (wire/arg-int raw-args :max-ms 0) 0)
+        max-events  (or (wire/arg-int raw-args :max-events 0) 0)
+        incl?       (privacy/parse-include-sensitive raw-args)
+        {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
+    (cond
+      (or (nil? topic) (not (contains? recognised-topics topic)))
+      (js/Promise.resolve
+        (wire/err-text {:ok?    false
+                        :reason :unknown-topic
+                        :given  (wire/arg raw-args :topic)
+                        :hint   "Recognised topics: :trace :epoch :fx :error."}))
+
+      :else
+      (run-acquired
+        {:conn conn :build-id build-id :topic topic
+         :user-filter user-filter :frame frame
+         :poll-ms poll-ms :max-ms max-ms :max-events max-events
+         :incl? incl? :signal signal :send-note send-note
+         :progress-tk progress-tk}))))
+
+(def descriptor
+  {:name        "subscribe"
+   :description (str "Open a per-drain-batch streaming subscription on "
+                     "topic :trace / :epoch / :fx / :error. The "
+                     "tools/call stays open until the client aborts, "
+                     ":max-events / :max-ms is reached, or unsubscribe "
+                     "is called. Each non-empty polling tick emits one "
+                     "notifications/progress notification carrying the "
+                     "batch's events. The final tools/call result is a "
+                     "summary with cumulative :delivered + :ticks + "
+                     ":reason (terminated by). Sensitive events drop "
+                     "by default; pass :include-sensitive? true to opt "
+                     "in.")
+   :input-schema #js {:type "object"
+                      :required #js ["topic"]
+                      :properties #js {:topic              #js {:type "string"}
+                                       :filter             #js {:type "object"}
+                                       :frame              #js {:type "string"}
+                                       :poll-ms            #js {:type "integer"}
+                                       :max-events         #js {:type "integer"}
+                                       :max-ms             #js {:type "integer"}
+                                       :include-sensitive? #js {:type "boolean"}
+                                       :include-large?     #js {:type "boolean"}
+                                       :max-tokens         #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) subscribe-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/tail_build.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/tail_build.cljs
@@ -1,0 +1,167 @@
+(ns day8.re-frame2-causa-mcp.tools.tail-build
+  "Tool: `tail-build` — wait for hot-reload to land (rf2-8xzoe.31,
+  T-Meta-2 of the causa-mcp meta tranche).
+
+  Two modes:
+
+  - **Probe mode** (default when `:probe` supplied) — poll the
+    runtime's `tail-build-probe` accessor (a monotonic counter that
+    increments every call and survives `:after-load` but resets on
+    full page refresh). The user's `:probe` form is evaluated; if its
+    value differs from the value captured at start, the hot-reload
+    landed and the tool resolves `:ok? true`. If `:wait-ms` elapses
+    without change, the tool resolves `:ok? false` with
+    `:reason :timed-out` (likely a compile error — the operator can
+    look at the shadow-cljs build log).
+
+  - **Soft-delay mode** (no `:probe`) — resolves after a fixed
+    300ms delay (`no-probe-soft-delay-ms`). Mirrors pair2-mcp's
+    behaviour: the bundle-swap cycle empirically lands within ~300ms
+    of a source-file save; agents that just need 'a bit of breathing
+    room' get the same coarse delay without instrumenting a probe.
+
+  ## Why this lives MCP-server-side, not runtime-side
+
+  The runtime's `tail-build-probe` accessor returns the monotonic
+  counter; the change-detect logic (capture before, poll after,
+  compare) lives here per the runtime ns docstring's split. The
+  runtime's job is to expose a value that's stable across calls but
+  different after a real hot-reload; this tool's job is to wait for
+  the difference.
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — not applicable (build-status metadata).
+  - **W-6 size elision** — not applicable (envelope is tiny scalars).
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:probe` | string | nil | CLJS source whose value-change signals reload |
+  | `:wait-ms` | int | 5000 | timeout for probe-mode |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      ;; probe mode — change detected
+      {:ok? true :t <ms> :soft? false}
+
+      ;; probe mode — timeout
+      {:ok? false :reason :timed-out :timed-out? true
+       :note \"Probe did not change within wait-ms. Likely a compile error.\"}
+
+      ;; soft-delay mode
+      {:ok? true :t <ms> :soft? true :note <delay-explanation>}
+
+      ;; probe eval threw
+      {:ok? false :reason :probe-failed :message <s>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #31. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(def ^:private default-wait-ms
+  "Default deadline for the probe to change after a hot-reload. Five
+  seconds is generous for a typical shadow-cljs incremental rebuild;
+  heavy ns reloads / first-time-load scenarios can override via the
+  `:wait-ms` MCP arg."
+  5000)
+
+(def ^:private probe-poll-ms
+  "Cadence at which we re-evaluate the probe form when waiting for
+  its value to change. 100ms = ~10 probes/sec — fine-grained enough
+  to land within ~100ms of the reload completing, cheap enough on
+  the nREPL socket to not flood it."
+  100)
+
+(def ^:private no-probe-soft-delay-ms
+  "When the caller passes no probe form, we resolve after a fixed
+  soft delay — mirrors pair2-mcp's behaviour. 300ms is the span
+  empirical observation places shadow-cljs's bundle-swap cycle
+  within after the source-file save event fires."
+  300)
+
+(defn tail-build-tool [conn args]
+  (let [build-id (wire/arg-build args)
+        wait-ms  (or (wire/arg-int args :wait-ms default-wait-ms)
+                     default-wait-ms)
+        probe    (wire/arg args :probe)
+        poll-ms  probe-poll-ms]
+    (cond
+      (nil? probe)
+      ;; Soft delay — matches the bash version's behaviour when no probe
+      ;; is supplied. We just resolve after a short sleep.
+      (js/Promise.
+        (fn [resolve _]
+          (js/setTimeout
+            (fn []
+              (resolve (wire/ok-text
+                         {:ok?   true
+                          :t     (js/Date.now)
+                          :soft? true
+                          :note  (str "No probe supplied; waited a "
+                                      no-probe-soft-delay-ms
+                                      "ms fixed delay.")})))
+            no-probe-soft-delay-ms)))
+
+      :else
+      (let [start (js/Date.now)]
+        (-> (nrepl/cljs-eval-value conn build-id probe)
+            (.then
+              (fn [before]
+                (js/Promise.
+                  (fn [resolve _]
+                    (letfn [(poll []
+                              (js/setTimeout
+                                (fn []
+                                  (let [elapsed (- (js/Date.now) start)]
+                                    (if (>= elapsed wait-ms)
+                                      (resolve
+                                        (wire/ok-text
+                                          {:ok?        false
+                                           :reason     :timed-out
+                                           :timed-out? true
+                                           :note       (str "Probe did not change within "
+                                                            wait-ms
+                                                            "ms. Likely a compile error.")}))
+                                      (-> (nrepl/cljs-eval-value conn build-id probe)
+                                          (.then
+                                            (fn [now]
+                                              (if (not= now before)
+                                                (resolve (wire/ok-text
+                                                           {:ok?   true
+                                                            :t     (js/Date.now)
+                                                            :soft? false}))
+                                                (poll))))
+                                          (.catch (fn [_] (poll)))))))
+                                poll-ms))]
+                      (poll))))))
+            (.catch
+              (fn [err]
+                (wire/ok-text {:ok?     false
+                               :reason  :probe-failed
+                               :message (.-message err)}))))))))
+
+(def descriptor
+  {:name        "tail-build"
+   :description (str "Wait for hot-reload to land. Probe mode (when "
+                     ":probe is supplied): poll the form's value, "
+                     "resolve when it changes (signaling the reload "
+                     "completed) or :reason :timed-out after :wait-ms "
+                     "(default 5000). Soft-delay mode (no :probe): "
+                     "resolve after a fixed 300ms delay — gives "
+                     "shadow-cljs's bundle-swap cycle a chance to "
+                     "complete without instrumenting a probe.")
+   :input-schema #js {:type "object"
+                      :properties #js {:probe      #js {:type "string"}
+                                       :wait-ms    #js {:type "integer"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) tail-build-tool descriptor)

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/unsubscribe.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/unsubscribe.cljs
@@ -1,0 +1,94 @@
+(ns day8.re-frame2-causa-mcp.tools.unsubscribe
+  "Tool: `unsubscribe` — bookend tear-down for a streaming subscription
+  (rf2-8xzoe.27, T-Stream-2 of the causa-mcp streaming tranche).
+
+  Drops the subscription from the runtime's `subscriptions` atom. The
+  per-tick polling loop in an open `subscribe` `tools/call` observes
+  the missing sub-id on its next drain and terminates its outer
+  Promise with `:reason :sub-gone` (or, more precisely, with the
+  drain-side `:gone?` signal — see `subscribe.cljs` controller).
+
+  Idempotent — re-calling `unsubscribe` for an already-closed sub-id
+  returns `:ok? true` with `:existed? false`, mirroring the runtime
+  accessor's per-call ack shape.
+
+  ## Wire-boundary contract
+
+  - **B-1 privacy** — not applicable (ack envelope, not trace
+    events).
+  - **W-6 size elision** — counted defensively on the runtime
+    envelope.
+  - **W-1 token cap** — dispatcher-level via `tools.cljs/invoke`.
+
+  ## Args
+
+  | Arg | Type | Default | Notes |
+  |---|---|---|---|
+  | `:sub-id` | string | nil (REQUIRED) | the `sub-id` from a prior `subscribe` |
+  | `:max-tokens` | int | 5000 | per-call cap (`[500, 50000]`) |
+
+  ## Return shape
+
+      {:ok? true :sub-id <uuid> :existed? <bool>}
+
+  ## Source-coord pin
+
+  Cite: `ai/findings/causa-epics-breakdown-2026-05-17.md` §Part 1
+  bead #27. Catalogue entry lives in
+  `tools/causa-mcp/spec/004-Tools-Catalogue.md`."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa-mcp.elision :as elision]
+            [day8.re-frame2-causa-mcp.eval-form :as ef]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.wire :as wire]))
+
+(defn build-form
+  "Build the eval-form addressing the runtime accessor. Pure."
+  [sub-id]
+  (-> (ef/rt-call 'unsubscribe! {:sub-id sub-id})
+      (ef/emit)
+      (ef/wrap-origin)))
+
+(defn shape-envelope
+  "Merge the runtime's ack into the envelope; count defensive
+  elision markers. Pure — tests pin the indicator stamping."
+  [runtime-envelope sub-id]
+  (let [env (if (map? runtime-envelope) runtime-envelope {})
+        merged (merge {:ok? true :sub-id sub-id} env)
+        elided (elision/count-elided-markers merged)]
+    (wire/with-indicators merged {:elided elided})))
+
+(defn unsubscribe-tool [conn args]
+  (let [build-id (wire/arg-build args)
+        sub-id   (wire/arg args :sub-id)]
+    (cond
+      (or (nil? sub-id)
+          (and (string? sub-id) (str/blank? sub-id)))
+      (js/Promise.resolve
+        (wire/err-text {:ok?    false
+                        :reason :missing-sub-id
+                        :hint   "Pass :sub-id <uuid> from a prior subscribe."}))
+
+      :else
+      (-> (probe/ensure-runtime! conn build-id)
+          (.then (fn [_] (nrepl/cljs-eval-value conn build-id (build-form sub-id))))
+          (.then (fn [runtime-env]
+                   (wire/ok-text (shape-envelope runtime-env sub-id))))
+          (.catch (fn [err] (probe/err->result :unsubscribe-failed err)))))))
+
+(def descriptor
+  {:name        "unsubscribe"
+   :description (str "Close a streaming subscription by sub-id. "
+                     "Idempotent: re-calling for an already-closed "
+                     "sub-id returns :existed? false. An open "
+                     "subscribe tools/call observes the missing "
+                     "sub-id on its next polling tick and resolves "
+                     "with :reason :unsubscribed. Required :sub-id.")
+   :input-schema #js {:type "object"
+                      :required #js ["sub-id"]
+                      :properties #js {:sub-id     #js {:type "string"}
+                                       :max-tokens #js {:type "integer"}}}})
+
+(registry/register-tool! (:name descriptor) unsubscribe-tool descriptor)

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/discover_app_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/discover_app_test.cljs
@@ -1,0 +1,124 @@
+(ns day8.re-frame2-causa-mcp.tools.discover-app-test
+  "Unit tests for the T-Meta-1 tool `discover-app` (rf2-8xzoe.30).
+
+  Pins the five-rung warning ladder and the pre-flight probe gating."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.discover-app :as da]
+            [day8.re-frame2-causa-mcp.tools.eval-cljs :as eval-cljs]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+(def ^:private orig-runtime-health! probe/runtime-health!)
+(def ^:private orig-allow-eval? (eval-cljs/allow-eval-enabled?))
+
+(defn- restore-all! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!)
+  (set! probe/runtime-health! orig-runtime-health!)
+  (eval-cljs/set-allow-eval! orig-allow-eval?))
+
+(use-fixtures :each {:after (fn [] (restore-all!))})
+
+(defn- stub-health! [health]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! probe/runtime-health! (fn [_ _] (js/Promise.resolve health))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? da/discover-app-tool))
+  (is (fn? da/shape-envelope))
+  (is (= "discover-app" (:name da/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "discover-app"))))
+
+;; --- shape-envelope — warning ladder ----------------------------------------
+
+(deftest shape-envelope-healthy-app
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? true :frames [:app]
+                  :ambiguous-frame? false :coord-annotation-enabled? true
+                  :session-id "s-1" :origin :causa-mcp}
+                 :app false)]
+    (is (true? (:ok? shaped)))
+    (is (nil? (:warning shaped)))
+    (is (= :app (:build-id shaped)))
+    (is (false? (:eval-cljs-enabled? shaped)))))
+
+(deftest shape-envelope-debug-disabled-fails-loud
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? false :frames []}
+                 :app false)]
+    (is (false? (:ok? shaped)))
+    (is (= :debug-disabled (:reason shaped)))))
+
+(deftest shape-envelope-no-frames-fails-loud
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? true :frames []}
+                 :app false)]
+    (is (false? (:ok? shaped)))
+    (is (= :no-frames-registered (:reason shaped)))))
+
+(deftest shape-envelope-ambiguous-frame-warns
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? true :frames [:app :other]
+                  :ambiguous-frame? true :coord-annotation-enabled? true}
+                 :app false)]
+    (is (true? (:ok? shaped)))
+    (is (= :ambiguous-frame (:warning shaped)))
+    (is (string? (:note shaped)))))
+
+(deftest shape-envelope-no-coord-annotation-warns
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? true :frames [:app]
+                  :ambiguous-frame? false :coord-annotation-enabled? false}
+                 :app false)]
+    (is (true? (:ok? shaped)))
+    (is (= :no-source-coord-annotation (:warning shaped)))))
+
+(deftest shape-envelope-failing-health-passthrough
+  (let [env {:ok? false :reason :something}]
+    (is (= env (da/shape-envelope env :app false)))))
+
+(deftest shape-envelope-stamps-eval-cljs-enabled
+  (let [shaped (da/shape-envelope
+                 {:ok? true :debug-enabled? true :frames [:app]
+                  :ambiguous-frame? false :coord-annotation-enabled? true}
+                 :app true)]
+    (is (true? (:eval-cljs-enabled? shaped)))))
+
+;; --- end-to-end via stubs ---------------------------------------------------
+
+(deftest happy-path-via-stubs
+  (async done
+    (eval-cljs/set-allow-eval! false)
+    (stub-health! {:ok? true :debug-enabled? true :frames [:app]
+                   :ambiguous-frame? false :coord-annotation-enabled? true
+                   :session-id "s-1"})
+    (-> (da/discover-app-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= [:app] (:frames p)))
+                   (is (false? (:eval-cljs-enabled? p))))
+                 (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (da/discover-app-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/dispatch_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/dispatch_test.cljs
@@ -1,0 +1,157 @@
+(ns day8.re-frame2-causa-mcp.tools.dispatch-test
+  "Unit tests for the T-Mut-1 tool `dispatch` (rf2-8xzoe.23).
+
+  Pins:
+    - Public surface — `dispatch-tool`, `build-form`, `shape-envelope`,
+      `parse-event-arg`, `descriptor` resolvable.
+    - Load-time registration via `register-tool!`.
+    - B-3 origin stamp — `build-form` wraps the runtime call in a
+      `(binding [*current-origin* :causa-mcp] ...)` block.
+    - Pre-flight validation — missing / malformed / non-vector
+      `:event` short-circuits without an nREPL hit.
+    - Runtime envelope passthrough — `:ok? true` ack flows through
+      unchanged; structured runtime failure surfaces verbatim."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.dispatch :as dispatch]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? dispatch/dispatch-tool))
+  (is (fn? dispatch/build-form))
+  (is (fn? dispatch/shape-envelope))
+  (is (fn? dispatch/parse-event-arg))
+  (is (= "dispatch" (:name dispatch/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "dispatch")))
+  (is (= "dispatch" (:name (registry/descriptor-for "dispatch")))))
+
+;; --- parse-event-arg --------------------------------------------------------
+
+(deftest parse-event-arg-handles-nil-vector-string-malformed
+  (is (nil? (dispatch/parse-event-arg nil)))
+  (is (= [:foo 1] (dispatch/parse-event-arg [:foo 1])))
+  (is (= [:cart/add 42] (dispatch/parse-event-arg "[:cart/add 42]")))
+  (is (= ::dispatch/malformed (dispatch/parse-event-arg "not-edn-((")))
+  (is (= ::dispatch/malformed (dispatch/parse-event-arg "{:a 1}"))
+      "non-vector EDN parses to ::malformed"))
+
+;; --- build-form -------------------------------------------------------------
+
+(deftest build-form-wraps-origin-and-routes-runtime-ns
+  (let [form (dispatch/build-form [:foo 1] {:frame :app :sync? false})]
+    (is (string? form))
+    (is (.includes form "day8.re-frame2-causa.runtime/dispatch!"))
+    (is (.includes form ":causa-mcp")
+        "B-3 origin binding wraps the call")
+    (is (.includes form ":sync? false"))
+    (is (.includes form ":frame :app"))))
+
+;; --- shape-envelope ---------------------------------------------------------
+
+(deftest shape-envelope-happy-path
+  (let [shaped (dispatch/shape-envelope
+                 {:ok? true :event-id :cart/add :frame :app
+                  :origin :causa-mcp :mode :queued})]
+    (is (true? (:ok? shaped)))
+    (is (= :cart/add (:event-id shaped)))
+    (is (= :causa-mcp (:origin shaped)))
+    (is (= :queued (:mode shaped)))
+    (is (nil? (:elided-large shaped))
+        "zero-elide common path carries no counter")))
+
+(deftest shape-envelope-passes-runtime-failure-through
+  (let [env {:ok? false :reason :no-frame-resolved :hint "..."}]
+    (is (= env (dispatch/shape-envelope env)))))
+
+;; --- handler validation -----------------------------------------------------
+
+(deftest missing-event-short-circuits
+  (async done
+    (-> (dispatch/dispatch-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (= :missing-event (:reason p)))
+                   (is (false? (:ok? p))))
+                 (done))))))
+
+(deftest malformed-event-short-circuits
+  (async done
+    (-> (dispatch/dispatch-tool (atom {}) #js {"event" "((not-edn"})
+        (.then (fn [r]
+                 (is (= :event-malformed (:reason (payload-of r))))
+                 (done))))))
+
+(deftest non-vector-event-short-circuits
+  (async done
+    (-> (dispatch/dispatch-tool (atom {}) #js {"event" "{:a 1}"})
+        (.then (fn [r]
+                 (is (= :event-malformed (:reason (payload-of r)))
+                     "non-vector EDN routes through parse-event-arg's
+                      ::malformed path")
+                 (done))))))
+
+;; --- end-to-end via stubs ---------------------------------------------------
+
+(deftest happy-path-via-stubs
+  (async done
+    (stub-runtime! {:ok? true :event-id :cart/add :frame :app
+                    :origin :causa-mcp :mode :queued})
+    (-> (dispatch/dispatch-tool
+          (atom {})
+          #js {"event" "[:cart/add 42]" "frame" "app"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= :cart/add (:event-id p)))
+                   (is (= :causa-mcp (:origin p))))
+                 (done))))))
+
+(deftest sync-mode-flag-rides-through
+  (async done
+    (stub-runtime! {:ok? true :event-id :foo :frame :app
+                    :origin :causa-mcp :mode :sync})
+    (-> (dispatch/dispatch-tool
+          (atom {})
+          #js {"event" "[:foo]" "sync?" true})
+        (.then (fn [r]
+                 (is (= :sync (:mode (payload-of r))))
+                 (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (dispatch/dispatch-tool (atom {}) #js {"event" "[:foo]"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (= :runtime-not-preloaded (:reason p)))
+                   (is (= "setup-hint" (:hint p))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/eval_cljs_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/eval_cljs_test.cljs
@@ -1,0 +1,154 @@
+(ns day8.re-frame2-causa-mcp.tools.eval-cljs-test
+  "Unit tests for the T-Eval-1 tool `eval-cljs` (rf2-8xzoe.29).
+
+  Pins:
+    - `--allow-eval` gate — default OFF returns refusal envelope
+      without nREPL hit; ON routes through the runtime.
+    - Form composition wraps origin binding around the user form so
+      synchronous-extent mutations tag `:causa-mcp`.
+    - `:missing-form` pre-flight validation.
+    - Runtime envelope passthrough + elision counter stamping."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.eval-cljs :as ec]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+(def ^:private orig-allow-eval? (ec/allow-eval-enabled?))
+
+(defn- restore-all! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!)
+  (ec/set-allow-eval! orig-allow-eval?))
+
+(use-fixtures :each {:after (fn [] (restore-all!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? ec/eval-cljs-tool))
+  (is (fn? ec/build-form))
+  (is (fn? ec/shape-envelope))
+  (is (fn? ec/set-allow-eval!))
+  (is (fn? ec/allow-eval-enabled?))
+  (is (= "eval-cljs" (:name ec/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "eval-cljs"))))
+
+;; --- Launch-flag gate -------------------------------------------------------
+
+(deftest gate-default-off
+  (ec/set-allow-eval! false)
+  (is (false? (ec/allow-eval-enabled?))))
+
+(deftest gate-toggle
+  (ec/set-allow-eval! true)
+  (is (true? (ec/allow-eval-enabled?)))
+  (ec/set-allow-eval! false)
+  (is (false? (ec/allow-eval-enabled?))))
+
+(deftest gate-coerces-truthy-values
+  (ec/set-allow-eval! "anything")
+  (is (true? (ec/allow-eval-enabled?))
+      "non-nil truthy values coerce to true via (boolean ...)")
+  (ec/set-allow-eval! nil)
+  (is (false? (ec/allow-eval-enabled?))))
+
+;; --- Disabled refusal -------------------------------------------------------
+
+(deftest gate-off-returns-refusal-without-nrepl-hit
+  (async done
+    (ec/set-allow-eval! false)
+    ;; Stub eval to throw if called — must not be hit.
+    (set! nrepl/cljs-eval-value
+          (fn [& _]
+            (throw (js/Error. "nREPL was called despite --allow-eval OFF"))))
+    (-> (ec/eval-cljs-tool (atom {}) #js {"form" "(+ 1 2)"})
+        (.then (fn [r]
+                 (is (true? (j/get r :isError)))
+                 (let [p (payload-of r)]
+                   (is (= :rf.error/eval-cljs-disabled (:reason p)))
+                   (is (string? (:hint p))))
+                 (done))))))
+
+;; --- Pre-flight validation --------------------------------------------------
+
+(deftest missing-form-short-circuits
+  (async done
+    (ec/set-allow-eval! true)
+    (-> (ec/eval-cljs-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (= :missing-form (:reason (payload-of r))))
+                 (done))))))
+
+(deftest blank-form-short-circuits
+  (async done
+    (ec/set-allow-eval! true)
+    (-> (ec/eval-cljs-tool (atom {}) #js {"form" ""})
+        (.then (fn [r]
+                 (is (= :missing-form (:reason (payload-of r))))
+                 (done))))))
+
+;; --- Form composition -------------------------------------------------------
+
+(deftest build-form-wraps-origin-and-routes-runtime-result-shaper
+  (let [form (ec/build-form "(+ 1 2)" {:include-sensitive? false
+                                       :include-large? false})]
+    (is (string? form))
+    (is (.includes form "day8.re-frame2-causa.runtime/eval-form-result"))
+    (is (.includes form ":causa-mcp")
+        "synchronous-extent origin tag wraps the user form")
+    (is (.includes form "(+ 1 2)")
+        "user form is inlined verbatim")))
+
+;; --- Enabled happy path -----------------------------------------------------
+
+(deftest happy-path-via-stubs
+  (async done
+    (ec/set-allow-eval! true)
+    (stub-runtime! {:ok? true :value 42})
+    (-> (ec/eval-cljs-tool (atom {}) #js {"form" "(* 6 7)"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= 42 (:value p))))
+                 (done))))))
+
+;; --- Shape envelope ---------------------------------------------------------
+
+(deftest shape-envelope-counts-elided
+  (let [shaped (ec/shape-envelope
+                 {:ok? true
+                  :value {:big {:rf.size/large-elided {:bytes 1000}}}})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest shape-envelope-failure-passthrough
+  (let [env {:ok? false :reason :something :hint "..."}]
+    (is (= env (ec/shape-envelope env)))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (ec/set-allow-eval! true)
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (ec/eval-cljs-tool (atom {}) #js {"form" "(+ 1 1)"})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/list_subscriptions_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/list_subscriptions_test.cljs
@@ -1,0 +1,107 @@
+(ns day8.re-frame2-causa-mcp.tools.list-subscriptions-test
+  "Unit tests for the T-Stream-3 tool `list-subscriptions` (rf2-8xzoe.28)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.list-subscriptions :as ls]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? ls/list-subscriptions-tool))
+  (is (fn? ls/build-form))
+  (is (fn? ls/shape-envelope))
+  (is (= "list-subscriptions" (:name ls/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "list-subscriptions"))))
+
+(deftest build-form-routes-runtime-ns-with-origin
+  (let [form (ls/build-form {:topic :trace})]
+    (is (.includes form "day8.re-frame2-causa.runtime/list-subscriptions"))
+    (is (.includes form ":topic :trace"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest shape-envelope-happy-path
+  (let [shaped (ls/shape-envelope
+                 {:ok? true
+                  :subs [{:id "s-1" :topic :trace :filter {} :origin :causa-mcp :created-at 0}
+                         {:id "s-2" :topic :epoch :filter {} :origin :causa-mcp :created-at 100}]
+                  :count 2})]
+    (is (true? (:ok? shaped)))
+    (is (= 2 (:count shaped)))
+    (is (= 2 (count (:subs shaped))))))
+
+(deftest shape-envelope-empty-subs
+  (let [shaped (ls/shape-envelope {:ok? true :subs [] :count 0})]
+    (is (= 0 (:count shaped)))
+    (is (= [] (:subs shaped)))))
+
+(deftest shape-envelope-failure-passthrough
+  (let [env {:ok? false :reason :no-such-thing :hint "..."}]
+    (is (= env (ls/shape-envelope env)))))
+
+(deftest shape-envelope-defensive-elision-counter
+  (let [shaped (ls/shape-envelope
+                 {:ok? true
+                  :subs [{:id "s-1" :topic :trace
+                          :filter {:big {:rf.size/large-elided {:bytes 1000}}}}]
+                  :count 1})]
+    (is (= 1 (:elided-large shaped)))))
+
+(deftest happy-path-via-stubs
+  (async done
+    (stub-runtime! {:ok? true
+                    :subs [{:id "s-1" :topic :trace :filter {} :origin :causa-mcp :created-at 0}]
+                    :count 1})
+    (-> (ls/list-subscriptions-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= 1 (:count p))))
+                 (done))))))
+
+(deftest filter-args-route-through
+  (async done
+    (stub-runtime! {:ok? true :subs [] :count 0})
+    (set! nrepl/cljs-eval-value
+          (fn [_ _ form]
+            (is (.includes form ":topic :trace"))
+            (is (.includes form ":sub-id \"s-1\""))
+            (js/Promise.resolve {:ok? true :subs [] :count 0})))
+    (-> (ls/list-subscriptions-tool (atom {})
+                                    #js {"topic" "trace" "sub-id" "s-1"})
+        (.then (fn [_] (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (ls/list-subscriptions-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/reset_frame_db_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/reset_frame_db_test.cljs
@@ -1,0 +1,122 @@
+(ns day8.re-frame2-causa-mcp.tools.reset-frame-db-test
+  "Unit tests for the T-Mut-3 tool `reset-frame-db` (rf2-8xzoe.25).
+
+  Pins:
+    - Public surface + registration.
+    - `parse-value-arg` distinguishes `::absent` from `::malformed`
+      from `nil-parsed-value`.
+    - Origin tag wrap on the eval form.
+    - Three-row failure surface passthrough."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.reset-frame-db :as rfdb]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? rfdb/reset-frame-db-tool))
+  (is (fn? rfdb/build-form))
+  (is (fn? rfdb/shape-envelope))
+  (is (fn? rfdb/parse-value-arg))
+  (is (= "reset-frame-db" (:name rfdb/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "reset-frame-db"))))
+
+;; --- parse-value-arg --------------------------------------------------------
+
+(deftest parse-value-arg-distinguishes-absent-malformed-nil
+  (is (= ::rfdb/absent (rfdb/parse-value-arg nil)))
+  (is (= ::rfdb/malformed (rfdb/parse-value-arg "(((not-edn")))
+  (is (= {:a 1} (rfdb/parse-value-arg "{:a 1}")))
+  (is (nil? (rfdb/parse-value-arg "nil"))
+      "EDN nil parses to nil — distinct from ::absent (no input at all)")
+  (is (= {:cart {}} (rfdb/parse-value-arg {:cart {}}))
+      "CLJS-map passthrough"))
+
+;; --- build-form -------------------------------------------------------------
+
+(deftest build-form-wraps-origin-and-routes-runtime-ns
+  (let [form (rfdb/build-form {:frame :app :value {:cart {}}})]
+    (is (.includes form "day8.re-frame2-causa.runtime/reset-frame-db!"))
+    (is (.includes form ":causa-mcp"))
+    (is (.includes form ":value {:cart {}}"))))
+
+;; --- handler validation -----------------------------------------------------
+
+(deftest missing-value-short-circuits
+  (async done
+    (-> (rfdb/reset-frame-db-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (= :missing-value (:reason (payload-of r))))
+                 (done))))))
+
+(deftest malformed-value-short-circuits
+  (async done
+    (-> (rfdb/reset-frame-db-tool (atom {}) #js {"value" "((not-edn"})
+        (.then (fn [r]
+                 (is (= :value-malformed (:reason (payload-of r))))
+                 (done))))))
+
+;; --- shape-envelope ---------------------------------------------------------
+
+(deftest shape-envelope-success-passthrough
+  (let [shaped (rfdb/shape-envelope {:ok? true :frame :app :origin :causa-mcp})]
+    (is (true? (:ok? shaped)))
+    (is (= :causa-mcp (:origin shaped)))))
+
+(deftest shape-envelope-failure-passthrough
+  (testing "three-row failure: schema mismatch / unknown frame / reset
+            during drain all surface as :rf.epoch/reset-failed"
+    (let [env    {:ok? false :frame :app :origin :causa-mcp
+                  :reason :rf.epoch/reset-failed
+                  :hint   "Reset failed — read the trace bus..."}
+          shaped (rfdb/shape-envelope env)]
+      (is (false? (:ok? shaped)))
+      (is (= :rf.epoch/reset-failed (:reason shaped))))))
+
+;; --- end-to-end via stubs ---------------------------------------------------
+
+(deftest happy-path-via-stubs
+  (async done
+    (stub-runtime! {:ok? true :frame :app :origin :causa-mcp})
+    (-> (rfdb/reset-frame-db-tool (atom {}) #js {"value" "{:cart {}}"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= :causa-mcp (:origin p))))
+                 (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (rfdb/reset-frame-db-tool (atom {}) #js {"value" "{}"})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/restore_epoch_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/restore_epoch_test.cljs
@@ -1,0 +1,110 @@
+(ns day8.re-frame2-causa-mcp.tools.restore-epoch-test
+  "Unit tests for the T-Mut-2 tool `restore-epoch` (rf2-8xzoe.24).
+
+  Pins:
+    - Public surface + registration.
+    - `:missing-epoch-id` pre-flight short-circuit.
+    - Tool-Pair six-row failure surface — runtime `:ok? false` with
+      `:rf.epoch/restore-failed` rides through verbatim; per-row
+      `:rf.epoch/*` keyword lives on the trace bus, not the envelope.
+    - Origin tag wrap on the eval form."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.restore-epoch :as re]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? re/restore-epoch-tool))
+  (is (fn? re/build-form))
+  (is (fn? re/shape-envelope))
+  (is (= "restore-epoch" (:name re/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "restore-epoch")))
+  (is (= "restore-epoch" (:name (registry/descriptor-for "restore-epoch")))))
+
+(deftest build-form-wraps-origin-and-routes-runtime-ns
+  (let [form (re/build-form {:frame :app :epoch-id "ep-1"})]
+    (is (.includes form "day8.re-frame2-causa.runtime/restore-epoch!"))
+    (is (.includes form ":causa-mcp"))
+    (is (.includes form ":epoch-id \"ep-1\""))))
+
+(deftest missing-epoch-id-short-circuits
+  (async done
+    (-> (re/restore-epoch-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (= :missing-epoch-id (:reason (payload-of r))))
+                 (done))))))
+
+(deftest blank-epoch-id-short-circuits
+  (async done
+    (-> (re/restore-epoch-tool (atom {}) #js {"epoch-id" ""})
+        (.then (fn [r]
+                 (is (= :missing-epoch-id (:reason (payload-of r))))
+                 (done))))))
+
+(deftest shape-envelope-success-passthrough
+  (let [shaped (re/shape-envelope {:ok? true :frame :app :epoch-id "ep-1"
+                                   :origin :causa-mcp})]
+    (is (true? (:ok? shaped)))
+    (is (= "ep-1" (:epoch-id shaped)))
+    (is (= :causa-mcp (:origin shaped)))))
+
+(deftest shape-envelope-failure-passthrough
+  (testing "Tool-Pair six-row failure: runtime returns :ok? false with
+            :rf.epoch/restore-failed; per-row keyword lives on the
+            trace bus, not the envelope"
+    (let [env    {:ok? false :frame :app :epoch-id "ep-stale"
+                  :origin :causa-mcp
+                  :reason :rf.epoch/restore-failed
+                  :hint   "Restore failed — read the trace bus..."}
+          shaped (re/shape-envelope env)]
+      (is (false? (:ok? shaped)))
+      (is (= :rf.epoch/restore-failed (:reason shaped)))
+      (is (string? (:hint shaped))))))
+
+(deftest happy-path-via-stubs
+  (async done
+    (stub-runtime! {:ok? true :frame :app :epoch-id "ep-42"
+                    :origin :causa-mcp})
+    (-> (re/restore-epoch-tool (atom {}) #js {"epoch-id" "ep-42"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= "ep-42" (:epoch-id p))))
+                 (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (re/restore-epoch-tool (atom {}) #js {"epoch-id" "ep-1"})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/subscribe_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/subscribe_test.cljs
@@ -1,0 +1,158 @@
+(ns day8.re-frame2-causa-mcp.tools.subscribe-test
+  "Unit tests for the T-Stream-1 tool `subscribe` (rf2-8xzoe.26).
+
+  Pure-state tests pin the pieces that don't need the streaming loop:
+
+    - `topic->filter` — projection table per topic.
+    - `project-error-topic` — issue-tier post-filter.
+    - `merge-tick` — per-tick state-fold contract.
+    - `final-summary` — terminal envelope shape + cumulative indicators.
+    - `progress-payload` — per-tick `notifications/progress` shape.
+    - eval-form composition (drain/subscribe/unsubscribe).
+    - pre-flight validation — unknown topic short-circuits."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.subscribe :as sub]))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? sub/subscribe-tool))
+  (is (fn? sub/drain-form))
+  (is (fn? sub/subscribe-form))
+  (is (fn? sub/unsubscribe-form))
+  (is (fn? sub/topic->filter))
+  (is (fn? sub/project-error-topic))
+  (is (fn? sub/merge-tick))
+  (is (fn? sub/final-summary))
+  (is (fn? sub/progress-payload))
+  (is (= "subscribe" (:name sub/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "subscribe"))))
+
+;; --- topic->filter ----------------------------------------------------------
+
+(deftest topic-projection-trace-is-passthrough
+  (is (= {} (sub/topic->filter :trace nil nil 0)))
+  (is (= {:op-type :event/dispatched}
+         (sub/topic->filter :trace {:op-type :event/dispatched} nil 0))))
+
+(deftest topic-projection-epoch-stamps-op-type
+  (is (= {:op-type :epoch/closed}
+         (sub/topic->filter :epoch nil nil 0))))
+
+(deftest topic-projection-fx-stamps-op-type
+  (is (= {:op-type :fx/run}
+         (sub/topic->filter :fx nil nil 0))))
+
+(deftest topic-projection-frame-and-since-ms-stamp
+  (is (= {:frame :app :since-ms 12345}
+         (sub/topic->filter :trace nil :app 12345))))
+
+;; --- project-error-topic ----------------------------------------------------
+
+(deftest project-error-topic-filters-to-issue-tier
+  (let [events [{:op-type :event/dispatched}
+                {:op-type :error}
+                {:op-type :rf.schema/violation}
+                {:op-type :sub/updated}]]
+    (is (= 2 (count (sub/project-error-topic :error events))))
+    (is (= events (sub/project-error-topic :trace events))
+        "non-error topics pass through unchanged")))
+
+;; --- merge-tick -------------------------------------------------------------
+
+(deftest merge-tick-zero-events-no-op
+  (is (= sub/initial-state
+         (sub/merge-tick sub/initial-state {:n 0 :dropped 0 :elided 0}))))
+
+(deftest merge-tick-bumps-counters
+  (let [s' (sub/merge-tick sub/initial-state {:n 3 :dropped 1 :elided 2})]
+    (is (= 1 (:tick s')))
+    (is (= 3 (:delivered s')))
+    (is (= 1 (:dropped-sensitive s')))
+    (is (= 2 (:elided-large s')))))
+
+(deftest merge-tick-accumulates-across-ticks
+  (let [s1 (sub/merge-tick sub/initial-state {:n 2 :dropped 1 :elided 0})
+        s2 (sub/merge-tick s1 {:n 3 :dropped 0 :elided 4})]
+    (is (= 2 (:tick s2)))
+    (is (= 5 (:delivered s2)))
+    (is (= 1 (:dropped-sensitive s2)))
+    (is (= 4 (:elided-large s2)))))
+
+;; --- final-summary ----------------------------------------------------------
+
+(deftest final-summary-includes-indicators-when-non-zero
+  (let [^js result (sub/final-summary
+                     {:sub-id "s-1" :topic :trace
+                      :state  {:tick 5 :delivered 17 :dropped-sensitive 2
+                               :elided-large 3 :since-ms 0}
+                      :reason :max-events-reached})
+        payload    (payload-of result)]
+    (is (true? (:ok? payload)))
+    (is (= "s-1" (:sub-id payload)))
+    (is (= :trace (:topic payload)))
+    (is (= 17 (:delivered payload)))
+    (is (= 5 (:ticks payload)))
+    (is (= :max-events-reached (:reason payload)))
+    (is (= 2 (:dropped-sensitive payload)))
+    (is (= 3 (:elided-large payload)))))
+
+(deftest final-summary-omits-zero-indicators
+  (let [^js result (sub/final-summary
+                     {:sub-id "s-2" :topic :epoch
+                      :state  {:tick 0 :delivered 0 :dropped-sensitive 0
+                               :elided-large 0 :since-ms 0}
+                      :reason :aborted})
+        payload    (payload-of result)]
+    (is (nil? (:dropped-sensitive payload)))
+    (is (nil? (:elided-large payload)))))
+
+;; --- progress-payload -------------------------------------------------------
+
+(deftest progress-payload-shape
+  (let [p (sub/progress-payload "tk-1" 5 "edn-string")]
+    (is (= "tk-1" (j/get p :progressToken)))
+    (is (= 5     (j/get p :progress)))
+    (is (= "edn-string" (j/get p :message)))))
+
+;; --- eval-form composition --------------------------------------------------
+
+(deftest drain-form-routes-runtime-ns-with-origin
+  (let [form (sub/drain-form {:frame :app :since-ms 100})]
+    (is (.includes form "day8.re-frame2-causa.runtime/get-trace-buffer"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest subscribe-form-routes-runtime-ns-with-origin
+  (let [form (sub/subscribe-form :trace nil)]
+    (is (.includes form "day8.re-frame2-causa.runtime/subscribe!"))
+    (is (.includes form ":topic :trace"))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest unsubscribe-form-routes-runtime-ns
+  (let [form (sub/unsubscribe-form "sub-1")]
+    (is (.includes form "day8.re-frame2-causa.runtime/unsubscribe!"))
+    (is (.includes form "\"sub-1\""))))
+
+;; --- handler pre-flight -----------------------------------------------------
+
+(deftest unknown-topic-short-circuits
+  (async done
+    (-> (sub/subscribe-tool (atom {}) #js {"topic" "bogus"} nil)
+        (.then (fn [r]
+                 (is (= :unknown-topic (:reason (payload-of r))))
+                 (is (true? (j/get r :isError))
+                     "unknown-topic returns isError envelope")
+                 (done))))))
+
+(deftest missing-topic-short-circuits
+  (async done
+    (-> (sub/subscribe-tool (atom {}) #js {} nil)
+        (.then (fn [r]
+                 (is (= :unknown-topic (:reason (payload-of r))))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/tail_build_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/tail_build_test.cljs
@@ -1,0 +1,100 @@
+(ns day8.re-frame2-causa-mcp.tools.tail-build-test
+  "Unit tests for the T-Meta-2 tool `tail-build` (rf2-8xzoe.31).
+
+  Pins:
+    - Public surface + registration.
+    - Soft-delay mode (no `:probe`) returns `:soft? true`.
+    - Probe mode resolves `:ok? true` when probe value changes."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.tail-build :as tb]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? tb/tail-build-tool))
+  (is (= "tail-build" (:name tb/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "tail-build"))))
+
+;; --- Soft-delay mode (no probe) ---------------------------------------------
+
+(deftest soft-delay-mode-resolves-with-soft-flag
+  (async done
+    (-> (tb/tail-build-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (true? (:soft? p)))
+                   (is (number? (:t p)))
+                   (is (string? (:note p))))
+                 (done))))))
+
+;; --- Probe mode -------------------------------------------------------------
+
+(deftest probe-mode-detects-value-change
+  (async done
+    (let [call-counter (atom 0)]
+      ;; First call returns 1 (the "before" value); subsequent calls
+      ;; return 2 (signaling the probe changed → reload landed).
+      (set! nrepl/cljs-eval-value
+            (fn
+              ([_ _ _]   (js/Promise.resolve
+                           (if (zero? @call-counter)
+                             (do (swap! call-counter inc) 1)
+                             2)))
+              ([_ _ _ _] (js/Promise.resolve
+                           (if (zero? @call-counter)
+                             (do (swap! call-counter inc) 1)
+                             2)))))
+      (-> (tb/tail-build-tool (atom {}) #js {"probe" "(rand-int 100)"
+                                              "wait-ms" 2000})
+          (.then (fn [r]
+                   (let [p (payload-of r)]
+                     (is (true? (:ok? p)))
+                     (is (false? (:soft? p))))
+                   (done)))))))
+
+(deftest probe-mode-times-out-when-value-unchanged
+  (async done
+    ;; Probe always returns the same value — wait-ms elapses with no
+    ;; change → :timed-out.
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_ _ _]   (js/Promise.resolve 42))
+            ([_ _ _ _] (js/Promise.resolve 42))))
+    (-> (tb/tail-build-tool (atom {}) #js {"probe" "42" "wait-ms" 200})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (false? (:ok? p)))
+                   (is (= :timed-out (:reason p)))
+                   (is (true? (:timed-out? p))))
+                 (done))))))
+
+(deftest probe-mode-surfaces-eval-error
+  (async done
+    ;; First eval (the "before" capture) rejects → :probe-failed.
+    (set! nrepl/cljs-eval-value
+          (fn
+            ([_ _ _]   (js/Promise.reject (js/Error. "compile error: probe broken")))
+            ([_ _ _ _] (js/Promise.reject (js/Error. "compile error: probe broken")))))
+    (-> (tb/tail-build-tool (atom {}) #js {"probe" "(broken-form"
+                                            "wait-ms" 200})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (false? (:ok? p)))
+                   (is (= :probe-failed (:reason p)))
+                   (is (.includes (:message p) "compile error")))
+                 (done))))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/unsubscribe_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/tools/unsubscribe_test.cljs
@@ -1,0 +1,94 @@
+(ns day8.re-frame2-causa-mcp.tools.unsubscribe-test
+  "Unit tests for the T-Stream-2 tool `unsubscribe` (rf2-8xzoe.27)."
+  (:require [applied-science.js-interop :as j]
+            [cljs.reader :as edn]
+            [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa-mcp.nrepl :as nrepl]
+            [day8.re-frame2-causa-mcp.probe :as probe]
+            [day8.re-frame2-causa-mcp.registry :as registry]
+            [day8.re-frame2-causa-mcp.tools.unsubscribe :as u]))
+
+(def ^:private orig-cljs-eval-value nrepl/cljs-eval-value)
+(def ^:private orig-ensure-runtime! probe/ensure-runtime!)
+
+(defn- restore-stubs! []
+  (set! nrepl/cljs-eval-value orig-cljs-eval-value)
+  (set! probe/ensure-runtime! orig-ensure-runtime!))
+
+(use-fixtures :each {:after (fn [] (restore-stubs!))})
+
+(defn- stub-runtime! [runtime-env]
+  (set! probe/ensure-runtime! (fn [_ _] (js/Promise.resolve nil)))
+  (set! nrepl/cljs-eval-value
+        (fn
+          ([_ _ _]   (js/Promise.resolve runtime-env))
+          ([_ _ _ _] (js/Promise.resolve runtime-env)))))
+
+(defn- payload-of [^js result]
+  (-> result (j/get :content) (aget 0) (j/get :text) edn/read-string))
+
+(deftest public-surface-resolvable
+  (is (fn? u/unsubscribe-tool))
+  (is (fn? u/build-form))
+  (is (fn? u/shape-envelope))
+  (is (= "unsubscribe" (:name u/descriptor))))
+
+(deftest registered-in-the-catalogue
+  (is (some? (registry/handler-for "unsubscribe"))))
+
+(deftest build-form-routes-runtime-ns-with-origin
+  (let [form (u/build-form "sub-42")]
+    (is (.includes form "day8.re-frame2-causa.runtime/unsubscribe!"))
+    (is (.includes form ":sub-id \"sub-42\""))
+    (is (.includes form ":causa-mcp"))))
+
+(deftest missing-sub-id-short-circuits
+  (async done
+    (-> (u/unsubscribe-tool (atom {}) #js {})
+        (.then (fn [r]
+                 (is (true? (j/get r :isError)))
+                 (is (= :missing-sub-id (:reason (payload-of r))))
+                 (done))))))
+
+(deftest blank-sub-id-short-circuits
+  (async done
+    (-> (u/unsubscribe-tool (atom {}) #js {"sub-id" ""})
+        (.then (fn [r]
+                 (is (= :missing-sub-id (:reason (payload-of r))))
+                 (done))))))
+
+(deftest shape-envelope-merges-runtime-ack
+  (let [shaped (u/shape-envelope {:ok? true :existed? true} "sub-1")]
+    (is (true? (:ok? shaped)))
+    (is (= "sub-1" (:sub-id shaped)))
+    (is (true? (:existed? shaped)))))
+
+(deftest shape-envelope-idempotent-closed-sub
+  (testing "re-call for already-closed sub-id returns :existed? false"
+    (let [shaped (u/shape-envelope {:ok? true :existed? false} "sub-stale")]
+      (is (true? (:ok? shaped)))
+      (is (false? (:existed? shaped))))))
+
+(deftest happy-path-via-stubs
+  (async done
+    (stub-runtime! {:ok? true :sub-id "sub-1" :existed? true})
+    (-> (u/unsubscribe-tool (atom {}) #js {"sub-id" "sub-1"})
+        (.then (fn [r]
+                 (let [p (payload-of r)]
+                   (is (true? (:ok? p)))
+                   (is (= "sub-1" (:sub-id p)))
+                   (is (true? (:existed? p))))
+                 (done))))))
+
+(deftest probe-rejection-surfaces-runtime-not-preloaded
+  (async done
+    (set! probe/ensure-runtime!
+          (fn [_ _]
+            (js/Promise.reject
+              (ex-info "causa runtime not preloaded"
+                       {:reason :runtime-not-preloaded
+                        :hint   "setup-hint"}))))
+    (-> (u/unsubscribe-tool (atom {}) #js {"sub-id" "sub-1"})
+        (.then (fn [r]
+                 (is (= :runtime-not-preloaded (:reason (payload-of r))))
+                 (done))))))

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/indicator_field_test.clj
@@ -374,10 +374,25 @@
   - `elision.cljs` — auxiliary `stamp-elided-large` helper (parallel to
                      `privacy/stamp-dropped-sensitive`). Same posture —
                      a sibling stamper composed by the elision boundary
-                     when running independently of `wire/with-indicators`."
+                     when running independently of `wire/with-indicators`.
+  - `tools/subscribe.cljs` — per-stream rolling-accumulator atom holds
+                             the indicator counts as INTERNAL state
+                             slots (`{:dropped-sensitive 0 :elided-large 0}`
+                             in `initial-state`; bumped in `merge-tick`).
+                             Egress emits route through
+                             `wire/with-indicators` in `final-summary`
+                             (terminal summary) and `emit-progress-tick!`
+                             (per-tick `notifications/progress`). The
+                             internal slot names align with the egress
+                             slot names by convention (no rename layer)
+                             but the actual emit path goes through the
+                             helper. Mirrors pair2-mcp's
+                             `subscribe.cljs` whitelist entry (same
+                             rationale)."
   #{"tools/causa-mcp/src/day8/re_frame2_causa_mcp/wire.cljs"
     "tools/causa-mcp/src/day8/re_frame2_causa_mcp/privacy.cljs"
-    "tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs"})
+    "tools/causa-mcp/src/day8/re_frame2_causa_mcp/elision.cljs"
+    "tools/causa-mcp/src/day8/re_frame2_causa_mcp/tools/subscribe.cljs"})
 
 (defn- mcp-source-files
   "Walk `src-rel` (a repo-relative subdir) and return every `.cljs`


### PR DESCRIPTION
## Summary

Completes the causa-mcp tool catalogue (18 tools total — the T-Insp tranche shipped in #1304 with 9; this finishes the rest). 9 tools across 4 bands:

- **T-Mut** (3 tools, Class-1 named mutations, B-3 `:origin :causa-mcp` stamp via `*current-origin*` binding) — `dispatch`, `restore-epoch`, `reset-frame-db`. Server-launch consent; no per-call gate.
- **T-Stream** (3 tools, per-drain-batch port-pinning over the trace bus) — `subscribe` (one `progressToken` ↔ one stream of `notifications/progress` ticks ↔ one terminal summary on close), `unsubscribe` (bookend tear-down), `list-subscriptions` (Lock #12 18th-tool diagnostic).
- **T-Eval** (1 tool, `--allow-eval`-gated escape hatch) — `eval-cljs`. Default OFF; refuses with `:rf.error/eval-cljs-disabled` until `--allow-eval` set at server launch. Synchronous-extent origin tag (Lock #4 / I6).
- **T-Meta** (2 tools, introspection + build-tail) — `discover-app` (health summary + 5-rung warning ladder), `tail-build` (probe + soft-delay modes).

Every tool composes the existing B-1 (privacy) + W-1 (token cap) + W-2..W-5 (path/cursor/summary/dedup) + W-6 (size elision) boundary wrappers + F-4 runtime accessors. No new framework surface, no back-compat shims (pre-alpha posture).

Catalogue entries appended to `tools/causa-mcp/spec/004-Tools-Catalogue.md` under new **Mutation band**, **Streaming band**, and **Meta band** headings. `--allow-eval` flag plumbing wired into `server.cljs/main` (parses argv, sets `tools.eval-cljs/set-allow-eval!`, logs the boot-gate state).

## Test plan

- [x] `npm test` in `tools/causa-mcp/` — 482 tests / 1235 assertions (was 384 / 980 before this cluster); 98 new tests / 255 new assertions across 9 new test files.
- [x] `npm run test:cljs` in `implementation/` — 2300 tests / 6535 assertions (no regressions).
- [x] `clojure -M:test` in `tools/mcp-conformance/wire-vocab/` — 39 tests / 674 assertions. The `no-inline-indicator-slot-emit-outside-the-helper-causa-mcp` tripwire correctly flagged `subscribe.cljs`'s internal-state slot names; added to `causa-mcp-inline-emit-whitelist` with parallel justification to pair2-mcp's `subscribe.cljs` entry (rolling accumulator atom holds indicator names as INTERNAL state; egress emits route through `wire/with-indicators`).