### PR TITLE
feat(causa): rename *-view exports to Panel (rf2-sf38d, Mike decision A)

### DIFF
--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -150,30 +150,27 @@ test harnesses, and Settings UIs.
 
 ### `day8.re-frame2-causa.panels.*`
 
-Each panel exports its `*-view` component for embedding (per
-[`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). The
-embedding contract names the public symbol `Panel`; the present
-impl exports under `*-view`. Promoting to a capital-`Panel` alias
-is the open decision tracked under the embedding-facade bead — the
-canonical symbol list as of today is:
+Each panel namespace exports a single public `Panel` component for
+embedding (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)).
+The canonical symbol list:
 
 ```clojure
-day8.re-frame2-causa.panels.event-detail/event-detail-view
-day8.re-frame2-causa.panels.causality-graph/causality-graph-view
-day8.re-frame2-causa.panels.time-travel/time-travel-view
-day8.re-frame2-causa.panels.app-db-diff/app-db-diff-view
-day8.re-frame2-causa.panels.subscriptions/subscriptions-view
-day8.re-frame2-causa.panels.effects/effects-view
-day8.re-frame2-causa.panels.trace/trace-view
-day8.re-frame2-causa.panels.machine-inspector/machine-inspector-view
-day8.re-frame2-causa.panels.flows/flows-view
-day8.re-frame2-causa.panels.routes/routes-view
-day8.re-frame2-causa.panels.performance/performance-view
-day8.re-frame2-causa.panels.schema-violation-timeline/schema-violation-timeline-view
-day8.re-frame2-causa.panels.issues-ribbon/issues-ribbon-view
-day8.re-frame2-causa.panels.hydration-debugger/hydration-debugger-view
-day8.re-frame2-causa.panels.mcp-server/mcp-server-view
-day8.re-frame2-causa.panels.ai-co-pilot/ai-co-pilot-view
+day8.re-frame2-causa.panels.event-detail/Panel
+day8.re-frame2-causa.panels.causality-graph/Panel
+day8.re-frame2-causa.panels.time-travel/Panel
+day8.re-frame2-causa.panels.app-db-diff/Panel
+day8.re-frame2-causa.panels.subscriptions/Panel
+day8.re-frame2-causa.panels.effects/Panel
+day8.re-frame2-causa.panels.trace/Panel
+day8.re-frame2-causa.panels.machine-inspector/Panel
+day8.re-frame2-causa.panels.flows/Panel
+day8.re-frame2-causa.panels.routes/Panel
+day8.re-frame2-causa.panels.performance/Panel
+day8.re-frame2-causa.panels.schema-violation-timeline/Panel
+day8.re-frame2-causa.panels.issues-ribbon/Panel
+day8.re-frame2-causa.panels.hydration-debugger/Panel
+day8.re-frame2-causa.panels.mcp-server/Panel
+day8.re-frame2-causa.panels.ai-co-pilot/Panel
 ```
 
 Each accepts the props map specified in

--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -55,7 +55,7 @@ delegation" below).
 4. **Re-exports are minimal and intentional.** The facade re-exports:
    - `install!` (always, as the panel's installation entry point).
    - View vars that callers (typically `shell.cljs`) reference by name
-     (e.g. `app-db-diff/app-db-diff-view`,
+     (e.g. `app-db-diff/Panel`,
      `ai-co-pilot/ai-co-pilot-rail`).
 
    The facade does **NOT** re-export every leaf's surface. Leaves are
@@ -85,7 +85,7 @@ The facade's `reg-view` body is either:
   (parens), not a Reagent component vector (brackets):
 
   ```clojure
-  (rf/reg-view subscriptions-view
+  (rf/reg-view Panel
     "The Subscriptions panel's root view."
     []
     (views/subscriptions-panel))    ; parens — leaf body inlined

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot.cljs
@@ -3,7 +3,8 @@
 
   Follows the canonical panel facade pattern documented in
   `tools/causa/spec/Conventions.md` — the facade owns the panel's
-  three public `reg-view`s; bodies delegate to plain Reagent fns in
+  three public `reg-view`s (the canvas `Panel` plus the rail and cue
+  shells); bodies delegate to plain Reagent fns in
   `ai-co-pilot-views`. Subs/events leaves expose `install!`.
 
   The panel is split by responsibility:
@@ -40,7 +41,7 @@
   []
   (views/ai-co-pilot-cue))
 
-(rf/reg-view ai-co-pilot-view
+(rf/reg-view Panel
   "Canvas panel form of the AI Co-Pilot."
   []
   (views/ai-co-pilot-view))

--- a/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/ai_co_pilot_views.cljs
@@ -3,7 +3,7 @@
 
   Plain Reagent fns per the canonical facade convention — the panel's
   three public `reg-view` names (`ai-co-pilot-rail`,
-  `ai-co-pilot-cue`, `ai-co-pilot-view`) live in the facade
+  `ai-co-pilot-cue`, `Panel`) live in the facade
   `ai-co-pilot.cljs`; this leaf supplies the implementation bodies."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.ai-co-pilot-chrome :as chrome]

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -17,7 +17,7 @@
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens sans-stack]]))
 
