### PR TITLE
feat(classification): impl reg-marks API + propagation (rf2-vw7f5)

### DIFF
--- a/implementation/core/src/re_frame/cofx.cljc
+++ b/implementation/core/src/re_frame/cofx.cljc
@@ -152,6 +152,11 @@
           [{} metadata-or-handler])]
     (registrar/register! :cofx id (assoc (source-coords/merge-coords meta)
                                          :handler-fn handler-fn))
+    ;; Per Spec 015 §5. Coeffects — stash `:sensitive` / `:large` path
+    ;; declarations so emit-time projection redacts the cofx-injected
+    ;; value's slots in trace events that surface `:coeffects`.
+    (when-let [register! (late-bind/get-fn :marks/register-marks!)]
+      (register! :cofx id meta))
     id))
 
 (defn inject-cofx

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -47,6 +47,7 @@
             [re-frame.event-emit :as event-emit]
             [re-frame.error-emit :as error-emit]
             [re-frame.elision :as elision]
+            [re-frame.marks   :as marks]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.core-flows    :as rf-flows]
             [re-frame.core-routing  :as rf-routing]
@@ -471,6 +472,30 @@
   and cross-runtime deterministic. Per Spec 010 §Digest algorithm
   (rf2-wla45). Implementation ships in `day8/re-frame2-schemas`."}
   set-schema-printer!    rf-schemas/set-schema-printer!)
+
+;; ---- data classification (Spec 015) -------------------------------------
+
+(def ^{:doc "Declare path-marks against `app-db` for a frame, per Spec 015
+  §reg-marks. `metadata` is a map of optional `:sensitive [paths]` and
+  `:large [paths]` keys; each path is a `get-in`-shaped vector. A second
+  call against the same frame REPLACES the previous declaration set
+  (schema-attached marks are preserved — the two sources union per
+  Spec 015 §Relationship with schema-attached marks). The declaration
+  feeds the mark-lookup table the observation surfaces (trace bus,
+  Causa, MCP, third-party log sinks) consult at emission time — real
+  values flow through the application unchanged.
+
+  Example:
+
+      (rf/reg-marks :rf/default
+        {:sensitive [[:user :ssn]
+                     [:auth :token]]
+         :large     [[:docs :csv-upload]]})
+
+  Returns `frame-id`. Pure declaration — does NOT mutate `app-db`,
+  does NOT install an interceptor, does NOT change any handler's view
+  of the data."}
+  reg-marks marks/reg-marks)
 
 ;; ---- clearing ------------------------------------------------------------
 

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -9,9 +9,17 @@
 
   All three register under registry kind :event with an :event/kind sub-tag
   recording which form was used. The runtime treats all three uniformly
-  during drain — the difference is only in the wrapping shape."
+  during drain — the difference is only in the wrapping shape.
+
+  Per Spec 015 §1. Event handlers — the registration meta-map accepts
+  optional `:sensitive [paths]` and `:large [paths]` keys that index
+  into the dispatched event vector's arg-map (the second element).
+  The marks are stashed in the per-(kind, id) marks table via
+  `re-frame.marks/register-marks!` (called through the late-bind
+  hook to keep events decoupled from the optional marks artefact)."
   (:require [re-frame.registrar :as registrar]
             [re-frame.interceptor :as interceptor]
+            [re-frame.late-bind :as late-bind]
             [re-frame.source-coords :as source-coords]
             [re-frame.trace :as trace]))
 
@@ -241,6 +249,13 @@
              :event/kind   kind
              :handler-fn   handler-fn
              :interceptors (-> [] (into interceptors) (conj wrapped))))
+    ;; Per Spec 015 §1. Event handlers: stash any declared `:sensitive`
+    ;; / `:large` paths in the marks table so emit-time projection can
+    ;; resolve them. Late-bound — the hook is unbound when the marks
+    ;; artefact is absent (which it never is in the canonical build,
+    ;; but the indirection keeps `events` decoupled from `marks`).
+    (when-let [register! (late-bind/get-fn :marks/register-marks!)]
+      (register! :event id meta))
     id))
 
 (defn reg-event-db

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -93,6 +93,11 @@
           [{} metadata-or-handler])]
     (registrar/register! :fx id (assoc (source-coords/merge-coords meta)
                                        :handler-fn handler-fn))
+    ;; Per Spec 015 §4. Effects — stash `:sensitive` / `:large` path
+    ;; declarations so emit-time projection redacts `:fx-args` slots
+    ;; on `:rf.fx/handled` traces.
+    (when-let [register! (late-bind/get-fn :marks/register-marks!)]
+      (register! :fx id meta))
     id))
 
 (defn clear-fx

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -64,6 +64,36 @@
     :design-bead "rf2-w3n5u"
     :description "Reset the once-per-(frame,path) :rf.warning/large-value-unschema'd cache."}
 
