### PR TITLE
fix(causa-testbed): deterministic-wait for trace filter chip render (rf2-lml33)

### DIFF
--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -370,10 +370,18 @@ module.exports = {
       5000,
     );
 
+    // Wait for the chip row to render at least one op-type chip before
+    // asserting. The trace panel's projection sub fires asynchronously
+    // after the buffer-clear / repopulate cascade, so a synchronous
+    // count() can race the render and read zero. Gate on `>= 1`
+    // deterministically rather than gambling on render timing.
     const opTypeChips = page.locator('[data-testid^="rf-causa-trace-axis-chip-op-type-"]');
-    if ((await opTypeChips.count()) === 0) {
-      throw new Error('Expected at least one trace op-type filter chip.');
-    }
+    await waitForCondition(
+      () => opTypeChips.count(),
+      (count) => count >= 1,
+      'at least one trace op-type filter chip to render',
+      5000,
+    );
     await opTypeChips.first().click();
     await expectVisible(page.locator('[data-testid="rf-causa-trace-clear-filters"]'), 5000);
     const filteredCounts = await waitForCondition(


### PR DESCRIPTION
## Summary

- Replace the synchronous `opTypeChips.count()` + throw at `tools/causa/testbeds/rigorous/spec.cjs` §6 (~L375) with a `waitForCondition` polling `count >= 1` against a 5s ceiling.
- Same wait-loop pattern already used by the surrounding total / filtered / cleared count assertions in that section. No naive sleep.
- Root cause (per the original Tier-2 report on rf2-lml33): the trace panel's chip-row projection sub fires asynchronously after the buffer-clear / repopulate cascade, so a synchronous count immediately after the *total*-counts predicate could race the chip-row render and read zero (observed ~1-in-10 rate during Tier-2 cluster runs).

## Test plan

- [x] 30/30 consecutive runs of the rigorous spec against a freshly-served counter bundle (`shadow-cljs compile examples/counter` + staged index.html + http-server) — 10× streak then 20× streak, all PASS.
- [x] Diff is testbed-only; no production surface or shared helper changes.
- [ ] CI: `Causa browser smoke gate` (which includes `tools/causa/testbeds/rigorous`).

Closes rf2-lml33.