### PR TITLE
audit: implementation + comments + facade thinning — 5-bead cluster

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -253,6 +253,37 @@ the harness logs a warning and falls back to a free OS-chosen port.
 Set `BROWSER_TEST_PORT` to pin a specific port (CI determinism); the
 harness still falls back if that port is busy too.
 
+## Vocabulary — commonly confused public concepts
+
+When in doubt, the canonical reference is [`../spec/Conventions.md`](../spec/Conventions.md)
+and [`../spec/Ownership.md`](../spec/Ownership.md). The notes below
+disambiguate names that look interchangeable at a glance.
+
+- **`rf/handler-ids` vs `rf/registrations`** — `handler-ids` returns
+  ids only (`(rf/handler-ids :event) → #{...}`); use it for id-only
+  enumeration. `registrations` returns the full id→metadata map;
+  use it when the caller needs the per-handler value
+  (`:doc`, source coords, route template, fx fn, flow def).
+  Devtool panels that render only ids should prefer `handler-ids`.
+- **adapter vs substrate vs artefact** — *substrate* is the
+  reactive runtime (Reagent, UIx, Helix). *Adapter* is the
+  `re-frame.adapter.*` ns that bridges core to that substrate
+  (canonical naming per rf2-0imy; not "substrate adapter" or
+  "renderer"). *Artefact* is a Maven coordinate the adapter ships
+  as (e.g. `day8/re-frame2-reagent`, `day8/reagent-slim`).
+- **`story/ids` vs `rf/handler-ids`** — both return registered id
+  sets for a kind. `story/ids` is Story's re-export of
+  `registrar/ids` colocated with the Story facade so test-driver
+  code does not pull `re-frame.core`; `rf/handler-ids` is the
+  public surface for application code. They return the same data
+  for the same kind.
+- **projected epoch record vs raw `:db-after`** — `epoch/projected-
+  record` returns the elision-safe view of an epoch (the structured
+  `:sub-runs` / `:renders` / `:effects` projections) and is safe
+  for off-box surfaces (Causa, Story-MCP, Pair2-MCP). The raw
+  `:db-before` / `:db-after` snapshots on a record are devtools-local
+  and must not cross the elision boundary.
+
 ## What's not in scope
 
 - The migration agent (re-frame v1 → v2). That's a separate

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -13,12 +13,16 @@
       the late-bind hook table so requiring this ns does NOT pull
       the feature artefacts.
     - Macro-helper code is factored into three siblings —
-      `core-reg-macros`, `core-call-site-macros`, `core-reg-view-macro`
-      — keeping each leaf under the 250-LoC ceiling. The user-facing
-      `defmacro`s themselves stay in THIS ns (so `rf/reg-event-db`
-      etc. resolve alias-qualified per Clojure's standard
-      `ns-alias/Var` lookup); each is a one-line shell that delegates
-      to the sibling-ns expansion helper.
+      `core-reg-macros` (reg-event-db/fx, reg-sub, reg-fx, reg-cofx
+      expansion), `core-call-site-macros` (dispatch / dispatch-sync /
+      subscribe call-site expansion), `core-reg-view-macro`
+      (reg-view + view-component expansion). The boundary is the
+      *responsibility* — call-site vs registration vs view-registration
+      — so each helper ns owns one cohesive expansion family. The
+      user-facing `defmacro`s themselves stay in THIS ns (so
+      `rf/reg-event-db` etc. resolve alias-qualified per Clojure's
+      standard `ns-alias/Var` lookup); each is a one-line shell that
+      delegates to the sibling-ns expansion helper.
 
   File-naming uses the flat dash-form (`core_X.cljc`) because CLJS
   `goog.provide` for `re-frame.core` overwrites its parent object,

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -3,12 +3,14 @@
   `dispatch-sync`, `subscribe`, `inject-cofx`. Each user-facing surface
   ships as a macro + `*`-fn pair (Conventions §`*`-suffix naming).
 
