### PR TITLE
test(epoch): :redact-fn elides in production builds (rf2-wp70d.5)

### DIFF
--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -167,6 +167,7 @@
   ;;   :rf.epoch/db-replaced                       (rf2-zq55 — reset-frame-db! happy path)
   ;;   :rf.epoch/reset-frame-db-during-drain       (rf2-zq55 — failure mode A)
   ;;   :rf.epoch/reset-frame-db-schema-mismatch    (rf2-zq55 — failure mode B)
+  ;;   :rf.warning/epoch-redact-fn-exception       (rf2-wp70d — redact-fn throw)
   ;;
   ;; Every emit site sits inside `(when interop/debug-enabled? ...)`
   ;; (or guarded by an `if-not interop/debug-enabled?` early-return in
@@ -186,6 +187,35 @@
   ;;      `:rf.epoch/snapshotted` through trace/emit!, sourcing the
   ;;      snapshotted sentinel.
   (rf/configure :epoch-history {:depth 10})
+  ;; rf2-wp70d.5 — install a throwing :redact-fn so the gated
+  ;; `maybe-redact` branch (and its `:rf.warning/epoch-redact-fn-
+  ;; exception` emit site) is REACHED at probe time. Without an
+  ;; installed fn the `(if-let [f (redact-fn)] ...)` branch is taken
+  ;; via the nil arm and the catch's literals never see the closure
+  ;; reachability graph from the probe — the catalogue sentinel would
+  ;; still survive in the control bundle because the keyword literal
+  ;; lives in the source ns (which is required), but rooting the
+  ;; gated body through an actual call sharpens the methodology
+  ;; assertion: the control build proves the (when interop/debug-
+  ;; enabled? ...) gate is the load-bearing surface, not require-
+  ;; closure alone. The throw is caught by `maybe-redact` itself
+  ;; (`:rf.warning/epoch-redact-fn-exception` fires under DEBUG=true)
+  ;; so the probe does not crash.
+  (rf/configure :epoch-history
+                {:redact-fn (fn [_record]
+                              (throw (ex-info "probe-redact-throw" {})))})
+  ;; Register an event we own here (not :probe/inc, which
+  ;; touch-registrar! has already unregistered) and dispatch it so
+  ;; settle! reaches `maybe-redact` with the throwing fn installed.
+  ;; The catch branch fires `:rf.warning/epoch-redact-fn-exception`
+  ;; under DEBUG=true, exercising the gated body's literal
+  ;; reachability through an actual call site rather than relying
+  ;; on require-closure alone.
+  (rf/reg-event-db :probe/redact-fire (fn [_db _ev] {:redact :fired}))
+  (rf/dispatch-sync [:probe/redact-fire])
+  ;; Clear so subsequent probe sites (reset-frame-db! below,
+  ;; on-frame-destroyed!) are not perturbed by the throwing fn.
+  (rf/configure :epoch-history {:redact-fn nil})
   (rf/register-epoch-cb! ::probe-epoch (fn [_record] nil))
   (let [_history (rf/epoch-history :rf/default)]
     nil)

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -136,6 +136,101 @@
       (is (empty? (epoch/epoch-history :rf/default))
           "no record assembled — rollup never reached"))))
 
