### PR TITLE
refactor(epoch): cohesion split — 5 seams (rf2-0wi86 Phase-2)

### DIFF
--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -24,6 +24,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as epoch-state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -363,7 +364,7 @@
     (is (= [3 4] (get-in @flows/last-inputs [:composed/area :composed/leak-audit]))
         "precondition: flow last-inputs has a row for the frame")
 
-    (let [observed @(deref #'epoch/observed-frames-by-cb)]
+    (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
       (is (contains? (get observed ::composed-observer) :composed/leak-audit)
           "precondition: epoch cb has the frame in its observed-frames set"))
     (is (pos? (count (rf/epoch-history :composed/leak-audit)))
@@ -399,7 +400,7 @@
         "post: flow last-inputs row dropped for the destroyed frame")
     (is (= [] (rf/epoch-history :composed/leak-audit))
         "post: epoch ring buffer returns the empty vector for the destroyed frame")
-    (let [observed @(deref #'epoch/observed-frames-by-cb)]
+    (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
       (is (not (contains? (get observed ::composed-observer)
                           :composed/leak-audit))
           "post: epoch cb's observed-frames entry no longer includes the frame"))

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -34,11 +34,11 @@
   each emit a structured trace under `:rf.epoch/*` and leave the
   frame's app-db unchanged."
   (:require [re-frame.elision :as elision]
+            [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.privacy :as privacy]
             [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
@@ -114,49 +114,9 @@
   []
   (state/current-config))
 
-(defn- maybe-redact
-  "Run the installed `:redact-fn` against `record` and return its
-  result. nil `record` and nil `redact` are pass-throughs (no
-  invocation, no try/catch overhead). A throwing fn emits
-  `:rf.warning/epoch-redact-fn-exception` carrying `:frame` and
-  `:ex-msg`, then falls back to the raw record so the drain itself
-  is not broken.
-
-  Per Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch
-  privacy posture (rf2-wp70d): the fn runs ONCE at build-time,
-  BETWEEN `build-record` and ring-append / listener fan-out — the
-  ring buffer, every `register-epoch-cb!` listener, and any off-box
-  projection through `projected-record` all see the SAME redacted
-  shape. The `:rf.epoch/sensitive?` rollup is computed inside
-  `build-record` (which runs first) so the rollup reflects the RAW
-  signal even when the fn erases the leaves it keyed on.
-
-  Caller MUST wrap invocations in `(when interop/debug-enabled? ...)`
-  — the whole epoch surface shares that gate; this helper carries no
-  separate production gate.
-
-  HOT PATH: fires once per drain-settle. Hot-path cost when no fn is
-  installed is a single keyword lookup on the config map and an
-  identity return."
-  [record]
-  (if-let [f (state/redact-fn)]
-    (if (some? record)
-      (try
-        (f record)
-        (catch #?(:clj Throwable :cljs :default) e
-          ;; Failure isolation: emit the warning, fall back to the
-          ;; raw record. The keyword literal sits inside an
-          ;; `(when interop/debug-enabled? ...)` gate at the call
-          ;; site (every consumer of `maybe-redact` is itself gated),
-          ;; so Closure DCE elides the warning emit + literals
-          ;; under :advanced + goog.DEBUG=false.
-          (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
-                       {:frame  (:frame record)
-                        :ex-msg #?(:clj (.getMessage ^Throwable e)
-                                   :cljs (.-message e))})
-          record))
-      record)
-    record))
+;; The record-assembly helpers — `maybe-redact`, `current-schema-digest`,
+;; the sensitive-rollup family, and `build-record` itself — live in
+;; `re-frame.epoch.assembly` (Phase-2 seam D, rf2-0wi86).
 
 ;; ---- the per-frame ring buffer --------------------------------------------
 ;;
@@ -261,13 +221,6 @@
                                            :cljs (.-message ex))
                               :recovery :no-recovery}))))))
 
-;; Forward-declare `build-record` for `on-frame-destroyed!` below;
-;; the `defn-` lands in the record-assembly section. Per rf2-v0jwt
-;; the destroy hook must commit a `:halted-destroy` partial record
-;; before clearing the in-flight capture buffer, so it needs visibility
-;; into the record builder.
-(declare build-record)
-
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
   and rf2-v0jwt §Outcomes (`:halted-destroy`):
@@ -328,10 +281,10 @@
         ;; commit, `maybe-redact` runs once between `build-record`
         ;; and listener fan-out so listener consumers see the SAME
         ;; redacted shape they would see for an :ok cascade record.
