### PR TITLE
feat(story): viewport switcher + backgrounds switcher

### DIFF
--- a/tools/story/src/re_frame/story/backgrounds.cljc
+++ b/tools/story/src/re_frame/story/backgrounds.cljc
@@ -1,0 +1,189 @@
+(ns re-frame.story.backgrounds
+  "Backgrounds switcher — preset table + pure state model + localStorage
+  helpers (rf2-zll4h).
+
+  Mirrors Storybook's `addon-backgrounds`: a toolbar dropdown that swaps
+  the canvas background colour so an author can review the same story
+  against light / dark / paper / transparent backgrounds without
+  modifying the story body.
+
+  ## Surface
+
+  - `presets`                — the canonical preset table.
+  - `default-id`             — the neutral preset id (`:light`).
+  - `resolve`                — pure: turn a per-story override or a
+                               toolbar selection into the effective
+                               preset map.
+  - `valid-custom?`          — pure: validate a custom colour string.
+  - `wrap-style`             — pure: hiccup-style map for the canvas
+                               background.
+  - `load-from-storage`      — CLJS-only: read the persisted id /
+                               custom colour.
+  - `save-to-storage!`       — CLJS-only: persist.
+
+  ## Storage key
+
+  Chrome-wide localStorage key — `re-frame.story/background`. Stored
+  as a `pr-str`-encoded value: a keyword preset id (`:dark`) for a
+  named preset, or a string `\"#abc123\"` for the custom case.
+
+  ## Per-story override
+
+  A story / variant body MAY carry `:background` — either a keyword
+  preset id or a literal colour string (`\"#abc123\"`). When the canvas
+  mounts, the override wins over the toolbar selection.
+
+  ## Transparent / checkerboard
+
+  The `:transparent` preset renders via a CSS `linear-gradient`
+  checkerboard trick — two crossed gradients at 45° produce a familiar
+  alpha-pattern background without an SVG asset."
+  (:refer-clojure :exclude [resolve])
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]))
+
+;; ---- preset table --------------------------------------------------------
+
+(def presets
+  "The canonical background preset table. Values are
+  `{:label :color}` — `:color` is either a CSS colour string or the
+  sentinel keyword `:checkerboard` for the transparent preset."
+  {:light       {:label "Light"       :color "#ffffff"}
+   :dark        {:label "Dark"        :color "#1a1a1a"}
+   :paper       {:label "Paper"       :color "#f9f9f9"}
+   :midnight    {:label "Midnight"    :color "#0a0a0a"}
+   :transparent {:label "Transparent" :color :checkerboard}})
+
+(def preset-order
+  "Display order for the dropdown."
+  [:light :dark :paper :midnight :transparent])
+
+(def ^:const default-id
+  "Neutral default — light background."
+  :light)
+
+(def ^:const ls-key
+  "Chrome-wide localStorage key for the persisted background selection."
+  "re-frame.story/background")
+
+;; ---- pure: validate / coerce --------------------------------------------
+
+(def ^:private hex-colour-re
+  #"^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$")
+
+(defn valid-custom?
+  "True iff `s` is a string that looks like a usable CSS colour. The
+  validator accepts 3/6/8-digit hex strings — the colour input element
+  produces 7-char `#rrggbb` strings, so that's the common path. Other
+  shapes (named colours, `rgb()`) are intentionally not accepted at
+  storage time; authors who need them set them on the canvas wrap via
+  a decorator."
+  [s]
+  (boolean (and (string? s) (re-matches hex-colour-re (str/trim s)))))
+
+(defn valid-selection?
+  "True iff `sel` is a preset id we recognise OR a valid custom colour
+  string."
+  [sel]
+  (or (and (keyword? sel) (contains? presets sel))
+      (valid-custom? sel)))
+
+(defn coerce
+  "Coerce a `:background` slot into one of:
+
+  - a recognised preset keyword,
+  - a hex colour string,
+  - nil when unusable.
+
+  Pure data → data."
+  [v]
+  (cond
+    (and (keyword? v) (contains? presets v)) v
+    (valid-custom? v)                        (str/trim v)
+    :else                                    nil))
+
+(defn resolve
+  "Return the effective background `{:label :color}` map.
+
+  Args:
+    - `story-override` — the variant / story body's `:background` slot
+                         (or nil).
+    - `selection`      — the chrome toolbar selection (or nil).
+
+  Precedence: story-override > selection > `:light` default. Custom
+  hex strings render with a synthetic label (`\"Custom #abc123\"`)."
+  [story-override selection]
+  (let [pick (or (coerce story-override) (coerce selection) default-id)]
+    (if (keyword? pick)
+      (get presets pick)
+      {:label (str "Custom " pick)
+       :color pick})))
+
+(defn resolve-id
+  "Return the resolved selection id (a preset keyword) or `:custom`
+  for a custom colour string. Useful for `data-*` attributes."
+  [story-override selection]
+  (let [pick (or (coerce story-override) (coerce selection) default-id)]
+    (if (keyword? pick) pick :custom)))
+
+;; ---- pure: canvas-wrapper style -----------------------------------------
+
+(def ^:private checkerboard-style
+  "CSS-only checkerboard via two crossed linear-gradients. Renders a
+  familiar alpha-pattern background without an SVG asset."
+  {:background-color  "#ffffff"
+   :background-image
+   (str "linear-gradient(45deg, #cccccc 25%, transparent 25%), "
+        "linear-gradient(-45deg, #cccccc 25%, transparent 25%), "
+        "linear-gradient(45deg, transparent 75%, #cccccc 75%), "
+        "linear-gradient(-45deg, transparent 75%, #cccccc 75%)")
+   :background-size     "16px 16px"
+   :background-position "0 0, 0 8px, 8px -8px, -8px 0px"})
+
+(defn wrap-style
+  "Hiccup-style map for the canvas wrapper, given the resolved preset
+  `{:color}` value. Returns either a `:background-color` map for a
+  flat colour or the checkerboard background-image set for the
+  `:transparent` preset."
+  [{:keys [color]}]
+  (cond
+    (= :checkerboard color) checkerboard-style
+    (string? color)         {:background-color color}
+    :else                   nil))
+
+;; ---- CLJS-only: localStorage --------------------------------------------
+
+#?(:cljs
+   (defn- safe-local-storage []
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.-localStorage js/window)
+            (catch :default _ nil)))))
+
+(defn load-from-storage
+  "Read the persisted background selection from localStorage. Returns
+  one of: a preset id keyword, a hex colour string, or nil. JVM
+  returns nil unconditionally."
+  []
+  #?(:clj  nil
+     :cljs (when-let [ls (safe-local-storage)]
+             (try
+               (let [raw (.getItem ls ls-key)]
+                 (when (string? raw)
+                   (let [parsed (edn/read-string raw)]
+                     (when (valid-selection? parsed)
+                       (coerce parsed)))))
+               (catch :default _ nil)))))
+
+(defn save-to-storage!
+  "Persist `sel` to localStorage. Silently no-ops on JVM and when
+  localStorage is unavailable."
+  [sel]
+  #?(:clj  nil
+     :cljs (when-let [ls (safe-local-storage)]
+             (try
+               (if (nil? sel)
+                 (.removeItem ls ls-key)
+                 (when-let [normalised (coerce sel)]
+                   (.setItem ls ls-key (pr-str normalised))))
+               (catch :default _ nil))))
+  nil)

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -223,6 +223,28 @@
   "A set of registered mode ids the artefact opts into."
   [:set :keyword])
 
