### PR TITLE
feat(causa): spine substrate — :rf.causa/focus sub + remove bottom rail (rf2-adve5)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -29,7 +29,31 @@
   The palette modal renders its own ESC handler on the input
   element, so this listener does NOT close the palette on ESC —
   doing so would race the input's onKeyDown and risk
-  double-dispatch."
+  double-dispatch.
+
+  ## Spine keybindings (rf2-adve5 — spec/018-Event-Spine.md §3 + §6)
+
+  Five unmodified keys drive the spine sub:
+
+      Space  →  :rf.causa/toggle-live-pause      (pause/resume LIVE feed)
+      L      →  :rf.causa/follow-head            (snap-LIVE)
+      j      →  :rf.causa/focus-cascade-prev     (step back through events)
+      k      →  :rf.causa/focus-cascade-next     (step forward through events)
+      G      →  :rf.causa/follow-head            (fast-forward to head)
+
+  These keys collide with normal typing in any text field, so they
+  fire ONLY when:
+
+  1. The Causa shell is currently visible (`mount/visible?` true), AND
+  2. The keydown event's target is inside the Causa shell DOM tree
+     (`event.target.closest('[data-testid=rf-causa-shell]')` truthy), AND
+  3. The target is NOT an editable element (`<input>`, `<textarea>`,
+     `[contenteditable]`).
+
+  The closest-ancestor check is the right discriminator: Causa's shell
+  carries the `rf-causa-shell` testid; the host app doesn't. The
+  editable-element guard means even a future Causa-side input field
+  (e.g. the filter-pill edit popup) doesn't fight the user typing."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.mount :as mount]))
 
@@ -94,6 +118,61 @@
          (not alt?)
          (or (= "k" k) (= "K" k) (= "KeyK" code)))))
 
+(defn- target-inside-causa?
+  "True when `event.target` is a DOM node inside the Causa shell — the
+  ancestor walk hits the `data-testid=\"rf-causa-shell\"` envelope."
+  [^js event]
+  (when-let [target (.-target event)]
+    (when (and target (.-closest target))
+      (boolean (.closest target "[data-testid=\"rf-causa-shell\"]")))))
+
+(defn- target-editable?
+  "True when `event.target` is a text-input surface where unmodified
+  letter keys would otherwise type characters into a field — even
+  inside Causa's shell those keys belong to the field, not the spine."
+  [^js event]
+  (when-let [^js target (.-target event)]
+    (let [tag (some-> target .-tagName .toUpperCase)]
+      (or (= tag "INPUT")
+          (= tag "TEXTAREA")
+          (= tag "SELECT")
+          (and (.-isContentEditable target)
+               (boolean (.-isContentEditable target)))))))
+
+(defn- spine-key-id
+  "Map an unmodified keydown to the spine event id it dispatches, or
+  nil when the key is not a spine binding. Per spec/018 §3 + §6 the
+  five bindings are Space / L / j / k / G. Bare-key (no modifiers)
+  is required so the bindings don't collide with browser shortcuts
+  (Cmd+L → focus address bar, etc.)."
+  [^js event]
+  (when (and (not (.-ctrlKey event))
+             (not (.-metaKey event))
+             (not (.-altKey event)))
+    (let [k     (.-key event)
+          code  (.-code event)
+          shift? (.-shiftKey event)]
+      (cond
+        ;; Space — pause/resume LIVE feed
+        (or (= " " k) (= "Space" code) (= "Spacebar" k))
+        (when-not shift? :rf.causa/toggle-live-pause)
+
+        ;; L (lowercase, unshifted) — snap to LIVE
+        (and (not shift?) (or (= "l" k) (= "KeyL" code)))
+        :rf.causa/follow-head
+
+        ;; G (uppercase, Shift+G per the spec; mnemonic 'Go to head')
+        (and shift? (or (= "G" k) (= "KeyG" code)))
+        :rf.causa/follow-head
+
+        ;; j — step backward (vim convention reused)
+        (and (not shift?) (or (= "j" k) (= "KeyJ" code)))
+        :rf.causa/focus-cascade-prev
+
+        ;; k — step forward
+        (and (not shift?) (or (= "k" k) (= "KeyK" code)))
+        :rf.causa/focus-cascade-next))))
+
 (defn- handle-keydown [^js event]
   (cond
     (causa-toggle-key? event)
@@ -112,7 +191,20 @@
         (when-not (mount/visible?)
           (mount/open!))
         (rf/with-frame :rf/causa
-          (rf/dispatch [:rf.causa/palette-toggle])))))
+          (rf/dispatch [:rf.causa/palette-toggle])))
+
+    ;; Spine bindings — only fire inside the Causa shell, never on
+    ;; editable elements. Per spec/018 §3 + §6 the keys are
+    ;; Space / L / j / k / G.
+    :else
+    (when (and (mount/visible?)
+               (target-inside-causa? event)
+               (not (target-editable? event)))
+      (when-let [event-id (spine-key-id event)]
+        (.preventDefault event)
+        (.stopPropagation event)
+        (rf/with-frame :rf/causa
+          (rf/dispatch [event-id]))))))
 
 (defn attach!
   "Install the global Ctrl+Shift+C listener once. No-op on second +

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -47,6 +47,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
+            [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
             [day8.re-frame2-causa.theme.perf-tier :as perf-tier]))
@@ -486,13 +487,23 @@
          :selected-dispatch-frame selected-frame
          :selected-cascade     by-id})))
 
+  ;; Spine shim (rf2-adve5) — `:rf.causa/select-dispatch-id` is the
+  ;; legacy entry point used by causality / machine-inspector /
+  ;; issues-ribbon / performance / routes / schema-violation-timeline
+  ;; / trace / mcp-server. It now writes through the spine via the
+  ;; same reducer the spec-018 `:rf.causa/focus-cascade` event uses,
+  ;; so a click in any of those existing panels updates the
+  ;; `:rf.causa/focus` sub the next-generation Layer-2 event list
+  ;; will read. The reducer also continues writing the
+  ;; `:selected-dispatch-id` + `:selected-dispatch` legacy slots so
+  ;; this panel's own sub graph (and every consumer of those subs)
+  ;; keeps reading what it always has — the shim is transparent.
   (rf/reg-event-db :rf.causa/select-dispatch-id
     (fn [db [_ dispatch-id frame-id]]
-      (assoc db
-             :selected-dispatch-id dispatch-id
-             :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
-                                     frame-id (assoc :frame frame-id)))))
+      (spine/focus-cascade-reducer db dispatch-id frame-id)))
 
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
-      (dissoc db :selected-dispatch :selected-dispatch-id))))
+      (-> db
+          (dissoc :selected-dispatch :selected-dispatch-id)
+          (assoc-in [:focus :dispatch-id] nil)))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel_events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel_events.cljs
@@ -52,13 +52,24 @@
     (fn [db [_ text]]
       (assoc db :label-input (or text ""))))
 
