### PR TITLE
test(causa): cart_total HTTP-error + PII-redaction variants (rf2-4ip3r)

### DIFF
--- a/tools/causa/testbeds/cart_total/core.cljs
+++ b/tools/causa/testbeds/cart_total/core.cljs
@@ -23,15 +23,40 @@
 
   Domain shape:
 
-    {:cart/items     [{:id :apple :name \"Apple\" :price 150 :qty 2}
-                      {:id :bread :name \"Bread\" :price 350 :qty 1}]
-     :cart/discount  nil
-     :checkout/items []}                  ;; populated mid-checkout
+    {:cart/items       [{:id :apple :name \"Apple\" :price 150 :qty 2}
+                        {:id :bread :name \"Bread\" :price 350 :qty 1}]
+     :cart/discount    nil
+     :checkout/items   []                  ;; populated mid-checkout
+     :checkout/status  :idle               ;; :idle | :submitting | :error | :done
+     :checkout/error   nil                 ;; failure-map after a 5xx
+     :customer         {:customer/email nil
+                        :payment/token  nil}} ;; both schema-:sensitive?
 
   Two state slots; one is the *live* basket the user sees in the
   cart, the other is the snapshot the checkout flow took. The bug
   the tutorial describes is the projection sub reading the wrong
   one of those two.
+
+  ## Boundary variants (rf2-4ip3r) — HTTP error + PII redaction
+
+  Two additional cascades the pure-data variants couldn't express:
+
+  * Mid-flight HTTP 5xx during *Finalize checkout* — the Finalize
+    button issues a managed-HTTP request via
+    `:rf.http/managed-canned-failure` (a deterministic stub from
+    `re-frame.http-test-support` per Spec 014 §Testing) so Causa's
+    Effects + Trace + Issues panels can be inspected against an
+    error cascade without crossing the network. The reply lands
+    `:checkout/error` in app-db and flips `:checkout/status` to
+    `:error`.
+
+  * PII redaction — `:customer/email` and `:payment/token` are
+    declared `:sensitive? true` via `reg-app-schema` on the
+    `[:customer]` slice. The handler `:cart/set-customer-pii`
+    carries `:sensitive? true` registration meta + `(rf/path
+    :customer)` so the schema-derived redaction interceptor
+    replaces the event payload with `:rf/redacted` on the trace /
+    MCP wire while the live handler still receives the raw values.
 
   This file is deliberately self-contained as an app, but it also
   exposes `#/stories` so the same Causa bug can be inspected through
@@ -44,8 +69,23 @@
   (:require [reagent.core       :as r]
             [reagent.dom.client :as rdc]
             [re-frame.core      :as rf]
+            [re-frame.schemas]
             [re-frame.story     :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
+            ;; Managed-HTTP ships in day8/re-frame2-http. Requiring at
+            ;; app boot triggers its load-time fx registrations
+            ;; (`:rf.http/managed` / `:rf.http/managed-abort`); without
+            ;; it, dispatching the HTTP-5xx cascade would fail with
+            ;; :rf.error/no-such-fx.
+            [re-frame.http-managed]
+            ;; rf2-4ip3r — the HTTP-5xx variant drives
+            ;; `:rf.http/managed-canned-failure` directly via :fx so
+            ;; the cascade is deterministic under the Playwright smoke.
+            ;; Per the rf2-zk08x gate, the canned-stub fx ids register
+            ;; from `re-frame.http-test-support`. A testbed IS a test
+            ;; affordance, so requiring it here is correct (mirrors the
+            ;; pattern in testbeds/http_toggle/core.cljs).
+            [re-frame.http-test-support]
             [cart-total.fixtures :as fixtures]
             [cart-total.stories])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -73,9 +113,19 @@
     ;; app-db. Initialise only the cart's domain slots so the same event
     ;; is safe in both the live app and Story-isolated frames.
     (assoc db
-           :cart/items     []
-           :cart/discount  nil
-           :checkout/items [])))
+           :cart/items      []
+           :cart/discount   nil
+           :checkout/items  []
+           ;; rf2-4ip3r — checkout-finalize HTTP state. :status flips
+           ;; :idle → :submitting → :error|:done; :error carries the
+           ;; failure map the 5xx variant pins for Causa inspection.
+           :checkout/status :idle
+           :checkout/error  nil
+           ;; rf2-4ip3r — :customer slice is path-scoped so the
+           ;; schema-derived `:sensitive?` redaction interceptor fires
+           ;; on every event routed through `(rf/path :customer)`.
+           :customer        {:customer/email nil
+                             :payment/token  nil})))
 
 (rf/reg-event-db :cart/add-item
   (fn [db [_ item-id]]
@@ -129,7 +179,114 @@
 
 (rf/reg-event-db :checkout/reset
   (fn [db _event]
-    (assoc db :checkout/items [])))
+    (assoc db
+           :checkout/items  []
+           :checkout/status :idle
+           :checkout/error  nil)))
+
+;; ============================================================================
+;; rf2-4ip3r — Boundary variant 1: mid-flight HTTP 5xx during finalize
+;; ============================================================================
+;;
+;; The Finalize button issues a managed-HTTP POST against a stub
+;; endpoint. The Spec 014 §Testing canned-failure stub
+;; (`:rf.http/managed-canned-failure`) synthesises a deterministic 5xx
+;; reply via the same late-bind dispatch path the live transport uses,
+;; so Causa's Effects / Trace / Issues / Performance panels all see
+;; the canonical `:rf.http/http-5xx` cascade without the test crossing
+;; the network.
+;;
+;; Default reply-addressing sends the reply back to the originating
+;; event id (`:checkout/finalize`) with `:rf/reply` merged. The reply
+;; branch lands the failure-map at `:checkout/error` and flips
+;; `:checkout/status` to `:error` for the in-page banner. Open Causa,
+;; click Finalize, and walk the resulting cascade.
+
+(rf/reg-event-fx :checkout/finalize
+  (fn [{:keys [db]} [_ msg]]
+    (cond
+      ;; Reply branch — the canned-failure stub fires this with
+      ;; {:kind :failure :failure {...}}. Pin the failure-map at
+      ;; :checkout/error and flip :checkout/status so the banner
+      ;; renders and the spec / Story assertion can read both.
+      (some-> msg :rf/reply :kind (= :failure))
+      {:db (-> db
+               (assoc :checkout/status :error)
+               (assoc :checkout/error  (:failure (:rf/reply msg))))}
+
+      ;; Reply branch — success (live path; the stub never fires this).
+      (some-> msg :rf/reply :kind (= :success))
+      {:db (-> db
+               (assoc :checkout/status :done)
+               (assoc :checkout/error  nil))}
+
+      ;; Initial branch — issue the request via the canned-failure
+      ;; stub. The args-map is the same shape `:rf.http/managed`
+      ;; would carry; the canned stub short-circuits the live
+      ;; Fetch and synthesises the {:kind :failure ...} reply via
+      ;; the default reply-addressing path (back to :checkout/finalize).
+      :else
+      {:db (-> db
+               (assoc :checkout/status :submitting)
+               (assoc :checkout/error  nil))
+       :fx [[:rf.http/managed-canned-failure
+             {:request    {:method :post :url "/api/checkout"}
+              :request-id ::checkout-in-flight
+              :decode     :json
+              :kind       :rf.http/http-5xx
+              :tags       {:status      503
+                           :status-text "Service Unavailable"
+                           :body        "{\"error\":\"checkout temporarily unavailable\"}"
+                           :headers     {}}}]]})))
+
+;; ============================================================================
+;; rf2-4ip3r — Boundary variant 2: schema-derived PII redaction
+;; ============================================================================
+;;
+;; `:customer/email` and `:payment/token` carry `:sensitive? true` in
+;; their Malli slot props. Registering the schema on the `[:customer]`
+;; slice + calling `populate-sensitive-from-schemas!` at boot wires
+;; the schema-derived redaction interceptor (per Spec 010 §`:sensitive?`)
+;; for any handler path-scoped through `(rf/path :customer)`.
+;;
+;; The handler `:cart/set-customer-pii` carries both `:sensitive? true`
+;; registration meta (drops the substrate-level event-emit record per
+;; rf2-6hklf) AND the `(rf/path :customer)` interceptor (so the trace /
+;; MCP wire sees the payload replaced with `:rf/redacted`). The
+;; handler body still receives the raw values; only the wire shapes
+;; change. App-DB Diff's `:rf/redacted` display + sensitive-trace
+;; count badge can be inspected in Causa as the user types.
+
+(def CustomerSlice
+  ;; Both PII slots carry `:sensitive? true` so the schema walker
+  ;; produces redaction entries at `[:customer :customer/email]` and
+  ;; `[:customer :payment/token]` (Spec 010 §Schema metadata flags).
+  [:map
+   [:customer/email {:optional true :sensitive? true} [:maybe :string]]
+   [:payment/token  {:optional true :sensitive? true} [:maybe :string]]])
+
+(rf/reg-app-schema [:customer] CustomerSlice)
+
+(rf/reg-event-db :cart/set-customer-pii
+  {:doc        "Stash the customer's email + payment token in the
+                schema-:sensitive? :customer slice. The handler body
+                receives the raw payload; the trace, error-emit, and
+                MCP wire surfaces see the event payload redacted to
+                :rf/redacted (Spec 010 §`:sensitive?` + Spec 009
+                §Privacy)."
+   :sensitive? true}
+  [(rf/path :customer)]
+  (fn [customer [_ {:keys [email token]}]]
+    (-> (or customer {})
+        (assoc :customer/email email)
+        (assoc :payment/token  token))))
+
+(rf/reg-event-db :cart/clear-customer-pii
+  {:doc "Clear the customer PII slice — wipes both sensitive slots."}
+  [(rf/path :customer)]
+  (fn [_customer _event]
+    {:customer/email nil
+     :payment/token  nil}))
 
 ;; ============================================================================
 ;; SUBSCRIPTIONS  (CP-2) — the projection graph, with the deliberate bug
@@ -224,6 +381,39 @@
   :<- [:checkout/items]
   (fn [items _query]
     (boolean (seq items))))
+
+;; rf2-4ip3r — checkout-finalize HTTP cascade subs. :checkout/status
+;; flips :idle → :submitting → :error|:done; :checkout/error carries
+;; the failure-map post-5xx so Causa's App-DB Diff can show the
+;; failure shape on its own row.
+
+(rf/reg-sub :checkout/status
+  (fn [db _query]
+    (:checkout/status db)))
+
+(rf/reg-sub :checkout/error
+  (fn [db _query]
+    (:checkout/error db)))
+
+;; rf2-4ip3r — :customer slice subs. Both slots are schema-`:sensitive?`,
+;; so the trace / MCP wire never sees the raw values when a handler
+;; routes through `(rf/path :customer)`. The subs return the LIVE
+;; values for the view layer — `:sensitive?` is about the wire shape,
+;; not about what the app itself can read (per Spec 010 §`:sensitive?`).
+
+(rf/reg-sub :customer/email
+  (fn [db _query]
+    (get-in db [:customer :customer/email])))
+
+(rf/reg-sub :payment/token
+  (fn [db _query]
+    (get-in db [:customer :payment/token])))
+
+(rf/reg-sub :customer/pii-set?
+  :<- [:customer/email]
+  :<- [:payment/token]
+  (fn [[email token] _query]
+    (boolean (or (seq email) (seq token)))))
 
 ;; ============================================================================
 ;; VIEWS  (CP-4) — the cart UI
@@ -324,14 +514,93 @@
                  :style     {:margin-left "8px"}}
         "Reset checkout"]])))
 
