### PR TITLE
fix(spec): example drift — 010 :event-fx + 001 macro coords + Pattern-Boot :http (rf2-32i14)

### DIFF
--- a/spec/001-Registration.md
+++ b/spec/001-Registration.md
@@ -128,7 +128,8 @@ The CLJS reference uses macros to capture `:ns` / `:line` / `:column` / `:file` 
 (defmacro reg-event-db
   [id & args]
   (let [[metadata handler] (resolve-args args)
-        coords {:ns &env :line ... :column ... :file ...}]
+        {:keys [line column]} (meta &form)
+        coords {:ns (ns-name *ns*) :line line :column column :file *file*}]
     `(re-frame.core/-reg-event-db
        ~id
        ~(merge coords metadata)

--- a/spec/010-Schemas.md
+++ b/spec/010-Schemas.md
@@ -180,8 +180,8 @@ Production builds in this configuration: 99% of code has zero validation overhea
 Schemas registered against handlers and `app-db` paths are queryable via the public registrar query API ([002 §The public registrar query API](002-Frames.md#the-public-registrar-query-api)):
 
 ```clojure
-(rf/handler-meta :event-fx :auth/login)
-;; → {:doc "..." :spec [:cat ...] :ns ... :line ... :file ...}
+(rf/handler-meta :event :auth/login)
+;; → {:doc "..." :spec [:cat ...] :event/kind :fx :ns ... :line ... :file ...}
 
 (rf/app-schema-at [:user])
 ;; → UserSchema (the registered schema value, in whatever language the

--- a/spec/Pattern-Boot.md
+++ b/spec/Pattern-Boot.md
@@ -46,6 +46,8 @@ For trivial boots (one or two steps, no error states, no progress UI), a state m
   (fn [db _] (assoc db :app/booted? true)))
 ```
 
+(`:http` here is a placeholder for a user-supplied fx; the framework ships `:rf.http/managed` — see [014-HTTPRequests](014-HTTPRequests.md).)
+
 Each step is a Pattern-AsyncEffect interaction. The frame's `:on-create` fires `:app/init` (per [002 §`reg-frame` is atomic](002-Frames.md#reg-frame--atomic-create-and-register-and-the-canonical-metadata-grammar)), the chain runs to completion, the UI renders.
 
 Use this form when the boot graph is **3 steps or fewer**, has **no error states**, and the UI does **not** show per-phase progress.


### PR DESCRIPTION
## Summary

Three small example-drift fixes bundled (audit rf2-m84iv F8 + F14 + F10).

- **spec/010-Schemas.md** — `(rf/handler-meta :event-fx :auth/login)` was using a non-existent registrar kind. The Spec 001 closed kinds set has one `:event` kind for all three `reg-event-*` flavours; the sub-kind lives on metadata as `:event/kind`. Now `(rf/handler-meta :event :auth/login)`, and the example return-map carries `:event/kind :fx` to match the shape shown in 001/002/005/014/API.
- **spec/001-Registration.md** — the `reg-event-db` macro pseudo-code constructed coords as `{:ns &env :line ... :column ... :file ...}`, contradicting the prose immediately below ("`:ns` and `:file` come from the compile-time `*ns*` / `*file*`") and the CLJS reference impl (`re-frame.source-coords`). Rewrote to use `(ns-name *ns*)`, `(meta &form)`, and `*file*`.
- **spec/Pattern-Boot.md** — the chained-events example used `[:http {...}]` without the placeholder callout that Spec 002, 007 and 008 already ship. Added a one-line note pointing readers to `:rf.http/managed` in 014-HTTPRequests.

No semantic redesign — each edit aligns the example with canonical truth that already lives elsewhere in spec/ and implementation/.

## Hot-zone

010 is a hot-zone file; this PR is a single-keyword swap with zero semantic change. 001 and Pattern-Boot are not hot-zone.

## Build

`python -m mkdocs build --strict` → 68 warnings (baseline; none reference the three files touched).

## Test plan

- [x] mkdocs strict build matches 68-warning baseline
- [x] No new broken links from the three edited files
- [x] Edited examples now match canonical query shape (001 §184, 014 §204, API §316) and impl (`re-frame.source-coords`)

Closes rf2-32i14.