### PR TITLE
feat(causa): global Cmd/Ctrl+K command palette (rf2-wm7z4)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -23,7 +23,21 @@
   on `Ctrl+Shift+/`. The listener routes the keypress through the
   `:rf.causa/copilot-toggle` event dispatched on the Causa frame, so
   the panel's open / closed state lives in Causa's app-db (not the
-  host's)."
+  host's).
+
+  ## Phase 5 — Cmd/Ctrl+K command palette (rf2-wm7z4)
+
+  Per spec/007-UX-IA.md §Command palette the palette opens on
+  Cmd+K (macOS convention) or Ctrl+K (every other host). Unlike the
+  other shortcuts this one is a *single* modifier — no Shift — and
+  must accept either Meta (Cmd) or Ctrl. The listener routes the
+  keypress through `:rf.causa/palette-toggle` dispatched on the
+  Causa frame so the modal's open state lives in Causa's app-db.
+
+  The palette modal renders its own ESC handler on the input
+  element, so this listener does NOT close the palette on ESC —
+  doing so would race the input's onKeyDown and risk
+  double-dispatch."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.mount :as mount]))
 
@@ -69,6 +83,37 @@
     (fn [k code]
       (or (= "/" k) (= "?" k) (= "Slash" code)))))
 
+(defn- palette-toggle-key?
+  "True when `event` is a Cmd+K (macOS) or Ctrl+K (every other host)
+  keydown. Per spec/007-UX-IA.md §Command palette this is the
+  industry-standard 'open command palette' shortcut (VS Code, Linear,
+  GitHub, Slack).
+
+  Unlike the causa / copilot toggles this predicate is a *single*
+  modifier:
+  - meta XOR ctrl (exactly one) — Cmd on macOS, Ctrl elsewhere.
+  - no Shift / no Alt.
+
+  Allowing both Cmd and Ctrl gives mac users their muscle-memory
+  Cmd+K while keeping Ctrl+K live on Windows/Linux where there is
+  no Cmd key. Rejecting Shift / Alt means we don't collide with
+  printable-character shortcuts (Ctrl+Shift+K is browser dev-tools
+  on Firefox; Ctrl+Alt+K is some IME compositions). Checks the K
+  key via both `.key` and `.code`."
+  [event]
+  (let [^js e event
+        ctrl?  (.-ctrlKey e)
+        meta?  (.-metaKey e)
+        shift? (.-shiftKey e)
+        alt?   (.-altKey e)
+        k      (.-key e)
+        code   (.-code e)]
+    (and (or (and ctrl? (not meta?))
+             (and meta? (not ctrl?)))
+         (not shift?)
+         (not alt?)
+         (or (= "k" k) (= "K" k) (= "KeyK" code)))))
+
 (defn- handle-keydown [^js event]
   (cond
     (causa-toggle-key? event)
@@ -84,7 +129,20 @@
         ;; the panel's open / closed state lands on :rf/causa, not the
         ;; host's :rf/default.
         (rf/with-frame :rf/causa
-          (rf/dispatch [:rf.causa/copilot-toggle])))))
+          (rf/dispatch [:rf.causa/copilot-toggle])))
+
+    (palette-toggle-key? event)
+    (do (.preventDefault event)
+        (.stopPropagation event)
+        ;; Per spec/007-UX-IA.md §Command palette — Cmd/Ctrl+K
+        ;; toggles the command palette modal. Open the shell first
+        ;; if it's not visible so the palette has somewhere to mount;
+        ;; the toggle dispatch is routed through Causa's frame so the
+        ;; palette open-state lives on :rf/causa.
+        (when-not (mount/visible?)
+          (mount/open!))
+        (rf/with-frame :rf/causa
+          (rf/dispatch [:rf.causa/palette-toggle])))))
 
 (defn attach!
   "Install the global Ctrl+Shift+C listener once. No-op on second +

--- a/tools/causa/src/day8/re_frame2_causa/palette.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette.cljs
@@ -1,0 +1,51 @@
+(ns day8.re-frame2-causa.palette
+  "Facade for the Causa command palette (rf2-wm7z4).
+
+  Per the canonical Causa panel-facade pattern (see
+  `panels/ai_co_pilot.cljs`): the facade owns the `reg-view` that
+  wraps the plain-Reagent body in `palette/view`, and an `install!`
+  fn that wires the palette's subs / events / fxs through the
+  Causa-side registry.
+
+  ## Modal vs Panel
+
+  The palette is NOT a sidebar panel — it has no row in the sidebar
+  list and no canvas slot. The `Modal` reg-view is mounted at the
+  shell-view root (so it overlays the chrome and panels) and
+  short-circuits to `nil` when the palette is closed. The render
+  cost when closed is the subscribe call plus a `when` — i.e. the
+  same cost the shell already pays for the rail-gate / co-pilot
+  cue toggles.
+
+  ## Why the shell mounts the Modal
+
+  Mounting at the shell-root means the modal's subscribes resolve
+  through the same `frame-provider` the shell installed —
+  `:rf/causa` reads land on Causa's app-db, not the host's. A
+  top-level `js/document.body` portal would lose the frame context
+  and silently read from `:rf/default`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.palette.events :as events]
+            [day8.re-frame2-causa.palette.subs :as subs]
+            [day8.re-frame2-causa.palette.view :as view]))
+
+(rf/reg-view Modal
+  "The palette modal. Renders only when `:rf.causa/palette-open?` is
+  true; closed-state is a single subscribe + a `when` — cheap.
+
+  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
+  through the React-context tier to `:rf/causa`."
+  []
+  (when @(rf/subscribe [:rf.causa/palette-open?])
+    (view/palette-view)))
+
+(defn install!
+  "Idempotent install for the palette's Causa-side registrations.
+  Subs and events get wired through the framework registrar (which
+  is itself idempotent on re-register); the orchestrator
+  (`registry/register-causa-handlers!`) gates the whole sequence
+  with a sentinel so re-loads do not re-install."
+  []
+  (subs/install!)
+  (events/install!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
@@ -1,0 +1,258 @@
+(ns day8.re-frame2-causa.palette.events
+  "Events for the Causa command palette (rf2-wm7z4).
+
+  Every event is registered under `:rf.causa/palette-*` so the
+  `:rf.causa/*` collision contract (registry.cljs) holds. The events
+  fire against the `:rf/causa` frame — they are dispatched from
+  inside the palette modal (which renders under the shell's
+  `frame-provider`) so re-frame's frame-resolver routes them
+  correctly without further `with-frame` wrappers.
+
+  ## Action lowering
+
+  Source items in `palette/sources` declare their action as one of:
+
+    [:palette/select-panel id]
+    [:palette/select-event ev-id]
+    [:palette/select-frame fid]
+    [:palette/inspect-handler kind id]
+    [:palette/copilot-toggle]
+    [:palette/cycle-density]
+    [:palette/clear-trace-buffer]
+    [:palette/reset-suppressed-counters]
+    [:palette/open-popout]
+    [:palette/close]
+    [:palette/reopen-copilot-question text]
+
+  `:rf.causa/palette-invoke` lowers them into the right Causa-side
+  side-effect: most translate to a `[:rf.causa/<verb> ...]` dispatch;
+  a few invoke mount-layer fns directly via the `:rf.causa.palette
+  .fx/*` effect family. Keeping the lowering server-side (in the
+  events ns, not the view) means the view stays a pure subscriber +
+  dispatcher of a single uniform event id."
+  (:require [goog.object :as gobj]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.palette.sources :as sources]))
+
+;; ---- effect: mount-level pop-out -----------------------------------------
+;;
+;; The pop-out semantics for palette items reuse Causa's existing
+;; `mount/popout!` — `Ctrl+Enter` on a popout-eligible result opens
+;; the popout window (or focuses it if one already exists) and then
+;; lowers the underlying action.
+;;
+;; ## Why we late-bind through the browser API instead of requiring mount
+;;
+;; A direct `[day8.re-frame2-causa.mount]` require here would form the
+;; cycle: `mount → shell → palette → palette.events → mount`. The
+;; shell mounts the palette modal; the palette events lower into
+;; mount actions; mount requires the shell to render. Breaking the
+;; cycle by requiring mount only from non-shell call sites means we
+;; reach mount fns via the browser API exports `preload/install-
+;; browser-api-exports!` installs on `window.day8.re_frame2_causa.
+;; popout_BANG_`. Late-bound at fx-fire time, not at namespace-load
+;; time — preload runs BEFORE any palette dispatch can land, so the
+;; export is always present in production paths.
+;;
+;; Tests stub the `:rf.causa.palette.fx/popout` registration directly
+;; (see palette/events_cljs_test.cljs `with-popout-counter`) so the
+;; late-bind never matters for the registered-event contract — the fx
+;; redefinition wins.
+
+(defn- mount-popout!
+  "Reach `mount/popout!` through the browser API the preload installs.
+  Returns nil when the API is unreachable (preload not loaded, no
+  browser global — test runtime without the export, etc.). Swallows
+  any throw so a popup-blocked failure never poisons the event-
+  handler chain that dispatched it."
+  []
+  (try
+    (when (exists? js/window)
+      (let [day8  (gobj/get js/window "day8")
+            causa (when day8 (gobj/get day8 "re_frame2_causa"))
+            fn-h  (when causa (gobj/get causa "popout_BANG_"))]
+        (when (fn? fn-h) (fn-h))))
+    (catch :default _ nil)))
+
+(defn- popout-fx!
+  "Effect handler: open the Causa pop-out window."
+  [_]
+  (mount-popout!)
+  nil)
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- reset-cursor [db]
+  (assoc db :palette-cursor 0))
+
+(defn- close-palette [db]
+  (-> db
+      (assoc :palette-open? false)
+      (assoc :palette-query "")
+      (reset-cursor)))
+
+;; ---- install --------------------------------------------------------------
+
+(defn install!
+  "Install the palette's events + effects. Idempotent — re-frame's
+  registrar replaces handlers in place, so a second call is harmless
+  beyond the `:rf.warning/handler-replaced` trace it emits (which
+  the orchestrator's `registered?` sentinel already protects
+  against)."
+  []
+
+  (rf/reg-fx :rf.causa.palette.fx/popout popout-fx!)
+
+  ;; ---- open / close / toggle --------------------------------------------
+
+  (rf/reg-event-db :rf.causa/palette-open
+    (fn [db _event]
+      (-> db
+          (assoc :palette-open? true)
+          (assoc :palette-query "")
+          (reset-cursor))))
+
+  (rf/reg-event-db :rf.causa/palette-close
+    (fn [db _event]
+      (close-palette db)))
+
+  (rf/reg-event-db :rf.causa/palette-toggle
+    (fn [db _event]
+      (if (get db :palette-open? false)
+        (close-palette db)
+        (-> db
+            (assoc :palette-open? true)
+            (assoc :palette-query "")
+            (reset-cursor)))))
+
+  ;; ---- query / cursor ---------------------------------------------------
+
+  (rf/reg-event-db :rf.causa/palette-set-query
+    {:rf.trace/no-emit? true}
+    (fn [db [_ text]]
+      (-> db
+          (assoc :palette-query (or text ""))
+          (reset-cursor))))
+
+  (rf/reg-event-db :rf.causa/palette-cursor-up
+    {:rf.trace/no-emit? true}
+    (fn [db _event]
+      (update db :palette-cursor #(max 0 (dec (or % 0))))))
+
+  (rf/reg-event-db :rf.causa/palette-cursor-down
+    {:rf.trace/no-emit? true}
+    (fn [db [_ max-idx]]
+      (update db :palette-cursor
+              (fn [c]
+                (min (or max-idx 0) (inc (or c 0)))))))
+
+  (rf/reg-event-db :rf.causa/palette-cursor-set
+    {:rf.trace/no-emit? true}
+    (fn [db [_ idx]]
+      (assoc db :palette-cursor (max 0 (or idx 0)))))
+
+  ;; ---- invoke -----------------------------------------------------------
+  ;;
+  ;; The view dispatches `[:rf.causa/palette-invoke item popout?]`
+  ;; on Enter / Ctrl+Enter. The handler lowers the item's action
+  ;; tuple into the appropriate Causa-side dispatch (or mount-layer
+  ;; side effect) and closes the palette.
+
+  (rf/reg-event-fx :rf.causa/palette-invoke
+    (fn [{:keys [db]} [_ item popout?]]
+      (let [[verb & args]    (:action item)
+            close-db         (close-palette db)
+            ;; Pop-out is gated on the item's own opt-in (per
+            ;; sources/popoutable?) — Ctrl+Enter on a non-popoutable
+            ;; item invokes normally so the user never gets surprised
+            ;; with a no-op.
+            popout-now?      (and popout? (sources/popoutable? item))
+            base-fx          (cond-> []
+                               popout-now?
+                               (conj [:rf.causa.palette.fx/popout {}]))]
+        (case verb
+          :palette/select-panel
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/select-panel (first args)]])}
+
+          :palette/select-event
+          ;; Future: route to event-detail with the event pre-
+          ;; selected. Phase 1 routes to the event-detail panel; the
+          ;; detail panel reads `:rf.causa/selected-event-id` for the
+          ;; specific event focus (event-detail panel handles the
+          ;; missing-id gracefully — see panels/event_detail.cljs).
+          {:db (assoc close-db
+                      :selected-panel :event-detail
+                      :selected-event-id (first args))
+           :fx base-fx}
+
+          :palette/select-frame
+          ;; Frame focus is a Causa-side annotation today (rf2-wm7z4
+          ;; Phase 1 — frame picker UI lives at the top strip per
+          ;; spec/007-UX-IA.md). Store the choice; a follow-on bead
+          ;; wires the picker UI to read it.
+          {:db (assoc close-db :selected-target-frame (first args))
+           :fx base-fx}
+
+          :palette/inspect-handler
+          ;; Phase 1: route to a Causa-side store of the inspected
+          ;; handler choice. The handler-detail panel is itself a
+          ;; follow-on bead — for now the store is enough so the
+          ;; palette completes its part of the contract.
+          (let [[kind id] args]
+            {:db (assoc close-db
+                        :selected-panel :event-detail
+                        :inspecting-handler [kind id])
+             :fx base-fx})
+
+          :palette/copilot-toggle
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/copilot-toggle]])}
+
+          :palette/cycle-density
+          ;; Phase 1: density toggle is wired through the existing
+          ;; density-sub once the density-runtime bead lands. The
+          ;; palette event records the user intent so the follow-on
+          ;; bead has the data point.
+          {:db (assoc close-db :density-cycle-requested? true)}
+
+          :palette/clear-trace-buffer
+          (do
+            ;; The trace-bus atom is the canonical write surface
+            ;; (per registry.cljs §trace-buffer mirror); clearing
+            ;; the atom dispatches the coalesced sync into the
+            ;; mirrored slot so the panel re-renders on the
+            ;; standard reactive path.
+            (try (trace-bus/clear-buffer!) (catch :default _ nil))
+            {:db close-db
+             :fx base-fx})
+
+          :palette/reset-suppressed-counters
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/reset-suppressed-counters]])}
+
+          :palette/open-popout
+          {:db close-db
+           :fx [[:rf.causa.palette.fx/popout {}]]}
+
+          :palette/close
+          {:db close-db}
+
+          :palette/reopen-copilot-question
+          ;; Phase 1: drop the question text into the co-pilot
+          ;; input. The user reviews, edits if needed, and submits.
+          {:db close-db
+           :fx (conj base-fx
+                     [:dispatch [:rf.causa/copilot-set-input-text (first args)]])}
+
+          ;; Unknown verb — close the palette and log to console so
+          ;; the dev sees the gap. Never silently swallow.
+          (do
+            (when (and (exists? js/console) (.-warn js/console))
+              (.warn js/console
+                     (str "[rf2-causa] palette: unknown action verb "
+                          (pr-str verb))))
+            {:db close-db})))))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/palette/fuzzy.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/palette/fuzzy.cljc
@@ -1,0 +1,177 @@
+(ns day8.re-frame2-causa.palette.fuzzy
+  "Fuzzy subsequence scorer for the Causa command palette
+  (rf2-wm7z4).
+
+  Pure data; JVM-runnable so tests cover the scorer outside any
+  browser dep. The algorithm follows the sublime-fuzzy / fzf-lite
+  family: every query character must appear (in order, case-
+  insensitively) as a subsequence of the candidate; the score
+  rewards matches that land on word starts, consecutive runs, and
+  prefix position, and penalises long unmatched gaps.
+
+  ## Why we ship our own scorer
+
+  Verified-redundant (rf2-wm7z4 worker dispatch): there is no
+  existing fuzzy implementation under `tools/causa/` or
+  `implementation/core/`. Bringing in an npm dep would breach the
+  bundle-isolation contract for the dev surface and pull a runtime
+  dependency that production builds can't elide cleanly. ~60 lines
+  of CLJC is the right cost.
+
+  ## Score shape
+
+  Returns `nil` when the candidate does not contain every query
+  character as a subsequence. Returns a `long` ≥ 0 otherwise:
+
+  - Base: each matched char contributes +1.
+  - Word-start bonus: +8 when the char follows a separator
+    (`-`, `_`, `/`, `.`, `:`, ` `) or sits at index 0.
+  - CamelCase bonus: +6 when the matched char is uppercase and the
+    preceding char is lowercase (e.g. `EventDetail` — `E` and `D`
+    both qualify).
+  - Run bonus: +4 for each consecutive char immediately following
+    another matched char. Rewards tight typing (`evdet` → matches
+    `event-detail` with a run on `ev` and `det`).
+  - Prefix bonus: +12 when the very first char matches at index 0.
+  - Gap penalty: -1 per unmatched candidate char that sits BETWEEN
+    matched chars (trailing/leading non-matches are free).
+
+  ## Tie-break
+
+  Equal scores: pick the candidate with the earlier first-match
+  index, then the shorter candidate. `score-with-meta` returns the
+  raw score AND the first-match index so the caller can sort
+  deterministically.
+
+  ## Boundary split (spec/007-UX-IA.md §Indexed sources)
+
+  The spec calls for splits on camelCase / kebab-case / namespace
+  boundaries. The scorer already rewards matches on those boundaries
+  via the word-start / camelCase bonuses; the caller does not need
+  to pre-segment the candidate. A query like `evdt` against
+  `event-detail` scores higher than `event-detail` does against a
+  query like `vntd` precisely because the matched `e`+`d` land on
+  boundaries."
+  (:require [clojure.string :as str]))
+
+(def ^:private separators
+  "Characters that mark word boundaries for the word-start bonus.
+  Mirrors the spec's camelCase / kebab-case / namespace-boundary
+  split: `-` (kebab), `_` (snake), `/` `.` `:` (namespace + path),
+  ` ` (prose). Stored as a set for O(1) lookup."
+  #{\- \_ \/ \. \: \space \tab \> \<})
+
+(defn- separator?
+  [^Character ch]
+  (contains? separators ch))
+
+(defn- upper?
+  "True when `ch` is an ASCII uppercase letter. Cheap predicate over a
+  char range; avoids the platform-coupled `Character/isUpperCase` so
+  the scorer stays CLJC-clean (CLJS has the same range check)."
+  [ch]
+  (let [n (int ch)]
+    (and (>= n 65) (<= n 90))))
+
+(defn- lower?
+  [ch]
+  (let [n (int ch)]
+    (and (>= n 97) (<= n 122))))
+
+(defn- word-start?
+  "True when `idx` sits at a boundary: index 0, or the preceding char
+  is a separator, or the current char is uppercase and the preceding
+  char is lowercase (camelCase boundary)."
+  [candidate idx]
+  (cond
+    (zero? idx) true
+    :else
+    (let [prev (nth candidate (dec idx))
+          curr (nth candidate idx)]
+      (or (separator? prev)
+          (and (upper? curr) (lower? prev))))))
+
+(defn score-with-meta
+  "Score `candidate` against `query`. Both args are strings.
+
+  Returns `nil` when the query is not a case-insensitive subsequence
+  of the candidate. Returns `{:score long :first-match int :indices
+  [int ...]}` otherwise. The `:indices` vector is the per-char match
+  positions in the candidate — useful for caller-side highlight
+  rendering once the v1.0 styling pass lands.
+
+  Empty query short-circuits to a tiny non-zero score (`1`) with no
+  first-match — every candidate qualifies for empty-input mode and
+  the caller's recency / boost weights dominate the order."
+  [candidate query]
+  (cond
+    (nil? candidate) nil
+    (nil? query)     nil
+    (zero? (count query))
+    {:score 1 :first-match nil :indices []}
+
+    :else
+    (let [c-lc (str/lower-case candidate)
+          q-lc (str/lower-case query)
+          c-len (count c-lc)
+          q-len (count q-lc)]
+      (loop [ci 0
+             qi 0
+             score 0
+             last-match-idx -2
+             first-match nil
+             gap-since-match? false
+             indices (transient [])]
+        (cond
+          (= qi q-len)
+          {:score       score
+           :first-match first-match
+           :indices     (persistent! indices)}
+
+          (= ci c-len)
+          nil
+
+          :else
+          (let [cc-lc (nth c-lc ci)
+                qc-lc (nth q-lc qi)
+                cc    (nth candidate ci)]
+            (if (= cc-lc qc-lc)
+              (let [run?       (= ci (inc last-match-idx))
+                    prefix?    (and (zero? ci) (zero? qi))
+                    word-st?   (word-start? candidate ci)
+                    camel-bnd? (and (upper? cc)
+                                    (pos? ci)
+                                    (lower? (nth candidate (dec ci))))
+                    bonus      (cond-> 1
+                                 prefix?     (+ 12)
+                                 word-st?    (+ 8)
+                                 camel-bnd?  (+ 6)
+                                 run?        (+ 4))]
+                (recur (inc ci)
+                       (inc qi)
+                       (+ score bonus)
+                       ci
+                       (or first-match ci)
+                       false
+                       (conj! indices ci)))
+              (recur (inc ci)
+                     qi
+                     (if (and gap-since-match? (pos? last-match-idx))
+                       (dec score)
+                       score)
+                     last-match-idx
+                     first-match
+                     (pos? last-match-idx)
+                     indices))))))))
+
+(defn score
+  "Convenience: return just the score (`long` or `nil`)."
+  [candidate query]
+  (when-let [m (score-with-meta candidate query)]
+    (:score m)))
+
+(defn match?
+  "True iff `query` is a case-insensitive subsequence of `candidate`.
+  Cheap pre-filter when the caller does not need the score."
+  [candidate query]
+  (boolean (score-with-meta candidate query)))

--- a/tools/causa/src/day8/re_frame2_causa/palette/sources.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/palette/sources.cljc
@@ -1,0 +1,369 @@
+(ns day8.re-frame2-causa.palette.sources
+  "Pure-data palette source aggregator for the Causa command palette
+  (rf2-wm7z4).
+
+  Builds the indexed surface the fuzzy scorer ranks against. The fn
+  takes a single `inputs` map — the caller (sub layer in
+  `palette/subs.cljs`) gathers the live data from app-db / framework
+  queries and passes it in. Keeping the aggregator pure means the
+  JVM-runnable spec covers source weighting + dedup without driving a
+  browser.
+
+  ## Item shape
+
+  Each item is a map:
+
+    {:source        keyword     ; :panel | :recent-event | :frame
+                                ; | :handler | :setting | :command
+                                ; | :copilot-question
+     :id            anything    ; stable identifier within the source
+     :label         string      ; what fuzzy matches against + renders
+     :hint          string?     ; right-aligned hint (epoch N, file:line,
+                                ; shortcut, …)
+     :icon          string      ; 1-glyph type icon
+     :recency-rank  int?        ; 0 = most recent; absent = no recency
+     :boost         long        ; static weight added to fuzzy score
+     :action        vector      ; re-frame dispatch vector when invoked
+                                ; — wrapped by events.cljs so it can
+                                ; cross-frame back to `:rf/causa` for
+                                ; panel selection vs `:rf/default` for
+                                ; host re-dispatch.
+     :popout?       boolean?    ; when true, Ctrl+Enter pop-out semantics
+                                ; route the action via popout!
+                                ; Item may opt out (settings, palette-
+                                ; only commands) — see `popoutable?`.
+    }
+
+  ## Scoring
+
+  Final score = fuzzy-score + boost + recency-bonus. Recency adds at
+  most +30 (for `recency-rank = 0`), decaying linearly to 0 at
+  `recency-rank ≥ 30`. Boost defaults to 0; sources with a stable
+  hand-tuned weight (commands > panels > recent-events > frames >
+  handlers) set their own.
+
+  ## Dedup
+
+  When two items share the same `[:source :id]` pair, the first wins
+  (the aggregator orders sources by importance). Within a source, the
+  caller is responsible for upstream dedup."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.palette.fuzzy :as fuzzy]))
+
+;; ---- per-source boosts ---------------------------------------------------
+;;
+;; Hand-tuned weights so command verbs rank above panel jumps when
+;; both fuzzy-match the same query (e.g. typing "cle" yields the
+;; "Clear trace buffer" command above any incidentally-matching panel
+;; whose label contains those letters). Recent events sit below
+;; panels in static weight but typically dominate via their recency
+;; bonus.
+
+(def boost-table
+  {:command          40
+   :panel            30
+   :setting          20
+   :recent-event     10
+   :frame            5
+   :handler          2
+   :copilot-question 8})
+
+(def ^:private icon-table
+  {:command          "▸"
+   :panel            "◧"
+   :setting          "⚙"
+   :recent-event     "⟳"
+   :frame            "◆"
+   :handler          "ƒ"
+   :copilot-question "?"})
+
+;; ---- source builders -----------------------------------------------------
+
+(defn panel-items
+  "One row per sidebar panel. The action dispatches into `:rf/causa`
+  via the wrapping events fn (palette events resolve `[:panel id]`
+  into `[:rf.causa/select-panel id]`)."
+  [panel-entries]
+  (mapv
+    (fn [{:keys [id label]}]
+      {:source :panel
+       :id     id
+       :label  (str "Open " label " panel")
+       :hint   (str "panel/" (name id))
+       :icon   (icon-table :panel)
+       :boost  (boost-table :panel)
+       :action [:palette/select-panel id]
+       :popout? false})
+    panel-entries))
+
+(defn recent-event-items
+  "Indexed from Causa's `:trace-buffer` snapshot. Only `:event/handled`
+  + `:event/dispatched` rows are surfaced — the buffer carries every
+  trace kind but a recent-events palette source means recent
+  dispatches, not every internal trace event.
+
+  Recency rank rises with index from the end (the most-recently-
+  pushed event is rank 0). Caps at 30 rows by default — beyond that
+  the recency bonus is zero anyway, and the palette result list
+  itself is finite."
+  ([buffer]
+   (recent-event-items buffer 30))
+  ([buffer max-rows]
+   (let [event-rows (->> buffer
+                         (filter (fn [t]
+                                   (contains?
+                                     #{:event/handled :event/dispatched}
+                                     (:op t))))
+                         vec)
+         total      (count event-rows)
+         taken      (cond-> event-rows
+                      (pos? total)
+                      (subvec (max 0 (- total max-rows))))
+         taken-cnt  (count taken)]
+     (vec
+       (map-indexed
+         (fn [i t]
+           ;; Last row of `taken` is the most recent — recency-rank 0.
+           (let [rank   (- (dec taken-cnt) i)
+                 ev-id  (or (:event-id t)
+                            (get-in t [:tags :event])
+                            (:id t))
+                 label  (str (pr-str ev-id))]
+             {:source       :recent-event
+              :id           (or (:id t) [ev-id i])
+              :label        label
+              :hint         (str "recent · "
+                                 (if (zero? rank) "latest"
+                                     (str (inc rank) " ago")))
+              :icon         (icon-table :recent-event)
+              :recency-rank rank
+              :boost        (boost-table :recent-event)
+              :action       [:palette/select-event ev-id]
+              :popout?      true}))
+         taken)))))
+
+(defn frame-items
+  "Indexed from `frame-ids` (a seq of registered frame ids). The
+  Causa frame itself is excluded — switching focus to `:rf/causa`
+  via the palette is not a meaningful user operation."
+  [frame-ids]
+  (->> frame-ids
+       (remove #(= :rf/causa %))
+       (mapv (fn [fid]
+               {:source :frame
+                :id     fid
+                :label  (str "Switch focus to frame " (pr-str fid))
+                :hint   (str "frame/" (name fid))
+                :icon   (icon-table :frame)
+                :boost  (boost-table :frame)
+                :action [:palette/select-frame fid]
+                :popout? false}))))
+
+(defn handler-items
+  "Indexed from a `[{:id k :kind k :doc s :file s :line n} ...]`
+  seq. The caller assembles this seq from `re-frame.registrar/
+  registrations` calls; the aggregator stays substrate-agnostic.
+  Caps at 200 handlers by default — beyond that the fuzzy pass
+  starts to dominate sub recomputation cost."
+  ([handler-entries]
+   (handler-items handler-entries 200))
+  ([handler-entries max-rows]
+   (->> handler-entries
+        (take max-rows)
+        (mapv (fn [{:keys [id kind doc file line]}]
+                {:source :handler
+                 :id     [kind id]
+                 :label  (str (name kind) " " (pr-str id))
+                 :hint   (cond
+                           (and file line) (str file ":" line)
+                           doc             (str/replace
+                                             (subs doc 0 (min 60 (count doc)))
+                                             #"\s+" " ")
+                           :else           (name kind))
+                 :icon   (icon-table :handler)
+                 :boost  (boost-table :handler)
+                 :action [:palette/inspect-handler kind id]
+                 :popout? true})))))
+
+(defn setting-items
+  "Static settings the palette can flip / open. Phase 1 ships the co-
+  pilot parity entries (toggle rail, mark first-used)."
+  []
+  [{:source :setting
+    :id     :copilot-toggle
+    :label  "Toggle co-pilot rail"
+    :hint   "Ctrl+Shift+/"
+    :icon   (icon-table :setting)
+    :boost  (boost-table :setting)
+    :action [:palette/copilot-toggle]
+    :popout? false}
+   {:source :setting
+    :id     :density-toggle
+    :label  "Cycle display density"
+    :hint   "compact / cosy / comfy"
+    :icon   (icon-table :setting)
+    :boost  (boost-table :setting)
+    :action [:palette/cycle-density]
+    :popout? false}])
+
+(defn command-items
+  "Causa command verbs (Phase 1 subset). Each carries a stable id +
+  an action dispatch — the events ns owns the actual side-effect
+  fns; the aggregator just describes the choices."
+  []
+  [{:source :command
+    :id     :clear-trace-buffer
+    :label  "Clear trace buffer"
+    :hint   "drops Causa's ring buffer"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/clear-trace-buffer]
+    :popout? false}
+   {:source :command
+    :id     :reset-suppressed-counters
+    :label  "Reset redacted-events counter"
+    :hint   "clears the REDACTED N indicator"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/reset-suppressed-counters]
+    :popout? false}
+   {:source :command
+    :id     :open-popout
+    :label  "Open Causa in a pop-out window"
+    :hint   "rf-causa-popout"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/open-popout]
+    :popout? false}
+   {:source :command
+    :id     :close-palette
+    :label  "Close command palette"
+    :hint   "ESC"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/close]
+    :popout? false}])
+
+(defn copilot-question-items
+  "Indexed from a `[\"text1\" \"text2\" ...]` recency-ordered seq of
+  the last co-pilot questions. The seq's first entry is the most
+  recent question."
+  ([questions]
+   (copilot-question-items questions 10))
+  ([questions max-rows]
+   (->> questions
+        (take max-rows)
+        (map-indexed
+          (fn [i q]
+            {:source       :copilot-question
+             :id           [::copilot-q i q]
+             :label        (str "Re-ask co-pilot: " q)
+             :hint         (str "history · "
+                                (if (zero? i) "latest"
+                                    (str (inc i) " back")))
+             :icon         (icon-table :copilot-question)
+             :recency-rank i
+             :boost        (boost-table :copilot-question)
+             :action       [:palette/reopen-copilot-question q]
+             :popout?      false}))
+        vec)))
+
+;; ---- aggregator ----------------------------------------------------------
+
+(defn build-index
+  "Build the full searchable index from `inputs`. The result is a
+  vector of source items, dedup'd on `[:source :id]` (first-wins).
+  No fuzzy match runs here — this is the pre-query corpus.
+
+  Inputs map shape:
+
+    {:panels            [{:id kw :label str} ...]
+     :trace-buffer      [trace ...]
+     :frame-ids         (keyword?)
+     :handlers          [{:id :kind :doc :file :line} ...]
+     :copilot-questions [str ...]}
+
+  Missing keys default to empty inputs of that kind — partial drives
+  (e.g. recency-rank dragons without a populated buffer) are
+  tolerable for the empty-state surface."
+  [inputs]
+  (let [{:keys [panels trace-buffer frame-ids handlers copilot-questions]
+         :or   {panels             []
+                trace-buffer       []
+                frame-ids          []
+                handlers           []
+                copilot-questions  []}} inputs
+        all      (concat
+                   (command-items)
+                   (panel-items panels)
+                   (setting-items)
+                   (recent-event-items trace-buffer)
+                   (copilot-question-items copilot-questions)
+                   (frame-items frame-ids)
+                   (handler-items handlers))]
+    (loop [seen   (transient #{})
+           out    (transient [])
+           items  all]
+      (if (empty? items)
+        (persistent! out)
+        (let [it   (first items)
+              key  [(:source it) (:id it)]]
+          (if (contains? seen key)
+            (recur seen out (rest items))
+            (recur (conj! seen key) (conj! out it) (rest items))))))))
+
+;; ---- ranking -------------------------------------------------------------
+
+(defn- recency-bonus
+  "Linear decay: rank 0 → +30, rank 30+ → 0."
+  [rank]
+  (if (nil? rank)
+    0
+    (max 0 (- 30 rank))))
+
+(defn score-item
+  "Score a single item against `query`. Returns `nil` when the item's
+  label does not fuzzy-match the query; otherwise returns the item
+  augmented with `:score` (final) + `:fuzzy` (raw fuzzy score) +
+  `:indices` (matched char positions)."
+  [item query]
+  (when-let [m (fuzzy/score-with-meta (:label item) query)]
+    (let [fuzzy-s (:score m)
+          final   (+ fuzzy-s
+                     (or (:boost item) 0)
+                     (recency-bonus (:recency-rank item)))]
+      (assoc item
+             :score    final
+             :fuzzy    fuzzy-s
+             :indices  (:indices m)))))
+
+(defn rank
+  "Rank `index` against `query`. Returns a sorted vector of scored
+  items (highest score first). Empty query keeps every item and
+  orders by `boost + recency-bonus` alone — useful for the empty-
+  state surface where the palette shows the most-actionable choices."
+  ([index query]
+   (rank index query 30))
+  ([index query limit]
+   (let [scored (->> index
+                     (keep #(score-item % query))
+                     vec)
+         sorted (->> scored
+                     (sort-by (fn [it]
+                                ;; sort descending on score; tie-break
+                                ;; ascending on label length (shorter
+                                ;; labels are usually the more
+                                ;; specific match) then on label
+                                ;; lexicographic.
+                                [(- (:score it))
+                                 (count (:label it))
+                                 (:label it)])))]
+     (vec (take limit sorted)))))
+
+(defn popoutable?
+  "True when an item supports Ctrl+Enter pop-out semantics. The
+  palette UI reads this to decide whether to surface the pop-out
+  hint and whether to wrap the invoke through `popout!`. Defaults
+  to `false` — a source must explicitly opt in."
+  [item]
+  (true? (:popout? item)))

--- a/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
@@ -1,0 +1,159 @@
+(ns day8.re-frame2-causa.palette.subs
+  "Subscriptions for the Causa command palette (rf2-wm7z4).
+
+  ## Sub tree
+
+  - `:rf.causa/palette-open?`   — boolean. Drives the modal mount.
+  - `:rf.causa/palette-query`   — current input text.
+  - `:rf.causa/palette-cursor`  — selected row index (0-based).
+  - `:rf.causa/palette-index`   — full source-aggregator output.
+    Recomputes when its input subs (trace-buffer, frame-ids,
+    handler set, copilot questions) change.
+  - `:rf.causa/palette-results` — ranked rows for the current query.
+    Recomputes only when query OR index changes.
+  - `:rf.causa/palette-active-item` — convenience: results[cursor].
+
+  The `palette-index` sub deliberately pulls the registrar +
+  frame-ids snapshot inside the sub body (i.e. NOT via `:<-`) — the
+  registrar / frame registry are atoms outside re-frame's reactive
+  graph, so a `:<-` dependency on them would never recompute.
+  Recomputation happens whenever `:trace-buffer` writes (which is
+  every dispatch) — i.e. roughly the same cadence as the trace
+  panel's redraws — and the cost is bounded by `build-index` (linear
+  in source-item count). Acceptable because the modal is closed
+  most of the time; when open the user is actively typing.
+
+  ## Sidebar items reference
+
+  The panel list is the same one the sidebar renders (shell.cljs).
+  Importing the shell's `sidebar-items` directly would create a
+  shell→palette→shell cycle once we wire `Modal` into the shell;
+  instead the palette holds its own canonical list and the shell
+  reads from it. The list is small (~16 entries) and the
+  duplication cost is negligible compared to the cycle-break."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.palette.sources :as sources]))
+
+;; ---- canonical panel list ------------------------------------------------
+;;
+;; Single source of truth for both the sidebar (shell.cljs) and the
+;; palette source aggregator. Mirrors `shell/sidebar-items` minus the
+;; sidebar's `:dormant?` marker (the palette surfaces every panel
+;; regardless of activity — a Hydration row shows up even when the
+;; dormant glyph would otherwise hide it).
+(def palette-panels
+  [{:id :event-detail :label "Event detail"}
+   {:id :time-travel  :label "Time travel"}
+   {:id :app-db       :label "App-db"}
+   {:id :causality    :label "Causality"}
+   {:id :subs         :label "Subscriptions"}
+   {:id :fx           :label "Effects"}
+   {:id :trace        :label "Trace"}
+   {:id :machines     :label "Machines"}
+   {:id :flows        :label "Flows"}
+   {:id :routes       :label "Routes"}
+   {:id :performance  :label "Performance"}
+   {:id :issues       :label "Issues"}
+   {:id :schemas      :label "Schemas"}
+   {:id :hydration    :label "Hydration"}
+   {:id :mcp-server   :label "MCP"}
+   {:id :copilot      :label "Co-pilot"}])
+
+(defn- handler-entries
+  "Flat seq of `{:id :kind :doc :file :line}` rows from the framework
+  registrar. Kinds covered: :event, :sub, :fx, :cofx — the four the
+  user typically wants to jump to. The registrar query is dirt-cheap
+  (transient walk over an in-memory map) so the cost lives in the
+  downstream fuzzy pass."
+  []
+  (let [kinds [:event :sub :fx :cofx]]
+    (->> kinds
+         (mapcat
+           (fn [kind]
+             (->> (rf/registrations kind)
+                  (map (fn [[id meta]]
+                         {:id   id
+                          :kind kind
+                          :doc  (:doc meta)
+                          :file (:file meta)
+                          :line (:line meta)})))))
+         vec)))
+
+(defn- copilot-question-strings
+  "Pull the last N question texts from the co-pilot conversation in
+  app-db. Conversation shape is implemented by
+  `panels/ai-co-pilot-helpers` — each turn is a `{:role :type :text}`
+  map; we keep only `:question` turns. Most-recent first."
+  [db]
+  (->> (get db :copilot-conversation [])
+       (filter #(= :question (:type %)))
+       (map :text)
+       (filter some?)
+       reverse
+       (take 10)
+       vec))
+
+(defn install!
+  "Install the palette's subs. Idempotent under re-frame's replace-
+  in-place registrar semantics."
+  []
+
+  (rf/reg-sub :rf.causa/palette-open?
+    (fn [db _query]
+      (boolean (get db :palette-open? false))))
+
+  (rf/reg-sub :rf.causa/palette-query
+    (fn [db _query]
+      (or (get db :palette-query) "")))
+
+  (rf/reg-sub :rf.causa/palette-cursor
+    (fn [db _query]
+      (max 0 (or (get db :palette-cursor) 0))))
+
+  ;; Layer-2 — aggregates the searchable corpus. Depends on
+  ;; `:rf.causa/trace-buffer` (recent events) so it re-fires on every
+  ;; trace push; the registrar / frame snapshot lookups happen inside
+  ;; the body and ride that same recompute cadence.
+  (rf/reg-sub :rf.causa/palette-index
+    :<- [:rf.causa/trace-buffer]
+    (fn [buffer _query]
+      ;; The sub fn does not receive `db`; we reach into the registrar
+      ;; (a process-global atom) + the framework's frame registry
+      ;; via the public rf wrappers. For the copilot-questions
+      ;; source we still need db — pull it via a sibling sub below
+      ;; rather than thread db through this layer-2.
+      (sources/build-index
+        {:panels             palette-panels
+         :trace-buffer       buffer
+         :frame-ids          (rf/frame-ids)
+         :handlers           (handler-entries)
+         :copilot-questions  []})))
+
+  ;; Sibling layer-2 carrying the copilot-questions slice — separated
+  ;; so the index sub above stays decoupled from co-pilot conversation
+  ;; churn (every keystroke into the co-pilot input would otherwise
+  ;; recompute the whole palette index).
+  (rf/reg-sub :rf.causa/palette-copilot-questions
+    (fn [db _query]
+      (copilot-question-strings db)))
+
+  ;; Layer-3 — ranked results for the current query. Folds the
+  ;; copilot-questions slice into the index here so the cheap pull
+  ;; rides the rank pass without forcing the whole index to recompute.
+  (rf/reg-sub :rf.causa/palette-results
+    :<- [:rf.causa/palette-index]
+    :<- [:rf.causa/palette-query]
+    :<- [:rf.causa/palette-copilot-questions]
+    (fn [[index query questions] _query]
+      (let [with-q (into index
+                         (sources/copilot-question-items questions))]
+        (sources/rank with-q query))))
+
+  (rf/reg-sub :rf.causa/palette-active-item
+    :<- [:rf.causa/palette-results]
+    :<- [:rf.causa/palette-cursor]
+    (fn [[results cursor] _query]
+      (when (and (seq results) (< cursor (count results)))
+        (nth results cursor))))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -1,0 +1,279 @@
+(ns day8.re-frame2-causa.palette.view
+  "View for the Causa command palette (rf2-wm7z4).
+
+  Per `tools/causa/spec/007-UX-IA.md` §Command palette:
+  - 560px centred modal
+  - 40px row layout (compact 32, comfy 48 — Phase 1 ships 40)
+  - 16px type icon · label · right-aligned hint (epoch / coord / shortcut)
+  - Arrows navigate · Enter invokes · Ctrl+Enter pops out
+
+  The component is a plain Reagent fn — the facade
+  `palette.cljs` wraps it in `reg-view` so its subscribes route to
+  the surrounding `:rf/causa` frame via React context.
+
+  ## Modal layer
+
+  Phase 1 layers the palette over the Causa shell's `shell-view`
+  (mounted there so subscribes resolve through the shell's frame
+  provider). The backdrop swallows clicks outside the dialog and
+  closes the palette; the dialog itself stops propagation so input
+  / row clicks don't bubble.
+
+  ## Keyboard handling
+
+  The text input owns key handling: ArrowDown / ArrowUp moves the
+  cursor, Enter invokes, Ctrl+Enter (or Cmd+Enter on mac) invokes
+  in a pop-out, ESC closes. The shell-level Cmd/Ctrl+K listener
+  handles open; ESC inside the input also closes so the user does
+  not need to drop modifier hands."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.palette.sources :as sources]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+;; ---- per-source visual style --------------------------------------------
+
+(def ^:private source-colour
+  {:command          (:accent-violet tokens)
+   :panel            (:cyan tokens)
+   :setting          (:yellow tokens)
+   :recent-event     (:green tokens)
+   :frame            (:magenta tokens)
+   :handler          (:text-secondary tokens)
+   :copilot-question (:orange tokens)})
+
+(defn- backdrop-style []
+  {:position         "fixed"
+   :top              0
+   :left             0
+   :right            0
+   :bottom           0
+   :background       "rgba(0,0,0,0.55)"
+   :backdrop-filter  "blur(2px)"
+   :display          "flex"
+   :align-items      "flex-start"
+   :justify-content  "center"
+   :padding-top      "12vh"
+   :z-index          2147483646})
+
+(defn- dialog-style []
+  {:width            "560px"
+   :max-width        "92vw"
+   :max-height       "60vh"
+   :display          "flex"
+   :flex-direction   "column"
+   :background       (:bg-1 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "8px"
+   :box-shadow       "rgba(0,0,0,0.6) 0 24px 64px"
+   :overflow         "hidden"
+   :font-family      sans-stack
+   :color            (:text-primary tokens)})
+
+(defn- input-row-style []
+  {:display          "flex"
+   :align-items      "center"
+   :gap              "10px"
+   :padding          "12px 16px"
+   :border-bottom    (str "1px solid " (:border-subtle tokens))
+   :background       (:bg-2 tokens)})
+
+(defn- input-style []
+  {:flex             1
+   :background       "transparent"
+   :border           "none"
+   :outline          "none"
+   :color            (:text-primary tokens)
+   :font-family      sans-stack
+   :font-size        "14px"})
+
+(defn- list-style []
+  {:flex             1
+   :overflow-y       "auto"
+   :overflow-x       "hidden"
+   :margin           0
+   :padding          "4px 0"
+   :list-style       "none"})
+
+(defn- row-style [active?]
+  {:display          "flex"
+   :align-items      "center"
+   :gap              "12px"
+   :padding          "0 16px"
+   :height           "40px"
+   :cursor           "pointer"
+   :background       (if active? (:bg-active tokens) "transparent")
+   :color            (:text-primary tokens)
+   :font-family      sans-stack
+   :font-size        (:body type-scale)})
+
+(defn- icon-style [source]
+  {:width            "16px"
+   :flex-shrink      0
+   :text-align       "center"
+   :color            (or (source-colour source) (:text-secondary tokens))
+   :font-family      mono-stack
+   :font-size        "14px"})
+
+(defn- hint-style []
+  {:flex-shrink      0
+   :max-width        "220px"
+   :overflow         "hidden"
+   :text-overflow    "ellipsis"
+   :white-space      "nowrap"
+   :color            (:text-tertiary tokens)
+   :font-family      mono-stack
+   :font-size        (:caption type-scale)})
+
+(defn- footer-style []
+  {:display          "flex"
+   :align-items      "center"
+   :justify-content  "space-between"
+   :padding          "8px 16px"
+   :border-top       (str "1px solid " (:border-subtle tokens))
+   :background       (:bg-2 tokens)
+   :color            (:text-tertiary tokens)
+   :font-family      sans-stack
+   :font-size        (:caption type-scale)})
+
+(defn- footer-key-style []
+  {:padding          "1px 6px"
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "3px"
+   :background       (:bg-3 tokens)
+   :color            (:text-secondary tokens)
+   :font-family      mono-stack
+   :font-size        "10px"
+   :margin           "0 2px"})
+
+;; ---- empty state --------------------------------------------------------
+
+(defn- empty-message [query]
+  (if (seq query)
+    (str "No matches for " (pr-str query) " — try a shorter query.")
+    "Type to search. ↑↓ navigate · Enter invokes · Ctrl+Enter pops out · ESC closes."))
+
+(defn- empty-row []
+  [:li {:data-testid "rf-causa-palette-empty"
+        :style       (merge (row-style false)
+                            {:cursor "default"
+                             :color  (:text-tertiary tokens)})}
+   [:span {:style (icon-style :handler)} "·"]
+   [:span {:style {:flex 1}}
+    (empty-message @(rf/subscribe [:rf.causa/palette-query]))]])
+
+;; ---- row ----------------------------------------------------------------
+
+(defn- result-row
+  [{:keys [source label hint icon] :as item} active? idx]
+  [:li {:key          (str "row-" idx)
+        :data-testid  (str "rf-causa-palette-row-" idx)
+        :data-source  (name source)
+        :data-active  (str active?)
+        :on-click     #(rf/dispatch
+                         [:rf.causa/palette-invoke item
+                          (boolean (or (.-ctrlKey %) (.-metaKey %)))])
+        :on-mouse-enter #(rf/dispatch [:rf.causa/palette-cursor-set idx])
+        :style        (row-style active?)}
+   [:span {:style (icon-style source)} icon]
+   [:span {:style {:flex             1
+                   :overflow         "hidden"
+                   :text-overflow    "ellipsis"
+                   :white-space      "nowrap"}}
+    label]
+   (when hint
+     [:span {:style (hint-style)} hint])
+   (when (sources/popoutable? item)
+     [:span {:style (merge (hint-style)
+                           {:margin-left "8px"
+                            :color (:accent-violet tokens)})}
+      "⇱"])])
+
+;; ---- key handling -------------------------------------------------------
+
+(defn- handle-input-keydown
+  [^js e results]
+  (let [k         (.-key e)
+        ctrl?     (or (.-ctrlKey e) (.-metaKey e))
+        count     (count results)
+        cursor    @(rf/subscribe [:rf.causa/palette-cursor])
+        active    (when (and (seq results) (< cursor count))
+                    (nth results cursor))]
+    (case k
+      "ArrowDown" (do (.preventDefault e)
+                      (rf/dispatch
+                        [:rf.causa/palette-cursor-down (dec count)]))
+      "ArrowUp"   (do (.preventDefault e)
+                      (rf/dispatch [:rf.causa/palette-cursor-up]))
+      "Enter"     (when active
+                    (.preventDefault e)
+                    (rf/dispatch
+                      [:rf.causa/palette-invoke active (boolean ctrl?)]))
+      "Escape"    (do (.preventDefault e)
+                      (rf/dispatch [:rf.causa/palette-close]))
+      "Home"      (do (.preventDefault e)
+                      (rf/dispatch [:rf.causa/palette-cursor-set 0]))
+      "End"       (do (.preventDefault e)
+                      (rf/dispatch [:rf.causa/palette-cursor-set (dec count)]))
+      nil)))
+
+;; ---- main view ---------------------------------------------------------
+
+(defn palette-view
+  "The hiccup for the open palette. Caller (`palette/Modal`) gates
+  the mount on `:rf.causa/palette-open?` — this fn assumes it's open
+  and always renders."
+  []
+  (let [query   (or @(rf/subscribe [:rf.causa/palette-query]) "")
+        results @(rf/subscribe [:rf.causa/palette-results])
+        cursor  @(rf/subscribe [:rf.causa/palette-cursor])]
+    [:div {:data-testid "rf-causa-palette-backdrop"
+           :on-click    #(rf/dispatch [:rf.causa/palette-close])
+           :style       (backdrop-style)}
+     [:div {:data-testid "rf-causa-palette-dialog"
+            :data-rf-causa-mode "palette"
+            :on-click    #(.stopPropagation %)
+            :style       (dialog-style)}
+      [:div {:style (input-row-style)}
+       [:span {:style (icon-style :command)} "⌘"]
+       [:input {:data-testid  "rf-causa-palette-input"
+                :type         "text"
+                :auto-focus   true
+                :value        query
+                :placeholder  "Search panels, events, frames, commands…"
+                :on-change    #(rf/dispatch
+                                 [:rf.causa/palette-set-query
+                                  (.. % -target -value)])
+                :on-key-down  #(handle-input-keydown % results)
+                :style        (input-style)}]
+       [:span {:data-testid "rf-causa-palette-result-count"
+               :style {:color (:text-tertiary tokens)
+                       :font-family mono-stack
+                       :font-size "11px"}}
+        (str (count results)
+             (when (seq query) (str " / " (count results))))]]
+      (if (empty? results)
+        [:ul {:data-testid "rf-causa-palette-list"
+              :style       (list-style)}
+         [empty-row]]
+        (into [:ul {:data-testid "rf-causa-palette-list"
+                    :style       (list-style)}]
+              (map-indexed
+                (fn [idx item]
+                  (result-row item (= idx cursor) idx))
+                results)))
+      [:div {:style (footer-style)}
+       [:div
+        [:span {:style (footer-key-style)} "↑↓"]
+        [:span "navigate"]
+        [:span {:style {:margin "0 8px"}} "·"]
+        [:span {:style (footer-key-style)} "Enter"]
+        [:span "open"]
+        [:span {:style {:margin "0 8px"}} "·"]
+        [:span {:style (footer-key-style)} "Ctrl"]
+        [:span "+"]
+        [:span {:style (footer-key-style)} "Enter"]
+        [:span "pop-out"]]
+       [:div
+        [:span {:style (footer-key-style)} "ESC"]
+        [:span "close"]]]]]))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -34,6 +34,7 @@
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.ai-co-pilot :as ai-co-pilot]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
@@ -331,6 +332,7 @@
     ;; per-panel pattern.
 
     (open-in-editor/install!)
+    (palette/install!)
     (ai-co-pilot/install!)
     (app-db-diff/install!)
     (causality-graph/install!)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -74,6 +74,7 @@
             [day8.re-frame2-causa.panels.schema-violation-timeline :as schema-violation-timeline]
             [day8.re-frame2-causa.panels.subscriptions :as subscriptions]
             [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.theme.tokens :refer [tokens type-scale layout]]))
