### PR TITLE
feat(causa): Machine Inspector Phase 3 — UC2 Mode C

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -29,7 +29,8 @@
   layout in `layout.cljc` produces a readable chart for the
   4-12-state machines re-frame2 apps register today. Bigger
   topologies fall back to scrollable overflow."
-  (:require [day8.re-frame2-causa.chart.layout :as layout]
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.chart.layout :as layout]
             [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- visual constants ---------------------------------------------------
@@ -282,3 +283,80 @@
   ([definition] (render-from-definition definition {}))
   ([definition opts]
    (render (layout/layout definition) opts)))
+
+;; ---- sparkline primitive (rf2-juon8, Mode C) ---------------------------
+;;
+;; A tiny inline SVG sparkline for the cluster-row state-change rate
+;; indicator. Pure data → hiccup; JVM-runnable so the cluster-helpers
+;; tests can exercise the shape without a CLJS runtime.
+;;
+;; The glyph renders the sample vector (oldest-first) as a flat polyline,
+;; padded into the box. Empty / all-zero samples collapse to a centred
+;; baseline so the visual lane stays consistent across cluster rows.
+
+(defn sparkline
+  "Inline SVG glyph for `samples` — a vector of non-negative integers,
+  oldest-first. Used by the Mode C cluster view to show recent
+  state-change rate.
+
+  Options:
+
+    :width   (default 60)   — viewport width in px
+    :height  (default 16)   — viewport height in px
+    :stroke              — line colour (default `:cyan` token)
+    :testid              — overrides the root data-testid
+    :max-sample          — pin the y-axis ceiling (defaults to
+                            the data's `max`; useful when comparing
+                            multiple sparklines on the same scale)
+
+  Returns a hiccup `[:svg ...]` form. Pure fn."
+  ([samples] (sparkline samples {}))
+  ([samples {:keys [width height stroke testid max-sample]
+             :or   {width  60
+                    height 16
+                    stroke (:cyan tokens/tokens)
+                    testid "rf-causa-chart-sparkline"}}]
+   (let [n        (count samples)
+         max-v    (or max-sample
+                      (when (seq samples)
+                        (apply max samples))
+                      0)
+         pad-y    1
+         inner-h  (max 1 (- height (* 2 pad-y)))
+         baseline (- height pad-y)
+         ;; When n < 2 we can't draw a polyline; render an empty SVG
+         ;; with the baseline so callers still get a stable visual lane.
+         points   (when (>= n 2)
+                    (mapv (fn [i v]
+                            (let [x (if (= n 1)
+                                      (quot width 2)
+                                      (long (* (/ (double i) (double (- n 1)))
+                                               width)))
+                                  ratio (if (pos? max-v)
+                                          (/ (double v) (double max-v))
+                                          0.0)
+                                  y (long (- baseline
+                                             (* ratio inner-h)))]
+                              [x y]))
+                          (range n)
+                          samples))]
+     [:svg {:data-testid testid
+            :data-samples (pr-str samples)
+            :width  width
+            :height height
+            :viewBox (str "0 0 " width " " height)
+            :style {:display "inline-block"
+                    :vertical-align "middle"}}
+      ;; Baseline so the lane is visible even on empty / all-zero data.
+      [:line {:x1 0 :y1 baseline :x2 width :y2 baseline
+              :stroke (:border-subtle tokens/tokens)
+              :stroke-width 0.5}]
+      (when points
+        [:polyline {:fill "none"
+                    :stroke stroke
+                    :stroke-width 1.25
+                    :stroke-linecap "round"
+                    :stroke-linejoin "round"
+                    :points (str/join
+                              " "
+                              (map (fn [[x y]] (str x "," y)) points))}])])))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -77,6 +77,8 @@
             [day8.re-frame2-causa.chart.layout :as chart-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
+            [day8.re-frame2-causa.panels.machine-inspector-cluster :as cluster]
+            [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers :as ch]
             [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -464,12 +466,109 @@
   "Per spec/003-Machine-Inspector.md §UC2 Mode A/B/C — pick the mode
   based on live instance count. Pure fn for unit-testability; not
   marked private so the view-test suite can pin the classifier
-  directly without relying on `data-view-mode` round-trips."
+  directly without relying on `data-view-mode` round-trips.
+
+  This is the *auto* classification — Mode A when there are no live
+  instances (definition-only view), Mode B for a handful, Mode C when
+  the population outgrows the per-tab strip. The Mode C threshold here
+  is the back-compat conservative one (4+ instances); the panel's mode
+  resolver below honours the user's forced selection and falls back to
+  the cluster-helpers' `mode-c-suggested?` threshold (10 by default)
+  for the auto-switch hint surfaced via the mode tab strip."
   [instance-count]
   (cond
     (or (nil? instance-count) (zero? instance-count)) :mode-a
     (<= instance-count 3) :mode-b
     :else :mode-c))
+
+(defn resolve-mode
+  "Combine the auto-classification with the user's forced selection.
+  Pure fn for unit-testability.
+
+  `forced` is one of `:mode-a / :mode-b / :mode-c / nil`. Nil falls
+  back to `view-mode`. When a force is set but instance-count = 0 the
+  resolver still honours the user's pick so the cluster view remains
+  reachable in the empty-population case (useful for the test
+  override path + future spawn workflow)."
+  [instance-count forced]
+  (if (some? forced)
+    forced
+    (view-mode instance-count)))
+
+;; ---- mode tab strip (UC2 Mode A | B | C selector) ---------------------
+
+(defn- mode-tab-strip
+  "Three-tab strip across the header that lets the user force Mode A
+  (definition), Mode B (instance tabs), or Mode C (cluster view) per
+  spec/003-Machine-Inspector.md §UC2. Auto-classification still drives
+  the default; clicking a tab sets a forced mode that overrides the
+  auto pick. Clicking the active tab clears the force (back to auto)."
+  [resolved-mode forced-mode instance-count]
+  (let [tabs [{:id :mode-a :label "Definition"}
+              {:id :mode-b :label "Instances"}
+              {:id :mode-c :label "Cluster"}]
+        suggest-c? (ch/mode-c-suggested? instance-count)]
+    [:div {:data-testid "rf-causa-machine-inspector-mode-strip"
+           :data-resolved-mode (name resolved-mode)
+           :data-forced-mode (when forced-mode (name forced-mode))
+           :data-suggest-mode-c (str suggest-c?)
+           :style {:display "flex"
+                   :align-items "center"
+                   :gap "4px"
+                   :padding "6px 12px"
+                   :background (:bg-3 tokens)
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-family sans-stack
+                     :font-size "10px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"
+                     :margin-right "6px"}}
+      "View"]
+     (for [{:keys [id label]} tabs]
+       (let [active? (= id resolved-mode)
+             ;; Suggest Mode C visually when the population is large
+             ;; but the user hasn't already forced something.
+             suggest? (and (= id :mode-c) suggest-c? (not active?))]
+         ^{:key (name id)}
+         [:button
+          {:data-testid (str "rf-causa-machine-inspector-mode-tab-" (name id))
+           :data-active (str active?)
+           :on-click (fn [_]
+                       (rf/dispatch
+                         [:rf.causa/set-forced-machine-mode
+                          (if (and active? (= forced-mode id))
+                            nil  ;; clicking active forced tab → auto
+                            id)]
+                         {:frame :rf/causa}))
+           :style {:padding "3px 10px"
+                   :background (cond active?    (:bg-1 tokens)
+                                     suggest?   "rgba(67, 195, 208, 0.10)"
+                                     :else      "transparent")
+                   :border (str "1px solid "
+                                (cond active?  (:cyan tokens)
+                                      suggest? (:cyan tokens)
+                                      :else    (:border-subtle tokens)))
+                   :color (cond active?  (:cyan tokens)
+                                suggest? (:cyan tokens)
+                                :else    (:text-secondary tokens))
+                   :border-radius "10px"
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :font-weight (if active? 600 400)
+                   :cursor "pointer"}}
+          label
+          (when suggest?
+            [:span {:style {:margin-left "4px" :font-size "9px"}}
+             "●"])]))
+     [:span {:style {:flex 1}}]
+     (when (and suggest-c? (not= :mode-c resolved-mode))
+       [:span {:data-testid "rf-causa-machine-inspector-mode-suggest"
+               :style {:color (:cyan tokens)
+                       :font-family sans-stack
+                       :font-size "10px"}}
+        (str instance-count
+             " instances — Cluster view recommended")])]))
 
 ;; ---- empty state --------------------------------------------------------
 
@@ -504,12 +603,17 @@
   []
   (let [{:keys [machines total selected selected-id chart-props transitions empty-kind]}
         @(rf/subscribe [:rf.causa/machine-inspector-data])
-        ;; Phase 1: instance-count is 1 when there's a registered snapshot,
-        ;; 0 otherwise. When the multi-instance spawn surface lands a
-        ;; follow-on bead replaces this with `count` over the spawned-
-        ;; instances vector.
-        instance-count (if (and selected (:state selected)) 1 0)
-        mode           (view-mode instance-count)
+        ;; Phase 3 (rf2-juon8): instance-count is the length of the
+        ;; per-machine instances vector. Production reads through the
+        ;; Phase-1 single-snapshot widening; test override surfaces a
+        ;; richer multi-instance projection so Mode C is exercisable
+        ;; before spawn lands upstream.
+        instances      @(rf/subscribe [:rf.causa/machine-instances])
+        instance-count (count (or instances []))
+        ;; The user's forced-mode override; nil = auto (defer to
+        ;; `view-mode`). Set via the mode tab strip below.
+        forced-mode    @(rf/subscribe [:rf.causa/forced-machine-mode])
+        mode           (resolve-mode instance-count forced-mode)
         ;; Phase 2 (rf2-v869p): pull sim state via the per-machine sub.
         ;; When active, the chart highlight + banner shift to sim mode
         ;; and the side rail mounts between the chart and the ribbon.
@@ -519,6 +623,7 @@
     [:section {:data-testid "rf-causa-machine-inspector"
                :data-view-mode (name mode)
                :data-instance-count instance-count
+               :data-forced-mode (when forced-mode (name forced-mode))
                :data-sim-active (str sim-active?)
                :style       {:height         "100%"
                              :display        "flex"
@@ -542,6 +647,7 @@
        [:div {:style {:flex 1 :display "flex" :flex-direction "column"
                       :overflow "hidden"}}
         [machine-picker machines selected-id]
+        [mode-tab-strip mode forced-mode instance-count]
         [instance-tabs (or selected {}) instance-count mode]
         [:div {:style {:flex 1 :overflow "auto"}}
          (placeholder-banner
@@ -551,6 +657,8 @@
             :definition     (:definition selected)
             :sim-active?    sim-active?})
          (placeholder-chart chart-props sim-snapshot)
+         (when (= :mode-c mode)
+           [cluster/ClusterView])
          (when sim-active?
            [sim/SimSideRail])]
         (transition-ribbon transitions)])]))
@@ -714,6 +822,27 @@
     (fn [db [_ _payload]]
       db))
 
