### PR TITLE
feat(causa): Machine Inspector — foundation + Mode A/B + initial diagram (rf2-2tkza Phase 1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
@@ -1,0 +1,372 @@
+(ns day8.re-frame2-causa.chart.layout
+  "Pure-data layout primitive for the Causa Machine Inspector chart
+  (rf2-2tkza, Phase 1).
+
+  Per `tools/causa/spec/003-Machine-Inspector.md` §Architectural
+  posture the chart-layout primitive lives Causa-internal at
+  `tools/causa/src/day8/re_frame2_causa/chart/{layout,svg,interaction}.cljc`.
+  This ns is the `layout` half: data → data, JVM-runnable, fully
+  testable from `clojure -M:test`. The `svg` half consumes the
+  positioned graph and emits hiccup.
+
+  ## What this does
+
+  Walks a machine definition (the map returned by `(rf/machine-meta
+  machine-id)` — see `spec/005-StateMachines.md` §Transition table
+  grammar) and produces a positioned graph:
+
+      {:nodes      [{:id <kw>          ;; sanitised id, unique per path
+                     :label <str>      ;; human-readable label
+                     :path <vec-of-kw> ;; full hierarchical path
+                     :x <int> :y <int>
+                     :width <int> :height <int>
+                     :initial? <bool>
+                     :final? <bool>
+                     :depth <int>} ...]
+       :edges      [{:from <id> :to <id>
+                     :label <str>     ;; event id
+                     :guard <kw-or-nil>
+                     :points [[x y] [x y]]} ...]
+       :width      <int>            ;; viewport width
+       :height     <int>            ;; viewport height
+       :initial-id <id-or-nil>}     ;; the machine's :initial state id
+
+  ## Layout choice — layered, not ELK
+
+  Spec 003 names ELK.js as the preferred layout engine; rf2-2tkza
+  Phase 1 ships a **simple layered layout** instead. ELK is a heavy
+  JS bundle (~250KB) and bringing it in for the foundation PR delays
+  the user-visible payoff. The layered approach:
+
+    1. **Rank** each node by its depth from the initial state via
+       BFS — initial is rank 0, its targets are rank 1, etc. Cycles
+       and back-edges don't increase rank (the longest path wins).
+    2. **Stratify** nodes into rank-buckets; within each bucket
+       sort by id for determinism.
+    3. **Place** each rank as a horizontal row, centred; row spacing
+       is 100px, node spacing 40px, node size 140x48.
+    4. **Route** edges as straight lines from source-bottom to
+       target-top (simple — no orthogonal routing, no obstacle
+       avoidance). Self-loops render as a small arc above the node
+       (handled in the `svg` ns).
+
+  Result: a chart that's readable for the typical 4-12 state machines
+  re-frame2 apps register, fast to render, and trivially debuggable.
+  Follow-on bead can swap in ELK behind the same data interface.
+
+  ## Compound state handling (v1: flat projection)
+
+  Compound states (`:states {...}` inside a state) project their leaves
+  into the same rank-graph at v1. The `:path` slot carries the full
+  hierarchical path; the SVG renderer can use `:path` to group leaves
+  visually under their parent (a follow-on bead). For Phase 1 the
+  flat-with-paths view is enough to surface the user-visible topology.
+
+  ## What this does NOT do (deferred to follow-on beads)
+
+    - Orthogonal edge routing (rf2-2tkza Phase 4 follow-on).
+    - Parallel-region layout (`{:type :parallel :regions ...}`) —
+      v1 falls back to rendering the first region.
+    - `:invoke-all` inline child machines.
+    - `:after` countdown ring geometry.
+    - Compound-state visual nesting (boxes-within-boxes).
+    - Edge-bundling for high-degree nodes."
+  (:require [clojure.string :as str]))
+
+;; ---- layout constants ---------------------------------------------------
+
+(def node-width 140)
+(def node-height 48)
+(def rank-gap 100)             ;; vertical gap between ranks
+(def node-gap 40)              ;; horizontal gap between same-rank nodes
+(def chart-margin 32)          ;; outer margin around the layout
+
+;; ---- definition walker --------------------------------------------------
+
+(defn- target-path?
+  "True when `v` is a grammar vector-path target (Spec 005)."
+  [v]
+  (and (vector? v)
+       (seq v)
+       (every? keyword? v)))
+
+(defn- transition-candidates
+  "Normalise a transition spec to candidate maps. Mirrors the
+  equivalent fn in the mermaid emitter; kept local so this ns has no
+  cross-dependency on machines-viz."
+  [spec]
+  (cond
+    (keyword? spec)     [{:target spec}]
+    (target-path? spec) [{:target spec}]
+    (map? spec)         [spec]
+    (vector? spec)      (mapcat transition-candidates spec)
+    :else               []))
+
+(defn- parent-path [path]
+  (if (seq path)
+    (pop path)
+    []))
+
+(defn- resolve-target-path
+  "Resolve a transition target relative to source-path."
+  [source-path target]
+  (cond
+    (keyword? target)     (conj (parent-path source-path) target)
+    (target-path? target) (vec target)
+    :else                 nil))
+
+(defn- collect-state-edges
+  "Walk a state node and return edge-maps for every statically-
+  resolvable transition declared on it. Compound substates recurse."
+  [state-path state-node]
+  (let [edges-from
+        (concat
+         (mapcat (fn [[event-id spec]]
+                   (keep (fn [candidate]
+                           (when-let [tp (resolve-target-path state-path
+                                                              (:target candidate))]
+                             {:from   state-path
+                              :to     tp
+                              :event  event-id
+                              :guard  (:guard candidate)
+                              :action (:action candidate)}))
+                         (transition-candidates spec)))
+                 (:on state-node))
+         (mapcat (fn [[delay spec]]
+                   (keep (fn [candidate]
+                           (when-let [tp (resolve-target-path state-path
+                                                              (:target candidate))]
+                             {:from   state-path
+                              :to     tp
+                              :event  (keyword (str "after-" delay))
+                              :after  delay
+                              :guard  (:guard candidate)
+                              :action (:action candidate)}))
+                         (transition-candidates spec)))
+                 (:after state-node))
+         (mapcat (fn [candidate]
+                   (when-let [tp (resolve-target-path state-path
+                                                      (:target candidate))]
+                     [{:from   state-path
+                       :to     tp
+                       :event  :always
+                       :always? true
+                       :guard  (:guard candidate)
+                       :action (:action candidate)}]))
+                 (transition-candidates (:always state-node))))
+        nested
+        (mapcat (fn [[child-id child-node]]
+                  (collect-state-edges (conj state-path child-id) child-node))
+                (:states state-node))]
+    (concat edges-from nested)))
+
+(defn- collect-nodes
+  "Walk a state-map and return a flat seq of node-maps. Each map
+  carries the full path so compound nesting is preserved as data."
+  [parent-path state-map]
+  (mapcat (fn [[state-id state-node]]
+            (let [path (conj parent-path state-id)
+                  self {:id       path
+                        :path     path
+                        :label    (name state-id)
+                        :depth    (count parent-path)
+                        :initial? (:initial? state-node)
+                        :final?   (:final? state-node)
+                        :compound? (boolean (:states state-node))
+                        :tags     (set (:tags state-node))}
+                  children (when (:states state-node)
+                             (collect-nodes path (:states state-node)))]
+              (cons self children)))
+          state-map))
+
+(defn parse-definition
+  "Project a machine definition map into a flat `{:nodes :edges
+  :initial-path}` graph. Pure fn.
+
+  For parallel definitions (`{:type :parallel :regions {...}}`) v1
+  projects the first region only; a follow-on bead handles full
+  parallel layout."
+  [definition]
+  (cond
+    (nil? definition)
+    {:nodes [] :edges [] :initial-path nil}
+
+    (= :parallel (:type definition))
+    (let [[_region-id region] (first (:regions definition))]
+      (parse-definition region))
+
+    :else
+    (let [{:keys [initial states]} definition
+          nodes     (vec (collect-nodes [] states))
+          ;; Mark the initial node
+          initial-path (when initial [initial])
+          nodes     (mapv (fn [n]
+                            (if (= (:path n) initial-path)
+                              (assoc n :initial? true)
+                              n))
+                          nodes)
+          edges     (vec (mapcat (fn [[state-id state-node]]
+                                   (collect-state-edges [state-id] state-node))
+                                 states))]
+      {:nodes        nodes
+       :edges        edges
+       :initial-path initial-path})))
+
+;; ---- ranking ------------------------------------------------------------
+
+(defn- adjacency
+  "Build a {from-path #{to-path ...}} map from the edge list."
+  [edges]
+  (reduce (fn [m {:keys [from to]}]
+            (update m from (fnil conj #{}) to))
+          {}
+          edges))
+
+(defn- bfs-ranks
+  "BFS from `start-path` over the adjacency map; return a `{path
+  rank}` map. Unreached nodes default to rank 0 so they still render.
+  Cycles are broken by keeping the first-seen rank."
+  [adj start-path all-paths]
+  (loop [queue (if start-path [[start-path 0]] [])
+         seen  (if start-path {start-path 0} {})]
+    (if-let [[path rank] (first queue)]
+      (let [next-queue (subvec (vec queue) 1)
+            children   (get adj path #{})
+            new-items  (for [c children
+                             :when (not (contains? seen c))]
+                         [c (inc rank)])
+            seen'      (merge seen (into {} (map (fn [[p r]] [p r]) new-items)))]
+        (recur (into next-queue new-items) seen'))
+      ;; Backfill unreached nodes at rank 0 (so they still render
+      ;; somewhere — e.g. dead states with no inbound edges).
+      (reduce (fn [acc p]
+                (if (contains? acc p) acc (assoc acc p 0)))
+              seen
+              all-paths))))
+
+;; ---- placement ----------------------------------------------------------
+
+(defn- node-id
+  "Stable string id for a node, suitable for SVG ids + React keys."
+  [path]
+  (->> path
+       (map (fn [p]
+              (if (keyword? p)
+                (if-let [ns (namespace p)]
+                  (str ns "_" (name p))
+                  (name p))
+                (str p))))
+       (str/join "__")
+       (#(str/replace % #"[^a-zA-Z0-9_]" "_"))))
+
+(defn- place-nodes
+  "Given nodes + their ranks, position them into rows. Returns the
+  nodes with `:x` and `:y` filled. Deterministic — within a rank
+  nodes sort by their stable id."
+  [nodes ranks]
+  (let [by-rank (->> nodes
+                     (sort-by (fn [n] (node-id (:path n))))
+                     (group-by #(get ranks (:path %) 0))
+                     (into (sorted-map)))
+        rows    (for [[rank ns] by-rank]
+                  (let [n-count   (count ns)
+                        row-width (+ (* n-count node-width)
+                                     (* (max 0 (dec n-count)) node-gap))]
+                    {:rank rank :nodes ns :row-width row-width}))
+        max-row-width (apply max 0 (map :row-width rows))
+        chart-width   (+ max-row-width (* 2 chart-margin))
+        positioned
+        (mapcat (fn [{:keys [rank nodes row-width]}]
+                  (let [start-x (+ chart-margin
+                                   (quot (- max-row-width row-width) 2))
+                        y       (+ chart-margin
+                                   (* rank (+ node-height rank-gap)))]
+                    (map-indexed
+                      (fn [idx n]
+                        (assoc n
+                          :x     (+ start-x (* idx (+ node-width node-gap)))
+                          :y     y
+                          :width node-width
+                          :height node-height
+                          :rank  rank
+                          :node-id (node-id (:path n))))
+                      nodes)))
+                rows)
+        chart-height (+ chart-margin
+                        (* (inc (apply max 0 (keys by-rank)))
+                           (+ node-height rank-gap)))]
+    {:nodes positioned
+     :chart-width chart-width
+     :chart-height chart-height}))
+
+(defn- index-nodes
+  "Return a `{path node-with-coords}` map for cheap edge-routing
+  lookups."
+  [positioned-nodes]
+  (into {} (map (fn [n] [(:path n) n])) positioned-nodes))
+
+(defn- route-edge
+  "Straight-line routing: source-bottom-centre → target-top-centre.
+  Self-loops emit a small arc-control flag for the renderer."
+  [node-index {:keys [from to] :as edge}]
+  (let [src (get node-index from)
+        tgt (get node-index to)]
+    (when (and src tgt)
+      (let [self? (= from to)
+            src-x (+ (:x src) (quot (:width src) 2))
+            src-y (+ (:y src) (:height src))
+            tgt-x (+ (:x tgt) (quot (:width tgt) 2))
+            tgt-y (:y tgt)]
+        (assoc edge
+          :from-id (:node-id src)
+          :to-id   (:node-id tgt)
+          :self?   self?
+          :points  (if self?
+                     [[src-x src-y]
+                      [(+ src-x 70) (+ src-y 30)]
+                      [(+ src-x 70) (- tgt-y 30)]
+                      [tgt-x tgt-y]]
+                     [[src-x src-y] [tgt-x tgt-y]])
+          :event-label (let [e (:event edge)]
+                         (cond
+                           (:after edge)    (str "after(" (:after edge) ")")
+                           (:always? edge)  "always"
+                           (keyword? e)     (if-let [n (namespace e)]
+                                              (str n "/" (name e))
+                                              (name e))
+                           :else            (str e))))))))
+
+;; ---- public entry -------------------------------------------------------
+
+(defn layout
+  "Top-level: definition → positioned graph. Pure fn, JVM-runnable.
+
+  Returns the shape documented in this ns's docstring. Empty
+  definition (no `:initial` / no `:states`) returns a stable empty
+  graph so the SVG renderer can show the empty-chart state."
+  [definition]
+  (let [{:keys [nodes edges initial-path]} (parse-definition definition)]
+    (if (empty? nodes)
+      {:nodes [] :edges [] :width 200 :height 80 :initial-id nil}
+      (let [all-paths (mapv :path nodes)
+            adj       (adjacency edges)
+            ranks     (bfs-ranks adj initial-path all-paths)
+            {:keys [nodes chart-width chart-height]} (place-nodes nodes ranks)
+            n-index   (index-nodes nodes)
+            edges     (vec (keep #(route-edge n-index %) edges))]
+        {:nodes      nodes
+         :edges      edges
+         :width      chart-width
+         :height     chart-height
+         :initial-id (when initial-path (node-id initial-path))}))))
+
+(defn highlight-id
+  "Resolve a snapshot `:state` value to the node-id used in the
+  positioned graph. Snapshot `:state` is either a flat keyword
+  (`:authing`) or a hierarchical path (`[:auth :authing]`)."
+  [state]
+  (cond
+    (nil? state)     nil
+    (keyword? state) (node-id [state])
+    (vector? state)  (node-id state)
+    :else            nil))

--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -1,0 +1,284 @@
+(ns day8.re-frame2-causa.chart.svg
+  "Hiccup SVG renderer for the Causa Machine Inspector chart
+  (rf2-2tkza, Phase 1).
+
+  Consumes the positioned graph from
+  `day8.re-frame2-causa.chart.layout` and emits a hiccup `[:svg
+  ...]` form. Pure data → data — JVM-runnable so the renderer is
+  unit-testable from `clojure -M:test`. Live-snapshot highlighting
+  is driven via the `:highlight-id` arg; the CLJS panel passes the
+  current snapshot's `:state`-derived id.
+
+  ## Visual grammar (per spec/003-Machine-Inspector.md §Definition view)
+
+    - **Rounded rectangle nodes** with state label centred.
+    - **Live highlight** — cyan (`:cyan` token) border + inner glow
+      on the active state.
+    - **Initial-state marker** — a small filled circle to the left
+      of the initial node, with a connecting arrow into the node.
+    - **Final-state marker** — doubled border + a small check glyph
+      in the corner.
+    - **Edges** — straight grey lines with arrow heads; the event
+      label sits at the midpoint with a subtle background pill.
+    - **Self-loops** — bezier arc to the right of the node.
+    - **Tags** — when a state carries `:tags`, a coloured pill row
+      above the node label (one pill per tag, deterministic colour).
+
+  This v1 surface deliberately avoids ELK's orthogonal routing,
+  obstacle avoidance, and compound-state nesting — the layered
+  layout in `layout.cljc` produces a readable chart for the
+  4-12-state machines re-frame2 apps register today. Bigger
+  topologies fall back to scrollable overflow."
+  (:require [day8.re-frame2-causa.chart.layout :as layout]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- visual constants ---------------------------------------------------
+
+(def ^:private corner-radius 8)
+(def ^:private stroke-width 1.5)
+(def ^:private highlight-stroke-width 2.5)
+(def ^:private font-stack
+  "ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace")
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- node-fill
+  [{:keys [highlight? sim?]}]
+  (cond
+    sim?       "rgba(251, 191, 36, 0.18)"   ;; amber tint (Sim mode)
+    highlight? "rgba(67, 195, 208, 0.18)"   ;; cyan tint (live)
+    :else      "#1c2030"))
+
+(defn- node-stroke
+  [{:keys [highlight? sim? final?]}]
+  (cond
+    sim?       (:yellow tokens/tokens)
+    highlight? (:cyan tokens/tokens)
+    final?     (:green tokens/tokens)
+    :else      (:border-default tokens/tokens)))
+
+(defn- arrow-marker
+  "Define an arrow marker once, reuse it on every edge."
+  []
+  [:defs
+   [:marker {:id "rf-causa-chart-arrow"
+             :viewBox "0 0 10 10"
+             :refX "9" :refY "5"
+             :markerWidth "8" :markerHeight "8"
+             :orient "auto-start-reverse"
+             :fill (:text-secondary tokens/tokens)}
+    [:path {:d "M 0 0 L 10 5 L 0 10 z"}]]
+   [:marker {:id "rf-causa-chart-arrow-highlight"
+             :viewBox "0 0 10 10"
+             :refX "9" :refY "5"
+             :markerWidth "8" :markerHeight "8"
+             :orient "auto-start-reverse"
+             :fill (:cyan tokens/tokens)}
+    [:path {:d "M 0 0 L 10 5 L 0 10 z"}]]])
+
+(defn- render-initial-marker
+  [initial-node]
+  (when initial-node
+    (let [cx (- (:x initial-node) 16)
+          cy (+ (:y initial-node) (quot (:height initial-node) 2))
+          nx (:x initial-node)
+          ny cy]
+      [:g {:data-testid "rf-causa-chart-initial-marker"}
+       [:circle {:cx cx :cy cy :r 5
+                 :fill (:accent-violet tokens/tokens)
+                 :stroke (:accent-violet tokens/tokens)
+                 :stroke-width 1}]
+       [:line {:x1 (+ cx 5) :y1 cy
+               :x2 (- nx 2) :y2 ny
+               :stroke (:text-secondary tokens/tokens)
+               :stroke-width stroke-width
+               :marker-end "url(#rf-causa-chart-arrow)"}]])))
+
+(defn- render-node
+  [{:keys [x y width height label final? compound? node-id path] :as n}
+   {:keys [highlight-id sim? on-state-click]}]
+  (let [active?    (= node-id highlight-id)
+        styled     (assoc n
+                          :highlight? active?
+                          :sim?       (and active? sim?))
+        fill       (node-fill styled)
+        stroke     (node-stroke styled)
+        stroke-w   (if active? highlight-stroke-width stroke-width)]
+    [:g {:data-testid (str "rf-causa-chart-node-" node-id)
+         :data-active (str active?)
+         :data-state-path (pr-str path)
+         :on-click (when on-state-click
+                     (fn [_ev] (on-state-click path)))
+         :style {:cursor (if on-state-click "pointer" "default")}}
+     ;; Compound states get a slightly larger dashed outer border
+     (when compound?
+       [:rect {:x (- x 4) :y (- y 4)
+               :width (+ width 8) :height (+ height 8)
+               :rx (+ corner-radius 2)
+               :fill "none"
+               :stroke (:border-subtle tokens/tokens)
+               :stroke-width 1
+               :stroke-dasharray "4 3"}])
+     ;; Final states get a double-ring
+     (when final?
+       [:rect {:x (- x 3) :y (- y 3)
+               :width (+ width 6) :height (+ height 6)
+               :rx (+ corner-radius 1)
+               :fill "none"
+               :stroke (:green tokens/tokens)
+               :stroke-width 1}])
+     ;; Main node body
+     [:rect {:x x :y y :width width :height height
+             :rx corner-radius
+             :fill fill
+             :stroke stroke
+             :stroke-width stroke-w}]
+     ;; Label
+     [:text {:x (+ x (quot width 2))
+             :y (+ y (quot height 2) 4)
+             :text-anchor "middle"
+             :font-family font-stack
+             :font-size 12
+             :font-weight (if active? 600 400)
+             :fill (if active?
+                     (:text-primary tokens/tokens)
+                     (:text-secondary tokens/tokens))}
+      label]
+     ;; Final-state check glyph
+     (when final?
+       [:text {:x (+ x width -10)
+               :y (+ y 14)
+               :font-family font-stack
+               :font-size 11
+               :fill (:green tokens/tokens)}
+        "✓"])]))
+
+(defn- path-from-points
+  "Render an SVG path `d` attribute from a point list. Straight lines
+  for 2 points, cubic bezier for 4."
+  [points]
+  (case (count points)
+    2 (let [[[x1 y1] [x2 y2]] points]
+        (str "M " x1 " " y1 " L " x2 " " y2))
+    4 (let [[[x1 y1] [cx1 cy1] [cx2 cy2] [x2 y2]] points]
+        (str "M " x1 " " y1
+             " C " cx1 " " cy1
+             " "  cx2 " " cy2
+             " "  x2  " " y2))
+    ""))
+
+(defn- edge-label-position
+  "Mid-point of the edge for label placement. For self-loops, place
+  the label to the right of the control points."
+  [points]
+  (if (= 4 (count points))
+    (let [[_ [cx _] _ _] points] [(+ cx 30) (second (second points))])
+    (let [[[x1 y1] [x2 y2]] points]
+      [(quot (+ x1 x2) 2) (- (quot (+ y1 y2) 2) 6)])))
+
+(defn- render-edge
+  [{:keys [event-label points guard from-id to-id]
+    :as _edge}
+   {:keys [highlight-id]}]
+  (let [active? (or (= from-id highlight-id)
+                    (= to-id   highlight-id))
+        stroke  (if active?
+                  (:cyan tokens/tokens)
+                  (:border-default tokens/tokens))
+        marker  (if active?
+                  "url(#rf-causa-chart-arrow-highlight)"
+                  "url(#rf-causa-chart-arrow)")
+        [lx ly] (edge-label-position points)
+        full-label (if guard
+                     (str event-label " [" (if (keyword? guard)
+                                             (name guard) (str guard)) "]")
+                     event-label)]
+    [:g {:data-testid (str "rf-causa-chart-edge-" from-id "-to-" to-id)
+         :data-event event-label
+         :data-active (str active?)}
+     [:path {:d (path-from-points points)
+             :fill "none"
+             :stroke stroke
+             :stroke-width (if active? highlight-stroke-width stroke-width)
+             :marker-end marker}]
+     (when (seq full-label)
+       [:g
+        ;; Background pill for legibility
+        [:rect {:x (- lx (* 4 (count full-label)))
+                :y (- ly 9)
+                :width (* 8 (count full-label))
+                :height 14
+                :rx 3
+                :fill (:bg-2 tokens/tokens)
+                :opacity 0.85}]
+        [:text {:x lx :y (+ ly 1)
+                :text-anchor "middle"
+                :font-family font-stack
+                :font-size 10
+                :fill (:text-secondary tokens/tokens)}
+         full-label]])]))
+
+;; ---- public entry -------------------------------------------------------
+
+(defn render
+  "Render a positioned graph (from `layout/layout`) as a hiccup SVG.
+
+  Options:
+
+    :highlight-id     — node-id to render as the active state (cyan
+                        when `:sim?` is false, amber when true)
+    :sim?             — flips the highlight palette to amber
+                        (UC1 sim mode — follow-on bead wires this)
+    :on-state-click   — `(fn [path] ...)` called when a node is clicked
+                        (Causa wires this to its source-coord jump)
+    :testid           — overrides the root SVG data-testid
+
+  Returns a stable hiccup form. Empty graphs (no nodes) render an
+  inline note so the panel never sees an empty SVG container."
+  ([positioned] (render positioned {}))
+  ([{:keys [nodes edges width height] :as positioned}
+    {:keys [highlight-id sim? on-state-click testid]}]
+   (if (empty? nodes)
+     [:div {:data-testid (or testid "rf-causa-chart-empty")
+            :style {:padding "16px"
+                    :font-family (str "Inter, system-ui, sans-serif")
+                    :font-size "12px"
+                    :color (:text-tertiary tokens/tokens)}}
+      "Machine has no states to render."]
+     (let [initial-node (some (fn [n]
+                                (when (and (:initial? n)
+                                           (= 0 (:depth n))) n))
+                              nodes)]
+       [:svg {:data-testid (or testid "rf-causa-chart-svg")
+              :data-highlight-id (or highlight-id "")
+              :viewBox (str "0 0 " width " " height)
+              :width "100%"
+              :preserveAspectRatio "xMidYMin meet"
+              :style {:background (:bg-1 tokens/tokens)
+                      :border-radius "4px"
+                      :max-height "100%"
+                      :display "block"}}
+        (arrow-marker)
+        ;; Edges first so nodes paint over them
+        (into [:g {:data-testid "rf-causa-chart-edges"}]
+              (for [edge edges]
+                ^{:key (str (:from-id edge) "->" (:to-id edge)
+                            "/" (:event-label edge))}
+                (render-edge edge {:highlight-id highlight-id})))
+        (render-initial-marker initial-node)
+        (into [:g {:data-testid "rf-causa-chart-nodes"}]
+              (for [node nodes]
+                ^{:key (:node-id node)}
+                (render-node node
+                             {:highlight-id   highlight-id
+                              :sim?           sim?
+                              :on-state-click on-state-click})))]))))
+
+(defn render-from-definition
+  "Convenience: lay out + render in one call. Useful for the panel
+  and for the panel-gallery testbed.
+
+  See `render` for the option map."
+  ([definition] (render-from-definition definition {}))
+  ([definition opts]
+   (render (layout/layout definition) opts)))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -74,6 +74,8 @@
   unit-test target. The view here is a thin renderer that reads the
   `:rf.causa/machine-inspector-data` composite sub."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.chart.layout :as chart-layout]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -128,35 +130,60 @@
 ;; ---- placeholder chart --------------------------------------------------
 
 (defn- placeholder-banner
-  "Banner above the prop-summary view of the selected machine.
+  "Header above the chart canvas. Per spec/003-Machine-Inspector.md
+  §Definition view this banner names the current selection and (when
+  no live instances exist) nudges Sim mode (deferred to a follow-on
+  bead — the toggle stub renders disabled with a tooltip).
 
-  At v1 the panel renders a text view of the machine's current state
-  and props; the visual state-chart rendering surface lives in
-  `tools/machines-viz/` and is not yet wired in. The view function
-  keeps the `placeholder-banner` name so tests pin it via testid; the
-  user-visible text simply labels what is shown."
-  []
+  The fn keeps its historical name (`placeholder-banner`) so existing
+  tests pin it via testid; the user-visible text reflects what is
+  now actually shown — the rendered chart with live highlighting."
+  [{:keys [machine-id state instance-count]}]
   [:div {:data-testid "rf-causa-machine-inspector-placeholder-banner"
          :style       {:padding "10px 12px"
                        :margin "10px 12px 0 12px"
-                       :border (str "1px dashed " (:accent-violet tokens))
+                       :display "flex"
+                       :align-items "center"
+                       :justify-content "space-between"
+                       :gap "12px"
+                       :border (str "1px solid " (:border-subtle tokens))
                        :border-radius "4px"
-                       :background "rgba(124, 92, 255, 0.08)"
+                       :background (:bg-1 tokens)
                        :color (:text-secondary tokens)
                        :font-family sans-stack
                        :font-size "11px"
                        :line-height 1.5}}
-   [:strong {:style {:color (:accent-violet tokens)
-                     :font-weight 600
-                     :font-size "11px"
-                     :text-transform "uppercase"
-                     :letter-spacing "0.5px"}}
-    "Current state"]
-   [:p {:style {:margin "4px 0 0 0"}}
-    "Text view of the selected machine — its id, frame, and live state snapshot."]])
+   [:div
+    [:strong {:style {:color (:accent-violet tokens)
+                      :font-weight 600
+                      :font-size "11px"
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"}}
+     "Definition view"]
+    [:p {:style {:margin "4px 0 0 0"
+                 :color (:text-tertiary tokens)}}
+     (if (zero? (or instance-count 0))
+       (str (h/format-machine-id machine-id)
+            " — 0 live instances (toggle Sim ○ to walk topology — coming soon)")
+       (str (h/format-machine-id machine-id)
+            " — current state: "
+            (h/format-state state)))]]
+   ;; Sim toggle stub (rf2-2tkza Phase 2 will wire this)
+   [:span {:data-testid "rf-causa-machine-inspector-sim-toggle"
+           :title       "Sim mode coming soon — Phase 2 (rf2-2tkza)"
+           :style       {:color (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size "11px"
+                         :padding "2px 8px"
+                         :border (str "1px solid " (:border-subtle tokens))
+                         :border-radius "10px"
+                         :cursor "not-allowed"
+                         :opacity 0.6}}
+    "Sim ○"]])
 
 (defn- prop-row
-  "One labelled row inside the placeholder's prop summary."
+  "One labelled row inside the prop summary (used for the metadata
+  rail when no definition is introspectable)."
   [label value]
   [:div {:data-testid (str "rf-causa-machine-inspector-prop-" label)
          :style       {:display "flex"
@@ -176,47 +203,75 @@
                    :word-break "break-all"}}
     value]])
 
-(defn- placeholder-chart
-  "Renders the prop map a real MachineChart would consume. This is
-  the v1 surface — when machines-viz ships the placeholder becomes
-  `[viz/MachineChart props]`."
+(defn- chart-fallback
+  "Rendered when the panel has a selection but no machine-definition
+  to layout (e.g. an event-handler that lacks the introspection
+  metadata)."
   [props]
-  (if (nil? props)
+  [:div {:data-testid "rf-causa-machine-inspector-placeholder"
+         :style       {:padding "12px"
+                       :background (:bg-1 tokens)
+                       :border (str "1px solid " (:border-subtle tokens))
+                       :border-radius "4px"
+                       :margin "12px"}}
+   [prop-row "machine-id" (h/format-machine-id (:machine-id props))]
+   [prop-row "frame-id"   (h/format-machine-id (:frame-id props))]
+   (when-let [override (:current-state-override props)]
+     [prop-row "current-state-override"
+      (pr-str (select-keys override [:state :data]))])
+   [:div {:style {:margin-top "10px"
+                  :font-family sans-stack
+                  :font-size "11px"
+                  :color (:text-tertiary tokens)}}
+    "No introspectable definition available — chart cannot render."]])
+
+(defn- placeholder-chart
+  "Renders the live MachineChart (Causa-internal SVG primitive at
+  `day8.re-frame2-causa.chart.{layout,svg}`).
+
+  Phase 1 (rf2-2tkza): the chart reads the registered definition from
+  the composite sub's `:definition` slot, lays it out via the layered
+  primitive in `chart/layout.cljc`, and renders to hiccup SVG via
+  `chart/svg.cljc`. Live state highlighting reflects the snapshot's
+  `:state` slot. The fn keeps the historical name `placeholder-chart`
+  so existing tests pin it via testid; the user-visible surface is now
+  the real chart, not a prop summary."
+  [props]
+  (cond
+    (nil? props)
     [:div {:data-testid "rf-causa-machine-inspector-placeholder-empty"
            :style       {:padding "16px"
                          :color (:text-tertiary tokens)
                          :font-family sans-stack
                          :font-size "12px"}}
      "No machine selected — nothing to chart."]
-    [:div {:data-testid "rf-causa-machine-inspector-placeholder"
-           :style       {:padding "12px"
-                         :background (:bg-1 tokens)
-                         :border (str "1px solid " (:border-subtle tokens))
-                         :border-radius "4px"
-                         :margin "12px"}}
-     [prop-row "machine-id" (h/format-machine-id (:machine-id props))]
-     [prop-row "frame-id"   (h/format-machine-id (:frame-id props))]
-     (when-let [override (:current-state-override props)]
-       [prop-row "current-state-override"
-        (pr-str (select-keys override [:state :data]))])
-     [:div {:style {:margin-top "10px"
-                    :font-family sans-stack
-                    :font-size "10px"
-                    :color (:text-tertiary tokens)
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"}}
-      "Defaults in effect:"]
-     [:ul {:style {:margin "4px 0 0 0"
-                   :padding "0 0 0 16px"
-                   :color (:text-secondary tokens)
-                   :font-family mono-stack
-                   :font-size "11px"
-                   :list-style "disc"}}
-      [:li ":read-only? false"]
-      [:li ":show-microsteps? true"]
-      [:li ":show-after-rings? true"]
-      [:li ":show-invoke-all? true"]
-      [:li ":auto-pan? false"]]]))
+
+    (nil? (:definition props))
+    (chart-fallback props)
+
+    :else
+    (let [definition  (:definition props)
+          override    (:current-state-override props)
+          state-value (:state override)
+          highlight-id (chart-layout/highlight-id state-value)]
+      [:div {:data-testid "rf-causa-machine-inspector-chart"
+             :data-machine-id (str (:machine-id props))
+             :data-highlight-id (or highlight-id "")
+             :style       {:margin "12px"
+                           :padding "12px"
+                           :background (:bg-1 tokens)
+                           :border (str "1px solid " (:border-subtle tokens))
+                           :border-radius "4px"
+                           :overflow "auto"}}
+       (chart-svg/render-from-definition
+         definition
+         {:highlight-id   highlight-id
+          :on-state-click (fn [path]
+                            (rf/dispatch
+                              [:rf.causa/machine-state-clicked
+                               {:machine-id (:machine-id props)
+                                :path       path}]
+                              {:frame :rf/causa}))})])))
 
 ;; ---- transition history ribbon ------------------------------------------
 
@@ -301,6 +356,59 @@
                ^{:key (:id row)}
                (transition-entry row))))]))
 
+;; ---- instance tabs (UC2 Mode B foundation) -----------------------------
+
+(defn- instance-tabs
+  "Renders the inline instance-tabs strip across the top of the
+  diagram per spec/003-Machine-Inspector.md §UC2 Mode B. Each tab
+  shows the instance id and its current state; clicking re-focuses.
+
+  Phase 1 scaffold (rf2-2tkza): re-frame2's snapshot surface today is
+  one snapshot per machine-id (`[:rf/machines <id>]`); explicit
+  multi-instance via `:rf.machine/spawn` lands in a follow-on bead.
+  The strip renders the single registered snapshot as the focused
+  instance so the Mode B chrome is in place when the upstream
+  multi-instance surface ships."
+  [{:keys [machine-id state]} instance-count mode]
+  (when (and (= mode :mode-b) (pos? instance-count))
+    [:div {:data-testid "rf-causa-machine-inspector-instance-tabs"
+           :data-mode (name mode)
+           :style {:display "flex"
+                   :align-items "center"
+                   :gap "8px"
+                   :padding "6px 12px"
+                   :background (:bg-3 tokens)
+                   :border-bottom (str "1px solid " (:border-subtle tokens))
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :overflow-x "auto"
+                   :white-space "nowrap"}}
+     (for [idx (range instance-count)]
+       ^{:key idx}
+       [:span {:data-testid (str "rf-causa-machine-inspector-instance-tab-" idx)
+               :style {:padding "3px 10px"
+                       :background (if (zero? idx) (:bg-1 tokens) "transparent")
+                       :border (str "1px solid "
+                                    (if (zero? idx)
+                                      (:cyan tokens)
+                                      (:border-subtle tokens)))
+                       :border-radius "10px"
+                       :color (:text-primary tokens)
+                       :cursor "pointer"}}
+        (str "● " (h/format-machine-id machine-id)
+             "  " (h/format-state state))])]))
+
+(defn view-mode
+  "Per spec/003-Machine-Inspector.md §UC2 Mode A/B/C — pick the mode
+  based on live instance count. Pure fn for unit-testability; not
+  marked private so the view-test suite can pin the classifier
+  directly without relying on `data-view-mode` round-trips."
+  [instance-count]
+  (cond
+    (or (nil? instance-count) (zero? instance-count)) :mode-a
+    (<= instance-count 3) :mode-b
+    :else :mode-c))
+
 ;; ---- empty state --------------------------------------------------------
 
 (defn- empty-state
@@ -332,9 +440,17 @@
   state (no machines registered) or the picker + chart placeholder +
   transition-history ribbon."
   []
-  (let [{:keys [machines total selected-id chart-props transitions empty-kind]}
-        @(rf/subscribe [:rf.causa/machine-inspector-data])]
+  (let [{:keys [machines total selected selected-id chart-props transitions empty-kind]}
+        @(rf/subscribe [:rf.causa/machine-inspector-data])
+        ;; Phase 1: instance-count is 1 when there's a registered snapshot,
+        ;; 0 otherwise. When the multi-instance spawn surface lands a
+        ;; follow-on bead replaces this with `count` over the spawned-
+        ;; instances vector.
+        instance-count (if (and selected (:state selected)) 1 0)
+        mode           (view-mode instance-count)]
     [:section {:data-testid "rf-causa-machine-inspector"
+               :data-view-mode (name mode)
+               :data-instance-count instance-count
                :style       {:height         "100%"
                              :display        "flex"
                              :flex-direction "column"
@@ -357,8 +473,12 @@
        [:div {:style {:flex 1 :display "flex" :flex-direction "column"
                       :overflow "hidden"}}
         [machine-picker machines selected-id]
+        [instance-tabs (or selected {}) instance-count mode]
         [:div {:style {:flex 1 :overflow "auto"}}
-         (placeholder-banner)
+         (placeholder-banner
+           {:machine-id     (:machine-id selected)
+            :state          (:state selected)
+            :instance-count instance-count})
          (placeholder-chart chart-props)]
         (transition-ribbon transitions)])]))
 
@@ -446,6 +566,38 @@
         (dissoc db :machine-snapshots-override)
         (assoc db :machine-snapshots-override ov))))
 
+  ;; The registered-machine-definition map for every machine, keyed
+  ;; by machine-id (rf2-2tkza Phase 1). Production path reads through
+  ;; `(rf/machine-meta <id>)` for each registered id; the resulting
+  ;; map is what the chart primitive consumes to lay out the SVG. The
+  ;; per-id `try` is belt-and-braces — `machine-meta` is pure but a
+  ;; future API change shouldn't tear the whole composite.
+  (rf/reg-sub :rf.causa/machine-definitions-override
+    (fn [db _query]
+      (get db :machine-definitions-override)))
+
+  (rf/reg-sub :rf.causa/machine-definitions
+    :<- [:rf.causa/registered-machines]
+    :<- [:rf.causa/machine-definitions-override]
+    (fn [[machines override] _query]
+      (or override
+          (into {}
+                (keep (fn [id]
+                        (let [m (try (rf/machine-meta id)
+                                     (catch :default _ nil))]
+                          (when m [id m]))))
+                (or machines [])))))
+
+  ;; Test-only override for the definitions surface — mirrors the
+  ;; snapshot / registered-machines test hooks so JVM + node-test
+  ;; suites can drive the chart projection without booting a host
+  ;; with `rf/reg-machine` calls.
+  (rf/reg-event-db :rf.causa/set-machine-definitions-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :machine-definitions-override)
+        (assoc db :machine-definitions-override ov))))
+
   ;; The user's per-panel machine selection (drives the picker
   ;; focus). nil = default to first row.
   (rf/reg-sub :rf.causa/selected-machine-id
@@ -459,14 +611,15 @@
     :<- [:rf.causa/registered-machines]
     :<- [:rf.causa/machine-snapshots]
     :<- [:rf.causa/machine-snapshots-override]
+    :<- [:rf.causa/machine-definitions]
     :<- [:rf.causa/trace-buffer]
     :<- [:rf.causa/selected-machine-id]
     :<- [:rf.causa/target-frame]
-    (fn [[machines live-snapshots snapshots-override buffer selected-id target-frame]
+    (fn [[machines live-snapshots snapshots-override definitions buffer selected-id target-frame]
          _query]
       (let [snapshots (or snapshots-override live-snapshots {})]
         (h/project-data
-          machines snapshots buffer selected-id target-frame))))
+          machines snapshots definitions buffer selected-id target-frame))))
 
   ;; ---- Machine Inspector panel events ----------------------------
 
@@ -476,4 +629,14 @@
 
   (rf/reg-event-db :rf.causa/clear-machine-selection
     (fn [db _event]
-      (dissoc db :selected-machine-id))))
+      (dissoc db :selected-machine-id)))
+
+  ;; Source-coord jump trigger (rf2-2tkza Phase 1 scaffold). Clicking
+  ;; a state in the chart fires this event; Phase 2 (follow-on bead)
+  ;; wires it through to `:rf.causa/open-in-editor` once the
+  ;; `:rf.machine/source-coords {:state <path>}` slot stabilises in
+  ;; spec/005. v1 swallows the event so the click surface is testable
+  ;; without an editor-jump side effect leaking into smoke tests.
+  (rf/reg-event-db :rf.causa/machine-state-clicked
+    (fn [db [_ _payload]]
+      db)))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
@@ -141,33 +141,42 @@
   "One row per registered machine. `machine-id` is the keyword the
   machine is registered under (per Spec 005); `snapshot` is the
   current `{:state :data}` map (or nil for uninitialised machines).
+  `definition` is the registered machine spec (`(rf/machine-meta
+  machine-id)`); nil when the spec is not yet introspectable.
 
   Per the panel's minimum-viable contract the row carries:
 
     :machine-id   — the registered id (keyword)
     :state        — the snapshot's :state keyword (nil if uninit)
     :data         — the snapshot's :data map (nil if uninit)
+    :definition   — the registered machine spec (nil if not available)
     :registered?  — always true (the row exists because the id is
                     registered); included so the view can render the
                     fact distinctly from `:state` (an uninitialised
                     registered machine still appears in the picker)."
-  [machine-id snapshot]
-  {:machine-id  machine-id
-   :state       (when (map? snapshot) (:state snapshot))
-   :data        (when (map? snapshot) (:data snapshot))
-   :registered? true})
+  ([machine-id snapshot] (project-machine-row machine-id snapshot nil))
+  ([machine-id snapshot definition]
+   {:machine-id  machine-id
+    :state       (when (map? snapshot) (:state snapshot))
+    :data        (when (map? snapshot) (:data snapshot))
+    :definition  definition
+    :registered? true}))
 
 (defn project-machine-rows
-  "Project the registered-machine set + the live snapshots map into
-  one row per id. Sorted alphabetically by `(name machine-id)` for
-  deterministic test output. Pure fn — JVM-runnable."
-  [machines snapshots]
-  (->> (or machines [])
-       (map (fn [id]
-              (project-machine-row id (get snapshots id))))
-       (sort-by (fn [{:keys [machine-id]}]
-                  (str machine-id)))
-       vec))
+  "Project the registered-machine set + the live snapshots map (+
+  the per-id definition map, when available) into one row per id.
+  Sorted alphabetically by `(name machine-id)` for deterministic
+  test output. Pure fn — JVM-runnable."
+  ([machines snapshots] (project-machine-rows machines snapshots nil))
+  ([machines snapshots definitions]
+   (->> (or machines [])
+        (map (fn [id]
+               (project-machine-row id
+                                    (get snapshots id)
+                                    (get definitions id))))
+        (sort-by (fn [{:keys [machine-id]}]
+                   (str machine-id)))
+        vec)))
 
 (defn pick-selected
   "Resolve the row for the selected machine-id. When `selected-id` is
@@ -199,13 +208,15 @@
   renders the empty-chart state in that case."
   [selected-row frame-id]
   (when selected-row
-    (let [{:keys [machine-id state data]} selected-row]
+    (let [{:keys [machine-id state data definition]} selected-row]
       (cond-> {:machine-id machine-id
                :frame-id   frame-id}
         (some? state)
         (assoc :current-state-override
                (cond-> {:state state}
-                 (some? data) (assoc :data data)))))))
+                 (some? data) (assoc :data data)))
+        (some? definition)
+        (assoc :definition definition)))))
 
 ;; ---- transition history --------------------------------------------------
 
@@ -291,21 +302,23 @@
        :chart-props  <props-or-nil>
        :transitions  [<transition-row> ...]
        :empty-kind   <:no-machines / nil>}"
-  [machines snapshots trace-buffer selected-id frame-id]
-  (let [rows         (project-machine-rows machines snapshots)
-        total        (count rows)
-        selected     (pick-selected rows selected-id)
-        effective-id (:machine-id selected)
-        props        (chart-props selected frame-id)
-        transitions  (project-transitions trace-buffer effective-id)
-        empty-kind   (when (zero? total) :no-machines)]
-    {:machines    rows
-     :total       total
-     :selected-id effective-id
-     :selected    selected
-     :chart-props props
-     :transitions transitions
-     :empty-kind  empty-kind}))
+  ([machines snapshots trace-buffer selected-id frame-id]
+   (project-data machines snapshots nil trace-buffer selected-id frame-id))
+  ([machines snapshots definitions trace-buffer selected-id frame-id]
+   (let [rows         (project-machine-rows machines snapshots definitions)
+         total        (count rows)
+         selected     (pick-selected rows selected-id)
+         effective-id (:machine-id selected)
+         props        (chart-props selected frame-id)
+         transitions  (project-transitions trace-buffer effective-id)
+         empty-kind   (when (zero? total) :no-machines)]
+     {:machines    rows
+      :total       total
+      :selected-id effective-id
+      :selected    selected
+      :chart-props props
+      :transitions transitions
+      :empty-kind  empty-kind})))
 
 ;; ---- formatting helpers (consumed by the view) --------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc
@@ -1,0 +1,141 @@
+(ns day8.re-frame2-causa.chart.layout-cljs-test
+  "Pure-data tests for the chart-layout primitive (rf2-2tkza Phase 1).
+
+  Dual-target convention: `.cljc` + `_cljs_test` ns name so the
+  Cognitect runner (CLJ) and Shadow's `:node-test` build both pick
+  it up via their default suffix regex."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.chart.layout :as layout]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(def idle-loading-success
+  "Canonical small machine: idle → loading → success/failed."
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :success :err :failed}}
+             :success {:final? true}
+             :failed  {:final? true}}})
+
+(def compound-machine
+  "One compound state with a nested region."
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+;; ---- parse-definition ---------------------------------------------------
+
+(deftest parse-definition-empty-for-nil
+  (let [g (layout/parse-definition nil)]
+    (is (= [] (:nodes g)))
+    (is (= [] (:edges g)))))
+
+(deftest parse-definition-extracts-flat-machine-nodes
+  (let [{:keys [nodes initial-path]} (layout/parse-definition idle-loading-success)
+        paths (set (map :path nodes))]
+    (is (= [:idle] initial-path))
+    (is (= #{[:idle] [:loading] [:success] [:failed]} paths))
+    (is (some :initial? nodes) "the initial state is flagged")
+    (is (= 2 (count (filter :final? nodes)))
+        "final states are flagged")))
+
+(deftest parse-definition-extracts-edges
+  (let [{:keys [edges]} (layout/parse-definition idle-loading-success)
+        edge-pairs (set (map (juxt :from :to :event) edges))]
+    (is (contains? edge-pairs [[:idle] [:loading] :start]))
+    (is (contains? edge-pairs [[:loading] [:success] :ok]))
+    (is (contains? edge-pairs [[:loading] [:failed] :err]))))
+
+(deftest parse-definition-extracts-compound-nodes
+  (let [{:keys [nodes]} (layout/parse-definition compound-machine)
+        paths (set (map :path nodes))
+        top   (filter #(= 1 (count (:path %))) nodes)]
+    (is (contains? paths [:unauth]))
+    (is (contains? paths [:authenticated]))
+    (is (contains? paths [:authenticated :browsing]))
+    (is (contains? paths [:authenticated :paying]))
+    (is (= 2 (count top))
+        "two top-level states (:unauth + :authenticated)")
+    (is (some :compound? top)
+        "the compound parent carries the :compound? flag")))
+
+(deftest parse-definition-supports-parallel-projects-first-region
+  (let [parallel {:type :parallel
+                  :regions {:r1 {:initial :a :states {:a {:on {:go :b}}
+                                                      :b {}}}
+                            :r2 {:initial :x :states {:x {:on {:go :y}}
+                                                      :y {}}}}}
+        {:keys [nodes]} (layout/parse-definition parallel)
+        paths (set (map :path nodes))]
+    (is (contains? paths [:a]))
+    (is (contains? paths [:b]))
+    (is (not (contains? paths [:x]))
+        "v1 projects only the first region — :r2's nodes do not surface")))
+
+;; ---- layout ------------------------------------------------------------
+
+(deftest layout-empty-for-nil-definition
+  (let [g (layout/layout nil)]
+    (is (= [] (:nodes g)))
+    (is (= [] (:edges g)))
+    (is (pos? (:width g)))
+    (is (pos? (:height g)))))
+
+(deftest layout-positions-every-node
+  (let [g (layout/layout idle-loading-success)]
+    (is (= 4 (count (:nodes g))))
+    (doseq [n (:nodes g)]
+      (is (integer? (:x n)) (str "node " (:path n) " missing :x"))
+      (is (integer? (:y n)) (str "node " (:path n) " missing :y"))
+      (is (pos? (:width n)))
+      (is (pos? (:height n)))
+      (is (string? (:node-id n))))))
+
+(deftest layout-stratifies-by-rank-from-initial
+  (testing "initial state sits at rank 0 (top row); BFS ranks grow downward"
+    (let [{:keys [nodes]} (layout/layout idle-loading-success)
+          rank-of (fn [path]
+                    (some (fn [n] (when (= (:path n) path) (:rank n)))
+                          nodes))]
+      (is (= 0 (rank-of [:idle])))
+      (is (= 1 (rank-of [:loading])))
+      (is (= 2 (rank-of [:success])))
+      (is (= 2 (rank-of [:failed]))))))
+
+(deftest layout-routes-edges-with-points
+  (let [{:keys [edges]} (layout/layout idle-loading-success)]
+    (is (every? :from-id edges))
+    (is (every? :to-id edges))
+    (is (every? (comp #(= 2 (count %)) :points) edges)
+        "straight-line edges carry two points each")
+    (is (every? :event-label edges)
+        "every edge has a human-readable event-label")))
+
+(deftest layout-unreached-nodes-still-render-at-rank-zero
+  (testing "a state with no inbound edges still appears in the layout"
+    (let [orphan {:initial :a
+                  :states  {:a       {}
+                            :orphan  {:on {:noop :a}}}}
+          {:keys [nodes]} (layout/layout orphan)]
+      (is (= 2 (count nodes)))
+      (is (some #(= [:orphan] (:path %)) nodes)))))
+
+;; ---- highlight-id ------------------------------------------------------
+
+(deftest highlight-id-handles-flat-state
+  (is (some? (layout/highlight-id :authing)))
+  (is (= (layout/highlight-id :authing)
+         (layout/highlight-id [:authing]))
+      "flat keyword and 1-element vector resolve to the same id"))
+
+(deftest highlight-id-handles-hierarchical-path
+  (let [id (layout/highlight-id [:authenticated :browsing])]
+    (is (string? id))
+    (is (not= id (layout/highlight-id [:authenticated])))))
+
+(deftest highlight-id-nil-for-nil-state
+  (is (nil? (layout/highlight-id nil))))

--- a/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
@@ -1,0 +1,101 @@
+(ns day8.re-frame2-causa.chart.svg-cljs-test
+  "Pure-data tests for the chart-SVG renderer (rf2-2tkza Phase 1).
+
+  The renderer returns hiccup. Tests walk the tree by `data-testid`
+  rather than mounting to a DOM — same approach the panel view tests
+  use (see machine_inspector_view_cljs_test.cljs)."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.chart.layout :as layout]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]))
+
+;; ---- fixtures ----------------------------------------------------------
+
+(def small-machine
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :success :err :failed}}
+             :success {:final? true}
+             :failed  {:final? true}}})
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (when-let [tid (:data-testid (second node))]
+                   #?(:clj  (.startsWith ^String tid ^String prefix)
+                      :cljs (.startsWith tid prefix)))))
+          (hiccup-seq tree)))
+
+;; ---- empty ------------------------------------------------------------
+
+(deftest render-empty-shows-fallback
+  (let [tree (chart-svg/render-from-definition nil)]
+    (is (some? (find-by-testid tree "rf-causa-chart-empty"))
+        "nil definition renders a friendly fallback")))
+
+;; ---- happy path -------------------------------------------------------
+
+(deftest render-emits-svg-root
+  (let [tree (chart-svg/render-from-definition small-machine)]
+    (is (some? (find-by-testid tree "rf-causa-chart-svg"))
+        "root SVG present")))
+
+(deftest render-emits-one-node-per-state
+  (let [tree    (chart-svg/render-from-definition small-machine)
+        nodes   (find-all-by-testid-prefix tree "rf-causa-chart-node-")]
+    (is (= 4 (count nodes))
+        "four state nodes — :idle :loading :success :failed")))
+
+(deftest render-emits-edges
+  (let [tree (chart-svg/render-from-definition small-machine)
+        edges (find-all-by-testid-prefix tree "rf-causa-chart-edge-")]
+    (is (= 3 (count edges))
+        "three edges — :start, :ok, :err")))
+
+(deftest render-marks-active-node
+  (let [hid  (layout/highlight-id :loading)
+        tree (chart-svg/render-from-definition
+               small-machine
+               {:highlight-id hid})
+        ;; node-id derived from path
+        node (find-by-testid tree (str "rf-causa-chart-node-" hid))]
+    (is (some? node))
+    (is (= "true" (:data-active (second node)))
+        ":loading node is data-active=\"true\"")))
+
+(deftest render-no-active-when-no-highlight
+  (let [tree (chart-svg/render-from-definition small-machine)
+        nodes (find-all-by-testid-prefix tree "rf-causa-chart-node-")]
+    (is (every? (fn [n] (= "false" (:data-active (second n)))) nodes)
+        "no node is active when highlight-id is omitted")))
+
+(deftest render-initial-marker-present
+  (let [tree (chart-svg/render-from-definition small-machine)]
+    (is (some? (find-by-testid tree "rf-causa-chart-initial-marker"))
+        "the initial-state marker is rendered")))
+
+(deftest render-on-state-click-fires-with-path
+  (let [seen   (atom [])
+        tree   (chart-svg/render-from-definition
+                 small-machine
+                 {:on-state-click (fn [p] (swap! seen conj p))})
+        node   (find-by-testid
+                 tree
+                 (str "rf-causa-chart-node-" (layout/highlight-id :loading)))
+        click  (:on-click (second node))]
+    (is (some? click))
+    (when click (click nil))
+    (is (= [[:loading]] @seen)
+        "click handler receives the state's :path")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
@@ -93,6 +93,18 @@
         ids  (map :machine-id rows)]
     (is (= [:a/first :m/middle :z/last] ids))))
 
+(deftest project-machine-rows-3-arity-fills-definition
+  (testing "the 3-arity overload propagates the machine definition into
+            the row so the chart primitive can lay it out"
+    (let [defs {:auth/login {:initial :idle
+                             :states  {:idle    {:on {:start :authing}}
+                                       :authing {:on {:ok :done}}
+                                       :done    {:final? true}}}}
+          rows (h/project-machine-rows [:auth/login] {} defs)
+          row  (first rows)]
+      (is (= :auth/login (:machine-id row)))
+      (is (= (:auth/login defs) (:definition row))))))
+
 ;; ---- (4) pick-selected -------------------------------------------------
 
 (deftest pick-selected-returns-matching-row
@@ -140,6 +152,26 @@
     (is (= {:state :idle}
            (:current-state-override props))
         "data slot is omitted rather than nil")))
+
+(deftest chart-props-carries-definition-when-present
+  (testing "the chart-props payload threads the machine definition so
+            the chart primitive can lay it out without a second sub"
+    (let [def-map {:initial :idle
+                   :states  {:idle    {:on {:start :ready}}
+                             :ready   {:final? true}}}
+          props   (h/chart-props {:machine-id :auth/login
+                                  :state      :ready
+                                  :data       nil
+                                  :definition def-map}
+                                 :rf/default)]
+      (is (= def-map (:definition props))
+          "definition is passed through to the chart layer"))))
+
+(deftest chart-props-omits-definition-when-nil
+  (let [props (h/chart-props {:machine-id :auth/login :state :idle :data nil}
+                             :rf/default)]
+    (is (not (contains? props :definition))
+        "no :definition key when the row carries no definition")))
 
 ;; ---- (6) project-transitions -------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -102,21 +102,40 @@
   (rf/dispatch-sync
     [:rf.causa/set-machine-snapshots-override-for-test snapshots]))
 
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-definitions-override-for-test definitions]))
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
 ;; ---- (1) registry wiring ------------------------------------------------
 
 (deftest registry-installs-machine-inspector-handlers
-  (testing "register-causa-handlers! installs every rf2-r9f9u handler"
+  (testing "register-causa-handlers! installs every rf2-r9f9u handler
+            (plus the rf2-2tkza Phase 1 chart + Mode A/B additions)"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/registered-machines)))
     (is (some? (registrar/handler :sub :rf.causa/machine-snapshots)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-definitions)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-definitions-override)))
     (is (some? (registrar/handler :sub :rf.causa/selected-machine-id)))
     (is (some? (registrar/handler :sub :rf.causa/machine-inspector-data)))
     (is (some? (registrar/handler :event :rf.causa/select-machine-id)))
     (is (some? (registrar/handler :event :rf.causa/clear-machine-selection)))
+    (is (some? (registrar/handler :event :rf.causa/machine-state-clicked))
+        "rf2-2tkza Phase 1: chart click → source-coord jump trigger")
     (is (some? (registrar/handler
                  :event :rf.causa/set-registered-machines-override-for-test)))
     (is (some? (registrar/handler
-                 :event :rf.causa/set-machine-snapshots-override-for-test)))))
+                 :event :rf.causa/set-machine-snapshots-override-for-test)))
+    (is (some? (registrar/handler
+                 :event :rf.causa/set-machine-definitions-override-for-test))
+        "rf2-2tkza Phase 1: definitions test override hook")))
 
 (deftest composite-defaults-to-empty-when-no-override
   (testing "with an empty machines override the composite returns the
@@ -216,9 +235,10 @@
                      tree "rf-causa-machine-inspector-placeholder-banner"))
             "placeholder banner present — surfaces the deferred impl")))))
 
-(deftest placeholder-shows-prop-summary-with-selection
-  (testing "the placeholder renders the MachineChart prop summary for
-            the selected machine — the contract is what matters at v1"
+(deftest placeholder-falls-back-to-prop-summary-without-definition
+  (testing "when no machine-definition is available (no introspection
+            metadata), the panel falls back to the prop-summary
+            view so the panel still renders something useful"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!  [:auth/login])
@@ -227,6 +247,35 @@
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-placeholder")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-machine-id")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-frame-id")))))))
+
+(deftest chart-renders-when-definition-is-available
+  (testing "with the definitions override populated, the panel renders
+            the live SVG chart instead of the prop-summary fallback"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-snapshots!   {:auth/login {:state :authing :data {}}})
+      (override-definitions! {:auth/login fixture-definition})
+      (let [tree (machine-inspector/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-machine-inspector-chart"))
+            "the chart container replaces the prop-summary fallback")
+        (is (some? (find-by-testid tree "rf-causa-chart-svg"))
+            "the SVG primitive emits a root <svg>")
+        (is (nil? (find-by-testid tree "rf-causa-machine-inspector-placeholder"))
+            "the fallback is suppressed when a definition is available")))))
+
+(deftest chart-highlights-active-state-from-snapshot
+  (testing "the chart's root data-highlight-id matches the snapshot's :state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-snapshots!   {:auth/login {:state :authing :data {}}})
+      (override-definitions! {:auth/login fixture-definition})
+      (let [tree (machine-inspector/Panel)
+            chart (find-by-testid tree "rf-causa-machine-inspector-chart")]
+        (is (some? chart))
+        (is (= "authing" (:data-highlight-id (second chart)))
+            "the chart container carries the resolved highlight-id")))))
 
 ;; ---- (5) transition history ribbon --------------------------------------
 
@@ -291,6 +340,50 @@
             (when handler (handler))))
         (is (some #(= [:rf.causa/select-dispatch-id "d-42"] %) @dispatches)
             "select-dispatch-id fired with the dispatch-id from the trace event")))))
+
+;; ---- (5b) Mode A / Mode B (UC2 dynamic instance modes) ----------------
+
+(deftest view-mode-helper-routes-by-instance-count
+  (testing "the view-mode classifier returns :mode-a / :mode-b / :mode-c
+            per spec/003-Machine-Inspector.md §UC2"
+    (is (= :mode-a (machine-inspector/view-mode 0)))
+    (is (= :mode-a (machine-inspector/view-mode nil)))
+    (is (= :mode-b (machine-inspector/view-mode 1)))
+    (is (= :mode-b (machine-inspector/view-mode 3)))
+    (is (= :mode-c (machine-inspector/view-mode 4)))
+    (is (= :mode-c (machine-inspector/view-mode 100)))))
+
+(deftest mode-a-renders-when-no-snapshot-state
+  (testing "with a registered machine but no snapshot :state, the panel
+            renders in Mode A (definition view; instance-tabs hidden)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (let [tree (machine-inspector/Panel)
+            root (find-by-testid tree "rf-causa-machine-inspector")]
+        (is (= "mode-a" (:data-view-mode (second root))))
+        (is (= 0 (:data-instance-count (second root))))
+        (is (nil? (find-by-testid
+                    tree "rf-causa-machine-inspector-instance-tabs"))
+            "instance-tabs strip is hidden in Mode A")))))
+
+(deftest mode-b-renders-instance-tabs-when-snapshot-present
+  (testing "with a registered machine + a live snapshot, the panel
+            renders in Mode B (instance tabs visible above the chart)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-snapshots!   {:auth/login {:state :authing :data {}}})
+      (override-definitions! {:auth/login fixture-definition})
+      (let [tree (machine-inspector/Panel)
+            root (find-by-testid tree "rf-causa-machine-inspector")
+            tabs (find-by-testid
+                   tree "rf-causa-machine-inspector-instance-tabs")]
+        (is (= "mode-b" (:data-view-mode (second root))))
+        (is (= 1 (:data-instance-count (second root))))
+        (is (some? tabs) "instance-tabs strip is present in Mode B")
+        (is (= "mode-b" (:data-mode (second tabs))))))))
 
 ;; ---- (6) frame isolation ------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -117,6 +117,8 @@
    :rf.causa/hydration-reroot-path
    :rf.causa/issues-filters
    :rf.causa/issues-ribbon
+   :rf.causa/machine-definitions
+   :rf.causa/machine-definitions-override
    :rf.causa/machine-inspector-data
    :rf.causa/machine-snapshots
    :rf.causa/machine-snapshots-override
@@ -208,6 +210,7 @@
    :rf.causa/focus-slice-path
    :rf.causa/follow-head
    :rf.causa/hide-invalidation-chain
+   :rf.causa/machine-state-clicked
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
    :rf.causa/open-in-editor
@@ -240,6 +243,7 @@
    :rf.causa/select-violation
    :rf.causa/set-active-route-slice-override-for-test
    :rf.causa/set-frame
+   :rf.causa/set-machine-definitions-override-for-test
    :rf.causa/set-machine-snapshots-override-for-test
    :rf.causa/set-mcp-since-seconds
    :rf.causa/set-performance-budget-ms
@@ -334,7 +338,10 @@
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
     ;; + 2 spine (rf2-adve5): :rf.causa/focus + :rf.causa/focus-slot
-    (is (= 74 (count all-sub-names)))
+    ;; + 2 machine-inspector (rf2-2tkza Phase 1):
+    ;;   :rf.causa/machine-definitions (production sub) +
+    ;;   :rf.causa/machine-definitions-override (test-override sub).
+    (is (= 76 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -344,7 +351,10 @@
     ;; + 7 spine (rf2-adve5): focus-cascade + focus-cascade-prev +
     ;;   focus-cascade-next + follow-head + toggle-live-pause +
     ;;   set-frame + preview-cascade
-    (is (= 82 (count all-event-names)))
+    ;; + 2 machine-inspector (rf2-2tkza Phase 1):
+    ;;   :rf.causa/machine-state-clicked (chart click handler) +
+    ;;   :rf.causa/set-machine-definitions-override-for-test
+    (is (= 84 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary

Phase 1 of the Machine Inspector rebuild per `tools/causa/spec/003-Machine-Inspector.md` (rewritten in #1392). Replaces the v1 placeholder prop-summary with a live SVG state-chart driven by the registered machine definition; lays the Mode A / Mode B chrome around it.

- New Causa-internal chart primitive at `tools/causa/src/day8/re_frame2_causa/chart/{layout,svg}.cljc` — pure-data, JVM-runnable, no ELK dep. Layered BFS-rank layout + straight-line edges + simple SVG renderer with live state highlighting.
- Panel reads the registered definition through a new `:rf.causa/machine-definitions` sub (composite over `(rf/machine-meta <id>)` for every id from `(rf/machines)`) and renders the chart inline; falls back to the prop-summary view when no definition is available.
- Mode classifier (`view-mode` → `:mode-a` / `:mode-b` / `:mode-c`) drives the panel's `data-view-mode` axis. Mode B inline instance-tabs strip ships as a scaffold so the affordance surface is in place when the upstream multi-instance spawn surface lands.
- New `:rf.causa/machine-state-clicked` event hook for the future source-coord jump.

## Shipped vs deferred

**Shipped (Phase 1):**

- Foundation: panel header, picker, banner, transition-history ribbon (kept from rf2-r9f9u).
- Mode A definition view with the live SVG chart.
- Mode B scaffold (instance-tabs strip, hue scaffolding).
- Chart primitive (`chart/layout.cljc`, `chart/svg.cljc`) with rank-based layout, edge routing, compound-state path projection, parallel projection (first-region v1), initial-state marker, final-state double-ring, click-through hook.
- Tests: chart-layout (JVM-runnable), chart-svg renderer, panel view (Mode A/B classification, chart render path, definition fallback), registry catalogue updates.

**Deferred to follow-on beads (will file as `rf2-2tkza` children):**

- **Phase 2 — UC1 Sim sub-mode**: event picker, mock `:data` form, failed-guard handling with `Shift+Enter`-fires-despite-guard, sim trail, 24px tinted banner, amber highlight.
- **Phase 3 — UC2 Mode C**: Erlang-Observer virtualised table, cluster-by-state count badges, shift-click multi-select with divergence highlight.
- **Phase 4 — ELK.js swap**: the current layered layout is readable for 4-12 state machines (covers most re-frame2 apps); ELK is ~250KB and the bead's pragmatic recommendation deferred it to a follow-on.
- **Phase 5 — XState parity supervision**: already shipped per rf2-ocp7a in `implementation/machines/`. This PR consumes the contract but does not re-validate it.
- **Mermaid emitter relocation** (`tools/machines-viz/` → `implementation/machines/`) per spec/003 §Architectural posture; tracked separately.
- Per-instance arc + mini-scrubber, share-as-PNG/SVG/Mermaid, registry-index view, Cmd-K `:machine` palette source.

## Test plan

- [x] `bash scripts/test-fast-pr.sh` — 2428 CLJS tests, 0 failures.
- [x] `cd implementation && npm run test:browser` — 2417 tests, 0 failures.
- [x] `cd tools/causa && clojure -M:test` — 596 JVM tests, 0 failures.

## Files

- `tools/causa/src/day8/re_frame2_causa/chart/layout.cljc` (new)
- `tools/causa/src/day8/re_frame2_causa/chart/svg.cljc` (new)
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs` (chart wiring, Mode A/B chrome, new sub + event)
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc` (definitions threaded through `chart-props` + `project-machine-rows`)
- `tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc` (new)
- `tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc` (new)
- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc` (3-arity coverage + definition propagation)
- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs` (chart render path, Mode A/B classification)
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` (catalogue + counts)