### PR TITLE
perf+fix(causa): trace-feed projection + orphan-filter (rf2-44vzy + rf2-vu0mp cluster)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -63,7 +63,8 @@
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
-             :refer [tokens mono-stack sans-stack]]))
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- axis labelling -----------------------------------------------------
 
@@ -94,17 +95,24 @@
 
 (defn- chip
   "One filter chip. `active?` drives the highlighted styling.
-  `on-click` fires the relevant axis toggle."
-  [{:keys [label active? on-click test-id colour]}]
+  `on-click` fires the relevant axis toggle. `orphan?` (rf2-vu0mp)
+  marks chips whose value is no longer represented in the current
+  buffer — the chip still renders so the user always sees what's
+  narrowing the ribbon, but is styled dashed-border + italic to
+  signal 'no buffered matches'."
+  [{:keys [label active? on-click test-id colour orphan? title]}]
   [:button {:data-testid test-id
             :on-click    on-click
+            :title       title
             :style       {:background    (if active?
                                            (:bg-active tokens)
                                            "transparent")
                           :color         (if active?
                                            (:text-primary tokens)
                                            (or colour (:text-secondary tokens)))
-                          :border        (str "1px solid "
+                          :border        (str "1px "
+                                              (if orphan? "dashed" "solid")
+                                              " "
                                               (if active?
                                                 (or colour (:border-default tokens))
                                                 (:border-subtle tokens)))
@@ -114,6 +122,7 @@
                           :font-family   sans-stack
                           :font-size     "11px"
                           :font-weight   (if active? 600 400)
+                          :font-style    (if orphan? "italic" "normal")
                           :letter-spacing "0.2px"
                           :margin-right  "6px"
                           :margin-bottom "4px"}}
@@ -122,10 +131,21 @@
 (defn- axis-chip-row
   "Render a chip-row for one filter axis. Each chip toggles the axis
   to its value; the currently-active value (if any) renders highlit.
-  Only renders when there are at least two distinct values — a
-  single-value axis has nothing to filter on."
+  Renders when at least two distinct values are present OR when an
+  active filter selection is present (so the user can always see /
+  toggle off their narrowing — even when the selected value has
+  aged out of the buffer per rf2-vu0mp).
+
+  Per rf2-vu0mp the helper's `effective-distinct` ALREADY unions the
+  active value into the per-axis distinct vector, so an orphaned
+  active value renders as one of the chips. We mark it visually with
+  the orphan-styling discipline on the chip (dashed border + italic +
+  count `0`) so the user can tell `:source = :timer` is selected but
+  the buffer no longer carries any `:timer`-sourced events."
   [{:keys [axis active-value distinct counts axis-colour]}]
-  (when (and (sequential? distinct) (>= (count distinct) 2))
+  (when (and (sequential? distinct)
+             (or (>= (count distinct) 2)
+                 (some? active-value)))
     (into [:div {:data-testid (str "rf-causa-trace-axis-row-" (name axis))
                  :style       {:display    "flex"
                                :flex-wrap  "wrap"
@@ -142,6 +162,7 @@
           (for [value distinct
                 :let [active? (= active-value value)
                       n       (get counts value 0)
+                      orphan? (and active? (zero? n))
                       colour  (cond
                                 (and (= axis :op-type) (some? value))
                                 (h/op-type-colour value)
@@ -151,6 +172,12 @@
             (chip {:label    (str (format-axis-value value) " · " n)
                    :active?  active?
                    :colour   colour
+                   :orphan?  orphan?
+                   :title    (when orphan?
+                               (str "no buffered events match — "
+                                    (name axis) " = "
+                                    (format-axis-value value)
+                                    " (aged out of the ring buffer)"))
                    :test-id  (str "rf-causa-trace-axis-chip-"
                                   (name axis) "-"
                                   (if (keyword? value)
@@ -347,10 +374,61 @@
     "No events observed in this session. "
     "Once the host app dispatches anything the ribbon will fill."]])
 
+(defn- active-filter-pill
+  "Per rf2-vu0mp — one pill in the no-matches empty state's 'narrowing
+  on' strip. Clicking removes the axis from the filter map. Orphan
+  pills (value aged out of the buffer) carry an additional '(orphaned)'
+  marker so the user knows the active value will not match anything
+  in the current buffer until either the filter is cleared OR a new
+  event with that value arrives."
+  [{:keys [axis value present?]}]
+  (let [axis-name (name axis)
+        value-str (cond
+                    (nil? value)     "(none)"
+                    (keyword? value) (str value)
+                    :else            (pr-str value))
+        test-id   (str "rf-causa-trace-empty-active-" axis-name)
+        label     (if present?
+                    (str axis-name " = " value-str)
+                    (str axis-name " = " value-str " (orphaned)"))]
+    [:button {:data-testid test-id
+              :on-click    #(rf/dispatch [:rf.causa/set-trace-filter
+                                          axis nil] {:frame :rf/causa})
+              :title       (if present?
+                             (str "click to drop the " axis-name " filter")
+                             (str axis-name " = " value-str
+                                  " — value aged out of the buffer; click to drop"))
+              :style       {:background    (if present?
+                                             (:bg-active tokens)
+                                             "transparent")
+                            :color         (if present?
+                                             (:text-primary tokens)
+                                             (:text-secondary tokens))
+                            :border        (str "1px "
+                                                (if present? "solid" "dashed")
+                                                " "
+                                                (:border-default tokens))
+                            :border-radius "999px"
+                            :padding       "3px 10px"
+                            :cursor        "pointer"
+                            :font-family   sans-stack
+                            :font-size     "11px"
+                            :font-style    (if present? "normal" "italic")
+                            :margin-right  "6px"
+                            :margin-bottom "4px"}}
+     label]))
+
 (defn- empty-state-no-matches
   "Per the bead's contract — events exist but the active filters
-  hide them all. Carries a Clear filters affordance."
-  []
+  hide them all. Carries a Clear filters affordance.
+
+  Per rf2-vu0mp: surfaces an 'narrowing on:' strip listing every
+  active axis=value pair with an orphan marker. Without this strip
+  the user has no in-panel cue WHICH filter is responsible when the
+  selected value has aged out of the buffer (the chip in the header
+  may not be obvious; with multiple axes active the user has to
+  scan)."
+  [{:keys [active-filters]}]
   [:div {:data-testid "rf-causa-trace-empty-no-matches"
          :style       {:padding     "24px"
                        :font-family sans-stack
@@ -361,9 +439,22 @@
                 :color (:text-primary tokens)
                 :font-weight 600}}
     "No events match current filters."]
+   (when (seq active-filters)
+     [:div {:data-testid "rf-causa-trace-empty-active-filters"
+            :style       {:margin "0 0 12px 0"}}
+      [:span {:style {:font-size      "10px"
+                      :color          (:text-tertiary tokens)
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"
+                      :margin-right   "8px"}}
+       "narrowing on:"]
+      (into [:span {:style {:display "inline-flex" :flex-wrap "wrap"
+                            :align-items "baseline"}}]
+            (for [{:keys [axis] :as pill} active-filters]
+              ^{:key axis} [active-filter-pill pill]))])
    [:p {:style {:margin "0 0 12px 0"
                 :color (:text-tertiary tokens)}}
-    "Adjust the chip rows above — clearing any one axis widens the ribbon."]
+    "Click a pill above to drop that axis, or use Clear filters to widen the ribbon."]
    [:button {:data-testid "rf-causa-trace-empty-clear-filters"
              :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
              :style       {:background "transparent"
@@ -383,7 +474,7 @@
   and renders either the chip-filterable ribbon or the empty-state."
   []
   (let [{:keys [rows total rendered distinct counts filters
-                any-filter? empty-kind]
+                any-filter? empty-kind active-filters]
          :as _data}
         @(rf/subscribe [:rf.causa/trace-feed])]
     [:section {:data-testid "rf-causa-trace"
@@ -403,7 +494,7 @@
      [:div {:style {:flex 1 :overflow "auto"}}
       (case empty-kind
         :no-events  (empty-state-no-events)
-        :no-matches (empty-state-no-matches)
+        :no-matches (empty-state-no-matches {:active-filters active-filters})
         nil         (overflow/capped-list
                       rows
                       {:panel-id "trace"
@@ -445,14 +536,48 @@
     (fn [db _query]
       (get db :trace-filters {})))
 
+  ;; Per rf2-44vzy: the trace-feed projection now reads a pre-
+  ;; computed snapshot maintained incrementally by the
+  ;; `:rf.causa/note-trace-event` handler in `registry.cljs`. The
+  ;; snapshot carries the projected rows plus per-axis distinct /
+  ;; counts / seen state and is updated in O(axes) on every push
+  ;; (and O(axes) on every cap eviction). Pre-rf2-44vzy the sub re-
+  ;; walked the entire buffer on every push — at 60Hz × 1000-event
+  ;; buffer that was ~60k row-touches/sec on the main thread before
+  ;; any render work happened.
+  ;;
+  ;; Fallback path: when `:trace-feed-state` is absent (a consumer
+  ;; that bypasses the mirror — e.g. a headless test driving
+  ;; `collect-trace!` without the `mount.cljs/open!` seed) the sub
+  ;; rebuilds the snapshot from the raw buffer on read. The rebuild
+  ;; is the same cost shape as the pre-rf2-44vzy sub, so the worst
+  ;; case under the fallback path is no slower than the prior shape.
+  ;;
+  ;; The fallback chain mirrors `:rf.causa/trace-buffer`'s contract
+  ;; (registry.cljs L100-102): app-db slot → trace-bus atom. The
+  ;; atom path keeps headless tests (`collect-trace!` without
+  ;; `mount.cljs/open!`) functional — the prior `project-feed` sub
+  ;; consumed `:rf.causa/trace-buffer` which already chained through
+  ;; this fallback, so preserving the chain keeps headless behaviour
+  ;; identical.
+  (rf/reg-sub :rf.causa/trace-feed-state
+    (fn [db _query]
+      (or (get db :trace-feed-state)
+          (h/rebuild-feed-state
+            (or (get db :trace-buffer)
+                (trace-bus/buffer))))))
+
   ;; Composite — produces every slot the view consumes. Reactive
-  ;; surface: trace-buffer + filter state. The helper's
-  ;; `project-feed` does the heavy lifting.
+  ;; surface: trace-feed-state (incrementally maintained) + filter
+  ;; state. The helper's `project-feed-from-state` does the read-
+  ;; side work: a single reverse-then-filter walk over already-
+  ;; projected rows. Filter-only changes still O(rows) but with no
+  ;; per-event `project-row` cost.
   (rf/reg-sub :rf.causa/trace-feed
-    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/trace-feed-state]
     :<- [:rf.causa/trace-filters]
-    (fn [[buffer filters] _query]
-      (h/project-feed buffer filters)))
+    (fn [[state filters] _query]
+      (h/project-feed-from-state state filters)))
 
   ;; Set or clear one axis. Passing nil-value clears that axis;
   ;; setting a value replaces any existing value on that axis (the

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -234,6 +234,97 @@
     {}
     rows))
 
+;; ---- orphan-filter surfacing (rf2-vu0mp) --------------------------------
+;;
+;; The chip-row enumeration is built from the events currently in the
+;; buffer. When the buffer rotates past the cap, the oldest event(s)
+;; age out and any axis value carried ONLY by those events drops out
+;; of `:distinct` / `:counts` / `:seen`. If the user has narrowed the
+;; ribbon on that value, the filter remains active (it lives in
+;; `:trace-filters`, separate from the buffer) but the chip that
+;; represents it has nothing to highlight, the empty-state paints
+;; `:no-matches`, and there is no in-panel surface telling the user
+;; what value is responsible. The user is left guessing.
+;;
+;; The fix has two faces, both surfaced through this ns so the algebra
+;; stays JVM-testable:
+;;
+;;   1. `effective-distinct` unions every active filter value into the
+;;      per-axis distinct list (preserving first-seen order and
+;;      avoiding duplication) so the chip ALWAYS renders for the
+;;      currently-active value — orphan or not. The chip-row in the
+;;      header keeps its existing "active value renders highlit"
+;;      discipline; absent values render at the tail of the row.
+;;
+;;   2. `active-filters-summary` produces an ordered list of
+;;      `{:axis :value :present?}` entries the no-matches empty state
+;;      renders as 'narrowing on: axis=value (orphaned)' affordances.
+;;      `:present?` is false iff the value is no longer represented
+;;      in `seen` for that axis, i.e. has aged out of the buffer.
+;;
+;; Both helpers are total over their inputs (nil-tolerant). Per Spec
+;; 009 §Filter vocabulary the active filter map is the canonical
+;; source of truth — the buffer is the renderable substrate.
+
+(defn- distinct-append
+  "Append `value` to `distinct-vec` iff not already present. Stable —
+  preserves first-seen order. Pure data → vector."
+  [distinct-vec value]
+  (if (some #(= value %) distinct-vec)
+    distinct-vec
+    (conj distinct-vec value)))
+
+(defn effective-distinct
+  "Union the currently-active filter values into the per-axis
+  `distinct` map so the chip rows ALWAYS render the active selection
+  — even when the value has aged out of the buffer (rf2-vu0mp).
+
+  `distinct-map` is the per-axis `{axis [value ...]}` first-seen
+  vectors produced by the projection walk; `seen-map` is the parallel
+  `{axis #{value ...}}` membership sets the walk maintains; `filters`
+  is the normalised filter map. For each active axis whose filter
+  value is NOT in `(seen-map axis)`, append the value to the axis
+  distinct vector. Other axes pass through unchanged.
+
+  Pure data → map; JVM-testable."
+  [distinct-map seen-map filters]
+  (reduce-kv
+    (fn [acc axis value]
+      (cond
+        (nil? value)                         acc
+        (and (some? (get seen-map axis))
+             (contains? (get seen-map axis) value)) acc
+        :else
+        (update acc axis (fnil distinct-append []) value)))
+    distinct-map
+    (or filters {})))
+
+(defn active-filters-summary
+  "Ordered list of `{:axis :value :present?}` entries for every
+  active filter axis (rf2-vu0mp). `:present?` is true when the
+  value is still represented in the buffer (via `seen-map`),
+  false when the value has aged out (orphaned). The view renders
+  this in the `:no-matches` empty state so the user always sees
+  what is narrowing the ribbon, even when no buffered event
+  carries the value any more.
+
+  Iteration follows `filter-axes` order so the empty state's chip
+  list matches the header's chip-row ordering.
+
+  Pure data → vector; JVM-testable."
+  [filters seen-map]
+  (let [norm (normalise-filters filters)]
+    (into []
+          (keep (fn [axis]
+                  (let [v (get norm axis)]
+                    (when (some? v)
+                      {:axis     axis
+                       :value    v
+                       :present? (boolean
+                                   (and (some? (get seen-map axis))
+                                        (contains? (get seen-map axis) v)))}))))
+          filter-axes)))
+
 ;; ---- composite projection (the panel reads this) ------------------------
 
 (defn project-feed
@@ -254,6 +345,21 @@
   Spec 009 §Filter vocabulary the algebra delegates to the framework
   filter so the contract stays in lockstep.
 
+  ## Incremental update path (rf2-44vzy)
+
+  This function performs a **full re-walk** of `events` on every
+  call. Under burst traffic (60Hz × 1000-event buffer) that costs
+  ~60k row-touches/sec on the main thread before any actual render.
+  The reactive path in `panels/trace.cljs` now consults
+  `:rf.causa/trace-feed-state` — an incrementally-maintained snapshot
+  of the projection (`init-feed-state` / `feed-state+ev` /
+  `feed-state-evict`) that updates in O(axes) on each
+  `:rf.causa/note-trace-event` rather than re-walking the buffer.
+  This `project-feed` retains the from-scratch shape as the JVM-
+  testable reference + the fallback when no state is precomputed
+  (mount-time seed, headless tests, code paths that hold a raw event
+  vector without a prior state).
+
   Returns:
 
       {:rows              [<row> ...]    ;; post-filter, newest first
@@ -263,7 +369,8 @@
        :counts            {<axis> {<value> <int>}}
        :filters           <pass-through normalised>
        :any-filter?       <bool>
-       :empty-kind        <:no-events / :no-matches / nil>}
+       :empty-kind        <:no-events / :no-matches / nil>
+       :active-filters    [{:axis <kw> :value <v> :present? <bool>} ...]}
 
   `events` is the raw trace-buffer. `filters` is the 13-axis filter
   map (per Spec 009 §Filter vocabulary).
@@ -274,7 +381,14 @@
       :no-matches — events exist but the active filters hide them
                     all. The view paints 'No events match current
                     filters' with a clear-filters affordance.
-      nil         — at least one event passes; render the ribbon."
+      nil         — at least one event passes; render the ribbon.
+
+  `:active-filters` (rf2-vu0mp) lists each active axis/value pair
+  with a `:present?` flag — true when the value is still represented
+  in the current distinct values for that axis, false when the value
+  has aged out of the buffer (orphaned). The view surfaces this in
+  the no-matches empty state so the user always knows what is
+  narrowing the ribbon."
   [events filters]
   (let [normalised   (normalise-filters filters)
         passes?      (trace-bus/build-filter-predicate normalised)
@@ -340,15 +454,216 @@
         empty-kind  (cond
                       (zero? (:total result))    :no-events
                       (zero? (:rendered result)) :no-matches
-                      :else                      nil)]
-    {:rows         sorted-display
-     :total        (:total result)
-     :rendered     (:rendered result)
-     :distinct     (:distinct result)
-     :counts       (:counts result)
-     :filters      normalised
-     :any-filter?  (boolean (seq normalised))
-     :empty-kind   empty-kind}))
+                      :else                      nil)
+        active-filters (active-filters-summary normalised (:seen result))]
+    {:rows           sorted-display
+     :total          (:total result)
+     :rendered       (:rendered result)
+     :distinct       (effective-distinct (:distinct result)
+                                         (:seen result)
+                                         normalised)
+     :counts         (:counts result)
+     :filters        normalised
+     :any-filter?    (boolean (seq normalised))
+     :empty-kind     empty-kind
+     :active-filters active-filters}))
+
+;; ---- incremental projection state (rf2-44vzy) ---------------------------
+;;
+;; `project-feed` is single-pass over the buffer (rf2-7mwc8), but the
+;; reactive sub re-runs the whole walk on every `:rf.causa/note-trace-
+;; event` dispatch — at 60Hz × 1000-event buffer that's ~60k
+;; row-touches/sec on the main thread before any render work happens.
+;;
+;; The fix folds the work into the buffer-write path: a small
+;; `:rf.causa/trace-feed-state` snapshot is maintained in app-db
+;; alongside `:trace-buffer`, updated in O(axes) per push and O(axes)
+;; per evict — so the cost is bounded by the axis count (13), not the
+;; buffer size. The sub reads the snapshot, applies filters, and
+;; returns the same shape `project-feed` always returned.
+;;
+;; The state shape mirrors `project-feed`'s pre-filter accumulator
+;; (post-renaming):
+;;
+;;     {:projected-rows [<projected-row> ...]  ;; one-to-one with buffer
+;;      :distinct       {<axis> [<value> ...]} ;; first-seen order
+;;      :seen           {<axis> #{<value>}}    ;; dedup set
+;;      :counts         {<axis> {<value> <n>}} ;; per-value count
+;;      :total          <int>}                 ;; same as count rows
+;;
+;; Add path: `feed-state+ev` runs `project-row` once + walks 13 axes,
+;; incrementing counts and appending to distinct on first-seen.
+;;
+;; Evict path: `feed-state-evict` walks 13 axes on the head row,
+;; decrementing counts. When a count drops to zero, drop the value
+;; from `:seen` and `:distinct` (the chip row must stop offering a
+;; value the buffer no longer carries). Compaction is O(distinct-
+;; size) per evicted axis in the worst case — bounded in practice by
+;; the panel's chip-row vocabulary (op-types, sources, frames, etc.
+;; are small enumerations).
+;;
+;; ## Privacy invariant (rf2-lqmje / Spec 009 §Privacy)
+;;
+;; The privacy gate sits in `trace-bus/collect-trace!` BEFORE any
+;; buffer push; sensitive events are dropped at ingest and never reach
+;; either the `:trace-buffer` slot or the `:trace-feed-state`
+;; accumulator. The `set-show-sensitive!` toggle-off path clears the
+;; buffer via `clear-buffer!`, which mirrors `:rf.causa/clear-trace-
+;; buffer` into Causa's app-db. The matching event handler in
+;; `registry.cljs` dissocs `:trace-feed-state` in lockstep so the
+;; projection never carries pre-toggle distinct values, counts, or
+;; rows. The incremental shape therefore inherits the same retroactive-
+;; scrub guarantee `clear-buffer!` provides — no new surface where
+;; privacy-sensitive data could survive a toggle.
+
+(defn init-feed-state
+  "Fresh per-axis accumulator state with empty distinct / seen /
+  counts maps for every axis in `filter-axes`, an empty
+  `:projected-rows` vector, and a zero `:total`. Pure data; JVM-
+  testable."
+  []
+  {:projected-rows []
+   :distinct       (into {} (map (fn [a] [a []])) filter-axes)
+   :seen           (into {} (map (fn [a] [a #{}])) filter-axes)
+   :counts         (into {} (map (fn [a] [a {}])) filter-axes)
+   :total          0})
+
+(defn- inc-axis
+  "Bump the count of `row`'s value on `axis` in `state`. Appends to
+  `:distinct` on first-seen. Pure data; JVM-testable."
+  [state axis row]
+  (let [v (get row axis)]
+    (cond
+      (nil? v)
+      state
+
+      (contains? (get-in state [:seen axis]) v)
+      (update-in state [:counts axis v] (fnil inc 0))
+
+      :else
+      (-> state
+          (update-in [:distinct axis] conj v)
+          (update-in [:seen axis] conj v)
+          (update-in [:counts axis v] (fnil inc 0))))))
+
+(defn- dec-axis
+  "Drop one occurrence of `row`'s value on `axis` in `state`. When
+  the count hits zero, drop the value from `:seen` and `:distinct`
+  too so the chip row stops offering an axis value the buffer no
+  longer carries. Pure data; JVM-testable."
+  [state axis row]
+  (let [v   (get row axis)
+        cur (get-in state [:counts axis v] 0)]
+    (cond
+      (nil? v)
+      state
+
+      (<= cur 1)
+      (-> state
+          (update-in [:counts axis] dissoc v)
+          (update-in [:seen axis] disj v)
+          (update-in [:distinct axis] (fn [vs] (filterv #(not= % v) vs))))
+
+      :else
+      (update-in state [:counts axis v] dec))))
+
+(defn feed-state+ev
+  "Fold `event` into the incremental projection state — append the
+  projected row, bump axis counts, and grow distinct values
+  on first-seen. O(axes) per call regardless of buffer size. Pure
+  data → state; JVM-testable."
+  [state event]
+  (let [row (project-row event)]
+    (-> (reduce (fn [s axis] (inc-axis s axis row)) state filter-axes)
+        (update :projected-rows conj row)
+        (update :total inc))))
+
+(defn feed-state-evict
+  "Evict the head (oldest) projected row from `state`, decrementing
+  per-axis counts and compacting distinct entries that hit zero.
+  Returns `state` unchanged when `:projected-rows` is empty. Pure
+  data → state; JVM-testable."
+  [state]
+  (let [rows (:projected-rows state)]
+    (if (empty? rows)
+      state
+      (let [head (nth rows 0)
+            state' (reduce (fn [s axis] (dec-axis s axis head))
+                           state filter-axes)]
+        (-> state'
+            (update :projected-rows subvec 1)
+            (update :total dec))))))
+
+(defn feed-state-push
+  "Append `event` to `state`, evicting the oldest projected row when
+  the post-push total would exceed `depth`. Mirrors `trace-bus/push`'s
+  capped-vector eviction algebra — the projection state stays in
+  lockstep with the buffer slot. O(axes) per call. Pure data; JVM-
+  testable."
+  [state depth event]
+  (let [state' (feed-state+ev state event)]
+    (if (> (:total state') depth)
+      (feed-state-evict state')
+      state')))
+
+(defn rebuild-feed-state
+  "Build `:trace-feed-state` from scratch over `events`. Used at
+  mount-time seed (the trace-bus atom may already hold pre-mount
+  emits) and as the fallback when the slot has not been initialised.
+  Pure data → state; JVM-testable."
+  [events]
+  (reduce feed-state+ev (init-feed-state) events))
+
+(defn project-feed-from-state
+  "Like `project-feed` but reads the pre-computed `:trace-feed-state`
+  snapshot rather than re-walking the buffer. The state is kept in
+  lockstep with `:trace-buffer` by the `:rf.causa/note-trace-event`
+  handler in `registry.cljs` (push) and the `:rf.causa/clear-trace-
+  buffer` / `:rf.causa/sync-trace-buffer` handlers (reset/seed). Pure
+  data → data; JVM-testable.
+
+  The filter pass still walks the projected-row vector (a single
+  reverse-then-filter over rows that are ALREADY projected — no
+  per-event `project-row` cost) and stops at `cap` matches so the
+  view never sees more than its render-cap rows. The buffer's full
+  size is reflected by `:total`; the panel's overflow indicator
+  surfaces 'hidden N' from the cap-rows helper downstream."
+  [state filters]
+  (let [normalised (normalise-filters filters)
+        passes?    (trace-bus/build-filter-predicate normalised)
+        rows       (:projected-rows state)
+        total      (:total state)
+        rev-rows   (rseq rows)
+        rendered+rows
+        (if (empty? normalised)
+          [(count rows) (vec rev-rows)]
+          (loop [remain rev-rows
+                 rendered 0
+                 acc      (transient [])]
+            (if (nil? (seq remain))
+              [rendered (persistent! acc)]
+              (let [row (first remain)
+                    ev  (:raw row)]
+                (if (passes? ev)
+                  (recur (next remain) (inc rendered) (conj! acc row))
+                  (recur (next remain) rendered acc))))))
+        [rendered display-rows] rendered+rows
+        empty-kind (cond
+                     (zero? total)    :no-events
+                     (zero? rendered) :no-matches
+                     :else            nil)
+        active-filters (active-filters-summary normalised (:seen state))]
+    {:rows           display-rows
+     :total          total
+     :rendered       rendered
+     :distinct       (effective-distinct (:distinct state)
+                                         (:seen state)
+                                         normalised)
+     :counts         (:counts state)
+     :filters        normalised
+     :any-filter?    (boolean (seq normalised))
+     :empty-kind     empty-kind
+     :active-filters active-filters}))
 
 ;; ---- React keys ---------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -50,7 +50,8 @@
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.time-travel :as time-travel]
-            [day8.re-frame2-causa.panels.trace :as trace]))
+            [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
 
 ;; ---- defaults (re-exported for back-compat callers) ---------------------
 ;;
@@ -210,16 +211,40 @@
               ev-id (:id event)]
           (if (and ev-id (some #(= ev-id (:id %)) buf))
             db
-            (assoc db :trace-buffer (trace-bus/push buf depth event))))))
+            ;; Dual-write: keep the raw `:trace-buffer` slot in
+            ;; lockstep with the incrementally-maintained
+            ;; `:trace-feed-state` snapshot (rf2-44vzy). The trace
+            ;; panel's `:rf.causa/trace-feed` sub reads
+            ;; `:trace-feed-state`; every other consumer that holds
+            ;; a raw event vector keeps reading `:trace-buffer`.
+            ;; `feed-state-push` mirrors `trace-bus/push`'s capped
+            ;; eviction so the snapshot stays bounded by the same
+            ;; depth contract.
+            (let [feed-state (or (get db :trace-feed-state)
+                                 (trace-helpers/init-feed-state))]
+              (-> db
+                  (assoc :trace-buffer
+                         (trace-bus/push buf depth event))
+                  (assoc :trace-feed-state
+                         (trace-helpers/feed-state-push
+                           feed-state depth event))))))))
 
     ;; Clear the mirrored slot in lockstep with the trace-bus atom
     ;; (dispatched from `trace-bus/clear-buffer!` in CLJS). Per
     ;; rf2-qsjda the `:rf.trace/no-emit?` flag applies for the same
     ;; loop-avoidance reason as `:rf.causa/note-trace-event`.
+    ;;
+    ;; Per rf2-44vzy: drop `:trace-feed-state` alongside the raw
+    ;; buffer so the precomputed projection inherits the same
+    ;; retroactive-scrub guarantee `trace-bus/clear-buffer!`
+    ;; provides — no projection residue surviving a privacy toggle
+    ;; (rf2-lqmje §Privacy / retroactive-scrub).
     (rf/reg-event-db :rf.causa/clear-trace-buffer
       {:rf.trace/no-emit? true}
       (fn [db _event]
-        (dissoc db :trace-buffer)))
+        (-> db
+            (dissoc :trace-buffer)
+            (dissoc :trace-feed-state))))
 
     ;; Wholesale overwrite of the mirrored slot. Dispatched from
     ;; `mount.cljs/open!` on first Ctrl+Shift+C to seed `:rf/causa`'s
@@ -228,10 +253,20 @@
     ;; when the depth shrinks so the mirror reflects the post-shrink
     ;; contents. Per rf2-qsjda `:rf.trace/no-emit? true` for the same
     ;; loop-avoidance reason.
+    ;;
+    ;; Per rf2-44vzy: rebuild `:trace-feed-state` from the seeded
+    ;; buffer so the incremental projection starts in lockstep with
+    ;; the slot. The rebuild is O(buffer × axes); paid once on seed
+    ;; (mount-time or post-shrink) — every subsequent note-trace-
+    ;; event runs in O(axes).
     (rf/reg-event-db :rf.causa/sync-trace-buffer
       {:rf.trace/no-emit? true}
       (fn [db [_ buffer]]
-        (assoc db :trace-buffer (vec buffer))))
+        (let [buf (vec buffer)]
+          (-> db
+              (assoc :trace-buffer buf)
+              (assoc :trace-feed-state
+                     (trace-helpers/rebuild-feed-state buf))))))
 
     ;; Bump the per-frame suppressed-events counter (rf2-0vxdn).
     ;; Dispatched from `trace-bus/collect-trace!` (CLJS) under

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -466,3 +466,314 @@
         (doseq [id [6 7 8]]
           (is (some? (get keys-2 id)))
           (is (not (contains? keys-1 id))))))))
+
+;; ---- (14) orphan-filter surfacing — rf2-vu0mp --------------------------
+;;
+;; The chip-row enumeration is built from the events currently in the
+;; buffer. When the buffer rotates past the cap and the selected
+;; filter value's last instance ages out, `:trace-filters` still
+;; carries the selection but the chip row no longer shows that value
+;; — user sees `:no-matches` with no visible cue what's narrowing the
+;; view. Per rf2-vu0mp the fix surfaces the active value in BOTH the
+;; chip row (orphan still rendered, marked) AND the empty state
+;; (`:active-filters` strip).
+
+(deftest effective-distinct-passes-through-when-active-is-present
+  (testing "no orphan: active filter value is in seen → distinct map
+            passes through unchanged"
+    (let [distinct-map {:op-type [:event :error]
+                        :source  [:ui :timer]}
+          seen-map     {:op-type #{:event :error}
+                        :source  #{:ui :timer}}]
+      (is (= distinct-map
+             (h/effective-distinct distinct-map seen-map
+                                   {:op-type :error :source :ui}))))))
+
+(deftest effective-distinct-appends-orphan-active-value
+  (testing "active filter value NOT in seen → appended to distinct
+            so the chip ALWAYS renders for the user's selection"
+    (let [distinct-map {:source [:ui]}
+          seen-map     {:source #{:ui}}
+          result       (h/effective-distinct distinct-map seen-map
+                                             {:source :timer})]
+      (is (= [:ui :timer] (get result :source))
+          "the orphan :timer value lands at the tail of :source"))))
+
+(deftest effective-distinct-handles-axis-absent-from-seen
+  (testing "axis missing entirely from seen → still appends orphan"
+    (let [distinct-map {}
+          seen-map     {}
+          result       (h/effective-distinct distinct-map seen-map
+                                             {:frame :rf/test})]
+      (is (= [:rf/test] (get result :frame))))))
+
+(deftest effective-distinct-skips-no-duplicate-active-value
+  (testing "if active value is already in distinct it is not duplicated"
+    (let [distinct-map {:source [:timer :ui]}
+          seen-map     {:source #{:ui}}  ;; :timer dropped from seen
+          result       (h/effective-distinct distinct-map seen-map
+                                             {:source :timer})]
+      (is (= [:timer :ui] (get result :source))
+          "no duplicate — first-seen order preserved"))))
+
+(deftest effective-distinct-tolerates-nil-filters
+  (testing "nil / empty filters → pass-through"
+    (let [distinct-map {:source [:ui]}
+          seen-map     {:source #{:ui}}]
+      (is (= distinct-map (h/effective-distinct distinct-map seen-map nil)))
+      (is (= distinct-map (h/effective-distinct distinct-map seen-map {}))))))
+
+(deftest active-filters-summary-marks-present-and-orphaned
+  (let [seen-map {:op-type #{:event :error}
+                  :source  #{:ui}
+                  :frame   #{:rf/default}}
+        summary  (h/active-filters-summary
+                   {:op-type :error
+                    :source  :timer    ;; orphan
+                    :frame   :rf/default}
+                   seen-map)]
+    (testing "every active axis has an entry"
+      (is (= 3 (count summary))))
+    (testing "iteration follows filter-axes order (op-type, severity,
+              source, origin, frame, ...)"
+      (is (= [:op-type :source :frame] (mapv :axis summary))))
+    (testing "present? is true when value is in seen"
+      (is (true?  (:present? (some #(when (= :op-type (:axis %)) %) summary))))
+      (is (false? (:present? (some #(when (= :source  (:axis %)) %) summary))))
+      (is (true?  (:present? (some #(when (= :frame   (:axis %)) %) summary)))))
+    (testing "value is preserved verbatim for the empty-state render"
+      (is (= :timer (:value (some #(when (= :source (:axis %)) %) summary)))))))
+
+(deftest active-filters-summary-handles-empty-or-nil
+  (is (= [] (h/active-filters-summary nil nil)))
+  (is (= [] (h/active-filters-summary {} {})))
+  (is (= [] (h/active-filters-summary {:source nil} {}))
+      "nil-valued filters are dropped by normalise-filters first"))
+
+(deftest project-feed-orphan-filter-distinct-is-effective
+  (testing "rf2-vu0mp: filtering on a value not present in the buffer
+            still produces a distinct entry for that value so the chip
+            row keeps rendering the user's selection"
+    (let [events (events-fixture)
+          ;; No :source = :timer in the all-:ui-/-:http events besides id=3.
+          ;; Filter on an axis where the value DOES NOT exist in buffer:
+          feed   (h/project-feed events
+                                 {:source :sse})]
+      (testing "the orphan value lands in distinct so the chip is rendered"
+        (is (some #(= :sse %) (get-in feed [:distinct :source]))
+            "orphan :sse appended to :source distinct"))
+      (testing ":counts is unchanged — the value has 0 buffered events"
+        (is (not (contains? (get-in feed [:counts :source]) :sse))
+            "no synthetic count entry — the renderer reads 0 via get-default"))
+      (testing ":active-filters surfaces the orphan with :present? false"
+        (let [src-pill (some #(when (= :source (:axis %)) %)
+                             (:active-filters feed))]
+          (is (= :sse (:value src-pill)))
+          (is (false? (:present? src-pill)))))
+      (testing "empty-kind is :no-matches"
+        (is (= :no-matches (:empty-kind feed)))))))
+
+(deftest project-feed-active-filters-empty-when-no-filters
+  (let [feed (h/project-feed (events-fixture) {})]
+    (is (= [] (:active-filters feed))
+        "no active filter → empty pill list")))
+
+;; ---- (15) incremental projection state — rf2-44vzy ---------------------
+;;
+;; The trace-feed projection now reads a pre-computed snapshot
+;; maintained incrementally by `:rf.causa/note-trace-event` rather
+;; than re-walking the full buffer on every push. The snapshot is
+;; updated in O(axes) per add and O(axes) per evict — bounded by the
+;; axis count (13), not the buffer size.
+;;
+;; These tests pin the incremental algebra against the from-scratch
+;; `project-feed` reference: for any sequence of events, building
+;; the state event-by-event must produce the same distinct/counts/
+;; rows shape as walking the events end-to-end in one shot.
+
+(deftest init-feed-state-has-empty-axis-maps
+  (let [state (h/init-feed-state)]
+    (is (= 0 (:total state)))
+    (is (= [] (:projected-rows state)))
+    (doseq [axis h/filter-axes]
+      (is (= [] (get-in state [:distinct axis]))
+          (str "axis " axis " starts with empty distinct"))
+      (is (= #{} (get-in state [:seen axis]))
+          (str "axis " axis " starts with empty seen"))
+      (is (= {} (get-in state [:counts axis]))
+          (str "axis " axis " starts with empty counts")))))
+
+(deftest feed-state+ev-bumps-axis-counts
+  (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
+                   :time 100 :source :ui :origin :app
+                   :frame :rf/default})
+        e2    (ev {:id 2 :op-type :event :operation :event/dispatched
+                   :time 200 :source :ui :origin :app
+                   :frame :rf/default})
+        state (-> (h/init-feed-state)
+                  (h/feed-state+ev e1)
+                  (h/feed-state+ev e2))]
+    (is (= 2 (:total state)))
+    (is (= 2 (count (:projected-rows state))))
+    (is (= [:event]      (get-in state [:distinct :op-type])))
+    (is (= [:ui]         (get-in state [:distinct :source])))
+    (is (= {:event 2}    (get-in state [:counts :op-type])))
+    (is (= {:ui 2}       (get-in state [:counts :source])))))
+
+(deftest feed-state-evict-decrements-and-compacts
+  (testing "evicting the head row decrements per-axis counts; when a
+            count hits zero the value is dropped from seen + distinct
+            so the chip row stops offering an aged-out value"
+    (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
+                     :time 100 :source :timer :origin :app
+                     :frame :rf/default})
+          e2    (ev {:id 2 :op-type :error :operation :rf.error/x
+                     :time 200 :source :ui :origin :app
+                     :frame :rf/default})
+          state (-> (h/init-feed-state)
+                    (h/feed-state+ev e1)
+                    (h/feed-state+ev e2)
+                    h/feed-state-evict)]
+      (is (= 1 (:total state)))
+      (is (= 1 (count (:projected-rows state))))
+      (testing ":source :timer was unique to the evicted row → dropped"
+        (is (= [:ui] (get-in state [:distinct :source])))
+        (is (not (contains? (get-in state [:seen :source]) :timer)))
+        (is (not (contains? (get-in state [:counts :source]) :timer))))
+      (testing ":source :ui still present (carried by e2)"
+        (is (contains? (get-in state [:seen :source]) :ui))
+        (is (= 1 (get-in state [:counts :source :ui])))))))
+
+(deftest feed-state-evict-decrements-shared-value-without-compaction
+  (testing "if two rows share a value, evicting one only decrements
+            the count — the value stays in distinct / seen"
+    (let [e1    (ev {:id 1 :op-type :event :operation :event/dispatched
+                     :source :ui :frame :rf/default})
+          e2    (ev {:id 2 :op-type :event :operation :event/dispatched
+                     :source :ui :frame :rf/default})
+          state (-> (h/init-feed-state)
+                    (h/feed-state+ev e1)
+                    (h/feed-state+ev e2)
+                    h/feed-state-evict)]
+      (is (= [:ui] (get-in state [:distinct :source])))
+      (is (= 1 (get-in state [:counts :source :ui]))))))
+
+(deftest feed-state-evict-noop-on-empty
+  (testing "evicting from empty state returns the same shape"
+    (let [empty-state (h/init-feed-state)]
+      (is (= empty-state (h/feed-state-evict empty-state))))))
+
+(deftest feed-state-push-respects-depth-cap
+  (testing "feed-state-push mirrors trace-bus/push's eviction algebra
+            — total never exceeds depth, oldest is evicted"
+    (let [depth 3
+          evs   (mapv #(ev {:id %1 :op-type :event :operation :event/dispatched
+                            :source (case (mod %1 3)
+                                      0 :ui 1 :timer 2 :http)
+                            :frame :rf/default})
+                      (range 1 11))
+          state (reduce (fn [s e] (h/feed-state-push s depth e))
+                        (h/init-feed-state)
+                        evs)]
+      (is (= depth (:total state)))
+      (is (= depth (count (:projected-rows state))))
+      (testing "the head row is the (depth)-most-recent"
+        (let [retained-ids (mapv :id (:projected-rows state))]
+          (is (= [8 9 10] retained-ids)))))))
+
+(deftest rebuild-feed-state-equals-incremental
+  (testing "building state from scratch via rebuild-feed-state
+            equals folding events one at a time via feed-state+ev"
+    (let [evs        (events-fixture)
+          rebuilt    (h/rebuild-feed-state evs)
+          folded     (reduce h/feed-state+ev (h/init-feed-state) evs)]
+      (is (= rebuilt folded)))))
+
+(deftest project-feed-from-state-matches-project-feed-no-filter
+  (testing "project-feed-from-state produces the same shape as
+            project-feed when no filter is active"
+    (let [evs        (events-fixture)
+          state      (h/rebuild-feed-state evs)
+          from-state (h/project-feed-from-state state {})
+          from-raw   (h/project-feed evs {})]
+      (is (= (:total from-state)    (:total from-raw)))
+      (is (= (:rendered from-state) (:rendered from-raw)))
+      (is (= (mapv :id (:rows from-state))
+             (mapv :id (:rows from-raw))))
+      (is (= (:distinct from-state) (:distinct from-raw)))
+      (is (= (:counts from-state)   (:counts from-raw)))
+      (is (= (:empty-kind from-state) (:empty-kind from-raw))))))
+
+(deftest project-feed-from-state-matches-project-feed-with-filter
+  (testing "project-feed-from-state produces equivalent shape under
+            active filters — early-stop filter walk preserves rendered
+            count and row order"
+    (let [evs        (events-fixture)
+          filters    {:dispatch-id 10}
+          state      (h/rebuild-feed-state evs)
+          from-state (h/project-feed-from-state state filters)
+          from-raw   (h/project-feed evs filters)]
+      (is (= (:total from-state)    (:total from-raw)))
+      (is (= (:rendered from-state) (:rendered from-raw)))
+      (is (= (mapv :id (:rows from-state))
+             (mapv :id (:rows from-raw))))
+      (is (= (:filters from-state)  (:filters from-raw)))
+      (is (= (:empty-kind from-state) (:empty-kind from-raw))))))
+
+(deftest project-feed-from-state-orphan-filter-surfaces
+  (testing "rf2-vu0mp via incremental path: orphan filter value still
+            renders in distinct + active-filters carries :present? false"
+    (let [evs   (events-fixture)
+          state (h/rebuild-feed-state evs)
+          feed  (h/project-feed-from-state state {:source :sse})]
+      (is (some #(= :sse %) (get-in feed [:distinct :source])))
+      (is (= :no-matches (:empty-kind feed)))
+      (let [pill (some #(when (= :source (:axis %)) %)
+                       (:active-filters feed))]
+        (is (= :sse (:value pill)))
+        (is (false? (:present? pill)))))))
+
+(deftest project-feed-from-state-empty-buffer
+  (let [feed (h/project-feed-from-state (h/init-feed-state) {})]
+    (is (= 0 (:total feed)))
+    (is (= 0 (:rendered feed)))
+    (is (= :no-events (:empty-kind feed)))))
+
+(deftest incremental-and-from-scratch-equivalence-under-cap-rotation
+  (testing "after pushing 5× the cap, the incremental state matches a
+            from-scratch rebuild over the same retained window — the
+            evict path correctly compacts dropped values"
+    (let [depth 5
+          all   (mapv #(ev {:id %1 :op-type (case (mod %1 3)
+                                              0 :event 1 :error 2 :warning)
+                             :operation (case (mod %1 2)
+                                          0 :event/dispatched
+                                          :rf.error/handler-exception)
+                             :time %1
+                             :source (case (mod %1 4)
+                                       0 :ui 1 :timer 2 :http 3 :sse)
+                             :origin :app
+                             :frame  :rf/default
+                             :dispatch-id (quot %1 2)})
+                      (range 1 26))
+          state (reduce (fn [s e] (h/feed-state-push s depth e))
+                        (h/init-feed-state)
+                        all)
+          ;; What the buffer should look like post-rotation:
+          retained (vec (drop (- (count all) depth) all))
+          rebuilt  (h/rebuild-feed-state retained)]
+      (is (= (:total state)    (:total rebuilt)))
+      (is (= (:projected-rows state) (:projected-rows rebuilt)))
+      (is (= (:counts state)   (:counts rebuilt)))
+      (is (= (:seen state)     (:seen rebuilt)))
+      (testing "distinct may differ in order (incremental preserves
+                first-seen-since-eviction order, not all-time order)
+                — assert content equality via set, not vector"
+        (doseq [axis h/filter-axes]
+          (is (= (set (get-in state [:distinct axis]))
+                 (set (get-in rebuilt [:distinct axis])))))))))
+
+(deftest project-feed-from-state-active-filters-empty-when-no-filters
+  (let [state (h/rebuild-feed-state (events-fixture))
+        feed  (h/project-feed-from-state state {})]
+    (is (= [] (:active-filters feed)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -524,3 +524,209 @@
         (is (string? k11)
             "key is a string (not the positional-tuple from the
              pre-rf2-z4fza shape)")))))
+
+;; ---- (9) orphan-filter surfacing — rf2-vu0mp ---------------------------
+;;
+;; When the buffer rotates past the cap and the selected filter value's
+;; last instance ages out, :trace-filters still carries the selection
+;; but the chip-row no longer shows that value (audit F6). Per rf2-vu0mp
+;; the fix:
+;;
+;;   1. The header's chip-row keeps rendering the active value (the
+;;      helper's effective-distinct unions it back into distinct);
+;;      orphan chips are marked visually (count = 0, dashed border,
+;;      italic).
+;;   2. The :no-matches empty state surfaces an 'narrowing on:' strip
+;;      listing every active axis=value pair so the user always has
+;;      an in-panel cue what is filtering the ribbon — orphan or not.
+
+(deftest orphan-chip-renders-in-header-when-filter-value-aged-out
+  (testing "rf2-vu0mp: filtering on a value not present in the buffer
+            still renders an axis chip for that value so the user can
+            see / toggle off their selection. The chip carries count 0."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push a single :ui-sourced event then narrow on :timer — the
+      ;; :timer value is NOT in the buffer (orphan).
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace-axis-row-source"))
+            "the :source chip-row renders even though only one buffered
+             distinct value exists (the active orphan brings the chip
+             count to 2 — distinct :ui + orphan :timer)")
+        (is (some? (find-by-testid tree "rf-causa-trace-axis-chip-source-timer"))
+            "an orphan chip for the active :timer selection renders")))))
+
+(deftest orphan-empty-state-surfaces-active-filter-strip
+  (testing "rf2-vu0mp: the :no-matches empty state surfaces an
+            'narrowing on:' strip listing each active axis=value pair
+            so the user always sees what is filtering the ribbon"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push two events that won't match the filter.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :origin :app :frame :rf/default}))
+      (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
+                             :source :ui :origin :app :frame :rf/default}))
+      ;; Narrow on a value the buffer doesn't carry — orphan.
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
+      (let [tree (trace/trace-view)]
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
+            ":no-matches empty state renders")
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-active-filters"))
+            "rf2-vu0mp: active-filters strip renders inside no-matches")
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-active-source"))
+            "a pill for the :source axis surfaces")))))
+
+(deftest active-filter-pill-click-drops-the-axis
+  (testing "rf2-vu0mp: clicking an active-filter pill drops that axis
+            from the filter map (lets the user clear an orphan without
+            hunting through the header)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame :rf/missing])
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _o]   (swap! dispatches conj ev) nil))]
+          (let [tree    (trace/trace-view)
+                pill    (find-by-testid tree "rf-causa-trace-empty-active-source")
+                handler (:on-click (second pill))]
+            (is (some? pill) ":source pill rendered")
+            (when handler (handler))))
+        (is (some #(= [:rf.causa/set-trace-filter :source nil] %) @dispatches)
+            "clicking the pill fires set-trace-filter with nil-value
+             (the canonical 'drop this axis' shape)")))))
+
+(deftest empty-state-active-filter-pill-marks-present-vs-orphan
+  (testing "rf2-vu0mp: a present axis pill (the value still exists in
+            the buffer) is styled differently from an orphan pill — the
+            data-driven marker on the chip label."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Push :ui-sourced events; then add TWO filters: source = :ui
+      ;; (present, but combined with the second filter renders zero
+      ;; rows) AND frame = :rf/missing (orphan).
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default}))
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/missing])
+      (let [tree         (trace/trace-view)
+            source-pill  (find-by-testid tree "rf-causa-trace-empty-active-source")
+            frame-pill   (find-by-testid tree "rf-causa-trace-empty-active-frame")
+            label-of     (fn [node]
+                           (->> (hiccup-seq node)
+                                (filter string?)
+                                (apply str)))]
+        (is (some? source-pill) "present axis pill renders")
+        (is (some? frame-pill)  "orphan axis pill renders")
+        (testing "present pill has no orphan marker"
+          (is (not (re-find #"orphaned" (label-of source-pill)))))
+        (testing "orphan pill carries the orphan marker"
+          (is (re-find #"orphaned" (label-of frame-pill))))))))
+
+;; ---- (10) incremental projection wiring — rf2-44vzy --------------------
+;;
+;; The trace-feed sub now reads :trace-feed-state — an incrementally-
+;; maintained snapshot of the projection updated O(axes) per push by
+;; the :rf.causa/note-trace-event handler. These tests pin the wiring
+;; contract: registry installs the new state-keeping handlers; the
+;; sub returns the same shape as before; clear/sync drop the
+;; snapshot in lockstep with the buffer (privacy invariant from
+;; rf2-lqmje §Privacy retroactive-scrub).
+
+(deftest trace-feed-state-sub-registered
+  (testing "registry registers the :rf.causa/trace-feed-state sub
+            (the per-rf2-44vzy reactive surface)"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/trace-feed-state))
+        ":rf.causa/trace-feed-state sub registered")))
+
+(deftest note-trace-event-updates-feed-state-snapshot
+  (testing "rf2-44vzy: the note-trace-event handler dual-writes —
+            populates both :trace-buffer and :trace-feed-state. The
+            snapshot's :total, :counts, and :seen mirror what a from-
+            scratch project-feed would produce."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default}))
+      (sync-push! (mk-trace {:id 2 :op-type :error :operation :rf.error/x
+                             :source :timer :frame :rf/causa}))
+      (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
+        (is (= 2 (:total state)))
+        (is (= 2 (count (:projected-rows state))))
+        (is (contains? (get-in state [:seen :source]) :ui))
+        (is (contains? (get-in state [:seen :source]) :timer))
+        (is (= 1 (get-in state [:counts :source :ui])))
+        (is (= 1 (get-in state [:counts :source :timer])))))))
+
+(deftest clear-trace-buffer-drops-feed-state
+  (testing "rf2-44vzy + rf2-lqmje §Privacy retroactive-scrub: the
+            `:rf.causa/clear-trace-buffer` handler dissocs BOTH
+            `:trace-buffer` and `:trace-feed-state` in lockstep so
+            the incremental snapshot never carries pre-clear residue.
+
+            We assert the handler shape directly (sync dispatch) — the
+            production path is `trace-bus/clear-buffer!`, which also
+            clears the atom + queues this dispatch."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Populate both the app-db slot AND the atom by going through
+      ;; sync-push! (dispatches :rf.causa/note-trace-event sync).
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui}))
+      (is (pos? (:total @(rf/subscribe [:rf.causa/trace-feed-state])))
+          "snapshot populated before clear")
+      ;; Clear the atom + the slot atomically: drop the atom first so
+      ;; the sub's fallback path produces an empty state, then sync-
+      ;; dispatch the clear handler so the slot is dissoced too.
+      (trace-bus/clear-buffer!)
+      (rf/dispatch-sync [:rf.causa/clear-trace-buffer])
+      (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
+        (testing "post-clear: snapshot rebuilt from now-empty buffer →
+                 empty / fresh state"
+          (is (= 0 (:total state)))
+          (is (= [] (:projected-rows state))))))))
+
+(deftest sync-trace-buffer-rebuilds-feed-state
+  (testing "rf2-44vzy: :rf.causa/sync-trace-buffer rebuilds the
+            snapshot from the seeded buffer — every distinct value
+            present in the seed must land in :seen"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [seed [(mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default})
+                  (mk-trace {:id 2 :op-type :error :operation :rf.error/x
+                             :source :timer :frame :rf/causa})]]
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer seed])
+        (let [state @(rf/subscribe [:rf.causa/trace-feed-state])]
+          (is (= 2 (:total state)))
+          (is (contains? (get-in state [:seen :source]) :ui))
+          (is (contains? (get-in state [:seen :source]) :timer)))))))
+
+(deftest trace-feed-shape-stable-across-incremental-path
+  (testing "rf2-44vzy: the public :rf.causa/trace-feed shape is
+            unchanged — :rows / :total / :rendered / :distinct /
+            :counts / :filters / :any-filter? / :empty-kind all
+            present. Adds rf2-vu0mp's :active-filters key."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :source :ui :frame :rf/default}))
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (contains? feed :rows))
+        (is (contains? feed :total))
+        (is (contains? feed :rendered))
+        (is (contains? feed :distinct))
+        (is (contains? feed :counts))
+        (is (contains? feed :filters))
+        (is (contains? feed :any-filter?))
+        (is (contains? feed :empty-kind))
+        (is (contains? feed :active-filters)
+            "rf2-vu0mp adds :active-filters for the empty-state strip")))))

--- a/tools/causa/test/day8/re_frame2_causa/perf_budget_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/perf_budget_cljs_test.cljc
@@ -82,7 +82,8 @@
             [day8.re-frame2-causa.panels.causality-graph-helpers :as cg]
             [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.panels.performance-helpers :as perf]
-            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs]))
+            [day8.re-frame2-causa.panels.subscriptions-helpers :as subs]
+            [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
 
 ;; ---- spec-derived budget constants --------------------------------------
 
@@ -654,3 +655,125 @@
           "DOM-mount ceiling holds regardless of input size")
       (is (true? over-cap?))
       (is (= (- (count rows) panel-row-cap) hidden)))))
+
+;; -------------------------------------------------------------------------
+;; (9) Trace-feed incremental projection — rf2-44vzy
+;;     The trace-feed sub reads a snapshot maintained incrementally
+;;     by `:rf.causa/note-trace-event`; per-push cost is bounded by
+;;     the axis count (13), not the buffer size. These tests pin the
+;;     algorithmic invariant: pushing N events into a state that
+;;     already holds M events costs O(N × axes) — not O(N × (M+N)).
+;; -------------------------------------------------------------------------
+
+(defn- trace-event-fixture
+  "Build a Spec 009-shaped trace event for the perf scaling tests.
+  Varies per-axis values across a small enumeration so distinct +
+  counts compaction is exercised on the evict path."
+  [i]
+  {:id        i
+   :time      i
+   :op-type   (case (mod i 4) 0 :event 1 :error 2 :warning 3 :info)
+   :operation :event/dispatched
+   :source    (case (mod i 3) 0 :ui 1 :timer 2 :http)
+   :tags      {:origin      (case (mod i 2) 0 :app 1 :pair)
+               :frame       (case (mod i 2) 0 :rf/default 1 :rf/causa)
+               :event-id    (keyword (str "ev/n" (mod i 8)))
+               :handler-id  (keyword (str "hh/n" (mod i 8)))
+               :dispatch-id i}})
+
+(deftest trace-feed-state-add-cost-is-bounded-by-axes-not-buffer
+  (testing "rf2-44vzy: pushing one event into a state with 1000
+            already-buffered rows must NOT walk those rows — cost
+            is O(axes), not O(buffer). Asserted via ratio: pushing
+            into a state with 10× more pre-existing rows costs no
+            more than ~1× (within slack) — the existing rows do not
+            participate in the per-event work."
+    (let [build-state (fn [n]
+                        (reduce trace-helpers/feed-state+ev
+                                (trace-helpers/init-feed-state)
+                                (mapv trace-event-fixture (range n))))
+          state-small (build-state 100)
+          state-big   (build-state 1000)
+          run         (fn [state n-pushes start-id]
+                        (timed
+                          (fn []
+                            (reduce (fn [s i]
+                                      (trace-helpers/feed-state+ev
+                                        s (trace-event-fixture i)))
+                                    state
+                                    (range start-id (+ start-id n-pushes))))))
+          [_ t-small] (run state-small 100 100)
+          [_ t-big]   (run state-big   100 1000)
+          r           (ratio t-small t-big)]
+      (is (<= r (* 1.0 scaling-slack))
+          (str "feed-state+ev 100 pushes into 1000-row state scaled "
+               r "× over 100 pushes into 100-row state (slack "
+               scaling-slack "×). A per-push O(buffer) regression "
+               "(e.g. distinct rebuilt from rows) would scale ~10×."))))
+  )
+
+(deftest trace-feed-state-push-respects-cap-under-burst
+  (testing "rf2-44vzy: under burst (50× the cap), the snapshot never
+            grows past depth, and the incremental shape matches a
+            from-scratch rebuild over the same retained window"
+    (let [depth   buffer-depth-default
+          n       (* 50 depth)
+          all     (mapv trace-event-fixture (range n))
+          state   (reduce (fn [s e]
+                            (trace-helpers/feed-state-push s depth e))
+                          (trace-helpers/init-feed-state)
+                          all)
+          retained (vec (drop (- n depth) all))
+          rebuilt  (trace-helpers/rebuild-feed-state retained)]
+      (is (= depth (:total state)))
+      (is (= depth (count (:projected-rows state))))
+      (is (= (:projected-rows state) (:projected-rows rebuilt))
+          "the incremental rows vector equals the retained window")
+      (is (= (:counts state) (:counts rebuilt))
+          "counts match — evict path correctly decrements")
+      (is (= (:seen state) (:seen rebuilt))
+          "seen sets match — drop-on-zero compaction holds"))))
+
+(deftest trace-feed-state-push-is-linear-over-events-pushed
+  (testing "rf2-44vzy: pushing 10× more events with the cap engaged
+            costs ~10× — O(events × axes), not O(events × buffer²)"
+    (let [depth buffer-depth-default
+          run   (fn [n]
+                  (timed
+                    (fn []
+                      (reduce (fn [s i]
+                                (trace-helpers/feed-state-push
+                                  s depth (trace-event-fixture i)))
+                              (trace-helpers/init-feed-state)
+                              (range n)))))
+          [_ t1]  (run (* 2 depth))
+          [_ t10] (run (* 20 depth))
+          r       (ratio t1 t10)]
+      (is (<= r (* 10.0 scaling-slack))
+          (str "feed-state-push 10× input scaled " r "× "
+               "(slack " scaling-slack "× over linear)")))))
+
+(deftest project-feed-from-state-equivalent-to-project-feed
+  (testing "rf2-44vzy: the incremental path produces an equivalent
+            shape to the full-walk reference under typical filter
+            mixes — no regression in :rows / :total / :rendered /
+            :empty-kind"
+    (doseq [filters [{}
+                     {:op-type :event}
+                     {:source :ui :op-type :error}
+                     {:dispatch-id 5}
+                     ;; orphan filter — value not in buffer:
+                     {:source :sse}]]
+      (let [evs        (mapv trace-event-fixture (range 200))
+            state      (trace-helpers/rebuild-feed-state evs)
+            from-state (trace-helpers/project-feed-from-state state filters)
+            from-raw   (trace-helpers/project-feed evs filters)]
+        (is (= (:total from-state) (:total from-raw))
+            (str "total under " (pr-str filters)))
+        (is (= (:rendered from-state) (:rendered from-raw))
+            (str "rendered under " (pr-str filters)))
+        (is (= (mapv :id (:rows from-state))
+               (mapv :id (:rows from-raw)))
+            (str "row id sequence under " (pr-str filters)))
+        (is (= (:empty-kind from-state) (:empty-kind from-raw))
+            (str "empty-kind under " (pr-str filters)))))))


### PR DESCRIPTION
## Summary

Two related fixes on the trace-feed pipeline; share helper substrate in `trace_helpers.cljc`, so landed together.

### rf2-44vzy — incremental trace-feed projection (perf)

The reactive `:rf.causa/trace-feed` sub re-walked the entire trace buffer on every `:rf.causa/note-trace-event` dispatch — under burst (60Hz × 1000-event buffer) that is ~60k row-touches/sec on the main thread before any render work.

A `:trace-feed-state` snapshot is now maintained incrementally in app-db alongside `:trace-buffer`. The note-trace-event handler dual-writes both slots in O(axes) per push; clear / sync handlers drop or rebuild the snapshot in lockstep. New sub `:rf.causa/trace-feed-state` exposes the snapshot; `project-feed-from-state` produces the same projection shape as the prior `project-feed` (retained as the JVM-testable reference + fallback).

**Measured (1000-event burst, JVM):**
- OLD `project-feed` full re-walk per push: **4.136 ms**
- NEW push + filter read: **0.086 ms** (~48× faster end-to-end)
- NEW push-only hot path (per-event work on dispatch): **0.020 ms** (~206× faster)

Privacy invariant (rf2-lqmje §Privacy retroactive-scrub): `:rf.causa/clear-trace-buffer` dissocs both `:trace-buffer` and `:trace-feed-state` so the incremental snapshot inherits the same retroactive-scrub guarantee `trace-bus/clear-buffer!` provides — no new surface where privacy-sensitive data could survive a toggle.

### rf2-vu0mp — orphan filter (chip row + empty state) (UX bug fix)

`distinct-values` was computed over the current buffer only. When the buffer rotated past cap and the selected filter value's last instance aged out, `:trace-filters` still carried the selection but the chip row no longer surfaced it — user saw `:no-matches` with no in-panel cue what was narrowing the view.

Fix has two faces:
1. **`effective-distinct`** unions the active filter value into the per-axis distinct vector (preserving first-seen order) so the chip ALWAYS renders for the user's selection — orphan or not. Orphan chips are marked visually (count=0, dashed border, italic).
2. **`active-filters-summary`** emits `[{:axis :value :present?}]` for every active filter; the `:no-matches` empty state now renders a 'narrowing on:' strip of pills. Clicking a pill drops that axis; orphan pills carry an '(orphaned)' marker.

## Test plan

- [x] `tools/causa: clojure -M:test` — 576 / 1694 / 0 fail / 0 err
- [x] `implementation: npm run test:cljs` — 2335 / 6697 / 0 fail / 0 err
- [x] `implementation: npm run test:bundle-isolation` — PASS
- [x] `implementation: npm run test:perf-bundle` — PASS
- [x] `bash scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] `bash scripts/test-jvm-tools.sh` — PASS tools JVM artefacts

Closes rf2-44vzy and rf2-vu0mp.