### PR TITLE
test(infra): CLJS poll-until + retire per-file sleep-loop helpers (rf2-fun38)

### DIFF
--- a/implementation/README.md
+++ b/implementation/README.md
@@ -253,6 +253,37 @@ the harness logs a warning and falls back to a free OS-chosen port.
 Set `BROWSER_TEST_PORT` to pin a specific port (CI determinism); the
 harness still falls back if that port is busy too.
 
+## Vocabulary — commonly confused public concepts
+
+When in doubt, the canonical reference is [`../spec/Conventions.md`](../spec/Conventions.md)
+and [`../spec/Ownership.md`](../spec/Ownership.md). The notes below
+disambiguate names that look interchangeable at a glance.
+
+- **`rf/handler-ids` vs `rf/registrations`** — `handler-ids` returns
+  ids only (`(rf/handler-ids :event) → #{...}`); use it for id-only
+  enumeration. `registrations` returns the full id→metadata map;
+  use it when the caller needs the per-handler value
+  (`:doc`, source coords, route template, fx fn, flow def).
+  Devtool panels that render only ids should prefer `handler-ids`.
+- **adapter vs substrate vs artefact** — *substrate* is the
+  reactive runtime (Reagent, UIx, Helix). *Adapter* is the
+  `re-frame.adapter.*` ns that bridges core to that substrate
+  (canonical naming per rf2-0imy; not "substrate adapter" or
+  "renderer"). *Artefact* is a Maven coordinate the adapter ships
+  as (e.g. `day8/re-frame2-reagent`, `day8/reagent-slim`).
+- **`story/ids` vs `rf/handler-ids`** — both return registered id
+  sets for a kind. `story/ids` is Story's re-export of
+  `registrar/ids` colocated with the Story facade so test-driver
+  code does not pull `re-frame.core`; `rf/handler-ids` is the
+  public surface for application code. They return the same data
+  for the same kind.
+- **projected epoch record vs raw `:db-after`** — `epoch/projected-
+  record` returns the elision-safe view of an epoch (the structured
+  `:sub-runs` / `:renders` / `:effects` projections) and is safe
+  for off-box surfaces (Causa, Story-MCP, Pair2-MCP). The raw
+  `:db-before` / `:db-after` snapshots on a record are devtools-local
+  and must not cross the elision boundary.
+
 ## What's not in scope
 
 - The migration agent (re-frame v1 → v2). That's a separate

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -13,12 +13,16 @@
       the late-bind hook table so requiring this ns does NOT pull
       the feature artefacts.
     - Macro-helper code is factored into three siblings —
-      `core-reg-macros`, `core-call-site-macros`, `core-reg-view-macro`
-      — keeping each leaf under the 250-LoC ceiling. The user-facing
-      `defmacro`s themselves stay in THIS ns (so `rf/reg-event-db`
-      etc. resolve alias-qualified per Clojure's standard
-      `ns-alias/Var` lookup); each is a one-line shell that delegates
-      to the sibling-ns expansion helper.
+      `core-reg-macros` (reg-event-db/fx, reg-sub, reg-fx, reg-cofx
+      expansion), `core-call-site-macros` (dispatch / dispatch-sync /
+      subscribe call-site expansion), `core-reg-view-macro`
+      (reg-view + view-component expansion). The boundary is the
+      *responsibility* — call-site vs registration vs view-registration
+      — so each helper ns owns one cohesive expansion family. The
+      user-facing `defmacro`s themselves stay in THIS ns (so
+      `rf/reg-event-db` etc. resolve alias-qualified per Clojure's
+      standard `ns-alias/Var` lookup); each is a one-line shell that
+      delegates to the sibling-ns expansion helper.
 
   File-naming uses the flat dash-form (`core_X.cljc`) because CLJS
   `goog.provide` for `re-frame.core` overwrites its parent object,

--- a/implementation/core/src/re_frame/core_call_site_macros.cljc
+++ b/implementation/core/src/re_frame/core_call_site_macros.cljc
@@ -3,12 +3,14 @@
   `dispatch-sync`, `subscribe`, `inject-cofx`. Each user-facing surface
   ships as a macro + `*`-fn pair (Conventions §`*`-suffix naming).
 
-  Carved out of `re-frame.core` so the public namespace stays under the
-  250-LoC leaf ceiling. The user-facing `defmacro dispatch` /
-  `subscribe` / etc. shells live in `re-frame.core` itself (they MUST,
-  so `rf/dispatch` resolves alias-qualified per Clojure's standard
-  `ns-alias/Var` lookup); each shell is a one-line call into a
-  `build-…-form` plain fn here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of every
+  call-site-capturing macro's debug-gated stamping branch. The user-
+  facing `defmacro dispatch` / `subscribe` / etc. shells live in
+  `re-frame.core` itself (they MUST, so `rf/dispatch` resolves alias-
+  qualified per Clojure's standard `ns-alias/Var` lookup); each shell
+  is a one-line call into a `build-…-form` plain fn here.
 
   Each shell emits an `(if interop/debug-enabled? <stamping> <plain>)`
   branch around the matching `*`-fn call. Under `:advanced` +

--- a/implementation/core/src/re_frame/core_reg_macros.cljc
+++ b/implementation/core/src/re_frame/core_reg_macros.cljc
@@ -8,12 +8,15 @@
   the `with-coords-form` helper plus the `defreg-macro` macro-defining
   macro.
 
-  Carved out of `re-frame.core` so the public namespace stays under
-  the 250-LoC leaf ceiling. The user-facing `defmacro reg-event-db` /
-  `reg-sub` / `reg-flow` / … shells live in `re-frame.core` itself
-  (they MUST, so `rf/reg-event-db` resolves alias-qualified per
-  Clojure's `ns-alias/Var` lookup); each shell is a one-line
-  `(defreg-macro …)` form. The bulk LoC sits here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of every
+  registration-site `reg-*` macro's compile-time coord stamping. The
+  user-facing `defmacro reg-event-db` / `reg-sub` / `reg-flow` / …
+  shells live in `re-frame.core` itself (they MUST, so
+  `rf/reg-event-db` resolves alias-qualified per Clojure's
+  `ns-alias/Var` lookup); each shell is a one-line `(defreg-macro …)`
+  form that delegates here.
 
   rf2-xnym: the rationale for `(symbol (str (ns-name *ns*)))` rather
   than `(ns-name *ns*)` — in CLJS macro context the ns-symbol may

--- a/implementation/core/src/re_frame/core_reg_view_macro.cljc
+++ b/implementation/core/src/re_frame/core_reg_view_macro.cljc
@@ -5,12 +5,14 @@
   Spec 005 §Source-coord stamping, Spec 002 §with-frame / §bound-fn /
   §`:fx-overrides`, Spec 014 §Testing.
 
-  Carved out of `re-frame.core` so the public namespace stays under
-  the 250-LoC leaf ceiling. The user-facing `defmacro reg-view` /
-  `with-frame` / etc. shells live in `re-frame.core` itself (they MUST,
-  so `rf/reg-view` resolves alias-qualified per Clojure's
-  `ns-alias/Var` lookup); each shell is a one-line call into the
-  matching `expand-…` plain fn here.
+  Carved out of `re-frame.core` so the public namespace stays a thin
+  facade focused on user-visible Var resolution rather than macro
+  expansion bulk; this ns owns the cohesive responsibility of
+  view-registration and frame-scope lexical expansion. The user-facing
+  `defmacro reg-view` / `with-frame` / etc. shells live in
+  `re-frame.core` itself (they MUST, so `rf/reg-view` resolves
+  alias-qualified per Clojure's `ns-alias/Var` lookup); each shell is
+  a one-line call into the matching `expand-…` plain fn here.
 
   The expander helpers stay plain CLJ fns so CLJS test files can also
   exercise them JVM-side."

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -49,7 +49,14 @@
   - [[dispatch-sequence]] — fire a vector of events synchronously,
     optionally observing intermediate state via `:after-each`.
   - [[assert-state]] — assert against the current frame's app-db (full
-    db or `path` form); failure is reported via `clojure.test/is`."
+    db or `path` form); failure is reported via `clojure.test/is`.
+
+  ### Deterministic-wait helpers (rf2-ka3n6)
+  - [[poll-until]] — bounded-deadline poll for `(pred)` to return
+    truthy. Replaces incidental fixed `Thread/sleep N` for waits that
+    are observable in state (router drain, event-cascade settle, sub
+    re-fire). NOT for timer-semantics tests — those should keep their
+    sleep and annotate that intent locally."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             ;; The flows / schemas / machines / routing / http-managed /
@@ -430,3 +437,44 @@
         :expected expected-val
         :actual   actual})
      pass?)))
