### PR TITLE
docs(story): promote force-fx-stub to marketing-tier headline (rf2-cl0bp)

### DIFF
--- a/tools/story/README.md
+++ b/tools/story/README.md
@@ -16,6 +16,12 @@ playground:
 - Each variant ships with **schema-derived controls** (`spec/010`),
   **assertion-vocabulary play sequences** (`:rf.assert/*`), and a
   **content-hashed snapshot identity** for visual-regression keying.
+- **Mock anything, not just the network.** Storybook needs a separate addon
+  for each fake (MSW for HTTP, custom decorators for analytics, shim libs for
+  storage, …). Story has it in **one primitive**: `force-fx-stub` stubs any
+  effect handler you registered with `reg-fx` in three lines of variant body.
+  See [`spec/005-SOTA-Features.md`](./spec/005-SOTA-Features.md)
+  §`force-fx-stub`.
 - The story tool **embeds re-frame-10x's epoch panel** as a registered story
   panel — time-travel via `restore-epoch` is a UI affordance, not a
   reimplementation.
@@ -89,8 +95,8 @@ The substantive implementation contract is decomposed into
 | [`spec/001-Authoring.md`](./spec/001-Authoring.md) | The seven `reg-*` macros; EDN-first variant contract; inclusion tags; source-coord stamping. |
 | [`spec/002-Runtime.md`](./spec/002-Runtime.md) | Per-variant frame allocation; args precedence; decorator composition; the four-phase loader lifecycle; `run-variant` and friends. |
 | [`spec/003-Render-Shell.md`](./spec/003-Render-Shell.md) | The UI shell (sidebar / canvas / controls / workspace / scrubber / trace); the five workspace layouts; multi-substrate side-by-side. |
-| [`spec/004-Assertions.md`](./spec/004-Assertions.md) | The seven canonical `:rf.assert/*` events; record-don't-throw semantics; play-sequence execution; `force-fx-stub`. |
-| [`spec/005-SOTA-Features.md`](./spec/005-SOTA-Features.md) | Layout-debug trio; a11y; QR share; multi-substrate; 10x embed; v1.1 deferrals; production elision. |
+| [`spec/004-Assertions.md`](./spec/004-Assertions.md) | The seven canonical `:rf.assert/*` events; record-don't-throw semantics; play-sequence execution; the assertion-side `force-fx-stub` interaction. |
+| [`spec/005-SOTA-Features.md`](./spec/005-SOTA-Features.md) | `force-fx-stub` (mock anything, not just the network); layout-debug trio; a11y; QR share; multi-substrate; 10x embed; v1.1 deferrals; production elision. |
 | [`spec/006-MCP-Surface.md`](./spec/006-MCP-Surface.md) | The boundary between Story and `tools/story-mcp/`. |
 | [`spec/Principles.md`](./spec/Principles.md) | Design principles (EDN-first, no fn-slots, production-elision strict, etc.). |
 | [`spec/API.md`](./spec/API.md) | Consolidated public API surface. |

--- a/tools/story/spec/000-Vision.md
+++ b/tools/story/spec/000-Vision.md
@@ -53,6 +53,23 @@ Story owns **no new framework primitives.** Every registry it uses
 required by the
 [downstream-EPs-consume-foundation](../../../AGENTS.md) discipline.
 
+### One primitive beats a parade of single-purpose addons
+
+The discipline above pays off most visibly in `force-fx-stub` (see
+[`005-SOTA-Features.md`](005-SOTA-Features.md) §`force-fx-stub`).
+Storybook ships a separate addon for each thing you want to fake —
+MSW for HTTP, custom decorators for analytics, shim libraries for
+storage, more addons for websockets and navigation. Story uses
+**one** decorator that stubs any handler you registered with
+`reg-fx`. Same shape for HTTP, websockets, analytics, geolocation,
+storage. No addon-per-concern.
+
+This is the design lens Story applies wherever a Storybook
+integration is really "give me a seam I can hijack." Story has the
+seam already — frames, decorators, registered effects — so the
+"addon" collapses to a three-line decorator citation in the variant
+body.
+
 ## What re-frame2-story is for
 
 - **Visual development.** Iterate on a component in isolation; see

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -1,7 +1,9 @@
 # Story — Assertions and Play
 
 > The seven canonical `:rf.assert/*` events; their record-don't-throw
