### PR TITLE
feat(causa): Machine Inspector Phase 5 — per-instance arc + mini-scrubber + share (rf2-nqw0v)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -81,6 +81,9 @@
             [day8.re-frame2-causa.panels.machine-inspector-cluster :as cluster]
             [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers :as ch]
             [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]
+            [day8.re-frame2-causa.panels.machine-inspector-arc :as arc]
+            [day8.re-frame2-causa.panels.machine-inspector-scrubber :as scrubber]
+            [day8.re-frame2-causa.share :as share]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -291,9 +294,15 @@
   Phase 2 (rf2-v869p): when `sim-snapshot` is non-nil the chart's
   highlight is sourced from the sim snapshot and the `:sim?` flag is
   flipped on `chart/svg.cljc`'s renderer so the highlight palette
-  shifts from cyan (live) to amber (sim) per design §5."
-  ([props] (placeholder-chart props nil))
-  ([props sim-snapshot]
+  shifts from cyan (live) to amber (sim) per design §5.
+
+  Phase 5 (rf2-nqw0v): when `arc-highlight-state` is non-nil (the
+  user has scrubbed back through the instance's state-arc), the chart
+  highlight is overridden to the scrubbed-to state and the per-
+  instance arc overlay mounts on top of the chart SVG."
+  ([props] (placeholder-chart props nil nil))
+  ([props sim-snapshot] (placeholder-chart props sim-snapshot nil))
+  ([props sim-snapshot arc-highlight-state]
    (cond
      (nil? props)
      [:div {:data-testid "rf-causa-machine-inspector-placeholder-empty"
@@ -310,9 +319,14 @@
      (let [definition   (:definition props)
            sim?         (some? sim-snapshot)
            override     (:current-state-override props)
-           state-value  (if sim?
-                          (:state sim-snapshot)
-                          (:state override))
+           ;; Phase 5: arc-highlight-state wins over the live snapshot
+           ;; when the user has scrubbed back. Sim still wins over
+           ;; arc — sim is the user's explicit "I'm walking topology"
+           ;; intent, the arc is a historical view.
+           state-value  (cond
+                          sim?                        (:state sim-snapshot)
+                          (some? arc-highlight-state) arc-highlight-state
+                          :else                       (:state override))
            highlight-id (chart-layout/highlight-id state-value)
            ;; Phase 4 (rf2-m7co9): ELK.js layout with layered fallback.
            ;;
@@ -352,16 +366,22 @@
               :data-machine-id (str (:machine-id props))
               :data-highlight-id (or highlight-id "")
               :data-sim-active (str sim?)
+              :data-arc-scrubbing (str (some? arc-highlight-state))
               :data-layout-engine engine
               :style       {:margin "12px"
                             :padding "12px"
                             :background (:bg-1 tokens)
                             :border (str "1px solid "
-                                         (if sim?
-                                           (:yellow tokens)
-                                           (:border-subtle tokens)))
+                                         (cond
+                                           sim?                        (:yellow tokens)
+                                           (some? arc-highlight-state) (:accent-violet tokens)
+                                           :else                       (:border-subtle tokens)))
                             :border-radius "4px"
-                            :overflow "auto"}}
+                            :overflow "auto"
+                            ;; Phase 5: position-relative so the arc
+                            ;; overlay can absolute-position itself
+                            ;; over the chart SVG.
+                            :position "relative"}}
         (chart-svg/render
           positioned
           {:highlight-id   highlight-id
@@ -371,7 +391,11 @@
                                [:rf.causa/machine-state-clicked
                                 {:machine-id (:machine-id props)
                                  :path       path}]
-                               {:frame :rf/causa}))})]))))
+                               {:frame :rf/causa}))})
+        ;; Phase 5: per-instance arc overlay. Hidden in sim mode (the
+        ;; arc represents the LIVE trajectory; sim is a clone walk).
+        (when (not sim?)
+          [arc/ArcOverlay positioned])]))))
 
 ;; ---- transition history ribbon ------------------------------------------
 
@@ -631,6 +655,31 @@
 
 ;; ---- public view --------------------------------------------------------
 
