### PR TITLE
chore+feat+refactor: residual cleanup — elision vocab + pair2-mcp app-db-hash + void-tag dedup (3 beads)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -98,6 +98,13 @@
 ;; Per §8.4 + rf2-6phn: bundle isolation forbids `:require` of the SSR
 ;; artefact (re-frame.ssr lives in day8/re-frame2-ssr), so we don't
 ;; share with that — only with the in-artefact template path.
+;;
+;; **Lockstep**: the void-tag set above (in template.cljs) duplicates
+;; `re-frame.ssr.emit/void-elements` (keyword form vs string form,
+;; same membership). If HTML5 extends the void-element list, both
+;; copies update. Boolean-attrs is local to this artefact (re-frame.ssr
+;; takes value-driven booleans through `html-helpers/attr-string`
+;; instead of carrying its own name set).
 ;; ---------------------------------------------------------------------------
 
 (def ^:private boolean-attrs

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -464,7 +464,13 @@
   children passed to these; the SSR walker emits bare `<br>` etc. and
   skips the close tag. The list is fixed in HTML5 — no maintenance
   burden. Shared between template (React) and server (HTML string)
-  paths to keep one source of truth across the artefact."
+  paths to keep one source of truth across the artefact.
+
+  Lockstep with `re-frame.ssr.emit/void-elements` (keyword form, same
+  membership). Bundle isolation forbids `:require` across artefacts
+  (per rf2-6phn + IMPL-SPEC §14.3), so the set is duplicated by
+  intent. If HTML5 ever extends the void element list (extraordinarily
+  unlikely), update both copies."
   #{"area" "base" "br" "col" "embed" "hr" "img" "input" "link"
     "meta" "param" "source" "track" "wbr"})
 

--- a/implementation/ssr/src/re_frame/ssr/emit.cljc
+++ b/implementation/ssr/src/re_frame/ssr/emit.cljc
@@ -41,6 +41,14 @@
 
 ;; Per HTML5 spec, these elements are void — they self-close and have no
 ;; closing tag.
+;;
+;; Lockstep with `reagent2.impl.template/void-tags` (in the
+;; `day8/reagent-slim-and-fast` artefact). Bundle isolation forbids
+;; `:require` across artefacts (reagent-slim must not pull in
+;; `re-frame.ssr` — that's the whole point of the slim artefact), so
+;; the set is duplicated by intent. If HTML5 ever extends the void
+;; element list (extraordinarily unlikely), update both copies. Per
+;; rf2-6phn + reagent-slim IMPL-SPEC §14.3.
 (def void-elements
   #{:area :base :br :col :embed :hr :img :input :link :meta :param :source
     :track :wbr})

