### PR TITLE
feat(security): implement with-redacted positional interceptor (rf2-461sp)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -899,6 +899,18 @@
   Conventions §Canonical event-vector shape (M-19)."}
   unwrap          std-interceptors/unwrap)
 
+(def ^{:doc "Build a positional interceptor that overwrites the named
+  payload keys with the `:rf/redacted` sentinel on the trace surface
+  while the handler body still sees the unredacted payload via the
+  `:event` coeffect. `paths` is a sequence of `get-in`-style key paths
+  into the M-19 payload map. The third composition site for
+  `:sensitive?` (alongside registration meta and schema-declared
+  paths) — see Security.md §Behavioural MUSTs across the privacy
+  surface. Usage:
+  `(reg-event-fx :auth/login [(with-redacted [[:password]])] ...)`.
+  Per spec/API.md §Privacy and Spec 009 §Privacy."}
+  with-redacted   privacy/with-redacted)
+
 ;; ---- privacy / spec / trace / emit / elision (Spec 009, 010) -------------
 
 (def ^{:doc "Predicate: returns `true` iff `trace-event` is a map carrying

--- a/implementation/core/src/re_frame/privacy.cljc
+++ b/implementation/core/src/re_frame/privacy.cljc
@@ -115,6 +115,99 @@
         (assoc ctx :rf/redacted-event
                (redact-event (interceptor/get-coeffect ctx :event) paths))))))
 