+;; ---- share button (Phase 5, rf2-nqw0v) ---------------------------------
+
+(defn- share-button
+  "Top-right Share button in the panel toolbar. Opens the Share
+  modal (mounted at the shell root). Per spec §Share affordance the
+  button is enabled whenever a machine is registered (the empty-state
+  branch hides it implicitly — the empty-state replaces the toolbar)."
+  []
+  [:button
+   {:data-testid "rf-causa-machine-inspector-share-button"
+    :on-click    (fn [_]
+                   (rf/dispatch [:rf.causa/share-modal-open] {:frame :rf/causa}))
+    :title       "Share this view (URL with focus + mode + scrubber)"
+    :style       {:background "transparent"
+                  :border (str "1px solid " (:border-default tokens))
+                  :color (:accent-violet tokens)
+                  :font-family sans-stack
+                  :font-size "11px"
+                  :font-weight 600
+                  :padding "4px 12px"
+                  :border-radius "10px"
+                  :cursor "pointer"
+                  :white-space "nowrap"}}
+   "⤴ Share"])
+
 (rf/reg-view Panel
   "The Machine Inspector panel's root view. Subscribes to
   `:rf.causa/machine-inspector-data` and renders either the empty
@@ -655,12 +704,27 @@
         ;; and the side rail mounts between the chart and the ribbon.
         sim-state      @(rf/subscribe [:rf.causa/sim-state])
         sim-active?    (boolean (:active? sim-state))
-        sim-snapshot   (when sim-active? (:snapshot sim-state))]
+        sim-snapshot   (when sim-active? (:snapshot sim-state))
+        ;; Phase 5 (rf2-nqw0v): arc + scrubber + share.
+        ;;
+        ;; `arc-data` powers the per-instance state-arc overlay; the
+        ;; scrubber-position governs which slice the chart highlight
+        ;; shows. Hidden in Mode A (no instance) and in sim mode (sim
+        ;; is its own walking-clone surface).
+        arc-data           @(rf/subscribe [:rf.causa/machine-arc-data])
+        scrubber-position  @(rf/subscribe [:rf.causa/machine-scrubber-position])
+        arc-active?        (and (not sim-active?)
+                                (contains? #{:mode-b :mode-c} mode)
+                                (seq arc-data))
+        arc-highlight      (when arc-active?
+                             @(rf/subscribe
+                                [:rf.causa/machine-arc-highlight-state]))]
     [:section {:data-testid "rf-causa-machine-inspector"
                :data-view-mode (name mode)
                :data-instance-count instance-count
                :data-forced-mode (when forced-mode (name forced-mode))
                :data-sim-active (str sim-active?)
+               :data-arc-active (str (boolean arc-active?))
                :style       {:height         "100%"
                              :display        "flex"
                              :flex-direction "column"
@@ -668,16 +732,27 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     [:header {:style {:padding "16px 16px 8px 16px"}}
-      [:h1 {:style {:font-size "16px"
-                    :font-weight 600
-                    :margin 0
-                    :color (:text-primary tokens)}}
-       "Machine inspector"]
-      [:p {:style {:font-size "12px"
-                   :color     (:text-tertiary tokens)
-                   :margin    "4px 0 0 0"}}
-       "Pick a machine to inspect its current state and recent transitions."]]
+     [:header {:data-testid "rf-causa-machine-inspector-header"
+               :style {:padding "16px 16px 8px 16px"
+                       :display "flex"
+                       :align-items "flex-start"
+                       :justify-content "space-between"
+                       :gap "12px"}}
+      [:div
+       [:h1 {:style {:font-size "16px"
+                     :font-weight 600
+                     :margin 0
+                     :color (:text-primary tokens)}}
+        "Machine inspector"]
+       [:p {:style {:font-size "12px"
+                    :color     (:text-tertiary tokens)
+                    :margin    "4px 0 0 0"}}
+        "Pick a machine to inspect its current state and recent transitions."]]
+      ;; Share button — visible whenever the panel has more than empty
+      ;; state. Empty-state branch hides the whole inner div below so
+      ;; the button only appears when there's something to share.
+      (when (not= :no-machines empty-kind)
+        (share-button))]
      (if (= :no-machines empty-kind)
        (empty-state)
        [:div {:style {:flex 1 :display "flex" :flex-direction "column"
@@ -692,7 +767,12 @@
             :instance-count instance-count
             :definition     (:definition selected)
             :sim-active?    sim-active?})
-         (placeholder-chart chart-props sim-snapshot)
+         (placeholder-chart chart-props sim-snapshot arc-highlight)
+         ;; Phase 5: scrubber strip beneath the chart. Visible whenever
+         ;; the arc has at least one step (i.e. ≥1 transition or an
+         ;; initial-state-only arc).
+         (when arc-active?
+           [scrubber/ScrubberStrip])
          (when (= :mode-c mode)
            [cluster/ClusterView])
          (when sim-active?
@@ -909,4 +989,24 @@
   ;; `panels/machine_inspector_cluster.cljs`. The install fn registers
   ;; `:rf.causa/mode-c-*` events + subs against the same `:rf/causa`
   ;; frame the panel reads.
-  (cluster/install!))
+  (cluster/install!)
+
+  ;; ---- Phase 5 (rf2-nqw0v) — per-instance arc + mini-scrubber -----
+  ;;
+  ;; The arc + scrubber sub/event family lives in
+  ;; `panels/machine_inspector_arc.cljs`. The install fn registers
+  ;; `:rf.causa/machine-arc-*` + `:rf.causa/set-scrubber-position` +
+  ;; `:rf.causa/set-arc-hover` against the same `:rf/causa` frame the
+  ;; panel reads. The arc-helper algebra is JVM-runnable and lives in
+  ;; `machine_inspector_arc_helpers.cljc`.
+  (arc/install!)
+
+  ;; ---- Phase 5 (rf2-nqw0v) — Share affordance --------------------
+  ;;
+  ;; The Share affordance encodes the current focus + mode + scrubber
+  ;; position into a URL the user can paste anywhere. The infra lives
+  ;; in `day8.re-frame2-causa.share` (subs + events + clipboard fx);
+  ;; the modal view lives in `day8.re-frame2-causa.share-modal`. The
+  ;; modal mounts at the shell root per the palette / settings popup
+  ;; pattern; this install registers the sub/event/fx family.
+  (share/install!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc.cljs
@@ -1,0 +1,265 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-arc
+  "Machine Inspector per-instance state-arc view (rf2-nqw0v, Phase 5,
+  parent rf2-2tkza).
+
+  Renders the focused instance's chronological state-trajectory as a
+  thin SVG overlay above the chart's positioned graph. Each arc point
+  is a node-centre coordinate (resolved via the chart's `highlight-id`
+  helper); segments are straight lines between adjacent points; the
+  segment colour gradient fades from a subtle origin tint to the
+  accent-violet endpoint so the eye reads time left-to-right.
+
+  ## Why a separate ns
+
+  Same posture as `machine_inspector_sim.cljs` / `..._cluster.cljs` —
+  one panel-side feature, its own ns + sub/event family. The panel
+  ns wires the install! call and mounts the view; the algebra lives
+  in `machine_inspector_arc_helpers.cljc`.
+
+  ## Pure hiccup
+
+  Every subscribe / dispatch resolves against `:rf/causa` via the
+  enclosing frame-provider in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.chart.layout :as chart-layout]
+            [day8.re-frame2-causa.panels.machine-inspector-arc-helpers
+             :as arc-h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- subs ---------------------------------------------------------------
+
+(defn install-subs!
+  "Register the arc sub family. Idempotent."
+  []
+  ;; The chronological arc-points for the focused machine. Reads off
+  ;; the trace buffer + the machine's registered definition (for the
+  ;; origin's initial-state) and builds the oldest-first trajectory.
+  ;;
+  ;; Falls back to the composite's effective selected-id (first row
+  ;; when nothing is explicitly picked) so the arc renders on first
+  ;; mount without the user having to interact with the picker —
+  ;; matches the picker / chart's default-focus behaviour.
+  (rf/reg-sub :rf.causa/machine-arc-data
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/machine-inspector-data]
+    :<- [:rf.causa/machine-definitions]
+    (fn [[buffer mi-data definitions] _query]
+      (let [machine-id (:selected-id mi-data)
+            definition (when machine-id (get definitions machine-id))]
+        (arc-h/build-arc buffer machine-id definition))))
+
+  ;; The current scrubber position. `:present` = head; an int = idx.
+  (rf/reg-sub :rf.causa/machine-scrubber-position
+    (fn [db _query]
+      (get db :machine-inspector/scrubber-position :present)))
+
+  ;; The trimmed arc — arc + scrubber → points up to and including
+  ;; the scrubber's idx.
+  (rf/reg-sub :rf.causa/machine-arc-trimmed
+    :<- [:rf.causa/machine-arc-data]
+    :<- [:rf.causa/machine-scrubber-position]
+    (fn [[arc position] _query]
+      (arc-h/trim-arc arc position)))
+
+  ;; The historic state at the scrubber position. Only returns a value
+  ;; when the scrubber is NOT at :present — at :present the chart
+  ;; should show the live snapshot's :state (unchanged from Phase 1
+  ;; behaviour). When the user scrubs back, this returns the historic
+  ;; state so the chart's highlight follows the scrub.
+  (rf/reg-sub :rf.causa/machine-arc-highlight-state
+    :<- [:rf.causa/machine-arc-data]
+    :<- [:rf.causa/machine-scrubber-position]
+    (fn [[arc position] _query]
+      (when (and (not (arc-h/at-present? arc position))
+                 (seq arc))
+        (arc-h/highlight-state-at arc position))))
+
+  ;; Which arc-segment is currently hovered (idx of the `:to` point).
+  ;; nil when nothing is hovered.
+  (rf/reg-sub :rf.causa/machine-arc-hover
+    (fn [db _query]
+      (get db :machine-inspector/arc-hover))))
+
+;; ---- events -------------------------------------------------------------
+
+(defn install-events!
+  "Register the arc + scrubber event family. Idempotent."
+  []
+  (rf/reg-event-db :rf.causa/set-scrubber-position
+    (fn [db [_ position]]
+      (cond
+        (= :present position)
+        (assoc db :machine-inspector/scrubber-position :present)
+
+        (integer? position)
+        (assoc db :machine-inspector/scrubber-position position)
+
+        (nil? position)
+        (assoc db :machine-inspector/scrubber-position :present)
+
+        :else
+        db)))
+
+  (rf/reg-event-db :rf.causa/set-arc-hover
+    (fn [db [_ idx]]
+      (if (or (nil? idx) (integer? idx))
+        (if (nil? idx)
+          (dissoc db :machine-inspector/arc-hover)
+          (assoc db :machine-inspector/arc-hover idx))
+        db))))
+
+;; ---- view: SVG arc overlay ---------------------------------------------
+
+(defn- arc-segment
+  "Render one arc segment between two points. Coordinates are computed
+  in the parent."
+  [{:keys [from to idx hovered?]}]
+  (let [[x1 y1] from
+        [x2 y2] to
+        ;; Gradient fade from a muted origin tint to the accent-violet
+        ;; endpoint — the renderer reads `idx / segment-count` for the
+        ;; relative position so the segment colour can interpolate.
+        stroke (if hovered? (:cyan tokens) (:accent-violet tokens))
+        width  (if hovered? 3 2)]
+    [:line {:data-testid (str "rf-causa-machine-inspector-arc-segment-" idx)
+            :data-idx    idx
+            :data-hovered (str hovered?)
+            :x1 x1 :y1 y1 :x2 x2 :y2 y2
+            :stroke stroke
+            :stroke-width width
+            :stroke-linecap "round"
+            :opacity (if hovered? 0.95 0.78)
+            :pointer-events "stroke"
+            :on-mouse-enter
+            (fn [_]
+              (rf/dispatch [:rf.causa/set-arc-hover idx] {:frame :rf/causa}))
+            :on-mouse-leave
+            (fn [_]
+              (rf/dispatch [:rf.causa/set-arc-hover nil] {:frame :rf/causa}))}]))
+
+(defn- arc-marker
+  "Render a small filled circle at an arc-point. The origin gets a
+  hollow circle; later points get filled dots whose radius scales
+  slightly with idx so the trajectory's direction reads visually."
+  [{:keys [point cx cy hovered? origin? endpoint?]}]
+  (let [r       (cond endpoint? 5 origin? 4 :else 3)
+        fill    (cond endpoint? (:accent-violet tokens)
+                      origin?   (:bg-1 tokens)
+                      :else     (:accent-violet tokens))
+        stroke  (cond hovered?  (:cyan tokens)
+                      origin?   (:accent-violet tokens)
+                      :else     (:accent-violet tokens))]
+    [:circle {:data-testid (str "rf-causa-machine-inspector-arc-marker-"
+                                (:idx point))
+              :data-idx    (:idx point)
+              :data-origin (str (boolean origin?))
+              :data-endpoint (str (boolean endpoint?))
+              :cx cx :cy cy :r r
+              :fill   fill
+              :stroke stroke
+              :stroke-width 1.5
+              :pointer-events "all"
+              :on-mouse-enter
+              (fn [_]
+                (rf/dispatch [:rf.causa/set-arc-hover (:idx point)]
+                             {:frame :rf/causa}))
+              :on-mouse-leave
+              (fn [_]
+                (rf/dispatch [:rf.causa/set-arc-hover nil] {:frame :rf/causa}))}
+     ;; Native SVG <title> for the tooltip — accessible + zero-cost.
+     [:title (arc-h/format-point-tooltip point)]]))
+
+(defn- legend
+  "Compact in-overlay legend showing what the arc represents."
+  [arc-point-count]
+  (when (pos? arc-point-count)
+    [:g {:data-testid "rf-causa-machine-inspector-arc-legend"
+         :transform "translate(8, 14)"}
+     [:rect {:x 0 :y -10 :width 110 :height 16
+             :rx 3
+             :fill (:bg-1 tokens)
+             :opacity 0.85}]
+     [:text {:x 6 :y 1
+             :font-family mono-stack
+             :font-size 10
+             :fill (:accent-violet tokens)}
+      (str "arc · " arc-point-count " step"
+           (when (not= 1 arc-point-count) "s"))]]))
+
+(defn ArcOverlay
+  "Renders the per-instance arc as an SVG overlay positioned over the
+  chart's `<svg>` viewport. Takes the chart's positioned graph (so it
+  can resolve arc-points to node-centres) as the only arg; subscribes
+  to the arc data + scrubber position internally.
+
+  Returns nil when the arc has fewer than two points (no trajectory
+  to draw)."
+  [{:keys [nodes width height]}]
+  (let [arc      @(rf/subscribe [:rf.causa/machine-arc-trimmed])
+        hover    @(rf/subscribe [:rf.causa/machine-arc-hover])
+        node-idx (arc-h/nodes->index nodes)
+        ;; Each arc-point → its node-centre. nil when the node-id is
+        ;; not in the positioned graph (the segment falls out).
+        centres  (mapv (fn [p]
+                         {:point p
+                          :centre (arc-h/point-center
+                                    p node-idx chart-layout/highlight-id)})
+                       arc)
+        renderable (filter :centre centres)
+        n          (count renderable)
+        segments   (when (>= n 2)
+                     (map (fn [a b]
+                            (let [from-idx (:idx (:point a))
+                                  to-idx   (:idx (:point b))
+                                  ;; Hovered when either endpoint matches.
+                                  hov?     (or (= hover from-idx)
+                                               (= hover to-idx))]
+                              {:from (:centre a)
+                               :to   (:centre b)
+                               :idx  to-idx
+                               :hovered? hov?}))
+                          renderable
+                          (rest renderable)))]
+    (when (pos? n)
+      [:svg {:data-testid "rf-causa-machine-inspector-arc-overlay"
+             :data-point-count (count arc)
+             :viewBox (str "0 0 " (or width 0) " " (or height 0))
+             :width "100%"
+             :preserveAspectRatio "xMidYMin meet"
+             :style {:position "absolute"
+                     :top 0
+                     :left 0
+                     :width "100%"
+                     :height "100%"
+                     :pointer-events "none"  ;; let segments opt in
+                     :overflow "visible"}}
+       (legend (count arc))
+       ;; Render segments first so markers paint on top.
+       (when (seq segments)
+         (into [:g {:data-testid "rf-causa-machine-inspector-arc-segments"
+                    :style {:pointer-events "stroke"}}]
+               (for [seg segments]
+                 ^{:key (:idx seg)}
+                 (arc-segment seg))))
+       (into [:g {:data-testid "rf-causa-machine-inspector-arc-markers"
+                  :style {:pointer-events "all"}}]
+             (for [{:keys [point centre]} renderable
+                   :let [[cx cy] centre
+                         origin?   (zero? (:idx point))
+                         endpoint? (= (:idx point) (:idx (:point (last renderable))))
+                         hovered?  (= hover (:idx point))]]
+               ^{:key (:idx point)}
+               (arc-marker {:point point
+                            :cx cx :cy cy
+                            :hovered? hovered?
+                            :origin?  origin?
+                            :endpoint? endpoint?})))])))
+
+;; ---- public install entry -----------------------------------------------
+
+(defn install!
+  "Idempotent install — called by `machine_inspector/install!`."
+  []
+  (install-subs!)
+  (install-events!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc_helpers.cljc
@@ -1,0 +1,311 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-arc-helpers
+  "Pure-data helpers for the Machine Inspector per-instance state-arc
+  (rf2-nqw0v, Phase 5, parent rf2-2tkza).
+
+  ## What this owns
+
+  The state-arc traces the focused instance's transition history over
+  the trace-buffer window. Each arc-point is one step in the
+  instance's chronological state trajectory:
+
+      {:idx <int>         ;; 0-indexed position in the trajectory
+       :state <kw|vec>    ;; the state at this point (the :to of a transition,
+                          ;;   or the :initial slot of the machine)
+       :event <vector>    ;; the event that caused entry (nil for the origin)
+       :time  <int>       ;; the trace event's :time (nil for the origin)
+       :from  <kw|vec>    ;; the prior state (nil for the origin)
+       :dispatch-id <id>} ;; the originating dispatch (nil for the origin)
+
+  The origin point is the machine's initial state; subsequent points
+  walk forward through `:rf.machine/transition` (+ microstep) events
+  for the focused instance. Each arc-point carries enough metadata
+  for the renderer to emit per-segment hover tooltips + the scrubber
+  to slice the arc to a historic point.
+
+  ## Why a separate .cljc
+
+  Same dual-target pattern every other panel helper uses (the JVM
+  test target drives the algebra without a CLJS runtime). The view
+  in `machine_inspector_arc.cljs` is a thin SVG renderer over the
+  positioned-graph data + the arc-points this ns produces.
+
+  ## Scrubber semantics
+
+  The scrubber-position is one of:
+    - `:present` — the arc renders all points (default; no scrub)
+    - `<int>`    — the arc renders points `[0..idx]` inclusive (idx
+                   is the 0-indexed scrubber position; 0 = origin only)
+
+  `trim-arc-to-position` applies the slice; the view passes the
+  trimmed arc + the most-recent point's `:state` as the highlight
+  override so the chart's highlighted node matches the scrubbed
+  position.
+
+  ## What this does NOT do
+
+    - SVG rendering — lives in `machine_inspector_arc.cljs`.
+    - Multi-instance trajectories — the v1 surface focuses one
+      instance; the helper takes a `machine-id` (instance-id today is
+      machine-id under the Phase 1/3 snapshot widening).
+    - Animation / replay — the scrubber is a slider; a `Replay`
+      button rides a follow-on bead."
+  (:require [clojure.string :as str]))
+
+;; ---- canonical operation set --------------------------------------------
+
+(def transition-operations
+  "Local mirror of the panel's transition vocabulary so this ns has no
+  upward cross-ns dep into the panel helpers (keeps the JVM compile
+  graph tight; mirrors the cluster helpers' local mirror)."
+  #{:rf.machine/transition
+    :rf.machine.microstep/transition})
+
+(defn transition-event?
+  [ev]
+  (and (map? ev)
+       (contains? transition-operations (:operation ev))))
+
+(defn- machine-id-of
+  [ev]
+  (or (get-in ev [:tags :machine-id])
+      (get-in ev [:tags :handler-id])))
+
+;; ---- arc construction ---------------------------------------------------
+
+(defn- initial-state
+  "Resolve the initial state slot of a machine definition. Tolerant of
+  nil + the two common spec shapes (`{:initial :foo}` and the deeper
+  `{:initial [:auth :idle]}`)."
+  [definition]
+  (when (map? definition)
+    (:initial definition)))
+
+(defn build-arc
+  "Build the chronological arc-points for `machine-id` from the trace
+  buffer. The origin (idx 0) is the machine's initial state; each
+  subsequent point is one outer or microstep transition for the
+  instance, ordered oldest-first.
+
+  Inputs:
+
+    `trace-buffer` — Causa's trace ring buffer. nil-safe.
+    `machine-id`   — the focused instance's machine-id. Required —
+                     nil returns `[]`.
+    `definition`   — the machine definition map (for the initial
+                     state). Optional — when nil the origin is
+                     synthesised from the oldest transition's `:from`.
+
+  Returns a vector of arc-points oldest-first. Each point:
+
+      {:idx <int>
+       :state <kw|vec>
+       :event <vec-or-nil>
+       :time  <int-or-nil>
+       :from  <kw|vec|nil>
+       :dispatch-id <id-or-nil>
+       :microstep? <bool>}
+
+  Pure fn — JVM-runnable."
+  [trace-buffer machine-id definition]
+  (if (nil? machine-id)
+    []
+    (let [transitions
+          (->> (or trace-buffer [])
+               (filter (fn [ev]
+                         (and (transition-event? ev)
+                              (= machine-id (machine-id-of ev)))))
+               ;; Oldest first — chronological trajectory.
+               (sort-by (fn [ev] (or (:id ev) (:time ev) 0)))
+               vec)
+          origin-state (or (initial-state definition)
+                           (when (seq transitions)
+                             (or (get-in (first transitions) [:tags :from])
+                                 (get-in (first transitions) [:tags :from-state]))))
+          origin (when origin-state
+                   {:idx         0
+                    :state       origin-state
+                    :event       nil
+                    :time        nil
+                    :from        nil
+                    :dispatch-id nil
+                    :microstep?  false})
+          steps
+          (map-indexed
+            (fn [i ev]
+              (let [tags (get ev :tags {})]
+                {:idx         (inc i)
+                 :state       (or (:to tags) (:to-state tags))
+                 :event       (or (:event tags) (:event-v tags))
+                 :time        (:time ev)
+                 :from        (or (:from tags) (:from-state tags))
+                 :dispatch-id (:dispatch-id tags)
+                 :microstep?  (= :rf.machine.microstep/transition (:operation ev))}))
+            transitions)]
+      (if origin
+        (vec (cons origin steps))
+        ;; No initial-state hint and no transitions — empty arc.
+        (vec steps)))))
+
+;; ---- scrubber slicing ---------------------------------------------------
+
+(defn arc-length
+  "Number of arc-points (origin + transitions). 0 when the arc is
+  empty. Pure fn."
+  [arc]
+  (count (or arc [])))
+
+(defn max-scrub-index
+  "Largest valid scrubber index for `arc`. -1 for an empty arc; (n-1)
+  otherwise."
+  [arc]
+  (dec (arc-length arc)))
+
+(defn clamp-position
+  "Clamp a scrubber position to a legal value for `arc`. `:present`
+  stays `:present`; otherwise an integer is bounded to
+  `[0, max-scrub-index]`. nil → `:present`."
+  [arc position]
+  (cond
+    (or (nil? position) (= :present position)) :present
+    (integer? position)
+    (let [max-idx (max-scrub-index arc)]
+      (cond
+        (neg? max-idx)         :present
+        (neg? position)        0
+        (> position max-idx)   :present
+        :else                  position))
+    :else :present))
+
+(defn resolve-position-index
+  "Resolve a scrubber position into a concrete idx. `:present` returns
+  the last idx; otherwise the clamped integer. -1 for an empty arc."
+  [arc position]
+  (let [clamped (clamp-position arc position)
+        max-idx (max-scrub-index arc)]
+    (cond
+      (neg? max-idx)        -1
+      (= :present clamped)  max-idx
+      :else                 clamped)))
+
+(defn trim-arc
+  "Slice `arc` down to the points the scrubber-position renders.
+  `:present` returns the full arc; an integer returns `arc[0..idx]`
+  inclusive.
+
+  Returns `[]` for an empty arc."
+  [arc position]
+  (if (empty? arc)
+    []
+    (let [idx (resolve-position-index arc position)]
+      (if (neg? idx)
+        []
+        (vec (take (inc idx) arc))))))
+
+(defn highlight-state-at
+  "Return the `:state` value of the point at `position` in `arc`, or
+  nil when the arc is empty / position is invalid. Used by the panel
+  to override the chart's highlight to the scrubbed-to historic
+  state."
+  [arc position]
+  (when (seq arc)
+    (let [idx (resolve-position-index arc position)]
+      (when-not (neg? idx)
+        (:state (nth arc idx nil))))))
+
+(defn context-at
+  "Return the snapshot's `:data` slot at `position`. Today's trace
+  events do not stamp the post-transition `:data` value, so this
+  returns nil at v1 — the slot exists in the API so a follow-on bead
+  that fattens trace events with post-state context can flip the
+  value to the historic context."
+  [arc position]
+  ;; Reserved API surface — see ns docstring §What this does NOT do.
+  ;; The scrubber's side-rail context-panel displays nil for historic
+  ;; positions and the live context (read off the snapshot) for
+  ;; :present positions; the panel handles that branch.
+  (when (and (seq arc) (integer? position))
+    nil))
+
+(defn at-present?
+  "True when the scrubber-position is `:present` OR points at the
+  latest arc-point. False otherwise. Pure fn."
+  [arc position]
+  (cond
+    (empty? arc)            true
+    (= :present position)   true
+    (integer? position)     (= position (max-scrub-index arc))
+    :else                   true))
+
+;; ---- segment + node geometry --------------------------------------------
+
+(defn arc-segments
+  "Pair adjacent arc-points into segment maps `{:from <point> :to <point>}`
+  for the renderer. An arc with N points produces N-1 segments. Pure fn."
+  [arc]
+  (if (< (count arc) 2)
+    []
+    (vec (map (fn [a b] {:from a :to b})
+              arc
+              (rest arc)))))
+
+(defn nodes->index
+  "Build a `{node-id node}` map for cheap arc-renderer lookups.
+  `positioned-nodes` is the `:nodes` vec returned by
+  `chart/layout/layout`. Pure fn."
+  [positioned-nodes]
+  (into {}
+        (map (fn [n] [(:node-id n) n]))
+        (or positioned-nodes [])))
+
+(defn point-center
+  "Return the `[cx cy]` centre of the chart node corresponding to
+  arc-point `point`. nil when the node-id isn't in the positioned
+  graph (e.g. compound state with no rendered leaf). Pure fn.
+
+  `id-fn` is the panel's `highlight-id` resolver — passed in so this
+  ns has no compile-time dep on the chart-layout ns (keeps the
+  cross-ns graph one-directional)."
+  [point node-index id-fn]
+  (when (and point id-fn)
+    (let [nid (id-fn (:state point))
+          n   (get node-index nid)]
+      (when n
+        [(+ (:x n) (quot (:width n) 2))
+         (+ (:y n) (quot (:height n) 2))]))))
+
+;; ---- display formatters -------------------------------------------------
+
+(defn format-point-tooltip
+  "Tooltip text for an arc-point hover. Reads:
+
+      `idx · from → to (event) @timeMs`
+
+  for transitions; `origin: <state>` for the origin point. Pure fn."
+  [{:keys [idx state event time from] :as point}]
+  (when point
+    (let [state-s (if (keyword? state) (str state) (pr-str state))
+          from-s  (when from
+                    (if (keyword? from) (str from) (pr-str from)))
+          ev-s    (when event
+                    (try (pr-str event)
+                         (catch #?(:clj Throwable :cljs :default) _
+                           (str event))))
+          time-s  (when time (str " @" time "ms"))]
+      (if (or (zero? idx) (nil? from))
+        (str "#" idx " · origin: " state-s)
+        (str "#" idx " · " from-s " → " state-s
+             (when ev-s (str "  (" ev-s ")"))
+             (or time-s ""))))))
+
+(defn format-position-label
+  "Compact label for the scrubber's current position — `present`
+  when at the head, `step N / M` otherwise. Pure fn."
+  [arc position]
+  (let [n (arc-length arc)
+        max-idx (dec n)]
+    (cond
+      (zero? n)               "(no history)"
+      (= :present position)   (str "present · " n " step" (when (not= 1 n) "s"))
+      (integer? position)     (let [clamped (max 0 (min max-idx position))]
+                                (str "step " clamped " / " max-idx))
+      :else                   (str "present · " n " step" (when (not= 1 n) "s")))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_scrubber.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_scrubber.cljs
@@ -1,0 +1,168 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-scrubber
+  "Machine Inspector mini-scrubber view (rf2-nqw0v, Phase 5, parent
+  rf2-2tkza).
+
+  A horizontal time-slider beneath the chart that scrubs back through
+  the focused instance's state history. Per the bead's divergence
+  allowance the scrubber is a thin HTML `<input type=\"range\">` with
+  custom CSS — D3-style brush polish is deferred to a follow-on bead.
+
+  ## What the scrubber drives
+
+    - `:rf.causa/set-scrubber-position <int|:present>` — moves the
+      scrub position. The arc trims to `[0..idx]` and the chart's
+      highlight overrides to the historic state at idx.
+    - The side-rail context-panel can show the historic context value
+      (today the trace events don't stamp post-transition `:data` so
+      the value is nil; the slot is reserved — see
+      `machine_inspector_arc_helpers.cljc/context-at`).
+    - The button beside the slider snaps back to `:present`.
+
+  ## Pure hiccup
+
+  Every subscribe / dispatch resolves against `:rf/causa` via the
+  enclosing frame-provider in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.machine-inspector-arc-helpers
+             :as arc-h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- slider input -------------------------------------------------------
+
+(defn- scrubber-input
+  [arc position]
+  (let [max-idx     (arc-h/max-scrub-index arc)
+        ;; The slider's value is a concrete integer; `:present` maps
+        ;; to `max-idx` for display purposes but the dispatch flips
+        ;; back to `:present` whenever the user releases at the head.
+        slider-val  (cond
+                      (neg? max-idx)                0
+                      (= :present position)         max-idx
+                      (integer? position)           (max 0 (min max-idx position))
+                      :else                         max-idx)
+        disabled?   (neg? max-idx)]
+    [:input
+     {:data-testid "rf-causa-machine-inspector-scrubber-input"
+      :data-position (cond
+                       (= :present position) "present"
+                       (integer? position)   (str position)
+                       :else                 "present")
+      :type        "range"
+      :min         0
+      :max         (max 0 max-idx)
+      :value       slider-val
+      :step        1
+      :disabled    disabled?
+      :on-change   (fn [^js e]
+                     (let [v   (-> e .-target .-value)
+                           n   (try (js/parseInt v 10)
+                                    (catch :default _ 0))
+                           pos (if (= n max-idx) :present n)]
+                       (rf/dispatch [:rf.causa/set-scrubber-position pos]
+                                    {:frame :rf/causa})))
+      :style       {:flex 1
+                    :accent-color (:accent-violet tokens)
+                    :cursor (if disabled? "not-allowed" "pointer")
+                    :height "20px"
+                    :margin 0}}]))
+
+(defn- present-button
+  [position]
+  (let [at-present? (or (nil? position) (= :present position))]
+    [:button
+     {:data-testid "rf-causa-machine-inspector-scrubber-present"
+      :on-click    (fn [_]
+                     (rf/dispatch [:rf.causa/set-scrubber-position :present]
+                                  {:frame :rf/causa}))
+      :disabled    at-present?
+      :title       "Snap to present (latest step)"
+      :style       {:background (if at-present?
+                                  "transparent"
+                                  (:bg-3 tokens))
+                    :border (str "1px solid "
+                                 (if at-present?
+                                   (:border-subtle tokens)
+                                   (:accent-violet tokens)))
+                    :color (if at-present?
+                             (:text-tertiary tokens)
+                             (:accent-violet tokens))
+                    :padding "3px 10px"
+                    :border-radius "10px"
+                    :font-family mono-stack
+                    :font-size "10px"
+                    :font-weight 600
+                    :cursor (if at-present? "default" "pointer")
+                    :white-space "nowrap"}}
+     "⏭ present"]))
+
+(defn- position-label
+  [arc position]
+  [:span {:data-testid "rf-causa-machine-inspector-scrubber-label"
+          :style       {:color (:text-tertiary tokens)
+                        :font-family mono-stack
+                        :font-size "11px"
+                        :min-width "120px"
+                        :text-align "right"}}
+   (arc-h/format-position-label arc position)])
+
+(defn- hover-tip
+  "Compact line showing the scrubbed-to state's metadata. Reads off the
+  arc + position so it follows the scrubber live."
+  [arc position]
+  (let [idx     (arc-h/resolve-position-index arc position)
+        point   (when-not (neg? idx) (nth arc idx nil))
+        tooltip (arc-h/format-point-tooltip point)]
+    [:div {:data-testid "rf-causa-machine-inspector-scrubber-tip"
+           :style       {:padding "4px 10px"
+                         :background (:bg-1 tokens)
+                         :border (str "1px solid " (:border-subtle tokens))
+                         :border-radius "3px"
+                         :color (:text-secondary tokens)
+                         :font-family mono-stack
+                         :font-size "11px"
+                         :min-height "18px"
+                         :overflow "hidden"
+                         :text-overflow "ellipsis"
+                         :white-space "nowrap"}}
+     (or tooltip "(no step at this position)")]))
+
+;; ---- main view ----------------------------------------------------------
+
+(defn ScrubberStrip
+  "The mini-scrubber strip — slider + present-button + position-label
+  + hover-tip. Mounted by the panel beneath the chart when the focused
+  instance has a non-empty arc."
+  []
+  (let [arc       @(rf/subscribe [:rf.causa/machine-arc-data])
+        position  @(rf/subscribe [:rf.causa/machine-scrubber-position])]
+    (when (seq arc)
+      [:section
+       {:data-testid "rf-causa-machine-inspector-scrubber"
+        :data-arc-length (count arc)
+        :data-position (cond
+                         (= :present position) "present"
+                         (integer? position)   (str position)
+                         :else                 "present")
+        :style {:margin "0 12px 12px 12px"
+                :padding "8px 12px"
+                :background (:bg-2 tokens)
+                :border (str "1px solid " (:border-subtle tokens))
+                :border-radius "4px"
+                :display "flex"
+                :flex-direction "column"
+                :gap "6px"}}
+       [:div {:style {:display "flex"
+                      :align-items "center"
+                      :gap "8px"}}
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "10px"
+                        :text-transform "uppercase"
+                        :letter-spacing "0.5px"
+                        :min-width "60px"}}
+         "Scrub"]
+        (scrubber-input arc position)
+        (present-button position)
+        (position-label arc position)]
+       (hover-tip arc position)])))

--- a/tools/causa/src/day8/re_frame2_causa/share.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share.cljs
@@ -1,0 +1,425 @@
+(ns day8.re-frame2-causa.share
+  "Causa-internal share-URL infra (rf2-nqw0v, Phase 5, parent rf2-2tkza).
+
+  ## What this owns
+
+  The Share affordance encodes a snapshot of the user's current
+  Causa-side context (focused machine + selected instance + scrubber
+  position + view-mode + selected tab) into a URL the user can paste
+  into chat, the bug tracker, or a teammate's IDE. On load, Causa
+  parses the URL and restores the context.
+
+  ## Encoding choice — flat query-string, no base64
+
+  Per the bead's divergence allowance the encoding is a flat
+  key→value query-string rather than base64-encoded EDN:
+
+      ?causa-share=1
+      &machine=auth%2Flogin
+      &instance=auth%2Flogin
+      &pos=3
+      &mode=mode-b
+      &tab=machines
+
+  Why flat: the encoded form is human-legible, diff-friendly, and
+  trivially editable in chat / bug-trackers (`&pos=3` vs an opaque
+  base64 blob). Transit-EDN + a short-URL service rides a follow-on
+  bead when the encoded surface area outgrows query-string-sized
+  ergonomics.
+
+  ## Reserved param keys
+
+    `causa-share` — sentinel; presence (`=1`) flips the restore path
+                    on. Lets a downstream short-URL service add
+                    arbitrary other params without false-positives.
+    `machine`     — focused machine-id (keyword string, ns/leaf form)
+    `instance`    — instance-id (same encoding as machine; for v1 the
+                    instance-id is the machine-id under the snapshot
+                    widening — the slot exists for the spawn-aware
+                    future)
+    `pos`         — scrubber position: integer or `present`
+    `mode`        — forced view-mode: `mode-a` / `mode-b` / `mode-c`
+                    / `auto`
+    `tab`         — L3 tab id: `event` / `app-db` / `views` / `trace`
+                    / `machines` / `issues`
+
+  ## Frame isolation
+
+  The events here all dispatch against `:rf/causa`. The browser
+  bridge — `js/window.location`, `navigator.clipboard` — is wrapped
+  so the JVM / Node test rigs can stub through plain test setters.
+
+  ## Helper algebra
+
+  Pure encode + decode + URL-build helpers live in this ns under
+  `encode-state` / `decode-query-string` / `build-share-url`. The
+  fxs + event-fxs are CLJS-only — the test surface drives them via
+  reg-fx replacement."
+  (:require [cljs.reader :as reader]
+            [clojure.string :as str]
+            [re-frame.core :as rf]))
+
+;; ---- encode / decode ----------------------------------------------------
+
+(defn- kw->encoded
+  "Encode a keyword for the query string. Namespaced keywords serialise
+  as `ns/name`; bare keywords as `name`. nil → nil. Strings pass
+  through. Anything else uses pr-str so the round-trip is faithful."
+  [v]
+  (cond
+    (nil? v)        nil
+    (keyword? v)    (if-let [ns (namespace v)]
+                      (str ns "/" (name v))
+                      (name v))
+    (string? v)     v
+    :else           (pr-str v)))
+
+(defn- encoded->kw
+  "Inverse of kw->encoded. The encoded form preserves the leading
+  `:` only when the value itself was pr-str'd (vectors, maps, etc.);
+  bare keywords roundtrip via `ns/name` form."
+  [s]
+  (cond
+    (nil? s)                          nil
+    (str/blank? s)                    nil
+    (and (> (count s) 1) (= \: (first s)))
+    ;; pr-str'd form — read back as EDN
+    (try (reader/read-string s) (catch :default _ nil))
+    :else
+    ;; plain keyword form: "auth/login" or "idle"
+    (if (str/includes? s "/")
+      (let [[ns name] (str/split s #"/" 2)]
+        (keyword ns name))
+      (keyword s))))
+
+(defn- url-encode
+  "Browser-side URL component encoder. Tests can rebind."
+  [s]
+  (when s
+    (js/encodeURIComponent s)))
+
+(defn- url-decode
+  "Browser-side URL component decoder. Tests can rebind."
+  [s]
+  (when s
+    (try (js/decodeURIComponent s) (catch :default _ s))))
+
+(defn encode-state
+  "Render the Causa-side state map into a query-param map. nil-safe;
+  drops empty / nil values so the URL stays compact. Pure fn.
+
+  Input shape:
+
+      {:machine-id  <keyword-or-nil>
+       :instance-id <keyword-or-nil>
+       :position    <int|:present|nil>
+       :mode        <:mode-a|:mode-b|:mode-c|nil>
+       :tab         <keyword-or-nil>}
+
+  Returns a sorted vec of `[key value]` pairs (sorted so the encoded
+  URL is deterministic; useful for round-trip tests + dedupe)."
+  [{:keys [machine-id instance-id position mode tab]}]
+  (let [pairs (cond-> []
+                true                       (conj ["causa-share" "1"])
+                (some? machine-id)         (conj ["machine" (kw->encoded machine-id)])
+                (some? instance-id)        (conj ["instance" (kw->encoded instance-id)])
+                (or (= :present position)
+                    (nil? position))       (conj ["pos" "present"])
+                (integer? position)        (conj ["pos" (str position)])
+                (some? mode)               (conj ["mode" (kw->encoded mode)])
+                (some? tab)                (conj ["tab" (kw->encoded tab)]))]
+    ;; Sort by key for deterministic encoding (test-friendly).
+    (vec (sort-by first pairs))))
+
+(defn query-string
+  "Render a sorted [[k v] ...] pair-vec into a `?a=b&c=d` query string
+  (with leading `?`). Pure fn."
+  [pairs]
+  (if (empty? pairs)
+    ""
+    (str "?" (str/join "&" (map (fn [[k v]]
+                                  (str (url-encode k) "=" (url-encode v)))
+                                pairs)))))
+
+(defn build-share-url
+  "Compose `origin` + `pathname` + the encoded state's query string.
+  Pure fn — tests pass an explicit base; the CLJS `current-share-url`
+  fn below reads `js/window.location` for the runtime."
+  [base state]
+  (str (or base "") (query-string (encode-state state))))
+
+(defn parse-query-string
+  "Inverse of `query-string` — parses a leading `?a=b&c=d` (or bare
+  `a=b&c=d`) into a `{key value}` string-map. nil / empty → `{}`.
+  Pure fn. Tolerant of malformed pairs (drops them rather than
+  throwing)."
+  [s]
+  (if (str/blank? s)
+    {}
+    (let [trimmed (if (str/starts-with? s "?") (subs s 1) s)
+          parts   (str/split trimmed #"&")]
+      (into {}
+            (keep (fn [part]
+                    (let [[k v] (str/split part #"=" 2)]
+                      (when (and k v)
+                        [(url-decode k) (url-decode v)]))))
+            parts))))
+
+(defn decode-state
+  "Inverse of `encode-state` — parses the query-string param map back
+  into a Causa-side state map. Returns nil when `causa-share` is
+  absent (so the restore path can short-circuit on non-share URLs).
+
+  Pure fn — does NOT touch app-db; the event handler in this ns
+  applies the state."
+  [params]
+  (when (and params (= "1" (get params "causa-share")))
+    (let [pos-raw (get params "pos")]
+      (cond-> {}
+        (get params "machine")
+        (assoc :machine-id (encoded->kw (get params "machine")))
+
+        (get params "instance")
+        (assoc :instance-id (encoded->kw (get params "instance")))
+
+        (= "present" pos-raw)
+        (assoc :position :present)
+
+        (and pos-raw (not= "present" pos-raw))
+        (assoc :position (try
+                           (let [n (js/parseInt pos-raw 10)]
+                             (if (js/isNaN n) :present n))
+                           (catch :default _ :present)))
+
+        (get params "mode")
+        (assoc :mode (encoded->kw (get params "mode")))
+
+        (get params "tab")
+        (assoc :tab (encoded->kw (get params "tab")))))))
+
+(defn decode-share-url
+  "Convenience: parse a full URL's query string into the Causa state
+  map. Pure fn. Returns nil when the URL doesn't carry the
+  `causa-share` sentinel."
+  [url]
+  (when url
+    (let [qs-idx (str/index-of url "?")
+          qs     (when qs-idx (subs url qs-idx))]
+      (decode-state (parse-query-string qs)))))
+
+;; ---- browser bridge -----------------------------------------------------
+
+(defn- window-location-base
+  "Read `js/window.location.origin + pathname` to produce the base
+  for the share URL. Tests rebind via `with-redefs`."
+  []
+  (try
+    (str (.. js/window -location -origin)
+         (.. js/window -location -pathname))
+    (catch :default _ "")))
+
+(defn current-share-url
+  "Render the share URL for the current Causa state. CLJS-only —
+  reads `js/window.location` for the base. Pure once the base is
+  passed in (the JVM/Node test target calls `build-share-url`
+  directly)."
+  [state]
+  (build-share-url (window-location-base) state))
+
+;; ---- subs ---------------------------------------------------------------
+
+(defn install-subs!
+  "Register the share-modal sub family."
+  []
+  (rf/reg-sub :rf.causa/share-modal-open?
+    (fn [db _query]
+      (boolean (get db :share/modal-open?))))
+
+  ;; The Causa-side state composite the share URL encodes. Built as a
+  ;; standalone sub so the modal can show the encoded URL live as the
+  ;; user moves the scrubber / picks a different machine.
+  ;;
+  ;; Pulls the explicit `:rf.causa/selected-machine-id` slot rather
+  ;; than the composite's effective fall-back: the user's INTENT (an
+  ;; explicit pick, or no pick at all) is what should round-trip
+  ;; through the share URL — sharing the implicit "first machine"
+  ;; would be a footgun for hosts whose registered-machines order
+  ;; changes between sessions.
+  (rf/reg-sub :rf.causa/share-state
+    :<- [:rf.causa/selected-machine-id]
+    :<- [:rf.causa/forced-machine-mode]
+    :<- [:rf.causa/selected-tab]
+    :<- [:rf.causa/machine-scrubber-position]
+    (fn [[machine-id forced-mode tab position] _query]
+      ;; instance-id == machine-id under the Phase 1/3 snapshot
+      ;; widening; the slot stays for the spawn-aware future.
+      (cond-> {}
+        (some? machine-id)  (assoc :machine-id machine-id
+                                   :instance-id machine-id)
+        (some? forced-mode) (assoc :mode forced-mode)
+        (some? tab)         (assoc :tab tab)
+        (some? position)    (assoc :position position))))
+
+  ;; The composed URL string. The modal renders this in its <input>
+  ;; field; the copy fx reads it via the same composite at fire time.
+  (rf/reg-sub :rf.causa/share-url
+    :<- [:rf.causa/share-state]
+    (fn [state _query]
+      (current-share-url state)))
+
+  ;; Effect status — `:idle | :copied | :failed`. The modal flips the
+  ;; copy button's label off this slot ("Copy" → "Copied!" → reset).
+  (rf/reg-sub :rf.causa/share-copy-status
+    (fn [db _query]
+      (get db :share/copy-status :idle))))
+
+;; ---- effects ------------------------------------------------------------
+
+(defn copy-to-clipboard!
+  "Native clipboard write. CLJS-only; returns a Promise. Tests can
+  stub via `with-redefs` since the event-fx wraps this call (so
+  redefining this fn is enough to mock the copy).
+
+  Per the Causa-wide fx convention the fire side uses the existing
+  `:rf.causa.fx/copy-to-clipboard` fx (registered in
+  `app_db_diff_events.cljs`); the post-copy status flip rides a
+  fire-and-forget `.then` on the Promise here so the modal's button
+  label flips on resolve / reject."
+  [text]
+  (when (and js/navigator (.-clipboard js/navigator))
+    (.writeText (.-clipboard js/navigator) (str text))))
+
+(defn install-fxs!
+  "Register the share-specific fxs. The clipboard fx itself reuses
+  the shared `:rf.causa.fx/copy-to-clipboard` fx already registered
+  by app_db_diff_events.cljs; this install only adds the new-tab fx."
+  []
+  ;; Open a URL in a new browser tab. Wrapped as an fx so the test
+  ;; rig can stub `:rf.causa.fx/open-in-new-tab` instead of touching
+  ;; `js/window.open` directly.
+  (rf/reg-fx :rf.causa.fx/open-in-new-tab
+    (fn [url]
+      (when (and url js/window)
+        (.open js/window (str url) "_blank")))))
+
+;; ---- events -------------------------------------------------------------
+
+(defn install-events!
+  "Register the share-modal event family."
+  []
+  (rf/reg-event-db :rf.causa/share-modal-open
+    (fn [db _event]
+      (-> db
+          (assoc :share/modal-open? true)
+          (assoc :share/copy-status :idle))))
+
+  (rf/reg-event-db :rf.causa/share-modal-close
+    (fn [db _event]
+      (-> db
+          (dissoc :share/modal-open?)
+          (dissoc :share/copy-status))))
+
+  (rf/reg-event-db :rf.causa/share-copy-status
+    (fn [db [_ status]]
+      (assoc db :share/copy-status (or status :idle))))
+
+  ;; Copy the current share URL. The handler reads the composite slots
+  ;; from app-db directly to capture the URL at fire-time — the modal's
+  ;; UI might be a tick behind on a fast scrub but the URL the user
+  ;; actually pastes always reflects the moment they clicked Copy.
+  ;;
+  ;; The fire path:
+  ;;   1. Compose the share-state from the per-slot app-db reads.
+  ;;   2. Render the URL.
+  ;;   3. Call `copy-to-clipboard!` directly (so tests can stub via
+  ;;      `with-redefs`) — the returned Promise (when clipboard is
+  ;;      available) fans out a status-update dispatch on resolve /
+  ;;      reject so the modal's button label flips. Fire-and-forget;
+  ;;      we don't `await` from inside the handler.
+  ;;   4. Stash the URL in app-db for test inspection.
+  (rf/reg-event-fx :rf.causa/copy-share-url-to-clipboard
+    (fn [{:keys [db]} _event]
+      (let [state (let [machine-id  (:selected-machine-id db)
+                        forced-mode (:machine-inspector/forced-mode db)
+                        tab         (or (:selected-tab db) :event)
+                        position    (:machine-inspector/scrubber-position db)]
+                    (cond-> {}
+                      (some? machine-id)  (assoc :machine-id machine-id
+                                                 :instance-id machine-id)
+                      (some? forced-mode) (assoc :mode forced-mode)
+                      (some? tab)         (assoc :tab tab)
+                      (some? position)    (assoc :position position)))
+            url   (current-share-url state)
+            p     (copy-to-clipboard! url)]
+        (when p
+          (.then p
+                 (fn [_]
+                   (rf/dispatch [:rf.causa/share-copy-status :copied]
+                                {:frame :rf/causa})
+                   (js/setTimeout
+                     (fn []
+                       (rf/dispatch [:rf.causa/share-copy-status :idle]
+                                    {:frame :rf/causa}))
+                     1500))
+                 (fn [_]
+                   (rf/dispatch [:rf.causa/share-copy-status :failed]
+                                {:frame :rf/causa}))))
+        {:db (assoc db :share/last-encoded-url url)})))
+
+  (rf/reg-event-fx :rf.causa/open-share-url-in-new-tab
+    (fn [{:keys [db]} _event]
+      (let [state (let [machine-id  (:selected-machine-id db)
+                        forced-mode (:machine-inspector/forced-mode db)
+                        tab         (or (:selected-tab db) :event)
+                        position    (:machine-inspector/scrubber-position db)]
+                    (cond-> {}
+                      (some? machine-id)  (assoc :machine-id machine-id
+                                                 :instance-id machine-id)
+                      (some? forced-mode) (assoc :mode forced-mode)
+                      (some? tab)         (assoc :tab tab)
+                      (some? position)    (assoc :position position)))
+            url   (current-share-url state)]
+        {:fx [[:rf.causa.fx/open-in-new-tab url]]})))
+
+  ;; Restore Causa state from a decoded share-state map. Drives the
+  ;; per-slot reducers so the same code-paths that handle interactive
+  ;; events handle the restored ones — no special-case branches.
+  (rf/reg-event-db :rf.causa/restore-from-share-url
+    (fn [db [_ {:keys [machine-id position mode tab] :as state}]]
+      (cond-> db
+        (some? machine-id) (assoc :selected-machine-id machine-id)
+        (some? position)   (assoc :machine-inspector/scrubber-position position)
+        (and (some? mode)
+             (contains? #{:mode-a :mode-b :mode-c} mode))
+        (assoc :machine-inspector/forced-mode mode)
+        (some? tab)        (assoc :selected-tab tab)))))
+
+;; ---- on-load restore hook -----------------------------------------------
+
+(defn maybe-restore-from-location!
+  "Inspect `js/window.location.search` and, if it carries the
+  `causa-share` sentinel, dispatch the restore event. Called from
+  `mount.cljs` after the Causa frame is registered. CLJS-only.
+
+  Returns the parsed state map (for test inspection) or nil when no
+  share URL is present."
+  []
+  (try
+    (let [qs    (.. js/window -location -search)
+          state (decode-state (parse-query-string qs))]
+      (when state
+        (rf/dispatch [:rf.causa/restore-from-share-url state]
+                     {:frame :rf/causa}))
+      state)
+    (catch :default _ nil)))
+
+;; ---- public install entry -----------------------------------------------
+
+(defn install!
+  "Idempotent install for the share infra. Called by
+  `machine_inspector/install!`. Wires subs + events + fxs through the
+  Causa-side registrar."
+  []
+  (install-subs!)
+  (install-fxs!)
+  (install-events!))

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -1,0 +1,256 @@
+(ns day8.re-frame2-causa.share-modal
+  "Causa Share modal view (rf2-nqw0v, Phase 5).
+
+  The modal mounts at the shell-view root (per the palette / settings
+  popup pattern); the modal short-circuits to nil when
+  `:rf.causa/share-modal-open?` is false, so the dormant cost is one
+  subscribe + a `when`.
+
+  ## Affordances
+
+    - **Copyable URL input** — selected by default for keyboard-only
+      flows; the Copy button writes via `navigator.clipboard`.
+    - **Reset button** — clears the focus / mode / scrubber slots
+      via the existing per-slot reducers, then re-renders the URL
+      so the user can confirm the reset took.
+    - **Open in new tab** — pops the encoded URL into a fresh tab so
+      a teammate can confirm the restore path before sharing.
+
+  ## Pure hiccup
+
+  Every subscribe / dispatch resolves against `:rf/causa` via the
+  enclosing frame-provider in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- view helpers -------------------------------------------------------
+
+(defn- backdrop-style []
+  {:position        "fixed"
+   :top             0
+   :left            0
+   :right           0
+   :bottom          0
+   :background      "rgba(8, 9, 12, 0.65)"
+   :backdrop-filter "blur(2px)"
+   :display         "flex"
+   :align-items     "center"
+   :justify-content "center"
+   :z-index         2147483100})
+
+(defn- dialog-style []
+  {:background    (:bg-1 tokens)
+   :border        (str "1px solid " (:border-default tokens))
+   :border-radius "6px"
+   :box-shadow    "rgba(0, 0, 0, 0.5) 0 12px 32px"
+   :width         "560px"
+   :max-width     "92vw"
+   :padding       "20px"
+   :display       "flex"
+   :flex-direction "column"
+   :gap           "14px"
+   :font-family   sans-stack
+   :color         (:text-primary tokens)})
+
+(defn- header
+  []
+  [:div {:style {:display "flex"
+                 :align-items "center"
+                 :justify-content "space-between"}}
+   [:h2 {:style {:margin 0
+                 :font-size "14px"
+                 :font-weight 600
+                 :color (:text-primary tokens)
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"}}
+    "Share Causa state"]
+   [:button
+    {:data-testid "rf-causa-share-modal-close"
+     :on-click    #(rf/dispatch [:rf.causa/share-modal-close] {:frame :rf/causa})
+     :style       {:background "transparent"
+                   :border "none"
+                   :color (:text-tertiary tokens)
+                   :font-size "16px"
+                   :cursor "pointer"
+                   :padding "0 6px"}
+     :title       "Close (Esc)"}
+    "✕"]])
+
+(defn- description
+  []
+  [:p {:style {:margin "0"
+               :color (:text-secondary tokens)
+               :font-size "12px"
+               :line-height 1.5}}
+   "Copy this URL to share your current Causa state — focused machine, "
+   "view mode, scrubber position, and selected tab will round-trip "
+   "when a teammate opens the link."])
+
+(defn- url-input
+  [url]
+  [:input
+   {:data-testid "rf-causa-share-modal-url"
+    :type        "text"
+    :read-only   true
+    :value       (or url "")
+    :on-click    (fn [e]
+                   ;; Select the contents on click so Cmd+C / Ctrl+C
+                   ;; works without an extra keystroke.
+                   (when-let [t (.-target e)]
+                     (try (.select t) (catch :default _ nil))))
+    :style       {:width "100%"
+                  :background (:bg-3 tokens)
+                  :border (str "1px solid " (:border-default tokens))
+                  :color (:text-primary tokens)
+                  :padding "8px 10px"
+                  :border-radius "4px"
+                  :font-family mono-stack
+                  :font-size "11px"
+                  :box-sizing "border-box"}}])
+
+(defn- copy-button
+  [copy-status]
+  (let [copied? (= :copied copy-status)
+        failed? (= :failed copy-status)
+        label   (cond
+                  copied? "Copied!"
+                  failed? "Copy failed"
+                  :else   "Copy URL")
+        tone    (cond
+                  copied? (:green tokens)
+                  failed? (:red tokens)
+                  :else   (:accent-violet tokens))]
+    [:button
+     {:data-testid    "rf-causa-share-modal-copy"
+      :data-status    (name (or copy-status :idle))
+      :on-click       #(rf/dispatch
+                         [:rf.causa/copy-share-url-to-clipboard]
+                         {:frame :rf/causa})
+      :style          {:background tone
+                       :border "none"
+                       :color "#101218"
+                       :font-family sans-stack
+                       :font-size "12px"
+                       :font-weight 600
+                       :padding "8px 16px"
+                       :border-radius "4px"
+                       :cursor "pointer"
+                       :min-width "120px"}}
+     label]))
+
+(defn- open-in-new-tab-button
+  []
+  [:button
+   {:data-testid "rf-causa-share-modal-open-new-tab"
+    :on-click    #(rf/dispatch [:rf.causa/open-share-url-in-new-tab]
+                               {:frame :rf/causa})
+    :style       {:background "transparent"
+                  :border (str "1px solid " (:border-default tokens))
+                  :color (:text-primary tokens)
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :padding "8px 14px"
+                  :border-radius "4px"
+                  :cursor "pointer"}}
+   "Open in new tab"])
+
+(defn- reset-button
+  []
+  [:button
+   {:data-testid "rf-causa-share-modal-reset"
+    :on-click    (fn [_]
+                   ;; Reset selection + forced mode + scrubber so the
+                   ;; URL collapses to the bare sentinel.
+                   (rf/dispatch [:rf.causa/clear-machine-selection]
+                                {:frame :rf/causa})
+                   (rf/dispatch [:rf.causa/set-forced-machine-mode nil]
+                                {:frame :rf/causa})
+                   (rf/dispatch [:rf.causa/set-scrubber-position :present]
+                                {:frame :rf/causa}))
+    :style       {:background "transparent"
+                  :border (str "1px solid " (:border-subtle tokens))
+                  :color (:text-tertiary tokens)
+                  :font-family sans-stack
+                  :font-size "12px"
+                  :padding "8px 14px"
+                  :border-radius "4px"
+                  :cursor "pointer"
+                  :margin-left "auto"}}
+   "Reset state"])
+
+(defn- state-summary
+  [share-state]
+  [:div {:data-testid "rf-causa-share-modal-state-summary"
+         :style       {:padding "10px 12px"
+                       :background (:bg-2 tokens)
+                       :border (str "1px solid " (:border-subtle tokens))
+                       :border-radius "4px"
+                       :font-family mono-stack
+                       :font-size "11px"
+                       :color (:text-secondary tokens)
+                       :line-height 1.7}}
+   [:div
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "machine "]
+    [:strong {:style {:color (:text-primary tokens)}}
+     (if (:machine-id share-state) (str (:machine-id share-state)) "(none)")]]
+   [:div
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "mode    "]
+    [:strong {:style {:color (:text-primary tokens)}}
+     (if (:mode share-state) (str (:mode share-state)) "auto")]]
+   [:div
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "tab     "]
+    [:strong {:style {:color (:text-primary tokens)}}
+     (if (:tab share-state) (str (:tab share-state)) "(default)")]]
+   [:div
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "pos     "]
+    [:strong {:style {:color (:text-primary tokens)}}
+     (cond
+       (= :present (:position share-state)) "present"
+       (integer? (:position share-state))   (str "step " (:position share-state))
+       :else                                 "present")]]])
+
+;; ---- main view ----------------------------------------------------------
+
+(defn share-dialog
+  "The Share dialog body. Pure hiccup."
+  []
+  (let [share-state @(rf/subscribe [:rf.causa/share-state])
+        share-url   @(rf/subscribe [:rf.causa/share-url])
+        copy-status @(rf/subscribe [:rf.causa/share-copy-status])]
+    [:div {:data-testid "rf-causa-share-modal-dialog"
+           :on-click    (fn [e] (.stopPropagation e))
+           :on-key-down (fn [^js e]
+                          (when (= "Escape" (.-key e))
+                            (rf/dispatch [:rf.causa/share-modal-close]
+                                         {:frame :rf/causa})))
+           :style       (dialog-style)}
+     (header)
+     (description)
+     (state-summary share-state)
+     (url-input share-url)
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :gap "8px"
+                    :flex-wrap "wrap"}}
+      (copy-button copy-status)
+      (open-in-new-tab-button)
+      (reset-button)]]))
+
+(rf/reg-view Modal
+  "The Share modal. Renders only when `:rf.causa/share-modal-open?`
+  is true; closed-state is one subscribe + a `when` — cheap.
+
+  Per rf2-in6l2 `reg-view`-registered so the body's subscribes
+  resolve through the React-context tier to `:rf/causa`."
+  []
+  (when @(rf/subscribe [:rf.causa/share-modal-open?])
+    [:div {:data-testid "rf-causa-share-modal-backdrop"
+           :on-click    #(rf/dispatch [:rf.causa/share-modal-close]
+                                      {:frame :rf/causa})
+           :style       (backdrop-style)}
+     (share-dialog)]))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -98,6 +98,7 @@
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.popover.causality :as causality-popover]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
+            [day8.re-frame2-causa.share-modal :as share-modal]
             [day8.re-frame2-causa.theme.tokens :refer [tokens type-scale layout sans-stack mono-stack]]))
 
 ;; ---- internal frames + tab inventory ------------------------------------