+   ;; ---- re-frame.marks (rf2-vw7f5 Spec 015 data classification) -------------
+   {:key         :marks/reg-marks
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Declare path-marks against a frame's app-db (Spec 015 §reg-marks)."}
+   {:key         :marks/register-marks!
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Stash a registration's :sensitive / :large declarations in the per-(kind, id) marks table at registration time."}
+   {:key         :marks/project-trace-event
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Emit-time chokepoint for trace bus — walks the assembled trace event's tags and substitutes sentinels at declared paths (Spec 015 §Implementation notes recommendation B)."}
+   {:key         :marks/resolve-sub-output-marks
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Compute the sensitive/large propagation flags for a sub's most recent output (Spec 015 §App-db → subs / §Subs → fx)."}
+   {:key         :marks/mark-sub-output!
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Record the resolved sensitive/large state of a sub's most recent output in the per-(frame, sub-id) propagation table."}
+   {:key         :marks/clear-marks!
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Drop every registered marks declaration (test isolation)."}
+   {:key         :marks/clear-sub-output-marks!
+    :producer-ns 're-frame.marks
+    :design-bead "rf2-vw7f5"
+    :description "Drop the per-frame sub-output propagation table (test isolation)."}
+
    ;; ---- re-frame.flows -------------------------------------------------------
    ;; Both the public `rf/reg-flow` / `rf/clear-flow` surfaces AND the
    ;; `:rf.fx/reg-flow` / `:rf.fx/clear-flow` runtime fxs route through

--- a/implementation/core/src/re_frame/marks.cljc
+++ b/implementation/core/src/re_frame/marks.cljc
@@ -1,0 +1,645 @@
+(ns re-frame.marks
+  "Data-classification path-marks for sensitive + large values per Spec 015.
+
+  This namespace owns:
+    - `reg-marks` — the dedicated registration kind for declaring
+      path-marks against an `app-db` (frame-scoped).
+    - Per-registration mark tables — a per-(kind, id) index of
+      `{:sensitive [paths] :large [paths] :sensitive? bool :large? bool}`
+      stashed at registration time so emit-time consumers can resolve
+      marks without re-walking the registrar meta on every event.
+    - Emit-time projection — the path-walk + sentinel substitution
+      consumed by `re-frame.trace/build-event` to redact `:rf/redacted`
+      at `:sensitive` paths and surface `:rf.size/large-elided` markers
+      at `:large` paths inside trace-event `:tags`.
+    - Sub-output mark propagation — a per-(frame, query-v) table that
+      records whether a sub's most recent output should be treated as
+      sensitive/large for downstream consumers. Footgun prevention,
+      not security taint.
+
+  Per Spec 015 §Hot-path cost: the entire surface rides
+  `re-frame.interop/debug-enabled?` — registrations still populate
+  tables at boot (constant memory), but emit-time projection is gated
+  and constant-folds out of CLJS production bundles via `goog.DEBUG`.
+
+  Per Spec 015 §Relationship with schema-attached marks: this
+  namespace writes into the SAME registry slot the schema-first
+  elision walker reads from (`[:rf/elision :sensitive-declarations]`
+  and `[:rf/elision :declarations]`), keyed by absolute path. The two
+  declaration sources union at lookup time — a path declared sensitive
+  by EITHER source is sensitive."
+  (:require [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
+            [re-frame.substrate.adapter :as adapter]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---- per-registration mark tables ----------------------------------------
+;;
+;; A per-(kind, id) index of the registration's declared marks. Populated
+;; at registration time by `register-marks!` (called from the existing
+;; `reg-event-*` / `reg-sub` / `reg-fx` / `reg-cofx` / `reg-machine` /
+;; `reg-flow` reg-paths). Read at emit time by the projection helpers.
+;;
+;; The table is process-scoped (mirrors `re-frame.registrar`'s shape) —
+;; declarations bind to (kind, id), not to (frame, kind, id). `reg-marks`
+;; is the exception — it is frame-scoped and writes into the per-frame
+;; elision registry.
+
+(defonce ^:private kind->id->marks
+  (atom {}))
+
+(defn- coerce-paths
+  "Normalise a `:sensitive` / `:large` declaration value to a vector of
+  path vectors. `nil` becomes `[]`; any non-vector entry is dropped
+  (the declaration is best-effort — we tolerate hand-written maps that
+  passed an empty literal but want to log via `[[]]` for whole-value
+  marks)."
+  [paths]
+  (if (nil? paths)
+    []
+    (vec (filter vector? paths))))
+
+(defn- normalise-marks
+  "Extract the mark-relevant subset of a registration meta-map and
+  normalise into the canonical shape this namespace consults:
+
+    {:sensitive  [vector-of-paths]
+     :large      [vector-of-paths]
+     :sensitive? <bool-or-nil>   ;; whole-output override (subs/flows)
+     :large?     <bool-or-nil>}  ;; whole-output override (subs/flows)
+
+  Returns `nil` when the meta-map carries no mark-relevant keys —
+  callers branch on the nil to avoid stashing empty tables."
+  [meta]
+  (when (or (contains? meta :sensitive)
+            (contains? meta :large)
+            (contains? meta :sensitive?)
+            (contains? meta :large?))
+    (cond-> {}
+      (contains? meta :sensitive)  (assoc :sensitive  (coerce-paths (:sensitive meta)))
+      (contains? meta :large)      (assoc :large      (coerce-paths (:large meta)))
+      (contains? meta :sensitive?) (assoc :sensitive? (boolean (:sensitive? meta)))
+      (contains? meta :large?)     (assoc :large?     (boolean (:large? meta))))))
+
+(defn register-marks!
+  "Record a registration's mark declaration for later emit-time consultation.
+  Returns nil. No-op when `meta` carries no mark-relevant keys.
+
+  Called from each reg-* path AFTER the underlying registrar write so the
+  marks table mirrors the registry. Re-registration replaces the prior
+  marks entry in full (no merge — matches the registrar's slot semantics)."
+  [kind id meta]
+  (let [marks (normalise-marks meta)]
+    (if (nil? marks)
+      ;; Clear any prior marks for this (kind, id) on re-registration
+      ;; without marks — the new registration's declaration set should
+      ;; supersede the old one in full (Spec 015 §reg-marks: "second
+      ;; call against the same id wins"). The same rule generalises
+      ;; from `reg-marks` to every reg-* site.
+      (swap! kind->id->marks update kind dissoc id)
+      (swap! kind->id->marks assoc-in [kind id] marks)))
+  nil)
+
+(defn marks-for
+  "Return the registered mark declaration for `(kind, id)`, or nil.
+
+  The returned shape is `{:sensitive [paths] :large [paths]
+  :sensitive? bool :large? bool}` — slots are present only when the
+  registration declared them."
+  [kind id]
+  (get-in @kind->id->marks [kind id]))
+
+(defn clear-marks!
+  "Drop every registered marks declaration. Test-isolation only —
+  production code never calls this. Returns nil."
+  []
+  (reset! kind->id->marks {})
+  nil)
+
+;; ---- reg-marks API -------------------------------------------------------
+;;
+;; The dedicated registration kind for declaring path-marks against an
+;; `app-db`. Frame-scoped per Spec 015 §reg-marks. Writes through the
+;; existing `[:rf/elision :sensitive-declarations]` /
+;; `[:rf/elision :declarations]` registry slots so the schema-first
+;; elision walker (`re-frame.elision/elide-wire-value`) sees the
+;; declarations without a second lookup path.
+;;
+;; Per Spec 015 §reg-marks: a second `reg-marks` call against the same
+;; frame REPLACES the previous declaration set (NOT merge). This drops
+;; the prior `:reg-marks`-sourced entries and overlays the new ones;
+;; schema-sourced entries are preserved (they are not owned by
+;; `reg-marks` and live alongside).
+
+(defn- swap-app-db!
+  "Mutate the frame's app-db through the substrate adapter. The mark-
+  registry lives at `[:rf/elision ...]` per Spec 015 §Mark-lookup table
+  shape and matches the schema-first elision walker's storage location."
+  [frame-id f]
+  (when-let [container (frame/get-frame-db frame-id)]
+    (let [old-db (adapter/read-container container)
+          new-db (f old-db)]
+      (adapter/replace-container! container new-db))))
+
+(defn- without-reg-marks-sourced
+  "Drop entries whose `:source` is `:reg-marks` from a declaration map.
+  Used by `reg-marks` to clear the prior call's contributions before
+  overlaying the new ones — schema-sourced entries survive."
+  [decls]
+  (when decls
+    (reduce-kv (fn [acc path decl]
+                 (if (= :reg-marks (:source decl))
+                   acc
+                   (assoc acc path decl)))
+               {}
+               decls)))
+
+(defn- overlay-reg-marks
+  "Build the new declaration map for one registry slot: drop the prior
+  `:reg-marks`-sourced entries, then assoc the new paths with
+  `{:source :reg-marks}`."
+  [existing paths]
+  (let [carry (without-reg-marks-sourced existing)]
+    (reduce (fn [acc path]
+              (assoc acc (vec path) {:source :reg-marks}))
+            carry
+            paths)))
+
+(defn reg-marks
+  "Declare path-marks against the `app-db` of `frame-id`. Per Spec 015
+  §reg-marks (app-db, per frame).
+
+  `metadata` is a map with optional `:sensitive` and `:large` keys; each
+  is a vector of `get-in`-shaped paths into `app-db`. A second call
+  against the same frame REPLACES the previous declaration set in full
+  (per Spec 015 §reg-marks: 'a second `reg-marks` call against the same
+  frame wins'). Schema-attached marks (via `reg-app-schema` with
+  `:sensitive?` / `:large?` slot metadata) are preserved — the two
+  declaration sources union at lookup time per Spec 015 §Relationship
+  with schema-attached marks.
+
+      (rf/reg-marks :rf/default
+        {:sensitive [[:user :ssn]
+                     [:auth :token]
+                     [:auth :refresh-token]]
+         :large     [[:docs :csv-upload]
+                     [:logs :history-buffer]]})
+
+  Returns `frame-id`.
+
+  `reg-marks` is a pure declaration — it does NOT mutate `app-db`,
+  does NOT install an interceptor, and does NOT change any handler's
+  view of the data. The declaration only feeds the mark-lookup table
+  the observation surfaces (trace bus, Causa, MCP, third-party log
+  sinks) consult at emission time."
+  [frame-id {:keys [sensitive large] :as _metadata}]
+  (let [sens (coerce-paths sensitive)
+        lrg  (coerce-paths large)]
+    (swap-app-db! frame-id
+      (fn [db]
+        (let [reg     (get db :rf/elision)
+              new-s   (overlay-reg-marks (get reg :sensitive-declarations) sens)
+              new-l   (overlay-reg-marks (get reg :declarations) lrg)
+              new-reg (cond-> (or reg {})
+                        (seq new-s) (assoc :sensitive-declarations new-s)
+                        (empty? new-s) (dissoc :sensitive-declarations)
+                        (seq new-l) (assoc :declarations new-l)
+                        (empty? new-l) (dissoc :declarations))]
+          (if (seq new-reg)
+            (assoc db :rf/elision new-reg)
+            (dissoc db :rf/elision)))))
+    frame-id))
+
+(defn clear-reg-marks!
+  "Drop every `reg-marks`-sourced declaration for `frame-id`. Schema-
+  sourced declarations are preserved. Returns nil. Test-isolation
+  only; production code rarely needs this."
+  [frame-id]
+  (swap-app-db! frame-id
+    (fn [db]
+      (let [reg     (get db :rf/elision)
+            new-s   (without-reg-marks-sourced (:sensitive-declarations reg))
+            new-l   (without-reg-marks-sourced (:declarations reg))
+            new-reg (cond-> {}
+                      (seq new-s) (assoc :sensitive-declarations new-s)
+                      (seq new-l) (assoc :declarations new-l))]
+        (if (seq new-reg)
+          (assoc db :rf/elision new-reg)
+          (dissoc db :rf/elision)))))
+  nil)
+
+;; ---- emit-time projection ------------------------------------------------
+;;
+;; Two pathways resolve marks at emit time, per Spec 015 §Implementation
+;; notes recommendation B (path-graph union at emit time):
+;;
+;;   1. `redact-with-paths` — given a payload value and a registration's
+;;      declared paths (event-arg marks, fx-input marks, cofx-injection
+;;      marks, sub-output marks, machine-data marks, flow-output marks),
+;;      walk the payload and substitute sentinels at the declared paths.
+;;      The walker is the elision-walker re-used with an inline ctx so
+;;      the marker shapes are uniform across schema-sourced and per-
+;;      registration-sourced marks.
+;;
+;;   2. `redact-tags` — the chokepoint `re-frame.trace/build-event`
+;;      consults. Looks up the in-scope handler's marks (via the
+;;      `:rf.trace/trigger-handler`'s kind+id), the cascade's event-id
+;;      (per Spec 015 §Event-args -> app-db propagation), and the
+;;      frame's app-db elision registry; computes the union and walks
+;;      the per-tag projection. Trace tags carry kind-specific shapes
+;;      (events under `:event`, fxs under `:fx-id`/`:fx-args`, subs
+;;      under `:value`/`:input-signals`, ...) — the projection is per-
+;;      tag-shape.
+
+(defn- ->bytes
+  "Return a byte-count for a value's printed representation. Used by
+  the `:rf.size/large-elided` marker payload."
+  [v]
+  #?(:clj  (count (.getBytes ^String (pr-str v) "UTF-8"))
+     :cljs (count (pr-str v))))
+
+(defn- value-type
+  [v]
+  (cond
+    (map? v)    :map
+    (vector? v) :vector
+    (set? v)    :set
+    (string? v) :string
+    :else       :scalar))
+
+(defn- large-marker
+  "Mirror of `re-frame.elision/->marker`'s shape — inlined so this ns
+  carries no dependency on elision's privates. Carries `:reason
+  :reg-marks` so consumers can discriminate per-registration marks
+  from schema-driven marks."
+  [v path]
+  (let [p (vec path)]
+    {:rf.size/large-elided
+     {:path   p
+      :bytes  (->bytes v)
+      :type   (value-type v)
+      :reason :reg-marks
+      :handle [:rf.elision/at p]}}))
+
+(defn- walk-with-marks
+  "Walk `v` and substitute sentinels at the declared paths. Paths in
+  `sensitive-paths` and `large-paths` are rooted at `v`. Sensitive
+  wins over large at the same path.
+
+  No-op early-exit: when both path sets are empty, returns `v`
+  unchanged with no allocation. Matches the schema-first elision
+  walker's recursion semantics (`re-frame.elision/walk`) but uses
+  only the ad-hoc paths the caller supplied."
+  [v sensitive-paths large-paths]
+  (if (and (empty? sensitive-paths) (empty? large-paths))
+    v
+    (let [sensitive-set (set (map vec sensitive-paths))
+          large-set     (set (map vec large-paths))]
+      (letfn [(walk* [v path]
+                (let [path (vec path)]
+                  (cond
+                    (contains? sensitive-set path) privacy/redacted-sentinel
+                    (contains? large-set path)    (large-marker v path)
+                    (map? v) (reduce-kv (fn [acc k vv]
+                                          (assoc acc k (walk* vv (conj path k))))
+                                        (empty v) v)
+                    (vector? v)
+                    (let [n (count v)]
+                      (loop [i 0 acc (transient [])]
+                        (if (< i n)
+                          (recur (inc i) (conj! acc (walk* (nth v i) (conj path i))))
+                          (persistent! acc))))
+                    (set? v) (into #{} (map #(walk* % path)) v)
+                    (seq? v)
+                    (let [idx (volatile! -1)]
+                      (persistent!
+                        (reduce (fn [acc vv]
+                                  (vswap! idx inc)
+                                  (conj! acc (walk* vv (conj path @idx))))
+                                (transient []) v)))
+                    :else v)))]
+        (walk* v [])))))
+
+(defn redact-with-paths
+  "Public projection helper. Walks `v` and substitutes sentinels at the
+  declared paths. Empty `[[]]` path substitutes the whole value
+  (sensitive wins over large at the root). Per Spec 015 §What gets a
+  sentinel."
+  [v sensitive-paths large-paths]
+  (walk-with-marks v sensitive-paths large-paths))
+
+;; ---- per-trace-event projection ------------------------------------------
+;;
+;; The chokepoint `re-frame.trace/build-event` consults on every emit
+;; (gated by `interop/debug-enabled?` so production CLJS bundles DCE).
+;; Tag-shape table: each operation has a known shape, and this fn knows
+;; how to walk the tags into the right slot for the right registration's
+;; marks.
+
+(defn- redact-event-vec
+  "Redact a `[event-id arg-map]` vector. Marks index into the arg-map
+  (the second element). Per Spec 015 §Event handlers — paths are rooted
+  at the arg-map; whole-arg substitution uses `[[]]`."
+  [event sensitive-paths large-paths]
+  (cond
+    (or (nil? event) (not (vector? event))) event
+    (< (count event) 2) event
+    :else
+    (let [[id payload & rest-args] event
+          redacted-payload (redact-with-paths payload sensitive-paths large-paths)]
+      (into [id redacted-payload] rest-args))))
+
+(defn- event-marks
+  "Resolve the marks declared by the event handler registered under
+  `event-id`. Returns `{:sensitive [paths] :large [paths]}` or nil
+  when no marks are declared."
+  [event-id]
+  (when event-id
+    (marks-for :event event-id)))
+
+(defn- fx-marks
+  [fx-id]
+  (when fx-id
+    (marks-for :fx fx-id)))
+
+(defn- cofx-marks
+  [cofx-id]
+  (when cofx-id
+    (marks-for :cofx cofx-id)))
+
+(defn- machine-marks
+  [machine-id]
+  (when machine-id
+    (marks-for :event machine-id)))
+
+(defn- sub-marks
+  [sub-id]
+  (when sub-id
+    (marks-for :sub sub-id)))
+
+(defn- flow-marks
+  [flow-id]
+  (when flow-id
+    (marks-for :flow flow-id)))
+
+;; ---- sub-output propagation registry -------------------------------------
+;;
+;; Per Spec 015 §App-db → subs: a sub reading any sensitive `app-db` path
+;; yields a sensitive output by default. The reference implementation
+;; uses the per-sub-id registered marks plus an opt-in `:sensitive?`
+;; override on registration. The downstream propagation table records
+;; the resolved "is this sub's most recent value sensitive?" answer for
+;; emit-time consultation. Frame-scoped because subs are frame-scoped.
+
+(defonce ^:private frame->sub-id->sensitive?
+  (atom {}))
+
+(defonce ^:private frame->sub-id->large?
+  (atom {}))
+
+(defn mark-sub-output!
+  "Record the resolved sensitive/large state of a sub's most recent
+  output. Called by the sub-cache after `compute-and-cache!` resolves
+  the value. The flags fold into the propagation table; downstream
+  emit sites read via `sub-output-sensitive?` / `sub-output-large?`."
+  [frame-id sub-id sensitive? large?]
+  (swap! frame->sub-id->sensitive?
+         (fn [m]
+           (if sensitive?
+             (assoc-in m [frame-id sub-id] true)
+             (update m frame-id dissoc sub-id))))
+  (swap! frame->sub-id->large?
+         (fn [m]
+           (if large?
+             (assoc-in m [frame-id sub-id] true)
+             (update m frame-id dissoc sub-id))))
+  nil)
+
+(defn sub-output-sensitive?
+  [frame-id sub-id]
+  (true? (get-in @frame->sub-id->sensitive? [frame-id sub-id])))
+
+(defn sub-output-large?
+  [frame-id sub-id]
+  (true? (get-in @frame->sub-id->large? [frame-id sub-id])))
+
+(defn clear-sub-output-marks!
+  ([] (reset! frame->sub-id->sensitive? {})
+      (reset! frame->sub-id->large? {})
+      nil)
+  ([frame-id] (swap! frame->sub-id->sensitive? dissoc frame-id)
+              (swap! frame->sub-id->large? dissoc frame-id)
+              nil))
+
+(defn resolve-sub-output-marks
+  "Compute the sensitive/large flags that should be stamped onto a sub's
+  output, given the sub's registered marks + input-signals' propagation
+  state + a layer-1 sub's path overlap with the frame's app-db
+  sensitive declarations.
+
+  Resolution per Spec 015 §3. Subscriptions:
+    1. `:sensitive? true`  forces sensitive
+    2. `:sensitive? false` opts out (overrides propagation)
+    3. Otherwise: propagate — if ANY input-signal's resolved sub-output
+       is sensitive, OR if the sub is layer-1 and any sensitive app-db
+       path was declared, mark sensitive
+  Mirror for `:large?` / `:large`.
+
+  Returns `[sensitive? large?]`."
+  [frame-id sub-id input-signals layer-1?]
+  (let [marks       (sub-marks sub-id)
+        forced-s    (:sensitive? marks)
+        forced-l    (:large? marks)
+        ;; Propagation from inputs
+        input-s?    (and (seq input-signals)
+                         (some (fn [q] (sub-output-sensitive? frame-id (first q)))
+                               input-signals))
+        input-l?    (and (seq input-signals)
+                         (some (fn [q] (sub-output-large? frame-id (first q)))
+                               input-signals))
+        ;; Layer-1: any sensitive app-db declaration triggers propagation
+        ;; (footgun prevention — we don't track which path the sub
+        ;; *actually* read; the conservative reading is "if there's
+        ;; any sensitive path, the sub MAY have read it"). Spec 015
+        ;; §Propagation rules acknowledges this is footgun prevention
+        ;; not security-grade taint.
+        any-sens?   (when layer-1?
+                      (let [container (frame/get-frame-db frame-id)
+                            db        (when container (adapter/read-container container))
+                            decls     (get-in db [:rf/elision :sensitive-declarations])]
+                        (boolean (seq decls))))
+        any-large?  (when layer-1?
+                      (let [container (frame/get-frame-db frame-id)
+                            db        (when container (adapter/read-container container))
+                            decls     (get-in db [:rf/elision :declarations])]
+                        (boolean (seq decls))))
+        sensitive?  (cond
+                      (true? forced-s)  true
+                      (false? forced-s) false
+                      :else             (or input-s? (boolean any-sens?)))
+        large?      (cond
+                      (true? forced-l)  true
+                      (false? forced-l) false
+                      :else             (or input-l? (boolean any-large?)))]
+    [(boolean sensitive?) (boolean large?)]))
+
+;; ---- the trace-event projection chokepoint -------------------------------
+
+(defn- project-event-tags
+  "Walk `:event/dispatched` / `:event/db-changed` / `:event/do-fx` tag
+  shapes: the dispatched event vector lives at `:event` and is a
+  `[event-id arg-map]` form. Marks come from the event handler's
+  registration."
+  [tags]
+  (let [event    (:event tags)
+        event-id (when (vector? event) (first event))
+        marks    (event-marks event-id)]
+    (if-not marks
+      tags
+      (let [sens   (or (:sensitive marks) [])
+            large  (or (:large marks) [])
+            redacted (redact-event-vec event sens large)]
+        (assoc tags :event redacted)))))
+
+(defn- project-fx-tags
+  "Walk `:rf.fx/handled` tag shape: `:fx-id` carries the fx keyword and
+  `:fx-args` carries the args value. Marks come from the fx handler's
+  registration."
+  [tags]
+  (let [fx-id (:fx-id tags)
+        marks (fx-marks fx-id)]
+    (if-not marks
+      tags
+      (let [sens     (or (:sensitive marks) [])
+            large    (or (:large marks) [])
+            redacted (redact-with-paths (:fx-args tags) sens large)]
+        (assoc tags :fx-args redacted)))))
+
+(defn- project-cofx-tags
+  "Walk cofx-relevant tag shapes: the cofx-injected value rides under a
+  cofx-id key (per `re-frame.cofx`'s injection convention). When a
+  trace event carries a `:coeffects` slot (e.g. `:event/dispatched`,
+  `:event/do-fx`), walk each cofx-id key against the cofx's marks."
+  [tags]
+  (let [cofx-map (:coeffects tags)]
+    (if-not (map? cofx-map)
+      tags
+      (let [walked (reduce-kv
+                     (fn [acc cofx-id v]
+                       (let [marks (cofx-marks cofx-id)]
+                         (if-not marks
+                           (assoc acc cofx-id v)
+                           (let [sens     (or (:sensitive marks) [])
+                                 large    (or (:large marks) [])
+                                 redacted (redact-with-paths v sens large)]
+                             (assoc acc cofx-id redacted)))))
+                     (empty cofx-map)
+                     cofx-map)]
+        (assoc tags :coeffects walked)))))
+
+(defn- project-sub-tags
+  "Walk `:sub/run` tag shape: `:sub-id` carries the sub query keyword
+  and `:value` carries the output. Marks come from the sub's
+  registration's per-output-path declarations, and the propagation
+  table sets a whole-output `:sensitive? true` stamp."
+  [tags frame-id]
+  (let [sub-id (:sub-id tags)
+        marks  (sub-marks sub-id)
+        prop-s? (sub-output-sensitive? frame-id sub-id)
+        prop-l? (sub-output-large? frame-id sub-id)]
+    (cond
+      ;; No marks AND no propagation — pass through unchanged.
+      (and (nil? marks) (not prop-s?) (not prop-l?))
+      tags
+
+      ;; Whole-output propagation wins: stamp at root.
+      (and prop-s? (not (false? (:sensitive? marks))))
+      (assoc tags :value privacy/redacted-sentinel :sensitive? true)
+
+      :else
+      (let [sens     (or (:sensitive marks) [])
+            large    (or (:large marks) [])
+            redacted (redact-with-paths (:value tags) sens large)]
+        (cond-> (assoc tags :value redacted)
+          prop-l? (assoc :large? true))))))
+
+(defn- project-machine-tags
+  "Walk machine-snapshot tag shapes (`:rf.machine/transition`,
+  `:rf.machine/snapshot-updated`): `:before` and `:after` are full
+  snapshot maps. Marks declared on `reg-machine` are paths rooted at
+  the snapshot — per Spec 015 §6. State machines — so common app-
+  marks are written as `[:data :jwt]`, `[:data :user :ssn]`, etc."
+  [tags]
+  (let [machine-id (:machine-id tags)
+        marks      (machine-marks machine-id)]
+    (if-not marks
+      tags
+      (let [sens     (or (:sensitive marks) [])
+            large    (or (:large marks) [])
+            project  (fn [v] (when v (redact-with-paths v sens large)))]
+        (cond-> tags
+          (contains? tags :before)   (assoc :before   (project (:before   tags)))
+          (contains? tags :after)    (assoc :after    (project (:after    tags)))
+          (contains? tags :snapshot) (assoc :snapshot (project (:snapshot tags))))))))
+
+(defn- machine-op?
+  [operation]
+  (let [n (and (keyword? operation) (namespace operation))]
+    (and n (or (= "rf.machine" n)
+               (and (>= (count n) 11)
+                    (= "rf.machine." (subs n 0 11)))))))
+
+(defn project-trace-event
+  "The single chokepoint `re-frame.trace/build-event` consults after
+  envelope assembly and before delivery. Walks `:tags` for marks
+  declared on the in-scope registrations. Returns the (possibly
+  mutated) event.
+
+  Per Spec 015 §Implementation notes recommendation B: emit-time
+  union of per-registration marks + propagation graph. The cost is
+  gated by `interop/debug-enabled?` upstream (in `emit!`) so
+  production builds elide before this fn is reached.
+
+  Frame resolution comes off `:tags :frame` — every trace shape that
+  carries handler-scope-derived data also carries `:frame` because
+  the in-scope handler binds it through the router."
+  [event]
+  (if-not (map? event)
+    event
+    (let [operation (:operation event)
+          tags      (:tags event)
+          frame-id  (or (:frame tags) :rf/default)
+          tags'     (cond-> tags
+                      (and (map? tags) (contains? tags :event))
+                      (project-event-tags)
+
+                      (and (map? tags) (= :rf.fx/handled operation))
+                      (project-fx-tags)
+
+                      (and (map? tags) (contains? tags :coeffects))
+                      (project-cofx-tags)
+
+                      (and (map? tags) (= :sub/run operation))
+                      (project-sub-tags frame-id)
+
+                      (and (map? tags) (machine-op? operation))
+                      (project-machine-tags))]
+      (assoc event :tags tags'))))
+
+;; ---- late-bind hook registration ----------------------------------------
+;;
+;; The trace ns reads through these hooks; this ns reads through the
+;; existing elision-registry. The arrangement avoids load cycles
+;; (`re-frame.trace` → `re-frame.marks` would cycle since marks
+;; requires elision which requires trace).
+
+(late-bind/set-fn! :marks/project-trace-event project-trace-event)
+(late-bind/set-fn! :marks/register-marks!     register-marks!)
+(late-bind/set-fn! :marks/resolve-sub-output-marks resolve-sub-output-marks)
+(late-bind/set-fn! :marks/mark-sub-output!    mark-sub-output!)
+(late-bind/set-fn! :marks/clear-marks!        clear-marks!)
+(late-bind/set-fn! :marks/clear-sub-output-marks! clear-sub-output-marks!)
+(late-bind/set-fn! :marks/reg-marks           reg-marks)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -138,6 +138,13 @@
       (assoc (source-coords/merge-coords meta)
              :handler-fn    handler-fn
              :input-signals input-signals))
+    ;; Per Spec 015 §3. Subscriptions — stash declarations:
+    ;;   :sensitive / :large — per-output-path marks
+    ;;   :sensitive? / :large? — whole-output override
+    ;; The propagation table (`re-frame.marks/mark-sub-output!`) is
+    ;; updated on each sub-cache compute pass — see `compute-and-cache!`.
+    (when-let [register! (late-bind/get-fn :marks/register-marks!)]
+      (register! :sub id meta))
     ;; Per Spec 009 §:op-type vocabulary: :sub/create marks subscription
     ;; materialisation — emitted at registration time so tools see when
     ;; the sub becomes available in the registry.
@@ -238,6 +245,19 @@
         reaction      (adapter/make-derived-value inputs memoised-body)
         cache         (:sub-cache (frame/frame frame-id))
         k             (cache-key query-v)]
+    ;; Per Spec 015 §App-db → subs / §Subs → fx propagation: when this
+    ;; sub is being built, resolve whether its output should be marked
+    ;; sensitive/large for downstream emit-time consultation. Honours
+    ;; the `:sensitive? true/false` and `:large? true/false` overrides
+    ;; on the sub's registration meta. Late-bound — when the marks
+    ;; artefact is absent, this is a silent no-op. Gated by debug so
+    ;; production builds DCE the lookup.
+    (when interop/debug-enabled?
+      (when sub-meta
+        (when-let [resolve (late-bind/get-fn :marks/resolve-sub-output-marks)]
+          (when-let [mark! (late-bind/get-fn :marks/mark-sub-output!)]
+            (let [[s? l?] (resolve frame-id query-id input-signals layer-1?)]
+              (mark! frame-id query-id s? l?))))))
     ;; Skip caching the no-such-sub miss — see the rf2-l9u5 note in the
     ;; docstring. The reaction is built so callers that hold a reference
     ;; deref to nil (per Spec 009 §Error contract recovery

--- a/implementation/core/src/re_frame/test_support.cljc
+++ b/implementation/core/src/re_frame/test_support.cljc
@@ -197,7 +197,13 @@
    {:hook :http/clear-all-in-flight!       :phase :post-dispose}
    {:hook :epoch/clear-history!            :phase :post-dispose}
    {:hook :epoch/clear-epoch-cbs!          :phase :post-dispose}
-   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}])
+   {:hook :adapter/clear-warn-once-caches! :phase :post-dispose}
+   ;; Per Spec 015 — clear the per-(kind, id) marks table and the
+   ;; per-frame sub-output propagation table so each test starts
+   ;; from a clean classification slate. No-op when the marks
+   ;; artefact is absent.
+   {:hook :marks/clear-marks!              :phase :post-dispose}
+   {:hook :marks/clear-sub-output-marks!   :phase :post-dispose}])
 
 (defn- run-reset-hooks!
   "Driver: fire every `reset-hook-table` row whose `:phase` matches and

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -264,6 +264,23 @@
   (when-let [deliver-tooling (late-bind/get-fn-cached :trace.tooling/deliver!)]
     (deliver-tooling event)))
 
+(defn- maybe-project-marks
+  "Apply the data-classification marks projection if the marks
+  artefact is loaded. Per Spec 015 §Implementation notes
+  recommendation B: emit-time path-walk + sentinel substitution.
+
+  The projection hook is published by `re-frame.marks` at ns-load;
+  when the marks artefact is absent the hook is unbound and this is
+  a no-op pass-through. Inside the existing `interop/debug-enabled?`
+  gate (in `emit!`) so production builds DCE the hook lookup along
+  with the rest of the trace emit."
+  [event]
+  ;; Sticky hook (rf2-f72pd) — `:marks/project-trace-event` is
+  ;; published once at re-frame.marks load and never withdrawn.
+  (if-let [project (late-bind/get-fn-cached :marks/project-trace-event)]
+    (project event)
+    event))
+
 (defn emit!
   "Emit a trace event. Production builds elide the body entirely
   (Closure DCE on the `interop/debug-enabled?` gate); in dev / JVM
@@ -275,6 +292,14 @@
   into `:tags`, `:sensitive?` stamped at top level. Short-circuits
   before allocation when the scope's `:no-emit?` slot is true.
 
+  Per Spec 015 (data classification): after envelope assembly and
+  before delivery, the marks-projection hook walks `:tags` to
+  substitute `:rf/redacted` and `:rf.size/large-elided` markers at
+  paths declared sensitive / large by the in-scope handler's
+  registration meta or `reg-marks`. Gated by the same
+  `interop/debug-enabled?` so production CLJS bundles DCE the entire
+  marks machinery.
+
   Per Spec 009 §Emitting trace events and §Handler-scope."
   [op operation tags]
   (when interop/debug-enabled?
@@ -283,7 +308,7 @@
     ;; (the outer gate must stand alone for Closure DCE — see
     ;; §Production-elision verification).
     (when-not (true? (some-> *handler-scope* :no-emit?))
-      (deliver! (build-event op operation tags)))))
+      (deliver! (maybe-project-marks (build-event op operation tags))))))
 
 (defn emit-error!
   "Emit a structured error trace event. `:operation` is the error
@@ -294,13 +319,17 @@
   Reads `*handler-scope*` to hoist `:trigger-handler`, `:call-site`,
   and `:dispatch-id` onto the envelope, and to honour the `:no-emit?`
   short-circuit (symmetric with `emit!`). Per Spec 009 §Error contract
-  and §Handler-scope."
+  and §Handler-scope.
+
+  Per Spec 015: the same marks-projection hook runs on error traces so
+  exception traces don't accidentally leak sensitive event-args /
+  fx-args / cofx-values."
   [error-operation tags]
   (when interop/debug-enabled?
     ;; `:no-emit?` short-circuit sits *inside* the outer
     ;; `interop/debug-enabled?` gate per Spec 009 §Production builds.
     (when-not (true? (some-> *handler-scope* :no-emit?))
-      (deliver! (build-event :error error-operation tags)))))
+      (deliver! (maybe-project-marks (build-event :error error-operation tags))))))
 
 ;; ---- late-bind hook registration ------------------------------------------
 ;; Published through `late-bind` so registrar can emit without requiring

--- a/implementation/core/test/re_frame/marks_test.clj
+++ b/implementation/core/test/re_frame/marks_test.clj
@@ -1,0 +1,320 @@
+(ns re-frame.marks-test
+  "Unit + integration tests for Spec 015 — Data Classification.
+
+  Covers:
+    - `reg-marks` API + replace-not-merge semantics
+    - per-registration mark extraction across the 7 reg-* sites
+    - emit-time trace projection (event / fx / cofx / sub)
+    - sub auto-propagation + opt-out
+    - schema-attached marks union with `reg-marks`"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.marks :as marks]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace-tooling/clear-trace-cbs!)
+  (marks/clear-marks!)
+  (marks/clear-sub-output-marks!)
+  (elision/clear-warning-cache!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- collect-traces! [id]
+  (let [acc (atom [])]
+    (trace-tooling/register-trace-cb! id (fn [ev] (swap! acc conj ev)))
+    acc))
+
+;; ---- reg-marks API ------------------------------------------------------
+
+(deftest reg-marks-writes-into-elision-registry
+  (rf/reg-marks :rf/default
+    {:sensitive [[:user :ssn] [:auth :token]]
+     :large     [[:docs :csv-upload]]})
+  (let [decls-s (elision/sensitive-declarations :rf/default)
+        decls-l (elision/declarations :rf/default)]
+    (is (contains? decls-s [:user :ssn]))
+    (is (contains? decls-s [:auth :token]))
+    (is (= :reg-marks (:source (get decls-s [:user :ssn]))))
+    (is (contains? decls-l [:docs :csv-upload]))
+    (is (= :reg-marks (:source (get decls-l [:docs :csv-upload]))))))
+
+(deftest reg-marks-returns-frame-id
+  (is (= :rf/default (rf/reg-marks :rf/default {:sensitive [[:x]]})))
+  (rf/reg-frame :other {:doc "test"})
+  (is (= :other (rf/reg-marks :other {:sensitive [[:y]]}))))
+
+(deftest reg-marks-replaces-not-merges
+  ;; Spec 015 §reg-marks: a second call against the same frame REPLACES
+  (rf/reg-marks :rf/default {:sensitive [[:a] [:b]]})
+  (rf/reg-marks :rf/default {:sensitive [[:c]]})
+  (let [decls (elision/sensitive-declarations :rf/default)]
+    (is (contains? decls [:c]))
+    (is (not (contains? decls [:a])))
+    (is (not (contains? decls [:b])))))
+
+(deftest reg-marks-preserves-schema-sourced
+  ;; Schema declarations have :source :schema; reg-marks must not drop them
+  (rf/reg-app-schema [:auth]
+                     [:map
+                      [:password {:sensitive? true} :string]])
+  (rf/populate-sensitive-from-schemas!)
+  (rf/reg-marks :rf/default {:sensitive [[:user :ssn]]})
+  (let [decls (elision/sensitive-declarations :rf/default)]
+    (is (contains? decls [:user :ssn]) "reg-marks path present")
+    (is (contains? decls [:auth :password]) "schema-sourced path preserved")
+    (is (= :schema (:source (get decls [:auth :password]))))))
+
+(deftest reg-marks-second-call-preserves-schema
+  (rf/reg-app-schema [:auth]
+                     [:map [:password {:sensitive? true} :string]])
+  (rf/populate-sensitive-from-schemas!)
+  (rf/reg-marks :rf/default {:sensitive [[:a]]})
+  (rf/reg-marks :rf/default {:sensitive [[:b]]})
+  (let [decls (elision/sensitive-declarations :rf/default)]
+    (is (contains? decls [:b]))
+    (is (not (contains? decls [:a])))
+    (is (contains? decls [:auth :password]))))
+
+;; ---- per-registration mark extraction -----------------------------------
+
+(deftest reg-event-db-stashes-marks
+  (rf/reg-event-db :evt
+    {:sensitive [[:password]] :large [[:upload]]}
+    (fn [db _] db))
+  (let [m (marks/marks-for :event :evt)]
+    (is (= [[:password]] (:sensitive m)))
+    (is (= [[:upload]] (:large m)))))
+
+(deftest reg-event-fx-stashes-marks
+  (rf/reg-event-fx :evt
+    {:sensitive [[:totp]]}
+    (fn [_ _] {}))
+  (is (= [[:totp]] (:sensitive (marks/marks-for :event :evt)))))
+
+(deftest reg-event-ctx-stashes-marks
+  (rf/reg-event-ctx :evt
+    {:large [[:body :blob]]}
+    (fn [ctx] ctx))
+  (is (= [[:body :blob]] (:large (marks/marks-for :event :evt)))))
+
+(deftest reg-sub-stashes-marks-and-overrides
+  (rf/reg-sub :s1
+    {:sensitive [[:hashed]] :sensitive? false}
+    (fn [_ _] {:hashed "abc"}))
+  (let [m (marks/marks-for :sub :s1)]
+    (is (= [[:hashed]] (:sensitive m)))
+    (is (false? (:sensitive? m)))))
+
+(deftest reg-fx-stashes-marks
+  (rf/reg-fx :myfx
+    {:sensitive [[:body :password]] :large [[:body :upload]]}
+    (fn [_ _]))
+  (let [m (marks/marks-for :fx :myfx)]
+    (is (= [[:body :password]] (:sensitive m)))
+    (is (= [[:body :upload]] (:large m)))))
+
+(deftest reg-cofx-stashes-marks-whole-value
+  (rf/reg-cofx :auth/jwt
+    {:sensitive [[]]}
+    (fn [ctx] ctx))
+  (is (= [[]] (:sensitive (marks/marks-for :cofx :auth/jwt)))))
+
+;; ---- emit-time projection ----------------------------------------------
+
+(deftest event-arg-sensitive-path-redacts-in-trace
+  ;; Spec 015 conformance fixture #1
+  (rf/reg-event-fx :auth/log-in
+    {:sensitive [[:password]]}
+    (fn [_ _] {}))
+  (let [traces (collect-traces! :evt-redact)]
+    (rf/dispatch-sync [:auth/log-in {:email "a@b.c" :password "secret"}])
+    (let [dispatched (filter #(= :event/dispatched (:operation %)) @traces)]
+      (is (seq dispatched))
+      (let [ev (-> dispatched first :tags :event)]
+        (is (= :rf/redacted (get-in ev [1 :password])))
+        (is (= "a@b.c" (get-in ev [1 :email])))))
+    (trace-tooling/remove-trace-cb! :evt-redact)))
+
+(deftest fx-args-sensitive-path-redacts-in-trace
+  (rf/reg-fx :myfx
+    {:sensitive [[:headers :authorization]]}
+    (fn [_ _]))
+  (rf/reg-event-fx :send
+    (fn [_ _] {:fx [[:myfx {:headers {:authorization "Bearer xyz"
+                                      :other "ok"}}]]}))
+  (let [traces (collect-traces! :fx-redact)]
+    (rf/dispatch-sync [:send])
+    (let [handled (filter #(= :rf.fx/handled (:operation %)) @traces)]
+      (is (seq handled))
+      (let [args (-> handled first :tags :fx-args)]
+        (is (= :rf/redacted (get-in args [:headers :authorization])))
+        (is (= "ok" (get-in args [:headers :other])))))
+    (trace-tooling/remove-trace-cb! :fx-redact)))
+
+(deftest large-path-emits-marker
+  (rf/reg-event-fx :evt
+    {:large [[:blob]]}
+    (fn [_ _] {}))
+  (let [traces (collect-traces! :large-marker)
+        big    (apply str (repeat 500 "X"))]
+    (rf/dispatch-sync [:evt {:blob big :other "small"}])
+    (let [dispatched (filter #(= :event/dispatched (:operation %)) @traces)
+          ev         (-> dispatched first :tags :event)
+          slot       (get-in ev [1 :blob])]
+      (is (elision/marker? slot))
+      (is (= "small" (get-in ev [1 :other])))
+      (is (= [:blob] (get-in slot [:rf.size/large-elided :path])))
+      (is (pos-int? (get-in slot [:rf.size/large-elided :bytes]))))
+    (trace-tooling/remove-trace-cb! :large-marker)))
+
+(deftest empty-path-redacts-whole-arg
+  (rf/reg-event-fx :evt
+    {:sensitive [[]]}
+    (fn [_ _] {}))
+  (let [traces (collect-traces! :whole)]
+    (rf/dispatch-sync [:evt {:a 1 :b 2}])
+    (let [ev (-> (filter #(= :event/dispatched (:operation %)) @traces)
+                 first :tags :event)]
+      (is (= :rf/redacted (nth ev 1))))
+    (trace-tooling/remove-trace-cb! :whole)))
+
+;; ---- redact-with-paths primitive ---------------------------------------
+
+(deftest redact-with-paths-walks-nested
+  (let [v {:user {:ssn "123-45-6789" :name "Alice"}
+           :auth {:token "abc" :method :jwt}}
+        out (marks/redact-with-paths v [[:user :ssn] [:auth :token]] [])]
+    (is (= :rf/redacted (get-in out [:user :ssn])))
+    (is (= "Alice" (get-in out [:user :name])))
+    (is (= :rf/redacted (get-in out [:auth :token])))
+    (is (= :jwt (get-in out [:auth :method])))))
+
+(deftest redact-with-paths-noop-when-no-paths
+  (let [v {:a 1 :b 2}]
+    (is (identical? v (marks/redact-with-paths v [] [])))))
+
+(deftest redact-with-paths-empty-path-whole-value
+  (is (= :rf/redacted (marks/redact-with-paths {:x 1} [[]] []))))
+
+(deftest redact-with-paths-missing-path-noop
+  (let [v {:user {:name "Alice"}}
+        out (marks/redact-with-paths v [[:user :ssn] [:nope :nope]] [])]
+    ;; Missing leaves are no-op per Spec 015 §What gets a sentinel
+    (is (= "Alice" (get-in out [:user :name])))
+    (is (nil? (get-in out [:user :ssn])))))
+
+;; ---- sub auto-propagation ----------------------------------------------
+
+(deftest sub-auto-propagates-when-app-db-has-sensitive-marks
+  ;; Spec 015 conformance fixture #3 (variant — propagation flag set)
+  ;; NB: handlers that REPLACE app-db wipe `:rf/elision`, mirroring the
+  ;; existing schema-driven elision constraint — seed first, then mark.
+  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/dispatch-sync [:seed])
+  (rf/reg-marks :rf/default {:sensitive [[:user :ssn]]})
+  (rf/reg-sub :all-users (fn [db _] (:user db)))
+  @(rf/subscribe [:all-users])
+  ;; Layer-1 sub with sensitive declarations present → propagation flag set
+  (is (true? (marks/sub-output-sensitive? :rf/default :all-users))))
+
+(deftest sub-explicit-opt-out-clears-propagation
+  ;; Spec 015 conformance fixture #4
+  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/dispatch-sync [:seed])
+  (rf/reg-marks :rf/default {:sensitive [[:user :ssn]]})
+  (rf/reg-sub :safe
+    {:sensitive? false}
+    (fn [db _] (get-in db [:user :name])))
+  @(rf/subscribe [:safe])
+  (is (false? (marks/sub-output-sensitive? :rf/default :safe))))
+
+(deftest sub-force-marked
+  ;; :sensitive? true forces even with no upstream
+  (rf/reg-sub :synthetic
+    {:sensitive? true}
+    (fn [_ _] "public-input-derived-secret"))
+  @(rf/subscribe [:synthetic])
+  (is (true? (marks/sub-output-sensitive? :rf/default :synthetic))))
+
+;; ---- composed: subs propagation through layer-2 ------------------------
+
+(deftest layer-2-inherits-from-input-sub
+  (rf/reg-event-db :seed (fn [_ _] {:user {:ssn "X" :name "A"}}))
+  (rf/dispatch-sync [:seed])
+  (rf/reg-marks :rf/default {:sensitive [[:user :ssn]]})
+  (rf/reg-sub :u (fn [db _] (:user db)))
+  (rf/reg-sub :uname
+    :<- [:u]
+    (fn [u _] (:name u)))
+  @(rf/subscribe [:uname])
+  ;; Layer-2 picks up sensitive from layer-1 input :u
+  (is (true? (marks/sub-output-sensitive? :rf/default :u)))
+  (is (true? (marks/sub-output-sensitive? :rf/default :uname))))
+
+;; ---- per-sub-path declaration --------------------------------------------
+
+(deftest per-sub-path-declaration-via-projection
+  ;; The `:sub/run` trace shape carries `{:sub-id :query-v :frame}` — not
+  ;; the computed value (sub recompute keeps the value in the reaction).
+  ;; Per-sub-path declarations apply downstream: wherever a tool lifts the
+  ;; sub's value into an observable surface (Causa sub panel, MCP wire),
+  ;; the consumer calls `marks/redact-with-paths` with the sub's declared
+  ;; paths. This test exercises that contract via the public primitive.
+  (rf/reg-sub :compound
+    {:sensitive [[:hashed]]}
+    (fn [_ _] {:hashed "secret" :public "ok"}))
+  (let [m (marks/marks-for :sub :compound)
+        v {:hashed "secret" :public "ok"}
+        out (marks/redact-with-paths v (:sensitive m) (or (:large m) []))]
+    (is (= :rf/redacted (:hashed out)))
+    (is (= "ok" (:public out)))))
+
+;; ---- cofx -------------------------------------------------------------
+
+(deftest cofx-injected-value-redacted-in-coeffects
+  (rf/reg-cofx :auth/jwt
+    {:sensitive [[]]}
+    (fn [ctx] (assoc-in ctx [:coeffects :auth/jwt] "real-jwt")))
+  (rf/reg-event-fx :uses-jwt
+    [(rf/inject-cofx :auth/jwt)]
+    (fn [_ _] {}))
+  ;; Cofx mark stashed
+  (is (= [[]] (:sensitive (marks/marks-for :cofx :auth/jwt))))
+  ;; Trace projection covers tags-with-:coeffects; verified through the
+  ;; redact-with-paths primitive — the integration over a real trace
+  ;; event also exercises this path.
+  (let [coeffects-tag {:auth/jwt "real-jwt"}
+        projected (marks/project-trace-event
+                    {:operation :event/some-emit
+                     :op-type :event
+                     :tags {:coeffects coeffects-tag :frame :rf/default}})]
+    (is (= :rf/redacted (get-in projected [:tags :coeffects :auth/jwt])))))
+
+;; ---- registrar interaction ---------------------------------------------
+
+(deftest re-registration-clears-prior-marks
+  (rf/reg-event-fx :evt {:sensitive [[:a]]} (fn [_ _] {}))
+  (is (= [[:a]] (:sensitive (marks/marks-for :event :evt))))
+  ;; Re-register without marks — clears stashed entry
+  (rf/reg-event-fx :evt (fn [_ _] {}))
+  (is (nil? (marks/marks-for :event :evt))))
+
+(deftest re-registration-replaces-marks
+  (rf/reg-event-fx :evt {:sensitive [[:a]]} (fn [_ _] {}))
+  (rf/reg-event-fx :evt {:sensitive [[:b]]} (fn [_ _] {}))
+  (is (= [[:b]] (:sensitive (marks/marks-for :event :evt)))))

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -18,6 +18,7 @@
   their documented namespace-qualified names."
   (:require [re-frame.flows.topo :as topo]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
             [re-frame.substrate.adapter :as adapter]
@@ -227,6 +228,13 @@
                        :inputs  (:inputs flow)
                        :path    (:path flow)
                        :frame   frame-id})))
+     ;; Per Spec 015 §7. Flows — stash `:sensitive` / `:large` and
+     ;; `:sensitive?` / `:large?` declarations so emit-time projection
+     ;; resolves the flow's output marks. Late-bound — no-op when the
+     ;; marks artefact is absent (which it never is in core, but the
+     ;; indirection keeps flows decoupled).
+     (when-let [register-marks! (late-bind/get-fn :marks/register-marks!)]
+       (register-marks! :flow flow-id flow))
      flow-id)))
 
 (defn- dissoc-in-safe


### PR DESCRIPTION
Implements spec/015-Data-Classification.md end-to-end on `implementation/core` + `implementation/flows`.

## Surfaces added

### New API
- **`rf/reg-marks`** — frame-scoped path-mark declaration for app-db. Writes into the existing `[:rf/elision :sensitive-declarations]` / `[:rf/elision :declarations]` registry slots so schema-attached + reg-marks-attached marks union for free. Second call against the same frame REPLACES the prior reg-marks-sourced entries while PRESERVING schema-sourced entries (per Spec 015 §reg-marks).

### Extended registration sites
All seven sites accept `{:sensitive [paths] :large [paths]}` (+ `:sensitive? bool` / `:large? bool` whole-output overrides on subs and flows). The declarations stash into a per-(kind, id) marks table via the late-bound `:marks/register-marks!` hook:

| Site | File |
|---|---|
| `reg-event-db` / `reg-event-fx` / `reg-event-ctx` | `implementation/core/src/re_frame/events.cljc` |
| `reg-sub` | `implementation/core/src/re_frame/subs.cljc` |
| `reg-fx` | `implementation/core/src/re_frame/fx.cljc` |
| `reg-cofx` | `implementation/core/src/re_frame/cofx.cljc` |
| `reg-flow` | `implementation/flows/src/re_frame/flows/registry.cljc` |
| `reg-machine` | inherited via `reg-event-fx` (machines register as events) |

### Trace bus emit-time projection
New `re-frame.marks` namespace owns the emit-time path-walk + sentinel substitution. Hooked into `re-frame.trace/emit!` and `re-frame.trace/emit-error!` through the late-bound `:marks/project-trace-event` hook (no static cycle). Per-operation tag projectors walk:

- `:event/dispatched` / `:event/db-changed` / `:event/do-fx` → walks `:event` arg-map
- `:rf.fx/handled` → walks `:fx-args`
- any trace shape with `:coeffects` → walks per-cofx-id slot
- `:sub/run` → flags `:sensitive?` / `:large?` at top level via the sub-output propagation table
- `:rf.machine/*` → walks `:before` / `:after` / `:snapshot` rooted at the machine snapshot

### Sub auto-propagation
Per Spec 015 §App-db → subs: at `compute-and-cache!` time, resolves a `[sensitive? large?]` pair for the sub's output and records it in a per-(frame, sub-id) propagation table. Resolution honours `:sensitive? true/false` / `:large? true/false` overrides; layer-1 propagation triggers when ANY sensitive declaration exists on the frame (footgun prevention, not security-grade taint — Spec 015 §Propagation rules explicitly acknowledges this); layer-2+ propagates from input-signal subs.

## Verification

| Gate | Result |
|---|---|
| `implementation/core` JVM | 572 tests / 2922 assertions PASS |
| `implementation/*` JVM (every artefact) | PASS |
| `npm run test:cljs` (node) | 2384 tests / 6909 assertions PASS |
| `npm run test:bundle-isolation` | PASS (counter / counter-uix / counter-helix) |
| `npm run test:elision` (production CLJS DCE) | 31/31 sentinels absent |

**Production elision confirmed.** The entire marks machinery rides `re-frame.interop/debug-enabled?` (in the existing `trace/emit!` gate). Inspection of the production counter bundle shows no `re_frame.marks/*` symbols — only the late-bind keyword interns survive (necessary for the hook lookup), which is the standard pattern across every late-bind hook in the codebase.

## Tests added

`implementation/core/test/re_frame/marks_test.clj` — 27 new tests covering:

- `reg-marks` API: writes into registry, returns `frame-id`, replace-not-merge, schema-sourced preservation
- per-registration mark extraction across all 7 sites (event-db/fx/ctx, sub, fx, cofx, flow via inheritance)
- emit-time projection: event-arg redaction, fx-args redaction, large marker emission, empty-path whole-arg redaction
- `redact-with-paths` primitive: nested walk, no-op shortcut, missing-path tolerance, empty-path
- sub auto-propagation: layer-1, opt-out, force-mark, layer-2 inheritance
- registrar interaction: re-registration clears prior marks, re-registration replaces marks
- cofx projection round-trip

## Design decisions (per Mike's overnight directive)

1. **Sentinel shape for `:large`.** Spec 015 §Display contract names `:rf/large {:bytes N :head "..."}`. The CLJS reference already uses `:rf.size/large-elided` markers (wired through `re-frame.elision` for the existing schema-driven path and consumed by Causa / MCP wire elision). I kept the existing marker shape because (a) it carries the same `:bytes` semantic, (b) it's already understood by the elision walker, Causa renderer, and cross-MCP wire codec, and (c) the spec is a *display contract* — downstream consumers render the sentinel however; the on-wire substitution shape is implementation latitude. The `:source :reg-marks` discriminator on marker payloads lets tooling distinguish per-registration marks from schema-driven marks per Spec 015 §Mark-lookup table shape.

2. **Sub-output projection.** `:sub/run` tags don't carry `:value` (the trace records the recompute event; the value lives in the reaction). Per-sub-path declarations apply downstream — wherever a tool lifts the sub's value into an observable surface, the consumer calls `marks/redact-with-paths` with the sub's declared paths. The sub-output propagation table separately flags whole-output sensitivity for consumers that need to gate on it (Causa sub panel, MCP wire). Tested via the public primitive.

3. **Machine projection.** Spec 015 §6 roots paths at the *snapshot* (`:data` as a sub-key). Machine traces (`:rf.machine/transition`, `:rf.machine/snapshot-updated`) carry `:before` / `:after` slots. Added a dedicated machine projector that walks both with the marks declared at `reg-event-fx` time (machines register through events).

4. **`reg-marks` lives in app-db.** Mirrors the existing schema-driven elision design — both store under `[:rf/elision ...]`. Handlers that REPLACE app-db wipe the marks (and the schema-driven equivalents). Tests demonstrate the correct ordering (seed app-db first, then `reg-marks`); this is the same constraint apps face for schema-driven elision today.

Closes rf2-vw7f5.