### PR TITLE
fix(examples): repair browser-gate regression (diagnosed from #1323+#1324 failures)

### DIFF
--- a/docs/causa/01-installation.md
+++ b/docs/causa/01-installation.md
@@ -33,6 +33,8 @@ second — flex flow puts the aside to the right of the app column:
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  box-sizing: border-box;            /* the 1px border lives inside the
+                                        documented width */
   border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
   resize: horizontal;                /* user-draggable width */
   overflow: auto;

--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -12,7 +12,7 @@
        the property anywhere up the cascade to resize the panel without
        JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
        give the user a browser-native drag handle on the host (rf2-e07yk). */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/skills/re-frame2-setup/reference/shadow-cljs.md
+++ b/skills/re-frame2-setup/reference/shadow-cljs.md
@@ -54,6 +54,8 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
     [data-rf-causa-host] {
       flex: 0 0 var(--rf-causa-inline-width, 420px);
       min-width: 320px;
+      box-sizing: border-box;            /* the border lives inside the
+                                            documented width */
       border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
       resize: horizontal;                /* user-draggable width */
       overflow: auto;

--- a/testbeds/deep_machine/index.html
+++ b/testbeds/deep_machine/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/deliberate_throw/index.html
+++ b/testbeds/deliberate_throw/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/drain_depth_trigger/index.html
+++ b/testbeds/drain_depth_trigger/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/http_toggle/index.html
+++ b/testbeds/http_toggle/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/large_dispatcher/index.html
+++ b/testbeds/large_dispatcher/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/long_flow_w_failure/index.html
+++ b/testbeds/long_flow_w_failure/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/multi_frame/index.html
+++ b/testbeds/multi_frame/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/non_trivial_app_db/index.html
+++ b/testbeds/non_trivial_app_db/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/schema_violation/index.html
+++ b/testbeds/schema_violation/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/sensitive_dispatcher/index.html
+++ b/testbeds/sensitive_dispatcher/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/ssr_hydration_mismatch/index.html
+++ b/testbeds/ssr_hydration_mismatch/index.html
@@ -6,7 +6,7 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1 { margin-top: 0; }
   </style>

--- a/testbeds/ssr_multi_frame/index.html
+++ b/testbeds/ssr_multi_frame/index.html
@@ -6,7 +6,7 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1, h3 { margin: 0.25em 0; }
     p { margin: 0.25em 0; }

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -80,6 +80,7 @@ right-side host to the app layout (DOM order: `<main>` first, host
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
   resize: horizontal;
   overflow: auto;

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -55,6 +55,10 @@ body { margin: 0; }
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  box-sizing: border-box;              /* the 1px border-left lives inside
+                                          the documented width — without
+                                          it, the host renders 1px wider
+                                          than the var(...) value */
   border-left: 1px solid #2a2a2a;     /* visual separator on the app side */
   resize: horizontal;                  /* user-draggable width (see below) */
   overflow: auto;
@@ -89,6 +93,7 @@ identical to the historical fixed-pixel default (420px):
 [data-rf-causa-host] {
   flex: 0 0 var(--rf-causa-inline-width, 420px);
   min-width: 320px;
+  box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
   resize: horizontal;
   overflow: auto;

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -87,6 +87,13 @@
   ;;     `resize: horizontal` + `overflow: auto` on the host
   ;;   - app content to the left stays in normal flex flow
   ;;     (no overlay, no body padding).
+  ;;
+  ;; `box-sizing: border-box` is required so the documented width
+  ;; (the `var(--rf-causa-inline-width, 420px)` value) is the actual
+  ;; rendered width INCLUDING the 1px `border-left` separator. Without
+  ;; it, the host renders one pixel wider than the documented value —
+  ;; an off-by-one that surfaces in any pixel-exact contract (see
+  ;; tools/causa/testbeds/inline_resize/spec.cjs).
   "<div class=\"app-shell\">
   <main id=\"app\"></main>
   <aside data-rf-causa-host></aside>
@@ -98,6 +105,7 @@
   [data-rf-causa-host] {
     flex: 0 0 var(--rf-causa-inline-width, 420px);
     min-width: 320px;
+    box-sizing: border-box;
     border-left: 1px solid #2a2a2a;
     resize: horizontal;
     overflow: auto;

--- a/tools/causa/testbeds/cart_total/index.html
+++ b/tools/causa/testbeds/cart_total/index.html
@@ -12,7 +12,7 @@
        the property anywhere up the cascade to resize the panel without
        JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
        give the user a browser-native drag handle on the host (rf2-e07yk). */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/tools/causa/testbeds/perf_counter/index.html
+++ b/tools/causa/testbeds/perf_counter/index.html
@@ -12,7 +12,7 @@
        the property anywhere up the cascade to resize the panel without
        JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
        give the user a browser-native drag handle on the host (rf2-e07yk). */
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 420px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -702,7 +702,14 @@ module.exports = {
     // cascade we just fired.
     const lastNode = graphNodes.last();
     const lastNodeTestid = await lastNode.getAttribute('data-testid');
-    const nodeDispatchId = lastNodeTestid.replace('rf-causa-graph-node-', '');
+    // `let` (not `const`) because section 10d's redaction probe flips
+    // `:trace/show-sensitive?` true → false, which (per rf2-lqmje /
+    // PR #1308) clears the trace buffer as an intentional privacy
+    // contract — the dispatch-id captured here is no longer present
+    // after that toggle. Section 10e re-selects a fresh node and
+    // overwrites this binding so the cross-panel selection invariant
+    // is still meaningful against a node that actually exists.
+    let nodeDispatchId = lastNodeTestid.replace('rf-causa-graph-node-', '');
     await lastNode.click();
     // Pivot to event-detail — the selection rides on Causa's app-db
     // so the cascade-detail mounts straight away with the matching
@@ -1178,6 +1185,57 @@ module.exports = {
       async () => page.locator(`[data-testid="${REDACTED_TESTID}"]`).count(),
       (count) => count === 0,
       'bottom-rail redacted indicator to disappear after explicit reset_suppressed_count',
+      5000,
+    );
+
+    // ----------------------------------------------------------------
+    // Re-establish the cascade selection invariant for section 10e.
+    //
+    // Section 10d's redaction probe toggled `:trace/show-sensitive?`
+    // true → false (via `set_show_sensitive_BANG_(null)`). Per the
+    // intentional rf2-lqmje contract (PR #1308), that transition
+    // CLEARS the trace buffer — already-buffered sensitive payloads
+    // must not survive a "flip back off" that the user expects to
+    // restore privacy. The clear is whole-buffer, so the dispatch-id
+    // captured in section 9d is no longer present, and the cascade
+    // detail panel cannot mount it.
+    //
+    // The section 10e cross-panel-selection invariant only makes
+    // sense against a cascade that actually exists in the current
+    // buffer, so we dispatch a fresh `+` click, snapshot the new
+    // last-graph-node dispatch-id, and rebind `nodeDispatchId`.
+    // ----------------------------------------------------------------
+    const counterBeforeReseed = parseInt(
+      ((await counterValue.textContent()) || '0').trim(),
+      10,
+    );
+    // Two `+` clicks: (a) the immediate section 10e invariant just
+    // needs one cascade for the cross-panel selection check, but
+    // (b) section 11e-1 later asserts a multi-node invariant
+    // (>= 2 graph nodes). Restoring two cascades here keeps both
+    // sections self-contained against the rf2-lqmje buffer-clear.
+    await clickHostButtonByLabel(page, '+');
+    await expectTextEquals(counterValue, String(counterBeforeReseed + 1), 5000);
+    await clickHostButtonByLabel(page, '+');
+    await expectTextEquals(counterValue, String(counterBeforeReseed + 2), 5000);
+    await clickSidebar(page, 'causality', 'rf-causa-causality-graph');
+    await waitForCondition(
+      async () => graphNodes.count(),
+      (count) => count >= 2,
+      'causality graph to re-render at least two nodes after redaction-probe buffer-clear',
+      5000,
+    );
+    const refreshedLastNode = graphNodes.last();
+    const refreshedLastNodeTestid = await refreshedLastNode.getAttribute('data-testid');
+    nodeDispatchId = refreshedLastNodeTestid.replace('rf-causa-graph-node-', '');
+    await refreshedLastNode.click();
+    await clickSidebar(page, 'event-detail', 'rf-causa-event-detail');
+    await expectVisible(page.locator('[data-testid="rf-causa-event-detail-cascade"]'), 5000);
+    const reseededCascade = page.locator('[data-testid="rf-causa-event-detail-cascade"]');
+    await waitForCondition(
+      async () => reseededCascade.getAttribute('data-dispatch-id'),
+      (val) => val === nodeDispatchId,
+      `event-detail cascade re-seeded after redaction-probe buffer-clear (=${nodeDispatchId})`,
       5000,
     );
 
@@ -2774,6 +2832,21 @@ module.exports = {
     if ((await page.locator('[data-testid="rf-causa-hydration-mismatch-list"]').count()) !== 0) {
       throw new Error('Expected hydration-mismatch-list to unmount after clear-buffer.');
     }
+
+    // Re-seed the trace buffer with host cascades so 11e-4 (Performance)
+    // has rows to inspect. Sidebar clicks alone won't populate the
+    // buffer — per rf2-xs8vu (PR #1314) Causa's collector filters
+    // `:frame :rf/causa` events at ingest. The Performance walk needs
+    // real host cascades; two `+` clicks give the panel a populated
+    // branch without changing any source contract.
+    const counterBeforePerf = parseInt(
+      ((await counterValue.textContent()) || '0').trim(),
+      10,
+    );
+    await clickHostButtonByLabel(page, '+');
+    await expectTextEquals(counterValue, String(counterBeforePerf + 1), 5000);
+    await clickHostButtonByLabel(page, '+');
+    await expectTextEquals(counterValue, String(counterBeforePerf + 2), 5000);
 
     // ----------------------------------------------------------------
     // 11e-4. Performance panel (matrix row 78).


### PR DESCRIPTION
## Summary

Two distinct regressions surfaced together on the `Examples (browser, headless Chromium, rf2-lyj0)` gate. Both landed on `main` before #1323 + #1324 were branched and went undetected because the gate's changed-surfaces classifier reported `skipped` on the merge commits that introduced them.

### Failure 1 — `causa-inline-resize` (pixel-exact 420px contract)

- **Root cause**: 0ea2ebbf (rf2-vbm7a, #1312, LEFT->RIGHT flip) added `border-left: 1px solid #2a2a2a` to the recommended host CSS but kept browser-default `box-sizing: content-box`, so painted width became flex-basis + 1px = 421px while the documented contract is 420px.
- **Fix at source**: add `box-sizing: border-box` to the recommended snippet across 20 surfaces — the canonical `config.cljc default-layout-host-snippet`, 16 testbed/example `index.html` files, and 4 docs/spec/readme/skill pastes. End-user override `--rf-causa-inline-width: 600px` now renders at exactly 600px.

### Failure 2 — `causa-rigorous` (cross-panel selection + perf rows)

Two intentional spec contracts shipped without follow-on test updates:
- 22e92857 (rf2-lqmje, #1308) — `set-show-sensitive!` true → false now wipes the trace buffer (privacy contract). Section 10d's redaction probe toggles the flag and thereby clears the buffer; section 10e's cross-panel-selection invariant then fails because the cascade selected in 9d is gone.
- a0afa955 (rf2-xs8vu, #1314) — trace collector filters `:rf/causa` frame events at ingest. Section 11e-3 clears the buffer; sidebar clicks between then and 11e-4 fire on the `:rf/causa` frame and are filtered, so Performance has zero rows.

**Fix at the test** (the spec contracts are correct and intentional per Mike's decisions): re-seed two host `+` cascades after each buffer-clear inflection (10d → 10e, 11e-3 → 11e-4), re-snapshot `nodeDispatchId`, re-pivot. Each insertion annotated with the bead reference explaining why the padding is required.

### Why neither was caught earlier

The `Examples` job is conditional on the changed-surfaces classifier and was `skipped` on every green main run after the regression-introducing PRs. Latent failures only surfaced when PRs (#1323, #1324) touched a classifier-included surface that also triggered the Examples job.

## Test plan

- [x] Reproduced both failures locally on Windows headless Chromium against `origin/main`.
- [x] `npm run test:examples` (full Playwright sweep) — 40 specs, 0 failures, 0 skipped.
- [x] `tools/causa: clojure -M:test` — 579 tests, 1708 assertions, 0/0.
- [ ] Wait for CI `Examples (browser, headless Chromium, rf2-lyj0)` gate to confirm green on linux/Chromium.