+;; ---- viewport + background (rf2-zll4h) -----------------------------------
+
+(def ViewportSlot
+  "Schema for the optional `:viewport` slot on a story / variant body.
+  Accepts either a preset id keyword (e.g. `:tablet`) — membership is
+  not enforced here so authors keep registration-time freedom — or a
+  literal `{:width N :height N}` map for an ad-hoc size. The runtime
+  drops unrecognised values back to `:full` at resolve time."
+  [:or
+   :keyword
+   [:map
+    [:width  [:int {:min 1}]]
+    [:height [:int {:min 1}]]]])
+
+(def BackgroundSlot
+  "Schema for the optional `:background` slot on a story / variant body.
+  Accepts either a preset id keyword (e.g. `:dark`) or a CSS-colour
+  string (the dropdown's colour-input emits `#rrggbb`-shaped strings).
+  Membership of the preset id is not enforced; the runtime drops
+  unrecognised values back to `:light` at resolve time."
+  [:or :keyword :string])
+
 ;; ---- :rf/story ------------------------------------------------------------
 
 (def CausaPreset
@@ -295,6 +317,12 @@
    [:platforms  {:optional true} PlatformSet]
    [:dispatch-console? {:optional true} :boolean]
    [:causa      {:optional true} CausaPreset]
+   ;; rf2-zll4h — viewport + background switchers. Per-story override
+   ;; that wins over the chrome toolbar selection at canvas mount time.
+   ;; Both slots are optional; absent means 'inherit the toolbar
+   ;; selection' (or the neutral default).
+   [:viewport   {:optional true} ViewportSlot]
+   [:background {:optional true} BackgroundSlot]
    ;; The Form-B combined-form sugar. Variant-name keys map to variant
    ;; bodies — the macro expands these into N independent reg-variant
    ;; calls. Validated separately when the macro desugars.
@@ -390,7 +418,11 @@
    ;; (default true at story level) or carry a Causa preset that
    ;; overrides the parent story's preset.
    [:dispatch-console?     {:optional true} :boolean]
-   [:causa                 {:optional true} CausaPreset]])
+   [:causa                 {:optional true} CausaPreset]
+   ;; rf2-zll4h — viewport + background per-variant overrides. Resolved
+   ;; with variant-first, then story-level, then chrome toolbar.
+   [:viewport              {:optional true} ViewportSlot]
+   [:background            {:optional true} BackgroundSlot]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
+++ b/tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs
@@ -1,0 +1,293 @@
+(ns re-frame.story.ui.backgrounds-switcher
+  "Toolbar chip + dropdown for the chrome-wide backgrounds switcher
+  (rf2-zll4h).
+
+  Mirrors Storybook's `addon-backgrounds` toolbar surface. The chip
+  shows a small swatch + the currently-selected preset label; clicking
+  opens a dropdown listing every preset (plus a colour-input row at
+  the bottom for ad-hoc colours). Per-story `:background` overrides
+  win at canvas mount time.
+
+  ## Storage
+
+  Chrome-wide selection persists to localStorage under
+  `re-frame.story/background` (see `re-frame.story.backgrounds/ls-key`).
+  Hydration runs once at shell mount via `hydrate!`.
+
+  ## Reset-gate compatibility
+
+  Like the viewport switcher, this chip uses `aria-haspopup=\"menu\"`
+  and `aria-expanded` rather than `aria-pressed` so the toolbar reset
+  assertion (`[aria-pressed=\"true\"]` count → 0 after reset) is never
+  tripped by background state."
+  (:require [reagent.core :as r]
+            [re-frame.story.backgrounds      :as backgrounds]
+            [re-frame.story.config           :as config]
+            [re-frame.story.predicates       :as pred]
+            [re-frame.story.registrar        :as registrar]
+            [re-frame.story.ui.state         :as state]))
+
+;; ---- dropdown state ------------------------------------------------------
+
+(defonce ^:private open?-atom (r/atom false))
+
+(defonce ^:private custom-input-atom
+  (r/atom "#888888"))
+
+(defn open!  [] (reset! open?-atom true))
+(defn close! [] (reset! open?-atom false))
+(defn toggle-open! []
+  (swap! open?-atom not))
+
+;; ---- mutators ------------------------------------------------------------
+
+(defn select!
+  "Persist `sel` (a preset keyword or a hex colour string) as the
+  chrome-wide background. nil clears the selection back to the
+  default. Writes through to localStorage."
+  [sel]
+  (when config/enabled?
+    (let [normalised (backgrounds/coerce sel)]
+      (state/swap-state! assoc :background normalised)
+      (backgrounds/save-to-storage! normalised)
+      (close!))))
+
+(defn submit-custom!
+  "Validate the custom colour-input value + persist if usable."
+  []
+  (let [cand @custom-input-atom]
+    (when (backgrounds/valid-custom? cand)
+      (select! cand))))
+
+;; ---- hydration -----------------------------------------------------------
+
+(defn hydrate!
+  "Seed `:background` on shell mount from localStorage. Idempotent."
+  []
+  (when (and config/enabled?
+             (nil? (:background @state/shell-state-atom)))
+    (when-some [persisted (backgrounds/load-from-storage)]
+      (state/swap-state! assoc :background persisted))))
+
+;; ---- per-story override lookup -------------------------------------------
+
+(defn effective-background
+  "Resolve the effective background preset for the currently-focused
+  variant. Returns the preset map `{:label :color}`."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        var-body   (when variant-id
+                     (registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id pred/parent-story-id)
+        story-body (when story-id
+                     (registrar/handler-meta :story story-id))
+        override   (or (:background var-body)
+                       (:background story-body))]
+    (backgrounds/resolve override (:background shell))))
+
+(defn effective-id
+  "Resolved id (preset keyword or `:custom`) for the focused variant."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        var-body   (when variant-id
+                     (registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id pred/parent-story-id)
+        story-body (when story-id
+                     (registrar/handler-meta :story story-id))
+        override   (or (:background var-body)
+                       (:background story-body))]
+    (backgrounds/resolve-id override (:background shell))))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:chip        {:padding         "3px 10px"
+                 :background      "#37373d"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :user-select     "none"
+                 :display         "inline-flex"
+                 :align-items     "center"
+                 :gap             "6px"}
+   :swatch      {:width  "12px"
+                 :height "12px"
+                 :border "1px solid #555"
+                 :border-radius "2px"
+                 :box-sizing "border-box"
+                 :flex-shrink "0"}
+   :wrap        {:position "relative"
+                 :display  "inline-block"}
+   :menu        {:position        "absolute"
+                 :top             "calc(100% + 4px)"
+                 :right           "0"
+                 :z-index         1500
+                 :background      "#1f1f1f"
+                 :border          "1px solid #444"
+                 :border-radius   "4px"
+                 :box-shadow      "0 8px 24px rgba(0,0,0,0.6)"
+                 :min-width       "200px"
+                 :padding         "6px"
+                 :display         "flex"
+                 :flex-direction  "column"
+                 :gap             "2px"
+                 :font-family     "monospace"
+                 :font-size       "11px"}
+   :item        {:display         "flex"
+                 :align-items     "center"
+                 :gap             "8px"
+                 :padding         "5px 8px"
+                 :background      "transparent"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "3px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :text-align      "left"
+                 :width           "100%"}
+   :item-active {:background "#0e639c"
+                 :color      "white"}
+   :divider     {:height          "1px"
+                 :background      "#333"
+                 :margin          "4px 0"}
+   :custom-row  {:display "flex"
+                 :gap "6px"
+                 :align-items "center"
+                 :padding "4px"}
+   :custom-input {:width        "60px"
+                  :height       "26px"
+                  :padding      "0"
+                  :border       "1px solid #444"
+                  :border-radius "3px"
+                  :background   "#252526"
+                  :cursor       "pointer"}
+   :custom-go   {:padding         "3px 8px"
+                 :background      "#0e639c"
+                 :color           "white"
+                 :border          "none"
+                 :border-radius   "3px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "10px"}
+   :backdrop    {:position "fixed"
+                 :top "0" :left "0" :right "0" :bottom "0"
+                 :z-index 1499
+                 :background "transparent"}})
+
+(def ^:private checkerboard-mini
+  "Mini checkerboard for the transparent-preset swatch."
+  {:background-color  "#ffffff"
+   :background-image
+   (str "linear-gradient(45deg, #cccccc 25%, transparent 25%), "
+        "linear-gradient(-45deg, #cccccc 25%, transparent 25%), "
+        "linear-gradient(45deg, transparent 75%, #cccccc 75%), "
+        "linear-gradient(-45deg, transparent 75%, #cccccc 75%)")
+   :background-size     "6px 6px"
+   :background-position "0 0, 0 3px, 3px -3px, -3px 0px"})
+
+(defn- swatch
+  "Render a swatch for `id` (a preset keyword) or a hex string. Pure-hiccup."
+  [id-or-color]
+  (cond
+    (= :transparent id-or-color)
+    [:span {:style (merge (:swatch styles) checkerboard-mini)}]
+
+    (and (keyword? id-or-color) (= :checkerboard
+                                   (:color (get backgrounds/presets id-or-color))))
+    [:span {:style (merge (:swatch styles) checkerboard-mini)}]
+
+    (keyword? id-or-color)
+    [:span {:style (merge (:swatch styles)
+                          {:background-color
+                           (:color (get backgrounds/presets id-or-color)
+                                   "#888888")})}]
+
+    (string? id-or-color)
+    [:span {:style (merge (:swatch styles) {:background-color id-or-color})}]
+
+    :else
+    [:span {:style (:swatch styles)}]))
+
+;; ---- dropdown row --------------------------------------------------------
+
+(defn- preset-row
+  [id active-id]
+  (let [{:keys [label]} (get backgrounds/presets id)
+        active? (= id active-id)]
+    [:button
+     {:style       (merge (:item styles)
+                          (when active? (:item-active styles)))
+      :data-test   "story-backgrounds-menu-item"
+      :data-id     (name id)
+      :aria-current (if active? "true" "false")
+      :on-click    (fn [e]
+                     (.stopPropagation e)
+                     (select! id))}
+     (swatch id)
+     [:span label]]))
+
+(defn- custom-row
+  []
+  [:div {:style (:custom-row styles)}
+   [:input
+    {:type        "color"
+     :value       @custom-input-atom
+     :style       (:custom-input styles)
+     :data-test   "story-backgrounds-custom-input"
+     :on-change   (fn [e] (reset! custom-input-atom (.. e -target -value)))}]
+   [:span @custom-input-atom]
+   [:button
+    {:style     (:custom-go styles)
+     :data-test "story-backgrounds-custom-apply"
+     :on-click  (fn [_] (submit-custom!))}
+    "Apply"]])
+
+;; ---- the chip ------------------------------------------------------------
+
+(defn chip
+  "Render the backgrounds switcher chip + dropdown."
+  []
+  (let [open?     @open?-atom
+        active-id (effective-id)
+        effective (effective-background)
+        label     (:label effective)
+        ;; For a custom selection, the swatch needs the raw colour
+        ;; string — pull it off the `:color` slot of the effective map.
+        swatch-arg (if (= :custom active-id) (:color effective) active-id)]
+    [:span {:style (:wrap styles)}
+     (when open?
+       [:div {:style    (:backdrop styles)
+              :data-test "story-backgrounds-backdrop"
+              :on-click (fn [_] (close!))}])
+     [:button
+      {:style              (:chip styles)
+       :data-test          "story-toolbar-backgrounds"
+       :data-background    (name active-id)
+       :aria-haspopup      "menu"
+       :aria-expanded      (if open? "true" "false")
+       :title              (str "Background: " label " — click to choose")
+       :on-click           (fn [e]
+                             (.stopPropagation e)
+                             (toggle-open!))}
+      (swatch swatch-arg)
+      [:span label]
+      [:span {:style {:opacity "0.6" :margin-left "2px"}} "▾"]]
+     (when open?
+       [:div {:style     (:menu styles)
+              :role      "menu"
+              :data-test "story-backgrounds-menu"}
+        (for [id backgrounds/preset-order]
+          ^{:key id} [preset-row id active-id])
+        [:div {:style (:divider styles)}]
+        (custom-row)])]))
+
+(defn chip-when-enabled
+  "Render the chip only when Story is enabled."
+  []
+  (when config/enabled? [chip]))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -49,6 +49,7 @@
             [re-frame.story.runtime :as runtime]
             [re-frame.trace :as rf-trace]
             [re-frame.story.ui.actions :as actions]
