### PR TITLE
spec(post-v1): tracking subsections — schemas + machines + reactive (7 beads)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1028,9 +1028,23 @@ Per-host adapters for non-CLJS implementations ship as separate packages, implem
 
 A cooperative rendering substrate — a rendering layer designed natively to cooperate with re-frame, instead of re-frame wrapping Reagent — is on the horizon. Substrate-agnostic decoupling (this Spec) is the prerequisite. Whether the cooperative variant ships depends on a benefits-vs-cost evaluation in a later cycle. Deferred to rf2-8fyig.
 
+#### Post-v1 Tracking — rf2-8fyig
+
+- **Foundation in v1.** The adapter contract (per [§The adapter API contract](#the-adapter-api-contract)) is the substrate-decoupling primitive — any cooperative variant ships as another adapter, no core change required.
+- **Scope deferred.** The evaluation itself: identifying the cooperation primitives a native substrate could expose (e.g., scheduler-aware re-render coalescing, subscription-graph-driven scheduling, batched view updates aligned to drain boundaries), and the benefits-vs-cost ledger against staying with Reagent / UIx / Helix adapters.
+- **Reconsideration trigger.** Either (a) measured re-render overhead in the Reagent path becomes the dominant cost on a real workload, or (b) a tool (causa / pair2 / story) needs scheduling hooks the React substrates can't surface.
+- **Out of scope for the bead.** Building the cooperative substrate itself — the bead tracks the *decision*, not the implementation. A separate bead is filed if the evaluation lands "yes".
+
 ### Multi-adapter coexistence (post-v1, rf2-uipko)
 
 The current contract is single-adapter-per-process. If a concrete use case for per-frame adapter selection emerges, multi-adapter support can be added additively without breaking the single-adapter contract. Deferred to rf2-uipko.
+
+#### Post-v1 Tracking — rf2-uipko
+
+- **Foundation in v1.** The single-adapter contract (per [§Single adapter per process](#single-adapter-per-process)) is locked; per-frame adapter selection is an extension, not a replacement — the install slot becomes a map keyed by frame-id rather than a singleton.
+- **Scope deferred.** The lifting itself: dispatch envelope carrying the in-scope adapter, registrar / tool branching on which adapter a frame uses, error categories for cross-frame view mounts that span adapters.
+- **Reconsideration trigger.** A concrete app use case — e.g., a single process embedding a Reagent host alongside a UIx subtree, both backed by re-frame, where running them as separate processes is infeasible.
+- **Out of scope for the bead.** Multi-adapter *within a single frame* (one view tree mixing adapters) — that path is rejected per [§Single adapter per process](#single-adapter-per-process)'s reasoning and is not on the post-v1 ledger.
 
 ## Resolved decisions
 

--- a/spec/007-Stories.md
+++ b/spec/007-Stories.md
@@ -501,6 +501,13 @@ Workspaces are *not* frames (or not necessarily — they may be ordinary frames 
 
 Existing CLJS projects using devcards or other workspace tools should be able to consume re-frame2 stories with adapter shims. Deferred to rf2-9amwm.
 
+#### Post-v1 Tracking — rf2-9amwm
+
+- **Foundation in v1.** The variant id surface (`:story.<ns>/<variant>`) is stable; the registry is readable via `rf/variants` (per the story registry shape); rendered hiccup is a plain value.
+- **Scope deferred.** A thin adapter shim per host tool — devcards (`defcard` wrapping a `story/run-variant` call) and nubank/workspaces (workspace card from variant id) are the obvious first targets. No story-side change required.
+- **Reconsideration trigger.** A downstream project migrating from devcards/workspaces asks for the shim, or the story tool's own UI needs an embeddable card form.
+- **Out of scope for the bead.** Reverse direction (rendering a devcard inside a story workspace) — devcards' macro-time registration model doesn't compose cleanly with story's variant registry.
+
 ## Resolved decisions
 
 ### Should `story/reg-story` and `story/reg-variant` be separate, or unified?

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -394,13 +394,35 @@ Testing and stories share infrastructure (frames, overrides, drain, dispatch-syn
 
 Some tests want to capture a frame's `app-db` and replay it later (golden-master testing, regression checks). Foundation supports this trivially (`(spit "fixture.edn" (pr-str (get-frame-db f)))`); a helper is user-space. Deferred to rf2-wqsoy.
 
+#### Post-v1 Tracking — rf2-wqsoy
+
+- **Foundation in v1.** `get-frame-db` returns a plain value; `pr-str` / EDN reader round-trips it. No framework change is needed for the raw capture/replay path.
+- **Scope deferred.** A packaged helper (`golden-master`, `regression-check`) with the ergonomic API (file-naming convention, diff rendering, `clojure.test`-style failure report) is user-space library work.
+- **Reconsideration trigger.** A repeated pattern emerging across `examples/` or downstream tests that all hand-roll the same snapshot/diff scaffolding.
+- **Out of scope for the bead.** Cross-process replay (record-on-prod, replay-on-dev) — that wants the trace-buffer surface, not a snapshot helper.
+
 ### Property-based testing integration (post-v1, rf2-rs0ux)
 
 `test.check`-style generative testing fits cleanly into re-frame2 — `make-frame` is cheap, generators produce event sequences, properties check invariants. Documented as a pattern post-v1. Deferred to rf2-rs0ux.
 
+#### Post-v1 Tracking — rf2-rs0ux
+
+- **Foundation in v1.** `make-frame` is cheap and isolated; `dispatch-sync` settles synchronously per [Resolved decisions](#resolved-decisions); the schema-validator hook (Spec 010) gives invariants a place to live.
+- **Scope deferred.** A guide-tier pattern document: generators for event sequences, invariants expressed as schemas, shrinking strategies for `dispatch-sequence` failures. No framework primitive missing.
+- **Reconsideration trigger.** If schema-driven generation (per [010 §Schema-driven generative tests](010-Schemas.md#schema-driven-generative-tests-post-v1-rf2-rs0ux)) lands first, the pattern doc folds in directly.
+- **Out of scope for the bead.** A bundled `test.check` dependency — re-frame2 stays library-agnostic.
+
 ### Model-based testing harness over `machine-transition` (post-v1, rf2-vishf)
 
 `@xstate/test`-style: treat a transition table as a graph and *generate* test cases automatically — paths, state-coverage, transition-coverage, shortest-path-to-state, guard-coverage. The pure `machine-transition` function makes this cheap; the transition contract is sufficient to build the harness externally without runtime changes. Deferred to rf2-vishf.
+
+#### Post-v1 Tracking — rf2-vishf
+
+- **Foundation in v1.** `machine-transition` is pure and JVM-runnable; `:guards` and `:actions` are machine-scoped fns the harness can call directly; the corpus shape per [005 §Future — Model-based testing harness](005-StateMachines.md#model-based-testing-harness--re-framemachinestest) is locked.
+- **Scope deferred.** The packaged library (`rf/test/machine-paths`, `rf/test/shortest-path-to`, coverage strategy selectors, EDN fixture emitter) ships as `re-frame.machines.test` post-v1.
+- **Reconsideration trigger.** Either an AI-implementor needs the coverage corpus for cross-language conformance, or app-side machines start exhibiting edge-case bugs that hand-written tests miss.
+- **Out of scope for the bead.** Time-travel / step-debugger over the generated paths — separate concern, lives in the tool layer (causa/pair2).
+- **Cross-link.** See [005 §Future — Model-based testing harness](005-StateMachines.md#model-based-testing-harness--re-framemachinestest) for the substrate-side framing.
 
 Sketch of the surface:
 

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -640,6 +640,13 @@ Most schema libraries ship generators that produce values matching a schema (Mal
 
 Apps evolve; `app-db` shapes evolve; schemas evolve. Whether re-frame2 ships a versioning convention (e.g., `(reg-app-schema [:user] UserSchema {:version 3})`) for schema-aware migration tooling is post-v1; tracked at rf2-7fk8a.
 
+#### Post-v1 Tracking — rf2-7fk8a
+
+- **Foundation in v1.** `reg-app-schema` already accepts an opts map (per [§The four normative claims](#the-four-normative-claims)); adding a `:version <pos-int>` key is additive — current registrations stay valid.
+- **Scope deferred.** The convention itself (canonical key name, default semantics when absent, comparison rule on hot-reload, migration-helper signature) is the post-v1 design surface. v1 ships the validator-pluggability primitive without locking the versioning grammar.
+- **Reconsideration trigger.** Either (a) a concrete app reports schema-evolution bugs that the hot-reload `:rf.spec/violation` trace (per [§Schema migration on hot-reload](#schema-migration-on-hot-reload)) cannot diagnose, or (b) a tool (story, causa, pair2) needs to assert a known shape-revision across runs.
+- **Out of scope for the bead.** App-level migration runner (sequenced `db -> db'` transforms keyed on version delta) is library territory, not framework.
+
 ## Resolved decisions
 
 ### Schema migration on hot-reload


### PR DESCRIPTION
## Scope
Adds tight, decision-anchored \"Post-v1 Tracking\" subsections to spec/010 + spec/008 + spec/007 + spec/006, one per bead. Each subsection carries: foundation in v1, scope deferred, reconsideration trigger, out-of-scope edge — keeping the SA-4 \`:post-v1 tracked\` items concrete rather than open-ended.

> WARNING: spec/006 is on the hot-zone list — committed last in this PR for clean partial-revert if needed.

## Files
- spec/010-Schemas.md (rf2-7fk8a — schema versioning)
- spec/008-Testing.md (rf2-wqsoy snapshots, rf2-rs0ux property-based, rf2-vishf model-based)
- spec/007-Stories.md (rf2-9amwm — devcards/workspaces interop)
- spec/006-ReactiveSubstrate.md (rf2-uipko multi-adapter, rf2-8fyig cooperative substrate) ← HOT-ZONE, sequenced last

## Commit order
1. spec(010) → rf2-7fk8a
2. spec(008) → rf2-wqsoy + rs0ux + vishf (batched)
3. spec(007) → rf2-9amwm
4. spec(006) → rf2-uipko + 8fyig (HOT, last)

## Gates
- mkdocs --strict: no regression vs origin/main baseline (both = 68 warnings — all pre-existing spec/ path issues unrelated to this PR; spec docs are not registered in mkdocs nav)

Closes rf2-7fk8a, rf2-vishf, rf2-rs0ux, rf2-wqsoy, rf2-9amwm, rf2-uipko, rf2-8fyig