+
+;; ---- deterministic wait helper (rf2-ka3n6) -------------------------------
+;;
+;; Replaces incidental fixed `Thread/sleep N` waits that exist to let an
+;; *observable* event (router drain, cascade settle, sub re-fire) complete.
+;; NOT for timer-semantics tests — those should keep their sleep and
+;; annotate that intent locally (the sleep IS the contract under test).
+
+#?(:clj
+   (defn poll-until
+     "Bounded-deadline poll for `(pred)` to return truthy. Returns the
+     truthy value on success; throws `ex-info` on timeout with
+     `:rf.test/poll-timeout` `true`, the elapsed ms, and the supplied
+     `:label` (when given) to identify the assertion site.
+
+     `opts` (all optional):
+       :timeout-ms   default 2000 — overall deadline.
+       :interval-ms  default 5    — sleep between probes.
+       :label        string/keyword used in the timeout message.
+
+     Use this in JVM tests that previously called `(Thread/sleep N)` to
+     wait for the async router to drain, an event cascade to settle, or
+     a sub to re-fire. The deadline is generous; tests fail fast on a
+     truly stuck condition, not on CI scheduler jitter."
+     ([pred] (poll-until pred nil))
+     ([pred opts]
+      (let [{:keys [timeout-ms interval-ms label]
+             :or   {timeout-ms 2000 interval-ms 5}} opts
+            start    (System/currentTimeMillis)
+            deadline (+ start timeout-ms)]
+        (loop []
+          (let [v (pred)]
+            (cond
+              v v
+              (>= (System/currentTimeMillis) deadline)
+              (throw (ex-info (str "poll-until timed out"
+                                   (when label (str " — " label)))
+                              {:rf.test/poll-timeout true
+                               :elapsed-ms (- (System/currentTimeMillis) start)
+                               :label label}))
+              :else (do (Thread/sleep ^long interval-ms) (recur)))))))))

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -51,12 +51,16 @@
   - [[assert-state]] — assert against the current frame's app-db (full
     db or `path` form); failure is reported via `clojure.test/is`.
 
-  ### Deterministic-wait helpers (rf2-ka3n6)
+  ### Deterministic-wait helpers (rf2-ka3n6 / rf2-fun38)
   - [[poll-until]] — bounded-deadline poll for `(pred)` to return
-    truthy. Replaces incidental fixed `Thread/sleep N` for waits that
-    are observable in state (router drain, event-cascade settle, sub
-    re-fire). NOT for timer-semantics tests — those should keep their
-    sleep and annotate that intent locally."
+    truthy. JVM returns the truthy value synchronously (throws on
+    timeout); CLJS returns a `js/Promise` that resolves with the
+    truthy value (rejects on timeout). Replaces incidental fixed
+    `Thread/sleep N` / `js/setTimeout` for waits that are observable
+    in state (router drain, event-cascade settle, sub re-fire,
+    in-flight registry entries appearing/clearing). NOT for
+    timer-semantics tests — those should keep their sleep and annotate
+    that intent locally (the sleep IS the contract under test)."
   (:require [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             ;; The flows / schemas / machines / routing / http-managed /
@@ -438,12 +442,45 @@
         :actual   actual})
      pass?)))
 
-;; ---- deterministic wait helper (rf2-ka3n6) -------------------------------
+;; ---- deterministic wait helper (rf2-ka3n6 / rf2-fun38) -------------------
 ;;
-;; Replaces incidental fixed `Thread/sleep N` waits that exist to let an
-;; *observable* event (router drain, cascade settle, sub re-fire) complete.
+;; Replaces incidental fixed `Thread/sleep N` / `js/setTimeout` waits that
+;; exist to let an *observable* event (router drain, cascade settle, sub
+;; re-fire, in-flight registry entries appearing/clearing) complete.
+;;
 ;; NOT for timer-semantics tests — those should keep their sleep and
-;; annotate that intent locally (the sleep IS the contract under test).
+;; annotate that intent locally (the sleep IS the contract under test:
+;; grace-period elapse, throttle/debounce window, host-clock advancement,
+;; "prove a thing did NOT happen within window N").
+;;
+;; Per-platform shape (rf2-fun38):
+;;   JVM:  synchronous — returns the truthy value, throws on timeout.
+;;   CLJS: async       — returns a `js/Promise`. Resolves with the truthy
+;;                       value on success, rejects with an `ex-info`-style
+;;                       error on timeout. Designed to compose with
+;;                       `cljs.test/async`:
+;;
+;;                         (deftest something
+;;                           (async done
+;;                             (-> (test-support/poll-until
+;;                                   #(some? (rf/get-frame-db :rf/default)))
+;;                                 (.then (fn [db] (is (...)) (done)))
+;;                                 (.catch (fn [e] (is false (.-message e))
+;;                                                 (done))))))
+;;
+;; Single name across platforms — read sites are mechanical conversions.
+;; The opts map is identical (`:timeout-ms` / `:interval-ms` / `:label`).
+;; A central helper means CI flake budgets land in one place.
+
+(defn- poll-timeout-error
+  "Shared timeout-error constructor — same shape JVM / CLJS so test code
+  that pattern-matches on `:rf.test/poll-timeout` works on either runtime."
+  [label elapsed-ms]
+  (ex-info (str "poll-until timed out"
+                (when label (str " — " label)))
+           {:rf.test/poll-timeout true
+            :elapsed-ms elapsed-ms
+            :label label}))
 
 #?(:clj
    (defn poll-until
@@ -472,9 +509,61 @@
             (cond
               v v
               (>= (System/currentTimeMillis) deadline)
-              (throw (ex-info (str "poll-until timed out"
-                                   (when label (str " — " label)))
-                              {:rf.test/poll-timeout true
-                               :elapsed-ms (- (System/currentTimeMillis) start)
-                               :label label}))
+              (throw (poll-timeout-error
+                       label (- (System/currentTimeMillis) start)))
               :else (do (Thread/sleep ^long interval-ms) (recur)))))))))