+;; ---- rf2-wp70d.5 :redact-fn surface JVM false-path coverage --------------
+
+(deftest redact-fn-never-invoked-under-disabled-gate
+  (testing "Per rf2-wp70d.5: with the JVM debug gate off, the
+            installed :redact-fn is NEVER invoked — `settle!`'s body
+            is the gated frontier and elides record assembly entirely.
+            An app that ships a `:redact-fn` and flips the gate to
+            false in production pays zero invocation cost (the slot
+            sits in `@config` but the call path is gone)."
+    (with-redefs [interop/debug-enabled? false]
+      (let [invocations (atom 0)]
+        (rf/configure :epoch-history
+                      {:redact-fn (fn [r]
+                                    (swap! invocations inc)
+                                    r)})
+        (rf/reg-event-db :prod-gate.redact/inc
+                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/dispatch-sync [:prod-gate.redact/inc])
+        (rf/dispatch-sync [:prod-gate.redact/inc])
+        (rf/dispatch-sync [:prod-gate.redact/inc])
+        (is (zero? @invocations)
+            ":redact-fn was never called — the gated build-record /
+             maybe-redact path is inert under the disabled gate")
+        ;; Cleanup: clear the fn so it doesn't survive into other
+        ;; tests via the global config atom.
+        (rf/configure :epoch-history {:redact-fn nil})))))
+
+(deftest redact-fn-not-invoked-on-reset-frame-db-under-disabled-gate
+  (testing "Per rf2-wp70d.5: `reset-frame-db!` returns false under the
+            disabled gate (already pinned above) — the gated arm that
+            would call `perform-reset-frame-db!` → `maybe-redact` is
+            elided. A throwing `:redact-fn` cannot run, so it cannot
+            cause a warning emit, and the early-return false is
+            preserved regardless of whether a fn is installed."
+    (with-redefs [interop/debug-enabled? false]
+      (let [invocations (atom 0)]
+        (rf/configure :epoch-history
+                      {:redact-fn (fn [r]
+                                    (swap! invocations inc)
+                                    r)})
+        (is (false? (rf/reset-frame-db! :rf/default {:any "db"}))
+            "reset-frame-db! refuses under the disabled gate")
+        (is (zero? @invocations)
+            ":redact-fn was never reached — perform-reset-frame-db!
+             never ran")
+        (rf/configure :epoch-history {:redact-fn nil})))))
+
+(deftest redact-fn-warning-not-emitted-under-disabled-gate
+  (testing "Per rf2-wp70d.5: a throwing :redact-fn cannot emit
+            `:rf.warning/epoch-redact-fn-exception` under the disabled
+            gate — the warning op is sourced inside `maybe-redact`'s
+            try/catch, and `maybe-redact` is unreachable because every
+            call site is itself gated. Pinned here so a future
+            refactor that hoists `maybe-redact` outside the universal
+            `interop/debug-enabled?` gate would break visibly."
+    (with-redefs [interop/debug-enabled? false]
+      (let [warnings (atom [])]
+        (rf/register-trace-cb! ::warn-watch
+                               (fn [ev]
+                                 (when (= :warning (:op-type ev))
+                                   (swap! warnings conj ev))))
+        (rf/configure :epoch-history
+                      {:redact-fn (fn [_r]
+                                    (throw (ex-info "boom" {})))})
+        (rf/reg-event-db :prod-gate.redact/throw
+                         (fn [db _] (update db :n (fnil inc 0))))
+        (rf/dispatch-sync [:prod-gate.redact/throw])
+        (rf/dispatch-sync [:prod-gate.redact/throw])
+        (let [redact-warns (filter (fn [ev]
+                                     (= :rf.warning/epoch-redact-fn-exception
+                                        (:operation ev)))
+                                   @warnings)]
+          (is (empty? redact-warns)
+              ":rf.warning/epoch-redact-fn-exception never fires —
+               maybe-redact is unreachable under the disabled gate"))
+        (rf/remove-trace-cb! ::warn-watch)
+        (rf/configure :epoch-history {:redact-fn nil})))))
+
+(deftest redact-fn-slot-survives-default-gate-as-sanity
+  (testing "Sanity companion to the above: under the default-true
+            gate, an installed :redact-fn DOES fire — fails fast if a
+            future refactor accidentally inverts the gate polarity in
+            the redact-fn surface."
+    (let [invocations (atom 0)]
+      (rf/configure :epoch-history
+                    {:redact-fn (fn [r]
+                                  (swap! invocations inc)
+                                  r)})
+      (rf/reg-event-db :prod-gate.redact/dev-inc
+                       (fn [db _] (update db :n (fnil inc 0))))
+      (rf/dispatch-sync [:prod-gate.redact/dev-inc])
+      (is (pos? @invocations)
+          ":redact-fn fires under the default-true gate")
+      (rf/configure :epoch-history {:redact-fn nil}))))
+
 (deftest projected-record-pure-transform-survives-disabled-gate
   (testing "Per rf2-vq5o0: projected-record is a pure data transform
             — it does NOT consult interop/debug-enabled?. A consumer


### PR DESCRIPTION
## Summary

Pin the production-elision contract for the `:redact-fn` surface (rf2-wp70d). Two halves of the contract are now under test:

- **CLJS — gated-body DCE**: extend `elision_probe.cljs` `touch-epoch!` to install a throwing `:redact-fn` and dispatch through `settle!`, rooting the gated `maybe-redact` body and its catch's `:rf.warning/epoch-redact-fn-exception` emit through an actual call site. The sentinel was already in `check-elision.cjs`'s catalogue; this strengthens the methodology assertion by exercising the gated body through a real path under DEBUG=true.
- **JVM — disabled-gate inertness**: extend `epoch_jvm_prod_gate_test.clj` with four assertions covering the `:redact-fn` surface under the disabled `re-frame.interop/debug-enabled?` gate.

## Verification

- `npm run test:elision`: **production 31/31 absent (329235 chars); control 31/31 present (372077 chars)**
- `clojure -M:test -n re-frame.epoch-jvm-prod-gate-test`: 12 tests / 14 assertions / 0 failures
- Full `implementation/epoch` JVM suite: 148/148 pass
- `npm run test:cljs`: 2346/2346 pass

## Findings

The `:redact-fn` surface elides cleanly today — no follow-on impl-fix bead needed. Every consumer of `maybe-redact` (settle!, perform-reset-frame-db! via the `if-not interop/debug-enabled?` early-return in reset-frame-db!, on-frame-destroyed!'s halted-destroy path) sits inside the universal `interop/debug-enabled?` gate, so closure DCE removes the gated bodies and the `:rf.warning/epoch-redact-fn-exception` keyword literal under `:advanced + goog.DEBUG=false`. The JVM gate disables `maybe-redact` for the same reason — the call sites short-circuit before reaching it.

## Test plan

- [x] `npm run test:elision` from `implementation/`
- [x] `clojure -M:test` from `implementation/epoch/`
- [x] `npm run test:cljs` from `implementation/`