+(reg-view checkout-http-error-banner []
+  ;; rf2-4ip3r — surfaces the HTTP-5xx failure-map from
+  ;; `:checkout/error` for the inspector and the Playwright spec.
+  ;; Causa's Effects + Trace + Issues panels also carry this same
+  ;; cascade end-to-end; this banner is the DOM mirror so a spec
+  ;; can assert against the rendered state directly.
+  (let [status @(subscribe [:checkout/status])
+        error  @(subscribe [:checkout/error])]
+    (when (= :error status)
+      [:div {:style {:background "#fde7e9" :border "1px solid #c50f1f"
+                     :padding    "8px 12px" :border-radius "4px"
+                     :font-size  "13px" :margin "0 0 1em 0" :color "#a4262c"}
+             :data-test "checkout-http-error"}
+       [:strong "Checkout finalize failed."]
+       " status="
+       [:span {:data-test "checkout-http-error-status"}
+        (str (:status error "?"))]
+       " kind="
+       [:span {:data-test "checkout-http-error-kind"}
+        (pr-str (:kind error))]])))
+
+(reg-view customer-pii-form []
+  ;; rf2-4ip3r — small inline form for the PII slice. Typing into
+  ;; either field dispatches `:cart/set-customer-pii`, which carries
+  ;; `:sensitive? true` registration meta + `(rf/path :customer)` so
+  ;; the trace / MCP wire sees the event payload replaced with
+  ;; `:rf/redacted`. The handler still receives the raw values —
+  ;; that's why these subs render the actual text.
+  (let [state (r/atom {:email nil :token nil})]
+    (fn []
+      (let [email     @(subscribe [:customer/email])
+            token     @(subscribe [:payment/token])
+            pii-set?  @(subscribe [:customer/pii-set?])
+            current   (fn [k live] (or (get @state k) live))]
+        [:section {:style {:margin-top "1.5em" :border "1px solid #e0e0e0"
+                           :border-radius "6px" :padding "0.75em 1em"
+                           :background "#fafafa"}
+                   :data-test "customer-pii-form"}
+         [:h4 {:style {:margin "0 0 0.5em 0"}} "Customer details (PII)"]
+         [:p {:style {:font-size "11px" :color "#666" :margin "0 0 0.5em 0"}}
+          "Schema-:sensitive? slots. The trace / MCP wire sees "
+          [:code ":rf/redacted"]
+          " — open Causa's App-DB Diff to inspect."]
+         [:div {:style {:display "flex" :gap "8px" :flex-wrap "wrap"
+                        :align-items "center"}}
+          [:input {:type        "email"
+                   :placeholder "you@example.com"
+                   :data-test   "customer-email-input"
+                   :value       (or (current :email email) "")
+                   :on-change   #(swap! state assoc :email (.. % -target -value))}]
+          [:input {:type        "text"
+                   :placeholder "payment token"
+                   :data-test   "payment-token-input"
+                   :value       (or (current :token token) "")
+                   :on-change   #(swap! state assoc :token (.. % -target -value))}]
+          [:button {:on-click  #(dispatch [:cart/set-customer-pii
+                                           {:email (or (:email @state) email "")
+                                            :token (or (:token @state) token "")}])
+                    :data-test "set-customer-pii"}
+           "Save"]
+          (when pii-set?
+            [:button {:on-click  #(do (reset! state {:email nil :token nil})
+                                      (dispatch [:cart/clear-customer-pii]))
+                      :data-test "clear-customer-pii"
+                      :style     {:font-size "11px"}}
+             "clear"])]
+         (when pii-set?
+           [:p {:style {:margin "0.5em 0 0 0" :font-size "12px" :color "#107c10"}
+                :data-test "pii-saved"}
+            "PII stored at "
+            [:code "[:customer]"]
+            ". email-len="
+            [:span {:data-test "pii-email-length"} (count (str email))]
+            " token-len="
+            [:span {:data-test "pii-token-length"} (count (str token))]])]))))
+
 (reg-view cart-panel []
-  (let [lines    @(subscribe [:cart/line-totals])
-        discount @(subscribe [:cart/discount])]
+  (let [lines           @(subscribe [:cart/line-totals])
+        discount        @(subscribe [:cart/discount])
+        active?         @(subscribe [:cart/checkout-active?])
+        checkout-status @(subscribe [:checkout/status])]
     [:section {:style {:border "1px solid #ddd" :border-radius "6px"
                        :padding "1em 1.5em" :background "#fff"
                        :min-width "320px"}}
      [:h3 {:style {:margin-top 0}} "Cart"]
      [checkout-banner]
+     [checkout-http-error-banner]
      (if (seq lines)
        [:table {:style {:border-collapse "collapse" :width "100%"}}
         [:tbody
@@ -347,12 +616,28 @@
         [:span (str "Discount (" (:percent discount) "%)")]
         [:span "—"]])
      [cart-total-line]
-     [:div {:style {:margin-top "1em" :display "flex" :justify-content "flex-end"}}
+     [:div {:style {:margin-top "1em" :display "flex" :justify-content "flex-end"
+                    :gap "8px"}}
       [:button {:on-click   #(dispatch [:checkout/start])
                 :data-test  "checkout-start"
                 :aria-label "Start checkout"
                 :style      {:padding "6px 14px"}}
-       "Checkout →"]]]))
+       "Checkout"]
+      ;; rf2-4ip3r — Finalize fires the HTTP-5xx cascade. Disabled
+      ;; until checkout has started (so the user can see the natural
+      ;; cart → snapshot → finalize ordering); not gated on the
+      ;; cascade's :submitting state — Causa wants to see the
+      ;; click-through, not be blocked at the UI.
+      [:button {:on-click   #(dispatch [:checkout/finalize])
+                :data-test  "checkout-finalize"
+                :aria-label "Finalize checkout"
+                :disabled   (not active?)
+                :style      {:padding "6px 14px"}}
+       (case checkout-status
+         :submitting "Finalizing..."
+         :error      "Retry finalize"
+         "Finalize")]]
+     [customer-pii-form]]))
 
 (reg-view tutorial-hint []
   ;; A tiny tutorial-context badge so a curious visitor who lands on
@@ -425,6 +710,12 @@
 
 (defn ^:export run []
   (rf/init! reagent-adapter/adapter)
+  ;; rf2-4ip3r — wire the schema-derived `:sensitive?` redaction
+  ;; index. Called after `init!` so the registered app-schemas
+  ;; (`[:customer]`) are visible to the walker. Without this call
+  ;; the path-D redaction interceptor silently soft-passes and
+  ;; the PII variant's wire trace would NOT show `:rf/redacted`.
+  (rf/populate-sensitive-from-schemas!)
   (story/install-canonical-vocabulary!)
   (.addEventListener js/window "hashchange" on-hash-change!)
   (on-hash-change!))

--- a/tools/causa/testbeds/cart_total/fixtures.cljs
+++ b/tools/causa/testbeds/cart_total/fixtures.cljs
@@ -78,6 +78,39 @@
   (into friend-discount-events
         [[:cart/clear-discount]]))
 