+            [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
             [re-frame.story.ui.canvas :as canvas]
             [re-frame.story.ui.command-palette.view :as command-palette]
             [re-frame.story.ui.controls :as controls]
@@ -69,7 +70,10 @@
             [re-frame.story.ui.test-mode.view :as test-mode-view]
             [re-frame.story.ui.toolbar :as toolbar]
             [re-frame.story.ui.trace :as trace]
-            [re-frame.story.ui.workspace :as workspace]))
+            [re-frame.story.ui.viewport-switcher :as viewport-switcher]
+            [re-frame.story.ui.workspace :as workspace]
+            [re-frame.story.backgrounds :as backgrounds]
+            [re-frame.story.viewport :as viewport]))
 
 ;; Styles live in `re-frame.story.ui.shell-styles` (pure-data leaf,
 ;; no Reagent dep). Required as `styles` above so the in-file call
@@ -484,6 +488,53 @@
      (when variant-id
        [panels/render-panels-at-placement :right variant-id vis])]))
 
+(defn- framed-canvas
+  "Render the variant `canvas/canvas` wrapped with the effective
+  viewport + background framing (rf2-zll4h).
+
+  The wrapper is a single `<div data-test=\"story-canvas-frame\">` so
+  Playwright specs can introspect the framed region. Resolution per
+  rf2-zll4h:
+    - per-variant `:viewport` / `:background` body slot wins
+    - then per-story `:viewport` / `:background` body slot
+    - then the chrome toolbar selection
+    - then the neutral defaults (`:full` / `:light`).
+
+  Both axes resolve via their respective switcher namespaces'
+  `effective-viewport` / `effective-background` helpers — keeping the
+  fallback logic in one place per axis so the chip label and the
+  rendered canvas always agree."
+  []
+  (let [vp        (viewport-switcher/effective-viewport)
+        bg        (backgrounds-switcher/effective-background)
+        vp-style  (viewport/wrap-style vp)
+        bg-style  (backgrounds/wrap-style bg)
+        ;; Match the canvas's own `.wrap` minimum so framed regions
+        ;; never collapse to zero height when the user picks a
+        ;; tiny custom viewport.
+        wrap-style (merge {:padding    "16px"
+                           :display    "flex"
+                           :flex       "1"
+                           :min-height "200px"
+                           :align-items "flex-start"
+                           :justify-content "center"
+                           :overflow   "auto"
+                           :box-sizing "border-box"}
+                          bg-style)
+        ;; When sizing is in effect, wrap canvas/canvas in an
+        ;; intermediate div with explicit width/height. Otherwise the
+        ;; framed-canvas just applies the background.
+        sized?   (some? vp-style)]
+    [:div {:style       wrap-style
+           :data-test   "story-canvas-frame"
+           :data-viewport (name (viewport-switcher/effective-id))
+           :data-background (name (backgrounds-switcher/effective-id))}
+     (if sized?
+       [:div {:style     vp-style
+              :data-test "story-canvas-frame-sized"}
+        [canvas/canvas]]
+       [canvas/canvas])]))
+
 (defn- main-pane
   "The main content pane — workspace if one is selected, otherwise the
   variant canvas. Stage 6 (rf2-zhwd) appends any registered
@@ -529,7 +580,11 @@
        variant-id (case mode-tab
                     :docs [docs/docs-view variant-id]
                     :test [test-mode-view/test-view variant-id]
-                    [canvas/canvas])
+                    ;; rf2-zll4h — wrap the canvas with viewport sizing
+                    ;; + background colour. The :docs and :test panes
+                    ;; are NOT framed (they're shell chrome, not the
+                    ;; variant render surface).
+                    [framed-canvas])
        :else
        [:div {:style {:padding "32px"
                       :color "#9a9a9a"
@@ -558,6 +613,12 @@
          ;; canvas. URL wins over localStorage per spec/010 §URL deep-
          ;; link. Idempotent and one-shot.
          (toolbar/hydrate!)
+         ;; rf2-zll4h: hydrate the chrome-wide viewport + background
+         ;; selections from localStorage. Both are idempotent and
+         ;; one-shot; they no-op when the slot is already populated
+         ;; (e.g. a programmatic test fixture seeded them).
+         (viewport-switcher/hydrate!)
+         (backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
          ;; Hydrate the share URL's focused variant / overrides /

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -129,7 +129,14 @@
    :rail-widths         {:left 260 :right 320}
    :tests               {:runs           {}
                          :watch-mode?    false
-                         :content-hashes {}}})
+                         :content-hashes {}}
+   ;; rf2-zll4h: chrome-wide toolbar selections for the viewport +
+   ;; background switchers. nil means "use neutral default" — the
+   ;; switcher resolves to `:full` / `:light` respectively. A per-story
+   ;; `:viewport` / `:background` override on the story / variant body
+   ;; takes precedence over the chrome-wide selection at resolve time.
+   :viewport            nil
+   :background          nil})
 
 ;; ---- pure transitions (extracted to state.transitions, rf2-gcpon) -------
 

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -49,9 +49,11 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [re-frame.story.registrar :as registrar]
+            [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
             [re-frame.story.ui.play-status :as play-status]
             [re-frame.story.ui.recorder :as ui-recorder]
-            [re-frame.story.ui.state :as state]))
+            [re-frame.story.ui.state :as state]
+            [re-frame.story.ui.viewport-switcher :as viewport-switcher]))
 
 ;; ---- localStorage --------------------------------------------------------
 
@@ -366,6 +368,17 @@
      ;; button. Self-elides when no script is present.
      (when (:selected-variant shell)
        [play-status/chip-when-enabled (:selected-variant shell)])
+     ;; rf2-zll4h — viewport + backgrounds switchers (Storybook addon-
+     ;; viewport + addon-backgrounds parity). Both chips are chrome-wide
+     ;; dropdowns; they live before the recorder REC chip so the
+     ;; left-side chrome cluster reads:
+     ;;   [dispatch] [play-status] [viewport] [backgrounds] [REC] [reset]
+     ;; Each chip uses `aria-haspopup`/`aria-expanded` (NOT
+     ;; `aria-pressed`) so the toolbar reset assertion in story-feature-
+     ;; load (which counts `[aria-pressed="true"]` post-reset) is not
+     ;; tripped by viewport / background state.
+     [viewport-switcher/chip-when-enabled]
+     [backgrounds-switcher/chip-when-enabled]
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
      ;; affordance so the chrome-wide recorder is reachable regardless of
      ;; which variant the user has focused.