+  ;; ---- Phase 3 (rf2-juon8) — UC2 Mode C forced-mode slot ----------
+
+  ;; The user's forced view-mode override; nil = auto-classify via
+  ;; `view-mode`. Set / cleared via `:rf.causa/set-forced-machine-mode`.
+  ;; The Mode tab strip in the header writes this slot; the panel
+  ;; reads it through `resolve-mode`. Stored under a `:mode-c/*`-style
+  ;; namespaced key for visual coherence with the rest of Mode C's
+  ;; app-db slots.
+  (rf/reg-sub :rf.causa/forced-machine-mode
+    (fn [db _query]
+      (get db :machine-inspector/forced-mode)))
+
+  (rf/reg-event-db :rf.causa/set-forced-machine-mode
+    (fn [db [_ mode]]
+      (if (or (nil? mode)
+              (contains? #{:mode-a :mode-b :mode-c} mode))
+        (if (nil? mode)
+          (dissoc db :machine-inspector/forced-mode)
+          (assoc db :machine-inspector/forced-mode mode))
+        db)))
+
   ;; ---- Phase 2 (rf2-v869p) — UC1 Sim sub-mode ---------------------
   ;;
   ;; The sim sub family lives in its own ns
@@ -721,4 +850,12 @@
   ;; focused on the live observation chrome. The sim install fn
   ;; registers `:rf.causa/sim-*` events + subs against the same
   ;; `:rf/causa` frame the panel reads.
-  (sim/install!))
+  (sim/install!)
+
+  ;; ---- Phase 3 (rf2-juon8) — UC2 Mode C cluster view --------------
+  ;;
+  ;; The cluster view + its sub/event family live in
+  ;; `panels/machine_inspector_cluster.cljs`. The install fn registers
+  ;; `:rf.causa/mode-c-*` events + subs against the same `:rf/causa`
+  ;; frame the panel reads.
+  (cluster/install!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
@@ -1,0 +1,547 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-cluster
+  "Machine Inspector UC2 Mode C view + sub/event family
+  (rf2-juon8, Phase 3, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/003-Machine-Inspector.md` §UC2 Mode C +
+  `ai/findings/causa-machines-design-2026-05-17.md` §3.3 the cluster
+  view replaces Mode B's per-instance tab strip when the population
+  outgrows ~10 instances. The Mode-C surface is three stacked
+  sections:
+
+    1. **Cluster-by selector** — `:state | :context-key |
+       :parent-machine`. The selection lives in Causa's app-db so the
+       user's pick survives panel re-renders.
+
+    2. **Cluster rows** — one row per group, sorted deterministically.
+       Each row shows the cluster label, an instance count badge, and
+       an inline sparkline glyph of recent state-change rate. Click
+       toggles inline expansion; expansion lists individual instances
+       within the cluster.
+
+    3. **Compare-table** — rendered when ≥2 instances are selected via
+       Shift+click. Cell-by-cell diff'd context + current-state.
+       Divergent cells get an amber tint to spotlight the difference.
+
+  ## What this ns owns
+
+    - The `ClusterView` hiccup view + the cluster-by selector +
+      cluster-row + compare-table sub-views.
+    - The `:rf.causa/machine-mode-c-*` events and subs:
+        `set-mode-c-cluster-by` (event)
+        `toggle-mode-c-cluster-expanded` (event)
+        `toggle-mode-c-selection` (event)
+        `clear-mode-c-selection` (event)
+        `set-mode-c-context-key` (event)
+        `set-machine-instances-override-for-test` (event)
+
+        `mode-c-cluster-by` (sub)
+        `mode-c-context-key` (sub)
+        `mode-c-expanded` (sub)
+        `mode-c-selection` (sub)
+        `machine-instances` (sub) — synthesises an instance vector
+                                     for the focused machine from the
+                                     snapshots map; tests can override
+                                     via the test-only hook above.
+        `mode-c-clusters` (sub)   — the composed cluster vector with
+                                     sparklines attached.
+        `mode-c-compare-table` (sub)
+
+  ## Pure hiccup (rf2-tijr)
+
+  Every subscribe / dispatch resolves against `:rf/causa` via the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in
+  `shell.cljs`. No Reagent / UIx / Helix references.
+
+  ## Helper algebra
+
+  Pure-data logic lives in `machine_inspector_cluster_helpers.cljc`."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers
+             :as ch]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- now-ms reader (overridable for tests) -----------------------------
+
+(defn- now-ms
+  "Wall-clock ms. Tests can rebind via `with-redefs`. CLJS-only — the
+  helper composite passes the result into the pure sparkline maths."
+  []
+  (.now js/Date))
+
+;; ---- subscription installers -------------------------------------------
+
+(defn install-subs!
+  "Register the Mode C sub family. Idempotent — the enclosing
+  `machine-inspector/install!` is itself guarded."
+  []
+  ;; The user's cluster-by selector (per-panel, defaults to :state).
+  (rf/reg-sub :rf.causa/mode-c-cluster-by
+    (fn [db _query]
+      (get db :mode-c/cluster-by :state)))
+
+  ;; When :cluster-by is :context-key, this slot carries the sub-key
+  ;; (the key into the instance's :context map to group on).
+  (rf/reg-sub :rf.causa/mode-c-context-key
+    (fn [db _query]
+      (get db :mode-c/context-key)))
+
+  ;; The set of cluster keys whose inline-expansion is currently open.
+  (rf/reg-sub :rf.causa/mode-c-expanded
+    (fn [db _query]
+      (get db :mode-c/expanded (ch/empty-expanded))))
+
+  ;; The set of instance-ids selected via Shift+click for the
+  ;; compare-table.
+  (rf/reg-sub :rf.causa/mode-c-selection
+    (fn [db _query]
+      (get db :mode-c/selection (ch/empty-selection))))
+
+  ;; Test-only override slot for the instance vector. Production reads
+  ;; through `:rf.causa/machine-snapshots` (Phase 1 single-snapshot
+  ;; path) → `ch/snapshots->instances` for the focused machine; tests
+  ;; can drive a multi-instance projection directly so Mode C
+  ;; behaviour doesn't wait on the upstream spawn surface.
+  (rf/reg-sub :rf.causa/machine-instances-override
+    (fn [db _query]
+      (get db :machine-instances-override)))
+
+  ;; The instance vector for the currently-selected machine. Production
+  ;; path: widen the Phase 1 snapshot via `ch/snapshots->instances`.
+  ;; Override path: dispatch the test event below.
+  ;;
+  ;; The effective `selected-id` comes from the composite (it falls back
+  ;; to the first registered row when nothing is explicitly picked,
+  ;; matching the picker's default-focus behaviour). Reading the raw
+  ;; `:rf.causa/selected-machine-id` sub would return nil for the
+  ;; first-mount case and Mode B / Mode C would never see the live
+  ;; snapshot's instance.
+  (rf/reg-sub :rf.causa/machine-instances
+    :<- [:rf.causa/machine-inspector-data]
+    :<- [:rf.causa/machine-snapshots]
+    :<- [:rf.causa/machine-snapshots-override]
+    :<- [:rf.causa/machine-instances-override]
+    (fn [[mi-data live-snapshots snapshots-override instances-override]
+         _query]
+      (or instances-override
+          (when-let [selected-id (:selected-id mi-data)]
+            (let [snapshots (or snapshots-override live-snapshots {})]
+              (ch/snapshots->instances selected-id snapshots))))))
+
+  ;; The composed cluster vector with sparklines attached. The composite
+  ;; pulls every input in one read so the view doesn't have to coordinate.
+  (rf/reg-sub :rf.causa/mode-c-clusters
+    :<- [:rf.causa/machine-instances]
+    :<- [:rf.causa/mode-c-cluster-by]
+    :<- [:rf.causa/mode-c-context-key]
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/selected-machine-id]
+    (fn [[instances cluster-by context-key trace-buffer machine-id] _query]
+      (let [clusters (ch/cluster-instances instances
+                                           {:cluster-by  cluster-by
+                                            :context-key context-key})]
+        (ch/attach-sparkline-samples
+          clusters
+          {:trace-buffer trace-buffer
+           :machine-id   machine-id
+           :cluster-by   cluster-by
+           :context-key  context-key
+           :now-ms       (now-ms)}))))
+
+  ;; The compare-table projection. Nil when fewer than 2 instances are
+  ;; selected (the view hides the table entirely in that case).
+  (rf/reg-sub :rf.causa/mode-c-compare-table
+    :<- [:rf.causa/machine-instances]
+    :<- [:rf.causa/mode-c-selection]
+    (fn [[instances selection] _query]
+      (ch/compare-table instances selection))))
+
+;; ---- event installers --------------------------------------------------
+
+(defn install-events!
+  "Register the Mode C event family. Idempotent."
+  []
+  (rf/reg-event-db :rf.causa/set-mode-c-cluster-by
+    (fn [db [_ cluster-by]]
+      (if (ch/cluster-by-valid? cluster-by)
+        (assoc db :mode-c/cluster-by cluster-by)
+        db)))
+
+  (rf/reg-event-db :rf.causa/set-mode-c-context-key
+    (fn [db [_ context-key]]
+      (if (nil? context-key)
+        (dissoc db :mode-c/context-key)
+        (assoc db :mode-c/context-key context-key))))
+
+  (rf/reg-event-db :rf.causa/toggle-mode-c-cluster-expanded
+    (fn [db [_ cluster-key]]
+      (update db :mode-c/expanded ch/expanded-toggle cluster-key)))
+
+  (rf/reg-event-db :rf.causa/toggle-mode-c-selection
+    (fn [db [_ instance-id]]
+      (update db :mode-c/selection ch/selection-toggle instance-id)))
+
+  (rf/reg-event-db :rf.causa/clear-mode-c-selection
+    (fn [db _event]
+      (update db :mode-c/selection ch/selection-clear)))
+
+  ;; Test-only override — production code paths never dispatch this.
+  ;; Mirrors the pattern used by every other Causa test surface.
+  (rf/reg-event-db :rf.causa/set-machine-instances-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :machine-instances-override)
+        (assoc db :machine-instances-override ov)))))
+
+;; ---- view helpers -------------------------------------------------------
+
+(defn- cluster-by-selector
+  "Dropdown that lets the user pick the cluster-by selector. Per design
+  §3.3 the default is `:state`."
+  [cluster-by context-key]
+  [:div {:data-testid "rf-causa-mode-c-cluster-by-selector"
+         :style       {:display "flex"
+                       :align-items "center"
+                       :gap "8px"
+                       :padding "8px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :background (:bg-3 tokens)}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"}}
+    "Cluster by"]
+   [:select {:data-testid "rf-causa-mode-c-cluster-by-select"
+             :value       (name (or cluster-by :state))
+             :on-change   (fn [e]
+                            (let [v (-> e .-target .-value)]
+                              (rf/dispatch
+                                [:rf.causa/set-mode-c-cluster-by (keyword v)]
+                                {:frame :rf/causa})))
+             :style       {:background (:bg-2 tokens)
+                           :border (str "1px solid " (:border-default tokens))
+                           :color (:text-primary tokens)
+                           :padding "3px 6px"
+                           :border-radius "3px"
+                           :font-family mono-stack
+                           :font-size "11px"
+                           :cursor "pointer"}}
+    (for [opt ch/cluster-by-options]
+      ^{:key (name opt)}
+      [:option {:value (name opt)} (name opt)])]
+   (when (= :context-key cluster-by)
+     [:input
+      {:data-testid "rf-causa-mode-c-context-key-input"
+       :type        "text"
+       :placeholder ":userId"
+       :value       (if context-key (str context-key) "")
+       :on-change   (fn [e]
+                      (let [v (-> e .-target .-value)]
+                        (rf/dispatch
+                          [:rf.causa/set-mode-c-context-key
+                           (when-not (= "" v) (keyword (str/replace v ":" "")))]
+                          {:frame :rf/causa})))
+       :style       {:background (:bg-2 tokens)
+                     :border (str "1px solid " (:border-default tokens))
+                     :color (:text-primary tokens)
+                     :padding "3px 6px"
+                     :border-radius "3px"
+                     :font-family mono-stack
+                     :font-size "11px"
+                     :width "120px"}}])])
+
+(defn- instance-row
+  "One instance entry inside an expanded cluster. Shift+click toggles
+  the selection-set; plain click does nothing (the cluster expansion
+  is the affordance for drill-down)."
+  [{:keys [instance-id state context]} selected?]
+  [:li {:data-testid (str "rf-causa-mode-c-instance-" (ch/format-instance-id instance-id))
+        :data-selected (str selected?)
+        :on-click (fn [e]
+                    ;; React synthetic event — `.-shiftKey` is the
+                    ;; cross-browser shift-key bit. Plain clicks
+                    ;; intentionally do nothing so the user has to
+                    ;; opt-in to multi-select via shift.
+                    (when (.-shiftKey e)
+                      (.preventDefault e)
+                      (rf/dispatch [:rf.causa/toggle-mode-c-selection instance-id]
+                                   {:frame :rf/causa})))
+        :style {:display "flex"
+                :align-items "center"
+                :gap "8px"
+                :padding "4px 8px 4px 22px"
+                :margin "2px 0"
+                :background (if selected?
+                              "rgba(168, 124, 230, 0.12)"
+                              "transparent")
+                :border (str "1px solid "
+                             (if selected?
+                               (:accent-violet tokens)
+                               (:border-subtle tokens)))
+                :border-radius "3px"
+                :cursor "pointer"
+                :font-family mono-stack
+                :font-size "11px"}}
+   [:span {:style {:color (if selected?
+                            (:accent-violet tokens)
+                            (:text-tertiary tokens))
+                   :min-width "12px"}}
+    (if selected? "✓" "○")]
+   [:span {:style {:color (:text-primary tokens)
+                   :min-width "120px"}}
+    (ch/format-instance-id instance-id)]
+   [:span {:style {:color (:text-secondary tokens) :min-width "100px"}}
+    (str state)]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-size "10px"
+                   :overflow "hidden"
+                   :text-overflow "ellipsis"
+                   :white-space "nowrap"
+                   :flex 1}}
+    (pr-str context)]])
+
+(defn- cluster-row
+  "One cluster row in the Mode-C surface."
+  [{:keys [cluster-key cluster-label count instances rate-samples]} expanded? selection]
+  [:li {:data-testid (str "rf-causa-mode-c-cluster-"
+                          (ch/format-instance-id cluster-key))
+        :data-cluster-key (pr-str cluster-key)
+        :data-expanded (str expanded?)
+        :style {:list-style "none"
+                :margin "4px 0"}}
+   [:div {:on-click (fn [_]
+                      (rf/dispatch
+                        [:rf.causa/toggle-mode-c-cluster-expanded cluster-key]
+                        {:frame :rf/causa}))
+          :style {:display "flex"
+                  :align-items "center"
+                  :gap "10px"
+                  :padding "6px 10px"
+                  :background (if expanded?
+                                (:bg-1 tokens)
+                                (:bg-3 tokens))
+                  :border (str "1px solid " (:border-subtle tokens))
+                  :border-radius "3px"
+                  :cursor "pointer"}}
+    [:span {:style {:color (:text-tertiary tokens)
+                    :font-family mono-stack
+                    :font-size "12px"
+                    :min-width "14px"}}
+     (if expanded? "▾" "▸")]
+    [:span {:style {:color (:text-primary tokens)
+                    :font-family mono-stack
+                    :font-size "12px"
+                    :font-weight 600
+                    :min-width "140px"}}
+     cluster-label]
+    [:span {:data-testid (str "rf-causa-mode-c-cluster-count-"
+                              (ch/format-instance-id cluster-key))
+            :style {:padding "1px 8px"
+                    :background (:bg-2 tokens)
+                    :border (str "1px solid " (:cyan tokens))
+                    :border-radius "10px"
+                    :color (:cyan tokens)
+                    :font-family mono-stack
+                    :font-size "11px"
+                    :font-weight 600
+                    :min-width "30px"
+                    :text-align "center"}}
+     (str "● " count)]
+    [:span {:style {:flex 1}}]
+    [:span {:data-testid (str "rf-causa-mode-c-cluster-spark-"
+                              (ch/format-instance-id cluster-key))
+            :style {:opacity 0.85}}
+     (chart-svg/sparkline
+       rate-samples
+       {:testid (str "rf-causa-mode-c-cluster-sparkline-"
+                     (ch/format-instance-id cluster-key))
+        :width 60 :height 16})]]
+   (when expanded?
+     (into [:ul {:data-testid (str "rf-causa-mode-c-cluster-expansion-"
+                                   (ch/format-instance-id cluster-key))
+                 :style {:list-style "none"
+                         :margin "4px 0 8px 0"
+                         :padding 0}}]
+           (for [inst instances]
+             ^{:key (str (:instance-id inst))}
+             (instance-row inst (ch/selection-contains?
+                                  selection (:instance-id inst))))))])
+
+(defn- compare-cell
+  "One cell inside the compare-table. Divergent cells get the amber
+  tint per design §3.9."
+  [value diff?]
+  [:td {:style {:padding "4px 8px"
+                :border (str "1px solid " (:border-subtle tokens))
+                :font-family mono-stack
+                :font-size "11px"
+                :color (if diff?
+                         (:yellow tokens)
+                         (:text-secondary tokens))
+                :background (if diff?
+                              "rgba(251, 191, 36, 0.08)"
+                              "transparent")
+                :white-space "nowrap"
+                :overflow "hidden"
+                :text-overflow "ellipsis"
+                :max-width "200px"}}
+   (ch/format-context-value value)])
+
+(defn- compare-row
+  [{:keys [column values diff?]}]
+  [:tr {:data-testid (str "rf-causa-mode-c-compare-row-"
+                          (ch/format-instance-id (:key column)))
+        :data-diff (str diff?)}
+   [:th {:style {:padding "4px 8px"
+                 :text-align "left"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "10px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :background (:bg-3 tokens)
+                 :border (str "1px solid " (:border-subtle tokens))
+                 :white-space "nowrap"}}
+    (:label column)]
+   (for [[idx v] (map-indexed vector values)]
+     ^{:key idx}
+     (compare-cell v diff?))])
+
+(defn- compare-table-view
+  "The compare-table side-panel. Renders below the cluster list when
+  the selection-set has ≥2 instances. Cells that differ across the
+  selection get the divergence tint."
+  [{:keys [instances rows state-row] :as ct}]
+  (when ct
+    [:section
+     {:data-testid "rf-causa-mode-c-compare-table"
+      :data-instance-count (count instances)
+      :style {:margin "12px 0"
+              :padding "10px"
+              :background (:bg-1 tokens)
+              :border (str "1px solid " (:accent-violet tokens))
+              :border-radius "4px"}}
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :justify-content "space-between"
+                    :margin-bottom "8px"}}
+      [:strong {:style {:color (:accent-violet tokens)
+                        :font-family sans-stack
+                        :font-size "11px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"}}
+       (str "Compare · " (count instances) " selected")]
+      [:button
+       {:data-testid "rf-causa-mode-c-compare-clear"
+        :on-click (fn [_]
+                    (rf/dispatch [:rf.causa/clear-mode-c-selection]
+                                 {:frame :rf/causa}))
+        :style {:background "transparent"
+                :border (str "1px solid " (:border-subtle tokens))
+                :color (:text-tertiary tokens)
+                :font-family sans-stack
+                :font-size "10px"
+                :padding "2px 8px"
+                :border-radius "10px"
+                :cursor "pointer"}}
+       "Clear"]]
+     [:table {:style {:width "100%"
+                      :border-collapse "collapse"
+                      :font-family mono-stack
+                      :font-size "11px"}}
+      [:thead
+       [:tr
+        [:th {:style {:padding "4px 8px"
+                      :background (:bg-3 tokens)
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "10px"
+                      :text-align "left"
+                      :border (str "1px solid " (:border-subtle tokens))}}
+         "Field"]
+        (for [{:keys [instance-id]} instances]
+          ^{:key (str instance-id)}
+          [:th {:style {:padding "4px 8px"
+                        :background (:bg-3 tokens)
+                        :color (:text-primary tokens)
+                        :font-family mono-stack
+                        :font-size "11px"
+                        :text-align "left"
+                        :border (str "1px solid " (:border-subtle tokens))}}
+           (ch/format-instance-id instance-id)])]]
+      [:tbody
+       ;; state row first so the user sees the load-bearing divergence
+       (compare-row state-row)
+       (for [row rows]
+         ^{:key (str (-> row :column :key))}
+         (compare-row row))]]]))
+
+;; ---- public view --------------------------------------------------------
+
+(defn ClusterView
+  "The Mode-C surface. Rendered inside the Machine Inspector panel
+  when `(view-mode instance-count)` resolves to `:mode-c` (or when
+  the user forces Mode C via the mode tab strip).
+
+  Pure hiccup — every subscribe / dispatch resolves against
+  `:rf/causa` via the enclosing frame-provider."
+  []
+  (let [cluster-by    @(rf/subscribe [:rf.causa/mode-c-cluster-by])
+        context-key   @(rf/subscribe [:rf.causa/mode-c-context-key])
+        clusters      @(rf/subscribe [:rf.causa/mode-c-clusters])
+        expanded      @(rf/subscribe [:rf.causa/mode-c-expanded])
+        selection     @(rf/subscribe [:rf.causa/mode-c-selection])
+        compare-table @(rf/subscribe [:rf.causa/mode-c-compare-table])]
+    [:section
+     {:data-testid "rf-causa-mode-c"
+      :data-cluster-by (name (or cluster-by :state))
+      :data-cluster-count (count clusters)
+      :data-selection-count (ch/selection-count selection)
+      :style {:padding "12px"
+              :display "flex"
+              :flex-direction "column"
+              :gap "8px"
+              :background (:bg-2 tokens)
+              :border-top (str "1px solid " (:border-default tokens))}}
+     (cluster-by-selector cluster-by context-key)
+     [:div {:data-testid "rf-causa-mode-c-summary"
+            :style {:padding "6px 10px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "11px"}}
+      (str (count clusters) " cluster"
+           (when (not= 1 (count clusters)) "s")
+           " · " (reduce + 0 (map :count clusters)) " instance"
+           (when (not= 1 (reduce + 0 (map :count clusters))) "s")
+           " · "
+           "Shift+click to compare")]
+     (if (empty? clusters)
+       [:div {:data-testid "rf-causa-mode-c-empty"
+              :style {:padding "12px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "12px"
+                      :font-style "italic"}}
+        "No instances for the selected cluster-by."]
+       (into [:ul {:data-testid "rf-causa-mode-c-cluster-list"
+                   :style {:list-style "none"
+                           :margin 0
+                           :padding 0}}]
+             (for [cluster clusters]
+               ^{:key (pr-str (:cluster-key cluster))}
+               (cluster-row cluster
+                            (ch/expanded-contains? expanded (:cluster-key cluster))
+                            selection))))
+     (when compare-table
+       (compare-table-view compare-table))]))
+
+;; ---- public install entry ----------------------------------------------
+
+(defn install!
+  "Idempotent install — called by `machine_inspector/install!`."
+  []
+  (install-subs!)
+  (install-events!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster_helpers.cljc
@@ -1,0 +1,498 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-cluster-helpers
+  "Pure-data helpers for the Machine Inspector UC2 Mode C cluster view
+  (rf2-juon8, Phase 3, parent rf2-5aw5v).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other Causa panel helper uses. This
+  ns owns the algebra; the CLJS view in
+  `machine_inspector_cluster.cljs` is the thin renderer. JVM-runnable
+  so `clojure -M:test` exercises the projections without a CLJS
+  runtime.
+
+  ## What this panel adds (per spec/003-Machine-Inspector.md §UC2 Mode C)
+
+  When the live-instance population of a machine exceeds Mode B's
+  sweet spot (~3 instances), Mode B's per-instance tab strip stops
+  scaling. Mode C is the Erlang-Observer-style aggregate view:
+
+    1. **Cluster rows** — instances grouped by some key (default
+       `:state`; user can pick `:context-key` or `:parent-machine`).
+       Each cluster row shows the cluster value + the count + a tiny
+       sparkline of recent state-change rate.
+
+    2. **Expand-on-click** — clicking a cluster row toggles an inline
+       expansion that lists the individual instances within the
+       cluster. The expansion is purely visual (a flag in the panel's
+       app-db slot); the instance projection stays untouched.
+
+    3. **Shift-click multi-select** — Shift+clicking instances within
+       expanded clusters accumulates them into a selection-set; a
+       compare-table renders below the cluster list when the set
+       contains ≥2 instances, diffing context + current-state cell-
+       by-cell so divergence is visible at a glance.
+
+  ## Instance shape
+
+  Each instance is a map:
+
+      {:instance-id     <keyword-or-string>     ;; unique per machine
+       :machine-id      <keyword>               ;; the parent machine
+       :state           <keyword-or-vector>     ;; current state
+       :context         <map>                   ;; user-defined :data
+       :age-ms          <int-or-nil>            ;; ms since spawn
+       :spawn-source    <event-vector-or-nil>   ;; the spawning event
+       :parent-machine  <keyword-or-nil>}       ;; parent for hierarchy
+
+  Phase 1/2's `snapshots` map (`{machine-id {:state ... :data ...}}`)
+  is widened into a multi-instance vector via `snapshots->instances`;
+  when the framework eventually ships `:rf.machine/spawn`, the
+  composite sub in `machine_inspector.cljs` swaps the synthetic
+  projection for the spawn-aware one without touching this ns.
+
+  ## Cluster grouping
+
+  `cluster-instances` takes the instance vector + a `:cluster-by`
+  selector and returns a deterministic vector of cluster rows. Each
+  cluster row is:
+
+      {:cluster-key    <value>     ;; the grouping value (e.g. :authing)
+       :cluster-label  <str>       ;; user-visible label
+       :count          <int>       ;; instances in this cluster
+       :instances      [<inst>...] ;; the cluster's members
+       :rate-samples   [<int>...]} ;; sparkline data (last N buckets)
+
+  ## Selection-set
+
+  The selection-set is a sorted-set of `instance-id`s. The helpers
+  here treat it as an immutable value; the view dispatches add /
+  remove / toggle / clear events that the registry's reducer applies
+  in the panel ns.
+
+  ## Sparkline data
+
+  Per design §3.5, sparklines capture **recent state-change rate**
+  bucketed into fixed-width windows. `sparkline-buckets` takes the
+  trace buffer + a cluster key + the cluster-by selector + a now-ms
+  origin and returns the per-bucket transition count for the rendered
+  glyph. Pure data; the SVG glyph generation lives in
+  `chart/svg.cljc`."
+  (:require [clojure.string :as str]))
+
+;; ---- threshold + mode classification -----------------------------------
+
+(def default-mode-c-threshold
+  "When instance count exceeds this, Mode C is auto-selected. Per the
+  bead's locked decisions the threshold is 10; user can force Mode C
+  at any count via the mode tab strip."
+  10)
+
+(defn mode-c-suggested?
+  "True iff the panel should auto-switch to Mode C. Pure predicate.
+
+  `instance-count` is the total live instances for the selected
+  machine. `threshold` defaults to `default-mode-c-threshold` (10)."
+  ([instance-count] (mode-c-suggested? instance-count default-mode-c-threshold))
+  ([instance-count threshold]
+   (and (integer? instance-count)
+        (> instance-count (or threshold default-mode-c-threshold)))))
+
+;; ---- instance projection -----------------------------------------------
+
+(defn snapshot->instance
+  "Widen a Phase 1/2 snapshot (`{:state :data}`) into a Mode-C
+  instance map. The `instance-id` defaults to the `machine-id` itself
+  — there's only one snapshot per machine-id today, so the synthetic
+  instance is the machine. When the spawn surface ships, the
+  composite sub feeds richer instance vectors directly and this
+  helper drops out of the hot path."
+  [machine-id snapshot]
+  (when (map? snapshot)
+    {:instance-id    machine-id
+     :machine-id     machine-id
+     :state          (:state snapshot)
+     :context        (or (:data snapshot) {})
+     :age-ms         (:age-ms snapshot)
+     :spawn-source   (:spawn-source snapshot)
+     :parent-machine (:parent-machine snapshot)}))
+
+(defn snapshots->instances
+  "Project the snapshots map for a single machine-id into an instance
+  vector. Returns `[]` when the snapshot is missing. The shape is the
+  Mode-C-friendly representation; the composite sub feeds it through
+  `cluster-instances`.
+
+  Phase 3 ships the single-snapshot path. A follow-on bead will swap
+  this for the multi-instance projection that consumes
+  `:rf/machine-instances` (when spawn ships)."
+  [machine-id snapshots]
+  (if-let [inst (snapshot->instance machine-id (get snapshots machine-id))]
+    [inst]
+    []))
+
+(defn normalise-instances
+  "Normalise an instance vector to ensure every map carries the slots
+  the cluster + compare helpers expect. Tolerates partial maps
+  (test fixtures, future extensions). Pure fn."
+  [instances]
+  (->> (or instances [])
+       (map (fn [inst]
+              (cond-> {:instance-id    (or (:instance-id inst)
+                                           (:machine-id inst))
+                       :machine-id     (:machine-id inst)
+                       :state          (:state inst)
+                       :context        (or (:context inst) {})
+                       :age-ms         (:age-ms inst)
+                       :spawn-source   (:spawn-source inst)
+                       :parent-machine (:parent-machine inst)})))
+       vec))
+
+;; ---- cluster grouping --------------------------------------------------
+
+(def cluster-by-options
+  "The valid `:cluster-by` selectors per design §3.3. Order matters
+  for the UI selector — the view renders these in order."
+  [:state :context-key :parent-machine])
+
+(defn cluster-by-valid?
+  [k]
+  (or (= k :state)
+      (= k :parent-machine)
+      ;; `:context-key` is invoked with a key sub-selector — the panel
+      ;; ns models the sub-selector as a separate slot. Either way the
+      ;; predicate accepts the canonical id.
+      (= k :context-key)))
+
+(defn- group-key-of
+  "Resolve the group key for `inst` under the given `cluster-by` +
+  optional `context-key` sub-selector."
+  [inst cluster-by context-key]
+  (case cluster-by
+    :state          (:state inst)
+    :parent-machine (:parent-machine inst)
+    :context-key    (get-in inst [:context context-key])
+    ;; Unknown selector falls back to :state so the cluster view
+    ;; always renders something rather than a blank.
+    (:state inst)))
+
+(defn- cluster-label-for
+  "Render a cluster value as a display label. Keywords keep their
+  `:`; nil becomes `(none)`; everything else falls back to `pr-str`."
+  [v]
+  (cond
+    (nil? v)         "(none)"
+    (keyword? v)     (str v)
+    (string? v)      v
+    :else            (try (pr-str v) (catch #?(:clj Throwable :cljs :default) _ (str v)))))
+
+(defn- sort-cluster-keys
+  "Deterministic sort for cluster keys. Numbers first, then strings,
+  then keywords, then everything else by `pr-str`. Pure fn."
+  [ks]
+  (sort-by (fn [k]
+             [(cond (nil? k)     4
+                    (number? k)  0
+                    (string? k)  1
+                    (keyword? k) 2
+                    :else        3)
+              (try (pr-str k) (catch #?(:clj Throwable :cljs :default) _ (str k)))])
+           ks))
+
+(defn cluster-instances
+  "Group `instances` by the given `cluster-by` selector. Returns a
+  deterministic vector of cluster rows sorted by cluster-key.
+
+  Options map:
+
+    :cluster-by    — one of `cluster-by-options` (default `:state`)
+    :context-key   — when `:cluster-by` is `:context-key`, the
+                     sub-key in `(:context instance)` to group on.
+                     Required for `:context-key`; ignored otherwise.
+
+  Each row carries:
+
+    :cluster-key    — the raw grouping value
+    :cluster-label  — display label
+    :count          — number of instances in this cluster
+    :instances      — the cluster's member instances (input order)
+    :rate-samples   — empty vector here; the panel composes
+                      `sparkline-buckets` separately and merges
+                      via `attach-sparkline-samples`."
+  ([instances]
+   (cluster-instances instances {}))
+  ([instances {:keys [cluster-by context-key] :or {cluster-by :state}}]
+   (let [norm    (normalise-instances instances)
+         groups  (group-by #(group-key-of % cluster-by context-key) norm)
+         ks      (sort-cluster-keys (keys groups))]
+     (->> ks
+          (mapv (fn [k]
+                  (let [members (vec (get groups k))]
+                    {:cluster-key   k
+                     :cluster-label (cluster-label-for k)
+                     :count         (count members)
+                     :instances     members
+                     :rate-samples  []})))))))
+
+;; ---- sparkline (state-change rate) -------------------------------------
+
+(def default-sparkline-buckets 12)
+(def default-sparkline-bucket-ms 5000)
+
+(defn- transition-event?
+  "Local mirror of the machine-inspector-helpers predicate to avoid a
+  cross-ns dep ordering edge case in CLJC tests."
+  [ev]
+  (and (map? ev)
+       (or (= :rf.machine/transition (:operation ev))
+           (= :rf.machine.microstep/transition (:operation ev)))))
+
+(defn sparkline-buckets
+  "Compute per-bucket transition counts for a cluster.
+
+  Inputs:
+
+    `trace-buffer` — Causa's ring buffer (nil-safe).
+    `machine-id`   — the focused machine (filters the buffer).
+    `cluster-pred` — a predicate `(fn [ev] boolean)` matched against
+                     the **trace event**. Typically `(fn [ev] (= (-> ev :tags :to) cluster-key))`
+                     for cluster-by-state, but the helper stays
+                     generic.
+    `now-ms`       — wall-clock origin; the buckets walk backwards
+                     from here. Tests pass an explicit value for
+                     determinism.
+    `opts`         — `{:bucket-count <int> :bucket-ms <int>}` —
+                     defaults from the `default-sparkline-*` Vars.
+
+  Returns a vector of `bucket-count` ints, **oldest first** (left to
+  right in the rendered sparkline). Counts the transition events
+  whose `:time` falls in each bucket window.
+
+  Pure fn — JVM-runnable."
+  ([trace-buffer machine-id cluster-pred now-ms]
+   (sparkline-buckets trace-buffer machine-id cluster-pred now-ms {}))
+  ([trace-buffer machine-id cluster-pred now-ms
+    {:keys [bucket-count bucket-ms]
+     :or   {bucket-count default-sparkline-buckets
+            bucket-ms    default-sparkline-bucket-ms}}]
+   (let [buf      (or trace-buffer [])
+         filtered (filter (fn [ev]
+                            (and (transition-event? ev)
+                                 (or (nil? machine-id)
+                                     (= machine-id
+                                        (or (get-in ev [:tags :machine-id])
+                                            (get-in ev [:tags :handler-id]))))
+                                 (cluster-pred ev)))
+                          buf)
+         oldest   (- now-ms (* bucket-count bucket-ms))
+         init     (vec (repeat bucket-count 0))]
+     (reduce
+       (fn [acc ev]
+         (let [t  (or (:time ev) 0)
+               dt (- t oldest)]
+           (if (and (>= dt 0)
+                    (< t now-ms))
+             (let [idx (quot dt bucket-ms)]
+               (if (and (>= idx 0) (< idx bucket-count))
+                 (update acc idx inc)
+                 acc))
+             acc)))
+       init
+       filtered))))
+
+(defn cluster-pred-for
+  "Build the per-cluster predicate that `sparkline-buckets` consumes.
+  Pure factory — keeps the cluster-by → trace-event-match mapping in
+  one place."
+  [cluster-by cluster-key context-key]
+  (case cluster-by
+    :state          (fn [ev]
+                      (= cluster-key
+                         (or (get-in ev [:tags :to])
+                             (get-in ev [:tags :to-state]))))
+    :parent-machine (fn [ev]
+                      (= cluster-key (get-in ev [:tags :parent-machine])))
+    :context-key    (fn [ev]
+                      (= cluster-key (get-in ev [:tags :context context-key])))
+    (constantly false)))
+
+(defn attach-sparkline-samples
+  "Compose `cluster-instances` output with `sparkline-buckets` per
+  cluster. Each cluster row gets `:rate-samples` populated. Pure fn —
+  the trace buffer is the only dynamic input."
+  [clusters {:keys [trace-buffer machine-id cluster-by context-key now-ms opts]
+             :or   {opts {}}}]
+  (mapv (fn [cluster]
+          (let [pred (cluster-pred-for cluster-by
+                                       (:cluster-key cluster)
+                                       context-key)]
+            (assoc cluster
+              :rate-samples
+              (sparkline-buckets trace-buffer machine-id pred
+                                 (or now-ms 0) opts))))
+        clusters))
+
+;; ---- selection-set ------------------------------------------------------
+
+(defn empty-selection
+  "Canonical empty selection-set. Pure — returned as a set so the
+  reducers below stay structural."
+  []
+  #{})
+
+(defn selection-add
+  "Add `instance-id` to `selection`. Idempotent (returns the same set
+  when already present). Pure."
+  [selection instance-id]
+  (if (nil? instance-id)
+    (or selection (empty-selection))
+    (conj (or selection (empty-selection)) instance-id)))
+
+(defn selection-remove
+  "Drop `instance-id` from `selection`. Idempotent. Pure."
+  [selection instance-id]
+  (if (nil? instance-id)
+    (or selection (empty-selection))
+    (disj (or selection (empty-selection)) instance-id)))
+
+(defn selection-toggle
+  "Toggle `instance-id` in `selection` — add when absent, remove when
+  present. Pure. The canonical UI primitive driven by shift-click."
+  [selection instance-id]
+  (let [sel (or selection (empty-selection))]
+    (if (contains? sel instance-id)
+      (disj sel instance-id)
+      (conj sel instance-id))))
+
+(defn selection-clear
+  "Drop every entry from `selection`. Returns the canonical empty set."
+  [_selection]
+  (empty-selection))
+
+(defn selection-contains?
+  [selection instance-id]
+  (boolean (and selection (contains? selection instance-id))))
+
+(defn selection-count
+  [selection]
+  (count (or selection (empty-selection))))
+
+;; ---- compare-table projection ------------------------------------------
+
+(defn- merge-context-keys
+  "Union of all keys present across the selected instances' `:context`
+  maps. Sorted deterministically for stable table column order."
+  [instances]
+  (->> instances
+       (mapcat #(keys (or (:context %) {})))
+       distinct
+       (sort-by str)
+       vec))
+
+(defn- value-set
+  "All distinct values for one column across `instances`. Used to flag
+  cells that differ from the rest of the row."
+  [instances col-key]
+  (->> instances
+       (map #(get (or (:context %) {}) col-key))
+       set))
+
+(defn compare-table
+  "Build the compare-table projection for the selected instances.
+  Returns nil when the selection is empty or has only one instance
+  (per design, the compare-table only renders when ≥2 instances are
+  selected — one instance is just the instance itself).
+
+  Inputs:
+
+    `instances`  — the full instance vector (all instances for the
+                   focused machine).
+    `selection`  — the selection-set (set of instance-ids).
+
+  Returns:
+
+      {:instances    [<inst> ...]      ;; the selected instances, in
+                                        ;; selection-order then id-order
+       :columns      [<col-def> ...]   ;; the column metadata
+       :rows         [<row> ...]       ;; one row per column with the
+                                        ;; per-instance values + diff flag
+       :state-row    {<col-def with
+                       :diff? + values}}
+                                       ;; the special :state row,
+                                        ;; surfaced separately so the
+                                        ;; view can pin it first}
+
+  Each column-def is `{:key <ctx-key> :label <str>}`. Each row is
+  `{:column <col-def> :values [<v> ...] :diff? <bool>}`. The `:diff?`
+  flag is true when not every value is equal — those cells get the
+  divergence highlight."
+  [instances selection]
+  (let [norm        (normalise-instances instances)
+        sel-inst    (->> norm
+                         (filter #(selection-contains? selection (:instance-id %)))
+                         vec)]
+    (when (>= (count sel-inst) 2)
+      (let [ctx-keys  (merge-context-keys sel-inst)
+            cols      (mapv (fn [k] {:key k :label (str k)}) ctx-keys)
+            state-vs  (mapv :state sel-inst)
+            state-row {:column {:key :state :label ":state"}
+                       :values state-vs
+                       :diff?  (> (count (set state-vs)) 1)}
+            rows      (mapv
+                        (fn [col]
+                          (let [vs (mapv #(get (or (:context %) {})
+                                               (:key col))
+                                          sel-inst)]
+                            {:column col
+                             :values vs
+                             :diff?  (> (count (set vs)) 1)}))
+                        cols)]
+        {:instances sel-inst
+         :columns   cols
+         :rows      rows
+         :state-row state-row}))))
+
+;; ---- expand state-set --------------------------------------------------
+;;
+;; The "which clusters are expanded inline" set is per-machine; the
+;; helpers below treat it as an immutable value. Reducers live here so
+;; the event handlers in the panel ns stay one-liners.
+
+(defn empty-expanded
+  []
+  #{})
+
+(defn expanded-toggle
+  "Toggle `cluster-key` in `expanded`. Pure."
+  [expanded cluster-key]
+  (let [s (or expanded (empty-expanded))]
+    (if (contains? s cluster-key)
+      (disj s cluster-key)
+      (conj s cluster-key))))
+
+(defn expanded-contains?
+  [expanded cluster-key]
+  (boolean (and expanded (contains? expanded cluster-key))))
+
+(defn expanded-clear
+  [_expanded]
+  (empty-expanded))
+
+;; ---- formatting helpers (view-consumed) --------------------------------
+
+(defn format-instance-id
+  [id]
+  (cond
+    (nil? id)     ""
+    (keyword? id) (str id)
+    :else         (str/trim (str id))))
+
+(defn format-context-value
+  "Compact one-line representation of a context cell. Strings stay
+  quoted (via `pr-str`) so empty / whitespace values are visible."
+  [v]
+  (cond
+    (nil? v)     "—"
+    (string? v)  (pr-str v)
+    (keyword? v) (str v)
+    :else        (try (pr-str v)
+                      (catch #?(:clj Throwable :cljs :default) _ (str v)))))

--- a/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
@@ -99,3 +99,38 @@
     (when click (click nil))
     (is (= [[:loading]] @seen)
         "click handler receives the state's :path")))
+
+;; ---- sparkline primitive (rf2-juon8, Mode C) ---------------------------
+
+(deftest sparkline-emits-stable-svg-root
+  (let [svg (chart-svg/sparkline [1 2 3])]
+    (is (vector? svg))
+    (is (= :svg (first svg)))
+    (is (= "rf-causa-chart-sparkline"
+           (:data-testid (second svg))))))
+
+(deftest sparkline-empty-samples-still-renders-baseline-only
+  (let [svg      (chart-svg/sparkline [])
+        polylines (filter #(and (vector? %) (= :polyline (first %)))
+                          (hiccup-seq svg))]
+    (is (vector? svg))
+    (is (zero? (count polylines))
+        "empty samples → baseline-only SVG (no polyline)")))
+
+(deftest sparkline-includes-polyline-when-enough-samples
+  (let [svg (chart-svg/sparkline [0 1 2 3])
+        ;; polyline is inline; walk and find one
+        nodes (filter #(and (vector? %) (= :polyline (first %)))
+                      (hiccup-seq svg))]
+    (is (= 1 (count nodes)))
+    (let [pl (first nodes)]
+      (is (string? (-> pl second :points)))
+      (is (= "none" (-> pl second :fill))))))
+
+(deftest sparkline-data-samples-attribute-roundtrips
+  (let [svg (chart-svg/sparkline [0 1 5 2 3])]
+    (is (= "[0 1 5 2 3]" (:data-samples (second svg))))))
+
+(deftest sparkline-honours-custom-testid
+  (let [svg (chart-svg/sparkline [1 2 3] {:testid "rf-cluster-rate-1"})]
+    (is (= "rf-cluster-rate-1" (:data-testid (second svg))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
@@ -1,0 +1,459 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-cluster-cljs-test
+  "CLJS-side wiring + view tests for Causa's Machine Inspector UC2
+  Mode C cluster view (rf2-juon8, Phase 3).
+
+  Tests live under the `:node-test` build via the `cljs-test$` regex.
+  Walks the rendered hiccup tree by `data-testid` rather than mounting
+  to the DOM — same approach as `machine_inspector_view_cljs_test.cljs`.
+
+  ## What's under test
+
+    1. Registry wires the Mode C sub + event family.
+    2. Mode C activation threshold — >10 instances suggests Mode C; the
+       user can force any mode.
+    3. ClusterView renders cluster rows with count badges + sparkline.
+    4. Cluster row click toggles inline expansion; second click collapses.
+    5. Shift+click on an instance accumulates the selection-set.
+    6. Compare-table renders when ≥2 instances are selected; cells
+       diff against each other."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.machine-inspector-cluster
+             :as cluster]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (same pattern as machine_inspector_view_cljs_test) --
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-fn-component tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-snapshots! [snapshots]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-snapshots-override-for-test snapshots]))
+
+(defn- override-instances! [instances]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-instances-override-for-test instances]))
+
+(defn- select-machine! [machine-id]
+  (rf/dispatch-sync [:rf.causa/select-machine-id machine-id]))
+
+(defn- gen-instances
+  "Synthesise a vector of `n` instances for a fixture machine, spread
+  across the supplied states + users so cluster-by-state /
+  cluster-by-context-key both produce multi-cluster fixtures."
+  [machine-id n]
+  (let [states [:idle :authing :sending :done]
+        users  ["ada" "bob" "cat"]]
+    (mapv (fn [i]
+            {:instance-id    (keyword (str "inst-" i))
+             :machine-id     machine-id
+             :state          (nth states (mod i (count states)))
+             :context        {:user (nth users (mod i (count users)))
+                              :counter i}
+             :parent-machine nil})
+          (range n))))
+
+;; ---- (1) registry wiring ------------------------------------------------
+
+(deftest registry-installs-mode-c-handlers
+  (testing "register-causa-handlers! installs every Mode C handler"
+    (registry/register-causa-handlers!)
+    ;; subs
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-cluster-by)))
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-context-key)))
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-expanded)))
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-selection)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-instances)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-instances-override)))
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-clusters)))
+    (is (some? (registrar/handler :sub :rf.causa/mode-c-compare-table)))
+    (is (some? (registrar/handler :sub :rf.causa/forced-machine-mode)))
+    ;; events
+    (is (some? (registrar/handler :event :rf.causa/set-mode-c-cluster-by)))
+    (is (some? (registrar/handler :event :rf.causa/set-mode-c-context-key)))
+    (is (some? (registrar/handler :event :rf.causa/toggle-mode-c-cluster-expanded)))
+    (is (some? (registrar/handler :event :rf.causa/toggle-mode-c-selection)))
+    (is (some? (registrar/handler :event :rf.causa/clear-mode-c-selection)))
+    (is (some? (registrar/handler :event :rf.causa/set-forced-machine-mode)))
+    (is (some? (registrar/handler :event :rf.causa/set-machine-instances-override-for-test)))))
+
+;; ---- (2) Mode C activation threshold ------------------------------------
+
+(deftest resolve-mode-honours-auto-classification
+  (testing "with no forced override, resolve-mode == view-mode"
+    (is (= :mode-a (machine-inspector/resolve-mode 0   nil)))
+    (is (= :mode-b (machine-inspector/resolve-mode 1   nil)))
+    (is (= :mode-c (machine-inspector/resolve-mode 100 nil)))))
+
+(deftest resolve-mode-honours-user-force
+  (testing "with a forced override, resolve-mode returns it directly"
+    (is (= :mode-c (machine-inspector/resolve-mode 0 :mode-c)))
+    (is (= :mode-a (machine-inspector/resolve-mode 100 :mode-a)))))
+
+(deftest set-forced-machine-mode-roundtrips
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (is (= :mode-c @(rf/subscribe [:rf.causa/forced-machine-mode])))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode nil])
+    (is (nil? @(rf/subscribe [:rf.causa/forced-machine-mode])))))
+
+(deftest set-forced-machine-mode-rejects-unknown-mode
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :bogus])
+    (is (nil? @(rf/subscribe [:rf.causa/forced-machine-mode]))
+        "an unknown mode is rejected, slot stays nil")))
+
+(deftest mode-strip-renders-when-machines-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:auth/login])
+    (let [tree (machine-inspector/Panel)
+          strip (find-by-testid tree "rf-causa-machine-inspector-mode-strip")]
+      (is (some? strip) "mode-strip is present whenever the panel renders content")
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-mode-tab-mode-a")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-mode-tab-mode-b")))
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-mode-tab-mode-c"))))))
+
+(deftest mode-c-auto-suggested-when-instance-count-exceeds-threshold
+  (testing "with >10 instances overridden the mode strip surfaces the
+            mode-c suggestion attr"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:req/protocol])
+      (select-machine! :req/protocol)
+      (override-instances! (gen-instances :req/protocol 11))
+      (let [tree (machine-inspector/Panel)
+            strip (find-by-testid tree "rf-causa-machine-inspector-mode-strip")]
+        (is (= "true" (:data-suggest-mode-c (second strip)))
+            "the strip surfaces the suggestion attr when instances > 10")))))
+
+(deftest mode-c-suggest-text-renders-when-not-already-in-mode-c
+  (testing "with >10 instances + a forced :mode-b override, the inline
+            mode-c suggestion text appears (the auto-resolve would already
+            be mode-c which suppresses the nudge)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:req/protocol])
+      (select-machine! :req/protocol)
+      (override-instances! (gen-instances :req/protocol 11))
+      (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-b])
+      (let [tree (machine-inspector/Panel)]
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-inspector-mode-suggest"))
+            "the inline suggestion text renders when the resolved mode != mode-c")))))
+
+(deftest mode-c-not-suggested-at-or-below-threshold
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 10))
+    (let [tree (machine-inspector/Panel)
+          strip (find-by-testid tree "rf-causa-machine-inspector-mode-strip")]
+      (is (= "false" (:data-suggest-mode-c (second strip)))
+          "threshold is exclusive — exactly 10 instances stays in Mode B"))))
+
+(deftest mode-c-renders-cluster-view-when-forced
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (let [tree (machine-inspector/Panel)
+          root (find-by-testid tree "rf-causa-machine-inspector")]
+      (is (= "mode-c" (:data-view-mode (second root))))
+      (is (some? (find-by-testid tree "rf-causa-mode-c"))
+          "cluster view mounts when mode resolves to :mode-c")
+      (is (some? (find-by-testid tree "rf-causa-mode-c-cluster-list"))))))
+
+;; ---- (3) Cluster rows ---------------------------------------------------
+
+(deftest cluster-rows-render-with-count-badges-and-sparkline
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (let [tree    (machine-inspector/Panel)
+          rows    (find-all-by-testid-prefix
+                    tree "rf-causa-mode-c-cluster-")
+          ;; subset: rows specifically prefixed `rf-causa-mode-c-cluster-:`
+          ;; corresponds to actual cluster `<li>` items (state keywords).
+          li-rows (filter
+                    (fn [node]
+                      (some-> (:data-testid (second node))
+                              (.startsWith "rf-causa-mode-c-cluster-:")))
+                    rows)]
+      ;; gen-instances spreads across :idle :authing :sending :done (4)
+      (is (= 4 (count li-rows)) "one row per distinct state")
+      ;; Each row should have a count badge somewhere in its subtree
+      (is (some? (find-by-testid tree "rf-causa-mode-c-cluster-count-:idle")))
+      (is (some? (find-by-testid tree "rf-causa-mode-c-cluster-count-:authing")))
+      ;; And a sparkline glyph
+      (is (some? (find-by-testid tree "rf-causa-mode-c-cluster-sparkline-:idle"))))))
+
+;; ---- (4) Cluster expansion toggle --------------------------------------
+
+(deftest toggle-cluster-expanded-event-roundtrips
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :authing])
+    (is (= #{:authing} @(rf/subscribe [:rf.causa/mode-c-expanded])))
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :authing])
+    (is (= #{} @(rf/subscribe [:rf.causa/mode-c-expanded])))))
+
+(deftest cluster-row-click-dispatches-toggle-expanded
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (let [tree   (machine-inspector/Panel)
+              row    (find-by-testid tree "rf-causa-mode-c-cluster-:idle")
+              ;; The clickable element is the inner :div wrapper. Walk
+              ;; into the row's body and pick the first node with an
+              ;; :on-click handler.
+              clickables (filter (fn [n]
+                                   (and (vector? n)
+                                        (map? (second n))
+                                        (:on-click (second n))))
+                                 (hiccup-seq row))
+              handler   (some-> clickables first second :on-click)]
+          (is (some? row) "cluster row is present")
+          (is (some? handler) "row carries an :on-click handler")
+          (when handler (handler #js {}))
+          (is (some #(= [:rf.causa/toggle-mode-c-cluster-expanded :idle] %)
+                    @dispatches)
+              "clicking the row dispatches :toggle-mode-c-cluster-expanded"))))))
+
+(deftest expanded-cluster-shows-instance-list
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :idle])
+    (let [tree     (machine-inspector/Panel)
+          expand   (find-by-testid tree "rf-causa-mode-c-cluster-expansion-:idle")
+          ;; Instances under :idle: with 12 instances spread across 4
+          ;; states (idle, authing, sending, done) by `mod 4`, :idle gets
+          ;; indices 0, 4, 8 → 3 instances.
+          insts    (find-all-by-testid-prefix tree "rf-causa-mode-c-instance-")]
+      (is (some? expand) "expansion <ul> is present")
+      (is (= 3 (count insts))
+          "three :idle instances visible (indices 0, 4, 8)"))))
+
+;; ---- (5) Shift+click multi-select --------------------------------------
+
+(deftest toggle-mode-c-selection-event-roundtrips
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-1])
+    (is (= #{:inst-1} @(rf/subscribe [:rf.causa/mode-c-selection])))
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-2])
+    (is (= #{:inst-1 :inst-2} @(rf/subscribe [:rf.causa/mode-c-selection])))
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-1])
+    (is (= #{:inst-2} @(rf/subscribe [:rf.causa/mode-c-selection])))))
+
+(deftest clear-mode-c-selection-event-clears-the-set
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-1])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-2])
+    (rf/dispatch-sync [:rf.causa/clear-mode-c-selection])
+    (is (= #{} @(rf/subscribe [:rf.causa/mode-c-selection])))))
+
+(deftest shift-click-instance-dispatches-toggle-selection
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :idle])
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (let [tree    (machine-inspector/Panel)
+              inst-li (find-by-testid tree "rf-causa-mode-c-instance-:inst-0")
+              handler (:on-click (second inst-li))
+              ;; Fake a React synthetic event with shiftKey true; the
+              ;; handler reads `(.-shiftKey e)` + `(.preventDefault e)`.
+              fake-ev #js {:shiftKey true
+                           :preventDefault (fn [] nil)}]
+          (is (some? inst-li) "instance <li> is present")
+          (is (some? handler))
+          (when handler (handler fake-ev))
+          (is (some #(= [:rf.causa/toggle-mode-c-selection :inst-0] %)
+                    @dispatches)
+              "shift+click dispatches :toggle-mode-c-selection"))))))
+
+(deftest plain-click-on-instance-does-not-dispatch
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :idle])
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev] (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (let [tree    (machine-inspector/Panel)
+              inst-li (find-by-testid tree "rf-causa-mode-c-instance-:inst-0")
+              handler (:on-click (second inst-li))
+              fake-ev #js {:shiftKey false
+                           :preventDefault (fn [] nil)}]
+          (when handler (handler fake-ev))
+          (is (not (some #(= :rf.causa/toggle-mode-c-selection (first %))
+                         @dispatches))
+              "plain click is intentionally a no-op for selection"))))))
+
+;; ---- (6) Compare table --------------------------------------------------
+
+(deftest compare-table-sub-returns-nil-when-fewer-than-two
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (is (nil? @(rf/subscribe [:rf.causa/mode-c-compare-table])))
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-0])
+    (is (nil? @(rf/subscribe [:rf.causa/mode-c-compare-table]))
+        "still nil with one selected")))
+
+(deftest compare-table-renders-when-two-instances-selected
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-0])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-4])
+    (let [tree    (machine-inspector/Panel)
+          compare (find-by-testid tree "rf-causa-mode-c-compare-table")]
+      (is (some? compare) "compare-table renders when ≥2 selected")
+      (is (= 2 (:data-instance-count (second compare))))
+      ;; :state row should be present and (in this fixture) consistent
+      ;; (both :inst-0 and :inst-4 are :idle, so no diff on state)
+      (let [state-row (find-by-testid tree "rf-causa-mode-c-compare-row-:state")]
+        (is (some? state-row))
+        (is (= "false" (:data-diff (second state-row))))))))
+
+(deftest compare-table-marks-divergent-cells
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+    ;; :inst-0 is :idle / user "ada"; :inst-1 is :authing / user "bob"
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-0])
+    (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-1])
+    (let [tree      (machine-inspector/Panel)
+          state-row (find-by-testid tree "rf-causa-mode-c-compare-row-:state")
+          user-row  (find-by-testid tree "rf-causa-mode-c-compare-row-:user")]
+      (is (= "true" (:data-diff (second state-row)))
+          ":idle vs :authing diverges")
+      (is (= "true" (:data-diff (second user-row)))
+          "ada vs bob diverges"))))
+
+;; ---- (7) cluster-by selector ------------------------------------------
+
+(deftest cluster-by-selector-roundtrips
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-mode-c-cluster-by :parent-machine])
+    (is (= :parent-machine @(rf/subscribe [:rf.causa/mode-c-cluster-by])))))
+
+(deftest set-mode-c-cluster-by-rejects-invalid-selector
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-mode-c-cluster-by :bogus])
+    (is (= :state @(rf/subscribe [:rf.causa/mode-c-cluster-by]))
+        "invalid selector is rejected; default :state stays put")))
+
+(deftest cluster-by-context-key-rejoins-on-the-sub-selector
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [:req/protocol])
+    (select-machine! :req/protocol)
+    (override-instances! (gen-instances :req/protocol 12))
+    (rf/dispatch-sync [:rf.causa/set-mode-c-cluster-by :context-key])
+    (rf/dispatch-sync [:rf.causa/set-mode-c-context-key :user])
+    (let [clusters @(rf/subscribe [:rf.causa/mode-c-clusters])
+          ks       (set (map :cluster-key clusters))]
+      ;; users in gen-instances are ada/bob/cat (3 distinct)
+      (is (= #{"ada" "bob" "cat"} ks)
+          "cluster-by-context-key on :user yields 3 clusters"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_helpers_cljs_test.cljc
@@ -1,0 +1,369 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-cluster-helpers-cljs-test
+  "Pure-data tests for Causa's Machine Inspector UC2 Mode C helpers
+  (rf2-juon8, Phase 3).
+
+  Dual-target via the `_cljs_test.cljc` extension — Cognitect's CLJ
+  test-runner picks the ns up via the `.*-test$` regex; Shadow's
+  `:node-test` build picks it up via `cljs-test$`. Same pattern every
+  Causa helper test uses.
+
+  ## What's under test
+
+    1. `mode-c-suggested?`     — threshold predicate.
+    2. `snapshot->instance` /
+       `snapshots->instances` — Phase 1/2 → Mode C widening.
+    3. `normalise-instances`   — slot completeness.
+    4. `cluster-instances`     — group-by `:state` / `:context-key`
+                                 / `:parent-machine` with
+                                 deterministic ordering.
+    5. `sparkline-buckets`     — per-bucket transition counts.
+    6. `cluster-pred-for`      — cluster-by → trace event match.
+    7. `attach-sparkline-samples` — compose clusters + sparklines.
+    8. Selection-set helpers   — add / remove / toggle / clear.
+    9. `compare-table`         — diff'd cell projection."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers
+             :as ch]))
+
+;; ---- (1) mode-c-suggested? ---------------------------------------------
+
+(deftest mode-c-suggested-respects-default-threshold
+  (is (false? (ch/mode-c-suggested? 0)))
+  (is (false? (ch/mode-c-suggested? 1)))
+  (is (false? (ch/mode-c-suggested? 10))
+      "threshold is exclusive — exactly 10 instances stays in Mode B")
+  (is (true?  (ch/mode-c-suggested? 11)))
+  (is (true?  (ch/mode-c-suggested? 100))))
+
+(deftest mode-c-suggested-honours-custom-threshold
+  (is (false? (ch/mode-c-suggested? 4 5)))
+  (is (true?  (ch/mode-c-suggested? 6 5))))
+
+(deftest mode-c-suggested-tolerates-nil
+  (is (false? (ch/mode-c-suggested? nil)))
+  (is (false? (ch/mode-c-suggested? :not-a-number))))
+
+;; ---- (2) snapshot widening ---------------------------------------------
+
+(deftest snapshot->instance-builds-the-mode-c-shape
+  (let [inst (ch/snapshot->instance :auth/login
+                                    {:state :authing :data {:user "ada"}})]
+    (is (= :auth/login (:instance-id inst)))
+    (is (= :auth/login (:machine-id inst)))
+    (is (= :authing    (:state inst)))
+    (is (= {:user "ada"} (:context inst)))
+    (is (nil? (:age-ms inst)))
+    (is (nil? (:spawn-source inst)))
+    (is (nil? (:parent-machine inst)))))
+
+(deftest snapshot->instance-nil-when-snapshot-is-nil
+  (is (nil? (ch/snapshot->instance :auth/login nil))))
+
+(deftest snapshot->instance-honours-rich-snapshot-slots
+  (let [inst (ch/snapshot->instance :auth/login
+                                    {:state          :authing
+                                     :data           {:user "ada"}
+                                     :age-ms         1500
+                                     :spawn-source   [:auth/begin]
+                                     :parent-machine :session/root})]
+    (is (= 1500            (:age-ms inst)))
+    (is (= [:auth/begin]   (:spawn-source inst)))
+    (is (= :session/root   (:parent-machine inst)))))
+
+(deftest snapshots->instances-returns-singleton-vector-when-present
+  (let [v (ch/snapshots->instances :auth/login
+                                   {:auth/login {:state :authing
+                                                 :data  {:x 1}}})]
+    (is (= 1 (count v)))
+    (is (= :authing (-> v first :state)))))
+
+(deftest snapshots->instances-empty-when-snapshot-missing
+  (is (= [] (ch/snapshots->instances :auth/login {})))
+  (is (= [] (ch/snapshots->instances :auth/login nil))))
+
+;; ---- (3) normalise-instances -------------------------------------------
+
+(deftest normalise-instances-fills-missing-slots
+  (let [v (ch/normalise-instances [{:machine-id :m :state :a}
+                                   {:instance-id :inst-1 :state :b}])]
+    (is (= 2 (count v)))
+    (is (every? :instance-id v)
+        "instance-id falls back to machine-id when only the latter is present")
+    (is (every? #(map? (:context %)) v))
+    (is (= :a (-> v first  :state)))
+    (is (= :b (-> v second :state)))
+    (is (= :m (-> v first  :instance-id))
+        "first instance got its instance-id from :machine-id")))
+
+(deftest normalise-instances-defaults-context-to-empty-map
+  (let [v (ch/normalise-instances [{:instance-id :a :state :idle}])]
+    (is (= {} (-> v first :context)))))
+
+(deftest normalise-instances-empty-tolerant
+  (is (= [] (ch/normalise-instances nil)))
+  (is (= [] (ch/normalise-instances []))))
+
+;; ---- (4) cluster-instances ---------------------------------------------
+
+(def ^:private ten-instances
+  [{:instance-id :i1  :machine-id :req :state :idle    :context {:user "ada"}}
+   {:instance-id :i2  :machine-id :req :state :idle    :context {:user "bob"}}
+   {:instance-id :i3  :machine-id :req :state :idle    :context {:user "cat"}}
+   {:instance-id :i4  :machine-id :req :state :authing :context {:user "ada"}}
+   {:instance-id :i5  :machine-id :req :state :authing :context {:user "bob"}}
+   {:instance-id :i6  :machine-id :req :state :sending :context {:user "ada"}}
+   {:instance-id :i7  :machine-id :req :state :sending :context {:user "ada"}}
+   {:instance-id :i8  :machine-id :req :state :sending :context {:user "bob"}}
+   {:instance-id :i9  :machine-id :req :state :error   :context {:user "ada"}}
+   {:instance-id :i10 :machine-id :req :state :ok      :context {:user "cat"}}])
+
+(deftest cluster-by-state-groups-correctly
+  (let [clusters (ch/cluster-instances ten-instances)]
+    (is (= 5 (count clusters))
+        ":idle :authing :sending :error :ok = 5 distinct states")
+    (let [by-key (into {} (map (juxt :cluster-key :count) clusters))]
+      (is (= 3 (get by-key :idle)))
+      (is (= 2 (get by-key :authing)))
+      (is (= 3 (get by-key :sending)))
+      (is (= 1 (get by-key :error)))
+      (is (= 1 (get by-key :ok))))))
+
+(deftest cluster-by-state-orders-deterministically
+  (let [clusters (ch/cluster-instances ten-instances)
+        keys-out (mapv :cluster-key clusters)]
+    (is (= keys-out (sort-by str keys-out))
+        "cluster keys appear in lexicographic order for stable test output")))
+
+(deftest cluster-by-state-default-when-no-options
+  (let [clusters (ch/cluster-instances ten-instances)
+        first-c  (first clusters)]
+    (is (vector? (:instances first-c)))
+    (is (every? map? (:instances first-c)))
+    (is (= [] (:rate-samples first-c))
+        "rate-samples is empty until attach-sparkline-samples runs")))
+
+(deftest cluster-by-context-key-groups-on-the-sub-selector
+  (let [clusters (ch/cluster-instances ten-instances
+                                       {:cluster-by :context-key
+                                        :context-key :user})
+        by-key   (into {} (map (juxt :cluster-key :count) clusters))]
+    (is (= 3 (count clusters))
+        "three distinct :user values: ada, bob, cat")
+    (is (= 5 (get by-key "ada")))
+    (is (= 3 (get by-key "bob")))
+    (is (= 2 (get by-key "cat")))))
+
+(deftest cluster-by-parent-machine-groups-correctly
+  (let [insts    [{:instance-id :a :state :s1 :parent-machine :p1}
+                  {:instance-id :b :state :s1 :parent-machine :p1}
+                  {:instance-id :c :state :s2 :parent-machine :p2}]
+        clusters (ch/cluster-instances insts {:cluster-by :parent-machine})
+        by-key   (into {} (map (juxt :cluster-key :count) clusters))]
+    (is (= 2 (count clusters)))
+    (is (= 2 (get by-key :p1)))
+    (is (= 1 (get by-key :p2)))))
+
+(deftest cluster-by-empty-returns-empty
+  (is (= [] (ch/cluster-instances [])))
+  (is (= [] (ch/cluster-instances nil))))
+
+(deftest cluster-label-renders-keywords-and-nil
+  (let [clusters (ch/cluster-instances [{:state :authing}
+                                        {:state nil}])
+        by-label (into #{} (map :cluster-label clusters))]
+    (is (contains? by-label ":authing"))
+    (is (contains? by-label "(none)"))))
+
+;; ---- (5) sparkline-buckets ---------------------------------------------
+
+(deftest sparkline-buckets-counts-transitions-into-buckets
+  ;; Now = 10000; 2 buckets of 5000ms => oldest = 0.
+  ;; bucket 0 = [0, 5000)   -> id 1 (time 1000)
+  ;; bucket 1 = [5000,10000) -> ids 2, 3 (time 6500, 6800)
+  (let [buf [{:id 1 :operation :rf.machine/transition
+              :time 1000
+              :tags {:machine-id :req :to :authing}}
+             {:id 2 :operation :rf.machine/transition
+              :time 6500
+              :tags {:machine-id :req :to :authing}}
+             {:id 3 :operation :rf.machine/transition
+              :time 6800
+              :tags {:machine-id :req :to :authing}}]
+        samples (ch/sparkline-buckets
+                  buf :req
+                  (fn [ev] (= :authing (get-in ev [:tags :to])))
+                  10000
+                  {:bucket-count 2 :bucket-ms 5000})]
+    (is (= [1 2] samples)
+        "buckets are oldest-first; expected per-bucket counts")))
+
+(deftest sparkline-buckets-filters-by-machine-id
+  (let [buf [{:id 1 :operation :rf.machine/transition
+              :time 1000 :tags {:machine-id :other :to :authing}}
+             {:id 2 :operation :rf.machine/transition
+              :time 1000 :tags {:machine-id :req   :to :authing}}]
+        samples (ch/sparkline-buckets buf :req (constantly true) 5000
+                                      {:bucket-count 1 :bucket-ms 5000})]
+    (is (= [1] samples)
+        ":other machine's transition is filtered out")))
+
+(deftest sparkline-buckets-drops-non-transition-events
+  (let [buf [{:id 1 :operation :event/dispatched :time 1000
+              :tags {:machine-id :req :to :authing}}
+             {:id 2 :operation :rf.machine/transition :time 1000
+              :tags {:machine-id :req :to :authing}}]
+        samples (ch/sparkline-buckets buf :req (constantly true) 5000
+                                      {:bucket-count 1 :bucket-ms 5000})]
+    (is (= [1] samples)
+        ":event/dispatched is not a transition event")))
+
+(deftest sparkline-buckets-empty-when-no-trace
+  (is (= [0 0 0 0]
+         (ch/sparkline-buckets nil :req (constantly true) 1000
+                               {:bucket-count 4 :bucket-ms 250}))))
+
+;; ---- (6) cluster-pred-for ----------------------------------------------
+
+(deftest cluster-pred-for-state-matches-on-tags-to
+  (let [pred (ch/cluster-pred-for :state :authing nil)]
+    (is (true?  (pred {:tags {:to :authing}})))
+    (is (true?  (pred {:tags {:to-state :authing}}))
+        "tolerates the :to-state alias")
+    (is (false? (pred {:tags {:to :idle}})))))
+
+(deftest cluster-pred-for-parent-machine-matches-on-tags
+  (let [pred (ch/cluster-pred-for :parent-machine :session/root nil)]
+    (is (true?  (pred {:tags {:parent-machine :session/root}})))
+    (is (false? (pred {:tags {:parent-machine :other}})))))
+
+;; ---- (7) attach-sparkline-samples --------------------------------------
+
+(deftest attach-sparkline-samples-fills-rate-samples-per-cluster
+  ;; With now-ms=3000 + 2 buckets of 1500ms, oldest = 0.
+  ;; bucket 0 = [0, 1500); bucket 1 = [1500, 3000).
+  (let [buf       [{:id 1 :operation :rf.machine/transition
+                    :time 1000 :tags {:machine-id :req :to :idle}}
+                   {:id 2 :operation :rf.machine/transition
+                    :time 2000 :tags {:machine-id :req :to :authing}}]
+        clusters  (ch/cluster-instances ten-instances)
+        attached  (ch/attach-sparkline-samples
+                    clusters
+                    {:trace-buffer buf
+                     :machine-id   :req
+                     :cluster-by   :state
+                     :now-ms       3000
+                     :opts {:bucket-count 2 :bucket-ms 1500}})
+        by-key    (into {} (map (juxt :cluster-key :rate-samples) attached))]
+    (is (= [1 0] (get by-key :idle))
+        ":idle saw one transition at t=1000 (bucket 0)")
+    (is (= [0 1] (get by-key :authing))
+        ":authing saw one transition at t=2000 (bucket 1)")
+    (is (= [0 0] (get by-key :sending))
+        ":sending has no matching transitions in window")))
+
+;; ---- (8) selection-set helpers -----------------------------------------
+
+(deftest empty-selection-is-a-set
+  (is (set? (ch/empty-selection)))
+  (is (zero? (count (ch/empty-selection)))))
+
+(deftest selection-add-is-idempotent
+  (let [s1 (ch/selection-add (ch/empty-selection) :i1)
+        s2 (ch/selection-add s1 :i1)]
+    (is (= #{:i1} s1))
+    (is (= s1 s2))))
+
+(deftest selection-add-handles-nil-selection
+  (is (= #{:i1} (ch/selection-add nil :i1))))
+
+(deftest selection-add-tolerates-nil-id
+  (is (= #{} (ch/selection-add nil nil)))
+  (is (= #{:i1} (ch/selection-add #{:i1} nil))))
+
+(deftest selection-remove-drops-id
+  (is (= #{:i2} (ch/selection-remove #{:i1 :i2} :i1)))
+  (is (= #{}    (ch/selection-remove #{:i1} :i1))))
+
+(deftest selection-toggle-roundtrip
+  (let [s0 (ch/empty-selection)
+        s1 (ch/selection-toggle s0 :i1)
+        s2 (ch/selection-toggle s1 :i1)
+        s3 (ch/selection-toggle s2 :i2)
+        s4 (ch/selection-toggle s3 :i1)]
+    (is (= #{:i1}     s1))
+    (is (= #{}        s2))
+    (is (= #{:i2}     s3))
+    (is (= #{:i1 :i2} s4))))
+
+(deftest selection-clear-returns-empty
+  (is (= #{} (ch/selection-clear #{:i1 :i2}))))
+
+(deftest selection-contains?-and-count
+  (is (true?  (ch/selection-contains? #{:i1} :i1)))
+  (is (false? (ch/selection-contains? #{:i1} :i2)))
+  (is (false? (ch/selection-contains? nil :i1)))
+  (is (= 2 (ch/selection-count #{:i1 :i2})))
+  (is (= 0 (ch/selection-count nil))))
+
+;; ---- (9) compare-table -------------------------------------------------
+
+(deftest compare-table-nil-when-fewer-than-two-selected
+  (is (nil? (ch/compare-table ten-instances #{})))
+  (is (nil? (ch/compare-table ten-instances #{:i1}))))
+
+(deftest compare-table-renders-diff-flags-correctly
+  ;; i1 :idle  user ada
+  ;; i2 :idle  user bob   (state same; user differs)
+  ;; i4 :authing user ada (state differs)
+  (let [ct (ch/compare-table ten-instances #{:i1 :i2 :i4})]
+    (is (some? ct))
+    (is (= 3 (count (:instances ct))))
+    (let [state-row (:state-row ct)]
+      (is (true? (:diff? state-row))
+          ":idle / :idle / :authing → differs"))
+    (let [user-row (some #(when (= :user (-> % :column :key)) %) (:rows ct))]
+      (is (some? user-row))
+      (is (true? (:diff? user-row))
+          "user values ada / bob / ada → differs"))))
+
+(deftest compare-table-no-diff-when-all-instances-share-values
+  (let [insts [{:instance-id :a :state :idle :context {:user "ada"}}
+               {:instance-id :b :state :idle :context {:user "ada"}}]
+        ct    (ch/compare-table insts #{:a :b})]
+    (is (some? ct))
+    (is (false? (:diff? (:state-row ct))))
+    (let [user-row (some #(when (= :user (-> % :column :key)) %) (:rows ct))]
+      (is (false? (:diff? user-row))))))
+
+(deftest compare-table-columns-cover-the-union-of-context-keys
+  (let [insts [{:instance-id :a :state :s :context {:k1 1}}
+               {:instance-id :b :state :s :context {:k2 2}}]
+        ct    (ch/compare-table insts #{:a :b})
+        col-keys (set (map (comp :key :column) (:rows ct)))]
+    (is (= #{:k1 :k2} col-keys))))
+
+;; ---- (10) expanded set --------------------------------------------------
+
+(deftest expanded-toggle-roundtrip
+  (let [e0 (ch/empty-expanded)
+        e1 (ch/expanded-toggle e0 :authing)
+        e2 (ch/expanded-toggle e1 :authing)]
+    (is (= #{:authing} e1))
+    (is (= #{}         e2))))
+
+(deftest expanded-contains?-tests
+  (is (true?  (ch/expanded-contains? #{:authing} :authing)))
+  (is (false? (ch/expanded-contains? #{:idle}    :authing)))
+  (is (false? (ch/expanded-contains? nil         :authing))))
+
+;; ---- (11) formatting ----------------------------------------------------
+
+(deftest format-instance-id-keyword
+  (is (= ":auth/login" (ch/format-instance-id :auth/login)))
+  (is (= ""            (ch/format-instance-id nil))))
+
+(deftest format-context-value
+  (is (= "—"        (ch/format-context-value nil)))
+  (is (= "\"ada\""  (ch/format-context-value "ada")))
+  (is (= ":authing" (ch/format-context-value :authing))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -128,11 +128,20 @@
    :rf.causa/hydration-reroot-path
    :rf.causa/issues-filters
    :rf.causa/issues-ribbon
+   :rf.causa/forced-machine-mode
    :rf.causa/machine-definitions
    :rf.causa/machine-definitions-override
    :rf.causa/machine-inspector-data
+   :rf.causa/machine-instances
+   :rf.causa/machine-instances-override
    :rf.causa/machine-snapshots
    :rf.causa/machine-snapshots-override
+   :rf.causa/mode-c-cluster-by
+   :rf.causa/mode-c-clusters
+   :rf.causa/mode-c-compare-table
+   :rf.causa/mode-c-context-key
+   :rf.causa/mode-c-expanded
+   :rf.causa/mode-c-selection
    :rf.causa/mcp-filters
    :rf.causa/mcp-origin-filter-enabled?
    :rf.causa/mcp-server
@@ -223,6 +232,7 @@
    :rf.causa/clear-machine-selection
    :rf.causa/clear-mcp-filters
    :rf.causa/clear-mismatch-selection
+   :rf.causa/clear-mode-c-selection
    :rf.causa/clear-route-selection
    :rf.causa/clear-selected-dispatch-id
    :rf.causa/clear-selected-epoch
@@ -284,10 +294,14 @@
    :rf.causa/select-tab
    :rf.causa/select-violation
    :rf.causa/set-active-route-slice-override-for-test
+   :rf.causa/set-forced-machine-mode
    :rf.causa/set-frame
    :rf.causa/set-machine-definitions-override-for-test
+   :rf.causa/set-machine-instances-override-for-test
    :rf.causa/set-machine-snapshots-override-for-test
    :rf.causa/set-mcp-since-seconds
+   :rf.causa/set-mode-c-cluster-by
+   :rf.causa/set-mode-c-context-key
    :rf.causa/set-performance-budget-ms
    :rf.causa/set-registered-flows-override-for-test
    :rf.causa/set-registered-fxs-override-for-test
@@ -310,6 +324,8 @@
    :rf.causa/toggle-live-pause
    :rf.causa/toggle-mcp-op-type
    :rf.causa/toggle-mcp-origin-filter
+   :rf.causa/toggle-mode-c-cluster-expanded
+   :rf.causa/toggle-mode-c-selection
    :rf.causa/unpin
    :rf.causa/unpin-slice
    ;; Views panel events (rf2-21ob3) — replaces the legacy Subscriptions
@@ -396,7 +412,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 91 subs + 113 events + 6 fxs"
+  (testing "registry holds exactly 100 subs + 120 events + 6 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
@@ -423,8 +439,13 @@
     ;; + 3 popover (rf2-dqnuu) − 1 deleted panel sub:
     ;;   :rf.causa/causality-popover-open? + -layout + -payload added;
     ;;   :rf.causa/causality-graph-data deleted with the panel.
-    ;;   Net +2 → 91.
-    (is (= 91 (count all-sub-names)))
+    ;;   Net +2.
+    ;; + 9 machine-inspector Mode C (rf2-juon8 Phase 3):
+    ;;   :rf.causa/mode-c-cluster-by + mode-c-context-key +
+    ;;   mode-c-expanded + mode-c-selection + machine-instances +
+    ;;   machine-instances-override + mode-c-clusters +
+    ;;   mode-c-compare-table + forced-machine-mode.
+    (is (= 100 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -457,8 +478,13 @@
     ;; + 5 popover (rf2-dqnuu):
     ;;   causality-popover-open / -close / -toggle / -toggle-layout /
     ;;   -layout-pulse. The popover replaces the dropped Causality
-    ;;   tab — see spec/018-Event-Spine.md §10. Net +5 → 113.
-    (is (= 113 (count all-event-names)))
+    ;;   tab — see spec/018-Event-Spine.md §10. Net +5.
+    ;; + 7 machine-inspector Mode C (rf2-juon8 Phase 3):
+    ;;   :rf.causa/set-mode-c-cluster-by + set-mode-c-context-key +
+    ;;   toggle-mode-c-cluster-expanded + toggle-mode-c-selection +
+    ;;   clear-mode-c-selection + set-forced-machine-mode +
+    ;;   set-machine-instances-override-for-test.
+    (is (= 120 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary

- Adds the **Erlang-Observer-style aggregate cluster view** to the Machine Inspector. Mode B's per-instance tab strip stops scaling beyond ~10 instances; Mode C is the answer for the multi-instance debugging story (bead rf2-juon8, Phase 3).
- Pure-data cluster algebra in `panels/machine_inspector_cluster_helpers.cljc` (group-by `:state | :context-key | :parent-machine`, sparkline-bucket projection, selection-set + compare-table helpers).
- New `chart/svg/sparkline` primitive for the per-cluster recent state-change rate glyph.
- Mode tab strip in the panel header (Definition | Instances | Cluster) with auto-suggest nudge when instance count > 10.

## What it looks like

```
╭─ Machine Inspector · :request/protocol ── :app/main ▾ ──╮
│ View [Definition] [Instances] [Cluster ●]   ● 12 instances — Cluster recommended│
├──────────────────────────────────────────────────────────┤
│ Cluster by [state ▾]                                     │
│ 3 clusters · 12 instances · Shift+click to compare       │
│                                                          │
│ ▸ :idle      ● 3       ───╱╲___                          │
│ ▾ :authing   ● 5       ___╱╲_╱                           │
│    ○ :inst-1   :authing   {:user "ada"}                  │
│    ✓ :inst-2   :authing   {:user "bob"}    ← shift+clicked│
│    ○ :inst-3   :authing   {:user "cat"}                  │
│ ▸ :sending   ● 3       ____╱╲_                           │
│ ▸ :done      ● 1       ______                            │
╰──────────────────────────────────────────────────────────╯
```

Compare-table (when ≥2 instances are shift-clicked):

```
╭─ Compare · 2 selected ─────────────── [Clear] ────╮
│ Field     │ :inst-0   │ :inst-1                   │
│ :state    │ :idle     │ :authing  ← amber-tinted  │
│ :counter  │ 0         │ 1         ← amber         │
│ :user     │ "ada"     │ "bob"     ← amber         │
╰────────────────────────────────────────────────────╯
```

## New files

- `tools/causa/src/.../panels/machine_inspector_cluster.cljs` (view + 9 subs + 7 events)
- `tools/causa/src/.../panels/machine_inspector_cluster_helpers.cljc` (pure projections)
- `tools/causa/test/.../panels/machine_inspector_cluster_cljs_test.cljs` (19 deftests — wiring, threshold, shift-click, compare-table, cluster-by selector)
- `tools/causa/test/.../panels/machine_inspector_cluster_helpers_cljs_test.cljc` (41 deftests — grouping, sparkline math, selection set, compare diff)

## Modified files

- `tools/causa/src/.../panels/machine_inspector.cljs` — mode tab strip, `resolve-mode`, instance-count from new sub, ClusterView mount + cluster `install!` call, forced-mode sub/event.
- `tools/causa/src/.../chart/svg.cljc` — `sparkline` primitive.
- `tools/causa/test/.../chart/svg_cljs_test.cljc` — 5 sparkline deftests.
- `tools/causa/test/.../registry_cljs_test.cljs` — catalogue +9 subs +7 events (100 / 120 / 6).

## Locked decisions honoured

- Mode C auto-suggested when instances > 10 (default threshold).
- Cluster-by selector: `:state` (default) / `:context-key` / `:parent-machine`.
- Cluster badges: per-state count + sparkline of recent state-change rate.
- Shift-click multi-select for cross-instance compare; plain click on instance row intentionally inert.
- Selected cluster expansion: inline (toggle), not a separate mode.

## Phase 1/2 widening

Phase 1/2's single-snapshot pathway (`{machine-id snapshot}`) is widened into a multi-instance vector via `ch/snapshots->instances`. Production still rides the single-snapshot path; a new `:rf.causa/set-machine-instances-override-for-test` lets tests drive richer multi-instance projections so Mode C is exercisable before the upstream `:rf.machine/spawn` surface lands.

## Divergences from the bead's design ceiling

- Sparkline is inline-SVG polyline (no per-state shading on the diagram itself — that's the §3.3 cluster-overlay tint, deferred to follow-on).
- Compare-table is cell-by-cell diff; divergence-arc visualisation (§3.9) deferred.
- ELK.js layout swap (Phase 4 rf2-m7co9) remains out of scope.

## Test plan

- [x] `scripts/test-fast-pr.sh` (CLJS spine — 2633 tests pass)
- [x] `cd tools/causa && clojure -M:test` (703 tests pass)
- [x] `cd implementation && npm run test:browser` (2605 tests pass)
- [x] `scripts/test-jvm-tools.sh` (tools artefacts pass)
- [x] Registry catalogue updated (100 subs / 120 events / 6 fxs)

Bead: rf2-juon8 (do NOT close — Phase 3 in a multi-phase epic).