@@ -722,4 +723,11 @@
     ;; ("Press [c] for the causality graph"). Same mount semantics as
     ;; the palette Modal: closed-state is one subscribe + when-gate,
     ;; so the dormant cost is negligible.
-    [causality-popover/Popover]]])
+    [causality-popover/Popover]
+    ;; Share modal (rf2-nqw0v Phase 5) — encodes the current Causa
+    ;; state (focused machine + mode + scrubber + tab) into a URL the
+    ;; user can paste anywhere. Same mount discipline as the other
+    ;; modals: shell-root mount so subscribes resolve through the
+    ;; `:rf/causa` frame-provider; closed-state cost is one subscribe
+    ;; + a when-gate.
+    [share-modal/Modal]]])

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_cljs_test.cljs
@@ -1,0 +1,199 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-arc-cljs-test
+  "CLJS-side wiring tests for Causa's Machine Inspector per-instance
+  state-arc (rf2-nqw0v, Phase 5).
+
+  Covers:
+
+    1. Registry wires the arc sub family + the scrubber event family.
+    2. `:rf.causa/machine-arc-data` composes trace buffer + selected
+       machine + definitions into an arc.
+    3. `:rf.causa/machine-arc-trimmed` reacts to scrubber position.
+    4. `:rf.causa/machine-arc-highlight-state` returns the historic
+       state at the scrubber position.
+    5. The set-scrubber-position event writes to the Causa frame.
+    6. The set-arc-hover event writes and clears the slot."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.machine-inspector-arc :as arc]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-definitions-override-for-test definitions]))
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(defn- push-transition!
+  [id from to event]
+  (trace-bus/collect-trace!
+    {:id id :time id
+     :operation :rf.machine/transition
+     :tags {:machine-id :auth/login
+            :from from
+            :to to
+            :event event
+            :dispatch-id (str "d-" id)}}))
+
+;; ---- (1) registry wiring -----------------------------------------------
+
+(deftest registry-installs-arc-handlers
+  (testing "register-causa-handlers! installs the arc sub + event family"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/machine-arc-data)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-scrubber-position)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-arc-trimmed)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-arc-highlight-state)))
+    (is (some? (registrar/handler :sub :rf.causa/machine-arc-hover)))
+    (is (some? (registrar/handler :event :rf.causa/set-scrubber-position)))
+    (is (some? (registrar/handler :event :rf.causa/set-arc-hover)))))
+
+;; ---- (2) arc-data composite -------------------------------------------
+
+(deftest arc-data-empty-when-no-machine-selected
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [])
+    (is (= [] @(rf/subscribe [:rf.causa/machine-arc-data])))))
+
+(deftest arc-data-includes-origin-from-definition
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (let [arc @(rf/subscribe [:rf.causa/machine-arc-data])]
+      (is (= 1 (count arc)) "origin-only when no transitions in buffer")
+      (is (= :idle (-> arc first :state))))))
+
+(deftest arc-data-folds-transitions
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (let [arc @(rf/subscribe [:rf.causa/machine-arc-data])]
+      (is (= 3 (count arc)) "origin + two transitions"))))
+
+;; ---- (3) trimmed arc reacts to scrubber --------------------------------
+
+(deftest arc-trimmed-defaults-to-full
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (let [arc     @(rf/subscribe [:rf.causa/machine-arc-data])
+          trimmed @(rf/subscribe [:rf.causa/machine-arc-trimmed])]
+      (is (= (count arc) (count trimmed))
+          "default :present position renders the full arc"))))
+
+(deftest arc-trimmed-slices-on-scrubber-position
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 1])
+    (let [trimmed @(rf/subscribe [:rf.causa/machine-arc-trimmed])]
+      (is (= 2 (count trimmed))
+          "scrubber at idx=1 → origin + first transition"))))
+
+;; ---- (4) highlight-state-at -------------------------------------------
+
+(deftest highlight-state-tracks-scrubber
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 0])
+    (is (= :idle
+           @(rf/subscribe [:rf.causa/machine-arc-highlight-state]))
+        "scrub to origin → highlight :idle")
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 1])
+    (is (= :authing
+           @(rf/subscribe [:rf.causa/machine-arc-highlight-state])))
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position :present])
+    (is (nil? @(rf/subscribe [:rf.causa/machine-arc-highlight-state]))
+        "scrub at :present → nil so the chart shows the live snapshot")))
+
+;; ---- (5) set-scrubber-position event ----------------------------------
+
+(deftest set-scrubber-position-writes-int
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 5])
+    (is (= 5 @(rf/subscribe [:rf.causa/machine-scrubber-position])))))
+
+(deftest set-scrubber-position-writes-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 5])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position :present])
+    (is (= :present @(rf/subscribe [:rf.causa/machine-scrubber-position])))))
+
+(deftest set-scrubber-position-nil-flips-to-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 3])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position nil])
+    (is (= :present @(rf/subscribe [:rf.causa/machine-scrubber-position])))))
+
+;; ---- (6) set-arc-hover ------------------------------------------------
+
+(deftest set-arc-hover-writes-and-clears
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa/machine-arc-hover]))
+        "no hover by default")
+    (rf/dispatch-sync [:rf.causa/set-arc-hover 2])
+    (is (= 2 @(rf/subscribe [:rf.causa/machine-arc-hover])))
+    (rf/dispatch-sync [:rf.causa/set-arc-hover nil])
+    (is (nil? @(rf/subscribe [:rf.causa/machine-arc-hover])))))
+
+;; ---- frame isolation --------------------------------------------------
+
+(deftest scrubber-position-lives-on-causa-frame
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 3]))
+  (let [causa-db   (frame/frame-app-db-value :rf/causa)
+        default-db (frame/frame-app-db-value :rf/default)]
+    (is (= 3 (:machine-inspector/scrubber-position causa-db)))
+    (is (nil? (:machine-inspector/scrubber-position default-db))
+        "host frame is untouched")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_helpers_cljs_test.cljc
@@ -1,0 +1,269 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-arc-helpers-cljs-test
+  "Pure-data tests for Causa's Machine Inspector per-instance state-arc
+  helpers (rf2-nqw0v, Phase 5).
+
+  Dual-target via the `_cljs_test.cljc` extension — Cognitect's CLJ
+  test-runner picks the ns up via the `.*-test$` regex; Shadow's
+  `:node-test` build picks it up via `cljs-test$`. Same pattern every
+  Causa helper test uses.
+
+  ## What's under test
+
+    1. `build-arc`           — fold trace buffer + definition into
+                              chronological arc-points (origin + each
+                              transition).
+    2. `arc-length` / `max-scrub-index` — geometry.
+    3. `clamp-position` / `resolve-position-index` — scrubber bounds.
+    4. `trim-arc`            — slice arc to a scrubber position.
+    5. `highlight-state-at`  — historic state at scrubber position.
+    6. `at-present?`         — head detection.
+    7. `arc-segments`        — adjacent pair-vec for the renderer.
+    8. `nodes->index` / `point-center` — node-centre resolution.
+    9. `format-*` helpers    — display formatters."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.machine-inspector-arc-helpers
+             :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def ^:private fixture-def
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(defn- transition-event
+  ([id from to event] (transition-event id from to event id))
+  ([id from to event time]
+   {:id id :time time
+    :operation :rf.machine/transition
+    :tags {:machine-id :auth/login
+           :from from
+           :to to
+           :event event
+           :dispatch-id (str "d-" id)}}))
+
+(defn- microstep-event
+  [id from to event]
+  {:id id :time id
+   :operation :rf.machine.microstep/transition
+   :tags {:machine-id :auth/login
+          :from from
+          :to to
+          :event event
+          :dispatch-id (str "d-" id)}})
+
+;; ---- (1) build-arc ------------------------------------------------------
+
+(deftest build-arc-empty-when-machine-id-nil
+  (is (= [] (h/build-arc [] nil fixture-def))))
+
+(deftest build-arc-origin-only-when-no-transitions
+  (testing "with no transitions in the buffer the arc carries just the
+            initial-state origin"
+    (let [arc (h/build-arc [] :auth/login fixture-def)]
+      (is (= 1 (count arc)))
+      (let [origin (first arc)]
+        (is (= 0      (:idx origin)))
+        (is (= :idle  (:state origin)))
+        (is (nil?     (:from origin)))
+        (is (nil?     (:event origin)))
+        (is (false?   (:microstep? origin)))))))
+
+(deftest build-arc-folds-transitions-into-trajectory
+  (let [buf [(transition-event 1 :idle    :authing [:auth/start])
+             (transition-event 2 :authing :done    [:auth/ok])]
+        arc (h/build-arc buf :auth/login fixture-def)]
+    (is (= 3 (count arc)) "origin + two transitions")
+    (is (= [:idle :authing :done] (mapv :state arc)))
+    (is (= [0 1 2] (mapv :idx arc)))
+    (is (= [:auth/start] (-> arc (nth 1) :event)))
+    (is (= "d-1" (-> arc (nth 1) :dispatch-id)))))
+
+(deftest build-arc-sorts-by-id-when-out-of-order
+  (testing "events arriving out of order in the buffer still produce a
+            chronological arc"
+    (let [buf [(transition-event 2 :authing :done    [:auth/ok])
+               (transition-event 1 :idle    :authing [:auth/start])]
+          arc (h/build-arc buf :auth/login fixture-def)]
+      (is (= [:idle :authing :done] (mapv :state arc))))))
+
+(deftest build-arc-filters-by-machine-id
+  (let [buf [(transition-event 1 :idle :authing [:auth/start])
+             {:id 2 :time 2 :operation :rf.machine/transition
+              :tags {:machine-id :checkout/flow
+                     :from :foo :to :bar :event [:other]}}]
+        arc (h/build-arc buf :auth/login fixture-def)]
+    (is (= 2 (count arc)) "the other machine's transition is dropped")
+    (is (= [:idle :authing] (mapv :state arc)))))
+
+(deftest build-arc-includes-microstep-with-flag
+  (let [buf [(transition-event 1 :idle    :authing [:auth/start])
+             (microstep-event  2 :authing :checking [:always])]
+        arc (h/build-arc buf :auth/login fixture-def)]
+    (is (= 3 (count arc)))
+    (is (false? (:microstep? (nth arc 1))))
+    (is (true?  (:microstep? (nth arc 2))))))
+
+(deftest build-arc-synthesises-origin-from-oldest-from-when-no-definition
+  (testing "with no definition map the arc origin reads off the oldest
+            transition's :from slot"
+    (let [buf [(transition-event 1 :idle :authing [:auth/start])]
+          arc (h/build-arc buf :auth/login nil)]
+      (is (= 2 (count arc)))
+      (is (= :idle (:state (first arc)))))))
+
+(deftest build-arc-empty-when-no-definition-and-no-transitions
+  (is (= [] (h/build-arc [] :auth/login nil))))
+
+;; ---- (2) length + index helpers ----------------------------------------
+
+(deftest arc-length-counts-points
+  (is (= 0 (h/arc-length [])))
+  (is (= 0 (h/arc-length nil)))
+  (is (= 3 (h/arc-length [{} {} {}]))))
+
+(deftest max-scrub-index-returns-n-minus-1
+  (is (= -1 (h/max-scrub-index [])))
+  (is (= 0  (h/max-scrub-index [{}])))
+  (is (= 2  (h/max-scrub-index [{} {} {}]))))
+
+;; ---- (3) clamp + resolve -----------------------------------------------
+
+(deftest clamp-position-handles-special-values
+  (let [arc [{} {} {}]]
+    (is (= :present (h/clamp-position arc nil)))
+    (is (= :present (h/clamp-position arc :present)))
+    (is (= 0       (h/clamp-position arc 0)))
+    (is (= 2       (h/clamp-position arc 2)))
+    (is (= :present (h/clamp-position arc 99))
+        "out-of-bounds positive flips to :present (sticky head)")
+    (is (= 0       (h/clamp-position arc -5))
+        "negative clamps to 0")))
+
+(deftest clamp-position-empty-arc
+  (is (= :present (h/clamp-position [] 0)))
+  (is (= :present (h/clamp-position [] :present))))
+
+(deftest resolve-position-index-maps-present-to-tail
+  (let [arc [{} {} {}]]
+    (is (= 2 (h/resolve-position-index arc :present)))
+    (is (= 0 (h/resolve-position-index arc 0)))
+    (is (= 1 (h/resolve-position-index arc 1)))
+    (is (= -1 (h/resolve-position-index [] :present)))))
+
+;; ---- (4) trim-arc ------------------------------------------------------
+
+(deftest trim-arc-present-returns-full-arc
+  (let [arc [{:idx 0} {:idx 1} {:idx 2}]]
+    (is (= arc (h/trim-arc arc :present)))))
+
+(deftest trim-arc-index-slices-inclusive
+  (let [arc [{:idx 0} {:idx 1} {:idx 2}]]
+    (is (= [{:idx 0}]                 (h/trim-arc arc 0)))
+    (is (= [{:idx 0} {:idx 1}]        (h/trim-arc arc 1)))
+    (is (= arc                        (h/trim-arc arc 2)))))
+
+(deftest trim-arc-empty-returns-empty
+  (is (= [] (h/trim-arc [] :present)))
+  (is (= [] (h/trim-arc nil 0))))
+
+(deftest trim-arc-out-of-bounds-clamps
+  (let [arc [{:idx 0} {:idx 1}]]
+    (is (= arc (h/trim-arc arc 99)) "high → :present → full arc")
+    (is (= [{:idx 0}] (h/trim-arc arc -3)) "negative → 0 → origin only")))
+
+;; ---- (5) highlight-state-at --------------------------------------------
+
+(deftest highlight-state-at-returns-state-at-position
+  (let [arc [{:idx 0 :state :idle}
+             {:idx 1 :state :authing}
+             {:idx 2 :state :done}]]
+    (is (= :idle    (h/highlight-state-at arc 0)))
+    (is (= :authing (h/highlight-state-at arc 1)))
+    (is (= :done    (h/highlight-state-at arc 2)))
+    (is (= :done    (h/highlight-state-at arc :present)))))
+
+(deftest highlight-state-at-nil-when-empty
+  (is (nil? (h/highlight-state-at [] :present)))
+  (is (nil? (h/highlight-state-at nil 0))))
+
+;; ---- (6) at-present? ---------------------------------------------------
+
+(deftest at-present?-detects-head
+  (let [arc [{:idx 0} {:idx 1} {:idx 2}]]
+    (is (true?  (h/at-present? arc :present)))
+    (is (true?  (h/at-present? arc 2))   "explicit tail idx counts as present")
+    (is (false? (h/at-present? arc 0)))
+    (is (false? (h/at-present? arc 1)))))
+
+(deftest at-present?-empty-arc-is-present
+  (is (true? (h/at-present? [] :present)))
+  (is (true? (h/at-present? [] 0))))
+
+;; ---- (7) arc-segments --------------------------------------------------
+
+(deftest arc-segments-pairs-adjacent
+  (let [arc [{:idx 0} {:idx 1} {:idx 2}]
+        segs (h/arc-segments arc)]
+    (is (= 2 (count segs)))
+    (is (= {:idx 0} (-> segs first :from)))
+    (is (= {:idx 1} (-> segs first :to)))
+    (is (= {:idx 1} (-> segs second :from)))
+    (is (= {:idx 2} (-> segs second :to)))))
+
+(deftest arc-segments-empty-when-arc-too-short
+  (is (= [] (h/arc-segments [])))
+  (is (= [] (h/arc-segments [{:idx 0}]))))
+
+;; ---- (8) nodes->index + point-center -----------------------------------
+
+(deftest nodes->index-keys-by-node-id
+  (let [nodes [{:node-id "idle" :x 0 :y 0 :width 100 :height 40}
+               {:node-id "authing" :x 200 :y 0 :width 100 :height 40}]
+        idx   (h/nodes->index nodes)]
+    (is (= 2 (count idx)))
+    (is (= 0 (get-in idx ["idle" :x])))))
+
+(deftest point-center-returns-node-midpoint
+  (let [nodes [{:node-id "idle" :x 10 :y 20 :width 100 :height 40}]
+        idx   (h/nodes->index nodes)
+        ;; A trivial id-fn that just turns the state into its name string.
+        id-fn (fn [state] (when state (name state)))
+        point {:idx 0 :state :idle}]
+    (is (= [60 40] (h/point-center point idx id-fn))
+        "centre = (x + w/2, y + h/2)")))
+
+(deftest point-center-nil-when-node-missing
+  (let [idx   {}
+        id-fn (fn [s] (name s))
+        point {:idx 0 :state :foo}]
+    (is (nil? (h/point-center point idx id-fn)))))
+
+;; ---- (9) format helpers ------------------------------------------------
+
+(deftest format-point-tooltip-origin
+  (let [t (h/format-point-tooltip {:idx 0 :state :idle :from nil :event nil})]
+    (is (some? t))
+    (is (re-find #"origin" t))
+    (is (re-find #":idle" t))))
+
+(deftest format-point-tooltip-transition
+  (let [t (h/format-point-tooltip
+            {:idx 2 :state :done :from :authing
+             :event [:auth/ok] :time 5000})]
+    (is (re-find #":authing" t))
+    (is (re-find #":done" t))
+    (is (re-find #":auth/ok" t))
+    (is (re-find #"@5000ms" t))))
+
+(deftest format-position-label-renders-modes
+  (let [arc [{:idx 0} {:idx 1} {:idx 2}]]
+    (is (re-find #"present" (h/format-position-label arc :present)))
+    (is (re-find #"step 1"  (h/format-position-label arc 1)))
+    (is (re-find #"present" (h/format-position-label arc nil)))))
+
+(deftest format-position-label-empty-arc
+  (is (re-find #"no history" (h/format-position-label [] :present))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_scrubber_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_scrubber_cljs_test.cljs
@@ -1,0 +1,241 @@
+(ns day8.re-frame2-causa.panels.machine-inspector-scrubber-cljs-test
+  "CLJS-side view tests for Causa's Machine Inspector mini-scrubber
+  (rf2-nqw0v, Phase 5).
+
+  Covers:
+
+    1. The scrubber renders nothing when no arc data is present.
+    2. With an arc, the slider + present-button + label all render.
+    3. The slider's `data-position` reflects the scrubber sub.
+    4. The slider's max attribute = arc-length - 1.
+    5. Drag (`on-change`) dispatches `:rf.causa/set-scrubber-position`.
+    6. The present-button is disabled at :present and enabled when
+       scrubbed back."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.machine-inspector-scrubber
+             :as scrubber]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers -----------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-fn-component tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-definitions-override-for-test definitions]))
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on {:start :authing}}
+             :authing {:on {:ok :done :err :failed}}
+             :done    {:final? true}
+             :failed  {:final? true}}})
+
+(defn- push-transition!
+  [id from to event]
+  (trace-bus/collect-trace!
+    {:id id :time id
+     :operation :rf.machine/transition
+     :tags {:machine-id :auth/login
+            :from from
+            :to to
+            :event event
+            :dispatch-id (str "d-" id)}}))
+
+;; ---- (1) renders nothing when arc empty --------------------------------
+
+(deftest scrubber-renders-nil-when-arc-empty
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [])
+    (let [tree (scrubber/ScrubberStrip)]
+      (is (nil? tree)
+          "no arc data → no scrubber"))))
+
+;; ---- (2) renders chrome when arc present -------------------------------
+
+(deftest scrubber-renders-when-arc-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (let [tree (scrubber/ScrubberStrip)]
+      (is (some? (find-by-testid tree "rf-causa-machine-inspector-scrubber"))
+          "scrubber container present")
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-scrubber-input"))
+          "slider input present")
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-scrubber-present"))
+          "present-button present")
+      (is (some? (find-by-testid
+                   tree "rf-causa-machine-inspector-scrubber-label"))
+          "position-label present"))))
+
+;; ---- (3) slider data-position reflects scrubber sub --------------------
+
+(deftest slider-data-position-is-present-by-default
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle :authing [:auth/start])
+    (let [tree  (scrubber/ScrubberStrip)
+          input (find-by-testid
+                  tree "rf-causa-machine-inspector-scrubber-input")]
+      (is (= "present" (:data-position (second input)))))))
+
+(deftest slider-data-position-updates-on-scrub
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 1])
+    (let [tree  (scrubber/ScrubberStrip)
+          input (find-by-testid
+                  tree "rf-causa-machine-inspector-scrubber-input")]
+      (is (= "1" (:data-position (second input)))))))
+
+;; ---- (4) slider max attr = arc-length - 1 ------------------------------
+
+(deftest slider-max-is-arc-tail-index
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (let [tree  (scrubber/ScrubberStrip)
+          input (find-by-testid
+                  tree "rf-causa-machine-inspector-scrubber-input")]
+      ;; arc-length = 3 (origin + 2 transitions); max idx = 2
+      (is (= 2 (:max (second input)))))))
+
+;; ---- (5) on-change dispatches set-scrubber-position --------------------
+
+(deftest slider-onchange-dispatches-scrubber-position
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]      (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (let [tree    (scrubber/ScrubberStrip)
+              input   (find-by-testid
+                        tree "rf-causa-machine-inspector-scrubber-input")
+              handler (:on-change (second input))
+              fake-ev #js {:target #js {:value "1"}}]
+          (is (some? handler))
+          (when handler (handler fake-ev))))
+      (is (some (fn [ev] (and (= :rf.causa/set-scrubber-position (first ev))
+                              (= 1 (second ev))))
+                @dispatches)
+          "dragging the slider to 1 dispatches position=1"))))
+
+(deftest slider-at-tail-position-flips-to-present
+  (testing "when the user drags to the max-idx value, the dispatch sends
+            :present rather than the literal max-idx int so the head-
+            tracking semantics survive."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (push-transition! 1 :idle    :authing [:auth/start])
+      (push-transition! 2 :authing :done    [:auth/ok])
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]      (swap! dispatches conj ev) nil)
+                                     ([ev _opts] (swap! dispatches conj ev) nil))]
+          (let [tree    (scrubber/ScrubberStrip)
+                input   (find-by-testid
+                          tree "rf-causa-machine-inspector-scrubber-input")
+                handler (:on-change (second input))
+                fake-ev #js {:target #js {:value "2"}}]  ;; max idx = 2
+            (when handler (handler fake-ev))))
+        (is (some (fn [ev] (= [:rf.causa/set-scrubber-position :present] ev))
+                  @dispatches)
+            "dragging to max-idx dispatches :present")))))
+
+;; ---- (6) present-button disabled at :present ---------------------------
+
+(deftest present-button-disabled-at-present
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle :authing [:auth/start])
+    (let [tree  (scrubber/ScrubberStrip)
+          btn   (find-by-testid
+                  tree "rf-causa-machine-inspector-scrubber-present")]
+      (is (true? (:disabled (second btn)))))))
+
+(deftest present-button-enabled-when-scrubbed-back
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    (rf/dispatch-sync [:rf.causa/set-scrubber-position 0])
+    (let [tree (scrubber/ScrubberStrip)
+          btn  (find-by-testid
+                 tree "rf-causa-machine-inspector-scrubber-present")]
+      (is (false? (:disabled (second btn)))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -129,11 +129,17 @@
    :rf.causa/issues-filters
    :rf.causa/issues-ribbon
    :rf.causa/forced-machine-mode
+   ;; rf2-nqw0v Phase 5 — Machine Inspector per-instance arc + scrubber.
+   :rf.causa/machine-arc-data
+   :rf.causa/machine-arc-highlight-state
+   :rf.causa/machine-arc-hover
+   :rf.causa/machine-arc-trimmed
    :rf.causa/machine-definitions
    :rf.causa/machine-definitions-override
    :rf.causa/machine-inspector-data
    :rf.causa/machine-instances
    :rf.causa/machine-instances-override
+   :rf.causa/machine-scrubber-position
    :rf.causa/machine-snapshots
    :rf.causa/machine-snapshots-override
    :rf.causa/mode-c-cluster-by
@@ -194,6 +200,11 @@
    :rf.causa/sim-by-machine
    :rf.causa/sim-event-suggestions
    :rf.causa/sim-state
+   ;; rf2-nqw0v Phase 5 — Share affordance subs.
+   :rf.causa/share-copy-status
+   :rf.causa/share-modal-open?
+   :rf.causa/share-state
+   :rf.causa/share-url
    :rf.causa/suppressed-sensitive-count
    :rf.causa/target-frame
    :rf.causa/target-frame-db
@@ -248,6 +259,7 @@
    :rf.causa/close-edit-popup
    :rf.causa/close-shell
    :rf.causa/copy-path-to-clipboard
+   :rf.causa/copy-share-url-to-clipboard
    :rf.causa/copy-value-to-clipboard
    :rf.causa/delete-edit-popup
    :rf.causa/dismiss-pin-overflow-toast
@@ -270,6 +282,7 @@
    :rf.causa/open-edit-popup
    :rf.causa/open-in-editor
    :rf.causa/open-settings
+   :rf.causa/open-share-url-in-new-tab
    :rf.causa/palette-close
    :rf.causa/palette-cursor-down
    :rf.causa/palette-cursor-set
@@ -289,6 +302,7 @@
    :rf.causa/reset-suppressed-counters
    :rf.causa/reset-to-epoch
    :rf.causa/reset-to-pinned
+   :rf.causa/restore-from-share-url
    :rf.causa/save-edit-popup
    :rf.causa/select-dispatch-id
    :rf.causa/select-epoch
@@ -313,8 +327,10 @@
    :rf.causa/set-registered-flows-override-for-test
    :rf.causa/set-registered-fxs-override-for-test
    :rf.causa/set-registered-machines-override-for-test
+   :rf.causa/set-arc-hover
    :rf.causa/set-registered-routes-override-for-test
    :rf.causa/set-schema-filter
+   :rf.causa/set-scrubber-position
    :rf.causa/set-schema-timeline-window
    :rf.causa/set-target-frame
    :rf.causa/set-trace-filter
@@ -324,6 +340,10 @@
    :rf.causa/settings-select-tab
    :rf.causa/settings-toggle
    :rf.causa/settings-update
+   ;; rf2-nqw0v Phase 5 — Share affordance events.
+   :rf.causa/share-copy-status
+   :rf.causa/share-modal-close
+   :rf.causa/share-modal-open
    ;; rf2-v869p Phase 2 — UC1 Sim sub-mode events.
    :rf.causa/sim-reset
    :rf.causa/sim-set-pending-data
@@ -355,6 +375,8 @@
 
 (def ^:private all-fx-names
   [:rf.causa.fx/copy-to-clipboard
+   ;; rf2-nqw0v Phase 5 — Share affordance: new-tab open fx.
+   :rf.causa.fx/open-in-new-tab
    :rf.causa.fx/reset-frame-db!
    :rf.causa.fx/restore-epoch
    ;; rf2-ak4ms — auto-filter persistence side-effect. Lives under the
@@ -459,7 +481,12 @@
     ;;   mode-c-expanded + mode-c-selection + machine-instances +
     ;;   machine-instances-override + mode-c-clusters +
     ;;   mode-c-compare-table + forced-machine-mode.
-    (is (= 104 (count all-sub-names)))
+    ;; + 9 machine-inspector Phase 5 (rf2-nqw0v):
+    ;;   :rf.causa/machine-arc-data + machine-arc-trimmed +
+    ;;   machine-arc-highlight-state + machine-arc-hover +
+    ;;   machine-scrubber-position + share-modal-open? + share-state +
+    ;;   share-url + share-copy-status.
+    (is (= 113 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -502,13 +529,20 @@
     ;;   set-machine-instances-override-for-test.
     ;; + 1 machine-inspector Phase 4 (rf2-m7co9):
     ;;   :rf.causa/machine-chart-layout-pulse — ELK layout async pulse.
-    (is (= 126 (count all-event-names)))
+    ;; + 10 machine-inspector Phase 5 (rf2-nqw0v):
+    ;;   :rf.causa/set-scrubber-position + set-arc-hover +
+    ;;   share-modal-open + share-modal-close + share-copy-status +
+    ;;   copy-share-url-to-clipboard + open-share-url-in-new-tab +
+    ;;   restore-from-share-url (8 share/arc events) + the
+    ;;   arc-data implicit composite has no event of its own. The
+    ;;   correct count rises by 8 events; subs add another 9.
+    (is (= 134 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,
     ;; rf2-wm7z4) + 1 auto-filter (`:rf.causa.filters/persist`,
     ;; rf2-ak4ms).
-    (is (= 6  (count all-fx-names)))))
+    (is (= 7  (count all-fx-names)))))
 
 (deftest registry-is-idempotent
   (testing "calling register-causa-handlers! twice is a no-op (same handler instance)"

--- a/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
@@ -1,0 +1,265 @@
+(ns day8.re-frame2-causa.share-cljs-test
+  "CLJS tests for the Causa Share infra (rf2-nqw0v, Phase 5).
+
+  Covers:
+
+    1. `encode-state` / `decode-state` round-trip — the encoded URL
+       restores the same Causa state map.
+    2. `build-share-url` / `decode-share-url` — full-URL round-trip.
+    3. The query-string sentinel — non-share URLs return nil from
+       `decode-state` so the on-load restore path short-circuits.
+    4. Registry wiring — install! registers the share sub family.
+    5. Open / close modal events flip the slot.
+    6. The copy event-fx queues the clipboard fx with the encoded URL.
+    7. `restore-from-share-url` writes the per-slot values into the
+       Causa app-db."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.share :as share]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- (1) encode / decode round-trip ------------------------------------
+
+(deftest encode-state-includes-sentinel
+  (let [pairs (share/encode-state {})]
+    (is (some (fn [[k _]] (= "causa-share" k)) pairs)
+        "the sentinel key is always present")))
+
+(deftest encode-state-includes-namespaced-keyword
+  (let [pairs (share/encode-state {:machine-id :auth/login})
+        m     (into {} pairs)]
+    (is (= "auth/login" (get m "machine")))))
+
+(deftest encode-state-handles-bare-keyword
+  (let [pairs (share/encode-state {:machine-id :foo})
+        m     (into {} pairs)]
+    (is (= "foo" (get m "machine")))))
+
+(deftest encode-state-includes-mode-tab-pos
+  (let [pairs (share/encode-state {:machine-id :auth/login
+                                   :mode :mode-b
+                                   :tab :machines
+                                   :position 5})
+        m     (into {} pairs)]
+    (is (= "mode-b" (get m "mode")))
+    (is (= "machines" (get m "tab")))
+    (is (= "5" (get m "pos")))))
+
+(deftest encode-state-present-position
+  (let [pairs (share/encode-state {:machine-id :auth/login
+                                   :position :present})
+        m     (into {} pairs)]
+    (is (= "present" (get m "pos")))))
+
+(deftest encode-state-pos-defaults-to-present-when-nil
+  (let [pairs (share/encode-state {:machine-id :auth/login})
+        m     (into {} pairs)]
+    (is (= "present" (get m "pos")))))
+
+(deftest encode-state-deterministic-ordering
+  (testing "the encoded pair-vec is sorted by key so the URL is stable
+            across calls"
+    (let [a (share/encode-state {:machine-id :a :mode :mode-b :tab :event})
+          b (share/encode-state {:tab :event :machine-id :a :mode :mode-b})]
+      (is (= a b)))))
+
+(deftest query-string-builds-leading-question-mark
+  (let [pairs [["a" "1"] ["b" "2"]]
+        qs    (share/query-string pairs)]
+    (is (= "?a=1&b=2" qs))))
+
+(deftest query-string-empty
+  (is (= "" (share/query-string []))))
+
+(deftest parse-query-string-inverts-query-string
+  (let [pairs [["a" "1"] ["b" "2"]]
+        qs    (share/query-string pairs)
+        m     (share/parse-query-string qs)]
+    (is (= {"a" "1" "b" "2"} m))))
+
+(deftest parse-query-string-tolerant-of-blank
+  (is (= {} (share/parse-query-string nil)))
+  (is (= {} (share/parse-query-string "")))
+  (is (= {} (share/parse-query-string "?"))))
+
+(deftest decode-state-nil-without-sentinel
+  (is (nil? (share/decode-state {})))
+  (is (nil? (share/decode-state {"machine" "auth/login"}))
+      "missing causa-share=1 sentinel → non-share URL → nil"))
+
+(deftest decode-state-restores-namespaced-keyword
+  (let [s (share/decode-state {"causa-share" "1"
+                               "machine"     "auth/login"})]
+    (is (= :auth/login (:machine-id s)))))
+
+(deftest decode-state-restores-pos-int
+  (let [s (share/decode-state {"causa-share" "1"
+                               "pos"         "5"})]
+    (is (= 5 (:position s)))))
+
+(deftest decode-state-restores-pos-present
+  (let [s (share/decode-state {"causa-share" "1"
+                               "pos"         "present"})]
+    (is (= :present (:position s)))))
+
+(deftest decode-state-restores-mode-and-tab
+  (let [s (share/decode-state {"causa-share" "1"
+                               "mode"        "mode-c"
+                               "tab"         "machines"})]
+    (is (= :mode-c (:mode s)))
+    (is (= :machines (:tab s)))))
+
+(deftest encode-decode-round-trip
+  (testing "encode → decode preserves every payload slot"
+    (let [original {:machine-id  :auth/login
+                    :instance-id :auth/login
+                    :mode        :mode-b
+                    :tab         :machines
+                    :position    7}
+          encoded  (share/encode-state original)
+          qs       (share/query-string encoded)
+          decoded  (share/decode-state (share/parse-query-string qs))]
+      (is (= (:machine-id original)  (:machine-id decoded)))
+      (is (= (:instance-id original) (:instance-id decoded)))
+      (is (= (:mode original)        (:mode decoded)))
+      (is (= (:tab original)         (:tab decoded)))
+      (is (= (:position original)    (:position decoded))))))
+
+;; ---- (2) build / decode full URL ---------------------------------------
+
+(deftest build-share-url-prefixes-base
+  (let [url (share/build-share-url "https://example.com/app"
+                                   {:machine-id :auth/login})]
+    (is (re-find #"^https://example.com/app\?" url))))
+
+(deftest decode-share-url-extracts-state-from-full-url
+  (let [url   (share/build-share-url "https://example.com/app"
+                                     {:machine-id :auth/login
+                                      :position   3
+                                      :mode       :mode-b})
+        state (share/decode-share-url url)]
+    (is (= :auth/login (:machine-id state)))
+    (is (= 3 (:position state)))
+    (is (= :mode-b (:mode state)))))
+
+(deftest decode-share-url-nil-on-non-share-url
+  (is (nil? (share/decode-share-url "https://example.com/app")))
+  (is (nil? (share/decode-share-url "https://example.com/app?other=foo"))))
+
+;; ---- (4) registry wiring -----------------------------------------------
+
+(deftest install-registers-share-handlers
+  (testing "register-causa-handlers! installs every Phase 5 share handler"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/share-modal-open?)))
+    (is (some? (registrar/handler :sub :rf.causa/share-state)))
+    (is (some? (registrar/handler :sub :rf.causa/share-url)))
+    (is (some? (registrar/handler :sub :rf.causa/share-copy-status)))
+    (is (some? (registrar/handler :event :rf.causa/share-modal-open)))
+    (is (some? (registrar/handler :event :rf.causa/share-modal-close)))
+    (is (some? (registrar/handler :event :rf.causa/share-copy-status)))
+    (is (some? (registrar/handler :event :rf.causa/copy-share-url-to-clipboard)))
+    (is (some? (registrar/handler :event :rf.causa/open-share-url-in-new-tab)))
+    (is (some? (registrar/handler :event :rf.causa/restore-from-share-url)))
+    (is (some? (registrar/handler :fx :rf.causa.fx/open-in-new-tab)))))
+
+;; ---- (5) open / close --------------------------------------------------
+
+(deftest open-and-close-modal
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (is (false? @(rf/subscribe [:rf.causa/share-modal-open?]))
+        "modal closed by default")
+    (rf/dispatch-sync [:rf.causa/share-modal-open])
+    (is (true? @(rf/subscribe [:rf.causa/share-modal-open?])))
+    (rf/dispatch-sync [:rf.causa/share-modal-close])
+    (is (false? @(rf/subscribe [:rf.causa/share-modal-open?])))))
+
+(deftest open-resets-copy-status
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/share-copy-status :failed])
+    (rf/dispatch-sync [:rf.causa/share-modal-open])
+    (is (= :idle @(rf/subscribe [:rf.causa/share-copy-status]))
+        "opening the modal clears any leftover :failed / :copied status")))
+
+;; ---- (6) copy event-fx queues clipboard fx -----------------------------
+
+(deftest copy-event-queues-clipboard-fx
+  (testing "the copy event-fx schedules :rf.causa/copy-to-clipboard
+            with the encoded URL"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+      (let [captured (atom nil)]
+        (with-redefs [share/copy-to-clipboard! (fn [t] (reset! captured t) nil)]
+          (rf/dispatch-sync [:rf.causa/copy-share-url-to-clipboard]))
+        (is (some? @captured)
+            "clipboard fx fires with a URL")
+        (is (re-find #"machine=auth(?:%2F|/)login" @captured)
+            "URL carries the encoded machine-id (URL-encoded or raw)")))))
+
+;; ---- (7) restore-from-share-url writes per-slot values -----------------
+
+(deftest restore-writes-selection
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/restore-from-share-url
+                       {:machine-id :auth/login
+                        :mode       :mode-c
+                        :tab        :machines
+                        :position   3}])
+    (is (= :auth/login @(rf/subscribe [:rf.causa/selected-machine-id])))
+    (is (= :mode-c     @(rf/subscribe [:rf.causa/forced-machine-mode])))
+    (is (= :machines   @(rf/subscribe [:rf.causa/selected-tab])))
+    (is (= 3           @(rf/subscribe [:rf.causa/machine-scrubber-position])))))
+
+(deftest restore-ignores-invalid-mode
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/restore-from-share-url
+                       {:mode :not-a-real-mode}])
+    (is (nil? @(rf/subscribe [:rf.causa/forced-machine-mode]))
+        "invalid mode value is dropped rather than written")))
+
+(deftest restore-tolerates-empty-state
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/restore-from-share-url {}])
+    (is (nil? @(rf/subscribe [:rf.causa/selected-machine-id]))
+        "empty state map = no-op")))
+
+;; ---- frame isolation ---------------------------------------------------
+
+(deftest share-state-lives-on-causa-frame
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/share-modal-open]))
+  (let [causa-db   (frame/frame-app-db-value :rf/causa)
+        default-db (frame/frame-app-db-value :rf/default)]
+    (is (true? (:share/modal-open? causa-db))
+        "modal-open flag lands on Causa")
+    (is (nil? (:share/modal-open? default-db))
+        "host frame is untouched")))