-(rf/reg-view app-db-diff-view
+(rf/reg-view Panel
   "The App-DB Diff panel's root view."
   []
   (let [{:keys [target-frame

--- a/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/causality_graph.cljs
@@ -253,7 +253,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view causality-graph-view
+(rf/reg-view Panel
   "The Causality Graph panel's root view. Subscribes to
   `:rf.causa/causality-graph-data` and renders either the empty
   state (no cascades) or the SVG canvas (one or more cascades)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/effects.cljs
@@ -264,7 +264,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view effects-view
+(rf/reg-view Panel
   "The Effects panel's root view. Subscribes to
   `:rf.causa/effects-data` and renders the summary header + fx list
   (or the empty state when no fxs are registered)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -365,7 +365,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view event-detail-view
+(rf/reg-view Panel
   "The hero panel's root view. Subscribes to
   `:rf.causa/event-detail` and renders either the cascade-detail
   layout (when a dispatch-id is selected) or the cascade-list empty

--- a/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/flows.cljs
@@ -244,7 +244,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view flows-view
+(rf/reg-view Panel
   "The Flows panel's root view. Subscribes to
   `:rf.causa/flows-data` and renders the summary header + flow
   list (or the empty state when no flows are registered)."

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -357,7 +357,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view hydration-debugger-view
+(rf/reg-view Panel
   "The Hydration Debugger panel's root view. Subscribes to
   `:rf.causa/hydration-debugger-data` and renders either:
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -338,7 +338,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view issues-ribbon-view
+(rf/reg-view Panel
   "The Issues ribbon panel's root view. Subscribes to
   `:rf.causa/issues-ribbon` and renders the empty-state or the feed."
   []

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -326,7 +326,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view machine-inspector-view
+(rf/reg-view Panel
   "The Machine Inspector panel's root view. Subscribes to
   `:rf.causa/machine-inspector-data` and renders either the empty
   state (no machines registered) or the picker + chart placeholder +

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server.cljs
@@ -19,7 +19,7 @@
 
   Per the convention §Re-exports are minimal and intentional, the
   facade re-exports `install!` (the panel's installation entry) and
-  `mcp-server-view` (the view name `shell.cljs` references). Leaf
+  `Panel` (the view name `shell.cljs` references). Leaf
   subs/events/feed/chrome/style surfaces are NOT re-exported — they
   are internal organisation reached via the `install!` chain or
   direct sibling :require, and re-exporting them would invert the
@@ -29,7 +29,7 @@
             [day8.re-frame2-causa.panels.mcp-server-subs :as subs]
             [day8.re-frame2-causa.panels.mcp-server-views :as views]))
 
-(rf/reg-view mcp-server-view
+(rf/reg-view Panel
   "The MCP Server panel's root view.
 
   The body invokes the leaf as a plain function call —

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_views.cljs
@@ -2,7 +2,7 @@
   "Top-level view shell for the MCP Server panel.
 
   Plain Reagent fn per the canonical facade convention — the panel's
-  public `reg-view` (`mcp-server-view`) lives in the facade
+  public `reg-view` (`Panel`) lives in the facade
   `mcp-server.cljs`; this leaf supplies the implementation body."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.mcp-server-chrome :as chrome]

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -251,7 +251,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view performance-view
+(rf/reg-view Panel
   "The Performance panel's root view. Subscribes to
   `:rf.causa/performance-data` and renders the empty-state or the
   feed."

--- a/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
@@ -367,7 +367,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view routes-view
+(rf/reg-view Panel
   "The Routes panel's root view. Subscribes to `:rf.causa/routes-data`
   and renders the active-route breadcrumb + registered-routes list +
   navigation-history feed (or the empty state when no routes are

--- a/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/schema_violation_timeline.cljs
@@ -336,7 +336,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view schema-violation-timeline-view
+(rf/reg-view Panel
   "The Schema-violation Timeline panel's root view. Subscribes to
   `:rf.causa/schema-violation-timeline` and renders the empty-state
   or the per-schema track stack."

--- a/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/subscriptions.cljs
@@ -13,7 +13,7 @@
             [day8.re-frame2-causa.panels.subscriptions-views
              :as views]))
 
-(rf/reg-view subscriptions-view
+(rf/reg-view Panel
   "The Subscriptions panel's root view.
 
   The body invokes the leaf as a plain function call —

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -208,7 +208,7 @@
                              :font-size "11px"}}
         (str "Pin cap reached (" h/default-pin-cap "). Remove a pin to capture more.")])]))
 
-(rf/reg-view time-travel-view
+(rf/reg-view Panel
   []
   (let [{:keys [target-frame history] :as data}
         @(rf/subscribe [:rf.causa/time-travel])]

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -469,7 +469,7 @@
 
 ;; ---- public view --------------------------------------------------------
 
-(rf/reg-view trace-view
+(rf/reg-view Panel
   "The Trace panel's root view. Subscribes to `:rf.causa/trace-feed`
   and renders either the chip-filterable ribbon or the empty-state."
   []

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -252,29 +252,29 @@
   (let [selected (or @(rf/subscribe [:rf.causa/selected-panel])
                      registry/default-panel-id)]
     (case selected
-      :event-detail [event-detail/event-detail-view]
-      :time-travel  [time-travel/time-travel-view]
-      :app-db       [app-db-diff/app-db-diff-view]
-      :causality    [causality-graph/causality-graph-view]
+      :event-detail [event-detail/Panel]
+      :time-travel  [time-travel/Panel]
+      :app-db       [app-db-diff/Panel]
+      :causality    [causality-graph/Panel]
       ;; ── effects panel begin ──
-      :fx           [effects/effects-view]
+      :fx           [effects/Panel]
       ;; ── effects panel end ──
-      :flows        [flows/flows-view]
-      :routes       [routes/routes-view]
-      :schemas      [schema-violation-timeline/schema-violation-timeline-view]
-      :subs         [subscriptions/subscriptions-view]
-      :machines     [machine-inspector/machine-inspector-view]
-      :hydration    [hydration-debugger/hydration-debugger-view]
-      :issues       [issues-ribbon/issues-ribbon-view]
-      :trace        [trace/trace-view]
-      :performance  [performance/performance-view]
+      :flows        [flows/Panel]
+      :routes       [routes/Panel]
+      :schemas      [schema-violation-timeline/Panel]
+      :subs         [subscriptions/Panel]
+      :machines     [machine-inspector/Panel]
+      :hydration    [hydration-debugger/Panel]
+      :issues       [issues-ribbon/Panel]
+      :trace        [trace/Panel]
+      :performance  [performance/Panel]
       ;; ── mcp-server panel begin ──
-      :mcp-server   [mcp-server/mcp-server-view]
+      :mcp-server   [mcp-server/Panel]
       ;; ── mcp-server panel end ──
       ;; Sidebar Co-pilot row renders the panel-style view in the
       ;; canvas; the rail still lives in the shell's right margin per
       ;; spec/007-UX-IA.md §The five regions item 4.
-      :copilot      [ai-co-pilot/ai-co-pilot-view]
+      :copilot      [ai-co-pilot/Panel]
       [unknown-panel selected])))
 
 (rf/reg-view bottom-rail
@@ -346,26 +346,26 @@
   canvas — every sidebar selection resolves to the matching panel view."
   [selected]
   (case selected
-    :event-detail [event-detail/event-detail-view]
-    :time-travel  [time-travel/time-travel-view]
-    :app-db       [app-db-diff/app-db-diff-view]
-    :causality    [causality-graph/causality-graph-view]
+    :event-detail [event-detail/Panel]
+    :time-travel  [time-travel/Panel]
+    :app-db       [app-db-diff/Panel]
+    :causality    [causality-graph/Panel]
     ;; ── effects panel begin ──
-    :fx           [effects/effects-view]
+    :fx           [effects/Panel]
     ;; ── effects panel end ──
-    :flows        [flows/flows-view]
-    :routes       [routes/routes-view]
-    :schemas      [schema-violation-timeline/schema-violation-timeline-view]
-    :subs         [subscriptions/subscriptions-view]
-    :machines     [machine-inspector/machine-inspector-view]
-    :hydration    [hydration-debugger/hydration-debugger-view]
-    :issues       [issues-ribbon/issues-ribbon-view]
-    :trace        [trace/trace-view]
-    :performance  [performance/performance-view]
+    :flows        [flows/Panel]
+    :routes       [routes/Panel]
+    :schemas      [schema-violation-timeline/Panel]
+    :subs         [subscriptions/Panel]
+    :machines     [machine-inspector/Panel]
+    :hydration    [hydration-debugger/Panel]
+    :issues       [issues-ribbon/Panel]
+    :trace        [trace/Panel]
+    :performance  [performance/Panel]
     ;; ── mcp-server panel begin ──
-    :mcp-server   [mcp-server/mcp-server-view]
+    :mcp-server   [mcp-server/Panel]
     ;; ── mcp-server panel end ──
-    :copilot      [ai-co-pilot/ai-co-pilot-view]
+    :copilot      [ai-co-pilot/Panel]
     [unknown-panel selected]))
 
 (rf/reg-view shell-view

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_cljs_test.cljs
@@ -190,7 +190,7 @@
       ;; Render both the rail view and the panel-style view. Neither
       ;; should fire an LLM call.
       (copilot/ai-co-pilot-rail)
-      (copilot/ai-co-pilot-view)
+      (copilot/Panel)
       (copilot/ai-co-pilot-cue))
     (is (= 0 (count (captured)))
         "no outbound LLM call fired by render")))
@@ -401,7 +401,7 @@
     (frame/reg-frame :rf/causa {})
     (rf/with-frame :rf/causa
       (let [rail-tree  (copilot/ai-co-pilot-rail)
-            panel-tree (copilot/ai-co-pilot-view)
+            panel-tree (copilot/Panel)
             text-of-tree
             (fn [tree]
               (->> (hiccup-seq tree)

--- a/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_views_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/ai_co_pilot_views_cljs_test.cljs
@@ -2,7 +2,8 @@
   "Per-leaf smoke test for `ai-co-pilot-views` (rf2-nb8if).
 
   Renders each plain Reagent fn (`ai-co-pilot-rail`,
-  `ai-co-pilot-cue`, `ai-co-pilot-view`) once and asserts the load-
+  `ai-co-pilot-cue`, `ai-co-pilot-view` — the leaf delegate behind
+  the facade `Panel`) once and asserts the load-
   bearing data-testid hook is present. The leaf is plain-fn-only
   per the canonical convention — the public `reg-view` lives in
   the facade `ai-co-pilot.cljs`."

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -481,7 +481,7 @@
     (frame/reg-frame :rf/causa {})
     (frame/reg-frame :rf/default {})
     (rf/with-frame :rf/causa
-      (let [tree (app-db-diff/app-db-diff-view)]
+      (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-empty"))
             "empty-state container present")
         (is (nil? (find-by-testid tree "rf-causa-app-db-diff-slices")))))))
@@ -495,7 +495,7 @@
                              {:cart {:items []} :user "ada"}
                              {:cart {:items [{:id 7}]} :user "ada"})])
     (rf/with-frame :rf/causa
-      (let [tree (app-db-diff/app-db-diff-view)]
+      (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-slices"))
             "slice container present")
         (is (nil? (find-by-testid tree "rf-causa-app-db-diff-empty"))
@@ -513,7 +513,7 @@
                              {:cart {:items []}}
                              {:cart {:items []} :rf/route {:id :app/cart}})])
     (rf/with-frame :rf/causa
-      (let [tree (app-db-diff/app-db-diff-view)]
+      (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-reserved-group"))
             "runtime group container present")
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-reserved-:rf/route"))
@@ -533,7 +533,7 @@
                              {:cart {:items [{:id 7}]}})])
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]])
-      (let [tree (app-db-diff/app-db-diff-view)]
+      (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-focus-result"))
             "focus-result panel present")
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-focus-hits"))
@@ -552,7 +552,7 @@
                  [])
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]])
-      (let [tree (app-db-diff/app-db-diff-view)]
+      (let [tree (app-db-diff/Panel)]
         (is (some? (find-by-testid tree "rf-causa-app-db-diff-pinned-group"))
             "pinned group container present")
         (is (some? (find-by-testid tree
@@ -567,7 +567,7 @@
                              {:cart {:items []}}
                              {:cart {:items [{:id 7}]}})])
     (rf/with-frame :rf/causa
-      (let [tree     (app-db-diff/app-db-diff-view)
+      (let [tree     (app-db-diff/Panel)
             btn      (find-by-testid tree
                                      "rf-causa-app-db-diff-pin-[:cart :items]")
             on-click (:on-click (second btn))]
@@ -588,7 +588,7 @@
                              {:cart {:items []}}
                              {:cart {:items [{:id 7}]}})])
     (rf/with-frame :rf/causa
-      (let [tree (app-db-diff/app-db-diff-view)
+      (let [tree (app-db-diff/Panel)
             btn  (find-by-testid tree
                                  "rf-causa-app-db-diff-show-when-[:cart :items]")
             on-click (:on-click (second btn))]

--- a/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/causality_graph_view_cljs_test.cljs
@@ -143,7 +143,7 @@
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
     (rf/with-frame :rf/causa
-      (let [tree (causality-graph/causality-graph-view)]
+      (let [tree (causality-graph/Panel)]
         (is (some? (find-by-testid tree "rf-causa-causality-graph-empty"))
             "empty-state container present")
         (is (nil?  (find-by-testid tree "rf-causa-causality-graph-svg"))
@@ -155,7 +155,7 @@
     (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
                           (cascade-evs 200 [:user/redirect] 100 100)))
     (rf/with-frame :rf/causa
-      (let [tree (causality-graph/causality-graph-view)]
+      (let [tree (causality-graph/Panel)]
         (is (some? (find-by-testid tree "rf-causa-causality-graph-svg"))
             "SVG container present")
         (is (nil?  (find-by-testid tree "rf-causa-causality-graph-empty"))
@@ -179,7 +179,7 @@
             writes to the right frame)."
     (seed-buffer! (cascade-evs 100 [:user/login] 0))
     (rf/with-frame :rf/causa
-      (let [tree     (causality-graph/causality-graph-view)
+      (let [tree     (causality-graph/Panel)
             node     (find-by-testid tree "rf-causa-graph-node-100")
             on-click (:on-click (second node))]
         (is (fn? on-click)
@@ -330,7 +330,7 @@
     (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
                           (cascade-evs 200 [:user/redirect] 100 100)))
     (rf/with-frame :rf/causa
-      (let [tree (causality-graph/causality-graph-view)
+      (let [tree (causality-graph/Panel)
             svg  (find-by-testid tree "rf-causa-causality-graph-svg")
             attrs (second svg)]
         (is (some? svg) "SVG canvas present")
@@ -356,7 +356,7 @@
             deliberate change."
     (seed-buffer! (cascade-evs 100 [:user/login] 0))
     (rf/with-frame :rf/causa
-      (let [tree  (causality-graph/causality-graph-view)
+      (let [tree  (causality-graph/Panel)
             svg   (find-by-testid tree "rf-causa-causality-graph-svg")
             attrs (second svg)]
         (is (nil? (:on-wheel attrs))
@@ -377,7 +377,7 @@
             mount lazily on first hover') rides a follow-on bead."
     (seed-buffer! (cascade-evs 100 [:user/login] 0))
     (rf/with-frame :rf/causa
-      (let [tree  (causality-graph/causality-graph-view)
+      (let [tree  (causality-graph/Panel)
             node  (find-by-testid tree "rf-causa-graph-node-100")
             attrs (second node)]
         (is (= "pointer" (get-in attrs [:style :cursor]))
@@ -411,7 +411,7 @@
     (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
                           (cascade-evs 200 [:user/redirect] 100 100)))
     (rf/with-frame :rf/causa
-      (let [tree   (causality-graph/causality-graph-view)
+      (let [tree   (causality-graph/Panel)
             parent (find-by-testid tree "rf-causa-graph-node-100")
             child  (find-by-testid tree "rf-causa-graph-node-200")]
         (is (fn? (:on-click (second parent))) "parent carries on-click")
@@ -435,7 +435,7 @@
             ignored (rf/dispatch returns nil)."
     (seed-buffer! (cascade-evs 100 [:user/login] 0))
     (rf/with-frame :rf/causa
-      (let [tree     (causality-graph/causality-graph-view)
+      (let [tree     (causality-graph/Panel)
             node     (find-by-testid tree "rf-causa-graph-node-100")
             on-click (:on-click (second node))]
         (is (fn? on-click))
@@ -480,7 +480,7 @@
       (rf/with-frame :rf/causa
         (let [data        @(rf/subscribe [:rf.causa/causality-graph-data])
               sub-ids     (set (map :dispatch-id (get-in data [:graph :nodes])))
-              tree        (causality-graph/causality-graph-view)
+              tree        (causality-graph/Panel)
               node-prefix "rf-causa-graph-node-"
               rendered    (find-all-by-testid-prefix tree node-prefix)
               rendered-ids (->> rendered
@@ -507,7 +507,7 @@
                           (cascade-evs 200 [:user/redirect] 100 100)))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 200])
-      (let [tree      (causality-graph/causality-graph-view)
+      (let [tree      (causality-graph/Panel)
             ;; The selected glyph (◉) is text inside the node `<g>`; the
             ;; outer `<g>` carries the data-testid. Walk the node's
             ;; subtree to find the <rect> child.

--- a/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/effects_view_cljs_test.cljs
@@ -141,7 +141,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-fxs! {})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-fx-empty"))
@@ -157,7 +157,7 @@
       (override-fxs!
         {:my/notify  {:platforms #{:client}}
          :my/persist {:platforms #{:client :server}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-list"))
             "list container present")
         (is (some? (find-by-testid tree "rf-causa-fx-row-:my/notify"))
@@ -173,7 +173,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-id-:my/notify")))))))
 
 (deftest never-invoked-badge-renders-by-default
@@ -183,7 +183,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-badge-never-invoked")))))))
 
 ;; ---- (3) outcome surfaces from trace events -----------------------------
@@ -205,7 +205,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-badge-ok"))
             ":ok badge surfaces")
         (is (some? (find-by-testid tree
@@ -227,7 +227,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-badge-skipped")))))))
 
 (deftest error-badge-renders-when-fx-handler-throws
@@ -244,7 +244,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-badge-error")))))))
 
 ;; ---- (4) stub indicator -------------------------------------------------
@@ -264,7 +264,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (some? (find-by-testid tree "rf-causa-fx-badge-overridden"))
             ":overridden badge surfaces")
         (is (some? (find-by-testid tree
@@ -284,7 +284,7 @@
     (rf/with-frame :rf/causa
       (override-fxs!
         {:my/notify {:platforms #{:client}}})
-      (let [tree (effects/effects-view)]
+      (let [tree (effects/Panel)]
         (is (nil? (find-by-testid tree
                                   "rf-causa-fx-row-stub-:my/notify"))
             "STUB indicator absent when no override active")))))
@@ -317,7 +317,7 @@
         {:a {:platforms #{:client}}
          :b {:platforms #{:client}}})
       ;; Both fxs :never-invoked — exactly one chip should render.
-      (let [tree  (effects/effects-view)
+      (let [tree  (effects/Panel)
             chips (find-all-by-testid-prefix tree "rf-causa-fx-summary-")]
         (is (= 1 (count chips))
             "one chip for the :never-invoked outcome")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -150,7 +150,7 @@
     (seed-buffer! (concat (cascade-evs 100 [:user/login {:id 42}] 0)
                           (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container present")
         (is (some? (find-by-testid tree "rf-causa-cascade-list"))
@@ -167,7 +167,7 @@
             renders the empty-state container"
     (seed-buffer! [])
     (rf/with-frame :rf/causa
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container present even with an empty buffer")
         (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
@@ -181,7 +181,7 @@
     (seed-buffer! (cascade-evs 100 [:user/login {:id 42}] 0))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
             "cascade-detail container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
@@ -198,7 +198,7 @@
       ;; :selected-cascade=nil; the view should surface the
       ;; orphaned-state branch rather than the cascade rows.
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 999])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
             "orphaned-selection container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
@@ -236,7 +236,7 @@
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (rf/dispatch-sync [:rf.causa/clear-selected-dispatch-id])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container present after clear")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
@@ -292,7 +292,7 @@
     (seed-buffer! [])
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 42])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
             "orphaned-selection container present when buffer is empty")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
@@ -307,7 +307,7 @@
             state container with the 'no cascades yet' placeholder copy"
     (seed-buffer! [])
     (rf/with-frame :rf/causa
-      (let [tree    (event-detail/event-detail-view)
+      (let [tree    (event-detail/Panel)
             empty   (find-by-testid tree "rf-causa-event-detail-empty")
             ;; Flatten every text node under the empty-state container
             ;; so the assertion is agnostic to the placeholder paragraph's
@@ -362,7 +362,7 @@
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/default])
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 777])
-      (let [tree   (event-detail/event-detail-view)
+      (let [tree   (event-detail/Panel)
             count* @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
         (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
             "orphaned-selection container present — the redacted cascade
@@ -401,7 +401,7 @@
                        (map #(assoc % :sensitive? true))))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 888])
-      (let [tree   (event-detail/event-detail-view)
+      (let [tree   (event-detail/Panel)
             count* @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
         (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
             "cascade-detail renders the six-domino layout under the
@@ -439,7 +439,7 @@
     (seed-buffer! (cascade-evs-with-duration 300 [:counter/inc] 300 5))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 300])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
             "fast-tier dot present alongside the :duration-ms text")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
@@ -451,7 +451,7 @@
     (seed-buffer! (cascade-evs-with-duration 301 [:counter/inc] 310 30))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 301])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium"))
             "medium-tier dot present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))))))
@@ -461,7 +461,7 @@
     (seed-buffer! (cascade-evs-with-duration 302 [:counter/inc] 320 75))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 302])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow"))
             "slow-tier dot present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
@@ -472,7 +472,7 @@
     (seed-buffer! (cascade-evs-with-duration 303 [:counter/inc] 330 250))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 303])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking"))
             "blocking-tier dot present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))))))
@@ -485,7 +485,7 @@
     (seed-buffer! (cascade-evs 304 [:counter/inc] 340))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 304])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
             "no tier-dot when :duration-ms is absent")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
@@ -500,7 +500,7 @@
     (seed-buffer! (cascade-evs-with-duration 305 [:counter/inc] 350 "not-a-number"))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 305])
-      (let [tree (event-detail/event-detail-view)]
+      (let [tree (event-detail/Panel)]
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/flows_view_cljs_test.cljs
@@ -139,7 +139,7 @@
   (testing "with no registered flows the panel renders the empty state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flows"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-flows-empty"))
@@ -155,7 +155,7 @@
       (override-flows!
         {:rect/area  {:inputs [[:w] [:h]] :path [:area]}
          :cart/total {:inputs [[:items]]  :path [:total]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flows-list"))
             "list container present")
         (is (some? (find-by-testid tree "rf-causa-flow-row-:rect/area"))
@@ -171,7 +171,7 @@
     (rf/with-frame :rf/causa
       (override-flows!
         {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flow-id-:rect/area")))
         (is (some? (find-by-testid tree "rf-causa-flow-inputs-:rect/area")))
         (is (some? (find-by-testid tree "rf-causa-flow-path-:rect/area")))))))
@@ -182,7 +182,7 @@
     (rf/with-frame :rf/causa
       (override-flows!
         {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flow-badge-idle")))))))
 
 ;; ---- (3) live recomputation indicator -----------------------------------
@@ -207,7 +207,7 @@
     (rf/with-frame :rf/causa
       (override-flows!
         {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flow-badge-computing"))
             "computing badge surfaces")
         (is (some? (find-by-testid tree
@@ -228,7 +228,7 @@
     (rf/with-frame :rf/causa
       (override-flows!
         {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flow-badge-skipping")))
         (is (nil? (find-by-testid tree
                                   "rf-causa-flow-row-recomputing-:rect/area"))
@@ -247,7 +247,7 @@
     (rf/with-frame :rf/causa
       (override-flows!
         {:rect/area {:inputs [[:w] [:h]] :path [:area]}})
-      (let [tree (flows/flows-view)]
+      (let [tree (flows/Panel)]
         (is (some? (find-by-testid tree "rf-causa-flow-badge-failed")))))))
 
 ;; ---- (4) selection ------------------------------------------------------
@@ -278,7 +278,7 @@
         {:a {:inputs [] :path [:a]}
          :b {:inputs [] :path [:b]}})
       ;; Both flows :idle — exactly one chip should render.
-      (let [tree  (flows/flows-view)
+      (let [tree  (flows/Panel)
             chips (find-all-by-testid-prefix tree "rf-causa-flows-summary-")]
         (is (= 1 (count chips))
             "one chip for the :idle status")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -199,7 +199,7 @@
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
     (rf/with-frame :rf/causa
-      (let [tree (hydration/hydration-debugger-view)]
+      (let [tree (hydration/Panel)]
         (is (some? (find-by-testid tree
                                    "rf-causa-hydration-debugger-empty-no-ssr"))
             "empty-state container present")
@@ -213,7 +213,7 @@
                                 [:p "3 items"]
                                 [:p "0 items"])])
     (rf/with-frame :rf/causa
-      (let [tree (hydration/hydration-debugger-view)]
+      (let [tree (hydration/Panel)]
         (is (some? (find-by-testid tree "rf-causa-hydration-mismatch-list"))
             "mismatch list present")
         (is (some? (find-by-testid tree "rf-causa-hydration-mismatch-detail"))
@@ -237,7 +237,7 @@
     (seed-buffer! [(mismatch-ev 1 [:div] [:a] [:b])
                    (mismatch-ev 2 [:span] [:c] [:d])])
     (rf/with-frame :rf/causa
-      (let [tree (hydration/hydration-debugger-view)
+      (let [tree (hydration/Panel)
             row  (find-by-testid tree "rf-causa-hydration-mismatch-row-1")]
         (is (some? row) "row 1 present in mismatch list")
         (is (fn? (:on-click (second row)))
@@ -257,7 +257,7 @@
                                 [:div [:p "match"] [:p "server"]]
                                 [:div [:p "match"] [:p "client"]])])
     (rf/with-frame :rf/causa
-      (let [tree  (hydration/hydration-debugger-view)
+      (let [tree  (hydration/Panel)
             chips (find-all-by-testid-prefix
                     tree "rf-causa-hydration-hash-chip-")]
         (is (pos? (count chips)) "at least one hash chip rendered")
@@ -303,7 +303,7 @@
   (testing "the hypothesis row carries one of the five hypothesis lines"
     (seed-buffer! [(mismatch-ev 1 [] [:p "3"] [:p "0"])])
     (rf/with-frame :rf/causa
-      (let [tree   (hydration/hydration-debugger-view)
+      (let [tree   (hydration/Panel)
             hyp    (find-by-testid tree "rf-causa-hydration-hypothesis")
             txt    (when hyp
                      (->> (hiccup-seq hyp)
@@ -320,7 +320,7 @@
                                 {:source-coord {:file "src/cart/views.cljs"
                                                 :line 42}})])
     (rf/with-frame :rf/causa
-      (let [tree  (hydration/hydration-debugger-view)
+      (let [tree  (hydration/Panel)
             row   (find-by-testid tree "rf-causa-hydration-source-coord")
             txt   (when row
                     (->> (hiccup-seq row)
@@ -337,7 +337,7 @@
                                 {:handler-source-coord
                                  {:file "src/cart/events.cljs" :line 13}})])
     (rf/with-frame :rf/causa
-      (let [tree (hydration/hydration-debugger-view)
+      (let [tree (hydration/Panel)
             row  (find-by-testid tree "rf-causa-hydration-source-coord")
             txt  (when row
                    (->> (hiccup-seq row)

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -175,7 +175,7 @@
   (testing "the panel renders its root container regardless of buffer state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-ribbon"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-issues-counts"))
@@ -192,7 +192,7 @@
             (the 'All clear' positive-result branch)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-empty-no-issues"))
             ":no-issues empty-state container present")
         (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
@@ -207,7 +207,7 @@
                               :operation :rf.error/handler-threw}))
       ;; Toggle in a severity the issue doesn't carry — filter excludes it.
       (rf/dispatch-sync [:rf.causa.issues/toggle-severity :advisory])
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-empty-no-matches"))
             ":no-matches empty-state container present")
         (is (some? (find-by-testid tree "rf-causa-issues-empty-clear-filters"))
@@ -228,7 +228,7 @@
       (push-trace! (mk-issue {:id 2 :op-type :warning
                               :operation :rf.warning/missing
                               :dispatch-id 1}))
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-feed"))
             "feed <ul> present")
         (is (some? (find-by-testid tree "rf-causa-issues-row-1"))
@@ -244,7 +244,7 @@
     (rf/with-frame :rf/causa
       (push-trace! (mk-issue {:id 3 :op-type :error
                               :operation :rf.error/handler-threw}))
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-time"))
             "row timestamp span present")
         (is (some? (find-by-testid tree "rf-causa-issues-row-3-severity"))
@@ -260,7 +260,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push at least one issue so any-filter? is false initially.
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-error")))
         (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-warning")))
         (is (some? (find-by-testid tree "rf-causa-issues-severity-chip-advisory")))))))
@@ -272,7 +272,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; No issues — prefix chip-row suppressed.
-      (is (nil? (find-by-testid (issues-ribbon/issues-ribbon-view)
+      (is (nil? (find-by-testid (issues-ribbon/Panel)
                                 "rf-causa-issues-prefix-chips"))
           "no prefix chip-row when buffer carries no issues"))))
 
@@ -286,7 +286,7 @@
     (push-trace! (mk-issue {:id 1 :op-type :error
                             :operation :rf.error/handler-threw}))
     (rf/with-frame :rf/causa
-      (let [tree (issues-ribbon/issues-ribbon-view)]
+      (let [tree (issues-ribbon/Panel)]
         (is (some? (find-by-testid tree "rf-causa-issues-prefix-chips"))
             "prefix chip-row renders once at least one prefix exists")
         (is (some? (find-by-testid tree "rf-causa-issues-prefix-chip-rf.error"))
@@ -389,11 +389,11 @@
     (rf/with-frame :rf/causa
       (push-trace! (mk-issue {:id 1 :op-type :error
                               :operation :rf.error/handler-threw}))
-      (is (nil? (find-by-testid (issues-ribbon/issues-ribbon-view)
+      (is (nil? (find-by-testid (issues-ribbon/Panel)
                                 "rf-causa-issues-clear-filters"))
           "no Clear filters button when no axis is active")
       (rf/dispatch-sync [:rf.causa.issues/toggle-severity :error])
-      (is (some? (find-by-testid (issues-ribbon/issues-ribbon-view)
+      (is (some? (find-by-testid (issues-ribbon/Panel)
                                  "rf-causa-issues-clear-filters"))
           "Clear filters button surfaces once a severity is active"))))
 
@@ -412,7 +412,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (issues-ribbon/issues-ribbon-view)
+          (let [tree    (issues-ribbon/Panel)
                 row     (find-by-testid tree "rf-causa-issues-row-4")
                 handler (:on-click (second row))]
             (is (some? row) "row node present in rendered tree")
@@ -439,7 +439,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (issues-ribbon/issues-ribbon-view)
+          (let [tree    (issues-ribbon/Panel)
                 node    (find-by-testid tree "rf-causa-issues-row-8-source")
                 handler (:on-click (second node))]
             (is (some? node) "source-coord chip rendered")

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -157,7 +157,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [])
-      (let [tree (machine-inspector/machine-inspector-view)]
+      (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-empty"))
@@ -172,7 +172,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login :checkout/flow])
-      (let [tree (machine-inspector/machine-inspector-view)]
+      (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-picker"))
             "picker container present")
         (is (some? (find-by-testid
@@ -211,7 +211,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
-      (let [tree (machine-inspector/machine-inspector-view)]
+      (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid
                      tree "rf-causa-machine-inspector-placeholder-banner"))
             "placeholder banner present — surfaces the deferred impl")))))
@@ -223,7 +223,7 @@
     (rf/with-frame :rf/causa
       (override-machines!  [:auth/login])
       (override-snapshots! {:auth/login {:state :authing :data {}}})
-      (let [tree (machine-inspector/machine-inspector-view)]
+      (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-placeholder")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-machine-id")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-frame-id")))))))
@@ -236,7 +236,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
-      (let [tree (machine-inspector/machine-inspector-view)]
+      (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon-empty")))))))
 
@@ -257,7 +257,7 @@
         {:id 2 :operation :rf.machine/transition :time 200
          :tags {:machine-id :auth/login :from :authing :to :idle
                 :event [:auth/cancel] :dispatch-id "d-2"}})
-      (let [tree    (machine-inspector/machine-inspector-view)
+      (let [tree    (machine-inspector/Panel)
             entries (find-all-by-testid-prefix
                       tree "rf-causa-machine-inspector-transition-")]
         (is (= 2 (count entries))
@@ -282,7 +282,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev] (swap! dispatches conj ev) nil)
                                      ([ev _opts] (swap! dispatches conj ev) nil))]
-          (let [tree    (machine-inspector/machine-inspector-view)
+          (let [tree    (machine-inspector/Panel)
                 entry   (find-by-testid
                           tree "rf-causa-machine-inspector-transition-1")
                 handler (:on-click (second entry))]

--- a/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/mcp_server_view_cljs_test.cljs
@@ -229,7 +229,7 @@
             empty state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (mcp-server/mcp-server-view)]
+      (let [tree (mcp-server/Panel)]
         (is (some? (find-by-testid tree "rf-causa-mcp-server"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-mcp-empty-no-activity"))
@@ -246,7 +246,7 @@
     (push-event! (mcp-event 2 :fx :fx/handled
                             {:tags {:tool :restore-epoch}}))
     (rf/with-frame :rf/causa
-      (let [tree (mcp-server/mcp-server-view)]
+      (let [tree (mcp-server/Panel)]
         (is (some? (find-by-testid tree "rf-causa-mcp-feed"))
             "feed container present")
         (is (some? (find-by-testid tree "rf-causa-mcp-row-1"))
@@ -269,7 +269,7 @@
     (push-event! (mcp-event 1 :event :event/dispatched))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/toggle-mcp-op-type :fx])
-      (let [tree (mcp-server/mcp-server-view)]
+      (let [tree (mcp-server/Panel)]
         (is (some? (find-by-testid tree "rf-causa-mcp-empty-no-matches"))
             ":no-matches empty state present")
         (is (nil? (find-by-testid tree "rf-causa-mcp-feed"))
@@ -280,7 +280,7 @@
             'no activity'"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree  (mcp-server/mcp-server-view)
+      (let [tree  (mcp-server/Panel)
             badge (find-by-testid tree "rf-causa-mcp-attached-badge")
             txt   (pr-str badge)]
         (is (re-find #"no activity" txt))
@@ -292,7 +292,7 @@
     (setup-causa-frame!)
     (push-event! (mcp-event 1 :event :event/dispatched))
     (rf/with-frame :rf/causa
-      (let [tree  (mcp-server/mcp-server-view)
+      (let [tree  (mcp-server/Panel)
             badge (find-by-testid tree "rf-causa-mcp-attached-badge")
             txt   (pr-str badge)]
         (is (re-find #"agent attached" txt))))))
@@ -312,7 +312,7 @@
                                    ([ev] (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/causa
-          (let [tree    (mcp-server/mcp-server-view)
+          (let [tree    (mcp-server/Panel)
                 row     (find-by-testid tree "rf-causa-mcp-row-1")
                 on-click (:on-click (second row))]
             (is (some? row) "row is present in the rendered tree")
@@ -335,7 +335,7 @@
                                    ([ev] (swap! dispatches conj ev) nil)
                                    ([ev _opts] (swap! dispatches conj ev) nil))]
         (rf/with-frame :rf/causa
-          (let [tree    (mcp-server/mcp-server-view)
+          (let [tree    (mcp-server/Panel)
                 row     (find-by-testid tree "rf-causa-mcp-row-1")
                 on-click (:on-click (second row))]
             (on-click))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/performance_view_cljs_test.cljs
@@ -176,7 +176,7 @@
   (testing "the panel renders its root container regardless of buffer state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (some? (find-by-testid tree "rf-causa-performance"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-perf-totals"))
@@ -190,7 +190,7 @@
   (testing "with no cascades the panel renders the empty container"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (some? (find-by-testid tree "rf-causa-perf-empty"))
             "empty-state container present")
         (is (nil? (find-by-testid tree "rf-causa-perf-feed"))
@@ -206,7 +206,7 @@
       (push-cascade! {:dispatch-id 1 :span-ms 5})
       (push-cascade! {:dispatch-id 2 :span-ms 25})
       (push-cascade! {:dispatch-id 3 :span-ms 200})
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (some? (find-by-testid tree "rf-causa-perf-feed"))
             "feed <ul> present")
         (is (some? (find-by-testid tree "rf-causa-perf-row-1"))
@@ -221,7 +221,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-cascade! {:dispatch-id 5 :span-ms 30 :event-vec [:cart/add 1]})
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (some? (find-by-testid tree "rf-causa-perf-row-5-tier"))
             "tier span present")
         (is (some? (find-by-testid tree "rf-causa-perf-row-5-id"))
@@ -241,7 +241,7 @@
     (rf/with-frame :rf/causa
       ;; Cascade spans 30ms; default budget is 16ms → over-budget.
       (push-cascade! {:dispatch-id 7 :span-ms 30})
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (some? (find-by-testid tree "rf-causa-perf-row-7-over-budget"))
             "over-budget marker present for over-budget row")
         (is (some? (find-by-testid tree "rf-causa-perf-over-budget-count"))
@@ -253,7 +253,7 @@
     (rf/with-frame :rf/causa
       ;; Cascade spans 5ms; default budget 16ms → within budget.
       (push-cascade! {:dispatch-id 11 :span-ms 5})
-      (let [tree (performance/performance-view)]
+      (let [tree (performance/Panel)]
         (is (nil? (find-by-testid tree "rf-causa-perf-row-11-over-budget"))
             "no over-budget marker for fast row")
         (is (nil? (find-by-testid tree "rf-causa-perf-over-budget-count"))
@@ -291,7 +291,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-cascade! {:dispatch-id 1 :span-ms 5})
-      (let [tree (performance/performance-view)
+      (let [tree (performance/Panel)
             chips (find-all-by-testid-prefix tree "rf-causa-perf-tier-chip-")]
         (is (= 4 (count chips))
             "4 chips — one per tier in tier-order")
@@ -312,7 +312,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (performance/performance-view)
+          (let [tree    (performance/Panel)
                 row     (find-by-testid tree "rf-causa-perf-row-42")
                 handler (:on-click (second row))]
             (is (some? row) "row node present in rendered tree")
@@ -333,7 +333,7 @@
       ;; 5ms → :fast, within-budget. 200ms → :blocking, over-budget.
       (push-cascade! {:dispatch-id 1 :span-ms 5})
       (push-cascade! {:dispatch-id 2 :span-ms 200})
-      (let [tree (performance/performance-view)
+      (let [tree (performance/Panel)
             r1   (find-by-testid tree "rf-causa-perf-row-1")
             r2   (find-by-testid tree "rf-causa-perf-row-2")]
         (is (= "fast"     (:data-tier (second r1))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routes_view_cljs_test.cljs
@@ -163,7 +163,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-routes! {})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routes"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-routes-empty"))
@@ -180,7 +180,7 @@
       (override-routes!
         {:route/home {:path "/"     :doc "Landing"}
          :route/cart {:path "/cart" :doc "Cart"}})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routes-list"))
             "list container present")
         (is (some? (find-by-testid tree "rf-causa-route-row-:route/home"))
@@ -196,7 +196,7 @@
     (rf/with-frame :rf/causa
       (override-routes!
         {:route/cart {:path "/cart" :doc "Cart"}})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-route-id-:route/cart")))
         (is (some? (find-by-testid tree "rf-causa-route-path-:route/cart")))))))
 
@@ -217,7 +217,7 @@
                         :fragment   nil
                         :transition :idle
                         :nav-token  "nav-1"})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routes-active"))
             "active-route strip rendered")
         (is (some? (find-by-testid tree "rf-causa-routes-active-route-id"))
@@ -237,7 +237,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-routes! {:route/home {:path "/"}})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routes-history"))
             "history section rendered when there are routes")
         (is (some? (find-by-testid tree "rf-causa-routes-history-empty"))
@@ -269,7 +269,7 @@
                               :dispatch-id 43}})
     (rf/with-frame :rf/causa
       (override-routes! {:route/cart {:path "/cart"}})
-      (let [tree (routes/routes-view)]
+      (let [tree (routes/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routes-history-row-1001"))
             "row for trace-event id=1001 present")
         (is (some? (find-by-testid tree "rf-causa-routes-history-row-1002"))

--- a/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/schema_violation_timeline_cljs_test.cljs
@@ -226,7 +226,7 @@
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
     (rf/with-frame :rf/causa
-      (let [tree (panel/schema-violation-timeline-view)]
+      (let [tree (panel/Panel)]
         (is (some? (find-by-testid tree "rf-causa-schema-violation-timeline")))
         (is (some? (find-by-testid tree "rf-causa-schema-timeline-empty-no-schemas")))))))
 
@@ -245,7 +245,7 @@
     (let [now-ms (.getTime (js/Date.))]
       (push-failures! [(failure-ev 1 :s/auth :skip-handler {:time now-ms})])
       (rf/with-frame :rf/causa
-        (let [tree (panel/schema-violation-timeline-view)]
+        (let [tree (panel/Panel)]
           (is (some? (find-by-testid tree "rf-causa-schema-violation-timeline")))
           (is (some? (find-by-testid tree "rf-causa-schema-timeline-rows"))
               "violations render the rows container")
@@ -262,7 +262,7 @@
     (let [now-ms (.getTime (js/Date.))]
       (push-failures! [(failure-ev 9 :s/critical :re-raised {:time now-ms})])
       (rf/with-frame :rf/causa
-        (let [tree (panel/schema-violation-timeline-view)
+        (let [tree (panel/Panel)
               dots (find-all-by-testid-prefix tree "rf-causa-schema-timeline-row-")]
           (is (some
                 (fn [node]
@@ -286,7 +286,7 @@
       (push-failures! [(failure-ev 11 :s/soft :replaced-with-default
                                    {:time now-ms})])
       (rf/with-frame :rf/causa
-        (let [tree (panel/schema-violation-timeline-view)]
+        (let [tree (panel/Panel)]
           (is (some
                 (fn [node]
                   (let [attrs (when (vector? node) (second node))]
@@ -309,18 +309,18 @@
                                     :value "not-an-email"})])
       (rf/with-frame :rf/causa
         ;; Before selection — no detail panel.
-        (let [tree (panel/schema-violation-timeline-view)]
+        (let [tree (panel/Panel)]
           (is (nil? (find-by-testid tree
                                     "rf-causa-schema-violation-detail-77"))))
         ;; Select.
         (rf/dispatch-sync [:rf.causa/select-violation 77])
-        (let [tree (panel/schema-violation-timeline-view)]
+        (let [tree (panel/Panel)]
           (is (some? (find-by-testid tree
                                      "rf-causa-schema-violation-detail-77"))
               "the detail side panel renders for the selected violation"))
         ;; Clear.
         (rf/dispatch-sync [:rf.causa/clear-violation-selection])
-        (let [tree (panel/schema-violation-timeline-view)]
+        (let [tree (panel/Panel)]
           (is (nil? (find-by-testid tree
                                     "rf-causa-schema-violation-detail-77"))
               "clearing selection unmounts the detail side panel"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/subscriptions_view_cljs_test.cljs
@@ -134,7 +134,7 @@
             empty state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-subscriptions"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-subscriptions-empty"))
@@ -150,7 +150,7 @@
       (override-cache!
         {[:cart/total] {:ref-count 1 :layer 3}
          [:user/auth]  {:ref-count 2 :layer 1}})
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-subscriptions-list"))
             "list container present")
         (is (some? (find-by-testid tree "rf-causa-sub-row-:cart/total"))
@@ -165,7 +165,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-cache! {[:a] {:ref-count 1}}) ; need >0 total to render filters
-      (let [tree  (subscriptions/subscriptions-view)
+      (let [tree  (subscriptions/Panel)
             chips (find-all-by-testid-prefix tree "rf-causa-sub-filter-")]
         (is (= 5 (count chips))
             "5 chips — one per status in the taxonomy")))))
@@ -193,7 +193,7 @@
         {[:fresh-sub]    {:ref-count 1}
          [:cached-sub]   {:ref-count 0}})
       (rf/dispatch-sync [:rf.causa/toggle-sub-filter :fresh])
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-sub-row-:fresh-sub"))
             "fresh sub passes the filter")
         (is (nil? (find-by-testid tree "rf-causa-sub-row-:cached-sub"))
@@ -234,7 +234,7 @@
                         :input-subs [[:cart/items]]}
          [:cart/items] {:ref-count 1 :layer 2}})
       (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:cart/total]])
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-subscriptions-chain"))
             "chain container present when chain-open? is true")
         (is (some? (find-by-testid tree "rf-causa-subscriptions-chain-focused"))
@@ -245,7 +245,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-cache! {[:cart/total] {:ref-count 1 :layer 3}})
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (nil? (find-by-testid tree "rf-causa-subscriptions-chain"))
             "no chain container when chain-open? is false")))))
 
@@ -256,7 +256,7 @@
     (rf/with-frame :rf/causa
       ;; No override — cache is nil; chain on any sub is :missing?
       (rf/dispatch-sync [:rf.causa/show-invalidation-chain [:nonexistent]])
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-subscriptions-chain-missing"))
             "missing branch surfaces")))))
 
@@ -271,7 +271,7 @@
          [:invalid-sub]  {:invalidated? true :ref-count 0}
          [:running-sub]  {:rerunning? true :ref-count 1}
          [:cached-sub]   {:ref-count 0}})
-      (let [tree (subscriptions/subscriptions-view)]
+      (let [tree (subscriptions/Panel)]
         (is (some? (find-by-testid tree "rf-causa-sub-badge-fresh")))
         (is (some? (find-by-testid tree "rf-causa-sub-badge-invalidated")))
         (is (some? (find-by-testid tree "rf-causa-sub-badge-re-running")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
@@ -439,7 +439,7 @@
     (install-capture-fx!)
     (frame/reg-frame :rf/causa {})
     (rf/with-frame :rf/causa
-      (let [tree (time-travel/time-travel-view)]
+      (let [tree (time-travel/Panel)]
         (is (some? (find-by-testid tree "rf-causa-time-travel-empty")))
         (is (nil?  (find-by-testid tree "rf-causa-time-travel-track")))))))
 
@@ -451,7 +451,7 @@
     (frame/reg-frame :rf/causa {})
     (seed-history! [(mk-record :e-1 {} 1) (mk-record :e-2 {} 2)])
     (rf/with-frame :rf/causa
-      (let [tree (time-travel/time-travel-view)]
+      (let [tree (time-travel/Panel)]
         (is (some? (find-by-testid tree "rf-causa-time-travel-track")))
         (is (some? (find-by-testid tree "rf-causa-time-travel-slider")))
         (is (some? (find-by-testid tree "rf-causa-time-travel-actions")))
@@ -471,7 +471,7 @@
       (rf/dispatch-sync [:rf.causa/pin-current :e-old "before-login"]))
     (seed-history! [(mk-record :e-new {} 200)])
     (rf/with-frame :rf/causa
-      (let [tree (time-travel/time-travel-view)
+      (let [tree (time-travel/Panel)
             chip (find-by-testid tree "rf-causa-pin-chip-:e-old")]
         (is (some? chip)
             "detached chip is still rendered (per spec §Pins on the scrubber)")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -107,7 +107,7 @@
   ;; of the public collector) lands the event in the atom and the
   ;; next subscribe sees it. We bypass `collect-trace!` because
   ;; rf2-xs8vu's self-noise filter drops `:frame :rf/causa` events
-  ;; before the buffer push — the trace-view filter axes need to
+  ;; before the buffer push — the trace Panel filter axes need to
   ;; assert against synthetic events with arbitrary `:frame` slots
   ;; (including `:rf/causa`) to lock the filter algebra, separately
   ;; from the ingest guard.
@@ -184,7 +184,7 @@
   (testing "the panel renders its root container regardless of buffer state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace"))
             "panel container present")
         (is (some? (find-by-testid tree "rf-causa-trace-counts"))
@@ -201,7 +201,7 @@
                               :dispatch-id 1}))
       (push-trace! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
                               :dispatch-id 1}))
-      (let [tree (trace/trace-view)
+      (let [tree (trace/Panel)
             rows (find-all-by-testid-prefix tree "rf-causa-trace-row-")]
         (is (some? (find-by-testid tree "rf-causa-trace-feed"))
             "feed <ul> present")
@@ -216,7 +216,7 @@
   (testing "with no events the panel renders the :no-events empty-state"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-empty-no-events"))
             ":no-events empty-state container present")
         (is (nil? (find-by-testid tree "rf-causa-trace-feed"))
@@ -230,7 +230,7 @@
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
                               :source :ui}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :no-such-source])
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
             ":no-matches empty-state container present")
         (is (some? (find-by-testid tree "rf-causa-trace-empty-clear-filters"))
@@ -335,7 +335,7 @@
                               :source :ui}))
       (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
                               :source :ui}))
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-axis-row-op-type"))
             ":op-type has two distinct values → chip row renders")
         (is (nil? (find-by-testid tree "rf-causa-trace-axis-row-source"))
@@ -348,10 +348,10 @@
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
                               :source :ui}))
-      (is (nil? (find-by-testid (trace/trace-view) "rf-causa-trace-clear-filters"))
+      (is (nil? (find-by-testid (trace/Panel) "rf-causa-trace-clear-filters"))
           "no Clear filters button when no axis is active")
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (is (some? (find-by-testid (trace/trace-view) "rf-causa-trace-clear-filters"))
+      (is (some? (find-by-testid (trace/Panel) "rf-causa-trace-clear-filters"))
           "Clear filters button surfaces once an axis is active"))))
 
 ;; ---- (6) row interactions -----------------------------------------------
@@ -367,7 +367,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/trace-view)
+          (let [tree    (trace/Panel)
                 row     (find-by-testid tree "rf-causa-trace-row-7")
                 handler (:on-click (second row))]
             (is (some? row) "row node present")
@@ -393,7 +393,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/trace-view)
+          (let [tree    (trace/Panel)
                 node    (find-by-testid tree "rf-causa-trace-row-9-source-coord")
                 handler (:on-click (second node))]
             (is (some? node) "source-coord chip rendered")
@@ -474,7 +474,7 @@
                              :time 200 :dispatch-id 1}))
       (sync-push! (mk-trace {:id 3 :op-type :sub/run :operation :sub/run
                              :time 300 :dispatch-id 1}))
-      (let [tree-1   (trace/trace-view)
+      (let [tree-1   (trace/Panel)
             keys-1   {1 (:key (second (row-li-by-id tree-1 1)))
                       2 (:key (second (row-li-by-id tree-1 2)))
                       3 (:key (second (row-li-by-id tree-1 3)))}]
@@ -490,7 +490,7 @@
                                :time 500 :dispatch-id 2}))
         (sync-push! (mk-trace {:id 6 :op-type :error :operation :rf.error/handler-threw
                                :time 600 :dispatch-id 2}))
-        (let [tree-2 (trace/trace-view)
+        (let [tree-2 (trace/Panel)
               keys-2 {1 (:key (second (row-li-by-id tree-2 1)))
                       2 (:key (second (row-li-by-id tree-2 2)))
                       3 (:key (second (row-li-by-id tree-2 3)))
@@ -520,7 +520,7 @@
                              :time 100 :dispatch-id 1}))
       (sync-push! (mk-trace {:id 22 :op-type :fx    :operation :rf.fx/handled
                              :time 200 :dispatch-id 1}))
-      (let [tree (trace/trace-view)
+      (let [tree (trace/Panel)
             k11  (:key (second (row-li-by-id tree 11)))
             k22  (:key (second (row-li-by-id tree 22)))]
         (is (= "t:11" k11)
@@ -557,7 +557,7 @@
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
                              :source :ui :frame :rf/default}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-axis-row-source"))
             "the :source chip-row renders even though only one buffered
              distinct value exists (the active orphan brings the chip
@@ -578,7 +578,7 @@
                              :source :ui :origin :app :frame :rf/default}))
       ;; Narrow on a value the buffer doesn't carry — orphan.
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (let [tree (trace/trace-view)]
+      (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
             ":no-matches empty state renders")
         (is (some? (find-by-testid tree "rf-causa-trace-empty-active-filters"))
@@ -600,7 +600,7 @@
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
                                      ([ev _o]   (swap! dispatches conj ev) nil))]
-          (let [tree    (trace/trace-view)
+          (let [tree    (trace/Panel)
                 pill    (find-by-testid tree "rf-causa-trace-empty-active-source")
                 handler (:on-click (second pill))]
             (is (some? pill) ":source pill rendered")
@@ -622,7 +622,7 @@
                              :source :ui :frame :rf/default}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
       (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/missing])
-      (let [tree         (trace/trace-view)
+      (let [tree         (trace/Panel)
             source-pill  (find-by-testid tree "rf-causa-trace-empty-active-source")
             frame-pill   (find-by-testid tree "rf-causa-trace-empty-active-frame")
             label-of     (fn [node]

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -175,22 +175,22 @@
   "Authoritative panel-id → view-fn mapping. Mirrors the `case` in
   shell.cljs's `canvas` so a typo in either place blows up here. The
   16 keys cover every entry in `shell/sidebar-items`."
-  {:event-detail event-detail/event-detail-view
-   :time-travel  time-travel/time-travel-view
-   :app-db       app-db-diff/app-db-diff-view
-   :causality    causality-graph/causality-graph-view
-   :subs         subscriptions/subscriptions-view
-   :fx           effects/effects-view
-   :trace        trace/trace-view
-   :machines     machine-inspector/machine-inspector-view
-   :flows        flows/flows-view
-   :routes       routes/routes-view
-   :performance  performance/performance-view
-   :issues       issues-ribbon/issues-ribbon-view
-   :schemas      svt/schema-violation-timeline-view
-   :hydration    hydration-debugger/hydration-debugger-view
-   :mcp-server   mcp-server/mcp-server-view
-   :copilot      ai-co-pilot/ai-co-pilot-view})
+  {:event-detail event-detail/Panel
+   :time-travel  time-travel/Panel
+   :app-db       app-db-diff/Panel
+   :causality    causality-graph/Panel
+   :subs         subscriptions/Panel
+   :fx           effects/Panel
+   :trace        trace/Panel
+   :machines     machine-inspector/Panel
+   :flows        flows/Panel
+   :routes       routes/Panel
+   :performance  performance/Panel
+   :issues       issues-ribbon/Panel
+   :schemas      svt/Panel
+   :hydration    hydration-debugger/Panel
+   :mcp-server   mcp-server/Panel
+   :copilot      ai-co-pilot/Panel})
 
 (deftest expected-panel-map-covers-sixteen-entries
   (testing "the expected panel map has the 16 entries the spec lists
@@ -233,7 +233,7 @@
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [rendered (#'shell/canvas)]
-        (is (= event-detail/event-detail-view (first rendered))
+        (is (= event-detail/Panel (first rendered))
             "canvas mounts :event-detail when :selected-panel is unset")))))
 
 ;; -------------------------------------------------------------------------
@@ -443,7 +443,7 @@
   (testing "clicking a sidebar row fires :rf.causa/select-panel with
             the row's :id. rf/dispatch is async so we capture via
             with-redefs on rf/dispatch* (same approach the
-            machine-inspector-view test uses) rather than racing the
+            machine-inspector Panel test uses) rather than racing the
             flush queue."
     (causa-setup!)
     (let [dispatches (atom [])]

--- a/tools/causa/testbeds/panel_gallery/ai_co_pilot_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/ai_co_pilot_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa AI Co-Pilot panel under gallery
   framing (rf2-8r20i, Phase 2).
 
-  Twelve variants, each one render of `ai-co-pilot-view` against a
+  Twelve variants, each one render of `ai-co-pilot/Panel` against a
   variant frame whose seven `:copilot-*` slots have been seeded by a
   REAL gallery-local init event fired into the variant frame.
 

--- a/tools/causa/testbeds/panel_gallery/app_db_diff_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/app_db_diff_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa app-db-diff panel under gallery
   framing (rf2-5nvk2, Phase 1b).
 
-  Ten variants, each one render of `app-db-diff-view` against a
+  Ten variants, each one render of `app-db-diff/Panel` against a
   variant frame whose `:epoch-history` (and optionally
   `:selected-epoch-id`, `:pinned-slices-store`, `:focused-slice-path`)
   has been seeded by REAL Causa init events fired into the variant

--- a/tools/causa/testbeds/panel_gallery/causality_graph_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/causality_graph_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa causality-graph panel under gallery
   framing (rf2-8r20i, Phase 2).
 
-  Ten variants, each one render of `causality-graph-view` against a
+  Ten variants, each one render of `causality-graph/Panel` against a
   variant frame whose `:trace-buffer` (and optionally
   `:selected-dispatch-id`) has been seeded by REAL Causa init events
   fired into the variant frame.

--- a/tools/causa/testbeds/panel_gallery/event_detail_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/event_detail_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa event-detail panel under gallery framing
   (rf2-1o7mp).
 
-  Twelve variants, each one render of `event-detail-view` against a
+  Twelve variants, each one render of `event-detail/Panel` against a
   variant frame whose `:trace-buffer` (and where relevant
   `:selected-dispatch-id` / `:selected-dispatch`) has been seeded by
   REAL Causa init events fired into the variant frame.
@@ -34,7 +34,7 @@
 ;;
 ;; Story requires `:component` to be a registered view-id (per the
 ;; canvas's `(re-frame.core/view <id>)` lookup). The gallery's
-;; component is a thin wrapper around `event-detail-view` so the panel
+;; component is a thin wrapper around `event-detail/Panel` so the panel
 ;; renders inside the variant's frame-provider unchanged. Wrapper
 ;; absorbs the Story-provided args map (the panel takes no args).
 

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -16,11 +16,11 @@
   ## Facade-mount discipline (rf2-043uz)
 
   Each gallery wrapper mounts the panel through its facade view —
-  `event-detail-view`, `app-db-diff-view`, `subscriptions-view`. All
+  `event-detail/Panel`, `app-db-diff/Panel`, `subscriptions/Panel`. All
   three are registered via `reg-view`, so their `render-fn` is
   wrapped with `:contextType frame-context` by
   `re-frame.views/reg-view*`. The Reagent component-vector form
-  `[event-detail/event-detail-view]` is therefore safe here — React
+  `[event-detail/Panel]` is therefore safe here — React
   resolves the wrapped class's `:contextType`, the facade body reads
   `current-frame` correctly, and inside the facade body the per-
   panel discipline (function-call for plain-fn leaves, vector for
@@ -66,7 +66,7 @@
   [_args]
   [:div {:style card-style
          :data-testid "panel-gallery-event-detail-card"}
-   [event-detail/event-detail-view]])
+   [event-detail/Panel]])
 
 (defn- app-db-diff-panel
   "Embedded mount of the Causa app-db-diff panel for one Story
@@ -76,13 +76,13 @@
   `:selected-epoch-id`, `:pinned-slices-store`, and
   `:focused-slice-path`.
 
-  `app-db-diff/app-db-diff-view` is a `reg-view` registration whose
+  `app-db-diff/Panel` is a `reg-view` registration whose
   body composes `app-db-diff-sections/*` plain fns via Reagent
   vectors — the facade is itself the frame-aware render boundary."
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-app-db-diff-card"}
-   [app-db-diff/app-db-diff-view]])
+   [app-db-diff/Panel]])
 
 (defn- subscriptions-panel
   "Embedded mount of the Causa subscriptions panel for one Story
@@ -91,7 +91,7 @@
   where the seed events have written `:sub-cache-override`,
   `:sub-error-cache`, `:selected-sub`, and `:sub-filters`.
 
-  `subscriptions/subscriptions-view` is a `reg-view` whose body
+  `subscriptions/Panel` is a `reg-view` whose body
   invokes `(subscriptions-views/subscriptions-panel)` via plain
   function call (rf2-043uz) — that internal call form keeps the
   leaf's subscribes inside the facade reg-view wrapper's render so
@@ -101,7 +101,7 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-subscriptions-card"}
-   [subscriptions/subscriptions-view]])
+   [subscriptions/Panel]])
 
 (defn- time-travel-panel
   "Embedded mount of the Causa time-travel panel for one Story
@@ -110,7 +110,7 @@
   the seed events have written `:epoch-history`, `:selected-epoch-id`,
   `:pin-store`, and `:label-input`.
 
-  `time-travel/time-travel-view` is a `reg-view` registration whose
+  `time-travel/Panel` is a `reg-view` registration whose
   body composes inline hiccup + sub-views via plain function calls —
   the facade is itself the frame-aware render boundary. The gallery
   wrapper mounts it as a Reagent vector — safe because reg-view
@@ -118,7 +118,7 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-time-travel-card"}
-   [time-travel/time-travel-view]])
+   [time-travel/Panel]])
 
 (defn- trace-panel
   "Embedded mount of the Causa trace panel for one Story variant.
@@ -127,13 +127,13 @@
   the seed events have written `:trace-buffer` and (optionally)
   `:trace-filters`.
 
-  `trace/trace-view` is a `reg-view` registration; the gallery
+  `trace/Panel` is a `reg-view` registration; the gallery
   wrapper mounts it as a Reagent vector — safe because reg-view
   threads `:contextType` through React."
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-trace-card"}
-   [trace/trace-view]])
+   [trace/Panel]])
 
 (defn- issues-ribbon-panel
   "Embedded mount of the Causa issues-ribbon panel for one Story
@@ -143,13 +143,13 @@
   `:issues-active-severities` / `:issues-active-prefixes` /
   `:issues-since-ms`.
 
-  `issues-ribbon/issues-ribbon-view` is a `reg-view` registration;
+  `issues-ribbon/Panel` is a `reg-view` registration;
   the gallery wrapper mounts it as a Reagent vector — safe because
   reg-view threads `:contextType` through React."
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-issues-ribbon-card"}
-   [issues-ribbon/issues-ribbon-view]])
+   [issues-ribbon/Panel]])
 
 (defn- causality-graph-panel
   "Embedded mount of the Causa causality-graph panel for one Story
@@ -158,7 +158,7 @@
   app-db, where the seed events have written `:trace-buffer` and
   (optionally) `:selected-dispatch-id`.
 
-  `causality-graph/causality-graph-view` is a `reg-view` registration;
+  `causality-graph/Panel` is a `reg-view` registration;
   the gallery wrapper mounts it as a Reagent vector — safe because
   reg-view threads `:contextType` through React.
 
@@ -172,7 +172,7 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-causality-graph-card"}
-   [causality-graph/causality-graph-view]])
+   [causality-graph/Panel]])
 
 (defn- ai-co-pilot-panel
   "Embedded mount of the Causa AI Co-Pilot canvas-form panel for one
@@ -181,7 +181,7 @@
   app-db, where the seed event has written `:copilot-conversation`,
   `:copilot-input-text`, `:copilot-provider`, etc.
 
-  `ai-co-pilot/ai-co-pilot-view` is a `reg-view` registration whose
+  `ai-co-pilot/Panel` is a `reg-view` registration whose
   body calls `(views/ai-co-pilot-view)` as a plain function per the
   rf2-043uz facade discipline — that internal call keeps the leaf's
   subscribes / dispatches inside the facade reg-view wrapper's
@@ -191,7 +191,7 @@
   [_args]
   [:div {:style       card-style
          :data-testid "panel-gallery-ai-co-pilot-card"}
-   [ai-co-pilot/ai-co-pilot-view]])
+   [ai-co-pilot/Panel]])
 
 (defn register!
   "Register every gallery view-id referenced by a variant `:component`.

--- a/tools/causa/testbeds/panel_gallery/issues_ribbon_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/issues_ribbon_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa issues-ribbon panel under gallery
   framing (rf2-8r20i, Phase 2).
 
-  Nine variants, each one render of `issues-ribbon-view` against a
+  Nine variants, each one render of `issues-ribbon/Panel` against a
   variant frame whose `:trace-buffer` (and optionally
   `:issues-active-severities` / `:issues-active-prefixes`) has been
   seeded by REAL Causa init events fired into the variant frame.

--- a/tools/causa/testbeds/panel_gallery/subscriptions_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/subscriptions_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa subscriptions panel under gallery
   framing (rf2-5nvk2, Phase 1b).
 
-  Ten variants, each one render of `subscriptions-view` against a
+  Ten variants, each one render of `subscriptions/Panel` against a
   variant frame whose `:sub-cache-override` (and optionally
   `:sub-error-cache`, `:selected-sub`, `:sub-filters`,
   `:sub-chain-open?`) has been seeded by REAL Causa init events

--- a/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa time-travel panel under gallery
   framing (rf2-8r20i, Phase 2).
 
-  Eight variants, each one render of `time-travel-view` against a
+  Eight variants, each one render of `time-travel/Panel` against a
   variant frame whose `:epoch-history` (and optionally
   `:selected-epoch-id`) has been seeded by REAL Causa init events
   fired into the variant frame.

--- a/tools/causa/testbeds/panel_gallery/trace_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/trace_stories.cljs
@@ -2,7 +2,7 @@
   "Story coverage for the Causa trace panel under gallery framing
   (rf2-8r20i, Phase 2).
 
-  Nine variants, each one render of `trace-view` against a variant
+  Nine variants, each one render of `trace/Panel` against a variant
   frame whose `:trace-buffer` (and optionally `:trace-filters`) has
   been seeded by REAL Causa init events fired into the variant frame.
 

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -2161,7 +2161,7 @@ module.exports = {
     // visible-surface contract.
     //
     // The panel-style view is a DIFFERENT reg-view than the rail
-    // (`ai-co-pilot-view` vs `ai-co-pilot-rail` in `ai-co-pilot.cljs`)
+    // (`Panel` vs `ai-co-pilot-rail` in `ai-co-pilot.cljs`)
     // and re-mounts the conversation + input row from the same leaf
     // components. Asserting the slash popover here proves the leaf
     // works through both mounting paths — guards against a single

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -134,7 +134,7 @@ Lock #1):
   {:doc       "Causa's epoch buffer for the active variant."
    :title     "Epochs (Causa)"
    :placement :bottom
-   :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+   :render    :day8.re-frame2-causa.panels.time-travel/Panel})
 ```
 
 The view is consumed from `day8/re-frame2-causa` (per the

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -163,7 +163,7 @@ Lock #1):
   {:doc       "Causa's epoch buffer for the active variant."
    :title     "Epochs (Causa)"
    :placement :bottom
-   :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+   :render    :day8.re-frame2-causa.panels.time-travel/Panel})
 ```
 
 The view is consumed from `day8/re-frame2-causa` (per the

--- a/tools/story/test/re_frame/story_mcp_boundary_test.clj
+++ b/tools/story/test/re_frame/story_mcp_boundary_test.clj
@@ -217,10 +217,10 @@
       {:doc       "Causa-shipped real view"
        :title     "Epochs (Causa)"
        :placement :bottom
-       :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+       :render    :day8.re-frame2-causa.panels.time-travel/Panel})
     (let [real-body (story/handler-meta :story-panel :rf.story/causa-epoch)]
       (is (= "Epochs (Causa)" (:title real-body)))
-      (is (= :day8.re-frame2-causa.panels.time-travel/time-travel-view
+      (is (= :day8.re-frame2-causa.panels.time-travel/Panel
              (:render real-body))
           "Causa's :render slot replaces the stub's"))))
 

--- a/tools/story/test/re_frame/story_test.clj
+++ b/tools/story/test/re_frame/story_test.clj
@@ -295,11 +295,11 @@
       {:doc       "Causa's epoch buffer."
        :title     "Epochs (Causa)"
        :placement :bottom
-       :render    :day8.re-frame2-causa.panels.time-travel/time-travel-view})
+       :render    :day8.re-frame2-causa.panels.time-travel/Panel})
     (let [body (story/handler-meta :story-panel :rf.story/causa-epoch)]
       (is (= "Epochs (Causa)" (:title body)))
       (is (= :bottom (:placement body)))
-      (is (= :day8.re-frame2-causa.panels.time-travel/time-travel-view (:render body))))))
+      (is (= :day8.re-frame2-causa.panels.time-travel/Panel (:render body))))))
 
 ;; ---- decorator (per-kind) ---------------------------------------------
 


### PR DESCRIPTION
## Summary

- Per Mike's decision A on rf2-sf38d (2026-05-17 00:27 AUSEST), rename the 16 per-panel root `reg-view` exports from `<panel>-view` to `Panel`, aligning the impl with the canonical symbol documented in `tools/causa/spec/008-Embedding-Contract.md`.
- Pre-alpha posture: no alias shim, no back-compat — clean cut in one PR.
- Every consumer flips in lockstep: shell router (case-switch + panel-content), per-panel CLJS view tests, panel-gallery testbeds + story docstrings, rigorous-testbed comment, `tools/causa/spec/API.md` canonical export list, `tools/causa/spec/Conventions.md` re-export example, plus the cross-tool Story canonical-embed surfaces (tests + 005-SOTA-Features + DESIGN-RATIONALE).
- `reg-view` derives the registry id from the symbol, so each panel's registered view-id moves from `:day8.re-frame2-causa.panels.<name>/<name>-view` to `:.../Panel` automatically.

## Scope notes

- Internal shell regions (`top-strip`, `sidebar`, `canvas`, `bottom-rail`, `rail-gate`, `shell-view`) keep their names — they are not panel exports.
- ai-co-pilot's `rail` and `cue` reg-views keep their names — only the canvas-form panel export becomes `Panel`.
- Leaf delegate fns (`views/ai-co-pilot-view`, `views/mcp-server-view`) keep their names — internal-only, reached from the facade.

## Gates

- [x] `tools/causa/` `clojure -M:test` — 579 tests, 1708 assertions, 0 failures
- [x] `implementation/` `npm run test:cljs` — 2344 tests, 6722 assertions, 0 failures
- [x] `tools/story/` `clojure -M:test` — 451 tests, 1400 assertions, 0 failures
- [x] `mkdocs build --strict` — only pre-existing unrelated link warnings on main; no causa/panel/view warnings introduced by this PR