@@ -458,5 +459,10 @@
      [sidebar]
      [canvas]
      [rail-gate]]
-    [bottom-rail]]])
+    [bottom-rail]
+    ;; Command palette (rf2-wm7z4) — mounted at the shell root so it
+    ;; overlays the chrome + panels. The Modal short-circuits to nil
+    ;; when `:rf.causa/palette-open?` is false; closed-state cost is
+    ;; a single subscribe + when-gate.
+    [palette/Modal]]])
 

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -60,6 +60,11 @@
   [event]
   (#'keybinding/copilot-toggle-key? event))
 
+(defn- palette-toggle-key?
+  "rf2-wm7z4 — the Cmd/Ctrl+K command-palette predicate."
+  [event]
+  (#'keybinding/palette-toggle-key? event))
+
 ;; ---- stub `js/document` --------------------------------------------------
 ;;
 ;; The `attach!` / `detach!` helpers are guarded by `(exists?
@@ -264,18 +269,70 @@
 ;; ---- (3) toggles are mutually exclusive ----------------------------------
 
 (deftest predicates-are-mutually-exclusive
-  (testing "no synthetic event satisfies both predicates simultaneously —
+  (testing "no synthetic event satisfies more than one predicate at once —
             mutual exclusivity matters because `handle-keydown` uses
-            `cond` and a both-match case would silently route to causa
-            and drop the copilot path"
+            `cond` and a multi-match case would silently route to the
+            first arm and drop the others"
     (doseq [event [(mk-event {:key "C" :ctrl? true :shift? true})
                    (mk-event {:key "/" :ctrl? true :shift? true})
                    (mk-event {:key "?" :ctrl? true :shift? true})
                    (mk-event {:code "KeyC" :ctrl? true :shift? true})
-                   (mk-event {:code "Slash" :ctrl? true :shift? true})]]
-      (is (not (and (causa-toggle-key? event)
-                    (copilot-toggle-key? event)))
-          (str "event " (js->clj event) " must match at most one predicate")))))
+                   (mk-event {:code "Slash" :ctrl? true :shift? true})
+                   (mk-event {:key "k" :ctrl? true})
+                   (mk-event {:key "k" :meta? true})
+                   (mk-event {:code "KeyK" :ctrl? true})]]
+      (let [matches (cond-> 0
+                      (causa-toggle-key? event)   inc
+                      (copilot-toggle-key? event) inc
+                      (palette-toggle-key? event) inc)]
+        (is (<= matches 1)
+            (str "event " (js->clj event) " must match at most one predicate"))))))
+
+;; ---- (3b) palette-toggle-key? truth table (rf2-wm7z4) --------------------
+
+(deftest palette-toggle-key-matches-cmd-k-and-ctrl-k
+  (testing "Ctrl+K — Windows / Linux convention"
+    (is (true? (palette-toggle-key?
+                 (mk-event {:key "k" :ctrl? true}))))
+    (is (true? (palette-toggle-key?
+                 (mk-event {:key "K" :ctrl? true})))))
+  (testing "Cmd+K — macOS convention (Meta modifier)"
+    (is (true? (palette-toggle-key?
+                 (mk-event {:key "k" :meta? true})))))
+  (testing "`code` fallback — KeyK"
+    (is (true? (palette-toggle-key?
+                 (mk-event {:code "KeyK" :ctrl? true}))))))
+
+(deftest palette-toggle-key-rejects-shift
+  (testing "Ctrl+Shift+K is Firefox dev-tools — must not be hijacked"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:key "k" :ctrl? true :shift? true})))))
+  (testing "Cmd+Shift+K likewise"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:key "k" :meta? true :shift? true}))))))
+
+(deftest palette-toggle-key-rejects-both-modifiers
+  (testing "Ctrl+Cmd+K — both modifiers held is ambiguous; reject"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:key "k" :ctrl? true :meta? true}))))))
+
+(deftest palette-toggle-key-rejects-no-modifier
+  (testing "plain k must NOT open the palette — that would hijack
+            every k keystroke in the host app"
+    (is (false? (palette-toggle-key? (mk-event {:key "k"}))))))
+
+(deftest palette-toggle-key-rejects-alt
+  (testing "Ctrl+Alt+K is an IME composition on some layouts — reject"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:key "k" :ctrl? true :alt? true}))))))
+
+(deftest palette-toggle-key-rejects-wrong-key
+  (testing "wrong key letter, right modifiers"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:key "j" :ctrl? true})))))
+  (testing "wrong `code`, right modifiers"
+    (is (false? (palette-toggle-key?
+                  (mk-event {:code "KeyJ" :ctrl? true}))))))
 
 ;; ---- (4) attach! / detach! idempotency sentinel --------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/palette/events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/palette/events_cljs_test.cljs
@@ -1,0 +1,245 @@
+(ns day8.re-frame2-causa.palette.events-cljs-test
+  "CLJS end-to-end tests for the palette's open/close/cursor/invoke
+  contracts (rf2-wm7z4).
+
+  Drives the registered events against the live registrar so the
+  test exercises the same code paths the keybinding + view dispatch
+  through. Mirrors the per-panel facade-pair test pattern (`subs +
+  events`, replay via `rf/dispatch-sync`).
+
+  The palette pop-out fx is replaced with a counting stub so the
+  Ctrl+Enter / open-popout invocations can be asserted without
+  driving the mount layer (which would need a real `window.open`)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!)
+  (config/set-project-root! nil))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- helpers -----------------------------------------------------------
+
+(def ^:private popout-calls (atom 0))
+
+(defn- install-popout-counter!
+  "Install the counting stub AFTER `setup!` has run — `register-causa-
+  handlers!` re-registers `:rf.causa.palette.fx/popout` from
+  events.cljs, so a stub installed before setup would be clobbered."
+  []
+  (reset! popout-calls 0)
+  (rf/reg-fx :rf.causa.palette.fx/popout
+             (fn [_ _] (swap! popout-calls inc) nil)))
+
+(defn- causa-db []
+  (rf/get-frame-db :rf/causa))
+
+;; ---- open / close / toggle --------------------------------------------
+
+(deftest palette-open-flips-flag
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open]))
+  (is (true? (boolean (:palette-open? (causa-db)))))
+  (is (= "" (:palette-query (causa-db))))
+  (is (= 0 (:palette-cursor (causa-db)))))
+
+(deftest palette-close-resets-state
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync [:rf.causa/palette-set-query "abc"])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-set 3])
+    (rf/dispatch-sync [:rf.causa/palette-close]))
+  (let [db (causa-db)]
+    (is (false? (boolean (:palette-open? db))))
+    (is (= "" (:palette-query db)))
+    (is (= 0 (:palette-cursor db)))))
+
+(deftest palette-toggle-cycles
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-toggle]))
+  (is (true? (boolean (:palette-open? (causa-db)))))
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-toggle]))
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+;; ---- cursor ------------------------------------------------------------
+
+(deftest cursor-up-clamps-at-zero
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-up])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-up]))
+  (is (= 0 (:palette-cursor (causa-db)))))
+
+(deftest cursor-down-respects-max
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4])
+    ;; one more — should clamp at 4
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-down 4]))
+  (is (= 4 (:palette-cursor (causa-db)))))
+
+(deftest set-query-resets-cursor
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync [:rf.causa/palette-cursor-set 5])
+    (rf/dispatch-sync [:rf.causa/palette-set-query "ev"]))
+  (is (= "ev" (:palette-query (causa-db))))
+  (is (= 0 (:palette-cursor (causa-db)))
+      "changing the query should snap the cursor back to the top
+       result — otherwise the cursor lands on a row that's no longer
+       in the filtered set"))
+
+;; ---- invoke ------------------------------------------------------------
+
+(deftest invoke-select-panel-dispatches-and-closes
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :panel
+        :id     :trace
+        :label  "Open Trace panel"
+        :action [:palette/select-panel :trace]}
+       false]))
+  (is (= :trace (:selected-panel (causa-db))))
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-select-event-routes-to-event-detail
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :recent-event
+        :id     [:foo/bar 1]
+        :label  "[:foo/bar]"
+        :action [:palette/select-event [:foo/bar]]
+        :popout? true}
+       false]))
+  (is (= :event-detail (:selected-panel (causa-db))))
+  (is (= [:foo/bar]    (:selected-event-id (causa-db))))
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-clear-trace-buffer-empties-buffer
+  (setup!)
+  ;; Seed the buffer first so we can observe the clear.
+  (trace-bus/seed-buffer-for-test! {:id 1 :op :event/handled :event-id [:foo]})
+  (is (pos? (count (trace-bus/buffer))))
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :clear-trace-buffer
+        :label  "Clear trace buffer"
+        :action [:palette/clear-trace-buffer]}
+       false]))
+  (is (zero? (count (trace-bus/buffer))))
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-copilot-toggle-dispatches-copilot-toggle
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :setting
+        :id     :copilot-toggle
+        :label  "Toggle co-pilot rail"
+        :action [:palette/copilot-toggle]}
+       false]))
+  (is (true? (boolean (:copilot-open? (causa-db))))
+      "palette-invoke lowers :palette/copilot-toggle into the
+       :rf.causa/copilot-toggle event the co-pilot already owns"))
+
+(deftest popout-flag-routes-through-fx-when-popoutable
+  (setup!)
+  (install-popout-counter!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :recent-event
+        :id     [:foo/bar 1]
+        :label  "[:foo/bar]"
+        :action [:palette/select-event [:foo/bar]]
+        :popout? true}
+       true]))
+  (is (= 1 @popout-calls)
+      "popout? true + popoutable item → fx fires once"))
+
+(deftest popout-flag-ignored-when-item-opts-out
+  (setup!)
+  (install-popout-counter!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :panel
+        :id     :trace
+        :label  "Open Trace panel"
+        :action [:palette/select-panel :trace]
+        :popout? false}
+       true]))
+  (is (zero? @popout-calls)
+      "non-popoutable items invoke normally even with the
+       Ctrl-modifier flag set — no surprise pop-out windows"))
+
+(deftest invoke-open-popout-fires-fx
+  (setup!)
+  (install-popout-counter!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :open-popout
+        :label  "Open Causa in a pop-out window"
+        :action [:palette/open-popout]}
+       false]))
+  (is (= 1 @popout-calls)))
+
+(deftest invoke-close-action-closes-palette
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :close-palette
+        :label  "Close command palette"
+        :action [:palette/close]}
+       false]))
+  (is (false? (boolean (:palette-open? (causa-db))))))

--- a/tools/causa/test/day8/re_frame2_causa/palette/fuzzy_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/palette/fuzzy_test.cljc
@@ -1,0 +1,108 @@
+(ns day8.re-frame2-causa.palette.fuzzy-test
+  "Tests for the palette's fuzzy subsequence scorer (rf2-wm7z4).
+
+  Pure-data CLJC: every assertion runs equally under JVM clojure.test
+  and the cljs node-test runtime. The scorer is the perceived-
+  quality lever for the whole palette — these tests pin its scoring
+  rules so a future tweak can be challenged against concrete
+  examples rather than vibes."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.palette.fuzzy :as fuzzy]))
+
+(deftest empty-query-matches-everything-with-tiny-score
+  (testing "empty query is the 'show everything' mode — the caller's
+            recency / boost weights dominate the order"
+    (is (= 1 (:score (fuzzy/score-with-meta "Open Time travel panel" ""))))
+    (is (= 1 (:score (fuzzy/score-with-meta "anything" ""))))
+    (is (nil? (:first-match (fuzzy/score-with-meta "anything" ""))))))
+
+(deftest nil-inputs-are-safe
+  (testing "nil candidate or nil query returns nil — defensive guard"
+    (is (nil? (fuzzy/score-with-meta nil "foo")))
+    (is (nil? (fuzzy/score-with-meta "foo" nil)))
+    (is (nil? (fuzzy/score-with-meta nil nil)))))
+
+(deftest non-matching-query-returns-nil
+  (testing "missing chars → nil; partial match is not a match"
+    (is (nil? (fuzzy/score "event-detail" "xyz")))
+    (is (nil? (fuzzy/score "event-detail" "evtz"))
+        "the t exists but z does not — whole query must match"))
+
+  (testing "out-of-order chars → nil; subsequence must preserve order"
+    (is (nil? (fuzzy/score "event-detail" "deve"))
+        "d comes after e in candidate but query asks for de-ve — fail")))
+
+(deftest case-insensitive-match
+  (testing "uppercase query matches lowercase candidate"
+    (is (some? (fuzzy/score "event-detail" "EV"))))
+  (testing "lowercase query matches CamelCase candidate"
+    (is (some? (fuzzy/score "EventDetail" "ed")))))
+
+(deftest prefix-bonus-beats-mid-string-match
+  (testing "match at index 0 outranks the same letters mid-string"
+    (let [prefix-s (fuzzy/score "event-detail" "ev")
+          mid-s    (fuzzy/score "the-event-feed" "ev")]
+      (is (> prefix-s mid-s)
+          "prefix should win — 'ev' as the start of 'event-detail' is
+           a stronger signal than 'ev' inside 'the-event-feed'"))))
+
+(deftest word-start-bonus-on-separator
+  (testing "matched char following `-` scores higher than matched char
+            inside a word run"
+    ;; 'fl' at word starts vs inside a word
+    (let [word-start (fuzzy/score "first-line" "fl")
+          inside     (fuzzy/score "filling" "fl")]
+      (is (> word-start inside)))))
+
+(deftest camelcase-boundary-bonus
+  (testing "uppercase-after-lowercase matched char gets the camel bonus"
+    ;; ED in EventDetail are both camelcase boundaries
+    (let [boundary (fuzzy/score "EventDetail" "ED")
+          flat     (fuzzy/score "Editable" "Ed")]
+      (is (> boundary flat)
+          "ED on the EventDetail camel boundaries should beat Ed at
+           the start of Editable"))))
+
+(deftest consecutive-match-run-bonus
+  (testing "consecutive matched chars score higher than scattered ones"
+    (let [run        (fuzzy/score "abcdef" "abc")
+          scattered  (fuzzy/score "axbxcx" "abc")]
+      (is (> run scattered)
+          "abc as a tight run scores higher than abc scattered"))))
+
+(deftest indices-track-match-positions
+  (testing "the per-char indices vector reflects where each query
+            char landed in the candidate"
+    (let [m (fuzzy/score-with-meta "event-detail" "edt")]
+      ;; 'event-detail' indices: e=0 v=1 e=2 n=3 t=4 -=5 d=6 e=7 t=8 …
+      ;; 'edt' matches e@0, d@6, t@8 (the t at index 4 is skipped because
+      ;; the matcher takes the FIRST d after 0 then the FIRST t after 6).
+      (is (= [0 6 8] (:indices m))
+          "e at 0, then d at 6, then t at 8 in 'event-detail'"))))
+
+(deftest first-match-tracks-leading-position
+  (testing "first-match is the index of the first query char in the
+            candidate — drives tie-break in the caller"
+    (is (= 0 (:first-match (fuzzy/score-with-meta "event-detail" "ev"))))
+    ;; 'the-event-detail' — the first 'e' is at index 2 ('t','h','e'),
+    ;; so the greedy matcher takes 'e' at 2 then 'v' at 5.
+    (is (= 2 (:first-match (fuzzy/score-with-meta "the-event-detail" "ev"))))
+    (is (nil? (:first-match (fuzzy/score-with-meta "anything" ""))))))
+
+(deftest match-predicate-mirrors-score-nil
+  (testing "(match? c q) is (some? (score c q))"
+    (is (true?  (fuzzy/match? "event-detail" "ev")))
+    (is (false? (fuzzy/match? "event-detail" "xyz")))
+    (is (true?  (fuzzy/match? "anything" ""))
+        "empty query → match")))
+
+(deftest representative-palette-queries
+  (testing "representative shortcuts the user is likely to type"
+    ;; 'evdt' → event-detail wins by a wide margin
+    (let [evdt-event-detail (fuzzy/score "Open Event detail panel" "evdt")
+          evdt-trace        (fuzzy/score "Open Trace panel" "evdt")]
+      (is (some? evdt-event-detail))
+      (is (or (nil? evdt-trace) (> evdt-event-detail evdt-trace))))
+
+    ;; 'cl' → 'Clear trace buffer' should match
+    (is (some? (fuzzy/score "Clear trace buffer" "cl")))))

--- a/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
@@ -1,0 +1,196 @@
+(ns day8.re-frame2-causa.palette.sources-test
+  "Tests for the palette source aggregator (rf2-wm7z4).
+
+  Pure-data CLJC. Covers:
+
+  - per-source item shape (the contract the view + events depend on)
+  - build-index dedup on [:source :id]
+  - rank scoring: boost + recency-bonus add to fuzzy score; cap order
+  - popoutable? gate
+  - empty-query mode keeps every item and orders by boost+recency"
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.palette.sources :as sources]))
+
+;; ---- fixture inputs -----------------------------------------------------
+
+(def sample-panels
+  [{:id :event-detail :label "Event detail"}
+   {:id :trace        :label "Trace"}
+   {:id :causality    :label "Causality"}])
+
+(def sample-trace-buffer
+  ;; oldest → newest order; recency-rank 0 sits at the end
+  [{:id 100 :op :event/handled :event-id [:user/login]}
+   {:id 101 :op :event/handled :event-id [:user/logout]}
+   {:id 102 :op :event/dispatched :event-id [:cart/add 42]}
+   {:id 103 :op :trace/note}            ;; filtered — not an event op
+   {:id 104 :op :event/handled :event-id [:cart/remove]}])
+
+(def sample-frames [:rf/default :rf/causa :app/main])
+
+(def sample-handlers
+  [{:id :user/login    :kind :event :file "user.cljs" :line 12}
+   {:id :user/profile  :kind :sub   :doc "Profile sub" :file "u.cljs" :line 30}
+   {:id :http/fetch    :kind :fx    :file "http.cljs" :line 8}])
+
+(def sample-copilot-questions
+  ["What is the last error?" "Show all flows"])
+
+;; ---- per-source shape ---------------------------------------------------
+
+(deftest panel-items-shape
+  (let [items (sources/panel-items sample-panels)]
+    (is (= 3 (count items)))
+    (is (every? #(= :panel (:source %)) items))
+    (is (every? #(string? (:label %)) items))
+    (is (every? #(string? (:icon %)) items))
+    (is (every? #(vector? (:action %)) items))
+    (is (every? #(false? (:popout? %)) items)
+        "panels are not popoutable in Phase 1")
+    (is (= [:palette/select-panel :event-detail]
+           (-> items first :action)))))
+
+(deftest recent-event-items-skips-non-event-ops
+  (let [items (sources/recent-event-items sample-trace-buffer)]
+    (is (= 4 (count items))
+        "buffer has 5 rows but one is :trace/note which is filtered out")
+    (is (every? #(= :recent-event (:source %)) items))
+    (is (every? #(true? (:popout? %)) items)
+        "recent events should pop out into event-detail when Ctrl+Enter")))
+
+(deftest recent-event-recency-rank-puts-latest-first
+  (let [items (sources/recent-event-items sample-trace-buffer)
+        latest (first (filter #(zero? (:recency-rank %)) items))]
+    (is (some? latest))
+    (is (= "[:cart/remove]" (:label latest))
+        "the most-recently-pushed event sits at rank 0")))
+
+(deftest recent-event-cap
+  (let [big-buffer (vec
+                     (for [i (range 50)]
+                       {:id i :op :event/handled :event-id [:noise i]}))
+        items      (sources/recent-event-items big-buffer 10)]
+    (is (= 10 (count items)))
+    (is (= 0 (:recency-rank (first
+                              (filter #(zero? (:recency-rank %)) items)))))))
+
+(deftest frame-items-excludes-causa
+  (let [items (sources/frame-items sample-frames)
+        ids   (set (map :id items))]
+    (is (contains? ids :rf/default))
+    (is (contains? ids :app/main))
+    (is (not (contains? ids :rf/causa))
+        "switching focus to :rf/causa is not a meaningful palette op")))
+
+(deftest handler-items-include-meta
+  (let [items (sources/handler-items sample-handlers)
+        login (first (filter #(= :user/login (second (:id %))) items))]
+    (is (some? login))
+    (is (= "user.cljs:12" (:hint login)))
+    (is (true? (:popout? login)))))
+
+(deftest setting-items-include-copilot-toggle
+  (let [items (sources/setting-items)
+        toggle (first (filter #(= :copilot-toggle (:id %)) items))]
+    (is (some? toggle))
+    (is (= [:palette/copilot-toggle] (:action toggle)))))
+
+(deftest command-items-include-core-verbs
+  (let [items   (sources/command-items)
+        ids     (set (map :id items))]
+    (is (contains? ids :clear-trace-buffer))
+    (is (contains? ids :reset-suppressed-counters))
+    (is (contains? ids :open-popout))
+    (is (contains? ids :close-palette))))
+
+(deftest copilot-question-items-rank-most-recent-first
+  (let [items (sources/copilot-question-items sample-copilot-questions)]
+    (is (= 2 (count items)))
+    (is (= 0 (:recency-rank (first items))))
+    (is (= 1 (:recency-rank (second items))))))
+
+;; ---- build-index --------------------------------------------------------
+
+(deftest build-index-includes-every-source
+  (let [index   (sources/build-index
+                  {:panels             sample-panels
+                   :trace-buffer       sample-trace-buffer
+                   :frame-ids          sample-frames
+                   :handlers           sample-handlers
+                   :copilot-questions  sample-copilot-questions})
+        sources (set (map :source index))]
+    (is (contains? sources :command))
+    (is (contains? sources :panel))
+    (is (contains? sources :setting))
+    (is (contains? sources :recent-event))
+    (is (contains? sources :frame))
+    (is (contains? sources :handler))
+    (is (contains? sources :copilot-question))))
+
+(deftest build-index-dedups-on-source-id
+  (let [dup-panels [{:id :trace :label "Trace"}
+                    {:id :trace :label "Trace (dup)"}]
+        index      (sources/build-index {:panels dup-panels})
+        traces     (filter #(and (= :panel (:source %))
+                                 (= :trace (:id %))) index)]
+    (is (= 1 (count traces))
+        "first :panel :trace wins, duplicates drop")))
+
+(deftest build-index-defaults-empty-inputs
+  (let [index (sources/build-index {})]
+    (is (vector? index))
+    (is (pos? (count index))
+        "commands + settings ship even with no host data")
+    (is (every? #(some? (:source %)) index))))
+
+;; ---- ranking ------------------------------------------------------------
+
+(deftest rank-empty-query-keeps-everything-orders-by-boost
+  (let [index   (sources/build-index
+                  {:panels sample-panels
+                   :trace-buffer sample-trace-buffer})
+        results (sources/rank index "" 100)]
+    (is (= (count index) (count results))
+        "empty query keeps every item")
+    (is (>= (-> results first :score) (-> results last :score))
+        "results are sorted highest-score first")))
+
+(deftest rank-non-matching-query-returns-empty
+  (let [index   (sources/build-index {:panels sample-panels})
+        results (sources/rank index "zzzzz")]
+    (is (empty? results))))
+
+(deftest rank-prefers-commands-over-panels-on-collision
+  ;; "cl" matches "Clear trace buffer" (command) AND "Causality" (panel)
+  ;; in label fragments. Command boost (40) > panel boost (30), so the
+  ;; command should win when fuzzy scores are comparable.
+  (let [index   (sources/build-index {:panels sample-panels})
+        results (sources/rank index "cl")
+        top     (first results)]
+    (is (= :command (:source top)))
+    (is (= :clear-trace-buffer (:id top)))))
+
+(deftest rank-respects-limit
+  (let [index   (sources/build-index
+                  {:panels sample-panels :trace-buffer sample-trace-buffer})
+        results (sources/rank index "" 3)]
+    (is (= 3 (count results)))))
+
+(deftest rank-recency-boosts-latest-event
+  ;; Two events whose labels both fuzzy-match the query; the more
+  ;; recent one should score higher because of the recency bonus.
+  (let [buf [{:id 1 :op :event/handled :event-id [:foo]}
+             {:id 2 :op :event/handled :event-id [:foo]}]
+        index   (sources/recent-event-items buf)
+        results (sources/rank index "foo" 10)
+        scores  (map :score results)]
+    (is (>= (first scores) (last scores))
+        "the higher-ranked (more recent) match scores ≥ the older one")))
+
+;; ---- popoutable? --------------------------------------------------------
+
+(deftest popoutable?-respects-opt-in
+  (is (true?  (sources/popoutable? {:popout? true})))
+  (is (false? (sources/popoutable? {:popout? false})))
+  (is (false? (sources/popoutable? {}))
+      "default: items are not popoutable unless they say so"))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -133,6 +133,13 @@
    :rf.causa/pin-store
    :rf.causa/pinned-slices
    :rf.causa/pinned-slices-store
+   :rf.causa/palette-active-item
+   :rf.causa/palette-copilot-questions
+   :rf.causa/palette-cursor
+   :rf.causa/palette-index
+   :rf.causa/palette-open?
+   :rf.causa/palette-query
+   :rf.causa/palette-results
    :rf.causa/pinned-snapshots
    :rf.causa/registered-flows
    :rf.causa/registered-fxs
@@ -206,6 +213,14 @@
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
    :rf.causa/open-in-editor
+   :rf.causa/palette-close
+   :rf.causa/palette-cursor-down
+   :rf.causa/palette-cursor-set
+   :rf.causa/palette-cursor-up
+   :rf.causa/palette-invoke
+   :rf.causa/palette-open
+   :rf.causa/palette-set-query
+   :rf.causa/palette-toggle
    :rf.causa/pin-current
    :rf.causa/pin-slice
    :rf.causa/rename-pin
@@ -251,6 +266,10 @@
   [:rf.causa.fx/copy-to-clipboard
    :rf.causa.fx/reset-frame-db!
    :rf.causa.fx/restore-epoch
+   ;; rf2-wm7z4 — palette pop-out side-effect. Lives under the
+   ;; palette-specific prefix because it wraps a mount-layer pop-out
+   ;; call that no other Causa surface invokes.
+   :rf.causa.palette.fx/popout
    ;; rf2-g5q8d — cross-panel open-in-editor side-effect. Lives under
    ;; the editor-generic `:rf.editor/*` prefix rather than `:rf.causa.fx/*`
    ;; because the rf2-cm93v allowlist seam is editor-related, not
@@ -310,17 +329,24 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 66 subs + 67 events + 4 fxs"
-    (is (= 66 (count all-sub-names)))
+  (testing "registry holds exactly 73 subs + 75 events + 5 fxs"
+    ;; 66 baseline + 7 palette (rf2-wm7z4):
+    ;;   palette-active-item / palette-copilot-questions /
+    ;;   palette-cursor / palette-index / palette-open? /
+    ;;   palette-query / palette-results
+    (is (= 73 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
-    (is (= 67 (count all-event-names)))
-    ;; 4 fxs = 3 baseline (`:rf.causa.fx/copy-to-clipboard`,
-    ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`)
-    ;; + rf2-g5q8d's `:rf.editor/open` (cross-panel open-in-editor
-    ;; launcher; lives under the editor-generic prefix because the
-    ;; rf2-cm93v allowlist is editor-related, not Causa-specific).
-    (is (= 4  (count all-fx-names)))))
+    ;; 67 baseline + 8 palette (rf2-wm7z4):
+    ;;   palette-close / palette-cursor-down / palette-cursor-set /
+    ;;   palette-cursor-up / palette-invoke / palette-open /
+    ;;   palette-set-query / palette-toggle
+    (is (= 75 (count all-event-names)))
+    ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
+    ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
+    ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,
+    ;; rf2-wm7z4).
+    (is (= 5  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
   (testing "calling register-causa-handlers! twice is a no-op (same handler instance)"


### PR DESCRIPTION
## Scope

Phase-1 ship of the spec/007-UX-IA.md §Command palette. A global,
fuzzy-matched command surface in the spirit of VS Code / Storybook 9 /
Chrome DevTools. Opens with Cmd+K (macOS) or Ctrl+K (other), closes
with ESC, navigates with arrows + Home/End, invokes with Enter,
pops-out with Ctrl+Enter for opt-in sources.

Closes rf2-wm7z4.

## Sources indexed (Phase 1)

| Source | What it surfaces | Action |
|---|---|---|
| Panel names | The 16 canonical Causa panels | open / focus the panel |
| Recent events | Last 30 :event/handled / :event/dispatched rows | jump to event-detail with event pre-selected; Ctrl+Enter pops out |
| Frames | Every registered frame except :rf/causa | set focus target |
| Handlers | Every :event / :sub / :fx / :cofx from the registrar (capped at 200) | route to event-detail with handler annotated; Ctrl+Enter pops out |
| Settings | Toggle co-pilot rail, cycle density | parity with existing keybindings |
| Command verbs | Clear trace buffer, reset redacted counter, open popout, close palette | side-effects via Causa events / mount-layer fx |
| Co-pilot questions | Last 10 asked, most-recent first | repopulate the co-pilot input |

Phase-2 sources (machines, flows, subs, the full handler catalogue
with grouping) are tracked as a follow-on under this bead — see
\"Out of scope\" below.

## Fuzzy match approach

Sublime-fuzzy / fzf-lite family in ~65 lines of CLJC:

- Every query char must appear in order, case-insensitively.
- Score bonuses: prefix (+12), word-start (+8, separators
  -_/.:space), camelCase boundary (+6), consecutive run (+4).
- Penalty: -1 per unmatched char between matches.
- Recency bonus: linear decay 30 → 0 over rank 0..30.
- Per-source boost: commands (40) > panels (30) > settings (20) >
  recent-events (10) > co-pilot (8) > frames (5) > handlers (2).
- Tie-break: shorter label, then lexicographic.

No new npm dep — CLJC means the scorer + aggregator run under both
JVM clojure.test and the CLJS node-test gate. Verified-redundant
pre-flight grep found nothing pre-existing to reuse.

## Keybinding integration

Adds palette-toggle-key? to keybinding.cljs alongside the existing
causa-toggle / copilot-toggle predicates. Accepts Ctrl XOR Meta (not
both), rejects Shift (avoids the Firefox Ctrl+Shift+K dev-tools
collision) and Alt (avoids IME compositions). Reuses the existing
document capture-phase listener pattern; the three predicates are
asserted mutually exclusive.

## Pop-out semantics

Per-item opt-in via sources/popoutable?. Recent events + handlers
opt in; panels / settings / commands / co-pilot questions do not
(opting out means Ctrl+Enter invokes normally — no surprise pop-up
windows). Lowering goes through a new :rf.causa.palette.fx/popout
effect that reaches mount/popout! via the browser API exports the
preload installs. This late-bind breaks the otherwise unavoidable
mount → shell → palette → palette.events → mount require cycle.

## Registry surface

- 7 new subs (palette-open? / query / cursor / index / results /
  active-item / copilot-questions)
- 8 new events (palette-open / close / toggle / set-query /
  cursor-up / cursor-down / cursor-set / invoke)
- 1 new fx (:rf.causa.palette.fx/popout)

registry_cljs_test.cljs's catalogue + counts updated in lockstep so
the orchestrator smoke gate stays meaningful.

## Test coverage

| Suite | Coverage | Counts |
|---|---|---|
| fuzzy_test.cljc | Scorer truth table (prefix bonus, word-start, camel, run, gap penalty, empty-query, nil-safety, indices) | 12 deftests |
| sources_test.cljc | Per-source shape, recency rank, dedup, rank order, popoutable? gate | 15 deftests |
| events_cljs_test.cljs | open/close/toggle, cursor clamp, query-resets-cursor, invoke lowering for every verb, popout-fx counting stub | 11 deftests |
| keybinding_cljs_test.cljs | Palette predicate truth table (Cmd, Ctrl, code fallback, rejects shift/alt/both-mods/wrong-key/plain-k); mutual-exclusivity with causa + copilot toggles | 7 deftests + extended exclusivity |
| registry_cljs_test.cljs | Updated catalogues + counts (73 subs, 75 events, 5 fxs) | existing smoke covers palette ids |

## Test outputs

- npm run test:cljs        → 2376 tests / 6826 assertions / 0 failures
- npm run test:browser     → 2365 tests / 6685 assertions / 0 failures
- npm run test:bundle-isolation → PASS (3 builds, 12 sentinels, 6 reagent-free checks)
- clojure -M:test (tools/causa) → 609 tests / 1783 assertions / 0 failures

## Out of scope (follow-on)

- Phase-2 sources: machines + flows + subs (full catalogue with
  grouping). The current aggregator already accepts these via the
  build-index inputs map — wiring is one sub-side addition each.
- Theming polish beyond the 560px / 40px row spec.
- Open-source / open-coord row actions for recent-event hits (today
  Enter routes to the event-detail panel; the per-row \"Open source\"
  action listed in spec/007-UX-IA.md §Empty palette is context-aware
  is a follow-on).

These can be filed as Phase-2 child beads under rf2-wm7z4 once Mike
prioritises them.

## Acceptance check

- [x] Palette opens with Cmd/Ctrl+K
- [x] ESC closes
- [x] Fuzzy match works (covered by unit + scorer truth tables)
- [x] Selecting a result navigates / invokes the right command
- [x] Bundle-isolation still passes (no leak into prod bundles)
- [x] Co-located tests under tools/causa/test