--- a/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
+++ b/skills/re-frame-pair2/preload/re_frame_pair2/runtime.cljs
@@ -414,6 +414,67 @@
   ;; last-pair-epoch). Populated by the dispatch helpers below.
   (atom #{}))
 
+;; ---- O(1) per-frame app-db hash cache (rf2-9pe31) ------------------------
+;;
+;; The pair2-mcp precheck (rf2-36xod) issues `(hash app-db)` to decide a
+;; cache hit before running the tool eval. `(hash <persistent-map>)` is
+;; cached on the map node itself in CLJS — the first call walks; every
+;; subsequent call returns the cached integer in O(1) (per
+;; `cljs.core/-hash` on `PersistentArrayMap` / `PersistentHashMap`). So
+;; the wire saving from a precheck-side cache here is small for the
+;; precheck hot path itself.
+;;
+;; What *is* expensive is the route through `(re-frame-pair2.runtime/
+;; snapshot frame)` → `(rf/get-frame-db frame-id)` → dereferences and
+;; map lookups, which the precheck eval form has to thread on every
+;; call. With the per-frame cached integer here, the precheck form
+;; resolves to a single atom deref + map lookup, completely independent
+;; of app-db size or structure.
+;;
+;; The cache is updated whenever an epoch settles — every mutation path
+;; (dispatch via the router, `rf/reset-frame-db!` synthetic `:rf.epoch/
+;; db-replaced`, `rf/restore-epoch`) produces an assembled-epoch record
+;; that arrives at `on-epoch-streaming`. We update the cache there from
+;; `(:db-after record)`. On the first read for a frame, if the slot is
+;; absent (no epoch has fired yet for this frame), we compute it lazily
+;; from `(rf/get-frame-db frame-id)` and stash it.
+;;
+;; Pre-alpha: no back-compat surface to keep — `app-db-hash` is the
+;; only accessor; callers needing a path-scoped hash hash the slice
+;; themselves until a sub-tree accessor is filed.
+
+(defonce ^:private frame-db-hashes
+  ;; frame-id -> cached `(hash app-db)` integer
+  (atom {}))
+
+(defn- update-frame-db-hash!
+  "Update the cached hash for `frame-id` from the epoch record's
+   `:db-after` slot. Called from the epoch listener."
+  [frame-id db-after]
+  (swap! frame-db-hashes assoc frame-id (hash db-after)))
+
+(defn app-db-hash
+  "Cheap O(1) accessor for the current `(hash app-db)` of `frame-id`.
+
+   Cached by the epoch listener at every settled mutation. On the first
+   read for a frame whose hash hasn't been observed yet (no epoch
+   fired since session start), the value is computed lazily from
+   `(rf/get-frame-db frame-id)` and stashed.
+
+   Returns an integer hash, or `nil` if the frame doesn't exist.
+
+   Per rf2-9pe31 (follow-on to rf2-36xod). The pair2-mcp precheck form
+   threads through this accessor so the cache-hit decision is a single
+   integer compare rather than a full app-db walk."
+  ([] (app-db-hash (current-frame)))
+  ([frame-id]
+   (when frame-id
+     (or (get @frame-db-hashes frame-id)
+         (let [db (rf/get-frame-db frame-id)
+               h  (hash db)]
+           (swap! frame-db-hashes assoc frame-id h)
+           h)))))
+
 ;; The per-frame `observed-epochs` stash and the streaming dispatch both
 ;; ride the same `register-epoch-cb!` slot — combined into
 ;; `on-epoch-streaming` below to keep listener ordering deterministic
