### PR TITLE
feat(release): Causa Clojars + Causa-mcp npm publish workflows (rf2-5aw5v.13 + rf2-8xzoe.36)

### DIFF
--- a/.github/workflows/release-causa-mcp.yml
+++ b/.github/workflows/release-causa-mcp.yml
@@ -1,0 +1,226 @@
+# Release workflow for tools/causa-mcp/ (rf2-8xzoe.36).
+#
+# Publishes `@day8/re-frame2-causa-mcp` to npm on a tag push of the
+# form `causa-mcp-v[0-9]+.[0-9]+.[0-9]+*`
+# (e.g. `causa-mcp-v0.0.1.alpha`).
+#
+# # Why a separate workflow per artefact
+#
+# tools/causa-mcp/ ships as a Node binary on npm — distinct registry,
+# distinct credentials, distinct cadence from the JVM artefacts.
+# It runs on its own tag prefix so a Causa-MCP-only fix doesn't
+# trigger the framework release.yml or the Causa Clojars workflow,
+# and vice versa.
+#
+# # Lockstep versioning
+#
+# Per spec/Conventions.md §Packaging conventions every published
+# artefact ships at the repo-root VERSION. The tag's version segment
+# (everything after `causa-mcp-v`) MUST match VERSION; the workflow
+# refuses to publish on mismatch. tools/causa-mcp/package.json
+# carries a placeholder `version` for local `npm install` ergonomics;
+# the Publish step below rewrites it to the lockstep VERSION on the
+# throwaway runner checkout immediately before `npm publish` so the
+# tarball ships at the right version. The rewrite is never committed
+# (same throwaway-checkout pattern as the Clojars deploy-leaf jobs).
+#
+# # Build + smoke
+#
+# shadow-cljs compiles `tools/causa-mcp/src/...` to a single
+# self-contained `out/server.js` (the `:server` build, configured in
+# tools/causa-mcp/shadow-cljs.edn). The smoke step invokes the
+# compiled binary in `--help` mode to assert that the build produced
+# a Node-runnable artefact before the publish step runs — failing
+# loudly is better than shipping a broken tarball that npm cannot
+# yank.
+#
+# # Secrets
+#
+# NPM_TOKEN is configured at the repository level as an npm Granular
+# Access Token scoped to the `@day8/re-frame2-causa-mcp` package
+# with `publish` rights. Neither value is committed — Mike configures
+# the secret out-of-band; this workflow only references it.
+#
+# # Failure recovery
+#
+# npm permits `npm unpublish` only within 72h of publish; after that
+# the version is permanent. If publish fails mid-stream and the
+# tarball is half-uploaded, DO NOT re-run with the same tag — bump
+# VERSION (0.0.1.alpha → 0.0.1.alpha-1), retag with the bumped value
+# (`causa-mcp-v0.0.1.alpha-1`), and rerun.
+#
+# # First publish protocol
+#
+# Mike triggers the first publish manually by pushing the tag once
+# the secret is wired. Subsequent releases run automatically on tag
+# push.
+
+name: release-causa-mcp
+
+on:
+  push:
+    tags:
+      - "causa-mcp-v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # 1. Lockstep version contract gate. Fails fast on a mismatched tag
+  #    or a hand-edited deps.edn (causa-mcp/ does not participate in
+  #    the verify-version-lockstep.sh tools/ loop today because it
+  #    ships on npm rather than Clojars and has no :clein/build alias —
+  #    but the tag-vs-VERSION assertion below covers the same intent).
+  # ─────────────────────────────────────────────────────────────────
+  verify-version:
+    name: Verify Causa-MCP tag matches lockstep VERSION
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Verify tag matches VERSION
+        id: version
+        # Tag form: `causa-mcp-v<VERSION>`. The version segment must
+        # equal the repo-root VERSION file content. Catches accidental
+        # tags before any deploy step runs.
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="$(tr -d '[:space:]' < VERSION)"
+          expected="causa-mcp-v${version}"
+          if [ "$tag" != "$expected" ]; then
+            echo "::error::tag '$tag' does not match repo-root VERSION '$expected' (refusing publish — bump VERSION or fix the tag)"
+            exit 1
+          fi
+          echo "tag $tag matches VERSION $expected — proceeding"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  # ─────────────────────────────────────────────────────────────────
+  # 2. Build + smoke + publish. The MCP server compiles to a single
+  #    self-contained Node script via shadow-cljs; the package.json
+  #    `files` array already restricts the tarball to {out/server.js,
+  #    README.md, LICENSE} so no extra prune step is needed.
+  # ─────────────────────────────────────────────────────────────────
+  publish-causa-mcp:
+    name: Publish @day8/re-frame2-causa-mcp
+    needs: verify-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        # shadow-cljs runs on the JVM; the `:server` build emits Node
+        # JS but the compiler is JVM-side.
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        # `registry-url` configures npm auth to read from NPM_TOKEN
+        # automatically — no manual .npmrc shuffle.
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: tools/causa-mcp/package.json
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-causa-mcp-${{ hashFiles('tools/causa-mcp/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-causa-mcp-
+            ${{ runner.os }}-clj-
+
+      - name: npm install
+        working-directory: tools/causa-mcp
+        run: npm install
+
+      # ─────────────────────────────────────────────────────────────
+      # Rewrite package.json `version` to the lockstep VERSION before
+      # the build/publish steps run. The in-tree placeholder
+      # (`"version": "0.1.0"` at the time of this workflow's
+      # authoring) is solely for local `npm install` ergonomics —
+      # the canonical version comes from the repo-root VERSION file.
+      # The rewrite happens on the throwaway runner checkout and is
+      # never committed.
+      # ─────────────────────────────────────────────────────────────
+      - name: Rewrite package.json version → lockstep VERSION
+        working-directory: tools/causa-mcp
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const target = process.env.VERSION;
+            console.log("Rewriting package.json version", pkg.version, "→", target);
+            pkg.version = target;
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          '
+          node -e '
+            const pkg = require("./package.json");
+            if (pkg.version !== process.env.VERSION) {
+              console.error("::error::version rewrite failed — package.json reads", pkg.version);
+              process.exit(1);
+            }
+            console.log("package.json version is now", pkg.version);
+          '
+
+      - name: Build server (shadow-cljs :server)
+        working-directory: tools/causa-mcp
+        run: npm run build
+
+      # ─────────────────────────────────────────────────────────────
+      # Build artefact smoke: invoke the compiled Node script with a
+      # 1s stdin timeout; the F-1 placeholder main currently prints a
+      # startup banner and exits, and later F-tranche surface will
+      # speak stdio JSON-RPC. Either way, asserting `node out/server.js`
+      # starts at all proves the build produced a runnable artefact
+      # before we ship it to npm. A 0 or 124 (timeout) exit is OK;
+      # any other exit is a broken build.
+      # ─────────────────────────────────────────────────────────────
+      - name: Smoke compiled server binary
+        working-directory: tools/causa-mcp
+        run: |
+          set -uo pipefail
+          if [ ! -f out/server.js ]; then
+            echo "::error::shadow-cljs did not produce out/server.js"
+            exit 1
+          fi
+          timeout 5s node out/server.js < /dev/null
+          rc=$?
+          # 0 = clean exit (placeholder main returns); 124 = timeout
+          # killed a long-running server (real F-tranche path). Anything
+          # else means the binary crashed on startup.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ]; then
+            echo "::error::server binary smoke exited with rc=$rc (expected 0 or 124)"
+            exit 1
+          fi
+          echo "server binary smoke OK (rc=$rc)"
+
+      - name: npm publish
+        working-directory: tools/causa-mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # `--access public` is required for scoped packages on npm
+        # (`@day8/…`) on first publish; harmless on subsequent
+        # publishes. `--tag` defaults to `latest`; we let npm tag any
+        # pre-release suffix (e.g. `alpha`) explicitly via the version
+        # segment — consumers `npm install @day8/re-frame2-causa-mcp`
+        # to pin the latest stable, or `…@0.0.1.alpha` to pin a
+        # specific pre-release.
+        run: npm publish --access public

--- a/.github/workflows/release-causa.yml
+++ b/.github/workflows/release-causa.yml
@@ -1,0 +1,219 @@
+# Release workflow for tools/causa/ (rf2-5aw5v.13).
+#
+# Publishes `day8/re-frame2-causa` to Clojars on a tag push of the
+# form `causa-v[0-9]+.[0-9]+.[0-9]+*` (e.g. `causa-v0.0.1.alpha`).
+#
+# # Why a separate workflow from .github/workflows/release.yml
+#
+# The framework release workflow (release.yml) ships every artefact
+# under implementation/* in one topologically-ordered deploy DAG.
+# Causa is a *consumer* of the framework — published from tools/ — so
+# it ships on its own cadence: a Causa-only fix doesn't warrant
+# republishing twelve framework artefacts, and vice versa. The
+# separate tag prefix (`causa-v…` vs `v…`) keeps the trigger paths
+# disjoint so a framework release does not accidentally republish
+# Causa and a Causa release does not accidentally republish core.
+#
+# # Lockstep versioning with the framework
+#
+# Per spec/Conventions.md §Packaging conventions (rf2-w05l), every
+# published artefact ships at the same version, sourced from the
+# repo-root VERSION file. tools/causa/deps.edn already declares
+# `:clein/build :version "../../VERSION"` so clein picks up the
+# lockstep version automatically. The version-check step below
+# enforces that the pushed tag's version segment (everything after
+# `causa-v`) matches the repo-root VERSION — a mismatched tag is
+# refused before any deploy step runs.
+#
+# # :local/root → :mvn/version rewrite
+#
+# tools/causa/deps.edn references core + reagent-slim via
+# `:local/root` for in-tree development. The release workflow
+# rewrites both to `:mvn/version "${VERSION}"` on the throwaway
+# runner checkout before invoking clein — same pattern as the
+# framework release workflow's deploy-leaf jobs. The rewrite is
+# never committed.
+#
+# # Failure recovery
+#
+# Clojars does not support yanking. If `deploy-causa` fails after
+# the artefact is published (e.g. network glitch on the upload
+# acknowledgement), DO NOT re-run with the same tag — Clojars will
+# 409. Bump VERSION (e.g. 0.0.1.alpha → 0.0.1.alpha-1), retag with
+# the bumped value (`causa-v0.0.1.alpha-1`), and rerun. The new
+# version supersedes the partial-state predecessor.
+#
+# # Secrets
+#
+# CLOJARS_USERNAME and CLOJARS_PASSWORD are configured at the
+# repository level (per the framework release.yml convention).
+# CLOJARS_PASSWORD is a Clojars deploy token; neither value is
+# committed. Mike configures the secrets out-of-band — this
+# workflow only references them.
+#
+# # First publish protocol
+#
+# Mike triggers the first deploy manually by pushing the tag once
+# the secrets are wired. Subsequent releases run automatically on
+# tag push.
+
+name: release-causa
+
+on:
+  push:
+    tags:
+      - "causa-v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────
+  # 1. Lockstep version contract gate. Fails fast on a mismatched tag
+  #    or a hand-edited deps.edn that breaks the framework-wide
+  #    lockstep (the shared script covers tools/causa/ per rf2-lwtke).
+  # ─────────────────────────────────────────────────────────────────
+  verify-version:
+    name: Verify Causa tag matches lockstep VERSION
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Verify tag matches VERSION
+        id: version
+        # Tag form: `causa-v<VERSION>`. The version segment must equal
+        # the repo-root VERSION file content. Catches accidental tags
+        # (e.g. someone tagging `causa-v0.0.2` while VERSION still
+        # reads 0.0.1.alpha) before any deploy step runs.
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          version="$(tr -d '[:space:]' < VERSION)"
+          expected="causa-v${version}"
+          if [ "$tag" != "$expected" ]; then
+            echo "::error::tag '$tag' does not match repo-root VERSION '$expected' (refusing publish — bump VERSION or fix the tag)"
+            exit 1
+          fi
+          echo "tag $tag matches VERSION $expected — proceeding"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify framework-wide lockstep contract
+        # Same script the framework release.yml + tests.yml run. Per
+        # rf2-lwtke its `tools/` loop covers tools/causa/deps.edn, so
+        # a hand-edited :mvn/version literal or a broken :version
+        # reference fails the gate here before clein touches Clojars.
+        run: ./.github/scripts/verify-version-lockstep.sh
+
+  # ─────────────────────────────────────────────────────────────────
+  # 2. Pre-release test gate for the Causa artefact. Runs the
+  #    artefact's JVM tests; CLJS/browser tests for Causa already run
+  #    in the regular tests workflow (the changed-surfaces classifier
+  #    routes them through `story_causa_browser`).
+  # ─────────────────────────────────────────────────────────────────
+  test-causa:
+    name: Causa pre-release test gate
+    needs: verify-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-causa-${{ hashFiles('tools/causa/deps.edn', 'implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-causa-
+            ${{ runner.os }}-clj-
+
+      - name: JVM tests (causa artefact)
+        working-directory: tools/causa
+        run: clojure -M:test
+
+  # ─────────────────────────────────────────────────────────────────
+  # 3. Deploy Causa. The lockstep root (day8/re-frame2 core) is NOT
+  #    deployed here — Causa pins the framework version via the
+  #    rewrite step, which assumes core is already on Clojars at the
+  #    same lockstep VERSION (cut by the framework release.yml on
+  #    the matching `v<VERSION>` tag).
+  # ─────────────────────────────────────────────────────────────────
+  deploy-causa:
+    name: Deploy day8/re-frame2-causa
+    needs: [verify-version, test-causa]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Clojure CLI
+        uses: DeLaGuardo/setup-clojure@02f5a82b79a547523e664fe8a7a32ea14884d7b2  # 13.6.0
+        with:
+          cli: latest
+
+      - name: Cache Maven / gitlibs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: ${{ runner.os }}-clj-release-causa-${{ hashFiles('tools/causa/deps.edn', 'implementation/**/deps.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-clj-release-causa-
+            ${{ runner.os }}-clj-
+
+      # ─────────────────────────────────────────────────────────────
+      # Rewrite :local/root → :mvn/version on the throwaway runner
+      # checkout (never committed). Causa's deps.edn references two
+      # framework artefacts; both pivot to the same lockstep VERSION.
+      # The literal substring match + python single-occurrence
+      # assertion is the same shape used by the framework release.yml
+      # deploy-leaf job — fails loudly if the source ever drifts.
+      # ─────────────────────────────────────────────────────────────
+      - name: Rewrite Causa :local/root → :mvn/version
+        working-directory: tools/causa
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          rewrite() {
+            local before="$1"
+            local after="$2"
+            if ! grep -qF "${before}" deps.edn; then
+              echo "::error::expected '${before}' substring not found in tools/causa/deps.edn"
+              exit 1
+            fi
+            BEFORE="${before}" AFTER="${after}" \
+              python3 -c 'import os, pathlib; p = pathlib.Path("deps.edn"); src = p.read_text(); before = os.environ["BEFORE"]; after = os.environ["AFTER"]; assert src.count(before) == 1, f"expected exactly one occurrence of {before!r}"; p.write_text(src.replace(before, after))'
+            echo "Rewrote ${before} → ${after}"
+          }
+          rewrite ':local/root "../../implementation/core"'              ":mvn/version \"${VERSION}\""
+          rewrite ':local/root "../../implementation/adapters/reagent-slim"' ":mvn/version \"${VERSION}\""
+          echo "--- Rewritten dep coords:"
+          grep -E "day8/(re-frame2|reagent-slim)" deps.edn
+
+      - name: Deploy day8/re-frame2-causa
+        working-directory: tools/causa
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
+        run: clojure -M:clein deploy

--- a/tools/causa-mcp/README.md
+++ b/tools/causa-mcp/README.md
@@ -58,6 +58,41 @@ flows) lives in
 until implementation lands and this folder grows
 `003-Tool-Catalogue.md`.
 
+## Publishing
+
+Causa-MCP publishes to npm as `@day8/re-frame2-causa-mcp` on a tag
+push of the form **`causa-mcp-v<VERSION>`**
+(e.g. `causa-mcp-v0.0.1.alpha`). The workflow lives at
+[`.github/workflows/release-causa-mcp.yml`](../../.github/workflows/release-causa-mcp.yml)
+and is triggered automatically — no manual `npm publish` step.
+
+The tag's version segment must equal the repo-root
+[`VERSION`](../../VERSION) file (lockstep convention per
+[`spec/Conventions.md`](../../spec/Conventions.md) §Packaging
+conventions); a mismatched tag is refused before any publish step
+runs. The in-tree `package.json` `version` is a placeholder for
+local `npm install` ergonomics; the workflow rewrites it to the
+lockstep VERSION on the throwaway runner checkout immediately
+before `npm publish`.
+
+To cut a release (Mike-only):
+
+```bash
+# 1. Ensure VERSION reads the target (e.g. 0.0.1.alpha)
+# 2. Tag and push:
+git tag causa-mcp-v$(cat VERSION)
+git push origin causa-mcp-v$(cat VERSION)
+```
+
+Causa-MCP runs out-of-process and does not have a Clojure runtime
+dependency on the framework jars — so unlike `tools/causa/`, the
+Causa Clojars release does not need to precede the Causa-MCP npm
+release. Either order is fine.
+
+Required GitHub secrets (configured at the repository level):
+`NPM_TOKEN` — an npm Granular Access Token scoped to the
+`@day8/re-frame2-causa-mcp` package with `publish` rights.
+
 ## See also
 
 - [`spec/`](./spec/) — this jar's contract.

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -224,6 +224,40 @@ may `:require` from Causa. The preload pulls only when shadow-cljs's
 `:devtools` config asks for it; production builds (`goog.DEBUG=false`)
 elide every surface Causa consumes (per Spec 009 §Production builds).
 
+## Publishing
+
+Causa publishes to Clojars as `day8/re-frame2-causa` on a tag push
+of the form **`causa-v<VERSION>`** (e.g. `causa-v0.0.1.alpha`). The
+workflow lives at
+[`.github/workflows/release-causa.yml`](../../.github/workflows/release-causa.yml)
+and is triggered automatically — no manual deploy step.
+
+The tag's version segment must equal the repo-root
+[`VERSION`](../../VERSION) file (lockstep convention per
+[`spec/Conventions.md`](../../spec/Conventions.md) §Packaging
+conventions); a mismatched tag is refused before any deploy step
+runs. The dep on `day8/re-frame2` + `day8/reagent-slim` is pinned
+to the same lockstep version on the throwaway runner checkout
+immediately before `clein deploy`.
+
+To cut a release (Mike-only):
+
+```bash
+# 1. Ensure VERSION reads the target (e.g. 0.0.1.alpha)
+# 2. Tag and push:
+git tag causa-v$(cat VERSION)
+git push origin causa-v$(cat VERSION)
+```
+
+The framework release (the matching `v<VERSION>` tag on
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml))
+must precede the Causa release: Causa's published pom depends on
+`day8/re-frame2 {:mvn/version <VERSION>}` and that artefact must
+already be discoverable on Clojars when `clein deploy` runs.
+
+Required GitHub secrets (configured at the repository level):
+`CLOJARS_USERNAME`, `CLOJARS_PASSWORD` (Clojars deploy token).
+
 ## Status
 
 Pre-alpha. Running shell with the full 16-panel layout, two wired


### PR DESCRIPTION
## Scope

Sets up the publish workflows for the Causa v1.0 release pair.

- rf2-5aw5v.13: Clojars publish workflow for tools/causa/
- rf2-8xzoe.36: npm publish workflow for tools/causa-mcp/

Workflows trigger on tag-push (e.g. `causa-v0.0.1.alpha`). Mike triggers
the actual publish manually by pushing the tag once secrets are wired.

## Required GitHub secrets (Mike to configure separately)

- CLOJARS_USERNAME, CLOJARS_PASSWORD (deploy token)
- NPM_TOKEN (with publish scope)

Closes rf2-5aw5v.13, rf2-8xzoe.36