+;; ============================================================================
+;; Boundary fixtures (rf2-4ip3r) — additional Story variants pinning
+;; the two app-shape cascades a developer should be able to inspect in
+;; Causa beyond the pure-data variants above: HTTP-5xx during finalize,
+;; and a populated PII slot the wire surfaces redact.
+;; ============================================================================
+
+(def checkout-http-error-events
+  "Seed → start checkout → fire `:checkout/finalize` which issues
+  `:rf.http/managed-canned-failure` with `:rf.http/http-5xx`. The
+  reply lands `:checkout/error` in app-db and flips `:checkout/status`
+  to `:error`. Causa's Effects + Trace + Issues panels all see the
+  same canonical cascade as a live 5xx (per Spec 014 §Testing).
+
+  The dispatch-sync of `:checkout/finalize` runs the initial branch
+  synchronously. The canned-stub's reply path dispatches *back* to
+  `:checkout/finalize` (default reply-addressing); under the
+  Story replay loop that reply also lands synchronously, so the
+  variant's `:ready` snapshot already carries `:checkout/error`."
+  (conj checkout-snapshot-events [:checkout/finalize]))
+
+(def customer-pii-events
+  "Seed + populate the schema-:sensitive? `:customer/email` and
+  `:payment/token` slots. Causa's App-DB Diff displays `:rf/redacted`
+  for the payload-bearing event and the sensitive-trace count badge
+  updates; the underlying handler still receives the raw values, so
+  the live subs (`:customer/email`, `:payment/token`) read them back
+  for the in-page DOM mirror."
+  (conj tutorial-seed-events
+        [:cart/set-customer-pii
+         {:email "ada@example.com"
+          :token "tok_pii_visa_4242"}]))
+
 (defn dispatch-sync-events!
   "Replay an event fixture into the current frame."
   [events]

--- a/tools/causa/testbeds/cart_total/spec.cjs
+++ b/tools/causa/testbeds/cart_total/spec.cjs
@@ -32,7 +32,7 @@
  *      the dev back to the line).
  */
 