--- a/tools/story/src/re_frame/story/ui/viewport_switcher.cljs
+++ b/tools/story/src/re_frame/story/ui/viewport_switcher.cljs
@@ -1,0 +1,314 @@
+(ns re-frame.story.ui.viewport-switcher
+  "Toolbar chip + dropdown for the chrome-wide viewport switcher
+  (rf2-zll4h).
+
+  Mirrors Storybook's `addon-viewport` toolbar surface. The chip shows
+  the currently-selected preset label; clicking opens a dropdown
+  listing every preset (plus a custom Width × Height row at the
+  bottom). Per-story `:viewport` overrides win at canvas mount time —
+  the chip surfaces the toolbar selection (the override is what
+  the canvas renders).
+
+  ## Storage
+
+  The chrome-wide selection persists to localStorage under
+  `re-frame.story/viewport` (see `re-frame.story.viewport/ls-key`).
+  Hydration runs once at shell mount via `hydrate!`.
+
+  ## Reset-gate compatibility
+
+  The toolbar's `[reset]` affordance asserts that no element under the
+  toolbar carries `aria-pressed=\"true\"` after a reset click. This
+  chip is a `aria-haspopup=\"menu\"` dropdown, NOT a toggle button —
+  it deliberately does not emit `aria-pressed` so the reset assertion
+  is never tripped by viewport state."
+  (:require [reagent.core :as r]
+            [re-frame.story.config           :as config]
+            [re-frame.story.predicates       :as pred]
+            [re-frame.story.registrar        :as registrar]
+            [re-frame.story.ui.state         :as state]
+            [re-frame.story.viewport         :as viewport]))
+
+;; ---- dropdown state ------------------------------------------------------
+;;
+;; The dropdown's open/close is local UI state — the persisted choice
+;; lives on `shell-state-atom`, the open flag does not. A `r/atom`
+;; here keeps the chip's render lean and the open-state out of the
+;; shared shell-state shape.
+
+(defonce ^:private open?-atom (r/atom false))
+
+(defonce ^:private custom-input-atom
+  (r/atom {:width "" :height ""}))
+
+(defn open!  [] (reset! open?-atom true))
+(defn close! [] (reset! open?-atom false))
+(defn toggle-open! []
+  (swap! open?-atom not))
+
+;; ---- mutators ------------------------------------------------------------
+
+(defn select!
+  "Persist `sel` (a preset keyword or a `{:width :height}` map) as the
+  chrome-wide viewport. nil clears the toolbar selection back to the
+  default. Also writes through to localStorage."
+  [sel]
+  (when config/enabled?
+    (let [normalised (viewport/coerce sel)]
+      (state/swap-state! assoc :viewport normalised)
+      (viewport/save-to-storage! normalised)
+      (close!))))
+
+(defn submit-custom!
+  "Validate the custom input map (the dropdown's bottom row) and
+  persist if it's a usable `{:width :height}` pair. No-op + leaves the
+  inputs intact when invalid."
+  []
+  (let [{:keys [width height]} @custom-input-atom
+        w (some-> width (js/parseInt 10))
+        h (some-> height (js/parseInt 10))
+        cand {:width w :height h}]
+    (when (viewport/valid-custom? cand)
+      (select! cand)
+      (reset! custom-input-atom {:width "" :height ""}))))
+
+;; ---- hydration -----------------------------------------------------------
+
+(defn hydrate!
+  "Seed `:viewport` on shell mount from localStorage. Idempotent. No-ops
+  when localStorage carries no value or the slot is already populated."
+  []
+  (when (and config/enabled?
+             (nil? (:viewport @state/shell-state-atom)))
+    (when-some [persisted (viewport/load-from-storage)]
+      (state/swap-state! assoc :viewport persisted))))
+
+;; ---- per-story override lookup -------------------------------------------
+
+(defn effective-viewport
+  "Resolve the effective viewport preset for the currently-focused
+  variant. Pure-ish — reads the registrar + shell-state. Returns the
+  preset map `{:label :width :height}` (with nils on `:full`)."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        var-body   (when variant-id
+                     (registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id pred/parent-story-id)
+        story-body (when story-id
+                     (registrar/handler-meta :story story-id))
+        override   (or (:viewport var-body)
+                       (:viewport story-body))]
+    (viewport/resolve override (:viewport shell))))
+
+(defn effective-id
+  "Like `effective-viewport` but returns the resolved id (preset keyword
+  or `:custom`). Used for `data-*` attributes."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)
+        var-body   (when variant-id
+                     (registrar/handler-meta :variant variant-id))
+        story-id   (some-> variant-id pred/parent-story-id)
+        story-body (when story-id
+                     (registrar/handler-meta :story story-id))
+        override   (or (:viewport var-body)
+                       (:viewport story-body))]
+    (viewport/resolve-id override (:viewport shell))))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:chip        {:padding         "3px 10px"
+                 :background      "#37373d"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "10px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :user-select     "none"
+                 :display         "inline-flex"
+                 :align-items     "center"
+                 :gap             "6px"}
+   :chip-icon   {:font-size "10px"
+                 :opacity   "0.85"}
+   :wrap        {:position "relative"
+                 :display  "inline-block"}
+   :menu        {:position        "absolute"
+                 :top             "calc(100% + 4px)"
+                 :right           "0"
+                 :z-index         1500
+                 :background      "#1f1f1f"
+                 :border          "1px solid #444"
+                 :border-radius   "4px"
+                 :box-shadow      "0 8px 24px rgba(0,0,0,0.6)"
+                 :min-width       "240px"
+                 :padding         "6px"
+                 :display         "flex"
+                 :flex-direction  "column"
+                 :gap             "2px"
+                 :font-family     "monospace"
+                 :font-size       "11px"}
+   :item        {:display         "flex"
+                 :align-items     "center"
+                 :justify-content "space-between"
+                 :padding         "5px 8px"
+                 :background      "transparent"
+                 :color           "#cccccc"
+                 :border          "none"
+                 :border-radius   "3px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "11px"
+                 :text-align      "left"
+                 :width           "100%"}
+   :item-active {:background "#0e639c"
+                 :color      "white"}
+   :item-label  {:display "flex"
+                 :align-items "center"
+                 :gap "8px"}
+   :item-size   {:color     "#888"
+                 :font-size "10px"
+                 :font-style "italic"}
+   :divider     {:height          "1px"
+                 :background      "#333"
+                 :margin          "4px 0"}
+   :custom-row  {:display "flex"
+                 :gap "4px"
+                 :align-items "center"
+                 :padding "4px"}
+   :custom-input {:width        "60px"
+                  :padding      "3px 5px"
+                  :background   "#252526"
+                  :color        "white"
+                  :border       "1px solid #444"
+                  :border-radius "3px"
+                  :font-family  "monospace"
+                  :font-size    "11px"}
+   :custom-x    {:color "#888"
+                 :font-size "10px"}
+   :custom-go   {:padding         "3px 8px"
+                 :background      "#0e639c"
+                 :color           "white"
+                 :border          "none"
+                 :border-radius   "3px"
+                 :cursor          "pointer"
+                 :font-family     "monospace"
+                 :font-size       "10px"}
+   :backdrop    {:position "fixed"
+                 :top "0" :left "0" :right "0" :bottom "0"
+                 :z-index 1499
+                 :background "transparent"}})
+
+;; ---- icon ----------------------------------------------------------------
+
+(defn- viewport-icon
+  "Tiny device-shaped indicator for the chip / menu rows. Pure-hiccup."
+  [id]
+  (let [glyph (case id
+                :full              "[ ]"
+                :mobile-portrait   "[|]"
+                :mobile-landscape  "[--]"
+                :tablet            "[ ]"
+                :desktop           "[#]"
+                :desktop-wide      "[##]"
+                :custom            "[?]"
+                "[ ]")]
+    [:span {:style (:chip-icon styles)} glyph]))
+
+;; ---- dropdown row --------------------------------------------------------
+
+(defn- preset-row
+  [id active-id]
+  (let [{:keys [label width height]} (get viewport/presets id)
+        active? (= id active-id)]
+    [:button
+     {:style       (merge (:item styles)
+                          (when active? (:item-active styles)))
+      :data-test   "story-viewport-menu-item"
+      :data-id     (name id)
+      :aria-current (if active? "true" "false")
+      :on-click    (fn [e]
+                     (.stopPropagation e)
+                     (select! id))}
+     [:span {:style (:item-label styles)}
+      (viewport-icon id)
+      [:span label]]
+     [:span {:style (:item-size styles)}
+      (cond
+        (or (nil? width) (nil? height)) "Full"
+        :else (str width " × " height))]]))
+
+(defn- custom-row
+  []
+  [:div {:style (:custom-row styles)}
+   [:input
+    {:type        "number"
+     :min         "1"
+     :placeholder "W"
+     :value       (:width @custom-input-atom)
+     :style       (:custom-input styles)
+     :data-test   "story-viewport-custom-width"
+     :on-change   (fn [e] (swap! custom-input-atom assoc :width
+                                 (.. e -target -value)))}]
+   [:span {:style (:custom-x styles)} "×"]
+   [:input
+    {:type        "number"
+     :min         "1"
+     :placeholder "H"
+     :value       (:height @custom-input-atom)
+     :style       (:custom-input styles)
+     :data-test   "story-viewport-custom-height"
+     :on-change   (fn [e] (swap! custom-input-atom assoc :height
+                                 (.. e -target -value)))}]
+   [:button
+    {:style     (:custom-go styles)
+     :data-test "story-viewport-custom-apply"
+     :on-click  (fn [_] (submit-custom!))}
+    "Apply"]])
+
+;; ---- the chip ------------------------------------------------------------
+
+(defn chip
+  "Render the viewport switcher chip + dropdown. Public so the toolbar
+  composes it directly. Form-1; auto-tracks `shell-state-atom`."
+  []
+  (let [open?     @open?-atom
+        active-id (effective-id)
+        effective (effective-viewport)
+        label     (:label effective)]
+    [:span {:style (:wrap styles)}
+     ;; The backdrop is a transparent full-screen layer that closes the
+     ;; menu when clicked outside. Mounted only while open.
+     (when open?
+       [:div {:style    (:backdrop styles)
+              :data-test "story-viewport-backdrop"
+              :on-click (fn [_] (close!))}])
+     [:button
+      {:style          (:chip styles)
+       :data-test      "story-toolbar-viewport"
+       :data-viewport  (name active-id)
+       :aria-haspopup  "menu"
+       :aria-expanded  (if open? "true" "false")
+       :title          (str "Viewport: " label " — click to choose")
+       :on-click       (fn [e]
+                         (.stopPropagation e)
+                         (toggle-open!))}
+      (viewport-icon active-id)
+      [:span label]
+      [:span {:style {:opacity "0.6" :margin-left "2px"}} "▾"]]
+     (when open?
+       [:div {:style     (:menu styles)
+              :role      "menu"
+              :data-test "story-viewport-menu"}
+        (for [id viewport/preset-order]
+          ^{:key id} [preset-row id active-id])
+        [:div {:style (:divider styles)}]
+        (custom-row)])]))
+
+(defn chip-when-enabled
+  "Render the chip only when Story is enabled. Production builds with
+  `re-frame.story.config/enabled?` false get nothing."
+  []
+  (when config/enabled? [chip]))

