### PR TITLE
feat(causa): Machine Inspector Phase 4 — ELK.js layout engine

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs
@@ -1,0 +1,456 @@
+(ns day8.re-frame2-causa.chart.elk-layout
+  "ELK.js-driven layout for the Causa Machine Inspector chart
+  (rf2-m7co9 Phase 4 — child of rf2-2tkza Phase 1).
+
+  Per `tools/causa/spec/003-Machine-Inspector.md` §Architectural
+  posture ELK is the preferred layout engine for the state-chart
+  diagram. Phase 1 shipped a simple layered BFS-rank layout (still in
+  `chart/layout.cljc` as `layered-fallback`); this ns is the ELK swap
+  behind the same `{:nodes :edges :width :height :initial-id}` data
+  interface so the SVG renderer in `chart/svg.cljc` consumes either
+  engine's output unchanged.
+
+  ## Lazy load — mirror the Causality popover pattern
+
+  ELK.js is a ~250 kB browser bundle (gzipped). Loading it at preload
+  time would inflate every Causa dev session whether the user opens
+  the Machine Inspector or not. The loader mirrors the pattern in
+  `popover/causality_graph.cljs`:
+
+    - First call from the panel triggers a `js/import` of
+      `elkjs/lib/elk.bundled.js`.
+    - Subsequent calls fast-path off a `defonce` atom that tracks
+      `nil → :loading → {:elk <inst>} | {:failed <msg>}`.
+    - If the import rejects (node-test rig, CSP block, offline) the
+      state flips to `{:failed ...}` and the consumer falls back to
+      the layered placement.
+    - Tests can pre-stub `js/window.ELK` to short-circuit the import
+      (sync wrap path) without bundling ELK into the test rig.
+
+  Both this ns and `popover/causality_graph.cljs` hold their own
+  loader atom so the two consumers can fail independently — but in
+  practice once one succeeds the other also will (both run in the
+  same JS host with the same module resolver). A future bead can
+  unify the loader into a shared `chart/elk_loader.cljs` ns.
+
+  ## Async layout, sync consumer
+
+  ELK's `layout` returns a Promise — pixel positions are not
+  available synchronously. The Causa pattern (already used by the
+  Causality popover) is:
+
+    1. Render the fallback layout immediately (no waiting).
+    2. Kick the ELK layout in the background; cache the result keyed
+       on the definition + direction.
+    3. When the layout resolves, dispatch a no-op render-pulse event
+       so the subscribe-driven view re-runs and picks up the cached
+       ELK positions.
+
+  The panel ns owns the pulse event; this ns just publishes
+  `compute-layout!` (async + cache write) + `cached-layout` (sync
+  read).
+
+  ## What this does NOT do (deferred)
+
+    - Edge polylines from ELK's bend-point output. v1 collapses ELK's
+      multi-point routes to straight lines between source/target
+      centres. `chart/svg.cljc` already supports the multi-point case
+      via `path-from-points`; lifting ELK's bend points into the
+      `:points` slot is a follow-on.
+    - Compound-state hierarchical containment in the ELK graph itself.
+      v1 ships every state as a flat ELK child + relies on the
+      existing dashed-border treatment in `chart/svg.cljc` for the
+      visual grouping. ELK's hierarchical mode (parent containers with
+      child layout) is a richer follow-on.
+
+  Both deferrals keep the data shape stable so the SVG renderer keeps
+  rendering without per-engine branching."
+  (:require [day8.re-frame2-causa.chart.layout :as layout]))
+
+;; ---- ELK lazy-load state -------------------------------------------------
+
+(defonce ^:private elk-state
+  ;; Holds one of:
+  ;;   nil             — not yet attempted
+  ;;   :loading        — import in flight
+  ;;   {:elk <obj>}    — loaded; obj is an ELK instance
+  ;;   {:failed err}   — load attempt rejected; fallback engaged
+  ;;
+  ;; defonce so shadow-cljs `:after-load` reloads don't re-trigger the
+  ;; import.
+  (atom nil))
+
+(defn elk-status
+  "Public read-accessor for the ELK loader state. Returns one of
+  `:idle | :loading | :ready | :failed`."
+  []
+  (let [s @elk-state]
+    (cond
+      (nil? s)                   :idle
+      (= s :loading)             :loading
+      (and (map? s) (:elk s))    :ready
+      (and (map? s) (:failed s)) :failed
+      :else                      :idle)))
+
+(defn- elk-instance
+  "Return the loaded ELK instance, or nil when not ready."
+  []
+  (when-let [s @elk-state]
+    (and (map? s) (:elk s))))
+
+(defn- maybe-window-elk
+  "Some test rigs pre-stub `js/window.ELK` so a synchronous load path
+  works without triggering a dynamic import. Returns that constructor
+  when present, nil otherwise."
+  []
+  (when (and (exists? js/window))
+    (let [w js/window]
+      (or (.-ELK w)
+          (.-elkjs w)))))
+
+(defn ensure-elk!
+  "Idempotent lazy load. Returns immediately. When loading completes
+  `done-fn` fires with the ELK instance (or nil on failure).
+
+  Three load paths (identical to `popover/causality_graph/ensure-elk!`):
+
+    1. Pre-stubbed `js/window.ELK` — sync wrap, no import.
+    2. `js/import` resolves `\"elkjs/lib/elk.bundled.js\"` — production
+       browser session.
+    3. Both fail → state flips to `{:failed ...}` and `done-fn` fires
+       with nil; subsequent calls fast-path with nil."
+  [done-fn]
+  (let [cur @elk-state]
+    (cond
+      (and (map? cur) (:elk cur))
+      (done-fn (:elk cur))
+
+      (and (map? cur) (:failed cur))
+      (done-fn nil)
+
+      (= cur :loading)
+      nil
+
+      :else
+      (do
+        (reset! elk-state :loading)
+        (if-let [Ctor (maybe-window-elk)]
+          (try
+            (let [inst (Ctor.)]
+              (reset! elk-state {:elk inst})
+              (done-fn inst))
+            (catch :default e
+              (reset! elk-state {:failed (.-message e)})
+              (done-fn nil)))
+          (try
+            (let [p (try
+                      (js/import "elkjs/lib/elk.bundled.js")
+                      (catch :default _ nil))]
+              (if (and p (.-then p))
+                (-> p
+                    (.then (fn [mod]
+                             (let [Ctor (or (.-default mod) (.-ELK mod) (.-elk mod))]
+                               (if Ctor
+                                 (let [inst (Ctor.)]
+                                   (reset! elk-state {:elk inst})
+                                   (done-fn inst))
+                                 (do
+                                   (reset! elk-state {:failed "no ELK constructor in module"})
+                                   (done-fn nil))))))
+                    (.catch (fn [e]
+                              (reset! elk-state {:failed (or (.-message e) "import failed")})
+                              (done-fn nil))))
+                (do
+                  (reset! elk-state {:failed "js/import unavailable"})
+                  (done-fn nil))))
+            (catch :default e
+              (reset! elk-state {:failed (or (.-message e) "import threw")})
+              (done-fn nil))))))))
+
+(defn reset-elk-state-for-test!
+  "Reset the loader state — test-only. Lets the test suite drive a
+  fresh load attempt with a stubbed `js/window.ELK`."
+  []
+  (reset! elk-state nil)
+  nil)
+
+;; ---- definition → ELK graph (pure) -------------------------------------
+
+(def ^:private default-node-width 140)
+(def ^:private default-node-height 48)
+
+(defn ->elk-graph
+  "Project a parsed machine-definition into the ELK JSON graph shape:
+
+      {:id        \"root\"
+       :layoutOptions {\"elk.algorithm\" \"layered\"
+                       \"elk.direction\" \"DOWN\"
+                       ...}
+       :children  [{:id <node-id> :width N :height N
+                    :labels [{:text <label>}]}]
+       :edges     [{:id <id> :sources [...] :targets [...]
+                    :labels [{:text <event-label>}]}]}
+
+  Pure data → data. JVM-runnable. The `direction` arg is `:tb`
+  (default) or `:lr`; ELK takes a single direction per graph. The
+  per-region LR/TB hybrid that Spec 003 sketches lives in a follow-on
+  bead.
+
+  Note: v1 projects the flat parsed graph (compound children appear
+  alongside their parents at the top level — same shape the layered
+  fallback produces). Hierarchical ELK containment is deferred — see
+  the ns docstring."
+  ([definition] (->elk-graph definition :tb))
+  ([definition direction]
+   (let [{:keys [nodes edges]} (layout/parse-definition definition)
+         dir-str (case direction
+                   :lr "RIGHT"
+                   :tb "DOWN"
+                   "DOWN")
+         mk-child (fn [n]
+                    {:id     (layout/node-id (:path n))
+                     :width  default-node-width
+                     :height default-node-height
+                     :labels [{:text (:label n)}]})
+         mk-edge  (fn [edge-idx {:keys [from to event] :as e}]
+                    {:id      (str "e" edge-idx "-"
+                                   (layout/node-id from) "-"
+                                   (layout/node-id to))
+                     :sources [(layout/node-id from)]
+                     :targets [(layout/node-id to)]
+                     :labels  [{:text (cond
+                                        (:after e)    (str "after(" (:after e) ")")
+                                        (:always? e)  "always"
+                                        (keyword? event)
+                                        (if-let [ns (namespace event)]
+                                          (str ns "/" (name event))
+                                          (name event))
+                                        :else (str event))}]})]
+     {:id            "root"
+      :layoutOptions {"elk.algorithm"                              "layered"
+                      "elk.direction"                              dir-str
+                      "elk.spacing.nodeNode"                       "32"
+                      "elk.layered.spacing.nodeNodeBetweenLayers"  "60"
+                      "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
+                      "elk.edgeRouting"                            "ORTHOGONAL"}
+      :children      (mapv mk-child nodes)
+      :edges         (vec (map-indexed mk-edge edges))})))
+
+;; ---- ELK output → chart-layout shape (pure) ----------------------------
+
+(defn- edge-event-label
+  "Build the human-readable event-label string for an edge — same shape
+  the layered fallback produces (so the SVG renderer reads either
+  identically)."
+  [{:keys [event after always?]}]
+  (cond
+    after            (str "after(" after ")")
+    always?          "always"
+    (keyword? event) (if-let [ns (namespace event)]
+                       (str ns "/" (name event))
+                       (name event))
+    :else            (str event)))
+
+(defn elk-result->chart-layout
+  "Adapter: parsed-definition + ELK layout result map → the same
+  `{:nodes :edges :width :height :initial-id}` shape `chart/layout/
+  layout` returns.
+
+  Pure data → data. `elk-result` is the ClojureScript projection of
+  ELK's output graph (the caller converts ELK's JS object via
+  `js->clj` with `:keywordize-keys true`). Looks like:
+
+      {:children [{:id <node-id> :x N :y N :width N :height N} ...]
+       :edges    [{:id <id> :sections [{:startPoint {:x :y}
+                                        :endPoint {:x :y}
+                                        :bendPoints [{:x :y} ...]}]} ...]
+       :width N :height N}
+
+  We preserve the parsed-definition's node metadata (`:label`,
+  `:compound?`, `:final?`, etc.) by joining on `node-id`. Edge points
+  come from ELK's `:sections` when present; the fallback is a straight
+  line from source-bottom to target-top, same as the layered engine."
+  [definition elk-result]
+  (let [{:keys [nodes edges initial-path]} (layout/parse-definition definition)
+        ;; Index ELK's positioned children by id for O(1) lookups.
+        elk-children-by-id (into {}
+                                 (map (fn [c] [(:id c) c]))
+                                 (:children elk-result))
+        positioned-nodes
+        (mapv (fn [n]
+                (let [nid       (layout/node-id (:path n))
+                      elk-child (get elk-children-by-id nid)
+                      ;; ELK output coordinates: top-left in graph
+                      ;; space. Fall back to (0,0) when ELK skipped
+                      ;; the node (shouldn't happen, but defensive).
+                      x         (or (:x elk-child) 0)
+                      y         (or (:y elk-child) 0)
+                      w         (or (:width elk-child) default-node-width)
+                      h         (or (:height elk-child) default-node-height)]
+                  (assoc n
+                    :x       x
+                    :y       y
+                    :width   w
+                    :height  h
+                    :node-id nid)))
+              nodes)
+        node-index (into {} (map (fn [n] [(:path n) n])) positioned-nodes)
+        ;; Index ELK edges by their composite id so we can pull the
+        ;; bend points back per edge.
+        elk-edges-by-id
+        (into {}
+              (map (fn [e] [(:id e) e]))
+              (:edges elk-result))
+        positioned-edges
+        (vec
+          (keep-indexed
+            (fn [edge-idx {:keys [from to] :as edge}]
+              (let [src       (get node-index from)
+                    tgt       (get node-index to)]
+                (when (and src tgt)
+                  (let [self?    (= from to)
+                        eid      (str "e" edge-idx "-"
+                                      (layout/node-id from) "-"
+                                      (layout/node-id to))
+                        elk-edge (get elk-edges-by-id eid)
+                        section  (first (:sections elk-edge))
+                        sp       (:startPoint section)
+                        ep       (:endPoint section)
+                        bends    (or (:bendPoints section) [])
+                        ;; Build a points vector. Prefer ELK's section
+                        ;; output (orthogonal routing); fall back to
+                        ;; centre-to-centre lines otherwise.
+                        points   (cond
+                                   (and sp ep)
+                                   (vec (concat
+                                          [[(:x sp) (:y sp)]]
+                                          (map (fn [p] [(:x p) (:y p)]) bends)
+                                          [[(:x ep) (:y ep)]]))
+
+                                   self?
+                                   (let [src-x (+ (:x src) (quot (:width src) 2))
+                                         src-y (+ (:y src) (:height src))
+                                         tgt-x (+ (:x tgt) (quot (:width tgt) 2))
+                                         tgt-y (:y tgt)]
+                                     [[src-x src-y]
+                                      [(+ src-x 70) (+ src-y 30)]
+                                      [(+ src-x 70) (- tgt-y 30)]
+                                      [tgt-x tgt-y]])
+
+                                   :else
+                                   (let [src-x (+ (:x src) (quot (:width src) 2))
+                                         src-y (+ (:y src) (:height src))
+                                         tgt-x (+ (:x tgt) (quot (:width tgt) 2))
+                                         tgt-y (:y tgt)]
+                                     [[src-x src-y] [tgt-x tgt-y]]))]
+                    (assoc edge
+                      :from-id     (:node-id src)
+                      :to-id       (:node-id tgt)
+                      :self?       self?
+                      :points      points
+                      :event-label (edge-event-label edge))))))
+            edges))
+        chart-width  (or (:width elk-result)
+                         (apply max 200
+                                (map (fn [n] (+ (:x n) (:width n))) positioned-nodes)))
+        chart-height (or (:height elk-result)
+                         (apply max 80
+                                (map (fn [n] (+ (:y n) (:height n))) positioned-nodes)))]
+    {:nodes      positioned-nodes
+     :edges      positioned-edges
+     :width      chart-width
+     :height     chart-height
+     :initial-id (when initial-path (layout/node-id initial-path))}))
+
+;; ---- async layout cache --------------------------------------------------
+
+(defonce ^:private layout-cache
+  ;; `{:key [<definition> <direction>] :layout {<chart-layout>}}` —
+  ;; ELK layout is expensive (a few ms even for small graphs) so we
+  ;; cache positions keyed on the exact definition + direction. The
+  ;; cache holds only the *most recent* layout — the panel typically
+  ;; only inspects one machine at a time. defonce survives hot-reload.
+  (atom nil))
+
+(defn cached-layout
+  "Synchronous read: return the cached chart-layout for `definition` +
+  `direction`, or nil when the cache is stale / empty. Pure read; the
+  caller is responsible for triggering a `compute-layout!` when this
+  returns nil."
+  [definition direction]
+  (let [c @layout-cache]
+    (when (and c (= (:key c) [definition direction]))
+      (:layout c))))
+
+(defn- write-cache!
+  [definition direction chart-layout]
+  (reset! layout-cache
+          {:key    [definition direction]
+           :layout chart-layout})
+  chart-layout)
+
+(defn reset-cache-for-test!
+  "Reset the layout cache — test-only."
+  []
+  (reset! layout-cache nil)
+  nil)
+
+(defn compute-layout!
+  "Async: run an ELK layout pass for `definition` + `direction` and
+  write the result to the cache. Calls `done-fn` with the chart-layout
+  map once available, or with nil if ELK isn't ready / layout failed.
+
+  Idempotent w.r.t. the cache: if a layout for this `[definition
+  direction]` key is already cached, the cached value is delivered
+  synchronously without re-running ELK.
+
+  The async path looks like:
+
+    1. Cache hit → callback fires sync with cached layout.
+    2. ELK ready, cache miss → build ELK input, call `.layout`,
+       project the Promise's result back through
+       `elk-result->chart-layout`, write to cache, fire callback.
+    3. ELK not ready → callback fires sync with nil. Caller falls
+       back to `layered-fallback` (and re-tries on the next render
+       tick after `ensure-elk!` resolves)."
+  [definition direction done-fn]
+  (if-let [cached (cached-layout definition direction)]
+    (done-fn cached)
+    (if-let [elk (elk-instance)]
+      (let [input    (->elk-graph definition direction)
+            input-js (clj->js input)
+            p        (try (.layout elk input-js)
+                          (catch :default _ nil))]
+        (if (and p (.-then p))
+          (-> p
+              (.then (fn [result]
+                       (let [clj-result (js->clj result :keywordize-keys true)
+                             chart-layout (elk-result->chart-layout
+                                            definition clj-result)]
+                         (write-cache! definition direction chart-layout)
+                         (done-fn chart-layout))))
+              (.catch (fn [_e]
+                        ;; Layout failure is transient — leave the
+                        ;; cache untouched so the next attempt can
+                        ;; retry. Caller falls back to layered.
+                        (done-fn nil))))
+          (done-fn nil)))
+      (done-fn nil))))
+
+;; ---- public entry --------------------------------------------------------
+
+(defn layout-or-fallback
+  "Sync entry. Returns a chart-layout map immediately:
+
+    - When ELK is ready AND the cache holds a layout for `[definition
+      direction]` → return the cached ELK layout.
+    - Otherwise → return the layered-fallback layout (sync, pure).
+
+  The caller (the panel) typically calls this once per render. The
+  panel is also responsible for calling `ensure-elk!` (to start the
+  lazy import) and `compute-layout!` (to populate the cache + trigger
+  a re-render via a dispatched pulse event)."
+  ([definition] (layout-or-fallback definition :tb))
+  ([definition direction]
+   (or (cached-layout definition direction)
+       (layout/layered-fallback definition))))