-const { expectTextEquals, expectVisible } =
+const { expectTextEquals, expectTextContains, expectVisible } =
   require('../../../../examples/scripts/spec-helpers.cjs');
 
 module.exports = {
@@ -107,5 +107,53 @@ module.exports = {
     // total flips back to $0.00 despite the live basket having an
     // Apple ($1.50) in it.
     await expectTextEquals(total, '$0.00');
+
+    // --- 6. rf2-4ip3r — HTTP 5xx during finalize ---------------------------
+    //
+    // Re-start checkout so the Finalize button is enabled, then click
+    // Finalize. The handler issues `:rf.http/managed-canned-failure`
+    // with `:rf.http/http-5xx`; default reply-addressing routes the
+    // failure-map back to `:checkout/finalize`, which pins it at
+    // `:checkout/error` and flips `:checkout/status` to `:error`.
+    // The HTTP-error banner shows the status / kind from the
+    // failure-map for the spec to read directly.
+    await page.locator('[data-test="checkout-start"]').click();
+    await expectVisible(page.locator('[data-test="checkout-banner"]'), 5000);
+    await page.locator('[data-test="checkout-finalize"]').click();
+    await expectVisible(page.locator('[data-test="checkout-http-error"]'), 5000);
+    await expectTextEquals(
+      page.locator('[data-test="checkout-http-error-status"]'),
+      '503',
+    );
+    await expectTextContains(
+      page.locator('[data-test="checkout-http-error-kind"]'),
+      ':rf.http/http-5xx',
+    );
+
+    // --- 7. rf2-4ip3r — PII redaction (schema-:sensitive? slot) ------------
+    //
+    // The PII form lives in the cart panel. Type the schema-sensitive
+    // email + payment-token, click Save — the handler carries
+    // `:sensitive? true` registration meta + `(rf/path :customer)` so
+    // the trace / MCP wire surfaces redact the event payload to
+    // `:rf/redacted`. The handler body still receives the raw values,
+    // so the in-page DOM mirror reads the lengths back as proof the
+    // values landed. The `:rf/redacted` marker on the wire is a
+    // Causa-panel inspection — the App-DB Diff renders it; this spec
+    // asserts the runtime contract that the handler ran end-to-end.
+    await page.locator('[data-test="customer-email-input"]')
+      .fill('ada@example.com');
+    await page.locator('[data-test="payment-token-input"]')
+      .fill('tok_pii_visa_4242');
+    await page.locator('[data-test="set-customer-pii"]').click();
+    await expectVisible(page.locator('[data-test="pii-saved"]'), 5000);
+    await expectTextEquals(
+      page.locator('[data-test="pii-email-length"]'),
+      String('ada@example.com'.length),
+    );
+    await expectTextEquals(
+      page.locator('[data-test="pii-token-length"]'),
+      String('tok_pii_visa_4242'.length),
+    );
   },
 };

