### PR TITLE
design(causa): tighten typography density + narrow sidebar (rf2-pcitk, shell+CSS only)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -13,12 +13,20 @@
       ├──────────────┬──────────────────────────────────────────┤
       │              │                                          │
       │  Sidebar     │  Canvas                                  │
-      │  (192px)     │  (active panel)                          │
+      │  (152px)     │  (active panel)                          │
       │              │                                          │
       │              │                                          │
       ├──────────────┴──────────────────────────────────────────┤
       │ Bottom rail (40px)                                      │
       └─────────────────────────────────────────────────────────┘
+
+  ## Density (rf2-pcitk)
+
+  Typography sizes and the sidebar width are read from
+  `theme.tokens/type-scale` + `theme.tokens/layout`. The shell ships
+  denser than spec-cosy (closer to compact) because Causa is an
+  info-dense dev surface — see the docstrings on those two defs for
+  the one-knob tuning model.
 
   ## Frame isolation (rf2-tijr Option C + rf2-in6l2)
 
@@ -68,7 +76,7 @@
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
-            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+            [day8.re-frame2-causa.theme.tokens :refer [tokens type-scale layout]]))
 
 ;; ---- sidebar items -------------------------------------------------------
 
@@ -119,24 +127,24 @@
   [:div {:style {:display          "flex"
                  :align-items      "center"
                  :justify-content  "space-between"
-                 :height           "56px"
+                 :height           (:top-strip-height layout)
                  :padding          "0 16px"
                  :background       (:bg-1 tokens)
                  :border-bottom    (str "1px solid " (:border-subtle tokens))
                  :color            (:text-primary tokens)
                  :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                 :font-size        "14px"
+                 :font-size        (:body type-scale)
                  :font-weight      600}}
    [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
     [:span {:style {:color (:accent-violet tokens)}} "◆"]
     [:span "Causa"]
     [:span {:style {:color       (:text-tertiary tokens)
-                    :font-size   "12px"
+                    :font-size   (:caption type-scale)
                     :font-weight 400}}
      "Phase 5 (rf2-pzxsr)"]]
    [:div {:style {:display "flex" :align-items "center" :gap "12px"
                   :color    (:text-secondary tokens)
-                  :font-size "12px"
+                  :font-size (:caption type-scale)
                   :font-weight 400}}
     ;; Collapsed-cue affordance per spec/007-UX-IA.md §The AI co-pilot
     ;; collapsed cue — the magenta `◇` glyph pulses every 8 seconds
@@ -161,14 +169,17 @@
   [{:keys [id label dormant?]} active?]
   [:li {:data-testid (str "rf-causa-sidebar-item-" (name id))
         :on-click    #(rf/dispatch [:rf.causa/select-panel id] {:frame :rf/causa})
-        :style       {:padding         "6px 16px"
+        :style       {:padding         "4px 12px"
                       :cursor          "pointer"
                       :background      (if active? (:bg-active tokens) "transparent")
                       :color           (cond
                                          active?  (:text-primary tokens)
                                          dormant? (:text-tertiary tokens)
                                          :else    (:text-secondary tokens))
-                      :font-weight     (if active? 600 400)}}
+                      :font-weight     (if active? 600 400)
+                      :white-space     "nowrap"
+                      :overflow        "hidden"
+                      :text-overflow   "ellipsis"}}
    [:span {:style {:margin-right "8px"
                    :color        (if active?
                                    (:accent-violet tokens)
@@ -180,9 +191,12 @@
    label])
 
 (rf/reg-view sidebar
-  "Sidebar (192px) — panel navigation + density toggle. Per spec/007-
-  UX-IA.md §Sidebar groups three groups (events/app-db/causality/...,
-  conditional-with-activity, dormant) divider-separated.
+  "Sidebar (152px, density-token driven) — panel navigation + density
+  toggle. Per spec/007-UX-IA.md §Sidebar groups three groups
+  (events/app-db/causality/..., conditional-with-activity, dormant)
+  divider-separated. Width comes from
+  `theme.tokens/layout :sidebar-width` (rf2-pcitk) — change in one
+  place to retune density.
 
   Phase 2: the active panel is driven by `:rf.causa/selected-panel`.
   Clicking a row dispatches `:rf.causa/select-panel`.
@@ -210,13 +224,15 @@
                   (and (= :hydration (:id item)) hydration-awake?)
                   (assoc :dormant? false)))
               sidebar-items)]
-    [:nav {:style {:width            "192px"
+    [:nav {:style {:width            (:sidebar-width layout)
                    :flex-shrink      0
                    :background       (:bg-1 tokens)
                    :border-right     (str "1px solid " (:border-subtle tokens))
                    :overflow-y       "auto"
+                   :overflow-x       "hidden"
                    :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                   :font-size        "13px"
+                   :font-size        (:body-tight type-scale)
+                   :line-height      (:line-height-tight type-scale)
                    :color            (:text-primary tokens)}}
      (into [:ul {:style {:list-style    "none"
                          :margin        0
@@ -237,7 +253,7 @@
                   :background  (:bg-2 tokens)
                   :color       (:text-primary tokens)
                   :font-family "Inter, system-ui, -apple-system, Segoe UI, sans-serif"}}
-   [:p {:style {:font-size "14px" :color (:text-secondary tokens)}}
+   [:p {:style {:font-size (:body type-scale) :color (:text-secondary tokens)}}
     "Unknown panel: " [:code (pr-str selected)]]])
 
 (rf/reg-view canvas
@@ -298,7 +314,7 @@
   through React context to `:rf/causa`."
   []
   (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
-    [:footer {:style {:height           "40px"
+    [:footer {:style {:height           (:bottom-rail-height layout)
                       :display          "flex"
                       :align-items      "center"
                       :justify-content  "space-between"
@@ -307,7 +323,7 @@
                       :border-top       (str "1px solid " (:border-subtle tokens))
                       :color            (:text-tertiary tokens)
                       :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                      :font-size        "12px"}}
+                      :font-size        (:caption type-scale)}}
      [:span "◀◀  ────●────  ▶▶  (scrubber)"]
      (when (pos? redacted-count)
        [:span {:data-testid "rf-causa-redacted-indicator"
@@ -399,8 +415,8 @@
                           :background       (:bg-0 tokens)
                           :color            (:text-primary tokens)
                           :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                          :font-size        "14px"
-                          :line-height      1.5}
+                          :font-size        (:body type-scale)
+                          :line-height      (:line-height-tight type-scale)}
                          (case mode
                            :inline
                            {:position   "relative"

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -32,6 +32,13 @@
     EDN / mono-column rendering.
   - **`sans-stack`** — the Inter font stack for chrome / labels /
     prose.
+  - **`type-scale`** — typography sizes (px strings) + base
+    line-height. The shell's default density (rf2-pcitk) — denser
+    than the spec's cosy baseline, closer to compact, because Causa
+    is an info-dense dev tool. One-knob tuning lives here; raise the
+    sizes one number to bring the shell back to spec-cosy.
+  - **`layout`** — chrome dimensions (sidebar width, etc.) consumed
+    by the shell. Single source for the density knob.
 
   ## What does not live here
 
@@ -87,3 +94,42 @@
   "Inter stack per spec/007-UX-IA.md §Typography. Used by chrome,
   labels, prose, and every non-mono surface in the panels."
   "Inter, system-ui, -apple-system, Segoe UI, sans-serif")
+
+(def type-scale
+  "Causa shell typography sizes (rf2-pcitk).
+
+  Causa is an info-dense dev surface. Mike's UX session against the
+  testbed flagged the cosy baseline (body 14 / mono 13 / line-height
+  1.5) as too LARGE — the eye has to travel further than the data
+  warrants. This scale runs ~1px below cosy across the board and
+  tightens line-height to 1.35, which is the readability floor for
+  monospaced data dumps.
+
+  spec/007-UX-IA.md §Typography catalogues the cosy baseline and a
+  ±1px density knob (compact/cosy/comfy). Rather than wire the
+  runtime density toggle now (a later v1.0 styling-pass bead), we
+  ship the denser scale as the default — closer to compact, but with
+  a few intermediate values that suit Causa's layout. Raise every
+  value 1px to revert to spec-cosy.
+
+  Values are CSS strings so call sites can drop them straight into
+  inline `:style` maps without unit conversion."
+  {;; Headings + prose
+   :display      "14px"     ; was 16 — panel titles
+   :body         "13px"     ; was 14 — default UI text
+   :body-tight   "12px"     ; sidebar entries, header chrome
+   :mono-body    "12px"     ; was 13 — code, EDN
+   :caption      "11px"     ; was 12 — hints, secondary labels
+   :micro        "10px"     ; was 11 — badges, tabs (refused-floor in spec is 10)
+   ;; Vertical rhythm
+   :line-height-tight 1.35   ; was 1.5 — denser blocks
+   :line-height-mono  1.4    ; mono needs a touch more leading for ascender clearance
+   })
+
+(def layout
+  "Causa shell layout dimensions (rf2-pcitk). Single source for the
+  density knob — narrowing the sidebar reclaims canvas width without
+  touching individual panels."
+  {:sidebar-width   "152px"   ; was 192px — between spec compact (160) and cosy (192)
+   :top-strip-height "56px"
+   :bottom-rail-height "40px"})


### PR DESCRIPTION
## Summary

Causa is an info-dense dev surface. Mike's UX testbed session flagged the cosy baseline (body 14 / mono 13 / line-height 1.5 / sidebar 192) as too LARGE — the eye travels further than the data warrants.

This PR introduces two new defs in `theme.tokens` — `type-scale` and `layout` — and refactors `shell.cljs` to consume them. Per-cell panel tweaks are deliberately **out of scope** (rf2-sf38d Panel rename owns `panels/*`; this PR is restricted to shell + shared tokens to keep the two PRs disjoint).

## Per-change before -> after

| Surface | Before | After |
|---|---|---|
| Body font (shell-view default, top strip) | 14px | 13px |
| Sidebar font | 13px | 12px |
| Mono font (mono-body token, for future panel use) | 13px | 12px |
| Caption ("Phase 5" tag, hint, bottom rail) | 12px | 11px |
| Line-height | 1.5 | 1.35 |
| Sidebar width | 192px | 152px (between spec compact 160 / cosy 192) |
| Sidebar row padding | 6/16 | 4/12 |

**Long-keyword handling:** sidebar rows now carry `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` at the shell level. Any future long label clips gracefully without per-cell wiring. Sidebar nav also gets `overflow-x: hidden` so the text-overflow can engage.

**Layout-knob model:** raising every `type-scale` value 1px reverts the shell to spec-cosy without touching call sites. The v1.0 styling pass that wires the runtime compact/cosy/comfy density toggle will swap this map for a reactive selection.

## Scope discipline (vs rf2-sf38d)

Only `shell.cljs` + `theme/tokens.cljc` modified — zero conflict with the in-flight Panel rename touching `panels/*` exports. Panels still cascade font-size/line-height from the shell's defaults (their explicit overrides take precedence).

## Test plan

- [x] `tools/causa` `clojure -M:test` -> 579 tests / 1708 assertions / 0 failures
- [x] `implementation` `npm run test:cljs` -> 2344 tests / 6722 assertions / 0 failures
- [x] `implementation` `npm run test:causa-feature-gate` -> 16 scenarios / 0 failures, 21 matrix rows covered

Closes rf2-pcitk.