@@ -881,16 +942,19 @@
     (dispatch-trace-to-subs! ev)))
 
 (defn- on-epoch-streaming
-  "Replacement assembled-epoch listener that drives both the observed
-   stash (legacy) and the streaming subs dispatch."
+  "Replacement assembled-epoch listener that drives the observed stash
+   (legacy), the per-frame app-db-hash cache (rf2-9pe31), and the
+   streaming subs dispatch."
   [record]
-  (swap! observed-epochs
-         (fn [m]
-           (let [frame-id (:frame record)
-                 v        (or (get m frame-id) [])
-                 v+       (conj v record)
-                 n        (count v+)]
-             (assoc m frame-id (if (> n 500) (subvec v+ (- n 500)) v+)))))
+  (let [frame-id (:frame record)]
+    (swap! observed-epochs
+           (fn [m]
+             (let [v        (or (get m frame-id) [])
+                   v+       (conj v record)
+                   n        (count v+)]
+               (assoc m frame-id (if (> n 500) (subvec v+ (- n 500)) v+)))))
+    (when frame-id
+      (update-frame-db-hash! frame-id (:db-after record))))
   (dispatch-epoch-to-subs! record))
 
 (defn subscribe!

--- a/skills/re-frame-pair2/tests/runtime/app_db_hash_test.clj
+++ b/skills/re-frame-pair2/tests/runtime/app_db_hash_test.clj
@@ -1,0 +1,143 @@
+;;;; tests/runtime/app_db_hash_test.clj
+;;;;
+;;;; Babashka-runnable verification of the `app-db-hash` O(1) accessor in
+;;;; `preload/re_frame_pair2/runtime.cljs` (rf2-9pe31) — the per-frame
+;;;; cached hash the pair2-mcp precheck (rf2-36xod) threads through to
+;;;; decide a cache hit in one bencode round-trip.
+;;;;
+;;;; Why a parallel implementation lives here:
+;;;;
+;;;;   `preload/re_frame_pair2/runtime.cljs` is a CLJS-only file loaded
+;;;;   into the consumer app via shadow-cljs `:devtools :preloads`. It
+;;;;   depends on the live re-frame2 frame registry + epoch listener
+;;;;   surface, neither of which run under bb. This file mirrors the
+;;;;   cache + lazy-compute + update-on-epoch behaviour and pins the
+;;;;   contract (every mutation rotates the cached hash; reads are O(1)
+;;;;   atom-deref + map-lookup).
+;;;;
+;;;;   KEEP IN SYNC WITH preload/re_frame_pair2/runtime.cljs §O(1)
+;;;;   per-frame app-db hash cache.
+;;;;
+;;;; Run:    bb tests/runtime/app_db_hash_test.clj
+;;;; Exit:   0 = pass, non-zero = fail.
+
+(ns app-db-hash-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]))
+
+;; ---------------------------------------------------------------------------
+;; Stubbed framework surfaces.
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-dbs (atom {:rf/default {:cart {:items 3}}
+                                :stories    {:scenarios {:checkout :ready}}}))
+
+(defn stub-get-frame-db [fid] (get @frame-dbs fid))
+
+;; ---------------------------------------------------------------------------
+;; Mirror of preload/re_frame_pair2/runtime.cljs §O(1) per-frame app-db
+;; hash cache. KEEP IN SYNC.
+;; ---------------------------------------------------------------------------
+
+(def ^:private frame-db-hashes (atom {}))
+
+(defn- update-frame-db-hash!
+  "Update the cached hash for `frame-id` from the epoch record's
+   `:db-after` slot. Called from the epoch listener."
+  [frame-id db-after]
+  (swap! frame-db-hashes assoc frame-id (hash db-after)))
+
+(defn app-db-hash
+  "Cheap O(1) accessor — cached value, lazy-compute on first read."
+  [frame-id]
+  (when frame-id
+    (or (get @frame-db-hashes frame-id)
+        (let [db (stub-get-frame-db frame-id)
+              h  (hash db)]
+          (swap! frame-db-hashes assoc frame-id h)
+          h))))
+
+;; Per-test reset.
+(defn- reset-state! []
+  (reset! frame-db-hashes {})
+  (reset! frame-dbs {:rf/default {:cart {:items 3}}
+                     :stories    {:scenarios {:checkout :ready}}}))
+
+;; ---------------------------------------------------------------------------
+;; Tests
+;; ---------------------------------------------------------------------------
+
+(deftest lazy-compute-on-first-read
+  (reset-state!)
+  (is (= {} @frame-db-hashes)
+      "precondition: cache is empty before first read")
+  (let [h1 (app-db-hash :rf/default)]
+    (is (integer? h1) "returns an integer hash")
+    (is (= h1 (hash {:cart {:items 3}}))
+        "computes via (hash db) on the lazy path")
+    (is (= h1 (get @frame-db-hashes :rf/default))
+        "stashes the computed value so subsequent reads are O(1)")))
+
+(deftest second-read-is-cache-hit
+  (reset-state!)
+  (let [h1 (app-db-hash :rf/default)
+        ;; Mutate the underlying db WITHOUT firing the epoch listener.
+        ;; The cache should still report the stale hash — proves the
+        ;; reader does not re-walk the db on every call.
+        _  (swap! frame-dbs assoc :rf/default {:wholly :different})
+        h2 (app-db-hash :rf/default)]
+    (is (= h1 h2)
+        "subsequent reads return the cached value verbatim")))
+
+(deftest update-rotates-the-cache
+  (reset-state!)
+  (let [h1 (app-db-hash :rf/default)
+        new-db {:cart {:items 99}}
+        _  (update-frame-db-hash! :rf/default new-db)
+        h2 (app-db-hash :rf/default)]
+    (is (not= h1 h2)
+        "mutation through update-frame-db-hash! rotates the cache")
+    (is (= h2 (hash new-db))
+        "rotated value matches (hash new-db)")))
+
+(deftest per-frame-isolation
+  (reset-state!)
+  (let [h-default (app-db-hash :rf/default)
+        h-stories (app-db-hash :stories)]
+    (is (not= h-default h-stories)
+        "different frames produce different cached hashes")
+    (update-frame-db-hash! :rf/default {:cart {:items 99}})
+    (is (not= h-default (app-db-hash :rf/default))
+        ":rf/default's hash rotated")
+    (is (= h-stories (app-db-hash :stories))
+        ":stories's hash is untouched by the :rf/default mutation")))
+
+(deftest nil-frame-returns-nil
+  (reset-state!)
+  (is (nil? (app-db-hash nil))
+      "nil frame-id short-circuits to nil"))
+
+(deftest deterministic-across-reads
+  (reset-state!)
+  (let [h1 (app-db-hash :rf/default)
+        h2 (app-db-hash :rf/default)
+        h3 (app-db-hash :rf/default)]
+    (is (= h1 h2 h3)
+        "the cached value is identical across repeated reads")))
+
+(deftest hash-equal-when-db-equal
+  ;; Pin the bedrock invariant the precheck depends on: structurally-
+  ;; equal app-db values hash to the same integer. This is a property
+  ;; of CLJS persistent maps' `-hash` — restated here so a future
+  ;; runtime change that swapped the cache key for, say, `identical?`
+  ;; would fail this test fast.
+  (reset-state!)
+  (let [h1 (app-db-hash :rf/default)
+        ;; A value-equal but freshly-constructed map.
+        new-db {:cart {:items 3}}
+        _  (update-frame-db-hash! :rf/default new-db)]
+    (is (= h1 (app-db-hash :rf/default))
+        "structurally-equal app-db values produce the same hash")))
+
+(let [{:keys [fail error]} (run-tests 'app-db-hash-test)
+      failures (+ (or fail 0) (or error 0))]
+  (System/exit (if (zero? failures) 0 1)))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/cursor_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/cursor_test.cljs
@@ -34,7 +34,7 @@
    {:path   [:trace 0 :coeffect :db]
     :bytes  102400
     :type   :map
-    :reason :declared
+    :reason :schema
     :handle [:rf.elision/at [:trace 0 :coeffect :db]]}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/dedup_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/dedup_test.cljs
@@ -39,7 +39,7 @@
    {:path   [:trace 0 :coeffect :db]
     :bytes  102400
     :type   :map
-    :reason :declared
+    :reason :schema
     :handle [:rf.elision/at [:trace 0 :coeffect :db]]}})
 
 (defn- expand

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/elision_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/elision_test.cljs
@@ -43,7 +43,7 @@
    {:path   [:user :uploaded-pdf]
     :bytes  102400
     :type   :string
-    :reason :declared
+    :reason :schema
     :handle [:rf.elision/at [:user :uploaded-pdf]]}})
 
 ;; ---------------------------------------------------------------------------
