### PR TITLE
docs(causa): post-impl spec sweep — backfill for landed features

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -333,6 +333,73 @@ per-machine in localStorage).
 - **Transition history** virtualises past 200 entries; older entries
   scroll into view but are not retained in DOM.
 
+## Layout engine — ELK with layered fallback
+
+Two layout engines flow through `chart/svg.cljc`'s renderer behind the
+same `{:nodes :edges :width :height :initial-id}` data shape:
+
+| Engine | Source ns | When used |
+|---|---|---|
+| **ELK.js** (preferred) | `chart/elk_layout.cljs` | Browser session once the lazy import resolves; produces orthogonal edge routing + layered placement. |
+| **Layered fallback** | `chart/layout.cljc` (`layered-fallback`) | Sync, pure, JVM-runnable. Used by the JVM + node-runtime test corpus, and as the runtime fallback whenever ELK is unavailable. Simple BFS-rank placement + straight-line edges. |
+
+### Lazy load + render-pulse cadence
+
+ELK.js is a ~250 kB browser bundle (gzipped). Bundling it into every
+Causa dev session would inflate the preload cost whether the user
+opens the Machines tab or not, so the loader mirrors the Causality
+popover pattern (per [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md)
+§Causality popover):
+
+1. First open of the Machines tab triggers a `js/import` of
+   `"elkjs/lib/elk.bundled.js"`.
+2. The loader atom tracks `nil → :loading → {:elk <inst>} | {:failed <msg>}`.
+3. ELK's `layout` returns a Promise — the synchronous renderer can't
+   wait. So the panel renders the **layered-fallback layout
+   immediately**, kicks the ELK pass in the background, caches the
+   result keyed on `[definition direction]`, and dispatches a no-op
+   render-pulse event so the subscribe-driven view re-runs and picks
+   up the cached ELK positions on the next tick.
+4. Subsequent renders of the same `[definition direction]` resolve
+   synchronously from the cache; the cache holds the most-recent
+   layout (one machine inspected at a time is the common case).
+
+### Fallback semantics
+
+The fallback engages whenever ELK is not ready or the layout call
+rejects — three concrete paths:
+
+| Trigger | Cause |
+|---|---|
+| Offline / CSP block | The dynamic `js/import` rejects with a module-not-found. |
+| Test rigs | Node + JVM runtimes have no bundler-resolvable `elkjs`; the import is unavailable. |
+| Transient layout failure | ELK's `.layout` Promise rejects (rare). The cache is left untouched; the next render-pulse retries. |
+
+In every fallback path the chart still mounts — the `layered-fallback`
+shape is data-compatible with ELK's positioned output. The user gets
+a readable chart that loses orthogonal routing but keeps the
+node/edge content. v1 does NOT surface a "layout engine: fallback"
+status indicator on the Machines tab itself (the chart just renders);
+the Causality popover surfaces an equivalent hint because its graph
+density makes the missing-orthogonal-router more visually jarring.
+
+### v1 ships (deferred follow-ons)
+
+- **Edge polylines from ELK's bend points** — v1 collapses ELK's
+  multi-point routes to straight lines between source/target centres.
+  `chart/svg.cljc` already supports the multi-point case via
+  `path-from-points`; lifting ELK's bend points into the `:points`
+  slot is follow-on work.
+- **Compound-state hierarchical containment in ELK** — v1 ships every
+  state as a flat ELK child + relies on the existing dashed-border
+  treatment for visual grouping. ELK's hierarchical mode (parent
+  containers with child layout) is a richer follow-on.
+- **Unified ELK loader** — both this surface and the Causality
+  popover (`popover/causality_graph.cljs`) hold their own loader atom
+  so the two consumers fail independently. In practice once one
+  succeeds the other will too. A future bead can fold the loader into
+  a shared `chart/elk_loader.cljs`.
+
 ## Share affordance
 
 Right-click on the machine chart (or use the panel header's `⋯`

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -528,6 +528,60 @@ Every value display in every tab's L4 detail panel uses
 the Chrome console (formatters API); its output is not in-page hiccup.
 Hand-built renderer matching the aesthetic using Causa's theme tokens.
 
+### Renderer contract (v1 ships)
+
+The cljs-devtools-shaped surface (rf2-x9fzk):
+
+| Knob | Default | Purpose |
+|---|---|---|
+| `collapse-threshold` | `5` | Collections longer than this start collapsed; the user clicks `▶` to expand. Map literals ≤ 5 keys render flat; typical app-db slices don't dump every key on initial render. |
+| `string-inline-cap` | `64` | Strings longer than this tail-ellide in `inspect-inline`; the full value remains visible via the parent collection's expand affordance. |
+| `large-fetch-warn-threshold-bytes` | `100000` (100 KB) | Per [`018-Event-Spine.md`](./018-Event-Spine.md) §12 — `:rf/large` expansions above this size gate behind a confirm step so a stray click can't pour a multi-megabyte expansion into the detail panel. |
+
+**Colour palette** (mapped onto Causa's theme tokens so the renderer
+reads as native shell chrome): keywords violet (`:accent-violet`),
+strings green, numbers cyan, nil tertiary, booleans orange, symbols
+magenta, default `text-primary`. Punctuation + meta render in
+`text-tertiary` / `text-secondary` to recede.
+
+**Substrate-agnostic state.** Per the pure-hiccup contract
+([Conventions rf2-tijr](./Conventions.md)) the renderer never
+references Reagent / UIx / Helix. Per-node expand state lives in
+`:rf/causa` app-db under `[:data-inspector <node-key> …]` and is
+read/written via re-frame primitives:
+
+- `:rf.causa.data-inspector/expansion <node-key>` — sub for one node's
+  state.
+- `:rf.causa.data-inspector/toggle-expanded <node-key>` — flip.
+- `:rf.causa.data-inspector/request-large-confirm <node-key>` /
+  `:rf.causa.data-inspector/confirm-large <node-key>` — two-step
+  confirmation for `:rf/large` sentinels above the size threshold.
+
+Each L4 panel mount supplies a unique `node-key` prefix so two panels
+rendered side-by-side don't share expand state. See
+[`014-Registry-Catalogue.md`](./014-Registry-Catalogue.md) for the
+catalogued ids.
+
+### Sentinel chips
+
+The renderer recognises three `spec/015-Data-Classification` sentinel
+shapes and emits bespoke chrome (per [`018-Event-Spine.md`](./018-Event-Spine.md)
+§12):
+
+- `:rf/redacted` (bare keyword) — magenta opaque chip
+  (`● redacted`); italic small-caps; **never** expandable, no reveal
+  affordance ever.
+- `{:rf/large {:bytes N :head "…"}}` — yellow chip
+  (`● large · N bytes · "head…"`); click reveals an inline expansion
+  showing the full `:head` preview. Sizes above
+  `large-fetch-warn-threshold-bytes` gate behind an inline confirm
+  prompt (textual "Expand N bytes? (>100000 threshold)" + Confirm
+  button) rather than a full modal — v1 ships the inline prompt so
+  the renderer doesn't drag in modal infrastructure.
+- `{:rf/redacted {:bytes N}}` — combined sensitive + large; magenta
+  with size shown for diagnostic; **never** expandable (sensitive
+  dominates content visibility).
+
 ## Data-classification rendering
 
 Per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md):

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -173,6 +173,69 @@ preload's adapter-ready probe sees the final launch posture before it
 would otherwise diagnose a missing host. The missing-host diagnostic is
 unchanged for the default path and for explicit opens.
 
