### PR TITLE
fix(scripts): strip inline-code spans before LINK_RE in check_doc_slugs (rf2-mqv8s)

### DIFF
--- a/scripts/_test_fixtures/check_doc_slugs/README.md
+++ b/scripts/_test_fixtures/check_doc_slugs/README.md
@@ -14,12 +14,14 @@ The expected broken-link count for each fixture is hard-coded in
 
 Fixtures:
 
-| Fixture                     | Expected broken | Exercises                                  |
-| --------------------------- | --------------- | ------------------------------------------ |
-| `valid_link`                | 0               | Cross-file link to existing file + anchor  |
-| `broken_target`             | 1               | Cross-file link to a missing `.md` file    |
-| `broken_anchor`             | 1               | Target file exists but anchor doesn't      |
-| `same_file_anchor_ok`       | 0               | `[text](#anchor)` resolving to local head  |
-| `same_file_anchor_broken`   | 1               | `[text](#anchor)` not in same file         |
-| `absolute_path_ok`          | 0               | `[text](/docs/foo.md)` repo-root-absolute  |
-| `relative_dotdot_ok`        | 0               | `[text](../foo.md)` from a subdirectory    |
+| Fixture                            | Expected broken | Exercises                                                                          |
+| ---------------------------------- | --------------- | ---------------------------------------------------------------------------------- |
+| `valid_link`                       | 0               | Cross-file link to existing file + anchor                                          |
+| `broken_target`                    | 1               | Cross-file link to a missing `.md` file                                            |
+| `broken_anchor`                    | 1               | Target file exists but anchor doesn't                                              |
+| `same_file_anchor_ok`              | 0               | `[text](#anchor)` resolving to local head                                          |
+| `same_file_anchor_broken`          | 1               | `[text](#anchor)` not in same file                                                 |
+| `absolute_path_ok`                 | 0               | `[text](/docs/foo.md)` repo-root-absolute                                          |
+| `relative_dotdot_ok`               | 0               | `[text](../foo.md)` from a subdirectory                                            |
+| `inline_code_placeholder_ignored`  | 0               | Backticked link-syntax placeholders are masked; real link still validates (rf2-mqv8s) |
+| `inline_code_negative_control`     | 1               | Same-line broken link OUTSIDE an inline-code span is still flagged (rf2-mqv8s)     |

--- a/scripts/_test_fixtures/check_doc_slugs/inline_code_negative_control/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/inline_code_negative_control/docs/index.md
@@ -1,0 +1,8 @@
+# Index — Inline-Code Negative Control (rf2-mqv8s)
+
+This fixture proves the inline-code stripping does NOT over-mask.  On the
+line below, the FIRST link sits inside an inline-code span (placeholder,
+ignore) and the SECOND link is real markdown pointing at a missing file
+(must still be flagged as BROKEN TARGET).
+
+`[placeholder](ignored.md)` but this one [is real and broken](missing.md).