### PR DESCRIPTION
## Summary

Phase 5 closes the Machine Inspector arc under rf2-2tkza. Three features land together: a per-instance state-arc overlay above the chart, a mini-scrubber for time-travel within the focused instance, and a Share affordance that encodes the current Causa state into a copyable URL.

## Features

### Per-instance state-arc

A thin SVG overlay above the chart that traces the focused instance's chronological state-trajectory.

```
  ●───────────●───────────●───────────●
  origin      step 1      step 2      present
  :idle       :authing    :checking   :done
```

- Origin (idx 0) is the machine's initial state (read from the definition's `:initial` slot, or synthesised from the oldest transition's `:from` when no definition is available).
- Each subsequent point is one outer or microstep transition for the focused instance, ordered oldest-first.
- Segment colour fades from origin to endpoint in the accent-violet palette; hovered segments + markers go cyan.
- Native SVG `<title>` tooltips on each marker carry `#idx · from → to (event) @timeMs`.
- Hidden in sim mode (sim is its own walking-clone surface).

### Mini-scrubber

A horizontal `<input type="range">` beneath the chart that scrubs back through the instance's state history.

```
  Scrub  [━━━━━━━●━━━━━━━━━━━━]  [⏭ present]  step 1 / 2
         0                    max
  ┌────────────────────────────────────────────────┐
  │ #1 · :idle → :authing  ([:auth/start])  @1ms   │
  └────────────────────────────────────────────────┘
```