--- a/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
@@ -246,8 +246,10 @@
 
 ;; ---- placement ----------------------------------------------------------
 
-(defn- node-id
-  "Stable string id for a node, suitable for SVG ids + React keys."
+(defn node-id
+  "Stable string id for a node, suitable for SVG ids + React keys.
+  Exported so the ELK adapter can mint matching ids on the way through
+  ELK's JSON graph + back."
   [path]
   (->> path
        (map (fn [p]
@@ -359,6 +361,25 @@
          :width      chart-width
          :height     chart-height
          :initial-id (when initial-path (node-id initial-path))}))))
+
+(defn layered-fallback
+  "Explicit alias for the simple layered BFS-rank `layout` fn — exported
+  so callers (e.g. the ELK adapter in
+  `day8.re-frame2-causa.chart.elk-layout`) can request the fallback path
+  by name when ELK.js is unavailable or the topology is small enough that
+  the layered placement reads cleanly.
+
+  Rationale: Phase 4 (rf2-m7co9) introduces an ELK-driven layout that
+  produces the same `{:nodes :edges :width :height :initial-id}` shape
+  this fn returns. Both routes flow through `chart/svg`'s renderer
+  unchanged. The fallback is what JVM tests + node-runtime tests assert
+  against (ELK is a browser-only async loader and is unavailable in
+  those rigs). Renaming the public surface to `layered-fallback`
+  documents the role so consumer code reads as `(layered-fallback def)`
+  rather than `(layout def)` — calling intent matters when there are
+  two layout engines."
+  [definition]
+  (layout definition))
 
 (defn highlight-id
   "Resolve a snapshot `:state` value to the node-id used in the

--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -58,6 +58,96 @@
     final?     (:green tokens/tokens)
     :else      (:border-default tokens/tokens)))
 
