### PR TITLE
feat(consistency): React 19 + Reagent 2.x floor — bump pkg + sweep stale docs (rf2-6ctt8)

### DIFF
--- a/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs
@@ -39,6 +39,22 @@
     "loop" "multiple" "muted" "novalidate" "open" "playsinline"
     "readonly" "required" "reversed" "selected" "itemscope"})
 
+(defn- strip-react-19-resource-hints
+  "React 19's `renderToStaticMarkup` auto-emits `<link rel=\"preload\">`
+  resource hints in front of certain media tags (`<img>`, `<script>`,
+  certain `<link>` and `<style>` cases) — see React 19's
+  Float / resource-loading docs. The pure-CLJS rewrite does not emit
+  these hints; they are React's runtime concern, not part of the
+  hiccup-to-HTML contract this parity suite asserts. Strip the
+  auto-emitted hints from React's output before the diff so the
+  comparison remains a static-markup parity check rather than a
+  resource-loading-strategy check."
+  [s]
+  (clojure.string/replace
+   s
+   #"<link[^>]*\srel=\"preload\"[^>]*>"
+   ""))
+
 (defn- normalise-attr-order
   "Canonicalise both serialisers' output for the parity diff. Per
   §8.7's known-difference allow-list:
@@ -51,34 +67,39 @@
        short form.
     3. React's attribute insertion order may differ from hiccup map
        order. Sort attributes within each tag.
+    4. React 19 auto-emits `<link rel=\"preload\">` resource hints in
+       front of `<img>` (and other media tags); these are React's
+       resource-loading concern and are stripped before the diff —
+       see `strip-react-19-resource-hints`.
 
   This canonicalisation operates ONLY on the open-tag region; nested
   HTML structure / element order / text content / escape sequences
   remain part of the diff."
   [s]
-  (clojure.string/replace
-   s
-   ;; Match `<tag ...>` (or `<tag .../>`) — captures tag, attr string, slash.
-   #"<([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^>]*?)?)(/?)>"
-   (fn [[_ tag attrs _slash]]
-     (let [parts (->> (re-seq #"\s+([^=\s>]+)(?:=\"([^\"]*)\")?" attrs)
-                      (map (fn [[_ k v]]
-                             (cond
-                               ;; Boolean attr with empty value → short form.
-                               (and (contains? boolean-attr-set
-                                               (clojure.string/lower-case k))
-                                    (or (nil? v) (= "" v)))
-                               (str " " k)
+  (-> s
+      strip-react-19-resource-hints
+      (clojure.string/replace
+       ;; Match `<tag ...>` (or `<tag .../>`) — captures tag, attr string, slash.
+       #"<([a-zA-Z][a-zA-Z0-9]*)((?:\s+[^>]*?)?)(/?)>"
+       (fn [[_ tag attrs _slash]]
+         (let [parts (->> (re-seq #"\s+([^=\s>]+)(?:=\"([^\"]*)\")?" attrs)
+                          (map (fn [[_ k v]]
+                                 (cond
+                                   ;; Boolean attr with empty value → short form.
+                                   (and (contains? boolean-attr-set
+                                                   (clojure.string/lower-case k))
+                                        (or (nil? v) (= "" v)))
+                                   (str " " k)
 
-                               v
-                               (str " " k "=\"" v "\"")
+                                   v
+                                   (str " " k "=\"" v "\"")
 
-                               :else
-                               (str " " k))))
-                      sort
-                      (apply str))]
-       ;; Always drop the trailing slash; HTML5 doesn't use it.
-       (str "<" tag parts ">")))))
+                                   :else
+                                   (str " " k))))
+                          sort
+                          (apply str))]
+           ;; Always drop the trailing slash; HTML5 doesn't use it.
+           (str "<" tag parts ">"))))))
 
 (defn- =parity
   "Assert that both serialisers produce byte-identical output (after

--- a/implementation/adapters/reagent/README.md
+++ b/implementation/adapters/reagent/README.md
@@ -1,10 +1,22 @@
 # Reagent adapter
 
-Maven artefact: `day8/re-frame2-reagent`. Target: Reagent 2.x. Public ns: `re-frame.adapter.reagent`.
+Maven artefact: `day8/re-frame2-reagent`. Target: Reagent 2.x on React 19. Public ns: `re-frame.adapter.reagent`.
 
 This is the canonical CLJS reference adapter — the substrate `reg-view` was designed against. It implements the contract from [Spec 006 — Reactive substrate](../../../spec/006-ReactiveSubstrate.md) on top of Reagent's RAtom/Reaction graph and React commit lifecycle.
 
 See [`../README.md`](../README.md) for the wider adapter tier and the substrate contract; [Spec 004 — Views](../../../spec/004-Views.md) for `reg-view` / `reg-view*` semantics.
+
+## Floor: Reagent 2.x + React 19
+
+The bridge supports **exactly one combination**: Reagent 2.x (currently pinned to `2.0.1` in [`implementation/core/deps.edn`](../../core/deps.edn)) running against React 19. There is no Reagent 1.x compat path and no React 17/18 fallback.
+
+Rationale, mirroring the `reagent-slim` `DECISION-5` framing ([`../reagent-slim/IMPL-SPEC.md`](../reagent-slim/IMPL-SPEC.md) §Hard constraints, Stage 1 §2.3a):
+
+- **Reagent 1.x is end-of-life for re-frame2.** Reagent 2.0 (released 2025-10-29) added React 19 support, dropped the deprecated `reagent.dom/dom-node`, and removed the second arity of `reagent.core/force-update`. Re-frame2 targets the modern Reagent surface; carrying a 1.x compat layer would freeze design choices that pre-date concurrent rendering.
+- **React 19 is the React floor.** The slim rewrite (`day8/reagent-slim`) sets a React 19 floor as a hard DECISION; the bridge follows the same floor so that adopters can move between bridge and slim without changing their `package.json`. Reagent 2.0.1's own `devDependencies` pin `react`/`react-dom` to `19.2.0`, so this is the version Reagent itself is tested against.
+- **No back-compat shims.** Per pre-alpha posture: there is no v1-Reagent compat, no React-18 fallback, no `reagent.dom`-legacy-mount support. Apps that need any of those stay on re-frame v1.
+
+The migration story for React-19-removed Reagent surfaces (`reagent.dom/render`, `reagent.core/dom-node`, etc.) lives in [`migration/from-re-frame-v1/README.md#m-42-react-19-removed-reagent-surfaces-ship-as-throw-on-call-shims-under-day8reagent-slim`](../../../migration/from-re-frame-v1/README.md) — that section is the canonical reference for both bridge and slim consumers because the *removal* is React's, not the rewrite's.
 
 ## Imperative escape hatch — when you need a DOM lifecycle
 

--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -11,8 +11,8 @@
         "http-server": "14.1.1",
         "playwright": "1.59.1",
         "qrcode-generator": "2.0.4",
-        "react": "18.3.1",
-        "react-dom": "18.3.1",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
         "shadow-cljs": "3.4.10",
         "todomvc-app-css": "2.4.3",
         "todomvc-common": "1.0.5"
@@ -509,26 +509,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -672,30 +652,26 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.0"
       }
     },
     "node_modules/readline-sync": {
@@ -723,14 +699,11 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/secure-compare": {
       "version": "3.0.1",

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -5,8 +5,8 @@
   "description": "CLJS test target for re-frame2 (node-runtime).",
   "devDependencies": {
     "shadow-cljs": "3.4.10",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
     "playwright": "1.59.1",
     "http-server": "14.1.1",
     "todomvc-app-css": "2.4.3",

--- a/skills/re-frame-migration/reference/setup.md
+++ b/skills/re-frame-migration/reference/setup.md
@@ -17,18 +17,18 @@ Operational detail for **M-0 — the dep-coord swap**. This is the precondition 
 
 ### Prerequisites — JS-level deps
 
-**React 18+ is required by `day8/re-frame2-reagent`.** The Reagent bridge adapter loads `reagent.dom.client` (the React-18 createRoot path); if the project's `package.json` pins `react`/`react-dom` below 18, the build either fails at module-resolve time or — worse — succeeds and crashes on first render with `createRoot is not a function`. Bump them in the same M-0 pass:
+**React 19 is the only supported floor for `day8/re-frame2-reagent`.** The Reagent bridge adapter targets Reagent 2.x, which ships against React 19; Reagent 1.x is no longer supported. The bridge loads `reagent.dom.client` (the `createRoot` path); if the project's `package.json` pins `react`/`react-dom` to 17 or 18, the build either fails at module-resolve time or succeeds and crashes on first render against React-19-only API surfaces. If your `package.json` pins `react` 17 or 18, bump to `^19` in the same M-0 pass:
 
 ```json
 "dependencies": {
-  "react":     "^18.3.1",
-  "react-dom": "^18.3.1"
+  "react":     "^19.0.0",
+  "react-dom": "^19.0.0"
 }
 ```
 
-Then `npm install` (or the project's package manager equivalent) before the first dev build. UIx and Helix users hit the same floor — both require React 18+ — so the bump applies regardless of substrate. If the project is already on React 18+, leave it alone; do not downgrade.
+Then `npm install` (or the project's package manager equivalent) before the first dev build. UIx and Helix users hit the same floor — all three substrates target React 19 — so the bump applies regardless of substrate. If the project is already on React 19, leave it alone; do not downgrade.
 
-If the v1 codebase has its own hand-rolled `ReactDOM.render` call surviving anywhere (rare; usually wrapped by Reagent), flag it — `ReactDOM.render` is removed in React 18 and that call site needs to migrate to `createRoot` in the same pass. Most v1 codebases route through Reagent and never see this.
+If the v1 codebase has its own hand-rolled `ReactDOM.render` call surviving anywhere (rare; usually wrapped by Reagent), flag it — `ReactDOM.render` was removed in React 18 and is still gone in React 19; that call site needs to migrate to `createRoot` in the same pass. Most v1 codebases route through Reagent and never see this.
 
 ### The swap itself
 

--- a/skills/re-frame2-setup/SKILL.md
+++ b/skills/re-frame2-setup/SKILL.md
@@ -79,7 +79,7 @@ Hand off: *"Setup is done. Switch to **`re-frame2`** for events/subs/machines/sc
 ## Troubleshooting (common build failures)
 
 - **`Could not locate re-frame/core.cljs`** — artefact not on classpath. Check `deps.edn` and that `shadow-cljs.edn` reads it (`clj -Stree | grep re-frame2`).
-- **`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` not installed. `npm install react react-dom`. Reagent 2.x needs React 18+.
+- **`Could not locate reagent/dom/client.cljs`** — `react` / `react-dom` not installed. `npm install react react-dom`. Reagent 2.x needs React 19.
 - **Counter doesn't update, no errors** — `(rf/init! reagent-adapter/adapter)` not called, or called after `rdc/render`. Move it to the top of `run`.
 - **Blank page, no console errors** — `index.html` missing `<main id="app">` / `<div id="app">`, or entry ns looking up a different id.
 - **Causa logs missing layout host** — add the true-inline host markup/CSS from `reference/shadow-cljs.md`, or configure `{:layout/host-selector "..."}` before Causa auto-opens. The same actionable diagnostic is available through `window.day8.re_frame2_causa.status()`.

--- a/skills/re-frame2-setup/reference/deps-versions.md
+++ b/skills/re-frame2-setup/reference/deps-versions.md
@@ -88,7 +88,7 @@ re-frame2 itself ships no npm code — but Reagent depends on React, and shadow-
 
 Read `<path-to-re-frame2>/implementation/package.json` (verified pinned checkout — see [`../SKILL.md`](../SKILL.md) cardinal rule 1) and copy the `shadow-cljs` / `react` / `react-dom` versions verbatim. This is the **default path** and the safer baseline; pinning what the framework itself builds against avoids surprise breakage and silent exposure to newly published packages.
 
-**Latest-from-npm is opt-in only.** If the author explicitly asks for the newest versions, run `npm view shadow-cljs version` / `npm view react version` / `npm view react-dom version` and **show the result for confirmation before writing it into `package.json`**. Do not auto-substitute. Reagent 2.x requires React 18+; flag any pick below 18 as a conflict and stop.
+**Latest-from-npm is opt-in only.** If the author explicitly asks for the newest versions, run `npm view shadow-cljs version` / `npm view react version` / `npm view react-dom version` and **show the result for confirmation before writing it into `package.json`**. Do not auto-substitute. Reagent 2.x requires React 19; flag any pick below 19 as a conflict and stop.
 
 Then `npm install` (after the author has approved the resolved `package.json`).
 

--- a/skills/re-frame2-setup/reference/entry-namespace.md
+++ b/skills/re-frame2-setup/reference/entry-namespace.md
@@ -72,10 +72,10 @@ The adapter map carries the substrate's `state-container`, `read-container`, `re
 
 Two contractual bits:
 
-- **`defonce`** — under shadow-cljs hot-reload, `core.cljs` reloads on every save. Without `defonce`, every reload calls `create-root` again on the same DOM node, and React 18 complains loudly (or, worse, silently mounts two roots that fight each other). `defonce` ensures the root is created exactly once per page load.
+- **`defonce`** — under shadow-cljs hot-reload, `core.cljs` reloads on every save. Without `defonce`, every reload calls `create-root` again on the same DOM node, and React 19 complains loudly (or, worse, silently mounts two roots that fight each other). `defonce` ensures the root is created exactly once per page load.
 - **`(js/document.getElementById "app")`** — must match the `id` in `index.html`. Mismatch here is the most common cause of a blank page with no console error.
 
-In `run`, `rdc/render` is called against `react-root` (not against the DOM node directly). Both `create-root` and `render` come from `reagent.dom.client` — that's the React 18 entry surface for Reagent 2.x.
+In `run`, `rdc/render` is called against `react-root` (not against the DOM node directly). Both `create-root` and `render` come from `reagent.dom.client` — that's the React 19 client-Root entry surface for Reagent 2.x.
 
 ## Where everything else goes
 
@@ -105,7 +105,7 @@ If the author is coming from re-frame v1 (re-frame's first version), three thing
 
 | v1 | v2 |
 |---|---|
-| `(:require [reagent.core :as r])` then `(r/render ...)` | `(:require [reagent.dom.client :as rdc])` then `(rdc/render root [view])` — React 18 surface |
+| `(:require [reagent.core :as r])` then `(r/render ...)` | `(:require [reagent.dom.client :as rdc])` then `(rdc/render root [view])` — React 19 client-Root surface |
 | No explicit boot — `re-frame.core` was self-installing against Reagent | `(rf/init! reagent-adapter/adapter)` is mandatory; adapter is a value the app supplies |
 | `defn` views — re-frame v1 had no view registration | `reg-view` macro registers views in a per-app registry; auto-injects `dispatch` / `subscribe` |
 | Implicit single global `app-db` | One default frame; multi-frame apps are first-class via `frame-provider` |

--- a/skills/re-frame2-setup/reference/first-counter.md
+++ b/skills/re-frame2-setup/reference/first-counter.md
@@ -88,7 +88,7 @@ Inside the body, two locals are **auto-injected** by the macro:
 
 This is what makes registered views frame-aware without you threading the frame through every component. The macro resolves both at render time against whatever frame is in scope (the default frame, here; `frame-provider` lets multi-frame apps swap it for a subtree).
 
-The result is regular Reagent hiccup. Reagent renders, the React 18 root commits, the DOM updates.
+The result is regular Reagent hiccup. Reagent renders, the React 19 root commits, the DOM updates.
 
 ### Mount
 

--- a/spec/002-Frames.md
+++ b/spec/002-Frames.md
@@ -525,7 +525,7 @@ The context's value is the **keyword**, not the frame record: each consumer reso
 - **No `frame-provider` in scope.** Reagent's `(.-context cmp)` returns the React empty default (`#js {}`); the keyword/string check fails and the lookup falls through to `:rf/default`. Function-component substrates read `_currentValue` directly, which equals the createContext default (`:rf/default`).
 - **Render fn invoked outside Reagent** (REPL, tests). `reagent.core/current-component` returns `nil`; the React-context tier is skipped. `with-frame` covers tests that need a non-default frame; bare invocations get `:rf/default`.
 - **Reagent prop-conversion of named values** (rf2-d4sf). Stock Reagent's `convert-prop-value` (`reagent.impl.template`) stringifies named values when they pass as React props. The canonical user-facing surface (`rf/frame-provider`) sidesteps this by mounting the Provider via Reagent's `:r>` interop head — the props map flows to React as a raw JS object, so `:value :foo/bar` reaches React as the original keyword and the namespace is preserved across the React-context round trip on every adapter. A user who writes `[:> (.-Provider frame-context) {:value :foo}]` directly (raw `:>` interop, not `rf/frame-provider`) still passes through stock Reagent's prop-conversion under the classic adapter: `convert-prop-value` rewrites `:foo` to `"foo"`, and `re-frame.adapter.context/coerce-context-value` rounds the string back to a keyword. Note that `(name kw)` is lossy for namespaced keywords (`(name :auth/main)` → `"main"`); raw-hiccup mounts that need a namespaced frame-id should switch to `rf/frame-provider` or `re-frame.adapter.context/provider-element`.
-- **Concurrent rendering.** React 18 may render the same component multiple times before commit. The context read is idempotent — same provider value across re-renders — so this is safe. Closures captured during render hold the keyword by value; re-render produces a new closure with the same keyword. See [§Open questions — Concurrent React rendering](#concurrent-react-rendering).
+- **Concurrent rendering.** React 19 (and the React 18 concurrent renderer before it) may render the same component multiple times before commit. The context read is idempotent — same provider value across re-renders — so this is safe. Closures captured during render hold the keyword by value; re-render produces a new closure with the same keyword. See [§Open questions — Concurrent React rendering](#concurrent-react-rendering).
 
 ### View-side details — see Spec 004
 
@@ -1254,7 +1254,7 @@ If two frames depend on a shared piece of *registry* state (handler definitions)
 
 ### Concurrent React rendering
 
-React 18's concurrent rendering can render the same component multiple times before committing. `reg-view`'s injected `dispatch` is a value, so it survives this fine. But any `dispatch` *executed during render* (Form-2's outer fn, `:on-create`-style patterns) may run more than once. Confirm with the substrate (Reagent today; possibly UIx tomorrow) and document.
+React 19's concurrent rendering can render the same component multiple times before committing. `reg-view`'s injected `dispatch` is a value, so it survives this fine. But any `dispatch` *executed during render* (Form-2's outer fn, `:on-create`-style patterns) may run more than once. Confirm with the substrate (Reagent today; possibly UIx tomorrow) and document.
 
 ### Sub-cache disposal on frame destroy
 

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -178,7 +178,7 @@ Renders the render-tree onto the substrate's surface and returns a function that
 ;; unmount-fn signature: (fn [] nil) — idempotent; releases all resources
 ```
 
-CLJS-Reagent: wraps `reagent.dom.client/create-root` + `reagent.dom.client/render` (React 18+ Root API); the unmount-fn closes over the Root and calls `(rdc/unmount root)`. Hydrate path uses `(rdc/hydrate-root mount-point render-tree)` which returns its own Root (rf2-fn5rk).
+CLJS-Reagent: wraps `reagent.dom.client/create-root` + `reagent.dom.client/render` (React 19 client-Root API; the same `createRoot` shape React 18 introduced); the unmount-fn closes over the Root and calls `(rdc/unmount root)`. Hydrate path uses `(rdc/hydrate-root mount-point render-tree)` which returns its own Root (rf2-fn5rk).
 SSR-on-JVM: this function isn't called server-side — `render-to-string` is used instead. The adapter may stub `render` to throw on the JVM.
 
 ### `(render-to-string render-tree opts) → string`
@@ -667,7 +667,7 @@ This section is the **bridging pseudocode** for both. For each contract function
     (fn [] (apply compute-fn (map deref source-containers)))))
 
 ;; -- 6. render --------------------------------------------------------------
-;; React 18+ takes a `Root` (from `reagent.dom.client/create-root`) — NOT
+;; React 19 takes a `Root` (from `reagent.dom.client/create-root`) — NOT
 ;; a raw DOM element. The non-hydrate path creates the Root then renders
 ;; into it; the hydrate path's `hydrate-root` returns its own Root. The
 ;; returned unmount-fn closes over the Root so the runtime can release it
@@ -716,7 +716,7 @@ This section is the **bridging pseudocode** for both. For each contract function
         (some-> (:pending-dispose entry) interop/clear-timeout!)
         (some-> (:reaction entry) interop/dispose!))
       (reset! cache {})))
-  ;; Step 2 — unmount any active React 18+ Roots (rf2-9fdkb).
+  ;; Step 2 — unmount any active React 19 Roots (rf2-9fdkb).
   (doseq [root @active-roots]
     (try (rdc/unmount root) (catch :default _ nil)))
   (reset! active-roots #{})

--- a/tools/story/spec/findings/re-frame-2-story-feature-set.md
+++ b/tools/story/spec/findings/re-frame-2-story-feature-set.md
@@ -348,7 +348,7 @@ Spec/007 doesn't mention MCP. Storybook v10 ships it built-in. **Decision needed
 
 ### 6.2 How does the substrate selector handle substrate-specific failures?
 
-A variant may render under reagent but fail under helix (e.g., a React-18-only API). **Decision needed:** does the multi-substrate pane render each substrate's failure inline (with the error), or auto-skip non-supporting substrates? Spec/007 doesn't address this.
+A variant may render under reagent but fail under helix (e.g., a React-19-only API). **Decision needed:** does the multi-substrate pane render each substrate's failure inline (with the error), or auto-skip non-supporting substrates? Spec/007 doesn't address this.
 
 **Recommended:** render the failure inline — making substrate-portability gaps *visible* is the entire point. Add `:platforms` analogue `:substrates #{:reagent :uix ...}` for explicit opt-in/out per variant.
 

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -611,7 +611,7 @@
   ([handle]
    (when handle
      ;; rf2-fq1yg: `rdc/unmount` requires the React Root, NOT the DOM
-     ;; node — `(.unmount root)` is the React 18 contract. Passing the
+     ;; node — `(.unmount root)` is the React 19 client-Root contract. Passing the
      ;; DOM node here silently no-op'd (DOM nodes have no `.unmount`
      ;; method), so the shell's root stayed alive on `#app` and a
      ;; subsequent `mount-app!` → `create-root` on the same node fired

--- a/tools/template/spec/001-Substrate-Variants.md
+++ b/tools/template/spec/001-Substrate-Variants.md
@@ -67,8 +67,8 @@ All three variants emit the same top-level project shape — see
 choice swaps:
 
 - `core.cljs` — the entry point. Reagent uses
-  `reagent.dom.client/create-root` + `.render` (the React-18
-  hooks-era API); UIx uses `uix.dom/render-root`; Helix uses
+  `reagent.dom.client/create-root` + `.render` (the React 19
+  client-Root API); UIx uses `uix.dom/render-root`; Helix uses
   `react-dom/client`'s `createRoot`.
 - `views.cljs` — the counter view. Reagent uses plain hiccup;
   UIx uses `$` with `defui`; Helix uses `defnc` and `d/...`


### PR DESCRIPTION
## Summary

Codify React 19 + Reagent 2.x as the sole supported floor across the project. Reagent 1.x is no longer supported (operator decision); the floor matches reagent-slim's DECISION-5 React 19 commitment and Reagent 2.0.1's own React 19.2.0 devDependency pin.

This finishes a story already established: `core/deps.edn` pins `reagent/reagent 2.0.1`; reagent-slim has React 19 floor per DECISION-5. The React 18 pin in `implementation/package.json` was the only remaining inconsistency.

## Pre-flight verification — Reagent 2.0.1 + React 19 compat: yes

- Reagent 2.0.1's `package.json` lists `react` and `react-dom` as devDependencies pinned to `19.2.0`.
- Reagent 2.0.0 release notes document "React 19 support" — tests now run against React 19 via the new `react-dom/client` API, with Concurrent Mode enabled.
- Reagent 2.0.1 (the version we pin) is a 2025-11-04 patch release fixing StrictMode-RAtoms-in-functional-components — confirms React 19 is the actively-tested target.

## Files modified

**Package + lockfile (1+1):**
- `implementation/package.json` — react 18.3.1 → 19.2.0, react-dom 18.3.1 → 19.2.0 (matches Reagent's own pin)
- `implementation/package-lock.json` — regenerated via `npm install`

**Skills (5):**
- `skills/re-frame-migration/reference/setup.md` — Prerequisites block rewritten: "React 19 is the only supported floor"; one-line migrator guidance: "If your package.json pins react 17 or 18, bump to ^19 in the same M-0 pass."
- `skills/re-frame2-setup/SKILL.md`, `reference/{deps-versions.md, entry-namespace.md, first-counter.md}` — "React 18" / "React 18+" → "React 19"

**Spec (2):**
- `spec/006-ReactiveSubstrate.md` — "React 18+ Root API" → "React 19 client-Root API" (×3)
- `spec/002-Frames.md` — concurrent-rendering refs updated (×2)

**Tools (3):**
- `tools/template/spec/001-Substrate-Variants.md`, `tools/story/spec/findings/re-frame-2-story-feature-set.md`, `tools/story/src/re_frame/story/ui/shell.cljs`

**Reagent bridge adapter doc (1):**
- `implementation/adapters/reagent/README.md` — explicit "Floor: Reagent 2.x + React 19" section mirroring reagent-slim DECISION-5 framing (the bridge has no IMPL-SPEC.md / DESIGN-RATIONALE.md — README is the canonical adapter doc).

**Test update for React 19 (1):**
- `implementation/adapters/reagent-slim/test/reagent2/dom/parity_cljs_test.cljs` — React 19's `renderToStaticMarkup` auto-emits `<link rel="preload">` resource hints in front of `<img>` (and other media tags). Added `strip-react-19-resource-hints` to the §8.7 known-difference allow-list — the resource-hint is React's runtime concern, not part of the hiccup-to-HTML contract the parity suite asserts. One failing test → green.

## Gate results

| Gate | Result | Detail |
|---|---|---|
| `npm install` | PASS | lockfile updated cleanly |
| `npm run test:cljs` | PASS | 2378 tests / 6839 assertions / 0 failures |
| `npm run test:browser` | PASS | 2367 tests / 6698 assertions / 0 failures |
| `npm run test:bundle-isolation` | PASS | 12 artefact entries; 27 internal sentinels absent |
| `npm run test:reagent-slim:bundle-isolation` | PASS | 3 contracts passed; 19 sentinel checks |
| `npm run test:elision` | PASS | production 31/31 absent; control 31/31 present |
| `npm run test:perf-bundle` | PASS | off-count=0; on-count=12 |
| `npm run test:schemas-bundle` | PASS | base 52.7 KB; +malli 82.4 KB |
| `npm run test:examples` | PASS | 40 specs, 0 failures (one flake on first run, green on second) |
| `mkdocs build --strict` | pre-existing 72 warnings | All warnings unrelated to this PR (broken nav refs to `spec/API.md`, `spec/Conventions.md`, etc. — same warnings appear on this branch before any changes are applied) |

## What stayed

- `implementation/adapters/reagent-slim/IMPL-SPEC.md`, `DESIGN-RATIONALE.md`, `FORM-3.md` — references to "React 18+ concurrent rendering" describe historical context (why Reagent's pre-concurrent design needed replacement), not a current-floor claim. DECISION-5 React 19 floor is already explicit there.
- `migration/from-re-frame-v1/README.md` — "stock Reagent" references are function-name references (`convert-prop-value`, etc.), not version claims. The §M-42 React-19-removed-surfaces section is already on the right framing.
- `tools/causa/deps.edn`, `tools/story/src/re_frame/story/ui/canvas.cljs` — same: "stock Reagent" is the bridge's reagent dep, technically correct.

Closes rf2-6ctt8.