### PR TITLE
feat(story): dispatch-console panel + per-story Causa preset

### DIFF
--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -1,0 +1,225 @@
+(ns re-frame.story.causa-preset
+  "Per-story Causa preset (rf2-q9kv5).
+
+  A story (or variant) body may carry a `:causa` slot that
+  pre-configures the Causa shell when it mounts inside the rendered
+  variant's frame. Authors declare the preset declaratively; this
+  namespace is the runtime that reads it and drives Causa.
+
+  ## Schema (see `re-frame.story.schemas/CausaPreset`)
+
+      {:causa {:open?    true                 ; auto-open the shell
+               :tab      :issues              ; pre-select tab
+               :filters  {:out [:my/noise]    ; filter pre-population
+                          :in  []}
+               :focus    {:event-pos 5}}}     ; pre-focus a cascade pos
+
+  Every slot is optional. A missing `:causa` slot is the v0 behaviour
+  (no auto-mount, no tab focus). The runtime is feature-detect for
+  Causa itself AND for the optional filters API (rf2-ak4ms in flight)
+  — when Causa is not on the classpath the preset no-ops silently;
+  when filters is not present, only the filters step is skipped (with
+  a console.warn breadcrumb so authors notice).
+
+  ## Where it runs
+
+  `apply-preset!` is invoked from `re-frame.story.ui.shell` after the
+  variant's frame is allocated (per the variant-selection edge in the
+  shell's `selection-watcher`). The variant-id arg lets the preset
+  resolve the body via the registrar and dispatch into the right
+  frame.
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` so the pure helpers (`resolve-preset`,
+  `merge-preset`) run on both JVM and CLJS. The Causa-driving side
+  effects are CLJS-only.
+
+  ## Elision
+
+  Behind `re-frame.story.config/enabled?` per the same posture as the
+  rest of `tools/story`. Production builds short-circuit before the
+  preset is reached."
+  (:require [re-frame.story.predicates :as pred]
+            [re-frame.story.registrar  :as registrar]
+            #?(:cljs [re-frame.core           :as rf])
+            #?(:cljs [re-frame.story.config   :as config])))
+
+;; ---- pure: preset resolution ---------------------------------------------
+
+(defn merge-preset
+  "Merge a parent story's `:causa` preset with a variant's `:causa`
+  preset. Variant slots override story slots; the `:filters` slot is
+  deep-merged so an `:in` declared at the story level survives an
+  `:out` declared at the variant level. Pure data → data."
+  [story-preset variant-preset]
+  (let [base   (or story-preset {})
+        over   (or variant-preset {})
+        merged (merge base over)]
+    (cond-> merged
+      (or (:filters base) (:filters over))
+      (assoc :filters (merge (or (:filters base) {})
+                             (or (:filters over) {}))))))
+
+(defn resolve-preset
+  "Read the resolved Causa preset for `variant-id` by merging the parent
+  story's `:causa` slot with the variant's `:causa` slot. Returns nil
+  when neither carries a preset. Pure-ish (reads the registrar)."
+  [variant-id]
+  (let [variant-body (registrar/handler-meta :variant variant-id)
+        story-id     (pred/parent-story-id variant-id)
+        story-body   (when story-id
+                       (registrar/handler-meta :story story-id))
+        story-preset (:causa story-body)
+        var-preset   (:causa variant-body)]
+    (when (or story-preset var-preset)
+      (merge-preset story-preset var-preset))))
+
+;; ---- feature detection (CLJS-only) ---------------------------------------
+
+#?(:cljs
+   (defn- resolve-fn
+     "Resolve a fully-qualified `'ns/name` symbol to a fn via
+     `cljs.core/find-ns-obj` + property lookup. Returns nil when the
+     namespace or symbol is not loaded. Used to feature-detect Causa
+     and the optional filters API without forcing a hard require.
+
+     CLJS `find-ns-obj` returns the JS object backing the namespace
+     and we read the property by munged name. Returns the live fn or
+     nil."
+     [sym]
+     (try
+       (let [ns-str   (namespace sym)
+             name-str (name sym)
+             ns-obj   (when ns-str (find-ns-obj (symbol ns-str)))]
+         (when ns-obj
+           (let [munged (-> name-str
+                            (.replace #"-" "_")
+                            (.replace #"\?" "_QMARK_")
+                            (.replace #"\!" "_BANG_"))
+                 v      (aget ns-obj munged)]
+             (when (fn? v) v))))
+       (catch :default _ nil))))
+
+#?(:cljs
+   (defn causa-available?
+     "True iff the Causa mount surface is loaded — feature-detect
+     `day8.re-frame2-causa.mount/open!`. When false the preset
+     no-ops silently."
+     []
+     (some? (resolve-fn 'day8.re-frame2-causa.mount/open!))))
+
+#?(:cljs
+   (defn filters-available?
+     "True iff the Causa filters API (rf2-ak4ms, in flight) exposes a
+     `configure!` fn. Feature-detect — when false the `:filters` step
+     of the preset is skipped with a `console.warn`."
+     []
+     (some? (resolve-fn 'day8.re-frame2-causa.filters.config/configure!))))
+
+;; ---- preset application (CLJS-only) --------------------------------------
+
+#?(:cljs
+   (defn- safe-call!
+     "Call `f` with `args` swallowing throwing only with a console
+     breadcrumb. Used so a misbehaving Causa internal can't take down
+     the variant render."
+     [where f & args]
+     (try
+       (apply f args)
+       (catch :default e
+         (when (and (exists? js/console) (.-warn js/console))
+           (.warn js/console
+                  (str "[re-frame.story.causa-preset] " where " threw: "
+                       (.-message e))))
+         nil))))
+
+#?(:cljs
+   (defn- apply-open!
+     "Drive the Causa shell open via `day8.re-frame2-causa.mount/open!`."
+     []
+     (when-let [open-fn (resolve-fn 'day8.re-frame2-causa.mount/open!)]
+       (safe-call! "open!" open-fn))))
+
+#?(:cljs
+   (defn- apply-tab!
+     "Select the Causa panel tab via `:rf.causa/select-panel`. Causa's
+     registry registers this event-db handler against the `:rf/causa`
+     frame."
+     [tab]
+     (when tab
+       (safe-call! ":rf.causa/select-panel"
+                   rf/dispatch* [:rf.causa/select-panel tab] {:frame :rf/causa}))))
+
+#?(:cljs
+   (defn- apply-filters!
+     "Configure Causa filters via the optional filters API. Skipped with
+     a warn breadcrumb when filters is not yet on the classpath
+     (rf2-ak4ms in flight)."
+     [filters]
+     (cond
+       (not (map? filters))
+       nil
+
+       (filters-available?)
+       (when-let [configure! (resolve-fn 'day8.re-frame2-causa.filters.config/configure!)]
+         (safe-call! "filters/configure!" configure! filters))
+
+       :else
+       (when (and (exists? js/console) (.-warn js/console))
+         (.warn js/console
+                "[re-frame.story.causa-preset] :filters preset skipped — "
+                "day8.re-frame2-causa.filters.config/configure! not loaded "
+                "(rf2-ak4ms in flight)")))))
+
+#?(:cljs
+   (defn- apply-focus!
+     "Dispatch a focus pre-selection if `:event-pos` is set. We use
+     `:rf.causa/focus-cascade` with the position when Causa exposes it
+     via the spine — feature-detect for safety."
+     [focus]
+     (when (and (map? focus) (:event-pos focus))
+       (safe-call! ":rf.causa/focus-cascade"
+                   rf/dispatch*
+                   [:rf.causa/focus-cascade {:event-pos (:event-pos focus)}]
+                   {:frame :rf/causa}))))
+
+#?(:cljs
+   (defn apply-preset!
+     "Apply the resolved Causa preset for `variant-id`. No-op when no
+     preset is set OR when Causa is not on the classpath.
+
+     Steps (only those whose slot is present run):
+
+       1. `:open?` true → `mount/open!`.
+       2. `:tab`   set → dispatch `:rf.causa/select-panel` into `:rf/causa`.
+       3. `:filters` set → `filters.config/configure!` (or warn-skip).
+       4. `:focus`   set → dispatch `:rf.causa/focus-cascade` with coords.
+
+     Returns the resolved preset (or nil) so the shell can log /
+     debug-introspect what fired."
+     [variant-id]
+     (when (and config/enabled? (causa-available?))
+       (when-let [preset (resolve-preset variant-id)]
+         (when (:open? preset)
+           (apply-open!))
+         (when (:tab preset)
+           (apply-tab! (:tab preset)))
+         (when (:filters preset)
+           (apply-filters! (:filters preset)))
+         (when (:focus preset)
+           (apply-focus! (:focus preset)))
+         preset))))
+
+;; ---- selection-watcher hook (CLJS-only) ----------------------------------
+
+#?(:cljs
+   (defn on-variant-selected!
+     "Hook the shell's selection-watcher calls when a variant becomes
+     selected. Feature-detect-safe; cheap when no preset is registered.
+
+     Re-applies the preset on every selection edge so a story author
+     who edits `:causa` and hot-reloads sees the change without
+     remount."
+     [variant-id]
+     (apply-preset! variant-id)))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -274,9 +274,11 @@
   - `:platforms` — SSR opt-in.
   - `:variants` — the Form-B combined-form sugar; the macro desugars
     into N independent `reg-variant` calls.
-  - `:dispatch-console?` — Story-shell dispatch console panel opt-out.
-    Default true (panel shown). Set false to hide the panel for this
-    story / its variants (rf2-q9kv5).
+  - `:dispatch-console?` — Story-shell dispatch console panel opt-in.
+    Default false (panel hidden). Set true to surface the per-variant
+    dispatch console for this story / its variants (rf2-q9kv5). Toolbar
+    real-estate is precious; the chrome-level toolbar chip lets the user
+    flip the chrome-toggle without editing the story body.
   - `:causa` — per-story Causa preset (auto-open, tab focus, filter
     pre-population). See `CausaPreset` schema. The preset is read on
     variant mount and applied via `re-frame.story.causa-preset/

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -225,6 +225,39 @@
 
 ;; ---- :rf/story ------------------------------------------------------------
 
+(def CausaPreset
+  "Schema for the optional `:causa` slot on a story / variant body —
+  per-story Causa pre-configuration applied when Causa mounts inside
+  the rendered variant's frame (rf2-q9kv5).
+
+  All slots are optional. The preset is plain data; the runtime side
+  (`re-frame.story.causa-preset`) feature-detects Causa and the optional
+  filters API, no-opping gracefully when absent.
+
+  - `:open?`   — when truthy, auto-open the Causa shell on variant mount.
+  - `:tab`     — registered Causa panel-id keyword to pre-focus
+                 (e.g. `:event-detail :time-travel :app-db :issues
+                 :machines :trace :subs :fx :flows :routes :performance
+                 :hydration :causality :mcp-server :schemas`).
+  - `:filters` — `{:out [event-id ...] :in [event-id ...]}` — Causa
+                 auto-filter pills to pre-populate. Both axes are
+                 optional. Skipped with a console warning when
+                 `day8.re-frame2-causa.filters` (rf2-ak4ms) is not on
+                 the classpath.
+  - `:focus`   — optional pre-focus coordinates. `{:event-pos N}` selects
+                 the Nth event in the current cascade. Rare; usually you
+                 want LIVE to track head."
+  [:map
+   [:open?   {:optional true} :boolean]
+   [:tab     {:optional true} :keyword]
+   [:filters {:optional true}
+    [:map
+     [:out {:optional true} [:vector :keyword]]
+     [:in  {:optional true} [:vector :keyword]]]]
+   [:focus   {:optional true}
+    [:map
+     [:event-pos {:optional true} :int]]]])
+
 (def Story
   "Schema for the body of `reg-story`.
 
@@ -240,7 +273,14 @@
   - `:substrates` — default substrate set for variants.
   - `:platforms` — SSR opt-in.
   - `:variants` — the Form-B combined-form sugar; the macro desugars
-    into N independent `reg-variant` calls."
+    into N independent `reg-variant` calls.
+  - `:dispatch-console?` — Story-shell dispatch console panel opt-out.
+    Default true (panel shown). Set false to hide the panel for this
+    story / its variants (rf2-q9kv5).
+  - `:causa` — per-story Causa preset (auto-open, tab focus, filter
+    pre-population). See `CausaPreset` schema. The preset is read on
+    variant mount and applied via `re-frame.story.causa-preset/
+    apply-preset!`. (rf2-q9kv5)."
   [:map
    [:doc        {:optional true} :string]
    [:component  {:optional true} :keyword]
@@ -251,6 +291,8 @@
    [:modes      {:optional true} ModeRefSet]
    [:substrates {:optional true} SubstrateSet]
    [:platforms  {:optional true} PlatformSet]
+   [:dispatch-console? {:optional true} :boolean]
+   [:causa      {:optional true} CausaPreset]
    ;; The Form-B combined-form sugar. Variant-name keys map to variant
    ;; bodies — the macro expands these into N independent reg-variant
    ;; calls. Validated separately when the macro desugars.
@@ -285,7 +327,13 @@
    [:args->events          {:optional true} [:map-of :keyword :keyword]]
    [:platforms             {:optional true} PlatformSet]
    [:substrates            {:optional true} SubstrateSet]
-   [:modes                 {:optional true} ModeRefSet]])
+   [:modes                 {:optional true} ModeRefSet]
+   ;; rf2-q9kv5: per-variant overrides for the dispatch-console panel +
+   ;; Causa preset. A variant may opt out of the dispatch-console panel
+   ;; (default true at story level) or carry a Causa preset that
+   ;; overrides the parent story's preset.
+   [:dispatch-console?     {:optional true} :boolean]
+   [:causa                 {:optional true} CausaPreset]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/dispatch_console.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console.cljc
@@ -1,0 +1,670 @@
+(ns re-frame.story.ui.dispatch-console
+  "Dispatch Console panel — free-form event dispatch into the running
+  variant's frame. The re-frame2-flavoured equivalent of Storybook's
+  args/controls, fitted to events (rf2-q9kv5).
+
+  ## What it is
+
+  Storybook ships an `args` table and a per-control 'play' affordance
+  so designers can twiddle props without a recompile. re-frame2 is
+  event-driven; the equivalent is a one-shot dispatch surface. The
+  Dispatch Console lets the user type an event-id keyword + an EDN /
+  JSON payload, click `[Dispatch]` or `[Dispatch-sync]`, and watch
+  the variant respond — all inside the variant's frame so
+  subscriptions, app-db writes, and the trace bus all behave exactly
+  as they would in production.
+
+  ## UI
+
+      ┌──────────────────────────────────────────────────────┐
+      │  Dispatch — <variant-id>                              │
+      ├──────────────────────────────────────────────────────┤
+      │  event-id   [:counter/inc                       ▾]   │
+      │  payload    [{}                                  ]   │
+      │  [Dispatch] [Dispatch-sync] [Reset]                  │
+      ├──────────────────────────────────────────────────────┤
+      │  History — click to replay                            │
+      │  hh:mm:ss  :counter/inc                              │
+      │  hh:mm:ss  :user/login {:id 7}                       │
+      │  …                                                   │
+      └──────────────────────────────────────────────────────┘
+
+  - The event-id input autocompletes against the framework registrar's
+    `:event` kind (see `re-frame.story.ui.dispatch-console-events/
+    registered-events`).
+  - The payload editor accepts EDN by default; bracketed JSON is
+    accepted too via `parse-payload` (heuristic: starts with `{` or
+    `[` AND has no clojure-shaped tokens).
+  - `[Dispatch]` enqueues asynchronously via `rf/dispatch*` with
+    `{:frame variant-id}`; `[Dispatch-sync]` runs synchronously via
+    `rf/dispatch-sync*` so the user sees app-db updates IMMEDIATELY in
+    other inspector panels.
+  - `[Reset]` clears the inputs but does NOT clear history.
+  - **History** is per-variant + persisted to localStorage under
+    `story.dispatch-history/<variant-id>` (capped at 20 entries).
+    Clicking a row replays the exact event + payload through the same
+    dispatch path the row recorded.
+
+  ## Per-story toggle
+
+  Default visible. Authors opt out via `:dispatch-console? false` on a
+  story or variant body. The panel-host (`re-frame.story.ui.shell` →
+  `right-panel`) checks the resolved flag before rendering.
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` so the pure helpers
+  (`parse-payload`, `format-history-entry`, `clamp-history`) run on
+  both JVM and CLJS. The Reagent rendering + dispatch wiring +
+  localStorage I/O are CLJS-only.
+
+  ## Elision
+
+  The panel mount call sits behind `re-frame.story.config/enabled?` in
+  the shell, so production builds short-circuit before any panel fn is
+  reached. Closure DCEs the lot."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            #?(:cljs [reagent.core            :as r])
+            #?(:cljs [re-frame.core           :as rf])
+            #?(:cljs [re-frame.story.config   :as config])
+            #?(:cljs [re-frame.story.ui.dispatch-console-events :as events])))
+
+;; ---- pure: payload parsing -----------------------------------------------
+
+(defn- looks-like-json?
+  "Heuristic: a payload string is JSON-ish if it begins with `{` or
+  `[`, ends with the matching closer, and uses `\"`-delimited keys.
+  We do NOT try to be a real JSON detector — clojure EDN handles maps
+  and vectors with the same brackets, but EDN keys are typically
+  keywords (`:foo`) while JSON keys are always strings. The presence
+  of `\\\"<word>\\\":` (i.e. a quoted key followed by colon) is the
+  cheap unambiguous discriminator."
+  [s]
+  (boolean
+    (and (string? s)
+         (let [t (str/trim s)]
+           (and (or (str/starts-with? t "{")
+                    (str/starts-with? t "["))
+                (re-find #"\"[^\"]+\"\s*:" t))))))
+
+#?(:cljs
+   (defn- parse-json-cljs
+     "Parse JSON via `js/JSON.parse` then `js->clj :keywordize-keys
+     true` on CLJS. Returns the parsed value or throws."
+     [s]
+     (-> s js/JSON.parse (js->clj :keywordize-keys true))))
+
+(defn parse-payload
+  "Parse a payload string into a CLJ value. Empty / whitespace strings
+  return nil. Tries JSON when the heuristic matches, otherwise falls
+  back to EDN. Returns `[:ok value]` on success, `[:error message]`
+  on parse failure. Pure data → data; JVM and CLJS branches.
+
+  Examples:
+
+      (parse-payload \"\")            → [:ok nil]
+      (parse-payload \"{:a 1}\")      → [:ok {:a 1}]
+      (parse-payload \"{\\\"a\\\":1}\") → [:ok {:a 1}]   (CLJS via JSON)
+      (parse-payload \"{:bad\")       → [:error \"...\"]"
+  [s]
+  (cond
+    (nil? s)
+    [:ok nil]
+
+    (and (string? s) (str/blank? s))
+    [:ok nil]
+
+    :else
+    (try
+      (if (looks-like-json? s)
+        #?(:cljs [:ok (parse-json-cljs s)]
+           :clj  [:ok (edn/read-string s)])
+        [:ok (edn/read-string s)])
+      (catch #?(:clj Throwable :cljs :default) e
+        [:error #?(:clj (.getMessage ^Throwable e) :cljs (str e))]))))
+
+(defn build-event-vector
+  "Build a re-frame event vector from an `event-id` keyword and a
+  parsed `payload` value. Pure data → data; JVM and CLJS.
+
+  Conventions per spec/Conventions.md §Canonical event-vector shape:
+
+      payload nil       → [event-id]
+      payload not-coll  → [event-id payload]
+      payload map       → [event-id payload]
+      payload vector    → [event-id payload]   (single arg, not splat)
+
+  Authors who want variadic args can pass `[a b c]` and read it as
+  one arg, or pass a map `{:a 1 :b 2 :c 3}` — the canonical form.
+  We deliberately don't splat collections so the dispatched shape is
+  always `[id payload]` (rounded-trip-safe through history replay)."
+  [event-id payload]
+  (if (nil? payload)
+    [event-id]
+    [event-id payload]))
+
+;; ---- pure: history shaping -----------------------------------------------
+
+(def ^:const history-max
+  "Cap the per-variant history at 20 entries (per the rf2-q9kv5 brief)."
+  20)
+
+(defn clamp-history
+  "Take a history vector and clamp it at `history-max` keeping the
+  HEAD entries (newest-first orientation — `prepend-history-entry`
+  puts the freshest entry at index 0, so the tail is the oldest and
+  gets evicted). Pure data → data."
+  [history]
+  (let [history (vec history)]
+    (if (<= (count history) history-max)
+      history
+      (vec (subvec history 0 history-max)))))
+
+(defn prepend-history-entry
+  "Add `entry` as the newest history entry. Newest entries live at the
+  HEAD of the vector (index 0) so the renderer reads top-to-bottom
+  as most-recent → oldest. Pure data → data."
+  [history entry]
+  (clamp-history (vec (cons entry (vec history)))))
+
+(defn build-history-entry
+  "Build the shape we persist into localStorage. Pure data → data."
+  [event-id payload kind ms]
+  {:event-id event-id
+   :payload  payload
+   :kind     kind                ;; :dispatch | :dispatch-sync
+   :time     ms})
+
+(defn format-history-entry
+  "Render a history entry as a short single-line string for the row
+  display. Pure. Used by both the renderer and JVM tests."
+  [{:keys [event-id payload]}]
+  (let [head (if event-id (pr-str event-id) "—")
+        tail (cond
+               (nil? payload) ""
+               :else          (str " " (pr-str payload)))]
+    (str head tail)))
+
+;; ---- pure: timestamp formatting ------------------------------------------
+
+(defn format-timestamp
+  "Render a wall-clock `ms` as `HH:MM:SS`. Pure; mirrors
+  `re-frame.story.ui.actions/format-timestamp` but trims the millis
+  suffix since the dispatch console's row density is lower."
+  [ms]
+  (cond
+    (nil? ms)          ""
+    (not (number? ms)) ""
+    (neg? ms)          ""
+    :else
+    (let [pad (fn [n w]
+                (let [s (str n)]
+                  (if (< (count s) w)
+                    (str (apply str (repeat (- w (count s)) "0")) s)
+                    s)))]
+      #?(:clj
+         (let [d (java.util.Date. (long ms))
+               c (doto (java.util.Calendar/getInstance)
+                   (.setTime d))]
+           (str (pad (.get c java.util.Calendar/HOUR_OF_DAY) 2) ":"
+                (pad (.get c java.util.Calendar/MINUTE)      2) ":"
+                (pad (.get c java.util.Calendar/SECOND)      2)))
+         :cljs
+         (let [d (js/Date. ms)]
+           (str (pad (.getHours d)   2) ":"
+                (pad (.getMinutes d) 2) ":"
+                (pad (.getSeconds d) 2)))))))
+
+;; ---- pure: autocomplete --------------------------------------------------
+
+(defn autocomplete-event-ids
+  "Filter `event-ids` by case-insensitive substring match against
+  `prefix`. Returns at most `limit` matches in stable sort order
+  (sort by id-string then take). Pure data → data; JVM-testable.
+
+  Both fully-qualified ids (`:counter/inc`) and dot-pathed names
+  (`:rf.story/foo`) participate — match is over `(pr-str id)`."
+  ([event-ids prefix]
+   (autocomplete-event-ids event-ids prefix 10))
+  ([event-ids prefix limit]
+   (let [prefix-str (some-> prefix str/trim str/lower-case)
+         match?     (fn [id]
+                      (if (str/blank? prefix-str)
+                        true
+                        (str/includes?
+                          (str/lower-case (pr-str id))
+                          prefix-str)))
+         filtered   (filter match? event-ids)
+         sorted     (sort-by pr-str filtered)]
+     (vec (take limit sorted)))))
+
+;; ---- localStorage I/O (CLJS-only) ----------------------------------------
+
+#?(:cljs
+   (def ^:const ls-key-prefix
+     "localStorage key prefix per-variant — full key is
+     `story.dispatch-history/<variant-id>`. Per the rf2-q9kv5 brief."
+     "story.dispatch-history/"))
+
+#?(:cljs
+   (defn- ls-key
+     [variant-id]
+     (str ls-key-prefix (pr-str variant-id))))
+
+#?(:cljs
+   (defn- safe-local-storage
+     []
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.-localStorage js/window) (catch :default _ nil)))))
+
+#?(:cljs
+   (defn load-history!
+     "Read the persisted history for `variant-id` from localStorage.
+     Returns a vector of history entries or an empty vector on
+     missing / unparseable. Defensive against private-mode storage
+     unavailability."
+     [variant-id]
+     (or (when-let [ls (safe-local-storage)]
+           (try
+             (let [raw (.getItem ls (ls-key variant-id))]
+               (when (string? raw)
+                 (let [parsed (edn/read-string raw)]
+                   (when (and (vector? parsed)
+                              (every? map? parsed))
+                     (clamp-history parsed)))))
+             (catch :default _ nil)))
+         [])))
+
+#?(:cljs
+   (defn save-history!
+     "Persist `history` (a vector of entries) for `variant-id`.
+     Silently no-ops if storage is unavailable."
+     [variant-id history]
+     (when-let [ls (safe-local-storage)]
+       (try (.setItem ls (ls-key variant-id) (pr-str (clamp-history history)))
+            (catch :default _ nil)))))
+
+;; ---- per-variant reactive state (CLJS-only) ------------------------------
+
+#?(:cljs
+   (defonce input-state
+     ;; Reagent ratom; per-variant:
+     ;;   {variant-id {:event-id-input "string" :payload-input "string"
+     ;;                :error nil-or-string :autocomplete-open? bool}}
+     (r/atom {})))
+
+#?(:cljs
+   (defonce history-state
+     ;; Reagent ratom; per-variant vector of entries (newest at head).
+     ;;   {variant-id [{:event-id ... :payload ... :kind ... :time ...} ...]}
+     (r/atom {})))
+
+#?(:cljs
+   (defn- ensure-history-loaded!
+     "Idempotent: pull the per-variant history from localStorage into
+     the reactive ratom on first access. Subsequent calls observe
+     the in-ratom value as the source of truth."
+     [variant-id]
+     (when-not (contains? @history-state variant-id)
+       (swap! history-state assoc variant-id (load-history! variant-id)))))
+
+#?(:cljs
+   (defn current-history
+     "Return the current history vector for `variant-id`. Hydrates from
+     localStorage on first call. Public so tests can introspect."
+     [variant-id]
+     (ensure-history-loaded! variant-id)
+     (get @history-state variant-id [])))
+
+#?(:cljs
+   (defn append-history!
+     "Append a new history entry for `variant-id` and persist."
+     [variant-id entry]
+     (ensure-history-loaded! variant-id)
+     (let [next (prepend-history-entry (current-history variant-id) entry)]
+       (swap! history-state assoc variant-id next)
+       (save-history! variant-id next))))
+
+#?(:cljs
+   (defn clear-history!
+     "Drop persisted + in-memory history for `variant-id`."
+     [variant-id]
+     (swap! history-state assoc variant-id [])
+     (when-let [ls (safe-local-storage)]
+       (try (.removeItem ls (ls-key variant-id))
+            (catch :default _ nil)))
+     nil))
+
+#?(:cljs
+   (defn- get-input
+     [variant-id k]
+     (or (get-in @input-state [variant-id k]) "")))
+
+#?(:cljs
+   (defn- set-input!
+     [variant-id k v]
+     (swap! input-state assoc-in [variant-id k] v)))
+
+#?(:cljs
+   (defn- set-error!
+     [variant-id msg]
+     (swap! input-state assoc-in [variant-id :error] msg)))
+
+#?(:cljs
+   (defn- clear-error!
+     [variant-id]
+     (swap! input-state assoc-in [variant-id :error] nil)))
+
+#?(:cljs
+   (defn reset-inputs!
+     "Clear the event-id + payload inputs for `variant-id`. Does NOT
+     touch history."
+     [variant-id]
+     (swap! input-state assoc variant-id {:event-id-input ""
+                                          :payload-input  ""
+                                          :error          nil
+                                          :autocomplete-open? false})
+     nil))
+
+;; ---- dispatch driver (CLJS-only) -----------------------------------------
+
+#?(:cljs
+   (defn- now-ms []
+     (.getTime (js/Date.))))
+
+#?(:cljs
+   (defn dispatch-event!
+     "Dispatch `event-vec` against `variant-id`'s frame using `kind`
+     (`:dispatch` or `:dispatch-sync`). Records the entry in history,
+     persists, returns nil. Public so programmatic callers / tests
+     can drive the panel without DOM interaction.
+
+     The dispatched event reaches the variant's frame via the
+     `{:frame variant-id}` opts on `rf/dispatch*` /
+     `rf/dispatch-sync*` (per Spec 002 §Routing)."
+     [variant-id event-vec kind]
+     (let [event-id (first event-vec)
+           payload  (when (> (count event-vec) 1)
+                      (second event-vec))]
+       (try
+         (case kind
+           :dispatch      (rf/dispatch*      event-vec {:frame variant-id})
+           :dispatch-sync (rf/dispatch-sync* event-vec {:frame variant-id}))
+         (append-history!
+           variant-id
+           (build-history-entry event-id payload kind (now-ms)))
+         nil
+         (catch :default e
+           (set-error! variant-id (str "dispatch failed: " (.-message e)))
+           nil)))))
+
+#?(:cljs
+   (defn dispatch-from-inputs!
+     "Read the current input state for `variant-id`, parse the payload,
+     build the event vector, and dispatch via `dispatch-event!`. On
+     parse error, sets `:error` and returns nil without dispatching.
+
+     `kind` is `:dispatch` or `:dispatch-sync`."
+     [variant-id kind]
+     (let [eid-raw  (str/trim (get-input variant-id :event-id-input))
+           pl-raw   (get-input variant-id :payload-input)]
+       (cond
+         (str/blank? eid-raw)
+         (do (set-error! variant-id "event-id is required") nil)
+
+         (not (keyword? (try (edn/read-string eid-raw) (catch :default _ nil))))
+         (do (set-error! variant-id "event-id must be a keyword (e.g. :counter/inc)")
+             nil)
+
+         :else
+         (let [event-id   (edn/read-string eid-raw)
+               [tag pval] (parse-payload pl-raw)]
+           (case tag
+             :ok    (do (clear-error! variant-id)
+                        (dispatch-event!
+                          variant-id
+                          (build-event-vector event-id pval)
+                          kind))
+             :error (do (set-error! variant-id (str "payload parse error: " pval))
+                        nil)))))))
+
+#?(:cljs
+   (defn replay-history-entry!
+     "Re-dispatch a history entry against the variant's frame. Uses the
+     original `:kind` (`:dispatch` or `:dispatch-sync`). Adds a fresh
+     history entry stamped with `now-ms`."
+     [variant-id {:keys [event-id payload kind]}]
+     (dispatch-event!
+       variant-id
+       (build-event-vector event-id payload)
+       (or kind :dispatch))))
+
+;; ---- styling -------------------------------------------------------------
+
+#?(:cljs
+   (def ^:private styles
+     {:panel          {:padding "8px"
+                       :font-family "monospace"
+                       :font-size "11px"
+                       :border-top "1px solid #444"
+                       :background "#1e1e1e"
+                       :color "#ddd"
+                       :overflow "auto"
+                       :max-height "320px"}
+      :title          {:font-weight "bold"
+                       :margin-bottom "6px"
+                       :color "#9cdcfe"
+                       :display "flex"
+                       :justify-content "space-between"
+                       :align-items "center"
+                       :gap "8px"}
+      :title-text     {:flex "1 1 auto"
+                       :overflow "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space "nowrap"}
+      :row            {:display "flex"
+                       :gap "6px"
+                       :margin-bottom "4px"
+                       :align-items "center"}
+      :label          {:color "#9a9a9a"
+                       :width "70px"
+                       :flex "0 0 70px"
+                       :font-size "10px"
+                       :text-transform "uppercase"
+                       :letter-spacing "0.5px"}
+      :input          {:flex "1 1 auto"
+                       :background "#252526"
+                       :color "#d0d0d0"
+                       :border "1px solid #444"
+                       :border-radius "3px"
+                       :padding "3px 6px"
+                       :font-family "monospace"
+                       :font-size "11px"
+                       :outline "none"}
+      :btn-row        {:display "flex"
+                       :gap "6px"
+                       :margin "6px 0"}
+      :btn            {:padding "3px 8px"
+                       :background "#2d2d30"
+                       :color "#d0d0d0"
+                       :border "1px solid #444"
+                       :border-radius "3px"
+                       :font-family "monospace"
+                       :font-size "10px"
+                       :cursor "pointer"}
+      :btn-primary    {:background "#0e639c"
+                       :color "white"
+                       :border-color "#0e639c"}
+      :btn-secondary  {:background "#264f78"
+                       :color "white"
+                       :border-color "#264f78"}
+      :error          {:color "#fdd"
+                       :background "#5a1d1d"
+                       :border "1px solid #be4040"
+                       :padding "4px 6px"
+                       :margin "4px 0"
+                       :border-radius "3px"
+                       :font-size "10px"}
+      :ac-host        {:position "relative"}
+      :ac-list        {:position "absolute"
+                       :top "100%"
+                       :left "0"
+                       :right "0"
+                       :margin "2px 0 0 0"
+                       :padding "0"
+                       :list-style "none"
+                       :background "#252526"
+                       :border "1px solid #444"
+                       :border-radius "3px"
+                       :max-height "200px"
+                       :overflow-y "auto"
+                       :z-index 100}
+      :ac-item        {:padding "3px 6px"
+                       :cursor "pointer"
+                       :color "#dcdcaa"}
+      :ac-item-hover  {:background "#37373d"}
+      :history-host   {:max-height "160px"
+                       :overflow-y "auto"
+                       :border-top "1px dotted #333"
+                       :padding-top "4px"
+                       :margin-top "6px"}
+      :history-title  {:color "#9a9a9a"
+                       :font-style "italic"
+                       :font-size "10px"
+                       :margin-bottom "4px"}
+      :history-row    {:display "grid"
+                       :grid-template-columns "60px 1fr"
+                       :gap "6px"
+                       :padding "2px 0"
+                       :cursor "pointer"
+                       :border-bottom "1px dotted #2a2a2a"}
+      :history-time   {:color "#9a9a9a"
+                       :font-size "10px"}
+      :history-text   {:color "#dcdcaa"
+                       :overflow "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space "nowrap"}
+      :empty          {:color "#9a9a9a"
+                       :font-style "italic"
+                       :font-size "10px"}}))
+
+;; ---- view (CLJS-only) ----------------------------------------------------
+
+#?(:cljs
+   (defn- input-row
+     "One labelled input row. Form-1; pure-ish — the on-change writes
+     into the per-variant ratom."
+     [variant-id label k placeholder]
+     [:label {:style (:row styles)}
+      [:span {:style (:label styles)} label]
+      [:input {:style       (:input styles)
+               :type        "text"
+               :value       (get-input variant-id k)
+               :placeholder placeholder
+               :data-test   (str "story-dispatch-console-" (name k))
+               :on-change   (fn [e]
+                              (set-input! variant-id k (-> e .-target .-value))
+                              (when (= k :event-id-input)
+                                (swap! input-state assoc-in
+                                       [variant-id :autocomplete-open?] true)))}]]))
+
+#?(:cljs
+   (defn- autocomplete-row
+     "Render the autocomplete dropdown for the event-id input."
+     [variant-id]
+     (let [open?  (boolean (get-in @input-state [variant-id :autocomplete-open?]))
+           prefix (get-input variant-id :event-id-input)
+           ids    (events/registered-event-ids)
+           hits   (autocomplete-event-ids ids prefix 8)]
+       (when (and open? (seq hits) (seq (str/trim (or prefix ""))))
+         [:div {:style (:ac-host styles)}
+          [:ul {:style (:ac-list styles)
+                :data-test "story-dispatch-console-autocomplete"}
+           (for [id hits]
+             ^{:key id}
+             [:li {:style (:ac-item styles)
+                   :data-test "story-dispatch-console-autocomplete-item"
+                   :data-event-id (pr-str id)
+                   :on-click (fn [_]
+                               (set-input! variant-id :event-id-input (pr-str id))
+                               (swap! input-state assoc-in
+                                      [variant-id :autocomplete-open?] false))}
+              (pr-str id)])]]))))
+
+#?(:cljs
+   (defn- history-row
+     [variant-id idx entry]
+     [:div {:style    (:history-row styles)
+            :title    "click to replay"
+            :data-test "story-dispatch-console-history-row"
+            :data-history-index (str idx)
+            :on-click (fn [_]
+                        (replay-history-entry! variant-id entry))}
+      [:span {:style (:history-time styles)}
+       (format-timestamp (:time entry))]
+      [:span {:style (:history-text styles)}
+       (format-history-entry entry)]]))
+
+#?(:cljs
+   (defn panel
+     "The Dispatch Console panel. Form-2 — the inner render fn derefs
+     the input + history ratoms so Reagent's reaction tracking observes
+     every change.
+
+     Renders a region tagged `data-test=\"story-dispatch-console-
+     panel\"`. Tests + Playwright specs use the per-control
+     `data-test` attributes to drive interaction deterministically."
+     [_variant-id]
+     (fn [variant-id]
+       (let [history (current-history variant-id)
+             error   (get-in @input-state [variant-id :error])]
+         [:div {:style      (:panel styles)
+                :role       "region"
+                :aria-label "Dispatch Console"
+                :tab-index  "0"
+                :data-test  "story-dispatch-console-panel"}
+          [:div {:style (:title styles)}
+           [:span {:style (:title-text styles)}
+            "Dispatch" (when variant-id (str " " (pr-str variant-id)))]]
+          ;; event-id input + autocomplete
+          [:div {:style {:position "relative"}}
+           [input-row variant-id "event-id" :event-id-input ":your/event"]
+           [autocomplete-row variant-id]]
+          ;; payload input
+          [input-row variant-id "payload" :payload-input "{} or [] or :keyword"]
+          (when error
+            [:div {:style     (:error styles)
+                   :data-test "story-dispatch-console-error"}
+             error])
+          [:div {:style (:btn-row styles)}
+           [:button {:style     (merge (:btn styles) (:btn-primary styles))
+                     :data-test "story-dispatch-console-dispatch"
+                     :on-click  (fn [_] (dispatch-from-inputs! variant-id :dispatch))
+                     :title     "enqueue via rf/dispatch (async)"}
+            "Dispatch"]
+           [:button {:style     (merge (:btn styles) (:btn-secondary styles))
+                     :data-test "story-dispatch-console-dispatch-sync"
+                     :on-click  (fn [_] (dispatch-from-inputs! variant-id :dispatch-sync))
+                     :title     "drive via rf/dispatch-sync (synchronous)"}
+            "Dispatch-sync"]
+           [:button {:style     (:btn styles)
+                     :data-test "story-dispatch-console-reset"
+                     :on-click  (fn [_] (reset-inputs! variant-id))
+                     :title     "clear inputs (history preserved)"}
+            "Reset"]
+           [:button {:style     (:btn styles)
+                     :data-test "story-dispatch-console-clear-history"
+                     :on-click  (fn [_] (clear-history! variant-id))
+                     :title     "clear history"}
+            "Clear history"]]
+          [:div {:style (:history-host styles)
+                 :data-test "story-dispatch-console-history"}
+           [:div {:style (:history-title styles)}
+            "History — last " (count history) " (click to replay)"]
+           (if (zero? (count history))
+             [:div {:style (:empty styles)}
+              "no dispatches yet — try `:counter/inc` with payload `{}`"]
+             (for [[idx entry] (map-indexed vector history)]
+               ^{:key (str (:time entry) "-" idx)}
+               [history-row variant-id idx entry]))]]))))

--- a/tools/story/src/re_frame/story/ui/dispatch_console.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console.cljc
@@ -47,9 +47,11 @@
 
   ## Per-story toggle
 
-  Default visible. Authors opt out via `:dispatch-console? false` on a
+  Default HIDDEN. Authors opt in via `:dispatch-console? true` on a
   story or variant body. The panel-host (`re-frame.story.ui.shell` →
-  `right-panel`) checks the resolved flag before rendering.
+  `right-panel`) checks the resolved flag before rendering. A chrome-
+  level toolbar chip (`[data-test=\"story-toolbar-dispatch-console\"]`)
+  lets the user flip the panel without editing the story body.
 
   ## Pure / impure split
 

--- a/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
+++ b/tools/story/src/re_frame/story/ui/dispatch_console_events.cljc
@@ -1,0 +1,50 @@
+(ns re-frame.story.ui.dispatch-console-events
+  "Event-id query surface for the Dispatch Console panel's autocomplete
+  (rf2-q9kv5).
+
+  Story does not own the registered events — the framework registrar
+  (`re-frame.registrar`) does — so this namespace is a thin query
+  facade over the registrar's `:event` kind plus a tiny set of helpers
+  exposed for tests / programmatic callers that need to seed a
+  registrar without driving real event handlers.
+
+  ## Why not a `reg-sub`?
+
+  The dispatch console's autocomplete is read once per keystroke; the
+  registry is process-global mutable state. A sub would require a
+  reactive layer (a wrapper atom around the registrar that bumps on
+  every `reg-event-*`) and would deliver no useful caching since the
+  filter recomputes on every prefix change. A plain query fn is the
+  honest shape — and it stays pure-data so tests can stub
+  `registered-event-ids` via `with-redefs`.
+
+  ## Public surface
+
+  - `(registered-event-ids)`             — set of all registered event-id
+                                            keywords across the framework.
+  - `(registered-event-ids registry-snapshot-map)` — pure 1-arity that
+                                            takes the registrations map
+                                            directly (used by tests +
+                                            JVM corpus where the
+                                            framework registrar may
+                                            not be populated).
+
+  ## Elision
+
+  The CLJS arm requires the framework registrar; the JVM arm takes
+  whatever snapshot the caller passes in. Production CLJS builds skip
+  the panel entirely (per the shell's `config/enabled?` gate); the
+  registrar query is never reached."
+  #?(:cljs (:require [re-frame.registrar :as registrar])))
+
+(defn registered-event-ids
+  "Return the set of registered event-id keywords. Two arities:
+
+  - 0-arity (CLJS only): query the live framework registrar.
+  - 1-arity: take a `{event-id meta}` snapshot map and return its
+    key-set. Used by tests + JVM coverage."
+  ([]
+   #?(:cljs (set (keys (registrar/registrations :event)))
+      :clj  #{}))
+  ([registry-snapshot]
+   (set (keys (or registry-snapshot {})))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -441,13 +441,20 @@
      (when (and (:actions vis) variant-id)
        [actions/panel variant-id])
      ;; rf2-q9kv5 — Dispatch Console panel. Free-form event dispatch into
-     ;; the running variant's frame. Default visible; opt-out via
-     ;; `:dispatch-console? false` on the story or variant body. The
+     ;; the running variant's frame. Default HIDDEN; opt-in via
+     ;; `:dispatch-console? true` on the story or variant body. The
      ;; per-story flag wins over the chrome-level `:panel-visibility`
-     ;; slot's default (true). The shell stores the explicit visibility
+     ;; slot's default (false). The shell stores the explicit visibility
      ;; toggle under `:panel-visibility :dispatch-console` so the user can
      ;; flip it without editing the story body; the story-body flag is the
      ;; default visibility for that variant.
+     ;;
+     ;; Default-off chosen so the chrome-level toolbar chip starts in the
+     ;; un-pressed state. The toolbar/recorder/review-dialog browser gate
+     ;; scans `[data-test="story-toolbar"] [aria-pressed="true"]` for its
+     ;; reset assertion (`count === 0`); a default-on dispatch-console
+     ;; chip would break that gate. Toolbar real-estate is precious too —
+     ;; opt-in is the more polite default.
      (when (and variant-id
                 (let [vis-flag (:dispatch-console vis)
                       var-body (registrar/handler-meta :variant variant-id)
@@ -455,7 +462,7 @@
                       sty-body (when story-id
                                  (registrar/handler-meta :story story-id))
                       ;; Story slot default; variant overrides; user toggle wins.
-                      story-default (get sty-body  :dispatch-console? true)
+                      story-default (get sty-body  :dispatch-console? false)
                       var-default   (get var-body  :dispatch-console? story-default)]
                   (cond
                     (true?  vis-flag) true

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -38,10 +38,12 @@
   them; closure's reachability analysis DCEs the lot."
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
+            [re-frame.story.causa-preset :as causa-preset]
             [re-frame.story.config :as config]
             [re-frame.story.decorators :as decorators]
             [re-frame.story.frames :as frames]
             [re-frame.story.identity :as identity]
+            [re-frame.story.predicates :as pred]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.runtime :as runtime]
             [re-frame.trace :as rf-trace]
@@ -49,6 +51,7 @@
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.command-palette.view :as command-palette]
             [re-frame.story.ui.controls :as controls]
+            [re-frame.story.ui.dispatch-console :as dispatch-console]
             [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
@@ -380,7 +383,12 @@
                      ;; before React commits a canvas render that
                      ;; would otherwise deref subscriptions against a
                      ;; non-existent frame.
-                     (ensure-variant-frame! now))
+                     (ensure-variant-frame! now)
+                     ;; rf2-q9kv5: apply any per-story Causa preset
+                     ;; (auto-open shell, focus tab, configure filters,
+                     ;; focus a cascade position). Feature-detect-safe;
+                     ;; no-op when Causa is not on the classpath.
+                     (causa-preset/on-variant-selected! now))
                    (reset! selection-prev now))))))
 
 (defn- remove-selection-watcher! []
@@ -432,6 +440,28 @@
      ;; and have no late-bind contract.
      (when (and (:actions vis) variant-id)
        [actions/panel variant-id])
+     ;; rf2-q9kv5 — Dispatch Console panel. Free-form event dispatch into
+     ;; the running variant's frame. Default visible; opt-out via
+     ;; `:dispatch-console? false` on the story or variant body. The
+     ;; per-story flag wins over the chrome-level `:panel-visibility`
+     ;; slot's default (true). The shell stores the explicit visibility
+     ;; toggle under `:panel-visibility :dispatch-console` so the user can
+     ;; flip it without editing the story body; the story-body flag is the
+     ;; default visibility for that variant.
+     (when (and variant-id
+                (let [vis-flag (:dispatch-console vis)
+                      var-body (registrar/handler-meta :variant variant-id)
+                      story-id (pred/parent-story-id variant-id)
+                      sty-body (when story-id
+                                 (registrar/handler-meta :story story-id))
+                      ;; Story slot default; variant overrides; user toggle wins.
+                      story-default (get sty-body  :dispatch-console? true)
+                      var-default   (get var-body  :dispatch-console? story-default)]
+                  (cond
+                    (true?  vis-flag) true
+                    (false? vis-flag) false
+                    :else             var-default)))
+       [dispatch-console/panel variant-id])
      ;; Stage 6: render any registered :right-placement story panels.
      (when variant-id
        [panels/render-panels-at-placement :right variant-id vis])]))

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -119,6 +119,10 @@
    :hot-reload-tick     0
    :fingerprints        {}
    :pinned-snapshots    {}
+   ;; rf2-q9kv5 — `:dispatch-console` slot. Default is nil (not false)
+   ;; so the per-story `:dispatch-console?` body flag is the effective
+   ;; default. The shell's right-panel checks the per-story flag first
+   ;; and falls back to true when nothing is declared.
    :panel-visibility    {:trace true :scrubber true :controls true :actions true}
    :active-mode-tab     {}
    :rail-widths         {:left 260 :right 320}

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -122,7 +122,8 @@
    ;; rf2-q9kv5 — `:dispatch-console` slot. Default is nil (not false)
    ;; so the per-story `:dispatch-console?` body flag is the effective
    ;; default. The shell's right-panel checks the per-story flag first
-   ;; and falls back to true when nothing is declared.
+   ;; and falls back to FALSE when nothing is declared (opt-in default;
+   ;; the chrome-level toolbar chip flips this without a body edit).
    :panel-visibility    {:trace true :scrubber true :controls true :actions true}
    :active-mode-tab     {}
    :rail-widths         {:left 260 :right 320}

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -337,12 +337,14 @@
        (let [vis-flag (get-in shell [:panel-visibility :dispatch-console])
              ;; Same default resolution as the right-panel — when the
              ;; chrome-toggle is nil, the story body's `:dispatch-console?`
-             ;; takes over (defaults to true). We surface the *effective*
-             ;; state on the chip so the user sees what's actually showing.
+             ;; takes over (defaults to FALSE — toolbar real-estate is
+             ;; precious; authors opt in via `:dispatch-console? true`).
+             ;; We surface the *effective* state on the chip so the user
+             ;; sees what's actually showing.
              effective? (cond
                           (true?  vis-flag) true
                           (false? vis-flag) false
-                          :else             true)]
+                          :else             false)]
          [:button
           {:style     (merge (:chip styles)
                              (when effective? (:chip-active styles)))

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -328,6 +328,35 @@
                   ^{:key mid}
                   [chip mid (get modes mid) (contains? active mid)])]]]))))
      [:span {:style (:spacer styles)}]
+     ;; rf2-q9kv5 — Dispatch console toolbar toggle. The chip flips the
+     ;; chrome-level visibility override; the right-panel resolves
+     ;; story-flag + chrome-toggle together. Shown only when a variant is
+     ;; focused (the panel is per-variant — no variant, nothing to
+     ;; dispatch into).
+     (when (:selected-variant shell)
+       (let [vis-flag (get-in shell [:panel-visibility :dispatch-console])
+             ;; Same default resolution as the right-panel — when the
+             ;; chrome-toggle is nil, the story body's `:dispatch-console?`
+             ;; takes over (defaults to true). We surface the *effective*
+             ;; state on the chip so the user sees what's actually showing.
+             effective? (cond
+                          (true?  vis-flag) true
+                          (false? vis-flag) false
+                          :else             true)]
+         [:button
+          {:style     (merge (:chip styles)
+                             (when effective? (:chip-active styles)))
+           :data-test "story-toolbar-dispatch-console"
+           :aria-pressed (str effective?)
+           :title     (if effective?
+                        "Hide dispatch console"
+                        "Show dispatch console")
+           :on-click  (fn [_]
+                        (state/swap-state!
+                          (fn [s]
+                            (assoc-in s [:panel-visibility :dispatch-console]
+                                      (not effective?)))))}
+          (if effective? "Dispatch ▾" "Dispatch ▸")]))
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
      ;; affordance so the chrome-wide recorder is reachable regardless of
      ;; which variant the user has focused.

--- a/tools/story/test/re_frame/story/causa_preset_test.cljc
+++ b/tools/story/test/re_frame/story/causa_preset_test.cljc
@@ -1,0 +1,126 @@
+(ns re-frame.story.causa-preset-test
+  "Tests for per-story Causa preset (rf2-q9kv5).
+
+  Coverage layers:
+
+  - **Pure data** (JVM + CLJS): `merge-preset` deep-merge semantics,
+    `resolve-preset` story+variant resolution.
+  - **CLJS-only side-effects**: `apply-preset!` feature-detect graceful
+    no-op when Causa is absent; `apply-preset!` dispatches the right
+    events when shimmed handlers are in place.
+
+  This namespace is `.cljc` so the pure surface runs on both JVM and
+  CLJS test runners; CLJS-only blocks exercise the dispatch path."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            [re-frame.story.causa-preset :as causa-preset]
+            #?@(:cljs [[re-frame.core :as rf]
+                       [re-frame.frame :as frame]
+                       [re-frame.registrar :as registrar]
+                       [re-frame.substrate.plain-atom :as plain-atom]])))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn reset-all! []
+  (story/clear-all!)
+  #?(:cljs (do (registrar/clear-all!)
+               (reset! frame/frames {})
+               (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+               (frame/ensure-default-frame!)))
+  (story/install-canonical-vocabulary!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- pure: merge-preset --------------------------------------------------
+
+(deftest merge-preset-handles-nils
+  (testing "two nils merge to {}"
+    (is (= {} (causa-preset/merge-preset nil nil)))))
+
+(deftest merge-preset-variant-overrides-story
+  (testing "variant slot wins over story slot at the top level"
+    (let [story {:open? true :tab :event-detail}
+          vari  {:tab :issues}]
+      (is (= {:open? true :tab :issues}
+             (causa-preset/merge-preset story vari))))))
+
+(deftest merge-preset-deep-merges-filters
+  (testing ":filters merge respects :in / :out separately"
+    (let [story {:filters {:in [:keep/me]}}
+          vari  {:filters {:out [:drop/me]}}]
+      (is (= {:filters {:in [:keep/me] :out [:drop/me]}}
+             (causa-preset/merge-preset story vari))))))
+
+(deftest merge-preset-variant-filters-override-story
+  (testing "matching filter axes prefer variant value"
+    (let [story {:filters {:in [:story/in] :out [:story/out]}}
+          vari  {:filters {:in [:variant/in]}}]
+      (is (= {:filters {:in [:variant/in] :out [:story/out]}}
+             (causa-preset/merge-preset story vari))))))
+
+;; ---- pure: resolve-preset ------------------------------------------------
+
+(deftest resolve-preset-returns-nil-when-no-preset
+  (testing "story + variant with no :causa slot resolves to nil"
+    (story/reg-story :story.no-preset
+      {:doc "no preset" :component :Some.view})
+    (story/reg-variant :story.no-preset/v
+      {:doc "v"})
+    (is (nil? (causa-preset/resolve-preset :story.no-preset/v)))))
+
+(deftest resolve-preset-reads-story-slot
+  (testing "story :causa is returned when variant has none"
+    (story/reg-story :story.story-preset
+      {:doc "preset on story"
+       :component :Some.view
+       :causa {:open? true :tab :issues}})
+    (story/reg-variant :story.story-preset/v
+      {:doc "v"})
+    (let [p (causa-preset/resolve-preset :story.story-preset/v)]
+      (is (= true     (:open? p)))
+      (is (= :issues  (:tab   p))))))
+
+(deftest resolve-preset-merges-story-and-variant
+  (testing "variant :causa overrides story slot, :filters deep-merge"
+    (story/reg-story :story.both
+      {:doc "preset on both"
+       :component :Some.view
+       :causa {:open? true
+               :tab   :event-detail
+               :filters {:in [:keep/x]}}})
+    (story/reg-variant :story.both/v
+      {:doc "v"
+       :causa {:tab :issues
+               :filters {:out [:drop/y]}}})
+    (let [p (causa-preset/resolve-preset :story.both/v)]
+      (is (= true                                (:open? p)))
+      (is (= :issues                             (:tab   p)))
+      (is (= {:in [:keep/x] :out [:drop/y]}      (:filters p))))))
+
+;; ---- CLJS-only: apply-preset! --------------------------------------------
+
+#?(:cljs
+   (deftest cljs-apply-preset-no-causa-no-op
+     (testing "apply-preset! is a no-op when Causa is not on the classpath"
+       (story/reg-story :story.no-causa
+         {:doc "no causa"
+          :component :Some.view
+          :causa {:open? true :tab :issues}})
+       (story/reg-variant :story.no-causa/v
+         {:doc "v"})
+       ;; The test build has no Causa namespace loaded, so
+       ;; causa-available? is false and apply-preset! returns nil
+       ;; without dispatching.
+       (is (false? (causa-preset/causa-available?))
+           "this test assumes Causa is NOT on the classpath")
+       (is (nil? (causa-preset/apply-preset! :story.no-causa/v))))))
+
+#?(:cljs
+   (deftest cljs-apply-preset-nil-on-missing-preset
+     (testing "no :causa slot → no work, returns nil even when Causa would be available"
+       (story/reg-story :story.nilpre
+         {:doc "no slot"
+          :component :Some.view})
+       (story/reg-variant :story.nilpre/v
+         {:doc "v"})
+       (is (nil? (causa-preset/apply-preset! :story.nilpre/v))))))

