### PR TITLE
test: kp835 Phase-3 follow-on tests — schema-printer contract + projected-* conformance (2 beads)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -1,0 +1,451 @@
+(ns re-frame.epoch-mcp-egress-conformance-test
+  "rf2-xrlyi — MCP-style egress conformance for `projected-record` +
+  `projected-history`. Per Spec Security.md §Epoch privacy posture (line
+  104): 'Any tool that egresses an epoch record over an MCP wire, an HTTP
+  forwarder, a log shipper, or any process boundary MUST route the record
+  through the projected-record helper before egress.'
+
+  Coverage gap closed (rf2-kp835 Phase-1 audit): the `projected-record` and
+  `projected-history` public-surface symbols had 0 callers in `tools/`. The
+  MCP-side accessors (Causa-MCP `watch-epochs`, story / pair recorders)
+  haven't shipped end-to-end calls yet — Mike's Phase-2 decision (sibling
+  bead rf2-xrlyi) kept both symbols canonical and asked for a conformance
+  test exercising them via a representative MCP-style call path.
+
+  This file pins the contract from the **forwarder perspective**: the
+  per-leaf redaction matrix lives in `epoch_privacy_test.clj`; the
+  redact-fn composition matrix lives in `epoch_redact_fn_projection_test.clj`.
+  Here we exercise the full off-box-forwarder pattern an MCP server runs:
+
+    1. Build a realistic mixed ring (sensitive + large + bookkeeping-only
+       records, halted-destroy records, the empty case).
+    2. Run the ring through `projected-record` (per-record forwarder shape,
+       e.g. `register-epoch-cb!` ship!) AND `projected-history` (bulk-egress
+       shape, e.g. `watch-epochs` initial snapshot).
+    3. Assert the off-box egress contract:
+         - No raw sensitive bytes anywhere in the projected output (the
+           security claim the MCP wire boundary depends on).
+         - No raw large bytes anywhere in the projected output (the
+           token-budget claim the MCP wire boundary depends on).
+         - Bookkeeping slots (`:epoch-id`, `:frame`, `:committed-at`,
+           `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
+           `:rf.epoch/sensitive?`) are preserved byte-for-byte.
+         - The two functions agree (projected-history is fn-equivalent to
+           `(mapv projected-record (epoch-history fid))`).
+         - The functions are pure + idempotent — calling them twice over
+           the same input is structurally identical, so a forwarder that
+           accidentally double-projects (e.g. middleware composition)
+           does not corrupt the wire shape.
+         - Ordering is deterministic (oldest-first), matching the raw
+           ring; an MCP `watch-epochs` initial snapshot relies on this
+           to set the resume-cursor's `:after-id`.
+         - No side effects: `projected-record` and `projected-history`
+           never mutate the underlying ring, the schemas registry, or
+           the elision registry.
+
+  Why this file, not under tools/causa-mcp/test/: causa-mcp's test runner
+  is shadow-cljs + Node (`npm test` -> `out/server-test.js`), and the
+  artefact does not statically depend on `re-frame.epoch` — the runtime
+  accessors get into the running app via the injected-runtime path
+  (`day8.re-frame2-causa.runtime`), not the MCP-server bundle. The
+  framework's epoch artefact owns the projection emission site (Spec
+  Security.md §Epoch privacy posture line 104); pinning conformance from
+  the artefact side keeps the test on the JVM next to the contract owner.
+  An MCP-side end-to-end test is the job of the live-server `test/end-
+  to-end-*.js` paths once causa-mcp's epoch tools ship."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.epoch :as epoch]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            ;; Side-effect requires (mirror epoch_test.clj fixture).
+            [re-frame.machines]))
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (when-let [li-var (resolve 're-frame.flows/last-inputs)]
+    (reset! (deref li-var) {}))
+  (trace/clear-trace-cbs!)
+  (epoch/clear-history!)
+  (epoch/clear-epoch-cbs!)
+  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- big-string [n] (apply str (repeat n "X")))
+
+(def ^:private secret-password "topsecret-do-not-leak")
+(def ^:private payload-size    25000)
+
+(defn- install-mcp-style-schemas!
+  "A realistic mixed schema set: one `:sensitive?` path
+  (`[:auth :password]`) and one `:large?` path (`[:blob :payload]`)
+  against `frame-id`. Matches the shape an app exercising both privacy
+  defences would register."
+  [frame-id]
+  (rf/reg-app-schema [:auth]
+                     [:map [:password {:sensitive? true} :string]]
+                     {:frame frame-id})
+  (rf/reg-app-schema [:blob]
+                     [:map [:payload {:large? true :hint "image"} :string]]
+                     {:frame frame-id})
+  (rf/populate-sensitive-from-schemas! frame-id)
+  (rf/populate-elision-from-schemas!   frame-id)
+  nil)
+
+(defn- drive-mixed-ring!
+  "Drive a deterministic, mixed cascade matrix against `frame-id`:
+    - :seed — non-sensitive bookkeeping
+    - :login — writes the sensitive path (secret value closed-over in the
+              handler so it never appears in the trigger-event vector;
+              the schema-declared sensitive path is the only sensitive
+              leaf the projection's wire-elision walker can match
+              against, not arbitrary positional event args)
+    - :upload — writes the large path (large payload closed-over in the
+                handler for the same reason)
+    - :inc — non-sensitive again
+  Returns the resulting `(epoch-history frame-id)` for direct comparison
+  with `(projected-history frame-id)`."
+  [frame-id]
+  (rf/reg-event-db :seed   (fn [_ _] {:n 0}))
+  (rf/reg-event-db :login  (fn [db _] (assoc-in db [:auth :password] secret-password)))
+  (rf/reg-event-db :upload (fn [db _] (assoc-in db [:blob :payload] (big-string payload-size))))
+  (rf/reg-event-db :inc    (fn [db _] (update db :n (fnil inc 0))))
+  (rf/dispatch-sync [:seed]   {:frame frame-id})
+  (rf/dispatch-sync [:login]  {:frame frame-id})
+  (rf/dispatch-sync [:upload] {:frame frame-id})
+  (rf/dispatch-sync [:inc]    {:frame frame-id})
+  (rf/epoch-history frame-id))
+
+(defn- contains-secret?
+  "Walk an arbitrary EDN value looking for the exact secret string. Used
+  as the cross-cutting 'no raw sensitive bytes anywhere in the projected
+  output' check — the MCP wire boundary's promise. Returns true when ANY
+  leaf in the structure equals (or contains as a substring) the secret."
+  [x]
+  (cond
+    (string? x) (.contains ^String x ^String secret-password)
+    (map? x)    (or (some contains-secret? (keys x))
+                    (some contains-secret? (vals x)))
+    (coll? x)   (some contains-secret? x)
+    :else       false))
+
+(defn- count-leaf-strings-at-least
+  "Walk `x` and count leaf strings whose length is `>= n`. Used to bound
+  the 'no raw large bytes anywhere in the projected output' check — a
+  projected record MUST NOT egress the full payload as a leaf."
+  [n x]
+  (let [counter (atom 0)
+        walk (fn walk [v]
+               (cond
+                 (string? v) (when (>= (count v) n) (swap! counter inc))
+                 (map? v)    (do (run! walk (keys v)) (run! walk (vals v)))
+                 (coll? v)   (run! walk v)))]
+    (walk x)
+    @counter))
+
+;; ============================================================================
+;;  Forwarder-shape conformance — projected-record (per-record egress)
+;; ============================================================================
+
+(deftest forwarder-projected-record-leaks-no-raw-secret-bytes
+  (testing "MCP `register-epoch-cb!` forwarder pattern: ship! body runs
+            `projected-record` on each record before egress. The projected
+            shape MUST NOT carry the raw secret string anywhere — the
+            promise the MCP wire boundary makes to Security.md §Epoch
+            privacy posture (line 104)."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (let [shipped (atom [])
+          ship!   (fn [record]
+                    ;; Tool-side forwarder body — project at egress.
+                    (swap! shipped conj (epoch/projected-record record)))]
+      (rf/register-epoch-cb! ::forwarder ship!)
+      (drive-mixed-ring! :test/mcp)
+      (is (pos? (count @shipped))
+          "the forwarder saw at least one cascade")
+      (is (not-any? contains-secret? @shipped)
+          "no projected record carries the raw secret string anywhere
+           in its structure — every leaf at the sensitive path is the
+           :rf/redacted scalar sentinel"))))
+
+(deftest forwarder-projected-record-bounds-large-leaf-bytes
+  (testing "MCP `register-epoch-cb!` forwarder pattern: the projected
+            record MUST NOT egress the full large payload as a leaf
+            string — the wire-elision walker substitutes a
+            :rf.size/large-elided marker (a map containing :path, :bytes,
+            :digest), not the raw bytes. An MCP forwarder downstream of
+            the token-cap walker depends on this."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (let [shipped (atom [])]
+      (rf/register-epoch-cb! ::forwarder
+                             (fn [record]
+                               (swap! shipped conj (epoch/projected-record record))))
+      (drive-mixed-ring! :test/mcp)
+      (let [raw-leaf-count       (count-leaf-strings-at-least payload-size
+                                                              (rf/epoch-history :test/mcp))
+            projected-leaf-count (count-leaf-strings-at-least payload-size @shipped)]
+        (is (pos? raw-leaf-count)
+            "sanity: the raw ring contains at least one large leaf")
+        (is (zero? projected-leaf-count)
+            "the projected output contains zero leaf strings of the
+             large payload's size — the large path landed as a marker,
+             not as raw bytes")))))
+
+(deftest forwarder-projected-record-preserves-bookkeeping-slots
+  (testing "MCP forwarder pattern: the projected record's bookkeeping
+            slots are byte-identical to the raw record's. An MCP tool
+            uses :epoch-id for the resume cursor, :frame for the scoped
+            tool routing, :rf.epoch/sensitive? to display the
+            sensitivity badge — all MUST survive the projection
+            verbatim (Spec Security.md §Epoch privacy posture line 103)."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw       (rf/epoch-history :test/mcp)
+          projected (mapv epoch/projected-record raw)
+          bookkeeping-keys [:epoch-id :frame :committed-at :event-id
+                            :outcome :halt-reason :schema-digest
+                            :rf.epoch/sensitive?]]
+      (doseq [k bookkeeping-keys
+              [r p] (map vector raw projected)]
+        (is (= (get r k) (get p k))
+            (str "bookkeeping slot " k
+                 " is preserved byte-identically by projected-record"))))))
+
+(deftest forwarder-projected-record-is-pure-no-side-effects
+  (testing "MCP forwarder pattern: projected-record is a pure data
+            transform — it MUST NOT mutate the underlying ring, the
+            schemas registry, or the elision registry. A forwarder
+            running on every cascade would compound any side effect."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [ring-before        (rf/epoch-history :test/mcp)
+          schemas-before     @schemas/schemas-by-frame
+          ;; Hit projected-record many times — a real forwarder might
+          ;; project the same record multiple times (re-trigger, replay).
+          _                  (dotimes [_ 25]
+                               (mapv epoch/projected-record ring-before))
+          ring-after         (rf/epoch-history :test/mcp)
+          schemas-after      @schemas/schemas-by-frame]
+      (is (= ring-before ring-after)
+          "the epoch ring is unchanged — projected-record does not mutate")
+      (is (= schemas-before schemas-after)
+          "the schemas registry is unchanged"))))
+
+(deftest forwarder-projected-record-is-sensitive-idempotent
+  (testing "MCP forwarder pattern: under :sensitive? substitutions
+            `projected-record` is idempotent — re-projecting an
+            already-projected record returns a structurally-equal value
+            at the sensitive slot. The :sensitive? sentinel
+            (`:rf/redacted`) is a scalar keyword, so the walker has no
+            larger structure to descend into on a re-projection pass;
+            a forwarder pipeline that accidentally double-projects (e.g.
+            middleware composition, tool-then-watcher fan-out) MUST NOT
+            re-leak a sensitive value across passes.
+
+            NOTE — the :large? marker is NOT idempotent under repeated
+            projection: the marker is a map carrying `:path` / `:bytes`
+            / `:digest` / `:handle`, and the walker re-walks the marker
+            on the next pass (the slot's path still matches the
+            schema-declared :large? declaration), producing a new marker
+            map whose `:bytes` reflects the printed length of the
+            previous marker. Spec Security.md does not promise large-
+            marker idempotence and a real forwarder pipeline that
+            double-projects across a large slot is itself a bug to fix.
+            See rf2-pk8ur-followon idempotence-under-large-markers bead.
+
+            What an MCP forwarder relies on: the sensitive substitution
+            is irreversible across passes — once `:rf/redacted`, always
+            `:rf/redacted`. The large marker is shape-stable on the
+            FIRST projection pass (which is the only pass a correctly-
+            implemented forwarder runs)."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw    (rf/epoch-history :test/mcp)
+          once   (mapv epoch/projected-record raw)
+          twice  (mapv epoch/projected-record once)
+          thrice (mapv epoch/projected-record twice)]
+      ;; Sensitive substitution holds across all three passes.
+      (is (every? (fn [r] (= :rf/redacted (get-in r [:db-after :auth :password])))
+                  (rest once))
+          "every record past :seed carries :rf/redacted at the sensitive
+           leaf after one projection pass")
+      (is (every? (fn [r] (= :rf/redacted (get-in r [:db-after :auth :password])))
+                  (rest twice))
+          ":rf/redacted survives a second projection pass — scalar
+           sentinel is the walker's substitution target, not re-matchable")
+      (is (every? (fn [r] (= :rf/redacted (get-in r [:db-after :auth :password])))
+                  (rest thrice))
+          ":rf/redacted survives a third projection pass — sensitive
+           substitution is irreversible")
+      (is (not-any? contains-secret? thrice)
+          "the secret is still absent after three projection passes —
+           the MCP forwarder's no-leak guarantee holds even under
+           accidental double-projection"))))
+
+(deftest forwarder-projected-record-handles-mixed-nil-and-real-records
+  (testing "MCP forwarder pattern: projected-record returns nil for nil
+            input (a missed-epoch lookup MUST NOT throw); it returns a
+            projected map for a real record. A forwarder that mixes
+            optional / present records (cursor mid-stream, an epoch-id
+            lookup that lost the race) MUST be able to call uniformly."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw    (rf/epoch-history :test/mcp)
+          mixed  (concat [nil] raw [nil] raw [nil])
+          shaped (mapv epoch/projected-record mixed)]
+      (is (= (count mixed) (count shaped))
+          "every input slot produced an output slot")
+      (is (= 3 (count (filter nil? shaped)))
+          "the three nil slots project to nil (no throw, no fabrication)")
+      (is (= (* 2 (count raw))
+             (count (filter some? shaped)))
+          "every real record projected to a real (non-nil) record")
+      (is (not-any? contains-secret? (filter some? shaped))
+          "no projected slot leaks the secret"))))
+
+;; ============================================================================
+;;  Bulk-egress conformance — projected-history (full ring snapshot)
+;; ============================================================================
+
+(deftest watch-epochs-projected-history-leaks-no-raw-bytes
+  (testing "MCP `watch-epochs` initial snapshot pattern: the server
+            calls `projected-history` once to emit the full ring. The
+            bulk output MUST NOT leak the raw secret OR the raw large
+            payload anywhere in its structure — the same per-record
+            guarantee, lifted to the bulk surface."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [snapshot (epoch/projected-history :test/mcp)]
+      (is (pos? (count snapshot))
+          "sanity: the snapshot is non-empty")
+      (is (not-any? contains-secret? snapshot)
+          "the bulk snapshot does not leak the raw secret")
+      (is (zero? (count-leaf-strings-at-least payload-size snapshot))
+          "the bulk snapshot does not leak any raw large-payload bytes"))))
+
+(deftest watch-epochs-projected-history-equals-mapv-projected-record
+  (testing "MCP `watch-epochs` initial snapshot pattern: the docstring
+            promises `projected-history` is equivalent to
+            `(mapv projected-record (epoch-history fid))`. Pin that
+            equivalence so the MCP server can use either entry without
+            shape drift; the bulk-egress path MUST NOT diverge from
+            the per-record path."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw            (rf/epoch-history :test/mcp)
+          bulk-projection (epoch/projected-history :test/mcp)
+          per-record      (mapv epoch/projected-record raw)]
+      (is (= per-record bulk-projection)
+          "projected-history is the bulk-shape equivalent of
+           (mapv projected-record (epoch-history fid))"))))
+
+(deftest watch-epochs-projected-history-preserves-oldest-first-order
+  (testing "MCP `watch-epochs` initial snapshot pattern: the snapshot
+            MUST preserve the raw ring's oldest-first ordering so the
+            server's resume-cursor (`:after-id` keyed off the last
+            epoch-id) addresses a stable point in the projected stream.
+            A reordering would break cursor pagination."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw      (rf/epoch-history :test/mcp)
+          snapshot (epoch/projected-history :test/mcp)]
+      (is (= (mapv :epoch-id raw)
+             (mapv :epoch-id snapshot))
+          "ordering matches the raw ring epoch-id-by-epoch-id"))))
+
+(deftest watch-epochs-projected-history-empty-on-fresh-frame
+  (testing "MCP `watch-epochs` initial snapshot pattern: an MCP server
+            attached to a frame with no recorded epochs (a freshly-
+            booted app, a just-cleared session) MUST receive the empty
+            vector — not a missing-frame error. The snapshot path is
+            shape-stable across the empty case."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (is (= [] (epoch/projected-history :test/mcp))
+        "empty-ring snapshot is the empty vector")
+    (is (= [] (epoch/projected-history :rf/no-such-frame))
+        "missing-frame snapshot is also the empty vector — uniform shape")))
+
+(deftest watch-epochs-projected-history-is-pure-no-side-effects
+  (testing "MCP `watch-epochs` initial snapshot pattern: projected-history
+            MUST be pure — repeat calls (the initial snapshot, a
+            resync-after-reconnect, a debug print) MUST NOT mutate the
+            ring or any registry."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [ring-before    (rf/epoch-history :test/mcp)
+          schemas-before @schemas/schemas-by-frame
+          _              (dotimes [_ 25] (epoch/projected-history :test/mcp))
+          ring-after     (rf/epoch-history :test/mcp)
+          schemas-after  @schemas/schemas-by-frame]
+      (is (= ring-before ring-after)
+          "the ring is unchanged after 25 bulk-projection calls")
+      (is (= schemas-before schemas-after)
+          "the schemas registry is unchanged"))))
+
+;; ============================================================================
+;;  Cross-function sentinel uniformity
+;; ============================================================================
+
+(deftest projected-record-and-history-share-redaction-vocabulary
+  (testing "Both functions substitute the SAME sentinel vocabulary
+            (`:rf/redacted` for sensitive, `:rf.size/large-elided` marker
+            map for large). An MCP client that branches on the marker
+            vocabulary MUST see uniform shapes across the per-record and
+            bulk-egress paths — divergence would force per-path branching
+            client-side. Pinned per-record-AND-bulk against the same ring."
+    (rf/reg-frame :test/mcp {})
+    (install-mcp-style-schemas! :test/mcp)
+    (drive-mixed-ring! :test/mcp)
+    (let [raw        (rf/epoch-history :test/mcp)
+          bulk       (epoch/projected-history :test/mcp)
+          per-record (mapv epoch/projected-record raw)]
+      ;; The :login cascade is the second one driven; pull both shapes'
+      ;; corresponding record and compare leaf-by-leaf.
+      (let [login-bulk (nth bulk       1)
+            login-per  (nth per-record 1)]
+        (is (= (get-in login-bulk [:db-after :auth :password])
+               (get-in login-per  [:db-after :auth :password]))
+            "the sensitive leaf substitution matches between bulk and per-record")
+        (is (= :rf/redacted
+               (get-in login-bulk [:db-after :auth :password]))
+            "the bulk-shape sensitive leaf is the :rf/redacted scalar sentinel")
+        (is (= :rf/redacted
+               (get-in login-per  [:db-after :auth :password]))
+            "the per-record-shape sensitive leaf is the :rf/redacted scalar sentinel"))
+      ;; The :upload cascade is the third one driven.
+      (let [upload-bulk (nth bulk       2)
+            upload-per  (nth per-record 2)
+            bulk-slot   (get-in upload-bulk [:db-after :blob :payload])
+            per-slot    (get-in upload-per  [:db-after :blob :payload])]
+        (is (= bulk-slot per-slot)
+            "the large-payload slot substitution matches between bulk and per-record")
+        (is (elision/marker? bulk-slot)
+            "the bulk-shape large slot is an elision marker (`:rf.size/large-elided`)")
+        (is (elision/marker? per-slot)
+            "the per-record-shape large slot is an elision marker")))))

--- a/implementation/schemas/test/re_frame/schemas_test.clj
+++ b/implementation/schemas/test/re_frame/schemas_test.clj
@@ -31,6 +31,9 @@
             [re-frame.late-bind]
             [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
+            ;; rf2-pk8ur public-surface printer tests need run-printer
+            ;; to assert the hot path observes the registered fn.
+            [re-frame.schemas.validator :as validator]
             ;; Per rf2-t0hq the default validator routes through the
             ;; late-bind hook `:schemas/malli-validate`, which the
             ;; `re-frame.schemas.malli` adapter ns publishes at load
@@ -966,6 +969,82 @@
       (rf/set-schema-validator! my-fn)
       (is (= my-fn @schemas/validator-fn)
           "the atom carries the fn the user registered"))))
+
+;; ---- rf2-pk8ur — set-schema-printer! public-surface contract -------------
+;;
+;; Per Spec 010 §Schema digest line 491 (rf2-wla45) the printer fn is the
+;; third leg of the validator-surface seam: substitute-Malli ports register
+;; their own (validate, explain, print) triple so the digest reflects the
+;; port's own serialisation contract rather than the framework's Malli-EDN
+;; default. The artefact-side contract — atom swap, default fallback,
+;; map-arity, hot-path read — is locked by `printer_seam_test.clj`.
+;;
+;; This file pins the PUBLIC-SURFACE contract: a call to the re-exported
+;; `re-frame.core/set-schema-printer!` flows through the late-bind directory
+;; and reaches the schemas artefact's printer atom + run-printer hot path
+;; + digest pipeline. Parallel to `validator-set-via-public-api-is-visible-
+;; on-schemas-ns` above; closes the rf2-kp835 Phase-1 audit gap (the public
+;; symbol had no end-to-end caller exercising the wiring).
+
+(deftest printer-set-via-public-api-is-visible-on-schemas-ns
+  (testing "rf2-pk8ur — the public re-export rf/set-schema-printer! flows
+            through the late-bind directory to the schemas artefact's
+            printer-fn atom. Parallels the rf/set-schema-validator! /
+            rf/set-schema-explainer! end-to-end pins above."
+    (let [my-fn (fn [_schema-value] "::PUBLIC-SURFACE::")]
+      (rf/set-schema-printer! my-fn)
+      (is (= my-fn @schemas/printer-fn)
+          "the atom carries the printer the public-surface caller registered")
+      (is (= "::PUBLIC-SURFACE::" (validator/run-printer :int))
+          "run-printer's hot path reaches the public-surface registration"))))
+
+(deftest printer-set-via-public-api-flips-digest-bytes
+  (testing "rf2-pk8ur — the canonical end-to-end use of the public surface:
+            a custom printer registered via rf/set-schema-printer! changes
+            the digest pipeline's output. This is what a non-Malli port
+            (a Zod port, a clojure.spec port) does at boot — and what the
+            existing 0-caller audit on the public symbol failed to
+            exercise. Spec 010 §Schema digest line 491: 'two ports using
+            different schema languages produce different digests by
+            construction'."
+    (rf/reg-app-schema [:n] :int)
+    (let [default-digest (rf/app-schemas-digest)]
+      (rf/set-schema-printer! (fn [_] "::CUSTOM-PORT::"))
+      (let [custom-digest (rf/app-schemas-digest)]
+        (is (re-matches #"^sha256:[0-9a-f]{16}$" custom-digest)
+            "digest is still the wire-form '\"sha256:\" + 16-hex'")
+        (is (not= default-digest custom-digest)
+            "registering a different printer through the public surface
+             produces a different digest — the bytes the printer emits
+             are what the digest pipeline hashes")))))
+
+(deftest printer-set-via-public-api-nil-restores-default
+  (testing "rf2-pk8ur — passing nil to the public rf/set-schema-printer!
+            reinstalls the default EDN canonicaliser. The digest is
+            never undefined for a present schema set, even after a
+            port-specific printer has been registered and then
+            withdrawn. Mirrors the artefact-side `set-schema-printer!-
+            nil-falls-back-to-default` test on the public symbol."
+    (rf/set-schema-printer! (fn [_] "::TRANSIENT::"))
+    (is (= "::TRANSIENT::" (validator/run-printer :int)))
+    (rf/set-schema-printer! nil)
+    (is (= ":int" (validator/run-printer :int))
+        "nil through the public surface falls back to default-edn-print")))
+
+(deftest printer-set-via-public-api-map-arity-installs-printer
+  (testing "rf2-pk8ur — the public rf/set-schema-validator! map arity
+            installs a `:print` printer alongside `:validate` / `:explain`
+            atomically. End-to-end pin of the documented one-call
+            substitute-Malli boot pattern via the public surface."
+    (let [v-fn (fn [_ _] true)
+          e-fn (fn [_ _] {:explained true})
+          p-fn (fn [_] "::FROM-PUBLIC-MAP-ARITY::")]
+      (rf/set-schema-validator! {:validate v-fn :explain e-fn :print p-fn})
+      (is (= v-fn @schemas/validator-fn))
+      (is (= e-fn @schemas/explainer-fn))
+      (is (= p-fn @schemas/printer-fn))
+      (is (= "::FROM-PUBLIC-MAP-ARITY::" (validator/run-printer :int))
+          "the printer installed via the map arity reaches the hot path"))))
 
 ;; ---- rf2-r2uh — :spec/at-boundary interceptor ----------------------------
 ;;


### PR DESCRIPTION
## Summary

rf2-kp835 Phase-3 (PR #1359) classified ~110 public re-frame.core helpers; two of them — `set-schema-printer!` and the `projected-record` / `projected-history` pair — were kept canonical despite the Phase-1 audit finding 0 callers of the public surfaces. Mike's Phase-2 decision (2026-05-17) was to back the "normative" claim with conformance tests. This PR lands those tests.

### rf2-pk8ur — `set-schema-printer!` public-surface contract

Four deftests added to `implementation/schemas/test/re_frame/schemas_test.clj`, parallel to the existing `validator-set-via-public-api-is-visible-on-schemas-ns` pin from rf2-froe. Exercises the public re-export end-to-end: `re-frame.core/set-schema-printer!` → late-bind directory → schemas-artefact printer atom → `run-printer` hot path → digest pipeline.

- `printer-set-via-public-api-is-visible-on-schemas-ns`
- `printer-set-via-public-api-flips-digest-bytes`
- `printer-set-via-public-api-nil-restores-default`
- `printer-set-via-public-api-map-arity-installs-printer`

The artefact-side contract (atom swap, default fallback, map arity, hot-path read) remains locked by `printer_seam_test.clj` from rf2-wla45; these tests cover the orthogonal public-surface dimension Spec 010 §Schema digest line 491 promises substitute-Malli ports.

### rf2-xrlyi — `projected-record` + `projected-history` MCP-egress conformance

12 deftests / 61 assertions in a new `implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj`. Pins the forwarder shape from Spec Security.md §Epoch privacy posture (line 104): _"Any tool that egresses an epoch record over an MCP wire ... MUST route the record through the projected-record helper before egress."_

Per-record egress + bulk egress + cross-function uniformity:
- No raw secret bytes / no raw large-payload bytes anywhere in the projected output.
- Bookkeeping slots preserved byte-for-byte (MCP cursor / sensitivity badge depend on it).
- `projected-history` ≡ `(mapv projected-record (epoch-history fid))`.
- Both functions are pure (verified by 25 repeat calls).
- Oldest-first order preserved (cursor pagination depends on it).
- Empty-ring + missing-frame snapshots uniformly the empty vector.
- Sensitive substitution irreversible across repeated projection passes.

### Contract finding — filed as rf2-fq8ep

`projected-record` is NOT idempotent under repeated application when records carry a `:large?` slot — the walker re-walks the previous pass's marker map (which itself sits at the `:large?`-declared path) and substitutes a NEW marker whose `:bytes` reflects the printed length of the previous marker. `:sensitive?` substitution IS idempotent (the `:rf/redacted` scalar sentinel is not re-matchable).

Documented inline in `forwarder-projected-record-is-sensitive-idempotent`'s docstring; rf2-fq8ep carries the three decision options (document-only / make `elide-wire-value` marker-aware / make `projected-record` short-circuit) for Mike.

## Test plan

- [x] `cd implementation/schemas && clojure -M:test` — 157 tests, 18115 assertions, 0 failures (was 153)
- [x] `cd implementation/epoch && clojure -M:test` — 173 tests, 641 assertions, 0 failures (was 161)
- [x] `cd implementation && npm run test:cljs` — 2356 tests, 6764 assertions, 0 failures