@@ -91,7 +91,7 @@
                       {:path   [:a :b]
                        :bytes  100
                        :type   :string
-                       :reason :declared
+                       :reason :schema
                        :handle [:rf.elision/at [:a :b]]
                        :extra  {:rf.size/large-elided {:bytes 1}}}}]
     (is (= 1 (elision/count-elided-markers pathological)))))

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/path_slice_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/path_slice_test.cljs
@@ -34,7 +34,7 @@
    {:path   [:user :uploaded-pdf]
     :bytes  102400
     :type   :string
-    :reason :declared
+    :reason :schema
     :handle [:rf.elision/at [:user :uploaded-pdf]]}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa-mcp/test/day8/re_frame2_causa_mcp/summary_test.cljs
+++ b/tools/causa-mcp/test/day8/re_frame2_causa_mcp/summary_test.cljs
@@ -35,7 +35,7 @@
    {:path   [:user :uploaded-pdf]
     :bytes  102400
     :type   :string
-    :reason :declared
+    :reason :schema
     :handle [:rf.elision/at [:user :uploaded-pdf]]}})
 
 ;; ---------------------------------------------------------------------------

--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -231,7 +231,7 @@
     [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
       :tags (assoc tag :event [:report/upload
                                {:rf.size/large-elided
-                                {:source :runtime-flagged
+                                {:source :schema
                                  :handle :report/payload-1234
                                  :original-size 4218543
                                  :truncated-preview "{\"rows\": [{...} ...]"}}])}

--- a/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/elision_test.clj
@@ -13,7 +13,7 @@
                 {:path   [:user :pdf]
                  :bytes  102400
                  :type   :string
-                 :reason :declared
+                 :reason :schema
                  :handle [:rf.elision/at [:user :pdf]]}}]
     ;; Empty / leaf cases — nothing to count.
     (is (= 0 (elision/count-elided-markers nil)))