+  ;; Spine shim (rf2-adve5) — `:rf.causa/select-epoch` continues to
+  ;; own the legacy `:selected-epoch-id` slot the time-travel panel
+  ;; sub graph reads, AND writes through the spine's `:focus`
+  ;; `:epoch-id` so the `:rf.causa/focus` sub the spec-018 surfaces
+  ;; consume rebinds when the user picks an epoch in the time-travel
+  ;; panel. Symmetric with `:rf.causa/select-dispatch-id` in
+  ;; event_detail.cljs.
   (rf/reg-event-db :rf.causa/select-epoch
     (fn [db [_ epoch-id]]
-      (assoc db :selected-epoch-id epoch-id)))
+      (-> db
+          (assoc :selected-epoch-id epoch-id)
+          (assoc-in [:focus :epoch-id] epoch-id))))
 
   (rf/reg-event-db :rf.causa/clear-selected-epoch
     (fn [db _event]
-      (dissoc db :selected-epoch-id)))
+      (-> db
+          (dissoc :selected-epoch-id)
+          (assoc-in [:focus :epoch-id] nil))))
 
   ;; Per rf2-q4rvx the payload is a single map: `{:eid <epoch-id> :label
   ;; <string>}`. The map shape composes cleanly with optional keys we

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -35,6 +35,7 @@
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.palette :as palette]
+            [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.causality-graph :as causality-graph]
@@ -332,6 +333,10 @@
 
     (open-in-editor/install!)
     (palette/install!)
+    ;; Spine MUST install before event-detail / time-travel — their
+    ;; legacy selection events shim writes through the spine slot,
+    ;; and the slot's reducer helpers live in spine.cljs.
+    (spine/install!)
     (app-db-diff/install!)
     (causality-graph/install!)
     (effects/install!)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -109,38 +109,105 @@
 
 ;; ---- regions -------------------------------------------------------------
 
-(rf/reg-view top-strip
-  "Top strip (56px). Per spec/007-UX-IA.md §The five regions item 1:
-  causality strip + frame picker + global actions (Issues badge,
-  epoch counter, command palette, help, close).
+(defn- mode-pill-text
+  "Render text for the mode-pill per spec/018 §3 Mode pill click
+  behaviour. `focus` is the `:rf.causa/focus` sub value."
+  [{:keys [mode paused? head?]}]
+  (case mode
+    :live  (if paused? "● LIVE (paused)" "● LIVE")
+    :retro (if head? "● LIVE" "◐ RETRO")
+    "● LIVE"))
 
-  v1 stub: brand mark + version label + close-affordance text.
-  Live causality strip / frame picker / Issues badge land as
-  follow-on work."
+(defn- mode-pill-on-click
+  "Dispatcher for the mode-pill click — Space-equivalent when in LIVE,
+  L-equivalent when in RETRO. Per spec/018 §3 table 'Mode pill click
+  behaviour'."
+  [{:keys [mode]}]
+  (if (= mode :retro)
+    #(rf/dispatch [:rf.causa/follow-head] {:frame :rf/causa})
+    #(rf/dispatch [:rf.causa/toggle-live-pause] {:frame :rf/causa})))
+
+(rf/reg-view top-strip
+  "Top strip (56px). Per spec/018-Event-Spine.md §3 Top ribbon anatomy
+  the bar carries the brand mark plus the LIVE/RETRO mode pill (moved
+  here from the dead bottom rail per spec/018 §1 'No bottom rail').
+  The REDACTED indicator surfaces next to the mode pill — the bottom
+  rail used to own it (rf2-azls9); spec/018 specifies the mode-pill
+  hover tooltip + the redaction marker per row, and as a smallest-
+  first-PR step we relocate the indicator to the top strip so the
+  existing redacted-counter assertion surface keeps working
+  unchanged. Frame picker + filter pills + right-cluster chrome land
+  under follow-on beads.
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribes route through
+  React context to `:rf/causa`."
   [_props]
-  [:div {:style {:display          "flex"
-                 :align-items      "center"
-                 :justify-content  "space-between"
-                 :height           (:top-strip-height layout)
-                 :padding          "0 16px"
-                 :background       (:bg-1 tokens)
-                 :border-bottom    (str "1px solid " (:border-subtle tokens))
-                 :color            (:text-primary tokens)
-                 :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                 :font-size        (:body type-scale)
-                 :font-weight      600}}
-   [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
-    [:span {:style {:color (:accent-violet tokens)}} "◆"]
-    [:span "Causa"]
-    [:span {:style {:color       (:text-tertiary tokens)
-                    :font-size   (:caption type-scale)
+  (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
+        focus          @(rf/subscribe [:rf.causa/focus])
+        pill-tone      (case (:mode focus)
+                         :live  (if (:paused? focus)
+                                  (:text-secondary tokens)
+                                  (:green tokens))
+                         :retro (if (:head? focus)
+                                  (:green tokens)
+                                  (:cyan tokens))
+                         (:green tokens))]
+    [:div {:data-testid "rf-causa-top-strip"
+           :style {:display          "flex"
+                   :align-items      "center"
+                   :justify-content  "space-between"
+                   :height           (:top-strip-height layout)
+                   :padding          "0 16px"
+                   :background       (:bg-1 tokens)
+                   :border-bottom    (str "1px solid " (:border-subtle tokens))
+                   :color            (:text-primary tokens)
+                   :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
+                   :font-size        (:body type-scale)
+                   :font-weight      600}}
+     [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
+      [:span {:style {:color (:accent-violet tokens)}} "◆"]
+      [:span "Causa"]
+      [:span {:style {:color       (:text-tertiary tokens)
+                      :font-size   (:caption type-scale)
+                      :font-weight 400}}
+       "Phase 5 (rf2-pzxsr)"]]
+     [:div {:style {:display "flex" :align-items "center" :gap "12px"
+                    :font-size (:caption type-scale)
                     :font-weight 400}}
-     "Phase 5 (rf2-pzxsr)"]]
-   [:div {:style {:display "flex" :align-items "center" :gap "12px"
-                  :color    (:text-secondary tokens)
-                  :font-size (:caption type-scale)
-                  :font-weight 400}}
-    [:span "Ctrl+Shift+C to toggle"]]])
+      ;; REDACTED indicator (rf2-azls9, relocated from bottom-rail per
+      ;; rf2-adve5). Only renders when the counter is positive.
+      (when (pos? redacted-count)
+        [:span {:data-testid "rf-causa-redacted-indicator"
+                :title       (str "Spec 009 §Privacy: " redacted-count
+                                  " sensitive trace event"
+                                  (when (not= 1 redacted-count) "s")
+                                  " suppressed by default. Set "
+                                  ":trace/show-sensitive? true via "
+                                  "(causa-config/configure! ...) to "
+                                  "surface them.")
+                :style       {:color       (:magenta tokens)
+                              :font-weight 600}}
+         (str "● REDACTED " redacted-count)])
+      ;; Mode pill — spec/018 §3 Mode pill cluster.
+      [:span {:data-testid "rf-causa-mode-pill"
+              :on-click    (mode-pill-on-click focus)
+              :title       (case (:mode focus)
+                             :live  (if (:paused? focus)
+                                      "Resume LIVE feed (Space)"
+                                      "Pause LIVE feed (Space)")
+                             :retro (if (:head? focus)
+                                      "Pause LIVE feed (Space)"
+                                      "Snap to LIVE (L)")
+                             "")
+              :style       {:color       pill-tone
+                            :cursor      "pointer"
+                            :font-weight 600
+                            :padding     "2px 8px"
+                            :border      (str "1px solid " pill-tone)
+                            :border-radius "10px"}}
+       (mode-pill-text focus)]
+      [:span {:style {:color (:text-secondary tokens)}}
+       "Ctrl+Shift+C to toggle"]]]))
 
 (defn- sidebar-item
   "Render one sidebar item. Clicking the row fires
@@ -293,51 +360,10 @@
        ;; ── mcp-server panel end ──
        [unknown-panel selected])]))
 
