### PR TITLE
feat(causa): panel-gallery variants for Settings + auto-filter + Causality popover

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
@@ -162,6 +162,16 @@
   (reset! elk-state nil)
   nil)
 
+(defn force-elk-failed-for-test!
+  "Force the loader state into the `:failed` shape — test / gallery
+  only. Pins the popover's render path to the failed-fallback branch
+  (flat list + 'Causality graph unavailable' footer) without running
+  a real import. Idempotent."
+  ([] (force-elk-failed-for-test! "forced fallback"))
+  ([reason]
+   (reset! elk-state {:failed reason})
+   nil))
+
 ;; ---- ELK layout sub-cache -----------------------------------------------
 
 (defonce ^:private layout-cache

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -132,6 +132,35 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-chrome-card',
         expectedAtLeast: 10,
       },
+      // Settings popup workspace (rf2-mpn8m) — 4 variants. Each
+      // cell mounts the chrome + opens the Settings popup on a
+      // different tab (General / Filters / Theme / Telemetry).
+      // Same shared :rf/causa caveat as the chrome workspace.
+      {
+        id:          'settings-popup',
+        workspaceRe: /Workspace\.causa\.settings-popup\/all/,
+        cardTestid:  'panel-gallery-chrome-card',
+        expectedAtLeast: 4,
+      },
+      // Auto-filter pill + edit-popup workspace (rf2-kbrkx) — 5
+      // variants. Each cell mounts the chrome and either seeds
+      // ribbon pill state or opens the edit popup against a
+      // different trigger shape (:add, :pill, :context).
+      {
+        id:          'filters',
+        workspaceRe: /Workspace\.causa\.filters\/all/,
+        cardTestid:  'panel-gallery-chrome-card',
+        expectedAtLeast: 5,
+      },
+      // Causality popover workspace (rf2-pt1e1) — 4 variants. Each
+      // cell mounts the chrome + opens the popover against a
+      // different graph / layout / fallback configuration.
+      {
+        id:          'causality-popover',
+        workspaceRe: /Workspace\.causa\.causality-popover\/all/,
+        cardTestid:  'panel-gallery-chrome-card',
+        expectedAtLeast: 4,
+      },
     ];
 
     const results = [];

--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -87,6 +87,17 @@ function waitForReady(url, timeoutMs) {
     // The chrome workspace uses :layout :tabs (not :variants-grid)
     // so it isn't subject to the same shared-cell concern as the
     // grid workspaces; we walk it last as a round-trip target.
+    // The chrome-follow-on workspaces (rf2-mpn8m settings popup,
+    // rf2-kbrkx auto-filter edit-popup, rf2-pt1e1 causality popover)
+    // are deliberately excluded from this single-session walk. They
+    // mount the chrome shell which writes to `:rf/causa` AND opens
+    // a global modal whose backdrop covers the entire viewport. The
+    // modal state lives in the process-global `:rf/causa` frame, so
+    // it persists across workspace switches (Story tears down the
+    // variant tree but the frame state survives). The sibling
+    // `_smoke.cjs` covers these workspaces on FRESH pages where the
+    // shared-state caveat is harmless; the rf2-kgn0c IDeref-null
+    // regression that THIS smoke pins is orthogonal to modal state.
     const walk = [
       { name: 'Workspace.causa.event/all',    expectedAtLeast: 12 },
       { name: 'Workspace.causa.app-db/all',   expectedAtLeast: 12 },

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -58,6 +58,7 @@
             [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.adapter.reagent :as reagent-adapter]
+            [day8.re-frame2-causa.popover.causality-graph :as causality-graph]
             [day8.re-frame2-causa.registry :as causa-registry]
             [panel-gallery.panel-views :as panel-views]
             ;; Side-effecting story registrations — namespaces fire
@@ -68,7 +69,13 @@
             [panel-gallery.gallery-trace]
             [panel-gallery.gallery-machines]
             [panel-gallery.gallery-issues]
-            [panel-gallery.gallery-chrome]))
+            [panel-gallery.gallery-chrome]
+            ;; Chrome follow-on galleries — rf2-mpn8m settings popup,
+            ;; rf2-kbrkx auto-filter pill / edit-popup, rf2-pt1e1
+            ;; Causality popover.
+            [panel-gallery.gallery-settings]
+            [panel-gallery.gallery-filters]
+            [panel-gallery.gallery-causality]))
 
 ;; ============================================================================
 ;; LANDING — the URL `/` view (no `#/stories` hash)
