### PR TITLE
feat(causa): auto-filter IN/OUT pills + edit popup

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -3,9 +3,9 @@
 
   Phase 1 held a single config concern: the 'Open in editor'
   preference (rf2-evgf5). Causa now also exposes the default inline
-  layout-host selector and default auto-open switch used by the dev
-  preload (rf2-eehov). Future phases extend this with theme defaults,
-  buffer depth, etc.
+  layout-host selector, default auto-open switch (rf2-eehov), and the
+  ribbon filter pill seed + persistence key (rf2-ak4ms). Future phases
+  extend this with theme defaults, buffer depth, etc.
 
   ## Why a separate config ns
 
@@ -522,6 +522,78 @@
           (rf/dispatch [:rf.causa/reset-suppressed-counters frame-id]))))
    nil))
 
+;; ---- *filter-pills* (rf2-ak4ms — ribbon filter seeds + storage key) -----
+;;
+;; Per `tools/causa/spec/018-Event-Spine.md` §7 ribbon pills persist
+;; via localStorage per host-app under a Causa-namespaced key. Two
+;; configure! axes:
+;;
+;;   - `:filters/seed` — initial pill set hosts can ship as a default
+;;     (Story testbeds use this to inject a known starting point for
+;;     reproducibility). Default `nil` — no seed; the user surfaces
+;;     filters themselves per spec/018 §7 'Empty defaults'.
+;;
+;;   - `:filters/storage-key` — localStorage key the persistence layer
+;;     reads / writes. Default `"re-frame2.causa.filters.v1"`. Hosts
+;;     that run multiple Causa instances (Story testbeds) override so
+;;     each instance keeps its own pill state.
+;;
+;; The atoms here are the data primitives; the CLJS-only
+;; `filters.persistence` ns thunks them through localStorage. CLJC so
+;; the JVM test corpus can exercise the configure! round-trip without
+;; a CLJS runtime.
+
+(def default-filters
+  "Default ribbon filter set Causa ships with — empty, per spec/018 §7
+  'Empty defaults' / rf2-ak4ms: first-session honesty beats first-
+  session quietness. Shipping a default `:mouse-move` filter would
+  silently hide events the user didn't know they were emitting."
+  {:in [] :out []})
+
+(defonce
+  ^{:doc "Atom holding the host-supplied seed filter set Causa
+         hydrates the slot with on FIRST install (when localStorage
+         is empty). Default `nil` — no seed; the registry's default
+         empty shape wins."}
+  filter-seed
+  (atom nil))
+
+(defn set-filter-seed!
+  "Set the seed filter set the registry hydrates `:active-filters`
+  with on first install when localStorage is empty. `nil` clears the
+  seed. Shape: `{:in [{:pattern <kw-or-str>}] :out [{:pattern <…>}]}`."
+  [seed]
+  (reset! filter-seed seed)
+  nil)
+
+(defn get-filter-seed
+  "Return the current host-supplied filter seed, or nil when unset."
+  []
+  @filter-seed)
+
+(defonce
+  ^{:doc "Atom holding the localStorage key the filter-persistence
+         layer reads / writes. Default
+         `\"re-frame2.causa.filters.v1\"`. Hosts mount multiple
+         Causa instances (Story testbeds) override for isolation."}
+  filters-storage-key
+  (atom "re-frame2.causa.filters.v1"))
+
+(defn set-filters-storage-key!
+  "Replace the localStorage key Causa uses for filter persistence.
+  `nil` resets to the default. The CLJS-side `filters.persistence`
+  ns reads this atom directly at every load / save so the round-trip
+  always honours the current setting — no separate sync call."
+  [k]
+  (reset! filters-storage-key
+          (or k "re-frame2.causa.filters.v1"))
+  nil)
+
+(defn get-filters-storage-key
+  "Return the current localStorage key for filter persistence."
+  []
+  @filters-storage-key)
+
 ;; ---- configure! convenience ---------------------------------------------
 
 (defn configure!
@@ -547,6 +619,16 @@
        and the shell's bottom rail surfaces a `[● REDACTED N]` hint.
        Set to `true` while debugging redaction policy to see the raw
        cascade.
+    `{:filters <{:in [...] :out [...]}>}` — host-supplied seed pill
+       set the registry hydrates `:active-filters` with on FIRST
+       install (when localStorage is empty). Default `nil` per
+       spec/018 §7 'Empty defaults' — first-session honesty beats
+       first-session quietness (rf2-ak4ms). Story testbeds use this
+       to inject a known starting point for reproducibility.
+    `{:filters/storage-key <string>}` — localStorage key the filter
+       persistence layer reads / writes. Default
+       `\"re-frame2.causa.filters.v1\"`. Hosts that run multiple
+       Causa instances (Story testbeds) override for isolation.
 
   Future phases extend this with theme / buffer / placement keys.
 
@@ -556,13 +638,16 @@
       (causa-config/configure! {:editor       :cursor
                                 :project-root \"C:/Users/me/code/my-app\"
                                 :layout/host-selector \"#causa\"
-                                :launch/auto-open? true})
+                                :launch/auto-open? true
+                                :filters {:out [{:pattern \":mouse-move\"}]}})
 
   Returns nothing."
   [{:keys [editor project-root]
     host-selector-opt :layout/host-selector
     auto-open-opt :launch/auto-open?
     show-sensitive-opt :trace/show-sensitive?
+    filters-opt :filters
+    filters-key-opt :filters/storage-key
     :as opts}]
   (when (some? editor)
     (set-editor! editor))
@@ -574,6 +659,13 @@
     (set-auto-open! auto-open-opt))
   (when (contains? opts :trace/show-sensitive?)
     (set-show-sensitive! show-sensitive-opt))
+  ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
+  ;; seed so a host that overrides both in one call gets the seed
+  ;; persisted under the right key.
+  (when (contains? opts :filters/storage-key)
+    (set-filters-storage-key! filters-key-opt))
+  (when (contains? opts :filters)
+    (set-filter-seed! filters-opt))
   nil)
 
 ;; ---- pass-through: editor-uri --------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -1,0 +1,304 @@
+(ns day8.re-frame2-causa.filters
+  "Facade for Causa's IN/OUT auto-filter subsystem (rf2-ak4ms).
+
+  Per the canonical Causa panel-facade pattern (mirrored from
+  `palette.cljs`): the facade owns the `reg-view` Modal wrapper for
+  the edit popup + an `install!` fn that wires every filter-side
+  registration through the Causa registry.
+
+  ## What lives here
+
+  - `Modal` — `reg-view` mounting the edit popup. Mounted at the
+    shell-view root so the popup overlays the chrome and panels;
+    short-circuits to nil when `:rf.causa/edit-popup-open?` is false.
+    Mounting at the shell root also keeps the popup's subscribes
+    inside the `:rf/causa` frame-provider's React context.
+  - `install!` — orchestrator that installs the subs / events / fxs
+    + the persistence fx + the load-time hydration.
+
+  ## What does NOT live here
+
+  - The ribbon pill cluster is in `filters/pills.cljs`; the shell's
+    `ribbon-filter-pills` reg-view in `shell.cljs` delegates to it
+    so the cluster carries the ribbon's frame-context.
+  - Pattern matching is in `filters/matcher.cljc` (JVM-portable).
+  - localStorage round-trip is in `filters/persistence.cljs`."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.filters.edit-popup :as edit-popup]
+            [day8.re-frame2-causa.filters.matcher :as matcher]
+            [day8.re-frame2-causa.filters.persistence :as persistence]))
+
+;; ---- Modal --------------------------------------------------------------
+
+(rf/reg-view Modal
+  "The edit popup. Renders only when `:rf.causa/edit-popup-open?` is
+  true; closed-state is a single subscribe + a `when`. Per rf2-in6l2
+  `reg-view`-registered so the body's subscribes route through the
+  React-context tier to `:rf/causa`."
+  []
+  (when @(rf/subscribe [:rf.causa/edit-popup-open?])
+    (edit-popup/popup-view)))
+
+;; ---- hydration ---------------------------------------------------------
+
+(defn hydrate!
+  "Drive the localStorage / seed / empty hydration order per spec/018
+  §7 + rf2-ak4ms:
+
+    1. localStorage value (the user's last-session pill set);
+    2. host-supplied seed via `(causa-config/configure! {:filters …})`
+       — used only when localStorage is empty so a seed never clobbers
+       a user's hand-tuned set;
+    3. registry default empty shape `{:in [] :out []}` per
+       'Empty defaults' (first-session honesty).
+
+  Re-entrant. Safe to call from `install!` (preload-time, before the
+  frame is registered) AND from `mount.cljs/ensure-causa-frame!`
+  (first open, frame registered). Both invocations converge on the
+  same slot because:
+
+  - the load + seed reads are pure;
+  - the hydrate dispatch is a wholesale `(assoc db :active-filters …)`
+    so re-running with the same source produces the same slot;
+  - the frame guard short-circuits the pre-mount call without losing
+    state — the seed lives in the config atom, the localStorage value
+    lives in localStorage; both are still readable at second call.
+
+  Returns nil. No-op when no source has any pills."
+  []
+  (let [loaded (persistence/load)
+        seed   (config/get-filter-seed)
+        chosen (cond
+                 (or (seq (:in loaded)) (seq (:out loaded))) loaded
+                 (and seed (or (seq (:in seed)) (seq (:out seed)))) seed
+                 :else nil)]
+    (when (and chosen
+               ;; require the :rf/causa frame to exist; if not, the
+               ;; first `ensure-causa-frame!` call will re-invoke
+               ;; this fn.
+               (some? (frame/frame :rf/causa)))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/hydrate-filters chosen]))
+      nil)))
+
+;; ---- install -----------------------------------------------------------
+
+(defn- close-popup
+  "Pure reducer — reset the popup slots."
+  [db]
+  (-> db
+      (assoc :edit-popup-open? false)
+      (assoc :edit-popup-trigger nil)
+      (assoc :edit-popup-draft nil)))
+
+(defn install!
+  "Idempotent install for the filter subsystem's Causa-side surface.
+  Wires:
+
+    - Subs:   `:rf.causa/active-filters` (already in registry; we read
+              + extend it here too), `:rf.causa/filtered-cascades`,
+              `:rf.causa/edit-popup-open?`, `:rf.causa/edit-popup-
+              trigger`, `:rf.causa/edit-popup-draft`.
+
+    - Events: `:rf.causa/open-edit-popup`, `:rf.causa/close-edit-popup`,
+              `:rf.causa/edit-popup-set-mode`,
+              `:rf.causa/edit-popup-set-pattern`,
+              `:rf.causa/edit-popup-toggle-scope`,
+              `:rf.causa/save-edit-popup`,
+              `:rf.causa/delete-edit-popup`,
+              `:rf.causa/hide-event-type`,
+              `:rf.causa/hydrate-filters`.
+
+    - Effects: `:rf.causa.filters/persist` — localStorage write fx.
+
+    - Side-effect: hydrate `:active-filters` from localStorage at
+      first install via a no-history dispatch.
+
+  Called from `registry/register-causa-handlers!` after the legacy
+  `:rf.causa/active-filters` slot is registered (so the sub-graph
+  resolves in declaration order)."
+  []
+  ;; ---- fx ---------------------------------------------------------------
+  (persistence/install-fx!)
+
+  ;; ---- subs -------------------------------------------------------------
+  ;;
+  ;; Spec/018 §6 sub-graph: the matter-of-fact path is `:rf.causa/
+  ;; cascades → :rf.causa/filtered-cascades`. Every consumer of the
+  ;; cascade list (event-list, scrubber, palette, Issues counter)
+  ;; reads `:rf.causa/filtered-cascades`; raw `:rf.causa/cascades`
+  ;; stays available for unfiltered totals.
+  (rf/reg-sub :rf.causa/filtered-cascades
+    :<- [:rf.causa/cascades]
+    :<- [:rf.causa/active-filters]
+    (fn [[cascades filters] _query]
+      (matcher/filter-cascades cascades filters)))
+
+  ;; Popup state — three slots so the open / trigger / draft tiers
+  ;; are individually subscribable.
+  (rf/reg-sub :rf.causa/edit-popup-open?
+    (fn [db _query]
+      (boolean (get db :edit-popup-open?))))
+
+  (rf/reg-sub :rf.causa/edit-popup-trigger
+    (fn [db _query]
+      (get db :edit-popup-trigger)))
+
+  (rf/reg-sub :rf.causa/edit-popup-draft
+    (fn [db _query]
+      (get db :edit-popup-draft)))
+
+  ;; ---- events: popup open / close / mutate -----------------------------
+  ;;
+  ;; The trigger payload tells the popup whether it's editing an
+  ;; existing pill (`:source :pill`), adding from the trailing `+`
+  ;; (`:source :add`), or adding from a right-click context menu
+  ;; (`:source :context`). The draft is initialised from the trigger
+  ;; so 'click pill → edit' arrives pre-populated and 'right-click
+  ;; row → add' arrives with the event-id pre-filled.
+
+  (rf/reg-event-db :rf.causa/open-edit-popup
+    (fn [db [_ {:keys [source mode idx pill] :as trigger}]]
+      (let [draft (-> (edit-popup/pill->draft (or pill {}))
+                      (assoc :mode (or mode :in)))]
+        (-> db
+            (assoc :edit-popup-open? true)
+            (assoc :edit-popup-trigger
+                   {:source source
+                    :mode   (or mode :in)
+                    :idx    idx
+                    :pill   pill})
+            (assoc :edit-popup-draft draft)))))
+
+  (rf/reg-event-db :rf.causa/close-edit-popup
+    (fn [db _event]
+      (close-popup db)))
+
+  (rf/reg-event-db :rf.causa/edit-popup-set-mode
+    {:rf.trace/no-emit? true}
+    (fn [db [_ mode]]
+      (assoc-in db [:edit-popup-draft :mode] mode)))
+
+  (rf/reg-event-db :rf.causa/edit-popup-set-pattern
+    {:rf.trace/no-emit? true}
+    (fn [db [_ pattern]]
+      (assoc-in db [:edit-popup-draft :pattern] (or pattern ""))))
+
+  (rf/reg-event-db :rf.causa/edit-popup-toggle-scope
+    {:rf.trace/no-emit? true}
+    (fn [db [_ scope-key]]
+      (let [current (or (get-in db [:edit-popup-draft :scope]) #{:event-id})
+            next    (if (contains? current scope-key)
+                      (disj current scope-key)
+                      (conj current scope-key))]
+        (assoc-in db [:edit-popup-draft :scope] next))))
+
+  ;; ---- events: save / delete -------------------------------------------
+  ;;
+  ;; Save and Delete both mutate the live `:active-filters` slot and
+  ;; close the popup. Persistence is bound by the `:rf.causa.filters/
+  ;; persist` fx so the post-mutation slot lands in localStorage in
+  ;; one place (no fx-per-handler duplication).
+
+  (rf/reg-event-fx :rf.causa/save-edit-popup
+    (fn [{:keys [db]} _event]
+      (let [draft  (get db :edit-popup-draft)
+            trig   (get db :edit-popup-trigger)
+            mode   (or (:mode draft) :in)
+            pill   (edit-popup/draft->pill draft)
+            valid? (some? (:pattern pill))]
+        (if (not valid?)
+          ;; Pattern empty — keep the popup open so the user can fix
+          ;; the input. The Apply button is also disabled in this
+          ;; state, but a programmatic dispatch (test path) lands here.
+          {:db db}
+          (let [editing-existing? (= :pill (:source trig))
+                old-mode          (:mode trig)
+                ;; If the user flipped IN ↔ OUT we delete from the old
+                ;; bucket and append to the new; if they edited a pill
+                ;; in place we replace at the same idx.
+                same-mode?        (= mode old-mode)
+                idx               (:idx trig)
+                without-old
+                (if (and editing-existing? (some? idx))
+                  (update-in db [:active-filters old-mode]
+                             (fn [v]
+                               (let [v (or v [])]
+                                 (vec (concat (subvec v 0 (min idx (count v)))
+                                              (subvec v (min (inc idx) (count v))))))))
+                  db)
+                next-db
+                (if (and editing-existing? same-mode? (some? idx))
+                  ;; Replace at the original index so pill order is
+                  ;; preserved across an edit.
+                  (update-in db [:active-filters mode]
+                             (fn [v]
+                               (let [v (or v [])]
+                                 (vec (concat (subvec v 0 (min idx (count v)))
+                                              [pill]
+                                              (subvec v (min (inc idx) (count v))))))))
+                  ;; New pill or mode-flip — append to the target
+                  ;; bucket of the without-old base.
+                  (update-in without-old [:active-filters mode]
+                             (fnil conj []) pill))
+                final-db (close-popup next-db)]
+            {:db final-db
+             :fx [[:rf.causa.filters/persist (get final-db :active-filters)]]})))))
+
+  (rf/reg-event-fx :rf.causa/delete-edit-popup
+    (fn [{:keys [db]} _event]
+      (let [trig (get db :edit-popup-trigger)
+            mode (:mode trig)
+            idx  (:idx trig)]
+        (if (and (= :pill (:source trig)) (some? idx) (some? mode))
+          (let [next-db (-> db
+                            (update-in [:active-filters mode]
+                                       (fn [v]
+                                         (let [v (or v [])]
+                                           (vec (concat (subvec v 0 (min idx (count v)))
+                                                        (subvec v (min (inc idx) (count v))))))))
+                            (close-popup))]
+            {:db next-db
+             :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})
+          {:db (close-popup db)}))))
+
+  ;; ---- right-click row → OUT filter shortcut --------------------------
+  ;;
+  ;; Spec/018 §7 Right-click event-row → context menu carries an
+  ;; 'Always hide this event-type' item; this is the canonical
+  ;; lowering. The event-row's on-context-menu handler dispatches
+  ;; this event; the popup opens pre-populated (so the user can fine-
+  ;; tune or simply hit Apply). Pre-alpha we open the popup rather
+  ;; than silently appending — the user sees what's about to land in
+  ;; the OUT bucket and can cancel.
+
+  (rf/reg-event-db :rf.causa/hide-event-type
+    (fn [db [_ event-id]]
+      (let [pill {:pattern (when event-id (str event-id))
+                  :scope   #{:event-id}}]
+        (-> db
+            (assoc :edit-popup-open? true)
+            (assoc :edit-popup-trigger
+                   {:source :context :mode :out :pill pill})
+            (assoc :edit-popup-draft
+                   (-> (edit-popup/pill->draft pill)
+                       (assoc :mode :out)))))))
+
+  ;; ---- load: hydrate from localStorage --------------------------------
+
+  (rf/reg-event-db :rf.causa/hydrate-filters
+    {:rf.trace/no-emit? true}
+    (fn [db [_ filters]]
+      (assoc db :active-filters
+                (or filters {:in [] :out []}))))
+
+  ;; Hydrate on install. The actual logic lives in `hydrate!` below
+  ;; so `ensure-causa-frame!` (in mount.cljs) can call it again on
+  ;; first open — the production order is preload-time install
+  ;; (`:rf/causa` frame not yet registered) then keypress-time
+  ;; `ensure-causa-frame!` (frame registered). Either call path
+  ;; converges on the same slot.
+  (hydrate!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -1,0 +1,364 @@
+(ns day8.re-frame2-causa.filters.edit-popup
+  "Edit popup for IN/OUT filter pills (rf2-ak4ms).
+
+  Per `tools/causa/spec/018-Event-Spine.md` §7 'Click-pill → edit
+  popup' the popup is a modal overlay with:
+
+      ┌─ Edit filter ──────────────────────┐
+      │ Mode    ◉ IN   ○ OUT               │
+      │                                    │
+      │ Pattern                            │
+      │   :auth/*                          │
+      │   (keyword · glob · namespace)     │
+      │                                    │
+      │ Match scope                        │
+      │   ☑ event-id                       │
+      │   ☐ event-args                     │
+      │   ☐ source-coord                   │
+      │   ☐ tags                           │
+      │                                    │
+      │ ──────────────────────────────────  │
+      │ [Delete]      [Cancel]    [Apply]  │
+      └────────────────────────────────────┘
+
+  ## Pre-alpha scope
+
+  Pre-alpha the matcher (`filters/matcher.cljc`) operates on event-id
+  only — event-args / source-coord / tags scopes are surfaced in the
+  popup so the visual contract ships, but the checkboxes are stored
+  as data and consumed later when the matcher widens. The 'event-id'
+  scope is the default and always-on; widening the scope is a future
+  rev.
+
+  ## Trigger sources (spec/018 §7)
+
+  Three paths open the popup:
+
+  1. Click an existing pill → `{:source :pill :mode … :idx … :pill …}`
+     — popup pre-populated; `[Delete]` button visible.
+  2. Click the trailing `[ + ]` add-pill → `{:source :add :mode :in}`
+     — popup empty + IN default; no `[Delete]`.
+  3. Right-click an event row → `{:source :context :mode :out
+     :pill {:pattern <event-id>}}` — popup pre-populated with the
+     event-id + OUT default; no `[Delete]`.
+
+  The view reads the trigger payload from `:rf.causa/edit-popup-pill`
+  and the draft from `:rf.causa/edit-popup-draft` (a working copy the
+  user mutates without affecting the live filter slot)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens type-scale sans-stack mono-stack]]))
+
+;; ---- styles --------------------------------------------------------------
+
+(defn- backdrop-style []
+  {:position         "fixed"
+   :top              0
+   :left             0
+   :right            0
+   :bottom           0
+   :background       "rgba(0,0,0,0.55)"
+   :backdrop-filter  "blur(2px)"
+   :display          "flex"
+   :align-items      "flex-start"
+   :justify-content  "center"
+   :padding-top      "12vh"
+   ;; One above the palette so an edit popup opened over an open
+   ;; palette wins focus; the palette is z 2147483646 (rf2-wm7z4).
+   :z-index          2147483647})
+
+(defn- dialog-style []
+  {:width            "420px"
+   :max-width        "92vw"
+   :display          "flex"
+   :flex-direction   "column"
+   :background       (:bg-1 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "8px"
+   :box-shadow       "rgba(0,0,0,0.6) 0 24px 64px"
+   :overflow         "hidden"
+   :font-family      sans-stack
+   :color            (:text-primary tokens)})
+
+(defn- header-style []
+  {:display          "flex"
+   :align-items      "center"
+   :justify-content  "space-between"
+   :padding          "10px 16px"
+   :border-bottom    (str "1px solid " (:border-subtle tokens))
+   :background       (:bg-2 tokens)
+   :font-weight      600})
+
+(defn- section-style []
+  {:padding          "12px 16px"
+   :border-bottom    (str "1px solid " (:border-subtle tokens))})
+
+(defn- label-style []
+  {:display          "block"
+   :margin-bottom    "6px"
+   :color            (:text-secondary tokens)
+   :font-size        (:caption type-scale)
+   :font-weight      600
+   :letter-spacing   "0.04em"
+   :text-transform   "uppercase"})
+
+(defn- input-style []
+  {:width            "100%"
+   :background       (:bg-2 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "4px"
+   :color            (:text-primary tokens)
+   :padding          "6px 8px"
+   :font-family      mono-stack
+   :font-size        (:body type-scale)})
+
+(defn- radio-row-style []
+  {:display          "flex"
+   :align-items      "center"
+   :gap              "16px"})
+
+(defn- footer-style []
+  {:display          "flex"
+   :align-items      "center"
+   :justify-content  "space-between"
+   :padding          "10px 16px"
+   :background       (:bg-2 tokens)})
+
+(defn- btn-style [{:keys [primary? danger?]}]
+  {:background    (cond
+                    primary? (:accent-violet tokens)
+                    :else    "transparent")
+   :border        (str "1px solid "
+                       (cond
+                         danger?  (:red tokens)
+                         primary? (:accent-violet tokens)
+                         :else    (:border-default tokens)))
+   :color         (cond
+                    primary? "#0E0F12"           ; bg-0 — readable on violet
+                    danger?  (:red tokens)
+                    :else    (:text-primary tokens))
+   :padding       "6px 14px"
+   :border-radius "4px"
+   :cursor        "pointer"
+   :font-family   sans-stack
+   :font-size     (:body type-scale)
+   :font-weight   (if primary? 600 400)})
+
+;; ---- helpers (pure) ------------------------------------------------------
+
+(defn draft->pill
+  "Project the user-edited `draft` into the canonical pill record the
+  registry slot expects. Pre-alpha the canonical shape is `{:pattern
+  <str-or-kw>}` — the matcher only consults `:pattern`. A non-default
+  `:scope` is attached when present so the future widening pass has
+  the data; the default `#{:event-id}` scope (always-on per spec/018
+  §7) is NOT serialised because every pill carries it implicitly.
+
+  String patterns starting with `:` are normalised to keywords so the
+  stored shape matches what spec/018 §7 catalogues (`:auth/*`,
+  `:order/cart/*`). Whitespace-only / blank patterns survive as nil —
+  the registry's save handler drops the pill rather than persisting
+  an unmatchable one."
+  [{:keys [pattern scope]}]
+  (let [trimmed (when (string? pattern)
+                  (clojure.string/trim pattern))
+        p       (cond
+                  (keyword? pattern)         pattern
+                  (and trimmed (seq trimmed))
+                  (if (clojure.string/starts-with? trimmed ":")
+                    (try
+                      (keyword (subs trimmed 1))
+                      (catch :default _ trimmed))
+                    trimmed)
+                  :else                      nil)
+        ;; Only attach :scope when the user widened past the default
+        ;; #{:event-id} — pre-alpha there is no widening surface but
+        ;; the data plumbing carries any non-default set through.
+        non-default-scope?
+        (and (set? scope)
+             (not= scope #{:event-id})
+             (seq scope))]
+    (cond-> {:pattern p}
+      non-default-scope? (assoc :scope scope))))
+
+(defn pill->draft
+  "Hydrate a stored pill into the user-editable draft shape. nil pill
+  → empty draft."
+  [{:keys [pattern scope] :as _pill}]
+  {:pattern (cond
+              (nil? pattern)         ""
+              (keyword? pattern)     (str pattern)
+              :else                  (str pattern))
+   :scope   (or scope #{:event-id})})
+
+;; ---- view ----------------------------------------------------------------
+
+(defn- mode-radio
+  [{:keys [mode current-mode]}]
+  (let [tone   (case mode :in (:green tokens) :out (:magenta tokens))
+        on?    (= mode current-mode)]
+    [:label {:data-testid (str "rf-causa-edit-popup-mode-" (name mode))
+             :style {:display       "inline-flex"
+                     :align-items   "center"
+                     :gap           "6px"
+                     :cursor        "pointer"
+                     :color         (if on? tone (:text-secondary tokens))
+                     :font-family   sans-stack
+                     :font-size     (:body type-scale)}}
+     [:input {:type      "radio"
+              :name      "rf-causa-edit-popup-mode"
+              :value     (name mode)
+              :checked   on?
+              :on-change #(rf/dispatch
+                            [:rf.causa/edit-popup-set-mode mode]
+                            {:frame :rf/causa})}]
+     (case mode :in "IN (show only)" :out "OUT (hide)")]))
+
+(defn- scope-checkbox
+  [{:keys [scope-key label current-scope]}]
+  (let [checked? (boolean (and current-scope (contains? current-scope scope-key)))
+        ;; Pre-alpha the matcher only honours :event-id; the other
+        ;; scopes ship as data-only so the popup's visual contract is
+        ;; complete. event-id stays disabled — it's always on so a
+        ;; pattern always has somewhere to match.
+        always-on? (= scope-key :event-id)]
+    [:label {:data-testid (str "rf-causa-edit-popup-scope-" (name scope-key))
+             :style {:display     "flex"
+                     :align-items "center"
+                     :gap         "8px"
+                     :padding     "2px 0"
+                     :cursor      (if always-on? "default" "pointer")
+                     :color       (if always-on?
+                                    (:text-primary tokens)
+                                    (:text-secondary tokens))
+                     :font-family sans-stack
+                     :font-size   (:body type-scale)}}
+     [:input {:type      "checkbox"
+              :checked   (or always-on? checked?)
+              :disabled  always-on?
+              :on-change #(when-not always-on?
+                            (rf/dispatch
+                              [:rf.causa/edit-popup-toggle-scope scope-key]
+                              {:frame :rf/causa}))}]
+     label
+     (when (not always-on?)
+       [:span {:style {:margin-left "6px"
+                       :color (:text-tertiary tokens)
+                       :font-size (:caption type-scale)}}
+        "(pre-alpha: stored, not yet matched)"])]))
+
+(defn popup-view
+  "The popup body. Caller (`filters/Modal`) gates the mount on
+  `:rf.causa/edit-popup-open?`."
+  []
+  (let [trigger @(rf/subscribe [:rf.causa/edit-popup-trigger])
+        draft   @(rf/subscribe [:rf.causa/edit-popup-draft])
+        mode    (or (:mode draft) :in)
+        scope   (or (:scope draft) #{:event-id})
+        editing? (= :pill (:source trigger))
+        title    (case (:source trigger)
+                   :pill    "Edit filter"
+                   :context "Add filter for this event"
+                   "Add filter")
+        ;; Apply is enabled when the pattern is non-blank.
+        can-apply? (let [p (:pattern draft)]
+                     (and (string? p) (seq (clojure.string/trim p))))]
+    [:div {:data-testid "rf-causa-edit-popup-backdrop"
+           :on-click    #(rf/dispatch [:rf.causa/close-edit-popup] {:frame :rf/causa})
+           :style       (backdrop-style)}
+     [:div {:data-testid "rf-causa-edit-popup-dialog"
+            :on-click    #(.stopPropagation %)
+            :style       (dialog-style)}
+      [:div {:style (header-style)}
+       [:span title]
+       [:button {:data-testid "rf-causa-edit-popup-close"
+                 :on-click    #(rf/dispatch
+                                 [:rf.causa/close-edit-popup]
+                                 {:frame :rf/causa})
+                 :title       "Close (Esc)"
+                 :style {:background  "transparent"
+                         :border      "none"
+                         :color       (:text-secondary tokens)
+                         :cursor      "pointer"
+                         :font-size   "16px"}}
+        "✕"]]
+
+      [:div {:style (section-style)}
+       [:label {:style (label-style)} "Mode"]
+       [:div {:style (radio-row-style)}
+        [mode-radio {:mode :in :current-mode mode}]
+        [mode-radio {:mode :out :current-mode mode}]]]
+
+      [:div {:style (section-style)}
+       [:label {:style (label-style) :for "rf-causa-edit-popup-pattern"}
+        "Pattern"]
+       [:input {:data-testid  "rf-causa-edit-popup-pattern"
+                :id           "rf-causa-edit-popup-pattern"
+                :type         "text"
+                :auto-focus   true
+                :value        (or (:pattern draft) "")
+                :placeholder  ":auth/* or :mouse-move or /login"
+                :on-change    #(rf/dispatch
+                                 [:rf.causa/edit-popup-set-pattern
+                                  (.. % -target -value)]
+                                 {:frame :rf/causa})
+                :on-key-down  (fn [^js e]
+                                (case (.-key e)
+                                  "Enter"  (when can-apply?
+                                             (.preventDefault e)
+                                             (rf/dispatch
+                                               [:rf.causa/save-edit-popup]
+                                               {:frame :rf/causa}))
+                                  "Escape" (do (.preventDefault e)
+                                               (rf/dispatch
+                                                 [:rf.causa/close-edit-popup]
+                                                 {:frame :rf/causa}))
+                                  nil))
+                :style        (input-style)}]
+       [:div {:style {:margin-top "4px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size (:caption type-scale)}}
+        "keyword · glob (:foo/*) · namespace (:foo) · substring"]]
+
+      [:div {:style (section-style)}
+       [:label {:style (label-style)} "Match scope"]
+       [scope-checkbox {:scope-key :event-id
+                        :label "event-id"
+                        :current-scope scope}]
+       [scope-checkbox {:scope-key :event-args
+                        :label "event-args"
+                        :current-scope scope}]
+       [scope-checkbox {:scope-key :source-coord
+                        :label "source-coord"
+                        :current-scope scope}]
+       [scope-checkbox {:scope-key :tags
+                        :label "tags"
+                        :current-scope scope}]]
+
+      [:div {:style (footer-style)}
+       (if editing?
+         [:button {:data-testid "rf-causa-edit-popup-delete"
+                   :on-click    #(rf/dispatch
+                                   [:rf.causa/delete-edit-popup]
+                                   {:frame :rf/causa})
+                   :style       (btn-style {:danger? true})}
+          "Delete"]
+         [:span])
+       [:div {:style {:display "flex" :gap "8px"}}
+        [:button {:data-testid "rf-causa-edit-popup-cancel"
+                  :on-click    #(rf/dispatch
+                                  [:rf.causa/close-edit-popup]
+                                  {:frame :rf/causa})
+                  :style       (btn-style {})}
+         "Cancel"]
+        [:button {:data-testid "rf-causa-edit-popup-save"
+                  :disabled    (not can-apply?)
+                  :on-click    #(when can-apply?
+                                  (rf/dispatch
+                                    [:rf.causa/save-edit-popup]
+                                    {:frame :rf/causa}))
+                  :style       (merge (btn-style {:primary? true})
+                                      (when-not can-apply?
+                                        {:opacity 0.4 :cursor "default"}))}
+         (if editing? "Apply" "Add")]]]]]))

--- a/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
@@ -1,0 +1,173 @@
+(ns day8.re-frame2-causa.filters.matcher
+  "Pattern matching for Causa's IN/OUT filter pills (rf2-ak4ms).
+
+  Per `tools/causa/spec/018-Event-Spine.md` §7 the filter system runs
+  at the DATA layer (`:rf.causa/filtered-cascades` sub) — every consumer
+  (event list, scrubber, Issues counter, palette verbs) reads the
+  filtered list. The matcher in this ns is the pure data primitive
+  the sub composes against the raw cascade list.
+
+  ## Pattern syntax
+
+  Spec/018 §7 calls out four supported pattern shapes; this matcher
+  implements three first-class shapes (exact / prefix-glob / namespace)
+  + the substring fallback:
+
+  | Shape       | Example          | Matches                                   |
+  |-------------|------------------|-------------------------------------------|
+  | exact kw    | `:auth/login`    | event-id equal to the keyword             |
+  | prefix glob | `:auth/*`        | event-id whose `(str id)` starts with `:auth/` |
+  | namespace   | `:order`         | event-id whose namespace = `\"order\"`    |
+  | substring   | `/login`         | event-id whose `(str id)` contains `/login` |
+
+  Patterns may be supplied as keywords (`:auth/login`, `:auth/*`) or as
+  strings (`\":auth/*\"`, `\"login\"`). Strings without a leading `:`
+  fall through to substring; strings with a leading `:` are normalised
+  to keywords first.
+
+  ## Match composition (spec/018 §7)
+
+      ACTIVE = (match-any-IN) AND NOT (match-any-OUT)
+
+  - **No IN pills**  → show everything not blacklisted (OUT only).
+  - **Some IN pills** → restrict to events matching ANY IN pattern,
+    minus any OUT match.
+
+  ## Why CLJC
+
+  The matcher is pure data; JVM tests in
+  `tools/causa/test/.../filters/matcher_test.cljc` exercise the shape
+  without a CLJS runtime. The CLJS pill view + filtered-cascades sub
+  compose against this ns at render-time."
+  (:require [clojure.string :as str]))
+
+;; ---- pattern compilation -------------------------------------------------
+
+(defn- glob? [s]
+  (str/ends-with? s "*"))
+
+(defn- normalise-pattern
+  "Coerce a pattern (keyword or string) into the canonical match shape.
+  Returns `{:kind <:exact|:prefix|:substring|:never> :pattern <data>}`.
+
+  Per spec/018 §7 the supported pattern shapes are:
+
+    | input form    | example          | kind       |
+    |---------------|------------------|------------|
+    | exact kw      | `:auth/login`    | :exact     |
+    | prefix glob   | `:auth/*`        | :prefix    |
+    | bare kw       | `:mouse-move`    | :exact     |
+    | str with `:`  | `\":auth/*\"`    | (parses)   |
+    | bare str      | `\"/login\"`     | :substring |
+    | empty / nil   |                  | :never     |
+
+  Note: a bare unqualified keyword (e.g. `:mouse-move`) compiles to
+  `:exact`, NOT to a namespace matcher. The bare-keyword case is the
+  natural 'block this specific event-id' input — spec/018 §7's example
+  `[× :mouse-move]` lands there. Namespace-style matching is achieved
+  via the glob form (`:foo/*`)."
+  [pattern]
+  (cond
+    (keyword? pattern)
+    (let [s (str pattern)]
+      (if (glob? s)
+        ;; `:auth/*` → prefix `":auth/"`. Drop the trailing `*`.
+        {:kind :prefix :pattern (subs s 0 (dec (count s)))}
+        {:kind :exact :pattern pattern}))
+
+    (string? pattern)
+    (cond
+      (str/blank? pattern)
+      ;; A blank pattern matches nothing — guard so a half-filled pill
+      ;; doesn't silently match every event.
+      {:kind :never :pattern nil}
+
+      (str/starts-with? pattern ":")
+      (recur (keyword (subs pattern 1)))
+
+      :else
+      {:kind :substring :pattern pattern})
+
+    :else
+    {:kind :never :pattern nil}))
+
+;; ---- single-pill match ---------------------------------------------------
+
+(defn match-event-id?
+  "True iff `event-id` matches the compiled `pattern-spec` (output of
+  `normalise-pattern`).
+
+  - `:exact`      — keyword equality
+  - `:prefix`     — `(str event-id)` starts with the prefix
+  - `:substring`  — `(str event-id)` contains the substring
+  - `:never`      — always false (blank / malformed pill)
+
+  `event-id` may be nil (an unrouted cascade carrying no event); nil
+  never matches."
+  [event-id {:keys [kind pattern]}]
+  (cond
+    (nil? event-id) false
+    (= :never kind) false
+    (= :exact kind) (= event-id pattern)
+
+    (= :prefix kind)
+    (let [s (str event-id)]
+      (str/starts-with? s pattern))
+
+    (= :substring kind)
+    (str/includes? (str event-id) pattern)
+
+    :else false))
+
+(defn match-pill?
+  "True iff the pill matches `event-id`. Pills are
+  `{:pattern <kw-or-str>}`; an optional `:scope` set may be threaded
+  in future (event-args / source-coord / tags scopes per spec/018 §7)
+  — pre-alpha we match on event-id only.
+
+  Returns false when the pill is malformed (missing pattern)."
+  [{:keys [pattern]} event-id]
+  (and (some? pattern)
+       (match-event-id? event-id (normalise-pattern pattern))))
+
+;; ---- cascade-level filtering --------------------------------------------
+
+(defn- cascade-event-id
+  "Pluck the event-id from a cascade — same shape `shell/event-id-of-
+  cascade` plucks (`(first (:event cascade))`). Lifted here so the
+  matcher stays a self-contained pure unit; the shell delegates."
+  [cascade]
+  (let [ev (:event cascade)]
+    (when (vector? ev)
+      (first ev))))
+
+(defn cascade-matches?
+  "True iff `cascade`'s event-id matches *any* pill in `pills`.
+
+  - Empty / nil `pills` → false (no patterns to match against).
+  - Otherwise → true on first pill match."
+  [cascade pills]
+  (boolean
+    (when (seq pills)
+      (let [event-id (cascade-event-id cascade)]
+        (some #(match-pill? % event-id) pills)))))
+
+(defn keep-cascade?
+  "True iff `cascade` survives the active filter per spec/018 §7:
+
+      keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
+
+  Cascades that fail the keep test drop out of `:rf.causa/filtered-
+  cascades`. The L2 event list, scrubber, Issues counter, palette
+  verbs all read the filtered list — one filter, every consumer."
+  [cascade {:keys [in out]}]
+  (let [in-ok?  (or (empty? in)
+                    (cascade-matches? cascade in))
+        out-hit (cascade-matches? cascade out)]
+    (and in-ok? (not out-hit))))
+
+(defn filter-cascades
+  "Apply `filters` to `cascades`, returning the surviving subseq in
+  order. Pure — no I/O, no atoms read."
+  [cascades filters]
+  (filterv #(keep-cascade? % filters) cascades))

--- a/tools/causa/src/day8/re_frame2_causa/filters/persistence.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/persistence.cljs
@@ -1,0 +1,178 @@
+(ns day8.re-frame2-causa.filters.persistence
+  "localStorage round-trip for Causa's IN/OUT filter pills (rf2-ak4ms).
+
+  Per `tools/causa/spec/018-Event-Spine.md` §7 Filter persistence:
+  ribbon pills persist via localStorage per host-app under a Causa-
+  namespaced key. The Settings popup (follow-on) exposes the pill set
+  + Recommended quick-add + factory-reset; this ns owns the data layer.
+
+  ## Default is empty
+
+  Per Mike's call (rf2-ak4ms / 10x-config R5 / spec/018 §7 'Empty
+  defaults'): first-session honesty beats first-session quietness. No
+  events are filtered out by default — the user surfaces the noise
+  themselves with explicit filters. Shipping a default `:mouse-move`
+  filter would silently hide events the user didn't know they were
+  emitting.
+
+  ## Per-instance namespacing
+
+  The localStorage key is `re-frame2.causa.filters.v1`. Hosts that run
+  multiple Causa instances (Story testbeds) can override the key via
+  `(causa-config/configure! {:filters/storage-key \"<key>\"})` — Story
+  testbeds set this so their pill state doesn't leak between scenarios.
+
+  ## Production posture
+
+  The whole filters subsystem rides Causa's dev-only preload (gated on
+  `interop/debug-enabled?`), so production builds DCE this ns. Reads
+  / writes guard `js/window` existence so the JVM test path (which
+  loads this ns transitively via the registry) doesn't blow up on
+  classpath loads.
+
+  ## Shape
+
+      ;; localStorage value (EDN string):
+      {:in  [{:pattern \":auth/*\"}
+             {:pattern \":order/*\"}]
+       :out [{:pattern \":mouse-move\"}]}
+
+  Hand-edited values that fail to parse are ignored (return nil from
+  `load`); the slot stays at its registry-default empty shape rather
+  than throwing at boot."
+  (:require [cljs.reader :as reader]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.config :as config]))
+
+(def default-storage-key
+  "Default localStorage key Causa writes filter state under. Hosts
+  override via `(causa-config/configure! {:filters/storage-key …})`
+  for per-instance isolation (Story testbeds use this)."
+  "re-frame2.causa.filters.v1")
+
+;; ---- storage-key delegation ----------------------------------------------
+;;
+;; The authoritative storage-key lives in `config/filters-storage-key`
+;; (CLJC so the JVM test corpus can exercise the configure! round-trip).
+;; This ns thunks through so existing callers keep working — there's
+;; one source of truth, no atom-drift risk.
+
+(defn set-storage-key!
+  "Replace the localStorage key Causa uses for filter persistence. `nil`
+  resets to the default. Hosts that mount multiple Causa instances set
+  distinct keys so each instance's pill state stays isolated.
+
+  Thunk over `config/set-filters-storage-key!` so there is one source
+  of truth for the key."
+  [k]
+  (config/set-filters-storage-key! k))
+
+(defn get-storage-key
+  "Return the current localStorage key."
+  []
+  (config/get-filters-storage-key))
+
+;; ---- localStorage helpers ------------------------------------------------
+
+(defn- storage-available?
+  "True when `js/window.localStorage` is reachable. Tests that drive the
+  registry without a browser environment (node + no jsdom) need the
+  load path to no-op silently."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn read-raw
+  "Read the raw EDN string Causa wrote under `storage-key`. Returns nil
+  when the slot is empty or localStorage is unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil))))
+
+(defn write-raw!
+  "Write `s` (an EDN string) under `storage-key`. No-op when
+  localStorage is unavailable. Swallows any throw — a quota error must
+  not poison the dispatch chain."
+  [s]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) (get-storage-key) s)
+      (catch :default _ nil)))
+  nil)
+
+(defn clear!
+  "Remove the persisted filter state. No-op when localStorage is
+  unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil)))
+  nil)
+
+;; ---- (de)serialisation ---------------------------------------------------
+
+(defn ->edn
+  "Serialise `filters` (`{:in [...] :out [...]}`) into a stable EDN
+  string. Pre-alpha the value is the verbatim slot; future versions can
+  add a wrapping `{:v 1 :filters …}` envelope without breaking the load
+  path (the loader normalises the shape)."
+  [filters]
+  (pr-str (or filters {:in [] :out []})))
+
+(defn <-edn
+  "Parse a stored EDN string. Returns the parsed map on success, or
+  `{:in [] :out []}` on parse failure / unrecognised shape — the
+  load path never throws into init."
+  [s]
+  (let [parsed (try (reader/read-string s)
+                    (catch :default _ nil))]
+    (if (map? parsed)
+      {:in  (vec (get parsed :in []))
+       :out (vec (get parsed :out []))}
+      {:in [] :out []})))
+
+;; ---- public API ----------------------------------------------------------
+
+(defn load
+  "Read + parse the persisted filter slot. Returns `{:in [] :out []}` —
+  always a well-shaped map, never nil — so the registry's
+  `:rf.causa/active-filters` default lines up with the load result.
+
+  Returns the default empty shape when:
+    - localStorage is unavailable (no browser, no jsdom)
+    - the slot is empty (first-session honesty per spec/018 §7)
+    - the stored EDN is malformed"
+  []
+  (if-let [raw (read-raw)]
+    (<-edn raw)
+    {:in [] :out []}))
+
+(defn save!
+  "Write `filters` into localStorage. No-op when localStorage is
+  unavailable. Swallows quota / serialisation errors."
+  [filters]
+  (write-raw! (->edn filters))
+  nil)
+
+;; ---- re-frame fx ---------------------------------------------------------
+
+(defn install-fx!
+  "Install the `:rf.causa.filters/persist` effect. Idempotent (re-
+  frame's registrar replaces in place). Handlers in the registry
+  attach this fx to every event that mutates `:rf.causa/active-
+  filters`; the fx writes the post-mutation slot to localStorage so
+  the round-trip happens in one place instead of being repeated at
+  every call site.
+
+  Handler signature is `(fn [ctx args])` per the v2 reg-fx contract
+  (Spec 002 §`:fx` ordering). `ctx` is the frame-scoped envelope;
+  `args` is the second element of the `[id args]` pair emitted by
+  the event handler — here the filters map."
+  []
+  (rf/reg-fx :rf.causa.filters/persist
+    (fn [_ctx filters]
+      (save! filters)))
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
@@ -1,0 +1,189 @@
+(ns day8.re-frame2-causa.filters.pills
+  "Top-ribbon IN/OUT filter pills for Causa (rf2-ak4ms).
+
+  Per `tools/causa/spec/018-Event-Spine.md` §3 + §7 the L1 ribbon
+  carries a filter cluster — IN pills (green `+`) + OUT pills (magenta
+  `×`) + trailing `[ + ]` add-pill. Clicking any pill opens the rich
+  edit popup (see `filters/edit_popup.cljs`); clicking `×` on a pill
+  removes it without round-tripping through the popup. The trailing
+  add-pill opens the popup empty + defaulted to IN.
+
+  ## Replaces #1397's window.prompt stub
+
+  PR #1397 shipped the 4-layer chrome with a `js/window.prompt` stub
+  inside `shell.cljs`'s `ribbon-filter-pills`. This ns is the proper
+  UI. The shell's `ribbon-filter-pills` delegates here so the only
+  surviving consumer of the prompt stub is the `(throw …)` line in
+  the test that asserts the stub is gone.
+
+  ## Pills hover tooltip
+
+  Per spec/018 §3 the filter cluster shows a hover tooltip with
+  counts: `IN: 3 patterns / OUT: 5 patterns`. We surface this as the
+  cluster's `title` attribute.
+
+  ## Right-click context menu
+
+  Per spec/018 §7 right-click on an event-row opens a context menu
+  with 'Always hide this event-type' / 'Show only events with id
+  …' / etc. The event-row's `on-context-menu` handler dispatches
+  `:rf.causa/open-edit-popup` with the event-id pre-filled; the popup
+  opens in 'add' mode with the OUT default selected. See
+  `shell.cljs`'s `event-row` for the wiring.
+
+  ## Pure hiccup
+
+  Same posture as the rest of Causa's view code (rf2-tijr): pure
+  hiccup, no per-substrate switches. Mount is via `reg-view` from the
+  caller (`shell.cljs`'s `ribbon-filter-pills`)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens type-scale sans-stack mono-stack]]))
+
+;; ---- one pill ------------------------------------------------------------
+
+(defn- pill-glyph [mode]
+  (case mode :in "+" :out "×"))
+
+(defn- pill-tone [mode]
+  (case mode :in (:green tokens) :out (:magenta tokens)))
+
+(defn- format-pattern
+  "Render the pill's pattern text. Keywords render with their leading
+  `:`; strings render verbatim. nil / blank falls back to `<empty>`
+  so a partially-saved pill is still visually addressable."
+  [pattern]
+  (cond
+    (nil? pattern)              "<empty>"
+    (keyword? pattern)          (str pattern)
+    (and (string? pattern)
+         (seq pattern))         pattern
+    :else                       "<empty>"))
+
+(defn pill
+  "One filter pill — clickable body that opens the edit popup, plus
+  an inline `×` button that removes the pill directly (no popup
+  round-trip for the common 'just delete it' case).
+
+  Props:
+    `:mode`    `:in` | `:out`
+    `:pill`    the pill record `{:pattern <kw-or-str> :scope #{…}}`
+    `:idx`     position in the mode bucket (drives the testid + the
+               remove-filter event payload)"
+  [{:keys [mode pill idx]}]
+  (let [tone   (pill-tone mode)
+        glyph  (pill-glyph mode)
+        testid (str "rf-causa-filter-pill-" (name mode) "-" idx)]
+    [:span {:data-testid testid
+            :style {:display        "inline-flex"
+                    :align-items    "center"
+                    :gap            "4px"
+                    :border         (str "1px solid " tone)
+                    :color          tone
+                    :padding        "1px 4px 1px 8px"
+                    :border-radius  "10px"
+                    :font-family    mono-stack
+                    :font-size      (:caption type-scale)
+                    :white-space    "nowrap"}}
+     [:button {:data-testid  (str testid "-body")
+               :on-click     #(rf/dispatch
+                                [:rf.causa/open-edit-popup
+                                 {:source :pill :mode mode :idx idx :pill pill}]
+                                {:frame :rf/causa})
+               :title        "Click to edit"
+               :style {:background  "transparent"
+                       :border      "none"
+                       :color       tone
+                       :cursor      "pointer"
+                       :padding     "0"
+                       :font-family mono-stack
+                       :font-size   (:caption type-scale)
+                       :white-space "nowrap"}}
+      (str glyph " " (format-pattern (:pattern pill)) " ")
+      ;; Pencil glyph per spec/018 §7 'Pill visual contract' — visual
+      ;; cue that the pill body is the click-to-edit target.
+      [:span {:style {:opacity 0.7}} "✎"]]
+     [:button {:data-testid  (str testid "-remove")
+               :on-click     #(rf/dispatch
+                                [:rf.causa/remove-filter mode idx]
+                                {:frame :rf/causa})
+               :title        "Remove this filter"
+               :aria-label   (str "Remove " (name mode) " filter "
+                                  (format-pattern (:pattern pill)))
+               :style {:background    "transparent"
+                       :border        "none"
+                       :color         tone
+                       :cursor        "pointer"
+                       :padding       "0 2px"
+                       :margin-left   "2px"
+                       :font-family   sans-stack
+                       :font-size     (:caption type-scale)
+                       :line-height   "1"
+                       :border-left   (str "1px solid " tone)
+                       :opacity       0.7}}
+      "×"]]))
+
+;; ---- add-pill affordance -------------------------------------------------
+
+(defn- add-pill
+  "Trailing `[ + ]` affordance — opens the edit popup empty +
+  defaulted to IN per spec/018 §7 'Trailing +'."
+  []
+  [:button {:data-testid "rf-causa-filter-add"
+            :on-click    #(rf/dispatch
+                            [:rf.causa/open-edit-popup
+                             {:source :add :mode :in}]
+                            {:frame :rf/causa})
+            ;; Accessible name doubles the visible label so screen-
+            ;; reader users hear 'Add filter pill' not the bare
+            ;; brackets. The `[ + ]` glyph (not `+` alone) avoids
+            ;; colliding with host apps that own a `+` button —
+            ;; Playwright `getByRole('button', {name: '+'})` lassoes
+            ;; both surfaces when names overlap.
+            :aria-label  "Add filter pill"
+            :title       "Add filter pill"
+            :style       {:background    "transparent"
+                          :border        (str "1px dashed "
+                                              (:text-tertiary tokens))
+                          :color         (:text-tertiary tokens)
+                          :cursor        "pointer"
+                          :padding       "2px 8px"
+                          :border-radius "10px"
+                          :font-family   sans-stack
+                          :font-size     (:caption type-scale)
+                          :white-space   "nowrap"}}
+   "[ + ]"])
+
+;; ---- cluster -------------------------------------------------------------
+
+(defn- counts-tooltip
+  "Per spec/018 §3 the cluster carries a hover tooltip with pill
+  counts. Pluralises 'pattern' / 'patterns' for honesty (a count of
+  `1 patterns` reads as a bug)."
+  [filters]
+  (let [in-n  (count (:in filters))
+        out-n (count (:out filters))
+        word  (fn [n] (if (= 1 n) "pattern" "patterns"))]
+    (str "IN: " in-n " " (word in-n)
+         " / OUT: " out-n " " (word out-n))))
+
+(defn pills-view
+  "The full ribbon filter cluster — IN pills, then OUT pills, then the
+  add-pill. Reads `:rf.causa/active-filters` via the caller; the
+  caller is expected to be inside a `reg-view` so subscribes resolve
+  to `:rf/causa`."
+  [{:keys [filters]}]
+  [:div {:data-testid "rf-causa-ribbon-filters"
+         :title (counts-tooltip filters)
+         :style {:display     "flex"
+                 :align-items "center"
+                 :gap         "6px"
+                 :flex        "1 1 auto"
+                 :flex-wrap   "wrap"}}
+   (for [[idx p] (map-indexed vector (:in filters))]
+     ^{:key (str "in-" idx)}
+     [pill {:mode :in :pill p :idx idx}])
+   (for [[idx p] (map-indexed vector (:out filters))]
+     ^{:key (str "out-" idx)}
+     [pill {:mode :out :pill p :idx idx}])
+   [add-pill]])

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -48,6 +48,7 @@
             [re-frame.substrate.adapter :as substrate-adapter]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.defaults :as defaults]
+            [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.shell :as shell]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
@@ -310,7 +311,14 @@
   (rf/with-frame :rf/causa
     (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])
     (rf/dispatch-sync [:rf.causa/sync-epoch-history
-                       (vec (rf/epoch-history defaults/default-target-frame))])))
+                       (vec (rf/epoch-history defaults/default-target-frame))]))
+  ;; Hydrate the auto-filter pills (rf2-ak4ms). The preload-time
+  ;; `filters/install!` call ran BEFORE the `:rf/causa` frame was
+  ;; registered, so its hydrate attempt no-op'd; re-running here
+  ;; under the now-registered frame lifts the localStorage / seed
+  ;; value into the slot. Idempotent — re-running with an unchanged
+  ;; source produces the same slot.
+  (filters/hydrate!))
 
 (defn open!
   "Mount + show the default Causa shell in the app-provided true-inline

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -33,6 +33,7 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.defaults :as defaults]
+            [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.spine :as spine]
@@ -152,14 +153,20 @@
     ;;
     ;; The ribbon's filter cluster reads `:rf.causa/active-filters` —
     ;; shape `{:in [{:pattern <str> :scope #{:event-id ...}}]
-    ;;         :out [{:pattern <str> :scope #{...}}]}`. Pre-alpha the
-    ;; pills do not actually filter the cascade list — that wiring
-    ;; lands in the follow-on `:rf.causa/filtered-cascades` sub
-    ;; (spec/018 §6 sub-graph). For now the pills round-trip through
-    ;; the slot so the visual contract is testable.
+    ;;         :out [{:pattern <str> :scope #{...}}]}`. The
+    ;; `:rf.causa/filtered-cascades` sub (rf2-ak4ms, installed via
+    ;; `filters/install!` further down) composes against this slot to
+    ;; produce the filtered cascade list every consumer reads.
+    ;;
+    ;; The sub returns a well-shaped map even when one bucket is
+    ;; absent — a save into just `:out` leaves `:in` as `nil` in
+    ;; the raw db, but consumers downstream count on `(:in filters)`
+    ;; resolving to a vector.
     (rf/reg-sub :rf.causa/active-filters
       (fn [db _query]
-        (or (get db :active-filters) {:in [] :out []})))
+        (let [stored (get db :active-filters)]
+          {:in  (vec (get stored :in []))
+           :out (vec (get stored :out []))})))
 
     ;; Shared cascade projection. The event-detail, causality-graph,
     ;; and performance composites all consume `projection/group-cascades`
@@ -188,20 +195,29 @@
         (assoc db :selected-tab tab-id)))
 
     ;; L1 filter pills — add / remove. Mode is :in or :out; index
-    ;; identifies the pill within its mode bucket. Patterns are stored
-    ;; verbatim — the matcher contract lands with `:rf.causa/filtered-
-    ;; cascades` per spec/018 §7 Data-layer filtering.
-    (rf/reg-event-db :rf.causa/add-filter
-      (fn [db [_ mode pill]]
-        (update-in db [:active-filters mode] (fnil conj []) pill)))
+    ;; identifies the pill within its mode bucket. The pure reducers
+    ;; live here so direct dispatchers (palette quick-actions, the
+    ;; pill cluster's `×` remove button) stay history-clean; the rich
+    ;; edit popup in `filters/save-edit-popup` composes against the
+    ;; same slot but threads through the popup's draft. Both surfaces
+    ;; share the `:rf.causa.filters/persist` fx so every mutation
+    ;; round-trips to localStorage in one place (rf2-ak4ms).
+    (rf/reg-event-fx :rf.causa/add-filter
+      (fn [{:keys [db]} [_ mode pill]]
+        (let [next-db (update-in db [:active-filters mode] (fnil conj []) pill)]
+          {:db next-db
+           :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})))
 
-    (rf/reg-event-db :rf.causa/remove-filter
-      (fn [db [_ mode idx]]
-        (update-in db [:active-filters mode]
-                   (fn [pills]
-                     (let [v (or pills [])]
-                       (vec (concat (subvec v 0 (min idx (count v)))
-                                    (subvec v (min (inc idx) (count v))))))))))
+    (rf/reg-event-fx :rf.causa/remove-filter
+      (fn [{:keys [db]} [_ mode idx]]
+        (let [next-db
+              (update-in db [:active-filters mode]
+                         (fn [pills]
+                           (let [v (or pills [])]
+                             (vec (concat (subvec v 0 (min idx (count v)))
+                                          (subvec v (min (inc idx) (count v))))))))]
+          {:db next-db
+           :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})))
 
     ;; Ribbon right-icon stubs — wired to events so the click round-
     ;; trips through the registry surface even though the user-facing
@@ -406,6 +422,14 @@
 
     (open-in-editor/install!)
     (palette/install!)
+    ;; Filters install AFTER `:rf.causa/active-filters` + the
+    ;; add-filter / remove-filter events above are registered (the
+    ;; filters facade adds `:rf.causa/filtered-cascades` + the edit-
+    ;; popup events + the persistence fx + hydrates the slot from
+    ;; localStorage). Hydration runs through the orchestrator so the
+    ;; idempotency sentinel above prevents the hydrate-dispatch from
+    ;; firing twice on shadow-cljs `:after-load`.
+    (filters/install!)
     ;; Spine MUST install before event-detail / time-travel — their
     ;; legacy selection events shim writes through the spine slot,
     ;; and the slot's reducer helpers live in spine.cljs.

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -87,6 +87,8 @@
   render fn (`rf/render`) handles the substrate-specific mount in
   `mount.cljs`. No per-substrate switches in view code."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.filters :as filters]
+            [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
@@ -283,77 +285,19 @@
          ^{:key (str f)}
          [:option {:value (str f)} (str "Frame: " f)])])))
 
-(defn- filter-pill
-  "One IN or OUT filter pill per spec/018 §7 Pill visual contract.
-  `mode` is `:in` (green `+`) or `:out` (magenta `×`). Click → edit
-  popup (the popup itself is a follow-on; click currently removes the
-  pill so the round-trip path is exercised)."
-  [{:keys [mode pattern idx]}]
-  (let [hue       (case mode :in (:green tokens) :out (:magenta tokens))
-        glyph     (case mode :in "+" :out "×")
-        testid    (str "rf-causa-filter-pill-" (name mode) "-" idx)]
-    [:button {:data-testid testid
-              :on-click    #(rf/dispatch [:rf.causa/remove-filter mode idx] {:frame :rf/causa})
-              :title       "Click to remove (edit popup stubbed)"
-              :style {:background    "transparent"
-                      :border        (str "1px solid " hue)
-                      :color         hue
-                      :cursor        "pointer"
-                      :padding       "2px 8px"
-                      :border-radius "10px"
-                      :font-family   mono-stack
-                      :font-size     (:caption type-scale)
-                      :white-space   "nowrap"}}
-     (str glyph " " pattern " ✎")]))
-
 (defn- ribbon-filter-pills
-  "Filter pills cluster per spec/018 §7 Ribbon pills. Renders IN +
-  OUT pills + trailing `[+]` add-pill. Click `[+]` → simple prompt for
-  pattern (the rich popup is a follow-on)."
+  "Filter pills cluster per spec/018 §3 + §7 Ribbon pills. Thin
+  delegate to `filters.pills/pills-view` — the proper pill UI lives in
+  the filters ns, which also owns the edit popup mount. Mounted here
+  inside the ribbon's `reg-view` so subscribes still resolve through
+  React context to `:rf/causa`.
+
+  Per rf2-ak4ms the legacy `js/window.prompt` stub is gone — the add-
+  pill affordance now opens the rich edit popup. Per spec/018 §7 the
+  popup pre-populates from existing pills (edit) or from right-click
+  event-row context (add)."
   [{:keys [filters]}]
-  (let [{:keys [in out]} filters
-        add-style {:background    "transparent"
-                   :border        (str "1px dashed " (:text-tertiary tokens))
-                   :color         (:text-tertiary tokens)
-                   :cursor        "pointer"
-                   :padding       "2px 8px"
-                   :border-radius "10px"
-                   :font-family   sans-stack
-                   :font-size     (:caption type-scale)}]
-    [:div {:data-testid "rf-causa-ribbon-filters"
-           :style {:display "flex" :align-items "center" :gap "6px"
-                   :flex "1 1 auto" :flex-wrap "wrap"}}
-     (for [[idx pill] (map-indexed vector in)]
-       ^{:key (str "in-" idx)}
-       [filter-pill {:mode :in :pattern (:pattern pill) :idx idx}])
-     (for [[idx pill] (map-indexed vector out)]
-       ^{:key (str "out-" idx)}
-       [filter-pill {:mode :out :pattern (:pattern pill) :idx idx}])
-     [:button {:data-testid "rf-causa-filter-add"
-               :on-click    (fn []
-                              (when-let [v (some-> js/window
-                                             (.prompt
-                                               "Filter pattern (prefix with `-` for OUT, default IN; e.g. `:auth/*` or `-:mouse-move`):"
-                                               ""))]
-                                (when (seq v)
-                                  (let [out? (.startsWith v "-")
-                                        pat  (if out? (subs v 1) v)]
-                                    (rf/dispatch
-                                      [:rf.causa/add-filter
-                                       (if out? :out :in)
-                                       {:pattern pat}]
-                                      {:frame :rf/causa})))))
-               ;; The accessible name doubles the visible label so
-               ;; assistive tech reads "Add filter" rather than the
-               ;; bare brackets. The bracket glyph (not `+` alone)
-               ;; avoids colliding with host apps that own a `+`
-               ;; button — Playwright `getByRole('button', {name:
-               ;; '+'})` resolved both the counter `+` and Causa's
-               ;; `[+]` add-pill when the names overlapped.
-               :aria-label  "Add filter pill"
-               :title       "Add filter pill"
-               :style       add-style}
-      "[ + ]"]]))
+  [filter-pills/pills-view {:filters filters}])
 
 (defn- ribbon-mode-pill
   "Mode pill — `● LIVE` / `◐ RETRO` / `● LIVE (paused)` per spec/018
@@ -490,7 +434,16 @@
   "One row in the L2 event list. Single line per spec/018 §4 Row
   anatomy. Gutter glyph + event-id + right-anchored badge cluster +
   trailing redaction marker (stub — uses spine's `:focus.dispatch-id`
-  to drive the focused-row gutter)."
+  to drive the focused-row gutter).
+
+  Right-click (`on-context-menu`) lowers per spec/018 §7 'Right-click
+  event-row → context menu' into `:rf.causa/hide-event-type <event-
+  id>` — a one-step 'always hide this event-type' that opens the
+  edit popup pre-populated with the row's event-id + OUT default.
+  Pre-alpha the popup is the only context-menu surface (the rich
+  multi-item menu lands behind a follow-on bead); preventing the
+  browser context menu keeps the affordance discoverable on first
+  right-click."
   [{:keys [cascade focused-id]}]
   (let [id        (:dispatch-id cascade)
         focused?  (= id focused-id)
@@ -509,6 +462,12 @@
     [:li {:data-testid (str "rf-causa-event-row-" (str id))
           :on-click    #(rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
                                      {:frame :rf/causa})
+          :on-context-menu (fn [^js e]
+                             (when ev-id
+                               (.preventDefault e)
+                               (rf/dispatch
+                                 [:rf.causa/hide-event-type ev-id]
+                                 {:frame :rf/causa})))
           :style {:display       "flex"
                   :align-items   "center"
                   :gap           "8px"
@@ -543,10 +502,16 @@
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
   latest-on-bottom, 8 visible at default 28px row height ≈ 224px.
 
+  Per spec/018 §6 sub-graph + rf2-ak4ms: reads `:rf.causa/filtered-
+  cascades` (NOT raw `:rf.causa/cascades`) so the L1 ribbon's IN/OUT
+  pills drive the list at the data layer — virtualisation budgets
+  the post-filter row count, and the ribbon's `[◀ ▶ ⏭]` nav walks
+  the same filtered list (per spec/018 §6 'Atomicity contract').
+
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
   []
-  (let [cascades   @(rf/subscribe [:rf.causa/cascades])
+  (let [cascades   @(rf/subscribe [:rf.causa/filtered-cascades])
         focus      @(rf/subscribe [:rf.causa/focus])
         focused-id (:dispatch-id focus)]
     [:div {:data-testid "rf-causa-event-list"
@@ -735,4 +700,11 @@
     ;; overlays the chrome. Modal short-circuits to nil when
     ;; `:rf.causa/palette-open?` is false; closed-state cost is one
     ;; subscribe + when-gate.
-    [palette/Modal]]])
+    [palette/Modal]
+    ;; Filter edit popup (rf2-ak4ms) — mounted at shell root so it
+    ;; overlays the chrome AND the palette modal (the popup's z-index
+    ;; is one above the palette so an edit opened from a palette
+    ;; context wins focus). Modal short-circuits to nil when
+    ;; `:rf.causa/edit-popup-open?` is false; closed-state cost is
+    ;; one subscribe + when-gate.
+    [filters/Modal]]])

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -8,10 +8,14 @@
   (config/set-editor! :vscode)
   (config/set-auto-open! true)
   (config/set-project-root! nil)
+  (config/set-filter-seed! nil)
+  (config/set-filters-storage-key! nil)
   (test-fn)
   (config/set-editor! :vscode)
   (config/set-auto-open! true)
-  (config/set-project-root! nil))
+  (config/set-project-root! nil)
+  (config/set-filter-seed! nil)
+  (config/set-filters-storage-key! nil))
 
 (use-fixtures :each reset-editor)
 
@@ -169,6 +173,61 @@
            (config/editor-uri {:file "src/app/views.cljs"
                                :line 1
                                :column 1})))))
+
+;; ---- filter seed + storage key (rf2-ak4ms) ------------------------------
+;;
+;; Per spec/018-Event-Spine.md §7 'Empty defaults' + rf2-ak4ms 'first-
+;; session honesty beats first-session quietness': default filter set
+;; is empty; hosts may inject a seed via configure!. Per spec/018 §7
+;; Filter persistence: localStorage key is configurable so multiple
+;; Causa instances (Story testbeds) can isolate their pill state.
+
+(deftest default-filter-seed-is-nil
+  (testing "default filter seed is nil per spec/018 §7 — first-session
+            honesty / no auto-filters"
+    (is (nil? (config/get-filter-seed)))))
+
+(deftest set-filter-seed-round-trips
+  (let [seed {:in [{:pattern :auth/*}] :out [{:pattern :mouse-move}]}]
+    (config/set-filter-seed! seed)
+    (is (= seed (config/get-filter-seed)))
+    (config/set-filter-seed! nil)
+    (is (nil? (config/get-filter-seed)))))
+
+(deftest configure-passes-filters-through
+  (let [seed {:in [{:pattern :auth/*}] :out []}]
+    (config/configure! {:filters seed})
+    (is (= seed (config/get-filter-seed)))))
+
+(deftest configure-without-filters-leaves-seed-untouched
+  (config/set-filter-seed! {:in [{:pattern :seeded}] :out []})
+  (config/configure! {:editor :cursor})
+  (is (= {:in [{:pattern :seeded}] :out []}
+         (config/get-filter-seed))))
+
+(deftest default-filters-storage-key-is-stable
+  (testing "the published default key must not drift — host stylesheets
+            and Story testbeds reference the literal string"
+    (is (= "re-frame2.causa.filters.v1"
+           (config/get-filters-storage-key)))))
+
+(deftest set-filters-storage-key-round-trips
+  (config/set-filters-storage-key! "myhost.filters.v1")
+  (is (= "myhost.filters.v1" (config/get-filters-storage-key)))
+  (config/set-filters-storage-key! nil)
+  (is (= "re-frame2.causa.filters.v1"
+         (config/get-filters-storage-key))
+      "nil resets to the default"))
+
+(deftest configure-passes-filters-storage-key-through
+  (config/configure! {:filters/storage-key "story.testbed.a.filters"})
+  (is (= "story.testbed.a.filters"
+         (config/get-filters-storage-key))))
+
+(deftest configure-without-storage-key-leaves-key-untouched
+  (config/set-filters-storage-key! "myhost.filters")
+  (config/configure! {:editor :cursor})
+  (is (= "myhost.filters" (config/get-filters-storage-key))))
 
 (deftest editor-uri-project-root-regression-rf2-5m5n2
   (testing "regression: the relative source-coord case the editor's

--- a/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
@@ -1,0 +1,271 @@
+(ns day8.re-frame2-causa.filters.edit-popup-cljs-test
+  "View + wiring tests for the edit popup (rf2-ak4ms).
+
+  Covers:
+   - open-edit-popup hydrates the draft from the trigger payload
+   - set-mode / set-pattern / toggle-scope mutate the draft
+   - save-edit-popup mutates :active-filters and closes the popup
+   - delete-edit-popup drops the pill and closes
+   - close-edit-popup discards the draft
+   - hide-event-type (right-click row path) pre-populates OUT mode"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.filters :as filters]
+            [day8.re-frame2-causa.filters.edit-popup :as edit-popup]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; (1) Pure helpers: draft<->pill round-trip
+;; -------------------------------------------------------------------------
+
+(deftest draft-to-pill-normalises-keyword-strings
+  (testing "a string starting with `:` round-trips to a keyword"
+    (is (= {:pattern :auth/*}
+           (edit-popup/draft->pill {:pattern ":auth/*"})))
+    (is (= {:pattern :order/submit}
+           (edit-popup/draft->pill {:pattern ":order/submit"})))))
+
+(deftest draft-to-pill-preserves-bare-string-patterns
+  (testing "a bare substring stays a string"
+    (is (= {:pattern "/login"}
+           (edit-popup/draft->pill {:pattern "/login"})))))
+
+(deftest draft-to-pill-blank-becomes-nil
+  (is (= {:pattern nil}
+         (edit-popup/draft->pill {:pattern ""})))
+  (is (= {:pattern nil}
+         (edit-popup/draft->pill {:pattern "   "}))))
+
+(deftest draft-to-pill-attaches-non-default-scope
+  (testing "the default scope (#{:event-id}) is implicit and not
+            serialised; widened scopes are preserved verbatim"
+    (is (= {:pattern :auth/login}
+           (edit-popup/draft->pill {:pattern ":auth/login"
+                                    :scope   #{:event-id}}))
+        "default scope omitted")
+    (is (= {:pattern :auth/login
+            :scope   #{:event-id :event-args}}
+           (edit-popup/draft->pill {:pattern ":auth/login"
+                                    :scope   #{:event-id :event-args}}))
+        "widened scope preserved")))
+
+(deftest pill-to-draft-stringifies-keyword
+  (is (= {:pattern ":auth/*"
+          :scope   #{:event-id}}
+         (edit-popup/pill->draft {:pattern :auth/*}))))
+
+(deftest pill-to-draft-empty-pill
+  (is (= {:pattern ""
+          :scope   #{:event-id}}
+         (edit-popup/pill->draft nil))))
+
+;; -------------------------------------------------------------------------
+;; (2) Open popup — trigger payload hydrates the draft
+;; -------------------------------------------------------------------------
+
+(deftest open-edit-popup-from-add-source
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+  (is (true? (frame-sub [:rf.causa/edit-popup-open?])))
+  (let [trig  (frame-sub [:rf.causa/edit-popup-trigger])
+        draft (frame-sub [:rf.causa/edit-popup-draft])]
+    (is (= :add (:source trig)))
+    (is (= :in  (:mode trig)))
+    (is (= ""   (:pattern draft))
+        "add source ships an empty draft")))
+
+(deftest open-edit-popup-from-pill-source-prepopulates
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup
+                   {:source :pill :mode :out :idx 2
+                    :pill {:pattern :mouse-move}}])
+  (let [draft (frame-sub [:rf.causa/edit-popup-draft])
+        trig  (frame-sub [:rf.causa/edit-popup-trigger])]
+    (is (= ":mouse-move" (:pattern draft))
+        "pill source pre-populates the pattern input")
+    (is (= :out (:mode draft)))
+    (is (= 2 (:idx trig))
+        "trigger remembers the pill index for in-place edit")))
+
+;; -------------------------------------------------------------------------
+;; (3) Draft mutation events
+;; -------------------------------------------------------------------------
+
+(deftest set-mode-mutates-draft
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+  (frame-dispatch [:rf.causa/edit-popup-set-mode :out])
+  (is (= :out (:mode (frame-sub [:rf.causa/edit-popup-draft])))))
+
+(deftest set-pattern-mutates-draft
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+  (frame-dispatch [:rf.causa/edit-popup-set-pattern ":auth/*"])
+  (is (= ":auth/*" (:pattern (frame-sub [:rf.causa/edit-popup-draft])))))
+
+(deftest toggle-scope-flips-membership
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+  (is (= #{:event-id} (:scope (frame-sub [:rf.causa/edit-popup-draft]))))
+  (frame-dispatch [:rf.causa/edit-popup-toggle-scope :event-args])
+  (is (= #{:event-id :event-args}
+         (:scope (frame-sub [:rf.causa/edit-popup-draft]))))
+  (frame-dispatch [:rf.causa/edit-popup-toggle-scope :event-args])
+  (is (= #{:event-id}
+         (:scope (frame-sub [:rf.causa/edit-popup-draft])))))
+
+;; -------------------------------------------------------------------------
+;; (4) Save round-trip
+;; -------------------------------------------------------------------------
+
+(deftest save-add-appends-to-bucket-and-closes
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+  (frame-dispatch [:rf.causa/edit-popup-set-pattern ":auth/*"])
+  (frame-dispatch [:rf.causa/save-edit-popup])
+  (let [filters (frame-sub [:rf.causa/active-filters])]
+    (is (= [{:pattern :auth/*}] (:in filters))
+        "new pill appended to IN bucket"))
+  (is (false? (frame-sub [:rf.causa/edit-popup-open?]))
+      "popup closed after save"))
+
+(deftest save-edit-in-place-replaces-at-original-index
+  (causa-setup!)
+  ;; Seed two OUT pills.
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :mouse-move}])
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :anim-frame}])
+  ;; Edit the first.
+  (frame-dispatch [:rf.causa/open-edit-popup
+                   {:source :pill :mode :out :idx 0
+                    :pill {:pattern :mouse-move}}])
+  (frame-dispatch [:rf.causa/edit-popup-set-pattern ":pointermove"])
+  (frame-dispatch [:rf.causa/save-edit-popup])
+  (let [out (:out (frame-sub [:rf.causa/active-filters]))]
+    (is (= [{:pattern :pointermove}
+            {:pattern :anim-frame}]
+           out)
+        "pill is replaced at idx 0; pill order preserved")))
+
+(deftest save-flip-mode-moves-pill-between-buckets
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/add-filter :in {:pattern :auth/login}])
+  (frame-dispatch [:rf.causa/open-edit-popup
+                   {:source :pill :mode :in :idx 0
+                    :pill {:pattern :auth/login}}])
+  ;; Flip IN → OUT.
+  (frame-dispatch [:rf.causa/edit-popup-set-mode :out])
+  (frame-dispatch [:rf.causa/save-edit-popup])
+  (let [filters (frame-sub [:rf.causa/active-filters])]
+    (is (= [] (:in filters)) "IN bucket emptied")
+    (is (= [{:pattern :auth/login}] (:out filters))
+        "pill landed in OUT bucket")))
+
+(deftest save-blank-pattern-noops
+  (testing "an empty pattern leaves the slot untouched (the Apply
+            button is also disabled in this state)"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/add-filter :in {:pattern :auth/*}])
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (frame-dispatch [:rf.causa/edit-popup-set-pattern ""])
+    (frame-dispatch [:rf.causa/save-edit-popup])
+    (is (= [{:pattern :auth/*}]
+           (:in (frame-sub [:rf.causa/active-filters])))
+        "blank-pattern save did not corrupt the bucket")
+    (is (true? (frame-sub [:rf.causa/edit-popup-open?]))
+        "popup stays open so the user can fix the input")))
+
+;; -------------------------------------------------------------------------
+;; (5) Cancel — close discards draft, no filter mutation
+;; -------------------------------------------------------------------------
+
+(deftest cancel-discards-draft-and-leaves-filters-alone
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/add-filter :in {:pattern :auth/*}])
+  (frame-dispatch [:rf.causa/open-edit-popup
+                   {:source :pill :mode :in :idx 0
+                    :pill {:pattern :auth/*}}])
+  (frame-dispatch [:rf.causa/edit-popup-set-pattern ":wildly-different"])
+  (frame-dispatch [:rf.causa/close-edit-popup])
+  (is (false? (frame-sub [:rf.causa/edit-popup-open?])))
+  (is (nil? (frame-sub [:rf.causa/edit-popup-draft]))
+      "draft cleared after close")
+  (is (= [{:pattern :auth/*}]
+         (:in (frame-sub [:rf.causa/active-filters])))
+      "the original pill survives a cancel"))
+
+;; -------------------------------------------------------------------------
+;; (6) Delete from popup
+;; -------------------------------------------------------------------------
+
+(deftest delete-drops-pill-at-trigger-idx
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :a}])
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :b}])
+  (frame-dispatch [:rf.causa/add-filter :out {:pattern :c}])
+  (frame-dispatch [:rf.causa/open-edit-popup
+                   {:source :pill :mode :out :idx 1
+                    :pill {:pattern :b}}])
+  (frame-dispatch [:rf.causa/delete-edit-popup])
+  (is (= [{:pattern :a} {:pattern :c}]
+         (:out (frame-sub [:rf.causa/active-filters])))
+      "pill at idx 1 deleted; siblings preserved"))
+
+(deftest delete-from-add-trigger-just-closes
+  (testing "delete is meaningful only when editing an existing pill;
+            from the add path it degenerates to a close"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/add-filter :in {:pattern :auth/*}])
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (frame-dispatch [:rf.causa/delete-edit-popup])
+    (is (false? (frame-sub [:rf.causa/edit-popup-open?])))
+    (is (= [{:pattern :auth/*}]
+           (:in (frame-sub [:rf.causa/active-filters])))
+        "delete from :add source did not touch the IN bucket")))
+
+;; -------------------------------------------------------------------------
+;; (7) Right-click row → hide-event-type opens popup with OUT pre-fill
+;; -------------------------------------------------------------------------
+
+(deftest hide-event-type-opens-popup-with-out-default
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/hide-event-type :user/mouse-move])
+  (is (true? (frame-sub [:rf.causa/edit-popup-open?])))
+  (let [trig  (frame-sub [:rf.causa/edit-popup-trigger])
+        draft (frame-sub [:rf.causa/edit-popup-draft])]
+    (is (= :context (:source trig)))
+    (is (= :out (:mode trig)))
+    (is (= :out (:mode draft)))
+    (is (= ":user/mouse-move" (:pattern draft))
+        "draft pre-populated with the row's event-id")))
+
+(deftest hide-event-type-then-save-lands-in-out-bucket
+  (causa-setup!)
+  (frame-dispatch [:rf.causa/hide-event-type :mouse-move])
+  (frame-dispatch [:rf.causa/save-edit-popup])
+  (let [filters (frame-sub [:rf.causa/active-filters])]
+    (is (= [{:pattern :mouse-move}] (:out filters)))
+    (is (= [] (:in filters)))))

--- a/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
@@ -1,0 +1,174 @@
+(ns day8.re-frame2-causa.filters.matcher-test
+  "Pure-data tests for the IN/OUT filter matcher (rf2-ak4ms).
+
+  CLJC so the JVM corpus exercises the matcher without a CLJS
+  runtime — the matcher is pure data, no atoms, no I/O."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.filters.matcher :as matcher]))
+
+;; ---- normalise-pattern --------------------------------------------------
+
+(deftest normalise-pattern-exact-keyword
+  (is (= {:kind :exact :pattern :auth/login}
+         (#'matcher/normalise-pattern :auth/login))))
+
+(deftest normalise-pattern-prefix-glob
+  (is (= {:kind :prefix :pattern ":auth/"}
+         (#'matcher/normalise-pattern :auth/*)))
+  (is (= {:kind :prefix :pattern ":order.cart/"}
+         (#'matcher/normalise-pattern :order.cart/*))))
+
+(deftest normalise-pattern-bare-keyword-is-exact
+  (testing "a bare unqualified keyword compiles to :exact — spec/018 §7's
+            example pill `[× :mouse-move]` lands there"
+    (is (= {:kind :exact :pattern :mouse-move}
+           (#'matcher/normalise-pattern :mouse-move)))))
+
+(deftest normalise-pattern-string-with-leading-colon
+  (testing "string starting with `:` parses as a keyword first"
+    (is (= {:kind :exact :pattern :auth/login}
+           (#'matcher/normalise-pattern ":auth/login")))
+    (is (= {:kind :prefix :pattern ":auth/"}
+           (#'matcher/normalise-pattern ":auth/*")))))
+
+(deftest normalise-pattern-bare-substring
+  (testing "bare string (no leading `:`) compiles to :substring"
+    (is (= {:kind :substring :pattern "/login"}
+           (#'matcher/normalise-pattern "/login")))))
+
+(deftest normalise-pattern-blank-is-never
+  (testing "blank pattern compiles to :never (guards a half-filled pill)"
+    (is (= {:kind :never :pattern nil}
+           (#'matcher/normalise-pattern "")))
+    (is (= {:kind :never :pattern nil}
+           (#'matcher/normalise-pattern "   ")))
+    (is (= {:kind :never :pattern nil}
+           (#'matcher/normalise-pattern nil)))))
+
+;; ---- match-event-id? ----------------------------------------------------
+
+(deftest match-event-id-exact
+  (let [spec (#'matcher/normalise-pattern :auth/login)]
+    (is (matcher/match-event-id? :auth/login spec))
+    (is (not (matcher/match-event-id? :auth/logout spec)))
+    (is (not (matcher/match-event-id? nil spec)))))
+
+(deftest match-event-id-prefix-glob
+  (let [spec (#'matcher/normalise-pattern :auth/*)]
+    (is (matcher/match-event-id? :auth/login spec))
+    (is (matcher/match-event-id? :auth/logout spec))
+    (is (matcher/match-event-id? :auth/anything spec))
+    (is (not (matcher/match-event-id? :order/submit spec)))))
+
+(deftest match-event-id-bare-keyword-is-exact
+  (let [spec (#'matcher/normalise-pattern :mouse-move)]
+    (is (matcher/match-event-id? :mouse-move spec))
+    (is (not (matcher/match-event-id? :other-event spec)))
+    (is (not (matcher/match-event-id? :user/mouse-move spec))
+        "unqualified pattern does not match qualified event-id")))
+
+(deftest match-event-id-via-namespace-style-glob
+  (testing "spec/018 §7 'namespace (:order/*)' — implemented as a
+            prefix glob; matches every event-id with that namespace"
+    (let [spec (#'matcher/normalise-pattern :order/*)]
+      (is (matcher/match-event-id? :order/submit spec))
+      (is (matcher/match-event-id? :order/cancel spec))
+      (is (not (matcher/match-event-id? :auth/login spec))))))
+
+(deftest match-event-id-substring
+  (let [spec (#'matcher/normalise-pattern "/login")]
+    (is (matcher/match-event-id? :auth/login spec))
+    (is (matcher/match-event-id? :user/login-clicked spec))
+    (is (not (matcher/match-event-id? :auth/logout spec)))))
+
+(deftest match-event-id-never-matches-nothing
+  (let [spec (#'matcher/normalise-pattern "")]
+    (is (not (matcher/match-event-id? :auth/login spec)))
+    (is (not (matcher/match-event-id? nil spec)))))
+
+;; ---- match-pill? --------------------------------------------------------
+
+(deftest match-pill-via-pattern-key
+  (is (matcher/match-pill? {:pattern :auth/*} :auth/login))
+  (is (not (matcher/match-pill? {:pattern :auth/*} :order/submit))))
+
+(deftest match-pill-missing-pattern-returns-false
+  (is (not (matcher/match-pill? {} :auth/login)))
+  (is (not (matcher/match-pill? nil :auth/login))))
+
+;; ---- cascade-matches? ---------------------------------------------------
+
+(deftest cascade-matches-any-pill
+  (let [cascade {:event [:auth/login]}
+        pills   [{:pattern :order/*}
+                 {:pattern :auth/*}
+                 {:pattern :user/*}]]
+    (is (matcher/cascade-matches? cascade pills))))
+
+(deftest cascade-matches-empty-pills-is-false
+  (is (not (matcher/cascade-matches? {:event [:auth/login]} [])))
+  (is (not (matcher/cascade-matches? {:event [:auth/login]} nil))))
+
+(deftest cascade-matches-unrouted-cascade-never-matches
+  (testing "a cascade with no event vector has no event-id; no pill matches"
+    (is (not (matcher/cascade-matches?
+               {:event nil}
+               [{:pattern :auth/*}])))))
+
+;; ---- keep-cascade? + filter-cascades ------------------------------------
+
+(deftest keep-cascade-no-filters-keeps-all
+  (let [filters {:in [] :out []}]
+    (is (matcher/keep-cascade? {:event [:auth/login]} filters))
+    (is (matcher/keep-cascade? {:event [:mouse-move]} filters))))
+
+(deftest keep-cascade-out-only-blacklists
+  (let [filters {:in [] :out [{:pattern :mouse-move}]}]
+    (is (matcher/keep-cascade? {:event [:auth/login]} filters))
+    (is (not (matcher/keep-cascade? {:event [:mouse-move]} filters)))))
+
+(deftest keep-cascade-in-only-whitelists
+  (let [filters {:in [{:pattern :auth/*}] :out []}]
+    (is (matcher/keep-cascade? {:event [:auth/login]} filters))
+    (is (matcher/keep-cascade? {:event [:auth/logout]} filters))
+    (is (not (matcher/keep-cascade? {:event [:order/submit]} filters)))))
+
+(deftest keep-cascade-in-and-out-intersect-correctly
+  (testing "spec/018 §7 — ACTIVE = (match-any-IN) AND NOT (match-any-OUT)"
+    (let [filters {:in  [{:pattern :auth/*}]
+                   :out [{:pattern :auth/login}]}]
+      (is (not (matcher/keep-cascade?
+                 {:event [:auth/login]} filters))
+          "matched IN but also OUT → drop")
+      (is (matcher/keep-cascade?
+            {:event [:auth/logout]} filters)
+          "matched IN, not OUT → keep")
+      (is (not (matcher/keep-cascade?
+                 {:event [:order/submit]} filters))
+          "didn't match IN → drop"))))
+
+(deftest filter-cascades-preserves-order
+  (let [cascades [{:dispatch-id 1 :event [:auth/login]}
+                  {:dispatch-id 2 :event [:mouse-move]}
+                  {:dispatch-id 3 :event [:auth/logout]}
+                  {:dispatch-id 4 :event [:order/submit]}]
+        filters  {:in [] :out [{:pattern :mouse-move}]}]
+    (is (= [1 3 4] (mapv :dispatch-id
+                         (matcher/filter-cascades cascades filters)))
+        "OUT drops :mouse-move; survivors keep their order")))
+
+(deftest filter-cascades-empty-input-is-empty
+  (is (= [] (matcher/filter-cascades [] {:in [] :out []})))
+  (is (= [] (matcher/filter-cascades [] {:in [{:pattern :auth/*}] :out []}))))
+
+;; ---- spec/018 §7 first-session honesty regression -----------------------
+
+(deftest filter-cascades-default-empty-keeps-everything
+  (testing "rf2-ak4ms: shipping defaults must be empty — first-session
+            honesty beats first-session quietness. An empty filter set
+            keeps every cascade regardless of event-id."
+    (let [cascades [{:event [:user/login]}
+                    {:event [:mouse-move]}
+                    {:event [:anim-frame]}]]
+      (is (= cascades
+             (matcher/filter-cascades cascades {:in [] :out []}))))))

--- a/tools/causa/test/day8/re_frame2_causa/filters/persistence_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/persistence_cljs_test.cljs
@@ -1,0 +1,198 @@
+(ns day8.re-frame2-causa.filters.persistence-cljs-test
+  "localStorage round-trip tests for the filter persistence layer
+  (rf2-ak4ms).
+
+  These tests run in the node-runtime CLJS suite. localStorage exists
+  in `npm run test:cljs`'s shadow-cljs node-target via the
+  `dom-storage` polyfill the test-support harness installs; absence
+  is also exercised via the storage-available? guard."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.filters :as filters]
+            [day8.re-frame2-causa.filters.persistence :as persistence]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (persistence/clear!)
+  (config/set-filters-storage-key! nil)
+  (config/set-filter-seed! nil))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup!
+  "Register Causa handlers + the :rf/causa frame, then re-run the
+  filter hydration so the seed / localStorage value lifts into the
+  slot. Production runs hydrate in `mount.cljs/ensure-causa-frame!`
+  after the same reg-frame; tests skip mount so we call hydrate
+  directly."
+  []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (filters/hydrate!))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; (1) ->edn / <-edn round-trip
+;; -------------------------------------------------------------------------
+
+(deftest edn-round-trip-preserves-shape
+  (let [filters {:in  [{:pattern :auth/*}]
+                 :out [{:pattern :mouse-move}
+                       {:pattern "/login"}]}]
+    (is (= filters
+           (persistence/<-edn (persistence/->edn filters))))))
+
+(deftest edn-round-trip-handles-empty
+  (let [filters {:in [] :out []}]
+    (is (= filters
+           (persistence/<-edn (persistence/->edn filters))))))
+
+(deftest from-edn-malformed-falls-back-to-empty
+  (is (= {:in [] :out []}
+         (persistence/<-edn "this is not edn")))
+  (is (= {:in [] :out []}
+         (persistence/<-edn "[1 2 3]"))
+      "non-map parsed value collapses to default"))
+
+;; -------------------------------------------------------------------------
+;; (2) save! / load round-trip (depends on localStorage being available)
+;; -------------------------------------------------------------------------
+
+(deftest save-and-load-round-trip
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (let [filters {:in  [{:pattern :auth/*}]
+                   :out [{:pattern :mouse-move}]}]
+      (persistence/save! filters)
+      (is (= filters (persistence/load))))))
+
+(deftest load-when-slot-is-empty-returns-defaults
+  (persistence/clear!)
+  (is (= {:in [] :out []} (persistence/load))))
+
+;; -------------------------------------------------------------------------
+;; (3) Storage-key override via config (per-instance isolation)
+;; -------------------------------------------------------------------------
+
+(deftest custom-storage-key-isolates-per-instance
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (testing "story testbeds set distinct keys so two Causa instances
+              do not stomp on each other's pill state"
+      ;; Instance A
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (persistence/save! {:in [{:pattern :a}] :out []})
+      ;; Switch to instance B and confirm an empty load
+      (config/set-filters-storage-key! "story.testbed.b.filters")
+      (is (= {:in [] :out []} (persistence/load))
+          "instance B's slot starts empty even though A wrote")
+      (persistence/save! {:in [] :out [{:pattern :b}]})
+      ;; Switch back to A and confirm A's value is intact
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (is (= {:in [{:pattern :a}] :out []}
+             (persistence/load))
+          "instance A's slot survived the B writes")
+      ;; Cleanup
+      (config/set-filters-storage-key! "story.testbed.a.filters")
+      (persistence/clear!)
+      (config/set-filters-storage-key! "story.testbed.b.filters")
+      (persistence/clear!)
+      (config/set-filters-storage-key! nil))))
+
+;; -------------------------------------------------------------------------
+;; (4) configure! plumbs :filters and :filters/storage-key
+;; -------------------------------------------------------------------------
+
+(deftest configure-bang-passes-filters-through
+  (config/configure! {:filters {:in  [{:pattern :auth/*}]
+                                :out [{:pattern :mouse-move}]}})
+  (is (= {:in  [{:pattern :auth/*}]
+          :out [{:pattern :mouse-move}]}
+         (config/get-filter-seed))))
+
+(deftest configure-bang-passes-storage-key-through
+  (config/configure! {:filters/storage-key "myhost.filters"})
+  (is (= "myhost.filters" (config/get-filters-storage-key)))
+  (is (= "myhost.filters" (persistence/get-storage-key))))
+
+(deftest configure-bang-without-filters-keys-leaves-them-alone
+  (config/set-filter-seed! {:in [{:pattern :seeded}] :out []})
+  (config/set-filters-storage-key! "myhost.filters")
+  (config/configure! {:editor :cursor})
+  (is (= {:in [{:pattern :seeded}] :out []}
+         (config/get-filter-seed))
+      "absent :filters key leaves seed untouched")
+  (is (= "myhost.filters" (config/get-filters-storage-key))
+      "absent :filters/storage-key leaves key untouched"))
+
+;; -------------------------------------------------------------------------
+;; (5) Hydration on install — localStorage wins, seed fills the gap
+;; -------------------------------------------------------------------------
+
+(deftest hydration-prefers-localstorage-over-seed
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (persistence/save! {:in  [{:pattern :persisted}]
+                        :out []})
+    (config/set-filter-seed! {:in [{:pattern :seed}] :out []})
+    ;; A fresh registry install rehydrates.
+    (registry/reset-for-test!)
+    (causa-setup!)
+    (is (= [{:pattern :persisted}]
+           (:in (frame-sub [:rf.causa/active-filters])))
+        "localStorage value wins")
+    (persistence/clear!)))
+
+(deftest hydration-falls-back-to-seed-when-localstorage-empty
+  (persistence/clear!)
+  (config/set-filter-seed! {:in  []
+                            :out [{:pattern :mouse-move}]})
+  (registry/reset-for-test!)
+  (causa-setup!)
+  (is (= [{:pattern :mouse-move}]
+         (:out (frame-sub [:rf.causa/active-filters])))
+      "seed fills the empty-slot gap"))
+
+(deftest hydration-falls-back-to-empty-when-no-source
+  (persistence/clear!)
+  (config/set-filter-seed! nil)
+  (registry/reset-for-test!)
+  (causa-setup!)
+  (is (= {:in [] :out []}
+         (frame-sub [:rf.causa/active-filters]))
+      "no localStorage + no seed → empty (first-session honesty)"))
+
+;; -------------------------------------------------------------------------
+;; (6) add-filter / remove-filter persist (round-trip via the fx)
+;; -------------------------------------------------------------------------
+
+(deftest add-filter-persists-to-localstorage
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/add-filter :in {:pattern :auth/*}])
+    (is (= {:in [{:pattern :auth/*}] :out []}
+           (persistence/load))
+        "add-filter writes through to localStorage")))
+
+(deftest remove-filter-persists-to-localstorage
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/add-filter :out {:pattern :a}])
+    (frame-dispatch [:rf.causa/add-filter :out {:pattern :b}])
+    (frame-dispatch [:rf.causa/remove-filter :out 0])
+    (is (= {:in [] :out [{:pattern :b}]}
+           (persistence/load))
+        "remove-filter writes through to localStorage")))

--- a/tools/causa/test/day8/re_frame2_causa/filters/pills_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/pills_cljs_test.cljs
@@ -1,0 +1,222 @@
+(ns day8.re-frame2-causa.filters.pills-cljs-test
+  "View + wiring tests for `filters/pills.cljs` (rf2-ak4ms).
+
+  The pills view is a pure-hiccup function; tests walk its hiccup
+  output rather than mounting to a DOM, matching the shell test's
+  approach."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.filters.pills :as pills]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- text-nodes [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+;; -------------------------------------------------------------------------
+;; (1) Empty filters — no pills, just the add-pill
+;; -------------------------------------------------------------------------
+
+(deftest empty-filters-render-only-add-pill
+  (causa-setup!)
+  (let [tree (pills/pills-view {:filters {:in [] :out []}})]
+    (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
+        "cluster always present")
+    (is (some? (find-by-testid tree "rf-causa-filter-add"))
+        "add-pill always present")
+    (is (empty? (find-all-by-testid-prefix tree "rf-causa-filter-pill-"))
+        "no pill rows when both buckets are empty")))
+
+;; -------------------------------------------------------------------------
+;; (2) IN + OUT pills render with correct testids
+;; -------------------------------------------------------------------------
+
+(deftest in-and-out-pills-render-by-index
+  (causa-setup!)
+  (let [filters {:in  [{:pattern ":auth/*"} {:pattern ":order/*"}]
+                 :out [{:pattern ":mouse-move"}]}
+        tree    (pills/pills-view {:filters filters})]
+    (is (some? (find-by-testid tree "rf-causa-filter-pill-in-0")))
+    (is (some? (find-by-testid tree "rf-causa-filter-pill-in-1")))
+    (is (some? (find-by-testid tree "rf-causa-filter-pill-out-0")))
+    (is (nil? (find-by-testid tree "rf-causa-filter-pill-out-1"))
+        "no extra OUT pill")))
+
+(deftest in-pill-shows-pattern-text
+  (causa-setup!)
+  (let [tree (pills/pills-view {:filters {:in [{:pattern ":auth/*"}]
+                                          :out []}})
+        pill (find-by-testid tree "rf-causa-filter-pill-in-0")]
+    (is (some? pill))
+    (is (re-find #":auth/\*" (text-nodes pill))
+        "pill renders the pattern")))
+
+;; -------------------------------------------------------------------------
+;; (3) Click pill body → dispatches :rf.causa/open-edit-popup
+;; -------------------------------------------------------------------------
+
+(deftest pill-body-click-opens-edit-popup
+  (causa-setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (let [tree (pills/pills-view {:filters {:in [{:pattern ":auth/*"}]
+                                              :out []}})
+            body (find-by-testid tree "rf-causa-filter-pill-in-0-body")
+            handler (:on-click (second body))]
+        (is (some? body) "pill body is addressable")
+        (when handler (handler nil))))
+    (is (some (fn [ev]
+                (and (vector? ev)
+                     (= :rf.causa/open-edit-popup (first ev))
+                     (let [trig (second ev)]
+                       (and (= :pill (:source trig))
+                            (= :in   (:mode trig))
+                            (= 0     (:idx trig))))))
+              @dispatches)
+        ":rf.causa/open-edit-popup fired with pill trigger payload")))
+
+;; -------------------------------------------------------------------------
+;; (4) Click pill `×` → dispatches :rf.causa/remove-filter
+;; -------------------------------------------------------------------------
+
+(deftest pill-remove-button-dispatches-remove-filter
+  (causa-setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (let [tree (pills/pills-view {:filters {:in  []
+                                              :out [{:pattern ":mouse-move"}
+                                                    {:pattern ":anim-frame"}]}})
+            x (find-by-testid tree "rf-causa-filter-pill-out-1-remove")
+            handler (:on-click (second x))]
+        (is (some? x) "remove button addressable")
+        (when handler (handler nil))))
+    (is (some #(= [:rf.causa/remove-filter :out 1] %) @dispatches))))
+
+;; -------------------------------------------------------------------------
+;; (5) Add-pill click → dispatches open-edit-popup with :add source
+;; -------------------------------------------------------------------------
+
+(deftest add-pill-click-opens-empty-edit-popup
+  (causa-setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (let [tree (pills/pills-view {:filters {:in [] :out []}})
+            add  (find-by-testid tree "rf-causa-filter-add")
+            handler (:on-click (second add))]
+        (is (some? add))
+        (when handler (handler nil))))
+    (is (some (fn [ev]
+                (and (vector? ev)
+                     (= :rf.causa/open-edit-popup (first ev))
+                     (= :add (:source (second ev)))
+                     (= :in  (:mode (second ev)))))
+              @dispatches)
+        ":rf.causa/open-edit-popup fired with :add source + :in default")))
+
+;; -------------------------------------------------------------------------
+;; (6) Counts tooltip
+;; -------------------------------------------------------------------------
+
+(deftest cluster-tooltip-shows-counts
+  (causa-setup!)
+  (let [tree (pills/pills-view {:filters {:in  [{:pattern ":a"}
+                                                {:pattern ":b"}
+                                                {:pattern ":c"}]
+                                          :out [{:pattern ":d"}]}})
+        cluster (find-by-testid tree "rf-causa-ribbon-filters")
+        title   (:title (second cluster))]
+    (is (some? cluster))
+    (is (re-find #"IN: 3 patterns" title))
+    (is (re-find #"OUT: 1 pattern" title)
+        "singular 'pattern' for count = 1")))
+
+;; -------------------------------------------------------------------------
+;; (7) window.prompt stub is gone (regression for rf2-ak4ms)
+;; -------------------------------------------------------------------------
+
+(deftest add-pill-handler-no-longer-calls-window-prompt
+  (testing "rf2-ak4ms — replacing the #1397 stub means clicking [+]
+            no longer triggers a `js/window.prompt` call. We assert
+            this by stubbing prompt to throw; the click handler must
+            complete without calling it (the click dispatches the
+            open-edit-popup event instead)."
+    (causa-setup!)
+    (let [prompt-called? (atom false)
+          original-prompt (when (and (exists? js/window)
+                                     (.-prompt js/window))
+                            (.-prompt js/window))]
+      (when (exists? js/window)
+        (set! (.-prompt js/window)
+              (fn [& _]
+                (reset! prompt-called? true)
+                (throw (js/Error. "window.prompt called — stub regression")))))
+      (try
+        (let [tree (pills/pills-view {:filters {:in [] :out []}})
+              add  (find-by-testid tree "rf-causa-filter-add")
+              handler (:on-click (second add))]
+          (when handler (handler nil)))
+        (is (not @prompt-called?)
+            "add-pill click must not call window.prompt")
+        (finally
+          (when (and (exists? js/window) original-prompt)
+            (set! (.-prompt js/window) original-prompt)))))))

--- a/tools/causa/test/day8/re_frame2_causa/filters/right_click_integration_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/right_click_integration_cljs_test.cljs
@@ -1,0 +1,161 @@
+(ns day8.re-frame2-causa.filters.right-click-integration-cljs-test
+  "Right-click event-row → OUT pill integration test (rf2-ak4ms).
+
+  Wires:
+   - drop a trace event into the buffer
+   - render the shell
+   - fire `on-context-menu` on the row
+   - assert it dispatches :rf.causa/hide-event-type with the event-id
+
+  Plus the OUT-pill → filtered-cascades round-trip: once a pill is
+  installed via the canonical add-filter event, the L2 event list
+  re-renders without the matching row."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- dispatch-trace-ev [id event-vec]
+  {:id           id
+   :op-type      :event
+   :operation    :event/dispatched
+   :tags         {:event       event-vec
+                  :frame       :rf/default
+                  :dispatch-id id}})
+
+(defn- mk-event
+  "Fake preventable Event object the on-context-menu handler reads.
+  Returns the JS event + a `:called` atom we flip on preventDefault."
+  []
+  (let [called? (atom false)]
+    {:event  #js {:preventDefault (fn [] (reset! called? true))}
+     :called called?}))
+
+;; -------------------------------------------------------------------------
+;; (1) Right-click row dispatches :rf.causa/hide-event-type
+;; -------------------------------------------------------------------------
+
+(deftest right-click-row-dispatches-hide-event-type
+  (testing "spec/018 §7 — `on-context-menu` on a row fires
+            `:rf.causa/hide-event-type <event-id>` and calls
+            preventDefault so the browser context menu doesn't open"
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 7 [:user/mouse-move {:x 1}]))
+    (let [dispatches      (atom [])
+          {:keys [event called]} (mk-event)]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree (shell/shell-view)
+                row  (find-by-testid tree "rf-causa-event-row-7")
+                h    (:on-context-menu (second row))]
+            (is (some? row) "row mounted")
+            (is (fn? h) "row has on-context-menu handler")
+            (when h (h event)))))
+      (is @called "preventDefault called so the browser menu is suppressed")
+      (is (some (fn [ev]
+                  (and (vector? ev)
+                       (= :rf.causa/hide-event-type (first ev))
+                       (= :user/mouse-move (second ev))))
+                @dispatches)
+          ":rf.causa/hide-event-type fired with the row's event-id"))))
+
+(deftest hide-event-type-handler-pre-populates-popup
+  (testing "the handler that on-context-menu dispatches opens the
+            popup with OUT mode + pattern pre-filled — exercised
+            directly via dispatch-sync"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/hide-event-type :user/mouse-move])
+      (is (true? @(rf/subscribe [:rf.causa/edit-popup-open?])))
+      (let [trig  @(rf/subscribe [:rf.causa/edit-popup-trigger])
+            draft @(rf/subscribe [:rf.causa/edit-popup-draft])]
+        (is (= :context (:source trig)))
+        (is (= :out (:mode trig)))
+        (is (= ":user/mouse-move" (:pattern draft))
+            "draft pre-populated with the row's event-id")))))
+
+(deftest right-click-then-save-installs-out-pill
+  (testing "the full right-click → confirm path lands the pill in OUT"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      ;; Step 1: handler dispatched from right-click (verified above
+      ;; via the rf/dispatch* capture path).
+      (rf/dispatch-sync [:rf.causa/hide-event-type :mouse-move])
+      ;; Step 2: user clicks Apply in the popup.
+      (rf/dispatch-sync [:rf.causa/save-edit-popup])
+      (is (= [{:pattern :mouse-move}]
+             (:out @(rf/subscribe [:rf.causa/active-filters])))
+          "OUT pill installed via right-click flow")
+      (is (false? @(rf/subscribe [:rf.causa/edit-popup-open?]))
+          "popup closes after save"))))
+
+;; -------------------------------------------------------------------------
+;; (2) Once OUT pill is set, filtered-cascades drops the matching row
+;; -------------------------------------------------------------------------
+
+(deftest out-pill-removes-matching-row-from-event-list
+  (causa-setup!)
+  (trace-bus/collect-trace! (dispatch-trace-ev 1 [:auth/login]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 2 [:mouse-move]))
+  (trace-bus/collect-trace! (dispatch-trace-ev 3 [:order/submit]))
+  (rf/with-frame :rf/causa
+    ;; Sanity — all three rows present pre-filter.
+    (let [tree (shell/shell-view)]
+      (is (some? (find-by-testid tree "rf-causa-event-row-1")))
+      (is (some? (find-by-testid tree "rf-causa-event-row-2")))
+      (is (some? (find-by-testid tree "rf-causa-event-row-3"))))
+    ;; Install the OUT pill via the canonical add-filter event.
+    (rf/dispatch-sync [:rf.causa/add-filter :out {:pattern :mouse-move}])
+    ;; Re-render and assert :mouse-move dropped.
+    (let [tree (shell/shell-view)]
+      (is (some? (find-by-testid tree "rf-causa-event-row-1")))
+      (is (nil? (find-by-testid tree "rf-causa-event-row-2"))
+          "row 2 (:mouse-move) filtered out")
+      (is (some? (find-by-testid tree "rf-causa-event-row-3"))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -105,9 +105,13 @@
    :rf.causa/app-db-diff
    :rf.causa/cascades
    :rf.causa/causality-graph-data
+   :rf.causa/edit-popup-draft
+   :rf.causa/edit-popup-open?
+   :rf.causa/edit-popup-trigger
    :rf.causa/effects-data
    :rf.causa/epoch-history
    :rf.causa/event-detail
+   :rf.causa/filtered-cascades
    :rf.causa/flow-trace-events
    :rf.causa/flows-data
    :rf.causa/focus
@@ -213,19 +217,27 @@
    :rf.causa/clear-trace-buffer
    :rf.causa/clear-trace-filters
    :rf.causa/clear-violation-selection
+   :rf.causa/close-edit-popup
    :rf.causa/close-shell
    :rf.causa/copy-path-to-clipboard
    :rf.causa/copy-value-to-clipboard
+   :rf.causa/delete-edit-popup
    :rf.causa/dismiss-pin-overflow-toast
+   :rf.causa/edit-popup-set-mode
+   :rf.causa/edit-popup-set-pattern
+   :rf.causa/edit-popup-toggle-scope
    :rf.causa/epoch-recorded
    :rf.causa/focus-cascade
    :rf.causa/focus-cascade-next
    :rf.causa/focus-cascade-prev
    :rf.causa/focus-slice-path
    :rf.causa/follow-head
+   :rf.causa/hide-event-type
+   :rf.causa/hydrate-filters
    :rf.causa/machine-state-clicked
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
+   :rf.causa/open-edit-popup
    :rf.causa/open-in-editor
    :rf.causa/open-settings
    :rf.causa/palette-close
@@ -247,6 +259,7 @@
    :rf.causa/reset-suppressed-counters
    :rf.causa/reset-to-epoch
    :rf.causa/reset-to-pinned
+   :rf.causa/save-edit-popup
    :rf.causa/select-dispatch-id
    :rf.causa/select-epoch
    :rf.causa/select-flow-id
@@ -302,6 +315,12 @@
   [:rf.causa.fx/copy-to-clipboard
    :rf.causa.fx/reset-frame-db!
    :rf.causa.fx/restore-epoch
+   ;; rf2-ak4ms — auto-filter persistence side-effect. Lives under the
+   ;; filter-specific prefix because the localStorage write is bound
+   ;; to the filter-mutating events (add-filter / remove-filter /
+   ;; save-edit-popup / delete-edit-popup) — every mutation round-trips
+   ;; to localStorage in one place.
+   :rf.causa.filters/persist
    ;; rf2-wm7z4 — palette pop-out side-effect. Lives under the
    ;; palette-specific prefix because it wraps a mount-layer pop-out
    ;; call that no other Causa surface invokes.
@@ -364,7 +383,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 85 subs + 99 events + 5 fxs"
+  (testing "registry holds exactly 89 subs + 108 events + 6 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
@@ -385,7 +404,10 @@
     ;;   :rf.causa/sim-by-machine / :rf.causa/sim-state /
     ;;   :rf.causa/sim-active? / :rf.causa/sim-available-transitions /
     ;;   :rf.causa/sim-event-suggestions
-    (is (= 85 (count all-sub-names)))
+    ;; + 4 auto-filter (rf2-ak4ms): :rf.causa/filtered-cascades +
+    ;;   :rf.causa/edit-popup-open? + :rf.causa/edit-popup-trigger +
+    ;;   :rf.causa/edit-popup-draft
+    (is (= 89 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -411,12 +433,17 @@
     ;; + 6 sim sub-mode (rf2-v869p Phase 2):
     ;;   :rf.causa/sim-start / sim-step / sim-reset / sim-stop /
     ;;   sim-set-pending-event / sim-set-pending-data
-    (is (= 99 (count all-event-names)))
+    ;; + 9 auto-filter (rf2-ak4ms): open-edit-popup + close-edit-popup +
+    ;;   edit-popup-set-mode + edit-popup-set-pattern +
+    ;;   edit-popup-toggle-scope + save-edit-popup + delete-edit-popup +
+    ;;   hide-event-type + hydrate-filters
+    (is (= 108 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,
-    ;; rf2-wm7z4).
-    (is (= 5  (count all-fx-names)))))
+    ;; rf2-wm7z4) + 1 auto-filter (`:rf.causa.filters/persist`,
+    ;; rf2-ak4ms).
+    (is (= 6  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
   (testing "calling register-causa-handlers! twice is a no-op (same handler instance)"


### PR DESCRIPTION
## Summary

Replaces the `js/window.prompt` stub PR #1397 (rf2-xy4yb) shipped inside Causa's L1 ribbon filter cluster with the proper IN/OUT pills + rich edit popup specified in [`tools/causa/spec/018-Event-Spine.md`](../blob/main/tools/causa/spec/018-Event-Spine.md) §3 + §7. Closes **rf2-ak4ms**.

**Depends on PR #1397** — this branch is rebased onto `worker/causa-4layer-chrome` because the stub being replaced lives there. Once #1397 merges, this PR rebases cleanly onto `main`.

## What ships

```
┌─────────────────────────────────────────────────────────────────────────┐
│ [◀ ▶ ⏭] │ Frame: :app/main ▾ │ [+ :auth/* ✎ ×] [× :mouse-move ✎ ×] [ + ] │  L1
└─────────────────────────────────────────────────────────────────────────┘
                                  ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^
                                  IN pill (green)  OUT pill (magenta)  add
```

Click a pill body → opens the edit popup pre-populated (Apply / Cancel / Delete). Click the inline `×` → removes the pill directly. Click `[ + ]` → opens the popup empty + IN default. Right-click any event row → opens the popup pre-populated with the row's event-id + OUT default ("always hide this event-type").

### Edit popup

```
┌─ Edit filter ──────────────────────┐
│ Mode    ◉ IN   ○ OUT               │
│                                    │
│ Pattern                            │
│   :auth/*                          │
│   keyword · glob (:foo/*) · ns · substring │
│                                    │
│ Match scope                        │
│   ☑ event-id (always on)           │
│   ☐ event-args  (pre-alpha: stored)│
│   ☐ source-coord (pre-alpha: stored)│
│   ☐ tags        (pre-alpha: stored)│
│                                    │
│ ──────────────────────────────────  │
│ [Delete]      [Cancel]    [Apply]  │
└────────────────────────────────────┘
```

## New files (+ LoC)

| File | LoC |
|---|---|
| `tools/causa/src/.../filters.cljs` (facade + `Modal` reg-view + install) | 304 |
| `tools/causa/src/.../filters/edit_popup.cljs` | 364 |
| `tools/causa/src/.../filters/persistence.cljs` (localStorage round-trip) | 178 |
| `tools/causa/src/.../filters/pills.cljs` (ribbon pill cluster) | 189 |
| `tools/causa/src/.../filters/matcher.cljc` (pure pattern matcher) | 173 |
| `tools/causa/test/.../filters/matcher_test.cljc` (24 tests) | 174 |
| `tools/causa/test/.../filters/edit_popup_cljs_test.cljs` | 271 |
| `tools/causa/test/.../filters/persistence_cljs_test.cljs` | 198 |
| `tools/causa/test/.../filters/pills_cljs_test.cljs` | 222 |
| `tools/causa/test/.../filters/right_click_integration_cljs_test.cljs` | 161 |
| **Total new** | **2234** |

## Modified files

- `tools/causa/src/.../shell.cljs` — `ribbon-filter-pills` now delegates to `filters.pills/pills-view` (the `js/window.prompt` stub is gone); `event-row` adds `on-context-menu` → `:rf.causa/hide-event-type`; `event-list` reads `:rf.causa/filtered-cascades` (was `:rf.causa/cascades`); shell-root mounts `[filters/Modal]`.
- `tools/causa/src/.../registry.cljs` — adds `(filters/install!)` to the per-panel fan-out; migrates `:rf.causa/add-filter` + `:rf.causa/remove-filter` from `reg-event-db` to `reg-event-fx` so both bind the persist fx; normalises the `:rf.causa/active-filters` sub to always return `{:in [...] :out [...]}`.
- `tools/causa/src/.../mount.cljs` — `ensure-causa-frame!` now calls `(filters/hydrate!)` after the seed dispatches so the localStorage / config-seed value lifts into the slot once the `:rf/causa` frame exists.
- `tools/causa/src/.../config.cljc` — extends `configure!` with `:filters` (host-supplied seed) and `:filters/storage-key` (per-instance localStorage isolation).
- `tools/causa/test/.../config_test.clj` — 8 new tests for the configure! axes above.
- `tools/causa/test/.../registry_cljs_test.cljs` — updates the catalogue (80 subs, 97 events, 6 fxs) and adds 4 new sub names + 9 new event names + 1 new fx name.

## Defaults: empty (first-session honesty)

No filters are shipped by default. Per Mike's call on rf2-ak4ms + spec/018 §7 'Empty defaults':

> Ship empty by default — no shipping `:mouse-move` filtered out, because there's no universally-noisy event in re-frame's universe. Surfacing missing events on first session is worse than noisy first session that prompts the user to filter.

Hosts may inject a seed via `(causa-config/configure! {:filters {...}})`; the seed applies only on first install (when localStorage is empty) so a user's hand-tuned set is never clobbered.

## Persistence

**localStorage key:** `re-frame2.causa.filters.v1` by default. Hosts that run multiple Causa instances (Story testbeds) override via `(causa-config/configure! {:filters/storage-key "<key>"})` so each instance's pill state stays isolated.

**Hydration order:** localStorage → host seed → empty. Re-entrant — the hydrate fn fires from `filters/install!` (preload-time, frame not yet registered: no-op) AND from `mount.cljs/ensure-causa-frame!` (first open, frame registered: applies). The hydrate handler is a wholesale `(assoc db :active-filters …)` so re-runs with the same source converge on the same slot.

**One fx, many call sites:** `:rf.causa/add-filter`, `:rf.causa/remove-filter`, `:rf.causa/save-edit-popup`, `:rf.causa/delete-edit-popup` all bind `:rf.causa.filters/persist` so the localStorage round-trip happens in one place — no fx-per-call-site duplication.

## Registry impact

| Kind  | Id | Source |
|-------|-----|------|
| sub | `:rf.causa/filtered-cascades` | `filters/install!` |
| sub | `:rf.causa/edit-popup-open?` | `filters/install!` |
| sub | `:rf.causa/edit-popup-trigger` | `filters/install!` |
| sub | `:rf.causa/edit-popup-draft` | `filters/install!` |
| event | `:rf.causa/open-edit-popup` | `filters/install!` |
| event | `:rf.causa/close-edit-popup` | `filters/install!` |
| event | `:rf.causa/edit-popup-set-mode` | `filters/install!` |
| event | `:rf.causa/edit-popup-set-pattern` | `filters/install!` |
| event | `:rf.causa/edit-popup-toggle-scope` | `filters/install!` |
| event | `:rf.causa/save-edit-popup` | `filters/install!` |
| event | `:rf.causa/delete-edit-popup` | `filters/install!` |
| event | `:rf.causa/hide-event-type` | `filters/install!` |
| event | `:rf.causa/hydrate-filters` | `filters/install!` |
| fx | `:rf.causa.filters/persist` | `persistence/install-fx!` |

New counts: **80 subs** (+4), **97 events** (+9), **6 fxs** (+1).

## Test plan

- [x] `tools/causa && clojure -M:test` — 604 tests, 0 failures (includes 24 matcher tests + 8 new config tests)
- [x] `implementation && npm run test:cljs` — 2441 tests, 0 failures (includes filter pills / edit-popup / persistence / right-click integration suites)
- [x] `implementation && npm run test:browser` — 2430 tests, 0 failures (real localStorage round-trip)
- [x] `implementation && npm run test:bundle-isolation` — PASS (no tool-side bleed into production bundles)