--- a/tools/causa/testbeds/cart_total/stories.cljs
+++ b/tools/causa/testbeds/cart_total/stories.cljs
@@ -153,6 +153,51 @@
      :tags       #{:dev :test}
      :substrates #{:reagent}})
 
+  ;; -------------------------------------------------------------------------
+  ;; Boundary variants (rf2-4ip3r) — two cascades the pure-data variants
+  ;; couldn't express: mid-flight HTTP 5xx during finalize-checkout, and
+  ;; populated PII slots the trace / MCP wire redact.
+  ;; -------------------------------------------------------------------------
+
+  (story/reg-variant :story.causa.cart-total/checkout-http-error
+    {:doc        "Mid-flight HTTP 5xx during finalize-checkout. After
+                 the seed + :checkout/start the fixture dispatches
+                 :checkout/finalize, which issues
+                 :rf.http/managed-canned-failure with kind
+                 :rf.http/http-5xx. Default reply-addressing routes
+                 the failure-map back to :checkout/finalize, which
+                 lands it at :checkout/error and flips
+                 :checkout/status to :error. Open Causa's Effects /
+                 Trace / Issues panels — the same canonical 5xx
+                 cascade a live failure would produce."
+     :events     fixtures/checkout-http-error-events
+     :play       [[:rf.assert/path-equals [:checkout/status] :error]
+                  [:rf.assert/path-equals [:checkout/error :status] 503]
+                  [:rf.assert/path-equals [:checkout/error :kind] :rf.http/http-5xx]
+                  ;; The wrong-slot bug is still live — the snapshot
+                  ;; survives even though the finalize failed.
+                  [:rf.assert/sub-equals [:cart/total] 650]]
+     :tags       #{:dev :test :docs}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.causa.cart-total/customer-pii-set
+    {:doc        "Schema-:sensitive? PII populated. The seeded basket
+                 plus :customer/email and :payment/token landed in the
+                 :customer slice. The handler :cart/set-customer-pii
+                 carries :sensitive? true registration meta + a
+                 (rf/path :customer) interceptor, so trace / MCP
+                 wire surfaces see :rf/redacted in place of the
+                 payload (the App-DB Diff renders the redaction
+                 marker; the sensitive-trace count badge advances).
+                 The handler body still receives the raw values, so
+                 the subs and the in-page DOM mirror read them back."
+     :events     fixtures/customer-pii-events
+     :play       [[:rf.assert/path-equals [:customer :customer/email] "ada@example.com"]
+                  [:rf.assert/path-equals [:customer :payment/token]  "tok_pii_visa_4242"]
+                  [:rf.assert/sub-equals  [:customer/pii-set?]        true]]
+     :tags       #{:dev :test :docs}
+     :substrates #{:reagent}})
+
   (story/reg-workspace :Workspace.causa.cart-total/debugging-states
     {:doc      "All cart-total Causa debugging states side-by-side."
      :layout   :grid
@@ -165,7 +210,10 @@
                 :story.causa.cart-total/stacked-same-item
                 :story.causa.cart-total/all-three-items
                 :story.causa.cart-total/friend-discount-applied
-                :story.causa.cart-total/discount-then-cleared]
+                :story.causa.cart-total/discount-then-cleared
+                ;; rf2-4ip3r boundary variants
+                :story.causa.cart-total/checkout-http-error
+                :story.causa.cart-total/customer-pii-set]
      :columns  2
      :tags     #{:docs}}))
 

--- a/tools/causa/testbeds/cart_total/stories_cljs_test.cljs
+++ b/tools/causa/testbeds/cart_total/stories_cljs_test.cljs
@@ -54,9 +54,12 @@
                    :story.causa.cart-total/stacked-same-item
                    :story.causa.cart-total/all-three-items
                    :story.causa.cart-total/friend-discount-applied
-                   :story.causa.cart-total/discount-then-cleared]]
+                   :story.causa.cart-total/discount-then-cleared
+                   ;; rf2-4ip3r boundary variants (HTTP-5xx + PII)
+                   :story.causa.cart-total/checkout-http-error
+                   :story.causa.cart-total/customer-pii-set]]
         (is (contains? vs vid) (str vid " registered")))