-(rf/reg-view bottom-rail
-  "Bottom rail (40px) — time-travel scrubber + frame info + issues
-  badge. Per spec/007-UX-IA.md §The five regions item 5.
-
-  Phase 1 stub: minimal frame-info text. Live scrubber lands with the
-  time-travel panel bead.
-
-  ## Redaction indicator (rf2-azls9)
-
-  When Causa's trace collector has dropped one or more `:sensitive?
-  true` events under the default privacy posture, render a
-  `[● REDACTED N]` hint in the centre of the rail. The hint
-  disappears on `trace-bus/clear-buffer!` (counter resets together
-  with the buffer) and when the host calls
-  `(causa-config/configure! {:trace/show-sensitive? true})` BEFORE
-  the events flow (the counter never bumps in that case).
-
-  Per rf2-in6l2 `reg-view`-registered so the subscribe routes
-  through React context to `:rf/causa`."
-  []
-  (let [redacted-count @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
-    [:footer {:style {:height           (:bottom-rail-height layout)
-                      :display          "flex"
-                      :align-items      "center"
-                      :justify-content  "space-between"
-                      :padding          "0 16px"
-                      :background       (:bg-1 tokens)
-                      :border-top       (str "1px solid " (:border-subtle tokens))
-                      :color            (:text-tertiary tokens)
-                      :font-family      "Inter, system-ui, -apple-system, Segoe UI, sans-serif"
-                      :font-size        (:caption type-scale)}}
-     [:span "◀◀  ────●────  ▶▶  (scrubber)"]
-     (when (pos? redacted-count)
-       [:span {:data-testid "rf-causa-redacted-indicator"
-               :title       (str "Spec 009 §Privacy: " redacted-count
-                                 " sensitive trace event"
-                                 (when (not= 1 redacted-count) "s")
-                                 " suppressed by default. Set "
-                                 ":trace/show-sensitive? true via "
-                                 "(causa-config/configure! ...) to "
-                                 "surface them.")
-               :style       {:color       (:magenta tokens)
-                             :font-weight 600}}
-        (str "● REDACTED " redacted-count)])
-     [:span "epoch — / —"]]))
+;; Bottom rail removed per spec/018-Event-Spine.md §2 'Why 4 layers,
+;; not 5' — the previous L0 scrubber rail collapses into the ribbon's
+;; `[◀ ▶ ⏭]` nav cluster + the event list. The REDACTED indicator
+;; relocated to the top strip (see top-strip docstring).
 
 ;; ---- shell view ----------------------------------------------------------
 
@@ -424,7 +450,7 @@
                    :overflow      "hidden"}}
      [sidebar]
      [canvas]]
-    [bottom-rail]
+    ;; Bottom rail removed per spec/018 §2 (rf2-adve5).
     ;; Command palette (rf2-wm7z4) — mounted at the shell root so it
     ;; overlays the chrome + panels. The Modal short-circuits to nil
     ;; when `:rf.causa/palette-open?` is false; closed-state cost is

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -1,0 +1,284 @@
+(ns day8.re-frame2-causa.spine
+  "The single-axis spine substrate (rf2-adve5).
+
+  Per `tools/causa/spec/018-Event-Spine.md` §6 Spine binding the spine
+  sub `:rf.causa/focus` is the one axis every dependent surface reads
+  from. When a user clicks a row, EVERY dependent surface (count
+  badges, gutter glyph, detail panel content, mode pill) rebinds via
+  the spine — no panel maintains its own selection state.
+
+  ## Shape
+
+      {:dispatch-id <id-or-nil>     ; cascade root the user focused on
+       :epoch-id    <id-or-nil>     ; epoch the cascade settled in
+       :frame       <frame-id>      ; frame the cascade ran in
+       :mode        :live | :retro  ; :live tracks head; :retro pins
+       :head?       <bool>          ; true when :dispatch-id is latest
+       :previewing? <bool>          ; true while user hovers without click
+       :paused?     <bool>}         ; true when LIVE buffer flow paused
+
+  ## Storage
+
+  The spine slot lives in Causa's app-db at `:focus`. The
+  `:rf.causa/focus` sub composes the slot with the live cascade list
+  (via `:rf.causa/cascades`) so `:head?` and the effective
+  `:dispatch-id` are always derived from the current cascade vector —
+  never stale.
+
+  ## Shim to legacy selection slots
+
+  Pre-rf2-adve5, two panels owned their own selection: event-detail
+  owned `:selected-dispatch-id` / `:selected-dispatch` and time-travel
+  owned `:selected-epoch-id`. Spec 018 §6 collapses those into the
+  spine, but legacy event handlers + their sibling subs continue to
+  exist (each panel reads its own slot directly today). The spine's
+  `:rf.causa/focus-cascade` event writes BOTH the new `:focus` slot
+  AND the legacy `:selected-dispatch-id` slot so existing panels keep
+  rendering with no per-panel change.
+
+  The legacy `:rf.causa/select-dispatch-id` and `:rf.causa/select-
+  epoch` events also write through the spine (in their existing
+  install! fns under event_detail.cljs / time_travel_events.cljs) so
+  the other direction shims too — a click in the existing Causality
+  Graph or Time Travel panel updates the spine, and a click in a
+  future spine-aware list updates the legacy slots."
+  (:require [re-frame.core :as rf]
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn head-cascade
+  "The latest cascade in the projected list — the cascade whose
+  `:dispatch-id` is the spine's 'head'. Returns nil when the list is
+  empty (cold start; buffer-cleared). Cascades are sorted oldest-first
+  (per `re-frame.trace.projection/group-cascades`), so the last entry
+  is the head."
+  [cascades]
+  (last cascades))
+
+(defn head-dispatch-id
+  "The `:dispatch-id` of the head cascade, or nil."
+  [cascades]
+  (:dispatch-id (head-cascade cascades)))
+
+(defn cascade-by-id
+  "Find a cascade in `cascades` by its `:dispatch-id`. Returns nil when
+  no match (id refers to an evicted cascade, or a fresh session)."
+  [cascades dispatch-id]
+  (when dispatch-id
+    (some #(when (= dispatch-id (:dispatch-id %)) %) cascades)))
+
+(defn step-dispatch-id
+  "Compute the new `:dispatch-id` when stepping by `delta` (-1 for
+  prev, +1 for next) from `current-id` through `cascades`.
+
+  - nil `current-id` (no focus yet) starts from the head.
+  - When `current-id` is not in `cascades` (was evicted), step from
+    head.
+  - Bounds-clamped — stepping past either edge stays at the edge.
+  - Returns nil only when `cascades` is empty."
+  [cascades current-id delta]
+  (let [n (count cascades)]
+    (when (pos? n)
+      (let [current-idx (some (fn [[idx c]]
+                                (when (= current-id (:dispatch-id c)) idx))
+                              (map-indexed vector cascades))
+            base-idx    (or current-idx (dec n))
+            new-idx     (-> (+ base-idx delta)
+                            (max 0)
+                            (min (dec n)))]
+        (:dispatch-id (nth cascades new-idx))))))
+
+(defn compose-focus
+  "Derive the public `:rf.causa/focus` map from a stored `:focus` slot
+  and the live cascade vector. Always re-derives `:head?` and the
+  effective `:dispatch-id` from the cascade list — never trusts a
+  stale stored value.
+
+  In `:live` mode an unset (or evicted) dispatch-id snaps to head so
+  a fresh session opens already pointing at the latest cascade per
+  §4 Defaults."
+  [focus cascades]
+  (let [head-id (head-dispatch-id cascades)
+        slot-id (:dispatch-id focus)
+        mode    (or (:mode focus)
+                    (if (or (nil? slot-id) (= slot-id head-id))
+                      :live
+                      :retro))
+        eff-id  (if (and (= :live mode)
+                         (or (nil? slot-id)
+                             (nil? (cascade-by-id cascades slot-id))))
+                  head-id
+                  slot-id)
+        cascade (cascade-by-id cascades eff-id)]
+    {:dispatch-id eff-id
+     :epoch-id    (:epoch-id focus)
+     :frame       (or (:frame cascade) (:frame focus))
+     :mode        mode
+     :head?       (or (nil? eff-id)
+                      (= eff-id head-id))
+     :previewing? (boolean (:previewing? focus))
+     :paused?     (boolean (:paused? focus))}))
+
+;; ---- pure reducers exposed for direct unit testing ----------------------
+
+(defn focus-cascade-reducer
+  "Pure reducer for the `:rf.causa/focus-cascade <id>` event. Writes
+  `:dispatch-id` into the `:focus` slot, flips to `:retro` mode, and
+  shims the legacy `:selected-dispatch-id` / `:selected-dispatch`
+  slots so the existing event-detail / causality / machine-inspector
+  panels keep rendering without per-panel change."
+  [db dispatch-id frame-id]
+  (cond-> db
+    true       (update :focus (fnil assoc {})
+                       :dispatch-id dispatch-id
+                       :mode :retro
+                       :previewing? false)
+    frame-id   (assoc-in [:focus :frame] frame-id)
+    ;; Legacy shim — panels reading these slots stay live.
+    true       (assoc :selected-dispatch-id dispatch-id
+                      :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
+                                              frame-id (assoc :frame frame-id)))))
+
+(defn focus-step-reducer
+  "Pure reducer for `:rf.causa/focus-cascade-prev` / `-next`. Steps
+  the `:dispatch-id` through the cascade vector by `delta` (-1 or
+  +1), updates the legacy shim slot, and flips mode based on the
+  step's outcome — stepping back from head → :retro; stepping
+  forward back to head → :live (the user has scrubbed home)."
+  [db cascades delta]
+  (let [current-id (or (get-in db [:focus :dispatch-id])
+                       (:selected-dispatch-id db))
+        new-id     (step-dispatch-id cascades current-id delta)
+        head-id    (head-dispatch-id cascades)
+        new-mode   (if (= new-id head-id) :live :retro)
+        cascade    (cascade-by-id cascades new-id)
+        frame-id   (:frame cascade)]
+    (cond-> db
+      true     (update :focus (fnil assoc {})
+                       :dispatch-id new-id
+                       :mode new-mode
+                       :previewing? false
+                       :paused? false)
+      frame-id (assoc-in [:focus :frame] frame-id)
+      true     (assoc :selected-dispatch-id new-id
+                      :selected-dispatch    (cond-> {:dispatch-id new-id}
+                                              frame-id (assoc :frame frame-id))))))
+
+(defn follow-head-reducer
+  "Pure reducer for `:rf.causa/follow-head`. Snaps the spine to LIVE,
+  clears the pinned id (`:dispatch-id nil` means 'track head'), and
+  clears `:paused?` so the LIVE buffer flow resumes. Also clears the
+  legacy `:selected-dispatch-id` so the event-detail panel returns to
+  the cascade-list landing view."
+  [db]
+  (-> db
+      (update :focus (fnil assoc {})
+              :dispatch-id nil
+              :mode :live
+              :paused? false
+              :previewing? false)
+      (dissoc :selected-dispatch :selected-dispatch-id)))
+
+(defn toggle-live-pause-reducer
+  "Pure reducer for `:rf.causa/toggle-live-pause`. Toggles `:paused?`
+  inside the `:focus` slot. Mode stays `:live` — the LIVE buffer
+  continues collecting; only auto-scrolling stops. When already in
+  `:retro`, toggling is a no-op (the Space key has no meaning when
+  the user has already pinned an older row — they would press `L` to
+  resume LIVE in that case)."
+  [db]
+  (if (= :retro (get-in db [:focus :mode]))
+    db
+    (update-in db [:focus :paused?] not)))
+
+(defn set-frame-reducer
+  "Pure reducer for `:rf.causa/set-frame <frame-id>`. Writes `:frame`
+  into the `:focus` slot and clears `:dispatch-id` so the spine snaps
+  to the new frame's head."
+  [db frame-id]
+  (-> db
+      (update :focus (fnil assoc {})
+              :frame frame-id
+              :dispatch-id nil
+              :mode :live)))
+
+(defn preview-cascade-reducer
+  "Pure reducer for `:rf.causa/preview-cascade <id>`. Sets `:previewing?
+  true` and writes `:dispatch-id` transiently. nil `id` clears the
+  preview without changing the committed selection."
+  [db dispatch-id]
+  (if (nil? dispatch-id)
+    (assoc-in db [:focus :previewing?] false)
+    (-> db
+        (assoc-in [:focus :previewing?] true)
+        (assoc-in [:focus :dispatch-id] dispatch-id))))
+
+;; ---- registration --------------------------------------------------------
+
+(defn- db->cascades
+  "Read the cascade vector by re-running the projection against the
+  Causa app-db's `:trace-buffer` slot (falling back to the trace-bus
+  atom for pre-mount callers). Used by the step events that need to
+  walk the cascade list inside an event-db handler — the equivalent
+  reactive path inside the `:rf.causa/focus` sub uses the
+  `:rf.causa/cascades` chain."
+  [db]
+  (let [buffer (or (get db :trace-buffer) (trace-bus/buffer))]
+    (projection/group-cascades buffer)))
+
+(defn install!
+  "Idempotent install — register the `:rf.causa/focus` sub + its
+  driving events. Called from `registry.cljs`'s
+  `register-causa-handlers!` fan-out."
+  []
+  ;; ---- :rf.causa/focus — the spine sub ---------------------------------
+  ;;
+  ;; Composes the stored `:focus` slot with the live cascade list so
+  ;; `:head?` is derived (never stored). The dependency on
+  ;; `:rf.causa/cascades` means the spine recomputes whenever a new
+  ;; cascade lands, which is what gives LIVE mode its auto-tracking
+  ;; behaviour: a fresh head cascade re-derives `:head?` to true and
+  ;; (in LIVE) snaps the effective `:dispatch-id` forward.
+  (rf/reg-sub :rf.causa/focus-slot
+    (fn [db _query]
+      (get db :focus)))
+
+  (rf/reg-sub :rf.causa/focus
+    :<- [:rf.causa/focus-slot]
+    :<- [:rf.causa/cascades]
+    (fn [[focus cascades] _query]
+      (compose-focus focus cascades)))
+
+  ;; ---- events ----------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa/focus-cascade
+    (fn [db [_ dispatch-id frame-id]]
+      (focus-cascade-reducer db dispatch-id frame-id)))
+
+  (rf/reg-event-db :rf.causa/focus-cascade-prev
+    (fn [db _event]
+      (focus-step-reducer db (db->cascades db) -1)))
+
+  (rf/reg-event-db :rf.causa/focus-cascade-next
+    (fn [db _event]
+      (focus-step-reducer db (db->cascades db) +1)))
+
+  (rf/reg-event-db :rf.causa/follow-head
+    (fn [db _event]
+      (follow-head-reducer db)))
+
+  (rf/reg-event-db :rf.causa/toggle-live-pause
+    (fn [db _event]
+      (toggle-live-pause-reducer db)))
+
+  (rf/reg-event-db :rf.causa/set-frame
+    (fn [db [_ frame-id]]
+      (set-frame-reducer db frame-id)))
+
+  (rf/reg-event-db :rf.causa/preview-cascade
+    (fn [db [_ dispatch-id]]
+      (preview-cascade-reducer db dispatch-id)))
+
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -61,6 +61,12 @@
   [event]
   (#'keybinding/palette-toggle-key? event))
 
+(defn- spine-key-id
+  "rf2-adve5 — the spine-binding predicate (Space / L / j / k / G).
+  Returns the spine event id or nil."
+  [event]
+  (#'keybinding/spine-key-id event))
+
 ;; ---- stub `js/document` --------------------------------------------------
 ;;
 ;; The `attach!` / `detach!` helpers are guarded by `(exists?
@@ -357,3 +363,65 @@
           "without js/document the sentinel must NOT flip — otherwise
           a subsequent stub-driven attach! would falsely think it had
           already wired up"))))
+
+;; ---- (5) spine-key-id (rf2-adve5) ---------------------------------------
+;;
+;; Per spec/018 §3 + §6 the five spine bindings are Space, L, j, k, G.
+;; The predicate is *unmodified* — modifier-held variants must not
+;; match (so Cmd+L → focus address bar still works inside Causa). The
+;; mapping table:
+;;
+;;     Space   →  :rf.causa/toggle-live-pause
+;;     L       →  :rf.causa/follow-head      (snap-LIVE)
+;;     G       →  :rf.causa/follow-head      (Shift+G; vim 'Go to head')
+;;     j       →  :rf.causa/focus-cascade-prev
+;;     k       →  :rf.causa/focus-cascade-next
+
+(deftest spine-key-id-space-is-toggle-live-pause
+  (is (= :rf.causa/toggle-live-pause
+         (spine-key-id (mk-event {:key " "}))))
+  (is (= :rf.causa/toggle-live-pause
+         (spine-key-id (mk-event {:code "Space"})))))
+
+(deftest spine-key-id-l-is-follow-head
+  (is (= :rf.causa/follow-head
+         (spine-key-id (mk-event {:key "l"}))))
+  (is (= :rf.causa/follow-head
+         (spine-key-id (mk-event {:code "KeyL"})))))
+
+(deftest spine-key-id-shift-g-is-follow-head
+  (is (= :rf.causa/follow-head
+         (spine-key-id (mk-event {:key "G" :shift? true}))))
+  (is (= :rf.causa/follow-head
+         (spine-key-id (mk-event {:code "KeyG" :shift? true})))))
+
+(deftest spine-key-id-j-is-prev
+  (is (= :rf.causa/focus-cascade-prev
+         (spine-key-id (mk-event {:key "j"}))))
+  (is (= :rf.causa/focus-cascade-prev
+         (spine-key-id (mk-event {:code "KeyJ"})))))
+
+(deftest spine-key-id-k-is-next
+  (is (= :rf.causa/focus-cascade-next
+         (spine-key-id (mk-event {:key "k"}))))
+  (is (= :rf.causa/focus-cascade-next
+         (spine-key-id (mk-event {:code "KeyK"})))))
+
+(deftest spine-key-id-rejects-modifiers
+  (testing "Ctrl+L must not be hijacked (focus address bar)"
+    (is (nil? (spine-key-id (mk-event {:key "l" :ctrl? true})))))
+  (testing "Cmd+L likewise"
+    (is (nil? (spine-key-id (mk-event {:key "l" :meta? true})))))
+  (testing "Alt+j must not match"
+    (is (nil? (spine-key-id (mk-event {:key "j" :alt? true})))))
+  (testing "Shift+j must not match (capital J is not a spine key)"
+    (is (nil? (spine-key-id (mk-event {:key "j" :shift? true})))))
+  (testing "Lowercase g without Shift must not match (only Shift+G is)"
+    (is (nil? (spine-key-id (mk-event {:key "g"}))))))
+
+(deftest spine-key-id-rejects-unknown-keys
+  (testing "unrelated keys return nil"
+    (is (nil? (spine-key-id (mk-event {:key "x"}))))
+    (is (nil? (spine-key-id (mk-event {:key "Enter"}))))
+    (is (nil? (spine-key-id (mk-event {})))
+        "empty event → nil")))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -109,6 +109,8 @@
    :rf.causa/event-detail
    :rf.causa/flow-trace-events
    :rf.causa/flows-data
+   :rf.causa/focus
+   :rf.causa/focus-slot
    :rf.causa/focused-slice-path
    :rf.causa/fx-trace-events
    :rf.causa/hydration-debugger-data
@@ -200,7 +202,11 @@
    :rf.causa/copy-value-to-clipboard
    :rf.causa/dismiss-pin-overflow-toast
    :rf.causa/epoch-recorded
+   :rf.causa/focus-cascade
+   :rf.causa/focus-cascade-next
+   :rf.causa/focus-cascade-prev
    :rf.causa/focus-slice-path
+   :rf.causa/follow-head
    :rf.causa/hide-invalidation-chain
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
@@ -215,6 +221,7 @@
    :rf.causa/palette-toggle
    :rf.causa/pin-current
    :rf.causa/pin-slice
+   :rf.causa/preview-cascade
    :rf.causa/rename-pin
    :rf.causa/reorder-pinned-slices
    :rf.causa/reroot-tree-view
@@ -232,6 +239,7 @@
    :rf.causa/select-sub
    :rf.causa/select-violation
    :rf.causa/set-active-route-slice-override-for-test
+   :rf.causa/set-frame
    :rf.causa/set-machine-snapshots-override-for-test
    :rf.causa/set-mcp-since-seconds
    :rf.causa/set-performance-budget-ms
@@ -248,6 +256,7 @@
    :rf.causa/sync-epoch-history
    :rf.causa/sync-trace-buffer
    :rf.causa/time-travel-set-label-input
+   :rf.causa/toggle-live-pause
    :rf.causa/toggle-mcp-op-type
    :rf.causa/toggle-mcp-origin-filter
    :rf.causa/toggle-sub-filter
@@ -320,18 +329,22 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 72 subs + 75 events + 5 fxs"
+  (testing "registry holds exactly 74 subs + 82 events + 5 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
-    (is (= 72 (count all-sub-names)))
+    ;; + 2 spine (rf2-adve5): :rf.causa/focus + :rf.causa/focus-slot
+    (is (= 74 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
     ;;   palette-close / palette-cursor-down / palette-cursor-set /
     ;;   palette-cursor-up / palette-invoke / palette-open /
     ;;   palette-set-query / palette-toggle
-    (is (= 75 (count all-event-names)))
+    ;; + 7 spine (rf2-adve5): focus-cascade + focus-cascade-prev +
+    ;;   focus-cascade-next + follow-head + toggle-live-pause +
+    ;;   set-frame + preview-cascade
+    (is (= 82 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -13,8 +13,9 @@
        one arm silently routes to the `unknown-panel` fallback. The
        arm count + each arm's mapping is asserted here.
 
-    2. The bottom-rail `[● REDACTED N]` indicator (rf2-azls9). The
-       `config/suppressed-counters` atom is well-tested in
+    2. The `[● REDACTED N]` indicator (rf2-azls9, relocated to the
+       top strip per rf2-adve5 — spec/018 removes the bottom rail).
+       The `config/suppressed-counters` atom is well-tested in
        `sensitive_trace_cljs_test.cljc`; the *render* gate
        `(pos? redacted-count)` and the pluralisation in the title
        attribute are asserted here. Includes the 1 → 2 transition.
@@ -467,9 +468,10 @@
 
 (deftest shell-view-mounts-the-three-regions
   (testing "the shell-view returns a tree containing the shell's
-            `data-testid` envelope plus the bottom-rail (no testid
-            — asserted by the REDACTED indicator's absence/presence
-            in companion tests) and the sidebar's 15 rows"
+            `data-testid` envelope, the top-strip (carries the
+            REDACTED indicator + mode pill per rf2-adve5 — the
+            bottom rail was removed per spec/018 §2), and the
+            sidebar's 15 rows"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)]

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -1,0 +1,405 @@
+(ns day8.re-frame2-causa.spine-cljs-test
+  "Direct CLJS coverage for the spine substrate (rf2-adve5) — pure-
+  reducer + sub composition + the legacy-slot shim contract.
+
+  Per `tools/causa/spec/018-Event-Spine.md` §6 Spine binding the spine
+  sub `:rf.causa/focus` is the one axis every dependent surface reads
+  from. This file asserts:
+
+  1. The pure reducers (`focus-cascade-reducer`, `follow-head-reducer`,
+     `toggle-live-pause-reducer`, `set-frame-reducer`, `focus-step-
+     reducer`, `preview-cascade-reducer`) — JVM-runnable shape, no
+     re-frame machinery needed.
+  2. `compose-focus` derives `:head?` + the effective `:dispatch-id`
+     correctly across LIVE / RETRO / paused / evicted-cascade states.
+  3. The legacy shim — `:rf.causa/select-dispatch-id` writes through
+     to `:focus`, and `:rf.causa/focus-cascade` writes through to the
+     legacy `:selected-dispatch-id` slot. Existing panels continue to
+     read the legacy slot; new spine consumers read `:rf.causa/focus`.
+  4. The registered sub composes the slot + cascades via the standard
+     re-frame reactive path."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- cascade fixture ----------------------------------------------------
+
+(defn- cascade
+  "Build a minimal cascade shape — enough for the spine helpers'
+  by-id lookups + head detection. Per
+  `re-frame.trace.projection/group-cascades` cascades carry at least
+  `:dispatch-id` and `:frame`; tests of the spine module don't need
+  the full domino shape, just the identifier slots."
+  [dispatch-id frame-id]
+  {:dispatch-id dispatch-id
+   :frame       frame-id
+   :event       nil
+   :handler     nil
+   :fx          nil
+   :effects     []
+   :subs        []
+   :renders     []
+   :other       []})
+
+(def ^:private fixture-cascades
+  "Three-cascade fixture; oldest-first per group-cascades' contract.
+  c3 is the head."
+  [(cascade :c1 :rf/default)
+   (cascade :c2 :rf/default)
+   (cascade :c3 :rf/default)])
+
+;; -------------------------------------------------------------------------
+;; (1) Pure helpers — head / by-id / step
+;; -------------------------------------------------------------------------
+
+(deftest head-cascade-returns-last-entry
+  (is (= (last fixture-cascades) (spine/head-cascade fixture-cascades)))
+  (is (nil? (spine/head-cascade []))
+      "empty cascade vector → nil head"))
+
+(deftest head-dispatch-id-returns-last-id
+  (is (= :c3 (spine/head-dispatch-id fixture-cascades)))
+  (is (nil? (spine/head-dispatch-id []))))
+
+(deftest cascade-by-id-finds-existing
+  (is (= (nth fixture-cascades 1)
+         (spine/cascade-by-id fixture-cascades :c2)))
+  (is (nil? (spine/cascade-by-id fixture-cascades :nonexistent)))
+  (is (nil? (spine/cascade-by-id fixture-cascades nil))
+      "nil id → nil match"))
+
+(deftest step-dispatch-id-prev-stays-bounded
+  (testing "stepping prev from c2 → c1; from c1 → c1 (bounded)"
+    (is (= :c1 (spine/step-dispatch-id fixture-cascades :c2 -1)))
+    (is (= :c1 (spine/step-dispatch-id fixture-cascades :c1 -1)))))
+
+(deftest step-dispatch-id-next-stays-bounded
+  (testing "stepping next from c2 → c3; from c3 → c3 (bounded)"
+    (is (= :c3 (spine/step-dispatch-id fixture-cascades :c2 +1)))
+    (is (= :c3 (spine/step-dispatch-id fixture-cascades :c3 +1)))))
+
+(deftest step-from-nil-starts-at-head
+  (testing "nil current-id (no focus yet) → step from head"
+    (is (= :c2 (spine/step-dispatch-id fixture-cascades nil -1))
+        "prev from head → c2")
+    (is (= :c3 (spine/step-dispatch-id fixture-cascades nil +1))
+        "next from head → c3 (bounded at head)")))
+
+(deftest step-from-evicted-starts-at-head
+  (testing "an evicted current-id (not in cascades) → step from head"
+    (is (= :c2 (spine/step-dispatch-id fixture-cascades :gone -1))
+        "evicted id → step from head")))
+
+(deftest step-on-empty-cascade-vector-returns-nil
+  (is (nil? (spine/step-dispatch-id [] :c1 +1)))
+  (is (nil? (spine/step-dispatch-id [] nil -1))))
+
+;; -------------------------------------------------------------------------
+;; (2) compose-focus — :head? + effective :dispatch-id derivation
+;; -------------------------------------------------------------------------
+
+(deftest compose-focus-empty-slot-defaults-to-live-at-head
+  (testing "empty :focus slot with cascades → :live :dispatch-id at head"
+    (let [r (spine/compose-focus nil fixture-cascades)]
+      (is (= :c3 (:dispatch-id r))
+          "no slot → snap to head")
+      (is (= :live (:mode r)))
+      (is (true? (:head? r))))))
+
+(deftest compose-focus-live-with-stale-id-snaps-head
+  (testing ":live mode + stored id that no longer exists → snap to head"
+    (let [r (spine/compose-focus {:dispatch-id :gone :mode :live}
+                                 fixture-cascades)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (true? (:head? r))))))
+
+(deftest compose-focus-retro-preserves-stored-id
+  (testing ":retro mode preserves the stored id even if not the head"
+    (let [r (spine/compose-focus {:dispatch-id :c1 :mode :retro}
+                                 fixture-cascades)]
+      (is (= :c1 (:dispatch-id r)))
+      (is (= :retro (:mode r)))
+      (is (false? (:head? r))))))
+
+(deftest compose-focus-empty-cascades-snaps-nil
+  (testing "no cascades yet → nil :dispatch-id, :head? true (vacuously)"
+    (let [r (spine/compose-focus nil [])]
+      (is (nil? (:dispatch-id r)))
+      (is (true? (:head? r))))))
+
+(deftest compose-focus-derives-frame-from-cascade
+  (testing ":frame derives from the focused cascade — overrides any
+            stored slot frame so retro selections track the cascade
+            they pin to"
+    (let [r (spine/compose-focus {:dispatch-id :c2 :mode :retro
+                                  :frame :stale-frame}
+                                 fixture-cascades)]
+      (is (= :rf/default (:frame r))
+          "frame comes from the cascade record, not the stored slot"))))
+
+(deftest compose-focus-paused-flag-rides-through
+  (let [r (spine/compose-focus {:dispatch-id nil :mode :live :paused? true}
+                               fixture-cascades)]
+    (is (true? (:paused? r)))
+    (is (= :live (:mode r)))
+    (is (true? (:head? r)))))
+
+(deftest compose-focus-previewing-flag-rides-through
+  (let [r (spine/compose-focus {:dispatch-id :c2 :mode :retro
+                                :previewing? true}
+                               fixture-cascades)]
+    (is (true? (:previewing? r)))))
+
+;; -------------------------------------------------------------------------
+;; (3) focus-cascade-reducer — writes :focus + legacy shim
+;; -------------------------------------------------------------------------
+
+(deftest focus-cascade-reducer-writes-focus-slot
+  (let [db {}
+        r  (spine/focus-cascade-reducer db :c2 :rf/default)]
+    (is (= :c2 (get-in r [:focus :dispatch-id])))
+    (is (= :retro (get-in r [:focus :mode])))
+    (is (= :rf/default (get-in r [:focus :frame])))))
+
+(deftest focus-cascade-reducer-writes-legacy-shim
+  (testing "the legacy :selected-dispatch-id + :selected-dispatch slots
+            update in lockstep so existing event-detail / causality /
+            machine-inspector panels keep rendering"
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default)]
+      (is (= :c2 (:selected-dispatch-id r)))
+      (is (= {:dispatch-id :c2 :frame :rf/default}
+             (:selected-dispatch r))))))
+
+(deftest focus-cascade-reducer-without-frame-omits-frame
+  (let [r (spine/focus-cascade-reducer {} :c2 nil)]
+    (is (= :c2 (get-in r [:focus :dispatch-id])))
+    (is (= :c2 (:selected-dispatch-id r)))
+    (is (= {:dispatch-id :c2} (:selected-dispatch r))
+        "no :frame key when frame-id was nil")))
+
+;; -------------------------------------------------------------------------
+;; (4) focus-step-reducer — prev/next stepping
+;; -------------------------------------------------------------------------
+
+(deftest focus-step-reducer-prev-flips-to-retro
+  (let [db {:focus {:dispatch-id :c3 :mode :live} :selected-dispatch-id :c3}
+        r  (spine/focus-step-reducer db fixture-cascades -1)]
+    (is (= :c2 (get-in r [:focus :dispatch-id])))
+    (is (= :retro (get-in r [:focus :mode])))
+    (is (= :c2 (:selected-dispatch-id r))
+        "legacy shim updated alongside")))
+
+(deftest focus-step-reducer-next-returns-to-head-as-live
+  (let [db {:focus {:dispatch-id :c2 :mode :retro} :selected-dispatch-id :c2}
+        r  (spine/focus-step-reducer db fixture-cascades +1)]
+    (is (= :c3 (get-in r [:focus :dispatch-id])))
+    (is (= :live (get-in r [:focus :mode]))
+        "stepping back to head implicitly re-engages LIVE")))
+
+(deftest focus-step-reducer-from-empty-slot-uses-legacy
+  (let [db {:selected-dispatch-id :c2}
+        r  (spine/focus-step-reducer db fixture-cascades -1)]
+    (is (= :c1 (get-in r [:focus :dispatch-id]))
+        "stepping reads current-id from legacy when :focus is empty")))
+
+;; -------------------------------------------------------------------------
+;; (5) follow-head-reducer
+;; -------------------------------------------------------------------------
+
+(deftest follow-head-reducer-snaps-to-live
+  (let [db {:focus {:dispatch-id :c1 :mode :retro :paused? true}
+            :selected-dispatch-id :c1
+            :selected-dispatch    {:dispatch-id :c1}}
+        r  (spine/follow-head-reducer db)]
+    (is (nil? (get-in r [:focus :dispatch-id]))
+        "follow-head clears :dispatch-id so compose-focus snaps to head")
+    (is (= :live (get-in r [:focus :mode])))
+    (is (false? (get-in r [:focus :paused?])))
+    (is (nil? (:selected-dispatch-id r))
+        "legacy slots cleared in lockstep")
+    (is (nil? (:selected-dispatch r)))))
+
+;; -------------------------------------------------------------------------
+;; (6) toggle-live-pause-reducer
+;; -------------------------------------------------------------------------
+
+(deftest toggle-live-pause-reducer-flips-paused
+  (let [db {:focus {:mode :live :paused? false}}
+        r  (spine/toggle-live-pause-reducer db)]
+    (is (true? (get-in r [:focus :paused?])))
+    (let [r2 (spine/toggle-live-pause-reducer r)]
+      (is (false? (get-in r2 [:focus :paused?]))
+          "second toggle reverses"))))
+
+(deftest toggle-live-pause-reducer-noop-in-retro
+  (testing "in :retro, toggle-live-pause is a no-op — Space has no
+            meaning when the user has pinned an older row"
+    (let [db {:focus {:mode :retro :paused? false} :selected-dispatch-id :c1}
+          r  (spine/toggle-live-pause-reducer db)]
+      (is (= db r) "db unchanged"))))
+
+;; -------------------------------------------------------------------------
+;; (7) set-frame-reducer + preview-cascade-reducer
+;; -------------------------------------------------------------------------
+
+(deftest set-frame-reducer-clears-dispatch-id
+  (let [db {:focus {:dispatch-id :c2 :frame :rf/default :mode :retro}}
+        r  (spine/set-frame-reducer db :app/dialog)]
+    (is (= :app/dialog (get-in r [:focus :frame])))
+    (is (nil? (get-in r [:focus :dispatch-id]))
+        "frame switch snaps to new frame's head")
+    (is (= :live (get-in r [:focus :mode])))))
+
+(deftest preview-cascade-reducer-sets-previewing-true
+  (let [db {}
+        r  (spine/preview-cascade-reducer db :c2)]
+    (is (true? (get-in r [:focus :previewing?])))
+    (is (= :c2 (get-in r [:focus :dispatch-id])))))
+
+(deftest preview-cascade-reducer-nil-clears-preview
+  (let [db {:focus {:dispatch-id :c1 :previewing? true :mode :retro}}
+        r  (spine/preview-cascade-reducer db nil)]
+    (is (false? (get-in r [:focus :previewing?])))
+    (is (= :c1 (get-in r [:focus :dispatch-id]))
+        "committed selection survives preview-clear")))
+
+;; -------------------------------------------------------------------------
+;; (8) Registered :rf.causa/focus sub — reactive composition
+;; -------------------------------------------------------------------------
+
+(defn- focus-sub []
+  (rf/with-frame :rf/causa
+    @(rf/subscribe [:rf.causa/focus])))
+
+(defn- seed-cascades! [cascades-vec]
+  ;; Build a minimal trace-buffer that re-projects to the desired
+  ;; cascade vector. Each cascade needs one trace event carrying the
+  ;; cascade's id so group-cascades' frame-index pairs the right
+  ;; events. The simplest shape: one :event/dispatched per cascade.
+  (let [events (map-indexed
+                 (fn [i {:keys [dispatch-id frame]}]
+                   {:id        (inc i)
+                    :op-type   :event
+                    :operation :event/dispatched
+                    :tags      {:dispatch-id dispatch-id
+                                :frame       frame
+                                :event       [(keyword "evt" (str (name dispatch-id)))]}})
+                 cascades-vec)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer (vec events)]))))
+
+(deftest focus-sub-returns-default-shape-on-empty-buffer
+  (setup-causa-frame!)
+  (let [r (focus-sub)]
+    (is (= :live (:mode r))
+        "empty buffer → :live (head-tracking)")
+    (is (nil? (:dispatch-id r)))
+    (is (true? (:head? r)))))
+
+(deftest focus-sub-snaps-to-head-on-empty-slot
+  (setup-causa-frame!)
+  (seed-cascades! fixture-cascades)
+  (let [r (focus-sub)]
+    (is (= :c3 (:dispatch-id r))
+        "empty :focus slot → :live → snap to head c3")
+    (is (true? (:head? r)))))
+
+(deftest focus-sub-preserves-retro-selection
+  (setup-causa-frame!)
+  (seed-cascades! fixture-cascades)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+  (let [r (focus-sub)]
+    (is (= :c1 (:dispatch-id r)))
+    (is (= :retro (:mode r)))
+    (is (false? (:head? r)))))
+
+(deftest focus-sub-shimmed-by-legacy-select-dispatch-id
+  (testing "dispatching the legacy :rf.causa/select-dispatch-id writes
+            through to the spine — proves the shim runs in BOTH
+            directions (legacy event → spine sub)"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id :c2 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c2 (:dispatch-id r))
+          "spine focus tracks the legacy selection event")
+      (is (= :retro (:mode r))))))
+
+(deftest legacy-selected-dispatch-id-shimmed-by-focus-cascade
+  (testing "dispatching the new :rf.causa/focus-cascade writes
+            through to the legacy slot — existing event-detail panel
+            keeps reading :selected-dispatch-id unchanged"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c2 :rf/default]))
+    (let [legacy (rf/with-frame :rf/causa
+                   @(rf/subscribe [:rf.causa/selected-dispatch-id]))]
+      (is (= :c2 legacy)
+          "legacy sub rebinds because the focus-cascade event also
+           wrote the legacy slot"))))
+
+(deftest focus-sub-step-events-walk-cascades
+  (setup-causa-frame!)
+  (seed-cascades! fixture-cascades)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade :c3 :rf/default])
+    (rf/dispatch-sync [:rf.causa/focus-cascade-prev]))
+  (let [r (focus-sub)]
+    (is (= :c2 (:dispatch-id r)) "prev steps from c3 to c2")
+    (is (= :retro (:mode r))))
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade-prev]))
+  (let [r (focus-sub)]
+    (is (= :c1 (:dispatch-id r)) "prev again → c1"))
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade-next])
+    (rf/dispatch-sync [:rf.causa/focus-cascade-next]))
+  (let [r (focus-sub)]
+    (is (= :c3 (:dispatch-id r)) "two nexts → back to head")
+    (is (= :live (:mode r))
+        "stepping back to head re-engages LIVE")))
+
+(deftest follow-head-event-resnaps-to-head
+  (setup-causa-frame!)
+  (seed-cascades! fixture-cascades)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default])
+    (rf/dispatch-sync [:rf.causa/follow-head]))
+  (let [r (focus-sub)]
+    (is (= :c3 (:dispatch-id r)) "follow-head snaps back to head c3")
+    (is (= :live (:mode r)))
+    (is (true? (:head? r)))))
+
+(deftest toggle-live-pause-event-flips-paused
+  (setup-causa-frame!)
+  (seed-cascades! fixture-cascades)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-live-pause]))
+  (let [r (focus-sub)]
+    (is (true? (:paused? r)))
+    (is (= :live (:mode r)))))