+(defn compound-containers
+  "rf2-m7co9 Phase 4 — compute the bounding box of each compound state
+  from the union of its descendant leaves' positions. Returns a vec of
+  `{:node-id :x :y :width :height :path :label}` maps, one per
+  compound parent that has at least one descendant in the positioned
+  graph. Pure fn — JVM-runnable.
+
+  Why an after-the-fact pass: the layered fallback engine places every
+  state (including compound parents) as a flat node so the data
+  interface stays uniform across engines. The compound container is a
+  *visual* concept — its rectangle is the union-bbox of its children
+  plus a small inset margin. Both the layered and ELK engines feed
+  this fn the same way.
+
+  When the compound parent itself has no children in the projected
+  graph (e.g. an empty `:states {}`) the container is dropped."
+  [nodes]
+  (let [compound-parents (filter :compound? nodes)
+        ;; Group every node by the prefix-paths of its ancestors so we
+        ;; can do a single pass instead of scanning per-parent.
+        by-parent-path
+        (reduce (fn [m n]
+                  (let [p (:path n)]
+                    (if (> (count p) 1)
+                      (let [parent-p (subvec p 0 (dec (count p)))]
+                        (update m parent-p (fnil conj []) n))
+                      m)))
+                {}
+                nodes)
+        pad-x 16
+        pad-y 24                            ;; extra top padding for the title strip
+        ;; For deeply-nested compounds, descendant leaves can sit
+        ;; multiple levels down; collect every descendant by
+        ;; checking the path-prefix.
+        descendants-of
+        (fn [parent-path]
+          (filter (fn [n]
+                    (let [p (:path n)]
+                      (and (> (count p) (count parent-path))
+                           (= parent-path (subvec p 0 (count parent-path))))))
+                  nodes))]
+    (vec
+      (keep
+        (fn [parent]
+          (let [parent-path (:path parent)
+                kids        (or (get by-parent-path parent-path) [])
+                ;; Use the full descendant set so a compound with a
+                ;; compound child still draws a sensible outer hull.
+                hull        (descendants-of parent-path)]
+            (when (seq hull)
+              (let [min-x (apply min (map :x hull))
+                    min-y (apply min (map :y hull))
+                    max-x (apply max (map (fn [n] (+ (:x n) (:width n))) hull))
+                    max-y (apply max (map (fn [n] (+ (:y n) (:height n))) hull))]
+                {:node-id (:node-id parent)
+                 :path    parent-path
+                 :label   (:label parent)
+                 :x       (- min-x pad-x)
+                 :y       (- min-y pad-y)
+                 :width   (+ (- max-x min-x) (* 2 pad-x))
+                 :height  (+ (- max-y min-y) pad-x pad-y)
+                 :leaf-count (count kids)}))))
+        compound-parents))))
+
+(defn- render-compound-container
+  "One translucent box around a compound state's children. Carries a
+  small title strip across the top with the compound state's label so
+  the visual grouping is self-explanatory."
+  [{:keys [x y width height label node-id]}]
+  [:g {:data-testid (str "rf-causa-chart-compound-" node-id)
+       :data-node-id node-id}
+   [:rect {:x x :y y :width width :height height
+           :rx 10
+           :fill "rgba(124, 92, 255, 0.06)"          ;; translucent violet
+           :stroke (:accent-violet tokens/tokens)
+           :stroke-width 1
+           :stroke-dasharray "4 3"
+           :pointer-events "none"}]
+   ;; Title strip — small label flushed top-left so the parent state's
+   ;; name reads as a "section heading" above its children.
+   (when label
+     [:text {:x (+ x 10)
+             :y (+ y 14)
+             :font-family font-stack
+             :font-size 10
+             :font-weight 600
+             :fill (:accent-violet tokens/tokens)
+             :pointer-events "none"}
+      label])])
+
 (defn- arrow-marker
   "Define an arrow marker once, reuse it on every edge."
   []
@@ -155,10 +245,17 @@
         "✓"])]))
 
 (defn- path-from-points
-  "Render an SVG path `d` attribute from a point list. Straight lines
-  for 2 points, cubic bezier for 4."
+  "Render an SVG path `d` attribute from a point list.
+
+    - 2 points → straight line.
+    - 4 points → cubic bezier (self-loop / hand-routed S-curve).
+    - 3 or 5+ points → polyline (ELK orthogonal routing returns
+      multi-segment edges via bend points; we render them as connected
+      `L` segments). rf2-m7co9 Phase 4."
   [points]
   (case (count points)
+    0 ""
+    1 ""
     2 (let [[[x1 y1] [x2 y2]] points]
         (str "M " x1 " " y1 " L " x2 " " y2))
     4 (let [[[x1 y1] [cx1 cy1] [cx2 cy2] [x2 y2]] points]
@@ -166,14 +263,34 @@
              " C " cx1 " " cy1
              " "  cx2 " " cy2
              " "  x2  " " y2))
-    ""))
+    ;; 3 or 5+ points → polyline.
+    (let [[[x0 y0] & rst] points]
+      (str "M " x0 " " y0
+           " "
+           (str/join " "
+                     (map (fn [[x y]] (str "L " x " " y)) rst))))))
 
 (defn- edge-label-position
-  "Mid-point of the edge for label placement. For self-loops, place
-  the label to the right of the control points."
+  "Mid-point of the edge for label placement.
+
+    - 4-point self-loop bezier → label to the right of the control
+      points.
+    - 2-point straight line → midpoint of the segment.
+    - 3+ point polyline (orthogonal routing) → midpoint of the middle
+      segment so the label sits near the visual centre of the path."
   [points]
-  (if (= 4 (count points))
+  (cond
+    (= 4 (count points))
     (let [[_ [cx _] _ _] points] [(+ cx 30) (second (second points))])
+
+    (>= (count points) 3)
+    (let [n (count points)
+          mid-idx (quot n 2)
+          [x1 y1] (nth points (dec mid-idx))
+          [x2 y2] (nth points mid-idx)]
+      [(quot (+ x1 x2) 2) (- (quot (+ y1 y2) 2) 6)])
+
+    :else
     (let [[[x1 y1] [x2 y2]] points]
       [(quot (+ x1 x2) 2) (- (quot (+ y1 y2) 2) 6)])))
 
@@ -249,7 +366,8 @@
      (let [initial-node (some (fn [n]
                                 (when (and (:initial? n)
                                            (= 0 (:depth n))) n))
-                              nodes)]
+                              nodes)
+           containers (compound-containers nodes)]
        [:svg {:data-testid (or testid "rf-causa-chart-svg")
               :data-highlight-id (or highlight-id "")
               :viewBox (str "0 0 " width " " height)
@@ -260,6 +378,12 @@
                       :max-height "100%"
                       :display "block"}}
         (arrow-marker)
