### PR TITLE
chore(core)+spec: rf2-kp835 Phase-3 — rare-helper classification (Mike decisions)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -290,15 +290,19 @@
 
 #?(:clj
    (do
-     (def ^{:doc "JVM-only macro-helper re-exposed for tests that reach
+     (def ^{:no-doc true
+            :doc "JVM-only macro-helper re-exposed for tests that reach
   `re-frame.core/expand-reg-view` directly (pre-split test access, per
   rf2-4rnui). Not part of the public surface — see
-  `re-frame.core-reg-view-macro/expand-reg-view`."}
+  `re-frame.core-reg-view-macro/expand-reg-view`. Internal per rf2-kp835
+  Phase-2 (2026-05-17)."}
        expand-reg-view             rvm/expand-reg-view)
-     (def ^{:doc "JVM-only macro-helper re-exposed for tests that reach
+     (def ^{:no-doc true
+            :doc "JVM-only macro-helper re-exposed for tests that reach
   `re-frame.core/parse-reg-view-args` directly (pre-split test access,
   per rf2-4rnui). Not part of the public surface — see
-  `re-frame.core-reg-view-macro/parse-reg-view-args`."}
+  `re-frame.core-reg-view-macro/parse-reg-view-args`. Internal per
+  rf2-kp835 Phase-2 (2026-05-17)."}
        parse-reg-view-args         rvm/parse-reg-view-args)))
 
 ;; ---- view registration ---------------------------------------------------

--- a/spec/API.md
+++ b/spec/API.md
@@ -31,6 +31,19 @@
 
 ---
 
+## Classification (rf2-kp835)
+
+Every public-surface row in this document is **Canonical** — a documented, supported, v1 (or post-v1 lib) API that downstream apps and tools may rely on, in the status the row's Status column gives. The rf2-kp835 audit (Phase-1, 2026-05-17) classified ~110 public defs of `re-frame.core` and confirmed 97% canonical; the rare-use helpers all justified canonical status (interceptor plumbing, adapter lifecycle, schema-printer swap seam, off-box-egress projections, v1-preserved teardown / clearing surfaces). No public surface is classified Deprecated; none is classified Advanced.
+
+The only **Internal** carve-outs are two JVM-only macro-helpers re-exposed in `re-frame.core` purely so pre-split tests can reach them (per rf2-4rnui):
+
+- `re-frame.core/expand-reg-view` — `^:no-doc`; the canonical home is `re-frame.core-reg-view-macro/expand-reg-view`.
+- `re-frame.core/parse-reg-view-args` — `^:no-doc`; the canonical home is `re-frame.core-reg-view-macro/parse-reg-view-args`.
+
+Neither is rowed in this projection. Applications and tools MUST NOT depend on these re-exports; reach the canonical homes directly.
+
+---
+
 ## Registration
 
 > **Return value.** Every `reg-*` row below returns its **primary id** — the keyword (or path, for `reg-app-schema`) the caller registered with. `reg-flow` returns the `:id` value of its flow-map (the primary id is carried by the map, not a separate arg). Per [Conventions §`reg-*` return-value convention](Conventions.md#reg--return-value-convention).


### PR DESCRIPTION
## Summary

Apply rf2-kp835 Phase-3: implement Mike's Phase-2 (2026-05-17) decisions on rare-use public helper classification.

**Phase-1 audit** (`ai/findings/rf2-kp835-rare-helper-classification-2026-05-17.md`, 2026-05-17) classified ~110 public defs of `re-frame.core` and confirmed **97% canonical**. The audit was a "validate the existing classification" exercise — the only true Internal candidates were the two JVM-only macro-helper re-exports already self-documented as "not part of the public surface."

## Mike's Phase-2 decisions (2026-05-17, all 4)

1. **`set-schema-printer!`** (0 callers) — **Keep canonical** + file test bead (the digest-pipeline print companion per Spec 010, rf2-wla45; non-Malli ports need it).
2. **`projected-record` / `projected-history`** (0 callers) — **Keep canonical** + file MCP-conformance bead (the single normative off-box-egress projection point per Security.md rf2-mrsck; MCP-side callers haven't shipped).
3. **`elision-sensitive-declarations`** (0 callers) — **Canonical** (symmetry sibling of the rowed `elision-declarations`).
4. **`expand-reg-view` / `parse-reg-view-args`** (8 + 5 in-tree-test callers) — **Light-touch `^:no-doc`** on both. Docstrings already say "Not part of the public surface" (rf2-4rnui); marking `^:no-doc` is the Clojure-idiomatic carve without moving namespaces or breaking the in-tree test callers.

## Changes

- **`implementation/core/src/re_frame/core.cljc`** — add `:no-doc true` to the metadata on `expand-reg-view` and `parse-reg-view-args` re-exports.
- **`spec/API.md`** — new `## Classification (rf2-kp835)` section documenting the policy (Canonical default; the two `^:no-doc` Internal carve-outs; no Advanced; no Deprecated). Free-standing section rather than a uniform-value column added to ~20 surface tables — the audit value is `Canonical` everywhere except the two helpers that aren't rowed at all.

## Follow-on beads filed

- **rf2-pk8ur** — `test(schemas): set-schema-printer! contract test` (decision 1)
- **rf2-xrlyi** — `test(causa-mcp): projected-record + projected-history conformance` (decision 2)

## Cross-refs

- Bead: rf2-kp835
- Findings: `ai/findings/rf2-kp835-rare-helper-classification-2026-05-17.md` (local-only per the-mayor-method)
- Date: 2026-05-17

## Test plan

- [x] `cd implementation && npm run test:cljs` — 2356 tests / 6764 assertions / 0 failures / 0 errors
- [x] `cd implementation/core && clojure -M:test` — 547 tests / 2846 assertions / 0 failures / 0 errors
- [x] `mkdocs build --strict` — 68 warnings unchanged from origin/main baseline (all pre-existing broken cross-links to spec/ from docs/guide and docs/skills; none introduced by this PR)