### PR TITLE
fix(http): abort-always-wins precedence + spec/014 pin (rf2-wez75, Mike decision a)

### DIFF
--- a/implementation/http/src/re_frame/http_transport.cljc
+++ b/implementation/http/src/re_frame/http_transport.cljc
@@ -366,6 +366,7 @@
 ;; ---- shared attempt-and-retry loop ----------------------------------------
 
 (declare run-attempt!)
+(declare finalise-failure!)
 
 (defn- dispatch-reply!
   [{:keys [origin-event explicit-on-success explicit-on-failure
@@ -397,24 +398,81 @@
   (when-let [flag (:finalised? (:handle ctx))]
     (not (compare-and-set! flag false true))))
 
-(defn- finalise-success! [ctx accepted]
-  (when-not (already-replied? ctx)
-    (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
-    (cond
-      (contains? accepted :ok)
-      (dispatch-reply! (assoc ctx
-                              :kind :success
-                              :reply-payload {:kind  :success
-                                              :value (:ok accepted)}))
+(defn- aborted-snapshot
+  "rf2-wez75 — abort-always-wins precedence (Mike decision a, aligned with
+  Fetch AbortController / Node HTTP / JVM HttpClient / gRPC universal
+  convention). Returns the abort-state map `{:reason :actor-id}` if the
+  handle's `:aborted?` atom has been flipped (by either `:rf.http/managed-
+  abort` user-aborts OR `abort-on-actor-destroy` per Spec 014 §Abort on
+  actor destroy), else nil. Read once at finalise-* entry so the late-
+  arriving decode / status / transport classification gets reclassified
+  to `:rf.http/aborted` rather than racing the abort-fn's CAS — see Spec
+  014 §Abort precedence (abort always wins)."
+  [ctx]
+  (when-let [abort-cell (:aborted? (:handle ctx))]
+    @abort-cell))
 
-      (contains? accepted :failure)
-      (dispatch-reply! (assoc ctx
-                              :kind :failure
-                              :reply-payload {:kind    :failure
-                                              :failure {:kind       :rf.http/accept-failure
-                                                        :detail     (:failure accepted)
-                                                        :decoded    (:decoded ctx)
-                                                        :request-id (:request-id ctx)}})))))
+(defn- aborted-failure
+  "Build the `:rf.http/aborted` failure shape from an abort snapshot."
+  [ctx abort-state]
+  {:kind       :rf.http/aborted
+   :request-id (:request-id ctx)
+   :reason     (:reason abort-state)
+   :actor-id   (or (:actor-id abort-state) (:actor-id ctx))})
+
+(defn- finalise-success! [ctx accepted]
+  ;; rf2-wez75 — abort-precedence check. Two sampling points:
+  ;;   (1) BEFORE the once-only CAS — covers the case where abort-fn
+  ;;       already flipped `:aborted?` and lost the CAS to a
+  ;;       synchronously-completing decode.
+  ;;   (2) AFTER winning the CAS — covers the narrower window where
+  ;;       abort-fn flips `:aborted?` between our sample-(1) read and
+  ;;       our CAS. Sampling after the CAS pins the contract:
+  ;;       any abort observed by a flag we hold ownership of has
+  ;;       precedence over the success-classification reply.
+  ;; Together these close every interleaving consistent with the
+  ;; abort-always-wins rule (Spec 014 §Abort precedence). The CAS-loser
+  ;; case (sample (1)) routes through finalise-failure! so the trace
+  ;; emit + supersede-suppression path stays in one place.
+  (if-let [abort-state (aborted-snapshot ctx)]
+    (finalise-failure! ctx (aborted-failure ctx abort-state))
+    (when-not (already-replied? ctx)
+      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      (if-let [post-cas-abort (aborted-snapshot ctx)]
+        ;; Sample (2): abort flipped between our pre-CAS sample and
+        ;; our CAS-win. We hold the once-only token; dispatch the
+        ;; aborted reply directly rather than re-entering
+        ;; finalise-failure! (which would double-clear the registry
+        ;; and re-check `already-replied?`).
+        (let [failure (aborted-failure ctx post-cas-abort)]
+          (when interop/debug-enabled?
+            (let [sensitive? (true? (:sensitive? ctx))
+                  redacted   (privacy/prepare-emit-failure
+                               (assoc failure
+                                      :url      (:url ctx)
+                                      :recovery :no-recovery)
+                               sensitive?)]
+              (trace/emit-error! :rf.http/aborted redacted)))
+          (when-not (= :request-id-superseded (:reason failure))
+            (dispatch-reply! (assoc ctx
+                                    :kind          :failure
+                                    :reply-payload {:kind    :failure
+                                                    :failure failure}))))
+        (cond
+          (contains? accepted :ok)
+          (dispatch-reply! (assoc ctx
+                                  :kind :success
+                                  :reply-payload {:kind  :success
+                                                  :value (:ok accepted)}))
+
+          (contains? accepted :failure)
+          (dispatch-reply! (assoc ctx
+                                  :kind :failure
+                                  :reply-payload {:kind    :failure
+                                                  :failure {:kind       :rf.http/accept-failure
+                                                            :detail     (:failure accepted)
+                                                            :decoded    (:decoded ctx)
+                                                            :request-id (:request-id ctx)}})))))))
 
 (defn- finalise-failure!
   "Final-failure dispatch (after retries exhausted or non-retriable).
@@ -432,43 +490,81 @@
   abort path and a later natural-completion path can't both dispatch
   a reply for the same request. The trace emit + registry clear ALSO
   live inside the guard — a doubled trace would be just as observable
-  as a doubled reply on the dev surface."
+  as a doubled reply on the dev surface.
+
+  Per rf2-wez75 (Mike decision a, abort-always-wins — aligned with
+  Fetch AbortController / Node HTTP / JVM HttpClient / gRPC universal
+  convention): the abort-precedence check fires BEFORE the CAS. If the
+  handle's `:aborted?` cell has been flipped (by user abort OR
+  actor-destroy), the incoming `failure` is replaced by the canonical
+  `:rf.http/aborted` shape before trace-emit and reply-dispatch. This
+  closes the window where a decode-failure / transport / 5xx
+  classification could synchronously win the once-only `:finalised?`
+  CAS in the same scheduler tick the abort-fn was running — the
+  user-visible outcome is now deterministic by classification, not by
+  CAS race ordering. See Spec 014 §Abort precedence (abort always wins)."
   [ctx failure]
   (when-not (already-replied? ctx)
-    (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
-    (when interop/debug-enabled?
-      ;; rf2-bma05 — redact response-side payload slots (body, body-text,
-      ;; decoded, detail) and the headers denylist before the trace
-      ;; surface sees them; stamp :sensitive? when applicable. The CLJS
-      ;; and JVM transports share the same contract.
-      (let [sensitive? (true? (:sensitive? ctx))
-            redacted   (privacy/prepare-emit-failure
-                         (assoc failure
-                                :request-id (:request-id ctx)
-                                :url        (:url ctx)
-                                :recovery   :no-recovery)
-                         sensitive?)]
-        (trace/emit-error! (:kind failure) redacted)))
-    (let [superseded? (and (= :rf.http/aborted (:kind failure))
-                           (= :request-id-superseded (:reason failure)))]
-      (when-not superseded?
-        (dispatch-reply! (assoc ctx
-                                :kind          :failure
-                                :reply-payload {:kind    :failure
-                                                :failure failure}))))))
+    (let [;; rf2-wez75 — abort-precedence reclassification. Sampled
+          ;; AFTER winning the once-only CAS so any abort-fn that
+          ;; flipped `:aborted?` between our caller's classification
+          ;; and this point is still observed. The abort-fn itself
+          ;; flips the cell BEFORE racing the CAS, so the cell is
+          ;; monotonic-set under contention — once flipped, every
+          ;; subsequent sample reads non-nil.
+          abort-state (aborted-snapshot ctx)
+          effective   (if (and abort-state
+                               (not= :rf.http/aborted (:kind failure)))
+                        (aborted-failure ctx abort-state)
+                        failure)]
+      (registry/clear-in-flight! (:request-id ctx) (:handle ctx))
+      (when interop/debug-enabled?
+        ;; rf2-bma05 — redact response-side payload slots (body, body-text,
+        ;; decoded, detail) and the headers denylist before the trace
+        ;; surface sees them; stamp :sensitive? when applicable. The CLJS
+        ;; and JVM transports share the same contract.
+        (let [sensitive? (true? (:sensitive? ctx))
+              redacted   (privacy/prepare-emit-failure
+                           (assoc effective
+                                  :request-id (:request-id ctx)
+                                  :url        (:url ctx)
+                                  :recovery   :no-recovery)
+                           sensitive?)]
+          (trace/emit-error! (:kind effective) redacted)))
+      (let [superseded? (and (= :rf.http/aborted (:kind effective))
+                             (= :request-id-superseded (:reason effective)))]
+        (when-not superseded?
+          (dispatch-reply! (assoc ctx
+                                  :kind          :failure
+                                  :reply-payload {:kind    :failure
+                                                  :failure effective})))))))
 
 (defn- maybe-retry!
   "Decide between retry, immediate-final-failure, and successful-completion.
-  `failure` is the failure map for the just-finished attempt."
+  `failure` is the failure map for the just-finished attempt.
+
+  Per rf2-wez75 (abort always wins): a request whose handle's
+  `:aborted?` cell has been flipped MUST NOT be retried, regardless of
+  the just-classified failure category or the caller's `:retry :on`
+  set. A user/actor-destroy abort that arrives mid-decode-failure
+  retry-eligible classification would otherwise schedule a fresh
+  attempt against a request the caller has already cancelled — a
+  contract violation under Spec 014 §Abort precedence. Routing the
+  aborted request through `finalise-failure!` lets the in-flight
+  reclassification (built into finalise-failure!'s abort-snapshot
+  read) replace the would-be retry-eligible failure with the canonical
+  `:rf.http/aborted` shape."
   [ctx failure]
   (let [{:keys [retry attempt request-id]} ctx
         {:keys [on max-attempts backoff]} retry
-        on-set (or on #{})
-        kind   (:kind failure)
-        can-retry? (and (some? max-attempts)
-                        (> max-attempts attempt)
-                        (contains? on-set kind)
-                        (not= :rf.http/aborted kind))]
+        on-set      (or on #{})
+        kind        (:kind failure)
+        aborted?    (some? (aborted-snapshot ctx))
+        can-retry?  (and (some? max-attempts)
+                         (> max-attempts attempt)
+                         (contains? on-set kind)
+                         (not= :rf.http/aborted kind)
+                         (not aborted?))]
     (if can-retry?
       (let [delay-ms (encoding/compute-backoff-ms (or backoff {}) attempt)]
         (when interop/debug-enabled?
@@ -619,6 +715,16 @@
         ;; CompletableFuture so the work actually stops (not just the
         ;; reply path).
         finalised? (atom false)
+        ;; rf2-wez75 — abort-precedence cell. The abort-fn flips this
+        ;; BEFORE racing the once-only `:finalised?` CAS, so even if a
+        ;; synchronously-completing decode wins the CAS, the finalise-*
+        ;; entry sees the abort snapshot and reclassifies the reply as
+        ;; `:rf.http/aborted` per Spec 014 §Abort precedence (abort
+        ;; always wins). The cell carries the abort reason map so the
+        ;; canonical reply shape (and the `:actor-id` slot, when
+        ;; actor-destroy was the source) is reconstructable inside
+        ;; finalise-failure! without re-deriving from `failure`.
+        aborted?   (atom nil)
         ;; rf2-on7sj (JVM) — the abort-fn closure must `.cancel cf true`
         ;; on the underlying CompletableFuture, but cf only exists AFTER
         ;; this binding (built inside the try-body below). Forward via a
@@ -662,6 +768,26 @@
         handle   (registry/record-in-flight!
                    request-id actor-id
                    {:abort-fn (fn [reason]
+                                ;; rf2-wez75 — flip `:aborted?` BEFORE the
+                                ;; once-only CAS so that a concurrently-
+                                ;; running finalise-* (decode-failure,
+                                ;; transport, http-5xx, success) that wins
+                                ;; the CAS still reads the abort snapshot
+                                ;; on entry and reclassifies. The reset!
+                                ;; is idempotent across re-entrant aborts
+                                ;; (supersede + actor-destroy in rapid
+                                ;; succession): subsequent flips just
+                                ;; overwrite with the same shape, which is
+                                ;; fine because the once-only CAS below
+                                ;; collapses everything after the first
+                                ;; pass into a no-op. We do NOT CAS this
+                                ;; cell because a racing finalise-* that
+                                ;; samples it as nil and then later sees
+                                ;; it as set is exactly the window we're
+                                ;; closing — abort always wins regardless
+                                ;; of which side flipped first.
+                                (reset! aborted? {:reason   reason
+                                                  :actor-id actor-id})
                                 ;; rf2-on7sj — single-shot CAS guard.
                                 ;; A re-entrant abort (e.g. supersede +
                                 ;; actor-destroy firing in rapid
@@ -702,6 +828,9 @@
                     :url url
                     ;; rf2-on7sj — once-only reply guard, see comment above.
                     :finalised? finalised?
+                    ;; rf2-wez75 — abort-precedence cell read at finalise-*
+                    ;; entry. See the `aborted?` binding above.
+                    :aborted?   aborted?
                     ;; rf2-bma05 — propagate the :sensitive? flag onto
                     ;; the in-flight handle so the actor-destroy abort
                     ;; emit (lives in the registry ns) can stamp the

--- a/implementation/http/test/re_frame/http_abort_precedence_test.clj
+++ b/implementation/http/test/re_frame/http_abort_precedence_test.clj
@@ -1,0 +1,305 @@
+(ns re-frame.http-abort-precedence-test
+  "Per rf2-wez75 (Mike decision a, 2026-05-17): abort always wins over
+  decode-failure / transport / accept-failure / success classification
+  in `:rf.http/managed`. Aligned with Fetch AbortController / Node HTTP
+  / JVM HttpClient / gRPC universal convention.
+
+  Spec references:
+   - Spec 014 §Abort precedence (abort always wins)
+   - Spec 014 §Aborts (`:request-id` (internal), `:abort-signal` (external))
+   - Spec 014 §Abort on actor destroy (rf2-wvkn)
+
+  Test strategy: each test deterministically interleaves the abort with a
+  late-classifying failure / success by gating the response side on a
+  `CountDownLatch`. Either the server blocks (decode never gets to run
+  while the abort is fired against an in-flight request) or a custom
+  decoder blocks (decode is mid-run when the abort fires — the most
+  contended race). The abort-wins seam in `re-frame.http-transport`
+  (`finalise-failure!` / `finalise-success!` re-sample the handle's
+  `:aborted?` cell after winning the once-only CAS) collapses the
+  observable outcome to `:rf.http/aborted` regardless of which side
+  classified first.
+
+  Three scenarios (each its own deftest):
+   1. abort-during-in-flight-decode-wins-over-decode-failure
+   2. abort-during-transport-error-wins-over-transport-classification
+   3. abort-via-actor-destroy-wins-over-decode-failure"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.http-managed :as http-managed]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom])
+  (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
+           [java.net InetSocketAddress ServerSocket]
+           [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---- per-test reset --------------------------------------------------------
+
+(defn- reset-runtime [t]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (require 're-frame.ssr     :reload)
+  (require 're-frame.machines :reload)
+  (require 're-frame.http-managed :reload)
+  (machines/reset-timers!)
+  (http-managed/clear-all-in-flight!)
+  (t))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- start-200-server!
+  "Start an HttpServer that always returns 200 with the given body. The
+  server processes requests on its default executor; no blocking on the
+  server side — the test interleaves on the decoder side via `latches`."
+  [content-type body]
+  (let [server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/"
+                    (reify HttpHandler
+                      (handle [_ ex]
+                        (let [^HttpExchange ex ex
+                              bs (.getBytes (str body) "UTF-8")]
+                          (when content-type
+                            (-> ex .getResponseHeaders (.set "Content-Type" content-type)))
+                          (try
+                            (.sendResponseHeaders ex 200 (long (count bs)))
+                            (with-open [os (.getResponseBody ex)]
+                              (.write os bs))
+                            (catch Throwable _ nil))))))
+    (.setExecutor server nil)
+    (.start server)
+    {:server server
+     :port   (.getPort (.getAddress server))}))
+
+(defn- stop-server! [{:keys [^HttpServer server]}]
+  (.stop server 0))
+
+(defn- pick-closed-port!
+  "Bind a transient socket on 127.0.0.1, capture the port, close. The
+  port is briefly free and unlikely to be re-bound before the test's
+  HTTP attempt — chosen specifically to provoke a connection-refused /
+  transport-error in the JVM transport classifier."
+  []
+  (let [s (ServerSocket. 0 1 (java.net.InetAddress/getByName "127.0.0.1"))
+        p (.getLocalPort s)]
+    (.close s)
+    p))
+
+(defn- await-condition!
+  ([pred] (await-condition! pred 5000))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (cond
+         (pred) true
+         (> (System/currentTimeMillis) deadline)
+         (throw (ex-info "timed out awaiting condition" {}))
+         :else (do (Thread/sleep 10) (recur)))))))
+
+;; ---- (1) abort during in-flight decode — must beat :rf.http/decode-failure
+;;
+;; Setup: server returns 200 with a JSON-shaped body; the request supplies
+;; a custom :decode fn that blocks on `decoder-entered` (signalling the
+;; test thread that decode is mid-run) and then blocks on `decoder-may-
+;; proceed` until the test fires the abort and lets the decoder throw
+;; (synthesising a decode-failure classification). Without rf2-wez75's
+;; abort-precedence seam, whichever of (a) the abort-fn's CAS or (b) the
+;; thrown-decoder's finalise-failure! CAS arrived first would win, and a
+;; user would observe :rf.http/decode-failure on the reply despite
+;; explicitly aborting. With the seam in place, the handle's :aborted?
+;; cell is sampled inside finalise-failure! AFTER winning the CAS, so
+;; the abort observation always wins regardless of CAS ordering.
+
+(deftest abort-during-in-flight-decode-wins-over-decode-failure
+  (testing "rf2-wez75 — abort fired while a slow decoder is in-flight reclassifies the reply as :rf.http/aborted, not :rf.http/decode-failure"
+    (let [srv               (start-200-server! "application/json" "{\"k\":1}")
+          decoder-entered   (CountDownLatch. 1)
+          decoder-may-throw (CountDownLatch. 1)
+          replies           (atom [])]
+      (try
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        (rf/reg-event-fx :issue
+          (fn [_ _]
+            {:fx [[:rf.http/managed
+                   {:request    {:url (str "http://127.0.0.1:" (:port srv) "/")}
+                    :decode     (fn [_text _headers]
+                                  (.countDown decoder-entered)
+                                  (.await decoder-may-throw 30 TimeUnit/SECONDS)
+                                  ;; Synthesise decode-failure — the
+                                  ;; finalise-failure! call site catches
+                                  ;; this and classifies as
+                                  ;; :rf.http/decode-failure absent the
+                                  ;; rf2-wez75 abort-precedence seam.
+                                  (throw (ex-info "decode-boom" {})))
+                    :request-id :race
+                    :on-failure [:reply/recorder]
+                    :on-success [:reply/recorder]}]]}))
+        (rf/reg-event-fx :do/abort
+          (fn [_ _] {:fx [[:rf.http/managed-abort :race]]}))
+        (rf/dispatch-sync [:issue])
+        ;; Wait for the decoder to enter — guarantees the response has
+        ;; landed and decode is mid-run. The in-flight registry holds
+        ;; the request handle right now.
+        (is (.await decoder-entered 5 TimeUnit/SECONDS)
+            "decoder entered — response landed, decode in progress, abort window open")
+        (is (= 1 (count (http-managed/in-flight-snapshot))))
+        ;; Fire the abort BEFORE letting the decoder throw. Both the
+        ;; abort-fn AND the about-to-fire finalise-failure! race for the
+        ;; once-only :finalised? CAS — but the abort-fn flips :aborted?
+        ;; FIRST, and finalise-failure! samples that cell after winning
+        ;; the CAS, so the visible classification is :rf.http/aborted.
+        (rf/dispatch-sync [:do/abort])
+        (.countDown decoder-may-throw)
+        (await-condition! #(seq @replies))
+        (let [reply (first @replies)]
+          (is (= :failure (:kind reply))
+              "the abort-precedence seam dispatches a failure reply, not a success")
+          (is (= :rf.http/aborted (get-in reply [:failure :kind]))
+              "the reply MUST be :rf.http/aborted, NOT :rf.http/decode-failure (rf2-wez75 Mike decision a)")
+          (is (= :user (get-in reply [:failure :reason]))
+              "user-initiated abort surfaces :reason :user"))
+        (is (= 1 (count @replies))
+            "exactly one reply — the once-only CAS still pins single-dispatch")
+        (is (empty? (http-managed/in-flight-snapshot))
+            "in-flight registry is clean after the aborted reply")
+        (finally
+          (stop-server! srv))))))
+
+;; ---- (2) abort during transport-error — must beat :rf.http/transport ------
+;;
+;; Setup: target a port that nothing's listening on so the JVM
+;; HttpClient surfaces a connection-refused / transport error from
+;; sendAsync. We fire the abort fx in the SAME dispatch as the managed
+;; request — the supersede semantics don't apply (different request-id),
+;; so the test exercises the user-abort-during-transport-error race.
+;;
+;; In practice the abort-fn flips :aborted? before the transport's
+;; whenComplete callback synthesises the :rf.http/transport failure;
+;; the precedence seam in finalise-failure! observes the flip and
+;; reclassifies. Because the JVM CompletableFuture path completes-
+;; exceptionally with a CancellationException once .cancel cf true fires,
+;; the natural classifier may produce :rf.http/aborted directly — but
+;; in either case the reply MUST be :rf.http/aborted, never
+;; :rf.http/transport. This test pins the contract end-to-end.
+
+(deftest abort-during-transport-error-wins-over-transport-classification
+  (testing "rf2-wez75 — abort fired against an in-flight request to an unreachable host yields :rf.http/aborted, not :rf.http/transport"
+    (let [closed-port (pick-closed-port!)
+          replies     (atom [])]
+      (rf/reg-event-fx :reply/recorder
+        (fn [_ [_ payload]] (swap! replies conj payload) {}))
+      ;; Issue the request and then immediately fire the abort against
+      ;; the same request-id. The transport hasn't finished resolving
+      ;; the connection-refused error yet (sendAsync is async).
+      (rf/reg-event-fx :issue
+        (fn [_ _]
+          {:fx [[:rf.http/managed
+                 {:request    {:url (str "http://127.0.0.1:" closed-port "/")}
+                  :request-id :race
+                  ;; Long-but-finite timeout — we want the test to bound,
+                  ;; not the transport.
+                  :decode     :json
+                  :on-failure [:reply/recorder]
+                  :on-success [:reply/recorder]}]
+                [:rf.http/managed-abort :race]]}))
+      (rf/dispatch-sync [:issue])
+      ;; Wait for SOME reply (either the abort beat the transport or
+      ;; vice versa). The contract under rf2-wez75 is that whichever
+      ;; arrived first, the reply MUST be :rf.http/aborted.
+      (await-condition! #(seq @replies))
+      (let [reply (first @replies)]
+        (is (= :failure (:kind reply))
+            "transport-error-or-aborted scenario surfaces a failure reply")
+        (is (= :rf.http/aborted (get-in reply [:failure :kind]))
+            "abort precedence pins the reply to :rf.http/aborted regardless of transport-classifier race ordering (rf2-wez75 Mike decision a)")
+        (is (contains? #{:user :request-id-superseded}
+                       (get-in reply [:failure :reason]))
+            ":reason discriminates user-abort from supersede; both are abort-flavoured"))
+      (is (= 1 (count @replies))
+          "exactly one reply — abort precedence does not double-dispatch")
+      (is (empty? (http-managed/in-flight-snapshot))
+          "in-flight registry is clean"))))
+
+;; ---- (3) abort-via-actor-destroy wins over decode-failure -----------------
+;;
+;; Setup: same slow-decoder gimmick as test (1), but the abort source
+;; is `abort-on-actor-destroy` (rf2-wvkn) — the cascade that fires when
+;; a spawned state-machine actor is destroyed. The request rides under
+;; the actor-in-flight index; destroying the actor calls the abort-fn
+;; with `:reason :actor-destroyed`. The precedence seam still observes
+;; the :aborted? flip, so the visible reply is :rf.http/aborted with
+;; :reason :actor-destroyed (the trace event :rf.http/aborted-on-actor-
+;; destroy fires independently from the abort-on-actor-destroy walker).
+
+(deftest abort-via-actor-destroy-wins-over-decode-failure
+  (testing "rf2-wez75 — actor-destroy abort wins over a synchronously-firing decode-failure; reply is :rf.http/aborted with :reason :actor-destroyed"
+    (let [srv               (start-200-server! "application/json" "{\"k\":1}")
+          decoder-entered   (CountDownLatch. 1)
+          decoder-may-throw (CountDownLatch. 1)
+          replies           (atom [])]
+      (try
+        (rf/reg-event-fx :reply/recorder
+          (fn [_ [_ payload]] (swap! replies conj payload) {}))
+        ;; Child machine — :entry fires the managed request with a
+        ;; latch-gated decoder. The decoder synthesises a decode-
+        ;; failure when released, but the abort-precedence seam
+        ;; intercepts.
+        (rf/reg-machine :worker/race
+          {:initial :idle
+           :data    {:port (:port srv)}
+           :actions {:fire (fn [data _]
+                             {:fx [[:rf.http/managed
+                                    {:request    {:url (str "http://127.0.0.1:" (:port data) "/")}
+                                     :decode     (fn [_text _headers]
+                                                   (.countDown decoder-entered)
+                                                   (.await decoder-may-throw 30 TimeUnit/SECONDS)
+                                                   (throw (ex-info "decode-boom" {})))
+                                     :request-id :race
+                                     :on-failure [:reply/recorder]
+                                     :on-success [:reply/recorder]}]]})}
+           :states  {:idle    {:on {:start :running}}
+                     :running {:entry :fire}}})
+        ;; Parent: :invoke spawns the child, :cancel transitions out.
+        (rf/reg-machine :sup/race
+          {:initial :idle
+           :states  {:idle    {:on {:start :working}}
+                     :working {:invoke {:machine-id :worker/race
+                                        :start      [:start]}
+                               :on    {:cancel :idle}}}})
+        (rf/dispatch-sync [:sup/race [:start]])
+        ;; Wait for the decoder to enter — response landed, decode in
+        ;; progress, child is in-flight under actor-in-flight.
+        (is (.await decoder-entered 5 TimeUnit/SECONDS)
+            "decoder entered while request was in flight under spawned actor")
+        (is (= 1 (count (http-managed/actor-in-flight-snapshot))))
+        ;; Destroy the actor — abort-on-actor-destroy walks the
+        ;; actor-in-flight index and fires :abort-fn with
+        ;; :reason :actor-destroyed.
+        (rf/dispatch-sync [:sup/race [:cancel]])
+        ;; Release the decoder — it throws, but the precedence seam
+        ;; has already flipped :aborted? so finalise-failure! observes
+        ;; the abort and reclassifies.
+        (.countDown decoder-may-throw)
+        (await-condition! #(seq @replies))
+        (let [reply (first @replies)]
+          (is (= :failure (:kind reply))
+              "actor-destroy abort surfaces as a failure reply")
+          (is (= :rf.http/aborted (get-in reply [:failure :kind]))
+              "abort precedence wins — reply MUST be :rf.http/aborted, NOT :rf.http/decode-failure (rf2-wez75 Mike decision a)")
+          (is (= :actor-destroyed (get-in reply [:failure :reason]))
+              ":reason discriminates the actor-destroy source from a user abort"))
+        (is (= 1 (count @replies)))
+        (is (empty? (http-managed/actor-in-flight-snapshot))
+            "actor-in-flight index is clean after the actor-destroy cascade")
+        (finally
+          (stop-server! srv))))))

--- a/spec/014-HTTPRequests.md
+++ b/spec/014-HTTPRequests.md
@@ -341,7 +341,7 @@ Pair tools and 10x panels surface the per-attempt trace; user code only sees the
 
 When a response arrives, the runtime classifies the outcome in this fixed order:
 
-1. **Transport / timeout / abort.** A network error, per-attempt timeout, or abort short-circuits the rest. Classified as `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, or `:rf.http/aborted`. The body never enters the picture.
+1. **Transport / timeout / abort.** A network error, per-attempt timeout, or abort short-circuits the rest. Classified as `:rf.http/transport`, `:rf.http/cors`, `:rf.http/timeout`, or `:rf.http/aborted`. The body never enters the picture. Per [§Abort precedence (abort always wins)](#abort-precedence-abort-always-wins--rf2-wez75) abort dominates the rest of this list — a request marked aborted always classifies as `:rf.http/aborted` regardless of any later-arriving decode / status / transport observation for the same request.
 2. **HTTP status.** Once a response lands, status is checked **before** the body is touched.
    - `2xx` → success-eligible; proceed to decode.
    - `4xx` → `:rf.http/http-4xx`; the raw response text is surfaced at `:body`. Decode is skipped.
@@ -353,6 +353,14 @@ When a response arrives, the runtime classifies the outcome in this fixed order:
 The order is **status-before-decode by design**: a JSON-API endpoint that returns an HTML 404 from a load balancer (or a CORS pre-flight 4xx with a generic HTML body, or a 503 with a Cloudfront error page) classifies as `:rf.http/http-4xx` / `:rf.http/http-5xx` with the raw body at `:body`, not as `:rf.http/decode-failure`. The HTTP failure category is the load-bearing piece of information for the caller; surfacing decode-failure on a 4xx would hide the real error.
 
 If a caller wants to see the structured error body that an API returns alongside a non-2xx (e.g., `{"error": "..."}` JSON on a 4xx), the caller decodes the raw `:body` themselves in the failure-handling branch — the framework hands you the bytes and the status, and you decide what to do with them.
+
+### Abort precedence (abort always wins) — rf2-wez75
+
+**Abort always wins.** Once a request is marked aborted (via [`:rf.http/managed-abort`](#request-id-internal), an external [`:abort-signal`](#abort-signal-external), or the [actor-destroy hook](#abort-on-actor-destroy)), classification short-circuits to `:rf.http/aborted` / `:reason :actor-destroyed` regardless of any subsequent decode, transport, status, or accept-projection state observed for the same request — including outcomes whose underlying transport completion arrived in the same scheduler tick as the abort. Implementations MUST NOT surface `:rf.http/decode-failure`, `:rf.http/transport`, `:rf.http/timeout`, `:rf.http/http-4xx`, `:rf.http/http-5xx`, or `:rf.http/accept-failure` on a request that has been aborted; the abort observation wins by classification, not by race ordering.
+
+This pins the universal cancellation convention (Fetch `AbortController` rejects with `AbortError`; Node HTTP's `req.destroy()`; JVM `HttpClient.cancel`; gRPC's `CANCELLED` status). User code that issued an abort sees an `:rf.http/aborted` reply — period — and never has to disambiguate "did my abort actually happen, or did the response just barely beat it?".
+
+The implementation seam is two-layered: an `:aborted?` cell on the in-flight handle is flipped by the abort path BEFORE racing the once-only `:finalised?` CAS; the natural-completion paths (`finalise-success!` / `finalise-failure!`) sample the cell AFTER winning the CAS and reclassify the would-be reply before dispatch. `maybe-retry!` additionally refuses to schedule a retry once the cell is flipped — a request the caller has cancelled MUST NOT issue a fresh attempt under any retry policy.
 
 ## Failure categories (closed set)
 


### PR DESCRIPTION
## Summary

- Make the abort-vs-decode/transport race in `:rf.http/managed` deterministic. Per Mike decision 2026-05-17 (a) — abort wins — aligned with Fetch AbortController / Node HTTP / JVM HttpClient / gRPC universal convention.
- Seam: each in-flight handle now carries an `:aborted?` atom (alongside the existing `:finalised?` CAS guard). The abort-fn flips `:aborted?` BEFORE racing the once-only CAS; `finalise-success!` / `finalise-failure!` re-sample the cell AFTER winning the CAS and reclassify the would-be decode-failure / transport / status / accept-failure / success reply to the canonical `:rf.http/aborted` shape. `maybe-retry!` also refuses to schedule a retry once the cell is flipped.
- Spec 014 §Classification order grows a new sub-section "Abort precedence (abort always wins) — rf2-wez75" pinning the normative rule; item 1 cross-references it.

## Test plan

- [x] New regression suite — three deterministic latch-gated tests in `implementation/http/test/re_frame/http_abort_precedence_test.clj`:
  - [x] `abort-during-in-flight-decode-wins-over-decode-failure`
  - [x] `abort-during-transport-error-wins-over-transport-classification`
  - [x] `abort-via-actor-destroy-wins-over-decode-failure`
- [x] `implementation/http` JVM — 190 tests / 576 assertions / 0 failures
- [x] CLJS node integration — 2344 tests / 6722 assertions / 0 failures
- [x] Full JVM implementation sweep (`scripts/test-jvm-implementation.sh`) — all artefacts green
- [x] Fast PR spine (`scripts/test-fast-pr.sh`) — pass
- [x] `mkdocs --strict` — baseline 68 warnings preserved (none introduced; the warnings predate this PR and reference path-rewrites in the guide tree, unrelated to spec/014)