### PR TITLE
test(elision): runtime DCE + advanced runners + async-escape warn (3 beads)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/frame_provider_render_key_elision_prod_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_render_key_elision_prod_test.cljs
@@ -1,0 +1,133 @@
+(ns re-frame.frame-provider-render-key-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-l7hlm) — `:advanced` +
+  `goog.DEBUG=false` runtime contract for the dev-only frame-provider /
+  render-tree machinery owned by `re-frame.views`. Companion to:
+
+   - `re-frame.source-coord-dom-elision-prod-test` (rf2-uwg5) — pins
+     the `data-rf2-source-coord` DOM-injection elision specifically.
+   - `re-frame.trace-listener-elision-prod-test` (rf2-2zdu) — pins the
+     trace surface elision.
+
+  This file pins the *render-key* binding + `:view/render` trace
+  surface that the `reg-view*` wrapper installs on every rendered view.
+  Under prod-mode the `emit-render-trace!` body (gated on
+  `interop/debug-enabled?`) DCEs, and the `view-coord-attr` capture
+  also DCEs — but the rest of the wrapper (the `:contextType`
+  attachment, the `*render-key*` binding, the `apply render-fn args`)
+  stays intact. The view renders correctly; the dev-only trace
+  metadata simply does not emit.
+
+  Surfaces exercised:
+
+  - The wrapper's `:view/render` trace — NO trace event observed under
+    prod.
+  - `*render-key*` — still BOUND under prod (the wrapper's `binding`
+    is not gated; the binding is read by `current-render-key` which
+    consumers may call defensively).
+  - `current-render-key` — returns the `[view-id token]` shape inside
+    the wrapper render even under prod (no anonymous fallback).
+  - Source-coord injection — already pinned in
+    `re-frame.source-coord-dom-elision-prod-test`; we touch it once
+    here to confirm the cross-cutting elision still holds when the
+    test exercises the render-key surface.
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. Running
+  under `goog.DEBUG=true` would FAIL — under dev the `:view/render`
+  trace fires for every render."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.views :as views]
+            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- :view/render trace does not fire under prod -------------------------
+
+(deftest reg-view-render-emits-no-view-render-trace-under-prod
+  (testing "Per Spec 009 §Production builds (rf2-l7hlm): every render
+            of a `reg-view*`-registered view fires a `:view/render`
+            trace under dev. Under prod the entire emit body (gated on
+            `interop/debug-enabled?`) DCEs — a registered trace
+            listener observes NO `:view/render` event when the wrapper
+            renders. The wrapper still calls the user fn — only the
+            trace metadata elides."
+    (let [seen (atom [])]
+      (trace-tooling/register-trace-cb!
+        ::prod-view-listener
+        (fn [ev] (swap! seen conj ev)))
+      (rf/reg-view* :prod-frame-provider/sample
+                    (fn [] [:span "rendered"]))
+      (let [wrapper (rf/view :prod-frame-provider/sample)
+            out     (wrapper)]
+        (is (vector? out) "wrapper invoked the user fn — render still produced hiccup")
+        (is (= :span (first out)) "root tag preserved"))
+      (is (empty? @seen)
+          "no trace events delivered — :view/render elides under
+           :advanced + goog.DEBUG=false")
+      (trace-tooling/remove-trace-cb! ::prod-view-listener))))
+
+;; ---- current-render-key still binds under prod ---------------------------
+
+(deftest current-render-key-binding-survives-elision-under-prod
+  (testing "Per Spec 004 §Render-tree primitives: the
+            `binding [*render-key* ...]` form sits in the wrapper body
+            BUT is not itself gated on `interop/debug-enabled?` — only
+            the `emit-render-trace!` body inside the binding is gated.
+            Under prod the binding still takes effect; consumers that
+            call `current-render-key` defensively (e.g. error-emit
+            source-coord stamping) get the proper shape, not the
+            anonymous fallback. This guards against a future change
+            that mistakenly tucks the binding under the gate."
+    (let [observed-key (atom nil)]
+      (rf/reg-view* :prod-frame-provider/key-reader
+        (fn []
+          (reset! observed-key (views/current-render-key))
+          [:span "key-reader"]))
+      (let [wrapper (rf/view :prod-frame-provider/key-reader)
+            _out    (wrapper)]
+        (is (vector? @observed-key)
+            "*render-key* is bound to a vector inside the render under prod")
+        (is (= :prod-frame-provider/key-reader (first @observed-key))
+            "the view-id slot of *render-key* survives under prod")
+        (is (some? (second @observed-key))
+            "the instance-token slot of *render-key* survives under prod")))))
+
+;; ---- mint-instance-token! survives (value-layer machinery) ---------------
+
+(deftest mint-instance-token-survives-under-prod
+  (testing "Per Spec 004 §Render-tree primitives: `mint-instance-token!`
+            is value-layer machinery (a swap! on the process-wide
+            `instance-counter` atom). It is NOT gated — calling it
+            under prod returns a fresh integer. The token's only
+            consumer (the trace emit and the dev source-coord stamp)
+            elides, but the mint surface itself is safe to call."
+    (let [t1 (views/mint-instance-token!)
+          t2 (views/mint-instance-token!)]
+      (is (integer? t1) "mint returns an integer under prod")
+      (is (integer? t2) "second call also returns an integer")
+      (is (not= t1 t2)
+          "the counter still advances under prod — the value-layer
+           machinery survives elision; only the dev-only consumer
+           (the trace surface) elides"))))
+
+;; ---- current-render-key outside a render-key binding falls through -------
+
+(deftest current-render-key-anonymous-fallback-under-prod
+  (testing "Per Spec 004 §Render-tree primitives: outside a registered
+            view's render, `current-render-key` returns the documented
+            anonymous fallback `[:rf.view/anonymous nil]`. The
+            fallback shape itself survives prod because the
+            `or *render-key* [:rf.view/anonymous nil]` form is not
+            gated — anonymous-render context is a documented prod-mode
+            shape too (e.g. headless tests calling `current-render-key`
+            outside any reg-view* wrapper)."
+    (is (= [:rf.view/anonymous nil]
+           (views/current-render-key))
+        "current-render-key returns the anonymous fallback outside a
+         render under prod")))

--- a/implementation/core/test/re_frame/dispatch_fallthrough_warn_cljs_test.cljs
+++ b/implementation/core/test/re_frame/dispatch_fallthrough_warn_cljs_test.cljs
@@ -1,0 +1,281 @@
+(ns re-frame.dispatch-fallthrough-warn-cljs-test
+  "Per rf2-nmusx — CLJS-side integration coverage for the async-escape
+  fallthrough warning (`:rf.warning/dispatch-from-async-callback-fell-
+  through-to-default`). The JVM test `re-frame.dispatch-fallthrough-
+  warn-test` simulates the trigger by rebinding `frame/*current-frame*`
+  to nil; this file exercises the REAL JS async-callback surfaces
+  (`setTimeout`, `addEventListener`, `requestAnimationFrame`) so the
+  end-to-end trigger path is pinned.
+
+  Why both: the JVM proxy validates the runtime's detection logic; the
+  CLJS integration test validates that the canonical JS async-escape
+  surfaces actually produce the trigger envelope. A future refactor of
+  the router's frame-resolution chain (or of how `*current-frame*`
+  loses its dynamic binding across the JS event loop) could regress
+  the integration shape without disturbing the JVM proxy.
+
+  Each test:
+  1. registers a non-default frame (precondition; single-frame apps
+     do not see the warning),
+  2. records every trace event via `register-trace-cb!`,
+  3. dispatches `[:game/tick]` (handler intentionally NOT registered)
+     from inside the relevant JS callback,
+  4. awaits the callback to fire via `cljs.test/async`,
+  5. asserts exactly one `:rf.warning/dispatch-from-async-callback-fell-
+     through-to-default` is observed with the documented payload shape.
+
+  The `:detected-at` numeric, the `:routed-to` :rf/default,
+  the `:recovery` :no-recovery, and the human-readable `:reason`
+  string are all pinned (they are the user-facing surface the warning
+  exists to deliver).
+
+  Naming convention: the `-cljs-test$` suffix means this file runs
+  under the default `:browser-test` build (Playwright + jsdom-style
+  shell). The async-callback surfaces are real browser APIs; jsdom
+  provides `setTimeout`, `addEventListener`, and `requestAnimationFrame`
+  via a polyfill where needed."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.test-support :as test-support]
+            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; Per cljs.test: async tests require fixtures supplied as a map
+;; (fn-form fixtures don't suspend across the async body, so a finally
+;; clause runs before the async work completes). Mirrors the rf2-l5q3
+;; CLJS async-test idiom in
+;; re-frame.dispatch-frame-capture-cljs-test.
+
+(def ^:private registrar-snapshot (atom nil))
+
+(defn- before! []
+  (reset! registrar-snapshot (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (trace-tooling/clear-trace-cbs!)
+  (substrate-adapter/install-adapter! reagent-adapter/adapter)
+  (frame/ensure-default-frame!))
+
+(defn- after! []
+  (when-let [snap @registrar-snapshot]
+    (test-support/restore-registrar! snap)
+    (reset! registrar-snapshot nil))
+  (reset! frame/frames {})
+  (trace-tooling/clear-trace-cbs!))
+
+(use-fixtures :each {:before before! :after after!})
+
+;; ---- browser gate --------------------------------------------------------
+;;
+;; This ns is loaded by both :node-test (matches `cljs-test$`) and
+;; :browser-test (matches `-cljs-test$`). Two of the three async-callback
+;; surfaces (`addEventListener` on a DOM node, `requestAnimationFrame`)
+;; require a real browser. setTimeout is universal. Each test gates its
+;; body on `(browser?)` where needed and exits early under :node-test
+;; with a `(is true ...)` placeholder so the silent-on-success reporter
+;; still observes a passing assertion.
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- raf-available? []
+  (exists? js/requestAnimationFrame))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces!
+  "Install a recording listener; return the atom that accumulates events."
+  [listener-id]
+  (let [a (atom [])]
+    (trace-tooling/register-trace-cb!
+      listener-id
+      (fn [ev] (swap! a conj ev)))
+    a))
+
+(defn- fallthrough-warnings
+  "Filter recorded events to the async-escape fallthrough warning."
+  [recorded]
+  (filterv (fn [ev]
+             (and (= :warning (:op-type ev))
+                  (= :rf.warning/dispatch-from-async-callback-fell-through-to-default
+                     (:operation ev))))
+           @recorded))
+
+(defn- assert-canonical-warn!
+  "Pin every documented payload slot on the captured warning event so a
+  silent shape-drift surfaces."
+  [warn]
+  (let [tags (:tags warn)]
+    (is (= [:game/tick] (:event tags))
+        ":event tag carries the original event vector")
+    (is (= :game/tick (:event-id tags))
+        ":event-id tag is the first-of-event keyword")
+    (is (= :rf/default (:routed-to tags))
+        ":routed-to tag pins the fallthrough target")
+    (is (number? (:detected-at tags))
+        ":detected-at tag is a numeric timestamp")
+    (is (string? (:reason tags))
+        ":reason tag is a human-readable explanation string")
+    (is (re-find #"setTimeout|addEventListener|async"
+                 (:reason tags))
+        ":reason references the async-callback trigger surfaces")
+    (is (= :no-recovery (:recovery warn))
+        ":recovery slot pins the no-recovery contract")))
+
+(defn- setup!
+  "Common setup: register a non-default frame so the warning's
+  single-frame-suppression guard does not fire. The :game/tick handler
+  is intentionally NOT registered — that is the precondition for the
+  warning."
+  []
+  (rf/reg-frame :game {:doc "non-default frame the user intended"}))
+
+;; ---- setTimeout integration ----------------------------------------------
+
+(deftest fires-from-setTimeout-callback
+  (testing "Per rf2-nmusx: dispatching from a `setTimeout(fn, 0)`
+            callback for a handler intended for a non-default frame
+            but missing on `:rf/default` fires the async-escape
+            fallthrough warning. The setTimeout callback runs on a
+            fresh JS event-loop turn — the surrounding
+            `*current-frame*` binding does NOT survive the boundary."
+    (async done
+      (setup!)
+      (let [recorded (record-traces! ::set-timeout-fallthrough)]
+        ;; Wrap the dispatch in a setTimeout-0 callback — the canonical
+        ;; "fresh stack, no surrounding frame binding" shape.
+        (js/setTimeout
+          (fn []
+            (try
+              (rf/dispatch-sync [:game/tick])
+              (catch :default _e
+                ;; The handler is intentionally missing — the runtime
+                ;; emits the :rf.error/no-such-handler trace and may
+                ;; or may not throw depending on the per-category
+                ;; recovery; we don't care about the throw here, only
+                ;; about the trace.
+                nil))
+            (let [warns (fallthrough-warnings recorded)]
+              (is (= 1 (count warns))
+                  (str "expected exactly one fallthrough warning from
+                        the setTimeout callback, got " (count warns)))
+              (when (seq warns)
+                (assert-canonical-warn! (first warns))))
+            (trace-tooling/remove-trace-cb! ::set-timeout-fallthrough)
+            (done))
+          0)))))
+
+;; ---- addEventListener integration ----------------------------------------
+
+(deftest fires-from-addEventListener-callback
+  (testing "Per rf2-nmusx: dispatching from an `addEventListener`
+            callback for a handler intended for a non-default frame
+            but missing on `:rf/default` fires the warning. The
+            listener runs on a fresh event-loop turn just like
+            setTimeout — the canonical 2048-tile rf2-o8m0 trigger."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the
+                addEventListener assertions")
+      (async done
+      (setup!)
+      (let [recorded     (record-traces! ::add-event-listener-fallthrough)
+            ;; Create a transient DOM node so we don't depend on
+            ;; anything ambient. jsdom supports document.createElement
+            ;; + dispatchEvent + addEventListener out of the box.
+            target       (js/document.createElement "div")
+            handler-ref  (atom nil)
+            handler      (fn [_ev]
+                           (try
+                             (rf/dispatch-sync [:game/tick])
+                             (catch :default _e nil))
+                           (let [warns (fallthrough-warnings recorded)]
+                             (is (= 1 (count warns))
+                                 (str "expected exactly one fallthrough
+                                       warning from the addEventListener
+                                       callback, got " (count warns)))
+                             (when (seq warns)
+                               (assert-canonical-warn! (first warns))))
+                           (.removeEventListener target "click" @handler-ref)
+                           (trace-tooling/remove-trace-cb!
+                             ::add-event-listener-fallthrough)
+                           (done))]
+        (reset! handler-ref handler)
+        (.addEventListener target "click" handler)
+        (.dispatchEvent target (js/Event. "click")))))))
+
+;; ---- requestAnimationFrame integration -----------------------------------
+
+(deftest fires-from-requestAnimationFrame-callback
+  (testing "Per rf2-nmusx: dispatching from a `requestAnimationFrame`
+            callback for a handler intended for a non-default frame
+            but missing on `:rf/default` fires the warning. rAF runs
+            on its own event-loop step; the surrounding frame binding
+            does not survive."
+    (if-not (raf-available?)
+      (is true ":node-test: no requestAnimationFrame — browser-test
+                runner exercises the rAF assertions")
+      (async done
+        (setup!)
+        (let [recorded (record-traces! ::raf-fallthrough)]
+          (js/requestAnimationFrame
+            (fn [_ts]
+              (try
+                (rf/dispatch-sync [:game/tick])
+                (catch :default _e nil))
+              (let [warns (fallthrough-warnings recorded)]
+                (is (= 1 (count warns))
+                    (str "expected exactly one fallthrough warning from
+                          the requestAnimationFrame callback, got "
+                         (count warns)))
+                (when (seq warns)
+                  (assert-canonical-warn! (first warns))))
+              (trace-tooling/remove-trace-cb! ::raf-fallthrough)
+              (done))))))))
+
+;; ---- suppression: single-frame app does not fire the warn ----------------
+
+(deftest suppressed-from-setTimeout-when-only-default-frame
+  (testing "Per rf2-nmusx / rf2-o8m0: single-frame apps (only
+            `:rf/default`) cannot hit the footgun — the warning is
+            suppressed even when dispatched from an async-callback
+            for a handler that does not exist on `:rf/default`. The
+            existing `:rf.error/no-such-handler` trace still fires
+            (existing contract preserved)."
+    (async done
+      ;; Note: no setup! call — the only frame is :rf/default.
+      (let [recorded (record-traces! ::single-frame-async)]
+        (js/setTimeout
+          (fn []
+            (try
+              (rf/dispatch-sync [:never-registered])
+              (catch :default _e nil))
+            (is (empty? (fallthrough-warnings recorded))
+                "warning suppressed: single-frame apps cannot hit the footgun")
+            (trace-tooling/remove-trace-cb! ::single-frame-async)
+            (done))
+          0)))))
+
+;; ---- suppression: explicit :frame opt is not a fallthrough ---------------
+
+(deftest suppressed-from-setTimeout-when-explicit-frame-opt
+  (testing "Per rf2-nmusx / rf2-o8m0: an explicit `:frame` opt on the
+            dispatch means the user was deliberate — the resolution
+            chain never falls through. No warning fires even from an
+            async callback, even when the handler is missing."
+    (async done
+      (setup!)
+      (let [recorded (record-traces! ::explicit-frame-async)]
+        (js/setTimeout
+          (fn []
+            (try
+              (rf/dispatch-sync [:game/tick] {:frame :game})
+              (catch :default _e nil))
+            (is (empty? (fallthrough-warnings recorded))
+                "explicit :frame opt is not a fallthrough — warning suppressed")
+            (trace-tooling/remove-trace-cb! ::explicit-frame-async)
+            (done))
+          0)))))

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -31,7 +31,17 @@
             ;; semantics rule 4 + Resolved decisions, rf2-0q0du).
             ;; This prod-elision test pins the production-survival
             ;; contract under `:advanced` + `goog.DEBUG=false`.
-            [re-frame.flow-eval-exception-elision-prod-test]))
+            [re-frame.flow-eval-exception-elision-prod-test]
+            ;; Per rf2-xxd6z — runtime prod-elision pins for the
+            ;; routing / http / flows trace-emit surfaces. Companion
+            ;; behavioural check to the string-grep sentinel sweep in
+            ;; `scripts/check-elision.cjs`; pins that no `:rf.route/*`
+            ;; / `:rf.http/*` / `:rf.flow/*` events are delivered to a
+            ;; registered trace listener under `:advanced` +
+            ;; `goog.DEBUG=false`.
+            [re-frame.routing-trace-emit-elision-prod-test]
+            [re-frame.http-trace-emit-elision-prod-test]
+            [re-frame.flows-trace-emit-elision-prod-test]))
 
 (defn ^:export init []
   (-> (env/get-test-data)

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -41,7 +41,18 @@
             ;; `goog.DEBUG=false`.
             [re-frame.routing-trace-emit-elision-prod-test]
             [re-frame.http-trace-emit-elision-prod-test]
-            [re-frame.flows-trace-emit-elision-prod-test]))
+            [re-frame.flows-trace-emit-elision-prod-test]
+            ;; Per rf2-l7hlm — `:advanced` prod-elision pins replicated
+            ;; for the trace-bus (ring buffer), epoch (Tool-Pair
+            ;; §Time-travel surface), and frame-provider / render-key
+            ;; (Spec 004 §Render-tree primitives) machinery. Sibling
+            ;; to the existing rf2-2zdu (trace listener),
+            ;; rf2-hqbeh (`:on-error`) and rf2-uwg5 (source-coord DOM)
+            ;; pins; together they cover every dev-only sub-surface
+            ;; under `:advanced` + `goog.DEBUG=false`.
+            [re-frame.trace-bus-elision-prod-test]
+            [re-frame.epoch-elision-prod-test]
+            [re-frame.frame-provider-render-key-elision-prod-test]))
 
 (defn ^:export init []
   (-> (env/get-test-data)

--- a/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/trace_bus_elision_prod_test.cljs
@@ -1,0 +1,103 @@
+(ns re-frame.trace-bus-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-l7hlm) — `:advanced` +
+  `goog.DEBUG=false` runtime contract for the `re-frame.trace.tooling`
+  RING BUFFER (the 'trace bus'). Companion to
+  `re-frame.trace-listener-elision-prod-test` (rf2-2zdu) which covers
+  the listener fan-out side of the trace surface; this file pins the
+  buffer side.
+
+  Under prod-mode the buffer surface's bodies all sit inside `(when
+  interop/debug-enabled? ...)` — `configure-trace-buffer!` /
+  `clear-trace-buffer!` no-op silently; `trace-buffer` returns nil
+  rather than the buffer vector. The defonce'd atom itself remains
+  (it's a value-layer artefact, not gated), but no caller can populate
+  it because every push site sits inside the gated `deliver!` /
+  `emit!` chain.
+
+  Per Spec 009 §Retain-N trace ring buffer (rf2-smee): the buffer is a
+  dev-only inspection surface. Production observability rides the
+  always-on event-emit / error-emit substrates instead.
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. Running
+  this file under `goog.DEBUG=true` would FAIL by design — under dev
+  the buffer accumulates events as designed."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]
+            ;; rf2-qwm0a — buffer + listener surface lives in
+            ;; `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- ring buffer is empty under prod -------------------------------------
+
+(deftest dispatched-events-do-not-populate-trace-buffer-under-prod
+  (testing "Per Spec 009 §Production builds (rf2-l7hlm): under
+            `:advanced` + `goog.DEBUG=false` a registered handler
+            fires through the router but NO events reach the trace
+            ring buffer. Every emit site's body sits inside the
+            `interop/debug-enabled?` gate; the buffer's push site
+            (inside `deliver!`) does not run."
+    (rf/reg-event-db :prod-bus/inc
+                     (fn [db _] (update db :n (fnil inc 0))))
+    (rf/dispatch-sync [:prod-bus/inc])
+    (rf/dispatch-sync [:prod-bus/inc])
+    (rf/dispatch-sync [:prod-bus/inc])
+    ;; trace-buffer's body is gated; under prod it returns nil.
+    (is (or (nil? (trace-tooling/trace-buffer))
+            (empty? (trace-tooling/trace-buffer)))
+        "trace-buffer is nil or empty under :advanced + goog.DEBUG=false
+         — buffer surface elides while the handler still runs")
+    ;; Cross-check: the handler DID run — only the trace surface elided.
+    (is (= 3 (:n (rf/get-frame-db :rf/default)))
+        "handler ran the expected number of times — only the trace
+         surface (buffer + listener) elided")))
+
+(deftest configure-trace-buffer-is-noop-under-prod
+  (testing "Per Spec 009 §Production builds: `configure-trace-buffer!`
+            is gated on `interop/debug-enabled?`. Under prod the call
+            returns nil silently — apps that boot with a
+            configure-trace-buffer call do not crash under :advanced,
+            but the requested depth has no effect."
+    (is (nil? (trace-tooling/configure-trace-buffer! {:depth 256}))
+        "configure-trace-buffer! returns nil consistently under prod")
+    ;; Subsequent dispatches still do not push to the buffer.
+    (rf/reg-event-db :prod-bus/touch (fn [db _] db))
+    (rf/dispatch-sync [:prod-bus/touch])
+    (is (or (nil? (trace-tooling/trace-buffer))
+            (empty? (trace-tooling/trace-buffer)))
+        "buffer remains empty after configure + dispatch under prod")))
+
+(deftest clear-trace-buffer-is-noop-under-prod
+  (testing "Per Spec 009 §Production builds: `clear-trace-buffer!` is
+            gated and a no-op under prod. Tools that call it as part of
+            a session-reset (re-frame-10x's `Clear` button) do not
+            crash on a production bundle that happens to load
+            re-frame.trace.tooling for non-buffer surfaces."
+    (is (nil? (trace-tooling/clear-trace-buffer!))
+        "clear-trace-buffer! returns nil under prod")))
+
+(deftest trace-emit-direct-call-does-not-populate-buffer-under-prod
+  (testing "Per Spec 009 §Production builds: directly invoking
+            `trace/emit!` does not push to the buffer. The emit body
+            elides before any deliver-to-buffer call site is reached."
+    (trace/emit! :info :rf.prod-bus/direct {:should "never appear"})
+    (trace/emit! :event :rf.prod-bus/sample {:also "never appear"})
+    (is (or (nil? (trace-tooling/trace-buffer))
+            (empty? (trace-tooling/trace-buffer)))
+        "buffer remains empty after direct emit calls under prod")))
+
+(deftest trace-configure-is-noop-under-prod
+  (testing "Per Spec 009 §Production builds: the generic `configure`
+            dispatch (currently `:trace-buffer`) is also gated. Apps
+            that boot via `(re-frame.core/configure :trace-buffer ...)`
+            do not crash under :advanced; the requested config is
+            silently dropped."
+    (is (nil? (rf/configure :trace-buffer {:depth 64}))
+        "configure :trace-buffer returns nil under prod")))

--- a/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_elision_prod_test.cljs
@@ -1,0 +1,164 @@
+(ns re-frame.epoch-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-l7hlm) — `:advanced` +
+  `goog.DEBUG=false` runtime contract for `re-frame.epoch` (Tool-Pair
+  §Time-travel). Companion to the string-grep sentinel sweep in
+  `scripts/check-elision.cjs` (which already covers every `:rf.epoch/*`
+  keyword's literal absence); this file pins the BEHAVIOUR.
+
+  Surfaces gated by `interop/debug-enabled?` (per `epoch.cljc` body
+  inspection):
+
+  - `settle!`                — `(when interop/debug-enabled? ...)` —
+                                no epoch-record is committed; the
+                                ring buffer stays empty; listeners do
+                                not fire.
+  - `capture-event!`          — `(when interop/debug-enabled? ...)` —
+                                trace events do not accumulate in the
+                                per-cascade capture buffer.
+  - `restore-epoch`           — `(if-not interop/debug-enabled? false ...)`
+                                — returns `false` and never invokes
+                                the restore machinery.
+  - `reset-frame-db!`         — `(if-not interop/debug-enabled? false ...)`
+                                — Pair-tool write surface returns
+                                `false` without mutating app-db.
+  - `on-frame-destroyed!`     — `(when interop/debug-enabled? ...)` —
+                                no `:rf.epoch.cb/silenced-on-frame-
+                                destroy` trace fires; no capture-buffer
+                                discard.
+
+  Surfaces deliberately NOT gated (value-layer registrar machinery —
+  registration sites survive; only the dev-side delivery elides):
+
+  - `register-epoch-cb!` / `remove-epoch-cb!` / `clear-epoch-cbs!`
+  - `epoch-history` / `clear-history!`
+  - `configure :epoch-history`
+
+  These are safe to invoke under prod; they just have nothing to do —
+  no record is ever produced by `settle!` for them to fan out, so the
+  registry remains valid but dead-on-arrival. The test below pins both
+  halves of the contract.
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. Running
+  under `goog.DEBUG=true` would FAIL — under dev these surfaces deliver
+  records, populate history, and accept time-travel restores."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            [re-frame.epoch :as epoch]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- settle! commits no record under prod --------------------------------
+
+(deftest dispatch-produces-no-epoch-record-under-prod
+  (testing "Per Spec 009 §Production builds (rf2-l7hlm): under
+            `:advanced` + `goog.DEBUG=false`, dispatching events
+            mutates app-db as expected but `settle!` does NOT commit
+            an `:rf/epoch-record`. The whole settle! body sits inside
+            `(when interop/debug-enabled? ...)` — the per-frame
+            history vector stays empty."
+    (rf/configure :epoch-history {:depth 100})
+    (rf/reg-event-db :prod-epoch/inc
+                     (fn [db _] (update db :n (fnil inc 0))))
+    (rf/dispatch-sync [:prod-epoch/inc])
+    (rf/dispatch-sync [:prod-epoch/inc])
+    (rf/dispatch-sync [:prod-epoch/inc])
+    (is (= 3 (:n (rf/get-frame-db :rf/default)))
+        "handler ran the expected number of times — only epoch surface elided")
+    (is (empty? (rf/epoch-history :rf/default))
+        "no records appended to per-frame history under prod —
+         settle! body DCE'd; the depth-100 configure has no effect")))
+
+;; ---- listeners do not fire under prod ------------------------------------
+
+(deftest registered-epoch-cb-does-not-fire-under-prod
+  (testing "Per Spec 009 §Production builds: an installed
+            `register-epoch-cb!` listener observes NO records under
+            prod. The settle! body's notify-listeners! call does not
+            run (it sits inside the same gate as the record build)."
+    (let [seen (atom [])]
+      (rf/register-epoch-cb! ::prod-epoch-listener
+        (fn [record] (swap! seen conj record)))
+      (rf/reg-event-db :prod-epoch/ping
+                       (fn [db _] (assoc db :pinged? true)))
+      (rf/dispatch-sync [:prod-epoch/ping])
+      (rf/dispatch-sync [:prod-epoch/ping])
+      (is (empty? @seen)
+          "no records delivered to the listener under
+           :advanced + goog.DEBUG=false")
+      (rf/remove-epoch-cb! ::prod-epoch-listener))))
+
+;; ---- restore-epoch is a no-op returning false under prod -----------------
+
+(deftest restore-epoch-returns-false-under-prod
+  (testing "Per Spec 009 §Production builds: `restore-epoch` is gated
+            on `interop/debug-enabled?` via an `(if-not …)`
+            early-return. Under prod it returns `false` for every
+            (frame-id, epoch-id) pair — the precondition checks and
+            perform-restore branch DCE entirely."
+    (is (false? (rf/restore-epoch :rf/default 0))
+        "restore-epoch returns false under prod for a never-recorded epoch")
+    (is (false? (rf/restore-epoch :rf/default 999999))
+        "restore-epoch returns false under prod for any epoch-id")
+    (is (false? (rf/restore-epoch :rf.nonexistent/frame 0))
+        "restore-epoch returns false under prod even for an unknown frame")))
+
+;; ---- reset-frame-db! is a no-op returning false under prod ---------------
+
+(deftest reset-frame-db-returns-false-under-prod
+  (testing "Per Spec 009 §Production builds: `reset-frame-db!` (Tool-
+            Pair §Pair-tool writes) is gated on `interop/debug-enabled?`
+            via an `(if-not …)` early-return. Under prod it returns
+            `false` WITHOUT mutating app-db — the dev-only Pair-tool
+            write surface is firewalled from production state."
+    (rf/reg-event-db :prod-epoch/seed
+                     (fn [_db _] {:original true}))
+    (rf/dispatch-sync [:prod-epoch/seed])
+    (is (= {:original true}
+           (rf/get-frame-db :rf/default))
+        "baseline: app-db has the seeded value")
+    (is (false? (rf/reset-frame-db! :rf/default {:replaced :should-not-stick}))
+        "reset-frame-db! returns false under prod")
+    (is (= {:original true}
+           (rf/get-frame-db :rf/default))
+        "app-db is UNCHANGED under prod — Pair-tool write firewalled
+         from production state")))
+
+;; ---- the lookup machinery survives (defonce'd registries) ----------------
+
+(deftest registration-machinery-survives-under-prod
+  (testing "Per Spec 009 §Production builds: the registration / lookup
+            surface is not gated — it's value-layer machinery
+            (defonce'd atoms + plain swap! / reset!). Under prod
+            `register-epoch-cb!` returns the id; `epoch-history` returns
+            a (necessarily empty) vector; `clear-history!` and
+            `clear-epoch-cbs!` return nil. Apps that boot with these
+            calls do not crash under :advanced."
+    (is (= ::prod-survives
+           (rf/register-epoch-cb! ::prod-survives (fn [_] nil)))
+        "register-epoch-cb! returns the id under prod")
+    (is (nil? (rf/remove-epoch-cb! ::prod-survives))
+        "remove-epoch-cb! returns nil under prod")
+    (is (vector? (rf/epoch-history :rf/default))
+        "epoch-history returns a vector (empty) under prod")
+    (is (nil? (epoch/clear-history!))
+        "clear-history! returns nil under prod")
+    (is (nil? (epoch/clear-epoch-cbs!))
+        "clear-epoch-cbs! returns nil under prod")))
+
+;; ---- on-frame-destroyed! is silent under prod ----------------------------
+
+(deftest on-frame-destroyed-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production builds (rf2-d656):
+            `on-frame-destroyed!` is gated on `interop/debug-enabled?`.
+            Under prod it does NOT emit
+            `:rf.epoch.cb/silenced-on-frame-destroy`; the
+            observed-frames-by-cb bookkeeping side-effect is dead too.
+            Frame-destroy paths that route through this hook do not
+            crash."
+    (is (nil? (epoch/on-frame-destroyed! :rf/default))
+        "on-frame-destroyed! returns nil under prod even for unknown frames")))

--- a/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
+++ b/implementation/flows/test/re_frame/flows_trace_emit_elision_prod_test.cljs
@@ -1,0 +1,193 @@
+(ns re-frame.flows-trace-emit-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-xxd6z) — RUNTIME prod-elision
+  contract for the `re-frame.flows` trace surface. Companion to the
+  string-grep sentinel sweep in `scripts/check-elision.cjs`: the grep
+  catches keyword-literal survival in the bundle blob; this file pins
+  the BEHAVIOUR — under `:advanced` + `goog.DEBUG=false`, a registered
+  trace listener observes NO `:rf.flow/*` events from the flows
+  lifecycle.
+
+  Gating contract: each `:rf.flow/*` emit site sits inside `(when
+  interop/debug-enabled? ...)` AND the body of `trace/emit!` itself is
+  gated. Under prod-mode both gates constant-fold to false. The flow's
+  `:output` fn still runs (recomputation is not gated; only the trace
+  fan-out and the `elision/elide-wire-value` walker that builds the tag
+  map are); the app-db slot at `:path` is still populated; only the
+  trace emission elides.
+
+  Surfaces exercised:
+
+  - `:rf.flow/registered`  (emitted by `reg-flow` on first-time register)
+  - `:rf.flow/computed`    (emitted by `recompute-flow` on successful run)
+  - `:rf.flow/skip`        (emitted by `recompute-flow` on value-equal inputs)
+  - `:rf.flow/failed`      (emitted by `recompute-flow` when :output throws)
+  - `:rf.flow/cleared`     (emitted by `clear-flow`)
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. Running
+  under `goog.DEBUG=true` would FAIL — the trace surface delivers under
+  dev-mode (which is the dev contract pinned in
+  `re-frame.flows-trace-test`).
+
+  Note: the cascade-level `:rf.error/flow-eval-exception` carried by
+  the always-on error-emit substrate is the production observability
+  signal for `:output` failures per rf2-gmrks; the per-flow
+  `:rf.flow/failed` trace is detail-grain only and DCEs in prod. The
+  prod-survival of the error-emit substrate is pinned by
+  `re-frame.flow-eval-exception-elision-prod-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Require flows directly so its ns body — including every
+            ;; gated trace/emit! call site — sits in the reachability
+            ;; graph for the closure compiler.
+            [re-frame.flows :as flows]
+            [re-frame.flows.registry]
+            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- listener-fixture
+  "Install a recording trace listener, run `body-fn`, and return the
+  captured events vector. Records EVERY trace event so the test asserts
+  on `empty?` without filtering — any leak surfaces."
+  [body-fn]
+  (let [seen   (atom [])
+        cb-key (keyword (str "elision-prod-" (gensym)))]
+    (trace-tooling/register-trace-cb!
+      cb-key
+      (fn [ev] (swap! seen conj ev)))
+    (try
+      (body-fn)
+      @seen
+      (finally
+        (trace-tooling/remove-trace-cb! cb-key)))))
+
+;; ---- :rf.flow/registered elides under prod --------------------------------
+
+(deftest reg-flow-emits-no-registered-trace-under-prod
+  (testing "Per Spec 009 §Production-elision (rf2-xxd6z): `reg-flow`
+            installs the flow via the registrar but emits NO
+            `:rf.flow/registered` trace under `:advanced` +
+            `goog.DEBUG=false`. The registrar's own
+            `:rf.registry/handler-registered` would also elide (its
+            gate is symmetric); the assertion below is total."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-flow
+                     {:id     :prod-elision/area
+                      :inputs [[:w] [:h]]
+                      :output (fn [w h] (* (or w 0) (or h 0)))
+                      :path   [:rect :area]})))]
+      (is (empty? seen)
+          "no trace events delivered under :advanced + goog.DEBUG=false"))
+    ;; Cross-check: the flow IS registered — the registrar mutation
+    ;; happened, only the trace surface elided. `flows/flows` is keyed
+    ;; `{frame-id {flow-id flow}}`; the flow registers under
+    ;; `:rf/default` by default.
+    (is (some? (get-in @flows/flows [:rf/default :prod-elision/area]))
+        "flow registered in the per-frame index — only trace surface elided")))
+
+;; ---- :rf.flow/computed elides under prod ----------------------------------
+
+(deftest flow-computed-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: a successful flow
+            recompute runs the `:output` fn and writes the result into
+            the app-db slot but emits NO `:rf.flow/computed` trace
+            under prod. The wire-value elision walker is also gated,
+            so the result/input-values payload construction elides too."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-event-db :prod-elision/seed-rect
+                     (fn [db _] (assoc db :w 3 :h 4)))
+                   (rf/reg-flow
+                     {:id     :prod-elision/area
+                      :inputs [[:w] [:h]]
+                      :output (fn [w h] (* (or w 0) (or h 0)))
+                      :path   [:rect :area]})
+                   ;; Seed inputs; the drain runs the flow.
+                   (rf/dispatch-sync [:prod-elision/seed-rect])))]
+      (is (empty? seen)
+          "no trace events delivered for the recompute under prod"))
+    ;; Cross-check: the flow computed the correct value into app-db.
+    (is (= 12
+           (get-in (rf/get-frame-db :rf/default) [:rect :area]))
+        "flow output written to app-db slot — only trace surface elided")))
+
+;; ---- :rf.flow/failed elides under prod ------------------------------------
+
+(deftest flow-failed-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: when a flow's `:output`
+            fn throws, the per-flow `:rf.flow/failed` trace elides
+            under prod. The cascade-level `:rf.error/flow-eval-exception`
+            still flows through the always-on error-emit substrate
+            (see `re-frame.flow-eval-exception-elision-prod-test` for
+            that pin); a `register-error-emit-listener!` here would
+            fire. We assert only on the TRACE listener, which must see
+            nothing."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-event-db :prod-elision/seed-throw-input
+                     (fn [db _] (assoc db :trigger? true)))
+                   (rf/reg-flow
+                     {:id     :prod-elision/throwing
+                      :inputs [[:trigger?]]
+                      :output (fn [t?]
+                                (when t?
+                                  (throw (ex-info "prod-elision throw" {}))))
+                      :path   [:prod-elision/result]})
+                   (rf/dispatch-sync [:prod-elision/seed-throw-input])))]
+      (is (empty? seen)
+          "no :rf.flow/failed (or any other) trace events under prod"))))
+
+;; ---- :rf.flow/skip elides under prod --------------------------------------
+
+(deftest flow-skip-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: a value-equal recompute
+            suppression — the flow's inputs hash equal to the prior
+            run's — emits NO `:rf.flow/skip` trace under prod. The
+            dirty-check still runs (it's necessary for correctness);
+            only the trace emit elides."
+    ;; First drain installs the flow + populates :last-inputs.
+    (rf/reg-event-db :prod-elision/seed-skip
+      (fn [db _] (assoc db :a 1)))
+    (rf/reg-event-db :prod-elision/touch-skip
+      (fn [db _] (update db :touched (fnil inc 0))))
+    (rf/reg-flow
+      {:id     :prod-elision/skipper
+       :inputs [[:a]]
+       :output (fn [a] (* (or a 0) 2))
+       :path   [:prod-elision/double]})
+    (rf/dispatch-sync [:prod-elision/seed-skip])
+    ;; Second dispatch leaves :a unchanged → inputs value-equal → skip.
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/dispatch-sync [:prod-elision/touch-skip])))]
+      (is (empty? seen)
+          "no :rf.flow/skip trace under prod for the value-equal recompute"))))
+
+;; ---- :rf.flow/cleared elides under prod -----------------------------------
+
+(deftest clear-flow-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: `clear-flow` removes the
+            flow registration but emits NO `:rf.flow/cleared` trace
+            under prod. The registry-mutation side-effect happens; the
+            trace fan-out elides."
+    (rf/reg-flow
+      {:id     :prod-elision/clearable
+       :inputs [[:w]]
+       :output (fn [w] (or w 0))
+       :path   [:prod-elision/copy]})
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/clear-flow :prod-elision/clearable)))]
+      (is (empty? seen)
+          "no :rf.flow/cleared trace under prod"))
+    (is (nil? (get-in @flows/flows [:rf/default :prod-elision/clearable]))
+        "flow removed from per-frame index — only trace surface elided")))

--- a/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
+++ b/implementation/http/test/re_frame/http_trace_emit_elision_prod_test.cljs
@@ -1,0 +1,129 @@
+(ns re-frame.http-trace-emit-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-xxd6z) — RUNTIME prod-elision
+  contract for the `re-frame.http-managed` trace surface. Companion to
+  the string-grep sentinel sweep in `scripts/check-elision.cjs`: the
+  grep catches keyword-literal survival in the bundle blob; this file
+  pins the BEHAVIOUR — under `:advanced` + `goog.DEBUG=false`, a
+  registered trace listener observes NO `:rf.http/*` /
+  `:rf.warning/*` events from the managed-HTTP surface.
+
+  Gating contract: each emit site sits inside `(when interop/debug-
+  enabled? ...)` AND the body of `trace/emit!` itself is gated. Under
+  prod-mode both gates constant-fold to false and the emit is a no-op.
+  The host call (e.g. `record-in-flight!`, `abort-on-actor-destroy`'s
+  swap!) still runs; only the trace fan-out elides.
+
+  Surfaces exercised:
+
+  - `:rf.http/aborted-on-actor-destroy`  (rf2-wvkn — emitted by
+                                          `abort-on-actor-destroy`
+                                          when handles exist)
+  - `:rf.http/retry-attempt`              (Spec 014 §Retry — emit site
+                                          gated; we do not actually run
+                                          a request here, but require
+                                          `http-transport` so the
+                                          reachability graph includes
+                                          the gated body)
+  - `:rf.warning/decode-defaulted`        (Spec 014 §`:auto` decode —
+                                          ditto reachability via
+                                          `http-decode` require)
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. Running
+  under `goog.DEBUG=true` would FAIL — the trace surface delivers under
+  dev-mode (which is the dev contract pinned in the existing JVM
+  `http-managed` tests)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Require every gated emit-site host ns so the reachability
+            ;; graph includes their compiled bodies — DCE only proves the
+            ;; gated branches dead from a reachable module.
+            [re-frame.http-managed :as http-managed]
+            [re-frame.http-registry :as http-registry]
+            [re-frame.http-transport]
+            [re-frame.http-decode]
+            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter
+     :init-fn (fn []
+                ;; Defonce'd indexes need to be clean between tests so a
+                ;; leaked handle from one test doesn't influence another.
+                (http-managed/clear-all-in-flight!))}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- listener-fixture
+  "Install a recording trace listener, run `body-fn`, and return the
+  captured events vector. Records EVERY trace event so the test asserts
+  on `empty?` without filtering — any leak surfaces."
+  [body-fn]
+  (let [seen   (atom [])
+        cb-key (keyword (str "elision-prod-" (gensym)))]
+    (trace-tooling/register-trace-cb!
+      cb-key
+      (fn [ev] (swap! seen conj ev)))
+    (try
+      (body-fn)
+      @seen
+      (finally
+        (trace-tooling/remove-trace-cb! cb-key)))))
+
+;; ---- :rf.http/aborted-on-actor-destroy elides under prod ----------------
+
+(deftest abort-on-actor-destroy-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision (rf2-xxd6z): calling
+            `abort-on-actor-destroy` against an actor with in-flight
+            handles fires every handle's `:abort-fn` but emits NO
+            `:rf.http/aborted-on-actor-destroy` trace under `:advanced`
+            + `goog.DEBUG=false`. The host work (the abort-fn callback)
+            still runs; only the trace fan-out elides."
+    (let [actor-id    :prod-elision/actor
+          aborts-seen (atom 0)
+          handle      {:abort-fn    (fn [_reason] (swap! aborts-seen inc))
+                       :url         "https://prod-elision.example/test"
+                       :sensitive?  false}
+          _           (http-registry/record-in-flight!
+                        :prod-elision/req-id actor-id handle)
+          seen        (listener-fixture
+                        (fn []
+                          (http-managed/abort-on-actor-destroy actor-id)))]
+      (is (= 1 @aborts-seen)
+          ":abort-fn ran exactly once — host side-effect not elided")
+      (is (empty? seen)
+          "no trace events delivered under :advanced + goog.DEBUG=false
+           — the :rf.http/aborted-on-actor-destroy emit body elided
+           while the abort callback still ran"))))
+
+(deftest abort-on-actor-destroy-empty-registry-emits-nothing-under-prod
+  (testing "Defensive cross-check: when no handles are recorded for the
+            actor, the no-op path runs and emits nothing — both under
+            dev (no handles → no emit) and prod (gate elides). Locks
+            the idempotency contract under prod-mode."
+    (let [seen (listener-fixture
+                 (fn []
+                   (http-managed/abort-on-actor-destroy
+                     :prod-elision/never-spawned)))]
+      (is (empty? seen)
+          "no trace events for the idempotent no-handle path under prod"))))
+
+(deftest http-managed-abort-fx-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: dispatching the public
+            `:rf.http/managed-abort` fx against a request-id with no
+            in-flight handle is a tolerated no-op (Spec 014 §Aborts) —
+            and emits NO trace events under prod. Exercises the fx
+            handler's load-bearing reachability through the public
+            dispatch surface."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-event-fx :prod-elision/abort-touch
+                     (fn [_ _]
+                       {:fx [[:rf.http/managed-abort
+                              :prod-elision/no-such-req]]}))
+                   (rf/dispatch-sync [:prod-elision/abort-touch])))]
+      (is (empty? seen)
+          "no trace events delivered for the abort-fx under prod"))))

--- a/implementation/routing/test/re_frame/routing_trace_emit_elision_prod_test.cljs
+++ b/implementation/routing/test/re_frame/routing_trace_emit_elision_prod_test.cljs
@@ -1,0 +1,153 @@
+(ns re-frame.routing-trace-emit-elision-prod-test
+  "Per Spec 009 §Production builds (bead rf2-xxd6z) — RUNTIME prod-elision
+  contract for the `re-frame.routing` trace surface. Companion to the
+  string-grep sentinel sweep in `scripts/check-elision.cjs`: the grep
+  catches keyword-literal survival in the bundle blob; this file pins
+  the BEHAVIOUR — under `:advanced` + `goog.DEBUG=false`, a registered
+  trace listener observes NO `:rf.route/*` / `:rf.warning/*` /
+  `:rf.route.nav-token/*` events when the routing entry points fire.
+
+  The gating contract sits inside `re-frame.trace/emit!` itself (the
+  whole body is wrapped in `(when interop/debug-enabled? ...)` per
+  Spec 009 §Production-elision verification). The routing call sites
+  invoke `trace/emit!` unconditionally — Closure constant-folds the
+  emit body to a no-op under prod-mode, so the host call (e.g.
+  `(.pushState js/window.history ...)`) still runs and the slice is
+  still updated, but the trace fan-out elides.
+
+  Surfaces exercised:
+
+  - `:rf.route/url-changed`              (emitted by `handle-url-change`)
+  - `:rf.route.nav-token/allocated`      (emitted by `navigate` / `handle-url-change`)
+  - `:rf.warning/malformed-url`          (emitted on URL parse failure)
+  - `:rf.warning/no-not-found-route`     (emitted when unmatched and no fallback)
+  - `:rf.route/navigation-blocked`       (emitted by the `:can-leave` guard)
+  - `:rf.warning/route-shadowed-by-equal-score` (emitted at `reg-route`)
+  - `:rf.warning/can-leave-guard-non-boolean`   (emitted by the `:can-leave` guard)
+  - `:rf.warning/can-leave-subs-artefact-missing` (emitted by the guard)
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are
+  picked up ONLY by the `:browser-test-prod-elision` build. The default
+  `:browser-test` / `:node-test` runners use regexes that do NOT match
+  this suffix, so these tests run only under prod-mode compilation.
+  Running this file under `goog.DEBUG=true` would FAIL — the trace
+  surface delivers under dev-mode, which is the dev contract documented
+  in `re-frame.routing-history-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]
+            ;; Touch the routing namespace directly so its ns body
+            ;; (including the gated `trace/emit!` call sites) is in
+            ;; the reachability graph for the closure compiler. Per
+            ;; the elision-probe pattern: requiring forces compilation;
+            ;; the gates do the elision work inside the closed body.
+            [re-frame.routing]
+            ;; rf2-qwm0a — listener surface lives in `re-frame.trace.tooling`.
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- listener-fixture
+  "Install a recording trace listener, run `body-fn`, and return the
+  captured events vector. Records EVERY trace event so the test asserts
+  on `empty?` without filtering — any leak surfaces."
+  [body-fn]
+  (let [seen   (atom [])
+        cb-key (keyword (str "elision-prod-" (gensym)))]
+    (trace-tooling/register-trace-cb!
+      cb-key
+      (fn [ev] (swap! seen conj ev)))
+    (try
+      (body-fn)
+      @seen
+      (finally
+        (trace-tooling/remove-trace-cb! cb-key)
+        (reset! seen [])))))
+
+;; ---- :rf.route/url-changed elides under prod ------------------------------
+
+(deftest handle-url-change-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision (rf2-xxd6z): dispatching
+            `:rf.route/handle-url-change` under `:advanced` +
+            `goog.DEBUG=false` runs the routing slice update but emits
+            NO trace events. The `:rf.route/url-changed` and
+            `:rf.route.nav-token/allocated` emits are DCE'd by the
+            gate inside `trace/emit!`."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-route :prod-elision/landing {:path "/"})
+                   (rf/dispatch-sync
+                     [:rf.route/handle-url-change "/"])))]
+      (is (empty? seen)
+          "no trace events delivered under :advanced + goog.DEBUG=false
+           — the routing entry point's trace/emit! body elides while the
+           slice update still runs"))
+    ;; Cross-check: the routing slice DID update (handler still runs;
+    ;; only the trace surface elides).
+    (is (= :prod-elision/landing
+           (:id (:rf/route (rf/get-frame-db :rf/default))))
+        "routing slice was populated — only the trace surface elided")))
+
+;; ---- :rf.warning/malformed-url elides under prod -------------------------
+
+(deftest malformed-url-warning-elides-under-prod
+  (testing "Per Spec 009 §Production-elision: feeding a malformed URL
+            to `:rf.route/handle-url-change` runs the fallback branch
+            but emits NO `:rf.warning/malformed-url` trace under prod."
+    (let [seen (listener-fixture
+                 (fn []
+                   ;; Register a not-found route so the malformed-url
+                   ;; path lands somewhere; the warn trace must elide.
+                   (rf/reg-route :rf.route/not-found {:path "/*splat"})
+                   (rf/dispatch-sync
+                     [:rf.route/handle-url-change "%E0%A4%A"])))]
+      (is (empty? seen)
+          "no :rf.warning/malformed-url delivered under prod"))))
+
+;; ---- :rf.route/navigation-blocked elides under prod ----------------------
+
+(deftest navigation-blocked-emits-no-trace-under-prod
+  (testing "Per Spec 009 §Production-elision: a `:can-leave` guard that
+            blocks navigation populates `:rf/pending-navigation` but
+            emits NO `:rf.route/navigation-blocked` trace under
+            `:advanced` + `goog.DEBUG=false`. The state side-effect
+            still happens; only the trace fan-out elides."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-sub :prod/leaver-can? (fn [_db _q] false))
+                   (rf/reg-route :prod/leaver
+                                 {:path      "/leaver"
+                                  :can-leave :prod/leaver-can?})
+                   (rf/reg-route :prod/dest {:path "/dest"})
+                   ;; Settle on the leaver route first.
+                   (rf/dispatch-sync
+                     [:rf.route/handle-url-change "/leaver"])
+                   ;; Now attempt to leave — guard blocks; trace elides.
+                   (rf/dispatch-sync
+                     [:rf.route/handle-url-change "/dest"])))]
+      (is (empty? seen)
+          "no trace events delivered for the blocked navigation under prod"))
+    ;; Cross-check: the pending-navigation slot WAS populated — the
+    ;; guard branch ran; only its trace emit elided.
+    (is (some? (:rf/pending-navigation (rf/get-frame-db :rf/default)))
+        ":rf/pending-navigation slot populated — handler ran, only trace elided")))
+
+;; ---- :rf.warning/route-shadowed-by-equal-score elides under prod ---------
+
+(deftest route-shadowed-warn-elides-under-prod
+  (testing "Per Spec 009 §Production-elision: registering two routes
+            whose rank scores collide emits NO
+            `:rf.warning/route-shadowed-by-equal-score` trace under
+            prod. The registration still succeeds (the warn is
+            informational); the trace fan-out elides."
+    (let [seen (listener-fixture
+                 (fn []
+                   (rf/reg-route :prod/shadow-a {:path "/x"})
+                   (rf/reg-route :prod/shadow-b {:path "/x"})))]
+      (is (empty? seen)
+          "no :rf.warning/route-shadowed-by-equal-score under prod"))))


### PR DESCRIPTION
## Summary

Three test-coverage beads under the prod-elision umbrella, each adding a small, focused test artefact targeting regressions where dev-only code leaks into `:advanced` production builds (or where the async-escape detection logic regresses).

- **rf2-xxd6z** — runtime prod-elision DCE pins for routing / http / flows trace-emit (companion to the string-grep sentinel sweep). Asserts that registered trace listeners observe NO `:rf.route/*` / `:rf.http/*` / `:rf.flow/*` events under `:advanced` + `goog.DEBUG=false` while the host side-effects (slice updates, abort callbacks, flow recomputes) still run.
- **rf2-l7hlm** — `:advanced` prod-elision pins for the trace bus (ring buffer), epoch (Tool-Pair §Time-travel surface), and frame-provider / render-key (Spec 004 §Render-tree primitives) machinery. Sibling to the existing rf2-2zdu (trace listener), rf2-hqbeh (`:on-error`), and rf2-uwg5 (source-coord DOM) pins.
- **rf2-nmusx** — CLJS integration test exercising the REAL JS async-callback surfaces (`setTimeout`, `addEventListener`, `requestAnimationFrame`) to pin the end-to-end `:rf.warning/dispatch-from-async-callback-fell-through-to-default` trigger path. JVM proxy validates detection logic; this validates the canonical JS escape paths actually produce the trigger envelope.

All seven new test files are wired into the existing `re-frame.prod-elision-runner` (`:browser-test-prod-elision` build) or the standard `:browser-test` build via the `-cljs-test$` / `-elision-prod-test$` naming conventions.

## Test plan

- [x] `npm run test:browser-prod-elision` — 56 tests / 158 assertions, all green (was 41/124 before).
- [x] `npm run test:browser` — 2340 tests / 6597 assertions, all green.
- [x] `npm run test:cljs` — 2356 tests / 6764 assertions, all green.
- [x] `npm run test:elision` — sentinel sweep still PASS (31/31 absent / 31/31 present control).