-  Carved out of `re-frame.core` so the public namespace stays under the
-  250-LoC leaf ceiling. The user-facing `defmacro dispatch` /
-  `subscribe` / etc. shells live in `re-frame.core` itself (they MUST,
-  so `rf/dispatch` resolves alias-qualified per Clojure's standard
-  `ns-alias/Var` lookup); each shell is a one-line call into a
-  `build-…-form` plain fn here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of every
+  call-site-capturing macro's debug-gated stamping branch. The user-
+  facing `defmacro dispatch` / `subscribe` / etc. shells live in
+  `re-frame.core` itself (they MUST, so `rf/dispatch` resolves alias-
+  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
+  is a one-line call into a `build-…-form` plain fn here.
 
   Each shell emits an `(if interop/debug-enabled? <stamping> <plain>)`
   branch around the matching `*`-fn call. Under `:advanced` +

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -8,12 +8,15 @@
   the `with-coords-form` helper plus the `defreg-macro` macro-defining
   macro.
 
-  Carved out of `re-frame.core` so the public namespace stays under
-  the 250-LoC leaf ceiling. The user-facing `defmacro reg-event-db` /
-  `reg-sub` / `reg-flow` / … shells live in `re-frame.core` itself
-  (they MUST, so `rf/reg-event-db` resolves alias-qualified per
-  Clojure's `ns-alias/Var` lookup); each shell is a one-line
-  `(defreg-macro …)` form. The bulk LoC sits here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of every
+  registration-site `reg-*` macro's compile-time coord stamping. The
+  user-facing `defmacro reg-event-db` / `reg-sub` / `reg-flow` / …
+  shells live in `re-frame.core` itself (they MUST, so
+  `rf/reg-event-db` resolves alias-qualified per Clojure's
+  `ns-alias/Var` lookup); each shell is a one-line `(defreg-macro …)`
+  form that delegates here.
 
   rf2-xnym: the rationale for `(symbol (str (ns-name *ns*)))` rather
   than `(ns-name *ns*)` — in CLJS macro context the ns-symbol may

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -5,12 +5,14 @@
   Spec 005 §Source-coord stamping, Spec 002 §with-frame / §bound-fn /
   §`:fx-overrides`, Spec 014 §Testing.
 
-  Carved out of `re-frame.core` so the public namespace stays under
-  the 250-LoC leaf ceiling. The user-facing `defmacro reg-view` /
-  `with-frame` / etc. shells live in `re-frame.core` itself (they MUST,
-  so `rf/reg-view` resolves alias-qualified per Clojure's
-  `ns-alias/Var` lookup); each shell is a one-line call into the
-  matching `expand-…` plain fn here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of
+  view-registration and frame-scope lexical expansion. The user-facing
+  `defmacro reg-view` / `with-frame` / etc. shells live in
+  `re-frame.core` itself (they MUST, so `rf/reg-view` resolves
+  alias-qualified per Clojure's `ns-alias/Var` lookup); each shell is
+  a one-line call into the matching `expand-…` plain fn here.
 
   The expander helpers stay plain CLJ fns so CLJS test files can also
   exercise them JVM-side."

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -49,7 +49,14 @@
   - [[dispatch-sequence]] — fire a vector of events synchronously,
     optionally observing intermediate state via `:after-each`.
   - [[assert-state]] — assert against the current frame's app-db (full
-    db or `path` form); failure is reported via `clojure.test/is`."
+    db or `path` form); failure is reported via `clojure.test/is`.
+
+  ### Deterministic-wait helpers (rf2-ka3n6)
+  - [[poll-until]] — bounded-deadline poll for `(pred)` to return
+    truthy. Replaces incidental fixed `Thread/sleep N` for waits that
+    are observable in state (router drain, event-cascade settle, sub
+    re-fire). NOT for timer-semantics tests — those should keep their
+    sleep and annotate that intent locally."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             ;; The flows / schemas / machines / routing / http-managed /
@@ -430,3 +437,44 @@
         :expected expected-val
         :actual   actual})
      pass?)))