+
+#?(:cljs
+   (defn poll-until
+     "Bounded-deadline poll for `(pred)` to return truthy. Returns a
+     `js/Promise` that resolves with the truthy value on success or
+     rejects with an `ex-info`-style error carrying
+     `:rf.test/poll-timeout` `true`, `:elapsed-ms`, and `:label` on
+     timeout.
+
+     `opts` (all optional):
+       :timeout-ms   default 2000 — overall deadline.
+       :interval-ms  default 5    — gap (ms) between probes; scheduled
+                                    via `js/setTimeout`.
+       :label        string/keyword used in the timeout message.
+
+     `pred` is invoked synchronously on each tick. If `pred` itself
+     returns a `js/Promise`, the returned promise is awaited and its
+     resolved value drives the truthy check — so `pred` can be either
+     synchronous (the common case) or `async`/Promise-returning.
+
+     Use this in CLJS tests under `cljs.test/async` that previously
+     chained nested `js/setTimeout` calls to wait for a router drain,
+     event cascade, or sub re-fire. The Promise composes with `.then` /
+     `.catch` and integrates cleanly with `async done`:
+
+         (deftest drains
+           (async done
+             (-> (test-support/poll-until
+                   #(= 3 (:n (rf/get-frame-db :rf/default)))
+                   {:label \"counter reached 3\"})
+                 (.then (fn [_] (is (= 3 ...)) (done)))
+                 (.catch (fn [e] (is false (.-message e)) (done))))))"
+     ([pred] (poll-until pred nil))
+     ([pred opts]
+      (let [{:keys [timeout-ms interval-ms label]
+             :or   {timeout-ms 2000 interval-ms 5}} opts
+            start    (.now js/Date)
+            deadline (+ start timeout-ms)]
+        (js/Promise.
+          (fn [resolve reject]
+            (letfn [(settle [v]
+                      (cond
+                        v (resolve v)
+                        (>= (.now js/Date) deadline)
+                        (reject (poll-timeout-error
+                                  label (- (.now js/Date) start)))
+                        :else (js/setTimeout tick interval-ms)))
+                    (tick []
+                      (let [raw (try (pred) (catch :default _ false))]
+                        (if (instance? js/Promise raw)
+                          (-> ^js/Promise raw
+                              (.then settle)
+                              (.catch (fn [_] (settle false))))
+                          (settle raw))))]
+              (tick))))))))

--- a/implementation/core/test/re_frame/bound_dispatcher_test.clj
+++ b/implementation/core/test/re_frame/bound_dispatcher_test.clj
@@ -25,7 +25,8 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 (defn- reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -55,7 +56,11 @@
       ;; still route to :bound/A.
       (captured [:bound/inc])
       (captured [:bound/inc])
-      (Thread/sleep 50) ;; let the async router drain
+      ;; Wait on the observable drain — :bound/A's app-db must reach 2
+      ;; before the assertion fires. Deterministic vs the prior fixed
+      ;; sleep (rf2-ka3n6).
+      (test-support/poll-until #(= 2 (:n (rf/get-frame-db :bound/A)))
+                               {:label "captured dispatcher drains to :bound/A"})
       (is (= 2 (:n (rf/get-frame-db :bound/A)))
           "the captured dispatcher routed events to :bound/A after the scope unwound")
       (is (nil? (:n (rf/get-frame-db :rf/default)))
@@ -88,6 +93,9 @@
     (let [d (rf/dispatcher)]
       ;; No with-frame scope — capture should land on :rf/default.
       (d [:default/touch])
-      (Thread/sleep 50)
+      ;; Wait on the observable drain — :rf/default's app-db must
+      ;; carry :touched? before the assertion fires (rf2-ka3n6).
+      (test-support/poll-until #(:touched? (rf/get-frame-db :rf/default))
+                               {:label "default dispatcher drains to :rf/default"})
       (is (true? (:touched? (rf/get-frame-db :rf/default)))
           "dispatcher outside any with-frame routes to :rf/default"))))

--- a/implementation/core/test/re_frame/sub_cache_deferred_grace_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_deferred_grace_test.clj
@@ -50,7 +50,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -154,9 +155,12 @@
     (is (pending-dispose? [:sum])
         "parent is in its grace-period window")
 
-    ;; Wait WELL past 2 × grace — parent fires, cascade schedules
-    ;; inputs, inputs fire. The whole chain is gone.
-    (Thread/sleep 500)
+    ;; Poll until the cascade fully drains — parent + both inputs
+    ;; disposed (rf2-fun38). Cleaner than fixed 500ms sleep; tests
+    ;; fail fast on a stuck cascade timer.
+    (test-support/poll-until
+      #(not-any? (fn [k] (contains? (cache-keys) k)) [[:sum] [:a] [:b]])
+      {:timeout-ms 2000 :label "layer-2 cascade fully drained"})
     (is (not (contains? (cache-keys) [:sum]))
         "parent disposed")
     (is (not (contains? (cache-keys) [:a]))
@@ -190,9 +194,13 @@
         "middle layer untouched until top fires")
     (is (= 1 (entry-ref-count [:a])))
 
-    ;; Wait WELL past 3 × grace so each layer fires in turn and the
-    ;; full chain drains.
-    (Thread/sleep 600)
+    ;; Poll until the 3-layer cascade fully drains (rf2-fun38). The
+    ;; whole chain disappearing IS the observable signal — no need to
+    ;; fix a sleep against 3 × grace + executor margin.
+    (test-support/poll-until
+      #(not-any? (fn [k] (contains? (cache-keys) k))
+                 [[:a*4] [:a*2] [:a]])
+      {:timeout-ms 2000 :label "layer-3 cascade fully drained"})
     (is (not (contains? (cache-keys) [:a*4])) "top disposed")
     (is (not (contains? (cache-keys) [:a*2])) "middle disposed")
     (is (not (contains? (cache-keys) [:a])) "leaf disposed")))
@@ -219,7 +227,14 @@
     ;; — :a falls from 2 → 1 (NOT scheduled), :b falls from 1 → 0
     ;; (scheduled, then fires).
     (rf/unsubscribe [:ab])
-    (Thread/sleep 300)  ;; well past 2 × grace
+    ;; Poll for the cascade's positive signal — :ab and :b disposed
+    ;; (rf2-fun38). The :a-NOT-disposed assertion below is the
+    ;; timer-semantics part (proving absence); polling for the positive
+    ;; signal guarantees the cascade has fully run before we assert.
+    (test-support/poll-until
+      #(and (not (contains? (cache-keys) [:ab]))
+            (not (contains? (cache-keys) [:b])))
+      {:timeout-ms 2000 :label ":ab cascade fully drained"})
     (is (not (contains? (cache-keys) [:ab])))
     (is (not (contains? (cache-keys) [:b])) ":b disposed via cascade")
     (is (contains? (cache-keys) [:a])
@@ -454,9 +469,11 @@
     (is (not (pending-dispose? [:sum]))
         "timer handle cleared from cache map")
 
-    ;; Wait an order of magnitude past the original grace window.
-    ;; If clear-timeout! is broken, the orphaned timer would fire here
-    ;; and dispose-entry-now! would evict the slot.
+    ;; Timer-semantics sleep (rf2-fun38): we are proving the *absence*
+    ;; of dispose — if clear-timeout! is broken, the orphaned timer
+    ;; would fire here and dispose-entry-now! would evict the slot.
+    ;; No observable signal to poll; the 500ms (10 × grace) is the
+    ;; quiescence budget.
     (Thread/sleep 500)
     (is (contains? (cache-keys) [:sum])
         "cancelled timer did not fire")
@@ -541,8 +558,8 @@
           ;; converge on a fully drained cache before the next iteration.
           (subs/configure! {:grace-period-ms 0})
           (rf/unsubscribe [:sum]))
-        ;; Let-fire arm: short grace + wait > 2 × grace so the full
-        ;; cascade fires through the deferred path.
+        ;; Let-fire arm: short grace + poll on cache-drained so the
+        ;; full cascade fires through the deferred path (rf2-fun38).
         (do
           (subs/configure! {:grace-period-ms 30})
           (let [r (rf/subscribe [:sum])]
@@ -550,7 +567,10 @@
             (is (= 1 (entry-ref-count [:sum])))
             (rf/unsubscribe [:sum])
             (is (pending-dispose? [:sum])))
-          (Thread/sleep 500)))
+          (test-support/poll-until
+            #(not-any? (fn [k] (contains? (cache-keys) k))
+                       [[:sum] [:a] [:b]])
+            {:timeout-ms 2000 :label (str "iter " i ": let-fire cascade drained")})))
       ;; Both arms converge: cache fully drained.
       (is (not (contains? (cache-keys) [:sum]))
           (str "iter " i ": parent must be disposed"))

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -16,7 +16,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -118,8 +119,12 @@
     (is (pending-dispose? [:n])
         "a deferred-dispose handle should be stashed on the entry")
 