### PR DESCRIPTION
## Summary

Smallest-first-PR for the Causa rewrite per [`tools/causa/spec/018-Event-Spine.md`](../blob/main/tools/causa/spec/018-Event-Spine.md) §6 Spine binding. Establishes the single-axis selection sub every Spec 018 surface will read from, shims the legacy per-panel selection slots so the existing 15 panels keep rendering, removes the dead bottom rail, and adds the spec-018 §3 + §6 keybindings.

Per the consolidated design §14 this PR is intentionally **invisible** to existing panels — the user-facing change is the new mode pill in the top strip, the bottom rail's disappearance, and the new keybindings inside the shell. Every existing panel keeps working through the lockstep shim.

## What landed

### Code

- **`tools/causa/src/day8/re_frame2_causa/spine.cljs`** (new) — owns `:rf.causa/focus` + the seven driving events:
  - `:rf.causa/focus-cascade <id> [frame]` — click row / palette jump
  - `:rf.causa/focus-cascade-prev` — ◀ / j / ←
  - `:rf.causa/focus-cascade-next` — ▶ / k / →
  - `:rf.causa/follow-head` — ⏭ / L / Shift+G
  - `:rf.causa/toggle-live-pause` — Space
  - `:rf.causa/set-frame <frame-id>` — frame picker
  - `:rf.causa/preview-cascade <id>` — row hover
  - `:rf.causa/focus` composes a stored `:focus` slot with the live cascade vector so `:head?` + the effective `:dispatch-id` are always derived (never stale).