--- a/tools/story/src/re_frame/story/viewport.cljc
+++ b/tools/story/src/re_frame/story/viewport.cljc
@@ -1,0 +1,195 @@
+(ns re-frame.story.viewport
+  "Viewport switcher — preset table + pure state model + localStorage
+  helpers (rf2-zll4h).
+
+  Mirrors Storybook's `addon-viewport`: a toolbar dropdown that frames
+  the canvas at a chosen width / height so authors can preview a story
+  at mobile / tablet / desktop sizes without reaching for the browser
+  devtools.
+
+  ## Surface
+
+  - `presets`                   — the canonical preset table.
+  - `default-id`                — the neutral preset id (`:full`).
+  - `resolve`                   — pure: turn a per-story override or a
+                                  toolbar selection into the effective
+                                  preset map.
+  - `valid-custom?`             — pure: validate a custom `{:width :height}`
+                                  map.
+  - `wrap-style`                — pure: hiccup-style map for the canvas
+                                  wrapper (or nil when full-bleed).
+  - `load-from-storage`         — CLJS-only: read the persisted id /
+                                  custom map.
+  - `save-to-storage!`          — CLJS-only: persist.
+
+  ## Storage key
+
+  Chrome-wide localStorage key — `re-frame.story/viewport`. Stored as a
+  `pr-str`-encoded value: a keyword preset id (`:tablet`) for a named
+  preset, or a `{:width N :height N}` map for the custom case. Read
+  back via `clojure.edn/read-string`.
+
+  ## Per-story override
+
+  A story / variant body MAY carry `:viewport` — either a keyword preset
+  id or a literal `{:width :height}` map. When the canvas mounts, the
+  override wins over the toolbar selection. The chip surfaces the
+  effective preset's label so the user knows which is in force.
+
+  ## Elision
+
+  Pure data + a defensive CLJS storage layer; no fn-valued slots. The
+  CLJS surfaces guard against missing `js/window.localStorage` (private
+  mode / file:// / Node test runner) by returning nil / no-op."
+  (:refer-clojure :exclude [resolve])
+  (:require [clojure.edn :as edn]))
+
+;; ---- preset table --------------------------------------------------------
+
+(def presets
+  "The canonical viewport preset table. Keys are preset ids; values are
+  `{:label :width :height}` — `:width`/`:height` are nil for the
+  `:full` (no resize) preset."
+  {:full              {:label "Full"             :width nil  :height nil}
+   :mobile-portrait   {:label "Mobile portrait"  :width 375  :height 667}
+   :mobile-landscape  {:label "Mobile landscape" :width 667  :height 375}
+   :tablet            {:label "Tablet"           :width 768  :height 1024}
+   :desktop           {:label "Desktop"          :width 1280 :height 800}
+   :desktop-wide      {:label "Desktop wide"     :width 1920 :height 1080}})
+
+(def preset-order
+  "Display order for the dropdown — `:full` first, then ascending width."
+  [:full
+   :mobile-portrait
+   :mobile-landscape
+   :tablet
+   :desktop
+   :desktop-wide])
+
+(def ^:const default-id
+  "Neutral default — no resize, full bleed."
+  :full)
+
+(def ^:const ls-key
+  "Chrome-wide localStorage key for the persisted viewport selection."
+  "re-frame.story/viewport")
+
+;; ---- pure: resolve / validate -------------------------------------------
+
+(defn valid-custom?
+  "True iff `m` is a `{:width N :height N}` map with positive integer
+  width and height. Pure."
+  [m]
+  (and (map? m)
+       (let [w (:width m)
+             h (:height m)]
+         (and (integer? w) (pos? w)
+              (integer? h) (pos? h)))))
+
+(defn valid-selection?
+  "True iff `sel` is a preset id keyword we recognise OR a valid custom
+  `{:width :height}` map. Pure."
+  [sel]
+  (or (and (keyword? sel) (contains? presets sel))
+      (valid-custom? sel)))
+
+(defn coerce
+  "Coerce a `:viewport` slot (per-story override or toolbar selection)
+  into one of:
+
+  - a recognised preset keyword,
+  - a `{:width :height}` map,
+  - nil when the input is unusable.
+
+  Pure data → data. Strings are NOT accepted; the schema rejects them."
+  [v]
+  (cond
+    (and (keyword? v) (contains? presets v)) v
+    (valid-custom? v)                        (select-keys v [:width :height])
+    :else                                    nil))
+
+(defn resolve
+  "Return the effective viewport `{:label :width :height}` map.
+
+  Args:
+    - `story-override` — the variant / story body's `:viewport` slot
+                         (or nil).
+    - `selection`      — the chrome toolbar selection (or nil).
+
+  Precedence: story-override > selection > `:full` default. Custom
+  `{:width :height}` selections render with a synthetic label
+  (`\"Custom WxH\"`)."
+  [story-override selection]
+  (let [pick (or (coerce story-override) (coerce selection) default-id)]
+    (if (keyword? pick)
+      (get presets pick)
+      {:label  (str "Custom " (:width pick) "x" (:height pick))
+       :width  (:width pick)
+       :height (:height pick)})))
+
+(defn resolve-id
+  "Like `resolve` but returns the resolved selection id (a preset
+  keyword) or `:custom` for a custom map. Useful for `data-*`
+  attributes."
+  [story-override selection]
+  (let [pick (or (coerce story-override) (coerce selection) default-id)]
+    (if (keyword? pick) pick :custom)))
+
+;; ---- pure: canvas-wrapper style -----------------------------------------
+
+(defn wrap-style
+  "Hiccup-style map for the canvas wrapper, given the resolved preset
+  `{:width :height}` pair. Returns nil for the `:full` preset (caller
+  skips the wrapper entirely).
+
+  The wrapper draws a soft border + shadow around the framed canvas so
+  the framed region is visually distinct from the surrounding chrome."
+  [{:keys [width height]}]
+  (when (and width height)
+    {:width        (str width "px")
+     :height       (str height "px")
+     :max-width    "100%"
+     :margin       "0 auto"
+     :border       "1px solid #444"
+     :box-shadow   "0 4px 14px rgba(0,0,0,0.4)"
+     :box-sizing   "border-box"
+     :overflow     "auto"}))
+
+;; ---- CLJS-only: localStorage --------------------------------------------
+
+#?(:cljs
+   (defn- safe-local-storage []
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.-localStorage js/window)
+            (catch :default _ nil)))))
+
+(defn load-from-storage
+  "Read the persisted viewport selection from localStorage. Returns
+  one of: a preset id keyword, a `{:width :height}` custom map, or nil
+  (no persisted value / unparseable). JVM returns nil unconditionally
+  (no localStorage)."
+  []
+  #?(:clj  nil
+     :cljs (when-let [ls (safe-local-storage)]
+             (try
+               (let [raw (.getItem ls ls-key)]
+                 (when (string? raw)
+                   (let [parsed (edn/read-string raw)]
+                     (when (valid-selection? parsed)
+                       (coerce parsed)))))
+               (catch :default _ nil)))))
+
+(defn save-to-storage!
+  "Persist `sel` to localStorage. `sel` may be a preset id keyword, a
+  `{:width :height}` custom map, or nil (clears the slot). Silently
+  no-ops on JVM and when localStorage is unavailable."
+  [sel]
+  #?(:clj  nil
+     :cljs (when-let [ls (safe-local-storage)]
+             (try
+               (if (nil? sel)
+                 (.removeItem ls ls-key)
+                 (when-let [normalised (coerce sel)]
+                   (.setItem ls ls-key (pr-str normalised))))
+               (catch :default _ nil))))
+  nil)