+### `:settings`
+
+Bulk-replace the Settings popup state map (rf2-9poxq). Shape mirrors
+the `default-settings` block in `config.cljc`:
+
+```clojure
+{:general   {:text-size           13          ; px; slider range 10–18
+             :panel-position      :right-rail ; :right-rail | :popout | :fullscreen
+             :auto-open-on-error? false}
+ :theme     :dark                              ; :dark | :light
+ :telemetry {:opt-in?             false}}
+```
+
+| Value | Meaning |
+|---|---|
+| Map | Deep-merge over `default-settings` (per-section). Persists immediately to the localStorage key `re-frame2.causa.settings.v1` so the next page load reads the host-supplied posture. |
+| (absent) | Leave the live settings map untouched. |
+
+The popup's per-knob event surface (`:rf.causa/settings-update`) is
+the normal write path; this key is the bulk-set escape hatch for
+hosts that want to ship their own factory defaults (corporate fork
+with light theme, embedded host that prefers `:fullscreen` panel
+position, etc.).
+
+Default-defining shape, per-knob rationale and the localStorage key
+are normatively documented in
+[`016-Auxiliary-Panels.md`](./016-Auxiliary-Panels.md) §Settings popup
+— v1 ships. The `:editor` / `:project-root` / `:launch/auto-open?` /
+`:trace/show-sensitive?` keys above remain process-global atoms
+distinct from `:settings` (their semantics predate the popup; the
+popup-managed surface is the `{:settings <map>}` shape).
+
+### `:filters`
+
+Host-supplied seed pill set the registry hydrates `:active-filters`
+with on **first install** (when localStorage is empty). Per
+[`018-Event-Spine.md`](./018-Event-Spine.md) §7 'Empty defaults',
+Causa ships with no filters by default (first-session honesty beats
+first-session quietness). The seed is the escape hatch for hosts
+that have a reason to ship a starting posture — typically Story
+testbeds that need a known starting point for reproducibility.
+
+| Value | Meaning |
+|---|---|
+| `{:in [{:pattern <…>} …] :out [{:pattern <…>} …]}` | Seed the slot on first install only. The seed never clobbers a user's hand-tuned set — once localStorage carries any pill, the seed is ignored. |
+| `nil` (default) | No seed; registry defaults to `{:in [] :out []}`. |
+
+### `:filters/storage-key`
+
+The localStorage key the filter persistence layer reads / writes.
+
+| Value | Meaning |
+|---|---|
+| String | Use this key for round-trip. Hosts that run multiple Causa instances in the same browser session (e.g. Story testbeds) override so each instance keeps its own pill state. |
+| `nil` | Reset to default. |
+
+Default: `"re-frame2.causa.filters.v1"` (versioned so future schema
+changes can ignore stale payloads).
+
+When both `:filters` and `:filters/storage-key` are passed in one
+call, the storage key is set BEFORE the seed so a host that overrides
+both gets the seed persisted under the right key.
+
 ## App-db slots
 
 `configure!` is the host-visible surface; under the hood, Causa