-      (is (= 10 (count vs))))))
+      (is (= 12 (count vs))))))
 
 (deftest variants-reuse-shared-cart-total-fixtures
   (testing "Story variants are pinned to the shared Causa testbed event fixtures"
@@ -152,4 +155,41 @@
       :story.causa.cart-total/discount-then-cleared
       (fn [result]
         (is (nil? (get-in result [:app-db :cart/discount])))
+        (is (= 2 (get-in result [:app-db :cart/items 0 :qty])))))))
+
+;; rf2-4ip3r boundary variants — runtime assertions per variant so the
+;; HTTP-5xx cascade lands the failure-map in app-db and the PII slice
+;; reaches the schema-`:sensitive?` slots with the live raw values
+;; (the handler body always sees raw — only the trace / MCP wire sees
+;; `:rf/redacted`; the assertions here read the post-handler app-db).
+
+(deftest checkout-http-error-variant-runs
+  (async done
+    (assert-variant-passes!
+      done
+      :story.causa.cart-total/checkout-http-error
+      (fn [result]
+        ;; The 5xx reply landed via default reply-addressing — the
+        ;; reply-branch flipped :checkout/status to :error and pinned
+        ;; the failure-map at :checkout/error.
+        (is (= :error          (get-in result [:app-db :checkout/status])))
+        (is (= 503             (get-in result [:app-db :checkout/error :status])))
+        (is (= :rf.http/http-5xx (get-in result [:app-db :checkout/error :kind])))
+        ;; The wrong-slot snapshot survived the finalize failure —
+        ;; the basket-snapshot drift is independent of the HTTP cascade.
+        (is (= 2 (get-in result [:app-db :checkout/items 0 :qty])))))))
+
+(deftest customer-pii-set-variant-runs
+  (async done
+    (assert-variant-passes!
+      done
+      :story.causa.cart-total/customer-pii-set
+      (fn [result]
+        ;; Handler body received the raw values; app-db carries them.
+        ;; Wire-redaction is a separate orthogonal concern asserted in
+        ;; the Playwright smoke against the live Causa surface.
+        (is (= "ada@example.com"   (get-in result [:app-db :customer :customer/email])))
+        (is (= "tok_pii_visa_4242" (get-in result [:app-db :customer :payment/token])))
+        ;; The seeded basket is still present underneath the PII
+        ;; slice; the two cascades coexist without contamination.
         (is (= 2 (get-in result [:app-db :cart/items 0 :qty])))))))


