### PR TITLE
feat(causa-mcp): C-3 bundle-isolation gate (rf2-8xzoe.35)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -172,8 +172,17 @@ else
         # noise for an MCP-wrapper-only diff. tools_jvm + mcp_conformance
         # cover the actual JVM probes (jvm-tools-story-mcp / wire-vocab) and
         # node integration tests.
+        #
+        # rf2-8xzoe.35 — causa-mcp adds a sentinel string under
+        # tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs that
+        # the cljs-bundle-isolation job greps against the counter bundle
+        # to prove the Node-only MCP server never leaks into a browser
+        # build. Source-tree changes under tools/causa-mcp/ must fire
+        # that gate so a future regression that adds the forbidden
+        # :require from a core/* or adapter ns gets caught at PR time.
         tools_jvm=true
         mcp_conformance=true
+        bundle_isolation=true
         ;;
       tools/pair2-mcp/*|tools/mcp-base/*)
         # rf2-os0c1 — mcp-base is .cljc shared by every MCP server (rf2-vw4sq),

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -28,7 +28,7 @@
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
     "test:causa-feature-gate": "node scripts/serve-and-run-causa-feature-gate.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
-    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",
+    "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs && node scripts/_check-bundle-isolation-causa-mcp.test.cjs",
     "test:script-helpers": "node scripts/_browser-test-report.test.cjs && node scripts/_gate-report.test.cjs && node scripts/_local-browser-harness.test.cjs"
   }
 }

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -56,6 +56,20 @@ test('targeted Story/Causa workflow runs the Story feature-load gate', () => {
   assert.match(workflow, /story-causa-browser:[\s\S]*npm run test:story-feature-load/);
 });
 
+// rf2-8xzoe.35 — causa-mcp source-tree changes must fire the
+// cljs-bundle-isolation job so the sentinel-based contract from
+// check-bundle-isolation.cjs catches a stray :require leaking the
+// Node-only MCP-server code into a browser bundle.
+test('causa-mcp source changes trigger bundle_isolation CI', () => {
+  const result = classify('tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
+test('causa-mcp test changes trigger bundle_isolation CI', () => {
+  const result = classify('tools/causa-mcp/test/day8/re_frame2_causa_mcp/server_test.cljs');
+  assert.equal(result.bundle_isolation, 'true');
+});
+
 let failed = 0;
 for (const { name, fn } of tests) {
   try {

--- a/implementation/scripts/_check-bundle-isolation-causa-mcp.test.cjs
+++ b/implementation/scripts/_check-bundle-isolation-causa-mcp.test.cjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+//
+// rf2-8xzoe.35 — Smoke test for the causa-mcp bundle-isolation gate.
+//
+// The bundle-isolation contract in scripts/check-bundle-isolation.cjs
+// catches a Node-only MCP-server leak into a browser-targeted bundle by
+// grepping the counter release bundle for a sentinel string planted at
+// the bottom of tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs.
+// This test pins three properties so the gate cannot silently lose signal:
+//
+//   1. The script declares an `causa-mcp` artefact entry (so the
+//      ARTEFACTS array iteration actually runs the check).
+//   2. The sentinel string is unique to the planted source location —
+//      no other namespace, doc, test fixture, or build artefact carries
+//      the literal. Uniqueness is what gives the grep its signal: any
+//      bundle hit means the planted ns body got pulled in.
+//   3. The CI workflow wires the gate behind the bundle_isolation
+//      changed-surface output (which the rf2-os0c1 + rf2-8xzoe.35
+//      tools/causa-mcp/* classifier branch fires).
+//
+// This is a structural test (no shadow-cljs build) so it stays fast and
+// runs alongside the other scripts/_*.test.cjs gate-helper tests via
+// `npm run test:script-policy`.
+
+'use strict';
+
+const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const IMPL_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(IMPL_ROOT, '..');
+const SCRIPT = path.join(IMPL_ROOT, 'scripts', 'check-bundle-isolation.cjs');
+const SENTINEL_NS = path.join(
+  REPO_ROOT,
+  'tools',
+  'causa-mcp',
+  'src',
+  'day8',
+  're_frame2_causa_mcp',
+  'server.cljs',
+);
+const WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'test.yml');
+const CHANGED_SURFACES = path.join(
+  REPO_ROOT,
+  '.github',
+  'scripts',
+  'report-changed-surfaces.sh',
+);
+
+// The sentinel string itself. Kept inline (not imported from the script)
+// so a refactor that renames the literal in one place but not the other
+// is caught by this test.
+const SENTINEL =
+  'day8.re-frame2-causa-mcp/sentinel:rf2-8xzoe.35-2026-05-17:do-not-rename';
+
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+// ---------------------------------------------------------------------------
+
+test('check-bundle-isolation.cjs declares a causa-mcp artefact entry', () => {
+  const script = fs.readFileSync(SCRIPT, 'utf8');
+  assert.match(
+    script,
+    /name:\s*'causa-mcp'/,
+    'expected ARTEFACTS to include a `causa-mcp` entry',
+  );
+});
+
+test('check-bundle-isolation.cjs references the planted sentinel string', () => {
+  const script = fs.readFileSync(SCRIPT, 'utf8');
+  assert.ok(
+    script.includes(SENTINEL),
+    `expected check-bundle-isolation.cjs to grep for sentinel ${JSON.stringify(SENTINEL)}`,
+  );
+});
+
+test('server.cljs plants the sentinel string in a defonce', () => {
+  const src = fs.readFileSync(SENTINEL_NS, 'utf8');
+  assert.match(
+    src,
+    /defonce\s+\^:private\s+bundle-isolation-sentinel/,
+    'expected server.cljs to plant the sentinel via defonce (mirrors trace.tooling / subs.tooling pattern)',
+  );
+  assert.ok(
+    src.includes(SENTINEL),
+    `expected server.cljs to contain sentinel literal ${JSON.stringify(SENTINEL)}`,
+  );
+});
+
+test('sentinel literal is unique across the repo (signal-bearing)', () => {
+  // The grep contract requires the literal to live in exactly one
+  // source location plus the check script. Walking the whole repo would
+  // be slow; we sample the directories the script greps against (the
+  // build bundle) and the source-of-truth ns. The single-source
+  // discipline is also enforced indirectly: shadow-cljs builds will
+  // fail loudly on a duplicate `(defonce ^:private bundle-isolation-
+  // sentinel ...)` collision if a sibling ns ever copies the form.
+  //
+  // Surfaces we want the sentinel to appear in (exactly one each):
+  //   - tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+  //   - implementation/scripts/check-bundle-isolation.cjs
+  //   - implementation/scripts/_check-bundle-isolation-causa-mcp.test.cjs (this file)
+  const srcCounts = countSentinelInDir(
+    path.join(REPO_ROOT, 'tools', 'causa-mcp', 'src'),
+  );
+  assert.equal(
+    srcCounts.total,
+    1,
+    `expected sentinel exactly once under tools/causa-mcp/src, found ${srcCounts.total} in: ${srcCounts.files.join(', ')}`,
+  );
+
+  // implementation/ source tree (under core/, adapters/, *-feature/)
+  // MUST NOT contain the sentinel. A non-zero hit would indicate the
+  // forbidden cross-tree reference the gate exists to catch — and it
+  // would also make the grep ambiguous (multiple source homes).
+  const implRoots = [
+    'core',
+    'adapters',
+    'schemas',
+    'machines',
+    'routing',
+    'flows',
+    'http',
+    'ssr',
+    'ssr-ring',
+    'epoch',
+  ];
+  for (const sub of implRoots) {
+    const dir = path.join(IMPL_ROOT, sub);
+    if (!fs.existsSync(dir)) continue;
+    const hits = countSentinelInDir(dir);
+    assert.equal(
+      hits.total,
+      0,
+      `sentinel must not appear under implementation/${sub}; found in ${hits.files.join(', ')}`,
+    );
+  }
+});
+
+test('CI workflow wires the cljs-bundle-isolation job behind bundle_isolation', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  assert.match(
+    workflow,
+    /cljs-bundle-isolation:[\s\S]*needs:\s*detect_changed_surfaces[\s\S]*needs\.detect_changed_surfaces\.outputs\.bundle_isolation\s*==\s*'true'/,
+    'expected cljs-bundle-isolation job to gate on bundle_isolation output',
+  );
+  assert.match(
+    workflow,
+    /cljs-bundle-isolation:[\s\S]*npm run test:bundle-isolation/,
+    'expected cljs-bundle-isolation job to invoke npm run test:bundle-isolation',
+  );
+});
+
+test('changed-surfaces classifier fires bundle_isolation for tools/causa-mcp/*', () => {
+  const src = fs.readFileSync(CHANGED_SURFACES, 'utf8');
+  // The branch matching tools/story-mcp/* | tools/causa-mcp/* must set
+  // bundle_isolation=true. Same branch handles both wrappers; this
+  // assertion is the structural twin of the dynamic _changed-
+  // surfaces.test.cjs invocation (which classifies a real file path),
+  // letting us catch a future revert of just the bundle_isolation=true
+  // line without re-running the bash classifier.
+  assert.match(
+    src,
+    /tools\/story-mcp\/\*\|tools\/causa-mcp\/\*\)[\s\S]*?bundle_isolation=true/,
+    'expected tools/story-mcp/*|tools/causa-mcp/*) branch to set bundle_isolation=true',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Helpers.
+
+function countSentinelInDir(dir) {
+  let total = 0;
+  const files = [];
+  walk(dir, (file) => {
+    let blob;
+    try {
+      blob = fs.readFileSync(file, 'utf8');
+    } catch (_) {
+      return;
+    }
+    let hits = 0;
+    let idx = 0;
+    while ((idx = blob.indexOf(SENTINEL, idx)) !== -1) {
+      hits += 1;
+      idx += SENTINEL.length;
+    }
+    if (hits > 0) {
+      total += hits;
+      files.push(path.relative(REPO_ROOT, file));
+    }
+  });
+  return { total, files };
+}
+
+function walk(dir, visit) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, visit);
+    } else if (entry.isFile()) {
+      visit(full);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+let failed = 0;
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(err && err.stack ? err.stack : err);
+  }
+}
+
+if (failed > 0) {
+  console.error(`check-bundle-isolation causa-mcp tests: ${failed} failed.`);
+  process.exit(1);
+}
+
+console.log(
+  `check-bundle-isolation causa-mcp tests: ${tests.length} passed.`,
+);

--- a/implementation/scripts/check-bundle-isolation.cjs
+++ b/implementation/scripts/check-bundle-isolation.cjs
@@ -309,6 +309,38 @@ const ARTEFACTS = [
     expectedAllowListHits: 0,
   },
 
+  // causa-mcp (rf2-8xzoe.35, parent rf2-8xzoe — the Causa MCP server).
+  // The Causa MCP server is a Node binary published to npm as
+  // @day8/re-frame2-causa-mcp; it never belongs in a browser-targeted
+  // CLJS bundle. The dependency arrow flows tool → implementation and
+  // NEVER the reverse (tools/README.md bundle-isolation contract,
+  // tools/causa-mcp/spec/DESIGN-RATIONALE.md Lock #11). The plain
+  // examples/counter bundle imports zero causa-mcp symbols; the
+  // tools/causa-mcp/ source tree is on the implementation shadow-cljs
+  // classpath (added by rf2-8xzoe.35 so this contract is testable —
+  // not vacuous), so the sentinel string is REACHABLE on the build
+  // classpath. If a future change accidentally `:require`s any
+  // `day8.re-frame2-causa-mcp.*` ns from a core/* or adapter ns, the
+  // sentinel below appears in the counter bundle and this check
+  // fails. The sentinel is the explicit `bundle-isolation-sentinel`
+  // string planted at the bottom of
+  // tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs — same
+  // shape as the rf2-qwm0a / rf2-bmzq0 trace.tooling + subs.tooling
+  // sentinels. The string survives `:advanced` (string literals are
+  // not renamed) and sits outside any debug-gate so DCE can't drop the
+  // literal independently of the surrounding ns body.
+  {
+    name: 'causa-mcp',
+    internalSentinels: [
+      // server.cljs — explicit sentinel planted at the bottom of the
+      // namespace body (`bundle-isolation-sentinel`).
+      { source: 'day8.re-frame2-causa-mcp.server (bundle-isolation-sentinel)',
+        sentinel: 'day8.re-frame2-causa-mcp/sentinel:rf2-8xzoe.35-2026-05-17:do-not-rename' },
+    ],
+    consumerAllowList: null,
+    expectedAllowListHits: 0,
+  },
+
   // Story Stage 8 (rf2-c9mm) per IMPL-SPEC §6.5. The plain
   // examples/counter bundle imports zero Story symbols — the
   // tools/story/ jar must DCE entirely when the consuming app

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -76,6 +76,23 @@
                 ;; implementation/ may :require anything under tools/.
                 "../tools/causa/src"
                 "../tools/causa/test"
+                ;; tools/causa-mcp (Causa MCP server, rf2-8xzoe parent).
+                ;; The MCP-server is a Node binary published to npm as
+                ;; @day8/re-frame2-causa-mcp; nothing under implementation/
+                ;; may :require its namespaces (the dependency arrow is
+                ;; tool → implementation, never the reverse — Lock #11 of
+                ;; tools/causa-mcp/spec/DESIGN-RATIONALE.md). The source
+                ;; path is added here so the rf2-8xzoe.35 bundle-isolation
+                ;; contract in implementation/scripts/check-bundle-isolation.cjs
+                ;; has the sentinel-bearing namespace on the classpath —
+                ;; making the contract testable rather than vacuous (if
+                ;; a future regression added the forbidden :require, the
+                ;; sentinel string would appear in the counter bundle and
+                ;; the gate would fail). Mirrors the tools/story + tools/causa
+                ;; pattern: classpath inclusion does NOT itself create a
+                ;; :require, so the bodies stay DCE'd in the no-feature
+                ;; counter reference app.
+                "../tools/causa-mcp/src"
                 ;; tools/causa/testbeds (rf2-p8f2s — examples-split step 1).
                 ;; Tool-owned testbeds colocate the testbed app source (where
                 ;; an app is needed — perf-counter) with the spec that drives

--- a/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
+++ b/tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs
@@ -216,3 +216,24 @@
       ;; as `{:ok? false :reason :nrepl-port-not-found}`.
       (let [server (build-server (degraded-handler e))]
         (connect-transport! server "ready (degraded — no nREPL port)")))))
+
+;; ---- bundle-isolation sentinel ------------------------------------------
+;;
+;; Per rf2-8xzoe.35: `implementation/scripts/check-bundle-isolation.cjs`
+;; greps the counter bundle for this exact string. The string lives
+;; ONLY in this file's source body — no other namespace, no docstring,
+;; no test fixture references it — so its presence in a production
+;; consumer bundle proves that the Node-only MCP-server code got
+;; pulled into a browser-targeted build (most likely via a stray
+;; `:require` from a core/* ns or an adapter, which would violate the
+;; tools/README.md bundle-isolation contract that dependencies flow
+;; tool → implementation and never the reverse).
+;;
+;; The sentinel survives `:advanced` because string literals are not
+;; renamed by the closure compiler; it sits outside any
+;; `interop/debug-enabled?` gate so DCE cannot drop the literal
+;; independently of the surrounding ns body. Mirrors the
+;; rf2-qwm0a / rf2-bmzq0 trace.tooling + subs.tooling pattern.
+
+(defonce ^:private bundle-isolation-sentinel
+  "day8.re-frame2-causa-mcp/sentinel:rf2-8xzoe.35-2026-05-17:do-not-rename")


### PR DESCRIPTION
## Summary

- Plants a `bundle-isolation-sentinel` defonce in `tools/causa-mcp/src/day8/re_frame2_causa_mcp/server.cljs` and wires `implementation/scripts/check-bundle-isolation.cjs` to grep the counter release bundle for it — proves the Node-only MCP server cannot leak into a browser-targeted CLJS bundle (dependency arrow flows tool → implementation only; tools/README.md + DESIGN-RATIONALE.md Lock #11).
- Mirrors the rf2-qwm0a / rf2-bmzq0 `trace.tooling` / `subs.tooling` pattern: explicit defonce, survives `:advanced`, sits outside any debug-gate so DCE can't drop the literal independently.
- Contract is non-vacuous: `tools/causa-mcp/src` is added to `implementation/shadow-cljs.edn` `:source-paths` so the sentinel-bearing ns is REACHABLE on the build classpath. A future stray `:require` from a `core/*` or adapter ns immediately fails the gate.
- CI wiring: `tools/story-mcp/* | tools/causa-mcp/*)` classifier branch now sets `bundle_isolation=true` so the existing `cljs-bundle-isolation` job picks up wrapper changes.
- New `_check-bundle-isolation-causa-mcp.test.cjs` smoke test (wired into `test:script-policy`) pins six structural invariants: script entry, sentinel reference, defonce shape, source-tree uniqueness, workflow gate, classifier branch.

## Test plan

- [x] `cd implementation && npm run test:bundle-isolation` — PASS (12 artefact entries; 27 internal sentinels absent; 3 allow-list budgets ok; counter bundle 369710 chars)
- [x] `cd implementation && npm run test:cljs` — PASS (2346 tests, 6726 assertions, 0 failures)
- [x] `cd implementation && npm run test:script-policy` — PASS (causa-mcp smoke 6/6; changed-surfaces 6/6)
- [x] `cd tools/causa-mcp && npm test` — PASS (482 tests, 1235 assertions)
- [x] Simulated-leak repro: fake bundle containing the sentinel triggers `exit 1` with a `causa-mcp` FAIL line — gate fires as designed