### PR TITLE
feat(causa): Machine Inspector Phase 2 — UC1 Sim sub-mode

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -77,6 +77,7 @@
             [day8.re-frame2-causa.chart.layout :as chart-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
+            [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -132,13 +133,14 @@
 (defn- placeholder-banner
   "Header above the chart canvas. Per spec/003-Machine-Inspector.md
   §Definition view this banner names the current selection and (when
-  no live instances exist) nudges Sim mode (deferred to a follow-on
-  bead — the toggle stub renders disabled with a tooltip).
+  no live instances exist) nudges Sim mode. rf2-v869p Phase 2 wires
+  the toggle through to the `:rf.causa/sim-start` / `sim-stop` events
+  (rf2-2tkza Phase 1 shipped the toggle stub).
 
   The fn keeps its historical name (`placeholder-banner`) so existing
   tests pin it via testid; the user-visible text reflects what is
   now actually shown — the rendered chart with live highlighting."
-  [{:keys [machine-id state instance-count]}]
+  [{:keys [machine-id state instance-count definition sim-active?]}]
   [:div {:data-testid "rf-causa-machine-inspector-placeholder-banner"
          :style       {:padding "10px 12px"
                        :margin "10px 12px 0 12px"
@@ -146,7 +148,10 @@
                        :align-items "center"
                        :justify-content "space-between"
                        :gap "12px"
-                       :border (str "1px solid " (:border-subtle tokens))
+                       :border (str "1px solid "
+                                    (if sim-active?
+                                      (:yellow tokens)
+                                      (:border-subtle tokens)))
                        :border-radius "4px"
                        :background (:bg-1 tokens)
                        :color (:text-secondary tokens)
@@ -154,32 +159,75 @@
                        :font-size "11px"
                        :line-height 1.5}}
    [:div
-    [:strong {:style {:color (:accent-violet tokens)
+    [:strong {:style {:color (if sim-active?
+                               (:yellow tokens)
+                               (:accent-violet tokens))
                       :font-weight 600
                       :font-size "11px"
                       :text-transform "uppercase"
                       :letter-spacing "0.5px"}}
-     "Definition view"]
+     (if sim-active? "Sim ●  Definition view" "Definition view")]
     [:p {:style {:margin "4px 0 0 0"
                  :color (:text-tertiary tokens)}}
-     (if (zero? (or instance-count 0))
+     (cond
+       sim-active?
        (str (h/format-machine-id machine-id)
-            " — 0 live instances (toggle Sim ○ to walk topology — coming soon)")
+            " — sim mode active; clicks walk the topology against a clone")
+
+       (zero? (or instance-count 0))
+       (str (h/format-machine-id machine-id)
+            " — 0 live instances "
+            (if definition
+              "(toggle Sim ▶︎ to walk topology)"
+              "(no introspectable definition — Sim unavailable)"))
+
+       :else
        (str (h/format-machine-id machine-id)
             " — current state: "
             (h/format-state state)))]]
-   ;; Sim toggle stub (rf2-2tkza Phase 2 will wire this)
-   [:span {:data-testid "rf-causa-machine-inspector-sim-toggle"
-           :title       "Sim mode coming soon — Phase 2 (rf2-2tkza)"
-           :style       {:color (:text-tertiary tokens)
-                         :font-family mono-stack
-                         :font-size "11px"
-                         :padding "2px 8px"
-                         :border (str "1px solid " (:border-subtle tokens))
-                         :border-radius "10px"
-                         :cursor "not-allowed"
-                         :opacity 0.6}}
-    "Sim ○"]])
+   ;; Sim toggle — active when a definition is available (rf2-v869p Phase 2).
+   (let [enabled? (some? definition)]
+     [:button
+      {:data-testid "rf-causa-machine-inspector-sim-toggle"
+       :on-click    (when enabled?
+                      (fn [_]
+                        (if sim-active?
+                          (rf/dispatch
+                            [:rf.causa/sim-stop {:machine-id machine-id}]
+                            {:frame :rf/causa})
+                          (rf/dispatch
+                            [:rf.causa/sim-start
+                             {:machine-id machine-id
+                              :definition definition}]
+                            {:frame :rf/causa}))))
+       :title       (cond
+                      (not enabled?) "Sim requires an introspectable machine definition"
+                      sim-active?    "Exit sim — disposes the cloned snapshot"
+                      :else          "Enter sim — clones the machine + walks transitions interactively")
+       :data-active (str (boolean sim-active?))
+       :style       {:color (cond
+                              (not enabled?) (:text-tertiary tokens)
+                              sim-active?    "#1c2030"
+                              :else          (:yellow tokens))
+                     :background (cond
+                                   (not enabled?) "transparent"
+                                   sim-active?    (:yellow tokens)
+                                   :else          "transparent")
+                     :font-family mono-stack
+                     :font-size "11px"
+                     :font-weight 600
+                     :padding "3px 10px"
+                     :border (str "1px solid "
+                                  (cond
+                                    (not enabled?) (:border-subtle tokens)
+                                    :else          (:yellow tokens)))
+                     :border-radius "10px"
+                     :cursor (if enabled? "pointer" "not-allowed")
+                     :opacity (if enabled? 1 0.6)}}
+      (cond
+        sim-active?    "Sim ●"
+        enabled?       "Sim ▶︎"
+        :else          "Sim ○")])])
 
 (defn- prop-row
   "One labelled row inside the prop summary (used for the metadata
@@ -235,43 +283,57 @@
   `chart/svg.cljc`. Live state highlighting reflects the snapshot's
   `:state` slot. The fn keeps the historical name `placeholder-chart`
   so existing tests pin it via testid; the user-visible surface is now
-  the real chart, not a prop summary."
-  [props]
-  (cond
-    (nil? props)
-    [:div {:data-testid "rf-causa-machine-inspector-placeholder-empty"
-           :style       {:padding "16px"
-                         :color (:text-tertiary tokens)
-                         :font-family sans-stack
-                         :font-size "12px"}}
-     "No machine selected — nothing to chart."]
+  the real chart, not a prop summary.
 
-    (nil? (:definition props))
-    (chart-fallback props)
+  Phase 2 (rf2-v869p): when `sim-snapshot` is non-nil the chart's
+  highlight is sourced from the sim snapshot and the `:sim?` flag is
+  flipped on `chart/svg.cljc`'s renderer so the highlight palette
+  shifts from cyan (live) to amber (sim) per design §5."
+  ([props] (placeholder-chart props nil))
+  ([props sim-snapshot]
+   (cond
+     (nil? props)
+     [:div {:data-testid "rf-causa-machine-inspector-placeholder-empty"
+            :style       {:padding "16px"
+                          :color (:text-tertiary tokens)
+                          :font-family sans-stack
+                          :font-size "12px"}}
+      "No machine selected — nothing to chart."]
 
-    :else
-    (let [definition  (:definition props)
-          override    (:current-state-override props)
-          state-value (:state override)
-          highlight-id (chart-layout/highlight-id state-value)]
-      [:div {:data-testid "rf-causa-machine-inspector-chart"
-             :data-machine-id (str (:machine-id props))
-             :data-highlight-id (or highlight-id "")
-             :style       {:margin "12px"
-                           :padding "12px"
-                           :background (:bg-1 tokens)
-                           :border (str "1px solid " (:border-subtle tokens))
-                           :border-radius "4px"
-                           :overflow "auto"}}
-       (chart-svg/render-from-definition
-         definition
-         {:highlight-id   highlight-id
-          :on-state-click (fn [path]
-                            (rf/dispatch
-                              [:rf.causa/machine-state-clicked
-                               {:machine-id (:machine-id props)
-                                :path       path}]
-                              {:frame :rf/causa}))})])))
+     (nil? (:definition props))
+     (chart-fallback props)
+
+     :else
+     (let [definition   (:definition props)
+           sim?         (some? sim-snapshot)
+           override     (:current-state-override props)
+           state-value  (if sim?
+                          (:state sim-snapshot)
+                          (:state override))
+           highlight-id (chart-layout/highlight-id state-value)]
+       [:div {:data-testid "rf-causa-machine-inspector-chart"
+              :data-machine-id (str (:machine-id props))
+              :data-highlight-id (or highlight-id "")
+              :data-sim-active (str sim?)
+              :style       {:margin "12px"
+                            :padding "12px"
+                            :background (:bg-1 tokens)
+                            :border (str "1px solid "
+                                         (if sim?
+                                           (:yellow tokens)
+                                           (:border-subtle tokens)))
+                            :border-radius "4px"
+                            :overflow "auto"}}
+        (chart-svg/render-from-definition
+          definition
+          {:highlight-id   highlight-id
+           :sim?           sim?
+           :on-state-click (fn [path]
+                             (rf/dispatch
+                               [:rf.causa/machine-state-clicked
+                                {:machine-id (:machine-id props)
+                                 :path       path}]
+                               {:frame :rf/causa}))})]))))
 
 ;; ---- transition history ribbon ------------------------------------------
 
@@ -447,10 +509,17 @@
         ;; follow-on bead replaces this with `count` over the spawned-
         ;; instances vector.
         instance-count (if (and selected (:state selected)) 1 0)
-        mode           (view-mode instance-count)]
+        mode           (view-mode instance-count)
+        ;; Phase 2 (rf2-v869p): pull sim state via the per-machine sub.
+        ;; When active, the chart highlight + banner shift to sim mode
+        ;; and the side rail mounts between the chart and the ribbon.
+        sim-state      @(rf/subscribe [:rf.causa/sim-state])
+        sim-active?    (boolean (:active? sim-state))
+        sim-snapshot   (when sim-active? (:snapshot sim-state))]
     [:section {:data-testid "rf-causa-machine-inspector"
                :data-view-mode (name mode)
                :data-instance-count instance-count
+               :data-sim-active (str sim-active?)
                :style       {:height         "100%"
                              :display        "flex"
                              :flex-direction "column"
@@ -478,8 +547,12 @@
          (placeholder-banner
            {:machine-id     (:machine-id selected)
             :state          (:state selected)
-            :instance-count instance-count})
-         (placeholder-chart chart-props)]
+            :instance-count instance-count
+            :definition     (:definition selected)
+            :sim-active?    sim-active?})
+         (placeholder-chart chart-props sim-snapshot)
+         (when sim-active?
+           [sim/SimSideRail])]
         (transition-ribbon transitions)])]))
 
 ;; ---- registration entry --------------------------------------------------
