### PR TITLE
docs(causa): vision-level spec — destination + bug-driven structure (rf2-2rp88)

### DIFF
--- a/tools/causa/spec/000-Vision.md
+++ b/tools/causa/spec/000-Vision.md
@@ -1,175 +1,253 @@
-# 000-Vision: Causa — the re-frame2 devtools surface
+# 000-Vision: Causa — the cascade you can see
 
-## Why it exists
+## The claim
 
-When a re-frame app misbehaves, the programmer should be able to ask
-five canonical questions and answer them in seconds, with click-to-source
-on every artefact:
+**Causa shows you what happens when an event fires.**
 
-1. **Why did this event fire?** (causal-ancestor walk)
-2. **What did that event change?** (`app-db` diff + flow recomputes + machine transitions)
-3. **Why is this subscription returning the wrong value?** (input-chain trace + cache state)
-4. **Why is this view re-rendering?** (subscription invalidation chain + render-key attribution)
-5. **What's currently broken?** (errors, warnings, schema violations, hydration mismatches — surfaced as one feed)
+When a re-frame2 app misbehaves, the programmer points at one event and Causa
+unfolds the full cascade behind it:
 
-v1 of re-frame-10x answered #1–#4 partially and #5 not really. Causa
-answers all five, in seconds, with click-to-source for every artefact.
+- every effect that ran,
+- every subscription that recomputed,
+- every component that re-rendered,
+- every state mutation in `app-db`,
+- every machine transition,
+- every HTTP request issued and received,
+- every flow that recomputed and every flow that was halted,
+- every route navigation and every nav-token suppression,
+- every SSR hydration mismatch, every schema violation,
+- every cancellation that fell out of a parent-actor exit.
 
-re-frame2's instrumentation surface (Spec 009 trace bus, Tool-Pair
-epoch history, source-coord stamping, machine and flow registries)
-emits structured data for every interesting moment. Causa's job is
-*presentation*: render the runtime to the human in the runtime's own
-terms.
+One event in; full insight out. Every artefact carries a source-coord chip;
+click jumps the editor to the line. Every wall-clock thing (a `:after` timer,
+an HTTP retry backoff, a streaming SSR boundary) carries the wall clock as a
+visible axis. Every silent contract (a guard rejecting, a nav-token
+suppressing, a fx skipped-on-platform, a flow cascade-halting) surfaces
+loudly. Causa is the only place these contracts become legible.
+
+re-frame-10x's claim was *"x-ray vision as tooling"*. Causa's claim is
+the next-gen version of that vision — same depth on one event, plus the
+cross-cutting machinery (machines · routes · SSR · managed effects) that
+re-frame2 introduced and that no peer tool has the structured runtime data
+to surface.
+
+## How the claim cashes out
+
+### One event at a time
+
+Every Causa surface orients around **one focused event** — the spine sub
+`:rf.causa/focus`. The user (or LIVE mode) picks an event in the L2 list;
+every dependent panel rebinds atomically. Tabs are **lenses on that one
+event**:
+
+| Tab | What it shows for the focused event |
+|---|---|
+| **Event** (`e`) | The event vector + the six dominoes of its cascade. |
+| **App-db** (`a`) | The diff `:db-before → :db-after` for this event. |
+| **Views** (`v`) | The subs recomputed because of this event + the views that re-rendered. |
+| **Trace** (`t`) | The raw trace stream filtered to this event's cascade. |
+| **Machines** (`m`) | The transitions this event triggered + the spawn/destroy cascades it produced. |
+| **Issues** (`i`) | The violations this event introduced — errors · warnings · schema · hydration · advisories. |
+
+Plus the **Causality popover** (`c`) — invokable from any tab, showing the
+graph of events that caused this event (ancestors) and the events this event
+spawned (descendants).
+
+This is the **single spine**: one selection, every surface rebinds. No
+two-axis selection (`:selected-dispatch-id` × `:selected-epoch-id` from the
+pre-spec drafts is gone). No panel reads `(peek history)`. No drift between
+what the user is looking at and what the panel is rendering.
+
+### Cross-cutting concerns extend the spine, never fragment it
+
+re-frame2 introduces SSR, Routes, Machines, Managed-Fx — surfaces that
+**unfold across wall-clock time and across boundaries** (server → client,
+parent → child, request → response, nav-1 → nav-2). These are the cases
+where stack traces are insufficient because the wall clock IS the bug
+surface.
+
+Causa does NOT fragment the chrome with per-area tabs (no Routes tab, no
+SSR tab, no managed-effects tab). Instead, each existing tab grows
+**deep specialised renderings** for the cross-cutting work that lands in it:
+
+- The Event tab grows a per-fx **wire-boundary diff** for managed effects
+  (request → wire → response → handler → app-db slice).
+- The Trace tab grows a **wall-clock axis** for timer rings, retry
+  waterfalls, deferred-dispatch arrivals.
+- The Machines tab grows **timer countdown rings** on state nodes,
+  **cancellation cascade visualisers**, **`:invoke-all` join inspectors**.
+- The Issues tab grows **nav-token timelines** (swimlanes), **hydration
+  mismatch bisectors**, **server error projection traces**.
+- The Causality popover grows **machine-edge types** (spawn, final, join).
+
+The five idioms — **wall-clock timelines · boundary diffs · cascade trees ·
+schema explanations · lifecycle accounting** — repeat across all four areas
+(SSR, Machines, Routes, Managed-Fx). One idiom, one rendering vocabulary;
+every area picks up every idiom. See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) for the
+5-idioms × 4-areas matrix.
+
+### Bug-driven, not feature-driven
+
+Every Causa feature is grounded in a **concrete bug-class a programmer
+hits**. The framing is uniform:
+
+> **Bug class:** what the user is staring at when the question forms.
+> **Example bug:** the vignette — "you dispatched X, expected Y, got Z because W."
+> **Insight Causa provides:** what the user SEES that resolves the mystery.
+> **Affordance:** the UI surface + interaction model.
+
+No feature lands in the spec without a bug-class motivation. When in doubt,
+add the bug; don't add the feature. The spec is auditable against this rule.
+
+## The five canonical questions (the bar)
+
+A programmer hits `Ctrl+Shift+C`, Causa lands on the freshest event
+(`:rf.causa/focus` already points), and within five seconds they answer one
+of:
+
+1. **Why did this event fire?** — `c` popover; ancestor walk.
+2. **What did this event change?** — App-db tab; diff `:db-before → :db-after`.
+3. **Why is this subscription returning the wrong value?** — Views tab; per-sub
+   invalidation chain + cache state.
+4. **Why is this view re-rendering?** — Views tab; sub-driven attribution
+   chain.
+5. **What's currently broken?** — Issues tab; unified feed (errors · warnings ·
+   schema violations · hydration mismatches · advisories).
+
+If a surface doesn't help answer "why?" or "what happened?" or "what's
+wrong?", it doesn't ship. Restraint is what keeps the tool habit-forming
+instead of impressive.
 
 ## What it is
 
 A re-frame2-native devtools surface that runs **in-app**, preloaded into
-dev builds. The shell is a **4-layer chrome** (ribbon · event list ·
-tab bar · detail panel) — see
+dev builds. The shell is the **4-layer chrome** (ribbon · event list · tab
+bar · detail panel) — see
 [`018-Event-Spine.md`](018-Event-Spine.md) for the full architectural
 contract.
 
-Every open lands the user on the latest cascade. The Event tab
-(default) shows the event vector, source, handler return, db writes,
-fx, and the fx-handlers that ran — the five canonical questions
-answer themselves on first paint; deeper investigation is one tab away
-(`a` App-db · `v` Views · `t` Trace · `m` Machines · `i` Issues) or one
-keypress away (`c` Causality popover from any tab).
-
-The single axis is **`:rf.causa/focus`** — pick an event in the list,
-every dependent panel rebinds. No two-axis selection; no `(peek
-history)` reads in panels.
+Every open lands on the latest cascade. The Event tab (default) shows the
+event vector, source, handler return, db writes, fx, and the fx-handlers
+that ran — the five canonical questions answer themselves on first paint;
+deeper investigation is one tab away (`a` App-db · `v` Views · `t` Trace ·
+`m` Machines · `i` Issues) or one keypress away (`c` Causality popover).
 
 ## What it isn't
 