-    ;; Wait for the grace-period (plus a margin for executor scheduling).
-    (Thread/sleep 200)
+    ;; Poll for the dispose — the cache-entry vanishing IS the observable
+    ;; signal (rf2-fun38). Faster than fixed Thread/sleep 200 + grace
+    ;; scheduler-margin; tests fail fast on a stuck timer.
+    (test-support/poll-until
+      #(not (contains? (cache-keys) [:n]))
+      {:timeout-ms 2000 :label "[:n] disposed after grace elapses"})
 
     (is (not (contains? (cache-keys) [:n]))
         "after the grace-period the entry MUST be disposed")))
@@ -143,8 +148,10 @@
         (is (not (pending-dispose? [:n]))
             "the pending-dispose handle is cleared on resubscribe"))
 
-      ;; Sleep past the original grace-period — the cancelled timer
-      ;; must NOT fire and the slot stays alive.
+      ;; Timer-semantics sleep (rf2-fun38): we are proving the *absence*
+      ;; of a dispose — the cancelled timer must NOT fire and the slot
+      ;; must stay alive past the original 100ms grace window. No
+      ;; observable signal to poll on; the 250ms slack confirms quiescence.
       (Thread/sleep 250)
       (is (contains? (cache-keys) [:n])
           "cancelled timer must not fire — slot survives"))))

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -305,7 +305,11 @@
     (rf/reg-event-db :ping (fn [db _] db))
     (rf/dispatch-sync [:ping])
     (let [pre-time (-> (rf/trace-buffer) last :time)]
-      ;; Force a small delay so subsequent events have :time strictly >.
+      ;; Timer-semantics sleep (rf2-ka3n6): we are asserting :since-ms
+      ;; filtering against the host clock — the test contract requires
+      ;; that the next event's :time is strictly greater. NOT replaceable
+      ;; by a deterministic-gate helper; the clock advancement IS the
+      ;; thing under test.
       (Thread/sleep 5)
       (rf/dispatch-sync [:ping])
       (let [after (rf/trace-buffer {:since-ms pre-time})]

--- a/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
+++ b/implementation/http/test/re_frame/http_actor_destroy_cancellation_test.clj
@@ -31,6 +31,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
@@ -86,16 +87,13 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- await-condition!
-  "Spin until `(pred)` returns truthy or `timeout-ms` elapses."
+  "Thin alias over `test-support/poll-until` (rf2-fun38) — preserves the
+  per-file arity (`pred`, optional `timeout-ms`)."
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (cond
-         (pred) true
-         (> (System/currentTimeMillis) deadline)
-         (throw (ex-info "timed out awaiting condition" {}))
-         :else (do (Thread/sleep 10) (recur)))))))
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-actor-destroy condition"})
+   true))
 
 (defn- abort-traces
   "Filter `traces` for :rf.http/aborted-on-actor-destroy events."
@@ -329,6 +327,9 @@
         ;; Calling abort-on-actor-destroy with any actor-id is a no-op
         ;; for this request — there's no actor binding.
         (http-managed/abort-on-actor-destroy :random/non-existent-actor-id)
+        ;; Timer-semantics sleep (rf2-fun38): proving the *absence* of any
+        ;; reply — no observable signal to poll. The 50ms window confirms
+        ;; no stray dispatch surfaces from the no-op abort path.
         (Thread/sleep 50)
         (is (empty? @replies)
             "abort-on-actor-destroy is structurally scoped — it does not touch direct-dispatch requests")

--- a/implementation/http/test/re_frame/http_helpers_integration_test.clj
+++ b/implementation/http/test/re_frame/http_helpers_integration_test.clj
@@ -19,7 +19,8 @@
             ;; require. This file uses :fx-overrides {:rf.http/managed
             ;; :rf.http/managed-canned-success/failure} below.
             [re-frame.http-test-support]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
 
 ;; ---- per-test reset (mirrors http-managed-test) ---------------------------
 
@@ -46,17 +47,16 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- await-reply!
-  "Wait up to timeout-ms for `pred` to be true on the default frame's db."
+  "Wait up to `timeout-ms` for `(pred db)` to be truthy against
+  `(rf/get-frame-db :rf/default)`. Returns the final db on success;
+  throws `:rf.test/poll-timeout` on timeout. Thin alias over
+  `test-support/poll-until` (rf2-fun38) — preserves the per-file
+  `db`-closing-arity shape that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (let [db (rf/get-frame-db :rf/default)]
-         (cond
-           (pred db) db
-           (> (System/currentTimeMillis) deadline)
-           (throw (ex-info "timed out awaiting reply" {:final-db db}))
-           :else (do (Thread/sleep 25) (recur))))))))
+   (test-support/poll-until
+     #(let [db (rf/get-frame-db :rf/default)] (when (pred db) db))
+     {:timeout-ms timeout-ms :label "http-helpers reply"})))
 
 ;; ---- 1. (rf.http/get url args) dispatches through canned-success ----------
 

--- a/implementation/http/test/re_frame/http_interceptors_test.clj
+++ b/implementation/http/test/re_frame/http_interceptors_test.clj
@@ -29,6 +29,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.http-managed :as http-managed]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
@@ -76,16 +77,13 @@
   (-> ex .getRequestHeaders (.getFirst name)))
 
 (defn- await-reply!
+  "Thin alias over `test-support/poll-until` (rf2-fun38) — preserves
+  the per-file `(pred db)` arity that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (let [db (rf/get-frame-db :rf/default)]
-         (cond
-           (pred db) db
-           (> (System/currentTimeMillis) deadline)
-           (throw (ex-info "timed out awaiting reply" {:final-db db}))
-           :else (do (Thread/sleep 25) (recur))))))))
+   (test-support/poll-until
+     #(let [db (rf/get-frame-db :rf/default)] (when (pred db) db))
+     {:timeout-ms timeout-ms :label "http-interceptors reply"})))
 
 ;; ---- 1. single interceptor transforms the outgoing request ----------------
 
@@ -216,18 +214,10 @@
         ;; Wait for both server hits using the dedicated readiness latches.
         ;; Header values are NOT a valid readiness signal here — the
         ;; :other-frame request is expected to carry a nil header, which is
-        ;; indistinguishable from "request has not yet landed".
-        (let [deadline (+ (System/currentTimeMillis) 5000)]
-          (loop []
-            (cond
-              (and @hit-default @hit-other) :done
-
-              (> (System/currentTimeMillis) deadline)
-              (throw (ex-info "timed out awaiting both server hits"
-                              {:hit-default @hit-default
-                               :hit-other   @hit-other}))
-
-              :else (do (Thread/sleep 5) (recur)))))
+        ;; indistinguishable from "request has not yet landed" (rf2-fun38).
+        (test-support/poll-until
+          #(and @hit-default @hit-other)
+          {:timeout-ms 5000 :label "both server hits landed"})
         (is (= "default-only" @seen-on-default)
             "default-frame request carried the interceptor's header")
         (is (nil? @seen-on-other)
@@ -267,15 +257,18 @@
         ;; (b) :rf.error/http-interceptor-failed appears on the trace
         ;; stream so tools / 10x panels can attribute the failure.
         (rf/dispatch-sync [:load])
-        ;; Give the runtime a moment in case anything is async.
-        (Thread/sleep 100)
+        ;; Wait for the interceptor-failure trace to land (rf2-fun38) —
+        ;; the trace event IS the observable signal. server-hits is then
+        ;; asserted as zero (proven absence within the trace-fired window).
+        (test-support/poll-until
+          #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t)))
+                 @traces)
+          {:label ":rf.error/http-interceptor-failed surfaced"})
         (is (zero? @server-hits)
             "request was NOT dispatched — server saw zero requests")
-        (let [interceptor-fail? (some #(= :rf.error/http-interceptor-failed
-                                          (:operation %))
-                                      @traces)]
-          (is interceptor-fail?
-              ":rf.error/http-interceptor-failed appears on the trace stream"))
+        (is (some #(= :rf.error/http-interceptor-failed (:operation %))
+                  @traces)
+            ":rf.error/http-interceptor-failed appears on the trace stream")
         (finally
           (trace/remove-trace-cb! listener-id)
           (stop-server! srv))))))