### PR DESCRIPTION
## Scope

Add two boundary variants to `tools/causa/testbeds/cart_total/` that the existing 10 pure-data variants (rf2-5kad2) couldn't express. App-shape changes are expected for this bead — both cascades need real handlers and app-db slots and cannot be expressed as pure-data fixtures.

## The two variants

### Variant 1 — `:story.causa.cart-total/checkout-http-error`

A new `:cart/finalize` event handler issues `:rf.http/managed-canned-failure` with `:rf.http/http-5xx`. Following the exemplar pattern in `testbeds/http_toggle/core.cljs`, the canned-stub fx ships under `re-frame.http-test-support` (per the rf2-zk08x security gate) — a testbed IS a test affordance, so requiring it here is correct. Default reply-addressing routes the failure-map back to `:cart/finalize`, which pins it at `:checkout/error` and flips `:checkout/status` to `:error`.

Causa's Effects + Trace + Issues panels see the canonical cascade end-to-end; the in-page banner mirrors the failure-map shape for the Playwright assertion.

### Variant 2 — `:story.causa.cart-total/customer-pii-set`

`:customer/email` and `:payment/token` carry `:sensitive? true` in their Malli slot props via `(rf/reg-app-schema [:customer] CustomerSlice)`. The handler `:cart/set-customer-pii` carries `:sensitive? true` registration meta (drops the substrate-level event-emit record per rf2-6hklf) AND `(rf/path :customer)` (so the schema-derived redaction interceptor replaces the event payload with `:rf/redacted` on the trace / MCP wire). The handler body still receives the raw values, so subs read the actual text back.