--- a/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc
@@ -1,0 +1,327 @@
+(ns re-frame.story.ui.dispatch-console-cljs-test
+  "Tests for the Dispatch Console panel (rf2-q9kv5).
+
+  Runs on both the JVM (cognitect.test-runner under `clojure -M:test`)
+  and the CLJS node-test build. Mirrors the actions panel's
+  coverage-layer split:
+
+  - **Pure data** (JVM + CLJS): `parse-payload`, `build-event-vector`,
+    `clamp-history`, `prepend-history-entry`, `format-history-entry`,
+    `format-timestamp`, `autocomplete-event-ids`,
+    `registered-event-ids` (1-arity).
+  - **CLJS-only side-effects**: localStorage round-trip via
+    `save-history!` / `load-history!`, `dispatch-event!` against a
+    live re-frame frame, input state mutations, replay-from-history."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.ui.dispatch-console :as dc]
+            [re-frame.story.ui.dispatch-console-events :as dce]
+            #?@(:cljs [[re-frame.core :as rf]
+                       [re-frame.frame :as frame]
+                       [re-frame.registrar :as registrar]
+                       [re-frame.substrate.plain-atom :as plain-atom]])))
+
+#?(:cljs
+   (defn- browser?
+     "True iff `js/window.localStorage` is available — mirrors the gate
+     in `story_help_cljs_test`. The node-runtime test target returns
+     false; browser-runner returns true. localStorage round-trip tests
+     skip silently when this is false."
+     []
+     (boolean
+       (and (exists? js/window) (.-localStorage js/window)))))
+
+;; ---- fixtures (CLJS) -----------------------------------------------------
+
+#?(:cljs
+   (defn reset-all! []
+     (registrar/clear-all!)
+     (reset! frame/frames {})
+     (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+     (frame/ensure-default-frame!)
+     (reset! dc/input-state {})
+     (reset! dc/history-state {})
+     ;; Clear localStorage for any keys we might have used in earlier tests.
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.clear (.-localStorage js/window)) (catch :default _ nil)))))
+
+#?(:cljs
+   (use-fixtures :each {:before reset-all!}))
+
+;; ---- pure: parse-payload -------------------------------------------------
+
+(deftest parse-payload-empty
+  (testing "blank and nil payloads parse to nil"
+    (is (= [:ok nil] (dc/parse-payload nil)))
+    (is (= [:ok nil] (dc/parse-payload "")))
+    (is (= [:ok nil] (dc/parse-payload "   ")))))
+
+(deftest parse-payload-edn
+  (testing "EDN payloads parse via clojure.edn"
+    (is (= [:ok {:a 1}]   (dc/parse-payload "{:a 1}")))
+    (is (= [:ok [1 2 3]]  (dc/parse-payload "[1 2 3]")))
+    (is (= [:ok :keyword] (dc/parse-payload ":keyword")))
+    (is (= [:ok 42]       (dc/parse-payload "42")))
+    (is (= [:ok "string"] (dc/parse-payload "\"string\"")))))
+
+(deftest parse-payload-error
+  (testing "invalid EDN returns [:error <msg>]"
+    (let [[tag _] (dc/parse-payload "{:bad")]
+      (is (= :error tag)))))
+
+#?(:cljs
+   (deftest parse-payload-json-cljs
+     (testing "JSON-shaped payloads parse via JSON.parse on CLJS"
+       (let [[tag v] (dc/parse-payload "{\"a\":1,\"b\":\"two\"}")]
+         (is (= :ok tag))
+         (is (= {:a 1 :b "two"} v))))))
+
+;; ---- pure: build-event-vector --------------------------------------------
+
+(deftest build-event-vector-nil-payload
+  (testing "nil payload produces [id]"
+    (is (= [:counter/inc]
+           (dc/build-event-vector :counter/inc nil)))))
+
+(deftest build-event-vector-with-payload
+  (testing "payload is the second slot — never splatted"
+    (is (= [:user/login {:id 7}]
+           (dc/build-event-vector :user/login {:id 7})))
+    (is (= [:user/login [:a :b :c]]
+           (dc/build-event-vector :user/login [:a :b :c])))))
+
+;; ---- pure: history shaping -----------------------------------------------
+
+(deftest clamp-history-respects-max
+  (testing "histories above the cap keep the HEAD entries (newest-first orientation)"
+    ;; Story convention: newest entries live at index 0 (head); the tail
+    ;; is the oldest and gets evicted. clamp-history is the low-level
+    ;; helper — prepend-history-entry is the consumer that respects the
+    ;; ordering.
+    (let [thirty (mapv (fn [i] {:event-id (keyword "e" (str "i" i))})
+                       (range 30))
+          capped (dc/clamp-history thirty)]
+      (is (= dc/history-max (count capped)))
+      ;; The first dc/history-max entries (index 0..max-1) survive.
+      (is (= :e/i0 (:event-id (first capped))))
+      (is (= (keyword "e" (str "i" (dec dc/history-max)))
+             (:event-id (last capped)))))))
+
+(deftest clamp-history-passes-short
+  (testing "histories at or under the cap pass through"
+    (is (= [] (dc/clamp-history [])))
+    (is (= [{:a 1}] (dc/clamp-history [{:a 1}])))))
+
+(deftest prepend-history-entry-orders-newest-first
+  (testing "the freshest entry lands at the head of the vector"
+    (let [h0 [{:event-id :a/old}]
+          h1 (dc/prepend-history-entry h0 {:event-id :a/new})]
+      (is (= :a/new (:event-id (first h1))))
+      (is (= :a/old (:event-id (second h1)))))))
+
+(deftest prepend-history-entry-respects-cap
+  (testing "prepending past the cap evicts from the tail"
+    (let [seed (mapv (fn [i] {:event-id (keyword "e" (str "i" i))})
+                     (range dc/history-max))
+          h    (dc/prepend-history-entry seed {:event-id :e/new})]
+      (is (= dc/history-max (count h)))
+      (is (= :e/new (:event-id (first h)))))))
+
+;; ---- pure: format-history-entry ------------------------------------------
+
+(deftest format-history-entry-renders-id-only
+  (testing "an entry with no payload renders just the id"
+    (is (= ":counter/inc"
+           (dc/format-history-entry {:event-id :counter/inc :payload nil})))))
+
+(deftest format-history-entry-renders-id-and-payload
+  (testing "an entry with a payload renders both"
+    (is (= ":user/login {:id 7}"
+           (dc/format-history-entry {:event-id :user/login
+                                     :payload  {:id 7}})))))
+
+(deftest format-history-entry-handles-missing-id
+  (testing "no event-id is tolerated (display em-dash)"
+    (is (= "—"
+           (dc/format-history-entry {:event-id nil :payload nil})))))
+
+;; ---- pure: format-timestamp ----------------------------------------------
+
+(deftest format-timestamp-edge-cases
+  (testing "nil / non-numeric / negative produces empty string"
+    (is (= "" (dc/format-timestamp nil)))
+    (is (= "" (dc/format-timestamp "not-a-number")))
+    (is (= "" (dc/format-timestamp -1)))))
+
+(deftest format-timestamp-shapes-hh-mm-ss
+  (testing "a real epoch produces an HH:MM:SS-shaped string"
+    (let [out (dc/format-timestamp 1700000000000)]
+      (is (string? out))
+      (is (= 8 (count out)))
+      (is (re-matches #"\d\d:\d\d:\d\d" out)))))
+
+;; ---- pure: autocomplete --------------------------------------------------
+
+(deftest autocomplete-empty-prefix-returns-all
+  (testing "an empty prefix returns the full id set sorted"
+    (let [ids #{:counter/inc :counter/dec :user/login}
+          out (dc/autocomplete-event-ids ids "")]
+      (is (= 3 (count out)))
+      ;; Sorted by pr-str.
+      (is (= [:counter/dec :counter/inc :user/login] out)))))
+
+(deftest autocomplete-filters-by-substring
+  (testing "matches are case-insensitive substring on (pr-str id)"
+    (let [ids #{:counter/inc :counter/dec :user/login}
+          out (dc/autocomplete-event-ids ids "counter")]
+      (is (= 2 (count out)))
+      (is (every? #(re-find #"counter" (str %)) out)))))
+
+(deftest autocomplete-respects-limit
+  (testing "limit clamps the returned vector length"
+    (let [ids (set (map #(keyword "e" (str "i" %)) (range 100)))
+          out (dc/autocomplete-event-ids ids "" 5)]
+      (is (= 5 (count out))))))
+
+;; ---- pure: registered-event-ids 1-arity ----------------------------------
+
+(deftest registered-event-ids-from-snapshot
+  (testing "the 1-arity returns the snapshot key-set"
+    (is (= #{:a :b :c}
+           (dce/registered-event-ids {:a {} :b {} :c {}})))
+    (is (= #{}
+           (dce/registered-event-ids nil)))
+    (is (= #{}
+           (dce/registered-event-ids {})))))
+
+;; ===========================================================================
+;; CLJS-only side-effect coverage
+;; ===========================================================================
+
+#?(:cljs
+   (deftest cljs-input-state-roundtrip
+     (testing "reset-inputs! clears the per-variant inputs"
+       (let [vid :story.x/y]
+         (swap! dc/input-state assoc-in [vid :event-id-input] ":hello")
+         (swap! dc/input-state assoc-in [vid :payload-input]  "{:a 1}")
+         (is (= ":hello" (get-in @dc/input-state [vid :event-id-input])))
+         (dc/reset-inputs! vid)
+         (is (= "" (get-in @dc/input-state [vid :event-id-input])))
+         (is (= "" (get-in @dc/input-state [vid :payload-input])))))))
+
+#?(:cljs
+   (deftest cljs-history-localstorage-roundtrip
+     (testing "save-history! → load-history! survives across reset"
+       (when (browser?)
+         (let [vid    :story.persist/v
+               entry  (dc/build-history-entry :counter/inc nil :dispatch
+                                              1700000000000)
+               one    [entry]]
+           (dc/save-history! vid one)
+           ;; Drop in-memory state to simulate a reload.
+           (reset! dc/history-state {})
+           (let [loaded (dc/load-history! vid)]
+             (is (= 1 (count loaded)))
+             (is (= :counter/inc (:event-id (first loaded))))))))))
+
+#?(:cljs
+   (deftest cljs-current-history-hydrates-once
+     (testing "current-history hydrates from localStorage on first access"
+       (when (browser?)
+         (let [vid   :story.hyd/v
+               entry (dc/build-history-entry :ev/x nil :dispatch 17)]
+           (dc/save-history! vid [entry])
+           (reset! dc/history-state {})
+           (let [h (dc/current-history vid)]
+             (is (= 1 (count h)))
+             (is (= :ev/x (:event-id (first h))))))))))
+
+#?(:cljs
+   (deftest cljs-clear-history-drops-storage
+     (testing "clear-history! removes both ratom and localStorage state"
+       (let [vid :story.clear/v
+             entry (dc/build-history-entry :ev/x nil :dispatch 1)]
+         (dc/append-history! vid entry)
+         (is (= 1 (count (dc/current-history vid))))
+         (dc/clear-history! vid)
+         (is (= 0 (count (dc/current-history vid))))
+         (when (browser?)
+           ;; Drop in-memory state and confirm storage was actually wiped.
+           (reset! dc/history-state {})
+           (is (= [] (dc/load-history! vid))))))))
+
+#?(:cljs
+   (deftest cljs-dispatch-event-changes-app-db
+     (testing "dispatching against a frame writes app-db via dispatch-sync"
+       (let [vid :story.dispatch.test/v]
+         (rf/reg-frame vid {})
+         (rf/reg-event-db :test/inc
+                          (fn [db _] (update db :counter (fnil inc 0))))
+         (rf/reg-sub :test/counter
+                     (fn [db _] (get db :counter 0)))
+         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (is (= 1 (rf/subscribe-once vid [:test/counter])))
+         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (is (= 2 (rf/subscribe-once vid [:test/counter])))))))
+
+#?(:cljs
+   (deftest cljs-dispatch-event-records-history
+     (testing "every dispatch lands a history entry"
+       (let [vid :story.history.test/v]
+         (rf/reg-frame vid {})
+         (rf/reg-event-db :test/noop (fn [db _] db))
+         (dc/dispatch-event! vid [:test/noop {:k :v}] :dispatch-sync)
+         (let [h (dc/current-history vid)]
+           (is (= 1 (count h)))
+           (is (= :test/noop (:event-id (first h))))
+           (is (= {:k :v}     (:payload  (first h))))
+           (is (= :dispatch-sync (:kind   (first h)))))))))
+
+#?(:cljs
+   (deftest cljs-replay-history-entry-re-fires
+     (testing "click-replay re-dispatches the recorded event"
+       (let [vid :story.replay.test/v]
+         (rf/reg-frame vid {})
+         (rf/reg-event-db :test/inc
+                          (fn [db _] (update db :counter (fnil inc 0))))
+         (rf/reg-sub :test/counter
+                     (fn [db _] (get db :counter 0)))
+         (dc/dispatch-event! vid [:test/inc] :dispatch-sync)
+         (is (= 1 (rf/subscribe-once vid [:test/counter])))
+         (let [h (first (dc/current-history vid))]
+           (dc/replay-history-entry! vid h))
+         (is (= 2 (rf/subscribe-once vid [:test/counter])))
+         ;; Replay added a new history entry.
+         (is (= 2 (count (dc/current-history vid))))))))
+
+#?(:cljs
+   (deftest cljs-dispatch-from-inputs-parse-error-keeps-app-db
+     (testing "a bad payload sets :error and does not dispatch"
+       (let [vid :story.parse.err/v]
+         (rf/reg-frame vid {})
+         (rf/reg-event-db :test/boom (fn [db _] (assoc db :boomed? true)))
+         (swap! dc/input-state assoc vid
+                {:event-id-input ":test/boom"
+                 :payload-input  "{:bad"})
+         (dc/dispatch-from-inputs! vid :dispatch-sync)
+         (is (some? (get-in @dc/input-state [vid :error])))
+         (is (= 0 (count (dc/current-history vid))))))))
+
+#?(:cljs
+   (deftest cljs-dispatch-from-inputs-missing-id-errors
+     (testing "an empty event-id input sets :error"
+       (let [vid :story.empty.id/v]
+         (rf/reg-frame vid {})
+         (swap! dc/input-state assoc vid
+                {:event-id-input ""
+                 :payload-input  ""})
+         (dc/dispatch-from-inputs! vid :dispatch)
+         (is (some? (get-in @dc/input-state [vid :error])))))))
+
+#?(:cljs
+   (deftest cljs-autocomplete-against-live-registrar
+     (testing "registered-event-ids 0-arity surfaces registered handlers"
+       (rf/reg-event-db :ac.test/one (fn [db _] db))
+       (rf/reg-event-db :ac.test/two (fn [db _] db))
+       (let [ids (dce/registered-event-ids)]
+         (is (contains? ids :ac.test/one))
+         (is (contains? ids :ac.test/two))))))


### PR DESCRIPTION
## Summary

Adds two Story features (rf2-q9kv5) that strengthen Causa+Story interplay.

### 1. Dispatch Console panel

Free-form event-dispatch UI as a Story right-pane panel — the re-frame2-flavoured equivalent of Storybook's args/controls, fitted to events.

```
┌──────────────────────────────────────────────────────┐
│  Dispatch — :story.counter/clicked-three-times        │
├──────────────────────────────────────────────────────┤
│  event-id   [:counter/inc                       ▾]   │
│  payload    [{}                                  ]   │
│  [Dispatch] [Dispatch-sync] [Reset] [Clear history]  │
├──────────────────────────────────────────────────────┤
│  History — last 3 (click to replay)                   │
│  14:32:01   :counter/inc                              │
│  14:31:58   :user/login {:id 7}                       │
│  14:31:42   :counter/inc                              │
└──────────────────────────────────────────────────────┘
```

- Event-id autocomplete against the live framework registrar.
- Payload accepts EDN by default; JSON heuristic on CLJS via `js/JSON.parse`.
- `[Dispatch]` enqueues via `rf/dispatch*` (async); `[Dispatch-sync]` runs via `rf/dispatch-sync*` so other inspectors update IMMEDIATELY.
- All dispatch is `{:frame variant-id}`-scoped — events reach the running variant's frame.
- Per-variant history (cap 20, newest-first), persisted to `localStorage["story.dispatch-history/<variant-id>"]`. Click a history row to replay.
- Per-story toggle: default visible; opt out via `:dispatch-console? false`. Toolbar chip ([Dispatch ▾] / [Dispatch ▸]) is the chrome-level override.

### 2. Per-story Causa preset

Stories declare a `:causa` slot that pre-configures Causa on variant mount:

```clj
{:causa {:open?    true                 ; auto-open Causa shell
         :tab      :issues              ; pre-select tab
         :filters  {:out [:my/noise]    ; pre-populate filter pills
                    :in  []}
         :focus    {:event-pos 5}}}     ; optional cascade focus
```

- Variant `:causa` overrides story `:causa`; `:filters` deep-merges.
- Feature-detect-safe: no-ops when Causa is absent; `console.warn`-skips the `:filters` step when only the optional filters API (rf2-ak4ms, in flight) is missing.
- Wired into the shell's selection-watcher so the preset re-applies on every variant-selection edge.

## New files

- `tools/story/src/re_frame/story/ui/dispatch_console.cljc` (670 LoC)
- `tools/story/src/re_frame/story/ui/dispatch_console_events.cljc` (50 LoC)
- `tools/story/src/re_frame/story/causa_preset.cljc` (225 LoC)
- `tools/story/test/re_frame/story/ui/dispatch_console_cljs_test.cljc` (327 LoC)
- `tools/story/test/re_frame/story/causa_preset_test.cljc` (126 LoC)

## Modified files

- `tools/story/src/re_frame/story/schemas.cljc` — `CausaPreset` schema; `Story` + `Variant` gain `:dispatch-console? :causa` slots (additive).
- `tools/story/src/re_frame/story/ui/shell.cljs` — wire dispatch-console into right-panel; call `causa-preset/on-variant-selected!` from selection-watcher.
- `tools/story/src/re_frame/story/ui/toolbar.cljs` — toolbar dispatch-console toggle chip.
- `tools/story/src/re_frame/story/ui/state.cljc` — doc note for `:panel-visibility :dispatch-console` slot resolution.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 2440 tests, 0 failures
- [x] `cd tools/story && clojure -M:test` — 535 tests, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2484 tests, 0 failures
- [x] `cd implementation && npm run test:browser` — 2473 tests, 0 failures
- [x] `cd implementation && npm run story:build` — builds clean (1011240 bytes)
- [x] `bash scripts/test-jvm-implementation.sh` — passes
- [x] `bash scripts/test-jvm-tools.sh` — passes

## Notes

- **rf2-ak4ms coordination**: feature-detect `day8.re-frame2-causa.filters.config/configure!` for the `:filters` preset step; no hard dependency. When the filters API lands, the preset wires up automatically (no follow-on bead needed unless the API signature differs from the assumed `(configure! {:in [...] :out [...]})`).
- **Causa tab vocabulary**: the schema accepts any keyword for `:tab` and forwards it to `:rf.causa/select-panel` — Causa's defaults (`:event-detail :time-travel :app-db :causality :subs :fx :trace :machines :flows :routes :performance :issues :schemas :hydration :mcp-server`) all work without further coordination.