- The slider drives `:rf.causa/set-scrubber-position`; the chart's highlight overrides to the scrubbed-to state via `:rf.causa/machine-arc-highlight-state`; the arc trims to `[0..idx]` via `:rf.causa/machine-arc-trimmed`.
- A "⏭ present" button snaps back to `:present`; disabled when already at present.
- Dragging the slider to the max idx auto-flips the dispatch to `:present` so head-tracking semantics survive a future-tense scrub.
- A live hover-tip beneath the slider shows the same `format-point-tooltip` text for the scrubbed-to point.

### Share affordance

A `⤴ Share` button in the panel header opens a modal dialog with a copyable URL encoding the current Causa state.

```
  ┌─────────────────────────────────────────────────┐
  │  SHARE CAUSA STATE                          ✕   │
  │                                                  │
  │  Copy this URL to share your current Causa…     │
  │                                                  │
  │  ┌───────────────────────────────────────────┐  │
  │  │ machine  :auth/login                      │  │
  │  │ mode     :mode-b                          │  │
  │  │ tab      :machines                        │  │
  │  │ pos      step 3                           │  │
  │  └───────────────────────────────────────────┘  │
  │                                                  │
  │  [https://app/?causa-share=1&machine=auth/login…]│
  │                                                  │
  │  [Copy URL] [Open in new tab]       [Reset]     │
  └─────────────────────────────────────────────────┘
```

