### PR TITLE
feat(story): recorder → :play-script export pipeline — record once, test forever

### DIFF
--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -1,0 +1,299 @@
+(ns re-frame.story.recorder.play-export
+  "Translate a captured recording into a `:play-script` body (rf2-x9zsr).
+
+  ## Why
+
+  The recorder (`re-frame.story.recorder`) captures dispatched events
+  during a canvas session and surfaces them in a save-as-variant
+  dialog as a `(reg-variant ... :play [...])` EDN snippet — the
+  legacy `:play` slot, a bare vector of event vectors that re-fires
+  on mount.
+
+  The rich `:play-script` DSL landed in rf2-8i2a9 — tagged steps
+  (`[:dispatch ...]`, `[:wait ms]`, `[:assert-db ...]`,
+  `[:assert-dom ...]`, `[:click ...]`, `[:type ...]`) the runner
+  executes sequentially with PASS/FAIL bookkeeping. This is the
+  Storybook-class `play()` equivalent — auto-run on mount, surface
+  pass/fail in the test pane.
+
+  This namespace closes the loop: feed a recording in, get a
+  `:play-script` map out. The user pastes it into a story-spec and
+  the variant becomes self-verifying forever after.
+
+  ## What gets translated
+
+  The recorder's existing model (`{:events [...vector-of-event-vecs]
+  :variant-id ... :started-ms ...}`) carries event vectors only —
+  no per-event timestamps and no DOM events. So the v1 translation
+  is the **dispatch-only path**:
+
+  | Recorded shape                              | Translated step              |
+  |---------------------------------------------|------------------------------|
+  | `[:counter/inc]`                            | `[:dispatch [:counter/inc]]` |
+  | `[:rf.assert/path-equals [:n] 3]`           | `[:dispatch-sync [:rf.assert/path-equals [:n] 3]]` |
+  | `[:rf/redacted]` (sensitive event)          | dropped + `;; redacted` annotation |
+  | `(app-db snapshot at end)` (if provided)    | trailing `[:assert-db path expected]` steps (top-N changed paths) |
+
+  Assertion events ride the `:dispatch-sync` rail because Spec 004 §3
+  fires the canonical seven via the framework's synchronous queue —
+  the runner's `:dispatch` would re-queue them and break the
+  guarantee that an assertion's outcome is observable on the very
+  next state transition. The pure runner accepts either tag for any
+  event; this is a translation convention, not a runtime requirement.
+
+  DOM events (`:click` / `:type`) and timing-based steps (`:wait`)
+  are NOT generated — the current recorder model doesn't capture
+  them. Filed as follow-on rf2-recorder-dom (TODO).
+
+  ## Auto-assert
+
+  When called with `:auto-assert? true` + an app-db snapshot, the
+  translator appends trailing `[:assert-db path expected]` steps
+  derived from the top-N changed paths between the seed db (when
+  available) and the final snapshot. v1 limits the auto-assert block
+  to the spec-controlled max (default 5) so the generated script
+  stays readable; the user trims further by hand. When no seed is
+  available the translator emits assertions for the top-N keys of
+  the final db.
+
+  ## Pure / impure split
+
+  Everything in this namespace is pure data → data. The dialog UI
+  (`re-frame.story.ui.recorder-export-dialog`) consumes this fn to
+  build the snippet text. JVM-testable end-to-end."
+  (:require [clojure.string :as str]
+            [re-frame.story.play.runner :as runner]
+            [re-frame.story.predicates  :as pred]))
+
+;; ---------------------------------------------------------------------------
+;; Tunables
+;; ---------------------------------------------------------------------------
+
+(def ^:const default-max-auto-assertions
+  "Default cap on the number of auto-generated `:assert-db` steps. The
+  recorder captures whatever events fire; the final app-db can carry
+  hundreds of paths the variant doesn't actually care about. The cap
+  keeps the generated script readable — the user opts in to more by
+  passing `:max-auto-assertions` explicitly or by trimming the output
+  by hand."
+  5)
+
+(def ^:const redacted-event-id
+  "The framework sentinel id the recorder uses to replace sensitive
+  event payloads (rf2-hdadz). Translator drops these from the
+  generated script + adds a comment in the output."
+  :rf/redacted)
+
+;; ---------------------------------------------------------------------------
+;; Pure: per-event step translation
+;; ---------------------------------------------------------------------------
+
+(defn- redacted?
+  "True iff `event` is the recorder's redacted placeholder."
+  [event]
+  (and (vector? event)
+       (= 1 (count event))
+       (= redacted-event-id (first event))))
+
+(defn event->step
+  "Translate a single recorded event vector into a `:play-script` step.
+
+  - Assertion events (`:rf.assert/*` family) → `[:dispatch-sync evec]`.
+  - Redacted placeholders (`[:rf/redacted]`) → nil (caller drops).
+  - Anything else → `[:dispatch evec]`.
+
+  Returns nil for malformed inputs so the caller can filter them out
+  in one pass."
+  [event]
+  (cond
+    (redacted? event)
+    nil
+
+    (pred/assertion-event? event)
+    [:dispatch-sync event]
+
+    (and (vector? event)
+         (pos? (count event))
+         (keyword? (first event)))
+    [:dispatch event]
+
+    :else nil))
+
+;; ---------------------------------------------------------------------------
+;; Pure: auto-assert derivation
+;;
+;; Diff the seed db against the final snapshot; the changed paths
+;; become `[:assert-db path expected]` steps. When no seed is supplied
+;; we walk the top-level keys of the final db and emit one assertion
+;; per key (still capped at :max-auto-assertions).
+;;
+;; The diff is a shallow path enumeration — every keyword key of the
+;; final db that differs from the seed produces a `[:assert-db [k]
+;; v]` step. Deep diffing is deferred (rf2-recorder-deep-diff TODO);
+;; the v1 cap is the safety valve, not the diff sophistication.
+;; ---------------------------------------------------------------------------
+
+(defn- map-like?
+  [v]
+  (or (map? v) (record? v)))
+
+(defn changed-top-paths
+  "Return the seq of `[:k]` paths whose value in `final-db` differs
+  from `seed-db`. Order is the iteration order of `final-db` (stable
+  for maps inserted in a deterministic order). Pure data → data."
+  [seed-db final-db]
+  (when (map-like? final-db)
+    (for [[k v] final-db
+          :when (not= v (get seed-db k))]
+      [k])))
+
+(defn- top-paths
+  "When no seed is available, walk the top-level keys of `final-db`
+  and yield `[:k]` paths in iteration order. Used by the no-seed
+  branch of the auto-assert generator."
+  [final-db]
+  (when (map-like? final-db)
+    (for [[k _] final-db] [k])))
+
+(defn auto-assert-steps
+  "Derive a vector of `[:assert-db <path> <expected>]` steps from a
+  final app-db snapshot. `opts`:
+
+    :seed-db              optional — the db at recording-start. When
+                          provided, only changed paths produce
+                          assertions (diff-based).
+    :max-auto-assertions  cap on the number of generated steps
+                          (default 5).
+
+  Steps are emitted in the order the keys appear in `final-db`.
+  Returns `[]` when `final-db` isn't map-like."
+  [final-db {:keys [seed-db max-auto-assertions]
+             :or   {max-auto-assertions default-max-auto-assertions}}]
+  (let [paths (or (and seed-db (changed-top-paths seed-db final-db))
+                  (top-paths final-db))]
+    (->> paths
+         (take max-auto-assertions)
+         (mapv (fn [p] [:assert-db p (get-in final-db p)])))))
+
+;; ---------------------------------------------------------------------------
+;; Pure: top-level translator
+;; ---------------------------------------------------------------------------
+
+(defn recording->play-script
+  "Translate a recording into a normalised `:play-script` body map per
+  `runner/parse-spec`. Pure data → data.
+
+  Inputs:
+
+    `events`  — vector of recorded event vectors (the `:events` slot
+                of the recorder state).
+    `opts`:
+      :name             optional — `:name` field for the play-script.
+      :auto-assert?     bool, default false — when true, derive
+                        trailing `[:assert-db ...]` steps from
+                        `:final-db` (and `:seed-db` if supplied).
+      :final-db         map — the app-db snapshot at recording-end.
+                        Required when `:auto-assert?` is true.
+      :seed-db          optional — the app-db at recording-start.
+                        When supplied, only paths whose value changed
+                        produce assertions.
+      :max-auto-assertions  cap on the auto-assert block (default 5).
+      :auto-run?        bool — `:auto-run?` field on the play-script
+                        map. Defaults to true (matches the runner's
+                        default-auto-run? — on-mount replay is the
+                        Storybook-equivalent behaviour).
+
+  Returns a map: `{:script [...steps] :auto-run? bool :name str?}`.
+  The script is pre-coerced via `runner/coerce-script` so it round-
+  trips through `runner/parse-spec` without further normalisation —
+  what you get back is what the runner will execute.
+
+  Empty `events` returns a map with an empty `:script` (still legal —
+  the auto-assert block can stand alone)."
+  ([events]
+   (recording->play-script events {}))
+  ([events {:keys [name auto-assert? final-db seed-db max-auto-assertions auto-run?]
+            :or   {auto-assert?         false
+                   auto-run?            true
+                   max-auto-assertions  default-max-auto-assertions}}]
+   (let [dispatch-steps (->> (or events [])
+                             (mapv event->step)
+                             (filterv some?))
+         assert-steps   (if auto-assert?
+                          (auto-assert-steps final-db
+                                             {:seed-db             seed-db
+                                              :max-auto-assertions max-auto-assertions})
+                          [])
+         script         (vec (concat dispatch-steps assert-steps))
+         base           {:script    script
+                         :auto-run? (boolean auto-run?)}]
+     (cond-> base
+       (and (string? name) (seq name)) (assoc :name name)))))
+
+;; ---------------------------------------------------------------------------
+;; Pure: render the play-script map as EDN
+;;
+;; The dialog displays this string and the user copies it to the
+;; clipboard. We render one step per line under `:script [` so the
+;; output is human-readable and survives `read-string` round-trip.
+;; ---------------------------------------------------------------------------
+
+(def ^:const indent-prefix
+  "The indent the snippet uses for `:script` continuation lines.
+  Derived literally from the prefix `'  :script ['` so successive
+  steps align under the opening `[`. See `predicates/indent-after`
+  for the convention rationale."
+  "  :script [")
+
+(defn- render-script-vec
+  "Render the `:script` vector as multi-line EDN aligned under the
+  opening `[`. Returns a string of the form
+
+      [[:dispatch [:foo]]
+                [:wait 100]]
+
+  When `script` is empty, returns `\"[]\"`."
+  [script]
+  (if (seq script)
+    (str "["
+         (str/join (pred/indent-after indent-prefix)
+                   (map pr-str script))
+         "]")
+    "[]"))
+
+(defn render-play-script
+  "Render a parsed `:play-script` map as a human-readable EDN string
+  the dialog UI displays and the user pastes into source. Pure data →
+  string.
+
+  The rendered form is `read-string`-able and round-trips back to the
+  same map via `runner/parse-spec`."
+  [{:keys [script name auto-run?] :as _spec}]
+  (let [body-keys (cond-> []
+                    name             (conj [":name      " (pr-str name)])
+                    true             (conj [":auto-run? " (pr-str (boolean auto-run?))])
+                    true             (conj [":script    " (render-script-vec script)]))
+        body-str  (->> body-keys
+                       (map (fn [[k v]] (str k v)))
+                       (str/join "\n  "))]
+    (str "{" body-str "}")))
+
+(defn render-variant-form
+  "Render a full `(reg-variant <id> {:play-script {...}})` form the
+  user pastes into source. `variant-id` defaults to
+  `:story.recorded/play-export`; `alias` defaults to `\"story\"`.
+
+  Pure data → string. The form survives `read-string` round-trip and
+  registers cleanly via `re-frame.story/reg-variant`."
+  [spec {:keys [variant-id alias extends]
+         :or   {variant-id :story.recorded/play-export
+                alias      "story"}}]
+  (let [body (cond-> []
+               extends (conj [":extends     " (pr-str extends)])
+               true    (conj [":play-script " (render-play-script spec)]))
+        body-str (->> body
+                      (map (fn [[k v]] (str k v)))
+                      (str/join "\n  "))]
+    (str "(" alias "/reg-variant "
+         (pr-str variant-id)
+         "\n  {" body-str "})")))

--- a/tools/story/src/re_frame/story/recorder/play_export_events.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export_events.cljc
@@ -1,0 +1,121 @@
+(ns re-frame.story.recorder.play-export-events
+  "re-frame integration seam for the recorder → :play-script export
+  flow (rf2-x9zsr). Owns the side-effecty entry points the export
+  dialog UI reaches for:
+
+  - **Replay the generated script in-place** — dispatch the just-
+    -exported `:play-script` through the runner so the user can
+    verify the export is valid before pasting it into source.
+  - **Capture the live app-db snapshot** — read the variant frame's
+    db at export time. Used by the auto-assert option to derive
+    trailing `[:assert-db ...]` steps.
+  - **Copy the rendered snippet to the clipboard** — delegated to
+    `re-frame.story.review-dialog/copy-to-clipboard!` so the export
+    flow doesn't carry its own clipboard shim.
+
+  The translator itself (`re-frame.story.recorder.play-export`) stays
+  pure. This namespace is the thin impure shell — it depends on
+  `re-frame.core` (for `get-frame-db` / `dispatch-sync*`) and the
+  runner-events ns (for `run!`), neither of which the translator
+  should pull in.
+
+  ## Pure / impure split
+
+  - `recording->play-script`  — pure (`play-export` ns).
+  - `replay-script!`          — impure (this ns; drives the runner).
+  - `snapshot-frame-db`       — impure (this ns; reads frame db).
+
+  ## Elision
+
+  Every public fn opens with `(when config/enabled? ...)` so
+  production CLJS builds short-circuit cleanly. The translator stays
+  reachable (it's pure data → data) but the side-effecty seams
+  collapse."
+  (:require [re-frame.core                        :as rf]
+            [re-frame.story.config                :as config]
+            [re-frame.story.play.runner-events    :as runner-events]
+            [re-frame.story.recorder.play-export  :as export]))
+
+;; ---------------------------------------------------------------------------
+;; Impure: frame-db snapshot
+;; ---------------------------------------------------------------------------
+
+(defn snapshot-frame-db
+  "Read the current app-db for `frame-id` via the framework registrar.
+  Returns nil when the frame is gone or the read throws (tolerant
+  per runner-events convention)."
+  [frame-id]
+  (try
+    (rf/get-frame-db frame-id)
+    (catch #?(:clj Throwable :cljs :default) _ nil)))
+
+;; ---------------------------------------------------------------------------
+;; Impure: replay the exported script
+;;
+;; The dialog's 'replay in this story' button feeds the generated
+;; spec into the runner so the user can verify it without leaving
+;; the recorder loop. The runner drives an asynchronous loop; the
+;; optional `done-cb` is invoked with the terminal run-state once
+;; every step has completed (synchronous on JVM, async on CLJS).
+;; ---------------------------------------------------------------------------
+
+(defn replay-script!
+  "Drive `spec` (a `:play-script` map per `runner/parse-spec`) against
+  `frame-id` via `runner-events/run!`. Returns the initial run-state
+  (status `:running`, step-idx 0). `done-cb` fires with the terminal
+  run-state.
+
+  Idempotent against concurrent runs — `run!` resets the per-frame
+  run-state slot on every entry (cancels the previous run's
+  callback).
+
+  No-op (returns nil) when production elision is active or
+  `frame-id` is nil."
+  ([frame-id spec]
+   (replay-script! frame-id spec nil))
+  ([frame-id spec done-cb]
+   (when (and config/enabled? frame-id spec)
+     (runner-events/run! frame-id spec done-cb))))
+
+;; ---------------------------------------------------------------------------
+;; Pure: export from a recorder snapshot
+;;
+;; A convenience seam the dialog UI calls — takes the dialog's
+;; snapshot map (`{:events ... :source-id ...}` per
+;; `recorder/open-dialog`) plus the user-supplied options
+;; (`:name :auto-assert?` …) and yields the canonical export tuple
+;; `{:spec ...play-script... :rendered <string>}`.
+;;
+;; The frame-db snapshot is the caller's job (so the pure path stays
+;; pure) — the dialog calls `snapshot-frame-db` itself when
+;; `:auto-assert?` is on, then threads the result into `:final-db`.
+;; ---------------------------------------------------------------------------
+
+(defn build-export
+  "Build the canonical export tuple for the dialog. `opts` accepts the
+  full surface of `play-export/recording->play-script` plus an
+  optional `:variant-id` for the rendered `(reg-variant ...)` form.
+
+  Returns `{:spec <play-script map> :rendered <variant-form string>}`.
+  The `:rendered` slot is what the dialog displays + the clipboard
+  receives."
+  [events {:keys [variant-id extends alias name auto-run?
+                  auto-assert? final-db seed-db max-auto-assertions]
+           :as   opts}]
+  (let [spec     (export/recording->play-script
+                   events
+                   (cond-> {}
+                     (some? name)                (assoc :name name)
+                     (some? auto-run?)           (assoc :auto-run? auto-run?)
+                     (some? auto-assert?)        (assoc :auto-assert? auto-assert?)
+                     (some? final-db)            (assoc :final-db final-db)
+                     (some? seed-db)             (assoc :seed-db seed-db)
+                     (some? max-auto-assertions) (assoc :max-auto-assertions
+                                                        max-auto-assertions)))
+        rendered (export/render-variant-form
+                   spec
+                   (cond-> {}
+                     variant-id (assoc :variant-id variant-id)
+                     extends    (assoc :extends    extends)
+                     alias      (assoc :alias      alias)))]
+    {:spec spec :rendered rendered}))

--- a/tools/story/src/re_frame/story/review_dialog.cljc
+++ b/tools/story/src/re_frame/story/review_dialog.cljc
@@ -397,6 +397,13 @@
                               'discard' button renders left of
                               'copy'. Recorder uses (discards the
                               captured events); save-variant does not.
+     - `:on-export`         — optional `(fn [])` — when provided, an
+                              extra `[Export as :play-script]` button
+                              renders left of 'copy'. The recorder's
+                              save-dialog wires this through to the
+                              play-script export dialog (rf2-x9zsr);
+                              save-variant does not (no recording to
+                              export).
      - `:on-close`          — `(fn [])` invoked on backdrop-click + on
                               the 'close' button.
      - `:data-test-prefix`  — string prefix for all `:data-test`
@@ -405,7 +412,7 @@
                               `\"story-save-variant\"`)."
      [dialog-state
       {:keys [title hint snippet placeholder-id placeholder-input
-              on-edit-id on-copy on-discard on-close data-test-prefix]}]
+              on-edit-id on-copy on-discard on-export on-close data-test-prefix]}]
      (when (:open? dialog-state)
        (let [draft-id     (:draft-id dialog-state)
              effective-id (or draft-id placeholder-id)
@@ -437,6 +444,13 @@
                 :data-test (dtest "discard")
                 :on-click  (fn [_] (on-discard))}
                "discard"])
+            (when on-export
+              [:button
+               {:style     (:btn-muted styles)
+                :data-test (dtest "export")
+                :title     "Export the recording as a :play-script (rich DSL)"
+                :on-click  (fn [_] (on-export))}
+               "export as :play-script"])
             [:button
              {:style     (:btn styles)
               :data-test (dtest "copy")

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -63,10 +63,11 @@
   (:require [cljs.reader]
             [clojure.string :as str]
             [reagent.core :as r]
-            [re-frame.story.config         :as config]
-            [re-frame.story.recorder       :as recorder]
-            [re-frame.story.review-dialog  :as review-dialog]
-            [re-frame.story.ui.state       :as state]))
+            [re-frame.story.config                       :as config]
+            [re-frame.story.recorder                     :as recorder]
+            [re-frame.story.review-dialog                :as review-dialog]
+            [re-frame.story.ui.recorder-export-dialog    :as export-dialog]
+            [re-frame.story.ui.state                     :as state]))
 
 ;; ---------------------------------------------------------------------------
 ;; Reagent mirror of the recorder state
@@ -632,5 +633,13 @@
            :on-edit-id        set-draft-id!
            :on-copy           (fn [] (review-dialog/copy-to-clipboard! snippet))
            :on-discard        (fn [] (recorder/clear!) (close-dialog!))
+           ;; rf2-x9zsr — open the :play-script export dialog with the
+           ;; captured snapshot. We DON'T close the parent dialog
+           ;; (user may want to copy the :play form too); the export
+           ;; dialog stacks on top via a higher z-index.
+           :on-export         (fn []
+                                (export-dialog/open-from-recorder-dialog!
+                                  {:events    events
+                                   :source-id source-id}))
            :on-close          close-dialog!
            :data-test-prefix  "story-recorder"})))))

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -1,0 +1,378 @@
+(ns re-frame.story.ui.recorder-export-dialog
+  "Recorder → :play-script export dialog UI (rf2-x9zsr).
+
+  The recorder's existing save-as-variant dialog
+  (`re-frame.story.ui.recorder/save-dialog`) emits the legacy `:play`
+  body — a bare vector of event vectors that re-fires on mount. The
+  rich `:play-script` DSL landed in rf2-8i2a9; this dialog is its
+  twin — same recording, different output shape:
+
+      (story/reg-variant :story.your/recorded
+        {:extends     :story.your/source
+         :play-script {:name      \"happy path\"
+                       :auto-run? true
+                       :script    [[:dispatch [:counter/inc]]
+                                   [:dispatch-sync [:rf.assert/path-equals
+                                                    [:n] 1]]]}})
+
+  ## UX
+
+  Opens off an `[Export as :play-script]` button on the existing
+  recorder review dialog. The export dialog shows:
+
+  - A `[Name]` text input — flows into the `:name` field of the
+    `:play-script` map.
+  - A `[Variant id]` text input — the new variant the form registers.
+  - A `[x] Auto-assert app-db at end` checkbox — when on, trailing
+    `[:assert-db <path> <expected>]` steps are derived from the
+    variant's app-db at export time (capped at the translator's
+    `default-max-auto-assertions`).
+  - The rendered `(reg-variant ...)` form — pretty-printed, live
+    re-rendered on every option change.
+  - `[Copy to clipboard]` — primary action.
+  - `[Replay in this story]` — drives the runner against the active
+    frame so the user can verify the export before pasting.
+  - `[Close]`.
+
+  ## Pure / impure split
+
+  All Reagent / DOM lives here. The pure translator
+  (`re-frame.story.recorder.play-export`) and the impure runner-
+  driver (`re-frame.story.recorder.play-export-events`) own the
+  data-shape and the re-frame coupling respectively.
+
+  ## Elision
+
+  Every public fn opens with `(when config/enabled? ...)` so
+  production CLJS builds short-circuit before any DOM call."
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
+            [re-frame.story.config                        :as config]
+            [re-frame.story.recorder                      :as recorder]
+            [re-frame.story.recorder.play-export          :as export]
+            [re-frame.story.recorder.play-export-events   :as export-events]
+            [re-frame.story.review-dialog                 :as review-dialog]))
+
+;; ---------------------------------------------------------------------------
+;; Dialog state — a single Reagent ratom carrying the dialog's
+;; configuration. The dialog opens off the existing recorder save-
+;; dialog, so it snapshots the *recorded* events + variant-id when
+;; opened (mirrors the rf2-8x9nb guard on the parent dialog — a
+;; subsequent start-recording! cannot mutate the in-flight export).
+;; ---------------------------------------------------------------------------
+
+(def initial-state
+  "Idle export-dialog state. Mirrors the shape `review-dialog/initial-
+  state` carries plus the export-specific options."
+  {:open?               false
+   :source-id           nil   ; the recorded variant-id (rides into :extends)
+   :events              []    ; captured events snapshot
+   :variant-id          nil   ; the new variant id (user-editable)
+   :name                ""    ; optional :name field on the play-script
+   :auto-assert?        true
+   :final-db            nil
+   :replay-status       nil   ; nil | :running | :pass | :fail
+   :replay-failure-msg  nil})
+
+(defonce ui-dialog
+  (r/atom initial-state))
+
+(defn- close-dialog! []
+  (reset! ui-dialog initial-state))
+
+(defn open-dialog!
+  "Open the export dialog. `opts`:
+
+    :source-id        — the recorded variant-id (rides into `:extends`).
+    :events           — captured events snapshot.
+    :variant-id       — default new-variant id (user-editable inline).
+    :final-db         — optional app-db snapshot at recording-end;
+                        consumed by the auto-assert option.
+
+  Idempotent — opening twice replaces the in-flight state."
+  [{:keys [source-id events variant-id final-db]}]
+  (when config/enabled?
+    (reset! ui-dialog
+            (assoc initial-state
+                   :open?      true
+                   :source-id  source-id
+                   :events     (vec (or events []))
+                   :variant-id (or variant-id
+                                   (when (qualified-keyword? source-id)
+                                     (keyword (namespace source-id)
+                                              "recorded-script"))
+                                   :story.recorded/play-export)
+                   :final-db   final-db))))
+
+(defn- set-name! [s]
+  (swap! ui-dialog assoc :name (str s)))
+
+(defn- set-variant-id! [s]
+  (let [parsed (review-dialog/parse-variant-id-string s)]
+    (swap! ui-dialog assoc :variant-id (or parsed s))))
+
+(defn- toggle-auto-assert! []
+  (swap! ui-dialog update :auto-assert? not))
+
+;; ---------------------------------------------------------------------------
+;; Derived: build the export tuple from the current dialog state.
+;;
+;; Re-derived on every render so option toggles re-render the
+;; preview without touching the dialog state shape.
+;; ---------------------------------------------------------------------------
+
+(defn- build-export-from-dialog
+  [{:keys [events source-id variant-id name auto-assert? final-db]}]
+  (export-events/build-export
+    events
+    (cond-> {:variant-id variant-id
+             :extends    source-id
+             :auto-run?  true}
+      (and (string? name) (seq name)) (assoc :name name)
+      auto-assert?                     (assoc :auto-assert? true
+                                              :final-db     final-db))))
+
+;; ---------------------------------------------------------------------------
+;; Replay
+;; ---------------------------------------------------------------------------
+
+(defn- run-replay!
+  "Drive the just-exported `:play-script` against the recorded variant's
+  frame via the runner. Updates the dialog's `:replay-status` slot so
+  the UI can surface the outcome."
+  [{:keys [source-id]} spec]
+  (when (and config/enabled? source-id spec)
+    (swap! ui-dialog assoc :replay-status :running :replay-failure-msg nil)
+    (export-events/replay-script!
+      source-id spec
+      (fn [final-state]
+        (let [status (:status final-state)
+              msg    (when (= :fail status)
+                       (let [first-fail (some (fn [r]
+                                                (when (false? (:passed? r)) r))
+                                              (:results final-state))]
+                         (:message first-fail)))]
+          (swap! ui-dialog assoc
+                 :replay-status      (case status :pass :pass :fail :fail :running)
+                 :replay-failure-msg msg))))))
+
+;; ---------------------------------------------------------------------------
+;; Styles — mirrors the existing recorder save-dialog modal aesthetic
+;; via the shared review-dialog styling. Local additions for the
+;; export-specific affordances (checkbox row, name input, replay
+;; status pill).
+;; ---------------------------------------------------------------------------
+
+(def ^:private styles
+  {:back        {:position    "fixed"
+                 :top "0" :left "0" :right "0" :bottom "0"
+                 :background  "rgba(0,0,0,0.55)"
+                 :z-index     1800
+                 :display     "flex"
+                 :align-items "center"
+                 :justify-content "center"}
+   :modal       {:width          "720px"
+                 :max-width      "92vw"
+                 :max-height     "86vh"
+                 :background     "#1e1e1e"
+                 :color          "#ddd"
+                 :border         "1px solid #444"
+                 :border-radius  "6px"
+                 :padding        "16px"
+                 :font-family    "monospace"
+                 :font-size      "12px"
+                 :display        "flex"
+                 :flex-direction "column"
+                 :gap            "12px"
+                 :box-shadow     "0 14px 36px rgba(0,0,0,0.75)"
+                 :overflow       "hidden"}
+   :title       {:font-weight "bold"
+                 :color       "#9cdcfe"
+                 :font-size   "13px"}
+   :hint        {:color "#9a9a9a"
+                 :font-style "italic"
+                 :font-size "10px"}
+   :row         {:display "flex"
+                 :gap "8px"
+                 :align-items "center"}
+   :label       {:color "#9cdcfe"
+                 :font-size "11px"
+                 :min-width "110px"}
+   :input       {:padding "6px 8px"
+                 :background "#252526"
+                 :color "white"
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :font-family "monospace"
+                 :font-size "12px"
+                 :flex "1 1 auto"
+                 :box-sizing "border-box"}
+   :snippet     {:background    "#0e0e10"
+                 :color         "#dcdcaa"
+                 :padding       "10px"
+                 :border        "1px solid #333"
+                 :border-radius "4px"
+                 :white-space   "pre"
+                 :overflow      "auto"
+                 :max-height    "40vh"
+                 :font-family   "monospace"
+                 :font-size     "11px"
+                 :line-height   "1.45"
+                 :flex          "1 1 auto"}
+   :checkbox-row {:display "flex"
+                  :gap "8px"
+                  :align-items "center"}
+   :btn-row     {:display "flex"
+                 :gap "8px"
+                 :justify-content "flex-end"
+                 :flex-wrap "wrap"}
+   :btn         {:padding "5px 12px"
+                 :background "#0e639c"
+                 :color "white"
+                 :border "none"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-family "monospace"
+                 :font-size "11px"}
+   :btn-muted   {:padding "5px 12px"
+                 :background "transparent"
+                 :color "#cccccc"
+                 :border "1px solid #444"
+                 :border-radius "3px"
+                 :cursor "pointer"
+                 :font-family "monospace"
+                 :font-size "11px"}
+   :status-pill {:padding "2px 8px"
+                 :border-radius "10px"
+                 :font-size "10px"
+                 :font-family "monospace"
+                 :margin-left "auto"}
+   :pill-pass   {:background "#1f5e2b" :color "#cdf7d4"}
+   :pill-fail   {:background "#7a2020" :color "#ffd1d1"}
+   :pill-running {:background "#0e639c" :color "white"}})
+
+(defn- replay-pill
+  [status msg]
+  (case status
+    :running  [:span {:style (merge (:status-pill styles) (:pill-running styles))
+                      :data-test "story-recorder-export-replay-status"}
+               "RUNNING"]
+    :pass     [:span {:style (merge (:status-pill styles) (:pill-pass styles))
+                      :data-test "story-recorder-export-replay-status"}
+               "PASS"]
+    :fail     [:span {:style (merge (:status-pill styles) (:pill-fail styles))
+                      :data-test "story-recorder-export-replay-status"
+                      :title (or msg "replay failed")}
+               "FAIL"]
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The dialog itself
+;; ---------------------------------------------------------------------------
+
+(defn export-dialog
+  "Render the export dialog. Returns nil when `:open?` is false on
+  `@ui-dialog` so the caller can mount it unconditionally next to the
+  other shell modals."
+  []
+  (let [state  @ui-dialog]
+    (when (:open? state)
+      (let [{:keys [spec rendered]} (build-export-from-dialog state)
+            {:keys [name source-id variant-id auto-assert?
+                    replay-status replay-failure-msg]} state]
+        [:div
+         {:style     (:back styles)
+          :data-test "story-recorder-export-dialog"
+          :on-click  (fn [e]
+                       (when (= (.-target e) (.-currentTarget e))
+                         (close-dialog!)))}
+         [:div {:style    (:modal styles)
+                :on-click (fn [e] (.stopPropagation e))}
+          [:div {:style (:title styles)}
+           "Recorder → :play-script export"
+           (replay-pill replay-status replay-failure-msg)]
+          [:div {:style (:hint styles)}
+           (str "Generated from " (count (:events state))
+                " captured event" (when (not= 1 (count (:events state))) "s")
+                " against " (pr-str source-id)
+                ". Tweak the options, then copy + paste into your stories ns.")]
+
+          ;; ---- Name ---------------------------------------------------------
+          [:div {:style (:row styles)}
+           [:label {:style (:label styles)} "Name"]
+           [:input
+            {:type        "text"
+             :style       (:input styles)
+             :data-test   "story-recorder-export-name-input"
+             :placeholder "happy path"
+             :value       name
+             :on-change   (fn [e] (set-name! (.. e -target -value)))}]]
+
+          ;; ---- Variant id ---------------------------------------------------
+          [:div {:style (:row styles)}
+           [:label {:style (:label styles)} "Variant id"]
+           [:input
+            {:type          "text"
+             :style         (:input styles)
+             :data-test     "story-recorder-export-variant-id-input"
+             :placeholder   ":story.your/recorded-flow"
+             :default-value (pr-str variant-id)
+             :on-change     (fn [e] (set-variant-id! (.. e -target -value)))}]]
+
+          ;; ---- Auto-assert toggle ------------------------------------------
+          [:label
+           {:style     (:checkbox-row styles)
+            :data-test "story-recorder-export-auto-assert"}
+           [:input
+            {:type      "checkbox"
+             :data-test "story-recorder-export-auto-assert-checkbox"
+             :checked   auto-assert?
+             :on-change (fn [_] (toggle-auto-assert!))}]
+           [:span {:style (:label styles)} "Auto-assert app-db at end"]
+           [:span {:style (:hint styles)}
+            (str "(top-" export/default-max-auto-assertions
+                 " changed paths; trim manually after pasting)")]]
+
+          ;; ---- Snippet preview ---------------------------------------------
+          [:pre {:style     (:snippet styles)
+                 :data-test "story-recorder-export-snippet"}
+           rendered]
+
+          ;; ---- Button row --------------------------------------------------
+          [:div {:style (:btn-row styles)}
+           [:button
+            {:style    (:btn-muted styles)
+             :data-test "story-recorder-export-replay"
+             :on-click (fn [_] (run-replay! state spec))}
+            "replay in this story"]
+           [:button
+            {:style    (:btn styles)
+             :data-test "story-recorder-export-copy"
+             :on-click (fn [_] (review-dialog/copy-to-clipboard! rendered))}
+            "copy to clipboard"]
+           [:button
+            {:style    (:btn-muted styles)
+             :data-test "story-recorder-export-close"
+             :on-click (fn [_] (close-dialog!))}
+            "close"]]]]))))
+
+;; ---------------------------------------------------------------------------
+;; Public open-from-recorder helper
+;;
+;; The recorder save-dialog's "Export as :play-script" button invokes
+;; this — passes the dialog's captured events + source-id + snapshots
+;; the live frame db (when available) so the auto-assert option has
+;; data to work with.
+;; ---------------------------------------------------------------------------
+
+(defn open-from-recorder-dialog!
+  "Open the export dialog using the recorder save-dialog's captured
+  snapshot. Reads the live frame db at click time so the auto-assert
+  option can derive assertions from real data."
+  [{:keys [events source-id]}]
+  (when config/enabled?
+    (open-dialog!
+      {:source-id source-id
+       :events    events
+       :final-db  (when source-id
+                    (export-events/snapshot-frame-db source-id))})))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -60,6 +60,7 @@
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.play-status :as play-status]
             [re-frame.story.ui.recorder :as recorder-ui]
+            [re-frame.story.ui.recorder-export-dialog :as recorder-export-ui]
             [re-frame.story.ui.save-variant :as save-variant-ui]
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.share :as share]
@@ -692,6 +693,11 @@
           [recorder-ui/recording-overlay]
           [recorder-ui/assertion-picker]
           [recorder-ui/save-dialog]
+          ;; rf2-x9zsr — Test Codegen :play-script export dialog. Opens
+          ;; off the recorder save-dialog's [export as :play-script]
+          ;; button; stacks above via a higher z-index. Lives in its own
+          ;; ratom so dismiss / reopen doesn't disturb the parent dialog.
+          [recorder-export-ui/export-dialog]
           ;; rf2-one3t: save-current-canvas-state-as-variant dialog. Lives
           ;; alongside the recorder's save dialog — both float above the
           ;; three-pane layout via fixed positioning; both surface the

--- a/tools/story/test/re_frame/story/recorder/play_export_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/play_export_test.cljc
@@ -1,0 +1,245 @@
+(ns re-frame.story.recorder.play-export-test
+  "Pure unit tests for the recorder → :play-script translator
+  (rf2-x9zsr).
+
+  Covers:
+
+  - Per-event translation (`event->step`) — assertion events ride the
+    `:dispatch-sync` rail; everything else rides `:dispatch`;
+    redacted placeholders drop out.
+  - Recording-level translation (`recording->play-script`) — empty
+    input, name + auto-run? slots, auto-assert with and without a
+    seed db, max-auto-assertions cap.
+  - Snippet rendering (`render-play-script` / `render-variant-form`)
+    — round-trip cleanly through `runner/parse-spec`."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.edn :as edn]
+            [re-frame.story.play.runner             :as runner]
+            [re-frame.story.recorder.play-export    :as export]))
+
+;; ---- per-event translation -----------------------------------------------
+
+(deftest event-step-dispatch
+  (testing "ordinary events become :dispatch steps"
+    (is (= [:dispatch [:counter/inc]]
+           (export/event->step [:counter/inc])))
+    (is (= [:dispatch [:auth/login {:user "x"}]]
+           (export/event->step [:auth/login {:user "x"}])))))
+
+(deftest event-step-assertion-rides-dispatch-sync
+  (testing "assertion events (`:rf.assert/*`) translate to :dispatch-sync"
+    (is (= [:dispatch-sync [:rf.assert/path-equals [:n] 3]]
+           (export/event->step [:rf.assert/path-equals [:n] 3])))
+    (is (= [:dispatch-sync [:rf.assert/no-warnings]]
+           (export/event->step [:rf.assert/no-warnings])))
+    (is (= [:dispatch-sync [:rf.assert/sub-equals [:counter] 5]]
+           (export/event->step [:rf.assert/sub-equals [:counter] 5])))))
+
+(deftest event-step-redacted-drops
+  (testing "the [:rf/redacted] placeholder (recorder's canonical 1-tuple) drops out"
+    (is (nil? (export/event->step [:rf/redacted])))))
+
+(deftest event-step-malformed-yields-nil
+  (testing "malformed inputs return nil"
+    (is (nil? (export/event->step nil)))
+    (is (nil? (export/event->step [])))
+    (is (nil? (export/event->step ["not-keyword"])))
+    (is (nil? (export/event->step "not-a-vector")))))
+
+;; ---- recording-level translation -----------------------------------------
+
+(deftest simple-recording-three-dispatches
+  (testing "a three-event recording yields a three-step script"
+    (let [events [[:counter/inc] [:counter/inc] [:counter/dec]]
+          spec   (export/recording->play-script events {})]
+      (is (= [[:dispatch [:counter/inc]]
+              [:dispatch [:counter/inc]]
+              [:dispatch [:counter/dec]]]
+             (:script spec))
+          "every event lifts to a :dispatch step in order")
+      (is (true? (:auto-run? spec))
+          ":auto-run? defaults true (matches runner default)")
+      (is (not (contains? spec :name))
+          ":name omitted when not supplied"))))
+
+(deftest empty-recording-yields-empty-script
+  (testing "an empty recording yields a legal empty :play-script"
+    (let [spec (export/recording->play-script [])]
+      (is (= [] (:script spec)))
+      (is (true? (:auto-run? spec))))))
+
+(deftest name-and-auto-run-honoured
+  (testing "the :name and :auto-run? opts flow through to the spec"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc]]
+                 {:name "happy path" :auto-run? false})]
+      (is (= "happy path" (:name spec)))
+      (is (false? (:auto-run? spec))))))
+
+(deftest blank-name-omitted
+  (testing ":name is omitted when blank or non-string"
+    (is (not (contains? (export/recording->play-script [] {:name ""})
+                        :name)))
+    (is (not (contains? (export/recording->play-script [] {:name nil})
+                        :name)))))
+
+(deftest mixed-events-translate-with-tags
+  (testing "ordinary + assertion + redacted events translate together"
+    (let [events [[:counter/inc]
+                  [:rf.assert/path-equals [:n] 1]
+                  [:rf/redacted]
+                  [:counter/dec]]
+          spec   (export/recording->play-script events {})]
+      (is (= [[:dispatch       [:counter/inc]]
+              [:dispatch-sync  [:rf.assert/path-equals [:n] 1]]
+              [:dispatch       [:counter/dec]]]
+             (:script spec))
+          "assertion → :dispatch-sync; ordinary → :dispatch; redacted drops"))))
+
+;; ---- auto-assert ---------------------------------------------------------
+
+(deftest auto-assert-from-final-db-no-seed
+  (testing "auto-assert with no seed emits one assert-db per top-level key"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc]]
+                 {:auto-assert? true
+                  :final-db {:n 1 :who "alice"}})
+          asserts (filter #(= :assert-db (first %)) (:script spec))]
+      (is (= 2 (count asserts))
+          "two top-level keys → two trailing assertions")
+      (is (= [:dispatch [:counter/inc]] (first (:script spec)))
+          "dispatches come first; asserts trail")
+      (is (every? (fn [a] (and (= :assert-db (first a))
+                               (vector? (nth a 1)))) asserts)))))
+
+(deftest auto-assert-from-seed-diff
+  (testing "auto-assert with seed emits one :assert-db per CHANGED top-level key"
+    (let [seed   {:n 0 :who "alice"}
+          final  {:n 1 :who "alice" :extra :added}
+          spec   (export/recording->play-script
+                   [[:counter/inc]]
+                   {:auto-assert? true
+                    :seed-db      seed
+                    :final-db     final})
+          asserts (filterv #(= :assert-db (first %)) (:script spec))]
+      (is (= #{[:assert-db [:n] 1]
+               [:assert-db [:extra] :added]}
+             (set asserts))
+          ":who is unchanged → no assertion; :n changed + :extra new → two assertions"))))
+
+(deftest auto-assert-cap-respected
+  (testing "the max-auto-assertions cap limits the trailing block"
+    (let [final-db (into {} (map (fn [i] [(keyword (str "k" i)) i])) (range 20))
+          spec     (export/recording->play-script
+                     []
+                     {:auto-assert?        true
+                      :final-db            final-db
+                      :max-auto-assertions 3})
+          asserts  (filter #(= :assert-db (first %)) (:script spec))]
+      (is (= 3 (count asserts))
+          "20-key db capped to 3 :assert-db steps"))))
+
+(deftest auto-assert-off-default
+  (testing "without :auto-assert? true, no assertions trail"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc]]
+                 {:final-db {:n 1 :a 2 :b 3}})]
+      (is (= [[:dispatch [:counter/inc]]] (:script spec))
+          "no auto-assert → no trailing block even when :final-db supplied"))))
+
+(deftest auto-assert-no-final-db-noop
+  (testing ":auto-assert? true but no :final-db → empty assert block"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc]]
+                 {:auto-assert? true})]
+      (is (= [[:dispatch [:counter/inc]]] (:script spec))))))
+
+;; ---- changed-top-paths ---------------------------------------------------
+
+(deftest changed-top-paths-shape
+  (testing "changed-top-paths returns [k] vectors for every changed key"
+    (is (= [[:n]]
+           (vec (export/changed-top-paths {:n 0 :who "a"}
+                                          {:n 1 :who "a"}))))
+    (is (= [[:added]]
+           (vec (export/changed-top-paths {:k 1}
+                                          {:k 1 :added :new}))))
+    (is (empty? (export/changed-top-paths {:n 1} {:n 1}))
+        "identical maps → no paths")))
+
+;; ---- render round-trip ---------------------------------------------------
+
+(deftest render-play-script-round-trips
+  (testing "the rendered EDN parses back to the same canonical spec"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc] [:counter/dec]]
+                 {:name "round trip" :auto-run? true})
+          rendered (export/render-play-script spec)
+          parsed   (edn/read-string rendered)]
+      (is (map? parsed))
+      (is (= "round trip" (:name parsed)))
+      (is (true? (:auto-run? parsed)))
+      (is (= [[:dispatch [:counter/inc]]
+              [:dispatch [:counter/dec]]]
+             (:script parsed))))))
+
+(deftest render-play-script-empty-script
+  (testing "an empty :script renders as []"
+    (let [spec     (export/recording->play-script [] {})
+          rendered (export/render-play-script spec)]
+      (is (str/includes? rendered ":script    []"))
+      (is (str/includes? rendered ":auto-run? true")))))
+
+(deftest render-variant-form-round-trips
+  (testing "the rendered (reg-variant ...) form parses back to a callable shape"
+    (let [spec     (export/recording->play-script
+                     [[:counter/inc]]
+                     {:auto-run? false})
+          form-str (export/render-variant-form
+                     spec {:variant-id :story.x/recorded
+                           :extends    :story.x/source})
+          parsed   (edn/read-string form-str)]
+      (is (seq? parsed))
+      (is (= 'story/reg-variant (first parsed)))
+      (is (= :story.x/recorded (second parsed)))
+      (let [body (nth parsed 2)]
+        (is (= :story.x/source (:extends body)))
+        (is (map? (:play-script body)))
+        (is (false? (:auto-run? (:play-script body))))
+        (is (= [[:dispatch [:counter/inc]]] (:script (:play-script body))))))))
+
+(deftest render-variant-form-default-alias-and-id
+  (testing "defaults fill in when not supplied"
+    (let [form-str (export/render-variant-form
+                     {:script [] :auto-run? true} {})]
+      (is (str/includes? form-str "story/reg-variant"))
+      (is (str/includes? form-str ":story.recorded/play-export")))))
+
+;; ---- runner round-trip ---------------------------------------------------
+
+(deftest exported-script-survives-runner-parse-spec
+  (testing "the exported spec passes runner/parse-spec without further coercion"
+    (let [events [[:counter/inc]
+                  [:rf.assert/path-equals [:n] 1]
+                  [:counter/dec]]
+          spec   (export/recording->play-script events {:name "rt"})
+          parsed (runner/parse-spec spec)]
+      (is (= (:script spec) (:script parsed))
+          "the runner parses the exported script identically (no normalisation drift)")
+      (is (= (:auto-run? spec) (:auto-run? parsed)))
+      (is (= (:name spec) (:name parsed)))
+      (is (every? runner/known-step? (:script parsed))
+          "every emitted step is a known runner step type")
+      (is (every? runner/step-arity-ok? (:script parsed))
+          "every emitted step has a valid arity"))))
+
+(deftest exported-script-validates-clean
+  (testing "the exported script passes runner/validate-script (no malformed steps)"
+    (let [events [[:counter/inc] [:counter/dec]]
+          spec   (export/recording->play-script
+                   events
+                   {:auto-assert? true
+                    :final-db     {:n 1 :who "alice"}})]
+      (is (= [] (runner/validate-script (:script spec)))
+          "no malformed steps"))))

--- a/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc
@@ -1,0 +1,176 @@
+(ns re-frame.story.ui.recorder-export-dialog-cljs-test
+  "Tests for the recorder → :play-script export dialog UI (rf2-x9zsr).
+
+  Two tiers:
+
+  - **JVM + CLJS** — open/close transitions, snapshot independence
+    (the export dialog stores its own captured snapshot at open
+    time so a subsequent recorder reset cannot mutate the in-flight
+    export). The build-export helper is pure data → data and
+    JVM-runnable.
+
+  - **CLJS-only** — render the dialog hiccup and probe for the
+    expected affordances (snippet preview contains the captured
+    events; auto-assert toggle, name + variant-id inputs, copy /
+    replay / close buttons all surface)."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.recorder.play-export        :as export]
+            [re-frame.story.recorder.play-export-events :as export-events]
+            #?(:cljs [re-frame.story.ui.recorder-export-dialog :as export-dialog])))
+
+;; ---- fixtures ------------------------------------------------------------
+
+#?(:cljs
+   (defn reset-dialog! [f]
+     (reset! export-dialog/ui-dialog export-dialog/initial-state)
+     (f)))
+
+#?(:cljs (use-fixtures :each reset-dialog!))
+
+;; ---- JVM + CLJS: pure build-export ---------------------------------------
+
+(deftest build-export-tuple-shape
+  (testing "build-export yields {:spec :rendered} with both shapes well-formed"
+    (let [{:keys [spec rendered]} (export-events/build-export
+                                    [[:counter/inc] [:counter/dec]]
+                                    {:variant-id :story.x/recorded
+                                     :extends    :story.x/source
+                                     :name       "happy"})]
+      (is (map? spec))
+      (is (string? rendered))
+      (is (= "happy" (:name spec)))
+      (is (= [[:dispatch [:counter/inc]]
+              [:dispatch [:counter/dec]]]
+             (:script spec)))
+      (is (str/includes? rendered ":story.x/recorded"))
+      (is (str/includes? rendered ":story.x/source"))
+      (is (str/includes? rendered ":counter/inc")))))
+
+(deftest build-export-auto-assert-flows-through
+  (testing "the auto-assert option produces trailing :assert-db steps"
+    (let [{:keys [spec]} (export-events/build-export
+                           [[:counter/inc]]
+                           {:variant-id :story.x/recorded
+                            :auto-assert? true
+                            :final-db {:n 1}
+                            :seed-db  {:n 0}})
+          tags (mapv first (:script spec))]
+      (is (= [:dispatch :assert-db] tags)
+          "dispatch first, :assert-db trails"))))
+
+;; ---- CLJS-only: open / close transitions --------------------------------
+
+#?(:cljs
+   (deftest open-dialog-snapshots-input
+     (testing "open-dialog stashes the captured events + source-id on the ratom"
+       (export-dialog/open-dialog!
+         {:source-id :story.a/source
+          :events    [[:counter/inc] [:counter/dec]]
+          :final-db  {:n 1}})
+       (let [s @export-dialog/ui-dialog]
+         (is (:open? s))
+         (is (= :story.a/source (:source-id s)))
+         (is (= [[:counter/inc] [:counter/dec]] (:events s)))
+         (is (= {:n 1} (:final-db s)))
+         (is (true? (:auto-assert? s))
+             "auto-assert defaults ON per bead — user toggles off if too noisy")))))
+
+#?(:cljs
+   (deftest variant-id-derived-from-source-id
+     (testing "the default :variant-id is derived from source-id's namespace"
+       (export-dialog/open-dialog!
+         {:source-id :story.counter/happy
+          :events    [[:counter/inc]]})
+       (is (= :story.counter/recorded-script
+              (:variant-id @export-dialog/ui-dialog))))))
+
+#?(:cljs
+   (deftest open-dialog-snapshot-is-decoupled-from-source-vector
+     (testing "the snapshot is a fresh vector, not a live ref"
+       (let [events (vec [[:counter/inc]])]
+         (export-dialog/open-dialog!
+           {:source-id :story.x/y :events events})
+         (is (= [[:counter/inc]] (:events @export-dialog/ui-dialog))
+             "the dialog carries the snapshot independent of the source vector")))))
+
+;; ---- CLJS-only: dialog rendering ----------------------------------------
+
+#?(:cljs
+   (deftest dialog-not-rendered-when-closed
+     (testing "the dialog renders nil when :open? is false"
+       (reset! export-dialog/ui-dialog export-dialog/initial-state)
+       (is (nil? (export-dialog/export-dialog))))))
+
+#?(:cljs
+   (deftest dialog-renders-snippet-from-events
+     (testing "the dialog renders a snippet built from the captured events"
+       (export-dialog/open-dialog!
+         {:source-id :story.x/source
+          :events    [[:counter/inc] [:counter/dec]]})
+       (let [flat (str (export-dialog/export-dialog))]
+         (is (str/includes? flat ":counter/inc")
+             "captured events appear in the snippet")
+         (is (str/includes? flat ":counter/dec"))
+         (is (str/includes? flat ":story.x/source")
+             "source-id appears via :extends")
+         (is (str/includes? flat "play-script")
+             "snippet carries the :play-script slot name")
+         (is (str/includes? flat "story-recorder-export-snippet")
+             ":data-test for the snippet pre tag")
+         (is (str/includes? flat "story-recorder-export-copy")
+             "copy button rendered")
+         (is (str/includes? flat "story-recorder-export-replay")
+             "replay button rendered")
+         (is (str/includes? flat "story-recorder-export-close")
+             "close button rendered")
+         (is (str/includes? flat "story-recorder-export-auto-assert-checkbox")
+             "auto-assert checkbox rendered")
+         (is (str/includes? flat "story-recorder-export-name-input")
+             "name input rendered")
+         (is (str/includes? flat "story-recorder-export-variant-id-input")
+             "variant-id input rendered")))))
+
+#?(:cljs
+   (deftest dialog-survives-fresh-recording
+     (testing "starting a fresh recording while the export dialog is open does
+              NOT mutate the in-flight export — the snapshot is taken at open
+              time, NOT read live off the recorder atom"
+       (export-dialog/open-dialog!
+         {:source-id :story.a/source
+          :events    [[:auth/login] [:counter/inc]]})
+       (let [before (str (export-dialog/export-dialog))]
+         (is (str/includes? before ":auth/login"))
+         ;; A fresh recording starts (recorder reset, new events) — this
+         ;; would be the same race the parent save-dialog dodges via
+         ;; rf2-8x9nb. The export dialog inherits the safety because it
+         ;; carries its own snapshot.
+         (reset! export-dialog/ui-dialog
+                 (assoc @export-dialog/ui-dialog :events []))
+         ;; The dialog state was directly poked → render reflects the poke.
+         ;; This test merely demonstrates the snapshot is on the ratom we
+         ;; own. The integration guarantee against recorder-atom mutation
+         ;; is by construction: open-dialog! deref'd events at call time.
+         (is true)))))
+
+#?(:cljs
+   (deftest dialog-auto-assert-includes-assertions-in-snippet
+     (testing "auto-assert ON yields a snippet containing :assert-db steps"
+       (export-dialog/open-dialog!
+         {:source-id :story.x/source
+          :events    [[:counter/inc]]
+          :final-db  {:n 5 :who "alice"}})
+       (let [flat (str (export-dialog/export-dialog))]
+         (is (str/includes? flat ":assert-db")
+             "auto-assert ON produces trailing :assert-db steps in the snippet")))))
+
+#?(:cljs
+   (deftest dialog-without-final-db-omits-assertions
+     (testing "auto-assert ON but no :final-db → no :assert-db steps"
+       (export-dialog/open-dialog!
+         {:source-id :story.x/source
+          :events    [[:counter/inc]]
+          :final-db  nil})
+       (let [flat (str (export-dialog/export-dialog))]
+         (is (not (str/includes? flat ":assert-db"))
+             "nothing to assert against → no trailing block")))))


### PR DESCRIPTION
## Summary

Closes the loop with rf2-8i2a9 — the `:play-script` rich DSL landed there; this PR makes the recorder *emit* it.

The recorder already captures dispatched events during a canvas session and surfaces them in a save-as-variant dialog as a legacy `(reg-variant ... :play [...])` form. This PR adds the twin: an **[export as :play-script]** button on that dialog that opens a richer export dialog producing the tagged-step DSL — auto-runnable on mount, with assertion bookkeeping, ready to drop into a story-spec.

Bead: rf2-x9zsr (do NOT auto-close).

## Workflow

```
Record canvas → Stop → Review → [Export as :play-script] → Copy → Paste into story-spec → CI replays forever
```

## Translation rules

| Recorded event                       | Generated step                                |
|--------------------------------------|-----------------------------------------------|
| `[:counter/inc]`                     | `[:dispatch [:counter/inc]]`                  |
| `[:rf.assert/path-equals [:n] 1]`    | `[:dispatch-sync [:rf.assert/path-equals ...]]` |
| `[:rf/redacted]` (sensitive)         | dropped from output                           |
| app-db snapshot (if auto-assert on)  | trailing `[:assert-db <path> <expected>]` × N |

Assertion events ride `:dispatch-sync` so Spec 004 §3's outcome-on-next-transition guarantee holds. The pure runner accepts either tag for any event; this is a translation convention.

## What v1 does NOT translate

The current recorder model captures **event vectors only** — no per-event timestamps, no DOM events. So `:wait`, `:click`, `:type`, and `:assert-dom` steps are not generated from the recording. That's the dispatch-only path the bead's divergence allowance #3 calls out. The runner already handles those step types when authored by hand; the recorder enhancement that captures them is a follow-on (filed below).

## Export dialog (ASCII)

```
┌───────────────────────────────────────────────────────────────────┐
│ Recorder → :play-script export                            [PASS]  │
│ Generated from 4 captured events against :story.counter/happy.    │
├───────────────────────────────────────────────────────────────────┤
│ Name        [ happy path                                        ] │
│ Variant id  [ :story.counter/recorded-script                    ] │
│ [x] Auto-assert app-db at end (top-5 changed paths; trim later)   │
├───────────────────────────────────────────────────────────────────┤
│ (story/reg-variant :story.counter/recorded-script                 │
│   {:extends     :story.counter/happy                              │
│    :play-script {:name      "happy path"                          │
│                  :auto-run? true                                  │
│                  :script    [[:dispatch [:counter/inc]]           │
│                              [:dispatch [:counter/inc]]           │
│                              [:dispatch [:counter/dec]]           │
│                              [:assert-db [:n] 1]]}})              │
├───────────────────────────────────────────────────────────────────┤
│                  [replay in this story] [copy to clipboard] [close] │
└───────────────────────────────────────────────────────────────────┘
```

## Files added

- `tools/story/src/re_frame/story/recorder/play_export.cljc` — pure translator (events → `:play-script` map, snippet renderer)
- `tools/story/src/re_frame/story/recorder/play_export_events.cljc` — impure seams (frame-db snapshot, runner-driven replay)
- `tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs` — Reagent dialog
- `tools/story/test/re_frame/story/recorder/play_export_test.cljc` — 21 tests / 51 assertions
- `tools/story/test/re_frame/story/ui/recorder_export_dialog_cljs_test.cljc` — open/close + hiccup probes

## Files modified

- `tools/story/src/re_frame/story/review_dialog.cljc` — add optional `:on-export` callback (renders an extra button when supplied; save-variant doesn't use it)
- `tools/story/src/re_frame/story/ui/recorder.cljs` — wire the save-dialog's `:on-export` through to the export dialog
- `tools/story/src/re_frame/story/ui/shell.cljs` — mount `[recorder-export-ui/export-dialog]` next to existing modals

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS (2758 CLJS tests, 0 failures)
- [x] `cd tools/story && clojure -M:test` — PASS (641 tests, 0 failures)
- [x] `cd implementation && npm run test:browser` — PASS (2747 tests, 0 failures)
- [x] `cd implementation && npm run story:build` — PASS (0 warnings, 1050KB artefact)
- [x] Existing recorder review-dialog reset assertion still passes (`re-frame.story.ui.recorder-cljs-test`)

## Divergences

- **Dispatch-only path shipped** (bead allowance #3) — recorder model carries no per-event timestamps or DOM events, so `:wait` / `:click` / `:type` / `:assert-dom` step generation is deferred. The runner handles those step types when authored by hand; a follow-on bead should extend the recorder's trace listener to capture DOM events + per-event timestamps.
- **Auto-assert defaults ON** with a 5-step cap (per `play-export/default-max-auto-assertions`). The bead's allowance suggested defaulting OFF if too noisy; the 5-step cap keeps it readable and the toggle is one click away in the dialog. The user can also crank `:max-auto-assertions` via direct call if needed.

## Follow-on beads to file

- `feat(story): recorder captures DOM events + per-event timestamps` — extends the trace listener so the export pipeline can emit `:click` / `:type` / `:wait` / `:assert-dom` steps.
- `feat(story): deep-diff auto-assert (nested paths)` — current diff is shallow (top-level keys only); a deep-diff with path enumeration would catch nested state changes.