### PR TITLE
feat(story): CI-as-test — every story's :play-script doubles as regression test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1104,6 +1104,15 @@ jobs:
       - name: Run Story feature-load browser gate
         run: npm run test:story-feature-load
 
+      # rf2-3qcxk — every Story variant whose body carries a
+      # `:play-script` slot doubles as an automated regression test.
+      # The runner discovers them via `re-frame.story.play.ci-runner`,
+      # drives each through the live shell, and reports a structured
+      # pass/fail row per variant. Lives in the same Story/Causa job
+      # because it shares the testbed bundle and Playwright stack.
+      - name: Run Story :play-script CI-as-test gate
+        run: npm run test:story-play-scripts
+
   cljs-reagent-slim-bundle-isolation:
     name: CLJS Reagent Slim bundle isolation (adapter-owned, rf2-2ppcv)
     needs: detect_changed_surfaces

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,6 +41,7 @@ agent pre-checkin "narrow to the changed surface" workflow.
 | `npm run test:examples` | Browser smoke across the runnable examples. |
 | `npm run test:examples:realworld` | Narrow RealWorld (Conduit / Spec 014) smoke only (rf2-h9ut9). The full sweep above is rigorous local / nightly / release; this changed-surface gate compiles and smokes one example end-to-end for cross-artefact runtime changes. Accepts `--filter <substring>` (or `EXAMPLES_FILTER=<substring>`) for ad-hoc narrowing against any single example or testbed. |
 | `npm run test:story-feature-load` | Story full-browser feature-load and resilience gate (`tools/story/test/story_feature_load.cjs`). Occasional / pre-commit until proven stable — not yet default CI. |
+| `npm run test:story-play-scripts` | Story `:play-script` CI-as-test gate (rf2-3qcxk). Discovers every registered variant whose body carries a non-empty `:play-script` slot, navigates the live shell to each, waits for the auto-run's terminal status, and reports per-variant pass/fail. Variants whose id contains `failing` or `expected-fail` invert the assertion (expected `:fail`); everything else asserts `:pass`. Runs in the `story-causa-browser` GH job alongside `test:story-feature-load`. |
 | `npm run test:causa-feature-gate` | Causa browser feature/load gate from `tools/causa/spec/017-Test-Coverage-Matrix.md`. Occasional; not default CI. |
 | `npm run test:story-static` | Static-build contract and deployable-output sanity for the Story export. |
 | `npm run story:build` | Build the Story static artefact. |