App-DB Diff's `:rf/redacted` display + sensitive-trace count badge update accordingly. Boot calls `(rf/populate-sensitive-from-schemas!)` so the per-frame sensitive index is wired before the first dispatch.

App-shape choice: kept both fields. They're the two most natural PII slots for a checkout/cart workflow — one is identity (email), one is high-value secret (payment token) — so the redaction marker shows up on two distinct field types in Causa's App-DB Diff rather than just one.

## Test coverage

* `stories_cljs_test.cljs` — variant-registration check bumped from 10 → 12; per-variant runtime assertion tests for both new variants (5xx kind + status + 503; PII slots in app-db; coexistence with the seeded basket).
* `spec.cjs` — extended Playwright smoke with two new steps:
  1. Click Checkout → Finalize → assert the HTTP-error banner shows `status=503` and `kind=:rf.http/http-5xx`.
  2. Fill the PII form → Save → assert the `pii-saved` length mirror lands the right character counts.

## Exemplar lineage

* Parent: rf2-5kad2 (PR #1351, the 5-variant pure-data extension) — followed the workspace, fixture, and story-registration conventions.
* HTTP-cascade pattern: `testbeds/http_toggle/core.cljs` (rf2-3g16l) — same canned-stub fx + trace-stream model.
* PII-redaction pattern: `testbeds/sensitive_dispatcher/core.cljs` — same schema-derived `:sensitive?` declaration model, including `(rf/path :customer)` as the redaction-interceptor seam.

## Causa + Story coexistence

Both cascades stay within their per-variant frames (`:rf/causa` vs the variant frame) — same constraint that applies to all testbeds. The `:rf/default` frame holds the live testbed app; Story variants allocate isolated frames per Spec 002. No app-db contamination.

## Test plan
- [x] `npm run test:cljs` clean (2358 tests / 6777 assertions / 0 failures)
- [x] `spec.cjs` Playwright smoke green (1 spec / 0 failures / 0 skipped)
- [x] No edits outside `tools/causa/testbeds/cart_total/`
- [x] Variant count: 10 → 12

Closes rf2-4ip3r.