- **`panels/event_detail.cljs`** — `:rf.causa/select-dispatch-id` now writes through `spine/focus-cascade-reducer`; the legacy `:selected-dispatch-id` / `:selected-dispatch` slots are written in lockstep so existing panels read unchanged.

- **`panels/time_travel_events.cljs`** — `:rf.causa/select-epoch` writes both `:selected-epoch-id` (legacy) AND `[:focus :epoch-id]` (spine).

- **`registry.cljs`** — wires `(spine/install!)` into the `register-causa-handlers!` fan-out before per-panel installs so the spine slot exists when the shim writes land.

- **`shell.cljs`** — bottom rail removed per spec/018 §2; mode pill added to the top strip per spec/018 §3 (LIVE / LIVE (paused) / RETRO + click flips paused or snaps to LIVE); REDACTED indicator (rf2-azls9) relocates to the top strip with testid preserved so render tests stay green.

- **`keybinding.cljs`** — Space / L / j / k / Shift+G gated by (1) shell visible (2) target inside Causa shell DOM (3) target not editable. Bare keys (no modifiers) per spec/018.

### Tests

- **`spine_cljs_test.cljs`** (new) — 35 deftests covering pure reducers + `compose-focus` derivation across LIVE/RETRO/paused/evicted-cascade states + the registered sub composition + both shim directions (legacy → spine + spine → legacy).
- **`keybinding_cljs_test.cljs`** — 7 new deftests for `spine-key-id` (each key + modifier rejection + unknown-key).
- **`registry_cljs_test.cljs`** — name allowlist + count assertions updated for the new 2 subs + 7 events.

