### PR TITLE
refactor(core): cohesion split — subs.memo + subs.cache + router.diagnostics (rf2-0ytl4 Phase-2)

### DIFF
--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -34,6 +34,7 @@
             [re-frame.fx :as fx]
             [re-frame.cofx :as cofx]
             [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.interceptor :as interceptor]
             [re-frame.std-interceptors :as std-interceptors]
             [re-frame.privacy :as privacy]
@@ -494,7 +495,7 @@
   and clear the cache. Cancels any pending grace-period timers before
   disposing. For tests and hot-reload. Per spec/API.md §Clearing
   registrations."}
-  clear-sub-cache! subs/clear-sub-cache!)
+  clear-sub-cache! subs-cache/clear-sub-cache!)
 
 ;; ---- dispatch and subscribe ----------------------------------------------
 ;;
@@ -1152,7 +1153,7 @@
                      (f opts))
     :trace-buffer  (when-let [f (late-bind/get-fn :trace.tooling/configure-trace-buffer!)]
                      (f opts))
-    :sub-cache     (subs/configure! opts)
+    :sub-cache     (subs-cache/configure! opts)
     nil))
 
 (def ^{:doc "Install the substrate adapter for this process. Once. A

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -13,6 +13,7 @@
             [re-frame.interceptor :as interceptor]
             [re-frame.error-emit :as error-emit]
             [re-frame.fx :as fx]
+            [re-frame.router.diagnostics :as diag]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -151,88 +152,11 @@
 (defn- resolve-handler [event-id]
   (registrar/lookup :event event-id))
 
-(defn- non-default-frame-registered?
-  "True when at least one registered, non-destroyed frame other than
-  `:rf/default` exists. The `:rf.warning/dispatch-from-async-callback-
-  fell-through-to-default` warning is suppressed when this is false:
-  single-frame apps cannot hit the footgun (the resolution chain has
-  nowhere else to land), so emitting the warning would be noise rather
-  than signal. Per rf2-o8m0.
-
-  Body gated on `interop/debug-enabled?` (the sole caller is the dev-
-  only `emit-fallthrough-warning!`); production calls observe the
-  trivial `false` and the `frame/frame-ids` walk + transducer DCEs."
-  []
-  (when interop/debug-enabled?
-    (let [ids (frame/frame-ids)]
-      (boolean (some (fn [k] (not= :rf/default k)) ids)))))
-
-(defn- emit-fallthrough-warning!
-  "Per rf2-o8m0: dispatch landed on `:rf/default` purely because the
-  resolution chain found nothing else (dynamic var unbound, adapter
-  React-context unresolvable, no explicit `:frame` opt) AND the target
-  handler does not exist on `:rf/default`. The user almost certainly
-  wanted the dispatch to ride a non-default frame; the most common
-  trigger is dispatching from an async callback (setTimeout,
-  addEventListener, requestAnimationFrame, Promise.then) attached
-  inside a view body, where the surrounding `*current-frame*` binding
-  does not survive the async escape (per Spec 002 §Dispatches issued
-  from inside a handler body).
-
-  Suppressed when no non-default frame is registered — single-frame
-  apps cannot hit the footgun.
-
-  `:source-coord` is left to the existing `:rf.trace/trigger-handler`
-  surface (rf2-3nn8): when a handler is in scope, `emit-error!` /
-  `emit!` hoists the triggering handler's source-coord automatically.
-  When no handler is in scope (the async-callback case the warning is
-  primarily aimed at) `*handler-scope*`'s `:trigger-handler` is nil and the
-  field is omitted — `dispatch` is a fn, not a macro, so the call site
-  cannot be stamped without changing the public API. Documented
-  limitation; tools that need call-site attribution capture it
-  externally.
-
-  Body gated on `interop/debug-enabled?` so the warning surface DCEs
-  wholesale under `:advanced` + `goog.DEBUG=false` (rf2-gaqwr): the
-  `:fell-through-to-default?` envelope key is only set in dev (per
-  `build-envelope` line 122) so the inner `(when ...)` is always
-  falsy in production, but without the outer compile-time gate the
-  reason-string allocation, the warning keyword's interned slot, the
-  `non-default-frame-registered?` call, and the helper-fn closure all
-  survive Closure DCE."
-  [envelope]
-  (when interop/debug-enabled?
-    (when (and (:fell-through-to-default? envelope)
-               (non-default-frame-registered?))
-      (let [event    (:event envelope)
-            event-id (first event)
-            reason   (str "Dispatch of `" event-id "` resolved to `:rf/default` "
-                          "because no `:frame` was supplied and `*current-frame*` "
-                          "was unbound, but no handler for that event is "
-                          "registered on `:rf/default`. The dispatch most "
-                          "likely originated from an async callback "
-                          "(`setTimeout`, `addEventListener`, "
-                          "`requestAnimationFrame`, `Promise.then`) attached "
-                          "from inside a view body — the surrounding "
-                          "frame-context binding does not survive the async "
-                          "escape (per Spec 002 §Dispatches issued from "
-                          "inside a handler body). Fixes (priority order): "
-                          "(a) use `:dispatch-later` or a registered `reg-fx` "
-                          "— both capture the frame in their closure; "
-                          "(b) capture `(rf/dispatcher)` inside the "
-                          "render and call it from the callback; "
-                          "(c) attach the listener from a Form-3 "
-                          "`:component-did-mount` / `use-effect` hook so "
-                          "the dispatcher is captured during render but "
-                          "the listener runs after commit.")]
-        (trace/emit! :warning
-                     :rf.warning/dispatch-from-async-callback-fell-through-to-default
-                     {:event        event
-                      :event-id     event-id
-                      :detected-at  (interop/now-ms)
-                      :routed-to    :rf/default
-                      :reason       reason
-                      :recovery     :no-recovery})))))
+;; Fallthrough-to-default + cross-frame dispatch-sync warnings + the
+;; no-handler error path live in `re-frame.router.diagnostics` —
+;; extracted per rf2-0ytl4 Phase-2 seam R-B. Every one of those fns
+;; runs on a cold/error path or sits behind `interop/debug-enabled?`,
+;; so the cross-ns indirection adds no measurable cost.
 
 (def ^:private empty-fx-overrides
   "Shared sentinel returned by `apply-overrides` on the no-override hot
@@ -642,8 +566,10 @@
 ;;   handle-frame-destroyed!     early-exit: emit :rf.error/frame-destroyed
 ;;                               when the frame record is gone (frame disposed
 ;;                               between enqueue and dispatch)
-;;   handle-no-handler!          early-exit: emit fallthrough warning (when
-;;                               applicable) plus :rf.error/no-such-handler
+;;   diag/handle-no-handler!     early-exit: emit fallthrough warning (when
+;;                               applicable) plus :rf.error/no-such-handler.
+;;                               Lives in re-frame.router.diagnostics per
+;;                               rf2-0ytl4 seam R-B.
 ;;   prepare-handler-ctx         build the full interceptor chain + initial
 ;;                               context and the effective fx-overrides map;
 ;;                               returns a tight map consumed by run-chain
@@ -665,25 +591,6 @@
   [event frame]
   (trace/emit-error! :rf.error/frame-destroyed
                      {:frame frame :event event :reason :frame-destroyed}))
-
-(defn- handle-no-handler!
-  "Per rf2-o8m0: when a dispatch lands on `:rf/default` purely because
-  resolution fell through (no `:frame` opt, dynamic var unbound, adapter
-  context unresolvable) AND the handler is missing from `:rf/default`,
-  the user-supplied event almost certainly belongs to a different frame
-  and the dispatch lost its frame-context binding mid-flight (typically:
-  an async callback attached inside a view body). Emit the warning ahead
-  of the `:rf.error/no-such-handler` error so consumers see the specific
-  diagnostic; the error fires too, preserving the existing handler-
-  missing trace contract."
-  [envelope event-id event frame]
-  (emit-fallthrough-warning! envelope)
-  (trace/emit-error! :rf.error/no-such-handler
-                     {:event-id event-id
-                      :event    event
-                      :frame    frame
-                      :kind     :event
-                      :recovery :replaced-with-default}))
 
 (defn- refresh-elision-from-schemas!
   "Refresh schema-owned elision registries before a handler runs. No-op
@@ -915,7 +822,7 @@
       :else
       (let [handler-meta (resolve-handler event-id)]
         (if (nil? handler-meta)
-          (handle-no-handler! envelope event-id event frame)
+          (diag/handle-no-handler! envelope event-id event frame)
           (run-handler-cascade! envelope event-id event frame
                                 frame-record handler-meta))))))
 
@@ -1384,65 +1291,6 @@
          (ensure-drain-scheduled! (:frame envelope) router)))
      nil)))
 