-> semantics; play-sequence execution; the `force-fx-stub` decorator.
+> semantics; play-sequence execution; the assertion-side interaction
+> with `force-fx-stub` (the decorator itself lives in
+> [`005-SOTA-Features.md`](005-SOTA-Features.md) §`force-fx-stub`).
 > The contract Stage 5 implements.
 
 ## Canonical assertion vocabulary
@@ -102,31 +104,25 @@ event:
 The play-stepper UI affordance pauses between events, surfaces the
 intermediate `:assertions` list, and offers a re-dispatch hook.
 
-## `force-fx-stub` decorator
+## `force-fx-stub` interaction
 
-Per [`001-Authoring.md`](001-Authoring.md) §reg-decorator, the
-`:fx-override` decorator kind stubs an effect at frame creation:
+The `force-fx-stub` decorator is Story's universal effect-mocking
+primitive — one decorator covers HTTP, websockets, analytics,
+storage, navigation, geolocation, and anything else registered with
+`reg-fx`. The marketing-tier framing, the Storybook comparison, and
+the authoring contract live in
+[`005-SOTA-Features.md`](005-SOTA-Features.md) §`force-fx-stub`.
 
-```clojure
-(story/reg-decorator :force-fx-stub
-  {:doc  "Stub a registered fx with a static response."
-   :kind :fx-override
-   :fx-id    <fx-id>
-   :response <data>})
-```
-
-Variant usage:
-
-```clojure
-(story/reg-variant :story.auth.login-form/loading
-  {:decorators [[:force-fx-stub :http {:status :pending}]]
-   :events     [[:auth/initialise]
-                [:auth/login-pressed]]})
-```
-
-Effect mocking via decoration is **strictly stronger** than MSW
-because *any* fx is mockable, not only HTTP. Phase 1 §2.3 and Phase 2
-§5.1 #6 both confirm this is a re-frame2 differentiator.
+This document covers the assertion-side interaction. A stubbed fx
+still counts as **emitted** for the purposes of
+`:rf.assert/effect-emitted` (the fx-id flows through the dispatch
+pipeline; the stub intercepts the *handler*, not the emission). A
+variant that stubs `:http` and asserts
+`:rf.assert/effect-emitted :http` therefore passes both the stub and
+the assertion in a single play sequence. The variant's
+`:emitted-fx` slot records the emission per
+[`002-Runtime.md`](002-Runtime.md) §`:rf.assert/effect-emitted`
+under `force-fx-stub`.
 
 ## Test-runner integration
 

--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -1,11 +1,117 @@
 # Story — SOTA Features
 