+;; ---- with-redacted — user-installed positional interceptor ----------------
+;;
+;; The third composition site for `:sensitive?` (per Security.md §Behavioural
+;; MUSTs across the privacy surface): the positional `with-redacted`
+;; interceptor scrubs named payload keys *before* the handler body runs.
+;; The handler sees the unredacted value via the regular `:event` coeffect;
+;; the trace surface sees the redacted version via `:rf/redacted-event`.
+;;
+;; The interceptor carries its `:paths` on the interceptor map itself so
+;; the router can collect them at chain-assembly time and fold them into
+;; the pre-chain `:run-start` / `emit-cascade-trailers` event projection
+;; (which fires BEFORE any chain `:before` runs). The `:before` here remains
+;; load-bearing for the in-chain composition with `:rf/schema-redaction`:
+;; when both interceptors are present, this `:before` extends the already-
+;; stashed `:rf/redacted-event` rather than overwriting it, so the union
+;; of paths is scrubbed.
+
+(def with-redacted-interceptor-id :rf/with-redacted)
+
+(defn with-redacted
+  "Build a positional interceptor that overwrites the named keys in the
+  event vector's payload map with the `:rf/redacted` sentinel before the
+  handler body runs.
+
+  The handler itself receives the UNREDACTED payload via the regular
+  `:event` coeffect slot; the redaction is for the trace surface only
+  (`:event/*` trace events, `:event/db-changed`, `:rf.error/handler-
+  exception`, and the always-on error-emit substrate's record).
+
+  `paths` is a sequence of `get-in`-style key paths into the payload map
+  (the second element of the event vector, per the canonical M-19 map-
+  payload form). A path that targets a missing leaf is a no-op; an empty
+  path scrubs the whole payload to `:rf/redacted`. Non-map payload shapes
+  pass through unchanged.
+
+  Composition:
+    - With registration-meta `:sensitive? true` — orthogonal. The meta
+      stamps `:sensitive? true` on every trace event in the handler's
+      scope; `with-redacted` scrubs the payload slot. Both apply.
+    - With schema `:sensitive?` on a path-scoped handler — additive. The
+      router installs an internal redaction interceptor for schema-
+      declared paths; this user-installed interceptor extends (does not
+      replace) the stashed `:rf/redacted-event` with its own paths.
+    - With epoch `:redact-fn` — independent. The redact-fn runs at the
+      assembled epoch-record boundary; this interceptor runs per
+      handler invocation on the trace surface inside the cascade. The
+      record carries the already-scrubbed trace events into the fn.
+
+  Usage:
+
+      (rf/reg-event-fx :auth/login
+        [(rf/with-redacted [[:password] [:token]])]
+        (fn [{:keys [db]} [_ {:keys [username password token]}]]
+          ;; password + token visible HERE (unredacted via :event coeffect)
+          ;; trace surface sees them as :rf/redacted
+          ...))
+
+  Per [API.md §Privacy](API.md#privacy-spec-009-privacy--sensitive-data-in-traces)
+  and [Security.md §Behavioural MUSTs across the privacy surface](Security.md#behavioural-musts-across-the-privacy-surface)."
+  [paths]
+  (let [paths (vec paths)]
+    (interceptor/->interceptor
+      :id     with-redacted-interceptor-id
+      ;; Paths are exposed on the interceptor map for chain-walking
+      ;; consumers (router `prepare-handler-ctx` collects them so the
+      ;; pre-chain `:run-start` trace event already carries the
+      ;; redacted projection).
+      :paths  paths
+      :before
+      (fn [ctx]
+        (let [base    (or (:rf/redacted-event ctx)
+                          (interceptor/get-coeffect ctx :event))
+              scrubbed (redact-event base paths)]
+          (assoc ctx :rf/redacted-event scrubbed))))))
+
+(defn- with-redacted-interceptor?
+  [interceptor]
+  (and (map? interceptor)
+       (= with-redacted-interceptor-id (:id interceptor))))
+
+(defn user-redaction-paths
+  "Walk an interceptor chain and return the concatenated `:paths` vectors
+  of every `with-redacted` interceptor it contains.
+
+  Read by the router at chain-assembly time so the pre-chain trace events
+  (`:run-start`, `emit-cascade-trailers`'s `:run-end`) and the schema-
+  derived emit-event projection both honour user-declared payload paths."
+  [interceptors]
+  (into []
+        (comp (filter with-redacted-interceptor?)
+              (mapcat :paths))
+        interceptors))
+
 (defn clear-suppression-cache!
   "Compatibility hook name used by frame teardown. Path-D privacy has no
   registration-warning cache, so this is intentionally a no-op."

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -720,18 +720,37 @@
                           (:interceptors handler-meta))
         base-chain      (apply-icpt-overrides prepended-chain icpt-overrides)
         redaction-paths (privacy/schema-redaction-paths frame base-chain)
+        ;; Per rf2-461sp — user-installed `(rf/with-redacted paths)`
+        ;; interceptors expose their paths on the interceptor map so the
+        ;; pre-chain trace projection (`:run-start`, `emit-cascade-
+        ;; trailers`) honours them too. Each user `:before` ALSO runs
+        ;; during chain execution and extends `:rf/redacted-event`
+        ;; in-chain, which is what the schema-redaction interceptor
+        ;; (when also installed) composes with. The union here is the
+        ;; OUT-OF-CHAIN projection used by emit sites that fire BEFORE
+        ;; the chain.
+        user-paths      (privacy/user-redaction-paths base-chain)
         full-chain      (if (seq redaction-paths)
                           (into [(privacy/schema-redaction-interceptor
                                    redaction-paths)]
                                 base-chain)
                           base-chain)
-        initial-ctx     (assemble-initial-ctx envelope frame frame-record fx-overrides)]
+        initial-ctx     (assemble-initial-ctx envelope frame frame-record fx-overrides)
+        all-paths       (into (vec redaction-paths) user-paths)]
     {:full-chain   full-chain
      :initial-ctx  initial-ctx
      :fx-overrides fx-overrides
-     :emit-event   (if (seq redaction-paths)
-                     (privacy/redact-event (:event envelope) redaction-paths)
+     :emit-event   (if (seq all-paths)
+                     (privacy/redact-event (:event envelope) all-paths)
                      (:event envelope))
+     ;; `:schema-sensitive?` strictly tracks the schema-declared
+     ;; sensitive path overlap — it drives the scope-meta `:sensitive?`
+     ;; stamp on every emitted trace event. User `with-redacted` does
+     ;; NOT stamp `:sensitive?`; that remains registration-meta's job
+     ;; per [Security.md §Behavioural MUSTs across the privacy
+     ;; surface](Security.md#behavioural-musts-across-the-privacy-
+     ;; surface) — the two composition sites are intentionally
+     ;; independent.
      :schema-sensitive? (boolean (seq redaction-paths))}))
 
 (defn- run-chain

--- a/implementation/core/test/re_frame/with_redacted_test.clj
+++ b/implementation/core/test/re_frame/with_redacted_test.clj
@@ -1,0 +1,283 @@
+(ns re-frame.with-redacted-test
+  "Per rf2-461sp — `(rf/with-redacted paths)` positional interceptor.
+
+  The third composition site for `:sensitive?` (per [Security.md
+  §Behavioural MUSTs across the privacy surface](spec/Security.md)):
+
+    1. Handler body sees the UNREDACTED payload via `:event` coeffect.
+    2. Trace surface (`:run-start` / `:run-end` / `:event/db-changed` /
+       `:rf.error/handler-exception`) sees `:rf/redacted` at the named
+       payload keys.
+    3. Composes orthogonally with registration-meta `:sensitive? true`
+       (which stamps `:sensitive? true` on every emitted trace event).
+    4. Composes additively with schema-derived redaction
+       (`:rf/schema-redaction` interceptor; the user-installed
+       interceptor extends `:rf/redacted-event` rather than overwriting).
+    5. Composes independently with epoch `:redact-fn` (the per-record
+       hook reads already-scrubbed trace events).
+
+  Negative coverage: handlers without `with-redacted` see no redaction;
+  unrelated keys pass through; non-map payload shapes pass through; an
+  empty path scrubs the entire payload."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (privacy/clear-suppression-cache!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.elision :reload)
+  (require 're-frame.schemas :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- events-of [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+(defn- run-start-of [evs]
+  (first (filterv #(and (= :event (:operation %))
+                        (= :run-start (get-in % [:tags :phase])))
+                  evs)))
+
+;; ---- public-API + interceptor-shape sanity --------------------------------
+
+(deftest with-redacted-is-exported
+  (is (= rf/with-redacted privacy/with-redacted)
+      "rf/with-redacted is the rf.core alias of privacy/with-redacted"))
+
+(deftest with-redacted-returns-interceptor-with-paths
+  (testing "the returned interceptor map exposes its paths on `:paths` so the
+            router can fold them into the pre-chain trace projection"
+    (let [paths [[:password] [:token]]
+          icpt  (rf/with-redacted paths)]
+      (is (map? icpt))
+      (is (= :rf/with-redacted (:id icpt)))
+      (is (= paths (:paths icpt)))
+      (is (fn? (:before icpt))))))
+
+;; ---- scope-only redaction: handler sees raw, trace sees scrubbed ----------
+
+(deftest handler-sees-unredacted-trace-sees-redacted
+  (testing "the handler's `:event` coeffect is the raw payload; every trace
+            surface that uses `redacted-event-from-ctx` sees the scrub"
+    (let [seen (atom nil)]
+      (rf/reg-event-db :auth/login
+        [(rf/with-redacted [[:password] [:token]])]
+        (fn [db [_ payload]]
+          (reset! seen payload)
+          (assoc db :last-login payload)))
+      (let [evs        (record-traces
+                         #(rf/dispatch-sync
+                            [:auth/login {:username "ada"
+                                          :password "shh"
+                                          :token    "abc123"}]))
+            run-start  (run-start-of evs)
+            db-changed (first (events-of evs :event/db-changed))]
+        (is (= {:username "ada" :password "shh" :token "abc123"} @seen)
+            "handler body sees the raw payload — `with-redacted` is a
+             trace-surface scrub, not a handler-input rewrite")
+        (is (= :rf/redacted (get-in run-start [:tags :event 1 :password])))
+        (is (= :rf/redacted (get-in run-start [:tags :event 1 :token])))
+        (is (= "ada" (get-in run-start [:tags :event 1 :username]))
+            "non-declared keys pass through to the trace surface")
+        (is (= :rf/redacted (get-in db-changed [:tags :event 1 :password])))
+        (is (= :rf/redacted (get-in db-changed [:tags :event 1 :token])))
+        (is (= "ada" (get-in db-changed [:tags :event 1 :username])))))))
+
+(deftest declared-key-is-sentineled-even-when-absent
+  (testing "the redaction is explicit: a top-level declared key is always
+            written as `:rf/redacted`, even when absent from the source
+            payload. Opt-in privacy is additive, not conditional;
+            consistent with the schema-redaction helper's `redact-path`."
+    (rf/reg-event-db :neutral/save
+      [(rf/with-redacted [[:declared]])]
+      (fn [db [_ payload]] (assoc db :saved payload)))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync [:neutral/save {:keep "me"}]))
+          db-changed (first (events-of evs :event/db-changed))]
+      (is (= "me" (get-in db-changed [:tags :event 1 :keep]))
+          "unrelated keys flow through to the trace surface")
+      (is (= :rf/redacted (get-in db-changed [:tags :event 1 :declared]))
+          "declared key is sentineled even when absent in the source map")
+      (is (not (contains? (get-in db-changed [:tags :event 1]) :other))
+          "keys neither declared nor in the source remain absent"))))
+
+(deftest handler-without-with-redacted-sees-no-redaction
+  (testing "negative — a plain handler emits trace events with the raw payload"
+    (rf/reg-event-db :plain/save
+      (fn [db [_ payload]] (assoc db :saved payload)))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync [:plain/save {:password "shh"}]))
+          db-changed (first (events-of evs :event/db-changed))]
+      (is (= "shh" (get-in db-changed [:tags :event 1 :password]))
+          "no `:with-redacted` → trace surface carries the raw value"))))
+
+(deftest empty-path-scrubs-entire-payload
+  (testing "an empty path is the documented 'scrub everything' form"
+    (rf/reg-event-db :whole/payload
+      [(rf/with-redacted [[]])]
+      (fn [db _] (assoc db :ran? true)))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync [:whole/payload {:any "thing"}]))
+          db-changed (first (events-of evs :event/db-changed))]
+      (is (= :rf/redacted (get-in db-changed [:tags :event 1]))))))
+
+(deftest non-map-payload-passes-through
+  (testing "non-map payload shapes are out of scope (the canonical M-19 form
+            is `[id payload-map ...]`); the interceptor must not throw or
+            mangle a non-conforming event"
+    (rf/reg-event-db :raw/vec-payload
+      [(rf/with-redacted [[:password]])]
+      (fn [db _] (assoc db :ran? true)))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync [:raw/vec-payload "scalar"]))
+          db-changed (first (events-of evs :event/db-changed))]
+      (is (= "scalar" (get-in db-changed [:tags :event 1]))))))
+
+;; ---- composition with handler-meta `:sensitive?` --------------------------
+
+(deftest composes-with-handler-meta-sensitive
+  (testing "the two privacy sites are orthogonal: `:sensitive? true` meta
+            stamps `:sensitive? true` on every emitted trace event;
+            `with-redacted` scrubs the payload slot. Both apply."
+    (rf/reg-event-fx :auth/cross-cutting
+      {:sensitive? true}
+      [(rf/with-redacted [[:password]])]
+      (fn [{:keys [db]} [_ payload]]
+        {:db (assoc db :payload payload)}))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync
+                          [:auth/cross-cutting {:username "ada"
+                                                :password "shh"}]))
+          run-start  (run-start-of evs)
+          db-changed (first (events-of evs :event/db-changed))]
+      ;; Both stampings present on the same event:
+      (is (true? (:sensitive? run-start))
+          "handler-meta `:sensitive?` stamps every event in the scope")
+      (is (= :rf/redacted (get-in run-start [:tags :event 1 :password]))
+          "with-redacted scrubs the payload slot on the same event")
+      (is (= "ada" (get-in run-start [:tags :event 1 :username]))
+          "non-declared keys still flow through")
+      ;; Other emit sites in the cascade carry both as well:
+      (is (true? (:sensitive? db-changed)))
+      (is (= :rf/redacted (get-in db-changed [:tags :event 1 :password]))))))
+
+;; ---- composition with schema-derived redaction (additive) -----------------
+
+(deftest composes-additively-with-schema-redaction
+  (testing "when both a schema-declared sensitive slot AND a user
+            `with-redacted` apply, the trace surface scrubs the UNION of
+            paths. The user interceptor's `:before` reads the schema
+            interceptor's already-stashed `:rf/redacted-event` and extends
+            it, rather than overwriting it."
+    (rf/reg-app-schema [:auth]
+                       [:map
+                        [:username :string]
+                        [:password {:sensitive? true} :string]])
+    (let [seen (atom nil)]
+      (rf/reg-event-db :auth/login+token
+        ;; `path` focuses on `:auth`, which makes the schema-redaction
+        ;; auto-install for `:password` (schema-declared sensitive). The
+        ;; user `with-redacted` adds `:token` (NOT schema-declared).
+        [(rf/path :auth)
+         (rf/with-redacted [[:token]])]
+        (fn [auth [_ payload]]
+          (reset! seen payload)
+          (assoc auth :last payload)))
+      (let [evs        (record-traces
+                         #(rf/dispatch-sync
+                            [:auth/login+token {:username "ada"
+                                                :password "shh"
+                                                :token    "abc"}]))
+            run-start  (run-start-of evs)
+            db-changed (first (events-of evs :event/db-changed))]
+        (is (= {:username "ada" :password "shh" :token "abc"} @seen)
+            "handler still receives the raw payload")
+        ;; Both keys scrubbed on the trace surface (union):
+        (is (= :rf/redacted (get-in run-start [:tags :event 1 :password]))
+            "schema-declared key scrubbed")
+        (is (= :rf/redacted (get-in run-start [:tags :event 1 :token]))
+            "user-declared key scrubbed")
+        (is (= "ada" (get-in run-start [:tags :event 1 :username]))
+            "unrelated key flows through")
+        ;; And the schema-sensitive scope-stamp still fires (the schema
+        ;; path drove it; the user interceptor does NOT stamp):
+        (is (true? (:sensitive? run-start))
+            "schema-sensitive scope-stamp still fires (driven by the
+             schema-declared sensitive slot, not by `with-redacted`)")
+        ;; And the in-chain `:event/db-changed` also carries both:
+        (is (= :rf/redacted (get-in db-changed [:tags :event 1 :password])))
+        (is (= :rf/redacted (get-in db-changed [:tags :event 1 :token])))))))
+
+(deftest with-redacted-alone-does-not-stamp-sensitive-scope
+  (testing "regression — `with-redacted` is a payload-scrub, NOT a scope
+            stamper. The `:sensitive?` boolean on emitted events is the
+            registration-meta / schema-derived signal only."
+    (rf/reg-event-db :plain/scrub
+      [(rf/with-redacted [[:password]])]
+      (fn [db _] db))
+    (let [evs       (record-traces
+                      #(rf/dispatch-sync [:plain/scrub {:password "shh"}]))
+          run-start (run-start-of evs)]
+      (is (not (true? (:sensitive? run-start)))
+          "no schema overlap, no handler-meta — no `:sensitive?` stamp"))))
+
+;; ---- composition: handler exception path picks up the scrub ---------------
+
+(deftest handler-exception-trace-sees-redacted-payload
+  (testing "the always-on error path also reads
+            `privacy/redacted-event-from-ctx`, so a throwing handler that
+            had a `with-redacted` interceptor surfaces the scrub in the
+            `:rf.error/handler-exception` trace event"
+    (rf/reg-event-db :auth/explode
+      [(rf/with-redacted [[:password] [:token]])]
+      (fn [_ _] (throw (ex-info "boom" {}))))
+    (let [evs   (record-traces
+                  #(rf/dispatch-sync
+                     [:auth/explode {:username "ada"
+                                     :password "shh"
+                                     :token    "abc"}]))
+          [err] (events-of evs :rf.error/handler-exception)]
+      (is (some? err) "the exception path fired")
+      (is (= :rf/redacted (get-in err [:tags :event 1 :password])))
+      (is (= :rf/redacted (get-in err [:tags :event 1 :token])))
+      (is (= "ada" (get-in err [:tags :event 1 :username]))))))
+
+;; ---- multiple with-redacted interceptors in one chain ---------------------
+
+(deftest multiple-with-redacted-interceptors-union
+  (testing "stacking two `with-redacted` interceptors in one chain applies
+            the union of their paths. Useful when an interceptor library
+            ships its own privacy interceptor and the registration also
+            wants per-call scrubs."
+    (rf/reg-event-db :auth/dual
+      [(rf/with-redacted [[:password]])
+       (rf/with-redacted [[:token]])]
+      (fn [db _] (assoc db :ran? true)))
+    (let [evs        (record-traces
+                       #(rf/dispatch-sync
+                          [:auth/dual {:username "ada"
+                                       :password "shh"
+                                       :token    "abc"}]))
+          db-changed (first (events-of evs :event/db-changed))]
+      (is (= :rf/redacted (get-in db-changed [:tags :event 1 :password])))
+      (is (= :rf/redacted (get-in db-changed [:tags :event 1 :token])))
+      (is (= "ada" (get-in db-changed [:tags :event 1 :username]))))))