--- a/scripts/_test_fixtures/check_doc_slugs/inline_code_negative_control/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/inline_code_negative_control/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/docs/index.md
@@ -1,0 +1,37 @@
+# Index — Inline-Code Placeholder Regression (rf2-mqv8s)
+
+This fixture exercises the rule that link-syntax appearing inside
+inline-code spans is documentation-of-syntax, not a real link to resolve.
+
+## Real link (must still validate)
+
+This is a real link to [the target](target.md#hello-world) — the file
+exists, the anchor exists, the validator must NOT flag it.
+
+## Single-backtick placeholder (must be ignored)
+
+The skill docs use a backticked link-syntax template such as
+`[NNN-DocName](NNN-DocName.md)` to TALK ABOUT link syntax — the bracketed
+file does not exist and must not be flagged as BROKEN TARGET.
+
+## Double-backtick placeholder (must be ignored)
+
+Double-backtick spans wrap content containing a literal backtick, e.g.
+`` `[doc](missing-doc.md)` `` is a code span whose content is itself a
+backticked example.  The outer span must mask the inner link.
+
+## Mixed line — real link AND placeholder
+
+Here a real link to [the target](target.md) sits next to a placeholder
+`[fake](not-real.md)` on the same line — the real link must validate, the
+placeholder must be ignored.
+
+## Multiple placeholders on one line
+
+`[a](missing-a.md)` and `[b](missing-b.md)` and `[c](missing-c.md)` — all
+three are inline-code-masked and must be ignored.
+
+## Bare ATX heading slug check
+
+The `## Hello World` heading in `target.md` is what `#hello-world` resolves
+to; this paragraph is just narrative.

--- a/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/docs/target.md
+++ b/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/docs/target.md
@@ -1,0 +1,5 @@
+# Target
+
+## Hello World
+
+Some content here.

--- a/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/inline_code_placeholder_ignored/mkdocs.yml
@@ -1,0 +1,1 @@
+# Self-test fixture marker.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -121,6 +121,27 @@ _LINK_RE = re.compile(r"\[(?:[^\]\\]|\\.)*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 # Fenced code block delimiter (``` or ~~~ optionally followed by language).
 _FENCE_RE = re.compile(r"^(```|~~~)")
 
+# Inline-code span (CommonMark §6.1).  A span opens with a run of N
+# backticks and closes with the next run of EXACTLY N backticks on the same
+# line.  This regex implements that with a back-reference for the closing
+# run length and a `(?!`)` look-ahead that forbids a longer closing run
+# (which would belong to a different span, not this one).
+#
+# Used by `_extract_links` to mask out spans like
+# `` `[NNN-DocName](NNN-DocName.md)` `` — backticked link-syntax PLACEHOLDERS
+# authors use to denote a literal link template, not a real link.  Without
+# this mask `_LINK_RE` would treat the placeholder as a real link and
+# (often) flag it as BROKEN TARGET.
+#
+# Scope:
+# * Single-line only.  Multi-line inline code is rare in this corpus and
+#   the validator already processes line-by-line after `_strip_fences`.
+# * Backslash escaping of backticks (`\``) is NOT honoured — CommonMark
+#   itself does not honour it; backticks are always literal markup.
+# * `_strip_fences` has already blanked fenced-block lines, so this regex
+#   never sees the language tag of a fence as a stray backtick run.
+_INLINE_CODE_RE = re.compile(r"(`+)(?:.+?)\1(?!`)")
+
 
 def _is_excluded(path: Path, repo_root: Path) -> bool:
     """Return True if path lies under a directory we should skip."""
@@ -233,16 +254,33 @@ def _slug_index(path: Path) -> set[str]:
     return slugs
 
 
+def _strip_inline_code(line: str) -> str:
+    """Mask inline-code spans with spaces so `_LINK_RE` skips them.
+
+    Spaces (not empty replacement) preserve column offsets, which keeps
+    column-sensitive diagnostics honest if added later.  Length-preserving
+    masking also means `_LINK_RE` cannot bridge across a stripped span.
+
+    Backticked link-syntax PLACEHOLDERS such as
+    `` `[NNN-DocName](NNN-DocName.md)` `` are a documentation idiom in this
+    corpus — they're literal markup the author wants to TALK about, not a
+    real link to resolve.  Without this masking the validator flags every
+    such placeholder as BROKEN TARGET (rf2-mqv8s).
+    """
+    return _INLINE_CODE_RE.sub(lambda m: " " * (m.end() - m.start()), line)
+
+
 def _extract_links(path: Path) -> Iterable[tuple[int, str]]:
     """Yield (line-number, destination) for every inline markdown link.
 
-    Links inside fenced code blocks are skipped.
+    Links inside fenced code blocks AND inside inline-code spans are
+    skipped — both are "code", not real cross-references (rf2-mqv8s).
     """
     text = path.read_text(encoding="utf-8", errors="replace")
     for line_no, content in _strip_fences(text.splitlines()):
         if not content:
             continue
-        for m in _LINK_RE.finditer(content):
+        for m in _LINK_RE.finditer(_strip_inline_code(content)):
             yield line_no, m.group(1)
 
 
@@ -448,13 +486,15 @@ def _run_self_tests(verbose: bool = False) -> int:
     """Run fixture-based self-tests.  Return 0 on success, 1 on any failure."""
     cases: list[tuple[str, int]] = [
         # (fixture-dir, expected-broken-link-count)
-        ("valid_link",              0),
-        ("broken_target",           1),
-        ("broken_anchor",           1),
-        ("same_file_anchor_ok",     0),
-        ("same_file_anchor_broken", 1),
-        ("absolute_path_ok",        0),
-        ("relative_dotdot_ok",      0),
+        ("valid_link",                       0),
+        ("broken_target",                    1),
+        ("broken_anchor",                    1),
+        ("same_file_anchor_ok",              0),
+        ("same_file_anchor_broken",          1),
+        ("absolute_path_ok",                 0),
+        ("relative_dotdot_ok",               0),
+        ("inline_code_placeholder_ignored",  0),  # rf2-mqv8s
+        ("inline_code_negative_control",     1),  # rf2-mqv8s
     ]
 
     failures = 0


### PR DESCRIPTION
## Summary

`scripts/check_doc_slugs.py` was tripping on backticked link-syntax PLACEHOLDERS like `` `[NNN-DocName](NNN-DocName.md)` `` — docs that talk ABOUT link syntax rather than linking. `_strip_fences` masks triple-backtick fenced blocks, but inline-code spans (single/multi-backtick) were unmasked, so `_LINK_RE` matched the placeholder targets and flagged them as BROKEN TARGET. Discovered on the rf2-0hert / spec-corpus audit fix-up worker (PR #1320 follow-up).

## Fix shape

- Add `_INLINE_CODE_RE` + `_strip_inline_code` (CommonMark §6.1: N-backtick open, exactly-N backtick close, single-line scope; length-preserving space masking so `_LINK_RE` cannot bridge across a stripped span).
- Apply the stripper inside `_extract_links` only, just before `_LINK_RE` runs. `_slug_index` deliberately does NOT use it — inline code on a heading line is part of the heading title and must feed the slugifier verbatim.
- Backslash escaping of backticks is not honoured (CommonMark itself doesn't).

## Regression tests (two new self-test fixtures wired into `--self-test`)

- `inline_code_placeholder_ignored` (expected broken = 0) — covers single-backtick, double-backtick, mixed-line (real link + placeholder), and multi-placeholder cases; a real link on the same page still validates.
- `inline_code_negative_control` (expected broken = 1) — proves the stripper does NOT over-mask: a real broken link OUTSIDE an inline-code span on the same line as a placeholder is still flagged BROKEN TARGET.

Self-test count: 7 → 9. README table updated.

## Test plan

- [x] `python scripts/check_doc_slugs.py --self-test --verbose` — all 9 self-tests pass
- [x] `python scripts/check_doc_slugs.py --verbose` — full corpus (326 files) reports zero broken links (no regression)
- [x] Sanity-checked stripper behaviour on the five canonical input shapes (single-backtick, double-backtick, mixed-line, multi-placeholder, no-code-span)

Closes rf2-mqv8s.