+        ;; Compound containers sit BELOW edges + nodes so the dashed
+        ;; outline reads as a backdrop. rf2-m7co9 Phase 4.
+        (into [:g {:data-testid "rf-causa-chart-compounds"}]
+              (for [c containers]
+                ^{:key (:node-id c)}
+                (render-compound-container c)))
         ;; Edges first so nodes paint over them
         (into [:g {:data-testid "rf-causa-chart-edges"}]
               (for [edge edges]

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -75,6 +75,7 @@
   `:rf.causa/machine-inspector-data` composite sub."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.chart.layout :as chart-layout]
+            [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-causa.panels.machine-inspector-cluster :as cluster]
@@ -312,11 +313,46 @@
            state-value  (if sim?
                           (:state sim-snapshot)
                           (:state override))
-           highlight-id (chart-layout/highlight-id state-value)]
+           highlight-id (chart-layout/highlight-id state-value)
+           ;; Phase 4 (rf2-m7co9): ELK.js layout with layered fallback.
+           ;;
+           ;; The layout direction defaults to :tb; per-machine override
+           ;; lives in the panel app-db slot for a follow-on bead.
+           ;;
+           ;; Kick the loader (idempotent — second call after success
+           ;; is a no-op fast-path). When the loader resolves and the
+           ;; cache is empty, kick a layout pass; the layout's `.then`
+           ;; writes the cache + dispatches the pulse event that re-
+           ;; renders this view via the subscribe-driven recompute.
+           direction    :tb
+           _            (elk-layout/ensure-elk!
+                          (fn [_inst]
+                            (when (elk-layout/elk-status)
+                              ;; If ELK is ready and the cache is empty
+                              ;; for this combination, populate it.
+                              (when (and (= :ready (elk-layout/elk-status))
+                                         (nil? (elk-layout/cached-layout
+                                                 definition direction)))
+                                (elk-layout/compute-layout!
+                                  definition direction
+                                  (fn [chart-layout]
+                                    (when chart-layout
+                                      (rf/dispatch
+                                        [:rf.causa/machine-chart-layout-pulse]
+                                        {:frame :rf/causa}))))))))
+           ;; When ELK is ready+cached → ELK. Otherwise → layered
+           ;; fallback. Both produce the same `{:nodes :edges :width
+           ;; :height :initial-id}` shape so the SVG renderer is
+           ;; layout-engine-agnostic.
+           positioned   (elk-layout/layout-or-fallback definition direction)
+           engine       (if (some? (elk-layout/cached-layout definition direction))
+                          "elk"
+                          "layered")]
        [:div {:data-testid "rf-causa-machine-inspector-chart"
               :data-machine-id (str (:machine-id props))
               :data-highlight-id (or highlight-id "")
               :data-sim-active (str sim?)
+              :data-layout-engine engine
               :style       {:margin "12px"
                             :padding "12px"
                             :background (:bg-1 tokens)
@@ -326,8 +362,8 @@
                                            (:border-subtle tokens)))
                             :border-radius "4px"
                             :overflow "auto"}}
