### PR TITLE
fix(causa): UX polish + diff/contrast bugs + payload hygiene (6-bead cluster)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -132,7 +132,7 @@ Spec: [`002-Time-Travel.md`](./002-Time-Travel.md).
 |---|---|---|
 | `:rf.causa/select-epoch` | `[_ epoch-id]` | Passive scrub — does NOT call `restore-epoch`. |
 | `:rf.causa/clear-selected-epoch` | `[_]` | Drops view selection. |
-| `:rf.causa/pin-current` | `[_ epoch-id label]` | Eager-copies `:db-after` off the live history record. Enforces the 32-pin cap; surfaces `:pin-overflow-toast` when reached. |
+| `:rf.causa/pin-current` | `[_ {:eid epoch-id :label label}]` | Map payload per Conventions §multi-value events. Eager-copies `:db-after` off the live history record. Enforces the 32-pin cap; surfaces `:pin-overflow-toast` when reached. |
 | `:rf.causa/unpin` | `[_ epoch-id]` | Drops a pin. |
 | `:rf.causa/rename-pin` | `[_ epoch-id new-label]` | Rewrites a pin's `:label`; other 4-tuple slots are immutable. |
 | `:rf.causa/dismiss-pin-overflow-toast` | `[_]` | Dismisses the cap-reached toast. |

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -178,6 +178,7 @@
   (if-let [host (layout-host)]
     (do
       (remove-stale-root!)
+      (snapshot-host-display! host)
       (let [node (.createElement js/document "div")]
         (set! (.-id node) "rf-causa-root")
         (.setAttribute node "data-rf-causa-mode" "inline")
@@ -195,10 +196,45 @@
   (when (and (some? node) (.-querySelector node))
     (.querySelector node "[data-testid=\"rf-causa-shell\"]")))
 
+;; Per rf2-4itwg — toggle-off must collapse the layout host's flex/grid
+;; slot too, not just hide the mount root. The previous `display:none`
+;; on `#rf-causa-root` left the surrounding `[data-rf-causa-host]`
+;; aside still occupying its `flex-basis` slot (and rendering its
+;; `border-left` chrome), so the user perceived a sliver of Causa
+;; chrome residue on toggle-off. Recording the host's pre-Causa
+;; `display` value lets us restore it on toggle-on without guessing
+;; what the host's CSS intended.
+(defonce ^:private host-display-snapshot
+  ;; `{:host <element> :original-inline-display <string>}` once Causa
+  ;; has captured the host's inline `display` (empty string when no
+  ;; inline `display` was set — restoration writes "" so the host
+  ;; stylesheet takes over again). Nil before first capture.
+  (atom nil))
+
+(defn- snapshot-host-display! [host]
+  (when (and (some? host)
+             (not= host (:host @host-display-snapshot)))
+    (reset! host-display-snapshot
+            {:host                    host
+             :original-inline-display (or (some-> host .-style .-display) "")})))
+
+(defn- restore-host-display! []
+  (when-let [{:keys [host original-inline-display]} @host-display-snapshot]
+    (when (some? host)
+      (set! (-> host .-style .-display) original-inline-display))))
+
+(defn- collapse-host! []
+  (when-let [{:keys [host]} @host-display-snapshot]
+    (when (some? host)
+      (set! (-> host .-style .-display) "none"))))
+
 (defn- set-visible! [node visible?]
   (when (some? node)
     (set! (-> node .-style .-display)
-          (if visible? "block" "none"))))
+          (if visible? "block" "none"))
+    (if visible?
+      (restore-host-display!)
+      (collapse-host!))))
 
 (defn- set-mode-attrs!
   "Write the canonical `data-rf-causa-mode` attribute on both the
@@ -379,6 +415,12 @@
   exposure is test-only — the convention is pinned in
   `tools/causa/spec/Conventions.md` §Mount conventions."
   []
+  ;; Restore the host's inline `display` before clearing the snapshot —
+  ;; teardown is the cleanest exit and must leave the host element in
+  ;; the exact state it was in pre-Causa (no lingering `display:none`
+  ;; from a prior toggle-off).
+  (restore-host-display!)
+  (reset! host-display-snapshot nil)
   (when-let [{:keys [node unmount]} @mount-state]
     (when unmount
       (try (unmount) (catch :default _ nil)))

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -174,36 +174,15 @@
   (reset! diagnostic-state {:ok? true :reason :auto-open-disabled})
   nil)
 
-(defn- create-inline-mount-node! []
-  (if-let [host (layout-host)]
-    (do
-      (remove-stale-root!)
-      (snapshot-host-display! host)
-      (let [node (.createElement js/document "div")]
-        (set! (.-id node) "rf-causa-root")
-        (.setAttribute node "data-rf-causa-mode" "inline")
-        (set! (-> node .-style .-display) "block")
-        (set! (-> node .-style .-height) "100%")
-        (set! (-> node .-style .-minHeight) "100vh")
-        (.appendChild host node)
-        (clear-diagnostic!)
-        node))
-    (do
-      (report-diagnostic! (missing-host-diagnostic))
-      nil)))
-
-(defn- shell-node [node]
-  (when (and (some? node) (.-querySelector node))
-    (.querySelector node "[data-testid=\"rf-causa-shell\"]")))
-
-;; Per rf2-4itwg — toggle-off must collapse the layout host's flex/grid
-;; slot too, not just hide the mount root. The previous `display:none`
-;; on `#rf-causa-root` left the surrounding `[data-rf-causa-host]`
-;; aside still occupying its `flex-basis` slot (and rendering its
-;; `border-left` chrome), so the user perceived a sliver of Causa
-;; chrome residue on toggle-off. Recording the host's pre-Causa
-;; `display` value lets us restore it on toggle-on without guessing
-;; what the host's CSS intended.
+;; ---- layout-host display snapshot (rf2-4itwg) ----------------------------
+;;
+;; Toggle-off must collapse the layout host's flex/grid slot too, not just
+;; hide the mount root. The previous `display:none` on `#rf-causa-root`
+;; left the surrounding `[data-rf-causa-host]` aside still occupying its
+;; `flex-basis` slot (and rendering its `border-left` chrome), so the user
+;; perceived a sliver of Causa chrome residue on toggle-off. Recording the
+;; host's pre-Causa `display` value lets us restore it on toggle-on without
+;; guessing what the host's CSS intended.
 (defonce ^:private host-display-snapshot
   ;; `{:host <element> :original-inline-display <string>}` once Causa
   ;; has captured the host's inline `display` (empty string when no
@@ -227,6 +206,28 @@
   (when-let [{:keys [host]} @host-display-snapshot]
     (when (some? host)
       (set! (-> host .-style .-display) "none"))))
+
+(defn- create-inline-mount-node! []
+  (if-let [host (layout-host)]
+    (do
+      (remove-stale-root!)
+      (snapshot-host-display! host)
+      (let [node (.createElement js/document "div")]
+        (set! (.-id node) "rf-causa-root")
+        (.setAttribute node "data-rf-causa-mode" "inline")
+        (set! (-> node .-style .-display) "block")
+        (set! (-> node .-style .-height) "100%")
+        (set! (-> node .-style .-minHeight) "100vh")
+        (.appendChild host node)
+        (clear-diagnostic!)
+        node))
+    (do
+      (report-diagnostic! (missing-host-diagnostic))
+      nil)))
+
+(defn- shell-node [node]
+  (when (and (some? node) (.-querySelector node))
+    (.querySelector node "[data-testid=\"rf-causa-shell\"]")))
 
 (defn- set-visible! [node visible?]
   (when (some? node)

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -27,13 +27,22 @@
       (when selected-id
         (tt-helpers/find-epoch-in-history history selected-id))))
 
+  ;; Per rf2-drf32 — the diff sub falls back to `(peek history)` when
+  ;; the selected epoch is absent from history. The selection slot is
+  ;; shared with the Time Travel panel (so a scrub from there is
+  ;; visible here too), but a stale selection (e.g. an epoch that has
+  ;; aged out of the ring buffer, or persisted from a prior session)
+  ;; previously stranded this panel showing "no slice changes" for
+  ;; every subsequent dispatch. Always picking the latest record when
+  ;; the selection can't be located restores the user's expectation
+  ;; that "the diff panel shows whatever just happened".
   (rf/reg-sub :rf.causa/selected-epoch-diff
     :<- [:rf.causa/epoch-history]
     :<- [:rf.causa/selected-epoch-id]
     (fn [[history selected-id] _query]
-      (let [record (if selected-id
-                     (tt-helpers/find-epoch-in-history history selected-id)
-                     (peek history))]
+      (let [record (or (when selected-id
+                         (tt-helpers/find-epoch-in-history history selected-id))
+                       (peek history))]
         (when record
           (let [epoch-id (:epoch-id record)
                 cached   (get @diff-cache epoch-id ::miss)]

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -336,24 +336,10 @@
          :data-frame (str frame)
          :style       {:padding "8px 0"}}
    [:div {:style {:padding "0 12px 8px 12px"
-                  :display "flex"
-                  :align-items "center"
-                  :justify-content "space-between"
                   :font-family sans-stack
                   :font-size   "12px"
                   :color       (:text-tertiary tokens)}}
-    [:span "Cascade"]
-    [:button {:data-testid "rf-causa-event-detail-clear"
-              :on-click    #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
-              :style       {:background  "transparent"
-                            :border      (str "1px solid " (:border-default tokens))
-                            :color       (:text-secondary tokens)
-                            :padding     "2px 8px"
-                            :border-radius "4px"
-                            :cursor      "pointer"
-                            :font-family sans-stack
-                            :font-size   "11px"}}
-     "Clear"]]
+    [:span "Cascade"]]
    [:div {:style {:border-top (str "1px solid " (:border-subtle tokens))}}
     [event-row event (trigger-handler-coord (or handler fx))]
     (when handler [handler-row handler])
@@ -372,7 +358,8 @@
   state (when not)."
   []
   (let [{:keys [selected-dispatch-id selected-dispatch-frame selected-cascade cascades]}
-        @(rf/subscribe [:rf.causa/event-detail])]
+        @(rf/subscribe [:rf.causa/event-detail])
+        has-selection? (boolean selected-dispatch-id)]
     [:section {:data-testid "rf-causa-event-detail"
                :style       {:height         "100%"
                              :display        "flex"
@@ -382,6 +369,17 @@
                              :font-family    sans-stack
                              :font-size      "14px"}}
      [:header {:style {:padding "16px 16px 8px 16px"}}
+      (when has-selection?
+        [:button {:data-testid "rf-causa-event-detail-back"
+                  :on-click    #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
+                  :style       {:background  "transparent"
+                                :border      "none"
+                                :color       (:text-secondary tokens)
+                                :padding     "0 0 6px 0"
+                                :cursor      "pointer"
+                                :font-family sans-stack
+                                :font-size   "12px"}}
+         "← Events"])
       [:h1 {:style {:font-size   "16px"
                     :font-weight 600
                     :margin      0
@@ -411,7 +409,8 @@
            [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
             (str selected-dispatch-frame)]])
          " is no longer in the trace buffer. "
-         [:button {:on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
+         [:button {:data-testid "rf-causa-event-detail-orphaned-back"
+                   :on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
                    :style    {:margin-left "8px"
                               :background  "transparent"
                               :border      (str "1px solid " (:border-default tokens))
@@ -421,7 +420,7 @@
                               :cursor      "pointer"
                               :font-family sans-stack
                               :font-size   "11px"}}
-          "Clear"]]
+          "← Events"]]
 
         :else
         (cascade-list cascades))]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -171,7 +171,8 @@
      [:button {:data-testid "rf-causa-pin-current"
                :disabled    (or history-empty? cap-reached?)
                :on-click    #(when target-eid
-                               (rf/dispatch [:rf.causa/pin-current target-eid label]
+                               (rf/dispatch [:rf.causa/pin-current
+                                             {:eid target-eid :label label}]
                                             {:frame :rf/causa})
                                (rf/dispatch [:rf.causa/time-travel-set-label-input ""]
                                             {:frame :rf/causa}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel_events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel_events.cljs
@@ -60,12 +60,17 @@
     (fn [db _event]
       (dissoc db :selected-epoch-id)))
 
+  ;; Per rf2-q4rvx the payload is a single map: `{:eid <epoch-id> :label
+  ;; <string>}`. The map shape composes cleanly with optional keys we
+  ;; may add later (e.g. `:source`, `:auto?`) without churning every
+  ;; call site — the positional `[epoch-id label]` form was the v0
+  ;; shape and is gone (pre-alpha; no back-compat shim).
   (rf/reg-event-db :rf.causa/pin-current
-    (fn [db [_ epoch-id label]]
+    (fn [db [_ {:keys [eid label]}]]
       (let [target  (get db :target-frame defaults/default-target-frame)
             history (vec (or (get db :epoch-history)
                              (rf/epoch-history target)))
-            record  (h/find-epoch-in-history history epoch-id)
+            record  (h/find-epoch-in-history history eid)
             pin     (h/pin-from-epoch record label)]
         (if (some? pin)
           (let [{:keys [store overflow? dropped-pin]}

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -262,36 +262,52 @@
   `:rf.causa/select-panel <id>` the registry sets `:selected-panel`
   on the `:rf/causa` frame's app-db and this canvas recomputes.
 
+  ## Contrast safety net (rf2-q8154)
+
+  The wrapping `<div>` owns `flex: 1`, fills the row slot, and paints
+  the dark canvas surface (`bg-2`) so any panel whose root section
+  fails to fill or fails to set its own background still renders text
+  on a dark surface — never on the host body's default white. Every
+  Panel still sets its own `:background (:bg-2 tokens)` for parity
+  with the rest of the shell; the canvas paint is a defence-in-depth
+  layer, not a license to omit the panel-level styling.
+
   Per rf2-in6l2 `reg-view`-registered so the subscribe routes
   through React context to `:rf/causa`."
   []
   (let [selected (or @(rf/subscribe [:rf.causa/selected-panel])
                      registry/default-panel-id)]
-    (case selected
-      :event-detail [event-detail/Panel]
-      :time-travel  [time-travel/Panel]
-      :app-db       [app-db-diff/Panel]
-      :causality    [causality-graph/Panel]
-      ;; ── effects panel begin ──
-      :fx           [effects/Panel]
-      ;; ── effects panel end ──
-      :flows        [flows/Panel]
-      :routes       [routes/Panel]
-      :schemas      [schema-violation-timeline/Panel]
-      :subs         [subscriptions/Panel]
-      :machines     [machine-inspector/Panel]
-      :hydration    [hydration-debugger/Panel]
-      :issues       [issues-ribbon/Panel]
-      :trace        [trace/Panel]
-      :performance  [performance/Panel]
-      ;; ── mcp-server panel begin ──
-      :mcp-server   [mcp-server/Panel]
-      ;; ── mcp-server panel end ──
-      ;; Sidebar Co-pilot row renders the panel-style view in the
-      ;; canvas; the rail still lives in the shell's right margin per
-      ;; spec/007-UX-IA.md §The five regions item 4.
-      :copilot      [ai-co-pilot/Panel]
-      [unknown-panel selected])))
+    [:div {:style {:flex        1
+                   :min-width   0
+                   :display     "flex"
+                   :flex-direction "column"
+                   :background  (:bg-2 tokens)
+                   :color       (:text-primary tokens)}}
+     (case selected
+       :event-detail [event-detail/Panel]
+       :time-travel  [time-travel/Panel]
+       :app-db       [app-db-diff/Panel]
+       :causality    [causality-graph/Panel]
+       ;; ── effects panel begin ──
+       :fx           [effects/Panel]
+       ;; ── effects panel end ──
+       :flows        [flows/Panel]
+       :routes       [routes/Panel]
+       :schemas      [schema-violation-timeline/Panel]
+       :subs         [subscriptions/Panel]
+       :machines     [machine-inspector/Panel]
+       :hydration    [hydration-debugger/Panel]
+       :issues       [issues-ribbon/Panel]
+       :trace        [trace/Panel]
+       :performance  [performance/Panel]
+       ;; ── mcp-server panel begin ──
+       :mcp-server   [mcp-server/Panel]
+       ;; ── mcp-server panel end ──
+       ;; Sidebar Co-pilot row renders the panel-style view in the
+       ;; canvas; the rail still lives in the shell's right margin per
+       ;; spec/007-UX-IA.md §The five regions item 4.
+       :copilot      [ai-co-pilot/Panel]
+       [unknown-panel selected])]))
 
 (rf/reg-view bottom-rail
   "Bottom rail (40px) — time-travel scrubber + frame info + issues

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -70,7 +70,13 @@
 
 (defn- reset-mount-state! []
   (reset! @#'mount/mount-state nil)
-  (reset! @#'mount/popout-state nil))
+  (reset! @#'mount/popout-state nil)
+  ;; Per rf2-4itwg the layout host's `display` is snapshotted on mount
+  ;; so toggle-off can collapse the host slot and restore it on toggle-
+  ;; on. Tests cycling open!/close! across distinct stub documents must
+  ;; clear the snapshot too or the next test's host comparison will
+  ;; spuriously match the previous test's stale element reference.
+  (reset! @#'mount/host-display-snapshot nil))
 
 ;; ---- js/document stub ---------------------------------------------------
 ;;
@@ -394,6 +400,36 @@
                     "close! must NOT trigger a second render")
                 (is (= 1 (.-length (.-children (.-body doc))))
                     "the node stays attached to document.body")))))))))
+
+(deftest close!-collapses-layout-host-slot-and-open!-restores-it
+  (testing "rf2-4itwg — toggle-off must collapse the layout host's
+            flex/grid slot (display:none on the host), not just the
+            mount root. Otherwise the host's reserved width + its own
+            chrome (border-left, padding) remains as visible residue.
+            toggle-on (open!) must restore the host's original inline
+            display value so the host stylesheet's intent is honoured."
+    (with-stub-document
+      (fn [doc]
+        ;; Seed a non-empty inline display on the host so we can
+        ;; verify it's restored verbatim — not over-written with "".
+        (let [host (.-body doc)]
+          (set! (.-display (.-style host)) "flex"))
+        (let [host (.-body doc)
+              {:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn]
+            (mount/open!)
+            (is (= "flex" (.-display (.-style host)))
+                "open! preserves the host's pre-Causa inline display")
+            (mount/close!)
+            (is (= "none" (.-display (.-style host)))
+                "close! collapses the host's flex/grid slot — no
+                 residue chrome from the host's reserved width or
+                 border styling leaks through")
+            (mount/open!)
+            (is (= "flex" (.-display (.-style host)))
+                "subsequent open! restores the snapshotted display
+                 value verbatim — the user's stylesheet intent is
+                 honoured across toggle cycles")))))))
 
 (deftest close!-on-clean-state-is-safe
   (testing "calling close! before any open! is a no-op — does not

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -217,6 +217,26 @@
                  diff)
               ":e-2's diff selected, not :e-3's"))))))
 
+(deftest selected-epoch-diff-falls-back-to-latest-when-selection-stale
+  (testing "rf2-drf32 — a stale `:selected-epoch-id` (no record in
+            current history) falls back to (peek history) so the diff
+            panel never gets stranded on an aged-out selection. This
+            is the actual bug Mike's testbed UX hunt surfaced: clicking
+            a mutate button produced no visible diff because a prior
+            time-travel selection was no longer in history and the sub
+            returned nil instead of the latest record's diff."
+    (let [hist [(mk-record :e-99 [:counter/inc]
+                           {:counter 41} {:counter 42})]]
+      (seed-causa! {:counter 42} hist)
+      (rf/with-frame :rf/causa
+        ;; Set a selection that DOESN'T exist in history.
+        (rf/dispatch-sync [:rf.causa/select-epoch :stale-id-that-aged-out])
+        (let [diff @(rf/subscribe [:rf.causa/selected-epoch-diff])]
+          (is (= [{:op :modified :path [:counter] :before 41 :after 42}]
+                 diff)
+              "stale selection falls through to (peek history) — the
+               newest record's diff is shown rather than nil"))))))
+
 ;; ---- (3b) per-:epoch-id diff cache (rf2-qvaa0) --------------------------
 
 (deftest selected-epoch-diff-cache-hits-on-repeat-deref

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -186,8 +186,8 @@
             "cascade-detail container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container absent once a selection is set")
-        (is (some? (find-by-testid tree "rf-causa-event-detail-clear"))
-            "clear button is rendered alongside the cascade")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-back"))
+            "back-to-events button is rendered in the panel header")))))
 
 (deftest selecting-non-existent-dispatch-id-shows-orphaned-state
   (testing "selecting a dispatch-id that's not in the buffer surfaces

--- a/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/time_travel_cljs_test.cljs
@@ -193,7 +193,7 @@
     (seed-history! [(mk-record :e-1 {:counter 1} 100)
                     (mk-record :e-2 {:counter 2} 200)])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-current :e-2 "after-tick"])
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-2 :label "after-tick"}])
       (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])
             pin  (first pins)]
         (is (= 1 (count pins)))
@@ -215,7 +215,8 @@
       (rf/with-frame :rf/causa
         (doseq [i (range 1 34)]
           (rf/dispatch-sync
-            [:rf.causa/pin-current (keyword (str "e-" i)) (str "pin-" i)]))
+            [:rf.causa/pin-current {:eid   (keyword (str "e-" i))
+                                    :label (str "pin-" i)}]))
         (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])
               causa-db (frame/frame-app-db-value :rf/causa)]
           (is (= h/default-pin-cap (count pins))
@@ -241,7 +242,7 @@
     (seed-history! [(mk-record :e-1 {:counter 7} 1)])
     (rf/with-frame :rf/causa
       ;; Pin :e-1 with its db-after = {:counter 7}.
-      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "checkpoint"])
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-1 :label "checkpoint"}])
       (reset! captured-effects [])  ;; reset capture after pin
       (rf/dispatch-sync [:rf.causa/reset-to-pinned :e-1]))
     (let [effects (captured)]
@@ -376,7 +377,7 @@
     ;; survives.
     (seed-history! [(mk-record :e-old {:state :authed} 99)])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-current :e-old "before-login"]))
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-old :label "before-login"}]))
     ;; Re-seed (simulates ring-buffer roll forward — epoch artefact
     ;; would do this via the cb pump).
     (seed-history! [(mk-record :e-new {:state :anon} 200)])