-- **Not** the AI surface. There is no in-Causa AI co-pilot panel, no
-  Causa-MCP server, no LLM chat rail. AI access to the running
-  re-frame2 runtime goes through `tools/pair2-mcp/` (raw nREPL over
-  MCP) — the agent reads the same instrumentation Causa reads, not a
-  Causa-curated facade. **Causa is the human-only observability
-  surface; pair2-mcp is the AI access path.** Two doors, no
-  compromises.
-- **Not** a port of re-frame-10x v1. The chrome is 10x-shaped at the
-  layer level (events at the top, detail at the bottom, scrubber via
-  ribbon+list, keyboard-first) but the substrate is re-frame2's enriched
-  trace bus, multi-frame model, machine and flow registries, and
-  source-coord stamping.
-- **Not** a registrar, dispatch, effect, or component layer. Causa is a
-  downstream consumer of re-frame2's existing surfaces — per the
-  feedback that downstream EPs must not add new registries (this is
-  not even an EP; it is a tool).
-- **Not** writeable into `app-db`. Read-only forever. The runtime is
-  the source of truth; pokes from the debugger are out of scope (lock
-  #3 in `DESIGN-RATIONALE.md`).
-- **Not** a session recorder. No export, no import. Sessions are
-  ephemeral (lock #4).
-- **Not** a mobile surface. Desktop only; viewports below 600px refuse
-  to mount (lock #5).
-- **Not** a Chrome extension. In-app DOM injection plus a same-browser
-  pop-out via `window.opener`. Remote-attach lives over MCP, not over
-  a custom WebSocket protocol (lock #9).
-- **Not** part of any production bundle. Per the bundle-isolation
-  contract in `tools/README.md`, dependency arrows flow tool →
-  implementation; Causa is invisible to consumer apps after elision.
-- **Not** a Stately editor / exporter. No machine→xstate-json bridge;
-  no Stately compatibility. Causa is the canonical rendering surface
-  for re-frame2 machines.
+- **Not the AI surface.** AI access to the running re-frame2 runtime goes
+  through `tools/pair2-mcp/` (raw nREPL over MCP). Two doors, no compromises;
+  no in-Causa AI co-pilot panel, no Causa-MCP server, no LLM chat rail.
+- **Not a port of re-frame-10x.** The chrome is 10x-shaped at the layer
+  level (events at top, detail at bottom, scrubber via ribbon+list,
+  keyboard-first); the substrate is re-frame2's enriched trace bus, the
+  multi-frame model, the machine and flow registries, and source-coord
+  stamping.
+- **Not a registrar, dispatch, effect, or component layer.** Causa is a
+  downstream consumer of re-frame2's existing surfaces.
+- **Not writeable into `app-db`.** Read-only forever (lock #3 in
+  `DESIGN-RATIONALE.md`).
+- **Not a session recorder.** No export, no import; sessions are ephemeral
+  (lock #4). The recorder → `:play-script` export pipeline is a Story
+  integration (see [`018-Event-Spine.md`](018-Event-Spine.md) §Recorder /
+  Story integration); the running Causa session does not persist.
+- **Not a mobile surface.** Desktop only; viewports below 600px refuse to
+  mount (lock #5).
+- **Not a Chrome extension.** In-app DOM injection plus a same-browser
+  pop-out via `window.opener`. Remote-attach lives over pair2-mcp (lock #9).
+- **Not part of any production bundle.** Per the bundle-isolation contract
+  in `tools/README.md`, dependency arrows flow tool → implementation; Causa
+  is invisible to consumer apps after elision.
+- **Not a Stately editor / exporter.** No machine→xstate-json bridge; no
+  Stately compatibility. Causa is the canonical rendering surface for
+  re-frame2 machines.
 
 ## What re-frame2 unlocks
 
-Each row is "new in re-frame2 → new tooling story Causa must tell."
+Each row is "new in re-frame2 → new tooling story Causa tells."
 
 | re-frame2 capability | Causa surface |
 |---|---|
 | **Multi-frame** (Spec 002) | Per-frame inspection; single-select frame picker in ribbon; cross-frame causality via Causality popover. |
-| **Machines** (Spec 005) | Stately-quality state-chart per machine; transition log; `:after`-timer countdown; `:invoke-all` parallel-child viz; UC1 interactive simulation; UC2 multi-instance Mode A/B/C; XState-parity supervision tree. ELK+SVG primitive ships Causa-internal (no separate `tools/machines-viz/`). |
-| **Flows** (Spec 013) | Surfaced in Views tab when a flow's downstream sub recomputed (under "Re-rendered" group). |
-| **Source-coord stamping** (Spec 001 + 006) | Click-to-source on every node, view, machine guard, transition. |
-| **Trace bus** (Spec 009) | The substrate of everything. Causa does not invent its own trace shape. |
+| **Machines** (Spec 005) | Stately-quality state-chart per machine; transition log; **`:after`-timer countdown rings** with scrubber-aware retro-replay; **`:invoke-all` parallel-child viz + join inspector**; UC1 interactive simulation; UC2 multi-instance Mode A/B/C; **cancellation-cascade visualiser**; **per-instance "why am I stuck" trace**; XState-parity supervision tree. ELK+SVG primitive ships Causa-internal. |
+| **Flows** (Spec 013) | Surfaced in Views tab when a flow's downstream sub recomputed; **cascade-halt alarm** in Issues tab — names the downstream flows that did NOT run when an upstream flow's `:output` threw. |
+| **Source-coord stamping** (Spec 001 + 006) | Click-to-source on every node, view, machine guard, transition, fx-handler, schema declaration. |
+| **Trace bus** (Spec 009) | The substrate of everything. Causa does not invent its own trace shape. **Trace fattening** (carrying context-at-position on each event) enables the per-instance scrubber's Phase-5 replay-from-arbitrary-position affordance. |
 | **Epoch history + `:rf/epoch-record` projections** (Tool-Pair) | First-class time-travel via the ribbon's `[◀ ▶ ⏭]` nav + the event list (L2). |
 | **Six named restore failures** | Structured "this rewind won't work because X" rather than a silent no-op. |
 | **`register-epoch-cb!`** | The per-cascade listener routes the Event tab + Issues tab + Causality popover. |
-| **Schemas (Malli)** (Spec 010) | Schema-violation rows in the Issues tab. |
-| **SSR + hydration** (Spec 011) | Hydration-mismatch rows in the Issues tab. |
-| **Routing** (Spec 012) | Route is a sub-tree of app-db — surfaced in App-db tab; nav-token timeline via Trace tab when `event` chip ON. |
+| **Schemas (Malli)** (Spec 010) | Schema-violation rows in the Issues tab; **per-violation drill** with full Malli explanation + recovery-mode classification + source-coord. |
+| **SSR + hydration** (Spec 011) | **Hydration mismatch bisector** — canonical-EDN dfs to the first divergent node; server vs client side-by-side per `get-in` path; sub-attribution (which sub returned `nil` server / `:en-US` client + why). **Streaming SSR boundary timeline.** **Per-request response accumulator inspector.** **Head model inspector.** **Server error projection trace** (the security boundary visualised). |
+| **Routing** (Spec 012) | Route is a sub-tree of app-db — surfaced in App-db tab; **nav-token timeline** (swimlanes) makes stale-clobber races literally visible; **`:on-match` chain explicit in Event tab**; **match-rank explainer**; **pending-navigation card**; **route-chain visualiser**. |
 | **`:origin` opt on dispatch** | Filter by actor via ribbon IN/OUT pills. |
 | **Data classification** (Spec 015) | Path-marked sensitive + large rendering: `[● REDACTED N]` magenta opaque + `[● ELIDED N]` yellow drillable. See [`018-Event-Spine.md`](018-Event-Spine.md) §12 for the per-surface rendering contract. |
+| **Managed effects** (`spec/Managed-Effects.md` eight-property contract) | **Wire-boundary diff** in the Event tab's "fx handlers that ran" block — per fx, show request payload (post-elision) → wire transit (status / headers / timing waterfall) → response → handler dispatched → app-db slice touched. One template; five surfaces (HTTP, WebSocket, machine `:invoke`, SSR `:rf.server/*`, flows). **Active managed-effects dashboard** — Erlang-Observer for what the runtime is currently busy doing. **Stale-suppression badges** uniform across all four cross-cutting areas. |
 | **Production-elision verifier** | Causa runs `npm run test:elision` and warns before deploy if a dev sentinel leaked. |
 
 ## The 6-tab inventory
 
-The legacy 16-panel sidebar is dead. Causa now ships a **6-tab detail
-panel** (Layer 3 of the 4-layer chrome). Each tab is one projection of
-the focused event; selection in the L2 event list rebinds every tab.
+The legacy 16-panel sidebar is dead. Causa ships a **6-tab detail panel**
+(Layer 3 of the 4-layer chrome). Each tab is one projection of the focused
+event; selection in the L2 event list rebinds every tab. Cross-cutting
+concerns extend each tab; they do NOT add new tabs.
 
 | # | Tab | Mnem | What it shows | Spec |
 |---|---|---|---|---|
-| 1 | **Event** | `e` | Whole event vector + arg-map + source · handler return · db writes · fx vector · fx-handlers that ran. **Folds in the old Effects tab content.** | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Event-detail panel + [`018-Event-Spine.md`](018-Event-Spine.md) §5.1 |
-| 2 | **App-db** | `a` | Diff `:db-before` vs `:db-after` — slice-first · pinned watches · full-tree disclosure. | [`004-App-DB-Diff.md`](004-App-DB-Diff.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.2 |
-| 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; **subs nested under each view row** showing return values. **Replaces the old Subs panel.** | [`012-Views.md`](012-Views.md) |
-| 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to the focused cascade; trace-type toggle row + IN/OUT pills + sensible defaults. | [`013-Trace-Bus.md`](013-Trace-Bus.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.3 |
-| 5 | **Machines** | `m` | UC1 (definition + sim) + UC2 (Mode A/B/C dynamic instances); supervision tree. **MachineChart is now Causa-internal (`tools/machines-viz/` collapse).** | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
-| 6 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon + [`018-Event-Spine.md`](018-Event-Spine.md) §5.4 |
+| 1 | **Event** | `e` | Whole event vector + arg-map + source · handler return · db writes · fx vector · fx-handlers that ran (with wire-boundary diff per managed fx). | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Event-detail panel + [`018-Event-Spine.md`](018-Event-Spine.md) §5.1 |
+| 2 | **App-db** | `a` | Diff `:db-before` vs `:db-after` — slice-first · pinned watches · full-tree disclosure · branch-aware diff (for story sim-clones) · cross-frame diff (for multi-frame shared substates). | [`004-App-DB-Diff.md`](004-App-DB-Diff.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.2 |
+| 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; **subs nested under each view row** showing return values; **per-sub invalidation-chain drill** (why did this sub re-run); replaces the legacy Subs panel. | [`012-Views.md`](012-Views.md) |
+| 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to the focused cascade; **wall-clock axis** for timer rings, retry waterfalls, deferred-dispatch arrivals; trace-type toggle row + IN/OUT pills + sensible defaults. | [`013-Trace-Bus.md`](013-Trace-Bus.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.3 |
+| 5 | **Machines** | `m` | UC1 (definition + sim) + UC2 (Mode A/B/C dynamic instances); supervision tree; **`:after`-timer countdown rings**; **cancellation cascade visualiser**; **`:invoke-all` join inspector**; **per-instance "why am I stuck" trace strip**; **hierarchical cascade animator**; **shift-click divergence highlighter**; **per-instance mini-scrubber**. MachineChart is Causa-internal. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
+| 6 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns + **flow cascade-halt alarms** + **open-redirect advisories** + **`:platforms` skip tallies** + **stale-suppression group**. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon + [`018-Event-Spine.md`](018-Event-Spine.md) §5.4 |
 
-**Causality is a popover, not a tab** — invoke via `c` key from any
-tab. See [`018-Event-Spine.md`](018-Event-Spine.md) §10.
+**Popovers** (transient overlays, invokable from any tab):
 
-### What this inventory drops (vs the legacy 16 panels)
-
-| Dropped | Reason | Lives in |
+| Popover | Key | Content |
 |---|---|---|
-| **AI co-pilot panel** | Causa is the human surface; AI access goes via `tools/pair2-mcp/` over raw nREPL | `tools/pair2-mcp/` (sibling tool, not a Causa panel) |
-| **MCP Server panel** | `tools/causa-mcp/` artefact is dropped entirely; no Causa-curated MCP surface | nowhere (dropped) |
-| **Subscriptions panel** | Subs are nested under the views that consumed them; the view (not the sub) is the natural unit developers reason about | Views tab (`v`), per-row nested-subs |
-| **Effects panel** | The "fx handlers that ran" content folds into the fattened Event tab | Event tab (`e`), "fx handlers that ran" block |
-| **Performance panel** | Chrome DevTools' Performance tab renders the framework's `rf:event:*` / `rf:sub:*` / `rf:fx:*` / `rf:render:*` / `rf:cascade:*` User-Timing entries natively in the Timings track. Causa stops duplicating a surface Chrome does better. | Chrome DevTools → Performance tab |
-| **Causality graph as a tab** | Causality is consulted, not browsed — transient popover triggered by `c` from any tab fits the usage pattern better than an always-mounted tab | `c`-key popover (centred 640×480 floating overlay; see [`018-Event-Spine.md`](018-Event-Spine.md) §10) |
-| **Flows panel** | Flows surface when their downstream subs recompute — fold into the Views tab's "Re-rendered" group | Views tab (`v`) |
-| **Routes panel** | Route state is a sub-tree of app-db; navigation timeline lives in Trace tab | App-db tab (`a`) + Trace tab (`t`) |
-| **Schemas panel** | Schema violations are issues | Issues tab (`i`) |
-| **Hydration panel** | Hydration mismatches are issues (SSR-only) | Issues tab (`i`) |
-| **Time-travel panel** | The scrubber is now the ribbon `[◀ ▶ ⏭]` cluster + the event list (L2). No separate panel. | L1 ribbon nav cluster + L2 event list |
-| **Settings panel** | Settings is a modal popup anchored to the ribbon `⚙` icon — transient overlay, not a tab | Modal popup (`,` or `s` or click `⚙`); see [`018-Event-Spine.md`](018-Event-Spine.md) §9 |
+| **Causality** | `c` | Graph of events that led to this event (ancestors, LR layout) + events this event spawned (descendants, TB layout). Full hybrid LR+TB per-region layout. Resizable; per-session persisted size. Depth-disclosure text + per-segment hover tooltips. |
+| **Nav-token timeline** | `r` | Horizontal swimlanes — each navigation is a bar; in-flight `:on-match` events ride above; stale-suppressed completions strike-through with carried-vs-current token visible. |
+| **Wire-trace** | `f` | The active fx's wire-boundary diff popped out — same content as the Event-tab inline panel but floats over any tab. |
 
-**Tab count trajectory:** 16 (legacy) → 8 (Effects folded in round-1) →
-6 (round-2: Subs folded into Views; Performance dropped; Causality
-folded into popover). Six is the smaller number that better fits the
-chrome.
-
-See [`018-Event-Spine.md`](018-Event-Spine.md) for the full 4-layer
-chrome + spine-binding architectural contract.
+See [`018-Event-Spine.md`](018-Event-Spine.md) §10 for the popover invocation
+contract.
 
 ## The bar
 
-A programmer hits `Ctrl+Shift+C`, sees the cascade their last click
-triggered in the Event tab — `:rf.causa/focus` already points at the
-freshest event — asks "why?", and either reads the answer in the
-panel (event vector, source coord, db writes, fx outcomes) or presses
-`c` to see the causality graph. Five seconds.
+A programmer hits `Ctrl+Shift+C`, sees the cascade their last click triggered
+in the Event tab — `:rf.causa/focus` already points at the freshest event —
+asks "why?", and either reads the answer in the panel (event vector, source
+coord, db writes, fx outcomes) or presses `c` to see the causality graph.
+Five seconds.
 
-If a tab doesn't help answer "why?" or "what happened?" or "what's
-wrong?", it doesn't ship. Restraint is what keeps the tool
-habit-forming instead of impressive.
+If a tab doesn't help answer "why?" or "what happened?" or "what's wrong?",
+it doesn't ship. Restraint is what keeps the tool habit-forming instead of
+impressive.
 
 ## Audience
 
-- **The re-frame programmer mid-feature.** Wants the event list in
-  their face but unobtrusive; wants click-to-source from anywhere;
-  wants to scrub.
+- **The re-frame programmer mid-feature.** Wants the event list in their
+  face but unobtrusive; wants click-to-source from anywhere; wants to scrub.
 - **The programmer reading an unfamiliar codebase.** "Why does clicking
   Save eventually re-render this card three modules over?" — wants the
   causality popover (`c`) and the Views tab.
-- **The on-call programmer triaging a production-shaped repro.** Loads
-  the app, scrubs via `[◀ ▶ ⏭]` + L2, finds the divergence.
-- **The AI agent driving the runtime.** Doesn't open the UI; consumes
-  the same data through the same primitives via `tools/pair2-mcp/`
-  over raw nREPL. Causa and pair2-mcp are siblings; neither owns a
-  registry; neither writes to app-db.
+- **The on-call programmer triaging a production-shaped repro.** Loads the
+  app, scrubs via `[◀ ▶ ⏭]` + L2, finds the divergence.
+- **The programmer debugging a streaming SSR / hydration mismatch.** Opens
+  Causa, the Issues tab leads them to the divergent node; the bisector and
+  the side-by-side answer "why does the server say `nil` and the client say
+  `:en-US`?"
+- **The programmer debugging a cancellation cascade.** Sees the parent
+  machine's `:exit` ripple through three abort traces in one vertical
+  waterfall, not as a confusing flurry across the Trace firehose.
+- **The AI agent driving the runtime.** Doesn't open the UI; consumes the
+  same data through the same primitives via `tools/pair2-mcp/` over raw
+  nREPL. Causa and pair2-mcp are siblings; neither owns a registry; neither
+  writes to app-db.
 
 ## Where Causa fits
 
 Causa is one of two downstream consumers of the same re-frame2
-instrumentation surface (the "two doors" split — see What it isn't):
+instrumentation surface (the "two doors" split):
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -191,30 +269,33 @@ instrumentation surface (the "two doors" split — see What it isn't):
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
-**Causa and pair2-mcp are SIBLINGS.** Both read the same
-instrumentation; neither owns a registry; neither writes to app-db.
-The split is intentional and load-bearing:
+**Causa and pair2-mcp are SIBLINGS.** Both read the same instrumentation;
+neither owns a registry; neither writes to app-db. The split is intentional
+and load-bearing:
 
-- **Causa = human surface.** Visual chrome, keyboard-first power-user
-  UX, painted UI, virtualisation, animation. The five-canonical-questions
+- **Causa = human surface.** Visual chrome, keyboard-first power-user UX,
+  painted UI, virtualisation, animation. The five-canonical-questions
   answer themselves on first paint.
-- **pair2-mcp = AI surface.** Raw nREPL over MCP. Whatever the agent
-  wants to do, it does by evaluating Clojure against the runtime — no
-  curated AI-shaped facade in front.
+- **pair2-mcp = AI surface.** Raw nREPL over MCP. Whatever the agent wants
+  to do, it does by evaluating Clojure against the runtime — no curated
+  AI-shaped facade in front.
 
-This kills the false middle: a curated *Causa-MCP* would be a tax on
-both surfaces (it duplicates pair2-mcp's responsibility and degrades
-Causa's freedom to evolve its UI without breaking an AI contract).
-Drop it.
+This kills the false middle: a curated *Causa-MCP* would be a tax on both
+surfaces (it duplicates pair2-mcp's responsibility and degrades Causa's
+freedom to evolve its UI without breaking an AI contract). Drop it.
 
 **Story (`tools/story/`)** — the component playground — embeds Causa's
-Event tab as a per-variant observability ribbon (per the embedding
-contract in [`008-Embedding-Contract.md`](008-Embedding-Contract.md)).
+Event tab as a per-variant observability ribbon (per the embedding contract
+in [`008-Embedding-Contract.md`](008-Embedding-Contract.md)). The recorder
+→ `:play-script` pipeline (per
+[`018-Event-Spine.md`](018-Event-Spine.md) §Recorder / Story integration)
+turns a captured Causa session into a Story-runnable script — the only
+"export" Causa offers, and it lands in Story's persistent layer, not
+Causa's.
 
-The dependency arrows: Causa → `implementation/machines/` (directly;
-no `tools/machines-viz/` hop). Story → Causa → `implementation/`. No
-cycles, no shared registries, no parent/child relationships among the
-tools.
+The dependency arrows: Causa → `implementation/machines/` (directly; no
+`tools/machines-viz/` hop). Story → Causa → `implementation/`. No cycles,
+no shared registries, no parent/child relationships among the tools.
 
 ## Status
 
@@ -222,5 +303,14 @@ Pre-alpha. Substantial rewrite from the legacy 16-panel sidebar to the
 4-layer chrome (see [`018-Event-Spine.md`](018-Event-Spine.md)). All
 direction-setting decisions are locked — see
 [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md). Implementation work is
-sequenced after spec ratification; the bead matrix carries the
-sequencing.
+sequenced after spec ratification; the bead matrix carries the sequencing.
+
+This spec describes the **destination** — the full vision Causa is
+heading toward. Many features called out above are not in v1; they are
+documented here so the spec reads as the place we're going, not the place
+we've stopped. Where a section says "v1 ships X; future: Y", the **Y** is
+the main read; the **X** is the staged-delivery callout.
+
+For the cross-cutting vision — the 5-idioms × 4-areas (SSR · Machines ·
+Routes · Managed-Fx) matrix — see
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md).

--- a/tools/causa/spec/001-Causality-Graph.md
+++ b/tools/causa/spec/001-Causality-Graph.md
@@ -1,5 +1,50 @@
 # 001-Causality-Graph
 
+## Bug class
+
+**"I dispatched event X, why did event Y also fire 200ms later?"**
+
+The cascade tree is invisible from the call site. In re-frame2, one
+dispatch can cascade through fxs that dispatch other events, through
+machine transitions that emit their own dispatches, through cross-frame
+fxs, through `:dispatch-later` arrivals. The author sees the cascade
+TAIL (event Y firing) but not the CAUSE (event X's fx that dispatched
+Y). Stack traces are insufficient — the dispatcher unwinds before Y
+runs.
+
+## Example bug
+
+You clicked Save. The page eventually re-rendered a card three modules
+over. The Trace shows 18 events fired between your click and the
+re-render. You don't know which event in the chain caused the
+re-render; you don't know which fx in the chain dispatched which
+event; you don't know whether the re-render came from your code or
+from a third-party hook.
+
+## Insight Causa provides
+
+A **vertical directed graph** keyed by `:dispatch-id` /
+`:parent-dispatch-id`. Cascade roots are diamonds (`◆`); children are
+circles (`○`); the currently-selected dispatch is filled (`◉`). The
+walk from any node up through `:parent-dispatch-id` shows the
+ancestor chain ("why did this event fire?"); the walk down through
+the children index shows the descendant tree ("what did this event
+spawn?"). Cross-frame dispatches render as explicit arrows traversing
+horizontal swimlanes.
+
+The graph is the **deeper-walk** answer when the cascade is more than
+two hops, spans frames, or when triaging a session with 30+ events.
+
+## Affordance
+
+The causality graph is a **peer popover** — first-class, keyboard
+mnemonic `c`, transient overlay over any tab. It is **not** the front
+door (the front door is the Event tab + the inline mini-graph). The
+popover is the deeper-walk view when the cascade is more than two
+hops or spans frames.
+
+---
+
 The causality graph is a **peer** panel — first-class, sidebar entry,
 keyboard mnemonic `c`, but **not** the front door. The hero is the
 event-detail panel. The graph is the deeper-walk view when the cascade
@@ -345,3 +390,62 @@ framework's boot epoch.
 - **No edge labels.** Earlier drafts proposed labelling parent → child
   edges with the fx that caused them. The signal-to-noise was poor
   (every edge was labelled `:fx [[:dispatch ...]]`). Removed.
+
+## Vision — full hybrid LR+TB layout
+
+**v1 ships:** single-axis vertical layout (older at top, newer at
+bottom; frames as horizontal swimlanes). **Future:** **hybrid
+LR-ancestors + TB-descendants per-region layout** (Q12-lock):
+
+- **Ancestors** (parent walk from focused node) render LEFT-TO-RIGHT —
+  the older the ancestor, the further left. This matches the "left =
+  cause, right = effect" reading.
+- **Descendants** (children walk from focused node) render
+  TOP-TO-BOTTOM — the deeper the descendant, the further down. This
+  matches the cascade-tree mental model.
+- The **focused node** sits at the LR / TB hinge; the eye reads "cause
+  on the left, focus in the middle, consequences below."
+
+The hybrid layout is more legible than uniform TB for deep cascades
+because the cause-chain reads naturally left-to-right (like a
+narrative) while the consequence-tree branches naturally downward
+(like a stack trace).
+
+## Vision — resizable popover with per-session persistence
+
+The popover opens at 640×480 default. **Future:** it is **draggable to
+any size**, the user's size persists for the session (cleared on
+reload), and the layout reflows. For dense cascades the user wants
+larger; for shallow walks 640×480 is fine. The persistence is
+session-scoped — pins-do-not-survive-reload (Lock #4) extends to
+popover geometry.
+
+## Vision — depth-disclosure + per-segment hover tooltips
+
+For very deep cascades (>10 hops), the graph collapses runs of
+single-child segments into a **"... N steps ..." pill** that expands
+on click. Hovering any pill shows the collapsed events in a tooltip
+without committing to expansion. This is the same affordance pattern
+GitHub uses for collapsing large diffs into "Show N hidden lines."
+
+## Vision — machine-edge types (the cross-cutting growth)
+
+The causality graph's primitive grows new **edge vocabulary** to
+render machine relationships
+([`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §4):
+
+- **Spawn edges** (`─◇▶`) — when machine A's transition triggers
+  `[:rf.machine/spawn machine-B]`, the graph renders a hollow arrow
+  from A's node to B's spawn-dispatch.
+- **Final edges** (`═▶`) — when machine A reaches `:final`, the graph
+  renders a doubled arrow from A's `:final`-transition to the
+  `:on-done` cascade's dispatch.
+- **`:invoke-all` join edges** (`⋈`) — N parallel children converging
+  at a parent's join-condition render as N edges merging into a single
+  `⋈` join node before the parent's continuation.
+
+These are additions to the existing causality-graph rendering
+vocabulary, not a separate panel. The user reading "why did this
+`:order/notify` fire?" walks the graph and sees "because `:checkout`
+reached `:final`" — same affordance as walking any cascade, richer
+edge types.

--- a/tools/causa/spec/002-Time-Travel.md
+++ b/tools/causa/spec/002-Time-Travel.md
@@ -1,5 +1,48 @@
 # 002-Time-Travel
 
+## Bug class
+
+**"User reported the bug at the end of a 20-step interaction; I need to
+rewind to the moment it went wrong."**
+
+The bug appeared after a sequence of dispatches; the symptom is visible
+NOW but the cause is N events back. The author needs to scrub through
+history, find the divergence point, and either inspect it (passive) or
+rewind the runtime to it (active, opt-in).
+
+## Example bug
+
+A user reports "Submit is greyed out, can't recover." You load the
+session, see the current state, but the cascade that disabled Submit
+fired 8 dispatches ago. You need to walk back through history,
+inspect `app-db` at each step, find the moment Submit became disabled,
+then either re-read the cascade or rewind to it.
+
+## Insight Causa provides
+
+The **scrubber** (the ribbon `[◀ ▶ ⏭]` cluster + the L2 event list,
+per [`018-Event-Spine.md`](018-Event-Spine.md) §6) lets the programmer
+walk history **without disturbing the live app**. Scrubbing is
+**passive** — every Causa panel rebases to show "what the world looked
+like at epoch N" — but `(rf/get-frame-db ...)` still returns the live
+value. The user's mouse clicks against the app still hit live state.
+
+Rewinding the runtime is **explicit and confirmed** — a `Rewind here`
+button calls `(rf/restore-epoch frame-id target-epoch-id)`. Only then
+does the framework's `app-db` actually move. Six named restore
+failures surface as a modal BEFORE the rewind commits, so "this rewind
+won't work because X" is structured rather than a silent no-op.
+
+## Affordance
+
+Passive scrubbing + explicit `r` (rewind) + `Shift+r` (hard rewind
+with failure-mode modal) + `*` (pin a labelled snapshot at current
+epoch). Pins survive the ring buffer ageing-out the underlying epoch
+— the pin retains `:frame-db` so "Reset to pinned" works even after
+the epoch dropped off the scrubber.
+
+---
+
 The time-travel scrubber is pinned to the bottom rail. Its job is to
 let the programmer walk backward and forward through history *without
 disturbing the live app*. Rewinding the runtime is an explicit,
@@ -356,3 +399,40 @@ the scrubber renders an empty state ("no epoch history available; this
 is a production build") if mistakenly loaded.
 
 CI's `npm run test:elision` job verifies the contract.
+
+## Vision
+
+The time-travel surface is mature in v1 — the bones are right. Future
+growth is around two affordances:
+
+### Full bidirectional scrubbing + branch-and-explore
+
+**Bug class:** "I want to scrub back, dispatch a hypothetical event,
+see what would happen, then return to live."
+
+The user wants to **branch** off the timeline at an arbitrary epoch:
+rewind to epoch N, dispatch a different event, watch the new cascade
+play out, then either keep the branch or discard it and return to the
+live trunk. Today, dispatching after a rewind drops everything past
+the rewind point — there is no branch UI.
+
+The branch model: each branch is a labelled fork of the timeline.
+Branches are session-scoped (Lock #4 — no export). The scrubber renders
+branches as horizontal lanes above/below the trunk; clicking a branch
+switches the active scrubber to it. The user can compare two branches
+side-by-side in the App-db diff.
+
+### "Find me when path P last changed" walker (rf2-causa-find-path-change)
+
+**Bug class:** "I notice this value is wrong; show me when it became
+wrong." Both Causa today and re-frame-10x require manual scrubbing for
+this. The walker scans `epoch-history` backward, finds the most-recent
+epoch where path P had a non-equal value, and jumps the scrubber there.
+
+Right-click any app-db path → "Find epoch where this last changed" →
+scrubber seeks. Right-click → "Find next change after this" scans
+forward. This is the affordance that turns "I notice this is wrong"
+into "show me when it became wrong" in two clicks. Mature debuggers
+(Chrome DevTools watch-windows, Visual Studio data tooltips) have
+this for objects-in-watch-windows; re-frame has the entire history
+and should be able to do it natively.

--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -7,6 +7,15 @@ mode (UC1) and dynamic multi-instance views (UC2 Mode A/B/C). The
 state-chart layout primitive lives Causa-internal at
 `tools/causa/src/day8/re_frame2_causa/chart/{layout,svg,interaction}.cljc`.
 
+The Machines tab is the **single most distinctive Causa surface** because
+re-frame2's machine substrate (Spec 005) carries the richest runtime
+behaviour in the framework — cancellation cascades, `:after` timers,
+`:invoke-all` joins, microstep loops, hierarchical state transitions,
+parallel regions, supervision trees. Causa is the only place these
+contracts become legible. Bug-class motivation for each major feature in
+[§The bug catalogue](#the-bug-catalogue) below; see also
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.1.
+
 ## Architectural posture
 
 **The `tools/machines-viz/` artefact is gone** (collapsed into Causa
@@ -469,12 +478,296 @@ ships **without** a chart alt-view; the alt-view is a v1.1 commitment.
 Until then, the transition-history ribbon and the machines picker are
 the accessible surfaces — both are text-heavy and reach the same data.
 
+## The bug catalogue
+
+Every Machines-tab feature is grounded in a concrete bug-class. Format per
+[`000-Vision.md`](000-Vision.md) §Bug-driven, not feature-driven: bug class
+→ example → insight → affordance.
+
+### M.1 — Guard rejection (silent)
+
+**Bug class:** An event fires; the chosen `:on` entry's guard returns
+`false`; the snapshot doesn't move. The
+`:rf.machine.transition/suppressed` trace is the only signal, buried in
+the Trace firehose.
+
+**Example bug:** You dispatched `:auth/cancel` on machine `:checkout` in
+state `:authing`, expected a transition to `:idle`, nothing happened. The
+event landed; the guard `:no-pending-payment?` returned `false` because
+`:data.pending-payment` was `4232`.
+
+**Insight Causa provides:** The transition's edge in the chart **flashes
+red 400ms** with a tooltip naming the rejected event and the guard's
+return value. In the metadata rail (right of chart), a "Recent guard
+rejections (N)" section lists the rejected transitions; click-to-expand
+shows the `:data` snapshot at evaluation time and the guard's source-coord.
+
+**Affordance:** Guard-verdict overlay (M-C1). Three clicks from "huh,
+nothing happened" to "ah, my guard is wrong."
+
+**v1 ships:** the existing chart with no overlay. **Future:** the
+red-flash overlay + the metadata rail's rejections section.
+
+### M.2 — Stale `:after` timer / cancelled-on-resolution
+
+**Bug class:** Wall-clock time-bound bug. The timer arms; the wall clock
+advances; the timer expires; the snapshot doesn't move. Five
+possibilities: (1) epoch stale because we exited and re-entered the state;
+(2) guard returned false; (3) the synthetic event hit a `nil` `:on` entry;
+(4) the timer fired in SSR mode and was suppressed; (5) subscription-driven
+re-resolution cancelled the old timer in favour of a new one that hasn't
+fired yet. The user can't tell from snapshots alone.
+
+**Example bug:** You entered `:loading` with `:after 5000ms → :timeout`.
+30 seconds passed. The snapshot is still `:loading`. The Trace shows both
+`:rf.machine.timer/scheduled` (epoch 12) and `:rf.machine.timer/stale-after`
+(epoch 13) — the state re-entered between schedule and fire.
+
+**Insight Causa provides:** On each state with a live `:after` timer, the
+node has a **thin countdown ring** with an animated arc representing
+time-elapsed/total. Starts at 12 o'clock, rotates clockwise to fill.
+
+- **Live mode:** the ring animates in real time.
+- **Retro mode (scrubber-driven):** the ring is static at the
+  elapsed-fraction the timer had reached at the focused-cascade's
+  timestamp.
+- **Stale timer** (epoch mismatch): the ring is rendered dashed/grey +
+  tooltip "this timer was scheduled in a prior visit and is stale."
+- **Cancelled-on-resolution** (sub-driven re-resolve): the old ring
+  fades out (200ms); new ring fades in.
+
+Click any ring → opens a timer detail popover: `:scheduled-at`,
+`:delay`, `:epoch`, `:source` (`:literal` / `:sub` / `:timeout-config`
+/ `:fn`).
+
+**Affordance:** `:after` countdown rings + scrubber-aware retro-replay
+(M-C2). Time IS the bug surface; the ring makes wall clock visible on a
+tool that previously rendered only the snapshot. **Stately doesn't ship
+this. Nobody does.**
+
+**v1 ships:** no rings (transition-history ribbon only). **Future:** the
+full countdown-ring system + retro-replay (Phase 2 per
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §6).
+
+### M.3 — Cancellation cascade ambiguity
+
+**Bug class:** Parent state exits; child's `:invoke` destroyed; child had
+N in-flight HTTP requests; each aborts. The author sees a flurry of
+`:rf.http/aborted-on-actor-destroy` traces in the Trace firehose and one
+`:rf.machine.lifecycle/destroyed`. They cannot reconstruct which abort
+belongs to which destroy.
+
+**Example bug:** You clicked Cancel on a checkout flow. The Trace tab
+shows 4 abort traces + 1 destroyed trace, scattered through 200 unrelated
+rows. You can't tell which abort came from the cancel vs which were
+independent.
+
+**Insight Causa provides:** A **"Cancellation cascade" detail panel**
+that appears inline in the Machines tab when the focused cascade triggered
+a destroy. Header: "Parent `:checkout/main` exited `:processing` at
+16:42:14. Destroyed 1 child actor (`:http/post#347`) and aborted 3
+in-flight HTTP requests." Body: vertical waterfall showing the parent's
+exit → destroy → per-HTTP-abort → final destroyed trace, indented under
+its parent decision, each row with source-coord.
+
+What was "a flurry of confusing trace lines" becomes "one decision and
+its consequences, laid out vertically."
+
+**Affordance:** Cancellation cascade visualiser (M-C3) — the Machines
+tab's hero growth. Also a template for SSR cancellation cascade (when a
+streaming SSR boundary times out, the same waterfall idiom shows what
+cleanup ran).
+
+**v1 ships:** scattered Trace rows. **Future:** the cascade-grouping
+projection + the detail panel (Phase 3).
+
+### M.4 — `:invoke-all` never joins
+
+**Bug class:** N children spawned; join condition is `:all` (or `:any` /
+`{:n M}` / `{:fn ...}`); some complete, some don't, the parent stays
+stuck. Author wants per-child status, what each is doing right now, the
+join-state map (`:done #{:cfg :flag} :failed #{} :resolved? false`), and
+whether `:on-any-failed` is wired.
+
+**Example bug:** You entered `:hydrating` which declares `:invoke-all
+{:children {:cfg ... :flag ... :user ... :dash ...} :join :all}`. Two
+children completed in <200ms; two are still "running" 2 seconds in. The
+machine hasn't advanced.
+
+**Insight Causa provides:** When the focused machine is in an
+`:invoke-all`-bearing state, the metadata rail shows a **dedicated join
+card**:
+
+```
+┌─ :invoke-all  ·  invoke-id [:hydrating :invoke-all] ─────────────┐
+│ Join condition: :all                                              │
+│ Resolved: ✗   (waiting for 2 of 4)                                │
+│  ✓ :cfg     :load-config#1         done @ +124ms                  │
+│  ✓ :flag    :load-feature-flags#2  done @ +89ms                   │
+│  ⧖ :user    :load-user-profile#3   running 2.3s                   │
+│  ⧖ :dash    :load-dashboards#4     running 2.4s                   │
+│  :on-all-complete  → [:assets-loaded]                             │
+│  :on-any-failed    → [:asset-load-failed]                         │
+│  :cancel-on-decision?  true                                        │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Each running child row: click → pivots to that child's machine instance.
+Each done/failed: click → opens the per-child completion event.
+
+**Affordance:** `:invoke-all` join inspector card (M-C4).
+
+**v1 ships:** the `:invoke-all` viz row (children rendered inline; basic
+`done?` / `failed?` colouring). **Future:** the full join inspector card
+with click-to-pivot.
+
+### M.5 — Per-instance "why am I stuck"
+
+**Bug class:** Mode C debugging at scale. The user picks one instance
+out of 47 (e.g. `:checkout#c-047` stuck in `:authing` for 30s); they
+need the last few trace events filtered to THAT instance only. No
+cross-instance chatter.
+
+**Example bug:** Of 47 `:request/protocol` instances, `#c-047` is stuck
+in `:authing` for 30s. The Mode C table tells you the state and the
+duration but not WHY.
+
+**Insight Causa provides:** Click an instance row → opens a per-instance
+trace strip below the table showing the last 5 traces for THIS instance
+only. The "32s in state" auto-callout flags suspiciously-long state
+occupancy.
+
+```
+┌─ #c-047  ·  current state :authing  ·  in state for 32s ────────────────┐
+│ Last 5 traces for this instance:                                          │
+│ 16:42:14.103  :rf.machine.transition  :idle → :authing                   │
+│ 16:42:14.108  :rf.machine.timer/scheduled  :after 30000ms epoch 4         │
+│ 16:42:14.110  :rf.http/managed-issued  POST /api/auth/login              │
+│ 16:42:14.140  :rf.http/handled  POST /api/auth/login → 200 (30ms)         │
+│ 16:42:14.142  :rf.machine.transition/suppressed  :auth/ok                │
+│                  guard :2fa-not-required? = FALSE                         │
+│                  (data: {:requires-2fa? true})                            │
+│                                                                            │
+│ ⓘ Instance has not transitioned for 32s. 1 guard rejection pending.       │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Affordance:** Per-instance trace strip (M-C5). Phase 1 quick win.
+
+### M.6 — Hierarchical state cascade (entry/exit along the LCA)
+
+**Bug class:** A transition crosses multiple hierarchy levels. The
+exit-cascade and entry-cascade interleave per Spec 005 §Entry/exit
+cascading along the LCA. Today the chart highlights the new active state
+but doesn't show the cascade.
+
+**Insight Causa provides:** When a transition fires, the chart plays the
+cascade in sequence:
+
+1. The old leaf's `:exit` fires (node ring pulses red, then dims).
+2. Walking up to LCA: each intermediate `:exit` (rings pulse in
+   sequence; 80ms each).
+3. The LCA's level (no action).
+4. Walking down from LCA to new leaf: each intermediate `:entry` (rings
+   pulse green; 80ms each).
+5. The new leaf's `:entry` (ring settles to active-state amber/cyan).
+
+Total: ~500ms for a 3-level cascade. Skippable via Settings → View →
+"Reduced motion."
+
+**Affordance:** Hierarchical state cascade highlighter (M-C6). Phase 5.
+LCA semantics is the most subtle part of XState parity; the cascade
+visualisation makes it obvious in ways no doc ever could.
+
+### M.7 — Microstep loop visualiser
+
+**Bug class:** `:always` fires; lands in a state with `:always`; fires
+again; eventually hits the bounded-depth ceiling and emits
+`:rf.machine.microstep/depth-exceeded`. The microstep chain wants to be
+the diagnostic.
+
+**Insight Causa provides:** When a focused cascade contains ≥3 microsteps,
+render them as a **strip of micro-arrows** in the Machine tab header:
+
+```
+Microsteps (4 of max 12):
+:idle ──always→ :checking ──always→ :checking-deep ──always→ :ready ──always→ :idle
+                                                                                  ↑
+                                                              (loop detected — see ⚠)
+```
+
+If the chain returns to a previously-seen state, mark it `⚠ loop
+detected; will hit microstep depth limit in N more iterations`.
+
+**Affordance:** Microstep loop visualiser (M-C7). Phase 5.
+
+### M.8 — Path-walked transition explainer
+
+**Bug class:** In a hierarchical machine with parent fallthrough, the
+resolution rule is "deepest wins; parent fallthrough on miss." When a
+child consumes an event the parent expected to handle, the author is
+surprised.
+
+**Insight Causa provides:** In the Event tab's "fx handlers that ran"
+block, add a sub-row for each `:rf.machine/transition` showing the
+**path walked**:
+
+```
+:rf.machine/transition  :checkout
+  Path walked:
+    [:processing :paying]  :on {:pay/cancel ...}     ← MATCHED ✓
+    [:processing]          :on {:pay/cancel ...}     ← not reached (deepest wins)
+    [<top>]                :on {:pay/cancel ...}     ← not reached
+```
+
+**Affordance:** Path-walked sub-row (M-C8). Phase 1 quick win.
+
+### M.9 — Spawn ancestry
+
+**Bug class:** "Why is this instance still alive? Who's referencing it?"
+A spawned actor should have been destroyed but wasn't. Could be:
+`:system-id` reference held it alive; parent didn't fully exit
+(hierarchical sticking); manual `:rf.machine/destroy` was never
+dispatched; OR the destroy WAS dispatched but the snapshot's old state
+references it.
+
+**Insight Causa provides:** When an instance is focused, the metadata
+rail shows the **spawn tree leading to it**:
+
+```
+Spawn ancestry:
+  :app/start
+   └── spawned :auth/main#m-001
+        └── spawned :http/post#h-018  ← currently focused
+```
+
+Each ancestor click → focuses that instance. Bottom of card: "Will be
+auto-destroyed when `:auth/main#m-001` exits `:authing`."
+
+**Affordance:** Spawn-ancestry tree in metadata rail (M-C9). Phase 1.
+
+### M.10 — Snapshot diff across transitions
+
+**Bug class:** Each transition mutates the machine's snapshot
+(`:state` + `:data`). Today the chart highlights state changes; `:data`
+mutations are invisible unless the user opens the app-db diff.
+
+**Insight Causa provides:** A **diff card below the chart** when a
+transition fires: side-by-side `:data` before/after, action-attribution
+per slot (`:data.retry-count incremented from 2 → 3 by action
+:increment-retry`).
+
+**Affordance:** Snapshot diff visualisation (M-C10). Phase 5. Needs
+per-action attribution.
+
 ## Cross-references
 
 - [`018-Event-Spine.md`](018-Event-Spine.md) — Machines tab placement
   in the 4-layer chrome; spine-binding contract; isolation invariants.
 - [`007-UX-IA.md`](007-UX-IA.md) — typography, colour tokens, editor
   protocol matrix.
+- [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.1 —
+  the bug-class catalogue this spec normalises.
 - [Spec 005 — StateMachines](../../../spec/005-StateMachines.md) — the
   framework contract Causa renders.
 - [Spec 009 — Instrumentation](../../../spec/009-Instrumentation.md) —

--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -1,5 +1,40 @@
 # 004-App-DB-Diff
 
+## Bug class
+
+**"What part of app-db actually changed when I dispatched this event?"**
+
+Real app-dbs are big (1–50MB); the change from one event is small (a
+handful of paths). The author needs to see the slices that changed in
+THIS cascade — added, modified, removed — without scrolling through
+the whole tree.
+
+## Example bug
+
+You dispatched `:cart/add-item {:id 22 :qty 1}`. The UI didn't
+update. You don't know whether the cart slice changed at all, whether
+it changed at an unexpected path, or whether something else changed
+that you weren't expecting (a reset, a clobber).
+
+## Insight Causa provides
+
+A **slice-centric view** — the slices that changed in this epoch,
+each shown with `before` and `after` values, colour-coded by op
+(`:added` green, `:modified` yellow, `:removed` red). Plus **pinned
+watches** — slices the user explicitly marked, always visible across
+epochs. The full tree is one click away via the escape hatch.
+
+This is the **single most-used Causa surface** after the Event tab.
+The 400ms yellow → transparent diff-flash on touched slices is the
+attention-cue that keeps the user oriented across cascades.
+
+## Affordance
+
+App-db tab — slice-centric mini-panels above pinned-slices above the
+`Show full app-db tree ▸` escape hatch.
+
+---
+
 The app-db panel is **slice-centric**, not tree-centric. Real app-dbs
 run 1–50MB. Rendering the whole tree on every dispatch competes for
 canvas real estate, virtualisation only partly helps, and it isn't
@@ -203,3 +238,46 @@ Before any dispatches:
 ```
 
 The pinned-slices area is empty until the user pins something.
+
+## Vision
+
+### Branch-aware diff (Story integration)
+
+**Bug class:** "I'm running a Story variant that sim-clones app-db;
+which slices changed because of my dispatch and which were already
+different on the branch?"
+
+When Causa is embedded inside Story
+([`008-Embedding-Contract.md`](008-Embedding-Contract.md)) and the
+variant is a sim-clone (Story branches `app-db` so each variant runs in
+isolation without polluting the host), the diff has TWO axes:
+
+- **Branch baseline diff** — what's different between the variant's
+  app-db and the host's app-db, irrespective of any dispatch.
+- **Cascade diff** — what changed because of THIS dispatch.
+
+Causa renders both in separate sections; cascade-diff is the headline,
+branch-baseline-diff is a collapsed-by-default "What's different on this
+branch" group.
+
+### Cross-frame diff
+
+**Bug class:** "Multiple frames share substate via shared sub keys;
+where does an event in frame A change values that frame B reads?"
+
+When multi-frame apps share substate (e.g. an auth slice mirrored across
+two frames), Causa renders the diff per-frame and shows where a write
+in one frame propagates to another. Cross-frame causality arrows
+(per [`001-Causality-Graph.md`](001-Causality-Graph.md)) hand off to
+the App-db tab's cross-frame diff for the "what changed" follow-up.
+
+### Pin two epochs side-by-side
+
+**Bug class:** "I want to diff arbitrary epoch A vs epoch B, not just
+before/after of a single event."
+
+Pin two epochs via `*`; press `=` → opens a split view in the App-db
+tab showing slice-by-slice diff between the two pinned epochs. Closes
+a long-standing gap in both 10x and Causa (workflow-gap-4 from the
+findings). Needs Editscript A* for compact diffs over arbitrary epoch
+pairs.

--- a/tools/causa/spec/005-Schema-Timeline.md
+++ b/tools/causa/spec/005-Schema-Timeline.md
@@ -1,5 +1,40 @@
 # 005-Schema-Timeline
 
+## Bug class
+
+**"Schema violations are spamming the console; show me where + when."**
+
+Silent schema violations are real bugs in disguise. The runtime emits
+`:rf.error/schema-validation-failure` traces with recovery mode +
+Malli explanation; without a timeline view, the author has to grep
+the trace firehose to find them.
+
+## Example bug
+
+Your app subtly mis-renders. The console shows nothing dramatic; the
+trace firehose shows three `:rf.error/schema-validation-failure`
+events scattered across the last 100 traces. You can't tell which
+schema, which path, or whether the framework recovered (replaced with
+default) or rolled back app-db.
+
+## Insight Causa provides
+
+A **horizontal timeline** with one row per registered schema; coloured
+dot per failure (red = `:skip-handler` / `:rollback-db` /
+`:re-raised`; yellow = `:replaced-with-default`); a 600ms label-flash
+on the empty→non-empty transition so newly-failing schemas catch the
+eye. Click a dot → side panel with full Malli explanation, recovery
+mode, triggering cascade, registration source-coord, and three
+actions: open in causality graph, open source, filter timeline to
+just this schema.
+
+## Affordance
+
+Issues tab — schema-violation timeline (today as its own panel; future
+folds into Issues per [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md)).
+
+---
+
 Silent schema violations are real bugs in disguise. The schema
 violation timeline surfaces them temporally so they become impossible
 to ignore.

--- a/tools/causa/spec/006-Hydration-Debugger.md
+++ b/tools/causa/spec/006-Hydration-Debugger.md
@@ -1,5 +1,78 @@
 # 006-Hydration-Debugger
 
+## Bug class
+
+**Body / head hydration mismatch.** The server-rendered tree and the
+client first-render tree disagree at a node. The
+`:rf.ssr/hydration-mismatch` trace fires with `:first-diff-path`. The
+console error is one line; the divergent node is rarely the one the
+error points to. SSR debugging is **uniformly opaque** in every framework
+— React's "hydration error" message tells you a node mismatched but
+gives you nothing about WHY the upstream state diverged.
+
+## Example bug
+
+You run the page; SSR returned `<span class="user-name">Guest</span>`;
+the client first-render produced `<span class="user-name">Alice</span>`.
+The browser console says "hydration mismatch at `[:div.app :header
+:span.user-name]`." You don't know why — was the server missing the
+session? Was the sub computing `nil`? Was the `:user/display-name` sub
+watching the wrong slice?
+
+## Insight Causa provides
+
+The **hydration mismatch bisector** — a depth-first walk over the
+canonical EDN serialisation that finds the first divergent node,
+surfaces both trees side-by-side, names the **sub that produced the
+divergent value on each side**, names the **upstream `app-db` slice**
+each side observed, and emits a **heuristic "likely cause" hypothesis**
+that links to the source.
+
+This is the **hero SSR feature**. Causa is the only re-frame2-shaped tool
+that can do this — the framework already emits the structured data; this
+spec turns it into the picture.
+
+## Affordance
+
+Issues tab — hydration mismatch bisector with sub-attribution. Per
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.3 the
+canonical bug-class catalogue. The bisector replaces a generic Issues
+row with a dedicated drill-into surface:
+
+```
+┌─ Hydration mismatch  ·  cascade #1  :rf/hydrate ───────────────────────┐
+│ Failing-id:    :rf/hydrate (body mismatch)                              │
+│ Server hash:   abc123                                                    │
+│ Client hash:   def456                                                    │
+│                                                                          │
+│ Bisector (depth-first over canonical EDN):                              │
+│   ✓ root <div id="app">                                                  │
+│   ✓ <div.layout>                                                         │
+│   ✓ <header>                                                             │
+│   ✗ FIRST DIVERGENCE: <span.user-name>                                   │
+│                                                                          │
+│ Side-by-side:                                                            │
+│ ┌─ Server ─────────────────────┬─ Client ──────────────────────┐        │
+│ │  [:span.user-name "Guest"]    │  [:span.user-name "Alice"]    │        │
+│ │  Subbed to: :user/display-name│  Subbed to: :user/display-name│        │
+│ │  Server sub returned: "Guest" │  Client sub returned: "Alice" │        │
+│ │  Server :user value: nil      │  Client :user value: {:id 1 …}│        │
+│ │  Server :auth/session: nil    │  Client :auth state: :authed  │        │
+│ └────────────────────────────────┴────────────────────────────────┘     │
+│                                                                          │
+│ Likely cause: server-side session cofx not injected (request cookie     │
+│ was present but `:auth/server-init` event was not in `:on-create`)      │
+│ ↗ Open server-side init: src/server/init.cljs:42                        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The "Likely cause" line is heuristic — Causa suggests "session not
+injected" when the divergent sub depends on `:auth/*` and the server's
+`:auth/*` slice is empty. It is **a hint, not an answer**; it links to a
+panel pivot that lets the user verify.
+
+---
+
 SSR hydration mismatches are structurally hard to debug: the failing
 client render and the failing server render disagree on a tree, the
 console error is one line, and the divergent node is rarely the one
@@ -423,3 +496,106 @@ fires — the panel's render code is lazy-loaded on first activity
 
 (Second message is again deliberately a positive result — a clean
 hydration is the goal, not the absence of a result to display.)
+
+## Vision — beyond v1's bisector
+
+The bisector is the v1 hero. The next-step features push Causa from
+"shows you the mismatch" to "tells you the runtime story behind every
+SSR contract":
+
+### Sub-attribution at hydration time
+
+The bisector knows which subs ran on the server and which ran on the
+client. It can show, per divergent node, the **input chain** for the sub
+on each side — which slice the sub watched, which value it returned, and
+why the cache state differed.
+
+Phase 3 per [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md)
+§6. Needs sub-recompute attribution at hydration time (a new projection
+over the trace bus).
+
+### Schema digest mismatch — per-schema diff
+
+When `:rf.ssr/schema-digest-mismatch` fires, the author wants to see
+**which schemas diverged** (server's registered set vs client's). Causa
+surfaces a per-schema diff: schemas only on server (greyed); schemas
+only on client (highlighted); shared schemas whose digests don't match
+(side-by-side digest comparison + the registration source-coord on each
+side).
+
+### Server-side error projection trace
+
+When a server-side handler errored, the public-error projection
+sanitises the internal trace. In dev mode, `:dev-error-detail? true`
+includes `:details`. Causa surfaces the projector's work:
+
+```
+┌─ Server error projection  ·  cascade #1 :on-create ────────────────────┐
+│ Internal trace:                                                          │
+│   :rf.error/handler-exception                                            │
+│   :handler-id [:dispatch :user/load-profile]                             │
+│   :exception ArgumentError: user-id missing                              │
+│   :stack    at user.events.load-profile (src/user/events.cljs:42)       │
+│ Projector: :myapp/public-error  src/server/projector.cljs:18 ↗          │
+│ Public projection:                                                       │
+│   { :status 500, :code :internal-error, :message "Something went wrong",│
+│     :retryable? false, :details <absent in prod; …> }                   │
+│ Rendered to client:  HTTP 500 + error-page view rendered with public    │
+│                      projection. No internal detail crossed the wire.    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The security boundary is invisible to authors today; this surface makes
+it legible. "What did the client actually see?" gets a direct answer.
+
+### Payload-policy verdict
+
+When the hydration payload landed, surface the policy used + which keys
+shipped + which keys were dropped. Catches the
+`:payload-policy :rf.ssr.payload/whole-app-db` security mis-configuration
+loudly.
+
+### Head model inspector
+
+When the focused cascade involved a `reg-head` resolution, surface
+inputs (db slice + route) → head model output → rendered HTML head, in
+three columns.
+
+### Per-request frame teardown auditor (dev-only summary)
+
+At per-request frame destroy time, Causa verifies each slot was released.
+Surfaces a one-line "frame destroyed cleanly" + slot tally, or a leak
+warning if any slot persists. Summary only; deep audit lives in CI.
+
+### Streaming SSR boundary timeline
+
+When the focused cascade involves streaming SSR
+(`:rf.ssr/suspense-boundary-*` traces present), render a vertical
+waterfall in the Trace tab — shell flush time, per-boundary fallback
+emit times, per-boundary resolution times (or failures), final payload
+chunk status. Each boundary that failed shows the throwable + fallback
+retention status.
+
+### Side-by-side SSR replay (post-v1 dream)
+
+Causa offers a "replay SSR" affordance: given the live runtime, spin up
+a JVM SSR pipeline (if dev environment has it wired), render the page
+server-side from scratch, show the rendered HTML side-by-side with what
+the live browser is showing. Diff the two. Author sees exactly what's
+different. Way too ambitious for v1; documented as the eventual "SSR
+development is interactive" North Star.
+
+### Placement question — Mike's iteration surface
+
+The bisector deserves more than an Issues row. Three options (see
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §7):
+
+- **(a)** Conditional 7th tab — visible only when SSR is detected for
+  the session.
+- **(b)** Inline panel inside the Issues tab (the current v1 plan).
+- **(c)** `h`-keyboard popover (consistent with Causality `c` and
+  Nav-token `r`).
+
+**Lean: (c).** Keeps the chrome at 6 tabs; joins the popover pattern.
+But "always visible when relevant" is a strong (a) argument for SSR-heavy
+apps.

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1,5 +1,35 @@
 # 007-UX-IA
 
+## The one-event-spine model (the load-bearing statement)
+
+Every Causa surface orients around **one focused event** — the spine
+sub `:rf.causa/focus`. The user picks an event in the L2 list; every
+dependent surface rebinds atomically. Tabs are **lenses on that one
+event**:
+
+| Tab | Bug-class it answers |
+|---|---|
+| **Event** (`e`) | "What does this event do?" — six dominoes + wire-boundary diff per managed fx. |
+| **App-db** (`a`) | "What changed because of this event?" — slice diff. |
+| **Views** (`v`) | "Why did these views re-render?" — sub invalidation chain. |
+| **Trace** (`t`) | "What raw events fired in this cascade?" — wall-clock axis grows future. |
+| **Machines** (`m`) | "What did this event do to my machines?" — transitions, cancellation cascade, `:after` rings. |
+| **Issues** (`i`) | "What's wrong here?" — errors · warnings · schema violations · hydration mismatches · advisories. |
+
+Plus popovers (`c` causality · `r` nav-token timeline · `f` wire-trace
++ `h` hydration bisector, future). Every popover is invokable from any
+tab. Every popover anchors on `:rf.causa/focus`.
+
+**This is the single most important model in the spec.** Every
+information-architecture decision in this doc derives from "one event
+in, full insight out via tab + popover lenses." Cross-cutting concerns
+(SSR · Machines · Routes · Managed-Fx) extend tabs; they never
+fragment the chrome. See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) for the
+5-idioms × 4-areas matrix.
+
+---
+
 The user experience, the information architecture, the visual
 language. This doc is what an implementer reads to ship pixels that
 feel right — typography sizes, colour tokens, animation timings,
@@ -8,7 +38,9 @@ keyboard maps, density gradients.
 For the *why* behind these picks, see [`Principles.md`](./Principles.md)
 and [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md). For the
 architectural contract of the 4-layer chrome + spine binding + tab
-content, see [`018-Event-Spine.md`](./018-Event-Spine.md).
+content, see [`018-Event-Spine.md`](./018-Event-Spine.md). For the
+cross-cutting-concerns rendering vocabulary, see
+[`019-Cross-Cutting-Insight.md`](./019-Cross-Cutting-Insight.md).
 
 ## Layout
 

--- a/tools/causa/spec/008-Embedding-Contract.md
+++ b/tools/causa/spec/008-Embedding-Contract.md
@@ -255,3 +255,48 @@ it under a new sidebar entry with the same `Panel` shape.
 No commitment is made about the third-party plugin surface
 shape — the embedding contract above is for the **canonical
 first-party panels**, not for any future third-party kind.
+
+## Vision — Story ↔ Causa preset round-tripping
+
+**Bug class:** "I built a Story variant that captures a specific
+debugging posture (filters set, tab selected, pinned epoch); when
+someone else opens that story, they should land in the same posture."
+
+The Story embedding contract (above) covers the **structural** props
+the host passes to a panel. The next-step affordance is **deep preset
+round-tripping**: when a Story variant declares `{:causa/preset {…}}`,
+Causa restores **the full visible state** on mount:
+
+- **Selected tab** (`:tab :machines`).
+- **Active filters** (`:filters {:in […] :out […]}`).
+- **Focused machine** + **selected instance** (for Machines tab
+  embeds).
+- **Pinned cascade** (`:pinned-dispatch-id <id>`) — restored if the
+  cascade is still in the trace buffer at story mount; otherwise
+  surfaced as a "pinned cascade aged out — re-run to recapture" hint.
+- **Settings sub-state** — density, theme override per story.
+
+The preset is **per-Story** (not per-Causa-instance); each story
+carries its own preset; switching stories switches the preset.
+
+## Vision — per-story Causa state snapshots via share-URL
+
+Story already supports share-URLs that round-trip the story state.
+Causa extends this: when a developer pins an interesting debugging
+posture in a Story variant, the share-URL captures:
+
+- The Story variant (existing).
+- The Causa preset (above).
+- A **trace snapshot** — the last N cascades up to and including the
+  pinned focused cascade, serialised into the URL fragment (when small
+  enough) or fetched from a session-local cache when the URL refers
+  to a recent same-session pin.
+
+The recipient opens the share-URL → Story renders the variant → Causa
+mounts with the preset → the trace snapshot is loaded into Causa's
+read-only buffer → they see exactly what the sender saw.
+
+The snapshot is **read-only** (rewinds work; new dispatches do not
+mutate the snapshot — the story's app-db is the source of truth). Lock
+#4 (no session export) is preserved by scope: this is a Story-shared
+state, not a free-standing Causa export.

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -754,11 +754,65 @@ in parallel. The panel surfaces the agent's actions (the `:origin
 |---|---|
 | Working locally; want to inspect the runtime | In-app panel (`Ctrl+Shift+C`) |
 | Want a second monitor for Causa | In-app panel + `(causa/popout!)` |
-| Want my AI to inspect / time-travel programmatically | Causa-MCP (configure in agent host) |
+| Want my AI to inspect / time-travel programmatically | **pair2-mcp** (raw nREPL over MCP) |
 | Want to debug a colleague's browser | Out of scope at v1.0 |
 | Want to debug a mobile browser | Out of scope at v1.0 |
 
 The 95% of cases — local development with in-app inspection — is
-solved by the in-app true-inline panel. The MCP server covers the
-agent-driven case. The remaining 5% (cross-machine, mobile) is
-explicitly out of scope at v1.0.
+solved by the in-app true-inline panel. **pair2-mcp** (raw nREPL over
+MCP, sibling artefact at `tools/pair2-mcp/`) covers the agent-driven
+case. The remaining 5% (cross-machine, mobile) is explicitly out of
+scope at v1.0.
+
+Note: the **Causa-MCP** path (`tools/causa-mcp/`) was dropped per
+[`000-Vision.md`](000-Vision.md) §What it isn't ("two doors, no
+compromises"). Agents access the runtime through pair2-mcp (raw
+nREPL); Causa is the human-only observability surface. The split is
+intentional and load-bearing.
+
+## Vision — pair2 raw-nREPL launch path
+
+When a `pair2-mcp` session is active against the same shadow-cljs
+build that loaded Causa's preload, the agent can dispatch (via raw
+Clojure eval) commands that drive Causa's panel through the existing
+`day8.re-frame2-causa.core` namespace:
+
+```clojure
+;; Agent eval, via pair2-mcp:
+(require '[day8.re-frame2-causa.core :as causa])
+(causa/open!)
+(causa/target-frame :app/main)
+(causa/focus-cascade <dispatch-id>)
+(causa/select-tab :machines)
+```
+
+The agent uses the same primitives Causa's chrome uses. No curated
+`causa-mcp` facade in front; whatever the agent wants to do, it does
+by evaluating Clojure against the runtime. This is the **two doors**
+split in practice — Causa is the human surface; pair2-mcp is the AI
+access path; both read the same instrumentation; neither owns a
+curated middle layer.
+
+## Vision — coordination across multi-instance Causa
+
+When a developer has multiple browser tabs each running a re-frame2
+app with Causa loaded, each instance has its own preload + listener
+registration + atom state. The instances do not coordinate today.
+
+Future: a **broadcast channel** (`BroadcastChannel` API, same-origin)
+lets instances share:
+
+- **Filter posture** — IN/OUT pills set in one instance propagate to
+  siblings.
+- **Selected tab** — switching to Machines in one instance switches
+  in siblings (opt-in via Settings → Multi-instance → "Sync tab
+  selection").
+- **Pinned snapshots** — pinning an epoch in one instance reflects the
+  pin label in siblings as a hint (without sharing the pin store; pins
+  remain per-instance for the rewind-fidelity reason in
+  [`002-Time-Travel.md`](002-Time-Travel.md)).
+
+The broadcast channel is opt-in (default off); same-origin only;
+session-scoped (cleared on tab close). Surfaces in Settings →
+Multi-instance with a status indicator showing how many sibling
+instances are currently broadcasting.

--- a/tools/causa/spec/012-Views.md
+++ b/tools/causa/spec/012-Views.md
@@ -1,5 +1,43 @@
 # 012-Views
 
+## Bug class
+
+**"Component re-rendered 50 times when I dispatched once — why?"** And:
+**"Why is this subscription returning the wrong value?"**
+
+The render-cascade is invisible from the component. A dispatch
+invalidates N subs; each invalidated sub re-runs (or hits cache); each
+re-run sub triggers re-render of every view subscribed to it. The
+author sees the symptom (excess renders, stale value) but not the
+chain.
+
+## Example bug
+
+You dispatched `:cart/add-item`. You expected 1 view to re-render
+(`cart-summary`). The Views tab shows 50 view renders for THIS
+cascade. You don't know which sub invalidated which view, or whether
+some views re-rendered identically (wasted work) vs because their
+inputs actually changed.
+
+## Insight Causa provides
+
+A **three-group view list** (mounted / re-rendered / unmounted)
+attributed to the focused cascade. **Each view row carries its subs
+nested beneath** — the subs the view actually consumed, with their
+return values inline. Per-sub click → invalidation-chain drilldown
+("why did this sub re-run"). Cluster-large-grids (≥50
+same-identity-key) collapse into a single row with count. Heatmap
+mode tints rows by render cost.
+
+## Affordance
+
+Views tab — three-group layout, nested subs, per-component
+drilldown headline (props-diff). Replaces the pre-rewrite
+Subscriptions panel — subs are nested under their views, not a
+separate tab.
+
+---
+
 The Views tab (tab 3 of 6 in the 4-layer chrome — see
 [`018-Event-Spine.md`](018-Event-Spine.md) §5) is the answer to two of
 the five canonical questions:

--- a/tools/causa/spec/013-Trace-Bus.md
+++ b/tools/causa/spec/013-Trace-Bus.md
@@ -416,6 +416,47 @@ to the elision verifier so `npm run test:elision` ([Spec 009
 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code))
 blocks any leak.
 
+## Vision — trace fattening for context-at-position
+
+**Bug class:** "I want to replay this instance's history from epoch 47
+to epoch 53 — what was the `app-db` state at each step? what subs were
+cached? what was the in-flight HTTP set?"
+
+**v1 ships:** trace events carry an opaque `:dispatch-id` /
+`:parent-dispatch-id` linkage plus `:tags` payloads. Replay from
+arbitrary position requires re-applying the events forward from the
+last snapshot, which loses cache state and in-flight context.
+
+**Future:** trace events grow **context-at-position** payloads — per
+trace event, the runtime stamps a compact reference to the cache state,
+in-flight set, and machine snapshot at the time of emission. This
+enables:
+
+- **Per-instance Phase-5 replay** — the per-instance mini-scrubber
+  (003 §Per-instance mini-scrubber) can rebuild full context at any
+  position in an instance's arc without re-running.
+- **Side-by-side epoch diff** — pin two arbitrary epochs (004 §Pin two
+  epochs side-by-side); diff their cache state and in-flight set, not
+  just app-db.
+- **"What was running when this fired?"** — for any trace event,
+  surface the in-flight HTTP, the spawned machines, the queued
+  `:dispatch-later` arrivals at the moment of emission.
+
+The fattening is **opt-in via configure!** (`:trace/fatten? true`) and
+elides in production. The runtime memory cost is significant (one
+reference per event); the developer cost when the feature is needed is
+prohibitive without it.
+
+## Vision — wall-clock axis in the Trace tab
+
+Per [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §1.1,
+the Trace tab grows a **wall-clock axis** for timer rings, retry
+waterfalls, deferred-dispatch arrivals, streaming SSR boundary
+resolutions. The axis is rendered as a vertical time-strip on the
+left edge of the Trace tab; trace events plot against wall-clock time
+not just event sequence. Toggle via `t`-key chord or Settings →
+Trace → "Show wall-clock axis."
+
 ## Cross-references
 
 - [Spec 009 §Listener registration](../../../spec/009-Instrumentation.md#user-side-listener-registration)

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -487,3 +487,30 @@ For the API surface this catalogue describes from the *outside*
 [`API.md`](./API.md). API.md is consumer-facing; this doc is
 contributor-facing — the catalogue lets a new agent or human reader
 audit the registry surface without grepping the source.
+
+## Vision — per-id metadata for golden-path navigation
+
+**Bug class:** "I'm reading an unfamiliar Causa codebase; I see
+`:rf.causa/cascades` in the source; what's its shape? where is it
+registered? what consumes it?"
+
+Today the catalogue enumerates names + roles. The next-step affordance
+is **per-id metadata stamped at registration**:
+
+- **Source coords** — every `reg-sub` / `reg-event-*` / `reg-fx`
+  registration carries a `:source-coord` stamp (per Spec 001 + 006).
+  Causa's own registrations should expose theirs through this
+  catalogue so a human reader can jump directly to the registration
+  site.
+- **Version stamps** — when the registration shape changes (new input
+  sub, removed output key), bump a per-id version. This catalogue
+  surfaces the version alongside the id; downstream consumers can
+  audit "is my code calling the v1 or v2 shape?"
+- **Dependency arrows** — for composite subs, surface the input subs
+  inline so the catalogue reads as a topology, not a flat list.
+
+The catalogue grows from "reference list of names" to **"navigable
+golden-path map of Causa's internal registry"** — a contributor
+opening the spec can trace any path from a panel's high-level
+behaviour all the way down to the source file where the registration
+lives, in one click each step.

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -302,6 +302,83 @@ Note: `:theme` is **no longer reserved** — it now lives inside the
 `:settings` map (see above) and is reachable via the Settings popup's
 Theme tab or `(configure! {:settings {:theme :light}})`.
 
+## Vision — full configure! key inventory (30+ keys)
+
+v1 ships ~5 host-supplied keys (`:editor` / `:project-root` /
+`:layout/host-selector` / `:launch/auto-open?` / `:trace/show-sensitive?`)
+plus the `:filters` seed slot. The full destination per
+[`ai/findings/2026-05-17-10x-config-options-for-causa.md`](#findings)
+absorbs every re-frame-10x configuration option that translates plus
+several Causa-native additions. The full list, grouped by phase
+priority:
+
+### Must-haves (matched against re-frame-10x's anchor)
+
+- `:filters/auto-hide-events <set>` — exact event-ids to auto-hide
+  (re-frame-10x's `ignored-events`). Wired via the IN/OUT pill system
+  in [`018-Event-Spine.md`](./018-Event-Spine.md) §7.
+- `:filters/auto-hide-event-ns <vector>` — event-id namespace
+  patterns to auto-hide (e.g. `["my-app.noisy" "re-com.box"]`).
+- `:filters/auto-hide-error-overrides? <bool>` — when an auto-hidden
+  event raises an exception, surface it anyway (default `true`).
+  Errors override filters.
+- `:buffer/retained-epochs <int>` — exposed retainer-N depth control
+  (re-frame-10x's `retained-epochs`). Floor 25; ceiling 5000.
+- `:theme` — already wired in v1 via `:settings`. Future: `:light`,
+  `:dark`, `:dim`.
+
+### Should-adds
+
+- `:keybinding/handle-keys? <bool>` — master toggle for Causa's
+  keystroke capture; default `true`. Hosts with conflicting global
+  shortcuts can surrender.
+- `:keybinding/bindings <map>` — rebind any action; default carries
+  the spec-mandated set (`Ctrl+Shift+C`, `c`/`r`/`f`/`a`/`v`/`t`/`m`/`i`
+  + spine keys per [`018-Event-Spine.md`](./018-Event-Spine.md) §Keyboard map).
+- `:render/ns-aliases <map>` — rendering substitution so deeply-nested
+  namespaces (`{my-app.deeply.nested mnn}`) collapse in panel renders.
+  Re-frame-10x's `ns-aliases`.
+- `:render/alias-namespaces? <bool>` — master toggle for ns-aliases
+  substitution (paired with above).
+- `:render/auto-expand-below <int>` — auto-expand data nodes with
+  fewer than N children in the cljs-devtools-shaped renderer.
+- `:render/uuids-as <enum :plaintext :identicons :last-4>` — UUID
+  rendering format.
+- `:launch/restore-visibility? <bool>` — persist last-known visibility
+  across reloads.
+- `:launch/popout-geometry <map>` — remember last popout window
+  position `{:w :h :x :y}`.
+- `:trace/collect-when <enum :always :panel-open>` — gate trace
+  collection on panel visibility (re-frame-10x's `trace-when`).
+
+### Nice-to-haves
+
+- `:trace/fatten? <bool>` — opt into trace fattening for
+  context-at-position payloads (Phase 5 prereq per
+  [`013-Trace-Bus.md`](./013-Trace-Bus.md) §Vision).
+- `:settings.tab/persist? <bool>` — persist selected tab across
+  reloads.
+- `:logging/debug? <bool>` — Causa self-debug logs (re-frame-10x's
+  `debug?`). Backlog — Causa instruments itself via the trace bus;
+  redundant for most cases.
+
+### Recovery action (not a key)
+
+- `(causa-config/factory-reset!)` — wipes every
+  `day8.re-frame2-causa.*` localStorage key + resets in-memory atoms.
+  Red button in the Settings popup; CLI escape hatch for "I broke
+  something and don't know what to fix."
+
+The full destination is auditable against `tools/causa/test/.../config_cljc_test.cljc`
+which enforces no slot is forgotten when the surface grows.
+
+<a id="findings"></a>
+
+**Findings:** `ai/findings/2026-05-17-10x-config-options-for-causa.md`
+carries the per-key design rationale, cross-reference against
+re-frame-10x's 26 options, and the priority ranking that drives the
+phase plan above.
+
 ## Production posture
 
 Per [`API.md`](./API.md) §Force-disable, production builds DCE the

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -437,10 +437,116 @@ rejects immediately.
 - [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Layout
   engine — sibling consumer of the same ELK loader pattern.
 
+## Vision — auxiliary content growth
+
+### Event tab — per-fx wire-boundary diff
+
+**Bug class:** "I dispatched event X; it issued an HTTP request; the
+UI updated incorrectly. What went over the wire? What came back? What
+did the handler apply?"
+
+The Event tab's "fx handlers that ran" block grows a **rich expand
+block per managed-effect fx** showing the entire wire interaction:
+request payload (post-elision) → wire transit (status / headers /
+timing waterfall) → response → handler dispatched → app-db slice
+touched. One template; five surfaces (HTTP, WebSocket, machine
+`:invoke`, SSR `:rf.server/*`, flows). See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.4 F.1.
+
+### Event tab — `:on-match` event chain (Routes)
+
+When the focused cascade is a routing cascade
+(`:rf.route/navigate` or `:rf.route/handle-url-change`), the Event
+tab's "fx handlers that ran" block adds a dedicated `:on-match`
+dispatch chain sub-section showing each loader event, drain duration,
+and any `:on-error` consequence. See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.2 R.2.
+
+### Event tab — retry timeline
+
+When an `:rf.http/managed` retried, surface the per-attempt timeline
+(attempt id · result · category · backoff interval · total elapsed)
+under the fx row. See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.4 F.3.
+
+### Event tab — head model inspector (SSR)
+
+When the focused cascade involved a `reg-head` resolution, surface
+inputs (db slice + route) → head model output → rendered HTML head,
+in three columns. See
+[`006-Hydration-Debugger.md`](006-Hydration-Debugger.md)
+§Vision §Head model inspector.
+
+### Issues tab — pending-navigation card
+
+When `:rf/pending-navigation` is set in app-db (a `:can-leave` guard
+rejected), surface it as a yellow card at the top of the App-db tab
++ the Issues tab. Shows the requested URL, the reason, the rejecting
+route, the rejecting guard, and three action buttons (re-evaluate /
+force continue / cancel). See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.2 R.6.
+
+### Issues tab — flow cascade-halt alarm
+
+When `:rf.error/flow-eval-exception` fires, surface a high-priority
+entry listing the subsequent flows that did NOT run (the four-rule
+cascade-halt rule per Spec 013). See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.4 F.4.
+
+### Issues tab — open-redirect / CRLF / trusted-shell advisories
+
+Three security-class advisories surface in Issues at `:advisory`
+severity (different from `:error` / `:warning`, not pushed to top):
+
+- Open-redirect when `:rf.server/redirect` uses caller-untrusted
+  input (Spec 011 rf2-zfm8v).
+- CRLF in header value when `:rf.error/header-invalid-value` fires.
+- Trusted-shell opt advisory when `:head` / `:body-end` /
+  `:script-src` carry caller-controlled strings.
+
+Causa is a debugger, not a linter — advisories are quiet by default;
+configurable to "loud" via Settings → Trace → "Security advisories".
+
+### App-db tab — `:rf/route` slice always-visible
+
+The `:rf/route` slice is structured and small; it pins at the top of
+the App-db tab under a `[reserved]` group banner, always-expanded,
+with each sub-key on its own line. See
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.2 R.11.
+
+### Settings popup — full 6-section catalogue
+
+v1 ships the Settings popup with **4 sections** (Theme, Density,
+Editor, Trace). Future: **6 sections** (add **Keybindings** for in-app
+rebind UI; add **Buffer** for retained-epochs control; add **Popout**
+for popout-geometry; add **Actions** for factory-reset + clear-buffer):
+
+| Section | v1 | Future |
+|---|---|---|
+| **Theme** | dark / light / dim | + custom palettes |
+| **Density** | compact / cosy / comfy | (stable) |
+| **Editor** | URI scheme + project-root | (stable) |
+| **Trace** | sensitive-data gate + filter algebra | + security-advisory toggle |
+| **Keybindings** | — | Full rebind UI; conflict-detection; reset-to-defaults |
+| **Buffer** | — | Retained-epochs slider; clear-buffer button; filter persistence schema bump warning |
+| **Popout** | — | Window-geometry restore; "always popout" toggle |
+| **Actions** | — | Factory-reset (red button); clear-buffer-now; reload-without-state |
+
+### Causality popover — full Q12 hybrid layout
+
+The Causality popover ships v1 with single-axis vertical layout.
+Future: hybrid LR-ancestors + TB-descendants per-region; resizable +
+per-session persistence; depth-disclosure pills + per-segment hover
+tooltips; machine-edge types. See
+[`001-Causality-Graph.md`](001-Causality-Graph.md) §Vision.
+
 ## Cross-references
 
 - [`000-Vision.md`](./000-Vision.md) — the canonical-questions + 6-tab
   inventory.
+- [`019-Cross-Cutting-Insight.md`](./019-Cross-Cutting-Insight.md) —
+  the 5-idioms × 4-areas matrix driving the per-tab content growth
+  above.
 - [`007-UX-IA.md`](./007-UX-IA.md) — typography, colour tokens,
   density gradients, keyboard map.
 - [`018-Event-Spine.md`](./018-Event-Spine.md) — 4-layer chrome,

--- a/tools/causa/spec/017-Test-Coverage-Matrix.md
+++ b/tools/causa/spec/017-Test-Coverage-Matrix.md
@@ -122,9 +122,34 @@ and does NOT change any source-side panel.
 Tier-2 cluster — it depends on a release decision and is tracked as
 its own bead.
 
+## Vision — bug-class coverage column
+
+**Discipline:** every bug-class named in
+[`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2 (and
+in the per-tab spec's bug catalogue, e.g.
+[`003-Machine-Inspector.md`](003-Machine-Inspector.md) §The bug
+catalogue) MUST have at least one matrix row that exercises the
+**user-visible insight** the catalogue promises.
+
+Add a **`bug-class`** column to the matrix mapping each test row to
+the bug-class ids it covers (e.g. `M.1`, `M.2`, `S.1`, `F.4`, `R.3`).
+For a row covering more than one bug-class, list all ids
+comma-separated.
+
+The audit query: "every `M.*` / `R.*` / `S.*` / `F.*` id appears in
+at least one matrix row." A failing audit blocks PR merge — the
+spec promised the user this affordance; the matrix must verify it
+ships.
+
+This closes a structural gap: today's coverage matrix tests
+**surfaces** (does the panel render? does the click work?); the
+bug-class column tests **insight delivery** (does the surface answer
+the question the user came in with?).
+
 ## Cross-references
 
 - [`000-Vision.md`](./000-Vision.md) - panel inventory and the five canonical questions.
+- [`019-Cross-Cutting-Insight.md`](./019-Cross-Cutting-Insight.md) - the bug-class catalogue this matrix must cover.
 - [`007-UX-IA.md`](./007-UX-IA.md) - chrome, keyboard, source-coordinate, redaction, launch, and production posture.
 - [`011-Launch-Modes.md`](./011-Launch-Modes.md) - true-inline host default, optional overlay/debug chrome, pop-out, MCP coexistence, preload, and mount lifecycle.
 - [`013-Trace-Bus.md`](./013-Trace-Bus.md) - trace buffer, filter vocabulary, privacy gate, lifecycle, and production elision.

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -1116,6 +1116,72 @@ The [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matrix.md) rows for the dr
 
 ---
 
+## §13.5 Vision — wider matcher scopes + recorder → Story export
+
+### Wider matcher scopes
+
+v1 ships the IN/OUT pill matcher with **event-id substring/glob/exact**
+matching only. **Future:** the same pill machinery extends to:
+
+- **Event-args matchers** — `:order/* {:method :pay/* …}` matches
+  events with specific arg payload shape. Useful for filtering
+  high-volume events by their payload (e.g. `:input/changed` is noisy
+  but `:input/changed {:field :credit-card-number}` is interesting).
+- **Path matchers** — pills can match by app-db path touched
+  (`path:/cart/items`) — surface the cascades that modified this slice.
+- **Source-coord matchers** — pills can match by source file/line
+  range, useful for "show me everything dispatched from this module."
+- **Origin matchers** — already wired for `:origin` axis; future
+  expansion to include custom origins from third-party tools.
+
+The matcher algebra stays AND-across-modes / OR-within-mode (per §7);
+the matcher vocabulary grows.
+
+### Recorder → `:play-script` export pipeline (Story integration)
+
+**Bug class:** "I caught this bug in dev; I want a Story variant that
+reproduces it so my colleague can see the same thing."
+
+The Causa session has every dispatch (and its outcome) in the trace
+buffer. Story has the `:play-script` machinery (per Story's spec) for
+declarative variant replay. The pipeline bridges them:
+
+```clojure
+;; In Causa, right-click a focused cascade → "Record from here"
+;;   → marker dropped at the focused cascade.
+;; Continue clicking around the app to capture the repro path.
+;; Right-click → "Export to Story" → opens a dialog with the
+;;   generated `:play-script`:
+
+{:play-script
+ [{:dispatch [:cart/add-item {:id 22}]}
+  {:dispatch [:cart/begin-checkout]}
+  {:wait-for-machine [:checkout :review]}
+  {:dispatch [:pay/decline]}
+  {:assert-state [:checkout :failure]}]}
+```
+
+The pipeline:
+
+1. **Recorder mode** — Causa marks a cascade as the "start" of a
+   recording; subsequent cascades (until the user stops recording) are
+   captured as the script.
+2. **Sanitisation** — payloads with `:sensitive?` paths render as
+   `[:rf/redacted]` (the script captures the cascade structure, not
+   the secret).
+3. **Export dialog** — paste into a Story variant file, or "Save to
+   Story" (when Story is embedded in the same dev build) drops the
+   variant straight into the story.
+4. **Round-trip** — opening that Story variant runs the play-script;
+   Causa, embedded in the Story chrome, lands on the same cascade.
+
+This is the **only "export" Causa offers**, and it lands in Story's
+persistent layer — Lock #4 (no session export) is preserved because
+the export target is Story (which already has a persistence model),
+not Causa.
+
+---
+
 ## §14 Cross-references
 
 - [`000-Vision.md`](000-Vision.md) — 6-tab inventory; philosophy shift to human-only surface.

--- a/tools/causa/spec/019-Cross-Cutting-Insight.md
+++ b/tools/causa/spec/019-Cross-Cutting-Insight.md
@@ -1,0 +1,917 @@
+# 019-Cross-Cutting-Insight
+
+The vision-of-record for how Causa renders re-frame2's **cross-cutting
+runtime concerns** — SSR, Machines, Routes, Managed-Effects — without
+fragmenting the chrome. Distils [the 2026-05-18 cross-cutting design
+findings](#findings-anchor) into a normative reading: **5 visual idioms ×
+4 areas = a 20-cell matrix of features**, each anchored on a concrete
+bug-class.
+
+This doc is the **complement** to [`000-Vision.md`](000-Vision.md) and
+[`018-Event-Spine.md`](018-Event-Spine.md): Vision states the claim;
+Event-Spine specifies the chrome; this doc shows how the chrome accommodates
+the cross-cutting work without growing tabs.
+
+---
+
+## §0 The strategic shape (read this first)
+
+Causa today nails the **synchronous, single-frame, single-cascade**
+debugging story. The five canonical questions ([`000-Vision.md`](000-Vision.md)
+§The five canonical questions) answer themselves on first paint.
+
+What's under-developed is everything **across time**, **across boundaries**,
+**across networks** — exactly the territory where SSR · Machines · Routes ·
+Managed-Effects live. The four surfaces share three structural properties
+that make them hard to debug from code alone:
+
+1. **They unfold over wall-clock time.** A machine `:after` fires 30s after
+   entry; a route's `:on-match` cascade lands 200ms after click; a streaming
+   SSR boundary resolves seven chunks deep; an `:rf.http/managed` retry hits
+   its third attempt after exponential backoff. Stack traces are
+   insufficient — the wall clock IS the bug surface.
+2. **They span boundaries.** Server → client (SSR); browser → backend
+   (managed HTTP); parent machine → spawned child → in-flight HTTP; route
+   URL → app-db slice → on-match cascade. Each boundary is a place where
+   assumptions can quietly diverge.
+3. **They have rich, structured failure taxonomies the runtime already
+   emits.** `:rf.ssr/*`, `:rf.machine.*`, `:rf.route.*`, `:rf.http/*` — the
+   framework spec is unusually careful about naming failure categories.
+   Causa today funnels most of them through one generic Issues row; that
+   wastes signal the framework paid to capture.
+
+**The strategic move:** Causa's existing 6-tab chrome does NOT need a 7th,
+8th, 9th tab. It needs **deep specialised renderings inside the existing
+tabs**, surfaced through five reusable visual idioms:
+
+- **Wall-clock timelines** — rings (timer countdown), waterfalls (retry
+  backoff), swimlanes (nav-token races).
+- **Boundary diffs** — server vs client (hydration), request vs response
+  (wire-boundary), before vs after (app-db diff), parent vs child
+  (cascade-divergence).
+- **Cascade trees** — cancellation cascades, `:on-match` event chains,
+  exit/entry cascade animations, hydration mismatch bisectors.
+- **Schema explanations** — Malli explanations rendered inline, not buried
+  in trace.
+- **Lifecycle accounting** — per-frame teardown audit, per-instance trace,
+  stale-suppression tally, recently-destroyed buffer.
+
+Five idioms × four areas = **20 features**, sequenced into PR-sized work
+[§6 Sequencing](#6-sequencing).
+
+---
+
+## §1 The five visual idioms
+
+Each idiom has a uniform rendering vocabulary; the chrome should look
+consistent across all four areas. An author who learns "the timer ring"
+on a machine `:after` immediately understands "the retry waterfall" on an
+HTTP `:rf.http/managed` because both speak the same wall-clock language.
+
+### §1.1 Wall-clock timelines
+
+Time IS the bug surface for `:after` timers, HTTP retry backoffs, route
+nav-token races, WebSocket reconnects, streaming SSR boundary resolutions.
+
+**Sub-idioms:**
+
+- **Countdown ring** — a thin circle around a state node (or a wire
+  endpoint) with an animated arc representing time-elapsed/total. Starts
+  at 12 o'clock, rotates clockwise to fill. Live mode animates; retro
+  (scrubber-driven) is static at the elapsed-fraction at the focused
+  cascade's timestamp.
+- **Waterfall** — vertical stack of timestamped rows; each row is an
+  attempt / phase / chunk with its own duration band; total elapsed shown
+  at the foot.
+- **Swimlane** — horizontal bars on a shared time axis; each lane is one
+  in-flight thing (nav-token, WebSocket connection-epoch, machine `:after`
+  epoch). Suppressed completions render with a strike-through; the
+  carried-vs-current token is visible.
+
+**Reduced-motion handling:** the live arc animation flattens to a static
+amber arc + numeric percentage. The waterfall becomes a static stack with
+duration text. The swimlane stays — its content is structural.
+
+### §1.2 Boundary diffs
+
+A boundary is a place where two sides "should agree" and sometimes don't:
+
+- **Server vs client** (hydration; SSR sub-recompute attribution).
+- **Request vs response** (wire-boundary diff for managed effects).
+- **Before vs after** (the existing app-db diff; extends to cross-frame).
+- **Parent vs child** (cancellation cascade; shift-click multi-instance
+  divergence).
+
+**Uniform rendering:** two columns side-by-side, root flagged, walk to the
+first divergent node, highlight with `⚠`, surface the upstream value that
+each side observed. The user reads "server saw `:user/locale = nil`;
+client saw `:user/locale = :en-US`" in one glance.
+
+### §1.3 Cascade trees
+
+A cascade is "one decision and its consequences laid out as a tree." Four
+cases:
+
+- **Cancellation cascade** — parent machine exits → destroy fx →
+  in-flight HTTP aborts → child machine destroyed.
+- **`:on-match` event chain** — route navigation → declared loader events
+  drain (in order or in parallel) → on-error fires if any error.
+- **Exit/entry cascade** — leaving a hierarchical state walks the exit
+  chain up to the LCA; entering walks the entry chain down.
+- **Hydration mismatch bisector** — depth-first walk over canonical EDN
+  serialisation; first-divergent-node highlighted; side-by-side render
+  for that node.
+
+**Uniform rendering:** vertical waterfall, indentation = depth in the
+cascade, each row carries source-coord + trace event id + timestamp. The
+**root row** is the decision; the **leaf rows** are the consequences. The
+total fan-out + duration prints at the foot.
+
+### §1.4 Schema explanations
+
+Malli rejections live in the trace today as `:rf.error/schema-validation-failure`
+events with `:explain` payloads. The user shouldn't have to walk the trace
+to find them. Two surfaces:
+
+- **Inline Malli explanation** in the Issues tab — the human-readable
+  variant of `:explain`, with the offending path highlighted, the schema
+  source-coord linked.
+- **Per-violation drilldown** — click a schema-violation row → opens the
+  Event tab for the cascade that produced it; the violating handler's
+  `reg-event-*` registration is linked.
+
+This applies to: app-db shape violations, event coercion failures,
+fx-args validation failures, route param/query validation failures,
+schema-digest mismatches at hydration time.
+
+### §1.5 Lifecycle accounting
+
+Per-frame teardown, per-instance trace, stale-suppression tally,
+recently-destroyed buffer. These are the "did anything leak / get stuck
+/ silently discard?" surfaces:
+
+- **Per-frame teardown auditor** (dev-only summary; deep auditor in CI) —
+  at frame destroy, verify each slot was released; surface a one-line
+  "frame destroyed cleanly" or a leak warning.
+- **Per-instance trace strip** — for a focused machine instance, the last
+  5 trace events filtered to just that instance.
+- **Stale-suppression tally** — one chip per surface (timers, nav-tokens,
+  WebSocket epochs, sub-warmups); count of stale events suppressed this
+  session, click → grouped list.
+- **Recently-destroyed buffer** — destroyed machine instances persist 30s
+  in a recently-destroyed sub-list so the arc can still be inspected after
+  the instance is gone.
+
+---
+
+## §2 The four areas
+
+This section enumerates the bug classes Causa addresses in each area. Each
+bug-class follows the **bug → example → insight → affordance** structure
+from [`000-Vision.md`](000-Vision.md) §Bug-driven, not feature-driven.
+
+### §2.1 Machines
+
+(Full per-feature spec in [`003-Machine-Inspector.md`](003-Machine-Inspector.md);
+this section catalogues the bug classes the Machine surfaces address.)
+
+#### M.1 — "My machine is stuck. Why won't it transition?"
+
+**Bug class:** Guard rejection (silent). An event fires, the chosen `:on`
+entry's guard returns `false`, the snapshot doesn't move. The `:rf.machine.transition/suppressed`
+trace is the only signal, and it's buried in the firehose.
+
+**Example bug:** You dispatched `:auth/cancel` on machine `:checkout` in
+state `:authing`, expected a transition to `:idle`, nothing happened. The
+event landed; the guard `:no-pending-payment?` returned `false` because
+`:data.pending-payment` was `4232`.
+
+**Insight Causa provides:** The transition's edge in the chart **flashes red
+400ms** with a tooltip: `:auth/cancel-attempted from :authing → :idle |
+guard :no-pending-payment? returned FALSE (data: {:pending-payment 4232})`.
+In the metadata rail, a "Recent guard rejections" section listing the
+rejected transitions, each click-to-expand showing the `:data` snapshot at
+evaluation time and the guard's source-coord.
+
+**Affordance:** Machines tab — guard-verdict overlay (M-C1). Three clicks
+total from "huh, nothing happened" to "ah, my guard is wrong."
+
+#### M.2 — "My `:after` timer fired but nothing happened."
+
+**Bug class:** Stale `:after` timer (epoch advanced; timer scheduled in a
+prior visit) OR guard re-evaluation on `:after` resolution OR
+`:rf.machine.timer/cancelled-on-resolution` paired with new schedule.
+
+**Example bug:** You entered `:loading` with `:after 5000ms → :timeout`.
+30 seconds passed. The snapshot is still `:loading`. The Trace tab shows
+both `:rf.machine.timer/scheduled` (epoch 12) and
+`:rf.machine.timer/stale-after` (epoch 13) — the state re-entered between
+the schedule and the fire.
+
+**Insight Causa provides:** On each state with a live `:after` timer, the
+node has a **countdown ring** with an animated arc. Stale timers render
+dashed/grey with a tooltip "this timer was scheduled in a prior visit and
+is stale." Cancelled-on-resolution timers show the old ring fading out
+(200ms), new ring fading in. Click any ring → timer detail popover with
+`:scheduled-at`, `:delay`, `:epoch`, `:source` (`:literal` / `:sub` /
+`:timeout-config` / `:fn`).
+
+**Affordance:** Machines tab — `:after` countdown rings + scrubber-aware
+retro-replay (M-C2). Time IS the bug surface; the ring makes wall clock
+visible.
+
+#### M.3 — "The cancellation cascade fired and I don't know what happened."
+
+**Bug class:** Parent state exits; child's `:invoke` destroyed; child had
+N in-flight HTTP requests; each aborts. The author sees a flurry of
+`:rf.http/aborted-on-actor-destroy` traces in the firehose and one
+`:rf.machine.lifecycle/destroyed`. They cannot reconstruct the cascade.
+
+**Example bug:** You clicked Cancel on a checkout flow. The Trace tab shows
+4 abort traces + 1 destroyed trace, scattered through 200 unrelated rows.
+You can't tell which abort came from the cancel vs which were independent.
+
+**Insight Causa provides:** A dedicated **"Cancellation cascade" detail
+panel** that appears inline in the Machines tab when the focused cascade
+triggered a destroy:
+
+```
+┌─ Cancellation cascade · cascade #449 ──────────────────────────────────┐
+│  16:42:14.103   :checkout/main exits :processing → :cancelled           │
+│         ├── :rf.machine/destroy → :http/post#347                        │
+│         │     ├── :rf.http/aborted-on-actor-destroy  POST /finalize     │
+│         │     ├── :rf.http/aborted-on-actor-destroy  GET /cart/lock     │
+│         │     └── :rf.http/aborted-on-actor-destroy  POST /audit/log    │
+│         └── :rf.machine.lifecycle/destroyed → :http/post#347            │
+│  Total: 1 child destroyed · 3 requests aborted · 8ms elapsed            │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+What was "a flurry of confusing trace lines" becomes "one decision and its
+consequences, laid out vertically." Cancellation is no longer a mystery;
+it's a diagram.
+
+**Affordance:** Machines tab — cancellation cascade visualiser (M-C3).
+This is also a template for the SSR cancellation case — when an SSR
+request times out, the same cascade-waterfall idiom shows what cleanup
+ran (response slot dropped, request slot dropped, machine snapshots
+discarded).
+
+#### M.4 — "I'm in `:invoke-all` and it never joins."
+
+**Bug class:** Four children spawned; join condition is `:all`. Two
+completed; two never did. The user wants per-child status, what each is
+doing right now, what the join-state map looks like (`:done #{:cfg :flag}
+:failed #{} :resolved? false`), and whether `:on-any-failed` is wired.
+
+**Example bug:** You entered `:hydrating` which declares `:invoke-all
+{:children {:cfg ... :flag ... :user ... :dash ...} :join :all}`. Two
+children completed in <200ms; two are still "running" 2 seconds in. The
+machine hasn't advanced. The `[:rf/spawned <parent-id> <invoke-id>]` slot
+in app-db carries the structured state but you don't read it directly.
+
+**Insight Causa provides:** A dedicated **join card** in the metadata rail:
+
+```
+┌─ :invoke-all  ·  invoke-id [:hydrating :invoke-all] ─────────────┐
+│ Join condition: :all                                              │
+│ Resolved: ✗   (waiting for 2 of 4)                                │
+│  ✓ :cfg     :load-config#1         done @ +124ms                  │
+│  ✓ :flag    :load-feature-flags#2  done @ +89ms                   │
+│  ⧖ :user    :load-user-profile#3   running 2.3s                   │
+│  ⧖ :dash    :load-dashboards#4     running 2.4s                   │
+│  :on-all-complete  → [:assets-loaded]                             │
+│  :on-any-failed    → [:asset-load-failed]                         │
+│  :cancel-on-decision?  true                                        │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Click any running child → pivots to that child's machine. Click any
+done/failed → opens the per-child completion event.
+
+**Affordance:** Machines tab — `:invoke-all` join inspector (M-C4).
+
+#### M.5 — "Instance #c-047 stuck in `:authing` for 30s; what guard is blocking it?"
+
+**Bug class:** Per-instance debugging at scale. Mode C (4+ instances) ships
+with cluster-by-state badges + shift-click divergence, but the per-instance
+"what's stuck here" trace has no direct affordance.
+
+**Insight Causa provides:** Click an instance row in the Mode C table →
+opens a per-instance trace strip below the table showing the last 5 trace
+events for THIS instance only. The "32s in state" auto-callout flags
+suspiciously-long state occupancy. Filters out other instances' chatter.
+
+**Affordance:** Machines tab — per-instance "why am I stuck" trace strip
+(M-C5).
+
+#### M.6 — Other machine bug classes (catalogued; see 003)
+
+- **M.7** Hierarchical state cascade — exit-chain/entry-chain animation
+  along the LCA (M-C6).
+- **M.8** Microstep loop visualiser — when `:always` chains hit
+  bounded-depth (M-C7).
+- **M.9** Path-walked transition explainer — for hierarchical
+  deepest-wins resolution (M-C8).
+- **M.10** Spawn-ancestry tree in metadata rail (M-C9).
+- **M.11** Snapshot diff across transitions — per-action attribution of
+  `:data` mutations (M-C10).
+
+### §2.2 Routes
+
+(Full per-feature spec ships in [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md)
+§Route content + [`018-Event-Spine.md`](018-Event-Spine.md) §Nav-token
+popover; this section catalogues the bug classes.)
+
+#### R.1 — "Stale data clobbered my new route."
+
+**Bug class:** Stale nav-token race. User navigates A → B before A
+finishes loading; A's late result lands and overwrites B's state. Spec
+012's `:nav-token` epoch is the mechanism — but the user can't see it.
+
+**Example bug:** You navigated from `:route/cart` to `:route/checkout` in
+quick succession. The `:cart/load-items` loader from `:route/cart` was
+still in-flight when you arrived at `:route/checkout`. Its result landed
+800ms later, overwriting the checkout app-db state with cart data. You
+see "stale clobber" in your UI but can't tell which nav was the late one.
+
+**Insight Causa provides:** The **nav-token timeline** — a horizontal
+swimlane visualisation pinned at the top of the Trace tab (or as the `r`-key
+popover from any tab):
+
+```
+nav-1 │█████░░░░░░░░░░░░│░░░░ → suppressed (carried nav-1; current nav-2)
+      │  :on-match drain
+nav-2 │      ██████████████████████ → completed @ +812ms
+      │       :on-match drain
+nav-3 │                       ████│ in flight (185ms elapsed)
+      │                        :on-match drain
+```
+
+Each navigation = one horizontal bar. Failed/stale completions get a
+strike-through with the carried-vs-current token visible. Currently-in-flight
+navigations have an animated leading edge.
+
+Click any bar → spine seeks to that nav-token's allocation cascade.
+
+**Affordance:** Nav-token timeline popover (R-C3); cross-cuts the Trace
+tab and the Issues tab.
+
+#### R.2 — "My route's `:on-match` events didn't fire."
+
+**Bug class:** URL changed; the per-route loaders never dispatched.
+Possibilities: route's `:on-match` is `nil`; nav-token was already
+advanced (race); event handler threw silently; `:transition` is stuck on
+`:error` from a prior nav.
+
+**Insight Causa provides:** When the focused cascade is a routing cascade,
+the Event tab's "fx handlers that ran" block adds a dedicated **`:on-match`
+dispatch chain** sub-section showing the loader events, their drain
+durations, and any `:on-error` consequences:
+
+```
+:on-match dispatch chain (3 events, drained 124ms):
+  ✓ [:cart/load-items]       drained 87ms     src/cart/events.cljs:42 ↗
+  ✓ [:user/load-prefs]       drained 31ms     src/user/events.cljs:18 ↗
+  ✗ [:cart/load-promotions]  errored 6ms      src/cart/events.cljs:65 ↗
+       → exception :promotions-service-unavailable
+       → :on-error fired: [:route/cart-load-failed]
+```
+
+**Affordance:** Event tab — `:on-match` chain inline (R-C4).
+
+#### R.3 — "The route matched but the wrong one."
+
+**Bug class:** Two routes overlap; the 6-rule ranking cascade picks one;
+the user wanted the other.
+
+**Insight Causa provides:** A **match-rank explainer** tooltip on hover
+over any route id:
+
+```
+Match rank for :route/cart.item-detail vs URL /cart/items/abc:
+  Rule 1 (static count):     2 (this) vs 1 (:route/cart.* wildcard) → THIS WINS
+  Rule 2 (length):           3 vs 2                                  → n/a
+  ...
+```
+
+**Affordance:** App-db tab → `:rf/route` slice → rank-explainer (R-C5).
+
+#### R.4 — Other route bug classes (catalogued)
+
+- **R.5** `:rf.route/not-found` reason ambiguity — Malli explanation
+  inline (R-C6).
+- **R.6** `:can-leave` rejection with no UI — pending-navigation card
+  (R-C7).
+- **R.7** URL vs slice drift watchdog (R-C8 — ambitious).
+- **R.8** Route-chain visualiser (`:parent` → child chain) (R-C9).
+- **R.9** Open-redirect security advisory (R-C10).
+- **R.10** Routing badge `🧭` on Event-list rows (R-C1).
+- **R.11** `:rf/route` slice always-visible in App-db tab (R-C2).
+
+### §2.3 SSR / Hydration
+
+(Full per-feature spec in [`006-Hydration-Debugger.md`](006-Hydration-Debugger.md);
+this section catalogues the bug classes.)
+
+#### S.1 — "Hydration mismatch popped up; where in the tree?"
+
+**Bug class:** Body hydration mismatch. Server-rendered tree and client
+first-render tree disagree at a node. The `:rf.ssr/hydration-mismatch`
+trace fires with `:first-diff-path`; the panel needs to render the
+divergent node side-by-side with **sub-attribution** (which sub returned
+which value on which side, and why).
+
+**Example bug:** Server rendered `<span class="user-name">Guest</span>`;
+client rendered `<span class="user-name">Alice</span>`. The console error
+says "hydration mismatch at `[:div.app :header :span.user-name]`." You
+don't know why — was the server missing the session? Was the sub computing
+nil? Was the `:user/display-name` sub watching the wrong slice?
+
+**Insight Causa provides:** The **hydration mismatch bisector** — walks
+the canonical EDN serialisation depth-first, finds the first divergence,
+surfaces both trees + the SUBs that produced them + the upstream `app-db`
+slices both sides observed + a heuristic "likely cause" line:
+
+```
+Bisector:
+  ✓ root <div id="app">
+  ✓ <div.layout>
+  ✓ <header>
+  ✗ FIRST DIVERGENCE: <span.user-name>
+
+Side-by-side:
+┌─ Server ─────────────────────┬─ Client ──────────────────────┐
+│  [:span.user-name "Guest"]    │  [:span.user-name "Alice"]    │
+│  Subbed to: :user/display-name│  Subbed to: :user/display-name│
+│  Server sub returned: "Guest" │  Client sub returned: "Alice" │
+│  Server :user value: nil      │  Client :user value: {:id 1 …}│
+│  Server :auth/session: nil    │  Client :auth state: :authed  │
+└────────────────────────────────┴────────────────────────────────┘
+
+Likely cause: server-side session cofx not injected (request cookie
+was present but `:auth/server-init` event was not in `:on-create`)
+↗ Open server-side init: src/server/init.cljs:42
+```
+
+The "Likely cause" line is heuristic — Causa suggests "session not
+injected" when the divergent sub depends on `:auth/*` and the server's
+`:auth/*` slice is empty.
+
+**Affordance:** Issues tab — hydration mismatch bisector with
+sub-attribution (S-C2). The hero SSR feature.
+
+#### S.2 — "Server rendered a 500 page; what was the internal exception?"
+
+**Bug class:** The public-error projection sanitises the internal trace.
+In dev mode, `:dev-error-detail? true` includes `:details`. The author
+needs the internal trace alongside the public projection to see the
+security boundary.
+
+**Insight Causa provides:** A dedicated **server error projection** detail
+panel — shows the internal trace + the projector's source-coord + the
+public projection map + the rendered client response. The author sees
+exactly what crossed the wire and what did not.
+
+**Affordance:** Issues tab / Event tab — server error projection trace
+(S-C5).
+
+#### S.3 — "Streaming SSR shipped a chunk that hydrated incorrectly."
+
+**Bug class:** Per-subtree delta merged into client app-db but the view
+tree didn't update as expected.
+
+**Insight Causa provides:** A **streaming SSR boundary timeline** in the
+Trace tab — vertical waterfall showing shell flush time, per-boundary
+fallback emit times, per-boundary resolution times (or failures), final
+payload chunk status. Each boundary that failed shows the throwable + the
+fallback retention status.
+
+**Affordance:** Trace tab — streaming SSR boundary waterfall (F-C10 /
+S-C10).
+
+#### S.4 — Other SSR bug classes (catalogued)
+
+- **S.5** Head/meta hydration mismatch — head-model inspector (S-C6).
+- **S.6** Hydration payload policy verdict — payload-keys vs whole-app-db
+  (S-C4).
+- **S.7** `:rf/hydrate` over-replaced (replace-app-db policy clobbered
+  client-only state) (S-C3).
+- **S.8** `:after`-server-side anomaly badge (S-C7).
+- **S.9** Per-request frame teardown auditor — dev-mode summary; deep
+  audit in CI (S-C8).
+- **S.10** Trusted-shell opt visualiser (S-C9).
+- **S.11** Schema digest mismatch — per-schema diff (S-C5b).
+- **S.12** SSR ribbon indicator — `📄 SSR @ <hash>` (S-C1).
+- **S.13** Side-by-side SSR replay — the post-v1 dream (S-C11).
+
+### §2.4 Managed Effects
+
+(`spec/Managed-Effects.md` names the eight-property contract that HTTP,
+WebSocket, machine `:invoke`, SSR `:rf.server/*`, and flows all satisfy.
+This section catalogues the bug classes Causa addresses uniformly across
+all five surfaces.)
+
+#### F.1 — "What happens when this effect crosses the wire?"
+
+**Bug class:** Managed effects (HTTP, WS, invoke, server, flow) issue work
+across a boundary; the author needs to see the entire wire interaction in
+one picture — payload (post-elision) → wire (status / headers / timing
+waterfall) → response → handler dispatched → app-db slice touched.
+
+**Example bug:** Your `:order/submit` event issued `:rf.http/managed POST
+/api/checkout/finalize`. The UI shows "success" but the order doesn't
+appear in `:cart :orders`. You don't know: did the request go out? Did the
+response come back? Was the `:on-success` handler invoked? Did the handler
+write the right slice?
+
+**Insight Causa provides:** The **wire-boundary diff** in the Event tab's
+"fx handlers that ran" block:
+
+```
+┌─ :rf.http/managed  ·  POST /api/checkout/finalize ──────────────────────┐
+│ Issued by:    cascade #347 :order/submit  ·  src/order/events.cljs:42 ↗ │
+│ Request payload:                                                         │
+│   { :cart-id "abc-123"                                                   │
+│     :payment-method [● REDACTED · 92 bytes]                              │
+│     :total-cents 4232 }                                                  │
+│ ─── waterfall ──────────────────────────────────────────────             │
+│   issued       16:42:14.103   ●                                          │
+│   sent         16:42:14.105    ● 2ms                                     │
+│   received     16:42:14.187     ●─────── 82ms                            │
+│   decoded      16:42:14.189     ● 2ms                                    │
+│   on-success   16:42:14.190     ● dispatched [:checkout/done abc-123]    │
+│ ─────────────────────────────────────────────────────────────────────    │
+│ Response:     200 OK { :order-id "ord-991" :receipt-url "..." }         │
+│ Applied:                                                                 │
+│   [:cart :status]   :submitting → :completed                             │
+│   [:cart :order-id] (added: "ord-991")                                   │
+│ Retry policy:  :retry {:on #{:rf.http/transport :rf.http/http-5xx}      │
+│                        :max-attempts 3                                   │
+│                        :backoff {:initial 100 :max 5000}}                │
+│ Attempts (this call): 1 of 3                                             │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+The headline: **request → wire → response → handler → app-db slice
+touched** in one compact panel. The waterfall makes timing visible. The
+"Applied" section connects the http response to its downstream effect on
+app-db. **Privacy markers are visible at every layer.**
+
+For WebSocket: same shape but for a frame's send/recv, plus connection
+state at issue time.
+For machine `:invoke`: same shape but the "wire" is the spawn → run → reply.
+For SSR `:rf.server/*`: same shape but the "wire" is the server response
+accumulator's evolution.
+For flows: same shape but inputs/outputs.
+
+**Affordance:** Event tab — wire-boundary diff template (F-C2). The hero
+managed-effects feature. The single biggest "I get re-frame2 now" win for
+new authors. Implements the `Managed-Effects.md` eight-property contract
+as visible UI.
+
+#### F.2 — "What's the runtime currently busy doing?"
+
+**Bug class:** Classic ops question — which HTTP requests are in flight,
+which WebSocket connections are active, which machine actors are live,
+which flows recomputed recently. The runtime maintains the registry; the
+question deserves a one-glance answer.
+
+**Insight Causa provides:** The **active managed-effects dashboard**:
+
+```
+┌─ Active managed effects (frame :app/main) ─────────────────────────────┐
+│ HTTP (3 in-flight)                                                      │
+│   ⧖ req-449  POST /api/checkout/finalize  4.2s elapsed  attempt 2/3    │
+│   ⧖ req-512  GET  /api/cart/items         0.8s elapsed                  │
+│   ⧖ req-518  GET  /api/user/preferences   0.3s elapsed                  │
+│ WebSocket (1 connection)                                                │
+│   ● ws://chat.example.com  :connected  ↑ 5 queued · ↓ 1 in-flight       │
+│ Machine actors (2 live)                                                 │
+│   ⧖ :auth/main#m-001  state :authing  for 32s                           │
+│   ⧖ :http/post#h-018  state :sending  for 0.4s  (child of :auth/main)   │
+│ SSR responses (0; client only)                                          │
+│ Flows (12 registered, 1 recomputed in last 5s)                         │
+│   ↺ :flow/cart-subtotal  recomputed @ 16:42:14.140                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Surfacing: a ribbon chip `⧖ 3 HTTP · 1 WS · 2 actors` with click →
+popover dashboard, OR a Cmd-K palette entry "Show active effects."
+
+**Affordance:** Ribbon chip + popover dashboard (F-C4).
+Erlang-Observer-for-managed-effects.
+
+#### F.3 — "This request retried 5 times and finally failed. What was the backoff?"
+
+**Bug class:** Silent retry chain. `:retry {:on ... :max-attempts 5 :backoff
+{:initial 100 :max 5000}}` retried at growing intervals. Each attempt =
+`:rf.http/handled` trace. User wants a timeline of attempts with timing.
+
+**Insight Causa provides:** A **retry timeline** under the fx row:
+
+```
+:rf.http/managed  ·  POST /api/checkout/finalize  ·  retries
+  Attempt 1   16:42:14.103   FAILED  :rf.http/transport  (net::ERR_CONNECTION_REFUSED)
+  Attempt 2   16:42:14.205   FAILED  :rf.http/transport  (after 100ms backoff)
+  Attempt 3   16:42:14.408   FAILED  :rf.http/transport  (after 200ms backoff)
+  Attempt 4   16:42:14.812   SUCCESS 200 OK              (after 400ms backoff)
+  Total elapsed: 712ms · Backoff sum: 700ms
+```
+
+**Affordance:** Event tab — retry timeline (F-C3).
+
+#### F.4 — "A flow's `:output` threw and the cascade halted; what didn't run?"
+
+**Bug class:** Flow cascade-halt. When `:rf.error/flow-eval-exception`
+fires, the four-rule cascade-halt contract per Spec 013 means downstream
+flows in topological order do NOT run. Authors rarely realise this.
+
+**Insight Causa provides:** A high-priority **Issues entry** that lists
+the subsequent flows that did NOT run:
+
+```
+⚠ EXCEPTION  cascade #449  FLOW CASCADE HALTED
+  Flow:     :flow/cart-subtotal
+  Inputs:   {:cart {:items [...] :discount-code "INVALID"}}
+  Exception: ArithmeticException — Divide by zero
+  src/cart/flows.cljs:42 ↗
+  Recovery: prior values preserved; last-inputs NOT advanced; cascade halted
+  → Subsequent flows in topological order DID NOT run:
+       :flow/cart-total
+       :flow/checkout-readiness
+```
+
+The "Subsequent flows did not run" list is the killer feature — prevents a
+subtle data-corruption bug class.
+
+**Affordance:** Issues tab — flow cascade-halt alarm (F-C8).
+
+#### F.5 — Other managed-effects bug classes (catalogued)
+
+- **F.6** Per-request response accumulator inspector (SSR) — shows the
+  `:rf.server/set-status` / `:set-header` / `:set-cookie` evolution
+  with last-write-wins warnings (F-C7).
+- **F.7** Skipped-on-platform tally — `:rf.fx/skipped-on-platform` chip
+  with click-to-filter (F-C9).
+- **F.8** CRLF + open-redirect literal rendering in Issues — the attack
+  vector visualised (F-C11).
+- **F.9** Per-fx args + handler source-coord chip — every fx-row carries
+  the registered fx's source coord (F-C6).
+- **F.10** Expanded badge taxonomy — `🌐 🔌 📄 🌊 🤖` for HTTP /
+  WebSocket / SSR / Flow / Machine `:invoke` (F-C1).
+- **F.11** Cross-surface stale-suppression badge — unified `STALE`
+  rendering across all four surfaces (F-C5).
+
+---
+
+## §3 The 5 × 4 matrix
+
+The cells. Read across each row to see how an idiom recurs across all four
+areas; read down each column to see how an area's bug classes group by
+idiom.
+
+|                         | Machines                                | Routes                                  | SSR                                          | Managed-Fx                              |
+|-------------------------|------------------------------------------|------------------------------------------|----------------------------------------------|------------------------------------------|
+| **Wall-clock timeline** | `:after` countdown rings (M-C2)          | Nav-token swimlanes (R-C3)               | Streaming boundary waterfall (S-C10)         | Retry timeline (F-C3); WebSocket reconnect (F.3) |
+| **Boundary diff**       | Shift-click instance divergence (M.4)    | URL vs slice drift watchdog (R-C8)       | Hydration mismatch bisector (S-C2)           | Wire-boundary diff (F-C2)                |
+| **Cascade tree**        | Cancellation cascade visualiser (M-C3)   | `:on-match` event chain (R-C4)           | Per-request response accumulator (F-C7)      | Active managed-effects dashboard (F-C4)  |
+| **Schema explanation**  | Snapshot diff per transition (M-C10)    | Validation explanation in `:rf.route/not-found` (R-C6) | Server error projection (S-C5)               | Args validation (Spec 010 boundary) explainer (Issues) |
+| **Lifecycle accounting**| Per-instance trace strip (M-C5); spawn ancestry (M-C9) | Pending-navigation card (R-C7)           | Per-request frame teardown auditor (S-C8)    | Stale-suppression tally (F-C5); skipped-on-platform tally (F-C9) |
+
+The matrix is **descriptive**, not exhaustive — each cell points to the
+primary feature in that idiom-area intersection. Many cells have multiple
+features (see §2 for the full catalogue).
+
+---
+
+## §4 Surface placement — which tab grows which feature
+
+The matrix's 20 features land in the 6 existing tabs + 3 popovers, with
+NO new tabs. The placement is uniform across areas:
+
+| Tab | Cross-cutting growth |
+|---|---|
+| **Event** (`e`) | Per-fx **wire-boundary diff** (F-C2). `:on-match` event chain (R-C4). Retry timeline (F-C3). Head model inspector (S-C6). Server error projection (S-C5). Per-fx source-coord chip (F-C6). |
+| **App-db** (`a`) | `:rf/route` slice always-visible at top (R-C2). Hydration diff in App-db tab (S-C3). Route-chain visualiser (R-C9). Trusted-shell opt visualiser (S-C9). |
+| **Views** (`v`) | (Largely unchanged; flows surface in the "Re-rendered" group when a flow's downstream sub recomputed.) |
+| **Trace** (`t`) | **Wall-clock axis** for timer rings, retry waterfalls, deferred-dispatch arrivals. Nav-token timeline as sticky header (or via `r` popover). Streaming SSR boundary waterfall (F-C10 / S-C10). Skipped-on-platform tally chip (F-C9). |
+| **Machines** (`m`) | All of §2.1's M-C* features. The cancellation cascade visualiser (M-C3) is the tab's hero growth. |
+| **Issues** (`i`) | Hydration mismatch bisector (S-C2) — the SSR hero. Flow cascade-halt alarm (F-C8). Pending-navigation card (R-C7). CRLF + open-redirect rendering (F-C11). Open-redirect advisory (R-C10). Validation explanations inline (Malli rendering throughout). Per-request frame teardown summary (S-C8). |
+
+| Popover | Cross-cutting role |
+|---|---|
+| **Causality** (`c`) | Grows **machine-edge types** — spawn (`─◇▶`), final (`═▶`), `:invoke-all` join (`⋈`). Same primitive; richer edge vocabulary. |
+| **Nav-token timeline** (`r`) | NEW popover. Horizontal swimlanes; carried-vs-current tokens; click-bar → seek. |
+| **Wire-trace** (`f`) | NEW popover. The Event-tab wire-boundary diff popped out — floats over any tab. |
+
+| Ribbon (L1) | Cross-cutting growth |
+|---|---|
+| Active-managed-effects chip (`⧖ 3 HTTP · 1 WS · 2 actors`) — F-C4 entry. |
+| SSR indicator chip (`📄 SSR @ <hash>`) — S-C1 entry. |
+| Expanded event-list badge taxonomy on L2 rows: `🌐 🔌 📄 🌊 🤖 🧭` (F-C1, R-C1, S-C1). |
+
+---
+
+## §5 The recurring root causes
+
+Across all four areas, the recurring root-cause categories are:
+
+1. **Wall-clock / timing races** (stale tokens, stale epochs, retry
+   timing, hydration timing).
+2. **Boundary diffs** (server vs client, parent vs child, request vs
+   response, before vs after).
+3. **Cascade propagation** (parent destroys child, route triggers
+   loaders, flow cascade halts, event triggers multiple fxs).
+4. **Schema rejection / validation failures** (Malli explanations buried
+   in traces).
+5. **Resource lifecycle** (per-frame teardown, instance destruction,
+   response accumulator clearing).
+
+These five root-cause categories map 1:1 to the five visual idioms in
+[§1](#1-the-five-visual-idioms). The matrix is the answer: a debugger that
+excels at these five idioms — regardless of which surface they appear on —
+is the design target. Causa's existing chrome (cascade-as-unit,
+spine-binding, source-coord stamping) is the right substrate; this doc's
+20 cells specify the richer renderings for these specific idioms.
+
+---
+
+## §6 Sequencing
+
+A phase plan that turns the matrix into PR-sized work. Each phase is
+sequenced so authors see compounding improvement week over week.
+
+### Phase 1 — Quick wins compound (4 PRs)
+
+1. **Badge expansion + routing badge** (F-C1, R-C1, S-C1) — add `🔌 📄 🌊
+   🧭` to L2 event-list row badges; add SSR indicator to ribbon.
+2. **`:rf/route` slice always-visible + per-event route-chain + match-rank
+   tooltip** (R-C2, R-C5, R-C9) — App-db tab and Event tab inline content.
+3. **Machine quick wins** (M-C1 guard-verdict overlay + M-C4 `:invoke-all`
+   join card + M-C5 per-instance trace + M-C8 path-walked + M-C9 spawn-ancestry).
+4. **Effect surface quick wins** (F-C3 retry timeline + F-C5 stale badge
+   + F-C6 source-coord chip + F-C8 flow-cascade-halt alarm + F-C9
+   skipped-on-platform tally).
+
+Each is a small PR (<300 LoC); each lights up a meaningful workflow.
+
+### Phase 2 — `:after` timer rings + Hydration first surface (3 PRs)
+
+5. **M-C2 — `:after` timer countdown rings.** Big visual addition to
+   Machines tab. Animated ring around state nodes.
+6. **S-C3 — Hydration diff in App-db tab.** Pre-hydrate vs post-hydrate
+   sticky watch.
+7. **S-C4 + S-C5 + S-C6 — SSR inspectors** (payload policy verdict +
+   error projection trace + head model inspector).
+
+### Phase 3 — Hero features (3 PRs)
+
+8. **F-C2 — Wire-boundary diff.** The hero managed-effects feature. One
+   template per surface (HTTP / WS / invoke / server / flow).
+9. **S-C2 — Hydration mismatch bisector.** The hero SSR feature. Needs
+   canonical-EDN bisector + sub-attribution at hydration time.
+10. **M-C3 — Cancellation cascade visualiser.** The hero machine feature.
+    Needs cascade-grouping projection.
+
+### Phase 4 — Cross-cutting + ambitious (3 PRs)
+
+11. **R-C3 — Nav-token timeline + cross-surface stale-suppression badges.**
+    Generalises the swimlane primitive across nav-tokens, machine `:after`
+    epochs, WebSocket connection epochs.
+12. **F-C4 — Active managed-effects dashboard.** Ribbon chip + popover
+    dashboard.
+13. **F-C10 / S-C10 — Streaming SSR boundary timeline.**
+
+### Phase 5 — Polish + operational (when in real use)
+
+- S-C8 — Per-request frame teardown auditor summary.
+- M-C6 — Hierarchical state cascade highlighter (animation).
+- M-C7 — Microstep loop visualiser.
+- M-C10 — Snapshot diff visualisation across transitions.
+- R-C8 — URL vs slice drift watchdog.
+- S-C11 — Side-by-side SSR replay (post-v1 dream).
+
+---
+
+## §7 Open design questions (Mike's iteration surface)
+
+These are the locked-but-iterable decisions where Mike may want to push
+back after reading the spec as the destination:
+
+1. **Hydration tab vs popover vs Issues-inline.** The bisector (S-C2)
+   deserves more than a row. Options:
+   - **(a)** Add Hydration as a **conditional 7th tab** (visible only
+     when SSR is detected for the session). Tab count goes from 6 → 6-or-7.
+   - **(b)** Promote it to an inline panel inside the Issues tab. Stays
+     at 6.
+   - **(c)** Make it a `h`-keyboard popover (consistent with Causality
+     `c` and Nav-token `r`).
+   - **Lean: (c).** Keeps the chrome at 6 tabs; joins the popover
+     pattern. But "always visible when relevant" is a strong (a) argument.
+
+2. **Active managed-effects dashboard placement.**
+   - **(a)** New dashboard, accessed via Cmd-K palette only.
+   - **(b)** Inside the Trace tab as a sticky header above the firehose.
+   - **(c)** Per-frame chip in the L1 ribbon. `⧖ 3 HTTP · 1 WS · 2
+     actors` with click → opens the dashboard.
+   - **Lean: (c).** Ribbon chip is one-glance operational; dashboard as
+     popover is one click away.
+
+3. **Security advisor voice (open-redirect, trusted-shell, payload
+   leak).**
+   - **(a)** Quiet, surface-only. Show the warning if asked; don't push.
+   - **(b)** Loud, push to Issues tab. Make security mistakes a
+     first-class issue.
+   - **(c)** Configurable via Settings. Default to (a); power-users opt
+     into (b).
+   - **Lean: (a) for v1; (c) when patterns stabilise.** Causa is a
+     debugger, not a linter.
+
+4. **Per-request frame teardown auditor (S-C8) — Causa or tests?**
+   - **(a)** Causa shows it dev-mode-only (slow path on every per-request
+     frame destroy).
+   - **(b)** Ship as a separate testing tool (load-test fixture); Causa
+     surfaces nothing.
+   - **(c)** Causa surfaces only the SUMMARY; deep audit lives in tests.
+   - **Lean: (c).** Summary is a "did anything leak this session?" gut
+     check; the deep audit is CI-grade.
+
+5. **Wire-boundary diff (F-C2) — per-fx-id renderer hook?**
+   - **(a)** Hardcode 5 templates — one per managed-effect surface.
+   - **(b)** Each managed-effect surface registers its own per-fx-id
+     renderer. New surfaces extend by registering.
+   - **(c)** Single generic template that all 5 surfaces approximate.
+   - **Lean: (b).** Matches the framework's open-extension pattern.
+
+---
+
+<a id="findings-anchor"></a>
+
+## §8 Findings provenance
+
+This spec distils the following findings (local-only, in
+`ai/findings/`):
+
+- **[2026-05-18 cross-cutting design]** —
+  `ai/findings/2026-05-18-causa-ssr-machines-routes-fx-debugging.md`
+  (1404 LoC). The primary source for §2 bug catalogues, §3 matrix, and §6
+  sequencing.
+- **[2026-05-17 Causa consolidated design]** —
+  `ai/findings/2026-05-17-causa-consolidated-design.md` (2016 LoC). The
+  locked R3 design vocabulary + the 6-tab inventory + the 4-layer chrome
+  + the spine-binding architecture this all hangs off.
+- **[2026-05-17 re-frame-10x vs Causa workflows]** —
+  `ai/findings/2026-05-17-re-frame-10x-vs-causa-workflows.md` (492 LoC).
+  The W1-W18 workflow catalogue + the gap analysis (Gap A through Gap I)
+  that informed cross-tab rendering decisions.
+- **[2026-05-17 Causa machine design]** —
+  `ai/findings/causa-machines-design-2026-05-17.md` (619 LoC) +
+  `ai/findings/causa-uc1-simulation-design-2026-05-17.md`. The UC1/UC2
+  machine-inspector architecture that grounds §2.1.
+- **[2026-05-17 10x config options]** —
+  `ai/findings/2026-05-17-10x-config-options-for-causa.md` (390 LoC). The
+  30+ `configure!` keys that inform [`015-Configuration.md`](015-Configuration.md).
+- **[2026-05-17 event-spine pass 2]** —
+  `ai/findings/2026-05-17-causa-event-spine-design-pass-2.md` (881 LoC).
+  The 10x-respect 4-layer chrome design that grounds
+  [`018-Event-Spine.md`](018-Event-Spine.md).
+
+The findings carry the design-by-bug reasoning that this normative spec
+condenses into requirements. Where the spec is opinionated (a "MUST"
+clause), the findings carry the discussion that locked the opinion.
+
+---
+
+## §9 Cross-references
+
+- [`000-Vision.md`](000-Vision.md) — the claim, the five canonical
+  questions, the audience, the "where Causa fits" diagram.
+- [`018-Event-Spine.md`](018-Event-Spine.md) — the 4-layer chrome
+  contract; the spine sub; the 6-tab inventory; the popover invocation
+  contract.
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) — the Machines
+  tab's full feature spec; this doc's §2.1 catalogues the bug classes
+  that motivate each feature there.
+- [`006-Hydration-Debugger.md`](006-Hydration-Debugger.md) — the SSR
+  hydration mismatch bisector spec; this doc's §2.3 catalogues the bug
+  classes.
+- [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) — the Event-tab,
+  Issues-tab, Routes-content, Flows-content per-tab contracts; the
+  wire-boundary diff, server error projection, head model inspector,
+  retry timeline, on-match chain, pending-navigation card, and route-chain
+  visualiser all land here.
+- [`013-Trace-Bus.md`](013-Trace-Bus.md) — the trace fattening contract
+  that enables context-at-position (Phase 5 prereq for per-instance
+  replay).
+- [`015-Configuration.md`](015-Configuration.md) — the `configure!` keys
+  including `:filters/auto-hide-events`, `:buffer/retained-epochs`,
+  `:theme`, `:keybinding/bindings`.
+- [`spec/Managed-Effects.md`](../../../spec/Managed-Effects.md) — the
+  eight-property contract uniformly satisfied across HTTP, WebSocket,
+  `:invoke`, `:rf.server/*`, flows. This doc's wire-boundary diff (F-C2)
+  is its visible UI.
+- [`spec/Pattern-StaleDetection.md`](../../../spec/Pattern-StaleDetection.md)
+  — the cross-cutting stale-detection pattern. Causa's
+  stale-suppression tally (F-C5) and the nav-token timeline (R-C3) are
+  both visual treatments of this pattern.

--- a/tools/causa/spec/README.md
+++ b/tools/causa/spec/README.md
@@ -1,29 +1,135 @@
 # Causa — Spec
 
+This folder is the **vision-of-record** for Causa. It describes the full
+destination: the surfaces Causa will eventually offer, the bug-classes
+each surface answers, the chrome they live in. Where v1 ships only part
+of a surface, the spec says "v1 ships X; **future:** Y" — and **Y is the
+main read**.
+
 ## Files
 
-- **[000-Vision.md](000-Vision.md)** — Causa, the re-frame2 devtools panel; the five canonical questions an app's programmer should answer in seconds.
-- **[001-Causality-Graph.md](001-Causality-Graph.md)** — Causality graph as a peer panel — the deeper-walk view when a cascade spans frames or 30+ events.
-- **[002-Time-Travel.md](002-Time-Travel.md)** — Bottom-rail time-travel scrubber: walk history without disturbing the live app; rewind is explicit and confirmed.
-- **[003-Machine-Inspector.md](003-Machine-Inspector.md)** — Stately-quality state-chart per registered machine, embedded via `tools/machines-viz/`.
-- **[004-App-DB-Diff.md](004-App-DB-Diff.md)** — Slice-centric (not tree-centric) `app-db` panel: only the slices that changed this epoch, plus pinned watches.
-- **[005-Schema-Timeline.md](005-Schema-Timeline.md)** — Temporal surface for silent schema-violation traces from Spec 010 + Spec 009.
-- **[006-Hydration-Debugger.md](006-Hydration-Debugger.md)** — SSR hydration-mismatch debugger: renders the structured Spec 011 emissions no other JS devtool surfaces.
-- **[007-UX-IA.md](007-UX-IA.md)** — Typography, colour tokens, animation timings, keyboard maps, density gradients — the pixels-that-feel-right reference.
-- **[008-Embedding-Contract.md](008-Embedding-Contract.md)** — Per-panel `Panel` component contract so Story (and others) can embed Causa surfaces outside Causa's own chrome.
-- **[011-Launch-Modes.md](011-Launch-Modes.md)** — In-app true-inline host and standalone-via-MCP remote-attach.
-- **[012-Views.md](012-Views.md)** — Views tab: three-group layout (mounted / re-rendered / unmounted); subs nested under each view row with return values; cluster-large-grids (≥ 50 same-identity-key); heatmap mode; per-component inline drilldown with props-diff headline. Replaces the pre-rewrite Subscriptions panel — subs are nested under their views, not a separate tab.
-- **[013-Trace-Bus.md](013-Trace-Bus.md)** — The trace-bus + collector contract: the ring-buffer data plane every panel reads from, the consumer-side filter algebra, and the `:sensitive?` privacy gate.
-- **[014-Registry-Catalogue.md](014-Registry-Catalogue.md)** — Normative enumeration of every `:rf.causa/*` subscription, event, effect, and instrumentation callback Causa registers (~155 ids), grouped by owning panel.
-- **[015-Configuration.md](015-Configuration.md)** — `configure!` entry-point contract: every accepted key, default, and the `:rf/causa` app-db slot it drives.
-- **[016-Auxiliary-Panels.md](016-Auxiliary-Panels.md)** — Per-tab content contract for tabs beyond the hero 4-layer chrome (event-detail, issues-ribbon, routes content, flows content): inputs (subs / events consumed), main interactions, observable outputs (rf2-3lduz).
-- **[017-Test-Coverage-Matrix.md](017-Test-Coverage-Matrix.md)** — Browser-feature coverage matrix for every Causa panel/feature: user-visible contract, required testbed affordance, direct and failure paths, 20-event/load re-check, diagnostics, owning gate, and current status.
-- **[018-Event-Spine.md](018-Event-Spine.md)** — The architectural core: 4-layer chrome (ribbon · event list · tab bar · detail panel), spine sub `:rf.causa/focus`, 6-tab inventory, ribbon anatomy, IN/OUT filter pills, frame-observation isolation invariants, Settings modal popup, Causality popover, keyboard map, data-classification rendering contract. Reading order: read this FIRST for the architectural shape, then the per-tab specs (003 Machines, 004 App-db, 012 Views, 016 Event/Issues, 013 Trace) for content.
-- **[API.md](API.md)** — Consolidated user-facing reference: installation, configuration, public surface; per-area specs are normative.
-- **[Principles.md](Principles.md)** — Causa-specific load-bearing principles (read-only-by-default, etc.); cites framework `Principles.md` where they overlap.
-- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — The 13 direction-setting decisions: question, options, pick, why, date locked.
-- **[findings/](findings/)** — Exploratory working substrate (Causa UX/UI design, 10x-v2 blank-slate design); audit lineage, not normative.
+### Read these first (the architectural spine)
 
-## How to use
+- **[000-Vision.md](000-Vision.md)** — The claim. Causa shows you what
+  happens when an event fires. The five canonical questions; the audience;
+  the "two doors" split (Causa = human; pair2-mcp = AI); the 6-tab
+  inventory.
+- **[018-Event-Spine.md](018-Event-Spine.md)** — The architectural core:
+  the 4-layer chrome (ribbon · event list · tab bar · detail panel), the
+  spine sub `:rf.causa/focus`, the 6-tab inventory, the popover invocation
+  contract, the data-classification rendering contract. Reading order:
+  read THIS after 000-Vision, then per-tab specs.
+- **[019-Cross-Cutting-Insight.md](019-Cross-Cutting-Insight.md)** — The
+  **5 idioms × 4 areas** matrix. How Causa accommodates SSR, Machines,
+  Routes, Managed-Effects without growing tabs. The bug-class catalogue
+  for each area. Sequenced PR plan (Phase 1–5).
 
-This folder is complete enough to one-shot the tool. Read [`000-Vision.md`](000-Vision.md) first to anchor *why*; the capability docs (001–016) are normative — each owns its surface and is independent of the others bar explicit cross-references. [`Principles.md`](Principles.md) and [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) capture the locks. [`API.md`](API.md) is the consolidated reference. `findings/` preserves the audit lineage and is never normative.
+### Per-tab content specs
+
+- **[001-Causality-Graph.md](001-Causality-Graph.md)** — The Causality
+  popover (`c`-key). Peer affordance — first-class, but not the front
+  door. v1: single-axis vertical; future: hybrid LR-ancestors +
+  TB-descendants per-region layout; resizable + per-session persistence;
+  machine-edge types (spawn / final / `:invoke-all` join).
+- **[002-Time-Travel.md](002-Time-Travel.md)** — Time-travel scrubber:
+  passive scrubbing rebases panels; explicit `r` rewinds the runtime; six
+  named restore failures surface as a modal. Pins survive ring-buffer
+  age-out. Future: branch-and-explore; "find me when path P last changed"
+  walker.
+- **[003-Machine-Inspector.md](003-Machine-Inspector.md)** — The Machines
+  tab. UC1 simulation + UC2 dynamic Mode A/B/C; cancellation cascade
+  visualiser; `:after` timer countdown rings; `:invoke-all` join
+  inspector; per-instance "why am I stuck" trace; shift-click divergence;
+  ELK+SVG primitive Causa-internal. **The bug catalogue at the bottom
+  (M.1–M.10) is the per-feature motivation.**
+- **[004-App-DB-Diff.md](004-App-DB-Diff.md)** — Slice-centric (not
+  tree-centric) app-db panel. Future: branch-aware diff (for Story
+  sim-clones); cross-frame diff; pin-two-epochs side-by-side.
+- **[005-Schema-Timeline.md](005-Schema-Timeline.md)** — Per-schema
+  timeline; empty→non-empty flash; full Malli explanation in detail.
+- **[006-Hydration-Debugger.md](006-Hydration-Debugger.md)** — The
+  hydration mismatch bisector. Hero SSR feature. Side-by-side server vs
+  client with sub-attribution + likely-cause hypothesis. Future
+  sections: server error projection trace; payload-policy verdict; head
+  model inspector; per-request frame teardown auditor; streaming SSR
+  boundary timeline; side-by-side SSR replay (post-v1 dream).
+- **[007-UX-IA.md](007-UX-IA.md)** — Typography, colour tokens, animation
+  timings, keyboard maps, density gradients — the pixels-that-feel-right
+  reference.
+- **[008-Embedding-Contract.md](008-Embedding-Contract.md)** — Per-panel
+  `Panel` component contract so Story (and others) can embed Causa
+  surfaces outside Causa's own chrome.
+- **[011-Launch-Modes.md](011-Launch-Modes.md)** — In-app true-inline
+  host and standalone-via-MCP remote-attach.
+- **[012-Views.md](012-Views.md)** — Views tab: three-group layout
+  (mounted / re-rendered / unmounted); subs nested under each view row;
+  cluster-large-grids; heatmap mode; per-component inline drilldown.
+  Replaces the legacy Subscriptions panel.
+- **[013-Trace-Bus.md](013-Trace-Bus.md)** — The trace-bus + collector
+  contract: the ring-buffer data plane every panel reads from, the
+  consumer-side filter algebra, the `:sensitive?` privacy gate. Future:
+  trace fattening to enable context-at-position (Phase 5 prereq for
+  per-instance replay).
+- **[014-Registry-Catalogue.md](014-Registry-Catalogue.md)** — Normative
+  enumeration of every `:rf.causa/*` subscription, event, effect, and
+  instrumentation callback Causa registers (~155 ids), grouped by owning
+  panel.
+- **[015-Configuration.md](015-Configuration.md)** — `configure!`
+  entry-point contract. v1 ships ~5 keys; future: full 30+ keys
+  (auto-hide filters, theme, retained-epochs, keybindings, factory-reset,
+  ns-aliases, etc.).
+- **[016-Auxiliary-Panels.md](016-Auxiliary-Panels.md)** — Per-tab
+  content contract for the Event tab, Issues ribbon, Routes content,
+  Flows content. Future: wire-boundary diff per managed fx;
+  `:on-match` event chain; pending-navigation card; route-chain
+  visualiser; head model inspector; retry timeline; full 6-section
+  Settings popup (Keybindings, Buffer, Popout, Actions in addition to
+  v1's 4).
+- **[017-Test-Coverage-Matrix.md](017-Test-Coverage-Matrix.md)** —
+  Browser-feature coverage matrix. Future: bug-class coverage column
+  ensures every bug-class in spec has at least one test-row.
+
+### Reference
+
+- **[API.md](API.md)** — Consolidated user-facing reference: installation,
+  configuration, public surface.
+- **[Principles.md](Principles.md)** — Causa-specific load-bearing
+  principles (read-only-by-default, etc.).
+- **[Conventions.md](Conventions.md)** — Causa's reserved namespaces,
+  IDs, etc.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — The direction-setting
+  decisions: question, options, pick, why, date locked.
+- **[findings/](findings/)** — Exploratory working substrate; audit
+  lineage, not normative.
+
+## How to use this spec
+
+1. **Read [`000-Vision.md`](000-Vision.md) first.** Anchors the claim
+   ("Causa shows you what happens when an event fires") and the five
+   canonical questions.
+2. **Read [`018-Event-Spine.md`](018-Event-Spine.md) next** for the
+   chrome architecture — the 4-layer + spine + 6 tabs + popovers.
+3. **Read [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md)
+   third** for the matrix of features across the four cross-cutting areas
+   (SSR · Machines · Routes · Managed-Fx).
+4. **Then per-tab specs (003 Machines, 004 App-db, 006 Hydration, 012
+   Views, 013 Trace, 016 Event/Issues)** for the specific surfaces. Each
+   is independent of the others bar explicit cross-references.
+
+The 19-doc set is complete enough to one-shot the tool. Where v1's
+shipping surface and the spec's destination differ, the spec wins as the
+direction-setter; v1's staged delivery is called out in "v1 ships X;
+future: Y" markers in the per-tab specs.
+
+## Bug-driven design discipline
+
+Every feature in this spec is motivated by a concrete bug-class. The
+uniform structure:
+
+> **Bug class:** what the user is staring at when the question forms.
+> **Example bug:** the vignette — "you dispatched X, expected Y, got Z because W."
+> **Insight Causa provides:** what the user SEES that resolves the mystery.
+> **Affordance:** the UI surface + interaction model.
+
+When in doubt, add the bug; don't add the feature. The spec is auditable
+against this rule.


### PR DESCRIPTION
## Mike's brief (verbatim)

> "I need the tools/causa/spec to be the complete vision for where we are
> going to end up."
>
> "We might yet need to iterate on it."
>
> "The main purpose of Causa is **deep insight**. Its claim should be similar
> to re-frame-10x's — see the README."
>
> "re-frame2 is very event-oriented, so Causa should be oriented the same
> way, **one event at a time analysis**. But there are cross-cutting
> concerns like SSR, Routes, Machines, etc."
>
> "**Drive all design from example bugs** that a user might be trying to
> find, or from the insight that the programmer is seeking."

## Summary

Rewrites `tools/causa/spec/` so it reads as the **destination** Causa is
heading toward, not the current shipping surface. Every major feature is
anchored on a concrete bug-class via the uniform structure:

> **Bug class** → **Example bug** → **Insight Causa provides** → **Affordance**

Cross-cutting concerns (SSR · Machines · Routes · Managed-Effects) are
treated as **deep specialised renderings inside the existing 6 tabs** via
5 reusable visual idioms — they do NOT add tabs.

## Per-file LoC delta

| File | Delta | What changed |
|---|---|---|
| `000-Vision.md` | +93 / -3 | Lead with claim ("Causa shows you what happens when an event fires"); one-event spine model; bug-driven principle |
| `001-Causality-Graph.md` | +104 | Bug-class header; hybrid LR-ancestors+TB-descendants vision; resizable popover; machine-edge types |
| `002-Time-Travel.md` | +80 | Bug-class header; branch-and-explore vision; find-when-path-changed walker |
| `003-Machine-Inspector.md` | +293 | Bug catalogue M.1–M.10 (guard-verdict, `:after` rings, cancellation cascade, `:invoke-all` join, per-instance trace, hierarchical cascade, microsteps, path-walked, spawn-ancestry, snapshot diff) |
| `004-App-DB-Diff.md` | +78 | Bug-class header; branch-aware diff; cross-frame; pin-two-epochs |
| `005-Schema-Timeline.md` | +35 | Bug-class header |
| `006-Hydration-Debugger.md` | +176 | Hero SSR feature reframed (bisector + sub-attribution + likely-cause); 6 future affordances |
| `007-UX-IA.md` | +34 | Lead with one-event-spine model as top-level statement |
| `008-Embedding-Contract.md` | +45 | Story preset round-tripping; per-story state snapshots via share-URL |
| `011-Launch-Modes.md` | +62 | pair2 raw-nREPL launch path; multi-instance Causa coordination via BroadcastChannel |
| `012-Views.md` | +38 | Bug-class header |
| `013-Trace-Bus.md` | +41 | Trace fattening for context-at-position (Phase 5 prereq); wall-clock axis vision |
| `014-Registry-Catalogue.md` | +27 | Per-id metadata for golden-path navigation |
| `015-Configuration.md` | +77 | Full 30+ `configure!` keys vision (auto-hide filters, theme, retained-epochs, keybindings, factory-reset, ns-aliases, popout-geometry, etc.) |
| `016-Auxiliary-Panels.md` | +106 | Wire-boundary diff; `:on-match` chain; retry timeline; head model inspector; pending-nav card; flow cascade-halt alarm; full 6-section Settings popup |
| `017-Test-Coverage-Matrix.md` | +25 | Bug-class coverage column vision |
| `018-Event-Spine.md` | +66 | Wider matcher scopes vision; recorder → `:play-script` Story export pipeline |
| `README.md` | +130 / -25 | Reorganised: reading order leads with 000 → 018 → 019; "vision-of-record" framing; bug-driven discipline |
| **NEW: `019-Cross-Cutting-Insight.md`** | **+917** | **The big new file — see below** |

**Total: ~2400 LoC added (gross); ~200 LoC removed.**

## NEW: `019-Cross-Cutting-Insight.md` (917 LoC)

Distils the 2026-05-18 cross-cutting findings (1404 LoC) into normative
spec. Contents:

- **§0 The strategic shape** — three structural properties; the strategic
  move (no new tabs; deep renderings inside existing tabs).
- **§1 The five visual idioms** — wall-clock timelines · boundary diffs ·
  cascade trees · schema explanations · lifecycle accounting.
- **§2 The four areas** — Machines · Routes · SSR · Managed-Effects, with
  full bug-class catalogues (M.1–M.11, R.1–R.11, S.1–S.13, F.1–F.11). Each
  bug class follows bug → example → insight → affordance.
- **§3 The 5 × 4 matrix** — 20 features, indexed.
- **§4 Surface placement** — which existing tab grows which feature; the
  3 new popovers (`c` causality · `r` nav-token timeline · `f` wire-trace).
- **§5 Recurring root causes** — the 5 root-cause categories that map 1:1
  to the 5 visual idioms.
- **§6 Sequencing** — Phase 1 (quick wins) → Phase 5 (polish), with PR
  granularity.
- **§7 Open design questions** for Mike's iteration pass.
- **§8 Findings provenance** — full cross-reference back to source findings.

## Major reframes (sections rewritten in bug-driven structure)

1. **000-Vision** — entirely re-led with the re-frame-10x-style claim.
2. **003-Machine-Inspector** — bottom of doc grew a 10-bug-class catalogue
   (M.1–M.10), each with bug → example → insight → affordance.
3. **006-Hydration-Debugger** — bisector + sub-attribution + likely-cause
   hypothesis promoted from "v1 ships X" to the headline reading; 6
   forward-vision affordances added.
4. **019** (NEW) — every cell in the matrix is anchored on a bug-class.

## Reading time for Mike

~45–60 minutes for the full pass. Suggested order:

1. `000-Vision.md` (the claim + the one-event-spine model)
2. `018-Event-Spine.md` (the chrome architecture — unchanged in essence,
   small vision additions)
3. `019-Cross-Cutting-Insight.md` (the new strategic file)
4. `003-Machine-Inspector.md` §The bug catalogue (the bottom)
5. `006-Hydration-Debugger.md` §Vision (the new bottom)
6. Skim the others as time allows.

## Gates

- **mkdocs --strict:** zero NEW warnings vs main. (The worktree shows 72
  pre-existing warnings vs main's 6 due to a worktree-config gap about the
  `docs/spec/` directory; none of my added files generate warnings.)
- **Internal links:** all resolve.
- **No `ai/`-tree files added or committed** (per discipline).

## Open questions for Mike's iteration pass

Flagged in `019-Cross-Cutting-Insight.md` §7 with my lean per question:

1. **Hydration debugger placement** — 7th tab (conditional) vs Issues
   inline vs `h`-popover? Spec leans (c) popover.
2. **Active managed-effects dashboard** — Cmd-K-only vs Trace sticky vs
   ribbon chip? Spec leans (c) chip.
3. **Security advisor voice** — quiet vs loud vs configurable? Spec leans
   (a) quiet for v1.
4. **Per-request frame teardown auditor** — Causa dev-mode vs tests-only
   vs summary-in-Causa-deep-in-CI? Spec leans (c).
5. **Wire-boundary diff F-C2** — hardcoded templates vs per-fx renderer
   hook vs single generic? Spec leans (b) registration-based.

The riskiest reframes (where Mike may want to push back):

- The strict "no new tabs" stance in 019 may be too tight for Hydration
  (the bisector arguably wants its own tab when SSR is in play).
- The full 30+ `configure!` keys catalogue in 015 may include keys Mike
  wants to defer indefinitely (e.g. `:render/uuids-as :identicons` is a
  delight feature, not infrastructure).
- The recorder → `:play-script` Story export in 018 promises a Story
  integration that hasn't been designed yet — if Story's `:play-script`
  shape changes, this section needs revisiting.

This bead (rf2-2rp88) stays open per the brief — Mike may iterate.