-        (let [record (maybe-redact
-                       (build-record frame-id nil nil buffered-events
-                                     :halted-destroy
-                                     {:operation :rf.frame/destroyed-mid-drain}))]
+        (let [record (assembly/maybe-redact
+                       (assembly/build-record frame-id nil nil buffered-events
+                                              :halted-destroy
+                                              {:operation :rf.frame/destroyed-mid-drain}))]
           (trace/emit! :rf.epoch :rf.epoch/snapshotted
                        {:frame    frame-id
                         :epoch-id (:epoch-id record)
@@ -378,147 +331,6 @@
 ;; point, and the two read-only walks (`project-all`,
 ;; `find-trigger-event`) live in `re-frame.epoch.capture` (Phase-2
 ;; seam B, rf2-0wi86).
-
-;; ---- record assembly ------------------------------------------------------
-;;
-;; The monotonic `:epoch-id` counter lives in `re-frame.epoch.state`
-;; (Phase-2 seam A, rf2-0wi86) alongside the other shared atoms.
-
-(defn- current-schema-digest
-  "Return the live digest of the named frame's registered app-schema set,
-  or nil when the schemas namespace has not registered its late-bind
-  hook (e.g. an embedding host that ships no schema layer). Per Spec 010
-  §Per-frame schemas the digest is frame-scoped — restore-mismatch
-  reasoning runs against the frame the epoch belongs to."
-  [frame-id]
-  (when-let [digest (late-bind/get-fn :schemas/app-schemas-digest)]
-    (try (digest frame-id)
-         (catch #?(:clj Throwable :cljs :default) _ nil))))
-
-;; ---- sensitive rollup -----------------------------------------------------
-;;
-;; Per Security.md §Epoch privacy posture and rf2-mrsck: every assembled
-;; record carries a top-level boolean `:rf.epoch/sensitive?` rollup so
-;; listener fan-out, off-box egress, and recorder consumers can branch
-;; on one slot per record (parallel to the trace-event-level
-;; `:sensitive?` stamp per rf2-isdwf). Two cheap signals:
-;;
-;;   1. The captured trace stream already stamps `:sensitive?` per
-;;      handler-meta scope — if any event in `:trace-events` carries the
-;;      stamp, the record's cascade involved sensitive material.
-;;   2. The frame's schema-declared `[:rf/elision :sensitive-declarations]`
-;;      registry names paths that hold sensitive data; if any such path
-;;      resolves to a non-nil leaf in `:db-before` or `:db-after`, the
-;;      record's app-db state carries sensitive material.
-;;
-;; Either signal is sufficient. The check runs once at record-assembly
-;; time so listeners and the projected-record helper read the rollup
-;; without re-walking the record. Production builds elide the entire
-;; record-assembly path — the rollup is dev-only by construction.
-
-(defn- any-sensitive-event?
-  "True when any captured trace event carries a top-level `:sensitive?
-  true` stamp. Per privacy/sensitive? — the trace surface hoists the
-  boolean from handler-scope-meta to the event top level (rf2-isdwf)."
-  [events]
-  (boolean (some privacy/sensitive? events)))
-
-(defn- sensitive-paths-for
-  "Return the schema-declared sensitive paths for `frame-id`. Empty when
-  no schema layer is registered or when no slot carries
-  `{:sensitive? true}`."
-  [frame-id]
-  (try (keys (elision/sensitive-declarations frame-id))
-       (catch #?(:clj Throwable :cljs :default) _ nil)))
-
-(defn- any-sensitive-leaf?
-  "True when any sensitive-declared path resolves to a non-nil leaf in
-  `db`. nil-leaf paths do NOT count — the path is declared sensitive
-  but the slot is empty, so the record carries no actual sensitive
-  material from this signal. `db` is `:db-before` or `:db-after`; both
-  may be nil on halted paths (rf2-v0jwt :halted-destroy)."
-  [db sensitive-paths]
-  (and (some? db)
-       (boolean
-         (some (fn [path]
-                 (some? (get-in db path)))
-               sensitive-paths))))
-
-(defn- sensitive-rollup
-  "Compute the record-level `:rf.epoch/sensitive?` rollup for the
-  assembled record. Returns `true` when the record's content overlaps
-  a sensitive area — either via a stamped trace event or via a
-  schema-declared sensitive path that holds a non-nil leaf in the
-  recorded db. Returns `false` otherwise (always a strict boolean —
-  consumers branch on `(true? ...)` / `(false? ...)`).
-
-  HOT PATH: fires once per drain-settle. `sensitive-paths-for` derefs
-  the elision registry once; the leaf check short-circuits at the
-  first non-nil hit; the trace-event check short-circuits at the first
-  stamped event. For the common case (no schema-declared sensitive
-  paths, no sensitive handlers in scope) the cost is one keys-of-empty
-  call plus two sequence-with-no-work walks."
-  [frame-id db-before db-after events]
-  (boolean
-    (or (any-sensitive-event? events)
-        (let [sensitive-paths (sensitive-paths-for frame-id)]
-          (and (seq sensitive-paths)
-               (or (any-sensitive-leaf? db-before sensitive-paths)
-                   (any-sensitive-leaf? db-after  sensitive-paths)))))))
-
-(defn- build-record
-  ([frame-id db-before db-after events]
-   (build-record frame-id db-before db-after events :ok nil))
-  ([frame-id db-before db-after events outcome halt-reason]
-   ;; Per rf2-v0jwt §Outcomes — :outcome is required and pins the
-   ;; drain-boundary outcome (:ok / :halted-depth / :halted-destroy /
-   ;; :halted-handler-exception); :halt-reason is a structured
-   ;; descriptor populated on halt paths, absent on :ok. The schema
-   ;; in Spec-Schemas §:rf/epoch-record is the canonical pin.
-   ;;
-   ;; Per rf2-kl5p1 (audit r3 §F1): `:event-id` and `:trigger-event`
-   ;; are emitted only when `find-trigger-event` resolves them. The
-   ;; schema declares `:event-id :keyword` (required, non-maybe) per
-   ;; Spec-Schemas §`:rf/epoch-record` — emitting `:event-id nil` on a
-   ;; halt path where no `:event/run-start` trace was buffered would
-   ;; violate the schema; the open-map admits the slot's absence but
-   ;; rejects a nil value. The live router halt paths already short-
-   ;; circuit on an empty buffer via `(when (seq events) ...)` in
-   ;; `settle!`, so the only path that can reach this branch with a
-   ;; trigger-less buffer is `on-frame-destroyed!`'s `:halted-destroy`
-   ;; commit; the conditional `cond->` slots make that record valid
-   ;; against the schema.
-   (let [{:keys [event-id event]}     (capture/find-trigger-event events)
-         ;; Per rf2-ecu37: one fused walk producing all three
-         ;; projections, replacing three independent transducer
-         ;; passes over the same buffer. Mirrors `find-trigger-event`'s
-         ;; rf2-txrq9 single-walk pattern.
-         {:keys [sub-runs renders effects]} (capture/project-all events)
-         ;; Per rf2-mrsck and Security.md §Epoch privacy posture:
-         ;; the record-level boolean rollup mirrors the trace-event
-         ;; `:sensitive?` stamp (rf2-isdwf) so listener consumers and
-         ;; the projected-record helper branch on one slot per record.
-         sensitive? (sensitive-rollup frame-id db-before db-after events)]
-     (cond-> {:epoch-id           (state/next-epoch-id)
-              :frame              frame-id
-              :committed-at       (interop/now-ms)
-              :db-before          db-before
-              :db-after           db-after
-              :outcome            outcome
-              ;; Per Spec 010 §Schema digest — pinned at record time so a later
-              ;; restore can compare 'recorded vs current' digests in the
-              ;; :rf.epoch/restore-schema-mismatch trace tags. Optional per
-              ;; Spec-Schemas §:rf/epoch-record (a host without a schema layer
-              ;; produces nil; consumers tolerate the absent slot).
-              :schema-digest      (current-schema-digest frame-id)
-              :rf.epoch/sensitive? sensitive?
-              :trace-events       events
-              :sub-runs           sub-runs
-              :renders            renders
-              :effects            effects}
-       event-id    (assoc :event-id event-id)
-       event       (assoc :trigger-event event)
-       halt-reason (assoc :halt-reason halt-reason)))))
 
 ;; ---- drain-settle hook ----------------------------------------------------
 
@@ -575,9 +387,9 @@
          ;; `:rf.epoch/sensitive?` rollup inside `build-record` runs
          ;; FIRST — the rollup reflects raw signals even when the
          ;; redact-fn erases the leaves it keyed on.
-         (let [record (maybe-redact
-                        (build-record frame-id db-before db-after
-                                      events outcome halt-reason))]
+         (let [record (assembly/maybe-redact
+                        (assembly/build-record frame-id db-before db-after
+                                               events outcome halt-reason))]
            (state/record! record)
            (trace/emit! :rf.epoch :rf.epoch/snapshotted
                         {:frame    frame-id
@@ -863,7 +675,7 @@
                :tags    {:frame                  frame-id
                          :epoch-id               epoch-id
                          :schema-digest-recorded (:schema-digest epoch)
-                         :schema-digest-current  (current-schema-digest frame-id)
+                         :schema-digest-current  (assembly/current-schema-digest frame-id)
                          :failing-paths          (vec failing-paths)}}
 
               (if-let [missing (seq (missing-references db-target))]
@@ -1000,8 +812,8 @@
     ;; Per rf2-wp70d: `maybe-redact` runs once between assembly and
     ;; the record!/notify-listeners! split so ring + listeners see
     ;; the SAME redacted shape on this synthetic record too.
-    (let [record (maybe-redact
-                   (assoc (build-record frame-id db-before new-db [])
+    (let [record (assembly/maybe-redact
+                   (assoc (assembly/build-record frame-id db-before new-db [])
                           :event-id      :rf.epoch/db-replaced
                           :trigger-event [:rf.epoch/db-replaced]))]
       (state/record! record)

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -34,6 +34,7 @@
   each emit a structured trace under `:rf.epoch/*` and leave the
   frame's app-db unchanged."
   (:require [re-frame.elision :as elision]
+            [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -373,231 +374,15 @@
 ;; The atom + buffer-CRUD live in `re-frame.epoch.state` (Phase-2
 ;; seam A, rf2-0wi86).
 
-;; Operations this namespace itself emits with a `:frame` tag, all of
-;; which fire OUTSIDE a cascade (the drain has either not started, or
-;; has just settled and the buffer has been harvested). If `capture-
-;; event!` didn't skip them they would accrete into `capture-buffers`
-;; and leak into the NEXT cascade's harvested record for the same
-;; frame — a silent correctness bug surfacing as phantom `:trace-events`
-;; and a wrong `:trigger-event` via `find-trigger-event`'s fallback arm.
-;;
-;; Enumeration (not a `:rf.epoch/*` namespace-prefix filter) is the
-;; deliberate choice: a future in-cascade `:rf.epoch/*` op (e.g. an
-;; in-drain cascade-rollback trace) must continue to surface in epoch
-;; records. The companion test `skip-ops-catalogue-pins-every-rf-epoch-op`
-;; pins this catalogue against every `:rf.epoch/*` op the namespace
-;; emits, so an addition that forgets to update one or the other will
-;; fail loudly rather than drift silently.
-;;
-;; `:rf.epoch.cb/silenced-on-frame-destroy` is a different op-type
-;; (`:rf.epoch.cb`) and emits AFTER the frame's ring buffer has been
-;; dropped, so it can never race a future cascade for that frame.
-(def ^:private skip-ops
-  #{;; Drain-settle emit (after harvest-buffer! has emptied the buffer).
-    :rf.epoch/snapshotted
-    ;; restore-epoch success + the five documented failure modes.
-    :rf.epoch/restored
-    :rf.epoch/restore-unknown-epoch
-    :rf.epoch/restore-schema-mismatch
-    :rf.epoch/restore-missing-handler
-    :rf.epoch/restore-version-mismatch
-    :rf.epoch/restore-during-drain
-    :rf.epoch/restore-non-ok-record
-    ;; reset-frame-db! success + its two failure modes (Tool-Pair §Pair-
-    ;; tool writes, rf2-zq55). All three fire after the synthetic record
-    ;; has been built and the cascade-buffer (if any) has been harvested.
-    :rf.epoch/db-replaced
-    :rf.epoch/reset-frame-db-during-drain
-    :rf.epoch/reset-frame-db-schema-mismatch
-    ;; Redact-fn exception warning (rf2-wp70d / Tool-Pair §Time-travel
-    ;; §Redaction hook). Emitted by `maybe-redact` AFTER
-    ;; `harvest-buffer!` has emptied the cascade buffer for this
-    ;; frame; if left un-skipped, the `:frame`-tagged emit would
-    ;; otherwise accrete into the NEXT cascade's harvested record
-    ;; for this frame.
-    :rf.warning/epoch-redact-fn-exception})
-
-(defn- capture-event!
-  "Internal trace-capture entry point published through `re-frame.late-bind`
-  under `:epoch/capture-event`. `re-frame.trace/emit!` and
-  `re-frame.trace/emit-error!` invoke this for every event so the
-  cascade buffer is populated regardless of which user listeners are
-  registered.
-
-  Going through late-bind (rather than registering as a listener via
-  `register-trace-cb!`) ensures the user-facing `clear-trace-cbs!`
-  call does NOT wipe the internal capture path — pair tools that reset
-  the trace stream between sessions can do so without losing epoch
-  recording.
-
-  Events whose tags don't carry `:frame` are skipped — they can't be
-  tied to a specific cascade. The `:rf.epoch/*` trace events this
-  namespace emits OUTSIDE a cascade (catalogued in `skip-ops`) are
-  also skipped, so a snapshotted/restored/db-replaced emit cannot leak
-  into the next cascade's harvested record."
-  [event]
-  (when interop/debug-enabled?
-    (let [op       (:operation event)
-          tags     (:tags event)
-          frame-id (or (:frame tags)
-                       (:frame event))]
-      (when (and frame-id (not (contains? skip-ops op)))
-        (state/buffer-event! frame-id event)))))
-
-;; ---- record projection ----------------------------------------------------
-
-(defn- project-all
-  "Walk the captured trace events ONCE and emit the three `:sub-runs`,
-  `:renders`, `:effects` projections in a single reducer pass. Returns
-  `{:sub-runs <v> :renders <v> :effects <v>}` with each value a
-  persistent vector built via transient accumulators.
-
-  Per rf2-ecu37 (audit rf2-fzrav §M1): the prior shape was three
-  independent `into []` transducer walks of the same buffer — for an
-  N-event cascade that's 3·N operation reads where N suffice. The
-  fused reducer mirrors `find-trigger-event`'s style (rf2-txrq9):
-  one traversal, multiple accumulators, single allocation budget.
-
-  Per-projection contracts preserved verbatim (no schema change):
-
-    :sub-runs — Spec-Schemas §`:rf/epoch-record`. One entry per
-      `:sub/run` trace event. Cache-hit subs (rf2-719e fast-path) do
-      NOT emit `:sub/run` and are correctly absent.
-
-    :renders — Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree
-      primitives (rf2-t5tx Option C / rf2-piag). `:render-key` is the
-      `[<view-id> <instance-token>]` tuple; renders bypassing reg-view
-      (plain Reagent fns) use `[:rf.view/anonymous nil]` as the
-      documented fallback.
-
-    :effects — Spec-Schemas §`:rf/epoch-record` `:effects`. Every
-      dispatched fx emits exactly one of:
-
-        :fx :rf.fx/handled                    → :outcome :ok
-        :warning :rf.fx/skipped-on-platform   → :outcome :skipped-on-platform
-        :error :rf.error/fx-handler-exception → :outcome :error
-        :error :rf.error/no-such-fx           → :outcome :error
-
-      `:error-trace` (when present) references the corresponding error
-      trace event by `:id`."
-  [events]
-  ;; Single reduce; the accumulator is a 3-key transient map of
-  ;; transient vectors. `conj!` may rebind the inner transient vector
-  ;; identity at chunk boundaries (every 32 elements), so we thread
-  ;; the result back through `assoc!`. The outer transient map is
-  ;; mutated in place — no per-step map allocation.
-  ;;
-  ;; Internal slot keys are `:s` / `:r` / `:e` purely to keep this
-  ;; transient namespace local; the documented `:sub-runs` /
-  ;; `:renders` / `:effects` shape is materialised once at the end.
-  (let [acc (reduce
-              (fn [acc ev]
-                (let [op (:operation ev)
-                      t  (:tags ev)]
-                  (cond
-                    (= :sub/run op)
-                    (assoc! acc :s
-                            (conj! (get acc :s)
-                                   {:sub-id      (:sub-id t)
-                                    :query-v     (:query-v t)
-                                    :recomputed? true}))
-
-                    (= :view/render op)
-                    (assoc! acc :r
-                            (conj! (get acc :r)
-                                   {:render-key   (or (:render-key t)
-                                                      [:rf.view/anonymous nil])
-                                    :triggered-by (:triggered-by t)
-                                    :elapsed-ms   (:elapsed-ms t)}))
-
-                    (= :rf.fx/handled op)
-                    (assoc! acc :e
-                            (conj! (get acc :e)
-                                   {:fx-id   (:fx-id t)
-                                    :args    (:fx-args t)
-                                    :outcome :ok}))
-
-                    (= :rf.fx/skipped-on-platform op)
-                    (assoc! acc :e
-                            (conj! (get acc :e)
-                                   {:fx-id   (:fx-id t)
-                                    :args    (:fx-args t)
-                                    :outcome :skipped-on-platform}))
-
-                    (= :rf.error/fx-handler-exception op)
-                    (assoc! acc :e
-                            (conj! (get acc :e)
-                                   {:fx-id       (:fx-id t)
-                                    :args        (:fx-args t)
-                                    :outcome     :error
-                                    :error-trace (:id ev)}))
-
-                    (= :rf.error/no-such-fx op)
-                    (assoc! acc :e
-                            (conj! (get acc :e)
-                                   {:fx-id       (:fx-id t)
-                                    :args        (:fx-args t)
-                                    :outcome     :error
-                                    :error-trace (:id ev)}))
-
-                    :else acc)))
-              (transient {:s (transient [])
-                          :r (transient [])
-                          :e (transient [])})
-              events)]
-    {:sub-runs (persistent! (get acc :s))
-     :renders  (persistent! (get acc :r))
-     :effects  (persistent! (get acc :e))}))
+;; The skip-ops catalogue, the late-bind `:epoch/capture-event` entry
+;; point, and the two read-only walks (`project-all`,
+;; `find-trigger-event`) live in `re-frame.epoch.capture` (Phase-2
+;; seam B, rf2-0wi86).
 
 ;; ---- record assembly ------------------------------------------------------
 ;;
 ;; The monotonic `:epoch-id` counter lives in `re-frame.epoch.state`
 ;; (Phase-2 seam A, rf2-0wi86) alongside the other shared atoms.
-
-(defn- find-trigger-event
-  "Walk the buffered events to find the first :event/run-start trace.
-  That carries the `:event` and `:event-id` for the cascade.
-
-  When the cascade had no successful event handler (e.g. an unknown
-  event id or a frame-destroyed dispatch), no :run-start fires; fall
-  back to the first event we can find with an `:event-id` tag. Per
-  rf2-7kxxx (audit r3 §F2): if that fallback event carries no `:event`
-  tag we DO NOT synthesise `[eid]` — that would misrepresent an event
-  that originally carried payload as payload-less. `build-record`'s
-  conditional `cond->` (rf2-kl5p1) omits the `:trigger-event` slot
-  when `:event` is nil, which the schema's open map admits.
-
-  Per rf2-txrq9: single-walk reduction over `events` — the original
-  two-pass `or`-of-`some` reordered both walks across the buffer
-  on the degenerate path. We now accumulate the first
-  `:event/run-start` AND the first fallback `:event-id` in one
-  traversal and prefer the run-start. Either match short-circuits
-  at the earliest moment it can — a run-start hit immediately
-  reduces to the final result; a fallback-only stream walks once."
-  [events]
-  (let [result
-        (reduce
-          (fn [acc ev]
-            (let [tags (:tags ev)]
-              (if (and (= :event (:op-type ev))
-                       (= :event (:operation ev))
-                       (= :run-start (:phase tags)))
-                ;; run-start beats the fallback; short-circuit.
-                (reduced {:run-start {:event-id (:event-id tags)
-                                      :event    (:event tags)}})
-                ;; Capture the first :event-id we see as the fallback.
-                ;; Per rf2-7kxxx: do NOT fabricate `:event` — when the
-                ;; tag is absent we leave the field nil, and downstream
-                ;; `build-record` (rf2-kl5p1) omits the
-                ;; `:trigger-event` slot entirely rather than emit a
-                ;; misleading synthesised vector.
-                (if (or (:fallback acc) (nil? (:event-id tags)))
-                  acc
-                  (assoc acc :fallback {:event-id (:event-id tags)
-                                        :event    (:event tags)})))))
-          {}
-          events)]
-    (or (:run-start result) (:fallback result))))
 
 (defn- current-schema-digest
   "Return the live digest of the named frame's registered app-schema set,
@@ -703,12 +488,12 @@
    ;; trigger-less buffer is `on-frame-destroyed!`'s `:halted-destroy`
    ;; commit; the conditional `cond->` slots make that record valid
    ;; against the schema.
-   (let [{:keys [event-id event]}     (find-trigger-event events)
+   (let [{:keys [event-id event]}     (capture/find-trigger-event events)
          ;; Per rf2-ecu37: one fused walk producing all three
          ;; projections, replacing three independent transducer
          ;; passes over the same buffer. Mirrors `find-trigger-event`'s
          ;; rf2-txrq9 single-walk pattern.
-         {:keys [sub-runs renders effects]} (project-all events)
+         {:keys [sub-runs renders effects]} (capture/project-all events)
          ;; Per rf2-mrsck and Security.md §Epoch privacy posture:
          ;; the record-level boolean rollup mirrors the trace-event
          ;; `:sensitive?` stamp (rf2-isdwf) so listener consumers and
@@ -1363,7 +1148,7 @@
 
 (late-bind/set-fn! :epoch/settle!             settle!)
 (late-bind/set-fn! :epoch/discard-buffer!     discard-buffer!)
-(late-bind/set-fn! :epoch/capture-event       capture-event!)
+(late-bind/set-fn! :epoch/capture-event       capture/capture-event!)
 (late-bind/set-fn! :epoch/epoch-history       epoch-history)
 (late-bind/set-fn! :epoch/restore-epoch       restore-epoch)
 (late-bind/set-fn! :epoch/reset-frame-db!     reset-frame-db!)

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -34,6 +34,7 @@
   each emit a structured trace under `:rf.epoch/*` and leave the
   frame's app-db unchanged."
   (:require [re-frame.elision :as elision]
+            [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
@@ -43,45 +44,10 @@
             [re-frame.trace :as trace]))
 
 ;; ---- configuration --------------------------------------------------------
-
-(def ^:private default-depth
-  ;; Deep enough to hold a typical debug session's cascade history;
-  ;; trades bounded heap for stable time-travel coverage.
-  50)
-
-(def ^:private default-trace-events-keep
-  ;; Per rf2-mrsck and Security.md §Epoch privacy posture: a finite
-  ;; default that bounds dev-session heap growth from accumulated raw
-  ;; cascade traces. The most-recent N records keep `:trace-events`;
-  ;; older records keep only the cheap structured projections
-  ;; (`:sub-runs` / `:renders` / `:effects`). Five matches the pair-
-  ;; tool / Causa "what just happened?" working set — devs typically
-  ;; care about the latest handful of cascades' raw streams; a deeper
-  ;; ring depth is for time-travel reproducibility (`:db-after` is
-  ;; cheap), not raw-trace inspection. Apps that genuinely need the
-  ;; whole ring's traces can opt back in via
-  ;; `(rf/configure :epoch-history {:trace-events-keep nil})` (or any
-  ;; value >= the depth cap). Setting the slot to `0` drops every
-  ;; record's `:trace-events`.
-  5)
-
-(defonce ^:private config
-  ;; Three keys today (:depth, :trace-events-keep, :redact-fn). Map
-  ;; shape kept open so future (rf/configure :epoch-history {...})
-  ;; extensions don't break the shape. Per rf2-wp70d / Tool-Pair
-  ;; §Time-travel §Redaction hook + Security.md §Epoch privacy
-  ;; posture: :redact-fn defaults to nil — apps that record
-  ;; sensitive material into app-db opt in by installing a fn.
-  (atom {:depth             default-depth
-         :trace-events-keep default-trace-events-keep
-         :redact-fn         nil}))
-
-(defn- non-neg-int?
-  "True for non-negative integer values; nil and non-numeric values
-  fail. Mirrors the validation `re-frame.trace/configure-trace-buffer!`
-  applies at its own config boundary."
-  [x]
-  (and (integer? x) (not (neg? x))))
+;;
+;; Atoms, defaults, and config-merge validation live in `re-frame.epoch.state`
+;; (Phase-2 seam A, rf2-0wi86). The facade keeps the public docstrings and
+;; the late-bind hook publication.
 
 (defn configure!
   "Update the epoch-history configuration. Supported keys:
@@ -139,44 +105,13 @@
   Validation mirrors the pattern `re-frame.trace/configure-trace-
   buffer!` applies at its own config boundary."
   [opts]
-  (when (map? opts)
-    (let [numeric (select-keys opts [:depth :trace-events-keep])
-          numeric-valid (into {}
-                              (filter (fn [[_ v]] (non-neg-int? v)))
-                              numeric)
-          ;; :redact-fn validated separately — accept fn? OR nil
-          ;; (explicit-clear); anything else silently dropped.
-          ;; `contains?` distinguishes 'absent slot' from 'present
-          ;; nil' so the explicit-clear path lands while a callsite
-          ;; that didn't mention :redact-fn doesn't clobber a
-          ;; previously-installed fn.
-          redact (when (contains? opts :redact-fn)
-                   (let [v (:redact-fn opts)]
-                     (when (or (nil? v) (fn? v))
-                       {:redact-fn v})))
-          valid (merge numeric-valid redact)]
-      (when (seq valid)
-        (swap! config merge valid))))
-  nil)
+  (state/merge-config! opts))
 
 (defn current-config
   "Return the current epoch-history configuration map. Public for tests
   and tools that want to display the current depth."
   []
-  @config)
-
-(defn- depth []
-  (:depth @config default-depth))
-
-(defn- trace-events-keep []
-  (:trace-events-keep @config default-trace-events-keep))
-
-(defn- redact-fn []
-  ;; Per rf2-wp70d / Tool-Pair §Time-travel §Redaction hook. Returns
-  ;; the currently-installed redact-fn (or nil). One config-deref per
-  ;; record build — the hot path for installed-fn cases is one
-  ;; keyword lookup, no allocation.
-  (:redact-fn @config))
+  (state/current-config))
 
 (defn- maybe-redact
   "Run the installed `:redact-fn` against `record` and return its
@@ -203,7 +138,7 @@
   installed is a single keyword lookup on the config map and an
   identity return."
   [record]
-  (if-let [f (redact-fn)]
+  (if-let [f (state/redact-fn)]
     (if (some? record)
       (try
         (f record)
@@ -227,83 +162,15 @@
 ;; Per Tool-Pair §Time-travel "Bounded history": last N epochs per frame.
 ;; Stored as a map of frame-id → vector (oldest-first). New records append
 ;; to the back; the front evicts when the buffer exceeds the configured
-;; depth.
-
-;; Forward-declare `capture-buffers` (the in-flight per-frame trace
-;; capture, defonce'd in the per-cascade capture section below) so
-;; `clear-history!` can wipe it in lockstep with the ring buffer.
-;; Per rf2-v0jwt: fixtures that sequence runs need a fresh capture
-;; state per fixture; a stale buffer from a previous fixture would
-;; otherwise be harvested into the next fixture's first cascade.
-(declare capture-buffers)
-
-(defonce ^:private histories
-  (atom {}))
-
-(defn- elide-just-crossed-trace-events
-  "When the record at index `(- (count history) keep 1)` crosses the
-  keep-boundary, dissoc its `:trace-events`. O(1) per append: every
-  earlier record was already elided on its own crossing, so the only
-  record that needs work is the one that just slid out of the keep-
-  window. Records keep their structured projections (`:sub-runs` /
-  `:renders` / `:effects`) but lose the raw trace stream. nil `keep`
-  means 'keep every record's :trace-events'.
-
-  HOT PATH: invoked from `append-record` on every drain settle (every
-  user-facing event). Pre-rf2-1e38x this rewrote the whole history
-  vector via `map-indexed`; under steady state only one record per
-  append actually transitions, so the O(n) walk was wasted work. The
-  steady-state invariant holds because every prior append already
-  elided its own just-crossed record; runtime reductions of `keep`
-  via `(rf/configure :epoch-history ...)` will take full effect on
-  subsequent appends rather than retroactively rewriting the buffer
-  (pre-alpha posture)."
-  [history keep]
-  (let [n (count history)]
-    (if (and (some? keep) (nat-int? keep) (> n keep))
-      (let [idx (- n keep 1)
-            r   (nth history idx)]
-        (if (contains? r :trace-events)
-          (assoc history idx (dissoc r :trace-events))
-          history))
-      history)))
-
-(defn- append-record
-  "Conj `record` onto the frame's history vector, cap to `d` via
-  `subvec` (cheap structural reuse — no copy), then elide the just-
-  crossed record's `:trace-events` per `keep`.
-
-  HOT PATH: fires once per cascade settle, i.e. once per dispatched
-  user event under steady state. Cost is O(1) in both the depth cap
-  and the trace-events elision — the vector grows by one, optionally
-  drops its leftmost element via `subvec`, and at most one record's
-  `:trace-events` slot is dissoc'd."
-  [history record d keep]
-  (let [history+ (conj (or history []) record)
-        n        (count history+)
-        capped   (if (and (pos? d) (> n d))
-                   (subvec history+ (- n d))
-                   history+)]
-    (elide-just-crossed-trace-events capped keep)))
-
-(defn- record!
-  "Append a record into the frame's history. The depth cap and the
-  `:trace-events-keep` cap are read from the config atom on each
-  append so runtime `(rf/configure :epoch-history ...)` takes effect
-  immediately."
-  [record]
-  (let [d    (depth)
-        keep (trace-events-keep)]
-    (when (pos? d)
-      (let [frame-id (:frame record)]
-        (swap! histories update frame-id append-record record d keep)))))
+;; depth. The atom + ring-buffer mutators live in
+;; `re-frame.epoch.state` (Phase-2 seam A, rf2-0wi86).
 
 (defn epoch-history
   "Return the vector of `:rf/epoch-record` values for the frame, oldest-
   first. Empty vector when the frame has no recorded epochs (or when
   depth is 0, which disables recording)."
   [frame-id]
-  (or (get @histories frame-id) []))
+  (state/history-for frame-id))
 
 (defn clear-history!
   "Drop every recorded epoch for every frame. Test fixtures use this.
@@ -316,10 +183,8 @@
   whose drain didn't fire `harvest-buffer!`) would otherwise be
   picked up by the next fixture's first cascade."
   []
-  (reset! histories {})
-  ;; Forward-declared at the top of the file; the defonce lands in
-  ;; the per-cascade capture section further down.
-  (reset! capture-buffers {})
+  (state/reset-histories!)
+  (state/reset-capture-buffers!)
   nil)
 
 (defn- clear-frame-history!
@@ -331,23 +196,13 @@
   marking `defn-` keeps the surface area of the epoch public API
   tight without losing the pinned-seam test."
   [frame-id]
-  (swap! histories dissoc frame-id)
-  nil)
+  (state/drop-frame-history! frame-id))
 
 ;; ---- listener registry ----------------------------------------------------
-
-(defonce ^:private listeners (atom {}))
-
-;; Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656):
-;; track which frames each cb has been delivered records for. When a
-;; frame is destroyed, every cb whose observed-frames set contains
-;; that frame receives a one-shot :rf.epoch.cb/silenced-on-frame-destroy
-;; trace. The frame is then dropped from the cb's entry so a
-;; re-registration of a same-keyed frame (e.g. `reset-frame! :app/main`)
-;; can re-arm the silencing trace for a future destroy.
-(defonce ^:private observed-frames-by-cb
-  ;; cb-id → #{frame-id ...}
-  (atom {}))
+;;
+;; The listener / observed-frames atoms and their low-level CRUD live in
+;; `re-frame.epoch.state` (Phase-2 seam A, rf2-0wi86); the facade keeps
+;; the public docstrings and the fan-out / failure-isolation policy.
 
 (defn register-epoch-cb!
   "Register a callback fired once per drain-settle with the assembled
@@ -365,60 +220,21 @@
 
   Returns the id."
   [id f]
-  (swap! listeners assoc id f)
-  ;; A re-registration under the same id resets the observed-frames set
-  ;; so the new callback's silencing trace fires fresh against frames
-  ;; the new callback observes.
-  (swap! observed-frames-by-cb dissoc id)
-  id)
+  (state/put-listener! id f))
 
 (defn remove-epoch-cb!
   "Remove the listener registered under id."
   [id]
-  (swap! listeners dissoc id)
-  (swap! observed-frames-by-cb dissoc id)
-  nil)
+  (state/drop-listener! id))
 
 (defn clear-epoch-cbs!
   []
-  (reset! listeners {})
-  (reset! observed-frames-by-cb {})
-  nil)
-
-(defn- record-observation! [cb-id frame-id]
-  ;; Guard the swap on the already-observed case. `notify-listeners!`
-  ;; calls this once per listener per drain-settle, and for the common
-  ;; case (a long-lived listener observing the same frame on every
-  ;; cascade) the cb's observed-frames set already contains frame-id —
-  ;; an unconditional `swap!` fires every atom watcher for ZERO
-  ;; semantic change. Read once, fast-path return when the membership
-  ;; already holds; otherwise CAS through the swap.
-  (when frame-id
-    (let [current @observed-frames-by-cb]
-      (when-not (contains? (get current cb-id) frame-id)
-        (swap! observed-frames-by-cb
-               (fn [m]
-                 (if (contains? (get m cb-id) frame-id)
-                   m
-                   (update m cb-id (fnil conj #{}) frame-id))))))))
-
-(defn- drop-frame-from-cb-observations
-  "Drop `frame-id` from every cb's observed-frames set in `m`. When a
-  cb's set goes empty as a result, drop the cb entry entirely so the
-  map doesn't accrete keys to empty sets."
-  [m frame-id]
-  (reduce-kv (fn [acc cb-id frames]
-               (let [frames' (disj frames frame-id)]
-                 (if (empty? frames')
-                   (dissoc acc cb-id)
-                   (assoc acc cb-id frames'))))
-             {}
-             m))
+  (state/reset-listeners!))
 
 (defn- notify-listeners! [record]
   (let [frame-id (:frame record)]
-    (doseq [[id f] @listeners]
-      (record-observation! id frame-id)
+    (doseq [[id f] (state/listeners-snapshot)]
+      (state/record-observation! id frame-id)
       (try
         (f record)
         (catch #?(:clj Throwable :cljs :default) ex
@@ -448,8 +264,7 @@
 ;; the `defn-` lands in the record-assembly section. Per rf2-v0jwt
 ;; the destroy hook must commit a `:halted-destroy` partial record
 ;; before clearing the in-flight capture buffer, so it needs visibility
-;; into the record builder. `capture-buffers` is already forward-
-;; declared above (for `clear-history!`'s lockstep wipe).
+;; into the record builder.
 (declare build-record)
 
 (defn on-frame-destroyed!
@@ -501,7 +316,7 @@
     ;; state given `:outcome :halted-destroy` signals the destroy
     ;; context. The record is delivered to listeners only — the ring
     ;; buffer gets wiped in step 3.
-    (let [buffered-events  (get @capture-buffers frame-id)
+    (let [buffered-events  (state/buffer-for frame-id)
           in-cascade?      (some (fn [ev]
                                    (and (= :event (:op-type ev))
                                         (= :event (:operation ev))
@@ -522,7 +337,7 @@
                         :event-id (:event-id record)
                         :outcome  :halted-destroy})
           (notify-listeners! record))))
-    (let [silenced-cbs (->> @observed-frames-by-cb
+    (let [silenced-cbs (->> (state/observations-snapshot)
                             (keep (fn [[cb-id frames]]
                                     (when (contains? frames frame-id) cb-id)))
                             vec)]
@@ -530,19 +345,19 @@
         (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
                      {:frame  frame-id
                       :cb-id  cb-id})))
-    (swap! observed-frames-by-cb drop-frame-from-cb-observations frame-id)
+    (state/drop-frame-observation! frame-id)
     ;; Drop the per-frame ring buffer; epoch-history returns [] from
     ;; here on. (`reset-frame! :app/main` calls destroy-frame! followed
     ;; by reg-frame, so the ring buffer for the new same-keyed frame
     ;; starts empty per Spec 002 §reset-frame!.)
-    (swap! histories dissoc frame-id)
+    (state/drop-frame-history! frame-id)
     ;; Per rf2-zzper: also drop any in-flight capture buffer. A
     ;; mid-drain destroy that surfaces a halted record above leaves
     ;; the buffer behind (the partial-record commit doesn't harvest);
     ;; explicitly clear here so the next cascade against a same-keyed
     ;; frame starts from an empty buffer. Symmetric to the ring-buffer
     ;; drop above.
-    (swap! capture-buffers dissoc frame-id)))
+    (state/drop-frame-buffer! frame-id)))
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
@@ -555,26 +370,8 @@
 ;; The buffer is keyed by frame-id so concurrent drains across frames
 ;; don't co-mingle. Within a frame, drain-execution is single-threaded
 ;; (per Spec 002 §Run-to-completion) so no further locking is needed.
-
-(defonce ^:private capture-buffers
-  ;; frame-id → vector of trace events (in arrival order)
-  (atom {}))
-
-(defn- buffer-event!
-  "Append `event` onto the frame's in-flight cascade buffer.
-
-  HOT PATH: fires once per `trace/emit!` while a cascade is in flight,
-  which is the dominant per-event cost (sub-runs, renders, fx, error
-  emits all funnel here). O(1) swap! + (fnil conj []) — the buffer
-  vector grows by one and is harvested wholesale at cascade settle
-  via `harvest-buffer!`."
-  [frame-id event]
-  (swap! capture-buffers update frame-id (fnil conj []) event))
-
-(defn- harvest-buffer! [frame-id]
-  (let [b (get @capture-buffers frame-id [])]
-    (swap! capture-buffers dissoc frame-id)
-    b))
+;; The atom + buffer-CRUD live in `re-frame.epoch.state` (Phase-2
+;; seam A, rf2-0wi86).
 
 ;; Operations this namespace itself emits with a `:frame` tag, all of
 ;; which fire OUTSIDE a cascade (the drain has either not started, or
@@ -645,7 +442,7 @@
           frame-id (or (:frame tags)
                        (:frame event))]
       (when (and frame-id (not (contains? skip-ops op)))
-        (buffer-event! frame-id event)))))
+        (state/buffer-event! frame-id event)))))
 
 ;; ---- record projection ----------------------------------------------------
 
@@ -753,11 +550,9 @@
      :effects  (persistent! (get acc :e))}))
 
 ;; ---- record assembly ------------------------------------------------------
-
-(defonce ^:private epoch-counter (atom 0))
-
-(defn- next-epoch-id []
-  (swap! epoch-counter inc))
+;;
+;; The monotonic `:epoch-id` counter lives in `re-frame.epoch.state`
+;; (Phase-2 seam A, rf2-0wi86) alongside the other shared atoms.
 
 (defn- find-trigger-event
   "Walk the buffered events to find the first :event/run-start trace.
@@ -919,7 +714,7 @@
          ;; `:sensitive?` stamp (rf2-isdwf) so listener consumers and
          ;; the projected-record helper branch on one slot per record.
          sensitive? (sensitive-rollup frame-id db-before db-after events)]
-     (cond-> {:epoch-id           (next-epoch-id)
+     (cond-> {:epoch-id           (state/next-epoch-id)
               :frame              frame-id
               :committed-at       (interop/now-ms)
               :db-before          db-before
@@ -978,7 +773,7 @@
    (settle! frame-id db-before db-after :ok nil))
   ([frame-id db-before db-after outcome halt-reason]
    (when interop/debug-enabled?
-     (let [events (harvest-buffer! frame-id)]
+     (let [events (state/harvest-buffer! frame-id)]
        ;; Empty-buffer policy (consistent across outcomes): an empty
        ;; capture buffer means no cascade context was recorded for
        ;; this frame — skip emission rather than commit a record with
@@ -998,7 +793,7 @@
          (let [record (maybe-redact
                         (build-record frame-id db-before db-after
                                       events outcome halt-reason))]
-           (record! record)
+           (state/record! record)
            (trace/emit! :rf.epoch :rf.epoch/snapshotted
                         {:frame    frame-id
                          :epoch-id (:epoch-id record)
@@ -1024,7 +819,7 @@
   destroy-hook belt-and-braces path."
   [frame-id]
   (when interop/debug-enabled?
-    (harvest-buffer! frame-id))
+    (state/harvest-buffer! frame-id))
   nil)
 
 ;; ---- restore failure-mode predicates --------------------------------------
@@ -1424,7 +1219,7 @@
                    (assoc (build-record frame-id db-before new-db [])
                           :event-id      :rf.epoch/db-replaced
                           :trigger-event [:rf.epoch/db-replaced]))]
-      (record! record)
+      (state/record! record)
       (trace/emit! :rf.epoch :rf.epoch/db-replaced
                    {:frame    frame-id
                     :epoch-id (:epoch-id record)})

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -33,14 +33,13 @@
   epoch's `:db-after`. Six documented failure modes (Tool-Pair table)
   each emit a structured trace under `:rf.epoch/*` and leave the
   frame's app-db unchanged."
-  (:require [re-frame.elision :as elision]
-            [re-frame.epoch.assembly :as assembly]
+  (:require [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
+            [re-frame.epoch.write :as write]
+            [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.registrar :as registrar]
-            [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.trace :as trace]))
 
@@ -419,297 +418,13 @@
     (state/harvest-buffer! frame-id))
   nil)
 
-;; ---- restore failure-mode predicates --------------------------------------
-
-(defn- malli-validate-fn
-  "Return the malli validate fn or nil.
-
-  Per rf2-t0hq — CLJS has no runtime `resolve`, so the lookup order on
-  CLJS is: late-bind hook then nil. Returning nil is treated as
-  soft-pass by callers ('cannot disprove, treat as valid').
-
-  Lookup order matches `re-frame.schemas/default-malli-validate`:
-    1. Late-bind hook `:schemas/malli-validate` (published by
-       `re-frame.schemas.malli` when loaded).
-    2. JVM only — fall back to `(requiring-resolve 'malli.core/validate)`.
-    3. Return nil (soft-pass — the schema-validate-ok? caller treats
-       a nil validate fn as 'cannot disprove, treat as valid')."
-  []
-  (or (late-bind/get-fn :schemas/malli-validate)
-      #?(:clj  (try (requiring-resolve 'malli.core/validate)
-                    (catch Throwable _ nil))
-         :cljs nil)))
-
-(defn- registered-app-schemas
-  "Return the {path → schema-meta} map registered against the named
-  frame, or {}. Per Spec 010 §Per-frame schemas the schema set is
-  frame-scoped; restore-epoch validates against the schemas registered
-  against the frame the epoch belongs to, not a process-global set."
-  [frame-id]
-  (if-let [entries (late-bind/get-fn :schemas/frame-schema-entries)]
-    (entries frame-id)
-    {}))
-
-(defn- failing-schema-paths
-  "Return a vector of failing schema-paths for `db` against `frame-id`'s
-  registered app-schemas. Empty vector means valid — either every
-  registered schema accepted the path's value, OR no schemas are
-  registered, OR no Malli validator is on the classpath. The latter
-  two are soft-pass: we can't disprove validity, so we treat the db
-  as valid.
-
-  Single walk over the schema set — callers that previously chained
-  `schema-validate-ok?` + `failing-paths-for` paid two walks where one
-  suffices. The validity question is `(empty? (failing-schema-paths
-  frame-id db))`."
-  [frame-id db]
-  (let [schemas  (registered-app-schemas frame-id)
-        validate (malli-validate-fn)]
-    (if (or (empty? schemas) (nil? validate))
-      []
-      (vec
-        (keep (fn [[path meta]]
-                (let [schema (:schema meta)
-                      v      (get-in db path)]
-                  (when-not (try (validate schema v)
-                                 (catch #?(:clj Throwable :cljs :default) _ true))
-                    path)))
-              schemas)))))
-
-(defn- machine-registration
-  "Resolve a machine-id against the public machine registry. Per
-  Spec 005 §Registration / §Querying machines, machines are event
-  handlers whose registration metadata carries `:rf/machine? true`
-  and `:rf/machine` (the spec map). Returns the registration map
-  when machine-id names a registered machine, nil otherwise.
-
-  Per rf2-ocg1: epoch restore validates against this public surface,
-  not against the internal `:head` registrar kind that machines
-  never used."
-  [machine-id]
-  (let [reg (registrar/lookup :event machine-id)]
-    (when (:rf/machine? reg)
-      reg)))
-
-(defn- snapshot-version
-  "Read the recorded snapshot's `:rf/snapshot-version`. Per
-  Spec-Schemas §`:rf/machine-snapshot` and Spec 005 §Snapshot shape,
-  the canonical slot is `[:meta :rf/snapshot-version]`."
-  [snapshot]
-  (get-in snapshot [:meta :rf/snapshot-version]))
-
-(defn- machine-definition-version
-  "Read the currently-registered machine definition's
-  `:rf/snapshot-version`. Per Spec 005 §Snapshot shape — the
-  definition's `:meta :rf/snapshot-version` is the canonical slot."
-  [machine-id]
-  (when-let [reg (machine-registration machine-id)]
-    (let [machine (:rf/machine reg)]
-      (get-in machine [:meta :rf/snapshot-version]))))
-
-(defn- missing-references
-  "Walk the recorded db for ids that are no longer present in the
-  registrar. Closed v1 surface — `:rf/machines` (each machine-id
-  must reference a registered machine via the public event registry,
-  per Spec 005 §Registration — machines are event handlers tagged
-  with `:rf/machine?`) and `:route` (`:id` must reference a registered
-  :route).
-
-  Per rf2-ocg1: machine lookup goes through the event registry, NOT
-  the internal `:head` registrar kind. The latter is unrelated to
-  the public machine contract.
-
-  Returns a vector of {:kind <kind> :id <id>} entries. Empty when
-  every reference resolves."
-  [db]
-  (let [;; Machines under :rf/machines: registered as event handlers with
-        ;; :rf/machine? true (per Spec 005 §Registration).
-        missing-machines
-        (for [[machine-id _snapshot] (:rf/machines db)
-              :when (not (machine-registration machine-id))]
-          {:kind :machine :id machine-id})
-        ;; Active route
-        missing-route
-        (when-let [route-id (get-in db [:rf/route :id])]
-          (when-not (registrar/lookup :route route-id)
-            [{:kind :route :id route-id}]))]
-    (vec (concat missing-machines missing-route))))
-
-(defn- machine-version-mismatch
-  "Walk the recorded db's `:rf/machines` for snapshot version drift.
-  The recorded snapshot may carry `:rf/snapshot-version` under
-  `:meta`; the registered machine definition carries
-  `:rf/snapshot-version` under its own `:meta`. When they differ,
-  return the first mismatch as
-  `{:machine-id <id> :recorded <int> :current <int>}`. nil when no
-  mismatch is found.
-
-  Per rf2-ocg1: both versions are read through the public Spec 005
-  §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`
-  and the registered machine's `[:meta :rf/snapshot-version]`."
-  [db]
-  (some (fn [[machine-id snapshot]]
-          (let [recorded (snapshot-version snapshot)]
-            (when (some? recorded)
-              (let [current (machine-definition-version machine-id)]
-                (when (and (some? current) (not= recorded current))
-                  {:machine-id machine-id
-                   :recorded   recorded
-                   :current    current})))))
-        (:rf/machines db)))
-
 ;; ---- restore --------------------------------------------------------------
-
-(defn- find-epoch-in
-  "Search a resolved history vector for the record matching `epoch-id`.
-  Caller has already paid the `@histories` deref — `check-restore-
-  preconditions!` reads history once at the top and reuses the vector
-  for both the lookup and the `:history-size` count on the
-  unknown-epoch failure path (rf2-3g7x3 — was two derefs)."
-  [history epoch-id]
-  (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
-        history))
-
-(defn- emit-precondition-failure!
-  [operation tags]
-  (trace/emit-error! operation
-                     (assoc tags :recovery :no-recovery)))
-
-(defn- drain-in-flight?
-  "True when `frame-record`'s router is mid-drain (sync or async).
-  Shared by every precondition path that must refuse to write to
-  `app-db` while a cascade is being processed."
-  [frame-record]
-  (let [router (:router frame-record)
-        r      (when router @router)]
-    (boolean (and r (or (:in-drain? r) (:in-sync-drain? r))))))
-
-(defn- frame-exists-or-fail
-  "Resolve `frame-id` to its `frame-record` or yield the canonical
-  no-such-handler precondition-failure result. Returns
-  `{:outcome :ok :frame-record <record>}` or
-  `{:outcome :fail :op :rf.error/no-such-handler
-    :tags {:kind :frame :frame frame-id}}`. Shared by every Tool-Pair /
-  time-travel write surface so the no-such-handler tag shape stays
-  canonical."
-  [frame-id]
-  (if-let [frame-record (frame/frame frame-id)]
-    {:outcome :ok :frame-record frame-record}
-    {:outcome :fail
-     :op      :rf.error/no-such-handler
-     :tags    {:kind  :frame
-               :frame frame-id}}))
-
-(defn- check-restore-preconditions!
-  "Validate the seven documented preconditions for restoring `frame-id`
-  to `epoch-id`. Returns a result map:
-
-    {:outcome :ok :epoch <epoch>}
-                 — all checks passed; `:epoch` is the resolved history
-                   record whose `:db-after` is the restore target.
-    {:outcome :fail :op <kw> :tags <map>}
-                 — first failing check; `:op` is the trace operation
-                   the caller must emit, `:tags` are its tags. No
-                   trace events are emitted from inside this helper —
-                   emission is the caller's job so the
-                   precondition test stays a pure data check.
-
-  Failure modes preserve the exact operation keywords and tag shapes
-  the public surface has always emitted (see `restore-epoch`'s
-  docstring for the catalogue)."
-  [frame-id epoch-id]
-  (let [frame-result (frame-exists-or-fail frame-id)]
-    (cond
-      ;; (1) Frame registered?
-      (= :fail (:outcome frame-result))
-      frame-result
-
-      ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
-      {:outcome :fail
-       :op      :rf.epoch/restore-during-drain
-       :tags    {:frame    frame-id
-                 :epoch-id epoch-id}}
-
-      :else
-      (let [history (epoch-history frame-id)
-            epoch   (find-epoch-in history epoch-id)]
-        (cond
-          ;; (3) Epoch present in current history?
-          (nil? epoch)
-          {:outcome :fail
-           :op      :rf.epoch/restore-unknown-epoch
-           :tags    {:frame        frame-id
-                     :epoch-id     epoch-id
-                     :history-size (count history)}}
-
-          ;; (3a) Halted-cascade target? Per rf2-v0jwt: an epoch whose
-          ;; :outcome is not :ok records partial state the cascade
-          ;; never settled to, so it is not a valid restore target.
-          ;; Refuse before the schema / handler / version checks so
-          ;; the failure surfaces with the actual halt context, not
-          ;; a downstream consequence of the partial db.
-          (not= :ok (get epoch :outcome :ok))
-          {:outcome :fail
-           :op      :rf.epoch/restore-non-ok-record
-           :tags    {:frame       frame-id
-                     :epoch-id    epoch-id
-                     :outcome     (:outcome epoch)
-                     :halt-reason (:halt-reason epoch)}}
-
-          :else
-          (let [db-target (:db-after epoch)]
-            ;; Each helper is called once and its result bound, so the
-            ;; failure path walks the recorded db / schema set / machine
-            ;; map exactly once per check (rf2-081zk).
-            (if-let [failing-paths (seq (failing-schema-paths frame-id db-target))]
-              ;; (4) Schema mismatch?
-              ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
-              ;; the trace carries both the digest pinned on the
-              ;; epoch record (recorded) and the current frame's
-              ;; live digest, so pair tools can pinpoint *what
-              ;; changed* about the schema set, not merely *that*
-              ;; it changed.
-              {:outcome :fail
-               :op      :rf.epoch/restore-schema-mismatch
-               :tags    {:frame                  frame-id
-                         :epoch-id               epoch-id
-                         :schema-digest-recorded (:schema-digest epoch)
-                         :schema-digest-current  (assembly/current-schema-digest frame-id)
-                         :failing-paths          (vec failing-paths)}}
-
-              (if-let [missing (seq (missing-references db-target))]
-                ;; (5) Missing handler referenced from db?
-                {:outcome :fail
-                 :op      :rf.epoch/restore-missing-handler
-                 :tags    {:frame    frame-id
-                           :epoch-id epoch-id
-                           :missing  (vec missing)}}
-
-                (if-let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
-                  ;; (6) Machine snapshot version drift?
-                  {:outcome :fail
-                   :op      :rf.epoch/restore-version-mismatch
-                   :tags    {:frame            frame-id
-                             :epoch-id         epoch-id
-                             :machine-id       machine-id
-                             :version-recorded recorded
-                             :version-current  current}}
-
-                  {:outcome :ok :epoch epoch})))))))))
-
-(defn- perform-restore!
-  "Carry out the actual `app-db` rewind once preconditions have passed.
-  Replaces the frame's container with `epoch`'s `:db-after` and emits
-  `:rf.epoch/restored`. Returns `true`."
-  [frame-id epoch]
-  (let [container (frame/get-frame-db frame-id)
-        db-target (:db-after epoch)]
-    (adapter/replace-container! container db-target)
-    (trace/emit! :rf.epoch :rf.epoch/restored
-                 {:frame    frame-id
-                  :epoch-id (:epoch-id epoch)})
-    true))
+;;
+;; Precondition validators, schema/handler/version probes, and
+;; `perform-restore!` live in `re-frame.epoch.write` (Phase-2 seam E,
+;; rf2-0wi86). The orchestrator below stays in the facade — it wires
+;; the precondition check + the trace emission + the perform step into
+;; a four-line case-match.
 
 (defn restore-epoch
   "Rewind the frame's `app-db` to the named epoch's `:db-after`. Emits
@@ -733,10 +448,10 @@
   [frame-id epoch-id]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome epoch op tags]} (check-restore-preconditions! frame-id epoch-id)]
+    (let [{:keys [outcome epoch op tags]} (write/check-restore-preconditions! frame-id epoch-id)]
       (case outcome
-        :ok   (perform-restore! frame-id epoch)
-        :fail (do (emit-precondition-failure! op tags)
+        :ok   (write/perform-restore! frame-id epoch)
+        :fail (do (write/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- reset-frame-db! (Tool-Pair §Pair-tool writes, rf2-zq55) -------------
@@ -763,38 +478,6 @@
 ;; `restore-epoch` works against the previous state), emits
 ;; `:rf.epoch/db-replaced`, replaces the container, and fires registered
 ;; epoch listeners with the assembled record.
-
-(defn- check-reset-frame-db-preconditions!
-  "Validate the three documented preconditions for `reset-frame-db!`.
-  Returns `{:outcome :ok}` when all checks pass, otherwise
-  `{:outcome :fail :op <kw> :tags <map>}` matching the precondition-
-  failure shape of `check-restore-preconditions!`. Pure data — no
-  trace events emitted from here; emission is the caller's job."
-  [frame-id new-db]
-  (let [frame-result (frame-exists-or-fail frame-id)]
-    (cond
-      ;; (1) Frame registered?
-      (= :fail (:outcome frame-result))
-      frame-result
-
-      ;; (2) In-flight drain?
-      (drain-in-flight? (:frame-record frame-result))
-      {:outcome :fail
-       :op      :rf.epoch/reset-frame-db-during-drain
-       :tags    {:frame frame-id}}
-
-      :else
-      ;; (3) Schema mismatch? Single walk — `failing-schema-paths`
-      ;; returns the failing paths (or [] for the valid / soft-pass
-      ;; cases), folding what was previously a two-helper / two-walk
-      ;; chain into one.
-      (let [failing (failing-schema-paths frame-id new-db)]
-        (if (seq failing)
-          {:outcome :fail
-           :op      :rf.epoch/reset-frame-db-schema-mismatch
-           :tags    {:frame         frame-id
-                     :failing-paths failing}}
-          {:outcome :ok})))))
 
 (defn- perform-reset-frame-db!
   "Carry out the `app-db` replacement once preconditions have passed.
@@ -843,49 +526,17 @@
   [frame-id new-db]
   (if-not interop/debug-enabled?
     false
-    (let [{:keys [outcome op tags]} (check-reset-frame-db-preconditions! frame-id new-db)]
+    (let [{:keys [outcome op tags]} (write/check-reset-frame-db-preconditions! frame-id new-db)]
       (case outcome
         :ok   (perform-reset-frame-db! frame-id new-db)
-        :fail (do (emit-precondition-failure! op tags)
+        :fail (do (write/emit-precondition-failure! op tags)
                   false)))))
 
 ;; ---- projected egress -----------------------------------------------------
 ;;
-;; Per Security.md §Epoch privacy posture and rf2-mrsck: the framework's
-;; single normative projection emission site for off-box epoch egress.
-;; The in-process ring buffer (`epoch-history`) and `register-epoch-cb!`
-;; listener fan-out deliver RAW records — restore-epoch and on-box
-;; devtools (Causa diff, REPL inspection) need them. Tools that
-;; egress an epoch record across a process boundary (Causa-MCP
-;; `watch-epochs`, story / pair recorders, hosted forwarders) MUST
-;; route through `projected-record` first, parallel to how direct-read
-;; tools route through `elide-wire-value` (per rf2-czv3p).
-;;
-;; The projection wraps `re-frame.elision/elide-wire-value` against the
-;; record's frame-id and the four payload-bearing slots that may carry
-;; sensitive or large material: `:db-before`, `:db-after`,
-;; `:trigger-event`, and `:trace-events`. The cheap structured slots
-;; (`:sub-runs`, `:renders`, `:effects`) carry no app-db material —
-;; they project sub-ids, render-keys, fx-ids, and outcome tags — so
-;; the projection leaves them as-is. The record-level bookkeeping
-;; (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:outcome`,
-;; `:halt-reason`, `:schema-digest`, `:rf.epoch/sensitive?`) is
-;; structurally non-sensitive and passes through.
-;;
-;; Per-tool reimplementation of the projection is prohibited (the
-;; same posture as the wire-elision walker). New egress tools call
-;; `projected-record` and trust the contract.
-
-(defn- elide-payload-slot
-  "Walk one payload slot through `elide-wire-value` rooted at the named
-  frame, with off-box defaults (`:include-sensitive? false`,
-  `:include-large? false`). Returns the elided value; `nil` slots are
-  preserved as nil (a halted-destroy record's `:db-before` /
-  `:db-after` are nil per rf2-v0jwt; the schema admits the absent /
-  nil slot — the projection MUST NOT fabricate a value)."
-  [v frame-id]
-  (when (some? v)
-    (elision/elide-wire-value v {:frame frame-id})))
+;; The projection helpers live in `re-frame.epoch.write` (Phase-2
+;; seam E, rf2-0wi86); the public docstrings stay here so the facade
+;; remains the canonical API reference.
 
 (defn projected-record
   "Project an `:rf/epoch-record` for off-box egress. Routes the four
@@ -916,20 +567,7 @@
   `register-epoch-cb!` registration under `interop/debug-enabled?`
   per Spec 009 §User-side listener registration."
   [record]
-  (when (map? record)
-    (let [frame-id (:frame record)]
-      (cond-> record
-        (contains? record :db-before)
-        (update :db-before     elide-payload-slot frame-id)
-
-        (contains? record :db-after)
-        (update :db-after      elide-payload-slot frame-id)
-
-        (contains? record :trigger-event)
-        (update :trigger-event elide-payload-slot frame-id)
-
-        (contains? record :trace-events)
-        (update :trace-events  elide-payload-slot frame-id)))))
+  (write/projected-record record))
 
 (defn projected-history
   "Convenience: return the projected vector of records for a frame.
@@ -938,7 +576,7 @@
   snapshot, a recorder dumping the full session) can call this once
   rather than walking the raw ring and re-wrapping each record."
   [frame-id]
-  (mapv projected-record (epoch-history frame-id)))
+  (write/projected-history frame-id))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;;

--- a/implementation/epoch/src/re_frame/epoch.cljc
+++ b/implementation/epoch/src/re_frame/epoch.cljc
@@ -35,6 +35,7 @@
   frame's app-db unchanged."
   (:require [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
+            [re-frame.epoch.listeners :as listeners]
             [re-frame.epoch.state :as state]
             [re-frame.epoch.write :as write]
             [re-frame.frame :as frame]
@@ -191,34 +192,10 @@
   []
   (state/reset-listeners!))
 
-(defn- notify-listeners! [record]
-  (let [frame-id (:frame record)]
-    (doseq [[id f] (state/listeners-snapshot)]
-      (state/record-observation! id frame-id)
-      (try
-        (f record)
-        (catch #?(:clj Throwable :cljs :default) ex
-          ;; Per Spec 009 §Listener invocation rules: listener failures
-          ;; are isolated. Continue notifying. Per rf2-i5khp we ALSO
-          ;; emit a structured `:rf.epoch.cb/listener-exception` trace
-          ;; so devtools (re-frame-10x, Causa, pair2) can surface the
-          ;; broken listener — silently swallowing the throw left tool
-          ;; authors with no signal that their callback failed.
-          ;;
-          ;; Op-type `:rf.epoch.cb` matches the sibling
-          ;; `:rf.epoch.cb/silenced-on-frame-destroy` event (per Spec
-          ;; 009 §Op-type vocabulary catalogue and `epoch.cljc` row).
-          ;; `:recovery :no-recovery` mirrors the `:rf.http/aborted`
-          ;; trace shape — the listener's invocation is over; the next
-          ;; cascade re-invokes the same fn afresh, no automatic
-          ;; remediation happens between now and then.
-          (trace/emit-error! :rf.epoch.cb/listener-exception
-                             {:frame    frame-id
-                              :cb-id    id
-                              :epoch-id (:epoch-id record)
-                              :message  #?(:clj  (.getMessage ^Throwable ex)
-                                           :cljs (.-message ex))
-                              :recovery :no-recovery}))))))
+;; `notify-listeners!` (the fan-out + failure-isolation policy) and
+;; `on-frame-destroyed!` (the four-step destroy contract that
+;; straddles state, capture, and assembly) live in
+;; `re-frame.epoch.listeners` (Phase-2 seam C, rf2-0wi86).
 
 (defn on-frame-destroyed!
   "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
@@ -252,65 +229,7 @@
   the (already-cleared) ring-buffer / capture-buffer entries stay
   absent."
   [frame-id]
-  (when interop/debug-enabled?
-    ;; Step 1: mid-drain destroy detection. The capture-buffer holds
-    ;; every emit tagged with this frame, including non-cascade emits
-    ;; that fire OUTSIDE a drain (e.g. `:frame/created` at reg-frame
-    ;; time). Distinguish a real mid-drain destroy from
-    ;; registration-time tagalongs by gating on the presence of an
-    ;; `:event/run-start` emit — that is the canonical "a cascade
-    ;; started inside this drain" signal. When present, commit a
-    ;; partial `:halted-destroy` record so devtools (Causa,
-    ;; re-frame-pair2) receive the cascade context for the destroyed-
-    ;; mid-drain case. We can't read the frame's container here
-    ;; (destroy-frame!'s step 6 already dissoc'd the frame record);
-    ;; the partial record's `:db-before` / `:db-after` slots are nil
-    ;; — the schema allows `:any`, and consumers tolerate the absent
-    ;; state given `:outcome :halted-destroy` signals the destroy
-    ;; context. The record is delivered to listeners only — the ring
-    ;; buffer gets wiped in step 3.
-    (let [buffered-events  (state/buffer-for frame-id)
-          in-cascade?      (some (fn [ev]
-                                   (and (= :event (:op-type ev))
-                                        (= :event (:operation ev))
-                                        (= :run-start (-> ev :tags :phase))))
-                                 buffered-events)]
-      (when in-cascade?
-        ;; Per rf2-wp70d: even on the halted-destroy partial-record
-        ;; commit, `maybe-redact` runs once between `build-record`
-        ;; and listener fan-out so listener consumers see the SAME
-        ;; redacted shape they would see for an :ok cascade record.
-        (let [record (assembly/maybe-redact
-                       (assembly/build-record frame-id nil nil buffered-events
-                                              :halted-destroy
-                                              {:operation :rf.frame/destroyed-mid-drain}))]
-          (trace/emit! :rf.epoch :rf.epoch/snapshotted
-                       {:frame    frame-id
-                        :epoch-id (:epoch-id record)
-                        :event-id (:event-id record)
-                        :outcome  :halted-destroy})
-          (notify-listeners! record))))
-    (let [silenced-cbs (->> (state/observations-snapshot)
-                            (keep (fn [[cb-id frames]]
-                                    (when (contains? frames frame-id) cb-id)))
-                            vec)]
-      (doseq [cb-id silenced-cbs]
-        (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
-                     {:frame  frame-id
-                      :cb-id  cb-id})))
-    (state/drop-frame-observation! frame-id)
-    ;; Drop the per-frame ring buffer; epoch-history returns [] from
-    ;; here on. (`reset-frame! :app/main` calls destroy-frame! followed
-    ;; by reg-frame, so the ring buffer for the new same-keyed frame
-    ;; starts empty per Spec 002 §reset-frame!.)
-    (state/drop-frame-history! frame-id)
-    ;; Per rf2-zzper: also drop any in-flight capture buffer. A
-    ;; mid-drain destroy that surfaces a halted record above leaves
-    ;; the buffer behind (the partial-record commit doesn't harvest);
-    ;; explicitly clear here so the next cascade against a same-keyed
-    ;; frame starts from an empty buffer. Symmetric to the ring-buffer
-    ;; drop above.
-    (state/drop-frame-buffer! frame-id)))
+  (listeners/on-frame-destroyed! frame-id))
 
 ;; ---- per-cascade trace capture --------------------------------------------
 ;;
@@ -395,7 +314,7 @@
                          :epoch-id (:epoch-id record)
                          :event-id (:event-id record)
                          :outcome  outcome})
-           (notify-listeners! record)))))))
+           (listeners/notify-listeners! record)))))))
 
 (defn- discard-buffer!
   "Drop the in-flight capture buffer for frame-id WITHOUT committing a
@@ -503,7 +422,7 @@
       (trace/emit! :rf.epoch :rf.epoch/db-replaced
                    {:frame    frame-id
                     :epoch-id (:epoch-id record)})
-      (notify-listeners! record))
+      (listeners/notify-listeners! record))
     true))
 
 (defn reset-frame-db!
@@ -607,7 +526,7 @@
 (late-bind/set-fn! :epoch/configure!          configure!)
 (late-bind/set-fn! :epoch/clear-history!      clear-history!)
 (late-bind/set-fn! :epoch/clear-epoch-cbs!    clear-epoch-cbs!)
-(late-bind/set-fn! :epoch/on-frame-destroyed  on-frame-destroyed!)
+(late-bind/set-fn! :epoch/on-frame-destroyed  listeners/on-frame-destroyed!)
 ;; Per rf2-mrsck and Security.md §Epoch privacy posture: off-box
 ;; egress projection helpers, parallel to elide-wire-value for direct
 ;; reads. Tools that forward records over a process boundary use

--- a/implementation/epoch/src/re_frame/epoch/assembly.cljc
+++ b/implementation/epoch/src/re_frame/epoch/assembly.cljc
@@ -1,0 +1,220 @@
+(ns re-frame.epoch.assembly
+  "Record assembly — the pure-data builder that takes a frame-id, the
+  before/after app-db snapshots, and the harvested cascade trace
+  events, and yields a fully-formed `:rf/epoch-record` map.
+
+  Three responsibilities live here:
+
+    1. `build-record`   — produces the record (one allocation per
+                          drain-settle). Delegates the cascade-buffer
+                          walks to `re-frame.epoch.capture`.
+    2. `sensitive-rollup` — computes `:rf.epoch/sensitive?` from raw
+                          signals (trace-event stamps + schema-declared
+                          sensitive paths).
+    3. `maybe-redact`   — runs the installed `:redact-fn` once between
+                          assembly and ring-append / listener fan-out
+                          so every downstream consumer sees the SAME
+                          redacted shape.
+
+  Plus the `current-schema-digest` accessor that both `build-record`
+  (digest pinned on the record) and the restore-preconditions seam
+  (`re-frame.epoch.write`) consume.
+
+  Per rf2-0wi86 Phase-2 seam D: this namespace is dependency-free
+  beyond state (atoms + counter), capture (cascade walks), and the
+  shared `re-frame.elision` / `re-frame.late-bind` / `re-frame.privacy`
+  / `re-frame.trace` libs. No upstream seam consumes it; downstream
+  seams (write, listeners, facade orchestrators) call into it."
+  (:require [re-frame.elision :as elision]
+            [re-frame.epoch.capture :as capture]
+            [re-frame.epoch.state :as state]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
+            [re-frame.trace :as trace]))
+
+;; ---- redaction hook -------------------------------------------------------
+
+(defn maybe-redact
+  "Run the installed `:redact-fn` against `record` and return its
+  result. nil `record` and nil `redact` are pass-throughs (no
+  invocation, no try/catch overhead). A throwing fn emits
+  `:rf.warning/epoch-redact-fn-exception` carrying `:frame` and
+  `:ex-msg`, then falls back to the raw record so the drain itself
+  is not broken.
+
+  Per Tool-Pair §Time-travel §Redaction hook + Security.md §Epoch
+  privacy posture (rf2-wp70d): the fn runs ONCE at build-time,
+  BETWEEN `build-record` and ring-append / listener fan-out — the
+  ring buffer, every `register-epoch-cb!` listener, and any off-box
+  projection through `projected-record` all see the SAME redacted
+  shape. The `:rf.epoch/sensitive?` rollup is computed inside
+  `build-record` (which runs first) so the rollup reflects the RAW
+  signal even when the fn erases the leaves it keyed on.
+
+  Caller MUST wrap invocations in `(when interop/debug-enabled? ...)`
+  — the whole epoch surface shares that gate; this helper carries no
+  separate production gate.
+
+  HOT PATH: fires once per drain-settle. Hot-path cost when no fn is
+  installed is a single keyword lookup on the config map and an
+  identity return."
+  [record]
+  (if-let [f (state/redact-fn)]
+    (if (some? record)
+      (try
+        (f record)
+        (catch #?(:clj Throwable :cljs :default) e
+          ;; Failure isolation: emit the warning, fall back to the
+          ;; raw record. The keyword literal sits inside an
+          ;; `(when interop/debug-enabled? ...)` gate at the call
+          ;; site (every consumer of `maybe-redact` is itself gated),
+          ;; so Closure DCE elides the warning emit + literals
+          ;; under :advanced + goog.DEBUG=false.
+          (trace/emit! :warning :rf.warning/epoch-redact-fn-exception
+                       {:frame  (:frame record)
+                        :ex-msg #?(:clj (.getMessage ^Throwable e)
+                                   :cljs (.-message e))})
+          record))
+      record)
+    record))
+
+;; ---- schema-digest --------------------------------------------------------
+
+(defn current-schema-digest
+  "Return the live digest of the named frame's registered app-schema set,
+  or nil when the schemas namespace has not registered its late-bind
+  hook (e.g. an embedding host that ships no schema layer). Per Spec 010
+  §Per-frame schemas the digest is frame-scoped — restore-mismatch
+  reasoning runs against the frame the epoch belongs to."
+  [frame-id]
+  (when-let [digest (late-bind/get-fn :schemas/app-schemas-digest)]
+    (try (digest frame-id)
+         (catch #?(:clj Throwable :cljs :default) _ nil))))
+
+;; ---- sensitive rollup -----------------------------------------------------
+;;
+;; Per Security.md §Epoch privacy posture and rf2-mrsck: every assembled
+;; record carries a top-level boolean `:rf.epoch/sensitive?` rollup so
+;; listener fan-out, off-box egress, and recorder consumers can branch
+;; on one slot per record (parallel to the trace-event-level
+;; `:sensitive?` stamp per rf2-isdwf). Two cheap signals:
+;;
+;;   1. The captured trace stream already stamps `:sensitive?` per
+;;      handler-meta scope — if any event in `:trace-events` carries the
+;;      stamp, the record's cascade involved sensitive material.
+;;   2. The frame's schema-declared `[:rf/elision :sensitive-declarations]`
+;;      registry names paths that hold sensitive data; if any such path
+;;      resolves to a non-nil leaf in `:db-before` or `:db-after`, the
+;;      record's app-db state carries sensitive material.
+;;
+;; Either signal is sufficient. The check runs once at record-assembly
+;; time so listeners and the projected-record helper read the rollup
+;; without re-walking the record. Production builds elide the entire
+;; record-assembly path — the rollup is dev-only by construction.
+
+(defn- any-sensitive-event?
+  "True when any captured trace event carries a top-level `:sensitive?
+  true` stamp. Per privacy/sensitive? — the trace surface hoists the
+  boolean from handler-scope-meta to the event top level (rf2-isdwf)."
+  [events]
+  (boolean (some privacy/sensitive? events)))
+
+(defn- sensitive-paths-for
+  "Return the schema-declared sensitive paths for `frame-id`. Empty when
+  no schema layer is registered or when no slot carries
+  `{:sensitive? true}`."
+  [frame-id]
+  (try (keys (elision/sensitive-declarations frame-id))
+       (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+(defn- any-sensitive-leaf?
+  "True when any sensitive-declared path resolves to a non-nil leaf in
+  `db`. nil-leaf paths do NOT count — the path is declared sensitive
+  but the slot is empty, so the record carries no actual sensitive
+  material from this signal. `db` is `:db-before` or `:db-after`; both
+  may be nil on halted paths (rf2-v0jwt :halted-destroy)."
+  [db sensitive-paths]
+  (and (some? db)
+       (boolean
+         (some (fn [path]
+                 (some? (get-in db path)))
+               sensitive-paths))))
+
+(defn sensitive-rollup
+  "Compute the record-level `:rf.epoch/sensitive?` rollup for the
+  assembled record. Returns `true` when the record's content overlaps
+  a sensitive area — either via a stamped trace event or via a
+  schema-declared sensitive path that holds a non-nil leaf in the
+  recorded db. Returns `false` otherwise (always a strict boolean —
+  consumers branch on `(true? ...)` / `(false? ...)`).
+
+  HOT PATH: fires once per drain-settle. `sensitive-paths-for` derefs
+  the elision registry once; the leaf check short-circuits at the
+  first non-nil hit; the trace-event check short-circuits at the first
+  stamped event. For the common case (no schema-declared sensitive
+  paths, no sensitive handlers in scope) the cost is one keys-of-empty
+  call plus two sequence-with-no-work walks."
+  [frame-id db-before db-after events]
+  (boolean
+    (or (any-sensitive-event? events)
+        (let [sensitive-paths (sensitive-paths-for frame-id)]
+          (and (seq sensitive-paths)
+               (or (any-sensitive-leaf? db-before sensitive-paths)
+                   (any-sensitive-leaf? db-after  sensitive-paths)))))))
+
+;; ---- record assembly ------------------------------------------------------
+
+(defn build-record
+  ([frame-id db-before db-after events]
+   (build-record frame-id db-before db-after events :ok nil))
+  ([frame-id db-before db-after events outcome halt-reason]
+   ;; Per rf2-v0jwt §Outcomes — :outcome is required and pins the
+   ;; drain-boundary outcome (:ok / :halted-depth / :halted-destroy /
+   ;; :halted-handler-exception); :halt-reason is a structured
+   ;; descriptor populated on halt paths, absent on :ok. The schema
+   ;; in Spec-Schemas §:rf/epoch-record is the canonical pin.
+   ;;
+   ;; Per rf2-kl5p1 (audit r3 §F1): `:event-id` and `:trigger-event`
+   ;; are emitted only when `find-trigger-event` resolves them. The
+   ;; schema declares `:event-id :keyword` (required, non-maybe) per
+   ;; Spec-Schemas §`:rf/epoch-record` — emitting `:event-id nil` on a
+   ;; halt path where no `:event/run-start` trace was buffered would
+   ;; violate the schema; the open-map admits the slot's absence but
+   ;; rejects a nil value. The live router halt paths already short-
+   ;; circuit on an empty buffer via `(when (seq events) ...)` in
+   ;; `settle!`, so the only path that can reach this branch with a
+   ;; trigger-less buffer is `on-frame-destroyed!`'s `:halted-destroy`
+   ;; commit; the conditional `cond->` slots make that record valid
+   ;; against the schema.
+   (let [{:keys [event-id event]}     (capture/find-trigger-event events)
+         ;; Per rf2-ecu37: one fused walk producing all three
+         ;; projections, replacing three independent transducer
+         ;; passes over the same buffer. Mirrors `find-trigger-event`'s
+         ;; rf2-txrq9 single-walk pattern.
+         {:keys [sub-runs renders effects]} (capture/project-all events)
+         ;; Per rf2-mrsck and Security.md §Epoch privacy posture:
+         ;; the record-level boolean rollup mirrors the trace-event
+         ;; `:sensitive?` stamp (rf2-isdwf) so listener consumers and
+         ;; the projected-record helper branch on one slot per record.
+         sensitive? (sensitive-rollup frame-id db-before db-after events)]
+     (cond-> {:epoch-id           (state/next-epoch-id)
+              :frame              frame-id
+              :committed-at       (interop/now-ms)
+              :db-before          db-before
+              :db-after           db-after
+              :outcome            outcome
+              ;; Per Spec 010 §Schema digest — pinned at record time so a later
+              ;; restore can compare 'recorded vs current' digests in the
+              ;; :rf.epoch/restore-schema-mismatch trace tags. Optional per
+              ;; Spec-Schemas §:rf/epoch-record (a host without a schema layer
+              ;; produces nil; consumers tolerate the absent slot).
+              :schema-digest      (current-schema-digest frame-id)
+              :rf.epoch/sensitive? sensitive?
+              :trace-events       events
+              :sub-runs           sub-runs
+              :renders            renders
+              :effects            effects}
+       event-id    (assoc :event-id event-id)
+       event       (assoc :trigger-event event)
+       halt-reason (assoc :halt-reason halt-reason)))))

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -1,0 +1,246 @@
+(ns re-frame.epoch.capture
+  "Per-cascade trace-buffer write/read and the two read-only walks the
+  drain-settle assembly path runs against the harvested events:
+
+    capture-event!     -- the late-bind seam `re-frame.trace` invokes
+                          on every emit, gated on `:frame`-tag presence
+                          and the `skip-ops` self-emit catalogue.
+    project-all        -- one fused reducer pass producing the
+                          `:sub-runs`, `:renders`, `:effects` slots.
+    find-trigger-event -- one walk extracting `:event-id` + `:event`
+                          from the cascade's first `:event/run-start`,
+                          with a `:event-id`-only fallback.
+
+  Per rf2-0wi86 Phase-2 seam B: this namespace owns the cascade-buffer
+  *behaviour*; the buffer atom itself and the low-level
+  buffer-event! / harvest-buffer! mutators live in
+  `re-frame.epoch.state` (seam A). Splitting the catalogue + capture
+  + projection trio out of the facade keeps the cascade pipeline a
+  single grep target."
+  (:require [re-frame.epoch.state :as state]
+            [re-frame.interop :as interop]))
+
+;; ---- skip-ops catalogue --------------------------------------------------
+;;
+;; Operations this namespace itself emits with a `:frame` tag, all of
+;; which fire OUTSIDE a cascade (the drain has either not started, or
+;; has just settled and the buffer has been harvested). If `capture-
+;; event!` didn't skip them they would accrete into `capture-buffers`
+;; and leak into the NEXT cascade's harvested record for the same
+;; frame — a silent correctness bug surfacing as phantom `:trace-events`
+;; and a wrong `:trigger-event` via `find-trigger-event`'s fallback arm.
+;;
+;; Enumeration (not a `:rf.epoch/*` namespace-prefix filter) is the
+;; deliberate choice: a future in-cascade `:rf.epoch/*` op (e.g. an
+;; in-drain cascade-rollback trace) must continue to surface in epoch
+;; records. The companion test `skip-ops-catalogue-pins-every-rf-epoch-op`
+;; pins this catalogue against every `:rf.epoch/*` op the namespace
+;; emits, so an addition that forgets to update one or the other will
+;; fail loudly rather than drift silently.
+;;
+;; `:rf.epoch.cb/silenced-on-frame-destroy` is a different op-type
+;; (`:rf.epoch.cb`) and emits AFTER the frame's ring buffer has been
+;; dropped, so it can never race a future cascade for that frame.
+(def skip-ops
+  #{;; Drain-settle emit (after harvest-buffer! has emptied the buffer).
+    :rf.epoch/snapshotted
+    ;; restore-epoch success + the five documented failure modes.
+    :rf.epoch/restored
+    :rf.epoch/restore-unknown-epoch
+    :rf.epoch/restore-schema-mismatch
+    :rf.epoch/restore-missing-handler
+    :rf.epoch/restore-version-mismatch
+    :rf.epoch/restore-during-drain
+    :rf.epoch/restore-non-ok-record
+    ;; reset-frame-db! success + its two failure modes (Tool-Pair §Pair-
+    ;; tool writes, rf2-zq55). All three fire after the synthetic record
+    ;; has been built and the cascade-buffer (if any) has been harvested.
+    :rf.epoch/db-replaced
+    :rf.epoch/reset-frame-db-during-drain
+    :rf.epoch/reset-frame-db-schema-mismatch
+    ;; Redact-fn exception warning (rf2-wp70d / Tool-Pair §Time-travel
+    ;; §Redaction hook). Emitted by `maybe-redact` AFTER
+    ;; `harvest-buffer!` has emptied the cascade buffer for this
+    ;; frame; if left un-skipped, the `:frame`-tagged emit would
+    ;; otherwise accrete into the NEXT cascade's harvested record
+    ;; for this frame.
+    :rf.warning/epoch-redact-fn-exception})
+
+(defn capture-event!
+  "Internal trace-capture entry point published through `re-frame.late-bind`
+  under `:epoch/capture-event`. `re-frame.trace/emit!` and
+  `re-frame.trace/emit-error!` invoke this for every event so the
+  cascade buffer is populated regardless of which user listeners are
+  registered.
+
+  Going through late-bind (rather than registering as a listener via
+  `register-trace-cb!`) ensures the user-facing `clear-trace-cbs!`
+  call does NOT wipe the internal capture path — pair tools that reset
+  the trace stream between sessions can do so without losing epoch
+  recording.
+
+  Events whose tags don't carry `:frame` are skipped — they can't be
+  tied to a specific cascade. The `:rf.epoch/*` trace events this
+  namespace emits OUTSIDE a cascade (catalogued in `skip-ops`) are
+  also skipped, so a snapshotted/restored/db-replaced emit cannot leak
+  into the next cascade's harvested record."
+  [event]
+  (when interop/debug-enabled?
+    (let [op       (:operation event)
+          tags     (:tags event)
+          frame-id (or (:frame tags)
+                       (:frame event))]
+      (when (and frame-id (not (contains? skip-ops op)))
+        (state/buffer-event! frame-id event)))))
+
+;; ---- record projection ----------------------------------------------------
+
+(defn project-all
+  "Walk the captured trace events ONCE and emit the three `:sub-runs`,
+  `:renders`, `:effects` projections in a single reducer pass. Returns
+  `{:sub-runs <v> :renders <v> :effects <v>}` with each value a
+  persistent vector built via transient accumulators.
+
+  Per rf2-ecu37 (audit rf2-fzrav §M1): the prior shape was three
+  independent `into []` transducer walks of the same buffer — for an
+  N-event cascade that's 3·N operation reads where N suffice. The
+  fused reducer mirrors `find-trigger-event`'s style (rf2-txrq9):
+  one traversal, multiple accumulators, single allocation budget.
+
+  Per-projection contracts preserved verbatim (no schema change):
+
+    :sub-runs — Spec-Schemas §`:rf/epoch-record`. One entry per
+      `:sub/run` trace event. Cache-hit subs (rf2-719e fast-path) do
+      NOT emit `:sub/run` and are correctly absent.
+
+    :renders — Spec-Schemas §`:rf/epoch-record` and Spec 004 §Render-tree
+      primitives (rf2-t5tx Option C / rf2-piag). `:render-key` is the
+      `[<view-id> <instance-token>]` tuple; renders bypassing reg-view
+      (plain Reagent fns) use `[:rf.view/anonymous nil]` as the
+      documented fallback.
+
+    :effects — Spec-Schemas §`:rf/epoch-record` `:effects`. Every
+      dispatched fx emits exactly one of:
+
+        :fx :rf.fx/handled                    → :outcome :ok
+        :warning :rf.fx/skipped-on-platform   → :outcome :skipped-on-platform
+        :error :rf.error/fx-handler-exception → :outcome :error
+        :error :rf.error/no-such-fx           → :outcome :error
+
+      `:error-trace` (when present) references the corresponding error
+      trace event by `:id`."
+  [events]
+  ;; Single reduce; the accumulator is a 3-key transient map of
+  ;; transient vectors. `conj!` may rebind the inner transient vector
+  ;; identity at chunk boundaries (every 32 elements), so we thread
+  ;; the result back through `assoc!`. The outer transient map is
+  ;; mutated in place — no per-step map allocation.
+  ;;
+  ;; Internal slot keys are `:s` / `:r` / `:e` purely to keep this
+  ;; transient namespace local; the documented `:sub-runs` /
+  ;; `:renders` / `:effects` shape is materialised once at the end.
+  (let [acc (reduce
+              (fn [acc ev]
+                (let [op (:operation ev)
+                      t  (:tags ev)]
+                  (cond
+                    (= :sub/run op)
+                    (assoc! acc :s
+                            (conj! (get acc :s)
+                                   {:sub-id      (:sub-id t)
+                                    :query-v     (:query-v t)
+                                    :recomputed? true}))
+
+                    (= :view/render op)
+                    (assoc! acc :r
+                            (conj! (get acc :r)
+                                   {:render-key   (or (:render-key t)
+                                                      [:rf.view/anonymous nil])
+                                    :triggered-by (:triggered-by t)
+                                    :elapsed-ms   (:elapsed-ms t)}))
+
+                    (= :rf.fx/handled op)
+                    (assoc! acc :e
+                            (conj! (get acc :e)
+                                   {:fx-id   (:fx-id t)
+                                    :args    (:fx-args t)
+                                    :outcome :ok}))
+
+                    (= :rf.fx/skipped-on-platform op)
+                    (assoc! acc :e
+                            (conj! (get acc :e)
+                                   {:fx-id   (:fx-id t)
+                                    :args    (:fx-args t)
+                                    :outcome :skipped-on-platform}))
+
+                    (= :rf.error/fx-handler-exception op)
+                    (assoc! acc :e
+                            (conj! (get acc :e)
+                                   {:fx-id       (:fx-id t)
+                                    :args        (:fx-args t)
+                                    :outcome     :error
+                                    :error-trace (:id ev)}))
+
+                    (= :rf.error/no-such-fx op)
+                    (assoc! acc :e
+                            (conj! (get acc :e)
+                                   {:fx-id       (:fx-id t)
+                                    :args        (:fx-args t)
+                                    :outcome     :error
+                                    :error-trace (:id ev)}))
+
+                    :else acc)))
+              (transient {:s (transient [])
+                          :r (transient [])
+                          :e (transient [])})
+              events)]
+    {:sub-runs (persistent! (get acc :s))
+     :renders  (persistent! (get acc :r))
+     :effects  (persistent! (get acc :e))}))
+
+;; ---- trigger-event resolution --------------------------------------------
+
+(defn find-trigger-event
+  "Walk the buffered events to find the first :event/run-start trace.
+  That carries the `:event` and `:event-id` for the cascade.
+
+  When the cascade had no successful event handler (e.g. an unknown
+  event id or a frame-destroyed dispatch), no :run-start fires; fall
+  back to the first event we can find with an `:event-id` tag. Per
+  rf2-7kxxx (audit r3 §F2): if that fallback event carries no `:event`
+  tag we DO NOT synthesise `[eid]` — that would misrepresent an event
+  that originally carried payload as payload-less. `build-record`'s
+  conditional `cond->` (rf2-kl5p1) omits the `:trigger-event` slot
+  when `:event` is nil, which the schema's open map admits.
+
+  Per rf2-txrq9: single-walk reduction over `events` — the original
+  two-pass `or`-of-`some` reordered both walks across the buffer
+  on the degenerate path. We now accumulate the first
+  `:event/run-start` AND the first fallback `:event-id` in one
+  traversal and prefer the run-start. Either match short-circuits
+  at the earliest moment it can — a run-start hit immediately
+  reduces to the final result; a fallback-only stream walks once."
+  [events]
+  (let [result
+        (reduce
+          (fn [acc ev]
+            (let [tags (:tags ev)]
+              (if (and (= :event (:op-type ev))
+                       (= :event (:operation ev))
+                       (= :run-start (:phase tags)))
+                ;; run-start beats the fallback; short-circuit.
+                (reduced {:run-start {:event-id (:event-id tags)
+                                      :event    (:event tags)}})
+                ;; Capture the first :event-id we see as the fallback.
+                ;; Per rf2-7kxxx: do NOT fabricate `:event` — when the
+                ;; tag is absent we leave the field nil, and downstream
+                ;; `build-record` (rf2-kl5p1) omits the
+                ;; `:trigger-event` slot entirely rather than emit a
+                ;; misleading synthesised vector.
+                (if (or (:fallback acc) (nil? (:event-id tags)))
+                  acc
+                  (assoc acc :fallback {:event-id (:event-id tags)
+                                        :event    (:event tags)})))))
+          {}
+          events)]
+    (or (:run-start result) (:fallback result))))

--- a/implementation/epoch/src/re_frame/epoch/listeners.cljc
+++ b/implementation/epoch/src/re_frame/epoch/listeners.cljc
@@ -1,0 +1,164 @@
+(ns re-frame.epoch.listeners
+  "Epoch-listener fan-out + frame-destroy hook.
+
+  Two responsibilities live here:
+
+    1. `notify-listeners!` — fan a built record out to every registered
+       `register-epoch-cb!` callback. Each invocation is wrapped in a
+       try/catch so one broken listener cannot break the runtime or
+       block other listeners (Spec 009 §Listener invocation rules); a
+       failing cb emits `:rf.epoch.cb/listener-exception` so devtools
+       can surface the broken consumer (rf2-i5khp).
+
+    2. `on-frame-destroyed!` — the late-bind hook
+       `re-frame.frame/destroy-frame!` invokes against the
+       `:epoch/on-frame-destroyed` slot. Coordinates the four-step
+       destroy contract (rf2-d656 + rf2-v0jwt + rf2-zzper):
+
+         (a) mid-drain destroy detection → commit a `:halted-destroy`
+             partial record to listeners (NOT to the ring buffer).
+         (b) emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb
+             whose observed-frames set contained `frame-id`.
+         (c) drop the per-frame ring buffer.
+         (d) drop the in-flight capture buffer.
+
+  Per the Phase-1 finding (rf2-0wi86): on-frame-destroyed straddles
+  state (the three atoms it clears), capture (its mid-drain detection
+  reads the cascade buffer), and assembly (it builds a partial
+  record). This namespace is the rightful home — the destroy contract
+  IS the listener-side surface for frame teardown, and the
+  cross-cutting calls are now explicit cross-namespace requires
+  rather than forward-declares within a single 1500-LoC file.
+
+  Public re-frame.epoch facade fns (register-epoch-cb!,
+  remove-epoch-cb!, clear-epoch-cbs!, on-frame-destroyed!) delegate
+  here; the listener-registry atom + record-observation bookkeeping
+  live in `re-frame.epoch.state` (seam A)."
+  (:require [re-frame.epoch.assembly :as assembly]
+            [re-frame.epoch.state :as state]
+            [re-frame.interop :as interop]
+            [re-frame.trace :as trace]))
+
+(defn notify-listeners!
+  "Fan `record` out to every registered `:rf/epoch-record` listener.
+
+  Each cb is invoked once per record, wrapped in failure isolation:
+  Per Spec 009 §Listener invocation rules listener failures don't
+  stop the loop; per rf2-i5khp a failing cb emits a structured
+  `:rf.epoch.cb/listener-exception` trace so devtools can surface
+  the broken listener (silently swallowing the throw left tool
+  authors with no signal that their callback failed).
+
+  Op-type `:rf.epoch.cb` matches the sibling
+  `:rf.epoch.cb/silenced-on-frame-destroy` event (per Spec 009
+  §Op-type vocabulary catalogue and `epoch.cljc` row).
+  `:recovery :no-recovery` mirrors the `:rf.http/aborted` trace
+  shape — the listener's invocation is over; the next cascade
+  re-invokes the same fn afresh, no automatic remediation happens
+  between now and then."
+  [record]
+  (let [frame-id (:frame record)]
+    (doseq [[id f] (state/listeners-snapshot)]
+      (state/record-observation! id frame-id)
+      (try
+        (f record)
+        (catch #?(:clj Throwable :cljs :default) ex
+          (trace/emit-error! :rf.epoch.cb/listener-exception
+                             {:frame    frame-id
+                              :cb-id    id
+                              :epoch-id (:epoch-id record)
+                              :message  #?(:clj  (.getMessage ^Throwable ex)
+                                           :cljs (.-message ex))
+                              :recovery :no-recovery}))))))
+
+(defn on-frame-destroyed!
+  "Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656)
+  and rf2-v0jwt §Outcomes (`:halted-destroy`):
+
+    1. Mid-drain destroy detection — if `capture-buffers[frame-id]`
+       holds buffered events at destroy time, this is a mid-drain
+       destroy (the handler that called `destroy-frame!` was running
+       inside the drain; its trace events were captured into the
+       in-flight buffer). Notify epoch listeners with a partial
+       `:halted-destroy` record carrying the cascade's traces. The
+       record is NOT appended to the ring buffer — step 3 wipes the
+       ring buffer for the destroyed frame regardless. Devtools that
+       care about destroyed cascades receive the record via the
+       listener fan-out before the ring buffer is dropped.
+    2. Emit `:rf.epoch.cb/silenced-on-frame-destroy` once per cb whose
+       observed-frames set contains `frame-id`, then drop `frame-id`
+       from each cb's entry so a re-registration of a same-keyed frame
+       re-arms the silencing trace for a future destroy.
+    3. Drop the destroyed frame's per-frame ring buffer so subsequent
+       `(rf/epoch-history frame-id)` calls return the empty vector
+       (the read-empty shape the contract commits to).
+    4. Drop any in-flight capture buffer entry for `frame-id`
+       (rf2-zzper) so a mid-drain destroy can't leak its pre-destroy
+       events into the first cascade of the next same-keyed frame.
+
+  Called from `re-frame.frame/destroy-frame!` via the
+  `:epoch/on-frame-destroyed` late-bind hook. Idempotent across
+  repeated destroys of the same frame — once a cb's entry no longer
+  contains the frame-id, no further trace fires for that pair, and
+  the (already-cleared) ring-buffer / capture-buffer entries stay
+  absent."
+  [frame-id]
+  (when interop/debug-enabled?
+    ;; Step 1: mid-drain destroy detection. The capture-buffer holds
+    ;; every emit tagged with this frame, including non-cascade emits
+    ;; that fire OUTSIDE a drain (e.g. `:frame/created` at reg-frame
+    ;; time). Distinguish a real mid-drain destroy from
+    ;; registration-time tagalongs by gating on the presence of an
+    ;; `:event/run-start` emit — that is the canonical "a cascade
+    ;; started inside this drain" signal. When present, commit a
+    ;; partial `:halted-destroy` record so devtools (Causa,
+    ;; re-frame-pair2) receive the cascade context for the destroyed-
+    ;; mid-drain case. We can't read the frame's container here
+    ;; (destroy-frame!'s step 6 already dissoc'd the frame record);
+    ;; the partial record's `:db-before` / `:db-after` slots are nil
+    ;; — the schema allows `:any`, and consumers tolerate the absent
+    ;; state given `:outcome :halted-destroy` signals the destroy
+    ;; context. The record is delivered to listeners only — the ring
+    ;; buffer gets wiped in step 3.
+    (let [buffered-events  (state/buffer-for frame-id)
+          in-cascade?      (some (fn [ev]
+                                   (and (= :event (:op-type ev))
+                                        (= :event (:operation ev))
+                                        (= :run-start (-> ev :tags :phase))))
+                                 buffered-events)]
+      (when in-cascade?
+        ;; Per rf2-wp70d: even on the halted-destroy partial-record
+        ;; commit, `maybe-redact` runs once between `build-record`
+        ;; and listener fan-out so listener consumers see the SAME
+        ;; redacted shape they would see for an :ok cascade record.
+        (let [record (assembly/maybe-redact
+                       (assembly/build-record frame-id nil nil buffered-events
+                                              :halted-destroy
+                                              {:operation :rf.frame/destroyed-mid-drain}))]
+          (trace/emit! :rf.epoch :rf.epoch/snapshotted
+                       {:frame    frame-id
+                        :epoch-id (:epoch-id record)
+                        :event-id (:event-id record)
+                        :outcome  :halted-destroy})
+          (notify-listeners! record))))
+    (let [silenced-cbs (->> (state/observations-snapshot)
+                            (keep (fn [[cb-id frames]]
+                                    (when (contains? frames frame-id) cb-id)))
+                            vec)]
+      (doseq [cb-id silenced-cbs]
+        (trace/emit! :rf.epoch.cb :rf.epoch.cb/silenced-on-frame-destroy
+                     {:frame  frame-id
+                      :cb-id  cb-id})))
+    (state/drop-frame-observation! frame-id)
+    ;; Drop the per-frame ring buffer; epoch-history returns [] from
+    ;; here on. (`reset-frame! :app/main` calls destroy-frame! followed
+    ;; by reg-frame, so the ring buffer for the new same-keyed frame
+    ;; starts empty per Spec 002 §reset-frame!.)
+    (state/drop-frame-history! frame-id)
+    ;; Per rf2-zzper: also drop any in-flight capture buffer. A
+    ;; mid-drain destroy that surfaces a halted record above leaves
+    ;; the buffer behind (the partial-record commit doesn't harvest);
+    ;; explicitly clear here so the next cascade against a same-keyed
+    ;; frame starts from an empty buffer. Symmetric to the ring-buffer
+    ;; drop above.
+    (state/drop-frame-buffer! frame-id)))

--- a/implementation/epoch/src/re_frame/epoch/state.cljc
+++ b/implementation/epoch/src/re_frame/epoch/state.cljc
@@ -1,0 +1,343 @@
+(ns re-frame.epoch.state
+  "Shared state for the epoch surface — the six defonce atoms plus the
+  low-level CRUD against them, and the config knob accessors. Per
+  rf2-0wi86 (cohesion split): every other seam (`capture`, `assembly`,
+  `write`, `listeners`) and the `re-frame.epoch` facade reach the
+  shared atoms through this namespace; the atoms themselves stay
+  `^:private` so cross-seam access is exclusively through the named
+  helpers below.
+
+  The atoms in question:
+
+    config                  per-frame ring-buffer config + redact-fn
+    histories               frame-id → vector<:rf/epoch-record>
+    capture-buffers         frame-id → vector<trace-event> (in-flight)
+    listeners               cb-id    → fn
+    observed-frames-by-cb   cb-id    → #{frame-id ...}
+    epoch-counter           monotonically-increasing :epoch-id source
+
+  Per Phase-1 finding (rf2-0wi86): no two atoms are ever held in a
+  single critical section, so a tiny state ns owns all of them with
+  zero locking/ordering subtleties — the cross-cutting coupling is
+  cosmetic, not structural."
+  (:require [re-frame.interop :as interop]))
+
+;; ---- configuration --------------------------------------------------------
+
+(def ^:private default-depth
+  ;; Deep enough to hold a typical debug session's cascade history;
+  ;; trades bounded heap for stable time-travel coverage.
+  50)
+
+(def ^:private default-trace-events-keep
+  ;; Per rf2-mrsck and Security.md §Epoch privacy posture: a finite
+  ;; default that bounds dev-session heap growth from accumulated raw
+  ;; cascade traces. The most-recent N records keep `:trace-events`;
+  ;; older records keep only the cheap structured projections
+  ;; (`:sub-runs` / `:renders` / `:effects`). Five matches the pair-
+  ;; tool / Causa "what just happened?" working set — devs typically
+  ;; care about the latest handful of cascades' raw streams; a deeper
+  ;; ring depth is for time-travel reproducibility (`:db-after` is
+  ;; cheap), not raw-trace inspection. Apps that genuinely need the
+  ;; whole ring's traces can opt back in via
+  ;; `(rf/configure :epoch-history {:trace-events-keep nil})` (or any
+  ;; value >= the depth cap). Setting the slot to `0` drops every
+  ;; record's `:trace-events`.
+  5)
+
+(defonce ^:private config
+  ;; Three keys today (:depth, :trace-events-keep, :redact-fn). Map
+  ;; shape kept open so future (rf/configure :epoch-history {...})
+  ;; extensions don't break the shape. Per rf2-wp70d / Tool-Pair
+  ;; §Time-travel §Redaction hook + Security.md §Epoch privacy
+  ;; posture: :redact-fn defaults to nil — apps that record
+  ;; sensitive material into app-db opt in by installing a fn.
+  (atom {:depth             default-depth
+         :trace-events-keep default-trace-events-keep
+         :redact-fn         nil}))
+
+(defn non-neg-int?
+  "True for non-negative integer values; nil and non-numeric values
+  fail. Mirrors the validation `re-frame.trace/configure-trace-buffer!`
+  applies at its own config boundary."
+  [x]
+  (and (integer? x) (not (neg? x))))
+
+(defn merge-config!
+  "Validate and merge an `opts` map into the live config atom. Returns
+  nil. Silently drops invalid slot values (`:depth` /
+  `:trace-events-keep` must be non-negative integers; `:redact-fn`
+  accepts `fn?` or `nil` for explicit-clear; anything else is dropped).
+
+  Per refactor-audit r2 (rf2-lwn4t) §rf2-douii: validation at the
+  boundary keeps stored config sane — a `nil` or non-numeric value
+  would otherwise survive into `record!` and explode at the next
+  `pos?` / `nat-int?` call."
+  [opts]
+  (when (map? opts)
+    (let [numeric (select-keys opts [:depth :trace-events-keep])
+          numeric-valid (into {}
+                              (filter (fn [[_ v]] (non-neg-int? v)))
+                              numeric)
+          ;; :redact-fn validated separately — accept fn? OR nil
+          ;; (explicit-clear); anything else silently dropped.
+          ;; `contains?` distinguishes 'absent slot' from 'present
+          ;; nil' so the explicit-clear path lands while a callsite
+          ;; that didn't mention :redact-fn doesn't clobber a
+          ;; previously-installed fn.
+          redact (when (contains? opts :redact-fn)
+                   (let [v (:redact-fn opts)]
+                     (when (or (nil? v) (fn? v))
+                       {:redact-fn v})))
+          valid (merge numeric-valid redact)]
+      (when (seq valid)
+        (swap! config merge valid))))
+  nil)
+
+(defn current-config
+  "Return the current epoch-history configuration map."
+  []
+  @config)
+
+(defn depth []
+  (:depth @config default-depth))
+
+(defn trace-events-keep []
+  (:trace-events-keep @config default-trace-events-keep))
+
+(defn redact-fn
+  "Return the currently-installed `:redact-fn` (or nil). One config
+  deref per record-build — the hot path for installed-fn cases is one
+  keyword lookup, no allocation."
+  []
+  (:redact-fn @config))
+
+;; ---- epoch-id counter -----------------------------------------------------
+
+(defonce ^:private epoch-counter (atom 0))
+
+(defn next-epoch-id []
+  (swap! epoch-counter inc))
+
+;; ---- per-frame ring buffer ------------------------------------------------
+;;
+;; Per Tool-Pair §Time-travel "Bounded history": last N epochs per frame.
+;; Stored as a map of frame-id → vector (oldest-first). New records append
+;; to the back; the front evicts when the buffer exceeds the configured
+;; depth.
+
+(defonce ^:private histories (atom {}))
+
+(defn- elide-just-crossed-trace-events
+  "When the record at index `(- (count history) keep 1)` crosses the
+  keep-boundary, dissoc its `:trace-events`. O(1) per append: every
+  earlier record was already elided on its own crossing, so the only
+  record that needs work is the one that just slid out of the keep-
+  window. Records keep their structured projections (`:sub-runs` /
+  `:renders` / `:effects`) but lose the raw trace stream. nil `keep`
+  means 'keep every record's :trace-events'.
+
+  HOT PATH: invoked from `append-record` on every drain settle (every
+  user-facing event). Pre-rf2-1e38x this rewrote the whole history
+  vector via `map-indexed`; under steady state only one record per
+  append actually transitions, so the O(n) walk was wasted work. The
+  steady-state invariant holds because every prior append already
+  elided its own just-crossed record; runtime reductions of `keep`
+  via `(rf/configure :epoch-history ...)` will take full effect on
+  subsequent appends rather than retroactively rewriting the buffer
+  (pre-alpha posture)."
+  [history keep]
+  (let [n (count history)]
+    (if (and (some? keep) (nat-int? keep) (> n keep))
+      (let [idx (- n keep 1)
+            r   (nth history idx)]
+        (if (contains? r :trace-events)
+          (assoc history idx (dissoc r :trace-events))
+          history))
+      history)))
+
+(defn- append-record
+  "Conj `record` onto the frame's history vector, cap to `d` via
+  `subvec` (cheap structural reuse — no copy), then elide the just-
+  crossed record's `:trace-events` per `keep`.
+
+  HOT PATH: fires once per cascade settle, i.e. once per dispatched
+  user event under steady state. Cost is O(1) in both the depth cap
+  and the trace-events elision — the vector grows by one, optionally
+  drops its leftmost element via `subvec`, and at most one record's
+  `:trace-events` slot is dissoc'd."
+  [history record d keep]
+  (let [history+ (conj (or history []) record)
+        n        (count history+)
+        capped   (if (and (pos? d) (> n d))
+                   (subvec history+ (- n d))
+                   history+)]
+    (elide-just-crossed-trace-events capped keep)))
+
+(defn record!
+  "Append a record into the frame's history. The depth cap and the
+  `:trace-events-keep` cap are read from the config atom on each
+  append so runtime `(rf/configure :epoch-history ...)` takes effect
+  immediately."
+  [record]
+  (let [d    (depth)
+        keep (trace-events-keep)]
+    (when (pos? d)
+      (let [frame-id (:frame record)]
+        (swap! histories update frame-id append-record record d keep)))))
+
+(defn history-for
+  "Return the frame's history vector (oldest-first) or `[]`."
+  [frame-id]
+  (or (get @histories frame-id) []))
+
+(defn drop-frame-history!
+  "Drop the named frame's ring buffer."
+  [frame-id]
+  (swap! histories dissoc frame-id)
+  nil)
+
+;; ---- per-cascade capture buffer -------------------------------------------
+;;
+;; Per Tool-Pair §Per-cascade capture: the drain runs traces through
+;; `re-frame.trace/emit!` which fans out to every registered listener.
+;; An internal listener appends every event into a per-cascade buffer;
+;; when the cascade settles, the buffer is harvested and projected into
+;; the structured record slots. Keyed by frame-id so concurrent drains
+;; across frames don't co-mingle. Within a frame, drain-execution is
+;; single-threaded (Spec 002 §Run-to-completion).
+
+(defonce ^:private capture-buffers
+  ;; frame-id → vector of trace events (in arrival order)
+  (atom {}))
+
+(defn buffer-event!
+  "Append `event` onto the frame's in-flight cascade buffer.
+
+  HOT PATH: fires once per `trace/emit!` while a cascade is in flight,
+  which is the dominant per-event cost (sub-runs, renders, fx, error
+  emits all funnel here). O(1) swap! + (fnil conj []) — the buffer
+  vector grows by one and is harvested wholesale at cascade settle
+  via `harvest-buffer!`."
+  [frame-id event]
+  (swap! capture-buffers update frame-id (fnil conj []) event))
+
+(defn buffer-for
+  "Return the frame's in-flight capture buffer (vector) or `[]`. Used
+  by the destroy hook to inspect buffered events before deciding
+  whether to commit a `:halted-destroy` partial record."
+  [frame-id]
+  (get @capture-buffers frame-id []))
+
+(defn harvest-buffer!
+  "Atomically read-and-clear the frame's in-flight buffer."
+  [frame-id]
+  (let [b (get @capture-buffers frame-id [])]
+    (swap! capture-buffers dissoc frame-id)
+    b))
+
+(defn drop-frame-buffer!
+  "Drop the frame's in-flight capture buffer."
+  [frame-id]
+  (swap! capture-buffers dissoc frame-id)
+  nil)
+
+(defn reset-capture-buffers!
+  "Wipe every in-flight capture buffer across all frames. Test fixtures
+  use this in lockstep with `reset-histories!`.
+
+  Per rf2-v0jwt: fixtures that sequence runs need a fresh capture
+  state per fixture; a stale buffer from a previous fixture would
+  otherwise be harvested into the next fixture's first cascade."
+  []
+  (reset! capture-buffers {})
+  nil)
+
+(defn reset-histories!
+  "Wipe every frame's recorded epochs."
+  []
+  (reset! histories {})
+  nil)
+
+;; ---- listener registry ----------------------------------------------------
+
+(defonce ^:private listeners (atom {}))
+
+;; Per Tool-Pair §Surface behaviour against destroyed frames (rf2-d656):
+;; track which frames each cb has been delivered records for. When a
+;; frame is destroyed, every cb whose observed-frames set contains
+;; that frame receives a one-shot :rf.epoch.cb/silenced-on-frame-destroy
+;; trace. The frame is then dropped from the cb's entry so a
+;; re-registration of a same-keyed frame (e.g. `reset-frame! :app/main`)
+;; can re-arm the silencing trace for a future destroy.
+(defonce ^:private observed-frames-by-cb
+  ;; cb-id → #{frame-id ...}
+  (atom {}))
+
+(defn put-listener!
+  "Install or replace `f` under `id`. Also clears `id`'s
+  observed-frames set so the new callback's silencing trace fires
+  fresh against frames the new callback observes."
+  [id f]
+  (swap! listeners assoc id f)
+  (swap! observed-frames-by-cb dissoc id)
+  id)
+
+(defn drop-listener!
+  "Remove the listener registered under `id` and any observation
+  bookkeeping it carried."
+  [id]
+  (swap! listeners dissoc id)
+  (swap! observed-frames-by-cb dissoc id)
+  nil)
+
+(defn reset-listeners!
+  "Drop every registered listener and clear all observation bookkeeping."
+  []
+  (reset! listeners {})
+  (reset! observed-frames-by-cb {})
+  nil)
+
+(defn listeners-snapshot
+  "Return the current `{cb-id → f}` map. Callers iterate this snapshot
+  for fan-out — taking the snapshot once isolates iteration from
+  concurrent `put-listener!` / `drop-listener!` updates."
+  []
+  @listeners)
+
+(defn observations-snapshot
+  "Return the current `{cb-id → #{frame-id ...}}` map."
+  []
+  @observed-frames-by-cb)
+
+(defn record-observation!
+  "Mark that the cb registered under `cb-id` has seen a record from
+  `frame-id`. Guards against re-firing the atom watcher on the
+  no-op case (cb already observes that frame) — for the common
+  long-lived listener observing the same frame on every cascade,
+  this is a single deref + membership check with no swap."
+  [cb-id frame-id]
+  (when frame-id
+    (let [current @observed-frames-by-cb]
+      (when-not (contains? (get current cb-id) frame-id)
+        (swap! observed-frames-by-cb
+               (fn [m]
+                 (if (contains? (get m cb-id) frame-id)
+                   m
+                   (update m cb-id (fnil conj #{}) frame-id))))))))
+
+(defn drop-frame-observation!
+  "Drop `frame-id` from every cb's observed-frames set. cbs whose set
+  goes empty as a result are dropped from the map entirely so the
+  map doesn't accrete keys to empty sets."
+  [frame-id]
+  (swap! observed-frames-by-cb
+         (fn [m]
+           (reduce-kv (fn [acc cb-id frames]
+                        (let [frames' (disj frames frame-id)]
+                          (if (empty? frames')
+                            (dissoc acc cb-id)
+                            (assoc acc cb-id frames'))))
+                      {}
+                      m)))
+  nil)

--- a/implementation/epoch/src/re_frame/epoch/write.cljc
+++ b/implementation/epoch/src/re_frame/epoch/write.cljc
@@ -1,0 +1,461 @@
+(ns re-frame.epoch.write
+  "Tool-Pair write surfaces — the preconditions, restore-perform, and
+  off-box projection helpers behind `restore-epoch`, `reset-frame-db!`,
+  `projected-record`, and `projected-history`.
+
+  Responsibilities:
+
+    * **Precondition validators** — `check-restore-preconditions!` and
+      `check-reset-frame-db-preconditions!` are pure data transforms
+      (no trace emission, no app-db writes); they return
+      `{:outcome :ok ...}` or `{:outcome :fail :op <kw> :tags <map>}`
+      so the orchestrating facade fn can emit the trace and decide
+      flow control.
+
+    * **Schema / handler / version probes** — `failing-schema-paths`,
+      `missing-references`, `machine-version-mismatch`. Each is a
+      single walk over the recorded db; callers bind the result so
+      the failure path walks each substrate exactly once per check
+      (rf2-081zk).
+
+    * **Perform-restore** — `perform-restore!` carries out the
+      container replace + `:rf.epoch/restored` emit once preconditions
+      have passed.
+
+    * **Projected egress** — `projected-record` and `projected-history`
+      route the four payload-bearing slots through
+      `re-frame.elision/elide-wire-value` for off-box egress
+      (Causa-MCP `watch-epochs`, story / pair recorders).
+
+  Per rf2-0wi86 Phase-2 seam E. The orchestrators `restore-epoch` and
+  `reset-frame-db!` live in the `re-frame.epoch` facade — they wire
+  the precondition check + the trace emission + the perform / listener
+  fan-out steps together. Pure-data shape of the preconditions makes
+  the orchestrators a four-line case-match."
+  (:require [re-frame.elision :as elision]
+            [re-frame.epoch.assembly :as assembly]
+            [re-frame.epoch.state :as state]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.trace :as trace]))
+
+;; ---- restore failure-mode predicates --------------------------------------
+
+(defn- malli-validate-fn
+  "Return the malli validate fn or nil.
+
+  Per rf2-t0hq — CLJS has no runtime `resolve`, so the lookup order on
+  CLJS is: late-bind hook then nil. Returning nil is treated as
+  soft-pass by callers ('cannot disprove, treat as valid').
+
+  Lookup order matches `re-frame.schemas/default-malli-validate`:
+    1. Late-bind hook `:schemas/malli-validate` (published by
+       `re-frame.schemas.malli` when loaded).
+    2. JVM only — fall back to `(requiring-resolve 'malli.core/validate)`.
+    3. Return nil (soft-pass — the schema-validate-ok? caller treats
+       a nil validate fn as 'cannot disprove, treat as valid')."
+  []
+  (or (late-bind/get-fn :schemas/malli-validate)
+      #?(:clj  (try (requiring-resolve 'malli.core/validate)
+                    (catch Throwable _ nil))
+         :cljs nil)))
+
+(defn- registered-app-schemas
+  "Return the {path → schema-meta} map registered against the named
+  frame, or {}. Per Spec 010 §Per-frame schemas the schema set is
+  frame-scoped; restore-epoch validates against the schemas registered
+  against the frame the epoch belongs to, not a process-global set."
+  [frame-id]
+  (if-let [entries (late-bind/get-fn :schemas/frame-schema-entries)]
+    (entries frame-id)
+    {}))
+
+(defn failing-schema-paths
+  "Return a vector of failing schema-paths for `db` against `frame-id`'s
+  registered app-schemas. Empty vector means valid — either every
+  registered schema accepted the path's value, OR no schemas are
+  registered, OR no Malli validator is on the classpath. The latter
+  two are soft-pass: we can't disprove validity, so we treat the db
+  as valid.
+
+  Single walk over the schema set — callers that previously chained
+  `schema-validate-ok?` + `failing-paths-for` paid two walks where one
+  suffices. The validity question is `(empty? (failing-schema-paths
+  frame-id db))`."
+  [frame-id db]
+  (let [schemas  (registered-app-schemas frame-id)
+        validate (malli-validate-fn)]
+    (if (or (empty? schemas) (nil? validate))
+      []
+      (vec
+        (keep (fn [[path meta]]
+                (let [schema (:schema meta)
+                      v      (get-in db path)]
+                  (when-not (try (validate schema v)
+                                 (catch #?(:clj Throwable :cljs :default) _ true))
+                    path)))
+              schemas)))))
+
+(defn- machine-registration
+  "Resolve a machine-id against the public machine registry. Per
+  Spec 005 §Registration / §Querying machines, machines are event
+  handlers whose registration metadata carries `:rf/machine? true`
+  and `:rf/machine` (the spec map). Returns the registration map
+  when machine-id names a registered machine, nil otherwise.
+
+  Per rf2-ocg1: epoch restore validates against this public surface,
+  not against the internal `:head` registrar kind that machines
+  never used."
+  [machine-id]
+  (let [reg (registrar/lookup :event machine-id)]
+    (when (:rf/machine? reg)
+      reg)))
+
+(defn- snapshot-version
+  "Read the recorded snapshot's `:rf/snapshot-version`. Per
+  Spec-Schemas §`:rf/machine-snapshot` and Spec 005 §Snapshot shape,
+  the canonical slot is `[:meta :rf/snapshot-version]`."
+  [snapshot]
+  (get-in snapshot [:meta :rf/snapshot-version]))
+
+(defn- machine-definition-version
+  "Read the currently-registered machine definition's
+  `:rf/snapshot-version`. Per Spec 005 §Snapshot shape — the
+  definition's `:meta :rf/snapshot-version` is the canonical slot."
+  [machine-id]
+  (when-let [reg (machine-registration machine-id)]
+    (let [machine (:rf/machine reg)]
+      (get-in machine [:meta :rf/snapshot-version]))))
+
+(defn missing-references
+  "Walk the recorded db for ids that are no longer present in the
+  registrar. Closed v1 surface — `:rf/machines` (each machine-id
+  must reference a registered machine via the public event registry,
+  per Spec 005 §Registration — machines are event handlers tagged
+  with `:rf/machine?`) and `:route` (`:id` must reference a registered
+  :route).
+
+  Per rf2-ocg1: machine lookup goes through the event registry, NOT
+  the internal `:head` registrar kind. The latter is unrelated to
+  the public machine contract.
+
+  Returns a vector of {:kind <kind> :id <id>} entries. Empty when
+  every reference resolves."
+  [db]
+  (let [;; Machines under :rf/machines: registered as event handlers with
+        ;; :rf/machine? true (per Spec 005 §Registration).
+        missing-machines
+        (for [[machine-id _snapshot] (:rf/machines db)
+              :when (not (machine-registration machine-id))]
+          {:kind :machine :id machine-id})
+        ;; Active route
+        missing-route
+        (when-let [route-id (get-in db [:rf/route :id])]
+          (when-not (registrar/lookup :route route-id)
+            [{:kind :route :id route-id}]))]
+    (vec (concat missing-machines missing-route))))
+
+(defn machine-version-mismatch
+  "Walk the recorded db's `:rf/machines` for snapshot version drift.
+  The recorded snapshot may carry `:rf/snapshot-version` under
+  `:meta`; the registered machine definition carries
+  `:rf/snapshot-version` under its own `:meta`. When they differ,
+  return the first mismatch as
+  `{:machine-id <id> :recorded <int> :current <int>}`. nil when no
+  mismatch is found.
+
+  Per rf2-ocg1: both versions are read through the public Spec 005
+  §Snapshot shape contract — the snapshot's `[:meta :rf/snapshot-version]`
+  and the registered machine's `[:meta :rf/snapshot-version]`."
+  [db]
+  (some (fn [[machine-id snapshot]]
+          (let [recorded (snapshot-version snapshot)]
+            (when (some? recorded)
+              (let [current (machine-definition-version machine-id)]
+                (when (and (some? current) (not= recorded current))
+                  {:machine-id machine-id
+                   :recorded   recorded
+                   :current    current})))))
+        (:rf/machines db)))
+
+;; ---- shared precondition helpers ------------------------------------------
+
+(defn- find-epoch-in
+  "Search a resolved history vector for the record matching `epoch-id`.
+  Caller has already paid the `@histories` deref — `check-restore-
+  preconditions!` reads history once at the top and reuses the vector
+  for both the lookup and the `:history-size` count on the
+  unknown-epoch failure path (rf2-3g7x3 — was two derefs)."
+  [history epoch-id]
+  (some (fn [r] (when (= epoch-id (:epoch-id r)) r))
+        history))
+
+(defn emit-precondition-failure!
+  [operation tags]
+  (trace/emit-error! operation
+                     (assoc tags :recovery :no-recovery)))
+
+(defn- drain-in-flight?
+  "True when `frame-record`'s router is mid-drain (sync or async).
+  Shared by every precondition path that must refuse to write to
+  `app-db` while a cascade is being processed."
+  [frame-record]
+  (let [router (:router frame-record)
+        r      (when router @router)]
+    (boolean (and r (or (:in-drain? r) (:in-sync-drain? r))))))
+
+(defn- frame-exists-or-fail
+  "Resolve `frame-id` to its `frame-record` or yield the canonical
+  no-such-handler precondition-failure result. Returns
+  `{:outcome :ok :frame-record <record>}` or
+  `{:outcome :fail :op :rf.error/no-such-handler
+    :tags {:kind :frame :frame frame-id}}`. Shared by every Tool-Pair /
+  time-travel write surface so the no-such-handler tag shape stays
+  canonical."
+  [frame-id]
+  (if-let [frame-record (frame/frame frame-id)]
+    {:outcome :ok :frame-record frame-record}
+    {:outcome :fail
+     :op      :rf.error/no-such-handler
+     :tags    {:kind  :frame
+               :frame frame-id}}))
+
+;; ---- restore preconditions + perform --------------------------------------
+
+(defn check-restore-preconditions!
+  "Validate the seven documented preconditions for restoring `frame-id`
+  to `epoch-id`. Returns a result map:
+
+    {:outcome :ok :epoch <epoch>}
+                 — all checks passed; `:epoch` is the resolved history
+                   record whose `:db-after` is the restore target.
+    {:outcome :fail :op <kw> :tags <map>}
+                 — first failing check; `:op` is the trace operation
+                   the caller must emit, `:tags` are its tags. No
+                   trace events are emitted from inside this helper —
+                   emission is the caller's job so the
+                   precondition test stays a pure data check.
+
+  Failure modes preserve the exact operation keywords and tag shapes
+  the public surface has always emitted (see `restore-epoch`'s
+  docstring for the catalogue)."
+  [frame-id epoch-id]
+  (let [frame-result (frame-exists-or-fail frame-id)]
+    (cond
+      ;; (1) Frame registered?
+      (= :fail (:outcome frame-result))
+      frame-result
+
+      ;; (2) In-flight drain?
+      (drain-in-flight? (:frame-record frame-result))
+      {:outcome :fail
+       :op      :rf.epoch/restore-during-drain
+       :tags    {:frame    frame-id
+                 :epoch-id epoch-id}}
+
+      :else
+      (let [history (state/history-for frame-id)
+            epoch   (find-epoch-in history epoch-id)]
+        (cond
+          ;; (3) Epoch present in current history?
+          (nil? epoch)
+          {:outcome :fail
+           :op      :rf.epoch/restore-unknown-epoch
+           :tags    {:frame        frame-id
+                     :epoch-id     epoch-id
+                     :history-size (count history)}}
+
+          ;; (3a) Halted-cascade target? Per rf2-v0jwt: an epoch whose
+          ;; :outcome is not :ok records partial state the cascade
+          ;; never settled to, so it is not a valid restore target.
+          ;; Refuse before the schema / handler / version checks so
+          ;; the failure surfaces with the actual halt context, not
+          ;; a downstream consequence of the partial db.
+          (not= :ok (get epoch :outcome :ok))
+          {:outcome :fail
+           :op      :rf.epoch/restore-non-ok-record
+           :tags    {:frame       frame-id
+                     :epoch-id    epoch-id
+                     :outcome     (:outcome epoch)
+                     :halt-reason (:halt-reason epoch)}}
+
+          :else
+          (let [db-target (:db-after epoch)]
+            ;; Each helper is called once and its result bound, so the
+            ;; failure path walks the recorded db / schema set / machine
+            ;; map exactly once per check (rf2-081zk).
+            (if-let [failing-paths (seq (failing-schema-paths frame-id db-target))]
+              ;; (4) Schema mismatch?
+              ;; Per Spec 010 §Schema digest + Tool-Pair §Time-travel:
+              ;; the trace carries both the digest pinned on the
+              ;; epoch record (recorded) and the current frame's
+              ;; live digest, so pair tools can pinpoint *what
+              ;; changed* about the schema set, not merely *that*
+              ;; it changed.
+              {:outcome :fail
+               :op      :rf.epoch/restore-schema-mismatch
+               :tags    {:frame                  frame-id
+                         :epoch-id               epoch-id
+                         :schema-digest-recorded (:schema-digest epoch)
+                         :schema-digest-current  (assembly/current-schema-digest frame-id)
+                         :failing-paths          (vec failing-paths)}}
+
+              (if-let [missing (seq (missing-references db-target))]
+                ;; (5) Missing handler referenced from db?
+                {:outcome :fail
+                 :op      :rf.epoch/restore-missing-handler
+                 :tags    {:frame    frame-id
+                           :epoch-id epoch-id
+                           :missing  (vec missing)}}
+
+                (if-let [{:keys [machine-id recorded current]} (machine-version-mismatch db-target)]
+                  ;; (6) Machine snapshot version drift?
+                  {:outcome :fail
+                   :op      :rf.epoch/restore-version-mismatch
+                   :tags    {:frame            frame-id
+                             :epoch-id         epoch-id
+                             :machine-id       machine-id
+                             :version-recorded recorded
+                             :version-current  current}}
+
+                  {:outcome :ok :epoch epoch})))))))))
+
+(defn perform-restore!
+  "Carry out the actual `app-db` rewind once preconditions have passed.
+  Replaces the frame's container with `epoch`'s `:db-after` and emits
+  `:rf.epoch/restored`. Returns `true`."
+  [frame-id epoch]
+  (let [container (frame/get-frame-db frame-id)
+        db-target (:db-after epoch)]
+    (adapter/replace-container! container db-target)
+    (trace/emit! :rf.epoch :rf.epoch/restored
+                 {:frame    frame-id
+                  :epoch-id (:epoch-id epoch)})
+    true))
+
+;; ---- reset-frame-db! preconditions ----------------------------------------
+
+(defn check-reset-frame-db-preconditions!
+  "Validate the three documented preconditions for `reset-frame-db!`.
+  Returns `{:outcome :ok}` when all checks pass, otherwise
+  `{:outcome :fail :op <kw> :tags <map>}` matching the precondition-
+  failure shape of `check-restore-preconditions!`. Pure data — no
+  trace events emitted from here; emission is the caller's job."
+  [frame-id new-db]
+  (let [frame-result (frame-exists-or-fail frame-id)]
+    (cond
+      ;; (1) Frame registered?
+      (= :fail (:outcome frame-result))
+      frame-result
+
+      ;; (2) In-flight drain?
+      (drain-in-flight? (:frame-record frame-result))
+      {:outcome :fail
+       :op      :rf.epoch/reset-frame-db-during-drain
+       :tags    {:frame frame-id}}
+
+      :else
+      ;; (3) Schema mismatch? Single walk — `failing-schema-paths`
+      ;; returns the failing paths (or [] for the valid / soft-pass
+      ;; cases), folding what was previously a two-helper / two-walk
+      ;; chain into one.
+      (let [failing (failing-schema-paths frame-id new-db)]
+        (if (seq failing)
+          {:outcome :fail
+           :op      :rf.epoch/reset-frame-db-schema-mismatch
+           :tags    {:frame         frame-id
+                     :failing-paths failing}}
+          {:outcome :ok})))))
+
+;; ---- projected egress -----------------------------------------------------
+;;
+;; Per Security.md §Epoch privacy posture and rf2-mrsck: the framework's
+;; single normative projection emission site for off-box epoch egress.
+;; The in-process ring buffer (`epoch-history`) and `register-epoch-cb!`
+;; listener fan-out deliver RAW records — restore-epoch and on-box
+;; devtools (Causa diff, REPL inspection) need them. Tools that
+;; egress an epoch record across a process boundary (Causa-MCP
+;; `watch-epochs`, story / pair recorders, hosted forwarders) MUST
+;; route through `projected-record` first, parallel to how direct-read
+;; tools route through `elide-wire-value` (per rf2-czv3p).
+;;
+;; The projection wraps `re-frame.elision/elide-wire-value` against the
+;; record's frame-id and the four payload-bearing slots that may carry
+;; sensitive or large material: `:db-before`, `:db-after`,
+;; `:trigger-event`, and `:trace-events`. The cheap structured slots
+;; (`:sub-runs`, `:renders`, `:effects`) carry no app-db material —
+;; they project sub-ids, render-keys, fx-ids, and outcome tags — so
+;; the projection leaves them as-is. The record-level bookkeeping
+;; (`:epoch-id`, `:frame`, `:committed-at`, `:event-id`, `:outcome`,
+;; `:halt-reason`, `:schema-digest`, `:rf.epoch/sensitive?`) is
+;; structurally non-sensitive and passes through.
+;;
+;; Per-tool reimplementation of the projection is prohibited (the
+;; same posture as the wire-elision walker). New egress tools call
+;; `projected-record` and trust the contract.
+
+(defn- elide-payload-slot
+  "Walk one payload slot through `elide-wire-value` rooted at the named
+  frame, with off-box defaults (`:include-sensitive? false`,
+  `:include-large? false`). Returns the elided value; `nil` slots are
+  preserved as nil (a halted-destroy record's `:db-before` /
+  `:db-after` are nil per rf2-v0jwt; the schema admits the absent /
+  nil slot — the projection MUST NOT fabricate a value)."
+  [v frame-id]
+  (when (some? v)
+    (elision/elide-wire-value v {:frame frame-id})))
+
+(defn projected-record
+  "Project an `:rf/epoch-record` for off-box egress. Routes the four
+  payload-bearing slots (`:db-before`, `:db-after`, `:trigger-event`,
+  `:trace-events`) through `re-frame.elision/elide-wire-value` against
+  the record's frame, with the off-box defaults
+  `:include-sensitive? false` / `:include-large? false`. Sensitive
+  paths land as `:rf/redacted`; large paths land as
+  `:rf.size/large-elided` markers per the §Composition rule. The
+  record-level bookkeeping (`:epoch-id`, `:frame`, `:committed-at`,
+  `:event-id`, `:outcome`, `:halt-reason`, `:schema-digest`,
+  `:rf.epoch/sensitive?`) and the cheap structured projections
+  (`:sub-runs`, `:renders`, `:effects`) pass through unchanged —
+  they carry no app-db material.
+
+  Per Security.md §Epoch privacy posture and rf2-mrsck: this is the
+  single normative projection emission site for off-box egress. Tools
+  that forward epoch records across a process boundary (Causa-MCP
+  `watch-epochs`, story / pair recorders, hosted post-mortem
+  forwarders) MUST route through this fn at the wire boundary; the
+  on-box ring buffer and `register-epoch-cb!` listener fan-out
+  continue to deliver the RAW record so on-box devtools (Causa diff,
+  REPL, `restore-epoch`) can reason about exact state.
+
+  `record` may be `nil` (e.g. a missing epoch lookup) — the projection
+  returns `nil` in that case, no elision called. Production builds
+  elide the entire epoch surface; consumers gate any
+  `register-epoch-cb!` registration under `interop/debug-enabled?`
+  per Spec 009 §User-side listener registration."
+  [record]
+  (when (map? record)
+    (let [frame-id (:frame record)]
+      (cond-> record
+        (contains? record :db-before)
+        (update :db-before     elide-payload-slot frame-id)
+
+        (contains? record :db-after)
+        (update :db-after      elide-payload-slot frame-id)
+
+        (contains? record :trigger-event)
+        (update :trigger-event elide-payload-slot frame-id)
+
+        (contains? record :trace-events)
+        (update :trace-events  elide-payload-slot frame-id)))))
+
+(defn projected-history
+  "Convenience: return the projected vector of records for a frame.
+  Equivalent to `(mapv projected-record (epoch-history frame-id))`.
+  Tools that egress the whole ring (an MCP `watch-epochs` initial
+  snapshot, a recorder dumping the full session) can call this once
+  rather than walking the raw ring and re-wrapping each record."
+  [frame-id]
+  (mapv projected-record (state/history-for frame-id)))

--- a/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
+++ b/implementation/epoch/test/re_frame/epoch_cljs_test.cljs
@@ -43,6 +43,7 @@
             ;; rf2-qwm0a: listener / buffer surface lives in re-frame.trace.tooling.
             [re-frame.trace.tooling :as trace-tooling]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -66,7 +67,7 @@
                 ;; reset.
                 (epoch/clear-history!)
                 (epoch/clear-epoch-cbs!)
-                (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil}))}))
+                (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil}))}))
 
 ;; ---- 1. Recording — happy-path record shape -------------------------------
 

--- a/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_concurrency_stress_test.clj
@@ -115,6 +115,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -146,7 +147,7 @@
   ;; :depth from a sibling test can't leak; configure! merges, so a
   ;; per-test opt-in to elision would otherwise persist. Per rf2-mrsck
   ;; the default :trace-events-keep is 5 (finite).
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))
@@ -370,7 +371,7 @@
         (dotimes [i n-churners]
           (rf/remove-epoch-cb! (keyword "rd7a7.fanout"
                                         (str "churner-" i))))
-        (let [live (deref @#'epoch/listeners)
+        (let [live (deref @#'state/listeners)
               churner-keys (filter (fn [k]
                                      (and (keyword? k)
                                           (= "rd7a7.fanout"

--- a/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj
@@ -15,6 +15,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -36,7 +37,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -57,6 +57,7 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -78,7 +79,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_privacy_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_privacy_test.clj
@@ -28,6 +28,7 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -50,7 +51,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_projection_test.clj
@@ -59,6 +59,7 @@
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.privacy :as privacy]
@@ -81,7 +82,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_redact_fn_test.clj
@@ -34,6 +34,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -55,7 +56,7 @@
   (trace/clear-trace-cbs!)
   (epoch/clear-history!)
   (epoch/clear-epoch-cbs!)
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -26,6 +26,7 @@
             [re-frame.trace :as trace]
             [re-frame.elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when the namespace is
@@ -1621,7 +1622,7 @@
                      ;; frame's cascade buffer, so it must be skipped
                      ;; lest it accrete into the next cascade's record.
                      :rf.warning/epoch-redact-fn-exception}
-          actual   @#'epoch/skip-ops]
+          actual   @#'capture/skip-ops]
       (is (= expected actual)
           "skip-ops catalogue matches the documented set of
            out-of-cascade :rf.epoch/* + :rf.warning/* emits"))))
@@ -2126,7 +2127,7 @@
                               :operation :event
                               :tags      {:frame    :test/main
                                           :event-id :foo}}]
-          trigger           (#'epoch/find-trigger-event tag-less-fallback)]
+          trigger           (#'capture/find-trigger-event tag-less-fallback)]
       (is (= :foo (:event-id trigger))
           ":event-id is recovered from the fallback arm")
       (is (nil? (:event trigger))
@@ -2161,7 +2162,7 @@
                     :tags      {:frame    :test/main
                                 :event-id :foo
                                 :event    [:foo "bar" 42]}}]
-          trigger (#'epoch/find-trigger-event events)]
+          trigger (#'capture/find-trigger-event events)]
       (is (= :foo (:event-id trigger)))
       (is (= [:foo "bar" 42] (:event trigger))
           "the full event vector survives — payload is preserved"))))

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -26,6 +26,7 @@
             [re-frame.trace :as trace]
             [re-frame.elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.assembly :as assembly]
             [re-frame.epoch.capture :as capture]
             [re-frame.epoch.state :as state]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
@@ -2070,7 +2071,7 @@
                             :operation :event
                             :tags      {:frame :test/main
                                         :phase :run-start}}]
-          record          (#'epoch/build-record
+          record          (#'assembly/build-record
                             :test/main nil nil tag-less-events
                             :halted-destroy
                             {:operation :rf.frame/destroyed-mid-drain})]
@@ -2100,7 +2101,7 @@
                                :phase    :run-start
                                :event-id :seed
                                :event    [:seed 1 2 3]}}]
-          record (#'epoch/build-record :test/main {} {:n 0} events)]
+          record (#'assembly/build-record :test/main {} {:n 0} events)]
       (is (= :seed (:event-id record))
           ":event-id is the resolved event keyword")
       (is (= [:seed 1 2 3] (:trigger-event record))
@@ -2142,7 +2143,7 @@
                             :operation :event
                             :tags      {:frame    :test/main
                                         :event-id :foo}}]
-          record          (#'epoch/build-record
+          record          (#'assembly/build-record
                             :test/main nil nil tag-less-events
                             :halted-destroy
                             {:operation :rf.frame/destroyed-mid-drain})]

--- a/implementation/epoch/test/re_frame/epoch_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_test.clj
@@ -26,6 +26,7 @@
             [re-frame.trace :as trace]
             [re-frame.elision]
             [re-frame.epoch :as epoch]
+            [re-frame.epoch.state :as state]
             ;; rf2-v6z0: machines is a separate artefact whose late-bind
             ;; hook publishes `rf/reg-machine` only when the namespace is
             ;; loaded. Several restore-* tests register machines via
@@ -55,7 +56,7 @@
   ;; opt-in to elision would otherwise persist. Per rf2-mrsck the
   ;; default :trace-events-keep is 5 (finite); fixtures restore the
   ;; default map verbatim.
-  (reset! @#'epoch/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
+  (reset! @#'state/config {:depth 50 :trace-events-keep 5 :redact-fn nil})
   (rf/init! plain-atom/adapter)
   (require 're-frame.routing :reload)
   (test-fn))
@@ -259,7 +260,7 @@
     (rf/reg-frame :test/main {})
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
 
-    (let [observed (deref #'epoch/observed-frames-by-cb)
+    (let [observed (deref #'state/observed-frames-by-cb)
           a        (atom 0)
           b        (atom 0)
           c        (atom 0)]
@@ -2012,7 +2013,7 @@
     ;; capture-event! buffers since the tag carries `:frame`. Reset
     ;; explicitly so the test starts from a known-empty buffer
     ;; rather than relying on the reg-frame side-effect.)
-    (let [buffers-atom @#'epoch/capture-buffers]
+    (let [buffers-atom @#'state/capture-buffers]
       (reset! buffers-atom {})
 
       (swap! buffers-atom assoc :test/main
@@ -2187,7 +2188,7 @@
     (rf/reg-event-db :seed (fn [_ _] {:n 0}))
     (rf/reg-event-db :inc  (fn [db _] (update db :n inc)))
 
-    (let [observed-atom @#'epoch/observed-frames-by-cb
+    (let [observed-atom @#'state/observed-frames-by-cb
           swap-count    (atom 0)]
       (add-watch observed-atom ::swap-counter
                  (fn [_ _ _ _] (swap! swap-count inc)))


### PR DESCRIPTION
## Decision (Mike 2026-05-17)

Phase-2 = execute the 5-seam cut per Phase-1 recommendation.

Cut order: A (state) → B (capture) → D (assembly) → E (write) → C
(listeners — last because on-frame-destroyed straddles 4 seams).

Public re-frame.epoch surface (configure!, epoch-history, ...,
on-frame-destroyed!) stays IDENTICAL — every existing public symbol
resolves under the same name. All :epoch/* late-bind hooks unchanged.

## Result

- Facade 535 LoC (was 1586) — a 1051-LoC reduction
- 5 internal nss own implementation weight: state (343) / capture
  (246) / assembly (220) / write (461) / listeners (164)
- Total: 1969 LoC across 6 files (was 1586 in one file); the LoC
  growth is full per-seam docstrings + cross-ns delegation
  helpers, all in service of the named-seam navigation goal

## Public-surface verification

Before AND after (identical):
```
(clear-epoch-cbs! clear-history! configure! current-config
 epoch-history on-frame-destroyed! projected-history projected-record
 register-epoch-cb! remove-epoch-cb! reset-frame-db! restore-epoch
 settle!)
```

## Per-seam responsibilities

- **state** (seam A): the 6 shared atoms (config, histories,
  capture-buffers, listeners, observed-frames-by-cb, epoch-counter)
  plus the low-level CRUD against them. Phase-1 finding confirmed:
  the only cross-cutting coupling in the original file was these
  atoms; no two are ever held in a single critical section, so a
  small state ns owns them with zero locking subtleties.

- **capture** (seam B): the cascade pipeline — skip-ops catalogue
  (out-of-cascade emits to ignore), the :epoch/capture-event
  late-bind entry point, and the two read-only walks the assembly
  path runs against the harvested events (project-all,
  find-trigger-event).

- **assembly** (seam D): build-record + sensitive-rollup family
  + maybe-redact + current-schema-digest. The pure-data record
  builder; orchestrators in the facade call assembly/build-record
  + assembly/maybe-redact and then state/record! + listeners/notify.

- **write** (seam E): Tool-Pair write surfaces' machinery —
  precondition validators (failing-schema-paths,
  missing-references, machine-version-mismatch, frame-exists-or-fail,
  drain-in-flight?, check-restore-preconditions!,
  check-reset-frame-db-preconditions!), perform-restore!, and the
  off-box projection helpers (projected-record, projected-history).

- **listeners** (seam C): notify-listeners! fan-out +
  on-frame-destroyed! four-step destroy contract (the fn Phase-1
  flagged as straddling four seams).

## Gate results

- ✓ `clojure -M:test` in `implementation/epoch` — 174 tests, 645
  assertions, 0 failures, 0 errors (after EACH commit)
- ✓ `npm run test:cljs` — 2356 tests, 6764 assertions, 0 failures,
  0 errors
- ✓ `npm run test:elision` — PASS production 31/31 absent (329889
  chars); control 31/31 present (373174 chars). The epoch elision
  sentinels still elide cleanly under :advanced + goog.DEBUG=false.
- mkdocs has 68 pre-existing :strict warnings on origin/main
  unrelated to this refactor (broken spec/ cross-links in guide
  + skills MD files); not introduced or affected here.

## Test pin retargets

Several tests reached the private atoms / fns through facade vars
(`@#'epoch/config`, `#'epoch/build-record`, etc.); those pins were
retargeted at the new owning seams (`@#'state/config`,
`#'assembly/build-record`, `#'capture/find-trigger-event`,
`@#'capture/skip-ops`) and the test files added the corresponding
`:require` aliases. No test contract was weakened — the same atoms
and fns are pinned, just at their new homes.

## Cross-seam coupling notes

- assembly/build-record needs state (next-epoch-id) and capture
  (project-all, find-trigger-event). No surprise.
- assembly/current-schema-digest is used by both build-record AND
  write/check-restore-preconditions! — it lives in assembly (the
  digest is pinned on the record there); write requires assembly
  for the cross-call.
- listeners/notify-listeners! is called from settle! (facade),
  perform-reset-frame-db! (facade), and on-frame-destroyed!
  (listeners itself). The facade orchestrators import listeners
  for the fan-out call. write does NOT depend on listeners — the
  perform-reset-frame-db! orchestrator stays in the facade
  precisely because it bridges write (check-reset-preconditions!)
  to assembly (build-record + maybe-redact) to state (record!) to
  listeners (notify-listeners!).
- on-frame-destroyed! straddles state (3 atom drops), capture
  (buffer read for mid-drain detection), and assembly (partial
  record build) — as Phase-1 predicted. It lives in listeners
  because the destroy contract IS the listener-side surface for
  frame teardown.

Closes rf2-0wi86