### PR TITLE
fix(causa-testbed): rename stale warning names in panel_gallery (rf2-gnjyz)

### DIFF
--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -138,8 +138,8 @@
      {:id (+ id-base 6) :op-type :rf.error/handler-exception
       :operation :rf.error/handler-exception
       :tags (assoc tag :event [:user/save-profile {:id 7}])}
-     {:id (+ id-base 7) :op-type :rf.warning/runtime-large-elision
-      :operation :rf.warning/runtime-large-elision
+     {:id (+ id-base 7) :op-type :rf.warning/large-value-unschema'd
+      :operation :rf.warning/large-value-unschema'd
       :tags (assoc tag :sub-id :user/profile)}
      {:id (+ id-base 8) :op-type :rf.machine/transition
       :operation :rf.machine/transition

--- a/tools/causa/testbeds/panel_gallery/issues_ribbon_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/issues_ribbon_fixtures.cljs
@@ -99,7 +99,7 @@
       (let [sev (nth [:error :warning :advisory] (mod i 3))
             ops [:rf.error/handler-threw
                  :rf.error/fx-failed
-                 :rf.warning/runtime-large-elision
+                 :rf.warning/large-value-unschema'd
                  :rf.warning/handler-replaced
                  :rf.info/snapshot-restored
                  :rf.ssr/hydration-mismatch
@@ -123,7 +123,7 @@
            :operation :rf.error/fx-failed :dispatch-id 101
            :reason "HTTP 503 — upstream timeout"})
    (issue {:id 3 :time 1002 :severity :warning
-           :operation :rf.warning/runtime-large-elision :dispatch-id 100
+           :operation :rf.warning/large-value-unschema'd :dispatch-id 100
            :reason "payload truncated at 1MB"})
    (issue {:id 4 :time 1003 :severity :warning
            :operation :rf.warning/handler-replaced :dispatch-id 102
@@ -218,7 +218,7 @@
            :operation :rf.error/fx-failed :dispatch-id 101
            :reason "fx failed" :recovery :retry})
    (issue {:id 3 :time 1002 :severity :warning
-           :operation :rf.warning/runtime-large-elision :dispatch-id 102
+           :operation :rf.warning/large-value-unschema'd :dispatch-id 102
            :reason "large elided" :recovery :skip})
    (issue {:id 4 :time 1003 :severity :error
            :operation :rf.epoch/ring-evict :dispatch-id 103

--- a/tools/causa/testbeds/panel_gallery/trace_fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/trace_fixtures.cljs
@@ -113,7 +113,7 @@
             :source :timer :origin :story :frame :rf/causa
             :event-id :story/tick :dispatch-id 101 :fx-id :dispatch})]
       ;; Warning + error rows surface the severity axis chip-row.
-      [(ev {:id 9 :time 1200 :op-type :warning :operation :rf.warning/runtime-large-elision
+      [(ev {:id 9 :time 1200 :op-type :warning :operation :rf.warning/large-value-unschema'd
             :source :http :origin :app :frame :rf/default :dispatch-id 100
             :sub-id :user/profile :severity :warning
             :reason "payload truncated at 1MB"})
@@ -219,7 +219,7 @@
         :source :http :origin :app :frame :rf/default
         :event-id :report/upload :dispatch-id 101
         :severity :error :reason "HTTP 503 — upstream timeout"})
-   (ev {:id 3 :time 1020 :op-type :warning :operation :rf.warning/runtime-large-elision
+   (ev {:id 3 :time 1020 :op-type :warning :operation :rf.warning/large-value-unschema'd
         :source :http :origin :app :frame :rf/default :dispatch-id 100
         :sub-id :user/profile :severity :warning
         :reason "payload truncated at 1MB"})


### PR DESCRIPTION
## Summary
- The framework warning `:rf.warning/runtime-large-elision` was renamed to `:rf.warning/large-value-unschema'd` in rf2-o2gop (see `implementation/core/src/re_frame/elision.cljc` L163 + Spec 009 / Spec-Schemas L1172).
- The three causa `panel_gallery` testbed fixtures still referenced the old name — pure rendering fixtures, no Causa-runtime change. This rename brings the rendered chips/rows back in sync with the current Spec 009 warning catalogue.

## Files
- `tools/causa/testbeds/panel_gallery/fixtures.cljs` (L141-L142)
- `tools/causa/testbeds/panel_gallery/issues_ribbon_fixtures.cljs` (L102, L126, L221)
- `tools/causa/testbeds/panel_gallery/trace_fixtures.cljs` (L116, L222)

## Test plan
- [x] `tools/causa`: `clojure -M:test` -> 579 tests / 1708 assertions, 0 failures / 0 errors
- [x] `implementation`: `npm run test:cljs` -> 2344 tests / 6722 assertions, 0 failures / 0 errors

Closes rf2-gnjyz.