### PR DESCRIPTION
## Summary

The third composition site for `:sensitive?` (per Security.md §Behavioural MUSTs across the privacy surface) was documented in spec/API.md L489 + spec/Security.md L115 but never landed in `re-frame.core`. Audit-found by rf2-w0n68 (API-projection sync); this bead ships the feature.

`(rf/with-redacted paths)` returns a positional interceptor that scrubs named keys of the event-vector's payload map BEFORE the handler body runs. The handler still sees the raw payload via the `:event` coeffect; the trace surface (`:run-start`, `:event/db-changed`, `:rf.error/handler-exception`, always-on error-emit substrate) sees `:rf/redacted` at the declared paths via `:rf/redacted-event`.

## Composition

- **with handler-meta `:sensitive? true`** — orthogonal; the meta stamps every emitted event, the interceptor scrubs the payload slot
- **with schema `:sensitive?` on a path-scoped handler** — additive; the user `:before` reads the already-stashed `:rf/redacted-event` from the schema-redaction interceptor and extends it rather than overwriting (the union of paths is scrubbed)
- **with epoch `:redact-fn`** — independent layer; the per-record hook reads already-scrubbed trace events

Per Security.md, `with-redacted` does NOT auto-stamp `:sensitive?` on trace events — that remains registration-meta's job. The two composition sites are intentionally independent.