--- a/tools/story/test/re_frame/story/backgrounds_test.cljc
+++ b/tools/story/test/re_frame/story/backgrounds_test.cljc
@@ -1,0 +1,182 @@
+(ns re-frame.story.backgrounds-test
+  "Tests for the backgrounds switcher's pure state model (rf2-zll4h).
+
+  Runs on both JVM and CLJS — the CLJS arm exercises the localStorage
+  round-trip; both arms exercise the preset table + resolve precedence
+  + wrap-style shape.
+
+  Coverage layers:
+
+  - Preset lookup by id.
+  - Custom hex-colour validation.
+  - Selection precedence (story-override > toolbar selection > default).
+  - `wrap-style` shape for flat colour + transparent / checkerboard.
+  - localStorage round-trip — CLJS-only."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.backgrounds :as backgrounds]))
+
+;; ---- preset table --------------------------------------------------------
+
+(deftest preset-table-includes-every-bead-mandated-id
+  (testing "every preset id called out by rf2-zll4h is present"
+    (let [expected #{:light :dark :paper :midnight :transparent}]
+      (is (= expected (set (keys backgrounds/presets))))
+      (is (= expected (set backgrounds/preset-order))))))
+
+(deftest preset-dark-has-canonical-colour
+  (testing ":dark is #1a1a1a (bead-mandated)"
+    (is (= {:label "Dark" :color "#1a1a1a"}
+           (get backgrounds/presets :dark)))))
+
+(deftest preset-transparent-uses-checkerboard-sentinel
+  (testing ":transparent's :color is the :checkerboard keyword sentinel"
+    (is (= :checkerboard
+           (:color (get backgrounds/presets :transparent))))))
+
+;; ---- pure: valid-custom? ------------------------------------------------
+
+(deftest valid-custom-accepts-hex-strings
+  (testing "valid-custom? accepts 3 / 6 / 8-digit hex colours"
+    (is (true?  (backgrounds/valid-custom? "#abc")))
+    (is (true?  (backgrounds/valid-custom? "#abcdef")))
+    (is (true?  (backgrounds/valid-custom? "#abcdef12")))
+    (is (true?  (backgrounds/valid-custom? "#ABCDEF")))
+    (is (true?  (backgrounds/valid-custom? "  #abcdef  "))
+        "leading/trailing whitespace tolerated")))
+
+(deftest valid-custom-rejects-non-hex
+  (testing "valid-custom? rejects non-hex shapes"
+    (is (false? (backgrounds/valid-custom? "red")))
+    (is (false? (backgrounds/valid-custom? "rgb(1,2,3)")))
+    (is (false? (backgrounds/valid-custom? "#xyz")))
+    (is (false? (backgrounds/valid-custom? "#ab")))   ;; too short
+    (is (false? (backgrounds/valid-custom? "abcdef"))) ;; missing #
+    (is (false? (backgrounds/valid-custom? nil)))
+    (is (false? (backgrounds/valid-custom? :keyword)))))
+
+;; ---- pure: coerce -------------------------------------------------------
+
+(deftest coerce-preset-keyword-passes-through
+  (is (= :dark (backgrounds/coerce :dark)))
+  (is (= :transparent (backgrounds/coerce :transparent))))
+
+(deftest coerce-unknown-keyword-returns-nil
+  (is (nil? (backgrounds/coerce :Mode.unknown/whatever)))
+  (is (nil? (backgrounds/coerce :neon))))
+
+(deftest coerce-trims-custom-hex
+  (testing "a valid hex string coerces to the trimmed form"
+    (is (= "#abcdef"
+           (backgrounds/coerce "  #abcdef  ")))))
+
+(deftest coerce-bad-custom-returns-nil
+  (is (nil? (backgrounds/coerce "red")))
+  (is (nil? (backgrounds/coerce nil)))
+  (is (nil? (backgrounds/coerce 42))))
+
+;; ---- pure: resolve precedence -------------------------------------------
+
+(deftest resolve-falls-back-to-light-when-empty
+  (testing "no override + no selection → :light default"
+    (let [r (backgrounds/resolve nil nil)]
+      (is (= "Light"   (:label r)))
+      (is (= "#ffffff" (:color r))))))
+
+(deftest resolve-uses-toolbar-selection-when-no-override
+  (testing "toolbar selection wins when override absent"
+    (let [r (backgrounds/resolve nil :dark)]
+      (is (= "Dark"    (:label r)))
+      (is (= "#1a1a1a" (:color r))))))
+
+(deftest resolve-story-override-beats-toolbar
+  (testing "rf2-zll4h precedence: story-override wins"
+    (let [r (backgrounds/resolve :midnight :dark)]
+      (is (= "Midnight" (:label r))))))
+
+(deftest resolve-custom-override-beats-toolbar
+  (testing "a custom hex as the story-override is honoured"
+    (let [r (backgrounds/resolve "#abc123" :dark)]
+      (is (= "#abc123" (:color r)))
+      (is (re-find #"abc123" (:label r))))))
+
+(deftest resolve-bad-override-falls-through-to-toolbar
+  (testing "an unrecognised override does NOT block the toolbar fallback"
+    (let [r (backgrounds/resolve :neon :dark)]
+      (is (= "Dark" (:label r))
+          "unknown override fell through to the live toolbar selection"))))
+
+(deftest resolve-id-returns-keyword-or-custom
+  (is (= :light (backgrounds/resolve-id nil nil)))
+  (is (= :dark  (backgrounds/resolve-id nil :dark)))
+  (is (= :midnight (backgrounds/resolve-id :midnight :dark)))
+  (is (= :custom (backgrounds/resolve-id "#abc123" nil))))
+
+;; ---- pure: wrap-style ----------------------------------------------------
+
+(deftest wrap-style-flat-colour
+  (testing "a flat colour produces a :background-color CSS map"
+    (is (= {:background-color "#abcdef"}
+           (backgrounds/wrap-style {:color "#abcdef"})))))
+
+(deftest wrap-style-checkerboard
+  (testing "the :checkerboard sentinel produces a CSS gradient set"
+    (let [s (backgrounds/wrap-style {:color :checkerboard})]
+      (is (string? (:background-image s))
+          "checkerboard uses background-image gradients")
+      (is (= "#ffffff" (:background-color s))
+          "white base for the checkerboard")
+      (is (re-find #"linear-gradient"
+                   (:background-image s))))))
+
+(deftest wrap-style-nil-for-unknown
+  (testing "unknown colour shape → nil (caller falls back)"
+    (is (nil? (backgrounds/wrap-style {:color 42})))))
+
+;; ---- localStorage round-trip --------------------------------------------
+
+#?(:cljs
+   (defn- browser?
+     []
+     (and (exists? js/window) (.-localStorage js/window))))
+
+#?(:cljs
+   (defn- clear-storage!
+     []
+     (when (browser?)
+       (try (.removeItem (.-localStorage js/window) backgrounds/ls-key)
+            (catch :default _ nil)))))
+
+#?(:cljs
+   (deftest storage-roundtrip-preset
+     (when (browser?)
+       (clear-storage!)
+       (backgrounds/save-to-storage! :dark)
+       (is (= :dark (backgrounds/load-from-storage)))
+       (clear-storage!))))
+
+#?(:cljs
+   (deftest storage-roundtrip-custom
+     (when (browser?)
+       (clear-storage!)
+       (backgrounds/save-to-storage! "#abc123")
+       (is (= "#abc123" (backgrounds/load-from-storage)))
+       (clear-storage!))))
+
+#?(:cljs
+   (deftest storage-save-nil-clears
+     (when (browser?)
+       (clear-storage!)
+       (backgrounds/save-to-storage! :dark)
+       (is (some? (backgrounds/load-from-storage)))
+       (backgrounds/save-to-storage! nil)
+       (is (nil? (backgrounds/load-from-storage)))
+       (clear-storage!))))
+
+#?(:cljs
+   (deftest storage-rejects-invalid-on-save
+     (when (browser?)
+       (clear-storage!)
+       (backgrounds/save-to-storage! :neon)
+       (is (nil? (backgrounds/load-from-storage)))
+       (backgrounds/save-to-storage! "rgb(1,2,3)")
+       (is (nil? (backgrounds/load-from-storage))))))

--- a/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
@@ -1,0 +1,155 @@
+(ns re-frame.story.ui.backgrounds-switcher-cljs-test
+  "CLJS-side smoke tests for the backgrounds switcher chip (rf2-zll4h).
+
+  Coverage mirrors `viewport_switcher_cljs_test`:
+
+  - `select!` writes through to shell-state-atom.
+  - The chip renders without throwing.
+  - Per-story override beats the toolbar selection at resolve time.
+  - The chip emits `aria-haspopup` rather than `aria-pressed` so the
+    toolbar reset assertion is not tripped."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            #?@(:cljs [[re-frame.story.backgrounds :as backgrounds]
+                       [re-frame.story.ui.backgrounds-switcher :as bs]
+                       [re-frame.story.ui.state :as state]])))
+
+#?(:cljs
+   (defn reset-all! []
+     (story/clear-all!)
+     (state/reset-shell-state!)
+     (bs/close!)
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.removeItem (.-localStorage js/window) backgrounds/ls-key)
+            (catch :default _ nil)))
+     (story/install-canonical-vocabulary!)))
+
+#?(:cljs
+   (use-fixtures :each {:before reset-all!}))
+
+;; ---- pure-ish: select! mutations ----------------------------------------
+
+#?(:cljs
+   (deftest cljs-select-writes-shell-state
+     (testing "select! lands the normalised choice on shell-state-atom"
+       (bs/select! :dark)
+       (is (= :dark (:background (state/get-state))))
+       (bs/select! :midnight)
+       (is (= :midnight (:background (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-select-custom-writes-hex
+     (testing "a custom hex persists as a trimmed string"
+       (bs/select! "#abc123")
+       (is (= "#abc123" (:background (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-select-drops-unknown
+     (testing "unknown preset → slot cleared"
+       (bs/select! :dark)
+       (is (= :dark (:background (state/get-state))))
+       (bs/select! :neon)
+       (is (nil? (:background (state/get-state)))))))
+
+;; ---- per-story override resolution --------------------------------------
+
+#?(:cljs
+   (deftest cljs-effective-background-respects-variant-override
+     (testing "rf2-zll4h: per-variant :background body slot beats toolbar"
+       (story/reg-story* :story.bg-override
+         {:doc "background override fixture" :component :ignored
+          :background :paper})
+       (story/reg-variant* :story.bg-override/v
+         {:doc "child" :background :midnight})
+       (state/swap-state! assoc :background :dark)
+       (state/swap-state! assoc :selected-variant :story.bg-override/v)
+       (let [eff (bs/effective-background)]
+         (is (= "Midnight" (:label eff))
+             "variant :background (:midnight) wins over toolbar (:dark)"))
+       (is (= :midnight (bs/effective-id))))))
+
+#?(:cljs
+   (deftest cljs-effective-background-falls-through-to-story
+     (testing "no variant override → parent story's :background applies"
+       (story/reg-story* :story.bg-story-only
+         {:doc "story-level override only" :component :ignored
+          :background :paper})
+       (story/reg-variant* :story.bg-story-only/v
+         {:doc "child"})
+       (state/swap-state! assoc :background :dark)
+       (state/swap-state! assoc :selected-variant :story.bg-story-only/v)
+       (let [eff (bs/effective-background)]
+         (is (= "Paper" (:label eff))))
+       (is (= :paper (bs/effective-id))))))
+
+#?(:cljs
+   (deftest cljs-effective-background-falls-through-to-toolbar
+     (testing "no override → toolbar selection takes effect"
+       (state/swap-state! assoc :background :dark)
+       (let [eff (bs/effective-background)]
+         (is (= "Dark" (:label eff)))))))
+
+#?(:cljs
+   (deftest cljs-effective-background-default-is-light
+     (testing "no override + no selection → :light"
+       (let [eff (bs/effective-background)]
+         (is (= "Light" (:label eff)))
+         (is (= "#ffffff" (:color eff)))))))
+
+;; ---- the chip renders without throwing ----------------------------------
+
+#?(:cljs
+   (deftest cljs-chip-renders-without-throwing
+     (testing "chip-when-enabled returns a hiccup tree"
+       (let [hiccup (bs/chip-when-enabled)]
+         (is (some? hiccup))))))
+
+#?(:cljs
+   (deftest cljs-chip-uses-aria-haspopup-not-aria-pressed
+     (testing "rf2-zll4h reset-gate: chip MUST NOT emit aria-pressed='true'"
+       (let [hiccup (bs/chip)]
+         (let [flat (->> (tree-seq coll? seq hiccup)
+                         (filter map?))
+               attrs-with-button (filter #(or (:aria-haspopup %)
+                                              (:aria-pressed %)) flat)
+               aria-pressed-vals (keep :aria-pressed attrs-with-button)
+               aria-haspopup-vals (keep :aria-haspopup attrs-with-button)]
+           (is (seq aria-haspopup-vals))
+           (is (not-any? #(= "true" %) aria-pressed-vals)
+               "no element under the chip is aria-pressed='true' by default"))))))
+
+#?(:cljs
+   (deftest cljs-chip-data-attrs
+     (testing "chip carries data-test + data-background for browser specs"
+       (let [hiccup (bs/chip)
+             flat   (->> (tree-seq coll? seq hiccup)
+                         (filter map?))
+             attrs  (filter #(= "story-toolbar-backgrounds"
+                                (:data-test %)) flat)]
+         (is (= 1 (count attrs)))
+         (is (= "light" (:data-background (first attrs)))
+             "default render reports :light")))))
+
+;; ---- localStorage hydration ---------------------------------------------
+
+#?(:cljs
+   (defn- browser? []
+     (and (exists? js/window) (.-localStorage js/window))))
+
+#?(:cljs
+   (deftest cljs-hydrate-from-storage-seeds-empty-slot
+     (when (browser?)
+       (backgrounds/save-to-storage! :dark)
+       (state/reset-shell-state!)
+       (is (nil? (:background (state/get-state))))
+       (bs/hydrate!)
+       (is (= :dark (:background (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-hydrate-skips-populated-slot
+     (when (browser?)
+       (backgrounds/save-to-storage! :dark)
+       (state/swap-state! assoc :background :midnight)
+       (bs/hydrate!)
+       (is (= :midnight (:background (state/get-state)))
+           "populated slot was preserved"))))

--- a/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
@@ -1,0 +1,168 @@
+(ns re-frame.story.ui.viewport-switcher-cljs-test
+  "CLJS-side smoke tests for the viewport switcher chip (rf2-zll4h).
+
+  Runs in shadow's `:node-test` build (the ns name ends in `cljs-test`
+  to match `:ns-regexp \"cljs-test$\"`). The JVM gate is covered by
+  `re-frame.story.viewport-test`; this ns exercises the CLJS-only
+  surfaces:
+
+  - `select!` writes through to shell-state-atom.
+  - The chip renders without throwing.
+  - Per-story override beats the toolbar selection at resolve time.
+  - The chip emits `aria-haspopup` + `aria-expanded` (NOT
+    `aria-pressed`) so the toolbar reset assertion is not tripped."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story :as story]
+            #?@(:cljs [[re-frame.story.ui.state :as state]
+                       [re-frame.story.ui.viewport-switcher :as vs]
+                       [re-frame.story.viewport :as viewport]])))
+
+#?(:cljs
+   (defn reset-all! []
+     (story/clear-all!)
+     (state/reset-shell-state!)
+     (vs/close!)
+     (when (and (exists? js/window) (.-localStorage js/window))
+       (try (.removeItem (.-localStorage js/window) viewport/ls-key)
+            (catch :default _ nil)))
+     (story/install-canonical-vocabulary!)))
+
+#?(:cljs
+   (use-fixtures :each {:before reset-all!}))
+
+;; ---- pure-ish: select! mutations ----------------------------------------
+
+#?(:cljs
+   (deftest cljs-select-writes-shell-state
+     (testing "select! lands the normalised choice on shell-state-atom"
+       (vs/select! :tablet)
+       (is (= :tablet (:viewport (state/get-state))))
+       (vs/select! :mobile-portrait)
+       (is (= :mobile-portrait (:viewport (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-select-custom-writes-map
+     (testing "a custom map persists as a slim {:width :height}"
+       (vs/select! {:width 800 :height 600})
+       (is (= {:width 800 :height 600} (:viewport (state/get-state)))))))
+
+#?(:cljs
+   (deftest cljs-select-drops-unknown
+     (testing "an unknown preset coerces to nil — slot is cleared"
+       (vs/select! :tablet)
+       (is (= :tablet (:viewport (state/get-state))))
+       (vs/select! :phablet)
+       (is (nil? (:viewport (state/get-state)))))))
+
+;; ---- per-story override resolution --------------------------------------
+
+#?(:cljs
+   (deftest cljs-effective-viewport-respects-variant-override
+     (testing "rf2-zll4h: per-variant :viewport body slot beats toolbar"
+       (story/reg-story* :story.vp-override
+         {:doc "viewport override fixture" :component :ignored
+          :viewport :desktop})
+       (story/reg-variant* :story.vp-override/v
+         {:doc "child" :viewport :mobile-portrait})
+       (state/swap-state! assoc :viewport :tablet)
+       (state/swap-state! assoc :selected-variant :story.vp-override/v)
+       (let [eff (vs/effective-viewport)]
+         (is (= "Mobile portrait" (:label eff))
+             "variant body's :viewport (:mobile-portrait) wins over toolbar (:tablet)"))
+       (is (= :mobile-portrait (vs/effective-id))))))
+
+#?(:cljs
+   (deftest cljs-effective-viewport-falls-through-to-story
+     (testing "variant has no :viewport → parent story's :viewport applies"
+       (story/reg-story* :story.vp-story-only
+         {:doc "story-level override only" :component :ignored
+          :viewport :desktop})
+       (story/reg-variant* :story.vp-story-only/v
+         {:doc "child"})
+       (state/swap-state! assoc :viewport :tablet)
+       (state/swap-state! assoc :selected-variant :story.vp-story-only/v)
+       (let [eff (vs/effective-viewport)]
+         (is (= "Desktop" (:label eff))))
+       (is (= :desktop (vs/effective-id))))))
+
+#?(:cljs
+   (deftest cljs-effective-viewport-falls-through-to-toolbar
+     (testing "no override → toolbar selection takes effect"
+       (state/swap-state! assoc :viewport :tablet)
+       (let [eff (vs/effective-viewport)]
+         (is (= "Tablet" (:label eff)))))))
+
+#?(:cljs
+   (deftest cljs-effective-viewport-default-is-full
+     (testing "no override + no selection → :full"
+       (let [eff (vs/effective-viewport)]
+         (is (= "Full" (:label eff)))
+         (is (nil? (:width eff)))))))
+
+;; ---- the chip renders without throwing ----------------------------------
+
+#?(:cljs
+   (deftest cljs-chip-renders-without-throwing
+     (testing "chip-when-enabled returns a hiccup tree (no exceptions)"
+       (let [hiccup (vs/chip-when-enabled)]
+         (is (some? hiccup))))))
+
+#?(:cljs
+   (deftest cljs-chip-uses-aria-haspopup-not-aria-pressed
+     (testing "rf2-zll4h reset-gate: chip MUST NOT emit aria-pressed='true'
+               by default. The toolbar reset assertion in
+               story_feature_load counts [aria-pressed='true'] post-reset
+               and demands count === 0."
+       (let [hiccup (vs/chip)]
+         ;; The chip render returns [:span ... [:button {...}]]; the
+         ;; button's attribute map is the second element of the inner
+         ;; button vector. Walk the hiccup defensively.
+         (let [flat (->> (tree-seq coll? seq hiccup)
+                         (filter map?))
+               attrs-with-button (filter #(or (:aria-haspopup %)
+                                              (:aria-pressed %)) flat)
+               aria-pressed-vals (keep :aria-pressed attrs-with-button)
+               aria-haspopup-vals (keep :aria-haspopup attrs-with-button)]
+           (is (seq aria-haspopup-vals)
+               "the chip exposes aria-haspopup for screen readers")
+           (is (not-any? #(= "true" %) aria-pressed-vals)
+               "no element under the chip is aria-pressed='true' by default"))))))
+
+#?(:cljs
+   (deftest cljs-chip-data-attrs
+     (testing "chip carries data-test + data-viewport for browser specs"
+       (let [hiccup (vs/chip)
+             flat   (->> (tree-seq coll? seq hiccup)
+                         (filter map?))
+             attrs  (filter #(= "story-toolbar-viewport"
+                                (:data-test %)) flat)]
+         (is (= 1 (count attrs))
+             "exactly one chip element carries the data-test handle")
+         (is (= "full" (:data-viewport (first attrs)))
+             "default render reports :full")))))
+
+;; ---- localStorage hydration ---------------------------------------------
+
+#?(:cljs
+   (defn- browser? []
+     (and (exists? js/window) (.-localStorage js/window))))
+
+#?(:cljs
+   (deftest cljs-hydrate-from-storage-seeds-empty-slot
+     (testing "hydrate! seeds the shell slot from persisted localStorage"
+       (when (browser?)
+         (viewport/save-to-storage! :tablet)
+         (state/reset-shell-state!)
+         (is (nil? (:viewport (state/get-state))))
+         (vs/hydrate!)
+         (is (= :tablet (:viewport (state/get-state))))))))
+
+#?(:cljs
+   (deftest cljs-hydrate-skips-populated-slot
+     (testing "hydrate is idempotent — leaves an already-populated slot alone"
+       (when (browser?)
+         (viewport/save-to-storage! :tablet)
+         (state/swap-state! assoc :viewport :mobile-portrait)
+         (vs/hydrate!)
+         (is (= :mobile-portrait (:viewport (state/get-state)))
+             "populated slot was preserved")))))