@@ -44,7 +44,7 @@
                                {:path [:a :b]
                                 :bytes 100
                                 :type :string
-                                :reason :declared
+                                :reason :schema
                                 :handle [:rf.elision/at [:a :b]]
                                 ;; A pathological marker-shaped value
                                 ;; lodged inside the body would still
@@ -63,7 +63,7 @@
                 {:path   [:user :pdf]
                  :bytes  102400
                  :type   :string
-                 :reason :declared
+                 :reason :schema
                  :handle [:rf.elision/at [:user :pdf]]}}
         contents [{:slice 1} marker {:slice 2 :nested marker}]
         as-lazy  (map identity contents)]

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -241,7 +241,7 @@
    [:path    [:vector :any]]
    [:bytes   :int]
    [:type    [:enum :map :vector :set :scalar :string]]
-   [:reason  [:enum :declared :schema :runtime-flagged]]
+   [:reason  [:enum :schema]]
    [:hint    [:maybe :string]]
    [:handle  [:tuple [:= :rf.elision/at] [:vector :any]]]
    [:digest  {:optional true} :string]])
@@ -470,23 +470,24 @@
     ;; Reserved by Conventions / spec; pair2-mcp emits today and
     ;; causa-mcp's Principles cross-links the canonical shape from
     ;; its §"Streaming over batch" trimmer. Two fixtures below
-    ;; represent two distinct emission shapes — declared/string vs
-    ;; runtime-flagged/map-with-digest.
+    ;; represent two distinct emission shapes — schema/string vs
+    ;; schema/map-with-digest (the schema-driven nomination path is
+    ;; the only nomination path post Path-D / rf2-w3n5u).
     :servers  #{:pair2-mcp :causa-mcp}
-    :fixtures {:pair2-mcp-declared
+    :fixtures {:pair2-mcp-schema-string
                {:rf.size/large-elided
                 {:path   [:user :uploaded-pdf]
                  :bytes  102400
                  :type   :string
-                 :reason :declared
+                 :reason :schema
                  :hint   "User-uploaded PDF; fetch via get-path."
                  :handle [:rf.elision/at [:user :uploaded-pdf]]}}
-               :pair2-mcp-runtime-with-digest
+               :pair2-mcp-schema-with-digest
                {:rf.size/large-elided
                 {:path   [:cofx :db]
                  :bytes  524288
                  :type   :map
-                 :reason :runtime-flagged
+                 :reason :schema
                  :hint   nil
                  :handle [:rf.elision/at [:cofx :db]]
                  :digest "sha256:deadbeefcafef00d"}}}}
@@ -985,7 +986,7 @@
                  {:path [:user :pdf]
                   :bytes 102400
                   :type :string
-                  :reason :declared
+                  :reason :schema
                   :hint "User PDF; fetch via get-path."
                   :handle [:rf.elision/at [:user :pdf]]}}
                 :elided-large 1}}}])