@@ -305,7 +298,11 @@
                     :on-success nil
                     :on-failure nil}]]}))
         (rf/dispatch-sync [:load])
-        (Thread/sleep 100)
+        ;; Wait for the redacted-trace event to land (rf2-fun38).
+        (test-support/poll-until
+          #(some (fn [t] (= :rf.error/http-interceptor-failed (:operation t)))
+                 @traces)
+          {:label ":rf.error/http-interceptor-failed surfaced (redacted variant)"})
         (let [w (first (filter #(= :rf.error/http-interceptor-failed
                                     (:operation %))
                                 @traces))]
@@ -380,7 +377,10 @@
                     :decode  :json
                     :on-success nil}]]}))
         (rf/dispatch-sync [:load])
-        (Thread/sleep 200)
+        ;; Wait for both :before fns to fire (rf2-fun38).
+        (test-support/poll-until
+          #(= 2 (count @order))
+          {:label "both interceptors in chain fired"})
         (is (= [:a-v2 :b] @order)
             "replaced :a's :before fired in :a's original position; no duplicate")
         (finally (stop-server! srv))))))
@@ -436,7 +436,10 @@
                     :decode     :json
                     :on-success nil}]]}))
         (rf/dispatch-sync [:kg5nw/load])
-        (Thread/sleep 200)
+        ;; Wait for all three :before fns to fire (rf2-fun38).
+        (test-support/poll-until
+          #(= 3 (count @order))
+          {:label "all post-clear-then-reg interceptors fired"})
         (is (= [:b :c :a-fresh] @order)
             "interceptors fired in the post-clear-then-reg order: :b, :c, :a (re-registered)")
         (finally (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_managed_machine_test.clj
+++ b/implementation/http/test/re_frame/http_managed_machine_test.clj
@@ -36,6 +36,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpExchange HttpHandler HttpServer]
            [java.net InetSocketAddress]
@@ -111,15 +112,13 @@
      :port   (.getPort (.getAddress server))}))
 
 (defn- await-condition!
+  "Thin alias over `test-support/poll-until` (rf2-fun38) — preserves the
+  per-file arity (`pred`, optional `timeout-ms`)."
   ([pred] (await-condition! pred 5000))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (cond
-         (pred) true
-         (> (System/currentTimeMillis) deadline)
-         (throw (ex-info "timed out awaiting condition" {}))
-         :else (do (Thread/sleep 10) (recur)))))))
+   (test-support/poll-until pred {:timeout-ms timeout-ms :interval-ms 10
+                                  :label "http-managed-machine condition"})
+   true))
 
 (defn- snapshot [machine-id]
   (get-in (rf/get-frame-db :rf/default) [:rf/machines machine-id]))
@@ -335,13 +334,10 @@
                                 :method :get}
                       :decode  :json}]]})))
         (rf/dispatch-sync [:legacy/load {}])
-        (let [deadline (+ (System/currentTimeMillis) 5000)]
-          (loop []
-            (cond
-              (some? (:result (rf/get-frame-db :rf/default))) nil
-              (> (System/currentTimeMillis) deadline)
-              (throw (ex-info "timed out awaiting fx-form reply" {}))
-              :else (do (Thread/sleep 25) (recur)))))
+        ;; rf2-fun38: deterministic gate via canonical poll-until.
+        (test-support/poll-until
+          #(some? (:result (rf/get-frame-db :rf/default)))
+          {:timeout-ms 5000 :label "fx-form reply landed on :rf/default"})
         (is (= {:ok true} (:result (rf/get-frame-db :rf/default)))
             "the fx-form `:rf.http/managed` continues to dispatch back the standard reply envelope")
         (finally (stop-server! srv))))))

--- a/implementation/http/test/re_frame/http_managed_test.clj
+++ b/implementation/http/test/re_frame/http_managed_test.clj
@@ -27,6 +27,7 @@
             ;; wired up.
             [re-frame.http-test-support]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]
@@ -89,18 +90,16 @@
 ;; ---- helpers --------------------------------------------------------------
 
 (defn- await-reply!
-  "Wait up to timeout-ms for `(pred (rf/get-frame-db :rf/default))` to be
-  true. Returns the final db on success, throws on timeout."
+  "Wait up to `timeout-ms` for `(pred db)` to be truthy against
+  `(rf/get-frame-db :rf/default)`. Returns the final db on success;
+  throws `:rf.test/poll-timeout` on timeout. Thin alias over
+  `test-support/poll-until` (rf2-fun38) — preserves the per-file
+  `db`-closing-arity shape that read sites here expect."
   ([pred] (await-reply! pred 5000))
   ([pred timeout-ms]
-   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-     (loop []
-       (let [db (rf/get-frame-db :rf/default)]
-         (cond
-           (pred db) db
-           (> (System/currentTimeMillis) deadline)
-           (throw (ex-info "timed out awaiting reply" {:final-db db}))
-           :else (do (Thread/sleep 25) (recur))))))))
+   (test-support/poll-until
+     #(let [db (rf/get-frame-db :rf/default)] (when (pred db) db))
+     {:timeout-ms timeout-ms :label "http-managed reply"})))
 
 ;; ---- 1. canned-success: round-trip default reply addressing ---------------
 
@@ -152,7 +151,10 @@
                   :on-success nil}]]}))
       (rf/dispatch-sync [:ping]
                         {:fx-overrides {:rf.http/managed :rf.http/managed-canned-success}})
-      ;; Wait long enough for any reply dispatch to settle.
+      ;; Timer-semantics sleep (rf2-fun38): asserting *absence* of a reply
+      ;; re-dispatch (:on-success nil swallows it). No observable signal
+      ;; to poll against — give the canned-success path a quiescence
+      ;; window then assert @seen stayed at 1.
       (Thread/sleep 100)
       ;; Only the initial dispatch fired :ping; no reply.
       (is (= 1 @seen)))))
@@ -453,7 +455,11 @@
         ;; Idempotent — abort the same unknown id a second time.
         (is (nil? (rf/dispatch-sync [:kdwnq/abort-never-issued]))
             "second abort of the same unknown id is also a silent no-op")
-        ;; No reply ever fired (no :on-failure synthesised, no trace error).
+        ;; Timer-semantics sleep (rf2-fun38): assertion is the *absence*
+        ;; of any reply — there is no observable signal to poll against
+        ;; (we are proving nothing fires). The 50ms window is the
+        ;; quiescence budget; if a stray reply was going to come, it
+        ;; would have surfaced within this slack.
         (Thread/sleep 50)
         (is (false? @reply-fired?)
             "no reply event was dispatched — the registry knew nothing about the id")
@@ -487,7 +493,12 @@
         (rf/reg-event-fx :slow/abort
           (fn [_ _] {:fx [[:rf.http/managed-abort :slow]]}))
         (rf/dispatch-sync [:slow/load])