-        (chart-svg/render-from-definition
-          definition
+        (chart-svg/render
+          positioned
           {:highlight-id   highlight-id
            :sim?           sim?
            :on-state-click (fn [path]
@@ -821,6 +857,21 @@
   (rf/reg-event-db :rf.causa/machine-state-clicked
     (fn [db [_ _payload]]
       db))
+
+  ;; ---- Phase 4 (rf2-m7co9) — ELK layout pulse ---------------------
+  ;;
+  ;; The ELK layout pass is asynchronous (returns a Promise). When it
+  ;; resolves, we need to nudge the subscribe-driven view to recompute
+  ;; so the cached ELK positions land on the next render. A no-op
+  ;; event handler tick on the panel's app-db is the simplest pulse —
+  ;; it bumps the reactive graph without changing any user-visible
+  ;; state. Mirrors the `:rf.causa/causality-popover-layout-pulse`
+  ;; pattern in the Causality popover's ELK loader.
+  (rf/reg-event-db :rf.causa/machine-chart-layout-pulse
+    (fn [db _event]
+      ;; Increment a counter so the app-db value actually changes —
+      ;; some substrates short-circuit identical-value writes.
+      (update db :machine-inspector/elk-pulse-tick (fnil inc 0))))
 
   ;; ---- Phase 3 (rf2-juon8) — UC2 Mode C forced-mode slot ----------
 

--- a/tools/causa/test/day8/re_frame2_causa/chart/elk_integration_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/chart/elk_integration_cljs_test.cljs
@@ -1,0 +1,151 @@
+(ns day8.re-frame2-causa.chart.elk-integration-cljs-test
+  "Browser-only integration tests for the ELK adapter (rf2-m7co9 Phase 4).
+
+  These tests exercise the actual ELK.js lazy loader path against a
+  pre-stubbed `js/window.ELK` constructor (so the test does not depend
+  on the bundler resolving `elkjs`, which keeps the ELK package
+  optional at the consumer-classpath level). The pure-data adapter
+  tests live in `elk_layout_cljs_test.cljs`.
+
+  The browser-test build picks this ns up via the `-cljs-test$`
+  regex; the node-test build (which doesn't define `js/window`) skips
+  the body via a host check so this file is also safe to ship in the
+  node-test classpath."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [day8.re-frame2-causa.chart.layout :as layout]
+            [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- clear-elk-stub! []
+  (elk-layout/reset-elk-state-for-test!)
+  (elk-layout/reset-cache-for-test!)
+  (when (exists? js/window)
+    (set! (.-ELK js/window) js/undefined)))
+
+(use-fixtures :each
+  {:before clear-elk-stub!
+   :after  clear-elk-stub!})
+
+;; ---- ELK stub -----------------------------------------------------------
+
+(def three-state-machine
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :done}}
+             :done    {:final? true}}})
+
+(def compound-machine
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(defn- mk-deterministic-elk-stub
+  "Construct an ELK-shaped object whose .layout assigns x/y based on
+  child position in the input list. Good enough to assert 'ELK ran +
+  positions were honoured' without bundling real ELK into the rig."
+  []
+  (fn []
+    (this-as this
+      (set! (.-layout this)
+            (fn [graph]
+              (let [graph-clj  (js->clj graph :keywordize-keys true)
+                    children   (:children graph-clj)
+                    positioned (vec
+                                 (map-indexed
+                                   (fn [idx c]
+                                     (assoc c
+                                       :x (* idx 200)
+                                       :y (* idx 100)
+                                       :width  140
+                                       :height 48))
+                                   children))
+                    edges      (mapv (fn [e]
+                                       (assoc e :sections
+                                              [{:startPoint {:x 50 :y 50}
+                                                :endPoint   {:x 150 :y 150}
+                                                :bendPoints [{:x 100 :y 100}]}]))
+                                     (:edges graph-clj))
+                    result     (clj->js
+                                 (assoc graph-clj
+                                   :children positioned
+                                   :edges    edges
+                                   :width    800
+                                   :height   400))]
+                (js/Promise.resolve result))))
+      this)))
+
+;; ---- integration: stub-load + layout-or-fallback ------------------------
+
+(deftest elk-load-then-compute-then-cache
+  (testing "stub ELK, load it, compute layout, observe cache populated +
+            positions on the chart-layout match the stub's grid"
+    (when (exists? js/window)
+      (set! (.-ELK js/window) (mk-deterministic-elk-stub))
+      (async done
+        (elk-layout/ensure-elk!
+          (fn [_inst]
+            (is (= :ready (elk-layout/elk-status)))
+            (elk-layout/compute-layout!
+              three-state-machine :tb
+              (fn [chart-layout]
+                (is (some? chart-layout)
+                    "compute-layout! delivers the projected chart-layout")
+                (is (= 3 (count (:nodes chart-layout))))
+                (doseq [n (:nodes chart-layout)]
+                  (is (integer? (:x n)))
+                  (is (integer? (:y n))))
+                ;; The cache should now hold the same layout.
+                (let [cached (elk-layout/cached-layout three-state-machine :tb)]
+                  (is (some? cached))
+                  (is (= (count (:nodes chart-layout)) (count (:nodes cached)))))
+                (done)))))))))
+
+(deftest svg-renders-cleanly-from-elk-layout
+  (testing "stub ELK, compute layout, hand the result to chart-svg/render
+            — the SVG renders without bombing on multi-point edges"
+    (when (exists? js/window)
+      (set! (.-ELK js/window) (mk-deterministic-elk-stub))
+      (async done
+        (elk-layout/ensure-elk!
+          (fn [_inst]
+            (elk-layout/compute-layout!
+              three-state-machine :tb
+              (fn [chart-layout]
+                (let [tree (chart-svg/render chart-layout {})]
+                  ;; Just assert the root SVG comes through — the
+                  ;; renderer's `path-from-points` accepts the multi-
+                  ;; point polyline output from ELK without crashing.
+                  (is (vector? tree))
+                  (is (= :svg (first tree)))
+                  (done))))))))))
+
+(deftest svg-compound-container-renders-for-compound-machine
+  (testing "stub ELK, compute layout for a compound machine — the SVG
+            includes the compound-container <g> wrapping the children"
+    (when (exists? js/window)
+      (set! (.-ELK js/window) (mk-deterministic-elk-stub))
+      (async done
+        (elk-layout/ensure-elk!
+          (fn [_inst]
+            (elk-layout/compute-layout!
+              compound-machine :tb
+              (fn [chart-layout]
+                (let [tree (chart-svg/render chart-layout {})
+                      ;; walk the hiccup tree
+                      flat (tree-seq (some-fn vector? seq?) seq tree)
+                      compound? (some (fn [node]
+                                        (and (vector? node)
+                                             (map? (second node))
+                                             (= "rf-causa-chart-compounds"
+                                                (:data-testid (second node)))))
+                                      flat)]
+                  (is (true? (boolean compound?))
+                      "compound container <g> renders even when ELK
+                       placed every leaf flat — the visual hull is
+                       computed by chart/svg's `compound-containers`")
+                  (done))))))))))

--- a/tools/causa/test/day8/re_frame2_causa/chart/elk_layout_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/chart/elk_layout_cljs_test.cljs
@@ -1,0 +1,312 @@
+(ns day8.re-frame2-causa.chart.elk-layout-cljs-test
+  "CLJS tests for the ELK adapter (rf2-m7co9 Phase 4).
+
+  Two surfaces under test:
+
+    1. **Pure adapters** — `->elk-graph` (definition → ELK JSON) and
+       `elk-result->chart-layout` (ELK output → chart-layout shape).
+       Both run without ELK present.
+
+    2. **Lazy loader fallback** — `ensure-elk!` rolls into the
+       `:failed` state when no `js/window.ELK` stub is present and
+       `js/import` is unavailable (the node-test rig). The
+       `layout-or-fallback` fn then returns the layered fallback so
+       the panel always has a renderable graph.
+
+  Tests are CLJS-only (`.cljs`, `_cljs_test`) because the loader uses
+  `js/window` and `js/import`. The pure adapter helpers happen to be
+  CLJC-friendly but the loader pulls them into a CLJS-only consumer
+  so we colocate the test."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.chart.layout :as layout]
+            [day8.re-frame2-causa.chart.elk-layout :as elk-layout]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def small-machine
+  {:initial :idle
+   :states  {:idle    {:on {:start :loading}}
+             :loading {:on {:ok :success :err :failed}}
+             :success {:final? true}
+             :failed  {:final? true}}})
+
+(def compound-machine
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(use-fixtures :each
+  (fn [test-fn]
+    (elk-layout/reset-elk-state-for-test!)
+    (elk-layout/reset-cache-for-test!)
+    (test-fn)
+    (elk-layout/reset-elk-state-for-test!)
+    (elk-layout/reset-cache-for-test!)))
+
+;; ---- ->elk-graph (pure) ------------------------------------------------
+
+(deftest ->elk-graph-shape
+  (let [g (elk-layout/->elk-graph small-machine :tb)]
+    (is (= "root" (:id g)))
+    (is (= "layered" (get-in g [:layoutOptions "elk.algorithm"])))
+    (is (= "DOWN"    (get-in g [:layoutOptions "elk.direction"])))
+    (is (vector? (:children g)))
+    (is (vector? (:edges g)))))
+
+(deftest ->elk-graph-direction-switches-on-axis
+  (is (= "DOWN"  (get-in (elk-layout/->elk-graph small-machine :tb)
+                         [:layoutOptions "elk.direction"])))
+  (is (= "RIGHT" (get-in (elk-layout/->elk-graph small-machine :lr)
+                         [:layoutOptions "elk.direction"]))))
+
+(deftest ->elk-graph-one-child-per-state
+  (let [g (elk-layout/->elk-graph small-machine :tb)]
+    (is (= 4 (count (:children g)))
+        "four states → four ELK children")
+    (is (every? string? (map :id (:children g))))
+    (is (every? pos? (map :width  (:children g))))
+    (is (every? pos? (map :height (:children g))))))
+
+(deftest ->elk-graph-edge-per-transition
+  (let [g (elk-layout/->elk-graph small-machine :tb)]
+    (is (= 3 (count (:edges g)))
+        "three transitions: :start :ok :err")
+    (doseq [e (:edges g)]
+      (is (string? (:id e)))
+      (is (= 1 (count (:sources e))))
+      (is (= 1 (count (:targets e))))
+      (is (every? string? (:sources e)))
+      (is (every? string? (:targets e))))))
+
+(deftest ->elk-graph-edge-source-target-ids-match-children
+  (let [g          (elk-layout/->elk-graph small-machine :tb)
+        child-ids  (set (map :id (:children g)))
+        edge-ends  (set (mapcat (fn [e] (concat (:sources e) (:targets e)))
+                                (:edges g)))]
+    (is (every? child-ids edge-ends)
+        "every edge end-point is a child id")))
+
+(deftest ->elk-graph-compound-children-flat-in-v1
+  (let [g     (elk-layout/->elk-graph compound-machine :tb)
+        ids   (set (map :id (:children g)))]
+    (is (contains? ids (layout/node-id [:unauth])))
+    (is (contains? ids (layout/node-id [:authenticated])))
+    (is (contains? ids (layout/node-id [:authenticated :browsing])))
+    (is (contains? ids (layout/node-id [:authenticated :paying]))
+        "v1 projects compound children flat; hierarchical containment
+         is a follow-on")))
+
+(deftest ->elk-graph-edge-labels-include-event
+  (let [g     (elk-layout/->elk-graph small-machine :tb)
+        labels (set (mapcat (fn [e] (map :text (:labels e))) (:edges g)))]
+    (is (contains? labels "start"))
+    (is (contains? labels "ok"))
+    (is (contains? labels "err"))))
+
+;; ---- elk-result->chart-layout (pure) -----------------------------------
+
+(deftest elk-result->chart-layout-uses-positions-from-elk
+  (testing "ELK's per-child x/y/width/height land on the corresponding
+            chart-layout node"
+    (let [;; Hand-craft an ELK result for the small-machine. The id
+          ;; shape mirrors what ->elk-graph would have minted.
+          id-idle    (layout/node-id [:idle])
+          id-loading (layout/node-id [:loading])
+          id-success (layout/node-id [:success])
+          id-failed  (layout/node-id [:failed])
+          elk-result {:id "root"
+                      :children [{:id id-idle    :x 100 :y 50  :width 140 :height 48}
+                                 {:id id-loading :x 100 :y 200 :width 140 :height 48}
+                                 {:id id-success :x 30  :y 350 :width 140 :height 48}
+                                 {:id id-failed  :x 170 :y 350 :width 140 :height 48}]
+                      :edges []
+                      :width 400
+                      :height 500}
+          chart      (elk-layout/elk-result->chart-layout small-machine elk-result)
+          by-path    (into {} (map (juxt :path identity)) (:nodes chart))]
+      (is (= 100 (-> by-path (get [:idle]) :x)))
+      (is (= 200 (-> by-path (get [:loading]) :y)))
+      (is (= 400 (:width chart)))
+      (is (= 500 (:height chart)))
+      (is (string? (:initial-id chart))
+          "initial-id is set when :initial is declared"))))
+
+(deftest elk-result->chart-layout-uses-elk-section-bend-points
+  (testing "ELK edge sections produce a multi-point :points vector so
+            orthogonal routing renders through chart/svg's polyline path"
+    (let [id-idle    (layout/node-id [:idle])
+          id-loading (layout/node-id [:loading])
+          elk-result {:id "root"
+                      :children [{:id id-idle    :x 100 :y 50  :width 140 :height 48}
+                                 {:id id-loading :x 100 :y 200 :width 140 :height 48}
+                                 {:id (layout/node-id [:success]) :x 30  :y 350 :width 140 :height 48}
+                                 {:id (layout/node-id [:failed])  :x 170 :y 350 :width 140 :height 48}]
+                      :edges [{:id (str "e0-" id-idle "-" id-loading)
+                               :sources [id-idle]
+                               :targets [id-loading]
+                               :sections [{:startPoint {:x 170 :y 98}
+                                           :endPoint   {:x 170 :y 200}
+                                           :bendPoints [{:x 170 :y 150}]}]}]
+                      :width 400
+                      :height 500}
+          chart      (elk-layout/elk-result->chart-layout small-machine elk-result)
+          edge       (first (filter (fn [e] (and (= [:idle]    (:from e))
+                                                 (= [:loading] (:to e))))
+                                    (:edges chart)))]
+      (is (some? edge))
+      (is (= 3 (count (:points edge)))
+          "section with one bend point → three points (start, bend, end)")
+      (is (= [170 98]  (first (:points edge))))
+      (is (= [170 150] (second (:points edge))))
+      (is (= [170 200] (last (:points edge)))))))
+
+(deftest elk-result->chart-layout-preserves-node-metadata
+  (testing "compound? / final? / label / path / tags survive the
+            adapter so chart/svg renders the same affordances"
+    (let [id-unauth (layout/node-id [:unauth])
+          id-auth   (layout/node-id [:authenticated])
+          id-browse (layout/node-id [:authenticated :browsing])
+          id-pay    (layout/node-id [:authenticated :paying])
+          elk-result {:id "root"
+                      :children [{:id id-unauth :x 0 :y 0   :width 140 :height 48}
+                                 {:id id-auth   :x 0 :y 100 :width 140 :height 48}
+                                 {:id id-browse :x 0 :y 200 :width 140 :height 48}
+                                 {:id id-pay    :x 0 :y 300 :width 140 :height 48}]
+                      :edges []
+                      :width 200
+                      :height 400}
+          chart      (elk-layout/elk-result->chart-layout compound-machine elk-result)
+          by-path    (into {} (map (juxt :path identity)) (:nodes chart))]
+      (is (true? (-> by-path (get [:authenticated]) :compound?))
+          ":authenticated retains its :compound? flag")
+      (is (= "browsing" (-> by-path (get [:authenticated :browsing]) :label))))))
+
+(deftest elk-result->chart-layout-fallback-when-elk-skips-a-child
+  (testing "if ELK omits a child for any reason the adapter still
+            renders the node at (0,0) so the SVG never panics"
+    (let [elk-result {:id "root"
+                      :children []
+                      :edges []
+                      :width 200
+                      :height 200}
+          chart      (elk-layout/elk-result->chart-layout small-machine elk-result)]
+      (is (= 4 (count (:nodes chart))))
+      (doseq [n (:nodes chart)]
+        (is (integer? (:x n)))
+        (is (integer? (:y n)))
+        (is (string? (:node-id n)))))))
+
+;; ---- loader fallback ----------------------------------------------------
+
+(deftest ensure-elk-rolls-to-failed-without-stub-or-import
+  (testing "with no js/window.ELK stub and no working js/import the
+            loader rolls into :failed state and the callback fires
+            with nil — the panel then falls back to layered"
+    (elk-layout/reset-elk-state-for-test!)
+    (let [called (atom nil)
+          ran?   (atom false)]
+      (elk-layout/ensure-elk! (fn [inst]
+                                (reset! called inst)
+                                (reset! ran? true)))
+      (is (= :failed (elk-layout/elk-status)))
+      (is (true? @ran?))
+      (is (nil? @called)))))
+
+(deftest ensure-elk-idempotent-after-failed
+  (testing "second ensure-elk! fast-paths the callback via the :failed
+            cache — no second import attempt"
+    (elk-layout/reset-elk-state-for-test!)
+    (elk-layout/ensure-elk! (fn [_] nil))
+    (let [count2 (atom 0)]
+      (elk-layout/ensure-elk! (fn [_] (swap! count2 inc)))
+      (is (= 1 @count2)))))
+
+(deftest layout-or-fallback-returns-layered-when-elk-unavailable
+  (testing "when ELK isn't ready, layout-or-fallback returns the layered
+            engine's output — the panel always has a renderable graph"
+    (elk-layout/reset-elk-state-for-test!)
+    (elk-layout/reset-cache-for-test!)
+    (let [got (elk-layout/layout-or-fallback small-machine :tb)]
+      ;; Same shape the layered fallback emits — coll/seq, not strictly
+      ;; vector (`place-nodes` builds via mapcat).
+      (is (sequential? (:nodes got)))
+      (is (sequential? (:edges got)))
+      (is (= 4 (count (:nodes got))))
+      (is (every? integer? (map :x (:nodes got))))
+      (is (every? integer? (map :y (:nodes got)))))))
+
+(deftest cached-layout-returns-nil-on-miss
+  (elk-layout/reset-cache-for-test!)
+  (is (nil? (elk-layout/cached-layout small-machine :tb))))
+
+(deftest compute-layout-fires-nil-when-elk-not-ready
+  (testing "compute-layout! delivers nil sync when ELK isn't loaded so
+            the caller falls through to the layered fallback"
+    (elk-layout/reset-elk-state-for-test!)
+    (elk-layout/reset-cache-for-test!)
+    (let [called (atom :unset)]
+      (elk-layout/compute-layout! small-machine :tb
+                                  (fn [x] (reset! called x)))
+      (is (nil? @called)))))
+
+;; ---- loaded-path with a synchronous stub --------------------------------
+;;
+;; A minimal `js/window.ELK` stub exercises the ready-path adapter
+;; without bundling ELK into the test rig. The stub's .layout returns
+;; a thenable that resolves to a deterministic positioned graph.
+
+(defn- mk-elk-stub
+  "Construct an ELK-shaped object whose .layout resolves the input
+  graph by assigning incremental coordinates per child. Suitable as a
+  drop-in for the lazy loader's `js/window.ELK` short-circuit path."
+  []
+  (let [Ctor (fn []
+               (this-as this
+                 (set! (.-layout this)
+                       (fn [graph]
+                         (let [graph-clj   (js->clj graph :keywordize-keys true)
+                               children    (:children graph-clj)
+                               positioned  (vec
+                                             (map-indexed
+                                               (fn [idx c]
+                                                 (assoc c
+                                                   :x (* (mod idx 3) 200)
+                                                   :y (* (quot idx 3) 100)))
+                                               children))
+                               edges       (mapv (fn [e]
+                                                   (assoc e :sections
+                                                          [{:startPoint {:x 100 :y 100}
+                                                            :endPoint   {:x 200 :y 200}}]))
+                                                 (:edges graph-clj))
+                               result      (clj->js
+                                             (assoc graph-clj
+                                               :children positioned
+                                               :edges    edges
+                                               :width    800
+                                               :height   400))]
+                           (js/Promise.resolve result))))
+                 this))]
+    Ctor))
+
+(deftest ensure-elk-ready-when-window-stub-present
+  (testing "with a js/window.ELK stub, ensure-elk! flips into :ready
+            and the callback fires with the constructed instance.
+
+            Browser-only: node-test rigs don't define js/window so the
+            stub path is unreachable; the test is a no-op there. The
+            real ready-path is exercised by the elk_integration browser
+            test."
+    (when (exists? js/window)
+      (elk-layout/reset-elk-state-for-test!)
+      (set! (.-ELK js/window) (mk-elk-stub))
+      (let [called (atom nil)]
+        (try
+          (elk-layout/ensure-elk! (fn [inst] (reset! called inst)))
+          (is (= :ready (elk-layout/elk-status)))
+          (is (some? @called))
+          (finally
+            (set! (.-ELK js/window) js/undefined)
+            (elk-layout/reset-elk-state-for-test!)))))))

--- a/tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc
@@ -139,3 +139,36 @@
 
 (deftest highlight-id-nil-for-nil-state
   (is (nil? (layout/highlight-id nil))))
+
+;; ---- layered-fallback (rf2-m7co9 Phase 4) ----------------------------
+
+(deftest layered-fallback-matches-layout
+  (testing "rf2-m7co9 exports `layered-fallback` as an explicit alias
+            for the layered placement so consumer code can request the
+            fallback path by name (ELK is the new primary engine)."
+    (let [via-layout    (layout/layout idle-loading-success)
+          via-fallback  (layout/layered-fallback idle-loading-success)]
+      (is (= via-layout via-fallback)
+          "layered-fallback returns the exact same chart-layout shape
+           as `layout` — they're aliases by design"))))
+
+(deftest layered-fallback-handles-empty
+  (let [g (layout/layered-fallback nil)]
+    (is (= [] (:nodes g)))
+    (is (= [] (:edges g)))
+    (is (pos? (:width g)))
+    (is (pos? (:height g)))))
+
+;; ---- node-id (rf2-m7co9 Phase 4 — exported) --------------------------
+
+(deftest node-id-is-public-fn
+  (testing "node-id is exported (no longer private) so the ELK adapter
+            can mint matching ids on the way through ELK's graph"
+    (is (string? (layout/node-id [:idle])))
+    (is (= (layout/node-id [:idle])
+           (layout/node-id [:idle]))
+        "deterministic")))
+
+(deftest node-id-distinct-for-distinct-paths
+  (is (not= (layout/node-id [:authenticated])
+            (layout/node-id [:authenticated :browsing]))))

--- a/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
@@ -134,3 +134,58 @@
 (deftest sparkline-honours-custom-testid
   (let [svg (chart-svg/sparkline [1 2 3] {:testid "rf-cluster-rate-1"})]
     (is (= "rf-cluster-rate-1" (:data-testid (second svg))))))
+
+;; ---- compound containers (rf2-m7co9 Phase 4) -------------------------
+
+(def compound-machine
+  {:initial :unauth
+   :states  {:unauth        {:on {:login :authenticated}}
+             :authenticated {:initial :browsing
+                             :states  {:browsing {:on {:checkout :paying}}
+                                       :paying   {:on {:done :browsing}}}
+                             :on      {:logout :unauth}}}})
+
+(deftest compound-containers-bbox-around-children
+  (testing "compound-containers returns a translucent-box descriptor for
+            each compound parent, sized to the bounding box of its
+            descendant leaves plus padding"
+    (let [{:keys [nodes]} (layout/layout compound-machine)
+          containers       (chart-svg/compound-containers nodes)]
+      (is (= 1 (count containers))
+          "one compound parent (:authenticated) has children")
+      (let [c (first containers)
+            descendants (filter (fn [n] (= [:authenticated]
+                                           (when (> (count (:path n)) 1)
+                                             (subvec (:path n) 0 1))))
+                                nodes)
+            min-x (apply min (map :x descendants))
+            min-y (apply min (map :y descendants))]
+        ;; The container's top-left sits LEFT/ABOVE the descendants by
+        ;; the inset padding.
+        (is (< (:x c) min-x))
+        (is (< (:y c) min-y))))))
+
+(deftest compound-containers-rendered-in-svg
+  (testing "render-from-definition emits a compound container <g> with
+            the spec'd testid for each compound state"
+    (let [tree   (chart-svg/render-from-definition compound-machine)
+          group  (find-by-testid tree "rf-causa-chart-compounds")
+          inner  (find-all-by-testid-prefix tree "rf-causa-chart-compound-")]
+      (is (some? group)
+          "a top-level <g data-testid=\"rf-causa-chart-compounds\"> hosts
+           every compound rectangle")
+      (is (= 1 (count inner))
+          "exactly one compound-state rectangle (:authenticated)"))))
+
+(deftest compound-containers-empty-for-flat-machine
+  (testing "a flat machine (no compound states) produces no containers"
+    (let [tree   (chart-svg/render-from-definition small-machine)
+          inner  (find-all-by-testid-prefix tree "rf-causa-chart-compound-")]
+      (is (zero? (count inner))))))
+
+(deftest compound-container-honours-label
+  (testing "the compound container carries the parent state's label so
+            the visual grouping is self-explanatory"
+    (let [{:keys [nodes]} (layout/layout compound-machine)
+          [c]              (chart-svg/compound-containers nodes)]
+      (is (= "authenticated" (:label c))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -262,6 +262,8 @@
    :rf.causa/follow-head
    :rf.causa/hide-event-type
    :rf.causa/hydrate-filters
+   ;; Phase 4 (rf2-m7co9) — ELK chart layout pulse.
+   :rf.causa/machine-chart-layout-pulse
    :rf.causa/machine-state-clicked
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
@@ -423,7 +425,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 104 subs + 125 events + 6 fxs"
+  (testing "registry holds exactly 104 subs + 126 events + 6 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
@@ -498,7 +500,9 @@
     ;;   toggle-mode-c-cluster-expanded + toggle-mode-c-selection +
     ;;   clear-mode-c-selection + set-forced-machine-mode +
     ;;   set-machine-instances-override-for-test.
-    (is (= 125 (count all-event-names)))
+    ;; + 1 machine-inspector Phase 4 (rf2-m7co9):
+    ;;   :rf.causa/machine-chart-layout-pulse — ELK layout async pulse.
+    (is (= 126 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary

- Adds `chart/elk_layout.cljs` — lazy ELK.js loader (mirrors the pattern in `popover/causality_graph.cljs`), `->elk-graph` (definition → ELK JSON) + `elk-result->chart-layout` (ELK output → chart-layout shape) pure adapters, plus `ensure-elk!` / `compute-layout!` / `cached-layout` / `layout-or-fallback` for the async-load-then-cache flow.
- Modifies `chart/layout.cljc` to export `layered-fallback` as an explicit alias for the simple BFS-rank layout and to make `node-id` public so the ELK adapter can mint matching ids on the way through ELK's JSON graph.
- Modifies `chart/svg.cljc` to render compound states as translucent boxes around their descendant leaves (replacing the same-sized dashed border Phase 1 used). Adds N-point polyline support to `path-from-points` so ELK's orthogonal routing renders cleanly; edge-label position handles multi-segment paths.
- Modifies `panels/machine_inspector.cljs` to (1) kick `ensure-elk!` + `compute-layout!` on each render, (2) feed `layout-or-fallback` into `chart-svg/render`, (3) register a no-op `:rf.causa/machine-chart-layout-pulse` event so the subscribe-driven view re-renders once the async ELK layout resolves. `data-layout-engine` attribute distinguishes ELK vs layered for visual regression.

## ELK vs layered comparison (sketch)

- **Layered (Phase 1, still the fallback)** — BFS rank from `:initial`; nodes stratify into rows, edges as straight lines. Readable for 4–12 state machines; edge crossings visible in dense topologies.
- **ELK (Phase 4)** — `layered` algorithm with `LAYER_SWEEP` crossing minimisation + `ORTHOGONAL` edge routing. Scales cleanly to 20–50 states; edges route around nodes via bend points. TB primary; LR per-graph override via the `direction` arg.

## Fallback behavior

- `ensure-elk!` is invoked on every render (idempotent). When the load succeeds, `compute-layout!` populates the cache + dispatches `:rf.causa/machine-chart-layout-pulse`; the subscribe-driven view re-runs and `layout-or-fallback` returns the cached ELK layout.
- When ELK is unavailable (no `elkjs` on the classpath / offline test rig / CSP block), the loader rolls to `:failed` and `layout-or-fallback` returns the layered fallback. The panel always renders.
- Both layout paths produce the same `{:nodes :edges :width :height :initial-id}` data shape so the SVG renderer is layout-engine-agnostic.

## Files

### New
- `tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs`
- `tools/causa/test/day8/re_frame2_causa/chart/elk_layout_cljs_test.cljs`
- `tools/causa/test/day8/re_frame2_causa/chart/elk_integration_cljs_test.cljs`

### Modified
- `tools/causa/src/day8/re_frame2_causa/chart/layout.cljc` — export `layered-fallback` + public `node-id`.
- `tools/causa/src/day8/re_frame2_causa/chart/svg.cljc` — compound-state container rendering, N-point polyline support.
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs` — ELK loader wiring + pulse event.
- `tools/causa/test/day8/re_frame2_causa/chart/layout_cljs_test.cljc` — `layered-fallback` + public `node-id` smokes.
- `tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc` — compound-containers tests.
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — `:rf.causa/machine-chart-layout-pulse` added to catalogue, event count 125 → 126.

## Bundle-size impact

**Zero baseline.** ELK is lazy-loaded via the same `js/import` pattern the Causality popover already uses; absent the `elkjs` package on the consumer classpath, `ensure-elk!` rolls into the `:failed` state and the layered fallback engages. Causa is dev-tools only, so no production bundle exposure.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 711 tests / 2030 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2715 tests / 7824 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 2682 tests / 7670 assertions, 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine

## Divergences / follow-ons

- Hierarchical ELK containment (parent compound states as ELK containers with child layout) is deferred — v1 projects every state flat into ELK and computes compound bounding boxes after-the-fact in `chart/svg`. Filed as a potential follow-on; the data shape change is non-trivial.
- A future bead could unify the two ELK loader atoms (`elk_layout.cljs` + `popover/causality_graph.cljs`) into a shared `chart/elk_loader.cljs` ns. Today both consumers fail-then-fallback independently.