--- a/tools/pair2-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/pair2-mcp/spec/003-Tool-Catalogue.md
@@ -176,12 +176,14 @@ the hit:
   hash matched the stored entry for `(tool, args)`. The MCP
   server saved the **wire bytes** but paid the full nREPL
   round-trip and the local transform pipeline.
-- **`:precheck`** (rf2-36xod) — the pre-eval short-circuit. One
-  cheap bencode round-trip asked the runtime for
-  `(hash (re-frame-pair2.runtime/snapshot frame))`; the hash
-  matched the stored `:precheck-hash`. The MCP server saved
-  **both** the wire bytes AND the full tool eval + transform
-  pipeline. The tool body was never invoked.
+- **`:precheck`** (rf2-36xod, rf2-9pe31) — the pre-eval
+  short-circuit. One cheap bencode round-trip asked the runtime
+  for `(re-frame-pair2.runtime/app-db-hash frame)` — an O(1)
+  accessor over the runtime's per-frame cached hash, kept
+  current by its epoch listener (rf2-9pe31); the hash matched
+  the stored `:precheck-hash`. The MCP server saved **both** the
+  wire bytes AND the full tool eval + transform pipeline. The
+  tool body was never invoked.
 
 Same wire vocabulary, different cost saved. Agent hosts that
 diagnose latency / token usage can branch on `:via` — a

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/cache.cljs
@@ -42,12 +42,15 @@
   The original (rf2-3rt1f) shape paid the full nREPL round-trip and
   local transform pipeline; the cache only saved the *wire bytes*.
   rf2-36xod added a **precheck** path on top: an entry can carry a
