### PR TITLE
chore(causa): one-command serve for panel-gallery testbed

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -129,6 +129,27 @@
                 [com.pitch/uix.dom  "1.4.4"]
                 [lilactown/helix   "0.2.2"]]
 
+ ;; Top-level dev-http servers (rf2-aqcix). shadow-cljs's `:dev-http`
+ ;; map binds a port to a list of file roots; the dev server cascades
+ ;; through the roots in order, returning the first match. Used here for
+ ;; the :testbeds/panel-gallery build so `npx shadow-cljs watch
+ ;; :testbeds/panel-gallery` is a one-command UX — open
+ ;; http://localhost:8765 and the testbed loads.
+ ;;
+ ;; The two roots cascade:
+ ;;   1. ../tools/causa/testbeds/panel_gallery — source dir with the
+ ;;      hand-written index.html (under version control).
+ ;;   2. out/testbeds/panel-gallery — shadow's :output-dir with the
+ ;;      compiled main.js + cljs-runtime/.
+ ;;
+ ;; The order matters: shadow's push-state handler serves index.html
+ ;; for `/` (when Accept: text/html — every browser sends this) by
+ ;; scanning roots in order. Putting the source dir FIRST means the
+ ;; index.html is found without a copy step; per-file requests like
+ ;; /main.js fall through to the second root automatically.
+ :dev-http {8765 ["../tools/causa/testbeds/panel_gallery"
+                  "out/testbeds/panel-gallery"]}
+
  :builds
  {:node-test
   {:target    :node-test
@@ -422,6 +443,9 @@
   ;; <panel>_stories.cljs to this same testbed (one URL, one workspace
   ;; mega-grid). No Causa preload — the gallery embeds bare panels
   ;; inside Story variants and never mounts Causa's own shell.
+  ;;
+  ;; Served at http://localhost:8765 via the top-level `:dev-http` map
+  ;; (rf2-aqcix) — see the docstring on that key for the cascade rationale.
   :testbeds/panel-gallery
   {:target     :browser
    :output-dir "out/testbeds/panel-gallery"


### PR DESCRIPTION
## Summary

Adds a top-level `:dev-http` entry to `implementation/shadow-cljs.edn` so the `:testbeds/panel-gallery` build serves itself at a fixed port — no second terminal, no http-server, no copy step.

```bash
cd implementation
npx shadow-cljs watch :testbeds/panel-gallery
# Then open http://localhost:8765
```

### How it works

Port 8765 binds two roots in cascade order:

1. `../tools/causa/testbeds/panel_gallery/` — source dir with the hand-written `index.html` (already under version control).
2. `out/testbeds/panel-gallery/` — shadow's `:output-dir` with the compiled `main.js` + `cljs-runtime/`.

shadow's push-state handler scans roots in order, so `GET /` resolves to the source-dir `index.html` (every browser sends `Accept: text/html`), while `GET /main.js` falls through to the second root automatically. No copy step needed; `index.html` stays under version control where it belongs, compiled assets stay under `out/`.

### Port choice

`8765` — well clear of the in-use ports (`8021–8023` are the browser-test builds, `8280` is the template, `8030` is the pair2 fixture).

### Bead

rf2-aqcix (not closed by this PR — the bead remains open as a tracking marker).

## Test plan

- [x] `scripts/test-fast-pr.sh` — green (2724 tests, 7840 assertions, 0 failures).
- [x] `npx shadow-cljs watch :testbeds/panel-gallery` — `:dev-http http://localhost:8765 serving ["../tools/causa/testbeds/panel_gallery" "out/testbeds/panel-gallery"]` logged on startup.
- [x] `curl -H "Accept: text/html" http://localhost:8765/` → 200, returns the testbed `index.html`.
- [x] `curl -I http://localhost:8765/main.js` → 200, served from `out/`.