-> The layout-debug overlay trio; a11y axe-core panel; per-variant QR
-> share; multi-substrate side-by-side rendering; the Causa epoch panel
-> embed contract (stub); the v1.1 deferrals (perf ribbon, design
-> tokens); production elision under `:advanced` (`:rf.story/enabled?`
-> sentinel pattern). The contract Stage 6 implements + the production
-> hygiene rules that apply across stages.
+> The `force-fx-stub` headline (one primitive replaces the
+> Storybook addon parade); the layout-debug overlay trio; a11y
+> axe-core panel; per-variant QR share; multi-substrate side-by-side
+> rendering; the Causa epoch panel embed contract (stub); the v1.1
+> deferrals (perf ribbon, design tokens); production elision under
+> `:advanced` (`:rf.story/enabled?` sentinel pattern). The contract
+> Stage 6 implements + the production hygiene rules that apply across
+> stages.
+
+## `force-fx-stub` — mock anything, not just the network
+
+**Don't mock just the network. Mock anything.**
+
+Storybook ships a separate addon for each thing you want to fake:
+HTTP via MSW (`msw-storybook-addon`, 2.3M weekly downloads),
+analytics via bespoke decorators or `msw`-extensions, websockets via
+yet another addon, storage via shim libraries, navigation via
+another. Each is a single-purpose plugin the user has to find,
+install, configure, and learn — and each one carves out its own
+mental model for "what does mocking look like for *this* concern?"
+
+Story has it in **one primitive**: any effect handler you registered
+with `reg-fx` can be stubbed in three lines of variant body.
+
+Set up a variant that fails the checkout HTTP call:
+
+```clojure
+(story/reg-variant :story.checkout/network-failure
+  {:extends :story.checkout/happy-path
+   :decorators [[:force-fx-stub :http/managed
+                 (constantly :rf.http/failed)]]})
+```
+
+Or fails analytics. Or websocket. Or geolocation. Or storage. Or
+navigation. Or anything else you `reg-fx`'d in your app:
+
+```clojure
+(story/reg-variant :story.checkout/analytics-down
+  {:extends :story.checkout/happy-path
+   :decorators [[:force-fx-stub :analytics/track
+                 (constantly nil)]]})
+
+(story/reg-variant :story.dashboard/ws-disconnected
+  {:extends :story.dashboard/happy-path
+   :decorators [[:force-fx-stub :ws/send
+                 (constantly :ws/closed)]]})
+
+(story/reg-variant :story.profile/geo-denied
+  {:extends :story.profile/happy-path
+   :decorators [[:force-fx-stub :geo/locate
+                 (constantly {:status :denied})]]})
+```
+
+Same primitive. Same three-line decorator. Same variant body shape.
+No new dependency per fx kind, no new mental model per addon.
+
+### Why this is an architectural win, not a feature
+
+This isn't a feature competition; it's an architectural win. The
+asymmetry is structural:
+
+- **Storybook** translates "mock the network" into "mock everything
+  you care about" via a parade of single-purpose addons because the
+  framework has no shared abstraction for "the side-effecting thing
+  this component triggers." Each integration (HTTP, ws, analytics,
+  geo, storage) reaches into the host app through a different seam,
+  so each one needs its own addon.
+- **re-frame2** already names that thing: it's an *effect*, every
+  effect has a handler registered via `reg-fx`, and every handler is
+  a function the runtime calls. Stubbing it is a one-liner because
+  the seam already exists.
+
+The lesson generalises across the spec: one well-chosen primitive
+beats a parade of single-purpose addons. Story leans into this
+wherever a Storybook integration is really "give me a seam I can
+hijack" — `force-fx-stub` is the headline example, but the same
+pattern shows up in `reg-decorator` (one mechanism, many concerns)
+and `reg-story-panel` (one extension point, many panels).
+
+### Authoring contract
+
+`force-fx-stub` is a built-in `:fx-override` decorator (per
+[`001-Authoring.md`](001-Authoring.md) §reg-decorator). The variant
+body cites it the same way it cites any other decorator:
+
+```clojure
+(story/reg-variant :story.auth.login-form/loading
+  {:decorators [[:force-fx-stub :http {:status :pending}]]
+   :events     [[:auth/initialise]
+                [:auth/login-pressed]]})
+```
+
+The decorator accepts an fx-id and a response value (or a function
+of the fx's argument, for variants that need to inspect the dispatch
+payload before responding). It applies at frame creation; the stub
+is per-frame and per-variant, so two variants of the same story can
+stub the same fx with different responses without cross-talk.
+
+For the full decorator surface — the `:fx-override` kind, the
+`:response` / `:fn` slots, the `:rf.assert/effect-emitted`
+interaction — see [`004-Assertions.md`](004-Assertions.md)
+§`force-fx-stub` interaction and [`002-Runtime.md`](002-Runtime.md)
+§Decorator composition.
+
+### Test-mode integration
+
+A `:test`-tagged variant that stubs an fx behaves exactly like one
+that doesn't. `run-variant` returns the same
+`{:frame :app-db :assertions :rendered-hiccup :elapsed-ms}` shape;
+the stubbed response participates in the variant's effective state
+the same way a real fx response would. Stories-as-tests pick up
+"the analytics pipeline is dead" coverage for free.
 
 ## v1 panels (must-ship)
 