- Encoding is a flat query-string (`?causa-share=1&machine=auth/login&pos=3&mode=mode-b&tab=machines`) — human-legible and diff-friendly. Per the bead's divergence allowance, transit-EDN + short-URL rides a follow-on bead when the encoded surface area outgrows query-string-sized ergonomics.
- On load, `maybe-restore-from-location!` parses the URL and dispatches `:rf.causa/restore-from-share-url` into the per-slot reducers (no special-case branches).
- The modal mounts at the shell-view root per the palette / settings popup pattern.

## Pure-data algebra

`machine_inspector_arc_helpers.cljc` is JVM-runnable so `clojure -M:test` exercises the projections without a CLJS runtime. The CLJS view modules are thin renderers over the helper output + the positioned chart graph.

## Files

**Added**
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc.cljs`
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc_helpers.cljc`
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_scrubber.cljs`
- `tools/causa/src/day8/re_frame2_causa/share.cljs`
- `tools/causa/src/day8/re_frame2_causa/share_modal.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_helpers_cljs_test.cljc` (30 deftest / 81 assertions)
- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_cljs_test.cljs` (15 deftest)
- `tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_scrubber_cljs_test.cljs` (10 deftest)
- `tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs` (24 deftest)

**Modified**
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs` — wired arc + scrubber + share into Panel, added Share button to header
- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — mount `[share-modal/Modal]`
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — catalogued new subs (9) + events (8) + fxs (1)

## Registry surface added

**Subs** — `:rf.causa/machine-arc-data`, `:rf.causa/machine-arc-trimmed`, `:rf.causa/machine-arc-highlight-state`, `:rf.causa/machine-arc-hover`, `:rf.causa/machine-scrubber-position`, `:rf.causa/share-modal-open?`, `:rf.causa/share-state`, `:rf.causa/share-url`, `:rf.causa/share-copy-status`

**Events** — `:rf.causa/set-scrubber-position`, `:rf.causa/set-arc-hover`, `:rf.causa/share-modal-open`, `:rf.causa/share-modal-close`, `:rf.causa/share-copy-status`, `:rf.causa/copy-share-url-to-clipboard`, `:rf.causa/open-share-url-in-new-tab`, `:rf.causa/restore-from-share-url`

**Fxs** — `:rf.causa.fx/open-in-new-tab` (clipboard reuses the shared `:rf.causa.fx/copy-to-clipboard` already registered by `app_db_diff_events.cljs`)

## Divergences from the bead spec

1. **Share URL encoding** — used a flat query-string rather than base64-encoded EDN per the bead's allowance. Rationale documented in `share.cljs` ns docstring.
2. **Scrubber visualization** — simple HTML range input with custom CSS, no D3-style brush. Polish in a follow-on bead if needed.
3. **Hover tooltips** — implemented as native SVG `<title>` (zero-cost + a11y-friendly) rather than custom tooltip components. Per-segment + per-marker hover state updates `:rf.causa/machine-arc-hover` for the segment-highlight effect.
4. **Context-at-position side rail** — `arc-helpers/context-at` is a reserved API slot that returns nil at v1 (today's trace events don't stamp post-transition `:data`). A follow-on bead can fatten trace events with post-state context and flip the value.
5. **Replay button** — not in scope for Phase 5. Bead description mentions a Replay-arc button as a stretch goal; the scrubber covers the primary use case. Easy follow-on if desired.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 2803 tests, 8043 assertions, 0 failures / 0 errors
- [x] `cd tools/causa && clojure -M:test` — 741 tests, 2111 assertions, 0 failures / 0 errors
- [x] `cd implementation && npm run test:browser` — 2792 tests, 7957 assertions, 0 failures / 0 errors
- [x] Manual smoke: Causa preload compiles without warnings