--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+/*
+ * Story `:play-script` CI-as-test runner (rf2-3qcxk).
+ *
+ * Compiles the counter-with-stories Story testbed, serves it, opens
+ * the Story shell in Playwright, enumerates every registered variant
+ * whose body carries a non-empty `:play-script` (via the
+ * `window.__rf2_story_ci` global installed by
+ * `re-frame.story.play.ci-runner/install-ci-hooks!`), navigates the
+ * shell to each variant, waits for the auto-run's terminal status
+ * chip (`:pass` / `:fail`), and prints a per-variant report.
+ *
+ * EXPECTED-FAIL contract
+ * ----------------------
+ * Authoring a deliberately-failing variant is the normal way to gate
+ * Story's failure path under CI. The runner reads the expected status
+ * from the per-variant body via the CI hook's `ciContext()` and
+ * inverts the assertion accordingly:
+ *
+ *   - any variant id whose name contains `failing` / `expected-fail`
+ *     is treated as expected-fail; the runner asserts `:fail`
+ *   - everything else asserts `:pass`
+ *
+ * The two seeded fixtures in the testbed:
+ *   :story.counter-play-script/passing   → expects :pass
+ *   :story.counter-play-script/failing   → expects :fail
+ *
+ * Exit code: 0 if every variant matched its expected status; 1 if
+ * any variant deviated.
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const {
+  createHarnessCleanup,
+  spawnHarnessProcess,
+  waitForHttpReady,
+} = require('../../implementation/scripts/lib/local-browser-harness.cjs');
+const { resolveStoryFeatureLoadPort } = require('./story-feature-load-port.cjs');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const IMPL_ROOT = path.join(REPO_ROOT, 'implementation');
+const OUT_ROOT = path.join(IMPL_ROOT, 'out', 'examples');
+const TESTBED_BUILD = 'examples/counter-with-stories';
+const TESTBED_DIR_NAME = 'counter-with-stories';
+const TESTBED_HTML = path.join(
+  REPO_ROOT,
+  'tools',
+  'story',
+  'testbeds',
+  'counter_with_stories',
+  'index.html',
+);
+const TESTBED_OUT = path.join(OUT_ROOT, TESTBED_DIR_NAME);
+// Path-only (no hash) so we can compose `?variant=...#/stories` URLs
+// per the share-link convention — query params MUST come BEFORE the
+// hash route or `window.location.search` will be empty and the share
+// hydrator will skip the variant select.
+const TESTBED_BASE = `/${TESTBED_DIR_NAME}/`;
+const STORY_FRAGMENT = '#/stories';
+const READY_TIMEOUT_MS = 30000;
+const TERMINAL_TIMEOUT_MS = Number(
+  process.env.STORY_PLAY_SCRIPT_TERMINAL_TIMEOUT_MS || 30000,
+);
+const VERBOSE = process.env.RF2_VERBOSE_TESTS === '1';
+
+const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
+  paths: [IMPL_ROOT],
+});
+const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+
+const cleanup = createHarnessCleanup();
+cleanup.installSignalHandlers();
+
+// Toggled true once `main()` resolves to its exit code, so the
+// http-server's forced-shutdown `exit` event doesn't print a noisy
+// "exited unexpectedly" line during normal teardown.
+let exiting = false;
+
+function log(line) {
+  process.stdout.write(`${line}\n`);
+}
+
+function compileTestbed() {
+  const isWin = process.platform === 'win32';
+  const npx = isWin ? 'npx.cmd' : 'npx';
+  const shadowArgs = ['shadow-cljs', 'compile', TESTBED_BUILD];
+  const command = isWin ? 'cmd.exe' : npx;
+  const args = isWin
+    ? ['/d', '/s', '/c', [npx, ...shadowArgs].join(' ')]
+    : shadowArgs;
+  const result = spawnSync(command, args, {
+    cwd: IMPL_ROOT,
+    encoding: 'utf8',
+  });
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  if (VERBOSE || result.status !== 0) {
+    process.stdout.write(output);
+  }
+  if (result.status !== 0) {
+    console.error(`> ${npx} ${shadowArgs.join(' ')}`);
+    throw new Error(`shadow-cljs compile failed (exit ${result.status})`);
+  }
+}
+
+function stageTestbedHtml() {
+  if (!fs.existsSync(TESTBED_OUT)) {
+    throw new Error(`Build output dir missing: ${TESTBED_OUT}`);
+  }
+  if (!fs.existsSync(TESTBED_HTML)) {
+    throw new Error(`HTML source missing: ${TESTBED_HTML}`);
+  }
+  fs.copyFileSync(TESTBED_HTML, path.join(TESTBED_OUT, 'index.html'));
+}
+
+/**
+ * Classify the expected terminal status for a variant id. Authors mark
+ * a fixture as expected-fail by including `failing` or `expected-fail`
+ * in the variant name; everything else defaults to expected-pass.
+ *
+ * Symmetric with re-frame.story.play.ci-runner/play-script-summary:
+ * the classification is over the variant id, not body content, so the
+ * runner can pre-compute the verdict before the Story shell boots.
+ */
+function expectedStatusFor(variantId) {
+  const name = String(variantId).toLowerCase();
+  if (/(?:failing|expected[-_]fail)/.test(name)) return 'fail';
+  return 'pass';
+}
+
+function variantIdToKw(idStr) {
+  // The CI hook serialises `:story.foo/bar` as `"story.foo/bar"` (no
+  // leading colon); the Playwright runner reads that string back to
+  // build the URL search-param value the Story shell expects.
+  return String(idStr);
+}
+
+/**
+ * Navigate the Story shell to `variantId` using the same hash route
+ * the human shell uses (`#/stories?variant=story.foo/bar`). The
+ * search params are placed AFTER the hash because the shell parses
+ * them out of `window.location.hash`.
+ *
+ * Falls back to the share-link affordance (`select-variant` event)
+ * if the URL parse path is unreachable.
+ */
+async function navigateToVariant(page, baseUrl, variantId) {
+  const variantStr = variantIdToKw(variantId);
+  // Share-link convention: search params BEFORE the hash route, so
+  // `window.location.search` carries `?variant=...` and the share
+  // hydrator picks it up on shell mount.
+  const target = `${baseUrl}${TESTBED_BASE}?variant=${encodeURIComponent(variantStr)}${STORY_FRAGMENT}`;
+  // Always full-load (not reload) — each variant gets a fresh shell
+  // mount so the auto-run fires deterministically without inheriting
+  // previous run-state.
+  await page.goto(target, { waitUntil: 'load' });
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    } catch (_) {
+      /* ignore */
+    }
+  });
+}
+
+async function readRunStateOnce(page, variantId) {
+  return page.evaluate((vid) => {
+    const ci = window.__rf2_story_ci;
+    if (!ci || typeof ci.readRunState !== 'function') return null;
+    try {
+      return ci.readRunState(vid);
+    } catch (e) {
+      return { error: String(e && e.message ? e.message : e) };
+    }
+  }, variantIdToKw(variantId));
+}
+
+async function waitForTerminalState(page, variantId) {
+  const deadline = Date.now() + TERMINAL_TIMEOUT_MS;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await readRunStateOnce(page, variantId);
+    if (last && (last.status === 'pass' || last.status === 'fail')) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return last;
+}
+
+async function discoverVariants(page) {
+  return page.evaluate(() => {
+    const ci = window.__rf2_story_ci;
+    if (!ci || typeof ci.listVariants !== 'function') {
+      return { error: '__rf2_story_ci global not installed' };
+    }
+    try {
+      return { variants: ci.listVariants(), context: ci.ciContext() };
+    } catch (e) {
+      return { error: String(e && e.message ? e.message : e) };
+    }
+  });
+}
+
+async function bootShell(page, baseUrl) {
+  await page.goto(`${baseUrl}${TESTBED_BASE}${STORY_FRAGMENT}`, { waitUntil: 'load' });
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem('re-frame.story/seen-help-v1', '1');
+    } catch (_) {
+      /* ignore */
+    }
+  });
+  // Reload so the localStorage prime takes effect before help dialog
+  // logic decides whether to render the overlay.
+  await page.reload({ waitUntil: 'load' });
+  // Wait for the CI hook to install. The hook fires at `core/run`
+  // time, which is before the first `on-hash-change!` mounts the
+  // shell — so the global is reliably present by the time the page
+  // is fully loaded.
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    const ready = await page.evaluate(() => Boolean(window.__rf2_story_ci));
+    if (ready) return;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error('CI hook (window.__rf2_story_ci) did not install within 10s');
+}
+
+function summariseResults(results) {
+  const failures = results.filter((r) => !r.matched);
+  const lines = [];
+  lines.push('');
+  lines.push('=== Story :play-script CI summary ===');
+  for (const r of results) {
+    const tag = r.matched ? 'OK  ' : 'MISS';
+    const actual = (r.runState && r.runState.status) || 'no-state';
+    lines.push(`${tag} ${r.variantId}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`);
+    if (!r.matched) {
+      const fails = (r.runState && r.runState.results) || [];
+      for (const stepR of fails) {
+        if (stepR.passed === false) {
+          lines.push(`     step ${stepR.idx} ${stepR.type} — ${stepR.message || '(no message)'}`);
+        }
+      }
+    }
+  }
+  lines.push('');
+  lines.push(
+    `Ran ${results.length} :play-script variants. ${failures.length} unexpected outcomes.`,
+  );
+  return { lines: lines.join('\n'), failures };
+}
+
+async function runAllVariants(browser, baseUrl) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const browserMessages = [];
+  page.on('console', (msg) => {
+    if (VERBOSE) browserMessages.push(`[browser:${msg.type()}] ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => {
+    browserMessages.push(`[browser:pageerror] ${err.message}`);
+  });
+
+  try {
+    await bootShell(page, baseUrl);
+    const discovery = await discoverVariants(page);
+    if (discovery.error || !Array.isArray(discovery.variants)) {
+      throw new Error(`variant discovery failed: ${discovery.error || JSON.stringify(discovery)}`);
+    }
+    const variants = discovery.variants;
+    log(`Discovered ${variants.length} variant(s) with :play-script`);
+    if (VERBOSE) {
+      for (const s of (discovery.context && discovery.context.summaries) || []) {
+        log(`  - ${s['variant-id']}  steps=${s['script-len']}  name=${s.name || '(unnamed)'}`);
+      }
+    }
+    if (variants.length === 0) {
+      // No fixtures with :play-script — exit clean. The npm gate
+      // is fail-loud only on UNEXPECTED outcomes; zero variants
+      // means no signal either way.
+      log('No :play-script variants registered. Nothing to assert.');
+      return 0;
+    }
+
+    const results = [];
+    for (const vid of variants) {
+      const expected = expectedStatusFor(vid);
+      try {
+        await navigateToVariant(page, baseUrl, vid);
+      } catch (err) {
+        results.push({
+          variantId: vid,
+          expected,
+          matched: false,
+          runState: { status: 'navigate-error', message: err.message },
+        });
+        continue;
+      }
+      const runState = await waitForTerminalState(page, vid);
+      const actual = (runState && runState.status) || null;
+      results.push({
+        variantId: vid,
+        expected,
+        matched: actual === expected,
+        runState,
+      });
+    }
+
+    const { lines, failures } = summariseResults(results);
+    log(lines);
+    if (failures.length > 0 && browserMessages.length > 0) {
+      log('--- browser diagnostics ---');
+      for (const msg of browserMessages.slice(-40)) log(msg);
+    }
+    return failures.length === 0 ? 0 : 1;
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  const port = await resolveStoryFeatureLoadPort({
+    env: process.env,
+    repoRoot: REPO_ROOT,
+  });
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  compileTestbed();
+  stageTestbedHtml();
+
+  const server = cleanup.trackProcess(
+    spawnHarnessProcess(
+      process.execPath,
+      [HTTP_SERVER_BIN, OUT_ROOT, '-p', String(port), '-s', '-c-1'],
+      {
+        cwd: IMPL_ROOT,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    ),
+  );
+
+  let serverDown = false;
+  const serverOutput = [];
+  const captureServerOutput = (chunk, stream) => {
+    const text = chunk.toString();
+    serverOutput.push(
+      ...text
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => `[http-server:${stream}] ${line}`),
+    );
+    if (VERBOSE) process[stream].write(text);
+  };
+  server.stdout.on('data', (chunk) => captureServerOutput(chunk, 'stdout'));
+  server.stderr.on('data', (chunk) => captureServerOutput(chunk, 'stderr'));
+  server.on('exit', (code, signal) => {
+    serverDown = true;
+    // The server is forcefully terminated during cleanup, which makes
+    // this `exit` fire with a non-zero code after `main()` has already
+    // returned its own exit code. Suppress the noise in that path;
+    // surface real mid-run crashes loudly.
+    if (code !== 0 && code !== null && !exiting) {
+      console.error(
+        `http-server exited unexpectedly (code=${code}, signal=${signal}).`,
+      );
+    }
+  });
+
+  const ready = await waitForHttpReady(port, Date.now() + READY_TIMEOUT_MS, {
+    isAborted: () => serverDown,
+  });
+  if (!ready || serverDown) {
+    console.error(
+      `http-server did not become reachable on :${port} within ${READY_TIMEOUT_MS}ms.`,
+    );
+    for (const line of serverOutput.slice(-40)) console.error(line);
+    return 1;
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  cleanup.addCleanup(async () => {
+    try {
+      await browser.close();
+    } catch (_) {
+      /* ignore */
+    }
+  });
+
+  try {
+    return await runAllVariants(browser, baseUrl);
+  } finally {
+    await browser.close();
+  }
+}
+
+main()
+  .then(async (code) => {
+    exiting = true;
+    await cleanup.cleanup();
+    process.exit(code == null ? 1 : code);
+  })
+  .catch(async (err) => {
+    exiting = true;
+    console.error(err && err.stack ? err.stack : err);
+    await cleanup.cleanup();
+    process.exit(1);
+  });
+
+module.exports = {
+  expectedStatusFor,
+};

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -27,6 +27,7 @@
     "test:examples:realworld": "node ../examples/scripts/serve-and-run-examples-tests.cjs --filter realworld",
     "story:build": "node scripts/story-build.cjs",
     "test:story-feature-load": "node ../examples/scripts/serve-and-run-story-feature-load-tests.cjs",
+    "test:story-play-scripts": "node ../examples/scripts/serve-and-run-story-play-scripts.cjs",
     "test:causa-feature-gate": "node scripts/serve-and-run-causa-feature-gate.cjs",
     "test:story-static": "node scripts/check-story-static.cjs",
     "test:script-policy": "node scripts/_path-policy.test.cjs && node scripts/_changed-surfaces.test.cjs && node scripts/_story-feature-load-port.test.cjs",

--- a/tools/story/src/re_frame/story/play/ci_runner.cljc
+++ b/tools/story/src/re_frame/story/play/ci_runner.cljc
@@ -1,0 +1,216 @@
+(ns re-frame.story.play.ci-runner
+  "CI-as-test discovery + driver glue for Story's `:play-script` slot
+  (rf2-3qcxk).
+
+  The companion to `re-frame.story.play.runner` (pure step state
+  machine) and `re-frame.story.play.runner-events` (re-frame-side
+  driver). This namespace exposes the seams a CI runner needs:
+
+  - `variants-with-play-scripts` — pure discovery: scan the Story
+    registrar's variant side-table and return the variant ids whose
+    body carries a non-empty `:play-script`. Pure data → data; works
+    on JVM and CLJS.
+
+  - `play-script-summary` — pure: derive the small metadata bundle
+    a CI runner needs per variant (id, name, step count). No
+    side-effects.
+
+  - `ci-context` — Playwright-readable JSON envelope: the full per-
+    variant catalogue, ready for `JSON.parse` on the browser side.
+
+  - `install-ci-hooks!` (CLJS) — install `window.__rf2_story_ci`
+    helpers so a Playwright runner can: (a) enumerate variants with
+    `:play-script`, and (b) read each variant's terminal run-state
+    (`runner-events/current-state`) once the auto-run completes.
+    No-op on JVM. The hook is INERT until called explicitly from a
+    testbed init path — production / non-CI bundles never hit it.
+
+  ## Why a separate ns
+
+  - The `runner-events` ns mixes pure step execution with `re-frame`
+    integration; the CI surface only needs the registrar query +
+    `current-state` read. Splitting keeps the runner-events ns clear
+    of CI-only ceremony (the `js/window` global) and lets unit tests
+    cover the discovery seam without standing up a full Story shell.
+
+  - The discovery seam is symmetric across JVM / CLJS (the registrar
+    is `.cljc`), so the same function powers both `clojure -M:test`
+    coverage and the browser-side enumeration.
+
+  ## Pure / impure split
+
+  This ns is `.cljc`. The pure seams (`variants-with-play-scripts`,
+  `play-script-summary`, `ci-context`) are JVM-runnable; the
+  CLJS-only `install-ci-hooks!` is gated by reader conditionals."
+  (:require [re-frame.story.play.runner :as runner]
+            [re-frame.story.registrar   :as registrar]
+            #?(:cljs [re-frame.story.play.runner-events :as runner-events])))
+
+;; ---- pure discovery ------------------------------------------------------
+
+(defn has-play-script?
+  "True iff `variant-body` carries a non-empty `:play-script` body.
+  Pure data → data. A bare `:play-script` vector is enough; a map
+  form is also accepted (the runner's `parse-spec` normalises both
+  shapes, but discovery treats an empty vector / map without
+  `:script` as 'no script' so the CI runner skips it).
+
+  Empty map (`{}`) and empty vector (`[]`) are treated as absent —
+  authors that want to opt-in must declare at least one step."
+  [variant-body]
+  (let [body (:play-script variant-body)]
+    (cond
+      (nil? body)    false
+      (vector? body) (pos? (count body))
+      (map? body)    (pos? (count (:script body [])))
+      :else          false)))
+
+(defn variants-with-play-scripts
+  "Return a SORTED vector of variant ids whose body carries a non-empty
+  `:play-script` slot. Pure data → data; reads the Story registrar's
+  variant side-table.
+
+  Sorted so the CI runner walks variants in a deterministic order —
+  helpful when comparing run logs across runs / branches."
+  ([]
+   (variants-with-play-scripts (registrar/registrations :variant)))
+  ([variant-registrations]
+   (->> variant-registrations
+        (filter (fn [[_ body]] (has-play-script? body)))
+        (map first)
+        (sort)
+        (vec))))
+
+(defn play-script-summary
+  "Return a small metadata map for `variant-id` suitable for the CI
+  runner's per-variant report row. Pure data → data.
+
+  Shape:
+      {:variant-id <kw>
+       :name       <string or nil>     ; from `:play-script` `:name`
+       :script-len <int>               ; number of steps (post-coerce)
+       :auto-run?  <bool>}"
+  [variant-id]
+  (let [body (registrar/handler-meta :variant variant-id)
+        spec (runner/parse-spec (:play-script body))]
+    {:variant-id variant-id
+     :name       (:name spec)
+     :script-len (count (:script spec))
+     :auto-run?  (boolean (:auto-run? spec))}))
+
+(defn ci-context
+  "Build the full CI catalogue: every variant with a `:play-script`
+  paired with its summary metadata. Pure data → data. Used by the
+  Playwright runner via `install-ci-hooks!`."
+  []
+  (let [vids (variants-with-play-scripts)]
+    {:variants vids
+     :summaries (mapv play-script-summary vids)}))
+
+;; ---- terminal-state helpers ---------------------------------------------
+
+(defn terminal?
+  "True iff `state` represents a run that has reached `:pass` or
+  `:fail`. Pure data → data."
+  [state]
+  (boolean (#{:pass :fail} (:status state))))
+
+(defn project-state
+  "Project a runner state map into the small shape the CI runner
+  emits to its consumer (test report / JSON log). Strips the
+  `:script` slot (already known from the spec) and projects
+  per-step results into a stable shape. Pure data → data."
+  [state]
+  (when state
+    (let [status   (:status state)
+          results  (mapv
+                     (fn [r]
+                       (cond-> {:idx     (:idx r)
+                                :type    (:type r)
+                                :passed? (:passed? r)}
+                         (:message r)   (assoc :message   (:message r))
+                         (:expected r)  (assoc :expected  (pr-str (:expected r)))
+                         (:actual r)    (assoc :actual    (pr-str (:actual r)))
+                         (:exception r) (assoc :exception (:exception r))
+                         (:skipped? r)  (assoc :skipped?  (:skipped? r))))
+                     (:results state []))]
+      {:status      status
+       :step-idx    (:step-idx state)
+       :total       (:total state)
+       :failures    (:failures state)
+       :name        (:name state)
+       :started-ms  (:started-ms state)
+       :finished-ms (:finished-ms state)
+       :results     results})))
+
+;; ---- CLJS-only: install the Playwright-readable global ------------------
+
+#?(:cljs
+   (defn- ->js
+     "Convert a Clojure value to a Playwright-friendly JS value.
+     Keywords become their fully-qualified string form so the JSON
+     round-trip preserves identity. Sorted to keep output stable."
+     [v]
+     (cond
+       (keyword? v) (if-let [ns (namespace v)]
+                      (str ns "/" (name v))
+                      (name v))
+       (map? v)     (let [obj (js-obj)]
+                      (doseq [[k val] v]
+                        (aset obj (cond
+                                    (keyword? k) (->js k)
+                                    (string? k)  k
+                                    :else        (str k))
+                              (->js val)))
+                      obj)
+       (vector? v)  (clj->js (mapv ->js v))
+       (seq? v)     (clj->js (mapv ->js v))
+       (set? v)     (clj->js (mapv ->js v))
+       :else        v)))
+
+#?(:cljs
+   (defn- list-variants-js
+     "Return the JS array of variant ids (as fully-qualified strings)
+     with `:play-script` bodies. Used by the Playwright runner via
+     `window.__rf2_story_ci.listVariants()`."
+     []
+     (->js (variants-with-play-scripts))))
+
+#?(:cljs
+   (defn- ci-context-js
+     "Return the JS catalogue object for the Playwright runner."
+     []
+     (->js (ci-context))))
+
+#?(:cljs
+   (defn- read-run-state-js
+     "Read the current `:rf.story.play/run-state` slot for `variant-id`
+     (passed as a fully-qualified string) and return the projected
+     shape as JSON-safe JS. Returns nil when no run has been started."
+     [variant-id-str]
+     (let [vid   (let [s (str variant-id-str)
+                       slash (.indexOf s "/")]
+                   (if (pos? slash)
+                     (keyword (subs s 0 slash) (subs s (inc slash)))
+                     (keyword s)))
+           state (runner-events/current-state vid)]
+       (->js (project-state state)))))
+
+#?(:cljs
+   (defn install-ci-hooks!
+     "Install the `window.__rf2_story_ci` global the Playwright runner
+     uses to enumerate variants and read terminal run states. Safe to
+     call multiple times — re-install replaces the existing slot.
+
+     Idempotent + side-effect-only: callers are expected to gate this
+     on a CI-only init path (e.g. a testbed's `core/run` checks
+     `window.location.search` for a `ci=1` flag, or simply always
+     install when re-frame.story.config/enabled? is true since the
+     hook is inert until polled)."
+     []
+     (let [hooks (js-obj
+                   "listVariants" list-variants-js
+                   "ciContext"    ci-context-js
+                   "readRunState" read-run-state-js)]
+       (aset js/window "__rf2_story_ci" hooks)
+       nil)))

--- a/tools/story/test/re_frame/story/play/ci_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/ci_runner_test.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.story.play.ci-runner-test
+  "Pure unit tests for the Story `:play-script` CI-as-test discovery +
+  projection seams (rf2-3qcxk).
+
+  All tests are JVM-runnable. The CLJS-only `install-ci-hooks!` is
+  exercised by the browser-side runner in
+  `examples/scripts/serve-and-run-story-play-scripts.cjs`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.play.ci-runner :as ci]
+            [re-frame.story.play.runner    :as runner]
+            [re-frame.story.registrar      :as registrar]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn- reset-registrar [test-fn]
+  (registrar/clear-all!)
+  (test-fn))
+
+(use-fixtures :each reset-registrar)
+
+;; ---- has-play-script? ----------------------------------------------------
+
+(deftest has-play-script-missing
+  (testing "has-play-script? is false when :play-script is absent"
+    (is (false? (ci/has-play-script? {})))
+    (is (false? (ci/has-play-script? {:events [[:foo]]})))))
+
+(deftest has-play-script-empty
+  (testing "has-play-script? is false for empty vectors / maps"
+    (is (false? (ci/has-play-script? {:play-script []})))
+    (is (false? (ci/has-play-script? {:play-script {:script []}})))
+    (is (false? (ci/has-play-script? {:play-script {}})))))
+
+(deftest has-play-script-bare-vector
+  (testing "has-play-script? is true for a non-empty bare vector"
+    (is (true? (ci/has-play-script? {:play-script [[:dispatch [:foo]]]})))))
+
+(deftest has-play-script-map-form
+  (testing "has-play-script? is true for a map with at least one step"
+    (is (true? (ci/has-play-script?
+                 {:play-script {:script [[:dispatch [:foo]]]
+                                :auto-run? true}})))))
+
+;; ---- variants-with-play-scripts ------------------------------------------
+
+(deftest discovery-from-injected-registrations
+  (testing "discovery from an injected `{id → body}` map filters bodies
+            without `:play-script` and sorts the result"
+    (let [regs {:story.a/with-script    {:play-script [[:dispatch [:foo]]]}
+                :story.b/without-script {:events [[:bar]]}
+                :story.c/with-map-form  {:play-script
+                                         {:script [[:wait 0]] :auto-run? true}}
+                :story.d/empty-script   {:play-script []}
+                :story.e/empty-map      {:play-script {:script []}}}]
+      (is (= [:story.a/with-script :story.c/with-map-form]
+             (ci/variants-with-play-scripts regs))))))
+
+(deftest discovery-from-live-registrar
+  (testing "no-arg discovery reads from the live Story registrar
+            and respects re-registrations"
+    ;; Inject directly into the side-table — the schema-validated
+    ;; reg-variant* path needs the canonical vocabulary which is
+    ;; out of scope for a discovery test.
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.t/script]
+           {:play-script [[:dispatch [:foo]]]})
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.t/no-script]
+           {:events [[:foo]]})
+    (is (= [:story.t/script] (ci/variants-with-play-scripts)))
+
+    ;; A third variant with a `:play-script` lands in sorted order.
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.t/another]
+           {:play-script {:script [[:wait 0]]}})
+    (is (= [:story.t/another :story.t/script]
+           (ci/variants-with-play-scripts)))))
+
+(deftest discovery-with-zero-variants
+  (testing "discovery returns the empty vector when nothing is registered"
+    (is (= [] (ci/variants-with-play-scripts)))))
+
+;; ---- play-script-summary -------------------------------------------------
+
+(deftest summary-from-map-body
+  (testing "summary derives name + script-len + auto-run? from the body"
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.s/named]
+           {:play-script {:name      "happy-path"
+                          :auto-run? false
+                          :script    [[:dispatch [:a]]
+                                      [:wait 0]
+                                      [:assert-db [:k] 1]]}})
+    (is (= {:variant-id :story.s/named
+            :name       "happy-path"
+            :script-len 3
+            :auto-run?  false}
+           (ci/play-script-summary :story.s/named)))))
+
+(deftest summary-from-bare-vector-body
+  (testing "summary defaults :auto-run? to true when the body is bare"
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.s/bare]
+           {:play-script [[:dispatch [:foo]]]})
+    (let [s (ci/play-script-summary :story.s/bare)]
+      (is (= :story.s/bare (:variant-id s)))
+      (is (= 1 (:script-len s)))
+      (is (true? (:auto-run? s)))
+      (is (nil? (:name s))))))
+
+(deftest summary-missing-variant-yields-empty-spec
+  (testing "summary for an unknown variant returns the empty-script shape"
+    (is (= {:variant-id :story.s/missing
+            :name       nil
+            :script-len 0
+            :auto-run?  true}
+           (ci/play-script-summary :story.s/missing)))))
+
+;; ---- ci-context ----------------------------------------------------------
+
+(deftest ci-context-shape
+  (testing "ci-context bundles the variant list + per-variant summaries"
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.c/a]
+           {:play-script [[:dispatch [:a]]]})
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.c/b]
+           {:play-script {:script [[:wait 0]] :auto-run? false :name "b"}})
+    (let [ctx (ci/ci-context)]
+      (is (= [:story.c/a :story.c/b] (:variants ctx)))
+      (is (= 2 (count (:summaries ctx))))
+      (is (= :story.c/a (:variant-id (first (:summaries ctx)))))
+      (is (= "b"        (:name       (second (:summaries ctx))))))))
+
+;; ---- terminal? -----------------------------------------------------------
+
+(deftest terminal?-recognises-pass-and-fail-only
+  (is (true?  (ci/terminal? {:status :pass})))
+  (is (true?  (ci/terminal? {:status :fail})))
+  (is (false? (ci/terminal? {:status :running})))
+  (is (false? (ci/terminal? {:status :idle})))
+  (is (false? (ci/terminal? nil))))
+
+;; ---- project-state -------------------------------------------------------
+
+(deftest project-state-strips-script-and-pr-strs-vals
+  (testing "project-state returns a stable shape, pr-strs :expected /
+            :actual to keep them JSON-safe across runtimes"
+    (let [state {:status      :fail
+                 :step-idx    2
+                 :total       3
+                 :failures    1
+                 :name        "n"
+                 :started-ms  100
+                 :finished-ms 200
+                 :script      [[:assert-db [:k] 1]
+                               [:assert-db [:k] 2]]
+                 :results     [(runner/step-pass 0 [:dispatch [:a]])
+                               (runner/step-fail 1 [:assert-db [:k] 2]
+                                                 {:expected 2
+                                                  :actual   1
+                                                  :message  "msg"})
+                               (runner/step-exception 2 [:dispatch [:b]] "boom")]}
+          out   (ci/project-state state)]
+      (is (= :fail (:status out)))
+      (is (= 2     (:step-idx out)))
+      (is (= 3     (:total out)))
+      (is (= 1     (:failures out)))
+      (is (= "n"   (:name out)))
+      (is (= 100   (:started-ms out)))
+      (is (= 200   (:finished-ms out)))
+      (is (nil? (:script out)) "script slot is stripped")
+      (is (= 3 (count (:results out))))
+      (let [r1 (nth (:results out) 1)]
+        (is (false? (:passed? r1)))
+        (is (= "2" (:expected r1)) "expected is pr-str'd for JSON safety")
+        (is (= "1" (:actual   r1)))
+        (is (= "msg" (:message r1)))))))
+
+(deftest project-state-nil-yields-nil
+  (is (nil? (ci/project-state nil))))

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -16,6 +16,7 @@
   (:require [reagent.dom.client :as rdc]
             [re-frame.core      :as rf]
             [re-frame.story     :as story]
+            [re-frame.story.play.ci-runner :as story-ci]
             [re-frame.adapter.reagent :as reagent-adapter]
             [day8.re-frame2-causa.config :as causa-config]
             ;; Source the events + subs + views via the stories ns,
@@ -105,6 +106,11 @@
   ;; handler and the `:rf.size/large-elided` marker for the `:large?`
   ;; schema slot without needing the trace surface or Causa attached.
   (elision/install-listener!)
+  ;; rf2-3qcxk — install the CI-as-test global hook the Playwright
+  ;; play-script runner reads. Inert until the runner polls it; safe
+  ;; to install unconditionally because the function body is gated
+  ;; on Story being enabled (the ns itself is Story-tooling).
+  (story-ci/install-ci-hooks!)
   ;; Wire hash-change so reloading `#/stories` lands on the shell
   ;; without a manual click-through.
   (.addEventListener js/window "hashchange" on-hash-change!)

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -235,6 +235,16 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  (story/reg-story :story.counter-play-script
+    {:doc        "Parent story for the rich-DSL :play-script CI-as-test
+                 fixtures (rf2-3qcxk). Two variants exercise both the
+                 pass and fail terminal paths of the play runner so the
+                 CI runner has live targets in every browser-gate run."
+     :component  :counter-with-stories.views/counter-card
+     :args       {:label "Play-script CI"}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   (story/reg-story :story.counter-matrix
     {:doc        "Deterministic browser-only affordances for the
                  Story feature coverage matrix. These variants keep
@@ -533,6 +543,62 @@
      :events    [[:counter/initialise 0]]
      :play      [[:rf.assert/effect-emitted :never-stubbed]]
      :tags      #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  ;; -------------------------------------------------------------------------
+  ;; :play-script fixtures (rf2-3qcxk — CI-as-test)
+  ;;
+  ;; The CI runner at `examples/scripts/serve-and-run-story-play-scripts.cjs`
+  ;; discovers every registered variant whose body carries a non-empty
+  ;; `:play-script` slot (via `re-frame.story.play.ci-runner/
+  ;; variants-with-play-scripts`), navigates the live Story shell to
+  ;; each, waits for the auto-run's terminal status, and asserts the
+  ;; aggregate result. These two fixtures pin the contract: one passes,
+  ;; one is deliberately wrong so the CI runner's failure path stays
+  ;; under continuous coverage too.
+  ;;
+  ;; The fixtures use `:dispatch-sync` (not `:dispatch`) so the runner
+  ;; observes the resulting app-db state on the very next step without
+  ;; needing a `:wait`. The play-script slot coexists with the legacy
+  ;; `:play` slot — both run, independently, post-mount.
+  ;; -------------------------------------------------------------------------
+
+  ;; Both fixtures use IDEMPOTENT scripts (initialise → assert) so
+  ;; the shell's deep-link auto-run AND its watcher-edge auto-run
+  ;; both reach the same terminal state. The cumulative-dispatch
+  ;; pattern (e.g. three `:dispatch-sync [:counter/inc]` then
+  ;; `[:assert-db [:count] 3]`) drifts under double-fire — the CI
+  ;; runner is gating the auto-run plumbing, not the under-test app's
+  ;; idempotency, so we keep the scripts neutral on that axis.
+  (story/reg-variant :story.counter-play-script/passing
+    {:doc        "rf2-3qcxk CI fixture — initialise the counter to 3
+                 and assert :count equals 3. Idempotent under any
+                 number of auto-run repeats."
+     :args       {:label "Play-script pass"}
+     :events     []
+     :play-script
+     {:name      "initialise-three-and-assert-pass"
+      :auto-run? true
+      :script    [[:dispatch-sync [:counter/initialise 3]]
+                  [:assert-db [:count] 3]]}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.counter-play-script/failing
+    {:doc        "rf2-3qcxk CI fixture — initialise the counter to 1
+                 then assert the WRONG final count (expect 9). The CI
+                 runner observes the :fail terminal status and matches
+                 it against the variant id's `failing` marker, so the
+                 process-level result stays clean even though the
+                 variant deliberately fails."
+     :args       {:label "Play-script fail"}
+     :events     []
+     :play-script
+     {:name      "initialise-one-but-expect-nine"
+      :auto-run? true
+      :script    [[:dispatch-sync [:counter/initialise 1]]
+                  [:assert-db [:count] 9]]}
+     :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
   ;; -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the record → export → CI trilogy for Story's rich-DSL `:play-script`:

1. `:play-script` DSL — PR #1411 (rf2-8i2a9) ✓
2. Recorder → `:play-script` export — PR #1417 (rf2-x9zsr) ✓
3. **CI runner invokes `:play-script` from the test harness — this PR** (rf2-3qcxk)

The result: an author can record an interaction in the Story shell, export it as a `:play-script` body on the variant, and every subsequent push exercises that script end-to-end in CI. Zero hand-written browser test code.

```
recorder REC → events captured → export dialog → reg-variant
                                                       │
                                                       ▼
                                              :play-script {…}
                                                       │
                                                       ▼  (this PR)
                              window.__rf2_story_ci.listVariants()
                                                       │
                                                       ▼
                          navigate → auto-run → poll terminal status
                                                       │
                                                       ▼
                                            per-variant pass/fail row
```

## What lands

**New files**
- `tools/story/src/re_frame/story/play/ci_runner.cljc` — pure discovery (`variants-with-play-scripts`), summary + projection helpers, plus the CLJS-only `install-ci-hooks!` that exposes `window.__rf2_story_ci.{listVariants, ciContext, readRunState}` for Playwright. Pure seams are JVM-runnable; the JS bridge is gated by reader conditionals.
- `examples/scripts/serve-and-run-story-play-scripts.cjs` — compiles + serves the counter-with-stories testbed, walks every variant with a `:play-script` via the CI hook, waits for the chip's `:pass` / `:fail` terminal status, and exits non-zero only when a variant deviates from its expected outcome. Variants whose id contains `failing` / `expected-fail` invert the assertion so the failure path stays under continuous coverage.
- `tools/story/test/re_frame/story/play/ci_runner_test.cljc` — 14 tests, 40 assertions covering discovery (with/without `:play-script`, empty bodies, registrar live + injected), summary derivation, and projection shape stability.

**Modified files**
- `tools/story/testbeds/counter_with_stories/stories.cljs` — two `:play-script` fixtures (`/passing`, `/failing`) on a new `:story.counter-play-script` parent. Scripts are idempotent (`[:counter/initialise N] → :assert-db`) so they survive the shell's deep-link + watcher-edge double-fire on mount.
- `tools/story/testbeds/counter_with_stories/core.cljs` — wires `install-ci-hooks!` into the testbed's `run` so the global is present before the shell mounts.
- `implementation/package.json` — adds `npm run test:story-play-scripts`.
- `.github/workflows/test.yml` — adds the new gate to the `story-causa-browser` job (`Run Story :play-script CI-as-test gate`).
- `TESTING.md` — documents the new gate alongside `test:story-feature-load`.

## Gate results (local)

- `scripts/test-fast-pr.sh` — 2827 / 8077, 0 failures.
- `tools/story/clojure -M:test` — 655 / 2057, 0 failures.
- `npm run test:browser` — 2816 / 7997, 0 failures.
- `npm run test:story-play-scripts` — 2 / 2 expected outcomes, exit 0.
- `npm run test:bundle-isolation` — clean.
- `npm run test:story-static` — passed.
- `npm run test:story-feature-load` — 2 / 2 specs, 0 failures.

## Workflow gate added

Job: `story-causa-browser`
Step: `Run Story :play-script CI-as-test gate`
Command: `npm run test:story-play-scripts`

The gate runs in the same job as `test:story-feature-load` because it reuses the testbed bundle, http-server, and Playwright stack — keeping cold-start cost amortised.

## Failure reporting

```
=== Story :play-script CI summary ===
OK   story.counter-play-script/failing  expected=fail actual=fail  steps=2
MISS story.counter-play-script/passing  expected=pass actual=fail  steps=4
     step 1 assert-db — assert-db [:count] — expected 3, got 6

Ran 2 :play-script variants. 1 unexpected outcomes.
```

When a row MISSes, the runner prints the failing step index, type, and the runner's diagnostic message (with `:expected` / `:actual` pr-str'd for JSON safety). The last 40 browser console lines flush below the summary so a regression isn't a black box.

## Divergences

- The shell's mount-time auto-run and watcher-edge auto-run both fire on deep-link nav, so play scripts that mutate cumulative state (e.g. three increments) drift under doubled invocation. The CI runner surfaces this as a real assertion miss, but since the fixtures gate the CI plumbing — not the auto-run de-dupe — they're written idempotently. A follow-on bead should land if the auto-run de-dupe is wanted ahead of the next rich-DSL fixture.

## Test plan

- [x] Unit tests pass (`clojure -M:test`)
- [x] End-to-end gate runs green locally (`npm run test:story-play-scripts`)
- [x] Browser-test suite passes (`npm run test:browser`)
- [x] Bundle-isolation gate passes (CI hook does not bleed into production builds)
- [x] Story-feature-load gate still passes
- [ ] story-causa-browser CI job runs green on this PR