### PR TITLE
test(ssr): expand streaming + teardown corner-matrix (rf2-u91hb)

### DIFF
--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -1,0 +1,148 @@
+(ns re-frame.ssr.ring.streaming-writer-trace-test
+  "Pin the writer thread's load-bearing trace emission and frame teardown
+  composition. Per rf2-u91hb (audit follow-on from the rare-corner-cases
+  sweep).
+
+  ## Why this fills a real gap
+
+  `streaming_robustness_test` covers four behaviours of the streaming
+  writer's `catch Throwable` arm:
+
+    1. broken-pipe absorbed, OutputStream closed by `finally`,
+    2. real-network disconnect cleans up,
+    3. root-view throw absorbed, daemon terminates,
+    4. daemon thread name carries the frame-id.
+
+  What it does NOT cover — and what `re-frame.ssr.ring.streaming/run-
+  streaming-writer!` line 180 explicitly produces — is the
+  `:rf.error/ssr-streaming-writer-failed` trace event itself. The
+  streaming.cljc docstring (line 22-23) names the trace as the
+  load-bearing observability signal for writer-thread failures, but
+  no test grep'd anywhere in the suite finds an assertion on the
+  trace keyword: `ssr-streaming-writer-failed` appears only in the
+  impl + docstrings.
+
+  That's the gap this ns fills. Trace observability is a production-
+  monitoring contract — apps registering trace listeners for the
+  failure category MUST see events fire. If a refactor of
+  `run-streaming-writer!` drops the trace emit by accident (it would
+  pass every existing robustness test, since those only assert
+  absence-of-escape and pipe-close), the gap re-opens silently and
+  ops loses the signal.
+
+  Second gap covered here: the writer thread's `finally` arm wraps
+  the per-request frame destroy (`lifecycle/destroy-frame-quietly!`
+  in `stream-handler`'s spawn body — `streaming.clj` line 273). The
+  contract is that EVEN WHEN the writer body throws, the destroy
+  still runs in the spawned-thread `finally`. The existing tests
+  cover writer-body throws AND daemon thread cleanup, but not the
+  composition: a writer-body throw co-occurs with a frame whose
+  side-channel atoms become observable via the destroy hook."
+  (:require [clojure.set]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.streaming :as streaming]
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.trace :as trace])
+  (:import [java.io InputStream PipedInputStream PipedOutputStream]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(defn- with-trace-capture
+  [coll-atom body-fn]
+  (let [k (str (gensym "ssr-writer-trace-cb"))]
+    (trace/register-trace-cb! k (fn [ev] (swap! coll-atom conj ev)))
+    (try (body-fn)
+         (finally (trace/remove-trace-cb! k)))))
+
+;; ===========================================================================
+;; The trace emit itself — the gap streaming_robustness_test left open.
+;; ===========================================================================
+
+(deftest writer-catch-arm-emits-ssr-streaming-writer-failed-trace
+  (testing "rf2-u91hb: when run-streaming-writer!'s outer catch arm
+            absorbs a throw, it MUST emit :rf.error/ssr-streaming-
+            writer-failed on the trace bus per the streaming.cljc /
+            streaming.clj failure-semantics contract. The existing
+            robustness tests pin absorb behaviour + pipe-close, but
+            never the trace itself — a refactor that silently drops
+            the emit would pass every existing test."
+    (let [pipe-in  (PipedInputStream. 1024)
+          pipe-out (PipedOutputStream. pipe-in)
+          _        (.close pipe-in) ;; pre-broken pipe — every write throws
+          captured (atom [])]
+      ;; Drive the writer body directly against the pre-broken pipe;
+      ;; the writer's outer try fires on the first internal
+      ;; with-frame deref (no such frame) AND on every subsequent
+      ;; pipe write. Either way the catch arm runs.
+      (with-trace-capture captured
+        #(@#'streaming/run-streaming-writer!
+           pipe-out :no-such-frame {} {:root-view [:div]}))
+      (let [hits (filterv #(= :rf.error/ssr-streaming-writer-failed (:operation %))
+                          @captured)]
+        (is (= 1 (count hits))
+            (str "expected exactly one :rf.error/ssr-streaming-writer-
+                 failed trace; saw: " (count hits) " (all operations: "
+                 (pr-str (mapv :operation @captured)) ")"))
+        (when (seq hits)
+          (let [ev (first hits)]
+            (is (= :error (:op-type ev))
+                ":op-type is :error per Spec 009 — writer-failed is a
+                 hard failure, not a warning")
+            (is (some? (-> ev :tags :exception))
+                ":exception tag carries the throwable's message")
+            (is (some? (-> ev :tags :ex-class))
+                ":ex-class tag carries the throwable's class name")
+            (is (= :truncate-and-close (:recovery ev))
+                ":recovery is hoisted to top-level per Spec 009
+                 §Error event shape — names the failure-recovery
+                 policy (partial response on the wire, pipe closes)")
+            (is (= :no-such-frame (-> ev :tags :frame))
+                ":frame tag identifies which request failed — load-
+                 bearing for ops correlating writer failures to
+                 specific requests in JFR / log streams")))))))
+
+;; ===========================================================================
+;; Writer-throw composition with frame destroy — even when the writer
+;; body throws, the spawned-thread `finally` MUST run destroy-frame-
+;; quietly! so the per-request frame's app-db + side-channel slots are
+;; released. Pin the composition the existing tests test independently.
+;; ===========================================================================
+
+(deftest stream-handler-destroys-frame-when-writer-body-throws
+  (testing "rf2-u91hb: when the streaming writer body throws (root-view
+            throw), the spawned thread's finally MUST still invoke
+            destroy-frame-quietly! so the per-request frame's app-db
+            / sub-cache / side-channel slots are released. Without this
+            composition every aborted/failed streaming request would
+            leak a frame record. Per stream-handler line ~268-273."
+    (rf/reg-event-fx :rf.test.writer/init
+      {:platforms #{:server}}
+      (fn [_ _] {:db {}}))
+    (let [throwing-root (fn [] (throw (ex-info "writer-thread teardown probe"
+                                               {:reason :rf2-u91hb})))
+          handler  (ssr-ring/stream-handler
+                     {:on-create [:rf.test.writer/init]
+                      :root-view throwing-root
+                      :payload-policy :rf.ssr.payload/whole-app-db})
+          ;; Frame ids BEFORE the request — baseline.
+          baseline-fids (disj (frame/frame-ids) :rf/default)
+          response (handler {:uri "/" :request-method :get})
+          ;; Drain the body so the writer thread runs to completion +
+          ;; the spawned-thread `finally` fires.
+          _drain   (slurp ^InputStream (:body response))]
+      ;; Give the spawned thread a beat to finish its finally arm.
+      ;; The writer ran on a different thread; the destroy ran in
+      ;; its finally, but we just drained the InputStream and the
+      ;; writer's outer finally closed the pipe BEFORE the
+      ;; spawned-thread finally runs the destroy. Brief sleep is OK
+      ;; here; the post-condition is the load-bearing assertion.
+      (Thread/sleep 200)
+      (let [end-fids (disj (frame/frame-ids) :rf/default)
+            leaked   (clojure.set/difference end-fids baseline-fids)]
+        (is (empty? leaked)
+            (str "the per-request frame MUST be destroyed even though
+                 the writer body threw — found leaked frame-ids: "
+                 (vec leaked)))))))

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -1,0 +1,529 @@
+(ns re-frame.ssr-streaming-corner-test
+  "Corner-matrix coverage for the streaming SSR shell walker, continuation
+  drain, and final-payload build paths. Per rf2-u91hb (audit follow-on
+  from the rare-corner-cases sweep): the existing
+  `ssr_streaming_test.clj` pins the common shapes (single boundary,
+  duplicate id, failed continuation, payload shape); this ns pins the
+  composition corners — `n=0`/`n>=2` body children, nested boundaries,
+  boundaries inside view-refs and fragments, fallback-render-throw
+  recovery, delta capturing a real change, final-payload-build throw
+  composition with the writer's catch arm, and the allowlist projection
+  on the final payload.
+
+  Why a sibling ns rather than appending to `ssr_streaming_test`. Each
+  test here pins a documented invariant that's downstream of the basic
+  shapes — keeping them in a focused file makes the corner topology
+  obvious at-a-glance to anyone auditing the streaming surface. Mirrors
+  the rf2-jvpli / rf2-ozhy9 split (`streaming_robustness_test` +
+  `concurrency_stress_test`) where the basic ring-streaming pin lives in
+  `ring_streaming_test` and the failure-mode tests live in dedicated
+  sibling ns'.
+
+  All tests are JVM-only — streaming SSR is JVM-only by design (Ring is
+  Clojure-on-the-JVM)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ssr.streaming :as streaming]
+            [re-frame.ssr.test-fixture :as tf]
+            [re-frame.trace :as trace]))
+
+(defn- reset+reg
+  [test-fn]
+  (tf/reset-runtime
+    (fn []
+      (rf/reg-event-db :rf.test/seed-db (fn [_ [_ db]] db))
+      (rf/reg-event-db :rf.test/noop    (fn [db _] db))
+      (test-fn))))
+
+(use-fixtures :each reset+reg)
+
+(defn- with-trace-capture
+  "Capture every emitted trace event into `coll-atom` during `(body-fn)`."
+  [coll-atom body-fn]
+  (let [k (str (gensym "streaming-corner-cb"))]
+    (trace/register-trace-cb! k (fn [ev] (swap! coll-atom conj ev)))
+    (try (body-fn)
+         (finally (trace/remove-trace-cb! k)))))
+
+(defn- make-server-frame
+  "Register a per-request server frame and seed its app-db via :on-create.
+   Returns the frame-id."
+  ([] (make-server-frame {}))
+  ([db]
+   (let [fid (keyword "rf.frame" (str (gensym "")))]
+     (rf/reg-frame fid
+       {:doc       "streaming-corner frame"
+        :platform  :server
+        :on-create (if (seq db) [:rf.test/seed-db db] [:rf.test/noop])})
+     fid)))
+
+;; ===========================================================================
+;; Shell-walk body-arity corners — n=0, n>=2 (the case n=0/1/2 branch in
+;; streaming.cljc:249-252). The existing test suite only covered n=1.
+;; ===========================================================================
+
+(deftest boundary-with-zero-body-children-resolves-empty-html
+  (testing "rf2-u91hb: a :rf/suspense-boundary with NO body children
+            (n=0 branch) registers a continuation whose subtree is nil;
+            render-continuation resolves to empty HTML and does NOT
+            throw. The shell still emits the fallback placeholder."
+    (let [tree [:div
+                [:rf/suspense-boundary
+                 {:id :empty/body :fallback [:p "loading"]}]]
+          {:keys [shell-html continuations]}
+          (streaming/render-shell tree)]
+      (is (= 1 (count continuations))
+          "even a zero-body boundary registers a continuation")
+      (is (str/includes? shell-html "<p>loading</p>")
+          "fallback still materialised in the shell")
+      ;; Drain the continuation — the subtree is nil per the n=0 branch;
+      ;; emit-element returns "" for nil, so the resolved html is empty.
+      (let [fid    (make-server-frame)
+            entry  (assoc (first continuations) :fallback [:p "loading"])
+            result (streaming/render-continuation fid entry)]
+        (is (not (:failed? result))
+            "nil subtree is NOT a failure — render-to-string treats it
+             as an empty render per the emit-element nil branch")
+        (is (= "" (:html result))
+            "the zero-body resolved chunk's HTML is empty (per Spec 011
+             §The render-tree → HTML emitter — nil renders as empty)")
+        (is (map? (:delta result))
+            ":delta is still a (possibly empty) map even with no body")))))
+
+(deftest boundary-with-multi-child-body-wraps-in-fragment
+  (testing "rf2-u91hb: a :rf/suspense-boundary with TWO+ body children
+            (n>=2 branch) wraps them in a :<> fragment so a single
+            logical hiccup form drains; both children's HTML appears in
+            the resolved chunk."
+    (let [tree [:div
+                [:rf/suspense-boundary
+                 {:id :multi/body :fallback [:p "loading"]}
+                 [:p "first"]
+                 [:p "second"]
+                 [:p "third"]]]
+          {:keys [continuations]} (streaming/render-shell tree)]
+      (is (= 1 (count continuations))
+          "multi-child body still registers ONE continuation — the
+           fragment wraps all children")
+      (let [fid    (make-server-frame)
+            entry  (assoc (first continuations) :fallback [:p "loading"])
+            result (streaming/render-continuation fid entry)]
+        (is (not (:failed? result)))
+        (is (= "<p>first</p><p>second</p><p>third</p>" (:html result))
+            "all three children resolved — fragment splices them
+             without a wrapper element (Spec 011 §Source-coord
+             annotation: :<> is exempt from DOM-tag wrapping)")))))
+
+;; ===========================================================================
+;; Boundary composition — nesting + view-ref + fragment heads
+;; ===========================================================================
+
+(deftest boundary-nested-inside-resolved-subtree-registers-inner-continuation
+  (testing "rf2-u91hb: when a continuation's subtree contains ANOTHER
+            :rf/suspense-boundary, the inner boundary registers during
+            the continuation's render — at the tail of the drain queue
+            per Spec 011 §Boundary nesting and recursion (FIFO over
+            registration order)."
+    (let [tree [:div
+                [:rf/suspense-boundary
+                 {:id :outer :fallback [:p "outer loading"]}
+                 [:section
+                  [:rf/suspense-boundary
+                   {:id :inner :fallback [:p "inner loading"]}
+                   [:p "inner body"]]]]]
+          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+      ;; The SHELL walk only sees the outer boundary — the inner is
+      ;; buried inside the outer's subtree and registers when the outer
+      ;; continuation later drains.
+      (is (= 1 (count continuations))
+          "shell walk registers ONE outer continuation; inner is buried
+           inside the outer's subtree and registers at drain time")
+      (is (= :outer (-> continuations first :id)))
+      (is (str/includes? shell-html "outer loading")
+          "outer fallback in the shell")
+      (is (not (str/includes? shell-html "inner loading"))
+          "inner fallback NOT in the shell (still buried in the
+           unresolved outer subtree)")
+      ;; Drain the outer — the inner boundary's hiccup is emitted by
+      ;; the standard emitter (since render-continuation calls
+      ;; emit/render-to-string, not the walker). This means the inner
+      ;; boundary's HICCUP shape lands in the resolved chunk as-is —
+      ;; including the inner's fallback rendered inline. The wire
+      ;; contract per Spec 011: nested boundaries that fire inside a
+      ;; continuation register a new drain entry; the SSR ring adapter
+      ;; threads them through (`stream-handler` re-invokes the walker
+      ;; per resolved chunk). At the pure-streaming level
+      ;; (render-continuation), the inner boundary renders via the
+      ;; non-streaming emitter, which surfaces an exception on the
+      ;; unrecognised :rf/suspense-boundary head — caught as a
+      ;; failure and inline-fallback'd. Pin THAT contract.
+      (let [fid    (make-server-frame)
+            entry  (assoc (first continuations) :fallback [:p "outer loading"])
+            captured (atom [])
+            result (with-trace-capture captured
+                     #(streaming/render-continuation fid entry))]
+        ;; The pure render-continuation path (without the ring
+        ;; adapter's per-chunk re-walker) DOES fail on the buried
+        ;; suspense-boundary keyword — which exercises the
+        ;; inline-fallback contract. The ring host adapter's writer
+        ;; loop is what actually re-walks; the pure runtime layer
+        ;; pins the fail-soft semantics.
+        (is (or (not (:failed? result))
+                (and (:failed? result)
+                     (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                           @captured)))
+            "outer continuation either resolves cleanly (renderer
+             passed the unknown head through) OR fails-soft into the
+             fallback (per Spec 011 §Failure semantics — inline
+             fallback). Either is acceptable; what is NOT acceptable
+             is an uncaught throw escaping the drain.")))))
+
+(deftest boundary-inside-registered-view-body-is-reachable-by-walker
+  (testing "rf2-u91hb: when a registered view's body contains
+            :rf/suspense-boundary, the walker resolves the view-ref and
+            recurses into its hiccup output. This is the load-bearing
+            case for the conformance fixture's root view, which IS a
+            registered view containing boundaries."
+    (rf/reg-view ^{:rf/id :test/wrapper} wrapper-view []
+      [:section
+       [:h1 "wrapper"]
+       [:rf/suspense-boundary
+        {:id :buried/in-view :fallback [:p "buried loading"]}
+        [:p "buried body"]]])
+    (let [tree [:main [:test/wrapper]]
+          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+      (is (= 1 (count continuations))
+          "the walker recursed into the registered view and found the
+           boundary")
+      (is (= :buried/in-view (-> continuations first :id))
+          "the buried boundary's id propagates")
+      (is (str/includes? shell-html "<section")
+          "the view's wrapping <section> rendered in the shell
+           (source-coord injection adds a data-rf2-source-coord attr
+           on the registered view's root DOM element per Spec 006)")
+      (is (str/includes? shell-html "buried loading")
+          "the buried boundary's fallback materialised inline")
+      (is (str/includes? shell-html "data-rf2-suspense-id=\":buried/in-view\"")
+          "the boundary's id was stamped on the fallback template"))))
+
+(deftest boundary-inside-fragment-children-is-reachable-by-walker
+  (testing "rf2-u91hb: when a :<> fragment's children contain a
+            :rf/suspense-boundary, the walker splices the fragment and
+            finds the boundary. Critical for hiccup authors who use
+            fragments to group siblings without a wrapper element."
+    (let [tree [:main
+                [:<>
+                 [:h1 "header in fragment"]
+                 [:rf/suspense-boundary
+                  {:id :in-fragment :fallback [:p "fragment loading"]}
+                  [:p "fragment body"]]
+                 [:p "footer in fragment"]]]
+          {:keys [shell-html continuations]} (streaming/render-shell tree)]
+      (is (= 1 (count continuations))
+          "the walker spliced the fragment and reached the boundary")
+      (is (= :in-fragment (-> continuations first :id)))
+      (is (str/includes? shell-html "<h1>header in fragment</h1>")
+          "fragment sibling above the boundary emitted")
+      (is (str/includes? shell-html "<p>footer in fragment</p>")
+          "fragment sibling below the boundary emitted")
+      (is (str/includes? shell-html "fragment loading")
+          "the buried boundary's fallback materialised inline"))))
+
+(deftest triple-duplicate-id-keeps-only-last-of-three
+  (testing "rf2-u91hb: three boundaries with the same :id — dedup keeps
+            ONLY the LAST registration. Pins the last-write-wins shape
+            against more than two duplicates (the existing test covers
+            only the 2-duplicate case)."
+    (let [tree [:div
+                [:rf/suspense-boundary
+                 {:id :triple :fallback [:p "first fallback"]}
+                 [:p "first body"]]
+                [:rf/suspense-boundary
+                 {:id :triple :fallback [:p "second fallback"]}
+                 [:p "second body"]]
+                [:rf/suspense-boundary
+                 {:id :triple :fallback [:p "third fallback"]}
+                 [:p "third body"]]]
+          captured (atom [])
+          {:keys [continuations]}
+          (with-trace-capture captured #(streaming/render-shell tree))]
+      (is (= 1 (count continuations))
+          "only one continuation survives dedup across three duplicates")
+      ;; Drain it — the body should be the LAST registration's body
+      ;; (third), confirming last-write-wins.
+      (let [fid    (make-server-frame)
+            entry  (assoc (first continuations) :fallback [:p "third fallback"])
+            result (streaming/render-continuation fid entry)]
+        (is (str/includes? (:html result) "third body")
+            "the resolved chunk carries the LAST-registered body — not
+             the first or middle. Per Spec 011 §Boundary nesting and
+             recursion: 'the second registration overwrites the first'
+             generalises to N-deep — every-but-last is dropped."))
+      (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
+                @captured)
+          "the duplicate-id trace still fires across N=3 duplicates")
+      (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                    (:operation %))
+                                @captured)]
+        (is (= 1 (count dup-traces))
+            "one trace, not three — dedup groups all duplicates of
+             the same id into a single trace event")
+        (when (seq dup-traces)
+          (let [ev   (first dup-traces)
+                tags (:tags ev)]
+            (is (= 3 (:count tags))
+                ":count tag reports the duplicate cardinality (3)")
+            (is (= :last-write-wins (:recovery ev))
+                ":recovery is hoisted to top-level of the trace
+                 envelope per Spec 009 §Error event shape — names the
+                 policy applied")))))))
+
+;; ===========================================================================
+;; render-continuation — fallback-render throw + delta + stale frame
+;; ===========================================================================
+
+(deftest render-continuation-fallback-render-throw-emits-empty-html
+  (testing "rf2-u91hb: when the subtree throws AND the fallback ALSO
+            throws on render, render-continuation MUST NOT escape — it
+            returns :failed? true with empty :html (per streaming.cljc
+            line 397-404). The client-side runtime treats an empty
+            resolved chunk as a no-op."
+    ;; Spec 011 §Failure semantics: shell-walk throws escalate; only
+    ;; CONTINUATION-level throws are inline-fallback'd. So we render
+    ;; the shell with a NON-THROWING fallback (avoid the shell-walk-
+    ;; throw escalation path), then plant a throwing fallback on the
+    ;; entry before driving render-continuation.
+    (let [throws-sub (fn [] (throw (ex-info "subtree boom" {})))
+          throws-fb  (fn [] (throw (ex-info "fallback boom" {})))
+          tree   [:rf/suspense-boundary {:id :double-throw
+                                         :fallback [:p "ok in shell"]}
+                  [throws-sub]]
+          {:keys [continuations]} (streaming/render-shell tree)
+          fid (make-server-frame)
+          entry (assoc (first continuations) :fallback [throws-fb])
+          captured (atom [])
+          result (with-trace-capture captured
+                   #(streaming/render-continuation fid entry))]
+      (is (:failed? result)
+          ":failed? is true when the subtree throws — even though
+           the fallback render also throws")
+      (is (= "" (:html result))
+          "fallback-render throw → empty html (the inner try/catch in
+           streaming.cljc renders fallback OR returns \"\" on its own
+           throw)")
+      (is (nil? (:delta result))
+          "delta still omitted on failure")
+      (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                @captured)
+          "the suspense-boundary-failed trace still fires for the
+           subtree throw — even though the fallback also failed
+           (the trace describes the SUBTREE failure, which is what
+           the client cares about)"))))
+
+(deftest render-continuation-delta-captures-app-db-change-during-render
+  (testing "rf2-u91hb: render-continuation snapshots app-db before
+            render, then after; the resulting :delta carries the keys
+            that changed (per spec — :delta is the streaming hydration
+            speed prop). Pins that the diff actually fires."
+    (rf/reg-event-db :test/mutate-during-render
+      (fn [db _] (assoc db :new-key :new-value)))
+    (let [fid     (make-server-frame {:initial :state})
+          ;; A view that DISPATCHES (mutates app-db) during render —
+          ;; the canonical streaming pattern for async data resolution.
+          _       (rf/reg-view ^{:rf/id :test/mutating} mutating-view []
+                    (rf/dispatch-sync [:test/mutate-during-render] {:frame fid})
+                    [:p "mutated"])
+          tree    [:rf/suspense-boundary
+                   {:id :mutator :fallback [:p "loading"]}
+                   [:test/mutating]]
+          {:keys [continuations]} (streaming/render-shell tree)
+          entry   (first continuations)
+          result  (streaming/render-continuation fid entry)]
+      (is (not (:failed? result)))
+      (is (str/includes? (:html result) "mutated")
+          "the resolved chunk's html carries the view's rendered
+           output (source-coord injection rides the root element
+           per Spec 006 — we only assert the textual content)")
+      ;; The delta MUST include the new key that the render-time
+      ;; dispatch put on app-db.
+      (is (contains? (:delta result) :new-key)
+          ":delta carries the app-db key the render-time dispatch
+           added — pin that diff actually fires, not silently returns
+           empty (clojure.data/diff path; spec 011 §Hydration
+           interleaving — per-subtree deltas)")
+      (is (= :new-value (get-in result [:delta :new-key]))
+          "the delta's value matches the post-render app-db value"))))
+
+(deftest render-continuation-after-frame-destroy-still-fails-soft
+  (testing "rf2-u91hb: if the host adapter (incorrectly) drives
+            render-continuation against a frame-id whose frame has
+            been destroyed, the runtime MUST fail-soft (not escape
+            with NPE / NoSuchFrame). The continuation's failure
+            surfaces as :failed? true with the inline-fallback path."
+    (let [fid (make-server-frame {:initial :state})
+          tree [:rf/suspense-boundary
+                {:id :after-destroy :fallback [:p "loading"]}
+                [:p "body"]]
+          {:keys [continuations]} (streaming/render-shell tree)
+          entry (assoc (first continuations) :fallback [:p "loading"])]
+      ;; Destroy the frame.
+      (rf/destroy-frame! fid)
+      ;; Now drive the continuation against the dead frame-id. The
+      ;; pure render-continuation path either resolves cleanly
+      ;; (treating absent app-db as nil) or fails-soft via the
+      ;; inline-fallback contract. Either is acceptable per Spec 011
+      ;; §Failure semantics; what is NOT acceptable is an uncaught
+      ;; throw.
+      (let [captured (atom [])
+            result (with-trace-capture captured
+                     #(streaming/render-continuation fid entry))]
+        (is (map? result)
+            "render-continuation returned a result map — did NOT
+             escape with an uncaught exception even though the frame
+             was destroyed before the call")
+        (is (contains? result :failed?)
+            ":failed? key is present")
+        (is (contains? result :html)
+            ":html key is present")))))
+
+;; ===========================================================================
+;; build-final-payload — allowlist projection composition
+;; ===========================================================================
+
+(deftest build-final-payload-allowlist-drops-unpermitted-keys
+  (testing "rf2-u91hb: the streaming build-final-payload MUST honour
+            :payload-keys allowlist projection — same contract as
+            non-streaming build-payload (the streaming + non-streaming
+            payload builders share re-frame.ssr.payload-policy/apply-
+            policy per rf2-gtgf9). Pin that an un-permitted key on
+            app-db does NOT ride the wire under the streaming path."
+    (let [fid (make-server-frame {:public/articles [{:id "a"}]
+                                  :server-only/auth-token "RF2_U91HB_LEAK_PROBE_xyz"
+                                  :server-only/admin-flag true})
+          payload (streaming/build-final-payload
+                    fid "deadbeef"
+                    {:version       1
+                     :payload-keys  [:public/articles]})]
+      (is (= [{:id "a"}] (get-in payload [:rf/app-db :public/articles]))
+          "the public slice IS on the wire (sanity)")
+      (is (not (contains? (:rf/app-db payload) :server-only/auth-token))
+          "the un-permitted :server-only/auth-token key does NOT
+           appear in the streaming final payload — pin the rf2-gtgf9
+           fail-closed proof on the STREAMING path")
+      (is (not (contains? (:rf/app-db payload) :server-only/admin-flag))
+          "belt-and-braces over a second un-permitted slot"))))
+
+;; ===========================================================================
+;; clear-request! / clear-response! — idempotent no-ops on unpopulated
+;; frames (Spec 011 §Per-request frame teardown contract — \"idempotent\"
+;; in the on-frame-destroyed! docstring; pin the public surfaces too.)
+;; ===========================================================================
+
+(deftest clear-request-on-unpopulated-frame-is-noop
+  (testing "rf2-u91hb: ssr/clear-request! on a frame-id that was never
+            populated MUST be a no-op — host adapters that forget to
+            populate (or clear twice) must not observe any error or
+            side-effect"
+    (let [before @(requiring-resolve 're-frame.ssr.request/request-slots)]
+      ;; Call against a non-existent frame-id.
+      (is (= :never-populated
+             ((requiring-resolve 're-frame.ssr.request/clear-request!)
+              :never-populated))
+          "clear-request! returns the frame-id on the empty branch
+           (matches the populated-branch return shape)")
+      (let [after @(requiring-resolve 're-frame.ssr.request/request-slots)]
+        (is (= before after)
+            "the slot atom is unchanged — no spurious entry created
+             by a clear of a never-populated slot")))))
+
+(deftest clear-response-on-unpopulated-frame-is-noop
+  (testing "rf2-u91hb: ssr/clear-response! on a never-populated frame
+            MUST be a no-op (same idempotence contract as clear-
+            request!)"
+    (let [before @(requiring-resolve 're-frame.ssr.response/response-slots)]
+      (is (= :never-populated
+             ((requiring-resolve 're-frame.ssr.response/clear-response!)
+              :never-populated)))
+      (let [after @(requiring-resolve 're-frame.ssr.response/response-slots)]
+        (is (= before after))))))
+
+;; ===========================================================================
+;; Privacy boundary — request slot / response accumulator NOT readable
+;; from app-db. The privacy contract is "MUST NOT ride app-db"
+;; (Spec 011 §Request storage substrate + §Response storage substrate).
+;; Pre-rf2-jbcmt the response accumulator DID live on app-db; we pin
+;; the post-fix invariant so a regression that re-introduces an app-db
+;; backing fires loudly.
+;; ===========================================================================
+
+(deftest response-accumulator-not-on-app-db-privacy-invariant
+  (testing "rf2-u91hb: writing an :rf.server/* fx MUST NOT populate any
+            key under app-db. Per Spec 011 §Response storage substrate
+            (rf2-jbcmt) — privacy boundary: response accumulator data
+            (Set-Cookie, internal X-* headers) MUST NOT default-leak
+            into the hydration payload via an app-db backing store."
+    (rf/reg-event-fx :test/server-write
+      {:platforms #{:server}}
+      (fn [_ _]
+        {:fx [[:rf.server/set-header {:name "X-Internal-Token" :value "secret"}]
+              [:rf.server/set-cookie {:name "session" :value "sess-abc"}]]}))
+    (let [fid (keyword "rf.frame" (str (gensym "")))]
+      (rf/reg-frame fid
+        {:doc       "privacy-invariant frame"
+         :platform  :server
+         :on-create [:test/server-write]})
+      (let [app-db (frame/frame-app-db-value fid)]
+        ;; Spec 011 §Response storage substrate: NO app-db key may
+        ;; carry the accumulator. Pin both the published reserved key
+        ;; AND the sentinel key the pre-jbcmt path used.
+        (is (not (contains? app-db :rf/response))
+            "app-db MUST NOT carry :rf/response — pre-rf2-jbcmt this
+             was the storage path; the post-fix invariant is the
+             side-channel atom in re-frame.ssr.response/response-slots")
+        ;; Defensive: also assert no key with substring "response" or
+        ;; "cookie" in the keyword name (a sloppy refactor that picks
+        ;; a different key name on app-db would still violate).
+        (let [keys-named-response
+              (filter (fn [k] (and (keyword? k)
+                                   (or (str/includes? (name k) "response")
+                                       (str/includes? (name k) "cookie")
+                                       (str/includes? (name k) "header"))))
+                      (keys app-db))]
+          (is (empty? keys-named-response)
+              (str "app-db carries NO key with a response/cookie/header
+                   name — the accumulator MUST live off-band per Spec
+                   011 §Response storage substrate. Suspect keys: "
+                   (vec keys-named-response))))))))
+
+(deftest request-slot-not-on-app-db-privacy-invariant
+  (testing "rf2-u91hb: populating the per-request request slot MUST NOT
+            land any key on app-db. Per Spec 011 §Request storage
+            substrate — the request map carries Host, Cookie,
+            Authorization, X-Forwarded-For; an app-db backing would
+            default-leak it onto the hydration payload."
+    (let [fid (keyword "rf.frame" (str (gensym "")))]
+      (rf/reg-frame fid
+        {:doc       "request-slot privacy frame"
+         :platform  :server
+         :on-create [:rf.test/noop]})
+      (let [secret-request {:uri            "/secret"
+                            :request-method :get
+                            :headers        {"authorization" "Bearer SECRET_TOKEN"
+                                             "cookie"        "session=hot"}}]
+        ((requiring-resolve 're-frame.ssr.request/set-request!) fid secret-request)
+        (let [app-db (frame/frame-app-db-value fid)]
+          (is (not (contains? app-db :rf.server/request))
+              "app-db MUST NOT carry :rf.server/request")
+          (is (not (contains? app-db :request))
+              "app-db MUST NOT carry :request")
+          (let [all-vals (vals app-db)
+                serialised (pr-str all-vals)]
+            (is (not (str/includes? serialised "SECRET_TOKEN"))
+                "the request's bearer token does NOT appear anywhere
+                 in the serialised app-db values — privacy boundary
+                 holds across the population path")
+            (is (not (str/includes? serialised "session=hot"))
+                "the request's cookie value does NOT appear in
+                 serialised app-db")))))))

--- a/implementation/ssr/test/re_frame/ssr_teardown_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_teardown_corner_test.clj
@@ -1,0 +1,224 @@
+(ns re-frame.ssr-teardown-corner-test
+  "Corner-matrix coverage for per-request frame teardown — composition,
+  idempotence, cross-frame isolation, missing-hook tolerance. Per
+  rf2-u91hb (audit follow-on from the rare-corner-cases sweep).
+
+  ## Why this lives next to `ssr_teardown_load_test.clj`
+
+  `ssr_teardown_load_test` proves the teardown contract HOLDS UNDER
+  LOAD (2000 requests, every side-channel returns to baseline). It
+  drives the documented per-request flow N times and asserts the
+  aggregate invariant. What it does NOT do is exercise each named
+  invariant on its own (`re-frame.ssr.request/on-frame-destroyed!`
+  docstring claims four properties: drops pending-error-traces, drops
+  request-slots, drops response-slots, invokes head-cleanup hook;
+  idempotent; tolerates missing head hook). The load test will catch
+  a regression in the aggregate, but the per-invariant tests are the
+  triage hooks — they name the failing dimension at first sight, not
+  via a heap-delta detective story.
+
+  ## Scope
+
+  Composition: a single destroy of a fully-populated frame releases
+  all four side-channels in one call (test 1).
+  Idempotence: a second destroy of the same frame-id is a no-op (test 2).
+  Cross-frame isolation: destroying frame A leaves frame B's slots
+  intact (test 3).
+  Missing-hook tolerance: the head-cleanup hook can be absent (e.g. a
+  bundle that doesn't pull in re-frame.ssr.head); destroy still completes
+  (test 4)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.ssr.error-listener :as error-listener]
+            [re-frame.ssr.head :as head]
+            [re-frame.ssr.request :as request]
+            [re-frame.ssr.response :as response]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+;; ===========================================================================
+;; Composition — one destroy clears all four side-channels
+;; ===========================================================================
+
+(deftest on-frame-destroyed-clears-all-four-side-channels-in-one-call
+  (testing "rf2-u91hb: a single destroy call against a frame whose
+            request-slot, response-slot, pending-error-trace buffer,
+            AND head-snapshot are ALL populated MUST clear every one
+            of them. The pre-rf2-fcj33 / rf2-jbcmt teardown only
+            cleared a subset (or none); the post-fix contract pins
+            the all-four-in-one-call composition that the four
+            individual tests don't exercise together."
+    (rf/reg-head :head/composition-test (fn [_ _] {:title "composition"}))
+    (let [fid :rf.test/composition-target]
+      ;; Populate all four side-channel slots for fid.
+      (request/set-request! fid {:uri "/comp" :request-method :get})
+      (response/swap-response! fid (fn [r] (assoc r :status 200)))
+      ;; Plant a synthetic pending error trace.
+      (swap! error-listener/pending-error-traces
+             update fid (fnil conj [])
+             {:op-type :error :operation :rf.error/composition-probe})
+      ;; Make-frame + render-head to populate head-snapshot.
+      (rf/reg-frame fid
+        {:doc       "composition test"
+         :platform  :server
+         :on-create [:rf.test.composition/noop]})
+      (rf/reg-event-db :rf.test.composition/noop (fn [db _] db))
+      (rf/render-head :head/composition-test {:frame fid})
+
+      ;; All four populated — sanity.
+      (is (some? (request/get-request fid))
+          "request-slot populated (sanity)")
+      (is (contains? @response/response-slots fid)
+          "response-slot populated (sanity)")
+      (is (contains? @error-listener/pending-error-traces fid)
+          "pending-error-traces populated (sanity)")
+      (is (seq (head/head-snapshot fid))
+          "head-snapshot populated (sanity)")
+
+      ;; Drive the destroy hook directly — this is the single call the
+      ;; spec contract pins as the load-bearing release point.
+      (request/on-frame-destroyed! fid)
+
+      (is (nil? (request/get-request fid))
+          "request-slot released by on-frame-destroyed!")
+      (is (not (contains? @response/response-slots fid))
+          "response-slot released by on-frame-destroyed!")
+      (is (not (contains? @error-listener/pending-error-traces fid))
+          "pending-error-traces released by on-frame-destroyed!")
+      (is (= {} (head/head-snapshot fid))
+          "head-snapshot released by on-frame-destroyed! (via the
+           :ssr/head-on-frame-destroyed late-bind hook chain)"))))
+
+;; ===========================================================================
+;; Idempotence — second destroy is a no-op
+;; ===========================================================================
+
+(deftest on-frame-destroyed-is-idempotent
+  (testing "rf2-u91hb: the on-frame-destroyed! docstring promises
+            idempotence ('a second call against the same frame-id sees
+            the atoms already cleared and does nothing'). Pin that
+            promise — a host adapter that mistakenly invokes the hook
+            twice (e.g. via a defensive try/destroy AND a finally
+            destroy) MUST NOT throw or corrupt state."
+    (rf/reg-head :head/idempotence (fn [_ _] {:title "idem"}))
+    (let [fid :rf.test/idempotence-target]
+      (request/set-request! fid {:uri "/i" :request-method :get})
+      (response/swap-response! fid (fn [r] (assoc r :status 201)))
+      (rf/reg-frame fid
+        {:doc       "idempotence test"
+         :platform  :server
+         :on-create [:rf.test.composition/noop]})
+      (rf/reg-event-db :rf.test.composition/noop (fn [db _] db))
+      (rf/render-head :head/idempotence {:frame fid})
+
+      ;; First destroy releases everything.
+      (request/on-frame-destroyed! fid)
+      (is (nil? (request/get-request fid)))
+      (is (= {} (head/head-snapshot fid)))
+
+      ;; Second destroy MUST be a no-op — no throw, no spurious state
+      ;; change, no extra trace emission.
+      (is (nil? (request/on-frame-destroyed! fid))
+          "second destroy returns nil cleanly")
+      (is (nil? (request/get-request fid))
+          "request-slot still empty after second destroy")
+      (is (= {} (head/head-snapshot fid))
+          "head-snapshot still empty after second destroy"))))
+
+;; ===========================================================================
+;; Cross-frame isolation — destroying A leaves B intact
+;; ===========================================================================
+
+(deftest on-frame-destroyed-isolates-across-frames
+  (testing "rf2-u91hb: destroying frame A MUST NOT touch frame B's
+            slots. Per Spec 011 §Request/Response storage substrate —
+            'two simultaneous per-request frames carry independent
+            slots that cannot bleed into each other'. The four side-
+            channel atoms are keyed by frame-id; the contract is that
+            the destroy hook touches ONLY the keyed entry, not any
+            other frame's entries."
+    (rf/reg-head :head/iso (fn [_ _] {:title "iso"}))
+    (let [fid-a :rf.test/iso-frame-a
+          fid-b :rf.test/iso-frame-b]
+      ;; Populate both frames identically.
+      (doseq [fid [fid-a fid-b]]
+        (request/set-request! fid {:uri (str "/" (name fid))
+                                   :request-method :get})
+        (response/swap-response! fid (fn [r] (assoc r :status 200)))
+        (swap! error-listener/pending-error-traces
+               update fid (fnil conj [])
+               {:op-type :error :operation :rf.error/iso-probe})
+        (rf/reg-frame fid
+          {:doc       (str "iso " (name fid))
+           :platform  :server
+           :on-create [:rf.test.composition/noop]})
+        (rf/reg-event-db :rf.test.composition/noop (fn [db _] db))
+        (rf/render-head :head/iso {:frame fid}))
+
+      ;; Destroy ONLY fid-a.
+      (request/on-frame-destroyed! fid-a)
+
+      ;; fid-a cleared.
+      (is (nil? (request/get-request fid-a)))
+      (is (not (contains? @response/response-slots fid-a)))
+      (is (not (contains? @error-listener/pending-error-traces fid-a)))
+      (is (= {} (head/head-snapshot fid-a)))
+
+      ;; fid-b untouched.
+      (is (some? (request/get-request fid-b))
+          "fid-b's request-slot survived fid-a's destroy")
+      (is (contains? @response/response-slots fid-b)
+          "fid-b's response-slot survived fid-a's destroy")
+      (is (contains? @error-listener/pending-error-traces fid-b)
+          "fid-b's pending-error-traces survived fid-a's destroy")
+      (is (seq (head/head-snapshot fid-b))
+          "fid-b's head-snapshot survived fid-a's destroy"))))
+
+;; ===========================================================================
+;; Missing-hook tolerance — the head-cleanup hook can be absent
+;; ===========================================================================
+
+(deftest on-frame-destroyed-tolerates-missing-head-hook
+  (testing "rf2-u91hb: the :ssr/head-on-frame-destroyed late-bind hook
+            is OPTIONAL — re-frame.ssr.head publishes it at ns-load,
+            but a deployment that wires its own head substitute (or
+            wires NO head at all) leaves the hook unregistered.
+            on-frame-destroyed! MUST tolerate the absence — late-bind
+            lookup returns nil and the destroy completes."
+    (let [fid :rf.test/no-head-hook
+          prior-hook (late-bind/get-fn :ssr/head-on-frame-destroyed)]
+      ;; Populate the OTHER three slots (no head — that's the point).
+      (request/set-request! fid {:uri "/no-head" :request-method :get})
+      (response/swap-response! fid (fn [r] (assoc r :status 200)))
+      (swap! error-listener/pending-error-traces
+             update fid (fnil conj [])
+             {:op-type :error :operation :rf.error/no-head-probe})
+
+      (try
+        ;; Remove the head-cleanup hook by dropping it from the
+        ;; late-bind table — same shape as a deployment that never
+        ;; loaded re-frame.ssr.head.
+        (swap! late-bind/hooks dissoc :ssr/head-on-frame-destroyed)
+        (is (nil? (late-bind/get-fn :ssr/head-on-frame-destroyed))
+            "the hook is now absent (sanity)")
+
+        ;; Drive destroy. MUST NOT throw on the missing-hook path.
+        (is (nil? (request/on-frame-destroyed! fid))
+            "on-frame-destroyed! completes without throwing — the
+             when-let on the absent hook short-circuits to nil")
+
+        (is (nil? (request/get-request fid))
+            "the other three side-channels were still cleared
+             (request-slot)")
+        (is (not (contains? @response/response-slots fid))
+            "response-slot cleared")
+        (is (not (contains? @error-listener/pending-error-traces fid))
+            "pending-error-traces cleared")
+
+        (finally
+          ;; Restore the prior hook so subsequent tests see normal
+          ;; behaviour.
+          (when prior-hook
+            (late-bind/set-fn! :ssr/head-on-frame-destroyed prior-hook)))))))


### PR DESCRIPTION
## Summary

Audit follow-on from the rare-corner-cases sweep. Adds **20 new tests / 86 new assertions** across three focused namespaces, pinning streaming-SSR + per-request-teardown corners the existing suite left uncovered. No back-compat shims; every test pins a current, shipped invariant on a settled contract.

## Corner-matrix audit

55 corners inventoried across the SSR streaming + per-request teardown surfaces. Per-corner status:

- **Covered (already had a test):** 31
- **New test added:** 19
- **New bead filed:** 0
- **Out of scope:** 5

Findings doc: `ai/findings/ssr-streaming-teardown-audit-2026-05-16.md` (local-only, gitignored).

## What's added

### `implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj` (14 tests)

- `n=0` / `n>=2` body-children branches of `walk-suspense-boundary` (existing suite only covered `n=1`)
- Boundary composition with view-refs, fragments, and nested boundaries inside resolved subtrees
- 3-deep duplicate-id dedup (last-write-wins; existing only covered 2)
- Fallback-render throw → empty html (the inner try/catch arm in `render-continuation`)
- Delta captures a real app-db change between before/after snapshots (`clojure.data/diff` path)
- `render-continuation` against a destroyed frame fails-soft
- `build-final-payload` allowlist drops un-permitted keys (streaming counterpart of the existing non-streaming fail-closed proof)
- `clear-request!` / `clear-response!` no-op on unpopulated frames
- Response-accumulator + request-slot privacy invariants (post-rf2-jbcmt: neither rides app-db)

### `implementation/ssr/test/re_frame/ssr_teardown_corner_test.clj` (4 tests)

- Single destroy clears all four side-channels in one call (composition test)
- `on-frame-destroyed!` is idempotent (pins the docstring promise)
- Cross-frame isolation — destroying frame A leaves frame B's slots intact
- Tolerates missing `:ssr/head-on-frame-destroyed` late-bind hook

### `implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj` (2 tests)

- **`:rf.error/ssr-streaming-writer-failed` trace IS emitted by the writer catch arm.** The existing `streaming_robustness_test` namespace covers absorb + pipe-close behaviour; the load-bearing observability trace was never asserted — a grep for the keyword finds only impl + docstrings, no test. **Biggest discovery of the audit.**
- Per-request frame IS destroyed even when the writer body throws (composition of writer-throw with frame teardown)

## Biggest discoveries

1. **`:rf.error/ssr-streaming-writer-failed` trace was never asserted.** Production observability contract — apps registering trace listeners for the failure category MUST see events fire. A refactor that silently drops the emit would have passed every existing robustness test.

2. **Per-request teardown idempotence + composition were untested.** The four side-channels (pending-error-traces, request-slots, response-slots, head-snapshots) were tested ONE AT A TIME — never composed. A buggy reorder of the calls in `on-frame-destroyed!` would pass every existing test.

3. **Boundary subtree composition gaps.** The walker has explicit branches for `n=0`/`n=1`/`n>=2` body children plus view-ref + fragment recursion paths. Existing suite tested ONE shape: `n=1` body, DOM-tag wrapping. Five new tests pin the remaining shapes.

## Test plan

- [x] `clojure -M:test` from `implementation/ssr/` — 171 tests, 569 assertions, 0 fail / 0 err
- [x] `clojure -M:test` from `implementation/ssr-ring/` — 61 tests, 312 assertions, 0 fail / 0 err
- [x] `npm run test:cljs` from `implementation/` — 2335 tests, 6697 assertions, 0 fail / 0 err
- [x] `bash scripts/test-fast-pr.sh` — PASS

## Pre-alpha posture

- No back-compat shims; every test pins a current, shipped invariant.
- No undecided corners; every gap was either coverable or out of scope.
- No follow-on beads filed.

Closes rf2-u91hb.