--- a/tools/story/test/re_frame/story/viewport_test.cljc
+++ b/tools/story/test/re_frame/story/viewport_test.cljc
@@ -1,0 +1,193 @@
+(ns re-frame.story.viewport-test
+  "Tests for the viewport switcher's pure state model (rf2-zll4h).
+
+  Runs on both the JVM (cognitect.test-runner under `clojure -M:test`)
+  and the CLJS node-test build (shadow's `:node-test` target — the
+  ns name doesn't end in `cljs-test` so the JVM gate is the primary
+  surface; CLJS coverage comes from the parallel
+  `viewport_switcher_cljs_test`).
+
+  Coverage layers:
+
+  - Preset lookup by id.
+  - Custom `{:width :height}` validation.
+  - Selection precedence (story-override > toolbar selection > default).
+  - `wrap-style` shape (nil for `:full`, populated for sized presets).
+  - localStorage round-trip — CLJS-only, gated by `browser?`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.viewport :as viewport]))
+
+;; ---- preset table --------------------------------------------------------
+
+(deftest preset-table-includes-every-bead-mandated-id
+  (testing "every preset id called out by rf2-zll4h is present"
+    (let [expected #{:full :mobile-portrait :mobile-landscape
+                     :tablet :desktop :desktop-wide}]
+      (is (= expected (set (keys viewport/presets))))
+      (is (= expected (set viewport/preset-order))))))
+
+(deftest preset-full-has-no-dimensions
+  (testing ":full preset carries nil width + height (no resize)"
+    (let [p (get viewport/presets :full)]
+      (is (= "Full" (:label p)))
+      (is (nil? (:width p)))
+      (is (nil? (:height p))))))
+
+(deftest preset-tablet-has-canonical-dimensions
+  (testing ":tablet is 768x1024 (bead-mandated)"
+    (is (= {:label "Tablet" :width 768 :height 1024}
+           (get viewport/presets :tablet)))))
+
+;; ---- pure: valid-custom? ------------------------------------------------
+
+(deftest valid-custom-requires-positive-integer-dimensions
+  (testing "valid-custom? accepts only positive-integer width + height"
+    (is (true?  (viewport/valid-custom? {:width 800 :height 600})))
+    (is (true?  (viewport/valid-custom? {:width 1 :height 1})))
+    (is (false? (viewport/valid-custom? {:width 0 :height 600}))
+        "zero is not positive")
+    (is (false? (viewport/valid-custom? {:width -100 :height 600})))
+    (is (false? (viewport/valid-custom? {:width "800" :height "600"}))
+        "strings are not integers")
+    (is (false? (viewport/valid-custom? {:width 800})))
+    (is (false? (viewport/valid-custom? {})))
+    (is (false? (viewport/valid-custom? nil)))
+    (is (false? (viewport/valid-custom? "tablet")))))
+
+;; ---- pure: coerce -------------------------------------------------------
+
+(deftest coerce-preset-keyword-passes-through
+  (testing "a recognised preset keyword coerces to itself"
+    (is (= :tablet (viewport/coerce :tablet)))
+    (is (= :full   (viewport/coerce :full)))))
+
+(deftest coerce-unknown-keyword-returns-nil
+  (testing "an unrecognised keyword is dropped to nil"
+    (is (nil? (viewport/coerce :Mode.unknown/whatever)))
+    (is (nil? (viewport/coerce :phablet)))))
+
+(deftest coerce-custom-map-extracts-dims
+  (testing "a custom map coerces to a slim {:width :height} map"
+    (is (= {:width 800 :height 600}
+           (viewport/coerce {:width 800 :height 600 :label "extra"})))))
+
+(deftest coerce-bad-custom-returns-nil
+  (testing "a malformed custom map coerces to nil"
+    (is (nil? (viewport/coerce {:width "800" :height "600"})))
+    (is (nil? (viewport/coerce {:width 800})))
+    (is (nil? (viewport/coerce "800x600")))
+    (is (nil? (viewport/coerce nil)))))
+
+;; ---- pure: resolve precedence -------------------------------------------
+
+(deftest resolve-falls-back-to-full-when-empty
+  (testing "neither override nor selection → :full (no-resize) preset"
+    (let [r (viewport/resolve nil nil)]
+      (is (= "Full" (:label r)))
+      (is (nil? (:width r)))
+      (is (nil? (:height r))))))
+
+(deftest resolve-uses-toolbar-selection-when-no-override
+  (testing "toolbar selection wins when no per-story override is set"
+    (let [r (viewport/resolve nil :tablet)]
+      (is (= "Tablet" (:label r)))
+      (is (= 768 (:width r)))
+      (is (= 1024 (:height r))))))
+
+(deftest resolve-story-override-beats-toolbar
+  (testing "rf2-zll4h precedence: story-override wins over toolbar selection"
+    (let [r (viewport/resolve :mobile-portrait :tablet)]
+      (is (= "Mobile portrait" (:label r))
+          "override (:mobile-portrait) beat the toolbar (:tablet)"))))
+
+(deftest resolve-custom-override-beats-toolbar
+  (testing "a custom map as the story-override is honoured"
+    (let [r (viewport/resolve {:width 500 :height 300} :tablet)]
+      (is (= 500 (:width r)))
+      (is (= 300 (:height r)))
+      (is (re-find #"500" (:label r)))
+      (is (re-find #"300" (:label r))))))
+
+(deftest resolve-bad-override-falls-through-to-toolbar
+  (testing "an unrecognised override does NOT block the toolbar fallback"
+    (let [r (viewport/resolve :phablet :tablet)]
+      (is (= "Tablet" (:label r))
+          "unknown override fell through to the live toolbar selection"))))
+
+(deftest resolve-id-returns-keyword-or-custom
+  (testing "resolve-id surfaces the resolved id for data-* attributes"
+    (is (= :full    (viewport/resolve-id nil nil)))
+    (is (= :tablet  (viewport/resolve-id nil :tablet)))
+    (is (= :desktop (viewport/resolve-id :desktop :tablet)))
+    (is (= :custom  (viewport/resolve-id {:width 500 :height 300} nil)))))
+
+;; ---- pure: wrap-style ----------------------------------------------------
+
+(deftest wrap-style-nil-for-full
+  (testing ":full → nil wrapper (no sizing div needed)"
+    (is (nil? (viewport/wrap-style (get viewport/presets :full))))))
+
+(deftest wrap-style-populated-for-sized-preset
+  (testing "a sized preset produces width + height CSS"
+    (let [s (viewport/wrap-style (get viewport/presets :tablet))]
+      (is (= "768px" (:width s)))
+      (is (= "1024px" (:height s)))
+      (is (string? (:border s))
+          "the wrap carries a visible border")
+      (is (= "0 auto" (:margin s))
+          "centred horizontally"))))
+
+;; ---- localStorage round-trip --------------------------------------------
+;;
+;; CLJS only — JVM `load-from-storage` always returns nil.
+
+#?(:cljs
+   (defn- browser?
+     []
+     (and (exists? js/window) (.-localStorage js/window))))
+
+#?(:cljs
+   (defn- clear-storage!
+     []
+     (when (browser?)
+       (try (.removeItem (.-localStorage js/window) viewport/ls-key)
+            (catch :default _ nil)))))
+
+#?(:cljs
+   (deftest storage-roundtrip-preset
+     (testing "save → load returns the persisted preset id"
+       (when (browser?)
+         (clear-storage!)
+         (viewport/save-to-storage! :tablet)
+         (is (= :tablet (viewport/load-from-storage)))
+         (clear-storage!)))))
+
+#?(:cljs
+   (deftest storage-roundtrip-custom
+     (testing "save → load returns the persisted custom map"
+       (when (browser?)
+         (clear-storage!)
+         (viewport/save-to-storage! {:width 800 :height 600})
+         (is (= {:width 800 :height 600} (viewport/load-from-storage)))
+         (clear-storage!)))))
+
+#?(:cljs
+   (deftest storage-save-nil-clears
+     (testing "save-to-storage! nil clears the persisted slot"
+       (when (browser?)
+         (clear-storage!)
+         (viewport/save-to-storage! :tablet)
+         (is (some? (viewport/load-from-storage)))
+         (viewport/save-to-storage! nil)
+         (is (nil? (viewport/load-from-storage)))
+         (clear-storage!)))))
+
+#?(:cljs
+   (deftest storage-rejects-invalid-on-save
+     (testing "save-to-storage! drops invalid values to nil (no leak)"
+       (when (browser?)
+         (clear-storage!)
+         (viewport/save-to-storage! :phablet)         ;; unknown preset
+         (is (nil? (viewport/load-from-storage)))
+         (viewport/save-to-storage! {:width "no"})    ;; bad shape
+         (is (nil? (viewport/load-from-storage)))))))


### PR DESCRIPTION
## Summary

Storybook addon-viewport + addon-backgrounds parity for the re-frame2 Story tool (rf2-zll4h). Two new chrome-wide dropdowns let authors size the canvas at common viewports and swap the background colour without modifying the story body. Both axes support per-story / per-variant overrides via new `:viewport` and `:background` body slots.

## Viewport presets

| Id                  | Label             | Width × Height |
|---------------------|-------------------|----------------|
| `:full`             | Full              | (no resize)    |
| `:mobile-portrait`  | Mobile portrait   | 375 × 667      |
| `:mobile-landscape` | Mobile landscape  | 667 × 375      |
| `:tablet`           | Tablet            | 768 × 1024     |
| `:desktop`          | Desktop           | 1280 × 800     |
| `:desktop-wide`     | Desktop wide      | 1920 × 1080    |

Custom: ad-hoc `{:width N :height N}` map via the dropdown's bottom-row inputs.

## Background presets

| Id             | Label        | Colour                            |
|----------------|--------------|-----------------------------------|
| `:light`       | Light        | `#ffffff`                         |
| `:dark`        | Dark         | `#1a1a1a`                         |
| `:paper`       | Paper        | `#f9f9f9`                         |
| `:midnight`    | Midnight     | `#0a0a0a`                         |
| `:transparent` | Transparent  | CSS checkerboard (crossed gradients) |

Custom: hex colour string via `<input type=\"color\">`.

## Schema additions

Story + Variant gain two optional slots:

- `:viewport` — preset keyword or `{:width N :height N}` map.
- `:background` — preset keyword or hex colour string.

Resolution precedence at canvas mount: variant body > parent story body > chrome toolbar selection > neutral default (`:full` / `:light`). Unknown values fall through to the next level.

## Toolbar order

```
[modes-by-axis] ... [dispatch] [play-status] [viewport ▾] [backgrounds ▾] [REC] [reset]
```

Switcher chips use `aria-haspopup=\"menu\"` + `aria-expanded` (not `aria-pressed`) so the toolbar reset assertion in `story_feature_load.cjs` — `[aria-pressed=\"true\"]` count → 0 after reset — is never tripped by viewport / background state. The reset button still appears only when `:active-modes` is non-empty.

## Storage keys

- `re-frame.story/viewport`   — `pr-str`-encoded preset keyword or `{:width :height}` map.
- `re-frame.story/background` — `pr-str`-encoded preset keyword or hex colour string.

Hydration runs once on shell mount; no-op when slot is already populated.

## New files

- `tools/story/src/re_frame/story/viewport.cljc` — presets + pure resolve + storage round-trip.
- `tools/story/src/re_frame/story/backgrounds.cljc` — same.
- `tools/story/src/re_frame/story/ui/viewport_switcher.cljs` — toolbar chip + dropdown.
- `tools/story/src/re_frame/story/ui/backgrounds_switcher.cljs` — toolbar chip + dropdown.
- `tools/story/test/re_frame/story/viewport_test.cljc` — pure preset / resolve / storage tests.
- `tools/story/test/re_frame/story/backgrounds_test.cljc` — same.
- `tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc` — UI smoke (CLJS).
- `tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc` — UI smoke (CLJS).

## Modified files

- `tools/story/src/re_frame/story/schemas.cljc` — Story + Variant `:viewport` + `:background` slots.
- `tools/story/src/re_frame/story/ui/shell.cljs` — `framed-canvas` wrapper; hydrate switchers on mount.
- `tools/story/src/re_frame/story/ui/state.cljc` — `:viewport` + `:background` default-shell-state slots.
- `tools/story/src/re_frame/story/ui/toolbar.cljs` — register both chips before the recorder REC chip.

## Test plan

- [x] `clojure -M:test` in `tools/story` — 618 tests, 0 failures.
- [x] `npm run test:cljs` in `implementation` — 2748 tests, 0 failures.
- [x] `npm run test:browser` in `implementation` — 2737 tests, 0 failures.
- [x] `npm run story:build` in `implementation` — builds cleanly (251 files).
- [x] `npm run test:story-feature-load` in `implementation` — 2 specs, 0 failures (existing recorder review-dialog reset gate preserved).
- [x] `scripts/test-fast-pr.sh` — PASS.
- [x] `scripts/test-jvm-tools.sh` — PASS.

## Divergences / follow-ons

None. Both inline custom inputs (W×H + colour picker) ship in v1 as the bead allowed. No overflow menu needed — the chip cluster reads cleanly at typical viewport widths.