-(defn- other-frame-mid-drain
-  "Per rf2-fp97 — Spec 002 §dispatch-sync cross-frame note. Return the
-  frame-id of any registered, non-destroyed frame OTHER than `target-id`
-  whose router currently shows `:in-sync-drain?` or `:in-drain?` true.
-  Returns nil when no such frame exists.
-
-  Used by `dispatch-sync!` to detect the cross-frame cascade pattern
-  (frame A mid-drain, a handler calls `(rf/dispatch-sync! [...] {:frame :b})`).
-  The same-frame case is already an error; the cross-frame case is
-  intentional but surprising, so we surface it as
-  `:rf.warning/cross-frame-dispatch-sync-during-drain` rather than
-  refuse. Frames are independent state machines (per Spec 002 §Rules
-  rule 1) and frame B's drain doesn't violate frame A's contract.
-
-  Dev-only — the caller gates on `interop/debug-enabled?` to skip the
-  registry walk in production."
-  [target-id]
-  (some (fn [id]
-          (when (not= id target-id)
-            (when-let [fr (frame/frame id)]
-              (let [r @(:router fr)]
-                (when (or (:in-sync-drain? r) (:in-drain? r))
-                  id)))))
-        (frame/frame-ids)))
-
-(defn- emit-cross-frame-warning!
-  "Per rf2-fp97: emit `:rf.warning/cross-frame-dispatch-sync-during-drain`
-  when `dispatch-sync!` lands on frame `target-id` while a different
-  frame (`other-id`) is mid-drain. The caller frame is read from
-  `frame/*current-frame*`; when unbound (no frame context — e.g. a
-  process-level REPL caller threading the dispatch through some unusual
-  path) the field is `:rf/none`.
-
-  Per Mike's 2026-05-13 Option B decision: warn, do not refuse.
-  Continues with the dispatch."
-  [target-id other-id event]
-  (let [caller-id (or frame/*current-frame* :rf/none)
-        reason    (str "dispatch-sync! against `" target-id "` while frame `"
-                       other-id "` is mid-drain. The two cascades will "
-                       "interleave: `" target-id "`'s drain runs to settled "
-                       "while `" other-id "` is still in flight, then `"
-                       other-id "` continues. Frames are independent state "
-                       "machines so this does not violate either frame's "
-                       "contract (per Spec 002 §Run-to-completion §Rules "
-                       "rule 1 — no cross-frame drain), but the interleaved "
-                       "ordering is rarely the caller's intent. If the goal "
-                       "is fire-and-forget cross-frame coordination, prefer "
-                       "the async form `(rf/dispatch event {:frame other})` "
-                       "— it queues on the target frame's router and drains "
-                       "on a later cycle, after the caller's cascade settles.")]
-    (trace/emit! :warning
-                 :rf.warning/cross-frame-dispatch-sync-during-drain
-                 {:caller-frame caller-id
-                  :target-frame target-id
-                  :other-frame  other-id
-                  :event        event
-                  :reason       reason
-                  :recovery     :no-recovery})))
-
 (defn dispatch-sync!
   "Bypass the queue scheduler and process this single event end-to-end
   immediately, then drain any synchronously-enqueued events to fixed
@@ -1516,8 +1364,8 @@
          ;; `interop/debug-enabled?` so production skips the registry
          ;; walk.
          (when interop/debug-enabled?
-           (when-let [other-id (other-frame-mid-drain (:frame envelope))]
-             (emit-cross-frame-warning! (:frame envelope) other-id event)))
+           (when-let [other-id (diag/other-frame-mid-drain (:frame envelope))]
+             (diag/emit-cross-frame-warning! (:frame envelope) other-id event)))
          (emit-dispatched-trace! envelope true)
          (try
            ;; Per rf2-ynk7 §single-drainer invariant: dispatch-sync

--- a/implementation/core/src/re_frame/router/diagnostics.cljc
+++ b/implementation/core/src/re_frame/router/diagnostics.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.router.diagnostics
+  "Dev-only diagnostics for the router: fallthrough-to-default warnings
+  (rf2-o8m0), cross-frame dispatch-sync warnings (rf2-fp97), and the
+  no-handler error path. Extracted from `re-frame.router` per rf2-0ytl4
+  Phase-2 seam R-B.
+
+  Every fn here either runs on a cold/error path or sits behind
+  `interop/debug-enabled?` — production builds (`:advanced` +
+  `goog.DEBUG=false`) DCE the bodies and the keyword reason-strings.
+
+  The cross-ns indirection from the router facade is amortised: callers
+  (`process-event*`, `dispatch!`, `dispatch-sync!`) all sit on the
+  facade and reach into this ns only on the rare warning / error paths."
+  (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn non-default-frame-registered?
+  "True when at least one registered, non-destroyed frame other than
+  `:rf/default` exists. The `:rf.warning/dispatch-from-async-callback-
+  fell-through-to-default` warning is suppressed when this is false:
+  single-frame apps cannot hit the footgun (the resolution chain has
+  nowhere else to land), so emitting the warning would be noise rather
+  than signal. Per rf2-o8m0.
+
+  Body gated on `interop/debug-enabled?` (the sole caller is the dev-
+  only `emit-fallthrough-warning!`); production calls observe the
+  trivial `false` and the `frame/frame-ids` walk + transducer DCEs."
+  []
+  (when interop/debug-enabled?
+    (let [ids (frame/frame-ids)]
+      (boolean (some (fn [k] (not= :rf/default k)) ids)))))
+
+(defn emit-fallthrough-warning!
+  "Per rf2-o8m0: dispatch landed on `:rf/default` purely because the
+  resolution chain found nothing else (dynamic var unbound, adapter
+  React-context unresolvable, no explicit `:frame` opt) AND the target
+  handler does not exist on `:rf/default`. The user almost certainly
+  wanted the dispatch to ride a non-default frame; the most common
+  trigger is dispatching from an async callback (setTimeout,
+  addEventListener, requestAnimationFrame, Promise.then) attached
+  inside a view body, where the surrounding `*current-frame*` binding
+  does not survive the async escape (per Spec 002 §Dispatches issued
+  from inside a handler body).
+
+  Suppressed when no non-default frame is registered — single-frame
+  apps cannot hit the footgun.
+
+  `:source-coord` is left to the existing `:rf.trace/trigger-handler`
+  surface (rf2-3nn8): when a handler is in scope, `emit-error!` /
+  `emit!` hoists the triggering handler's source-coord automatically.
+  When no handler is in scope (the async-callback case the warning is
+  primarily aimed at) `*handler-scope*`'s `:trigger-handler` is nil and the
+  field is omitted — `dispatch` is a fn, not a macro, so the call site
+  cannot be stamped without changing the public API. Documented
+  limitation; tools that need call-site attribution capture it
+  externally.
+
+  Body gated on `interop/debug-enabled?` so the warning surface DCEs
+  wholesale under `:advanced` + `goog.DEBUG=false` (rf2-gaqwr): the
+  `:fell-through-to-default?` envelope key is only set in dev (per
+  `build-envelope`) so the inner `(when ...)` is always falsy in
+  production, but without the outer compile-time gate the reason-string
+  allocation, the warning keyword's interned slot, the
+  `non-default-frame-registered?` call, and the helper-fn closure all
+  survive Closure DCE."
+  [envelope]
+  (when interop/debug-enabled?
+    (when (and (:fell-through-to-default? envelope)
+               (non-default-frame-registered?))
+      (let [event    (:event envelope)
+            event-id (first event)
+            reason   (str "Dispatch of `" event-id "` resolved to `:rf/default` "
+                          "because no `:frame` was supplied and `*current-frame*` "
+                          "was unbound, but no handler for that event is "
+                          "registered on `:rf/default`. The dispatch most "
+                          "likely originated from an async callback "
+                          "(`setTimeout`, `addEventListener`, "
+                          "`requestAnimationFrame`, `Promise.then`) attached "
+                          "from inside a view body — the surrounding "
+                          "frame-context binding does not survive the async "
+                          "escape (per Spec 002 §Dispatches issued from "
+                          "inside a handler body). Fixes (priority order): "
+                          "(a) use `:dispatch-later` or a registered `reg-fx` "
+                          "— both capture the frame in their closure; "
+                          "(b) capture `(rf/dispatcher)` inside the "
+                          "render and call it from the callback; "
+                          "(c) attach the listener from a Form-3 "
+                          "`:component-did-mount` / `use-effect` hook so "
+                          "the dispatcher is captured during render but "
+                          "the listener runs after commit.")]
+        (trace/emit! :warning
+                     :rf.warning/dispatch-from-async-callback-fell-through-to-default
+                     {:event        event
+                      :event-id     event-id
+                      :detected-at  (interop/now-ms)
+                      :routed-to    :rf/default
+                      :reason       reason
+                      :recovery     :no-recovery})))))
+
+(defn handle-no-handler!
+  "Per rf2-o8m0: when a dispatch lands on `:rf/default` purely because
+  resolution fell through (no `:frame` opt, dynamic var unbound, adapter
+  context unresolvable) AND the handler is missing from `:rf/default`,
+  the user-supplied event almost certainly belongs to a different frame
+  and the dispatch lost its frame-context binding mid-flight (typically:
+  an async callback attached inside a view body). Emit the warning ahead
+  of the `:rf.error/no-such-handler` error so consumers see the specific
+  diagnostic; the error fires too, preserving the existing handler-
+  missing trace contract."
+  [envelope event-id event frame]
+  (emit-fallthrough-warning! envelope)
+  (trace/emit-error! :rf.error/no-such-handler
+                     {:event-id event-id
+                      :event    event
+                      :frame    frame
+                      :kind     :event
+                      :recovery :replaced-with-default}))
+
+(defn other-frame-mid-drain
+  "Per rf2-fp97 — Spec 002 §dispatch-sync cross-frame note. Return the
+  frame-id of any registered, non-destroyed frame OTHER than `target-id`
+  whose router currently shows `:in-sync-drain?` or `:in-drain?` true.
+  Returns nil when no such frame exists.
+
+  Used by `re-frame.router/dispatch-sync!` to detect the cross-frame
+  cascade pattern (frame A mid-drain, a handler calls
+  `(rf/dispatch-sync! [...] {:frame :b})`). The same-frame case is
+  already an error; the cross-frame case is intentional but surprising,
+  so we surface it as
+  `:rf.warning/cross-frame-dispatch-sync-during-drain` rather than
+  refuse. Frames are independent state machines (per Spec 002 §Rules
+  rule 1) and frame B's drain doesn't violate frame A's contract.
+
+  Dev-only — the caller gates on `interop/debug-enabled?` to skip the
+  registry walk in production."
+  [target-id]
+  (some (fn [id]
+          (when (not= id target-id)
+            (when-let [fr (frame/frame id)]
+              (let [r @(:router fr)]
+                (when (or (:in-sync-drain? r) (:in-drain? r))
+                  id)))))
+        (frame/frame-ids)))
+
+(defn emit-cross-frame-warning!
+  "Per rf2-fp97: emit `:rf.warning/cross-frame-dispatch-sync-during-drain`
+  when `dispatch-sync!` lands on frame `target-id` while a different
+  frame (`other-id`) is mid-drain. The caller frame is read from
+  `frame/*current-frame*`; when unbound (no frame context — e.g. a
+  process-level REPL caller threading the dispatch through some unusual
+  path) the field is `:rf/none`.
+
+  Per Mike's 2026-05-13 Option B decision: warn, do not refuse.
+  Continues with the dispatch."
+  [target-id other-id event]
+  (let [caller-id (or frame/*current-frame* :rf/none)
+        reason    (str "dispatch-sync! against `" target-id "` while frame `"
+                       other-id "` is mid-drain. The two cascades will "
+                       "interleave: `" target-id "`'s drain runs to settled "
+                       "while `" other-id "` is still in flight, then `"
+                       other-id "` continues. Frames are independent state "
+                       "machines so this does not violate either frame's "
+                       "contract (per Spec 002 §Run-to-completion §Rules "
+                       "rule 1 — no cross-frame drain), but the interleaved "
+                       "ordering is rarely the caller's intent. If the goal "
+                       "is fire-and-forget cross-frame coordination, prefer "
+                       "the async form `(rf/dispatch event {:frame other})` "
+                       "— it queues on the target frame's router and drains "
+                       "on a later cycle, after the caller's cascade settles.")]
+    (trace/emit! :warning
+                 :rf.warning/cross-frame-dispatch-sync-during-drain
+                 {:caller-frame caller-id
+                  :target-frame target-id
+                  :other-frame  other-id
+                  :event        event
+                  :reason       reason
+                  :recovery     :no-recovery})))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -31,9 +31,8 @@
             [re-frame.substrate.adapter :as adapter]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
-            [re-frame.performance :as performance
-             #?@(:cljs [:include-macros true])]
             [re-frame.source-coords :as source-coords]
+            [re-frame.subs.memo :as subs-memo]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
             ;; JVM autoload (rf2-bmzq0): the tooling sibling has zero
@@ -204,203 +203,13 @@
 
 (declare subscribe unsubscribe)
 
-(defn- maybe-validate-sub-return!
-  "Per Spec 010 §Validation order step 6 (rf2-wcam) — after a sub
-  recomputes, validate its return value against any :spec on the sub
-  meta. On failure, emit :rf.error/schema-validation-failure and
-  return nil per :replaced-with-default recovery; otherwise return
-  the value unchanged.
-
-  Looked up lazily through the late-bind registry so this namespace
-  stays free of a hard re-frame.schemas dep (avoids load-order
-  surprises)."
-  [value query-v sub-id sub-meta]
-  (if (and sub-meta (:spec sub-meta))
-    ;; Sticky hook (rf2-f72pd) — fires per-sub recompute.
-    (if-let [validate (late-bind/get-fn-cached :schemas/validate-sub-return!)]
-      (if (try (validate sub-id query-v value sub-meta)
-               (catch #?(:clj Throwable :cljs :default) _ true))
-        value
-        nil)
-      value)
-    value))
-
-(defn- validate-and-trace
-  "Run the user's sub body fn once and project the result through the
-  trace + performance + validate + error-recovery layer. Called by the
-  memo wrapper (`make-layer-1-memoised-body` for layer-1 subs,
-  `make-layer-n-memoised-body` for layer-2+) on a true recompute —
-  the memo path skips this entire function when input is `=` to
-  last-seen.
-
-  Concerns folded in here, in order:
-
-  1. Spec 009 §:op-type vocabulary — emit :sub/run for the recompute.
-     The memo-hit path does NOT emit (per Spec 006 §No-op via value
-     equality).
-  2. Spec 009 §Performance instrumentation (rf2-du3i) — bracket the
-     body call in performance marks so prod builds with the perf flag
-     enabled produce a `rf:sub:<sub-id>` measure entry. Default-off;
-     under `:advanced` + `re-frame.performance/enabled?=false` the
-     bracket DCEs.
-  3. Spec 010 §Validation order step 6 (rf2-wcam) — validate the body's
-     return value against the sub's `:spec` meta. Failures emit
-     :rf.error/schema-validation-failure and yield nil (recovery
-     :replaced-with-default).
-  4. Spec 009 §Error contract — `try/catch` around (1)+(2)+(3). On
-     exception emit :rf.error/sub-exception and yield nil (recovery
-     :replaced-with-default)."
-  [body-fn in-vals query-id query-v frame-id input-signals sub-meta]
-  ;; Publish the sub's HandlerScope for the duration of `:sub/run` emit
-  ;; + body-fn invocation + validation. Per Spec 009 §:rf.trace/
-  ;; trigger-handler the sub's source-coord rides every emit (`:sub/run`
-  ;; success, `:rf.error/sub-exception` / schema-validation / transitive
-  ;; sub-miss errors). The emit MUST sit inside the scope.
-  (trace/with-handler-scope
-    (trace/handler-scope-from-meta :sub query-id sub-meta)
-    (trace/emit! :sub/run :sub/run
-                 {:sub-id  query-id
-                  :query-v query-v
-                  :frame   frame-id})
-    (try
-      (let [computed (performance/mark-and-measure :sub query-id
-                      (if (empty? input-signals)
-                        (body-fn (first in-vals) query-v)
-                        ;; Layer-2+: deliver inputs as a coll if many,
-                        ;; or singleton when only one chain entry.
-                        (if (= 1 (count input-signals))
-                          (body-fn (first in-vals) query-v)
-                          (body-fn (vec in-vals) query-v))))]
-        (maybe-validate-sub-return! computed query-v query-id sub-meta))
-      (catch #?(:clj Throwable :cljs :default) e
-        (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
-          (trace/emit-error!
-            :rf.error/sub-exception
-            {:failing-id        query-id
-             :sub-id            query-id
-             :sub-query         query-v
-             :exception         e
-             :exception-message msg
-             :reason            (str "Subscription `" query-id
-                                     "` threw while computing: "
-                                     msg ". Returning nil.")
-             :recovery          :replaced-with-default}))
-        nil))))
-
-;; ---- memoisation wrappers ------------------------------------------------
-;;
-;; Per Spec 006 §No-op via value equality (rf2-719e). Reagent's auto-run
-;; reaction unconditionally invokes the compute fn on any source-watch
-;; fire, then dedups *downstream notification* by `=`. That's one level
-;; too late for the spec — the body fn itself must NOT re-run when the
-;; resolved input value is `=` to the last-seen. The memo wrappers
-;; compare the inputs against the previous invocation and short-circuit
-;; to the memoised return value when equal. Reagent's dependency
-;; tracking still observes every `deref` because the wrapper *is* the
-;; compute fn — only the user's body (and the trace+validate+perf+
-;; recovery layer that brackets it) is suppressed.
-;;
-;; The layer-1 path is specialised to a fixed-arity-1 wrapper that
-;; compares the db value directly. This skips the varargs-seq allocation
-;; a `(fn [& in-vals])` form would force on every recompute, and
-;; replaces the seq-vs-seq `=` walk with a direct value compare. Every
-;; layer-1 sub × every dispatch that touches it pays this — the hottest
-;; allocation in the artefact.
-;;
-;; Layer-2 with a single `:<-` input gets the same fixed-arity-1
-;; treatment (rf2-0y2bp). The adapter's `make-derived-value` already
-;; specialises its recompute closure to `(compute-fn @s0)` for the
-;; 1-source case (rf2-v1nu0) — but the layer-N memo wrapper was
-;; varargs (`(fn [& in-vals])`), which forces a one-element ArraySeq
-;; allocation on every recompute. The dominant layer-2 shape is
-;; 1-input, so we mirror the layer-1 specialisation here: fixed-arity-1
-;; wrapper, direct scalar compare against the last-seen input value.
-;; The ≥2-input path keeps the original varargs shape.
-
-(defn- make-layer-1-memoised-body
-  "Specialised memo wrapper for layer-1 subs (which read app-db
-  directly). Fixed-arity-1 — avoids the varargs-seq allocation that a
-  `(fn [& in-vals])` form would force on every reaction recompute, and
-  compares the db value to the last-seen scalar (no seq-vs-seq walk).
-
-  Returns a `(fn [db])`. When `body-fn` is nil (the unknown-sub path
-  — see `compute-and-cache!`) the wrapper yields nil on every call
-  without touching the memo cells.
-
-  The `::unset` sentinel guarantees the first invocation always
-  recomputes (the sentinel is never `=` to any db value)."
-  [body-fn query-id query-v frame-id sub-meta]
-  (let [last-db     (volatile! ::unset)
-        last-result (volatile! nil)]
-    (fn [db]
-      (when body-fn
-        (if (= @last-db db)
-          @last-result
-          (let [computed (validate-and-trace
-                           body-fn (list db) query-id query-v
-                           frame-id [] sub-meta)]
-            (vreset! last-db db)
-            (vreset! last-result computed)
-            computed))))))
-
-(defn- make-layer-n-1-memoised-body
-  "Specialised memo wrapper for layer-2 subs with a single `:<-` input
-  (the dominant layer-2 shape — see rf2-v1nu0 perf-sweep finding).
-  Fixed-arity-1 — avoids the varargs-seq allocation that a
-  `(fn [& in-vals])` form would force on every reaction recompute, and
-  compares the upstream value to the last-seen scalar (no seq-vs-seq
-  walk). Parity with `make-layer-1-memoised-body`.
-
-  Returns a `(fn [v0])`. When `body-fn` is nil (the unknown-sub path
-  — see `compute-and-cache!`) the wrapper yields nil on every call
-  without touching the memo cells.
-
-  The `::unset` sentinel guarantees the first invocation always
-  recomputes (the sentinel is never `=` to any input value).
-
-  `validate-and-trace` receives `in-vals` as a singleton list — the
-  same shape the varargs wrapper would have produced for arity-1 —
-  preserving the `(body-fn (first in-vals) query-v)` invocation path
-  inside the validate/trace bracket (rf2-0y2bp)."
-  [body-fn query-id query-v frame-id input-signals sub-meta]
-  (let [last-v0     (volatile! ::unset)
-        last-result (volatile! nil)]
-    (fn [v0]
-      (when body-fn
-        (if (= @last-v0 v0)
-          @last-result
-          (let [computed (validate-and-trace
-                           body-fn (list v0) query-id query-v
-                           frame-id input-signals sub-meta)]
-            (vreset! last-v0 v0)
-            (vreset! last-result computed)
-            computed))))))
-
-(defn- make-layer-n-memoised-body
-  "Memo wrapper for layer-2+ subs with two or more `:<-` inputs.
-  Varargs — the input arity matches the count of `:<-` entries on the
-  registration, and the wrapper compares the seq of input values
-  against the last-seen seq.
-
-  Returns a `(fn [& in-vals])`. When `body-fn` is nil the wrapper
-  yields nil on every call without touching the memo cells.
-
-  See `make-layer-1-memoised-body` for the layer-1 specialisation and
-  `make-layer-n-1-memoised-body` for the layer-2 single-input
-  specialisation (rf2-0y2bp)."
-  [body-fn query-id query-v frame-id input-signals sub-meta]
-  (let [last-in-vals (volatile! ::unset)
-        last-result  (volatile! nil)]
-    (fn [& in-vals]
-      (when body-fn
-        (if (= @last-in-vals in-vals)
-          @last-result
-          (let [computed (validate-and-trace
-                           body-fn in-vals query-id query-v
-                           frame-id input-signals sub-meta)]
-            (vreset! last-in-vals in-vals)
-            (vreset! last-result computed)
-            computed))))))
+;; The memo wrappers (`make-layer-1-memoised-body`,
+;; `make-layer-n-1-memoised-body`, `make-layer-n-memoised-body`) and
+;; the trace/perf/validate/recover bracket (`validate-and-trace`,
+;; `maybe-validate-sub-return!`) live in `re-frame.subs.memo` — extracted
+;; per rf2-0ytl4 Phase-2 seam S-B. Per-recompute hot path is the closure
+;; body (in-process); only the per-miss constructor call from
+;; `compute-and-cache!` below crosses the ns boundary.
 
 (defn- compute-and-cache!
   "Build the reaction for query-v and cache it. Per Spec 006 §Lookup
@@ -444,16 +253,16 @@
                         (mapv (fn [input-q] (subscribe frame-id input-q)) input-signals))
         memoised-body (cond
                         layer-1?
-                        (make-layer-1-memoised-body
+                        (subs-memo/make-layer-1-memoised-body
                           body-fn query-id query-v frame-id sub-meta)
                         ;; Layer-2 with a single `:<-` input — dominant
                         ;; shape per rf2-v1nu0; specialise to fixed-arity-1
                         ;; for parity with layer-1 (rf2-0y2bp).
                         (= 1 (count input-signals))
-                        (make-layer-n-1-memoised-body
+                        (subs-memo/make-layer-n-1-memoised-body
                           body-fn query-id query-v frame-id input-signals sub-meta)
                         :else
-                        (make-layer-n-memoised-body
+                        (subs-memo/make-layer-n-memoised-body
                           body-fn query-id query-v frame-id input-signals sub-meta))
         reaction      (adapter/make-derived-value inputs memoised-body)
         cache         (:sub-cache (frame/frame frame-id))
@@ -642,7 +451,7 @@
 
                     :else
                     (body-fn (mapv #(compute-sub % db) inputs) query-v))]
-            (maybe-validate-sub-return! v query-v query-id meta))
+            (subs-memo/maybe-validate-sub-return! v query-v query-id meta))
           (catch #?(:clj Throwable :cljs :default) _
             nil))))))
 

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -32,6 +32,7 @@
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.subs.memo :as subs-memo]
             [re-frame.trace :as trace
              #?@(:cljs [:include-macros true])]
@@ -164,42 +165,12 @@
   [query-v]
   query-v)
 
-;; ---- grace-period configuration -------------------------------------------
-;;
-;; Per Spec 006 §Reference counting and disposal. When the last subscriber
-;; detaches, we don't dispose immediately — we wait grace-period-ms in case
-;; a new subscriber arrives (e.g. across a React re-render). The default
-;; is short enough not to leak under genuine disposal but long enough to
-;; bridge typical React render churn. Tests that want to assert on disposal
-;; configure a short or zero value via configure!.
-
-(def ^:private default-grace-period-ms
-  ;; Long enough to bridge typical React render churn; short enough not
-  ;; to leak under genuine disposal.
-  50)
-
-(defonce ^:private config
-  ;; Map shape so future :sub-cache configure-keys land additively.
-  (atom {:grace-period-ms default-grace-period-ms}))
-
-(defn configure!
-  "Update the sub-cache configuration. Currently supports
-  `{:grace-period-ms N}` — a non-negative integer (or 0 to dispose
-  synchronously when ref-count drops to zero). Per Spec 006."
-  [opts]
-  (when (map? opts)
-    (swap! config merge (select-keys opts [:grace-period-ms])))
-  nil)
-
-(defn current-config
-  "Return the current sub-cache configuration map. Public for tests
-  and tools that want to display the current grace-period."
-  []
-  @config)
-
-(defn- grace-period-ms
-  []
-  (or (:grace-period-ms @config) 0))
+;; Grace-period configuration, ref-counting + scheduling, hot-reload
+;; invalidation, and `clear-sub-cache!` live in `re-frame.subs.cache` —
+;; extracted per rf2-0ytl4 Phase-2 seam S-A (fold-in of seam S-E). The
+;; public surface (`configure!`, `current-config`, `clear-sub-cache!`)
+;; is reached through `re-frame.core`'s defaliases pointing at
+;; `re-frame.subs.cache/*` directly (no facade re-export).
 
 (declare subscribe unsubscribe)
 
@@ -455,37 +426,6 @@
           (catch #?(:clj Throwable :cljs :default) _
             nil))))))
 
-(defn- dispose-entry-now!
-  "Synchronous disposal: remove the cache slot for k iff its ref-count
-  is still <= 0 (no resubscribe arrived) and dispose the reaction.
-  Idempotent — a second call is a no-op because the slot is gone.
-
-  The swap-fn body is pure — it returns the new cache map and nothing
-  else; the reaction to dispose is read from the PRE-swap snapshot
-  returned by `swap-vals!` and acted on AFTER the CAS commits. `swap!`
-  is allowed to retry on contention on the JVM, so any side-effect
-  (`interop/dispose!`) inside the swap-fn could fire 2+ times under
-  concurrent invalidate + grace-fire."
-  [cache k]
-  (let [[old new] (swap-vals! cache
-                              (fn [m]
-                                (if-let [entry (get m k)]
-                                  (if (<= (or (:ref-count entry) 0) 0)
-                                    (dissoc m k)
-                                    ;; Resubscribe arrived between schedule
-                                    ;; and fire — keep entry.
-                                    m)
-                                  m)))]
-    ;; The slot was evicted by THIS call iff it was present in `old` and
-    ;; absent in `new`. A concurrent evictor (e.g. invalidate-sub-on-
-    ;; replace! or clear-sub-cache!) that won the CAS race would
-    ;; have left the slot absent in `old` too, so we don't double-dispose.
-    (when (and (contains? old k) (not (contains? new k)))
-      (when-let [r (get-in old [k :reaction])]
-        (try (interop/dispose! r)
-             (catch #?(:clj Throwable :cljs :default) _ nil))))
-    nil))
-
 (defn unsubscribe
   "Decrement the ref-count on the cached subscription for query-v.
   When ref-count reaches 0, schedule the entry for disposal after the
@@ -508,155 +448,19 @@
   Reagent views auto-dispose via the reaction lifecycle and don't
   need to call this explicitly. Tests, REPL sessions, and tools that
   subscribe imperatively should call unsubscribe when they're done
-  to release the cache slot."
+  to release the cache slot.
+
+  Per rf2-0ytl4 seam S-A: ref-counting, grace scheduling, and dispose
+  live in `re-frame.subs.cache`; this facade fn holds the public API
+  shape and delegates to `subs-cache/unsubscribe!` after resolving the
+  cache + key."
   ([query-v]
    (unsubscribe (frame/resolve-current-frame) query-v nil))
   ([frame-id query-v]
    (unsubscribe frame-id query-v nil))
   ([frame-id query-v opts]
    (when-let [cache (:sub-cache (frame/frame frame-id))]
-     (let [k     (cache-key query-v)
-           ;; An explicit `:grace` in opts overrides the per-runtime
-           ;; configured grace-period. `contains?` (not `(:grace opts)`)
-           ;; so `{:grace 0}` is honoured.
-           grace (if (and (map? opts) (contains? opts :grace))
-                   (:grace opts)
-                   (grace-period-ms))
-           ;; The swap-fn body is pure — it returns only the new cache
-           ;; map. The drop-to-zero signal is read from the diff between
-           ;; `old` and `new` AFTER the CAS commits. `swap!` is allowed
-           ;; to retry on JVM contention, so a side-effecting
-           ;; `(reset! dropped-to-zero? true)` inside the swap-fn body
-           ;; could fire on a discarded retry whose CAS lost — leading
-           ;; to a spurious dispose schedule.
-           [old new] (swap-vals! cache
-                                 (fn [m]
-                                   (if-let [entry (get m k)]
-                                     (let [old-n (or (:ref-count entry) 1)
-                                           n     (max 0 (dec old-n))]
-                                       ;; Only trigger drop-to-zero on the 1→0
-                                       ;; transition AND only when no grace-period
-                                       ;; timer is already in flight. Calling
-                                       ;; `unsubscribe` past zero (idempotent
-                                       ;; misuse — e.g. cleanup in both a
-                                       ;; teardown hook and a `finally`) must not
-                                       ;; stack new `pending-dispose` timers on
-                                       ;; top of the prior handle.
-                                       (if (and (= 1 old-n)
-                                                (zero? n)
-                                                (nil? (:pending-dispose entry)))
-                                         (assoc m k (assoc entry :ref-count 0))
-                                         (assoc-in m [k :ref-count] n)))
-                                     m)))
-           ;; This swap drove the 1→0 transition (under no pending-dispose)
-           ;; iff the entry was present in both old and new AND old's
-           ;; ref-count was 1 AND new's ref-count is 0 AND old had no
-           ;; pending-dispose timer. Reading from the snapshots avoids
-           ;; the side-effect-in-swap-fn race.
-           dropped-to-zero? (and (contains? new k)
-                                 (= 1 (or (get-in old [k :ref-count]) 1))
-                                 (zero? (or (get-in new [k :ref-count]) 0))
-                                 (nil? (get-in old [k :pending-dispose])))]
-       (when dropped-to-zero?
-         (if (zero? grace)
-           ;; Grace = 0: dispose synchronously (the test/explicit-tear-down path).
-           (dispose-entry-now! cache k)
-           ;; Grace > 0: schedule deferred disposal. Stash the timer handle
-           ;; so a re-subscribe inside the window can cancel it.
-           (let [handle (interop/set-timeout!
-                          (fn []
-                            (dispose-entry-now! cache k))
-                          grace)
-                 ;; Pure swap-fn: return the new map and a flag indicating
-                 ;; whether the handle was actually stashed. The clear-
-                 ;; timeout! side-effect runs AFTER the CAS commits so
-                 ;; a discarded retry can't double-clear a live timer.
-                 [_ new2] (swap-vals! cache
-                                      (fn [m]
-                                        (if-let [entry (get m k)]
-                                          (if (<= (or (:ref-count entry) 0) 0)
-                                            (assoc m k (assoc entry :pending-dispose handle))
-                                            ;; Subscriber arrived between our swap!
-                                            ;; above and set-timeout! returning —
-                                            ;; do NOT stash; we'll cancel post-swap.
-                                            m)
-                                          m)))]
-             ;; If the handle did NOT land on the entry, cancel it once,
-             ;; outside the swap. Reading from the post-swap snapshot
-             ;; (`new2`) means we make this decision exactly once.
-             (when-not (identical? handle (get-in new2 [k :pending-dispose]))
-               (try (interop/clear-timeout! handle)
-                    (catch #?(:clj Throwable :cljs :default) _ nil))))))
-       nil))))
-
-;; ---- hot-reload invalidation ---------------------------------------------
-;;
-;; Per Spec 001 §Hot-reload semantics: when a :sub re-registers, every
-;; cached reaction whose query-id is that sub MUST be disposed and
-;; evicted across every frame's cache. Cached reactions hold the OLD
-;; body via closure; without explicit invalidation, they'd silently
-;; serve stale values.
-
-(defn- invalidate-sub-on-replace!
-  [{:keys [kind id]}]
-  (when (= kind :sub)
-    (doseq [frame-id (frame/frame-ids)]
-      (when-let [cache (:sub-cache (frame/frame frame-id))]
-        ;; The swap-fn body is pure — it returns only the new cache map.
-        ;; Reactions to dispose and timers to cancel are read from the
-        ;; diff between `old` and `new` AFTER the CAS commits (so a
-        ;; retried `swap!` can't fire dispose 2+ times).
-        (let [[old new] (swap-vals! cache
-                                    (fn [m]
-                                      (let [hit-keys (->> (keys m)
-                                                          (filter #(= id (first %))))]
-                                        (apply dissoc m hit-keys))))
-              ;; The keys actually evicted by THIS swap are those present
-              ;; in `old` but absent in `new`. A concurrent evictor that
-              ;; won the CAS race would have removed its keys before our
-              ;; swap saw them, so the diff names ONLY the keys we own.
-              evicted-keys (filterv #(not (contains? new %))
-                                    (keys old))]
-          ;; Cancel any pending grace-period timers for the evicted slots —
-          ;; the reaction is being disposed now, so the deferred path
-          ;; would fire against a stale closure.
-          (doseq [k evicted-keys]
-            (when-let [h (get-in old [k :pending-dispose])]
-              (try (interop/clear-timeout! h)
-                   (catch #?(:clj Throwable :cljs :default) _ nil))))
-          (doseq [k evicted-keys]
-            (when-let [r (get-in old [k :reaction])]
-              (try (interop/dispose! r)
-                   (catch #?(:clj Throwable :cljs :default) _ nil)))))))))
-
-(defonce ^:private _hot-reload-hook
-  (do (registrar/add-replacement-hook! invalidate-sub-on-replace!)
-      :installed))
-
-(defn clear-sub-cache!
-  "Dispose every cached entry in a frame's runtime sub-cache and clear
-  the cache. Cancels any pending grace-period timers before disposing —
-  a deferred disposal landing after this fn returned would close over
-  a stale reaction.
-
-  Test fixtures and REPL-driven reloads call this between scenarios
-  to ensure the cache is empty before re-subscribing. Test code
-  generally prefers `reset-runtime-fixture` (per `test_support`) which
-  bundles cache-clearing with registrar / frame state reset.
-
-  Zero-arity targets `:rf/default`; one-arity targets the named frame.
-  Returns nil. See also: `clear-sub` (registrar-side counterpart)."
-  ([] (clear-sub-cache! :rf/default))
-  ([frame-id]
-   (when-let [cache (:sub-cache (frame/frame frame-id))]
-     (doseq [[_k entry] @cache]
-       (when-let [h (:pending-dispose entry)]
-         (try (interop/clear-timeout! h)
-              (catch #?(:clj Throwable :cljs :default) _ nil)))
-       (when-let [r (:reaction entry)]
-         (try (interop/dispose! r)
-              (catch #?(:clj Throwable :cljs :default) _ nil))))
-     (reset! cache {}))))
+     (subs-cache/unsubscribe! cache (cache-key query-v) opts))))
 
 ;; ---- tooling sibling --------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/subs/cache.cljc
+++ b/implementation/core/src/re_frame/subs/cache.cljc
@@ -1,0 +1,270 @@
+(ns re-frame.subs.cache
+  "Sub-cache state, ref-counting, grace-period disposal, hot-reload
+  invalidation, and the test-fixture cache clear. Extracted from
+  `re-frame.subs` per rf2-0ytl4 Phase-2 seam S-A (fold-in of seam S-E
+  for the registrar-replacement hook).
+
+  Per Spec 006 §Subscription cache and §Reference counting and disposal.
+  This ns owns the per-frame `:sub-cache` shape:
+
+    {<cache-key> {:value v :reaction r :inputs [...] :ref-count n
+                  :on-dispose [...]
+                  :pending-dispose <timer-handle-or-nil>}}
+
+  Disposal is **deferred ref-counting with a grace-period** (rf2-s9dn,
+  per Spec 006 §Reference counting and disposal). When the last
+  subscriber drops, the cache entry is scheduled for disposal after the
+  configured grace-period (default 50ms — see `grace-period-ms` /
+  `configure!`). If a new subscriber arrives within that window,
+  disposal is cancelled and the cached value is reused.
+
+  The two `swap-vals!`-after-CAS patterns (in `dispose-entry-now!`,
+  `unsubscribe!`, and `invalidate-sub-on-replace!`) all encode the same
+  concurrency-safety property: any side-effect (`interop/dispose!`,
+  `interop/clear-timeout!`) reads from the PRE-swap snapshot and runs
+  AFTER the CAS commits. `swap!` is allowed to retry on JVM contention,
+  so a side-effecting body could fire 2+ times under concurrent
+  invalidate + grace-fire.
+
+  `cache-key` STAYS on the `re-frame.subs` facade ns — it's a one-liner
+  on the per-subscribe hit path and Closure inlines it across nss only
+  if it stays trivial. Keeping the constant chokepoint co-located with
+  `subscribe` preserves the hot-path lookup."
+  (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- grace-period configuration -------------------------------------------
+;;
+;; Per Spec 006 §Reference counting and disposal. When the last subscriber
+;; detaches, we don't dispose immediately — we wait grace-period-ms in case
+;; a new subscriber arrives (e.g. across a React re-render). The default
+;; is short enough not to leak under genuine disposal but long enough to
+;; bridge typical React render churn. Tests that want to assert on disposal
+;; configure a short or zero value via configure!.
+
+(def ^:private default-grace-period-ms
+  ;; Long enough to bridge typical React render churn; short enough not
+  ;; to leak under genuine disposal.
+  50)
+
+(defonce ^:private config
+  ;; Map shape so future :sub-cache configure-keys land additively.
+  (atom {:grace-period-ms default-grace-period-ms}))
+
+(defn configure!
+  "Update the sub-cache configuration. Currently supports
+  `{:grace-period-ms N}` — a non-negative integer (or 0 to dispose
+  synchronously when ref-count drops to zero). Per Spec 006."
+  [opts]
+  (when (map? opts)
+    (swap! config merge (select-keys opts [:grace-period-ms])))
+  nil)
+
+(defn current-config
+  "Return the current sub-cache configuration map. Public for tests
+  and tools that want to display the current grace-period."
+  []
+  @config)
+
+(defn- grace-period-ms
+  []
+  (or (:grace-period-ms @config) 0))
+
+;; ---- disposal ------------------------------------------------------------
+
+(defn dispose-entry-now!
+  "Synchronous disposal: remove the cache slot for k iff its ref-count
+  is still <= 0 (no resubscribe arrived) and dispose the reaction.
+  Idempotent — a second call is a no-op because the slot is gone.
+
+  The swap-fn body is pure — it returns the new cache map and nothing
+  else; the reaction to dispose is read from the PRE-swap snapshot
+  returned by `swap-vals!` and acted on AFTER the CAS commits. `swap!`
+  is allowed to retry on contention on the JVM, so any side-effect
+  (`interop/dispose!`) inside the swap-fn could fire 2+ times under
+  concurrent invalidate + grace-fire."
+  [cache k]
+  (let [[old new] (swap-vals! cache
+                              (fn [m]
+                                (if-let [entry (get m k)]
+                                  (if (<= (or (:ref-count entry) 0) 0)
+                                    (dissoc m k)
+                                    ;; Resubscribe arrived between schedule
+                                    ;; and fire — keep entry.
+                                    m)
+                                  m)))]
+    ;; The slot was evicted by THIS call iff it was present in `old` and
+    ;; absent in `new`. A concurrent evictor (e.g. invalidate-sub-on-
+    ;; replace! or clear-sub-cache!) that won the CAS race would
+    ;; have left the slot absent in `old` too, so we don't double-dispose.
+    (when (and (contains? old k) (not (contains? new k)))
+      (when-let [r (get-in old [k :reaction])]
+        (try (interop/dispose! r)
+             (catch #?(:clj Throwable :cljs :default) _ nil))))
+    nil))
+
+(defn unsubscribe!
+  "Decrement the ref-count on the cached subscription for `k`. When
+  ref-count reaches 0, schedule the entry for disposal after the
+  configured grace-period (default 50ms; see `configure!`). If a new
+  subscriber arrives within the window, disposal is cancelled and the
+  cached value is reused. Per Spec 006 §Reference counting and disposal.
+
+  When grace-period is 0, disposal is synchronous — useful for tests.
+
+  `opts` accepts:
+
+      {:grace N}   — override the configured grace-period for THIS
+                     call only. `{:grace 0}` forces synchronous
+                     disposal on the 1→0 transition. When `:grace` is
+                     absent, the configured per-runtime grace-period
+                     is used.
+
+  Called from the public `re-frame.subs/unsubscribe` after `cache-key`
+  + `cache` resolution; the facade fn holds the public API shape."
+  [cache k opts]
+  (let [;; An explicit `:grace` in opts overrides the per-runtime
+        ;; configured grace-period. `contains?` (not `(:grace opts)`)
+        ;; so `{:grace 0}` is honoured.
+        grace (if (and (map? opts) (contains? opts :grace))
+                (:grace opts)
+                (grace-period-ms))
+        ;; The swap-fn body is pure — it returns only the new cache
+        ;; map. The drop-to-zero signal is read from the diff between
+        ;; `old` and `new` AFTER the CAS commits. `swap!` is allowed
+        ;; to retry on JVM contention, so a side-effecting
+        ;; `(reset! dropped-to-zero? true)` inside the swap-fn body
+        ;; could fire on a discarded retry whose CAS lost — leading
+        ;; to a spurious dispose schedule.
+        [old new] (swap-vals! cache
+                              (fn [m]
+                                (if-let [entry (get m k)]
+                                  (let [old-n (or (:ref-count entry) 1)
+                                        n     (max 0 (dec old-n))]
+                                    ;; Only trigger drop-to-zero on the 1→0
+                                    ;; transition AND only when no grace-period
+                                    ;; timer is already in flight. Calling
+                                    ;; `unsubscribe` past zero (idempotent
+                                    ;; misuse — e.g. cleanup in both a
+                                    ;; teardown hook and a `finally`) must not
+                                    ;; stack new `pending-dispose` timers on
+                                    ;; top of the prior handle.
+                                    (if (and (= 1 old-n)
+                                             (zero? n)
+                                             (nil? (:pending-dispose entry)))
+                                      (assoc m k (assoc entry :ref-count 0))
+                                      (assoc-in m [k :ref-count] n)))
+                                  m)))
+        ;; This swap drove the 1→0 transition (under no pending-dispose)
+        ;; iff the entry was present in both old and new AND old's
+        ;; ref-count was 1 AND new's ref-count is 0 AND old had no
+        ;; pending-dispose timer. Reading from the snapshots avoids
+        ;; the side-effect-in-swap-fn race.
+        dropped-to-zero? (and (contains? new k)
+                              (= 1 (or (get-in old [k :ref-count]) 1))
+                              (zero? (or (get-in new [k :ref-count]) 0))
+                              (nil? (get-in old [k :pending-dispose])))]
+    (when dropped-to-zero?
+      (if (zero? grace)
+        ;; Grace = 0: dispose synchronously (the test/explicit-tear-down path).
+        (dispose-entry-now! cache k)
+        ;; Grace > 0: schedule deferred disposal. Stash the timer handle
+        ;; so a re-subscribe inside the window can cancel it.
+        (let [handle (interop/set-timeout!
+                       (fn []
+                         (dispose-entry-now! cache k))
+                       grace)
+              ;; Pure swap-fn: return the new map and a flag indicating
+              ;; whether the handle was actually stashed. The clear-
+              ;; timeout! side-effect runs AFTER the CAS commits so
+              ;; a discarded retry can't double-clear a live timer.
+              [_ new2] (swap-vals! cache
+                                   (fn [m]
+                                     (if-let [entry (get m k)]
+                                       (if (<= (or (:ref-count entry) 0) 0)
+                                         (assoc m k (assoc entry :pending-dispose handle))
+                                         ;; Subscriber arrived between our swap!
+                                         ;; above and set-timeout! returning —
+                                         ;; do NOT stash; we'll cancel post-swap.
+                                         m)
+                                       m)))]
+          ;; If the handle did NOT land on the entry, cancel it once,
+          ;; outside the swap. Reading from the post-swap snapshot
+          ;; (`new2`) means we make this decision exactly once.
+          (when-not (identical? handle (get-in new2 [k :pending-dispose]))
+            (try (interop/clear-timeout! handle)
+                 (catch #?(:clj Throwable :cljs :default) _ nil))))))
+    nil))
+
+;; ---- hot-reload invalidation ---------------------------------------------
+;;
+;; Per Spec 001 §Hot-reload semantics: when a :sub re-registers, every
+;; cached reaction whose query-id is that sub MUST be disposed and
+;; evicted across every frame's cache. Cached reactions hold the OLD
+;; body via closure; without explicit invalidation, they'd silently
+;; serve stale values.
+
+(defn- invalidate-sub-on-replace!
+  [{:keys [kind id]}]
+  (when (= kind :sub)
+    (doseq [frame-id (frame/frame-ids)]
+      (when-let [cache (:sub-cache (frame/frame frame-id))]
+        ;; The swap-fn body is pure — it returns only the new cache map.
+        ;; Reactions to dispose and timers to cancel are read from the
+        ;; diff between `old` and `new` AFTER the CAS commits (so a
+        ;; retried `swap!` can't fire dispose 2+ times).
+        (let [[old new] (swap-vals! cache
+                                    (fn [m]
+                                      (let [hit-keys (->> (keys m)
+                                                          (filter #(= id (first %))))]
+                                        (apply dissoc m hit-keys))))
+              ;; The keys actually evicted by THIS swap are those present
+              ;; in `old` but absent in `new`. A concurrent evictor that
+              ;; won the CAS race would have removed its keys before our
+              ;; swap saw them, so the diff names ONLY the keys we own.
+              evicted-keys (filterv #(not (contains? new %))
+                                    (keys old))]
+          ;; Cancel any pending grace-period timers for the evicted slots —
+          ;; the reaction is being disposed now, so the deferred path
+          ;; would fire against a stale closure.
+          (doseq [k evicted-keys]
+            (when-let [h (get-in old [k :pending-dispose])]
+              (try (interop/clear-timeout! h)
+                   (catch #?(:clj Throwable :cljs :default) _ nil))))
+          (doseq [k evicted-keys]
+            (when-let [r (get-in old [k :reaction])]
+              (try (interop/dispose! r)
+                   (catch #?(:clj Throwable :cljs :default) _ nil)))))))))
+
+(defonce ^:private _hot-reload-hook
+  (do (registrar/add-replacement-hook! invalidate-sub-on-replace!)
+      :installed))
+
+(defn clear-sub-cache!
+  "Dispose every cached entry in a frame's runtime sub-cache and clear
+  the cache. Cancels any pending grace-period timers before disposing —
+  a deferred disposal landing after this fn returned would close over
+  a stale reaction.
+
+  Test fixtures and REPL-driven reloads call this between scenarios
+  to ensure the cache is empty before re-subscribing. Test code
+  generally prefers `reset-runtime-fixture` (per `test_support`) which
+  bundles cache-clearing with registrar / frame state reset.
+
+  Zero-arity targets `:rf/default`; one-arity targets the named frame.
+  Returns nil. See also: `re-frame.subs/clear-sub` (registrar-side
+  counterpart)."
+  ([] (clear-sub-cache! :rf/default))
+  ([frame-id]
+   (when-let [cache (:sub-cache (frame/frame frame-id))]
+     (doseq [[_k entry] @cache]
+       (when-let [h (:pending-dispose entry)]
+         (try (interop/clear-timeout! h)
+              (catch #?(:clj Throwable :cljs :default) _ nil)))
+       (when-let [r (:reaction entry)]
+         (try (interop/dispose! r)
+              (catch #?(:clj Throwable :cljs :default) _ nil))))
+     (reset! cache {}))))

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -1,0 +1,213 @@
+(ns re-frame.subs.memo
+  "Memo wrappers + the trace/perf/validate/recover bracket that brackets
+  a user sub body. Extracted from `re-frame.subs` per rf2-0ytl4 Phase-2
+  seam S-B — pure cohesion split, public surface unchanged.
+
+  Per Spec 006 §No-op via value equality (rf2-719e). Reagent's auto-run
+  reaction unconditionally invokes the compute fn on any source-watch
+  fire, then dedups *downstream notification* by `=`. That's one level
+  too late for the spec — the body fn itself must NOT re-run when the
+  resolved input value is `=` to the last-seen. The memo wrappers
+  compare the inputs against the previous invocation and short-circuit
+  to the memoised return value when equal. Reagent's dependency
+  tracking still observes every `deref` because the wrapper *is* the
+  compute fn — only the user's body (and the trace+validate+perf+
+  recovery layer that brackets it) is suppressed.
+
+  The layer-1 path is specialised to a fixed-arity-1 wrapper that
+  compares the db value directly. This skips the varargs-seq allocation
+  a `(fn [& in-vals])` form would force on every recompute, and
+  replaces the seq-vs-seq `=` walk with a direct value compare. Every
+  layer-1 sub × every dispatch that touches it pays this — the hottest
+  allocation in the artefact.
+
+  Layer-2 with a single `:<-` input gets the same fixed-arity-1
+  treatment (rf2-0y2bp). The adapter's `make-derived-value` already
+  specialises its recompute closure to `(compute-fn @s0)` for the
+  1-source case (rf2-v1nu0) — but the layer-N memo wrapper was
+  varargs (`(fn [& in-vals])`), which forces a one-element ArraySeq
+  allocation on every recompute. The dominant layer-2 shape is
+  1-input, so we mirror the layer-1 specialisation here: fixed-arity-1
+  wrapper, direct scalar compare against the last-seen input value.
+  The ≥2-input path keeps the original varargs shape.
+
+  Per-recompute hot path is the closure body (in-process) — unaffected
+  by the ns boundary. Per-miss constructor call (from
+  `re-frame.subs/compute-and-cache!`) crosses the ns boundary once."
+  (:require [re-frame.late-bind :as late-bind]
+            [re-frame.performance :as performance
+             #?@(:cljs [:include-macros true])]
+            [re-frame.trace :as trace
+             #?@(:cljs [:include-macros true])]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defn maybe-validate-sub-return!
+  "Per Spec 010 §Validation order step 6 (rf2-wcam) — after a sub
+  recomputes, validate its return value against any :spec on the sub
+  meta. On failure, emit :rf.error/schema-validation-failure and
+  return nil per :replaced-with-default recovery; otherwise return
+  the value unchanged.
+
+  Looked up lazily through the late-bind registry so this namespace
+  stays free of a hard re-frame.schemas dep (avoids load-order
+  surprises)."
+  [value query-v sub-id sub-meta]
+  (if (and sub-meta (:spec sub-meta))
+    ;; Sticky hook (rf2-f72pd) — fires per-sub recompute.
+    (if-let [validate (late-bind/get-fn-cached :schemas/validate-sub-return!)]
+      (if (try (validate sub-id query-v value sub-meta)
+               (catch #?(:clj Throwable :cljs :default) _ true))
+        value
+        nil)
+      value)
+    value))
+
+(defn validate-and-trace
+  "Run the user's sub body fn once and project the result through the
+  trace + performance + validate + error-recovery layer. Called by the
+  memo wrapper (`make-layer-1-memoised-body` for layer-1 subs,
+  `make-layer-n-memoised-body` for layer-2+) on a true recompute —
+  the memo path skips this entire function when input is `=` to
+  last-seen.
+
+  Concerns folded in here, in order:
+
+  1. Spec 009 §:op-type vocabulary — emit :sub/run for the recompute.
+     The memo-hit path does NOT emit (per Spec 006 §No-op via value
+     equality).
+  2. Spec 009 §Performance instrumentation (rf2-du3i) — bracket the
+     body call in performance marks so prod builds with the perf flag
+     enabled produce a `rf:sub:<sub-id>` measure entry. Default-off;
+     under `:advanced` + `re-frame.performance/enabled?=false` the
+     bracket DCEs.
+  3. Spec 010 §Validation order step 6 (rf2-wcam) — validate the body's
+     return value against the sub's `:spec` meta. Failures emit
+     :rf.error/schema-validation-failure and yield nil (recovery
+     :replaced-with-default).
+  4. Spec 009 §Error contract — `try/catch` around (1)+(2)+(3). On
+     exception emit :rf.error/sub-exception and yield nil (recovery
+     :replaced-with-default)."
+  [body-fn in-vals query-id query-v frame-id input-signals sub-meta]
+  ;; Publish the sub's HandlerScope for the duration of `:sub/run` emit
+  ;; + body-fn invocation + validation. Per Spec 009 §:rf.trace/
+  ;; trigger-handler the sub's source-coord rides every emit (`:sub/run`
+  ;; success, `:rf.error/sub-exception` / schema-validation / transitive
+  ;; sub-miss errors). The emit MUST sit inside the scope.
+  (trace/with-handler-scope
+    (trace/handler-scope-from-meta :sub query-id sub-meta)
+    (trace/emit! :sub/run :sub/run
+                 {:sub-id  query-id
+                  :query-v query-v
+                  :frame   frame-id})
+    (try
+      (let [computed (performance/mark-and-measure :sub query-id
+                      (if (empty? input-signals)
+                        (body-fn (first in-vals) query-v)
+                        ;; Layer-2+: deliver inputs as a coll if many,
+                        ;; or singleton when only one chain entry.
+                        (if (= 1 (count input-signals))
+                          (body-fn (first in-vals) query-v)
+                          (body-fn (vec in-vals) query-v))))]
+        (maybe-validate-sub-return! computed query-v query-id sub-meta))
+      (catch #?(:clj Throwable :cljs :default) e
+        (let [msg #?(:clj (.getMessage e) :cljs (.-message e))]
+          (trace/emit-error!
+            :rf.error/sub-exception
+            {:failing-id        query-id
+             :sub-id            query-id
+             :sub-query         query-v
+             :exception         e
+             :exception-message msg
+             :reason            (str "Subscription `" query-id
+                                     "` threw while computing: "
+                                     msg ". Returning nil.")
+             :recovery          :replaced-with-default}))
+        nil))))
+
+;; ---- memoisation wrappers ------------------------------------------------
+
+(defn make-layer-1-memoised-body
+  "Specialised memo wrapper for layer-1 subs (which read app-db
+  directly). Fixed-arity-1 — avoids the varargs-seq allocation that a
+  `(fn [& in-vals])` form would force on every reaction recompute, and
+  compares the db value to the last-seen scalar (no seq-vs-seq walk).
+
+  Returns a `(fn [db])`. When `body-fn` is nil (the unknown-sub path
+  — see `re-frame.subs/compute-and-cache!`) the wrapper yields nil on
+  every call without touching the memo cells.
+
+  The `::unset` sentinel guarantees the first invocation always
+  recomputes (the sentinel is never `=` to any db value)."
+  [body-fn query-id query-v frame-id sub-meta]
+  (let [last-db     (volatile! ::unset)
+        last-result (volatile! nil)]
+    (fn [db]
+      (when body-fn
+        (if (= @last-db db)
+          @last-result
+          (let [computed (validate-and-trace
+                           body-fn (list db) query-id query-v
+                           frame-id [] sub-meta)]
+            (vreset! last-db db)
+            (vreset! last-result computed)
+            computed))))))
+
+(defn make-layer-n-1-memoised-body
+  "Specialised memo wrapper for layer-2 subs with a single `:<-` input
+  (the dominant layer-2 shape — see rf2-v1nu0 perf-sweep finding).
+  Fixed-arity-1 — avoids the varargs-seq allocation that a
+  `(fn [& in-vals])` form would force on every reaction recompute, and
+  compares the upstream value to the last-seen scalar (no seq-vs-seq
+  walk). Parity with `make-layer-1-memoised-body`.
+
+  Returns a `(fn [v0])`. When `body-fn` is nil (the unknown-sub path
+  — see `re-frame.subs/compute-and-cache!`) the wrapper yields nil on
+  every call without touching the memo cells.
+
+  The `::unset` sentinel guarantees the first invocation always
+  recomputes (the sentinel is never `=` to any input value).
+
+  `validate-and-trace` receives `in-vals` as a singleton list — the
+  same shape the varargs wrapper would have produced for arity-1 —
+  preserving the `(body-fn (first in-vals) query-v)` invocation path
+  inside the validate/trace bracket (rf2-0y2bp)."
+  [body-fn query-id query-v frame-id input-signals sub-meta]
+  (let [last-v0     (volatile! ::unset)
+        last-result (volatile! nil)]
+    (fn [v0]
+      (when body-fn
+        (if (= @last-v0 v0)
+          @last-result
+          (let [computed (validate-and-trace
+                           body-fn (list v0) query-id query-v
+                           frame-id input-signals sub-meta)]
+            (vreset! last-v0 v0)
+            (vreset! last-result computed)
+            computed))))))
+
+(defn make-layer-n-memoised-body
+  "Memo wrapper for layer-2+ subs with two or more `:<-` inputs.
+  Varargs — the input arity matches the count of `:<-` entries on the
+  registration, and the wrapper compares the seq of input values
+  against the last-seen seq.
+
+  Returns a `(fn [& in-vals])`. When `body-fn` is nil the wrapper
+  yields nil on every call without touching the memo cells.
+
+  See `make-layer-1-memoised-body` for the layer-1 specialisation and
+  `make-layer-n-1-memoised-body` for the layer-2 single-input
+  specialisation (rf2-0y2bp)."
+  [body-fn query-id query-v frame-id input-signals sub-meta]
+  (let [last-in-vals (volatile! ::unset)
+        last-result  (volatile! nil)]
+    (fn [& in-vals]
+      (when body-fn
+        (if (= @last-in-vals in-vals)
+          @last-result
+          (let [computed (validate-and-trace
+                           body-fn in-vals query-id query-v
+                           frame-id input-signals sub-meta)]
+            (vreset! last-in-vals in-vals)
+            (vreset! last-result computed)
+            computed))))))

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -20,7 +20,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.trace :as trace]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
@@ -36,7 +36,7 @@
        (finally
          ;; Restore defaults so we do not leak tweaks into other suites.
          (rf/configure :trace-buffer {:depth 200})
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -49,7 +49,7 @@
         ":trace-buffer {:depth 7} caps retained events at 7"))
   (testing ":sub-cache is wired"
     (rf/configure :sub-cache {:grace-period-ms 123})
-    (is (= 123 (:grace-period-ms (subs/current-config)))
+    (is (= 123 (:grace-period-ms (subs-cache/current-config)))
         ":sub-cache {:grace-period-ms N} reaches the subs config")))
 
 (deftest configure-unknown-key-is-silent-no-op
@@ -76,5 +76,5 @@
     (dotimes [_ 30] (rf/dispatch-sync [:ping]))
     (is (<= (count (rf/trace-buffer)) 11)
         ":trace-buffer depth survived bracketing unknown-key calls")
-    (is (= 71 (:grace-period-ms (subs/current-config)))
+    (is (= 71 (:grace-period-ms (subs-cache/current-config)))
         ":sub-cache grace-period survived bracketing unknown-key calls")))

--- a/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_concurrency_test.clj
@@ -32,7 +32,7 @@
   race from the same gun."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -52,7 +52,7 @@
   (require 're-frame.machines :reload)
   (try (test-fn)
        (finally
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -179,8 +179,8 @@
                                 :on-dispose []
                                 :pending-dispose nil})))
 
-      ;; The fn is private — reach it via var resolution.
-      (let [dispose-fn @#'subs/dispose-entry-now!]
+      ;; The fn lives in re-frame.subs.cache (post rf2-0ytl4 seam S-A).
+      (let [dispose-fn subs-cache/dispose-entry-now!]
         (with-redefs [interop/dispose!
                       (fn [r]
                         (swap! dispose-calls update r (fnil inc 0))
@@ -228,7 +228,7 @@
 ;; assert it under CAS contention rather than serialised calls.
 (deftest unsubscribe-drop-to-zero-no-spurious-fire-under-contention
   (testing "concurrent unsubscribe calls dispose exactly once per slot under contention"
-    (subs/configure! {:grace-period-ms 0})  ;; sync dispose so we can observe
+    (subs-cache/configure! {:grace-period-ms 0})  ;; sync dispose so we can observe
     (rf/reg-event-db :seed (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])

--- a/implementation/core/test/re_frame/sub_cache_deferred_grace_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_deferred_grace_test.clj
@@ -45,7 +45,7 @@
   ScheduledExecutorService has comfortable room."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -64,7 +64,7 @@
   (require 're-frame.machines :reload)
   (try (test-fn)
        (finally
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -106,7 +106,7 @@
             parent reaction is actually disposed (i.e. when the timer
             lands or when invalidate-sub-on-replace! evicts the slot)"
     ;; Long grace — we'll never let it fire naturally during this test.
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -140,7 +140,7 @@
   (testing "with a short grace, the parent's timer fires, the cascade
             schedules input dispose, and after waiting another grace
             window the entire chain is disposed"
-    (subs/configure! {:grace-period-ms 30})
+    (subs-cache/configure! {:grace-period-ms 30})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -173,7 +173,7 @@
             each level's grace fires, releases the next-down ref-count
             (which schedules ITS grace), and so on. The whole chain
             takes roughly N × grace to drain"
-    (subs/configure! {:grace-period-ms 30})
+    (subs-cache/configure! {:grace-period-ms 30})
     (rf/reg-event-db :init (fn [_ _] {:a 2}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :a*2 :<- [:a]   (fn [a _]  (* 2 a)))
@@ -210,7 +210,7 @@
             subs, disposing only one parent leaves the shared input at
             ref-count 1 — even after waiting past the parent's grace,
             the shared input is NEVER scheduled for dispose"
-    (subs/configure! {:grace-period-ms 30})
+    (subs-cache/configure! {:grace-period-ms 30})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3 :c 4}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -264,7 +264,7 @@
             reaction's on-dispose callback — no input ref-count leak"
     ;; Long grace so the eviction path is the only thing that can
     ;; release the parent slot.
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -310,7 +310,7 @@
             resubscribe path cancels it and increments the ref-count.
             Net effect: new parent at ref-count 1, inputs at ref-count 1,
             no leaked timers, no stale references."
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -355,7 +355,7 @@
             cascade-pending-dispose is in flight: invalidate-sub-on-
             replace! cancels the pending timer and disposes the input
             reaction. The parent (already disposed) is unaffected."
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -408,7 +408,7 @@
             new reaction (rf2-e8e74)."
     ;; Long grace — the timer cannot fire during this test under any
     ;; realistic scheduler.
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -453,7 +453,7 @@
             scheduler-jitter risk is gone — we're only asserting that
             the slot is STILL ALIVE after a wait that's an order of
             magnitude past the original window."
-    (subs/configure! {:grace-period-ms 50})
+    (subs-cache/configure! {:grace-period-ms 50})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -489,7 +489,7 @@
             per-input subscribe goes through the HIT branch on each
             input, cancelling its pending-dispose timer and bumping
             ref-count from 0 → 1"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -542,7 +542,7 @@
       (if (even? i)
         ;; Cancel-mid-window arm — long grace, no wall-clock dependency.
         (do
-          (subs/configure! {:grace-period-ms 60000})
+          (subs-cache/configure! {:grace-period-ms 60000})
           (let [r (rf/subscribe [:sum])]
             (is (= 5 @r))
             (is (= 1 (entry-ref-count [:sum])))
@@ -556,12 +556,12 @@
                   (str "iter " i ": timer cancelled on resubscribe"))))
           ;; Collapse grace to 0 to tear down synchronously — both arms
           ;; converge on a fully drained cache before the next iteration.
-          (subs/configure! {:grace-period-ms 0})
+          (subs-cache/configure! {:grace-period-ms 0})
           (rf/unsubscribe [:sum]))
         ;; Let-fire arm: short grace + poll on cache-drained so the
         ;; full cascade fires through the deferred path (rf2-fun38).
         (do
-          (subs/configure! {:grace-period-ms 30})
+          (subs-cache/configure! {:grace-period-ms 30})
           (let [r (rf/subscribe [:sum])]
             (is (= 5 @r))
             (is (= 1 (entry-ref-count [:sum])))

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -11,7 +11,7 @@
   fastest test path) and grace>0 (the production path)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -32,7 +32,7 @@
   ;; toggle it for assertions and we don't want the value to leak.
   (try (test-fn)
        (finally
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -54,21 +54,21 @@
   (testing "the default grace-period is 50ms"
     ;; 50ms is short enough not to leak under genuine disposal but long
     ;; enough to bridge React re-render churn (per Spec 006).
-    (subs/configure! {:grace-period-ms 50})  ;; explicit; the fixture restores
-    (is (= 50 (:grace-period-ms (subs/current-config))))))
+    (subs-cache/configure! {:grace-period-ms 50})  ;; explicit; the fixture restores
+    (is (= 50 (:grace-period-ms (subs-cache/current-config))))))
 
 (deftest configure-overrides-grace-period
   (testing "(rf/configure :sub-cache {...}) updates the grace-period"
     (rf/configure :sub-cache {:grace-period-ms 200})
-    (is (= 200 (:grace-period-ms (subs/current-config))))
+    (is (= 200 (:grace-period-ms (subs-cache/current-config))))
     (rf/configure :sub-cache {:grace-period-ms 0})
-    (is (= 0 (:grace-period-ms (subs/current-config))))))
+    (is (= 0 (:grace-period-ms (subs-cache/current-config))))))
 
 ;; ---- synchronous-disposal path (grace = 0) --------------------------------
 
 (deftest sync-disposal-when-grace-is-zero
   (testing "with grace=0, ref-count → 0 disposes the cache slot synchronously"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -83,7 +83,7 @@
 
 (deftest sync-disposal-respects-multiple-subscribers
   (testing "with grace=0, only the LAST subscriber dropping disposes"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -103,7 +103,7 @@
 
 (deftest deferred-disposal-after-grace-period
   (testing "ref-count → 0 → grace-period elapses → entry disposed"
-    (subs/configure! {:grace-period-ms 30})
+    (subs-cache/configure! {:grace-period-ms 30})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -131,7 +131,7 @@
 
 (deftest resubscribe-within-grace-cancels-disposal
   (testing "resubscribe inside the grace-period cancels disposal; cached value reused"
-    (subs/configure! {:grace-period-ms 100})
+    (subs-cache/configure! {:grace-period-ms 100})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -158,7 +158,7 @@
 
 (deftest grace-zero-disposes-without-pending-handle
   (testing "with grace=0 the synchronous path leaves no pending-dispose handle"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -179,7 +179,7 @@
 
 (deftest subscribe-once-disposes-synchronously
   (testing "subscribe-once's teardown is synchronous regardless of the configured grace-period (rf2-zmufj)"
-    (subs/configure! {:grace-period-ms 60000})  ;; long grace; pre-fix this leaked
+    (subs-cache/configure! {:grace-period-ms 60000})  ;; long grace; pre-fix this leaked
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -197,7 +197,7 @@
 
 (deftest subscribe-once-respects-concurrent-subscriber
   (testing "subscribe-once's :grace 0 teardown only disposes when it drove 1→0 (rf2-zmufj)"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -230,7 +230,7 @@
 
 (deftest unsubscribe-with-grace-opt-overrides-configured-grace
   (testing "(unsubscribe frame-id query-v {:grace 0}) disposes synchronously even when configured grace > 0"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -243,14 +243,14 @@
     (rf/unsubscribe :rf/default [:n] {:grace 0})
     (is (not (contains? (cache-keys) [:n]))
         "slot disposed synchronously despite configured grace=60000ms")
-    (is (= 60000 (:grace-period-ms (subs/current-config)))
+    (is (= 60000 (:grace-period-ms (subs-cache/current-config)))
         "per-runtime grace-period-ms is unchanged — only THIS call was overridden")))
 
 ;; ---- clear-sub-cache! cancels pending timers ---------------------
 
 (deftest clear-subscription-cache-cancels-pending
   (testing "clear-sub-cache! cancels any pending grace-period timers"
-    (subs/configure! {:grace-period-ms 60000})  ;; long grace; we'll clear before it fires
+    (subs-cache/configure! {:grace-period-ms 60000})  ;; long grace; we'll clear before it fires
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -269,7 +269,7 @@
 
 (deftest hot-reload-cancels-pending-and-disposes
   (testing "re-registering a sub disposes cached slots and cancels pending timers"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -294,7 +294,7 @@
 
 (deftest subscribe-before-register-does-not-cache
   (testing "subscribing before reg-sub does not cache; later registration is observed"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/dispatch-sync [:init])
 
@@ -323,7 +323,7 @@
 
 (deftest subscribe-before-register-survives-multiple-misses
   (testing "repeated subscribe-before-register calls do not poison the cache"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 11}))
     (rf/dispatch-sync [:init])
 
@@ -354,7 +354,7 @@
 
 (deftest clear-sub-id-leaves-cache-intact
   (testing "(clear-sub id) removes the registration but does not evict cache slots"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -383,7 +383,7 @@
 
 (deftest clear-sub-no-arg-leaves-cache-intact
   (testing "(clear-sub) clears every registration but leaves the cache untouched"
-    (subs/configure! {:grace-period-ms 60000})
+    (subs-cache/configure! {:grace-period-ms 60000})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :a (fn [db _] (:n db)))
     (rf/reg-sub :b (fn [db _] (* 2 (:n db))))
@@ -424,7 +424,7 @@
 
 (deftest unsubscribe-past-zero-is-idempotent
   (testing "calling unsubscribe twice for the same sub-id does not leak pending-dispose handles (rf2-zikr)"
-    (subs/configure! {:grace-period-ms 60000})  ;; long grace; we won't let it fire
+    (subs-cache/configure! {:grace-period-ms 60000})  ;; long grace; we won't let it fire
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -463,7 +463,7 @@
             "third unsubscribe still preserves the original handle"))))
 
   (testing "extra unsubscribe before any subscribe is a complete no-op"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:n 7}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:init])
@@ -485,7 +485,7 @@
   (testing "after full unsubscription, a state change does NOT re-invoke
             the sub's compute fn — the cache entry has been disposed,
             its watch on app-db unwound"
-    (subs/configure! {:grace-period-ms 0})  ;; sync dispose so the contract is observable
+    (subs-cache/configure! {:grace-period-ms 0})  ;; sync dispose so the contract is observable
     (let [recompute-count (atom 0)]
       (rf/reg-event-db :seed   (fn [_ _]   {:n 0}))
       (rf/reg-event-db :update (fn [db [_ n]] (assoc db :n n)))
@@ -551,7 +551,7 @@
 
 (deftest layer-2-disposal-decrements-input-ref-counts
   (testing "disposing a layer-2 sub decrements ref-counts on every :<- input"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -582,7 +582,7 @@
 
 (deftest layer-2-disposal-respects-shared-inputs
   (testing "disposing one layer-2 sub decrements shared input only by one"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3 :c 4}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -625,7 +625,7 @@
 
 (deftest layer-2-disposal-respects-externally-held-input
   (testing "an input also held by a direct subscribe is not over-disposed"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))
@@ -658,7 +658,7 @@
 
 (deftest layer-3-disposal-cascades-through-chain
   (testing "disposal cascades recursively through a layer-3 chain"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:a 2}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :a*2 :<- [:a]   (fn [a _] (* 2 a)))
@@ -680,7 +680,7 @@
 
 (deftest layer-2-multi-subscriber-disposal-keeps-inputs-alive
   (testing "with two parent subscribers, dropping one keeps inputs at ref-count 1"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :init (fn [_ _] {:a 2 :b 3}))
     (rf/reg-sub :a (fn [db _] (:a db)))
     (rf/reg-sub :b (fn [db _] (:b db)))

--- a/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_1_test.clj
@@ -19,7 +19,7 @@
   one-element seqs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -37,7 +37,7 @@
   (require 're-frame.machines :reload)
   (try (test-fn)
        (finally
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -45,7 +45,7 @@
 
 (deftest layer-1-memo-skips-recompute-on-equal-db
   (testing "two consecutive derefs against the same db value run the body once"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed (fn [_ _] {:n 7}))
       (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
@@ -63,7 +63,7 @@
 
 (deftest layer-1-memo-recomputes-on-changed-db
   (testing "deref after an app-db change runs the body again"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
       (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
@@ -82,7 +82,7 @@
 (deftest layer-1-memo-value-equal-but-not-identical-skips
   (testing "two `=`-but-not-`identical?` db values still short-circuit
             — the contract is value equality, not identity"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       ;; Two events that produce structurally-equal but non-identical maps.
       ;; `(assoc db :touched true)` would change the value; instead replace
@@ -103,7 +103,7 @@
 (deftest layer-1-body-receives-db-and-query-v
   (testing "the body fn still receives the canonical (db, query-v) shape
             under the specialised wrapper — no shape regression"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [captured (atom nil)]
       (rf/reg-event-db :seed (fn [_ _] {:n 99}))
       (rf/reg-sub :n (fn [db query-v]
@@ -120,7 +120,7 @@
   (testing "nil and false db values are not confused with the ::unset
             sentinel — the body runs once for each, memo skips on
             repeat"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed-nil   (fn [_ _] nil))
       (rf/reg-event-db :seed-false (fn [_ _] false))
@@ -152,7 +152,7 @@
 (deftest layer-1-and-layer-2-produce-the-same-stream-of-values
   (testing "a layer-1 sub and a layer-2 sub chained off it produce the
             same stream of values across N db updates"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
     (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
     (rf/reg-sub :n        (fn [db _] (:n db)))

--- a/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
+++ b/implementation/core/test/re_frame/sub_memo_layer_n_1_test.clj
@@ -21,7 +21,7 @@
   removes it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
-            [re-frame.subs :as subs]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -39,7 +39,7 @@
   (require 're-frame.machines :reload)
   (try (test-fn)
        (finally
-         (subs/configure! {:grace-period-ms 50}))))
+         (subs-cache/configure! {:grace-period-ms 50}))))
 
 (use-fixtures :each reset-runtime)
 
@@ -48,7 +48,7 @@
 (deftest layer-n-1-memo-skips-recompute-on-equal-upstream
   (testing "two consecutive derefs against an unchanged upstream value
             run the layer-2 body once"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed (fn [_ _] {:n 7}))
       (rf/reg-sub :n  (fn [db _] (:n db)))
@@ -65,7 +65,7 @@
 
 (deftest layer-n-1-memo-recomputes-on-changed-upstream
   (testing "deref after an upstream change runs the body again"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed   (fn [_ _]      {:n 0}))
       (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
@@ -87,7 +87,7 @@
             value is unchanged, even though the underlying db changed.
             This is the headline value of the no-op-by-equality contract
             — diamond-shape graphs do not over-compute downstream."
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed     (fn [_ _]      {:n 1 :other :a}))
       (rf/reg-event-db :touch    (fn [db _]     (assoc db :other :b)))
@@ -106,7 +106,7 @@
 (deftest layer-n-1-body-receives-upstream-value-and-query-v
   (testing "the body fn still receives the canonical (upstream, query-v)
             shape under the specialised wrapper — no shape regression"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [captured (atom nil)]
       (rf/reg-event-db :seed (fn [_ _] {:n 99}))
       (rf/reg-sub :n   (fn [db _] (:n db)))
@@ -126,7 +126,7 @@
   (testing "nil and false upstream values are not confused with the ::unset
             sentinel — the body runs once for each, memo skips on
             repeat"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (let [runs (atom 0)]
       (rf/reg-event-db :seed-nil   (fn [_ _] {:n nil}))
       (rf/reg-event-db :seed-false (fn [_ _] {:n false}))
@@ -161,7 +161,7 @@
   (testing "a 1-input layer-2 sub and a 2-input layer-2 sub (one of the
             inputs constant) produce the same stream of values across
             N db updates"
-    (subs/configure! {:grace-period-ms 0})
+    (subs-cache/configure! {:grace-period-ms 0})
     (rf/reg-event-db :seed   (fn [_ _]      {:n 0 :k :stable}))
     (rf/reg-event-db :update (fn [db [_ v]] (assoc db :n v)))
     (rf/reg-sub :n  (fn [db _] (:n db)))
@@ -185,7 +185,7 @@
 ;; should run A, B, C once each.
 
 (deftest layer-n-1-chain-propagates-and-suppresses-correctly
-  (subs/configure! {:grace-period-ms 0})
+  (subs-cache/configure! {:grace-period-ms 0})
   (let [a-runs (atom 0)
         b-runs (atom 0)
         c-runs (atom 0)]


### PR DESCRIPTION
## Scope

Phase-2 cohesion split for `re-frame.router` + `re-frame.subs` per the Phase-1 audit (rf2-0ytl4). Three low-risk seams — cut order **B -> A -> R-B**. ~664 LoC moved into three new *internal* nss. Facade `router.cljc` + `subs.cljc` combined drops from **2441 -> 1902 LoC**.

No public-ABI changes; no facade re-exports for movable internals; pre-alpha posture (no shims).

## Commits

1. **`refactor(subs): seam B — extract re-frame.subs.memo (rf2-0ytl4)`** (7ea0f2db) — 213 LoC moved.
2. **`refactor(subs): seam A — extract re-frame.subs.cache (rf2-0ytl4)`** (c99e30a5) — 270 LoC moved.
3. **`refactor(router): seam B — extract re-frame.router.diagnostics (rf2-0ytl4)`** (2718f7f2) — 181 LoC moved.

## Seam S-B → `re-frame.subs.memo`

The three layer memo wrappers + the trace/perf/validate/recover bracket.

- `make-layer-1-memoised-body`
- `make-layer-n-1-memoised-body`
- `make-layer-n-memoised-body`
- `maybe-validate-sub-return!`
- `validate-and-trace`

**Hot-path preservation**: per-recompute hot path is the memo closure body (in-process JIT) — unaffected by the ns boundary. Only the per-miss constructor call from `compute-and-cache!` crosses the boundary. `compute-sub` on the facade calls `subs-memo/maybe-validate-sub-return!` across the boundary on its cold testing path.

## Seam S-A → `re-frame.subs.cache`

Per-frame sub-cache state: grace-period config, ref-counting, deferred-dispose scheduling, hot-reload invalidation, test-fixture clear. Folds in seam S-E (the registrar-replacement hook).

- `default-grace-period-ms` / `config` / `grace-period-ms` (internals)
- `configure!`, `current-config` (public)
- `dispose-entry-now!`
- `unsubscribe!` (new helper — facade `re-frame.subs/unsubscribe` delegates after resolving cache + cache-key)
- `clear-sub-cache!` (public)
- `invalidate-sub-on-replace!` + `_hot-reload-hook` defonce

**Stays on the facade**: `cache-key` (one-liner — preserves Closure inlining on the per-subscribe hit path; the audit was explicit about this), plus `subscribe`, `subscribe-once`, `unsubscribe`, `reg-sub`, `clear-sub`, `compute-sub`, `parse-reg-sub-args`, the late-bind reg, the JVM aliases.

**Public-surface handling (option (a))**: `core.cljc`'s defaliases for `configure!` / `current-config` / `clear-sub-cache!` now point at `re-frame.subs.cache/*` directly — no facade shim, no re-export. Test files that referenced `subs/configure!` retargeted at `subs-cache/configure!`. `sub_cache_concurrency_test`'s `@#'subs/dispose-entry-now!` var-resolution retargets to the now-public `subs-cache/dispose-entry-now!`.

## Seam R-B → `re-frame.router.diagnostics`

Dev-only diagnostics: fallthrough-to-default warnings (rf2-o8m0), cross-frame dispatch-sync warnings (rf2-fp97), the no-handler error path.

- `non-default-frame-registered?`
- `emit-fallthrough-warning!`
- `other-frame-mid-drain`
- `emit-cross-frame-warning!`
- `handle-no-handler!`

Every body sits behind `interop/debug-enabled?` gating or runs on cold error paths. Production DCEs both the bodies and the keyword reason-strings.

## Hot-path preservation rationale

The audit (rf2-0ytl4 Phase-1) explicitly warned against per-recompute / per-dispatch indirection. The seams taken in this PR add **zero hot-path crossings**:

- **subs.memo**: the memo *closure body* runs in-process. Only the per-miss *constructor* crosses the ns boundary — that's the cold cache-miss path, not the recompute hot path.
- **subs.cache**: per-subscribe **hit** path (the common case) is unchanged because `cache-key` stays on the facade — `subscribe` resolves the cache + key locally and hits the cache atom directly. The cross-ns call from `unsubscribe` is per-subscribe (1→0 transition), not per-recompute.
- **router.diagnostics**: every body is either gated on `interop/debug-enabled?` or runs on cold error paths (`:rf.error/no-such-handler`).

The audit's R-A (router.envelope), R-C (router.cascade), R-D (router.drain), and S-C / S-D were deferred / rejected per the Phase-1 risk scoring — this PR takes only the low-risk seams.

## LoC delta

|                                          | Before | After |
| ---------------------------------------- | -----: | ----: |
| `re-frame.subs.cljc`                     |    883 |   496 |
| `re-frame.router.cljc`                   |   1558 |  1406 |
| **Facade total**                         | **2441** | **1902** |
| `re-frame.subs.memo.cljc` (new)          |      — |   213 |
| `re-frame.subs.cache.cljc` (new)         |      — |   270 |
| `re-frame.router.diagnostics.cljc` (new) |      — |   181 |

## Test results

- `npm run test:cljs` (node-test) — **2356 tests / 6764 assertions / 0 failures, 0 errors** ✓ (run after every commit and at the end)
- `clojure -M:test` in `implementation/core` — **549 tests / 2851 assertions / 0 failures, 0 errors** ✓ (run after every commit and at the end)
- `npm run test:browser` (Playwright) — **2345 tests / 6623 assertions / 0 failures, 0 errors** ✓ (final check)

## Closes

Closes `rf2-0ytl4` — Phase-2 cohesion split complete. Phase-1 audit findings (rf2-0ytl4-router-subs-seam-proposal-2026-05-17) identified five `router.cljc` seams + five `subs.cljc` seams; this PR delivers Mike's greenlit subset (S-B + S-A + R-B). The deferred seams (R-A envelope, R-D drain — both perf-risk 3-4/5) remain open for a future microbenchmarked Phase-3; R-C cascade and the public-surface fns (R-E, S-C, S-D's public ergonomics) are rejected.

## Verification

The seams chosen here mirror the architectural pattern Phase-2 has converged on across recent splits (rf2-icrxv routing #1365, rf2-l8eso story #1364): take only the low-risk seams the audit explicitly green-lit, keep the public ABI intact, retarget tests at the new canonical homes rather than maintaining facade shims.