-  cheap `:precheck-hash` (e.g. `(hash (re-frame-pair2.runtime/snapshot
-  frame))`). Before running the tool, the MCP server fetches the
-  current precheck-hash via one bencode round-trip; if it matches
-  the stored `:precheck-hash` for `(tool, args)`, the server emits
-  the `:rf.mcp/cache-hit` marker WITHOUT running the tool. Saves
-  both wire bytes AND the heavyweight tool eval + transform pipeline.
+  cheap `:precheck-hash` fetched via one bencode round-trip. rf2-9pe31
+  collapsed the precheck eval to `(re-frame-pair2.runtime/app-db-hash
+  frame)` — an O(1) accessor over a per-frame integer cache the
+  runtime keeps current via its epoch listener (every settled
+  mutation updates the cached hash). Before running the tool, the MCP
+  server fetches the current precheck-hash; if it matches the stored
+  `:precheck-hash` for `(tool, args)`, the server emits the
+  `:rf.mcp/cache-hit` marker WITHOUT running the tool. Saves both
+  wire bytes AND the heavyweight tool eval + transform pipeline.
 
   See `precheck` (decide before running the tool) vs `apply-cache`
   (decide after running the tool — the original behaviour, used as
@@ -326,10 +329,12 @@
   `current-precheck-hash` argument matches it.
 
   `current-precheck-hash` is the value the MCP server fetched in a
-  single bencode round-trip (e.g.
-  `(hash (re-frame-pair2.runtime/snapshot frame))`). When the caller
-  has no precheck wiring for this tool (yet), it passes `nil` and
-  this fn returns `nil`, leaving the legacy post-eval path in charge.
+  single bencode round-trip (today: `(re-frame-pair2.runtime/app-db-hash
+  frame)` — an O(1) accessor over the runtime's per-frame cached
+  hash, kept current by its epoch listener — see rf2-9pe31). When
+  the caller has no precheck wiring for this tool (yet), it passes
+  `nil` and this fn returns `nil`, leaving the legacy post-eval path
+  in charge.
 
   This fn does NOT mutate the cache on a miss — the subsequent
   `apply-cache` call records the new result+precheck-hash together

--- a/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
+++ b/tools/pair2-mcp/src/re_frame_pair2_mcp/tools/precheck.cljs
@@ -83,18 +83,19 @@
   the tag in `target` (`[:explicit <kw>]` / `[:operating-frame nil]`)
   — the keyword sentinel of the prior shape is gone.
 
-  We hash the full per-frame snapshot — `(hash db)` is O(n) on the
-  persistent map but the wire payload is a single integer, and the
-  alternative (running the full tool + transform pipeline) is strictly
-  more expensive. A cheaper O(1) hash kept at mutation time is the
-  follow-on optimisation (filed separately)."
+  Threads through `re-frame-pair2.runtime/app-db-hash` (rf2-9pe31),
+  which returns the per-frame cached `(hash app-db)` integer in O(1).
+  The cache is maintained by the runtime's epoch listener at every
+  settled mutation; lazy-computed on the first read for a frame whose
+  hash hasn't been observed yet. The wire payload is a single integer
+  regardless of app-db size."
   [[tag frame :as _target]]
   (case tag
     :explicit
-    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot frame)))
+    (ef/emit (ef/rt-call 'app-db-hash frame))
 
     :operating-frame
-    (ef/emit (ef/rt-call* 'hash (ef/rt-call 'snapshot)))
+    (ef/emit (ef/rt-call 'app-db-hash))
 
     nil))
 

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/elision_test.cljs
@@ -362,7 +362,7 @@
   `elide-wire-value` walker would emit."
   {:rf.size/large-elided
    {:path [:user :uploaded-pdf] :bytes 102400 :type :string
-    :reason :declared :handle [:rf.elision/at [:user :uploaded-pdf]]}})
+    :reason :schema :handle [:rf.elision/at [:user :uploaded-pdf]]}})
 
 (deftest snapshot-map-arm-uses-server-elided-when-supplied
   ;; rf2-e35a5: when `:server-elided` is on opts, the arm uses it

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/eval_form_test.cljs
@@ -133,14 +133,14 @@
          (ef/emit (ef/rt-call 'drain-subscription! "sub-xyz")))))
 
 (deftest precheck-form-shape-no-frame
-  (is (= "(hash (re-frame-pair2.runtime/snapshot))"
-         (ef/emit
-           (ef/rt-call* 'hash (ef/rt-call 'snapshot))))))
+  ;; rf2-9pe31 — precheck routes through the O(1) cached accessor.
+  (is (= "(re-frame-pair2.runtime/app-db-hash)"
+         (ef/emit (ef/rt-call 'app-db-hash)))))
 
 (deftest precheck-form-shape-with-frame
-  (is (= "(hash (re-frame-pair2.runtime/snapshot :rf/default))"
-         (ef/emit
-           (ef/rt-call* 'hash (ef/rt-call 'snapshot :rf/default))))))
+  ;; rf2-9pe31 — explicit-frame arm names the frame on the cheap accessor.
+  (is (= "(re-frame-pair2.runtime/app-db-hash :rf/default)"
+         (ef/emit (ef/rt-call 'app-db-hash :rf/default)))))
 
 (deftest snapshot-state-form-is-edn-readable
   ;; Migrated from snapshot.cljs:62. The non-elision arm.
@@ -162,8 +162,11 @@
          (ef/emit (ef/rt-call* 're-frame.core/elide-wire-value)))))
 
 (deftest rt-call*-bare-symbol-emits-verbatim
-  ;; A bare symbol (no namespace) emits as just the name. The
-  ;; precheck-form's `(rt-call* 'hash ...)` relies on this.
+  ;; A bare symbol (no namespace) emits as just the name. Pre-rf2-9pe31
+  ;; the precheck-form built `(hash ...)` via this path; post-rf2-9pe31
+  ;; the precheck routes through `app-db-hash` (the cached O(1)
+  ;; accessor), but the bare-symbol arm remains useful for other
+  ;; future call sites that need an unqualified host fn.
   (is (= "(hash)" (ef/emit (ef/rt-call* 'hash)))))
 
 (deftest rt-call*-string-qsym-emits-verbatim

--- a/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_pipeline_benchmark_test.cljs
+++ b/tools/pair2-mcp/test/re_frame_pair2_mcp/wire_pipeline_benchmark_test.cljs
@@ -157,7 +157,7 @@
   (let [marker (fn [path]
                  {:rf.size/large-elided
                   {:path path :bytes 102400 :type :string
-                   :reason :declared :handle [:rf.elision/at path]}})
+                   :reason :schema :handle [:rf.elision/at path]}})
         with-markers (reduce (fn [m i]
                                (assoc m
                                       (keyword (str "elided-" i))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -284,9 +284,9 @@
       knobs flipped on the walker yields `v` at every node (per
       `elide-wire-value`'s composition rule: `sensitive?` and `large?`
       both return `v` when their inclusion flag is true; no marker
-      emit, no `write-runtime-flagged!`, no warning). The walk is a
-      pure no-op — full traversal, zero edits — so we skip it. The
-      escape hatch should be free."
+      emit, no schema-driven elision, no warning). The walk is a pure
+      no-op — full traversal, zero edits — so we skip it. The escape
+      hatch should be free."
   [app-db variant-id include?]
   (cond
     (nil? app-db) app-db


### PR DESCRIPTION
## Summary

Cluster G: three small-residual beads across disjoint surfaces.

- **rf2-j3pw5** (P3 chore) — Finish residual deleted-vocabulary migration post-Path-D (PR #1212). Replaced `:reason :declared` / `:reason :runtime-flagged` / `:source :runtime-flagged` / `write-runtime-flagged!` references across causa testbeds + mcp-base/causa-mcp/pair2-mcp/mcp-conformance test fixtures + story-mcp helpers docstring. Schema-first `:reason :schema` is now the only nomination vocabulary across all tool tests. Spec-Schemas.md `:rf/elision-marker` already pins `[:reason [:enum :schema]]` — this finishes the migration outside the merged hot path.
- **rf2-6phn** (P4 refactor) — Track void-tag duplication between reagent2.dom.server (in `day8/reagent-slim-and-fast`) and re-frame.ssr.emit (in `day8/re-frame2-ssr`). Bundle isolation forbids `:require` across the two artefacts; HTML5's void-tag list is fixed, so duplication is the right shape. The reagent-slim side already cross-referenced re-frame.ssr; this commit adds the mirror reference on the re-frame.ssr side so a future modifier of either copy sees the lockstep requirement from whichever surface they encountered first. Clarified that boolean-attrs is one-sided — re-frame.ssr's `html-helpers/attr-string` is value-driven (no set to sync).
- **rf2-9pe31** (P4 feat) — Cheap O(1) runtime app-db-hash accessor for the pair2-mcp precheck (follow-on to rf2-36xod). Added `re-frame-pair2.runtime/app-db-hash` returning the per-frame cached `(hash app-db)` in O(1); cache populated by `on-epoch-streaming` from `(:db-after record)` at every settled mutation. `precheck-form` rewired to emit `(re-frame-pair2.runtime/app-db-hash <frame>)` instead of `(hash (snapshot <frame>))`. Wire contract unchanged.

## Test plan

- [x] `tools/mcp-conformance/wire-vocab` JVM tests — 39 / 674 green
- [x] `tools/mcp-base` JVM tests — 112 / 283 green
- [x] `implementation/ssr` JVM tests — 171 / 569 green
- [x] `implementation` `npm run test:elision` — production 31/31 absent, control 31/31 present
- [x] `implementation` `npm run test:cljs` — 2356 tests / 6764 assertions green
- [x] `tools/pair2-mcp` `npm test` — 442 / 1078 green
- [x] `tools/causa-mcp` `npm test` — 511 / 1432 green
- [x] `tools/story-mcp` `clojure -M:test` — 124 / 596 green
- [x] `skills/re-frame-pair2` `bb tests/runtime/app_db_hash_test.clj` — 7 tests / 13 assertions green