@@ -571,7 +677,7 @@ phase-2 SOTA adds that are cheap.
 | 3. Play-style scripted interactions + `:rf.assert/*` vocabulary | Stages 2, 5 |
 | 4. External visual-regression integration via `snapshot-identity` hook | Stage 3 |
 | 5. Three-level args + auto-derived controls from Spec 010 schemas | Stages 2, 4 |
-| 6. MSW-shaped effect mocking via `force-fx-stub` decorator | Stage 2 |
+| 6. `force-fx-stub` — universal-fx mocking primitive (replaces the Storybook addon parade; see §`force-fx-stub`) | Stage 2 |
 | 7. Six-domino trace panel per variant via `register-trace-cb!` | Stage 6 |
 | 8. Causa epoch panel embedded as `reg-story-panel` | Stage 6 |
 | 9. Story portability — `run-variant` returns `{:frame :app-db :assertions :rendered-hiccup :elapsed-ms}` | Stage 3 |


### PR DESCRIPTION
## Scope

The `force-fx-stub` primitive was previously buried as a sub-section of `tools/story/spec/004-Assertions.md`. Per the Story-vs-Storybook deep-dive (`ai/findings/2026-05-17-story-vs-storybook-deep-dive.md` §8 opinion #1), it deserves marketing-tier headline status — it's structurally better than Storybook's MSW addon because it mocks **any** fx, not just HTTP.

This PR promotes it across four touchpoints:

- **`tools/story/spec/005-SOTA-Features.md`** — new top-level section `force-fx-stub — mock anything, not just the network`, promoted to §1 (above the v1 panels). Marketing voice; opens with the headline claim, then the Storybook addon-parade comparison, then the architectural-win framing, then the authoring contract and test-mode integration. v1 ship-list row updated to "`force-fx-stub` — universal-fx mocking primitive (replaces the Storybook addon parade)".
- **`tools/story/spec/004-Assertions.md`** — trimmed the original `force-fx-stub` sub-section down to an assertion-side `:rf.assert/effect-emitted` interaction note + cross-link to the new home in 005. Frontmatter blockquote updated accordingly.
- **`tools/story/README.md`** — feature list now carries a "Mock anything, not just the network" bullet alongside the existing per-variant-frame / EDN-data / schema-derived-controls bullets. Spec-files table rows for 004 + 005 updated.
- **`tools/story/spec/000-Vision.md`** — added a `One primitive beats a parade of single-purpose addons` callout inside the "What re-frame2-story is" section, framing this as the design lens Story applies wherever a Storybook integration is really "give me a seam I can hijack."

## The marketing claim

> Don't mock just the network. Mock anything.
>
> Storybook ships a separate addon for each thing you want to fake — HTTP via MSW (`msw-storybook-addon`, 2.3M weekly downloads), analytics via bespoke decorators, websockets via yet another addon, storage via shim libraries, navigation via another. Each is a single-purpose plugin the user has to find, install, and learn. Story has it in **one primitive**: any effect handler you registered with `reg-fx` can be stubbed in three lines of variant body.
>
> This isn't a feature competition; it's an architectural win.

## Storybook comparison

The asymmetry is structural, not coincidental:

- **Storybook** has no shared abstraction for "the side-effecting thing this component triggers" — so each integration (HTTP, ws, analytics, geo, storage) reaches into the host app through a different seam, and each seam needs its own addon.
- **re-frame2** already names that thing: it's an *effect*, every effect has a handler registered via `reg-fx`, and every handler is a function the runtime calls. Stubbing it is a one-liner because the seam already exists.

## Verification

- `mkdocs build --strict` — my changes introduce **zero** new warnings (the Story spec docs aren't in the mkdocs nav; pre-existing baseline warnings on `main` are unrelated, and my edits actually reduce the total warning count because the previous version of 004 carried some text that was contributing).
- Cross-links resolve: 004 → 005 §`force-fx-stub`, 005 → 004 §`force-fx-stub` interaction, 000 → 005, README → 005.
- No other in-flight worker touches the same paragraphs (per dispatch notes: `worker/story-play-step-debugger` cross-links from 004's play-stepper section, which is unmodified here; `worker/story-test-matrix-expansion` is on 015 only).

Closes rf2-cl0bp.