### PR TITLE
docs(hygiene): CODE_OF_CONDUCT + CONTRIBUTING + SECURITY + version-pin (rf2-8l0lz)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+# Code of Conduct
+
+re-frame2 is a small project with a sharp focus: build a state-of-the-art
+specification for an AI-friendly front-end pattern, and a reference
+implementation that proves it. Everyone working on it — maintainers,
+contributors, casual passers-by, AI agents under human direction — is here for
+that work.
+
+## What we expect
+
+Treat one another professionally. Disagreement on technical points is welcome,
+expected, and often where the best decisions come from; aim it at the idea,
+not the person. Assume the other party is acting in good faith until you have
+hard evidence otherwise. Keep discussion grounded in the work — what the spec
+says, what the code does, what the trade-off is.
+
+If your contribution is generated or assisted by an AI, that is fine. You
+remain responsible for what you submit: it should be coherent, on-topic, and
+not waste reviewer time.
+
+## What we do not accept
+
+Personal attacks, harassment, sustained disruption, and conduct that makes the
+project unsafe or unproductive for other contributors. We will not enumerate
+an exhaustive list; the maintainers exercise judgement on the boundary case.
+
+## Scope
+
+This applies wherever someone is acting on behalf of, or interacting with, the
+re-frame2 project: this repository (issues, pull requests, code comments,
+commit messages), any future official chat or forum spaces, and conference
+talks or workshops presented under the re-frame2 banner.
+
+## Reporting
+
+If you observe or experience conduct that breaches this code, email
+**conduct@day8.com.au**. Reports go to the maintainers; we will read every one
+and reply with what we intend to do. We will treat the reporter's identity as
+confidential within the bounds of acting on the report.
+
+## Enforcement
+
+Maintainers may, at their discretion:
+
+- privately ask a contributor to stop a behaviour;
+- publicly correct a misstatement of project policy;
+- close, edit, or hide off-topic or hostile contributions;
+- temporarily or permanently remove a contributor's commit, comment, issue, or
+  pull-request privileges.
+
+We aim for the lightest intervention that returns the project to good
+working order. Repeat or severe breaches escalate.
+
+## Maintainers
+
+The maintainer group is currently Mike Thompson and the [Day8](https://day8.com.au)
+team. The contact address above reaches the same people.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to re-frame2
+
+Thank you for the interest. re-frame2 is currently pre-alpha and the public
+contribution surface is intentionally narrow while we stabilise the
+specification. This document explains where to start and what shape a useful
+contribution takes today.
+
+## The spec is the artefact
+
+Before changing code, please read [`spec/README.md`](spec/README.md). The
+normative description of re-frame2 lives in [`spec/`](spec/) — about 22K lines
+across 35+ documents. The CLJS reference in [`implementation/`](implementation/)
+exists to validate the spec, not the other way round. A change to behaviour
+almost always belongs in the spec first; the implementation change is the
+downstream proof.
+
+If a proposal would change behaviour, file an issue describing the spec
+implication before opening a code-only PR. This saves both sides time when the
+right answer turns out to be a spec edit you had not seen.
+
+## Pre-alpha posture
+
+We have not yet published artefacts to Clojars or npm. There is no backwards
+compatibility surface to preserve: if a design is wrong, the fix is to make it
+right, not to ship a shim. Please optimise contributions for elegance,
+correctness, and completeness rather than minimal-diff caution. The bar is
+high on purpose.
+
+## Reporting bugs and proposing changes
+
+For now, please use GitHub issues at
+<https://github.com/day8/re-frame2/issues>. Useful issues include:
+
+- a one-line summary of the problem or proposal;
+- the spec section or file path the issue touches;
+- a reproduction (link to a failing test, minimal example, or trace excerpt);
+- what you think the right resolution looks like, even if tentative.
+
+Internally we use [beads](https://github.com/gastownhall/beads) for issue
+tracking (see [`docs/the-mayor-method.md`](docs/the-mayor-method.md) for the
+workflow this repo is built with). External contributors do not need to learn
+beads; a GitHub issue is sufficient and will be mirrored into the bead graph
+by a maintainer when appropriate.
+
+## Project setup
+
+Top-level orientation lives in the repo's [`README.md`](README.md). For the
+CLJS reference:
+
+```bash
+cd implementation
+npm install            # one-time — installs shadow-cljs + React
+npm run test:cljs      # Node-runtime CLJS tests (fast)
+```
+
+The full test matrix and per-artefact entry-points are documented in
+[`TESTING.md`](TESTING.md). The fast pre-PR gate is `scripts/test-fast-pr.sh`
+from the repo root.
+
+## Pull request flow
+
+- Branch from `main`.
+- One coherent change per PR. Smaller is better; reviewers can hold one idea
+  at a time.
+- Descriptive title in the same shape as recent commits (run `git log
+  --oneline` for examples).
+- All CI gates must be green before review.
+- Spec edits and impl edits can sit in the same PR when the impl change is the
+  direct proof of the spec change; otherwise split them.
+- No AI-attribution trailers in commit messages or PR descriptions.
+
+## Version-pin convention
+
+All published artefacts in this repo version-lockstep. The single source of
+truth is the top-level [`VERSION`](VERSION) file. Pre-1.0, third-party tooling
+pins (shadow-cljs, React, Reagent, Malli) are **exact** versions — no caret,
+no tilde — so every artefact's lockfile and `deps.edn` resolves identically.
+If you bump a shared dep, bump it everywhere in the same PR; CI gates this
+across the matrix.
+
+## Security issues
+
+Please do not file security-relevant problems as public issues or pull
+requests. See [`SECURITY.md`](SECURITY.md) for the disclosure path.
+
+## Code of Conduct
+
+By participating you agree to abide by the project's
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in re-frame2 — the
+specification, the reference implementation, or any of the tools shipped from
+this repository — please email **security@day8.com.au** rather than opening a
+public GitHub issue or pull request. Include enough detail for us to reproduce
+the problem (a minimal example, expected vs. observed behaviour, and the
+affected file or surface).
+
+We will acknowledge receipt within seven days and keep you informed as we
+investigate and resolve. We ask that you give us a reasonable window to ship a
+fix before discussing the issue publicly; we will coordinate the disclosure
+timeline with you.
+
+## Supported versions
+
+re-frame2 is currently **pre-alpha**. No artefacts are published to Clojars or
+npm yet, and there is no formal support SLA. Fixes land on `main`; consumers
+pinning to a `:git/sha` coordinate are expected to update to pick them up.
+
+Once re-frame2 reaches 1.0, the supported-versions matrix will be published
+here. The expected baseline is: security fixes for the latest minor release.
+
+## Scope
+
+In scope:
+
+- the specification ([`spec/`](spec/)) where wording would mislead an
+  implementer into a security-relevant behaviour;
+- the CLJS reference implementation ([`implementation/`](implementation/));
+- the tools ([`tools/`](tools/)) — Causa, Story, the MCP servers, the
+  template, and supporting libraries.
+
+The implementation-specific security posture (named functions, numeric
+defaults, decisions log) is catalogued in
+[`implementation/SECURITY.md`](implementation/SECURITY.md), with the
+pattern-level companion in [`spec/Security.md`](spec/Security.md). Both are
+useful background when filing a report.

--- a/tools/causa-mcp/package.json
+++ b/tools/causa-mcp/package.json
@@ -22,7 +22,7 @@
     "bencode": "~2.0.3"
   },
   "devDependencies": {
-    "shadow-cljs": "^3.4.10"
+    "shadow-cljs": "3.4.10"
   },
   "keywords": [
     "re-frame",

--- a/tools/pair2-mcp/package.json
+++ b/tools/pair2-mcp/package.json
@@ -23,7 +23,7 @@
     "bencode": "~2.0.3"
   },
   "devDependencies": {
-    "shadow-cljs": "^3.4.10"
+    "shadow-cljs": "3.4.10"
   },
   "keywords": [
     "re-frame",

--- a/tools/pair2-mcp/pilot/package.json
+++ b/tools/pair2-mcp/pilot/package.json
@@ -14,6 +14,6 @@
     "bencode": "~2.0.3"
   },
   "devDependencies": {
-    "shadow-cljs": "^3.4.10"
+    "shadow-cljs": "3.4.10"
   }
 }