@@ -139,13 +146,25 @@
     chrome variants render their declared state.
 
     Payload is a map: `{:trace-buffer ... :epoch-history ...
-    :selected-tab ... :paused? ... :filters {:in [] :out []}}`.
-    Each key writes the corresponding `:rf/causa` slot through
-    the canonical Causa event."
+    :selected-tab ... :paused? ... :filters {:in [] :out []}
+    :after-seeds [<event-vec> ...]}`. Each key writes the
+    corresponding `:rf/causa` slot through the canonical Causa
+    event. `:after-seeds` runs additional event vectors against
+    `:rf/causa` after the canonical seeds — used by chrome-follow-
+    on galleries (Settings / Filters edit-popup / Causality
+    popover) that need to dispatch modal-open + section-select
+    events into the same frame.
+
+  - `:panel-gallery.causality/force-elk-fallback!` — testbed-only
+    forcer for the Causality popover's ELK-unavailable fallback
+    render. Calls `causality-graph/reset-elk-state-for-test!` then
+    swaps the loader atom to `{:failed ...}` so subsequent
+    `body` renders take the failed branch (flat list + footer
+    'Causality graph unavailable' hint)."
   []
   (rf/reg-event-fx :panel-gallery.chrome/seed!
     (fn [_cofx [_ {:keys [trace-buffer epoch-history selected-tab
-                          paused? filters]}]]
+                          paused? filters after-seeds]}]]
       ;; Re-dispatch into `:rf/causa` so the chrome's hardcoded
       ;; frame-provider sees the writes. Each :dispatch-later is
       ;; wrapped in a per-handler {:frame :rf/causa} so the
@@ -179,10 +198,29 @@
               ;; Paused — toggle from the default :live to
               ;; :live (paused).
               paused?
-              (conj [:rf.causa/toggle-live-pause]))]
+              (conj [:rf.causa/toggle-live-pause])
+
+              ;; Arbitrary follow-on dispatches into `:rf/causa`.
+              ;; The chrome-follow-on galleries (rf2-mpn8m settings,
+              ;; rf2-kbrkx auto-filter, rf2-pt1e1 causality) use this
+              ;; lane to drive modal-open + section-select +
+              ;; popover-open events against the shared frame.
+              (seq after-seeds)
+              (into (vec after-seeds)))]
         (doseq [ev seeds]
           (rf/dispatch-sync ev {:frame :rf/causa}))
-        {}))))
+        {})))
+
+  ;; ELK fallback forcer — testbed-only. Pins the popover's render
+  ;; path to the failed-fallback branch (flat list + 'Causality
+  ;; graph unavailable' footer) via the public test-support fn so
+  ;; the chrome gallery's causality variants exercise the fallback
+  ;; visual contract without depending on a real ELK load failure.
+  (rf/reg-event-fx :panel-gallery.causality/force-elk-fallback!
+    (fn [_cofx _event]
+      (causality-graph/force-elk-failed-for-test!
+        "panel-gallery: ELK fallback forced for variant")
+      {})))
 
 (defn- ensure-causa-frame!
   "Register the `:rf/causa` frame so the chrome gallery's

--- a/tools/causa/testbeds/panel_gallery/fixtures_causality.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_causality.cljs
@@ -1,0 +1,122 @@
+(ns panel-gallery.fixtures-causality
+  "Pure fixture builders for the Causality popover gallery (rf2-pt1e1).
+
+  The popover payload (`:rf.causa/causality-popover-payload`) derives
+  from three reactive inputs:
+
+    - `:rf.causa/cascades`       — projected cascade list
+    - `:rf.causa/trace-buffer`   — raw trace events (for
+                                   `panel-h/enrich-cascades`)
+    - `:rf.causa/focus`          — the spine-focused dispatch-id
+
+  The popover walks ancestor / descendant chains rooted at the focused
+  cascade via `:parent-dispatch-id` tags carried on each cascade's
+  `:event/dispatched` trace event. So fixtures here build trace
+  buffers whose dispatched events carry a `:parent-dispatch-id` tag
+  pointing at the parent cascade's dispatch-id — exactly mirroring the
+  production shape `re-frame.dispatch/dispatch` emits.
+
+  Cascade shape (per `re-frame.trace.projection/group-cascades`):
+
+      {:id <int>
+       :op-type :event
+       :operation :event/dispatched
+       :tags {:dispatch-id          <int>
+              :parent-dispatch-id   <int or nil>      ; cascade lineage
+              :event                <event-vec>
+              :origin               :app | :causa | ...}}")
+
+;; ---- per-cascade builders -----------------------------------------------
+
+(defn- cascade-evs
+  "Synthesize the canonical 4-row spine for a single cascade with a
+  `:parent-dispatch-id` tag carried on the `:event/dispatched` row so
+  the popover's graph-helper can reconstruct the lineage. Caller
+  supplies the dispatch-id, event vector, base trace-id, and (optional)
+  parent dispatch-id."
+  [dispatch-id event-vec id-base parent-id]
+  (let [base-tag {:dispatch-id dispatch-id}
+        disp-tag (cond-> (assoc base-tag :event event-vec :origin :app)
+                   parent-id (assoc :parent-dispatch-id parent-id))]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags disp-tag}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc base-tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :event :operation :event
+      :tags (assoc base-tag :phase :run-end :duration-ms 4)}
+     {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+      :tags base-tag}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc base-tag :fx-id :db)}]))
+
+;; ---- buffer builders ----------------------------------------------------
+
+(defn five-node-buffer
+  "Five-cascade chain: A → B → C → D (under A) plus E (sibling of B,
+  child of A). Focused-id = 200 (cascade C), so the popover renders
+  one ancestor (B → A) and one descendant (D), with E surfaced only
+  via its sibling relationship to B if visited.
+
+  Returns the trace-buffer vector ready to pass verbatim to
+  `:rf.causa/sync-trace-buffer`."
+  []
+  (let [;; A (root: 100) — no parent.
+        a  (cascade-evs 100 [:auth/login {:user :ada}]            100  nil)
+        ;; B (199) — child of A. C (200) — child of B. D (300) — child of C.
+        b  (cascade-evs 199 [:auth/load-profile :ada]            199  100)
+        c  (cascade-evs 200 [:profile/fetch-permissions :ada]    250  199)
+        d  (cascade-evs 300 [:permissions/cache-load :ada]       350  200)
+        ;; E (400) — sibling of B (also a child of A) so the popover's
+        ;; descendant walk from A surfaces both B and E. Focused = C
+        ;; though, so E only renders if the helper widens past
+        ;; ancestor-chain (it does not by default).
+        e  (cascade-evs 400 [:audit/note-login :ada]             450  100)]
+    (vec (concat a b c d e))))
+
+(defn twenty-node-buffer
+  "Twenty-cascade deep+wide graph rooted at A. Tests popover scrolling
+  + truncation (per-level breadth cap 8, ancestor cap 8). Focused-id
+  = 200 (mid-tree) so the popover renders ancestors AND descendants
+  in both directions.
+
+  Tree shape:
+
+      A (100)
+      ├── B  (199) ──── (focused parent)
+      │   └── C  (200) ── focused
+      │       ├── D1..D8 (300..307)  ; 8 children = breadth boundary
+      │       └── D9 (308)           ; 9th child triggers '… N more'
+      └── E1..E9 (400..408)          ; siblings of B (also clipped)
+
+  Twenty cascades total — exercises the popover's overflow + scroll
+  + per-level breadth-cap disclosure."
+  []
+  (let [a   (cascade-evs 100 [:auth/login {:user :ada}]              100  nil)
+        b   (cascade-evs 199 [:auth/load-profile :ada]               150  100)
+        c   (cascade-evs 200 [:profile/fetch-permissions :ada]       200  199)
+        ds  (vec (for [i (range 9)]
+                   (cascade-evs (+ 300 i)
+                                [(keyword "perm" (str "load-" i)) :ada]
+                                (+ 300 (* i 10))
+                                200)))
+        es  (vec (for [i (range 9)]
+                   (cascade-evs (+ 400 i)
+                                [(keyword "audit" (str "note-" i)) :ada]
+                                (+ 500 (* i 10))
+                                100)))]
+    (vec (concat a b c
+                 (mapcat identity ds)
+                 (mapcat identity es)))))
+
+(defn focused-dispatch-id-for-five
+  "The cascade-id to focus the spine on for `five-node-buffer`. Cascade
+  C — sits mid-chain so the popover shows ancestors AND descendants."
+  []
+  200)
+
+(defn focused-dispatch-id-for-twenty
+  "The cascade-id to focus the spine on for `twenty-node-buffer`. C
+  again — same mid-chain position so ancestor + 9-child descendants
+  both render (the 9th child exercises the '… more' disclosure)."
+  []
+  200)

--- a/tools/causa/testbeds/panel_gallery/gallery_causality.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_causality.cljs
@@ -1,0 +1,155 @@
+(ns panel-gallery.gallery-causality
+  "Story coverage for the **Causality popover** (rf2-pt1e1 follow-on
+  to rf2-dqnuu + rf2-sszlr chrome gallery).
+
+  The Causality popover replaces the legacy Causality tab — it's a
+  c-key triggered modal overlay rooted at the spine-focused event.
+  Per spec/018-Event-Spine.md §10 it renders the focused-event's
+  causal graph: ancestor chain (LR, root-cause → focused) + a TB
+  descendants tree, with ELK supplying pixel layout when available
+  and a flat-list fallback when ELK is unavailable.
+
+  Each variant renders the full Causa 4-layer chrome via
+  `:panel-gallery.chrome/Shell`, seeds `:rf/causa` with a trace
+  buffer that carries `:parent-dispatch-id` lineage tags, focuses
+  the spine on a mid-chain cascade, then dispatches the popover-
+  open event. The fallback variant additionally pins the ELK loader
+  state to `:failed` via the testbed-local
+  `:panel-gallery.causality/force-elk-fallback!` event.
+
+  ## Frame discipline (same caveat as gallery-chrome)
+
+  The chrome's `shell-view` body wraps itself in `[rf/frame-provider
+  {:frame :rf/causa}]`. All seed events route through the testbed's
+  `:panel-gallery.chrome/seed!` `:after-seeds` lane so the writes
+  land on `:rf/causa` (where the chrome + popover read), not on the
+  variant frame Story pre-allocated."
+  (:require [re-frame.story :as story]
+            [panel-gallery.fixtures-causality :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+(defn register-gallery-view! []
+  (panel-views/register!))
+
+(defn register-all!
+  "Register the Causality popover Story surface. Idempotent under
+  `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-causality-popover
+    {:axis :feature
+     :doc  "Causa Causality popover — c-key triggered overlay
+            with ELK-laid-out graph + fallback list per
+            spec/018-Event-Spine §10."})
+
+  (story/reg-story :story.causa.causality-popover
+    {:doc        "Visual gallery of the Causa Causality popover.
+                 Variants exercise the default TB layout, the
+                 footer-flipped LR layout, the ELK-unavailable
+                 fallback render, and a 20-node graph that pushes
+                 the popover's scroll + truncation surfaces."
+     :component  :panel-gallery.chrome/Shell
+     :tags       #{:dev :feature/causa-causality-popover}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. TB layout (default) — 5-node sample graph.
+  (story/reg-variant :story.causa.causality-popover/tb
+    {:doc        "Popover open with TB layout (default). Focused on
+                 cascade C (200) of the five-node sample graph —
+                 popover renders ancestor chain (A → B) above the
+                 focused node, with descendant (D) hanging below.
+                 TB orientation matches spec/018 §10 Q12 v1
+                 default — the descendants tree dominates the
+                 visual weight."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/five-node-buffer)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/focus-cascade
+                      (fixtures/focused-dispatch-id-for-five)]
+                     [:rf.causa/causality-popover-open]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. LR layout (footer-flipped) — same graph.
+  (story/reg-variant :story.causa.causality-popover/lr
+    {:doc        "Popover open with LR layout (footer toggle to
+                 :lr). Same 5-node graph as the TB variant; the
+                 layout flip rotates the ancestor + descendant
+                 stacks horizontally."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/five-node-buffer)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/focus-cascade
+                      (fixtures/focused-dispatch-id-for-five)]
+                     [:rf.causa/causality-popover-open]
+                     [:rf.causa/causality-popover-toggle-layout]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. ELK-unavailable fallback — list render with the
+  ;; 'Causality graph unavailable' footer status hint. Uses the
+  ;; testbed-local fallback forcer so the variant doesn't depend
+  ;; on a real ELK load failure.
+  (story/reg-variant :story.causa.causality-popover/fallback
+    {:doc        "Popover open in ELK-unavailable fallback mode.
+                 The view drops to a flat `<ul>` listing the
+                 focused event + its ancestors + descendants;
+                 footer surfaces 'Causality graph unavailable
+                 (ELK.js failed to load)'. The testbed-local
+                 forcer (`:panel-gallery.causality/force-elk-
+                 fallback!`) pins the loader state to `:failed`
+                 deterministically — no dependency on real ELK
+                 load behaviour."
+     :events     [[:panel-gallery.causality/force-elk-fallback!]
+                  [:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/five-node-buffer)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/focus-cascade
+                      (fixtures/focused-dispatch-id-for-five)]
+                     [:rf.causa/causality-popover-open]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. Deep — 20-node graph exercising scroll + per-level
+  ;; breadth-cap truncation disclosure ('… N more children').
+  (story/reg-variant :story.causa.causality-popover/deep
+    {:doc        "Popover open over a 20-node graph (A → B → C
+                 with 9 children + 9 siblings of B). Tests the
+                 popover's scrolling behaviour and the per-level
+                 breadth-cap (8) truncation disclosure ('… 1
+                 more children' on the focused node's child
+                 row). Focused on cascade C (200) at mid-chain."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/twenty-node-buffer)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/focus-cascade
+                      (fixtures/focused-dispatch-id-for-twenty)]
+                     [:rf.causa/causality-popover-open]]}]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.causality-popover/all
+    {:doc      "All four Causality popover variants. The chrome
+                internally wraps :rf/causa via a hardcoded frame-
+                provider, so workspace cells share interior state
+                + the popover's ELK loader atom is process-global
+                — see canvas-mode (sidebar pick) for per-variant
+                fidelity. In particular, the `:fallback` variant
+                pins the loader to `:failed` for the duration of
+                its render; subsequent variants in the same
+                workspace will also surface the fallback render
+                unless re-pinned."
+     :layout   :variants-grid
+     :story    :story.causa.causality-popover
+     :columns  1
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/gallery_filters.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_filters.cljs
@@ -1,0 +1,167 @@
+(ns panel-gallery.gallery-filters
+  "Story coverage for the **Auto-filter pill cluster + edit popup**
+  (rf2-kbrkx follow-on to rf2-ak4ms + rf2-sszlr chrome gallery).
+
+  The auto-filter feature spans two visual surfaces:
+
+    1. The top ribbon's pill cluster — IN pills tint green, OUT
+       pills tint magenta, each carries an `✎` edit affordance.
+    2. The edit popup — modal overlay opened via the trailing
+       `[ + ]` add button, via clicking an existing pill, or via
+       right-clicking an event-list row (which seeds an OUT pill
+       pre-populated with the row's event-id).
+
+  Each variant renders the full Causa 4-layer chrome via
+  `:panel-gallery.chrome/Shell` and seeds `:rf/causa` to drive the
+  ribbon + (optionally) open the edit popup against the expected
+  trigger shape.
+
+  ## Frame discipline (same caveat as gallery-chrome)
+
+  The chrome's `shell-view` body wraps itself in `[rf/frame-provider
+  {:frame :rf/causa}]`. All seed events route through the testbed's
+  `:panel-gallery.chrome/seed!` `:after-seeds` lane so the writes
+  land on `:rf/causa` (where the chrome + modal read), not on the
+  variant frame Story pre-allocated."
+  (:require [re-frame.story :as story]
+            [panel-gallery.fixtures :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+(defn register-gallery-view! []
+  (panel-views/register!))
+
+(defn register-all!
+  "Register the auto-filter Story surface. Idempotent under
+  `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-filters
+    {:axis :feature
+     :doc  "Causa auto-filter pills — IN / OUT pill cluster +
+            edit popup per spec/018-Event-Spine §7."})
+
+  (story/reg-story :story.causa.filters
+    {:doc        "Visual gallery of the auto-filter pill cluster
+                 + edit popup. Variants exercise the empty ribbon,
+                 a mixed-loaded ribbon, the edit popup in :add /
+                 :pill / :context trigger shapes, and the right-
+                 click context-menu shortcut to the OUT-filter
+                 draft."
+     :component  :panel-gallery.chrome/Shell
+     :tags       #{:dev :feature/causa-filters}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. Empty ribbon — no pills, just the trailing [ + ] add.
+  ;; The default first-session honest empty state per spec/018 §7
+  ;; 'Empty defaults'.
+  (story/reg-variant :story.causa.filters/empty
+    {:doc        "Top ribbon with no filter pills — the default
+                 first-session honest empty state. Only the
+                 trailing `[ + ]` add affordance is visible
+                 alongside the nav cluster + frame picker + mode
+                 pill + right icons."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :filters      {:in [] :out []}}]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. Mixed loaded — 3 IN + 5 OUT pills with diverse
+  ;; pattern shapes (keyword, glob, substring). Exercises the
+  ;; pill cluster's visual contract under realistic load.
+  (story/reg-variant :story.causa.filters/mixed-loaded
+    {:doc        "Top ribbon with 3 IN pills (keyword, glob,
+                 namespace) + 5 OUT pills spanning diverse
+                 patterns (event-id, glob, substring). Pins the
+                 pill cluster's visual contract under a realistic
+                 mixed load — green IN tint vs magenta OUT tint,
+                 with `✎` edit affordances on each."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 4)
+                    :selected-tab :event
+                    :filters
+                    {:in  [{:pattern :cart/add}
+                           {:pattern ":auth/*"}
+                           {:pattern ":order/cart/*"}]
+                     :out [{:pattern :mouse-move}
+                           {:pattern :anim-frame}
+                           {:pattern ":telemetry/*"}
+                           {:pattern "presence"}
+                           {:pattern ":heartbeat"}]}}]]
+     :tags       #{:dev :state/large}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. Edit popup open via the trailing `[ + ]` add
+  ;; affordance — `:source :add :mode :in` so the popup arrives
+  ;; empty + IN default, no Delete button.
+  (story/reg-variant :story.causa.filters/edit-popup-add
+    {:doc        "Edit popup open via the trailing `[ + ]` add
+                 affordance. Trigger `{:source :add :mode :in}` —
+                 popup arrives empty + IN default; no `[Delete]`."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :filters      {:in [] :out []}
+                    :after-seeds
+                    [[:rf.causa/open-edit-popup
+                      {:source :add :mode :in}]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. Edit popup open via pill click — `:source :pill`
+  ;; with pre-populated draft + `[Delete]` button visible.
+  (story/reg-variant :story.causa.filters/edit-popup-edit-existing
+    {:doc        "Edit popup open via clicking an existing pill.
+                 Trigger `{:source :pill :mode :in :idx 0 :pill
+                 {:pattern :auth/*}}` — popup pre-populated with
+                 `:auth/*`, IN selected, `[Delete]` visible."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :filters      {:in  [{:pattern :auth/*}]
+                                   :out []}
+                    :after-seeds
+                    [[:rf.causa/open-edit-popup
+                      {:source :pill
+                       :mode   :in
+                       :idx    0
+                       :pill   {:pattern :auth/*}}]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. Right-click context-menu shortcut — `:rf.causa/hide-
+  ;; event-type` opens the popup with `:source :context :mode :out`
+  ;; pre-populated with the row's event-id (OUT-filter draft).
+  (story/reg-variant :story.causa.filters/right-click-menu
+    {:doc        "Edit popup open via the right-click event-row
+                 context-menu shortcut (`:rf.causa/hide-event-
+                 type`). Trigger `{:source :context :mode :out
+                 :pill {:pattern :mouse-move}}` — popup pre-
+                 populated with the row's event-id + OUT default;
+                 no `[Delete]` (it's an Add)."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 4)
+                    :selected-tab :event
+                    :filters      {:in [] :out []}
+                    :after-seeds
+                    [[:rf.causa/hide-event-type :mouse-move]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  (story/reg-workspace :Workspace.causa.filters/all
+    {:doc      "All five auto-filter variants. The chrome
+                internally wraps :rf/causa via a hardcoded frame-
+                provider, so workspace cells share interior state —
+                see canvas-mode (sidebar pick) for per-variant
+                fidelity."
+     :layout   :variants-grid
+     :story    :story.causa.filters
+     :columns  1
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
@@ -1,0 +1,149 @@
+(ns panel-gallery.gallery-settings
+  "Story coverage for the **Settings popup modal** (rf2-mpn8m
+  follow-on to rf2-9poxq + rf2-sszlr chrome gallery).
+
+  The Settings popup mounts at `shell-view` root — same frame-
+  provider discipline as `palette/Modal` and `filters/Modal`. Each
+  variant here renders the full Causa 4-layer chrome via
+  `:panel-gallery.chrome/Shell` AND seeds the chrome's `:rf/causa`
+  slots so the popup opens against the declared tab + pre-populated
+  settings state.
+
+  ## Frame discipline
+
+  The chrome's `shell-view` body hardcodes `[rf/frame-provider
+  {:frame :rf/causa}]` so every subscribe inside the chrome — and
+  every subscribe inside the modal it mounts — reads from the
+  global `:rf/causa` frame regardless of the variant frame Story
+  pre-allocated. Variants therefore route their seed events
+  through `:panel-gallery.chrome/seed!`'s `:after-seeds` lane,
+  which dispatches each event with `{:frame :rf/causa}` so the
+  writes land on the frame the modal reads.
+
+  ## Shared-state caveat (same as gallery-chrome)
+
+  Because every variant writes to the same `:rf/causa` frame, a
+  `:variants-grid` layout renders every cell simultaneously and
+  the last-seeded variant wins in the shared interior. Use canvas
+  mode (sidebar pick) for per-variant fidelity — the grid still
+  proves the modal mounts + paints across each declared shape."
+  (:require [re-frame.story :as story]
+            [panel-gallery.fixtures :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+(defn register-gallery-view! []
+  (panel-views/register!))
+
+(defn register-all!
+  "Register the Settings popup Story surface. Idempotent under
+  `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-settings-popup
+    {:axis :feature
+     :doc  "Causa Settings popup modal — 4-tab strip (General /
+            Filters / Theme / Telemetry) per spec/018-Event-Spine §9."})
+
+  (story/reg-story :story.causa.settings-popup
+    {:doc        "Visual gallery of the Causa Settings popup modal.
+                 Each variant opens the popup pre-positioned on a
+                 different tab with different pre-populated values.
+                 All writes route through the chrome seed event's
+                 `:after-seeds` lane so they land on `:rf/causa`
+                 (where the chrome + modal read)."
+     :component  :panel-gallery.chrome/Shell
+     :tags       #{:dev :feature/causa-settings-popup}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. General tab — text-size mid-range, panel-position
+  ;; right-rail, auto-open-on-error OFF (the explicit-defaults
+  ;; baseline). The variant pre-writes the slot values so the
+  ;; render is deterministic.
+  (story/reg-variant :story.causa.settings-popup/general
+    {:doc        "Settings popup open on General tab. Text-size
+                 slider seeded mid-range (14 px), panel-position
+                 :right-rail (default), auto-open-on-error OFF
+                 (default)."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-update :general :text-size 14]
+                     [:rf.causa/settings-update :general :panel-position :right-rail]
+                     [:rf.causa/settings-update :general :auto-open-on-error? false]
+                     [:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :general]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. Filters tab — auto-filter ns is on the classpath in
+  ;; main (rf2-ak4ms landed) so the feature-detect surfaces the
+  ;; 'Open auto-filter UI' button rather than the install-hint.
+  (story/reg-variant :story.causa.settings-popup/filters-present
+    {:doc        "Settings popup open on Filters tab — auto-filter
+                 ns is on the classpath so the section renders the
+                 'Open auto-filter UI' button (feature-detect path
+                 from `settings/view.cljs` §filters-section)."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :filters]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. Theme tab — dark theme selected (the default but
+  ;; explicit so the radio selection is observable).
+  (story/reg-variant :story.causa.settings-popup/theme-dark
+    {:doc        "Settings popup open on Theme tab with the Dark
+                 radio selected (default). The Light option is the
+                 alternative; pre-alpha there is no accent picker."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-update :theme nil :dark]
+                     [:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :theme]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. Telemetry tab — opt-in checkbox checked.
+  (story/reg-variant :story.causa.settings-popup/telemetry-opt-in
+    {:doc        "Settings popup open on Telemetry tab with the
+                 anonymous-usage opt-in checkbox checked. v1
+                 ships the toggle round-tripped only (no live
+                 telemetry side-effect) — the popup contract is
+                 the user-facing surface."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-update :telemetry :opt-in? true]
+                     [:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :telemetry]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- workspace ---------------------------------------------------
+  ;;
+  ;; Same shared-state caveat as `Workspace.causa.chrome/all` — every
+  ;; cell shares `:rf/causa` (the chrome's hardcoded frame-provider).
+  ;; The last variant to seed wins the shared interior; canvas-mode
+  ;; (sidebar pick) is where per-variant fidelity is fully observable.
+  (story/reg-workspace :Workspace.causa.settings-popup/all
+    {:doc      "All four Settings popup variants. The chrome
+                internally wraps :rf/causa via a hardcoded frame-
+                provider, so workspace cells share interior state —
+                see canvas-mode (sidebar pick) for per-variant
+                fidelity."
+     :layout   :variants-grid
+     :story    :story.causa.settings-popup
+     :columns  1
+     :tags     #{:dev}}))
+
+(register-all!)


### PR DESCRIPTION
## Summary

Three beads addressed — adds 13 Story variants to the Causa
panel-gallery testbed covering the chrome-follow-on modal
surfaces. All mount the full 4-layer chrome and write to the
global `:rf/causa` frame via the existing testbed seed event
(extended with an `:after-seeds` lane).

| Bead         | Surface                              | Variants |
|--------------|--------------------------------------|----------|
| rf2-mpn8m    | Settings popup (4 tabs)              | 4        |
| rf2-kbrkx    | Auto-filter pills + edit-popup       | 5        |
| rf2-pt1e1    | Causality popover (TB/LR/fallback/deep) | 4     |

**Total gallery variant count: 68 → 81.**

### Variants per bead

**rf2-mpn8m Settings popup** (`Workspace.causa.settings-popup/all`):
- `general` — text-size 14 px, panel-position right-rail, auto-open-on-error OFF
- `filters-present` — Filters tab with 'Open auto-filter UI' button (feature-detect)
- `theme-dark` — Theme tab, Dark radio selected
- `telemetry-opt-in` — Telemetry tab, opt-in checkbox checked

**rf2-kbrkx Auto-filter** (`Workspace.causa.filters/all`):
- `empty` — ribbon with no pills (first-session honest empty state)
- `mixed-loaded` — 3 IN pills + 5 OUT pills spanning keyword / glob / substring patterns
- `edit-popup-add` — popup open via `[ + ]`, `:source :add :mode :in`
- `edit-popup-edit-existing` — popup open via pill click, pre-populated, `[Delete]` visible
- `right-click-menu` — popup open via `:rf.causa/hide-event-type` (right-click row → OUT-filter draft)

**rf2-pt1e1 Causality popover** (`Workspace.causa.causality-popover/all`):
- `tb` — TB layout (default), 5-node sample graph, focused on cascade C
- `lr` — same graph, footer-toggled to LR
- `fallback` — ELK loader pinned to `:failed` via `panel-gallery.causality/force-elk-fallback!` → flat-list render
- `deep` — 20-node graph (A → B → C with 9 children + 9 siblings), exercises scroll + per-level breadth-cap truncation

### Implementation notes

- Extended `:panel-gallery.chrome/seed!` (in `panel_gallery/core.cljs`) with an `:after-seeds [<event-vec> ...]` lane so the modal-bearing variants can dispatch `:rf.causa/settings-open`, `:rf.causa/open-edit-popup`, `:rf.causa/causality-popover-open`, etc. into `:rf/causa` after the canonical seeds.
- Added a public `force-elk-failed-for-test!` helper to `causality_graph.cljs` (sits next to the existing `reset-elk-state-for-test!`); the testbed-local `:panel-gallery.causality/force-elk-fallback!` event calls it so the fallback variant exercises the failed-render branch deterministically without depending on a real ELK load failure.

### New files

- `tools/causa/testbeds/panel_gallery/gallery_settings.cljs`
- `tools/causa/testbeds/panel_gallery/gallery_filters.cljs`
- `tools/causa/testbeds/panel_gallery/gallery_causality.cljs`
- `tools/causa/testbeds/panel_gallery/fixtures_causality.cljs`

### Modified files

- `tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs` — adds `force-elk-failed-for-test!`
- `tools/causa/testbeds/panel_gallery/core.cljs` — wires the 3 new gallery namespaces + adds the 2 new testbed seed events
- `tools/causa/testbeds/panel_gallery/_smoke.cjs` — enumerates the 3 new workspaces (4 + 5 + 4 cells)
- `tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` — comment-only update noting the chrome-follow-on workspaces are deliberately excluded (the smoke's pin is rf2-kgn0c IDeref-null regression, orthogonal to the shared `:rf/causa` modal-state caveat that switching out of a modal-bearing workspace would otherwise leak)

## Test plan

- [x] `scripts/test-fast-pr.sh` — 2687 tests, 0 failures
- [x] `cd tools/causa && clojure -M:test` — 711 tests, 0 failures
- [x] `cd implementation && npm run test:browser` — 2676 tests, 0 failures
- [x] `cd implementation && npm run story:build` — succeeded
- [x] `node tools/causa/testbeds/panel_gallery/_smoke.cjs` — 81/81 variants across 10 workspaces
- [x] `node tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` — 8/8 steps OK, 0 fatal page errors