+
+;; ---- deterministic wait helper (rf2-ka3n6) -------------------------------
+;;
+;; Replaces incidental fixed `Thread/sleep N` waits that exist to let an
+;; *observable* event (router drain, cascade settle, sub re-fire) complete.
+;; NOT for timer-semantics tests — those should keep their sleep and
+;; annotate that intent locally (the sleep IS the contract under test).
+
+#?(:clj
+   (defn poll-until
+     "Bounded-deadline poll for `(pred)` to return truthy. Returns the
+     truthy value on success; throws `ex-info` on timeout with
+     `:rf.test/poll-timeout` `true`, the elapsed ms, and the supplied
+     `:label` (when given) to identify the assertion site.
+
+     `opts` (all optional):
+       :timeout-ms   default 2000 — overall deadline.
+       :interval-ms  default 5    — sleep between probes.
+       :label        string/keyword used in the timeout message.
+
+     Use this in JVM tests that previously called `(Thread/sleep N)` to
+     wait for the async router to drain, an event cascade to settle, or
+     a sub to re-fire. The deadline is generous; tests fail fast on a
+     truly stuck condition, not on CI scheduler jitter."
+     ([pred] (poll-until pred nil))
+     ([pred opts]
+      (let [{:keys [timeout-ms interval-ms label]
+             :or   {timeout-ms 2000 interval-ms 5}} opts
+            start    (System/currentTimeMillis)
+            deadline (+ start timeout-ms)]
+        (loop []
+          (let [v (pred)]
+            (cond
+              v v
+              (>= (System/currentTimeMillis) deadline)
+              (throw (ex-info (str "poll-until timed out"
+                                   (when label (str " — " label)))
+                              {:rf.test/poll-timeout true
+                               :elapsed-ms (- (System/currentTimeMillis) start)
+                               :label label}))
+              :else (do (Thread/sleep ^long interval-ms) (recur)))))))))

--- a/implementation/core/test/re_frame/bound_dispatcher_test.clj
+++ b/implementation/core/test/re_frame/bound_dispatcher_test.clj
@@ -25,7 +25,8 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -55,7 +56,11 @@
       ;; still route to :bound/A.
       (captured [:bound/inc])
       (captured [:bound/inc])