## Design

Implementation mirrors `privacy/schema-redaction-interceptor`:
- The user interceptor carries its `:paths` vector on the interceptor map so `router/prepare-handler-ctx` can collect them at chain-assembly time and fold them into the pre-chain `emit-event` projection (used by `:run-start` and `emit-cascade-trailers`, which fire before any `:before` runs).
- The in-chain `:before` is load-bearing for the schema-redaction composition: it extends the existing `:rf/redacted-event` rather than overwriting it.

## Test plan

`implementation/core/test/re_frame/with_redacted_test.clj` (12 tests / 38 assertions):
- [x] `with-redacted-is-exported` — `rf/with-redacted` is `privacy/with-redacted`
- [x] `with-redacted-returns-interceptor-with-paths` — `:id :rf/with-redacted`, `:paths` exposed
- [x] `handler-sees-unredacted-trace-sees-redacted` — primary contract
- [x] `declared-key-is-sentineled-even-when-absent` — explicit redaction semantics
- [x] `handler-without-with-redacted-sees-no-redaction` — negative
- [x] `empty-path-scrubs-entire-payload` — `[[]]` scrubs the whole payload
- [x] `non-map-payload-passes-through` — graceful with non-canonical events
- [x] `composes-with-handler-meta-sensitive` — both stampings on the same event
- [x] `composes-additively-with-schema-redaction` — union of schema + user paths
- [x] `with-redacted-alone-does-not-stamp-sensitive-scope` — regression
- [x] `handler-exception-trace-sees-redacted-payload` — exception path composes
- [x] `multiple-with-redacted-interceptors-union` — chain stacks as union

## Gates

- core JVM: 543/543 tests, 2819 assertions, 0 failures, 0 errors
- CLJS node integration: 2344/2344 tests, 6722 assertions, 0 failures, 0 errors
- schemas-sensitive (existing schema-redaction): 23/23 tests

## Spec

spec/API.md row L489 was never demoted in tree (the audit cluster filed this bead instead of editing) — the row stays at `v1` status; the code now matches.

Closes rf2-461sp.