### Spec sync

`tools/causa/spec/018-Event-Spine.md` already describes everything implemented here — §3 Mode pill, §4 Defaults, §6 Spine binding (`:rf.causa/focus` shape + event table + transition table). No spec changes needed.

## Test plan

- [x] `cd implementation && npm run test:cljs` — 2368 tests / 6837 assertions / **0 failures**
- [x] `cd implementation && npm run test:browser` — 2357 tests / 6696 assertions / **0 failures**
- [x] `cd implementation && npm run test:bundle-isolation` — **pass**

## Non-obvious decisions (per overnight directive)

1. **REDACTED indicator placement.** Spec 018 §3 says it lives in the mode-pill *hover tooltip*. For this smallest-first-PR I relocated it adjacent to the mode pill in the top strip (preserving the `rf-causa-redacted-indicator` testid + render contract). Moving it into the tooltip is a follow-on; doing it in this PR would require restructuring the existing 4 `redacted-indicator-*` render tests.

2. **Step events run inside `reg-event-db`** by re-projecting the cascade list from the trace-buffer slot. Equivalent to what the reactive `:rf.causa/cascades` sub does; running the projection inline keeps the event-db pure (no `reg-event-fx` ceremony). O(buffer) cost per step is bounded by the same depth contract every other Causa consumer pays.

3. **Frame derives from cascade, not stored slot.** `compose-focus` reads `:frame` from the focused cascade record (falling back to the stored slot when no cascade matches). Means retro selections automatically track the cascade they pin to without per-event frame plumbing.

4. **`set-frame` + `preview-cascade` events** have no callers in this PR but are part of the spec/018 §6 event table; landed now so follow-on bead implementing the ribbon's frame picker + row-hover preview can wire them up without touching the spine again.

Closes rf2-adve5.