@@ -228,12 +291,16 @@ The following keys are **reserved** for future `configure!` extension.
 Hosts MUST NOT use them for their own purposes; future Causa releases
 MAY assign them semantics.
 
-- `:theme`, `:density`, `:default-frame`, `:ai-provider`,
-  `:buffer-depths`, `:sidebar-mode`, `:launcher-pill`, `:keybindings`
-  — all currently owned by `(causa/init! opts)` and the persisted
-  Settings shape per [`API.md`](./API.md). A future consolidation MAY
-  migrate them through `configure!`; until then, set them via the
-  per-instance / per-localStorage paths.
+- `:density`, `:default-frame`, `:ai-provider`, `:buffer-depths`,
+  `:sidebar-mode`, `:launcher-pill`, `:keybindings` — all currently
+  owned by `(causa/init! opts)` and the persisted Settings shape per
+  [`API.md`](./API.md). A future consolidation MAY migrate them
+  through `configure!`; until then, set them via the per-instance /
+  per-localStorage paths.
+
+Note: `:theme` is **no longer reserved** — it now lives inside the
+`:settings` map (see above) and is reachable via the Settings popup's
+Theme tab or `(configure! {:settings {:theme :light}})`.
 
 ## Production posture
 

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -265,6 +265,178 @@ filter-pill UX (per [`018-Event-Spine.md`](./018-Event-Spine.md) §5.3)
 covers "show me only what the agent did" via an IN pill on `:origin
 pair2-mcp`.
 