### PR DESCRIPTION
## Summary

Tail of rf2-mfi1s (PR #1150). Two prior agent attempts hit content-filter blocks copying Contributor Covenant text; this round hand-rolls the prose in re-frame2's own voice.

- **CODE_OF_CONDUCT.md** — 50 lines. Project-shape scope (this repo, future official chat, talks under the banner). Lightest-touch enforcement ladder. Reports to `conduct@day8.com.au`. Acknowledges AI-assisted contributions explicitly.
- **CONTRIBUTING.md** — 79 lines. Spec-is-the-artefact framing, pre-alpha posture (no back-compat shims), GitHub issues as the external surface (beads is internal), pre-PR fast gate, version-pin convention.
- **SECURITY.md** — 36 lines. One paragraph each: report channel (`security@day8.com.au`), 7-day acknowledgement, pre-alpha "no SLA, fixes on `main`" posture. Cross-refs to `spec/Security.md` + `implementation/SECURITY.md` for background.
- **Version-pin tightening (rf2-mfi1s item 6 tail)** — three MCP-server `package.json` files carried `^3.4.10` shadow-cljs; tightened to exact `3.4.10` to match `implementation/package.json` and the re-frame-pair2 test fixture. Pre-1.0 lockstep convention.

No Contributor Covenant verbatim copy. No AI-attribution trailers.

## Test plan

- [x] mkdocs strict not impacted (top-level repo docs are not in mkdocs nav; two pre-existing warnings unrelated to this PR).
- [x] Three policy files render cleanly on GitHub (markdown lint clean).
- [x] Version-pin diff is exact-text-only (`^3.4.10` → `3.4.10`); no semantic change.