@@ -639,4 +712,13 @@
   ;; without an editor-jump side effect leaking into smoke tests.
   (rf/reg-event-db :rf.causa/machine-state-clicked
     (fn [db [_ _payload]]
-      db)))
+      db))
+
+  ;; ---- Phase 2 (rf2-v869p) — UC1 Sim sub-mode ---------------------
+  ;;
+  ;; The sim sub family lives in its own ns
+  ;; (`panels/machine_inspector_sim.cljs`) so the panel ns stays
+  ;; focused on the live observation chrome. The sim install fn
+  ;; registers `:rf.causa/sim-*` events + subs against the same
+  ;; `:rf/causa` frame the panel reads.
+  (sim/install!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
@@ -1,0 +1,520 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-sim
+  "Machine Inspector UC1 Sim sub-mode (rf2-v869p, Phase 2, parent rf2-2tkza).
+
+  Per `ai/findings/causa-uc1-simulation-design-2026-05-17.md` Sim is a
+  **sub-mode of Mode A** (the static-definition view): a toggle in the
+  panel header flips the chart from live-highlight to sim-highlight and
+  surfaces a side rail with an event picker + Step / Reset buttons + an
+  audit trail.
+
+  ## Design highlights (full design in the findings doc)
+
+    - **Isolation**: sim **clones** the registered machine definition
+      into Causa's app-db; production registry is untouched. The
+      runtime calls `rf/machine-transition` — a pure fn — so we don't
+      touch the host's frame app-db either.
+    - **Guards**: mock-`:data` form (the user types/picks the event
+      vector + an optional EDN payload); guards evaluate against the
+      cloned snapshot's `:data`. Failed guards surface inline; the
+      snapshot stays put.
+    - **Visual distinction**: the chart's amber tint (`:sim?` flag on
+      `chart/svg.cljc`'s `render`) is the load-bearing cue; an amber
+      `Sim ●` indicator + a tinted banner on the side-rail header
+      reinforce it.
+    - **Exit**: toggling Sim off disposes the per-machine sim slot
+      (`:rf.causa/sim-stop`). Reset preserves sim mode but rewinds the
+      snapshot to the declared initial.
+
+  ## What this ns owns
+
+    - The `Sim` view (side-rail UI; the chart itself still renders out
+      of `machine_inspector.cljs` but reads sim state via subs to flip
+      its `:sim?` flag + highlight).
+    - The `:rf.causa/sim-*` events: `sim-start`, `sim-step`, `sim-reset`,
+      `sim-stop`, plus `sim-set-pending-event` / `sim-set-pending-data`.
+    - The `:rf.causa/sim-state` sub family.
+
+  ## Helper algebra
+
+  All pure-data logic lives in `machine_inspector_sim_helpers.cljc` so
+  the JVM test target drives it (`clojure -M:test`). This ns is the
+  thin CLJS wrapper that wires the helpers to the reactive substrate."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
+            [day8.re-frame2-causa.panels.machine-inspector-sim-helpers :as sim-h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- runtime hook -------------------------------------------------------
+;;
+;; `rf/machine-transition` is a late-bind wrapper that throws when the
+;; machines artefact is not on the classpath. The sim sub-mode only
+;; appears when there's at least one registered machine — so by the
+;; time a user clicks Step, the artefact IS loaded. We resolve the var
+;; defensively all the same so the JVM test target can stub it.
+
+(defn- run-machine-transition
+  "Call `rf/machine-transition` against the cloned definition + sim
+  snapshot. Returns a `result/ok` / `result/fail` map per the engine's
+  Result contract. Wrapped in `try` so a host that hasn't loaded the
+  machines artefact surfaces a friendly error instead of an
+  uncaught throw."
+  [definition snapshot event]
+  (try
+    (rf/machine-transition definition snapshot event)
+    (catch :default e
+      ;; Synthesise a fail-Result shape so the step orchestrator
+      ;; handles it uniformly.
+      {:re-frame.machines.result/tag :fail
+       :re-frame.machines.result/info
+       {:reason      :rf.causa.sim/engine-call-failed
+        :exception   (ex-message e)
+        :machines-on-classpath? false}})))
+
+;; ---- subscriptions ------------------------------------------------------
+
+(defn install-subs!
+  "Register the sub family for the Sim sub-mode. Idempotent — the
+  enclosing `machine-inspector/install!` is itself guarded."
+  []
+  ;; The whole sim-by-machine map. The view chooses its row by the
+  ;; selected machine-id; the composite below pre-narrows for the
+  ;; common case.
+  (rf/reg-sub :rf.causa/sim-by-machine
+    (fn [db _query]
+      (get db :sim/by-machine {})))
+
+  ;; The per-machine sim slot for the currently-selected machine.
+  ;; Returns nil when sim is not active for that machine.
+  (rf/reg-sub :rf.causa/sim-state
+    :<- [:rf.causa/sim-by-machine]
+    :<- [:rf.causa/selected-machine-id]
+    (fn [[by-machine selected-id] _query]
+      (when selected-id
+        (get by-machine selected-id))))
+
+  ;; True iff sim is active for the currently-selected machine. Used
+  ;; by the chart wrapper to flip its `:sim?` flag.
+  (rf/reg-sub :rf.causa/sim-active?
+    :<- [:rf.causa/sim-state]
+    (fn [sim _query]
+      (boolean (:active? sim))))
+
+  ;; The available-transitions projection for the picker. Memoised via
+  ;; the sub graph.
+  (rf/reg-sub :rf.causa/sim-available-transitions
+    :<- [:rf.causa/sim-state]
+    (fn [sim _query]
+      (when sim
+        (sim-h/available-transitions
+          (:definition sim) (:snapshot sim)))))
+
+  ;; Distinct event-id suggestions for the autocomplete datalist.
+  (rf/reg-sub :rf.causa/sim-event-suggestions
+    :<- [:rf.causa/sim-state]
+    (fn [sim _query]
+      (when sim
+        (sim-h/event-id-suggestions (:definition sim))))))
+
+;; ---- events -------------------------------------------------------------
+
+(defn install-events!
+  "Register the event family. Idempotent — the enclosing
+  `machine-inspector/install!` is itself guarded."
+  []
+  ;; Start sim for the currently-selected machine. The payload carries
+  ;; the cloned definition so the event handler doesn't need to reach
+  ;; back through `rf/machine-meta` (which would be re-resolved per
+  ;; step; sim wants the definition pinned at start time).
+  (rf/reg-event-db :rf.causa/sim-start
+    (fn [db [_ {:keys [machine-id definition]}]]
+      (assoc-in db [:sim/by-machine machine-id]
+        (sim-h/make-sim-state machine-id definition))))
+
+  ;; Stop sim for `machine-id`. Removes the per-machine slot so the
+  ;; clone is GC'd; production registry was never touched.
+  (rf/reg-event-db :rf.causa/sim-stop
+    (fn [db [_ {:keys [machine-id]}]]
+      (update db :sim/by-machine dissoc machine-id)))
+
+  ;; Reset sim for `machine-id` — rewind to the initial snapshot,
+  ;; clear the trail, but stay in sim mode.
+  (rf/reg-event-db :rf.causa/sim-reset
+    (fn [db [_ {:keys [machine-id]}]]
+      (if-let [sim (get-in db [:sim/by-machine machine-id])]
+        (assoc-in db [:sim/by-machine machine-id] (sim-h/reset-sim-state sim))
+        db)))
+
+  ;; Step the sim — fire one event against the cloned snapshot.
+  ;; `event` is a vector like `[:foo/bar {:x 1}]`.
+  (rf/reg-event-db :rf.causa/sim-step
+    (fn [db [_ {:keys [machine-id event]}]]
+      (if-let [sim (get-in db [:sim/by-machine machine-id])]
+        (let [runtime-fn (fn [ev]
+                           (run-machine-transition
+                             (:definition sim) (:snapshot sim) ev))
+              next-sim   (sim-h/step-sim sim event runtime-fn)]
+          (assoc-in db [:sim/by-machine machine-id] next-sim))
+        db)))
+
+  ;; Update the pending event-input text (controlled-input).
+  (rf/reg-event-db :rf.causa/sim-set-pending-event
+    (fn [db [_ {:keys [machine-id text]}]]
+      (if (get-in db [:sim/by-machine machine-id])
+        (assoc-in db [:sim/by-machine machine-id :pending-event] (or text ""))
+        db)))
+
+  ;; Update the pending payload-input text (controlled-input).
+  (rf/reg-event-db :rf.causa/sim-set-pending-data
+    (fn [db [_ {:keys [machine-id text]}]]
+      (if (get-in db [:sim/by-machine machine-id])
+        (assoc-in db [:sim/by-machine machine-id :pending-data] (or text ""))
+        db))))
+
+;; ---- view: side rail ----------------------------------------------------
+
+(defn- sim-banner
+  "Tinted banner above the side rail — fixed text per design §5."
+  []
+  [:div {:data-testid "rf-causa-machine-inspector-sim-banner"
+         :style       {:padding "8px 12px"
+                       :background "rgba(251, 191, 36, 0.12)"
+                       :border (str "1px solid " (:yellow tokens))
+                       :border-radius "4px"
+                       :color (:yellow tokens)
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :font-weight 600
+                       :margin-bottom "8px"}}
+   "SIMULATING — no live data; clicks walk the topology"])
+
+(defn- sim-current-state-row
+  [sim]
+  [:div {:data-testid "rf-causa-machine-inspector-sim-current-state"
+         :style       {:display "flex"
+                       :flex-direction "column"
+                       :gap "2px"
+                       :padding "6px 0"
+                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size "10px"
+                   :text-transform "uppercase"
+                   :letter-spacing "0.5px"}}
+    "Current sim state"]
+   [:code {:style {:color (:yellow tokens)
+                   :font-family mono-stack
+                   :font-size "13px"
+                   :font-weight 600}}
+    (sim-h/format-state-display (get-in sim [:snapshot :state]))]
+   [:code {:style {:color (:text-tertiary tokens)
+                   :font-family mono-stack
+                   :font-size "10px"
+                   :word-break "break-all"}}
+    (str ":data " (pr-str (get-in sim [:snapshot :data] {})))]])
+
+(defn- pending-event-input
+  [machine-id pending-event suggestions]
+  (let [datalist-id (str "rf-causa-sim-events-" (name machine-id))]
+    [:div {:style {:display "flex" :flex-direction "column" :gap "4px"}}
+     [:label {:style {:color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "10px"
+                      :text-transform "uppercase"
+                      :letter-spacing "0.5px"}}
+      "Event"]
+     [:input
+      {:data-testid "rf-causa-machine-inspector-sim-event-input"
+       :type        "text"
+       :placeholder ":foo/bar or [:foo/bar {:x 1}]"
+       :value       (or pending-event "")
+       :list        datalist-id
+       :on-change   (fn [e]
+                      (rf/dispatch
+                        [:rf.causa/sim-set-pending-event
+                         {:machine-id machine-id
+                          :text (-> e .-target .-value)}]
+                        {:frame :rf/causa}))
+       :style       {:background (:bg-3 tokens)
+                     :border (str "1px solid " (:border-default tokens))
+                     :color (:text-primary tokens)
+                     :padding "5px 8px"
+                     :border-radius "4px"
+                     :font-family mono-stack
+                     :font-size "12px"}}]
+     [:datalist {:id datalist-id}
+      (for [ev suggestions]
+        ^{:key (str ev)}
+        [:option {:value (str ev)}])]]))
+
+(defn- pending-data-input
+  [machine-id pending-data]
+  [:div {:style {:display "flex" :flex-direction "column" :gap "4px"}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    "Payload (optional EDN)"]
+   [:textarea
+    {:data-testid "rf-causa-machine-inspector-sim-data-input"
+     :placeholder "{:x 1}  ;; ignored when the Event input already carries a vector with a payload"
+     :value       (or pending-data "")
+     :rows        2
+     :on-change   (fn [e]
+                    (rf/dispatch
+                      [:rf.causa/sim-set-pending-data
+                       {:machine-id machine-id
+                        :text (-> e .-target .-value)}]
+                      {:frame :rf/causa}))
+     :style       {:background (:bg-3 tokens)
+                   :border (str "1px solid " (:border-default tokens))
+                   :color (:text-primary tokens)
+                   :padding "5px 8px"
+                   :border-radius "4px"
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :resize "vertical"}}]])
+
+(defn- step-button
+  [machine-id pending-event pending-data]
+  [:button
+   {:data-testid "rf-causa-machine-inspector-sim-step-button"
+    :on-click    (fn [_]
+                   (let [event-parsed (sim-h/parse-event-vector pending-event)]
+                     (cond
+                       (map? event-parsed)
+                       ;; parse error → swallow at the UI layer; the
+                       ;; user sees the same input still there.
+                       nil
+
+                       :else
+                       (let [;; If the user typed `:foo/bar` only and
+                             ;; also supplied a payload textarea, fold
+                             ;; the payload in. If they typed
+                             ;; `[:foo/bar {:x 1}]` already, the
+                             ;; payload textarea is ignored (the
+                             ;; vector wins).
+                             payload-form (try
+                                            (when-not (clojure.string/blank?
+                                                        (or pending-data ""))
+                                              (cljs.reader/read-string
+                                                pending-data))
+                                            (catch :default _ nil))
+                             event-v      (if (and (= 1 (count event-parsed))
+                                                   (some? payload-form))
+                                            (conj event-parsed payload-form)
+                                            event-parsed)]
+                         (rf/dispatch
+                           [:rf.causa/sim-step
+                            {:machine-id machine-id
+                             :event event-v}]
+                           {:frame :rf/causa})))))
+    :style       {:background (:yellow tokens)
+                  :border "none"
+                  :color "#1c2030"
+                  :padding "6px 14px"
+                  :border-radius "4px"
+                  :cursor "pointer"
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :font-weight 600}}
+   "Step ▶︎"])
+
+(defn- reset-button
+  [machine-id]
+  [:button
+   {:data-testid "rf-causa-machine-inspector-sim-reset-button"
+    :on-click    (fn [_]
+                   (rf/dispatch [:rf.causa/sim-reset {:machine-id machine-id}]
+                                {:frame :rf/causa}))
+    :style       {:background (:bg-3 tokens)
+                  :border (str "1px solid " (:border-default tokens))
+                  :color (:text-primary tokens)
+                  :padding "6px 12px"
+                  :border-radius "4px"
+                  :cursor "pointer"
+                  :font-family sans-stack
+                  :font-size "12px"}}
+   "Reset"])
+
+(defn- exit-button
+  [machine-id]
+  [:button
+   {:data-testid "rf-causa-machine-inspector-sim-exit-button"
+    :on-click    (fn [_]
+                   (rf/dispatch [:rf.causa/sim-stop {:machine-id machine-id}]
+                                {:frame :rf/causa}))
+    :style       {:background "transparent"
+                  :border (str "1px solid " (:border-subtle tokens))
+                  :color (:text-tertiary tokens)
+                  :padding "6px 12px"
+                  :border-radius "4px"
+                  :cursor "pointer"
+                  :font-family sans-stack
+                  :font-size "12px"}}
+   "Exit Sim"])
+
+(defn- available-transition-row
+  [machine-id pending-event {:keys [event target guard?]}]
+  [:li
+   {:data-testid (str "rf-causa-machine-inspector-sim-available-" (name event))
+    :on-click    (fn [_]
+                   (rf/dispatch
+                     [:rf.causa/sim-set-pending-event
+                      {:machine-id machine-id
+                       :text (str event)}]
+                     {:frame :rf/causa}))
+    :style       {:display "flex"
+                  :justify-content "space-between"
+                  :align-items "center"
+                  :padding "4px 8px"
+                  :margin "2px 0"
+                  :background (if (= (str event) (or pending-event ""))
+                                (:bg-1 tokens)
+                                "transparent")
+                  :border (str "1px solid "
+                               (if (= (str event) (or pending-event ""))
+                                 (:yellow tokens)
+                                 (:border-subtle tokens)))
+                  :border-radius "3px"
+                  :cursor "pointer"
+                  :font-family mono-stack
+                  :font-size "11px"}}
+   [:span {:style {:color (:text-primary tokens)}}
+    (str event)]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (str "→ "
+         (cond
+           (keyword? target) (str target)
+           (vector? target)  (pr-str target)
+           :else             (str target))
+         (when guard? " [guard]"))]])
+
+(defn- available-transitions-list
+  [machine-id pending-event transitions]
+  [:div {:style {:display "flex" :flex-direction "column" :gap "4px"}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    (str "Available from current state (" (count transitions) ")")]
+   (if (empty? transitions)
+     [:div {:data-testid "rf-causa-machine-inspector-sim-available-empty"
+            :style {:padding "8px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "11px"
+                    :font-style "italic"}}
+      "No outgoing transitions declared on this state."]
+     (into [:ul {:data-testid "rf-causa-machine-inspector-sim-available-list"
+                 :style {:list-style "none" :padding 0 :margin 0}}]
+           (for [t transitions]
+             ^{:key (str (:event t))}
+             (available-transition-row machine-id pending-event t))))])
+
+(defn- error-toast
+  [{:keys [event reason]}]
+  [:div {:data-testid "rf-causa-machine-inspector-sim-error"
+         :style       {:padding "8px 10px"
+                       :margin "8px 0"
+                       :background "rgba(248, 113, 113, 0.12)"
+                       :border (str "1px solid " (:red tokens))
+                       :border-radius "4px"
+                       :color (:red tokens)
+                       :font-family mono-stack
+                       :font-size "11px"}}
+   [:strong {:style {:display "block" :margin-bottom "2px"}}
+    "Transition rejected"]
+   [:span (str (sim-h/format-event-display event) " — " reason)]])
+
+(defn- audit-trail-row
+  [idx {:keys [from to event]}]
+  [:li {:data-testid (str "rf-causa-machine-inspector-sim-audit-" idx)
+        :style       {:display "flex"
+                      :gap "6px"
+                      :align-items "center"
+                      :padding "3px 6px"
+                      :margin "2px 0"
+                      :background (:bg-1 tokens)
+                      :border (str "1px solid " (:border-subtle tokens))
+                      :border-radius "3px"
+                      :font-family mono-stack
+                      :font-size "11px"
+                      :color (:text-primary tokens)}}
+   [:span {:style {:color (:text-tertiary tokens) :min-width "20px"}}
+    (str "#" idx)]
+   [:span (sim-h/format-state-display from)]
+   [:span {:style {:color (:yellow tokens)}} "→"]
+   [:span (sim-h/format-state-display to)]
+   [:span {:style {:color (:text-tertiary tokens) :margin-left "auto"}}
+    (sim-h/format-event-display event)]])
+
+(defn- audit-trail
+  [trail]
+  [:div {:style {:display "flex" :flex-direction "column" :gap "4px"}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    (str "Audit trail (" (count trail) ")")]
+   (if (empty? trail)
+     [:div {:data-testid "rf-causa-machine-inspector-sim-audit-empty"
+            :style {:padding "8px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "11px"
+                    :font-style "italic"}}
+      "No steps yet. Pick an event above and click Step."]
+     (into [:ol {:data-testid "rf-causa-machine-inspector-sim-audit-list"
+                 :style {:list-style "none" :padding 0 :margin 0}}]
+           (for [[idx row] (map-indexed vector trail)]
+             ^{:key idx}
+             (audit-trail-row idx row))))])
+
+(defn SimSideRail
+  "The Sim sub-mode's side rail. Mounted by the Machine Inspector
+  panel between the chart and the transition-history ribbon when
+  `:rf.causa/sim-active?` is true.
+
+  Pure hiccup (per Causa's rf2-tijr convention) — every subscribe /
+  dispatch resolves against `:rf/causa` via the enclosing
+  frame-provider in `shell.cljs`."
+  []
+  (let [sim          @(rf/subscribe [:rf.causa/sim-state])
+        transitions  @(rf/subscribe [:rf.causa/sim-available-transitions])
+        suggestions  @(rf/subscribe [:rf.causa/sim-event-suggestions])
+        machine-id   (:machine-id sim)]
+    (when sim
+      [:section
+       {:data-testid "rf-causa-machine-inspector-sim-rail"
+        :style       {:padding "12px"
+                      :display "flex"
+                      :flex-direction "column"
+                      :gap "10px"
+                      :background (:bg-2 tokens)
+                      :border-top (str "1px solid " (:yellow tokens))
+                      :border-bottom (str "1px solid " (:border-subtle tokens))}}
+       (sim-banner)
+       (sim-current-state-row sim)
+       (pending-event-input machine-id (:pending-event sim) suggestions)
+       (pending-data-input machine-id (:pending-data sim))
+       (when-let [err (:last-error sim)]
+         (error-toast err))
+       [:div {:style {:display "flex" :gap "8px"}}
+        (step-button machine-id (:pending-event sim) (:pending-data sim))
+        (reset-button machine-id)
+        (exit-button machine-id)]
+       (available-transitions-list machine-id (:pending-event sim) transitions)
+       (audit-trail (:audit-trail sim))])))
+
+;; ---- public install entry -----------------------------------------------
+
+(defn install!
+  "Idempotent install — called by `machine_inspector/install!`. Wires
+  the sub + event family for the UC1 Sim sub-mode."
+  []
+  (install-subs!)
+  (install-events!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim_helpers.cljc
@@ -1,0 +1,375 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-sim-helpers
+  "Pure-data helpers for Causa's Machine Inspector UC1 Sim sub-mode
+  (rf2-v869p, Phase 2, parent rf2-2tkza).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other Causa helper ns uses
+  (causality-graph, subscriptions, routes, machine-inspector-helpers).
+  The sim view in `machine_inspector_sim.cljs` builds the hiccup; the
+  *logic* — projecting a definition into an initial snapshot, deriving
+  available transitions, building audit-trail rows — lives here as
+  pure data → data so the JVM unit-test target (`clojure -M:test`)
+  drives it without a CLJS runtime.
+
+  ## Design source-of-truth
+
+  `ai/findings/causa-uc1-simulation-design-2026-05-17.md` carries the
+  full UC1 Sim design. Quick recap:
+
+    - Sim is a **sub-mode of Mode A** — a toggle in the panel header
+      flips the chart from live-highlight to sim-highlight (amber).
+    - The sim **clones** the registered machine definition into Causa
+      state; production registry is untouched.
+    - A user picks an event from an autocomplete-style picker (v1: a
+      text input + dropdown of declared events for the current state)
+      and clicks Step.
+    - The runtime calls `rf/machine-transition` (the public late-bind
+      surface) with the cloned definition + current sim snapshot +
+      event vector. On `result/ok`, the snapshot advances and an
+      audit-trail row is appended. On `result/fail`, the snapshot stays
+      and an error surfaces.
+    - Reset returns to the declared initial state.
+    - Exit disposes the sim state (per-machine slot deleted).
+
+  ## Sim-state shape
+
+  The Sim sub-mode keeps per-machine state on Causa's frame app-db at
+  `[:sim/by-machine <machine-id>]`. Each slot is:
+
+      {:active?         <bool>   ;; sub-mode toggled on?
+       :definition      <map>    ;; the cloned machine definition
+       :snapshot        <map>    ;; current {:state :data ...}
+       :audit-trail     <vec>    ;; [{:from :to :event :guard?} ...]
+       :last-error      <map>    ;; nil or {:event :info :reason}
+       :pending-event   <str>    ;; the event-id text the user is typing
+       :pending-data    <str>}   ;; EDN payload (optional)
+
+  ## What this ns exposes
+
+    1. `initial-snapshot`          — definition → seed `{:state :data}`
+    2. `available-transitions`     — definition + snapshot → seq of
+                                     {:event :target :guard} maps
+    3. `event-id-suggestions`      — definition → distinct sorted
+                                     event-ids (autocomplete source)
+    4. `parse-event-vector`        — string \"[:foo {:x 1}]\" → vector
+                                     or nil on parse error
+    5. `append-audit-row`          — push a step entry onto the trail
+    6. `format-state-display`      — sim chart state-keyword resolver
+    7. `result-ok?` / `result-snap` / `result-info` — thin shims so
+       the CLJS panel can read Result values without importing the
+       machines artefact ns directly (Causa has no compile-time dep
+       on `re-frame.machines.result`)."
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.edn :as edn]
+               :cljs [cljs.reader :as edn])))
+
+;; ---- definition introspection -------------------------------------------
+
+(defn- walk-states
+  "Walk `state-map` recursively, calling `(f path node)` for every leaf
+  and compound state node. Returns nothing — purely for side-effecting
+  reduction. The companion `collect-event-ids` / `available-transitions`
+  fns build their own accumulators around it."
+  ([f state-map] (walk-states f [] state-map))
+  ([f parent-path state-map]
+   (doseq [[state-id node] state-map]
+     (let [path (conj parent-path state-id)]
+       (f path node)
+       (when (:states node)
+         (walk-states f path (:states node)))))))
+
+(defn event-id-suggestions
+  "Return the distinct sorted event-ids declared anywhere in `definition`.
+  Walks every state-node's `:on` map and aggregates the keys. The
+  autocomplete in the sim event-picker is seeded from this set so the
+  user sees only events the machine actually responds to.
+
+  Returns `[]` when the definition is nil or has no `:states`."
+  [definition]
+  (if (or (nil? definition) (nil? (:states definition)))
+    []
+    (let [acc (atom #{})]
+      (walk-states
+        (fn [_path node]
+          (doseq [event-id (keys (:on node))]
+            (swap! acc conj event-id)))
+        (:states definition))
+      (vec (sort-by str @acc)))))
+
+(defn- node-at
+  "Walk `definition`'s `:states` down the given `path` (vector of
+  state-id keywords) and return the leaf node. Tolerates a path with a
+  single keyword or a hierarchical vector."
+  [definition path]
+  (loop [m  (:states definition)
+         p  (vec path)]
+    (cond
+      (empty? p)      nil
+      (nil? m)        nil
+      :else
+      (let [n (get m (first p))]
+        (cond
+          (nil? n)        nil
+          (= 1 (count p)) n
+          :else           (recur (:states n) (rest p)))))))
+
+(defn- normalise-path
+  "Coerce a snapshot `:state` (keyword OR vector) into a vector path
+  for `node-at` lookup."
+  [state]
+  (cond
+    (nil? state)     []
+    (keyword? state) [state]
+    (vector? state)  state
+    :else            []))
+
+(defn- candidates
+  "Mirror of `transition.cljc`'s normaliser — flatten a transition spec
+  into a seq of candidate maps each carrying `:target` / optional `:guard`
+  / optional `:action`. Pure-local copy so the helpers don't reach into
+  the machines artefact."
+  [spec]
+  (cond
+    (keyword? spec)            [{:target spec}]
+    (and (vector? spec)
+         (every? keyword? spec)) [{:target spec}]
+    (map? spec)                [spec]
+    (sequential? spec)         (mapcat candidates spec)
+    :else                      []))
+
+(defn available-transitions
+  "Return a seq of `{:event :target :guard?}` maps — one per outgoing
+  transition declared on the snapshot's current state node. The picker
+  surfaces these as the user's step options.
+
+  v1 scope: only direct `:on` transitions on the leaf state. `:always` /
+  `:after` / parent-state inheritance are deferred to a follow-on bead
+  (the engine handles them at step time; the picker only surfaces what
+  the user can fire interactively from the leaf).
+
+  Returns `[]` when the definition / snapshot is nil, or the current
+  path doesn't resolve to a registered state."
+  [definition snapshot]
+  (let [path (normalise-path (:state snapshot))
+        node (node-at definition path)]
+    (if (nil? node)
+      []
+      (vec
+        (for [[event-id spec] (:on node)
+              candidate       (candidates spec)
+              :let [t (:target candidate)]
+              :when (some? t)]
+          {:event   event-id
+           :target  t
+           :guard?  (some? (:guard candidate))
+           :guard   (:guard candidate)})))))
+
+;; ---- initial snapshot ---------------------------------------------------
+
+(defn initial-snapshot
+  "Build the seed sim snapshot for `definition`. Shape:
+
+      {:state <keyword-or-vector>  ;; the declared :initial leaf
+       :data  <map>}               ;; the declared :data initial map
+
+  Phase 2 keeps the initial-state cascade simple (the `:initial` slot
+  shallow-read) — the runtime's own `apply-initial-entry-cascade` would
+  fire `:entry` actions, which sim deliberately skips at v1 (we want a
+  pure, hermetic step machine the user drives). The first user-fired
+  event runs `rf/machine-transition` which DOES execute entry / exit /
+  action cascades — so action evaluation kicks in from step 1 onwards,
+  not from initial bootstrap.
+
+  Returns nil when `definition` is nil or has no `:initial`."
+  [definition]
+  (when (and (map? definition) (some? (:initial definition)))
+    {:state (:initial definition)
+     :data  (or (:data definition) {})}))
+
+;; ---- sim-state lifecycle ------------------------------------------------
+
+(defn make-sim-state
+  "Build a fresh sim-state map for `machine-id` + `definition`. Called
+  when the user toggles Sim on for a machine. The `:active?` flag stays
+  true until `dispose-sim-state` zeros the slot."
+  [machine-id definition]
+  {:machine-id     machine-id
+   :active?        true
+   :definition     definition
+   :snapshot       (initial-snapshot definition)
+   :audit-trail    []
+   :last-error     nil
+   :pending-event  ""
+   :pending-data   ""})
+
+(defn reset-sim-state
+  "Return `sim-state` reset to its initial snapshot, audit trail
+  cleared, error cleared. Preserves `:definition` + `:active?` so the
+  user stays in sim mode after a reset. Pending input is preserved (the
+  user likely wants to re-fire what they were sketching)."
+  [sim-state]
+  (assoc sim-state
+    :snapshot    (initial-snapshot (:definition sim-state))
+    :audit-trail []
+    :last-error  nil))
+
+(defn append-audit-row
+  "Push one step entry onto the trail. `row` is `{:from :to :event
+  :guard? :data}`. The trail grows newest-last (the view renders it in
+  insertion order)."
+  [sim-state row]
+  (update sim-state :audit-trail (fnil conj []) row))
+
+(defn record-error
+  "Stamp an error onto sim-state without advancing the snapshot. The
+  view surfaces this in a red toast / inline. `info` is whatever the
+  fail-Result's `::info` slot carried; `reason` is a human-readable
+  string."
+  [sim-state event info reason]
+  (assoc sim-state :last-error {:event event :info info :reason reason}))
+
+(defn clear-error
+  "Drop any stamped error. Called on the next successful step."
+  [sim-state]
+  (assoc sim-state :last-error nil))
+
+;; ---- event-vector parsing -----------------------------------------------
+
+(defn parse-event-vector
+  "Parse the user's typed event input into a re-frame event vector.
+
+  Accepts:
+
+    - a keyword string like `:foo/bar`        → `[:foo/bar]`
+    - a vector form like `[:foo/bar {:x 1}]` → `[:foo/bar {:x 1}]`
+
+  Returns the event vector on success, or a `{:error <str>}` map on
+  parse failure. Whitespace-only input returns `{:error \"empty\"}`.
+
+  Pure fn — JVM-runnable so the parsing rules are unit-testable."
+  [text]
+  (cond
+    (nil? text)
+    {:error "empty"}
+
+    (str/blank? text)
+    {:error "empty"}
+
+    :else
+    (let [trimmed (str/trim text)]
+      (try
+        (let [parsed (edn/read-string trimmed)]
+          (cond
+            (keyword? parsed)
+            [parsed]
+
+            (and (vector? parsed) (keyword? (first parsed)))
+            parsed
+
+            :else
+            {:error (str "expected a keyword or vector starting with a keyword, got "
+                         (pr-str parsed))}))
+        (catch #?(:clj Throwable :cljs :default) e
+          {:error (str "EDN parse error: " (ex-message e))})))))
+
+;; ---- Result shims --------------------------------------------------------
+;;
+;; `rf/machine-transition` returns a `re-frame.machines.result/Result` —
+;; a map shaped `{:re-frame.machines.result/tag :ok|:fail ...}`. Causa
+;; has no compile-time dep on the machines artefact (the artefact may
+;; not be on the classpath at all if the host hasn't installed it). We
+;; shim the slot reads here via the literal qualified keywords so the
+;; sim code path stays artefact-agnostic — the keyword shape is part of
+;; the Result's public contract (per `result.cljc` docstring).
+
+(def ^:private result-tag-kw :re-frame.machines.result/tag)
+(def ^:private result-snap-kw :re-frame.machines.result/snap)
+(def ^:private result-fx-kw :re-frame.machines.result/fx)
+(def ^:private result-info-kw :re-frame.machines.result/info)
+
+(defn result-ok?
+  "True iff `r` is an `:ok` Result. Mirrors `result/ok?` without
+  requiring the artefact ns at compile time."
+  [r]
+  (and (map? r) (= :ok (get r result-tag-kw))))
+
+(defn result-fail?
+  "True iff `r` is a `:fail` Result."
+  [r]
+  (and (map? r) (= :fail (get r result-tag-kw))))
+
+(defn result-snap
+  "Read the post-transition snapshot off an `:ok` Result."
+  [r]
+  (get r result-snap-kw))
+
+(defn result-fx
+  "Read the emitted fx vector off an `:ok` Result. Sim renders these in
+  the audit trail entry but does NOT execute them — sim is hermetic."
+  [r]
+  (get r result-fx-kw))
+
+(defn result-info
+  "Read the diagnostic info map off a `:fail` Result."
+  [r]
+  (get r result-info-kw))
+
+;; ---- step orchestrator (pure shape, runtime-callable) -------------------
+
+(defn step-sim
+  "Fold one engine call into a sim-state update. `runtime-fn` is a
+  unary fn `(fn [event] result)` that closes over `(rf/machine-transition
+  definition snapshot ...)`; the helper is shaped this way so the JVM
+  test target can substitute a stub Result without booting the machines
+  artefact (production CLJS passes the real fn).
+
+  Returns the next `sim-state` — either with an advanced snapshot +
+  trail entry, or with `:last-error` populated.
+
+  Per the UC1 design (§4 Guards) failed-guard transitions surface
+  inline; sim does NOT mutate the snapshot on fail."
+  [sim-state event runtime-fn]
+  (let [{:keys [snapshot]} sim-state
+        prior-state        (:state snapshot)
+        result             (runtime-fn event)]
+    (cond
+      (result-fail? result)
+      (record-error sim-state event (result-info result) "transition failed")
+
+      (result-ok? result)
+      (let [new-snap (result-snap result)]
+        (-> sim-state
+            clear-error
+            (assoc :snapshot new-snap)
+            (append-audit-row
+              {:from   prior-state
+               :to     (:state new-snap)
+               :event  event
+               :data   (:data new-snap)
+               :fx     (result-fx result)})))
+
+      :else
+      (record-error sim-state event nil "engine returned a non-Result value"))))
+
+;; ---- display helpers ----------------------------------------------------
+
+(defn format-state-display
+  "Pretty-print a sim-snapshot `:state` for inline display. Keywords
+  keep their `:`; vectors join with `.` for hierarchical clarity."
+  [state]
+  (cond
+    (nil? state)     "(none)"
+    (keyword? state) (str state)
+    (vector? state)  (str "[" (str/join " " (map str state)) "]")
+    :else            (str state)))
+
+(defn format-event-display
+  "Compact event-vector formatter for the audit trail."
+  [event]
+  (if (nil? event)
+    ""
+    (try
+      (pr-str event)
+      (catch #?(:clj Throwable :cljs :default) _
+        (str event)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
@@ -1,0 +1,519 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-sim-cljs-test
+  "CLJS-side wiring + view + integration tests for the UC1 Sim
+  sub-mode (rf2-v869p, Phase 2, parent rf2-2tkza).
+
+  ## What's under test (in addition to the pure-data tests in
+  `machine_inspector_sim_helpers_cljs_test.cljc`)
+
+    1. **Registry** wires the `:rf.causa/sim-*` sub + event family
+       under `:rf/causa`.
+
+    2. **Sim start** clones the machine definition into Causa state +
+       seeds the initial snapshot (production registry untouched).
+
+    3. **Sim step** with a valid event → engine OK Result → snapshot
+       advances + audit-trail grows. Sim is hermetic — the host's
+       app-db / registered-machine snapshots stay put.
+
+    4. **Sim step** with a fail-Result → snapshot stays + `:last-error`
+       populated.
+
+    5. **Sim reset** rewinds the snapshot, clears the trail, preserves
+       the active flag.
+
+    6. **Sim stop** disposes the per-machine slot (no leak in
+       Causa's `:sim/by-machine` map).
+
+    7. **Chart integration**: when sim is active for the selected
+       machine, the chart's `data-sim-active` is `\"true\"` + the
+       `data-highlight-id` reflects the sim snapshot's `:state`.
+
+    8. **Sim side rail** mounts when active + carries the testid
+       hooks the design calls out (banner, event input, step button,
+       reset button, exit button, audit trail).
+
+    9. **Toggle button** is enabled when a definition is available +
+       dispatches `:rf.causa/sim-start` / `:sim-stop`.
+
+  Same hiccup-walker pattern as `machine_inspector_view_cljs_test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- hiccup walker -------------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-fn-component tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+;; ---- fixture data --------------------------------------------------------
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :data    {:counter 0}
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-snapshots! [snapshots]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-snapshots-override-for-test snapshots]))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-definitions-override-for-test definitions]))
+
+(def ^:private ok-result
+  {:re-frame.machines.result/tag :ok
+   :re-frame.machines.result/snap {:state :authing :data {:counter 1}}
+   :re-frame.machines.result/fx []})
+
+(def ^:private fail-result
+  {:re-frame.machines.result/tag :fail
+   :re-frame.machines.result/info {:reason :no-matching-transition}})
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-sim-handlers
+  (testing "register-causa-handlers! installs every rf2-v869p Phase 2 handler"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/sim-by-machine)))
+    (is (some? (registrar/handler :sub :rf.causa/sim-state)))
+    (is (some? (registrar/handler :sub :rf.causa/sim-active?)))
+    (is (some? (registrar/handler :sub :rf.causa/sim-available-transitions)))
+    (is (some? (registrar/handler :sub :rf.causa/sim-event-suggestions)))
+    (is (some? (registrar/handler :event :rf.causa/sim-start)))
+    (is (some? (registrar/handler :event :rf.causa/sim-step)))
+    (is (some? (registrar/handler :event :rf.causa/sim-reset)))
+    (is (some? (registrar/handler :event :rf.causa/sim-stop)))
+    (is (some? (registrar/handler :event :rf.causa/sim-set-pending-event)))
+    (is (some? (registrar/handler :event :rf.causa/sim-set-pending-data)))))
+
+;; ---- (2) sim-start ------------------------------------------------------
+
+(deftest sim-start-clones-definition-and-seeds-snapshot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+      (is (true? (:active? sim)))
+      (is (= :auth/login (:machine-id sim)))
+      (is (= fixture-definition (:definition sim))
+          "definition cloned into Causa state")
+      (is (= :idle (get-in sim [:snapshot :state])))
+      (is (= {:counter 0} (get-in sim [:snapshot :data]))))))
+
+(deftest sim-start-does-not-touch-production-registry
+  (testing "sim isolation — Causa's overrides for the *production*
+            machine surfaces (the registered set + snapshot map) are
+            unchanged by sim-start"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-snapshots!   {:auth/login {:state :idle :data {:counter 99}}})
+      (override-definitions! {:auth/login fixture-definition})
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+      (rf/dispatch-sync [:rf.causa/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      ;; Production-side snapshot still has counter 99 — sim's clone
+      ;; started fresh from the definition's :data slot.
+      (let [data @(rf/subscribe [:rf.causa/machine-inspector-data])]
+        (is (= 99 (-> data :selected :data :counter))
+            "the production snapshot's :data is untouched"))
+      ;; Sim's snapshot started clean from the definition's initial :data.
+      (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+        (is (= 0 (-> sim :snapshot :data :counter))
+            "the sim snapshot used the definition's :data, not the live snapshot")))))
+
+;; ---- (3) sim-step OK ----------------------------------------------------
+
+(deftest sim-step-ok-advances-snapshot-and-trail
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    ;; Stub the engine to return an OK Result without booting the
+    ;; machines artefact.
+    (with-redefs [rf/machine-transition (fn [_def _snap _event] ok-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:start]}]))
+    (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+      (is (= :authing (get-in sim [:snapshot :state]))
+          "snapshot advanced")
+      (is (= {:counter 1} (get-in sim [:snapshot :data])))
+      (is (= 1 (count (:audit-trail sim))))
+      (is (= :idle (-> sim :audit-trail last :from)))
+      (is (= :authing (-> sim :audit-trail last :to)))
+      (is (= [:start] (-> sim :audit-trail last :event)))
+      (is (nil? (:last-error sim))))))
+
+;; ---- (4) sim-step FAIL --------------------------------------------------
+
+(deftest sim-step-fail-leaves-snapshot-and-records-error
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (with-redefs [rf/machine-transition (fn [_d _s _e] fail-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:bad]}]))
+    (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+      (is (= :idle (get-in sim [:snapshot :state]))
+          "snapshot unchanged on fail")
+      (is (= 0 (count (:audit-trail sim)))
+          "trail unchanged on fail")
+      (is (= [:bad] (-> sim :last-error :event))
+          "error stamped onto sim state"))))
+
+(deftest sim-step-engine-throw-treated-as-fail
+  "When the machines artefact is not on the classpath, `rf/machine-
+  transition` throws; the sim handler catches and synthesises a fail-
+  Result so the user sees an error instead of a runtime crash."
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (with-redefs [rf/machine-transition (fn [_d _s _e]
+                                          (throw (js/Error. "no artefact")))]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:start]}]))
+    (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+      (is (= :idle (get-in sim [:snapshot :state])))
+      (is (some? (:last-error sim))))))
+
+;; ---- (5) sim-reset ------------------------------------------------------
+
+(deftest sim-reset-rewinds-snapshot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:start]}]))
+    ;; Confirm we moved
+    (is (= :authing (-> @(rf/subscribe [:rf.causa/sim-state])
+                        :snapshot :state)))
+    (rf/dispatch-sync [:rf.causa/sim-reset {:machine-id :auth/login}])
+    (let [sim @(rf/subscribe [:rf.causa/sim-state])]
+      (is (true? (:active? sim))
+          "still in sim mode after reset")
+      (is (= :idle (get-in sim [:snapshot :state]))
+          "snapshot rewound to initial")
+      (is (= [] (:audit-trail sim))
+          "trail cleared")
+      (is (nil? (:last-error sim))))))
+
+;; ---- (6) sim-stop --------------------------------------------------------
+
+(deftest sim-stop-disposes-per-machine-slot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (is (some? @(rf/subscribe [:rf.causa/sim-state])))
+    (rf/dispatch-sync [:rf.causa/sim-stop {:machine-id :auth/login}])
+    (is (nil? @(rf/subscribe [:rf.causa/sim-state]))
+        "per-machine slot deleted on stop")
+    (let [by-machine @(rf/subscribe [:rf.causa/sim-by-machine])]
+      (is (not (contains? by-machine :auth/login))
+          "Causa's :sim/by-machine map carries no entry for the stopped sim"))))
+
+;; ---- (7) chart integration ----------------------------------------------
+
+(deftest chart-flips-sim-active-when-sim-on
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-snapshots!   {:auth/login {:state :idle :data {}}})
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    ;; Before sim-start the chart's data-sim-active is "false".
+    (let [tree-before  (machine-inspector/Panel)
+          chart-before (find-by-testid tree-before "rf-causa-machine-inspector-chart")]
+      (is (= "false" (:data-sim-active (second chart-before)))
+          "sim is off — chart reflects this"))
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [tree-after  (machine-inspector/Panel)
+          chart-after (find-by-testid tree-after "rf-causa-machine-inspector-chart")]
+      (is (= "true" (:data-sim-active (second chart-after)))
+          "sim is on — chart reflects this"))))
+
+(deftest chart-highlight-shifts-to-sim-snapshot
+  (testing "with sim active, the chart's data-highlight-id is sourced
+            from the sim snapshot, not the production snapshot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      ;; The production snapshot says :authing — but sim's snapshot
+      ;; starts at :idle (the definition's :initial). The chart should
+      ;; pick the sim value when sim is active.
+      (override-snapshots!   {:auth/login {:state :authing :data {}}})
+      (override-definitions! {:auth/login fixture-definition})
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+      (rf/dispatch-sync [:rf.causa/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (let [tree  (machine-inspector/Panel)
+            chart (find-by-testid tree "rf-causa-machine-inspector-chart")]
+        (is (= "idle" (:data-highlight-id (second chart)))
+            "chart highlights the sim snapshot's :state (idle), not the live :authing")))))
+
+(deftest chart-highlight-follows-sim-step
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:start]}]))
+    (let [tree  (machine-inspector/Panel)
+          chart (find-by-testid tree "rf-causa-machine-inspector-chart")]
+      (is (= "authing" (:data-highlight-id (second chart)))
+          "after a sim step the chart re-renders with the new highlight"))))
+
+;; ---- (8) sim side rail ---------------------------------------------------
+
+(deftest side-rail-mounts-when-sim-active
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    ;; Off — no rail.
+    (is (nil? (find-by-testid (machine-inspector/Panel)
+                              "rf-causa-machine-inspector-sim-rail"))
+        "rail absent when sim is off")
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [tree (machine-inspector/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-rail"))
+          "rail present when sim is on")
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-banner")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-current-state")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-event-input")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-data-input")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-step-button")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-reset-button")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-sim-exit-button"))))))
+
+(deftest side-rail-renders-available-transitions
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [tree (machine-inspector/Panel)
+          available (find-all-by-testid-prefix
+                      tree "rf-causa-machine-inspector-sim-available-")]
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-sim-available-list")))
+      ;; :idle declares :start — should be in the available list.
+      (is (some #(= "rf-causa-machine-inspector-sim-available-start"
+                    (:data-testid (second %)))
+                available)))))
+
+(deftest side-rail-renders-audit-trail-after-step
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [tree (machine-inspector/Panel)]
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-sim-audit-empty"))
+          "empty audit message before any steps"))
+    (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:start]}]))
+    (let [tree (machine-inspector/Panel)]
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-sim-audit-list")))
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-sim-audit-0"))
+          "one audit row after one step"))))
+
+(deftest side-rail-surfaces-error-on-fail
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (with-redefs [rf/machine-transition (fn [_d _s _e] fail-result)]
+      (rf/dispatch-sync [:rf.causa/sim-step
+                         {:machine-id :auth/login
+                          :event [:bad]}]))
+    (let [tree (machine-inspector/Panel)]
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-sim-error"))
+          "error toast surfaces inline"))))
+
+;; ---- (9) toggle button ---------------------------------------------------
+
+(deftest toggle-button-enabled-when-definition-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (let [tree   (machine-inspector/Panel)
+          toggle (find-by-testid tree "rf-causa-machine-inspector-sim-toggle")]
+      (is (some? toggle))
+      (is (= "false" (:data-active (second toggle))))
+      (is (some? (:on-click (second toggle)))
+          "toggle carries an on-click handler when a definition is available"))))
+
+(deftest toggle-button-disabled-without-definition
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:auth/login])
+    ;; No definitions override — Causa has no way to clone.
+    (let [tree   (machine-inspector/Panel)
+          toggle (find-by-testid tree "rf-causa-machine-inspector-sim-toggle")]
+      (is (some? toggle))
+      (is (nil? (:on-click (second toggle)))
+          "toggle is non-interactive when no definition is available"))))
+
+(deftest toggle-button-dispatches-sim-start-and-stop
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (let [tree   (machine-inspector/Panel)
+              toggle (find-by-testid tree "rf-causa-machine-inspector-sim-toggle")
+              handler (:on-click (second toggle))]
+          (handler nil))
+        ;; sim-start should have been dispatched
+        (is (some (fn [ev]
+                    (and (vector? ev)
+                         (= :rf.causa/sim-start (first ev))))
+                  @dispatches)
+            "first toggle click fires sim-start")))))
+
+(deftest toggle-button-stops-sim-when-active
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+    (rf/dispatch-sync [:rf.causa/sim-start
+                       {:machine-id :auth/login
+                        :definition fixture-definition}])
+    (let [tree   (machine-inspector/Panel)
+          toggle (find-by-testid tree "rf-causa-machine-inspector-sim-toggle")]
+      (is (= "true" (:data-active (second toggle)))
+          "toggle reflects active sim state"))))
+
+;; ---- (10) frame isolation -----------------------------------------------
+
+(deftest sim-state-does-not-leak-into-default-frame
+  (testing "sim state lives on :rf/causa, never :rf/default"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}]))
+    (let [causa-db   (frame/frame-app-db-value :rf/causa)
+          default-db (frame/frame-app-db-value :rf/default)]
+      (is (some? (:sim/by-machine causa-db))
+          "sim slot lands on Causa")
+      (is (nil? (:sim/by-machine default-db))
+          "sim slot did NOT leak into :rf/default"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_helpers_cljs_test.cljc
@@ -1,0 +1,283 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-sim-helpers-cljs-test
+  "Pure-data tests for the UC1 Sim sub-mode helpers (rf2-v869p,
+  Phase 2, parent rf2-2tkza).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern every other Causa helper test uses:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. `initial-snapshot`        — seed shape derived from definition
+    2. `event-id-suggestions`    — autocomplete source
+    3. `available-transitions`   — picker source for the current state
+    4. `parse-event-vector`      — input-string parser
+    5. `make-sim-state` /
+       `reset-sim-state` /
+       `append-audit-row` /
+       `record-error` /
+       `clear-error`             — sim-state lifecycle ops
+    6. `result-*` shims          — Result destructuring without
+                                   reaching into the machines artefact
+    7. `step-sim`                — fold an engine Result into sim-state
+    8. `format-state-display` /
+       `format-event-display`    — UI-facing formatters"
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.machine-inspector-sim-helpers :as sim-h]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(def ^:private flat-definition
+  "Minimal flat machine for the picker / step exercises."
+  {:initial :idle
+   :data    {:counter 0}
+   :states  {:idle    {:on {:start :authing
+                            :reset :idle}}
+             :authing {:on {:ok  {:target :done}
+                            :err {:target :failed :guard :can-retry?}}}
+             :done    {:final? true}
+             :failed  {:final? true :on {:retry :idle}}}})
+
+(def ^:private hierarchical-definition
+  "Compound-state definition to exercise vector :state paths."
+  {:initial :auth
+   :states  {:auth {:initial :form
+                    :states  {:form   {:on {:submit :loading}}
+                              :loading {:on {:ok :done}}}}
+             :done {:final? true}}})
+
+;; ---- (1) initial-snapshot -----------------------------------------------
+
+(deftest initial-snapshot-builds-seed-from-flat-definition
+  (let [snap (sim-h/initial-snapshot flat-definition)]
+    (is (= :idle (:state snap)))
+    (is (= {:counter 0} (:data snap)))))
+
+(deftest initial-snapshot-defaults-data-to-empty-map
+  (let [snap (sim-h/initial-snapshot {:initial :a :states {:a {}}})]
+    (is (= :a (:state snap)))
+    (is (= {} (:data snap))
+        "missing :data slot defaults to {}")))
+
+(deftest initial-snapshot-returns-nil-for-bad-input
+  (is (nil? (sim-h/initial-snapshot nil)))
+  (is (nil? (sim-h/initial-snapshot {}))
+      "no :initial slot → nil")
+  (is (nil? (sim-h/initial-snapshot "not a map"))))
+
+;; ---- (2) event-id-suggestions -------------------------------------------
+
+(deftest event-id-suggestions-aggregates-all-on-keys
+  (let [suggestions (sim-h/event-id-suggestions flat-definition)]
+    (is (= [:err :ok :reset :retry :start] suggestions)
+        "all distinct :on keys, sorted by string")))
+
+(deftest event-id-suggestions-walks-compound-states
+  (let [suggestions (sim-h/event-id-suggestions hierarchical-definition)]
+    (is (= #{:submit :ok} (set suggestions))
+        "nested :states are walked")))
+
+(deftest event-id-suggestions-handles-nil-and-empty
+  (is (= [] (sim-h/event-id-suggestions nil)))
+  (is (= [] (sim-h/event-id-suggestions {})))
+  (is (= [] (sim-h/event-id-suggestions {:initial :a :states {:a {}}}))))
+
+;; ---- (3) available-transitions ------------------------------------------
+
+(deftest available-transitions-lists-outgoing-from-current-leaf
+  (let [snap {:state :authing :data {}}
+        ts   (sim-h/available-transitions flat-definition snap)
+        events (set (map :event ts))]
+    (is (= #{:ok :err} events))
+    (is (= true (-> (some #(when (= :err (:event %)) %) ts) :guard?))
+        ":err carries a :guard slot")))
+
+(deftest available-transitions-from-keyword-target
+  (let [snap {:state :idle :data {}}
+        ts   (sim-h/available-transitions flat-definition snap)]
+    (is (= #{:start :reset} (set (map :event ts))))
+    (is (every? (complement :guard?) ts)
+        "no :guard? on :idle's transitions")))
+
+(deftest available-transitions-empty-for-final-state
+  (let [snap {:state :done :data {}}]
+    (is (= [] (sim-h/available-transitions flat-definition snap)))))
+
+(deftest available-transitions-empty-for-unknown-state
+  (is (= [] (sim-h/available-transitions flat-definition {:state :nonexistent}))))
+
+(deftest available-transitions-nil-safe
+  (is (= [] (sim-h/available-transitions nil nil)))
+  (is (= [] (sim-h/available-transitions flat-definition nil))))
+
+;; ---- (4) parse-event-vector ---------------------------------------------
+
+(deftest parse-event-vector-accepts-keyword-string
+  (is (= [:foo/bar] (sim-h/parse-event-vector ":foo/bar"))))
+
+(deftest parse-event-vector-accepts-vector-form
+  (is (= [:foo/bar {:x 1}]
+         (sim-h/parse-event-vector "[:foo/bar {:x 1}]"))))
+
+(deftest parse-event-vector-trims-whitespace
+  (is (= [:foo/bar] (sim-h/parse-event-vector "  :foo/bar  "))))
+
+(deftest parse-event-vector-rejects-empty
+  (is (= {:error "empty"} (sim-h/parse-event-vector nil)))
+  (is (= {:error "empty"} (sim-h/parse-event-vector "")))
+  (is (= {:error "empty"} (sim-h/parse-event-vector "   "))))
+
+(deftest parse-event-vector-rejects-non-keyword-head
+  (let [r (sim-h/parse-event-vector "[\"foo\" 1]")]
+    (is (map? r))
+    (is (:error r))))
+
+(deftest parse-event-vector-rejects-malformed-edn
+  (let [r (sim-h/parse-event-vector "[:foo {bad")]
+    (is (map? r))
+    (is (:error r))))
+
+;; ---- (5) sim-state lifecycle --------------------------------------------
+
+(deftest make-sim-state-builds-active-slot
+  (let [s (sim-h/make-sim-state :auth/login flat-definition)]
+    (is (= :auth/login (:machine-id s)))
+    (is (true? (:active? s)))
+    (is (= flat-definition (:definition s)))
+    (is (= :idle (get-in s [:snapshot :state])))
+    (is (= [] (:audit-trail s)))
+    (is (nil? (:last-error s)))
+    (is (= "" (:pending-event s)))
+    (is (= "" (:pending-data s)))))
+
+(deftest reset-sim-state-rewinds-snapshot-clears-trail
+  (let [s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (-> s0
+               (assoc :snapshot {:state :done :data {:counter 5}})
+               (sim-h/append-audit-row {:from :idle :to :done :event [:start]})
+               (sim-h/record-error [:bad] {} "something went wrong"))
+        s2 (sim-h/reset-sim-state s1)]
+    (is (= :idle (get-in s2 [:snapshot :state]))
+        "snapshot rewound to initial")
+    (is (= [] (:audit-trail s2))
+        "trail cleared")
+    (is (nil? (:last-error s2))
+        "error cleared")
+    (is (true? (:active? s2))
+        "still in sim mode")))
+
+(deftest append-audit-row-grows-trail
+  (let [s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (sim-h/append-audit-row s0 {:from :idle :to :authing :event [:start]})
+        s2 (sim-h/append-audit-row s1 {:from :authing :to :done :event [:ok]})]
+    (is (= 2 (count (:audit-trail s2))))
+    (is (= :idle (-> s2 :audit-trail first :from))
+        "insertion order preserved (oldest first)")
+    (is (= :done (-> s2 :audit-trail last :to)))))
+
+(deftest record-and-clear-error-flips-error-slot
+  (let [s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (sim-h/record-error s0 [:bad] {:reason :unknown} "rejected")]
+    (is (= {:event [:bad] :info {:reason :unknown} :reason "rejected"}
+           (:last-error s1)))
+    (is (nil? (:last-error (sim-h/clear-error s1))))))
+
+;; ---- (6) Result shims ---------------------------------------------------
+
+(def ^:private ok-result
+  {:re-frame.machines.result/tag :ok
+   :re-frame.machines.result/snap {:state :authing :data {:counter 1}}
+   :re-frame.machines.result/fx []})
+
+(def ^:private fail-result
+  {:re-frame.machines.result/tag :fail
+   :re-frame.machines.result/info {:reason :no-matching-transition}})
+
+(deftest result-shims-discriminate
+  (is (true? (sim-h/result-ok? ok-result)))
+  (is (false? (sim-h/result-ok? fail-result)))
+  (is (true? (sim-h/result-fail? fail-result)))
+  (is (false? (sim-h/result-fail? ok-result))))
+
+(deftest result-shims-read-slots
+  (is (= {:state :authing :data {:counter 1}} (sim-h/result-snap ok-result)))
+  (is (= [] (sim-h/result-fx ok-result)))
+  (is (= {:reason :no-matching-transition} (sim-h/result-info fail-result))))
+
+;; ---- (7) step-sim ----------------------------------------------------------
+
+(deftest step-sim-ok-advances-snapshot-and-trail
+  (let [s0       (sim-h/make-sim-state :auth/login flat-definition)
+        runtime  (constantly ok-result)
+        s1       (sim-h/step-sim s0 [:start] runtime)]
+    (is (= :authing (get-in s1 [:snapshot :state]))
+        "snapshot advanced")
+    (is (= {:counter 1} (get-in s1 [:snapshot :data])))
+    (is (= 1 (count (:audit-trail s1))))
+    (is (= :idle (-> s1 :audit-trail last :from)))
+    (is (= :authing (-> s1 :audit-trail last :to)))
+    (is (= [:start] (-> s1 :audit-trail last :event)))
+    (is (nil? (:last-error s1)))))
+
+(deftest step-sim-fail-leaves-snapshot-and-stamps-error
+  (let [s0      (sim-h/make-sim-state :auth/login flat-definition)
+        runtime (constantly fail-result)
+        s1      (sim-h/step-sim s0 [:bad] runtime)]
+    (is (= :idle (get-in s1 [:snapshot :state]))
+        "snapshot unchanged on fail")
+    (is (= 0 (count (:audit-trail s1)))
+        "trail unchanged on fail")
+    (is (= [:bad] (-> s1 :last-error :event)))
+    (is (= "transition failed" (-> s1 :last-error :reason)))))
+
+(deftest step-sim-fail-then-ok-clears-prior-error
+  (let [s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (sim-h/step-sim s0 [:bad] (constantly fail-result))
+        s2 (sim-h/step-sim s1 [:start] (constantly ok-result))]
+    (is (some? (:last-error s1)))
+    (is (nil? (:last-error s2))
+        "the next OK step clears the prior error")
+    (is (= 1 (count (:audit-trail s2))))))
+
+(deftest step-sim-non-result-treated-as-fail
+  (let [s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (sim-h/step-sim s0 [:start] (constantly "not a result"))]
+    (is (= :idle (get-in s1 [:snapshot :state])))
+    (is (some? (:last-error s1)))
+    (is (= "engine returned a non-Result value" (-> s1 :last-error :reason)))))
+
+(deftest step-sim-audit-trail-order-newest-last
+  "Each step appends — the trail is insertion-ordered so the view can
+  render either direction. We pin the contract here so a downstream
+  view-test can rely on insertion order."
+  (let [results [{:re-frame.machines.result/tag :ok
+                  :re-frame.machines.result/snap {:state :authing :data {}}
+                  :re-frame.machines.result/fx []}
+                 {:re-frame.machines.result/tag :ok
+                  :re-frame.machines.result/snap {:state :done :data {}}
+                  :re-frame.machines.result/fx []}]
+        s0 (sim-h/make-sim-state :auth/login flat-definition)
+        s1 (sim-h/step-sim s0 [:start] (constantly (first results)))
+        s2 (sim-h/step-sim s1 [:ok]    (constantly (second results)))
+        trail (:audit-trail s2)]
+    (is (= 2 (count trail)))
+    (is (= [:start] (-> trail first :event)))
+    (is (= [:ok]    (-> trail last :event)))))
+
+;; ---- (8) format helpers --------------------------------------------------
+
+(deftest format-state-display-handles-shapes
+  (is (= "(none)" (sim-h/format-state-display nil)))
+  (is (= ":idle"  (sim-h/format-state-display :idle)))
+  (is (= "[:auth :form]" (sim-h/format-state-display [:auth :form]))))
+
+(deftest format-event-display-pr-strs
+  (is (= "" (sim-h/format-event-display nil)))
+  (is (= "[:foo]" (sim-h/format-event-display [:foo])))
+  (is (= "[:foo {:x 1}]" (sim-h/format-event-display [:foo {:x 1}]))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -162,6 +162,12 @@
    :rf.causa/selected-route-id
    :rf.causa/selected-violation-id
    :rf.causa/show-me-when-this-changed-result
+   ;; rf2-v869p Phase 2 — UC1 Sim sub-mode subs.
+   :rf.causa/sim-active?
+   :rf.causa/sim-available-transitions
+   :rf.causa/sim-by-machine
+   :rf.causa/sim-event-suggestions
+   :rf.causa/sim-state
    :rf.causa/suppressed-sensitive-count
    :rf.causa/target-frame
    :rf.causa/target-frame-db
@@ -257,6 +263,13 @@
    :rf.causa/set-schema-timeline-window
    :rf.causa/set-target-frame
    :rf.causa/set-trace-filter
+   ;; rf2-v869p Phase 2 — UC1 Sim sub-mode events.
+   :rf.causa/sim-reset
+   :rf.causa/sim-set-pending-data
+   :rf.causa/sim-set-pending-event
+   :rf.causa/sim-start
+   :rf.causa/sim-step
+   :rf.causa/sim-stop
    :rf.causa/sync-epoch-history
    :rf.causa/sync-trace-buffer
    :rf.causa/time-travel-set-label-input
@@ -343,7 +356,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 76 subs + 85 events + 5 fxs"
+  (testing "registry holds exactly 83 subs + 93 events + 5 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
@@ -358,7 +371,11 @@
     ;;   views-group-by, views-component-filter, views-cluster-threshold,
     ;;   views-expanded-rows, views-expanded-clusters,
     ;;   views-focused-cascade-pair, views-data.
-    (is (= 78 (count all-sub-names)))
+    ;; + 5 sim sub-mode (rf2-v869p Phase 2):
+    ;;   :rf.causa/sim-by-machine / :rf.causa/sim-state /
+    ;;   :rf.causa/sim-active? / :rf.causa/sim-available-transitions /
+    ;;   :rf.causa/sim-event-suggestions
+    (is (= 83 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -379,7 +396,10 @@
     ;;   views-set-component-filter, views-set-group-by,
     ;;   views-set-heatmap?, views-toggle-cluster, views-toggle-heatmap,
     ;;   views-toggle-row.
-    (is (= 87 (count all-event-names)))
+    ;; + 6 sim sub-mode (rf2-v869p Phase 2):
+    ;;   :rf.causa/sim-start / sim-step / sim-reset / sim-stop /
+    ;;   sim-set-pending-event / sim-set-pending-data
+    (is (= 93 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary

Phase 2 of the Machine Inspector epic (rf2-2tkza). Adds the **UC1 Sim
sub-mode**: a toggle in the Mode A header that flips the chart from
live-highlight to sim-highlight and surfaces a side rail letting users
sketch event sequences against a cloned machine definition WITHOUT
touching production state.

Design source-of-truth: `ai/findings/causa-uc1-simulation-design-2026-05-17.md`.

## Isolation

Sim CLONES the registered machine definition into Causa state. The
runtime calls `rf/machine-transition` — a pure fn — so neither the
production registry nor the host's frame app-db is touched. Toggling
Sim off disposes the per-machine slot; nothing leaks.

## Side rail layout (ASCII)

```
+--- Machine Inspector · :auth/login --------- Sim ● --+
|  Definition view: :auth/login — sim mode active     |
|  ........ <amber-tinted definition banner> ........ |
+------------------------------------------------------+
| <SVG chart, current sim state highlighted in amber> |
+------------------------------------------------------+
| +-- Sim rail (amber border top) ------------------+ |
| | SIMULATING — no live data; clicks walk topology | |
| |                                                 | |
| | CURRENT SIM STATE                               | |
| |   :idle                                         | |
| |   :data {:counter 0}                            | |
| |                                                 | |
| | EVENT  [ :start                       ]  ← list | |
| | PAYLOAD (optional EDN)                          | |
| |        [                              ]         | |
| |                                                 | |
| | [ Step ▶︎ ] [ Reset ] [ Exit Sim ]              | |
| |                                                 | |
| | Transition rejected  (red, when guard fails)    | |
| |                                                 | |
| | AVAILABLE FROM CURRENT STATE (2)                | |
| |   :start             → :authing                 | |
| |   :reset             → :idle                    | |
| |                                                 | |
| | AUDIT TRAIL (1)                                 | |
| |   #0   :idle → :authing       [:start]          | |
| +-------------------------------------------------+ |
+------------------------------------------------------+
| Transition history (live ribbon — unchanged)        |
+------------------------------------------------------+
```

## New files

- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim_helpers.cljc`
  (327 LoC) — pure-data algebra (initial-snapshot, available-
  transitions, event-id-suggestions, parse-event-vector, sim-state
  lifecycle, Result shims, step-sim orchestrator).

- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs`
  (399 LoC) — sub + event family + SimSideRail view.

- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_helpers_cljs_test.cljc`
  (236 LoC, 32 deftests) — pure-data algebra coverage.

- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs`
  (374 LoC, 20 deftests) — registry wiring, sim lifecycle, chart
  integration, side rail mount, toggle behaviour, frame isolation.

## Modified files

- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs`
  — wires sim into Mode A: toggle dispatches sim-start/stop, chart
  receives sim-snapshot, SimSideRail mounts when sim-active?,
  install! fan-out adds sim/install!.

- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` —
  catalogue + count assertions updated for the 5 new subs + 6 new
  events.

## Test cases (helper algebra)

- `initial-snapshot` from flat / hierarchical definition + nil safety
- `event-id-suggestions` walks compound states + sorted output
- `available-transitions` lists outgoing-from-leaf + guard? flag
- `parse-event-vector` accepts keyword + vector forms; rejects empty
  / non-keyword head / malformed EDN
- `make-sim-state` / `reset-sim-state` / `append-audit-row` /
  `record-error` / `clear-error` — sim-state lifecycle ops
- `result-ok?` / `result-fail?` / `result-snap` / `result-fx` /
  `result-info` — Result-shape destructuring shims
- `step-sim` OK / FAIL / non-Result / fail-then-ok-clears-error /
  audit-trail-order
- `format-state-display` / `format-event-display`

## Test cases (CLJS wiring + view)

- `registry-installs-sim-handlers` — all 5 subs + 6 events resolve
- `sim-start-clones-definition-and-seeds-snapshot`
- `sim-start-does-not-touch-production-registry` — explicit isolation
  assertion
- `sim-step-ok-advances-snapshot-and-trail`
- `sim-step-fail-leaves-snapshot-and-records-error`
- `sim-step-engine-throw-treated-as-fail` — friendly error when the
  machines artefact isn't on the classpath
- `sim-reset-rewinds-snapshot`
- `sim-stop-disposes-per-machine-slot`
- `chart-flips-sim-active-when-sim-on`
- `chart-highlight-shifts-to-sim-snapshot` — sim highlight wins over
  production snapshot
- `chart-highlight-follows-sim-step`
- `side-rail-mounts-when-sim-active` + every testid hook
- `side-rail-renders-available-transitions`
- `side-rail-renders-audit-trail-after-step`
- `side-rail-surfaces-error-on-fail`
- `toggle-button-enabled-when-definition-present`
- `toggle-button-disabled-without-definition`
- `toggle-button-dispatches-sim-start-and-stop`
- `toggle-button-stops-sim-when-active`
- `sim-state-does-not-leak-into-default-frame`

## Divergences

- **Mock-`:data` form only** in Phase 2 per Mike's locked decision
  (`ai/findings/2026-05-17-causa-consolidated-design.md`). Schema-
  derived form rides a follow-on bead.
- **Initial-entry cascade skipped** at sim-start — `:entry` actions
  don't fire on the seed snapshot; actions DO fire on subsequent
  steps via `rf/machine-transition`. Keeps sim hermetic from step 0.
- **`:invoke` / `:invoke-all` / `:after` are non-walkable** in
  Phase 2; the picker only lists direct `:on` transitions on the
  current leaf state. Listed as Phase 3+ work in the design doc.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 610 tests / 1802 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 2461 tests / 7178 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 2494 tests / 7145 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine

Parent epic rf2-2tkza stays open — mayor closes Phase-2 bead +
parent epic when all 5 phases land.