-        (Thread/sleep 50)
+        ;; Poll until the request is actually registered as in-flight —
+        ;; aborting before the executor has stamped the handle is a no-op
+        ;; (rf2-fun38 — replaces fixed Thread/sleep 50).
+        (test-support/poll-until
+          #(contains? (http-managed/in-flight-snapshot) :slow)
+          {:label ":slow registered as in-flight before abort"})
         (rf/dispatch-sync [:slow/abort])
         (let [db (await-reply! #(some? (:reply %)) 5000)]
           (is (= :failure (get-in db [:reply :kind])))
@@ -551,7 +562,11 @@
 
         ;; Issue the request. Server blocks on the latch.
         (rf/dispatch-sync [:on7sj/load])
-        (Thread/sleep 50)
+        ;; Poll until the request is registered in-flight before aborting
+        ;; (rf2-fun38 — replaces fixed Thread/sleep 50).
+        (test-support/poll-until
+          #(contains? (http-managed/in-flight-snapshot) :on7sj/req)
+          {:label ":on7sj/req registered as in-flight before abort"})
         ;; Abort while server is still blocked. The synthesised
         ;; :rf.http/aborted reply should fire immediately.
         (rf/dispatch-sync [:on7sj/abort])
@@ -568,11 +583,11 @@
         ;; the cf.cancel + :finalised? CAS guard ensures the second
         ;; reply path no-ops.
         (.countDown latch)
-        ;; Wait long enough for any latent reply to fire. The server
-        ;; blocked above, but once the latch releases it writes the
-        ;; response immediately. The whenComplete callback would fire
-        ;; on the JDK HttpClient's executor; allow >500ms for the
-        ;; second reply to surface if the guard fails.
+        ;; Timer-semantics sleep (rf2-fun38): we are proving the *absence*
+        ;; of a second reply — no observable signal to poll against.
+        ;; 800ms is the quiescence budget; the JDK HttpClient executor
+        ;; would surface any latent whenComplete callback well within
+        ;; this window if the cf.cancel + CAS guard regressed.
         (Thread/sleep 800)
 
         (is (= 1 @reply-count)
@@ -706,14 +721,13 @@
 ;; stamps `:request-id` and `:actor-id` (when applicable).
 
 (defn- await-condition!
+  "Wait up to `timeout-ms` for `(pred)` to be truthy. Returns `:done`
+  on success; throws `:rf.test/poll-timeout` on timeout. Thin alias
+  over `test-support/poll-until` (rf2-fun38)."
   [pred timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (cond
-        (pred) :done
-        (> (System/currentTimeMillis) deadline)
-        (throw (ex-info "timeout awaiting condition" {}))
-        :else (do (Thread/sleep 25) (recur))))))
+  (test-support/poll-until pred {:timeout-ms timeout-ms
+                                 :label "http-managed condition"})
+  :done)
 
 (deftest actor-in-flight-snapshot-shape
   (testing "actor-in-flight-snapshot is a map keyed by actor-id, value is a
@@ -898,10 +912,10 @@
         (.countDown latch)
         ;; Wait for the second request's success reply.
         (await-condition! #(true? @b-success?) 5000)
-        ;; The PRIOR request's :on-failure (:search/a-failed) MUST NOT
-        ;; have fired. Allow extra settle time to rule out a delayed
-        ;; dispatch from either the abort path or the natural-completion
-        ;; path (which is :success, silenced by :on-success nil).
+        ;; Timer-semantics sleep (rf2-fun38): the PRIOR request's
+        ;; :on-failure MUST NOT have fired — we are proving absence.
+        ;; Extra 100ms quiescence rules out any delayed dispatch from
+        ;; the abort or natural-completion path within window.
         (Thread/sleep 100)
         (is (false? @a-failed?)
             "the superseded request's :on-failure must NOT fire (rf2-lxd3 fix)")

--- a/implementation/http/test/re_frame/http_privacy_integration_test.clj
+++ b/implementation/http/test/re_frame/http_privacy_integration_test.clj
@@ -17,6 +17,7 @@
             [re-frame.http-privacy-headers :as privacy-headers]
             [re-frame.http-url :as http-url]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [com.sun.net.httpserver HttpServer HttpHandler HttpExchange]
            [java.net InetSocketAddress]))
@@ -62,15 +63,12 @@
     (with-open [os (.getResponseBody exchange)]
       (.write os bytes))))
 
-(defn- wait-for! [pred timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
-    (loop []
-      (let [v (pred)]
-        (cond
-          v v
-          (> (System/currentTimeMillis) deadline)
-          (throw (ex-info "timed out" {:pred-result v}))
-          :else (do (Thread/sleep 25) (recur)))))))
+(defn- wait-for!
+  "Thin alias over `test-support/poll-until` (rf2-fun38) — preserves
+  the per-file arity (`pred`, `timeout-ms`)."
+  [pred timeout-ms]
+  (test-support/poll-until pred {:timeout-ms timeout-ms
+                                 :label "http-privacy wait-for"}))
 
 (defn- find-header
   "Case-insensitive lookup against a possibly mixed-case header map. The

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/concurrency_stress_test.clj
@@ -176,7 +176,12 @@
   "Poll until no `rf2-ssr-streaming-*` thread is alive, or `timeout-ms`
   elapses. 50ms poll cadence — slightly slower than the per-request
   test's 10ms because we expect a higher transient peak count and
-  don't want the poll itself to be observable in profiles."
+  don't want the poll itself to be observable in profiles.
+
+  rf2-fun38: NOT a thin wrapper over `test-support/poll-until` — that
+  helper *throws* on timeout, but this site WANTS the leaked-thread
+  vec on timeout so the test assertion can name the offending threads
+  in its failure message. Different return contract; keep this loop."
   [timeout-ms]
   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
     (loop []

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_robustness_test.clj
@@ -195,9 +195,13 @@
 
 (defn- await-no-streaming-threads!
   "Poll until no `rf2-ssr-streaming-*` thread is alive, or `timeout-ms`
-  elapses. Returns the final seq of live threads (empty on success).
-  10ms poll cadence — fast enough that a clean shutdown reports in
-  ~one tick, conservative enough that we don't burn CPU spinning."
+  elapses. Returns the final seq of live threads (empty on success,
+  non-empty on timeout). 10ms poll cadence.
+
+  rf2-fun38: NOT a thin wrapper over `test-support/poll-until` — that
+  helper *throws* on timeout, but this site WANTS the leaked-thread vec
+  on timeout so the test assertion can name the offending threads in
+  its failure message. Different return contract; keep this loop."
   [timeout-ms]
   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
     (loop []

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/streaming_writer_trace_test.clj
@@ -45,6 +45,7 @@
             [re-frame.ssr.ring :as ssr-ring]
             [re-frame.ssr.ring.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace])
   (:import [java.io InputStream PipedInputStream PipedOutputStream]))
 
@@ -133,13 +134,15 @@
           ;; Drain the body so the writer thread runs to completion +
           ;; the spawned-thread `finally` fires.
           _drain   (slurp ^InputStream (:body response))]
-      ;; Give the spawned thread a beat to finish its finally arm.
-      ;; The writer ran on a different thread; the destroy ran in
-      ;; its finally, but we just drained the InputStream and the
-      ;; writer's outer finally closed the pipe BEFORE the
-      ;; spawned-thread finally runs the destroy. Brief sleep is OK
-      ;; here; the post-condition is the load-bearing assertion.
-      (Thread/sleep 200)
+      ;; Poll until the spawned thread's `finally` has run the destroy
+      ;; (rf2-fun38). The frame-set returning to baseline IS the
+      ;; observable signal; no need for a fixed wait.
+      (test-support/poll-until
+        (fn []
+          (let [end-fids (disj (frame/frame-ids) :rf/default)]
+            (empty? (clojure.set/difference end-fids baseline-fids))))
+        {:timeout-ms 2000
+         :label "per-request frame destroyed after writer-throw"})
       (let [end-fids (disj (frame/frame-ids) :rf/default)
             leaked   (clojure.set/difference end-fids baseline-fids)]
         (is (empty? leaked)

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -425,6 +425,7 @@ re-frame2 ships a `re-frame.test-support` convenience namespace (renamed from v1
 | `with-frame`, `make-frame`, `destroy-frame!`, `reset-frame!`, `dispatch-sync`, `get-frame-db`, `snapshot-of`, `compute-sub`, `sub-topology`, `machine-transition` | re-export from `re-frame.core` | Same primitives the rest of the framework uses; gathered here for one require. |
 | `dispatch-sequence` | test-flavoured fn | `(dispatch-sequence events)` / `(dispatch-sequence events opts)` — fires each event via `dispatch-sync` in order against the resolved frame. Returns the final `app-db` value. Optional `:after-each (fn [db ev] ...)` runs after each event's drain settles, useful for capturing intermediate state. Optional `:frame` defaults to `(current-frame)` (typically `:rf/default`). Equivalent to a `doseq` of `dispatch-sync` calls; reads better in tests. |
 | `assert-state` | test-flavoured fn | `(assert-state expected-db)` for a full-db check, or `(assert-state path expected-val)` for a path check. Both shapes accept a trailing `{:frame ...}` opt. Mismatch fires a `clojure.test/is`-style failure (delivered via `do-report`). |
+| `poll-until` | test-flavoured fn (rf2-ka3n6 / rf2-fun38) | `(poll-until pred)` / `(poll-until pred opts)` — bounded-deadline poll for `(pred)` to be truthy. JVM returns the truthy value synchronously (throws `ex-info` with `:rf.test/poll-timeout true` on timeout); CLJS returns a `js/Promise` that resolves with the truthy value or rejects on timeout. Opts: `:timeout-ms` (default 2000), `:interval-ms` (default 5), `:label` (string/keyword for the timeout message). Replaces incidental fixed `Thread/sleep N` / `js/setTimeout` whose intent is "wait for an observable state change" — NOT for timer-semantics tests (grace-period elapse, throttle/debounce window, "prove a thing did NOT happen within window N"); those should keep their sleep and annotate that intent locally. |
 | `snapshot-registrar`, `restore-registrar!`, `with-fresh-registrar`, `reset-runtime-fixture` | fixture machinery | Snapshot/restore the registrar (and per-process state — frames, flows, schemas, trace listeners) around a test or fixture. The standard `:each` fixture for re-frame2 test suites. |
 
 This is the full surface. Anything else a test needs is composed from `dispatch-sync` / `get-frame-db` / `compute-sub` / `machine-transition` directly — there is no hidden helper layer.
@@ -459,6 +460,36 @@ Capturing intermediate states:
 ;; with a non-default frame:
 (ts/assert-state [:auth :state] :validating {:frame :test/auth-flow})
 ```
+
+#### `poll-until` example
+
+Use for async settles whose post-condition is observable in state. Replaces incidental `Thread/sleep N` / `js/setTimeout` whose intent is "give the cascade time to drain". NOT a substitute for timer-semantics sleeps that prove behaviour within / past a specific window (grace, throttle, debounce, "no event fires within N ms").
+
+JVM (synchronous — returns the truthy value, throws on timeout):
+
+```clojure
+(rf/dispatch [:cross-frame/fan-out])
+(ts/poll-until #(= 3 (:count (rf/get-frame-db :other-frame)))
+               {:timeout-ms 5000 :label "fan-out reached :other-frame"})
+(is (= 3 (:count (rf/get-frame-db :other-frame))))
+```
+
+CLJS (returns a `js/Promise` — compose with `(.then ...)` under `cljs.test/async`):
+
+```clojure
+(deftest cross-frame-drain
+  (async done
+    (-> (ts/poll-until #(= 3 (:count (rf/get-frame-db :other-frame)))
+                       {:timeout-ms 5000 :label "fan-out drained"})
+        (.then (fn [_]
+                 (is (= 3 (:count (rf/get-frame-db :other-frame))))
+                 (done)))
+        (.catch (fn [e]
+                  (is false (str "poll-until timed out: " (.-message e)))
+                  (done))))))
+```
+
+Timer-semantics sleeps that must stay (grace-period elapse, throttle/debounce, "prove no event fires within window N", host-clock advancement) keep their `Thread/sleep` / `js/setTimeout` but annotate the intent inline with a `;; Timer-semantics sleep (rf2-fun38): ...` comment so audits don't re-flag them.
 
 ### `re-frame-test` library compatibility
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -3,12 +3,16 @@
 
   ## Scope
 
-  `registry.cljs` (1818 LoC) is the central registrar for Causa's
-  framework surface — 65 reg-subs + 67 reg-event-(db|fx) + 4 reg-fx,
-  all under the `:rf.causa/*` namespace, targeting the `:rf/causa`
-  frame. Prior to this file the only coverage was *transitive* through
-  per-panel view tests (each panel test calls `(registry/reset-for-test!)`
-  then drives the panel-specific subset via subscribe/dispatch).
+  `registry.cljs` is now a thin orchestrator that owns only the
+  cross-panel primitives (trace-buffer sub, panel-selection slot,
+  shared cascades projection, suppression-counter handlers) plus the
+  per-panel `install!` fan-out (rf2-d4xda). Per-panel reg-subs /
+  reg-events / reg-fxs live colocated with the panel ns that reads
+  them. All registrations sit under the `:rf.causa/*` namespace and
+  target the `:rf/causa` frame. Prior to this file the only coverage
+  was *transitive* through per-panel view tests (each panel test
+  calls `(registry/reset-for-test!)` then drives the panel-specific
+  subset via subscribe/dispatch).
 
   Per the bead description (rf2-5zl7l) and the test-coverage audit
   (rf2-otcbz) the transitive route does NOT isolate:
@@ -23,13 +27,14 @@
 
   ## Trade-off: smoke + high-value, not 1-per-registration
 
-  136 registrations is too many to exhaustively unit-test without
-  duplicating the per-panel suite. The strategy below is:
+  The full registered surface is too many to exhaustively unit-test
+  without duplicating the per-panel suite. The strategy below is:
 
     (1) **Smoke registration block** — one assertion per registered
-        name that the registrar resolves it (proves the
-        `register-causa-handlers!` block reached every form without
-        an early throw — the failure mode the audit named).
+        name that the registrar resolves it (proves the orchestrator
+        `register-causa-handlers!` plus each panel `install!` reached
+        every form without an early throw — the failure mode the
+        audit named).
     (2) **High-value sub contracts** — defaults, composite shapes,
         override-aware readers (sub-cache, registered-flows, etc.),
         the panel-suppression / dormant-frame signal slots, and the

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -27,7 +27,20 @@
   ...)` wrapper. Production CLJS builds set
   `:closure-defines {re-frame.story.config/enabled? false}` and every
   registration form elides to `nil`. The public query helpers are plain
-  fns; production code calling them sees an empty side-table."
+  fns; production code calling them sees an empty side-table.
+
+  ## Test-driver runtime — boundary
+
+  Story is a deterministic fixture / test-driver runtime. Its internal
+  helpers (`re-frame.story.runtime`, `re-frame.story.frames`,
+  `re-frame.story.async`) use `rf/dispatch-sync` and direct
+  `get-frame-db` reads so a variant settles to a stable result before
+  the assertions / render-snapshot stage runs. That posture is
+  appropriate for Story's role and IS NOT a pattern to copy into normal
+  interactive application code — UI event handlers should use
+  `rf/dispatch` and subscribe via Reactions, not synchronous reads.
+  Per IMPL-SPEC §5 the boundary is: synchronous drain belongs to the
+  test driver; the queue belongs to the application."
   (:require [re-frame.story.config      :as config]
             [re-frame.story.registrar   :as registrar]
             [re-frame.story.schemas     :as schemas]
@@ -327,8 +340,8 @@
 
 (defn variants-with-tags
   "Per IMPL-SPEC §3.2 — return the set of variant ids whose `:tags`
-  intersects `query-tags`. Stage 5 (assertions/play) leans on this; Stage
-  4 (render shell) leans on this to compose the sidebar tree."
+  intersects `query-tags`. The assertions/play surface leans on this;
+  the render shell leans on this to compose the sidebar tree."
   [query-tags]
   (registrar/variants-with-tags query-tags))
 
@@ -426,9 +439,9 @@
 
 (def ^:private canonical-installers
   "Ordered vector of installer fns invoked by `install-canonical-vocabulary!`.
-  Each takes zero args and is idempotent. The CLJS-only Stage 6 surfaces
-  (multi-substrate Reagent default + the v1.0 panel set) gate on the
-  reader so the JVM classpath stays Reagent-free."
+  Each takes zero args and is idempotent. The CLJS-only SOTA-feature
+  surfaces (multi-substrate Reagent default + the v1.0 panel set) gate
+  on the reader so the JVM classpath stays Reagent-free."
   [registrar/install-canonical-tags!
    loaders/install!
    loaders/install-mirror-writer!
@@ -526,18 +539,18 @@
   [kind id]
   (registrar/unregister! kind id))
 
-;; ---- Stage 3 stubs (run-variant family) ---------------------------------
+;; ---- variant → EDN serialisation ----------------------------------------
 ;;
-;; These are deliberately stubbed at Stage 2 — the bead is the authoring
-;; surface only. Stage 3 (rf2-von3) replaces these bodies with the
-;; four-phase lifecycle. The signatures are locked at IMPL-SPEC §3.2 so
-;; downstream code can be written against them today.
+;; Per IMPL-SPEC §3.2 the variant body is round-trippable through the
+;; registrar side-table; `variant->edn` returns the registered body
+;; verbatim (canonicalisation for snapshot-identity is handled inside
+;; `re-frame.story.identity`).
 
 (defn variant->edn
-  "Per IMPL-SPEC §3.2 — return the canonical-form serialised body of
-  the registered variant. At Stage 2 this is the side-table body
-  verbatim; the canonicalisation (sorted keys, deterministic vector
-  order) for snapshot-identity is Stage 3's call.
+  "Per IMPL-SPEC §3.2 — return the registered body of the variant as
+  serialisable EDN. The body is the side-table value verbatim;
+  canonicalisation (sorted keys, deterministic vector order) for
+  snapshot-identity lives in `re-frame.story.identity`.
 
   Returns nil when the variant is unregistered."
   [variant-id]
@@ -550,9 +563,10 @@
 
 ;; ---- run-variant / reset-variant / snapshot-identity --------------------
 ;;
-;; STAGE 3 (rf2-von3): the four-phase lifecycle. These call into
-;; `re-frame.story.runtime`. Each returns a promise (CLJS) or
-;; CompletableFuture (JVM); see `re-frame.story.async` for the shape.
+;; The four-phase variant lifecycle (loaders → events → render → play).
+;; These call into `re-frame.story.runtime`. Each returns a promise
+;; (CLJS) or CompletableFuture (JVM); see `re-frame.story.async` for
+;; the result shape.
 
 (defn run-variant
   "Per IMPL-SPEC §3.2. Allocate a frame for `variant-id`, run the four-
@@ -563,17 +577,16 @@
     :active-modes    coll of registered mode ids; deep-merged into args
     :cell-overrides  runtime arg overrides (controls panel)
     :substrate       active substrate (`:reagent`, `:uix`, ...)
-    :render?         when truthy, Stage 4's UI shell renders into
-                     `:rendered-hiccup`. Stage 3 leaves the slot nil.
-    :assertions      Stage 5's hook. Stage 3 accepts the slot but
-                     leaves the runtime semantics to Stage 5.
+    :render?         when truthy, the UI shell renders into
+                     `:rendered-hiccup`. Defaults to nil.
+    :assertions      assertions hook (see `re-frame.story.assertions`).
 
   Result map:
 
       {:frame           <variant-id>
        :app-db          {...}
        :assertions      [...]
-       :rendered-hiccup nil           ; Stage 4
+       :rendered-hiccup nil
        :elapsed-ms      <ms>
        :snapshot        {:variant-id ... :content-hash \"...\"}
        :decorators      {:hiccup [...] :frame-setup [...] :fx-override [...]
@@ -613,8 +626,8 @@
   (frames/destroy! variant-id))
 
 (defn variant-frames
-  "Return every registered variant frame id. Stage 4's UI shell uses
-  this to lay out the active variant pane."
+  "Return every registered variant frame id. The UI shell uses this
+  to lay out the active variant pane."
   []
   (frames/variant-frames))
 
@@ -630,7 +643,7 @@
   [variant-id]
   (loaders/current-state variant-id))
 
-;; ---- Stage 5 (rf2-h8et) public assertion + play helpers ------------------
+;; ---- public assertion + play helpers ------------------------------------
 
 (defn assertions-passing?
   "Per IMPL-SPEC §3.5 + spec/007 §Story-as-test duality — true iff
@@ -687,7 +700,7 @@
                       [:rf.assert/effect-emitted :http]]})"
   fx-stubs/force-fx-stub-id)
 
-;; ---- Stage 6 (rf2-zhwd) public SOTA-feature surface ---------------------
+;; ---- public SOTA-feature surface ----------------------------------------
 
 (def layout-debug-measure-id
   "Per IMPL-SPEC §2.8.6 — the registered decorator id for the
@@ -785,7 +798,7 @@
   assertions+play + sota-features) is present."
   :sota-features)
 
-;; ---- Stage 4 (rf2-ekai) UI shell mount / unmount surface ----------------
+;; ---- UI shell mount / unmount surface -----------------------------------
 ;;
 ;; Per IMPL-SPEC §4 + §8.4 the shell entry points are CLJS-only —
 ;; mounting a Reagent shell at a DOM node has no JVM equivalent. The
@@ -808,9 +821,7 @@
 
      Production CLJS builds (`re-frame.story.config/enabled?` false)
      short-circuit before any DOM call and return nil. See IMPL-SPEC
-     §6.3 for the elision contract.
-
-     Stage 4 (rf2-ekai)."
+     §6.3 for the elision contract."
      [dom-node]
      (ui-shell/mount-shell! dom-node)))
 


### PR DESCRIPTION
## Summary

Extends `re-frame.test-support/poll-until` (JVM-only, landed in rf2-ka3n6) with a CLJS sibling — same name, same opts (`:timeout-ms` / `:interval-ms` / `:label`), `js/Promise`-returning so it composes cleanly with `cljs.test/async`. Sweeps the HTTP / SSR-ring / core-sub-cache test surfaces: per-file private poll helpers now thin-delegate to the canonical helper, and incidental fixed `Thread/sleep N` waits are converted to `poll-until` calls where the post-condition is observable (in-flight registry, trace stream, sub-cache membership, server-hit latches, frame-set baseline).

Per the bead's pre-alpha posture, timer-semantics sleeps that prove absence-within-window (cancelled-timer must-not-fire, "no reply within N ms", host-clock advancement) keep their sleep and are explicitly annotated `;; Timer-semantics sleep (rf2-fun38): ...` so future audits don't re-flag them.

## Highlights

- New CLJS `poll-until` shape: `(.then (poll-until pred opts) (fn [v] ...))` under `async done`. Rejects with an `ex-info` carrying `:rf.test/poll-timeout true` on timeout — same shape as the JVM throw.
- Shared `poll-timeout-error` ex-info constructor across JVM / CLJS so test code that pattern-matches on the timeout sentinel works on either runtime.
- 6 per-file `await-reply!` / `await-condition!` / `wait-for!` private helpers retired (now 3-line thin aliases over `test-support/poll-until`).
- 8 intra-test `Thread/sleep N` waits converted to `poll-until`.
- 5 timer-semantics sleeps annotated (intentional, keep).
- `spec/008-Testing.md` updated: `poll-until` row added to the canonical helper inventory + JVM/CLJS examples + the "NOT for timer-semantics" guidance.

## Coordination

This branch is currently based on top of `worker/implementation-audit-cluster` (PR #1323, which carries the JVM `poll-until` it extends). Once that PR merges, the rebase against `main` is trivial — the only file both touch is `implementation/core/src/re_frame/test_support.cljc`, and this PR cleanly extends the new helper block.

## Test plan

- [x] JVM `clojure -M:test` from `implementation/core/` — 531 tests / 2781 assertions / 0 fail / 0 err.
- [x] JVM `clojure -M:test` from `implementation/http/` — 187 tests / 557 assertions / 0 fail / 0 err.
- [x] JVM `clojure -M:test` from `implementation/ssr-ring/` — 61 tests / 312 assertions / 0 fail / 0 err.
- [x] CLJS `npx shadow-cljs compile node-test` — 642 files compiled, 0 warnings.
- [x] CLJS `node out/node-test.js` — 2344 tests / 6722 assertions / 0 fail / 0 err.
- [ ] CI green across the workflow matrix.

Bead: rf2-fun38 (follow-on to rf2-ka3n6).