-      (Thread/sleep 50) ;; let the async router drain
+      ;; Wait on the observable drain — :bound/A's app-db must reach 2
+      ;; before the assertion fires. Deterministic vs the prior fixed
+      ;; sleep (rf2-ka3n6).
+      (test-support/poll-until #(= 2 (:n (rf/get-frame-db :bound/A)))
+                               {:label "captured dispatcher drains to :bound/A"})
       (is (= 2 (:n (rf/get-frame-db :bound/A)))
           "the captured dispatcher routed events to :bound/A after the scope unwound")
       (is (nil? (:n (rf/get-frame-db :rf/default)))
@@ -88,6 +93,9 @@
     (let [d (rf/dispatcher)]
       ;; No with-frame scope — capture should land on :rf/default.
       (d [:default/touch])
-      (Thread/sleep 50)
+      ;; Wait on the observable drain — :rf/default's app-db must
+      ;; carry :touched? before the assertion fires (rf2-ka3n6).
+      (test-support/poll-until #(:touched? (rf/get-frame-db :rf/default))
+                               {:label "default dispatcher drains to :rf/default"})
       (is (true? (:touched? (rf/get-frame-db :rf/default)))
           "dispatcher outside any with-frame routes to :rf/default"))))

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -305,7 +305,11 @@
     (rf/reg-event-db :ping (fn [db _] db))
     (rf/dispatch-sync [:ping])
     (let [pre-time (-> (rf/trace-buffer) last :time)]
-      ;; Force a small delay so subsequent events have :time strictly >.
+      ;; Timer-semantics sleep (rf2-ka3n6): we are asserting :since-ms
+      ;; filtering against the host clock — the test contract requires
+      ;; that the next event's :time is strictly greater. NOT replaceable
+      ;; by a deterministic-gate helper; the clock advancement IS the
+      ;; thing under test.
       (Thread/sleep 5)
       (rf/dispatch-sync [:ping])
       (let [after (rf/trace-buffer {:since-ms pre-time})]

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -3,12 +3,16 @@
 
   ## Scope
 
-  `registry.cljs` (1818 LoC) is the central registrar for Causa's
-  framework surface — 65 reg-subs + 67 reg-event-(db|fx) + 4 reg-fx,
-  all under the `:rf.causa/*` namespace, targeting the `:rf/causa`
-  frame. Prior to this file the only coverage was *transitive* through
-  per-panel view tests (each panel test calls `(registry/reset-for-test!)`
-  then drives the panel-specific subset via subscribe/dispatch).
+  `registry.cljs` is now a thin orchestrator that owns only the
+  cross-panel primitives (trace-buffer sub, panel-selection slot,
+  shared cascades projection, suppression-counter handlers) plus the
+  per-panel `install!` fan-out (rf2-d4xda). Per-panel reg-subs /
+  reg-events / reg-fxs live colocated with the panel ns that reads
+  them. All registrations sit under the `:rf.causa/*` namespace and
+  target the `:rf/causa` frame. Prior to this file the only coverage
+  was *transitive* through per-panel view tests (each panel test
+  calls `(registry/reset-for-test!)` then drives the panel-specific
+  subset via subscribe/dispatch).
 
   Per the bead description (rf2-5zl7l) and the test-coverage audit
   (rf2-otcbz) the transitive route does NOT isolate:
@@ -23,13 +27,14 @@
 
   ## Trade-off: smoke + high-value, not 1-per-registration
 
-  136 registrations is too many to exhaustively unit-test without
-  duplicating the per-panel suite. The strategy below is:
+  The full registered surface is too many to exhaustively unit-test
+  without duplicating the per-panel suite. The strategy below is:
 
     (1) **Smoke registration block** — one assertion per registered
-        name that the registrar resolves it (proves the
-        `register-causa-handlers!` block reached every form without
-        an early throw — the failure mode the audit named).
+        name that the registrar resolves it (proves the orchestrator
+        `register-causa-handlers!` plus each panel `install!` reached
+        every form without an early throw — the failure mode the
+        audit named).
     (2) **High-value sub contracts** — defaults, composite shapes,
         override-aware readers (sub-cache, registered-flows, etc.),
         the panel-suppression / dormant-frame signal slots, and the

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -27,7 +27,20 @@
   ...)` wrapper. Production CLJS builds set
   `:closure-defines {re-frame.story.config/enabled? false}` and every
   registration form elides to `nil`. The public query helpers are plain
-  fns; production code calling them sees an empty side-table."
+  fns; production code calling them sees an empty side-table.
+
+  ## Test-driver runtime — boundary
+
+  Story is a deterministic fixture / test-driver runtime. Its internal
+  helpers (`re-frame.story.runtime`, `re-frame.story.frames`,
+  `re-frame.story.async`) use `rf/dispatch-sync` and direct
+  `get-frame-db` reads so a variant settles to a stable result before
+  the assertions / render-snapshot stage runs. That posture is
+  appropriate for Story's role and IS NOT a pattern to copy into normal
+  interactive application code — UI event handlers should use
+  `rf/dispatch` and subscribe via Reactions, not synchronous reads.
+  Per IMPL-SPEC §5 the boundary is: synchronous drain belongs to the
+  test driver; the queue belongs to the application."
   (:require [re-frame.story.config      :as config]
             [re-frame.story.registrar   :as registrar]
             [re-frame.story.schemas     :as schemas]
@@ -327,8 +340,8 @@
 
 (defn variants-with-tags
   "Per IMPL-SPEC §3.2 — return the set of variant ids whose `:tags`
-  intersects `query-tags`. Stage 5 (assertions/play) leans on this; Stage
-  4 (render shell) leans on this to compose the sidebar tree."
+  intersects `query-tags`. The assertions/play surface leans on this;
+  the render shell leans on this to compose the sidebar tree."
   [query-tags]
   (registrar/variants-with-tags query-tags))
 
@@ -426,9 +439,9 @@
 
 (def ^:private canonical-installers
   "Ordered vector of installer fns invoked by `install-canonical-vocabulary!`.
-  Each takes zero args and is idempotent. The CLJS-only Stage 6 surfaces
-  (multi-substrate Reagent default + the v1.0 panel set) gate on the
-  reader so the JVM classpath stays Reagent-free."
+  Each takes zero args and is idempotent. The CLJS-only SOTA-feature
+  surfaces (multi-substrate Reagent default + the v1.0 panel set) gate
+  on the reader so the JVM classpath stays Reagent-free."
   [registrar/install-canonical-tags!
    loaders/install!
    loaders/install-mirror-writer!
@@ -526,18 +539,18 @@
   [kind id]
   (registrar/unregister! kind id))
 
-;; ---- Stage 3 stubs (run-variant family) ---------------------------------
+;; ---- variant → EDN serialisation ----------------------------------------
 ;;
-;; These are deliberately stubbed at Stage 2 — the bead is the authoring
-;; surface only. Stage 3 (rf2-von3) replaces these bodies with the
-;; four-phase lifecycle. The signatures are locked at IMPL-SPEC §3.2 so
-;; downstream code can be written against them today.
+;; Per IMPL-SPEC §3.2 the variant body is round-trippable through the
+;; registrar side-table; `variant->edn` returns the registered body
+;; verbatim (canonicalisation for snapshot-identity is handled inside
+;; `re-frame.story.identity`).
 
 (defn variant->edn
-  "Per IMPL-SPEC §3.2 — return the canonical-form serialised body of
-  the registered variant. At Stage 2 this is the side-table body
-  verbatim; the canonicalisation (sorted keys, deterministic vector
-  order) for snapshot-identity is Stage 3's call.
+  "Per IMPL-SPEC §3.2 — return the registered body of the variant as
+  serialisable EDN. The body is the side-table value verbatim;
+  canonicalisation (sorted keys, deterministic vector order) for
+  snapshot-identity lives in `re-frame.story.identity`.
 
   Returns nil when the variant is unregistered."
   [variant-id]
@@ -550,9 +563,10 @@
 
 ;; ---- run-variant / reset-variant / snapshot-identity --------------------
 ;;
-;; STAGE 3 (rf2-von3): the four-phase lifecycle. These call into
-;; `re-frame.story.runtime`. Each returns a promise (CLJS) or
-;; CompletableFuture (JVM); see `re-frame.story.async` for the shape.
+;; The four-phase variant lifecycle (loaders → events → render → play).
+;; These call into `re-frame.story.runtime`. Each returns a promise
+;; (CLJS) or CompletableFuture (JVM); see `re-frame.story.async` for
+;; the result shape.
 
 (defn run-variant
   "Per IMPL-SPEC §3.2. Allocate a frame for `variant-id`, run the four-
@@ -563,17 +577,16 @@
     :active-modes    coll of registered mode ids; deep-merged into args
     :cell-overrides  runtime arg overrides (controls panel)
     :substrate       active substrate (`:reagent`, `:uix`, ...)
-    :render?         when truthy, Stage 4's UI shell renders into
-                     `:rendered-hiccup`. Stage 3 leaves the slot nil.
-    :assertions      Stage 5's hook. Stage 3 accepts the slot but
-                     leaves the runtime semantics to Stage 5.
+    :render?         when truthy, the UI shell renders into
+                     `:rendered-hiccup`. Defaults to nil.
+    :assertions      assertions hook (see `re-frame.story.assertions`).
 
   Result map:
 
       {:frame           <variant-id>
        :app-db          {...}
        :assertions      [...]
-       :rendered-hiccup nil           ; Stage 4
+       :rendered-hiccup nil
        :elapsed-ms      <ms>
        :snapshot        {:variant-id ... :content-hash \"...\"}
        :decorators      {:hiccup [...] :frame-setup [...] :fx-override [...]
@@ -613,8 +626,8 @@
   (frames/destroy! variant-id))
 
 (defn variant-frames
-  "Return every registered variant frame id. Stage 4's UI shell uses
-  this to lay out the active variant pane."
+  "Return every registered variant frame id. The UI shell uses this
+  to lay out the active variant pane."
   []
   (frames/variant-frames))
 
@@ -630,7 +643,7 @@
   [variant-id]
   (loaders/current-state variant-id))
 
-;; ---- Stage 5 (rf2-h8et) public assertion + play helpers ------------------
+;; ---- public assertion + play helpers ------------------------------------
 
 (defn assertions-passing?
   "Per IMPL-SPEC §3.5 + spec/007 §Story-as-test duality — true iff
@@ -687,7 +700,7 @@
                       [:rf.assert/effect-emitted :http]]})"
   fx-stubs/force-fx-stub-id)
 
-;; ---- Stage 6 (rf2-zhwd) public SOTA-feature surface ---------------------
+;; ---- public SOTA-feature surface ----------------------------------------
 
 (def layout-debug-measure-id
   "Per IMPL-SPEC §2.8.6 — the registered decorator id for the
@@ -785,7 +798,7 @@
   assertions+play + sota-features) is present."
   :sota-features)
 
-;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
+;; ---- UI shell mount / unmount surface -----------------------------------
 ;;
 ;; Per IMPL-SPEC §4 + §8.4 the shell entry points are CLJS-only —
 ;; mounting a Reagent shell at a DOM node has no JVM equivalent. The
@@ -808,9 +821,7 @@
 
      Production CLJS builds (`re-frame.story.config/enabled?` false)
      short-circuit before any DOM call and return nil. See IMPL-SPEC
-     §6.3 for the elision contract.
-
-     Stage 4 (rf2-ekai)."
+     §6.3 for the elision contract."
      [dom-node]
      (ui-shell/mount-shell! dom-node)))
 


### PR DESCRIPTION
## Summary

Five-bead audit cluster sweeping implementation/, tools/causa, tools/story for stale comments, naming clarity, namespace cohesion (not line count), and incidental async sleeps.

- **rf2-xshc1 (causa)** — refresh stale registry_cljs_test docstring (claimed 1818 LoC / central registrar; the current ns is 358 LoC and a thin orchestrator).
- **rf2-lmd5t (implementation)** — replace 250-LoC ceiling rationale in implementation/core macro carve-outs with cohesion/coupling rationale.
- **rf2-ytazg (naming)** — add vocabulary note for commonly confused public concepts (handler-ids vs registrations, adapter/substrate/artefact, story/ids, projected epoch record).
- **rf2-6e2ph (story)** — replace stage-history comments with current-contract; document test-driver runtime boundary in the namespace docstring.
- **rf2-ka3n6 (testing)** — add re-frame.test-support/poll-until JVM helper; convert incidental router-drain sleeps in bound_dispatcher_test; annotate trace_buffer_test timer-semantics sleep.

Five commits, ~190 LoC net across docstrings + one new helper. Public symbols unchanged. Settled findings landed; six follow-on beads filed for code-level work that was either out of caveat scope (causa-testbed-bugs cluster active) or needed dedicated design + regression coverage (cohesion splits, facade thinning, CLJS poll helper + bulk sweep).

## Follow-on beads filed

- rf2-6j7fo (causa): id-only panel readers → handler-ids.
- rf2-q4rvx (causa): :rf.causa/pin-current → map payload.
- rf2-icrxv (impl): re-frame.routing cohesion split (2286 LoC).
- rf2-0wi86 (impl): re-frame.epoch cohesion split (1568 LoC).
- rf2-0ytl4 (impl): re-frame.router + re-frame.subs split (hot-path audit first).
- rf2-l8eso (story): re-frame.story facade thinning toward cohesive internal modules.
- rf2-fun38 (testing): CLJS Promise poll-until + Playwright helper bank + HTTP/SSR/sub-cache sweep.

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 523 tests / 2733 assertions / 0 failures / 0 errors.
- [x] `clojure -M:test` from `tools/causa/` — 579 tests / 1708 assertions / 0 failures / 0 errors.
- [x] `clojure -M:test` from `tools/story/` — 451 tests / 1400 assertions / 0 failures / 0 errors.
- [x] `npm run test:cljs` from `implementation/` — 2344 tests / 6722 assertions / 0 failures / 0 errors.
- [ ] mkdocs build not required (no `docs/` or `spec/` files touched).