+## Settings popup — v1 ships
+
+The Settings popup modal (trigger: `,` / `s` / ribbon `⚙`) is the
+transient overlay through which the user tunes Causa's preferences.
+The architectural shape — modal not panel, persistence-on-commit,
+section-per-row — is normatively specified in
+[`018-Event-Spine.md`](./018-Event-Spine.md) §9. This section
+backfills what v1 actually ships.
+
+### v1 tab inventory
+
+| Tab | What it carries |
+|---|---|
+| **General** (default) | Text-size slider (range 10–18 px; writes the `--rf-causa-text-size` CSS custom property on the shell root + `<html>`) · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen` — routes to `mount/open!` / `mount/popout!` / `mount/open-overlay!` via the browser API exports) · "Auto-open Causa when an issue is observed" checkbox |
+| **Filters** | Pointer into the auto-filter pills feature. When the `day8.re-frame2-causa.filters` ns is on the classpath the tab renders an "Open auto-filter UI" button that dispatches `:rf.causa.filters/open`; otherwise it shows the "install the feature first" hint. The full pill management surface lives in the ribbon (per [`018-Event-Spine.md`](./018-Event-Spine.md) §7) — this tab is a discoverability handle. |
+| **Theme** | Dark (default) / Light radio. Toggles the `rf-causa-theme-{dark,light}` class on the shell root + `<html>`. Accent picker deferred. |
+| **Telemetry** | Single "Send anonymous usage telemetry" checkbox, **default OFF** (opt-in). No telemetry endpoint exists in v1 — the toggle round-trips to localStorage so a future endpoint lands with the user's preference already persisted. |
+
+**v1 ships:** four tabs (General / Filters / Theme / Telemetry). The
+fuller [`018-Event-Spine.md`](./018-Event-Spine.md) §9 catalogue
+(Keybindings, Buffer, Popout, Actions) is deferred to follow-on
+beads.
+
+### Defaults
+
+| Slot | Default | Rationale |
+|---|---|---|
+| `:general :text-size` | `13` (px) | Matches `theme/tokens.cljc :type-scale :body`. |
+| `:general :panel-position` | `:right-rail` | Matches the existing `:layout/host-selector` inline-host posture per [`015-Configuration.md`](./015-Configuration.md). |
+| `:general :auto-open-on-error?` | `false` | The user is in their app, not asking Causa to interrupt them. |
+| `:theme` | `:dark` | Causa is a dev tool; the canvas-and-chrome palette in `theme/tokens.cljc` is the dark one. |
+| `:telemetry :opt-in?` | `false` | Opt-in; no payloads sent. |
+
+### Persistence
+
+- **Storage key:** `re-frame2.causa.settings.v1` (versioned so future
+  schema changes can ignore stale payloads without colliding with the
+  old shape).
+- **One nested map, not one atom per knob** — the round-trip is a
+  single `pr-str` of the whole settings shape; serialisation drift
+  between knobs is structurally impossible. Loaded from localStorage
+  at preload time via `config/load-settings-from-storage!`; applied to
+  the live shell before first paint via
+  `settings/effects/apply-all!`.
+- **Dual-write on change.** `:rf.causa/settings-update [section key
+  value]` writes through to (a) the in-process atom in `config.cljc`
+  (canonical, drives the localStorage round-trip) AND (b) Causa's
+  app-db at `[:settings <section> <key>]` (drives the immediate
+  reactive re-render of the popup's controls). Without the dual-write
+  the popup's radio buttons would not redraw until the user closed
+  and reopened the modal.
+
+### Auto-open-on-error semantics
+
+When `:auto-open-on-error?` flips ON, a sub-watcher is installed
+against the existing `:rf.causa/issues-ribbon` sub. On the **first
+empty → non-empty** transition (and only when Causa is not already
+visible) the watcher dispatches the late-bound `mount/open!` browser
+API export. Two install triggers (both idempotent): (1) on toggle
+flip-on inside `:rf.causa/settings-update`, and (2) on first Causa
+open via `mount/ensure-causa-frame!` when the persisted toggle is
+already on. The install is a **defensive no-op pre-mount** — if the
+`:rf/causa` frame isn't yet registered, the subscribe would return
+nil and `(add-watch nil …)` would throw; the frame-presence guard
+makes the early call safe and the watcher lands on first frame
+registration. Detached on flip-off.
+
+### Bulk configure! escape hatch
+
+`(causa-config/configure! {:settings <map>})` bulk-replaces the
+whole settings map. Shape mirrors the defaults table above. The
+popup's per-knob event surface is the normal write path; this key
+is for hosts that want to ship a non-default starting posture (e.g.
+a corporate fork that wants light theme as the factory default).
+
+### Reset to defaults
+
+`config/reset-settings-to-defaults!` clears the localStorage payload
+and resets the in-memory atom to `default-settings`. No popup
+affordance ships in v1 (deferred to the §018 §9 "Actions" tab
+follow-on).
+
+### Cross-references
+
+- [`015-Configuration.md`](./015-Configuration.md) — host-facing
+  `configure!` surface; `{:settings <map>}` bulk-set; `:editor` /
+  `:project-root` / `:layout/host-selector` / `:launch/auto-open?` /
+  `:trace/show-sensitive?` enumeration.
+- [`018-Event-Spine.md`](./018-Event-Spine.md) §9 — full architectural
+  contract (modal not panel, why; reset semantics; future sections).
+
+## Causality popover — v1 ships
+
+The Causality popover (trigger: `c` key from any tab; mouse:
+ancestor-graph icon next to source-coord in Event tab) renders the
+focused event's causal graph: ancestor chain + descendants tree on a
+centred floating overlay. Architectural shape is normatively
+specified in [`018-Event-Spine.md`](./018-Event-Spine.md) §10. This
+section backfills v1 implementation specifics.
+
+### Geometry
+
+- **Default size:** 640×480 (matches spec §10). `max-width: 92vw` /
+  `max-height: 82vh` so the dialog adapts to small viewports without
+  overflowing.
+- **Backdrop dim:** 15% black (spec §10).
+- **Resize handle:** deferred. v1 ships the default size only; the
+  resize-and-remember affordance per spec §10 §Interaction is a
+  follow-on bead.
+
+### Layout direction — single-axis with footer toggle
+
+**v1 ships:** the popover renders **a single direction at a time** —
+TB (descendants-tree dominant, default) OR LR (ancestor-chain
+dominant) — with a footer **LR ↔ TB toggle** persisting the choice
+in `:rf.causa/causality-popover-layout` per session.
+
+The §018 §10 "Q12 hybrid: ancestors-LR + descendants-TB in the same
+popover" remains the intent, but v1 ships single-axis-at-a-time
+because:
+
+- ELK's per-region direction support requires laying out two graphs
+  separately and stitching them into one SVG with a divider; that's
+  a stretch v1 doesn't yet do.
+- The footer toggle is one click; switching between "show me the
+  ancestor chain" and "show me the descendants tree" is the common
+  mode anyway. The hybrid is the polish.
+
+The Q12 hybrid lands when ELK's per-region wiring is tackled in a
+follow-on bead.
+
+### Lazy ELK load + fallback list
+
+The popover uses the same lazy-load pattern as the Machine Inspector
+chart (see [`003-Machine-Inspector.md`](003-Machine-Inspector.md)
+§Layout engine — ELK with layered fallback): ELK.js loads
+asynchronously on first popover open; the fallback path is a flat
+list render until ELK resolves.
+
+**Fallback render shape.** When ELK is unavailable (test rig, CSP
+block, offline) the popover drops into a `fallback-list` render — a
+flat `<ul>` listing the focused event + its ancestors and descendants
+with edges shown as `parent → child` lines. The cascade lineage is
+fully readable; the visual graph affordance is the only thing lost.
+The footer surfaces a "Causality graph unavailable (ELK.js failed to
+load)" status hint so the user understands why the layout looks
+different.
+
+The fallback is also what the test corpus asserts against — node
+runtimes have no bundler-resolvable `elkjs` package and the import
+rejects immediately.
+
+### Close + interaction (recap of spec §10)
+
+- **Close:** `Esc`, click backdrop, `c` again, or the `×` icon in the
+  header.
+- **Node click:** dispatches `:rf.causa/focus-cascade <id>` AND
+  `:rf.causa/causality-popover-close` — the user landed somewhere new
+  and the popover's job is done. Spine rebinds; tab content reflects
+  the new focus.
+- **Tab switch under popover (`1`–`6`)**: popover stays open; user
+  can survey the cascade graph against changing tab content
+  underneath.
+
+### Cross-references
+
+- [`018-Event-Spine.md`](./018-Event-Spine.md) §10 — full
+  architectural contract (trigger, geometry, interaction matrix,
+  depth limits, empty states).
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Layout
+  engine — sibling consumer of the same ELK loader pattern.
+
 ## Cross-references
 
 - [`000-Vision.md`](./000-Vision.md) — the canonical-questions + 6-tab

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -716,9 +716,25 @@ User CHOSE to load them. First session is honest about what's filtered.
 
 Per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md), the framework emits trace events with sentinel-tagged values. When the trace bus drops sensitive content (under default `:trace/show-sensitive? false`), Causa's chrome surfaces the count in the mode-pill hover tooltip + per-row redaction markers — NOT as an auto-filter chip. The auto-filter mechanism described in earlier round designs collapses into the standard ribbon-pill UX: any user-added OUT pill for an event-id is the canonical filter. Causa does not auto-add filters on the user's behalf.
 
+### v1 ships: right-click → edit-popup (NOT silent append)
+
+This section's earlier wording — that the right-click context menu's "Always hide this event-type" item silently appends to the OUT bucket — is **superseded by v1's actually-landed behaviour** (rf2-ak4ms).
+
+**v1 ships:** the right-click → "Always hide this event-type" item **opens the edit popup pre-populated** with the event-id as the pattern + mode = OUT, source = `:context`. The user sees what's about to land in the OUT bucket and can fine-tune the pattern, widen the match scope, or cancel before commit. No `[Delete]` button (the pill doesn't exist yet); `[Apply]` confirms.
+
+Rationale: pre-alpha posture (per the masterpiece principle). Silent mutation of the filter set on a right-click is the kind of surprise the visible-confirm flow trades a click to avoid. The popup's three trigger sources — `:pill` (edit existing), `:add` (trailing `+`), `:context` (right-click) — share the same modal so the edit-popup is the single mutation site for the IN/OUT slot.
+
+### Pre-alpha matcher scope
+
+The popup's "Match scope" checkboxes — `event-id` / `event-args` / `source-coord` / `tags` — surface the visual contract for spec/018 §7 'Click-pill → edit popup'. **v1's matcher (`filters/matcher.cljc`) operates on `event-id` only**; the wider scopes are stored as data in the pill record and consumed when the matcher widens in a follow-on bead. The `event-id` scope is the default and always-on; widening it is the future rev.
+
 ### Filter persistence
 
-Ribbon pills persist via localStorage per host-app (under a Causa-namespaced key). The Settings popup §9 exposes the pill set + Recommended quick-add + factory-reset.
+Ribbon pills persist via localStorage per host-app under a Causa-namespaced key. **v1 storage key:** `"re-frame2.causa.filters.v1"` (versioned so future schema changes can ignore stale payloads). Configurable via `(causa-config/configure! {:filters/storage-key "<key>"})` per [`015-Configuration.md`](015-Configuration.md) — hosts that run multiple Causa instances in the same browser session (Story testbeds) override so each instance keeps its own pill state.
+
+Host-supplied seed via `(causa-config/configure! {:filters {:in […] :out […]}})` lands ONLY on first install when localStorage is empty — the seed never clobbers a user's hand-tuned set. Per the [`Empty defaults`](#empty-defaults--recommended-quick-add) policy above, Causa itself ships with `nil` seed (first-session honesty).
+
+The Settings popup §9 exposes the pill set + Recommended quick-add + factory-reset (the §9 Filters tab in v1 is a pointer into the ribbon pill UI — full per-pill management surface lives in the ribbon per spec §3; see [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Settings popup — v1 ships).
 
 ### Error overrides
 
@@ -832,6 +848,26 @@ The browser feature gate that asserts I1 + I3 + I4 together is the canonical iso
 | **Popout** | `:popout/width <px>` (default 800) · `:popout/height <px>` (default 600) · `:popout/position <:right :left :centre>` (default `:right`) · "Open in popout now" button (= `o`) |
 | **Actions** | `[factory-reset!]` BIG RED BUTTON · "Reset to fresh-install state — clears filters, pins, watches, keybindings, theme. Buffer kept." Confirmation modal on click. Plus: "Reset filters only" / "Reset keybindings only" / "Clear pinned cascades" / "Clear pinned watches" finer-grained reset buttons. |
 
+### v1 ships
+
+**v1 ships four sections, NOT six** (rf2-9poxq): **General**,
+**Filters**, **Theme**, **Telemetry** — a top tab strip (not left-rail
+nav) drives which body section renders. Defaults: telemetry OFF
+(opt-in), auto-open-on-error OFF, panel-position `:right-rail`,
+theme `:dark`, text-size 13 px. Storage key
+`re-frame2.causa.settings.v1` (single nested map, one round-trip
+through `pr-str`). Full per-knob inventory + persistence rationale +
+auto-open-watcher semantics are in
+[`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Settings popup
+— v1 ships.
+
+The Keybindings, Buffer, Popout, and Actions sections (the bottom
+four rows of the table above) are the **full §9 catalogue intent**
+and remain the target for follow-on beads. v1's Filters tab is a
+discoverability pointer into the ribbon pill UI — not a full
+management surface — because that surface already lives in the
+ribbon and re-implementing it in two places would invite drift.
+
 ### "Show tool frames in picker" toggle
 
 - **Section:** View (NOT Filters — it's about what the picker shows, which is a view concern).
@@ -915,6 +951,12 @@ Every Settings popup field maps to a `(causa-config/configure! {…})` key. See 
 ### Layout direction (Q12 pick)
 
 Mixed LR (ancestors) + TB (descendants) single popover. ELK supports per-region direction. Implementation: layout the two regions separately, place above/below in the same SVG; first implementation will tell us if it reads well. If not, fall back to all-TB (a single tree with the focused node in the middle as a hinge).
+
+**v1 ships:** single-axis-at-a-time with a footer **LR ↔ TB toggle** (rf2-dqnuu). The popover renders TB (descendants-tree dominant; default) OR LR (ancestor-chain dominant) and persists the choice in `:rf.causa/causality-popover-layout` per session. The Q12 hybrid (per-region LR-ancestors + TB-descendants in one SVG) lands when ELK's per-region wiring is tackled in a follow-on bead. See [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Causality popover — v1 ships.
+
+### ELK lazy load + fallback
+
+The popover uses the same lazy ELK loader as the Machine Inspector chart per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Layout engine. **v1 ships:** when ELK is unavailable (test rig, CSP block, offline) the popover drops into a `fallback-list` render — a flat `<ul>` listing the focused event + ancestors + descendants with `parent → child` edges. The cascade lineage stays readable; the visual graph affordance is the only thing lost. Footer surfaces a "Causality graph unavailable (ELK.js failed to load)" hint.
 
 ### Depth limits
 


### PR DESCRIPTION
## Summary

Post-impl spec sweep for `tools/causa/spec/` — backfill the spec for features that landed tonight but whose details diverged from / were unspecified by the original (pre-impl) spec. Augment-only: no existing paragraphs deleted; "v1 ships" callouts mark divergences where impl took a path the spec listed as fallback or where v1 shipped less than the full vision.

Bead: **rf2-c8myv** (kept OPEN per dispatch instructions).

## Per-file change summary

**003-Machine-Inspector.md** — new §"Layout engine — ELK with layered fallback" covering the lazy ELK loader pattern (`elk_layout.cljs`), the async-layout / sync-renderer / render-pulse cadence, the three fallback paths (offline / test rigs / transient `.layout` failure), and the v1-ships deferrals (bend-point routing, hierarchical containment, unified ELK loader shared with the popover). The §Performance section stays unchanged; the new block fits between it and §Share affordance.

**007-UX-IA.md** — fleshed out §Detail panel renderer (`data_inspector.cljc`) with the v1 contract: `collapse-threshold` 5, `string-inline-cap` 64, `large-fetch-warn-threshold-bytes` 100 KB; substrate-agnostic per-node expand state in `:rf/causa` app-db (catalogued subs `:rf.causa.data-inspector/expansion`, events `…/toggle-expanded`, `…/request-large-confirm`, `…/confirm-large`); the three sentinel chip shapes (`:rf/redacted` bare / `:rf/large` with bytes+head / combined `:rf/redacted` with bytes).

**015-Configuration.md** — three new `configure!` keys: `:settings` (bulk-replace the Settings popup state map; cross-links to 016 for default rationale), `:filters` (seed-on-first-install — never clobbers user pills), `:filters/storage-key` (localStorage key override; default `"re-frame2.causa.filters.v1"`). Dropped `:theme` from the reserved-keys list (now lives inside `:settings`).

**016-Auxiliary-Panels.md** — two new sections:
- §"Settings popup — v1 ships" — v1 tab inventory (General / Filters / Theme / Telemetry), defaults table (text-size 13 px, panel-position `:right-rail`, theme `:dark`, telemetry OFF, auto-open-on-error OFF), persistence (single nested map; `pr-str` round-trip under `re-frame2.causa.settings.v1`; dual-write to atom + app-db for immediate reactive re-render), auto-open-on-error sub-watcher (frame-presence-guarded; two install triggers; detach on flip-off), bulk `(configure! {:settings …})` escape hatch.
- §"Causality popover — v1 ships" — geometry (640×480 default; resize deferred), single-axis layout with LR↔TB footer toggle (vs Q12 hybrid intent), lazy ELK + fallback-list render (with footer "Causality graph unavailable" hint), close/interaction recap.

**018-Event-Spine.md** — three v1-ships callouts:
- §7 auto-filter: marked the right-click "Always hide this event-type" path as v1-ships-edit-popup-pre-populated (NOT silent append per the spec's earlier wording); added pre-alpha matcher scope note (event-id only); fleshed out filter persistence with the v1 storage key + configure! seed + `:filters/storage-key` override.
- §9: "v1 ships four sections" callout pointing into 016 for the per-knob inventory; reframes the existing 6-section catalogue as the full intent / follow-on target.
- §10: "v1 ships" callout for single-axis-with-toggle vs Q12 hybrid; ELK lazy-load + fallback-list paragraph cross-linking to 003.

## Features backfilled

- ELK lazy-load + fallback contract (Machine Inspector + Causality popover; PR #1410 + #1406)
- Settings popup tab inventory + defaults + storage key + auto-open-on-error watcher (PR #1405)
- Auto-filter pill UI + edit-popup + right-click pre-populate + storage key (PR #1404)
- Causality popover 640×480 + TB/LR toggle + ELK fallback list (PR #1406)
- cljs-devtools data-inspector renderer contract (PR #1398)

## Divergences documented (v1 ships X; full spec calls for Y)

- **Settings popup sections:** v1 ships 4 (General/Filters/Theme/Telemetry) vs full §9 catalogue (+ Keybindings/Buffer/Popout/Actions).
- **Auto-filter context menu:** v1 opens edit-popup pre-populated vs the spec's earlier "silent append" wording — visible-confirm trades a click against surprise, fitting pre-alpha posture.
- **Causality popover layout:** v1 ships single-axis-with-toggle vs Q12 hybrid (ancestors-LR + descendants-TB in one SVG with per-region direction).
- **ELK rendering:** v1 ships lazy-loaded ELK with layered-fallback (Machine Inspector) / fallback-list (Causality popover); bend-point routing + hierarchical containment + unified ELK loader deferred.
- **Filter matcher scope:** v1 honours `event-id` only; the wider scopes (event-args / source-coord / tags) surface the visual contract in the edit popup but are not yet consumed by the matcher.
- **Settings popup tab strip:** v1 uses a top tab strip; §9's wireframe shows left-rail navigation. (Visual layout polish; not a contract divergence.)

## Skipped sweep targets

- **003 Phase 5 (per-instance arc + scrubber + share affordance):** PR #1413 doesn't exist on the repo; the source files (`machine_inspector_arc`, `machine_inspector_scrubber`, `share.cljs`) are absent. Skipped per the dispatch's "if merged, read main" allowance — nothing's landed to backfill. The §UC2 Per-instance mini-scrubber paragraph already covers the intent at the right architectural level.
- **README.md / 000-Vision.md:** no reorg needed; both already index/describe the new shape cleanly. Left alone per dispatch.

## mkdocs --strict result

mkdocs build runs with **72 warnings, same as baseline before this PR**. All warnings are pre-existing issues in `docs/guide/24-configuration-and-safety/*` and `docs/skills/re-frame2-implementor.md` linking into the global `spec/` tree (excluded from mkdocs nav). **Zero new warnings introduced by this PR**; zero warnings touch the five files modified.

## Test plan
- [ ] mkdocs build --strict produces no new warnings (verified locally: 72 baseline → 72 with PR)
- [ ] All internal links in the modified files resolve (verified — all cross-linked spec files exist)
- [ ] Manual review of the "v1 ships" callouts against actual source files (config.cljc defaults, settings/events.cljs dispatch shapes, filters/edit_popup.cljs trigger sources, popover/causality_graph.cljs ELK loader, theme/data_inspector.cljs sentinel chips)