@@ -408,8 +409,8 @@
     (frame/reg-frame :rf/causa {})
     (seed-history! [(mk-record :e-1 {} 1) (mk-record :e-2 {} 2)])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "a"])
-      (rf/dispatch-sync [:rf.causa/pin-current :e-2 "b"])
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-1 :label "a"}])
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-2 :label "b"}])
       (rf/dispatch-sync [:rf.causa/unpin :e-1])
       (let [pins @(rf/subscribe [:rf.causa/pinned-snapshots])]
         (is (= 1 (count pins)))
@@ -423,7 +424,7 @@
     (frame/reg-frame :rf/causa {})
     (seed-history! [(mk-record :e-1 {:x 1} 1)])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-current :e-1 "old"])
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-1 :label "old"}])
       (rf/dispatch-sync [:rf.causa/rename-pin :e-1 "new"])
       (let [pin (first @(rf/subscribe [:rf.causa/pinned-snapshots]))]
         (is (= "new" (:label pin)))
@@ -468,7 +469,7 @@
     (frame/reg-frame :rf/causa {})
     (seed-history! [(mk-record :e-old {:state :authed} 99)])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-current :e-old "before-login"]))
+      (rf/dispatch-sync [:rf.causa/pin-current {:eid :e-old :label "before-login"}]))
     (seed-history! [(mk-record :e-new {} 200)])
     (rf/with-frame :rf/causa
       (let [tree (time-travel/Panel)

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -198,6 +198,15 @@
     (is (= 16 (count expected-panel-fn))
         "16 sidebar entries -> 16 case arms in canvas")))
 
+(defn- canvas-panel-child
+  "The canvas wrapper is `[:div {...style...} <panel-or-unknown-hiccup>]`
+  (rf2-q8154 — the wrapping div paints the dark canvas surface as a
+  contrast safety net). Extract the panel child for the case-table
+  assertions so each test can keep stating `(= expected-fn (first
+  panel))` without re-stating the wrapper shape per arm."
+  [rendered]
+  (last rendered))
+
 (deftest canvas-routes-each-panel-id-to-its-view-fn
   (testing "every sidebar entry's :id routes to the matching view fn
             in shell/canvas's case-switch — guards against arm typos
@@ -206,10 +215,11 @@
     (rf/with-frame :rf/causa
       (doseq [[panel-id expected-fn] expected-panel-fn]
         (select-panel! panel-id)
-        (let [rendered (#'shell/canvas)]
+        (let [rendered (#'shell/canvas)
+              panel    (canvas-panel-child rendered)]
           (is (vector? rendered)
               (str "panel " panel-id " — canvas returned a hiccup vector"))
-          (is (= expected-fn (first rendered))
+          (is (= expected-fn (first panel))
               (str "panel " panel-id " — first element is the expected view fn")))))))
 
 (deftest canvas-routes-unknown-panel-id-to-fallback
@@ -232,8 +242,9 @@
             registry/default-panel-id"
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (let [rendered (#'shell/canvas)]
-        (is (= event-detail/Panel (first rendered))
+      (let [rendered (#'shell/canvas)
+            panel    (canvas-panel-child rendered)]
+        (is (= event-detail/Panel (first panel))
             "canvas mounts :event-detail when :selected-panel is unset")))))
 
 ;; -------------------------------------------------------------------------

--- a/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
+++ b/tools/causa/testbeds/panel_gallery/time_travel_stories.cljs
@@ -117,7 +117,7 @@
                  'before-purchase'. Panel-specific axis: pin chip
                  rendering is unique to this panel."
      :events     [[:rf.causa/sync-epoch-history (fixtures/cap-warning-history)]
-                  [:rf.causa/pin-current 2 "before-purchase"]]
+                  [:rf.causa/pin-current {:eid 2 :label "before-purchase"}]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -491,9 +491,9 @@ module.exports = {
     // co-pilot turn earlier in the spec may have left a selection in
     // place. Force a known-empty starting point.
     {
-      const lingeringClear = page.locator('[data-testid="rf-causa-event-detail-clear"]');
-      if ((await lingeringClear.count()) > 0) {
-        await lingeringClear.first().click();
+      const lingeringBack = page.locator('[data-testid="rf-causa-event-detail-back"]');
+      if ((await lingeringBack.count()) > 0) {
+        await lingeringBack.first().click();
       }
     }
     await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);
@@ -522,13 +522,13 @@ module.exports = {
       `cascade-detail data-dispatch-id=${clickedDispatchId}`,
       5000,
     );
-    // Click Clear — back to the list. The detail goes away and the
-    // empty-state list reappears.
-    await page.locator('[data-testid="rf-causa-event-detail-clear"]').click();
+    // Click ← Events — back to the list. The detail goes away and
+    // the empty-state list reappears.
+    await page.locator('[data-testid="rf-causa-event-detail-back"]').click();
     await waitForCondition(
       async () => page.locator('[data-testid="rf-causa-event-detail-cascade"]').count(),
       (count) => count === 0,
-      'cascade-detail to unmount after Clear',
+      'cascade-detail to unmount after ← Events',
       5000,
     );
     await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);


### PR DESCRIPTION
## Summary

Six-bead Causa UX/API polish cluster. Mike's testbed UX session surfaced the first four; the latter two are rf2-xshc1 audit follow-ups.

- **rf2-zij5a** — Event-detail 'Clear' button renamed to '← Events' and moved to the panel header (top-left). It was always a back-affordance, not a clear-data action; the label + position now match the convention. Testid updated `event-detail-clear → event-detail-back`; rigorous spec + panel test updated in lockstep.
- **rf2-q8154** — Canvas paints the dark `bg-2` surface itself so panel text never lands on the host body's default white. Defence-in-depth: every Panel still sets its own bg, but the canvas wrapper closes the residual gap that left `text-primary` (#E8EAF0) unreadable against the host body.
- **rf2-q4rvx** — `:rf.causa/pin-current` converts from `[_ epoch-id label]` positional → `[_ {:eid :label}]` map per Conventions §multi-value events. Handler, sole dispatch site, 8 tests, 1 testbed, and the registry catalogue all updated.
- **rf2-6j7fo** — Closed as audit-no-op. routes/effects/flows all consume per-handler metadata (`:path/:doc/:tags/:parent/:on-match`; `:platforms/:doc`; `:frame/:inputs/:path/:doc` respectively) — the bead explicitly acknowledges this case ('Where the panel also consumes per-handler metadata, leave the registrations call'). Rest of `tools/causa/src` audited — no id-only readers exist.
- **rf2-drf32** — App-db diff sub falls back to `(peek history)` when `:selected-epoch-id` doesn't resolve in current history. A stale Time-Travel selection (epoch aged out / cycle) previously stranded the diff panel showing 'no slice changes' for every dispatch. New test pins the contract.
- **rf2-4itwg** — `close!` collapses the layout host slot too (snapshots `host.style.display` on first mount, writes `display:none` on toggle-off, restores the snapshotted value on toggle-on). Host's `flex-basis` + `border-left` chrome no longer remains as residue. Spec contract (CSS-only show/hide, <80ms target) preserved.

## Gates

- `clojure -M:test` from `tools/causa/` — 579 tests, 1708 assertions, 0 failures
- `npm run test:cljs` from `implementation/` — 2346 tests (was 2345, +1 new), 6726 assertions, 0 failures
- `npm run test:causa-feature-gate` from `implementation/` — 16 scenarios, 0 failures, covered 21 matrix rows

## Test plan

- [x] CLJS node-test suite green
- [x] JVM unit-test suite green
- [x] Causa feature-gate scenarios green
- [ ] Manual smoke against `non-trivial-app-db` testbed: confirm '← Events' renders top-left in Event detail, app-db diff highlights changed slot on mutate, Ctrl+Shift+C toggle-off collapses the aside slot cleanly