### PR TITLE
feat(skills): add causa user skill — launch-mode + panel-tour (rf2-jw6lc)

### DIFF
--- a/skills/causa/SKILL.md
+++ b/skills/causa/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: causa
+description: >
+  Read-only tour of **Causa** — the re-frame2 devtools panel. Use when the
+  user wants to know how to *launch* Causa (in-app inline panel, pop-out
+  window, programmatic mount, or the two wired hotkeys), which of its 16
+  panels surfaces the data they're looking for, or what each panel is
+  *for*. Trigger phrases: "open Causa", "where is X in Causa",
+  "which Causa panel shows…", "Ctrl+Shift+C", "Causa hotkey",
+  "Causa popout", "Causa hydration debugger", "Causa schema timeline",
+  "Causa machine inspector", and similar. **Do not use** for: driving
+  Causa programmatically from a live REPL (that's `re-frame-pair2`),
+  authoring the host app (`re-frame2`), bootstrapping a new project
+  (`re-frame2-setup`), or implementing Causa itself (no skill yet — the
+  `causa-implementor` sibling is deferred to post-alpha). This skill
+  cites `tools/causa/spec/*` as the source of truth; where a spec doc
+  has an open question, hedge with "see spec/0NN" rather than freezing
+  prose.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+---
+
+# causa
+
+A tour skill for **Causa** — the re-frame2 in-app devtools panel. Causa is
+the structural successor to re-frame-10x: where v1 organised debugging
+around the *epoch panel*, Causa organises it around the *story a cascade
+tells*. Every dispatch is a node in a graph of causes; every state delta
+is a slice you can scrub; every machine transition lands on a chart; every
+schema violation surfaces as an issue you cannot miss.
+
+This skill answers two questions, and only two:
+
+1. **How do I launch Causa?** — the inline panel, the pop-out, the
+   programmatic entry points, the wired hotkeys.
+2. **Which panel shows X?** — a one-line purpose for each of the 16
+   panels Causa ships.
+
+Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source,
+redaction-indicator semantics) are **out of scope** in this iteration —
+see the *Out of scope* section below for what to do when one comes up.
+
+---
+
+## What Causa is
+
+An in-app true-inline devtools panel for re-frame2 applications, preloaded
+into dev builds via shadow-cljs `:preloads`. The host app provides a
+right-side `[data-rf-causa-host]` column in its normal layout; Causa
+auto-opens there once the substrate adapter is ready. Production builds
+elide the entire surface through the universal `interop/debug-enabled?`
+gate — zero bytes ship to consumers.
+
+Causa consumes re-frame2's instrumentation surface (Spec 009 trace bus,
+Tool-Pair epoch history, the registrar query API) — it adds nothing the
+framework didn't already expose. The 16 panels are *presentation* of an
+already-structured runtime.
+
+A separate jar `tools/causa-mcp/` exposes Causa's surfaces as MCP tools
+for AI agents — same architecture as `tools/pair2-mcp/`, different tool
+catalogue. This skill does not cover the MCP surface; see
+[`tools/causa-mcp/spec/004-Tools-Catalogue.md`](../../tools/causa-mcp/spec/004-Tools-Catalogue.md).
+
+---
+
+## Launching Causa — pick a mode
+
+Three launch modes ship today. Pick the one that matches the user's
+situation.
+
+| User wants to … | Use | How |
+|---|---|---|
+| Inspect the runtime while developing locally | **Default true-inline panel** | Add the preload + a `[data-rf-causa-host]` column in the app layout. Causa auto-opens on page load. |
+| Put Causa on a second monitor with the app full-screen | **Pop-out window** | `(causa/popout!)` from CLJS, or `window.day8.re_frame2_causa.popout_BANG_()` from devtools. |
+| Mount Causa from code (no preload, or alternative wiring) | **Programmatic `init!`** | Call `(causa/init! opts)` after `rf/init!`. Idempotent. |
+| Have an AI agent inspect the runtime | **Causa-MCP** (separate artefact) | Configure `tools/causa-mcp/` in the agent host. Out of scope for this skill — see [`tools/causa-mcp/`](../../tools/causa-mcp/). |
+| Debug a mobile browser | Not supported | Per `spec/011-Launch-Modes.md` §What this doesn't do — phones refuse to mount. |
+
+For the decision tree in depth (preload vs `init!`, suppress-auto-open
+on tool-only pages, the `:layout/host-selector` knob, host-CSS-variable
+resize, pop-out lifecycle), see [`reference/launch-modes.md`](reference/launch-modes.md).
+
+### Wired hotkeys
+
+Only two hotkeys are wired in `keybinding.cljs` pre-alpha. Spec
+[`007-UX-IA.md` §Keyboard](../../tools/causa/spec/007-UX-IA.md#keyboard)
+catalogues a richer global / navigation / panel-jump map, but only these
+two have a global keydown listener installed today:
+
+| Key | Action |
+|---|---|
+| `Ctrl+Shift+C` | Toggle the Causa panel (mount on first press; CSS show/hide after). |
+| `Ctrl+Shift+/` | Toggle the AI Co-Pilot rail. |
+
+The remaining keys catalogued in the spec (`?`, `,`, panel-jump
+mnemonics, scrubber controls, event-action shortcuts) require focus
+inside Causa and are not global; some are explicit follow-on work. The
+command-palette `Ctrl+K` was never wired and was struck under rf2-27zh2
+(Cluster C cleanup) — do not suggest it as a launch path. The pop-out
+has no hotkey; use `(causa/popout!)` or the future right-click affordance
+on the launcher pill.
+
+---
+
+## The 16 panels — what each surfaces
+
+The sidebar lists 16 panels in three groups (always-active, conditional,
+dormant). When the user asks "where is X?", route to the panel whose
+purpose covers it. For more detail on each — group membership, dormant
+state, activity badges, deeper "open it when…" guidance — see
+[`reference/panels.md`](reference/panels.md).
+
+| Panel | One-line purpose | When you'd open it |
+|---|---|---|
+| **Event detail** *(hero)* | The six-domino cascade for the selected dispatch: event vector, diff, fx fired, subs recomputed, renders, duration. | Default landing view. "What happened in this dispatch?" |
+| **Time travel** | Bottom-rail scrubber over per-frame `epoch-history`; passive scrub rebases view, explicit rewind calls `restore-epoch`. | "Walk me through the last N dispatches." |
+| **App-db** | Slice-centric diff: changed slices for the selected epoch + pinned live slices + reserved-key inspector. | "What in app-db just changed?" / "Show me when `[:cart :items]` last moved." |
+| **Causality** | Vertical directed graph keyed by `:dispatch-id` / `:parent-dispatch-id`. Non-dispatch traces attach as flags inside the parent node. | "This cascade is more than two hops" / "I'm triaging a session with 30+ events." |
+| **Subscriptions** | Registered subs + their invalidation chains + cache status + last-recomputed values. | "Why didn't my view update?" / "Trace the recompute chain for `:cart/total`." |
+| **Effects** *(fx)* | Registered fxs + per-fx invocations + outcome status + stub indicator. | "Which fx fired in this epoch?" / "Did `:http/get` get skipped?" |
+| **Trace** | Raw event ribbon — every trace event in the buffer as a timestamped row, filterable along the 13-axis Spec 009 vocabulary. | "Grep the full trace stream." / "Show me every `:rf.fx/*` event in the last minute." |
+| **Machines** | State-chart per registered machine (embeds `tools/machines-viz/`) + transition-history ribbon. Pre-alpha: chart is a placeholder pending the viz impl. | "What state is my checkout machine in?" / "What transition fired?" |
+| **Flows** | Registered flows + per-flow inputs / output path / live recomputation indicator. | "Is this flow recomputing?" / "Which inputs feed this flow?" |
+| **Routes** | Registered routes + active `:rf/route` slice + recent navigation history. | "What route am I on?" / "Show me the last few navigations." |
+| **Performance** | Per-cascade duration capture, perf-tier colour (`<16ms` / `16–50` / `50–100` / `>100`), budget-warning markers. | "Which cascades blew the INP budget?" |
+| **Issues** | Unified feed: errors + warnings + schema violations + hydration mismatches. Top-strip badge mirrors count. | "Anything broken?" / "Show me all schema failures." |
+| **Schemas** | One row per registered schema; coloured dot per failure with recovery-mode mapping. | "Has any schema violated this session?" / "When did `:user/profile` start failing?" |
+| **Hydration** *(dormant)* | Server-vs-client render-tree side-by-side with divergent node flagged and hash-bisector path highlighted. Dormant `◌` until the first `:rf.ssr/hydration-mismatch` trace lands. | "My SSR hydration is mismatching" — only visible when SSR runs. |
+| **MCP** | Live feed of MCP-server activity: tool calls in flight, recent results, per-origin colouring. | "What is my agent doing right now?" / "Did the MCP call land?" |
+| **Co-pilot** *(rail)* | Pull-only AI Q&A and slash commands over the live runtime. Collapsed by default; expand via `Ctrl+Shift+/`. Ephemeral (no persistence). | "Ask Causa why X happened." (Lock 8 — collapsed by default per `spec/007-UX-IA.md`.) |
+
+The hero on first open is **Event detail**. The Co-pilot rail is
+collapsed by default (Lock 8); the magenta `◇` cue glyph in the top
+strip pulses every 8 seconds until the user has invoked the co-pilot
+once.
+
+---
+
+## Out of scope (this iteration)
+
+When a user asks about any of the following, this skill does not have
+the answer — point them at the spec doc or pair-tool surface and stop
+short of improvising.
+
+- **Workflow recipes** (find-wrong-sub, scrub-bad-epoch,
+  redaction-indicator semantics, click-to-source / "open in editor"
+  details, pop-out lifecycle gotchas). Source of truth:
+  [`tools/causa/spec/007-UX-IA.md`](../../tools/causa/spec/007-UX-IA.md)
+  and the per-panel specs (`tools/causa/spec/00N-*.md`). A future
+  iteration may codify these as recipes; today the spec is the answer.
+- **Driving Causa programmatically** (hot-swap a sub via REPL, time-
+  travel from CLJS, dispatch into the runtime from a tool). Route to
+  the [`re-frame-pair2`](../re-frame-pair2/SKILL.md) skill — Causa
+  owns the *seeing*; pair2 owns the *driving*.
+- **Implementing Causa** (panel-facade/leaf split, mount lifecycle
+  internals, frame-provider isolation, the epoch pump's contract).
+  Source of truth:
+  [`tools/causa/spec/011-Launch-Modes.md` §Mount lifecycle](../../tools/causa/spec/011-Launch-Modes.md#mount-lifecycle-rf2-9kkrm)
+  and the per-panel implementation specs. A `causa-implementor` sibling
+  skill is **deferred to post-alpha** until the Causa surface stabilises.
+- **Causa-MCP tools.** Different artefact, different surface — see
+  [`tools/causa-mcp/spec/004-Tools-Catalogue.md`](../../tools/causa-mcp/spec/004-Tools-Catalogue.md).
+
+---
+
+## Style guidance
+
+- **Cite the spec, don't paraphrase it.** When a user asks for normative
+  detail (the mount contract, the epoch pump's ordering guarantees, the
+  redaction marker's grammar), link to the relevant
+  `tools/causa/spec/*.md` and quote sparingly.
+- **Pre-alpha hedge.** Some panels are partial (Machines depends on
+  `tools/machines-viz/` which is a placeholder pre-alpha; Schemas /
+  Hydration only render when the relevant feature is wired into the
+  host). When a user asks about an in-progress surface, say so and
+  point at the spec.
+- **Don't invent hotkeys.** Only `Ctrl+Shift+C` and `Ctrl+Shift+/` are
+  globally wired today. Everything else in
+  [`spec/007-UX-IA.md` §Keyboard](../../tools/causa/spec/007-UX-IA.md#keyboard)
+  is normative for the future, not for "what works in your build right
+  now."
+- **Route, don't blur.** If the user wants to drive Causa, point at
+  `re-frame-pair2`; if they want to implement it, point at the spec
+  and note that no implementor skill exists yet. This skill is a tour.
+
+---
+
+*For the full skill-disambiguation matrix (when to use which skill) see
+[`skills/README.md` §Skill routing — single source](../README.md#skill-routing--single-source).*

--- a/skills/causa/reference/launch-modes.md
+++ b/skills/causa/reference/launch-modes.md
@@ -1,0 +1,247 @@
+# launch-modes — getting Causa visible
+
+Source of truth: [`tools/causa/spec/011-Launch-Modes.md`](../../../tools/causa/spec/011-Launch-Modes.md).
+This leaf is the decision-tree-shaped tour of what the spec normalises.
+When a user's question hits a corner this leaf doesn't cover, defer to
+the spec doc rather than improvising prose.
+
+## Decision tree
+
+```
+Is the host app's dev build running with the Causa preload? ── no ──► §Install the preload
+                       │
+                      yes
+                       │
+            Has `rf/init!` run? ── no ──► §Programmatic init!
+                       │
+                      yes
+                       │
+        Is there a [data-rf-causa-host] in the page layout?
+                       │
+        ┌──────────────┴──────────────┐
+       yes                           no
+        │                             │
+        ▼                             ▼
+  Causa auto-opened into the    Causa logged the missing-host
+  inline host on page load.     diagnostic (console.error +
+  Toggle with Ctrl+Shift+C.     window.day8.re_frame2_causa.status())
+        │                             │
+        ▼                             ▼
+  Need a second monitor?        §Layout host contract (add the column)
+        │
+       yes
+        │
+        ▼
+  (causa/popout!) — same-origin
+  second window, reads the
+  opener's runtime atoms directly.
+```
+
+## Install the preload
+
+The default path. Add the preload namespace to shadow-cljs's
+`:devtools/preloads`:
+
+```clojure
+;; shadow-cljs.edn — dev build only
+{:builds {:app {:devtools {:preloads [day8.re-frame2-causa.preload]}}}}
+```
+
+The preload runs four foundation side-effects (per
+[`spec/011-Launch-Modes.md` §Mount lifecycle](../../../tools/causa/spec/011-Launch-Modes.md#mount-lifecycle-rf2-9kkrm)):
+
+1. Register `:rf.causa/*` handlers against the `:rf/causa` frame.
+2. Register the trace collector via `register-trace-cb!` under
+   `:rf.causa/trace-collector`.
+3. Register the epoch collector via `register-epoch-cb!` under
+   `:rf.causa/epoch-collector` (no-op when the
+   `day8/re-frame2-epoch` artefact is absent).
+4. Attach the global `Ctrl+Shift+C` keydown listener.
+
+It schedules an auto-open into `[data-rf-causa-host]` once
+`current-adapter` is ready. The preload MUST NOT mount synchronously
+during namespace load; it MAY schedule a bounded adapter-ready retry.
+
+Idempotency: every step is `defonce`-guarded. shadow-cljs `:after-load`
+reruns are safe — no double-attached listeners, no double-mount, no
+"already registered" warnings.
+
+## Layout host contract
+
+The host app provides a Causa column in its normal layout. Default
+selector: `[data-rf-causa-host]`. Minimal markup (DOM order matters —
+`<main>` first, host `<aside>` second, so flex puts the aside on the
+right):
+
+```html
+<div class="app-shell">
+  <main id="app"></main>
+  <aside data-rf-causa-host></aside>
+</div>
+```
+
+```css
+body { margin: 0; }
+.app-shell { display: flex; min-height: 100vh; }
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 420px);
+  min-width: 320px;
+  box-sizing: border-box;
+  border-left: 1px solid #2a2a2a;
+  resize: horizontal;
+  overflow: auto;
+}
+#app { flex: 1; min-width: 0; }
+```
+
+The host owns sizing and layout; Causa owns the shell rendered inside
+the host. Override the selector before Causa opens:
+
+```clojure
+(require '[day8.re-frame2-causa.config :as causa-config])
+(causa-config/configure! {:layout/host-selector "#devtools-causa"})
+```
+
+### Resizing the host
+
+The recommended CSS reads `--rf-causa-inline-width` for its
+`flex-basis`. Two cooperating resize mechanisms, both browser-native,
+both JS-free:
+
+1. **CSS variable** — host-owned, fixed-point sizing. Set the initial
+   width or override per route/per build via the cascade. One
+   declaration, no listeners.
+   ```css
+   :root { --rf-causa-inline-width: 560px; }       /* global default */
+   .debug-route { --rf-causa-inline-width: 720px; } /* per route */
+   ```
+2. **Browser-native drag** — `resize: horizontal` + `overflow: auto`
+   gives the host a drag handle in its bottom-right corner. The user
+   drags, the host's used width updates, flex reflow shrinks `#app` to
+   fill the remainder. No CLJS, no listener, no Causa surface.
+
+Causa MUST NOT introduce a JS-driven draggable separator and MUST NOT
+set the variable from CLJS — the host's stylesheet is the single source
+of truth.
+
+### Suppress auto-open
+
+Tool-owned pages that deliberately do not allocate layout space for
+Causa (Story-only browser-test canvases, headless probe pages) MAY
+suppress only the default page-load open before `rf/init!`:
+
+```clojure
+(causa-config/configure! {:launch/auto-open? false})
+```
+
+This does not disable Causa. The collectors, browser API, keybinding,
+and explicit `open!` / `toggle!` calls remain installed; an explicit
+open with no host still emits the actionable missing-host diagnostic.
+App dev pages should keep the default `true` posture and provide
+`[data-rf-causa-host]`.
+
+### Disable entirely
+
+```clojure
+;; Either: remove the preload entry from :devtools/preloads
+;; Or: closure-define the disable flag in the dev build
+:closure-defines {day8.re-frame2-causa.config/enabled? false}
+```
+
+## Programmatic init!
+
+Alternative to the preload — call `(causa/init! opts)` from app code
+after `rf/init!`. Idempotent; each underlying side-effect is `defonce`-
+guarded so a second call is a no-op.
+
+```clojure
+(require '[day8.re-frame2-causa.core :as causa])
+
+(causa/init!
+ {:default-frame :app/main          ; target-frame for the scrubber
+  :theme         :dark              ; / :light / :high-contrast
+  :density       :compact           ; / :cosy / :comfy
+  :ai-provider   {:provider :claude}
+  :buffer-depths {:trace 200 :epoch 50}})
+```
+
+Pre-alpha posture: `:default-frame` threads through to the
+`:rf.causa/set-target-frame` event. The other keys (`:theme`,
+`:density`, `:ai-provider`, `:buffer-depths`) are accepted today but
+not yet wired at runtime — passing them keeps host code forward-
+compatible. See `core.cljs` docstring for the current frontier.
+
+## Pop-out to a second window
+
+Solves "I want Causa on a second monitor while the app runs
+full-screen." Same-origin required.
+
+```clojure
+(causa/popout!)
+;; or, from a devtools console:
+;; window.day8.re_frame2_causa.popout_BANG_()
+```
+
+Mechanism: `window.open` whose JS realm is connected to the opener's
+via `window.opener`. The pop-out renders into the new window but
+**reads and dispatches against the opener's runtime atoms directly** —
+no `BroadcastChannel`, no `postMessage`, no structured-clone
+serialisation cost.
+
+Caveats inherited from the `window.opener` posture:
+
+- Same-origin required; do not open with `noopener` / `noreferrer`.
+- If the user closes the opener, the pop-out becomes orphaned. Pop-out
+  detects this via `window.opener.closed` and shows a clean
+  "opener gone — close this window" overlay (per rf2-h3ekl).
+- The pop-out can't survive a hard reload of the opener — atoms get
+  garbage-collected; the pop-out re-bootstraps via
+  `window.opener.causaRuntime` on opener reload.
+- No keybinding pre-alpha. The programmatic call is the contract.
+- A right-click → `Pop out` affordance on the launcher pill is the
+  canonical chrome-side path once that surface lands.
+
+## Wired hotkeys
+
+Only two listeners are attached today (`keybinding.cljs`), both using
+Ctrl+Shift to avoid Safari's Cmd+Shift+C Inspect collision on macOS:
+
+| Key | What it does |
+|---|---|
+| `Ctrl+Shift+C` | Toggle the Causa shell (mount on first press; CSS show/hide thereafter). |
+| `Ctrl+Shift+/` | Toggle the AI Co-Pilot rail. Dispatched into `:rf/causa` so open/closed state lives on Causa's app-db. |
+
+[`spec/007-UX-IA.md` §Keyboard](../../../tools/causa/spec/007-UX-IA.md#keyboard)
+catalogues additional shortcuts (`?`, `,`, `Ctrl+F`, `Esc`, `j`/`k`,
+`[`/`]`, panel-jump mnemonics). These are normative for the future but
+require focus inside Causa today; most are per-panel rather than
+global. The historical `Ctrl+K` command palette was never wired and
+was struck under rf2-27zh2 (Cluster C cleanup) — do not surface it
+as a launch path. The command palette opens through the top-strip
+control once that surface lands.
+
+## Hidden-state semantics
+
+When Causa is toggled off (Ctrl+Shift+C while open), the shell stays
+mounted with `display: none` on the container. The app receives no
+body padding, no viewport overlay, no fixed chrome. Re-open is a
+CSS-only `display: block` — no React remount, internal state
+(selected tab, scroll, AI conversation) survives. The first paint after
+the first toggle hits the <80ms target per
+[`spec/007-UX-IA.md` §Animation](../../../tools/causa/spec/007-UX-IA.md).
+
+`teardown!` is **test-only** and tears down both mount singletons
+(`mount-state` for the in-app shell, `popout-state` for the pop-out).
+Production sessions never tear down.
+
+## Production posture
+
+The preload's foundation block is gated on `re-frame.interop/debug-
+enabled?`. Production builds compiled with `(set! goog.DEBUG false)`
+strip every side-effect — the trace collector registration, the
+epoch-cb registration, the keybinding listener, the mount call. CI
+verifies via `npm run test:elision`.
+
+A non-elided dev build running in production-like conditions shows a
+yellow top banner: "Causa is enabled in this build. Disable for
+production." Single-click dismiss, remembered for the session.

--- a/skills/causa/reference/panels.md
+++ b/skills/causa/reference/panels.md
@@ -1,0 +1,244 @@
+# panels — the 16-panel tour
+
+Sources of truth: per-panel specs under
+[`tools/causa/spec/`](../../../tools/causa/spec/) (one `00N-*.md` per
+hero panel); [`007-UX-IA.md`](../../../tools/causa/spec/007-UX-IA.md)
+for chrome and sidebar grammar. Sidebar order is set in `shell.cljs`
+(`sidebar-items`).
+
+## Sidebar groups + badges
+
+Four groups, in `sidebar-items` order:
+
+- **Always-active** — Event detail, Time travel, App-db, Causality,
+  Subscriptions, Effects, Trace.
+- **Conditional with activity** — Machines, Flows, Routes,
+  Performance, Issues, Schemas.
+- **Dormant until first signal** — Hydration (wakes on the first
+  `:rf.ssr/hydration-mismatch`).
+- **Auxiliary** — MCP, Co-pilot.
+
+Activity badges (right-aligned, fade in once, never fade out): `●` =
+recent activity · `●N` = unread count · `●●●` = multiplicity · `◌` =
+dormant · `◇` = Co-pilot cue glyph.
+
+## Panel-by-panel
+
+### Event detail *(hero)*
+
+The default landing view. The six-domino cascade for the selected
+dispatch: event vector + source coord, the diff (slices moved between
+`:db-before` and `:db-after`), an inline mini-graph, fx fired, subs
+recomputed, renders triggered, total duration.
+
+**Open when:** you want the full picture of one dispatch. The hero
+answers the five canonical questions (what fired, what changed, what
+ran, what rendered, how long) on first paint.
+
+Spec: [`004-App-DB-Diff.md`](../../../tools/causa/spec/004-App-DB-Diff.md)
+(shares the diff surface);
+[`007-UX-IA.md` §The default landing view](../../../tools/causa/spec/007-UX-IA.md).
+
+### Time travel
+
+Bottom-rail scrubber over the target frame's `epoch-history`. Passive
+scrub rebases the view of history (App-db, Subscriptions, etc. follow
+the selected epoch); explicit rewind invokes `restore-epoch` with the
+six failure modes surfaced inline. Pinned snapshots live here too —
+session-scoped, useful for A/B comparison.
+
+**Open when:** walk recent history without dispatching; rewind and
+replay.
+
+Spec: [`002-Time-Travel.md`](../../../tools/causa/spec/002-Time-Travel.md).
+
+### App-db
+
+Slice-centric, not full-tree. Renders changed slices for the selected
+epoch + pinned live slices + a `[runtime] — reserved app-db keys`
+section for the `:rf/*` slots + "Show me when this changed" results
+for focused paths. Read-only — App-db edits happen in source or via
+the [`re-frame-pair2`](../../re-frame-pair2/SKILL.md) skill.
+
+**Open when:** "what changed in app-db?", "show me when `[:cart :items]`
+last moved", "what's in the `:rf/route` slot right now?"
+
+Spec: [`004-App-DB-Diff.md`](../../../tools/causa/spec/004-App-DB-Diff.md).
+
+### Causality
+
+The peer to Event detail — a vertical directed graph keyed by
+`:dispatch-id` / `:parent-dispatch-id`. Parent→child dispatches
+connect via arrows; non-dispatch traces (fx, sub, render, machine
+transitions, errors) attach as flags inside the parent node rather
+than spawning outbound edges. Clicking a node fires
+`:rf.causa/select-dispatch-id` — the same event Event detail consumes,
+so the two share selection. When Time Travel has a selected epoch,
+the graph filters to that cascade family.
+
+**Open when:** the cascade is > 2 hops, spans frames, or you're
+triaging a session with 30+ events. No other JS devtool renders this
+view — Causa's unique differentiator.
+
+Spec: [`001-Causality-Graph.md`](../../../tools/causa/spec/001-Causality-Graph.md).
+
+### Subscriptions
+
+Registered subs + their invalidation chains + cache status +
+last-recomputed values. The invalidation-chain affordance recomputes
+live as upstream slots move (`:cart/total` ← `:cart/items` ←
+`[:cart :items]`).
+
+**Open when:** "why didn't my view update?", "trace the recompute
+chain for sub X", "is this sub cached or did it recompute?"
+
+Spec: [`012-Subscriptions.md`](../../../tools/causa/spec/012-Subscriptions.md).
+
+### Effects *(fx)*
+
+Registered fxs + per-fx invocations + outcome status + a stub
+indicator (handler exists as a pre-alpha no-op). Consumer of
+`:rf.fx/*` trace events and `(rf/registrations :fx)`.
+
+**Open when:** "which fx fired in this epoch?", "did `:http/get` get
+skipped?", "is this fx stubbed?"
+
+Spec: ns docstring at
+[`panels/effects.cljs`](../../../tools/causa/src/day8/re_frame2_causa/panels/effects.cljs);
+no dedicated panel spec yet — see spec/0NN for the authoritative
+effects surface once it lands.
+
+### Trace
+
+Raw event ribbon — every trace event in the buffer as a timestamped
+row, filterable along the 13-axis vocabulary in
+[`spec/009-Instrumentation.md` §Filter vocabulary](../../../spec/009-Instrumentation.md).
+Where Issues collapses to issues-only, Trace surfaces every op-type.
+
+**Open when:** you want the unfiltered event stream; when you need
+detail the per-panel projections drop.
+
+Spec: [`013-Trace-Bus.md`](../../../tools/causa/spec/013-Trace-Bus.md).
+
+### Machines
+
+State-chart per registered machine — the chart lives in
+`tools/machines-viz/`; Causa embeds it as a thin wrapper that adds
+the machine picker + transition-history ribbon + (future) source-coord
+jump.
+
+**Pre-alpha hedge:** `tools/machines-viz/` has not landed. Only the
+spec scaffold exists (the `MachineChart` prop contract + share-URL
+encoding are normative per rf2-x50eu). The panel renders a placeholder
+until the viz impl is wired — see
+[`spec/003-Machine-Inspector.md`](../../../tools/causa/spec/003-Machine-Inspector.md).
+
+**Open when:** "what state is my checkout machine in?", "what
+transition just fired?"
+
+### Flows
+
+Registered flows + per-flow inputs / output path / live recomputation
+indicator. Filters the trace buffer to `:op-type :flow` and derives
+status from the latest event.
+
+**Open when:** "is this flow recomputing?", "which inputs feed this
+flow?", "did the output change this epoch?"
+
+Spec: [`013-Trace-Bus.md`](../../../tools/causa/spec/013-Trace-Bus.md)
+for the trace vocabulary; see spec/0NN for the authoritative
+flow-panel surface once it lands.
+
+### Routes
+
+Registered routes + the active `:rf/route` slice + recent navigation
+history. Reads the target frame's `:rf/route` slice; the trace
+stream's `:rf.route.nav-token/*` events drive the history ribbon.
+
+**Open when:** "what route am I on?", "what params did the nav-token
+resolve?", "show me the last few navigations."
+
+Spec: [`spec/012-Routing.md`](../../../spec/012-Routing.md) (the
+framework routing spec; Causa is a presentation consumer).
+
+### Performance
+
+Per-cascade duration capture surfacing the User Timing channel + the
+trace stream's per-event `:time` fields. Each cascade renders as a
+row with tier glyph + dispatch-id + event vector + duration + per-step
+bar. Tiers per [`spec/007-UX-IA.md` §Colour system](../../../tools/causa/spec/007-UX-IA.md):
+Fast `<16ms` (green) · Medium `16–50ms` (yellow) · Slow `50–100ms`
+(orange) · Blocking `>100ms` (red, the INP threshold).
+
+**Open when:** "which cascades blew the INP budget?", "is the
+checkout dispatch slow?"
+
+Spec: [`spec/009-Instrumentation.md` §Performance instrumentation](../../../spec/009-Instrumentation.md).
+
+### Issues
+
+Unified feed — errors + warnings + schema violations + hydration
+mismatches. The top-strip Issues badge mirrors the count. Consumes
+the ~95 categories enumerated in
+[`spec/009-Instrumentation.md` §Error event catalogue](../../../spec/009-Instrumentation.md).
+
+**Open when:** "anything broken?", "show me all schema failures",
+"what warnings have fired this session?"
+
+### Schemas
+
+One row per registered schema; coloured dot per failure with
+recovery-mode mapping. X-axis is time (default 60s window, drag-zoom
+expands); y-axis groups by schema. Dot colour encodes recovery mode
+(replaced-with-default, raised, silenced, etc.). Silent schema
+violations are real bugs in disguise; the timeline makes them
+impossible to ignore.
+
+**Open when:** "has any schema violated this session?", "when did
+`:user/profile` start failing?", "is this validation silently
+defaulting?"
+
+Spec: [`005-Schema-Timeline.md`](../../../tools/causa/spec/005-Schema-Timeline.md).
+
+### Hydration *(dormant)*
+
+Dormant `◌` until the first `:rf.ssr/hydration-mismatch` trace lands;
+clicking before then surfaces a "No SSR in this app" empty state. On
+first mismatch, renders a side-by-side server-vs-client render-tree
+view with the divergent node flagged and the hash-bisector path
+highlighted. SSR hydration mismatches are structurally hard to debug;
+no other JS devtool surfaces this view.
+
+**Open when:** the dormant marker has woken (you've seen a hydration
+error). Otherwise the panel has nothing to show.
+
+Spec: [`006-Hydration-Debugger.md`](../../../tools/causa/spec/006-Hydration-Debugger.md).
+
+### MCP
+
+Live feed of MCP-server activity: tool calls in flight, recent
+results, per-origin colouring (`:causa-mcp`, `:pair2-mcp`,
+`:story-mcp`, etc.).
+
+**Open when:** "what is my agent doing right now?", "did the MCP call
+land?", "which tool ran most recently?"
+
+Spec: [`010-MCP-Server.md`](../../../tools/causa/spec/010-MCP-Server.md).
+
+### Co-pilot *(rail)*
+
+Pull-only AI Q&A and slash commands over the live runtime. Collapsed
+by default per Lock 8 — the unobtrusive-debugger principle won. Expand
+via `Ctrl+Shift+/` or click the magenta `◇` cue glyph in the top
+strip (which pulses every 8s until first use, then stops permanently).
+Ephemeral: no persistence across page reloads.
+
+**Open when:** you want natural-language interrogation; when slash-
+commands (`/why <epoch>`, `/explain <epoch>`,
+`/diff <epoch-a> <epoch-b>`, `/state <machine-id>`, `/find <pattern>`)
+are easier than navigating panels.
+
+Spec: [`009-AI-CoPilot.md`](../../../tools/causa/spec/009-AI-CoPilot.md).
+
+For the user-question → panel routing table, see
+[`SKILL.md` §The 16 panels](../SKILL.md).


### PR DESCRIPTION
## Scope (Mike decisions 2026-05-17)

- Q1 = (a) launch-mode + panel-tour only. NO workflow catalogue.
- Q2 = (b) causa-implementor sibling skill deferred to post-alpha.
- Q3 = (b) write now, amend later as doc fixes land.

## New files

- `skills/causa/SKILL.md` (191 lines, 11.6 KB) — entry point: when-to-open, launch-mode table, 16-panel purpose table, out-of-scope routing.
- `skills/causa/reference/launch-modes.md` (247 lines, 9.5 KB) — decision tree + preload / layout host contract / programmatic `init!` / pop-out / wired hotkeys.
- `skills/causa/reference/panels.md` (244 lines, 9.7 KB) — per-panel one-pager: what it surfaces, when to open it, spec link.

Each leaf under the 250L / 16KB skill leaf-size ceiling.

## Calibration

Tone, structure, and reference layout mirror `skills/re-frame-pair2/`:
single `SKILL.md` router + `reference/` directory of focused leaves
loaded on demand. Frontmatter follows the published-skill conventions
(narrow `description`, explicit "do not use" triggers, `allowed-tools`
limited to read-only — `Read`, `Grep`, `Glob`).

## Wired hotkeys — verified against shell

Only `Ctrl+Shift+C` and `Ctrl+Shift+/` are surfaced as launch paths.
Confirmed against `tools/causa/src/day8/re_frame2_causa/keybinding.cljs`:
those are the only two `addEventListener` registrations. The historical
`Ctrl+K` command-palette path is explicitly excluded per the rf2-27zh2
Cluster C cleanup; `spec/007-UX-IA.md` §Keyboard's wider catalogue is
flagged as normative-for-the-future but not globally wired today.

## Panel count

Sixteen panels, confirmed against `shell.cljs`'s `sidebar-items`: Event
detail, Time travel, App-db, Causality, Subscriptions, Effects, Trace,
Machines, Flows, Routes, Performance, Issues, Schemas, Hydration (dormant),
MCP, Co-pilot. Pre-alpha hedges on Machines (depends on unimplemented
`tools/machines-viz/`) and Effects/Flows (no dedicated panel spec yet).

## mkdocs build

`mkdocs build --strict` aborts at the baseline 68 warnings (none new,
none cite `skills/causa/`). The `skills/` tree is outside the mkdocs nav.

## Out of scope (future iterations)

- Workflows: find-wrong-sub, scrub-bad-epoch, redaction-indicator semantics, click-to-source.
- causa-implementor sibling skill (deferred until Causa surface stabilises post-alpha).
- Panel-facade/leaf implementation guidance.

Closes rf2-jw6lc