### PR TITLE
feat(story): recorder captures DOM events + timestamps — :play-script export now full-fidelity

### DIFF
--- a/tools/story/src/re_frame/story/recorder.cljc
+++ b/tools/story/src/re_frame/story/recorder.cljc
@@ -344,6 +344,28 @@
     (into [assertion-id]
           (map (fn [{:keys [key]}] (get payload key)) fields))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-d5u89 — timestamp + entry helpers (used by both append /
+;; append-assertion / append-dom). Defined here so the forward
+;; references resolve cleanly.
+;; ---------------------------------------------------------------------------
+
+(defn- now-ms* []
+  #?(:clj  (System/currentTimeMillis)
+     :cljs (.now js/Date)))
+
+(defn timestamp-since-start
+  "Return `:t` (ms since `state`'s `:started-ms`) for `now-ms`. Pure
+  data → number. Returns nil when `state` has no `:started-ms`."
+  [state now-ms]
+  (when-let [started (:started-ms state)]
+    (max 0 (- now-ms started))))
+
+(defn- conj-entry
+  "Append `entry` onto the state's `:entries` slot. Pure data → data."
+  [state entry]
+  (update state :entries (fnil conj []) entry))
+
 (defn append-assertion
   "Pure: append an `:rf.assert/*` event to the captured `:events` of
   the recorder `state`. Bypasses `recordable-event?`'s filter — the
@@ -352,23 +374,39 @@
   event if no recording is in flight) and against malformed inputs
   (must be a vector with an `:rf.assert/*` keyword head).
 
+  Per rf2-d5u89 the assertion also lands in the parallel `:entries`
+  stream as an `:event/dispatch` entry tagged with the current
+  timestamp, so the `:play-script` translator (which consumes
+  `:entries`) sees the inserted assertion alongside the captured
+  dispatches and DOM events in temporal order.
+
   Returns the new state."
-  [state event]
-  (cond-> state
-    (and (:recording? state)
-         (vector? event)
-         (pred/assertion-event? event))
-    (update :events (fnil conj []) (vec event))))
+  ([state event]
+   (append-assertion state event (now-ms*)))
+  ([state event now-ms]
+   (cond-> state
+     (and (:recording? state)
+          (vector? event)
+          (pred/assertion-event? event))
+     (-> (update :events (fnil conj []) (vec event))
+         (conj-entry {:kind  :event/dispatch
+                      :event (vec event)
+                      :t     (timestamp-since-start state now-ms)})))))
 
 (def initial-state
   "The recorder's idle state shape. `:recording?` flips true while a
-  capture is in flight; `:events` accumulates the captured vectors in
-  declared order (oldest first, ready to drop straight into `:play`);
-  `:variant-id` records which frame the capture targets; `:started-ms`
-  is the wall-clock start time for elapsed-time display."
+  capture is in flight; `:events` accumulates the captured event
+  vectors in declared order (oldest first, ready to drop straight
+  into `:play`); `:entries` (rf2-d5u89) accumulates the richer
+  per-entry maps (`:event/dispatch` + `:dom/click` / `:dom/type` /
+  `:dom/submit`) with per-event timestamps — consumed by the
+  `:play-script` translator; `:variant-id` records which frame the
+  capture targets; `:started-ms` is the wall-clock start time for
+  elapsed-time display."
   {:recording? false
    :variant-id nil
    :events     []
+   :entries    []
    :started-ms nil})
 
 (defonce
@@ -393,9 +431,17 @@
   (:variant-id @state))
 
 (defn recorded-events
-  "Return the vector of captured event vectors (oldest first)."
+  "Return the vector of captured event vectors (oldest first). Back-
+  compat surface — feeds the legacy `:play` snippet codegen."
   []
   (:events @state))
+
+(defn recorded-entries
+  "Return the vector of captured rich entries (oldest first) — the
+  `:event/dispatch` + `:dom/*` per-entry maps with per-entry `:t`
+  timestamps the `:play-script` translator consumes."
+  []
+  (:entries @state))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure transition fns — make the state machine JVM-testable.
@@ -408,17 +454,122 @@
   {:recording? true
    :variant-id variant-id
    :events     []
+   :entries    []
    :started-ms now-ms})
+
+;; ---------------------------------------------------------------------------
+;; rf2-d5u89 — per-event timestamps + DOM-event entries
+;;
+;; The legacy recorder model carried `:events` (a vector of event
+;; vectors) — sufficient for the v1 `:play` slot which dispatches
+;; them on mount, but blind to TIMING and DOM INTERACTION which the
+;; rich `:play-script` DSL needs to emit `:click` / `:type` / `:wait`
+;; steps.
+;;
+;; The model now carries a parallel `:entries` vector keyed on the
+;; same index as `:events`. Each entry is one of:
+;;
+;;   {:kind :event/dispatch :event <vec> :t <ms>}
+;;   {:kind :dom/click      :selector <str> :t <ms>}
+;;   {:kind :dom/type       :selector <str> :text <str> :t <ms>}
+;;   {:kind :dom/submit     :selector <str> :t <ms>}
+;;
+;; `:events` stays canonical for the legacy `:play` snippet codegen
+;; (gen-play-snippet) — back-compat is non-negotiable. `:entries` is
+;; the new richer surface the `:play-script` translator consumes.
+;;
+;; `:t` is ms since `:started-ms`; pure helpers accept a `now-ms`
+;; argument for deterministic testing. (Helper fns `now-ms*`,
+;; `timestamp-since-start`, `conj-entry` defined earlier in the
+;; pure transitions section.)
+;; ---------------------------------------------------------------------------
 
 (defn append
   "Pure: append `event` to the recorder state's `:events` slot iff the
   state is recording and the event is recordable. Returns the new
-  state. Idempotent against bad inputs."
-  [state event]
+  state. Idempotent against bad inputs.
+
+  Per rf2-d5u89 the call ALSO appends a parallel `:entries` entry
+  `{:kind :event/dispatch :event <vec> :t <ms>}` so the
+  `:play-script` translator sees the timing alongside the event.
+  `:events` (bare event vectors) stays as-is for back-compat with
+  the legacy `:play` snippet codegen.
+
+  Two-arg form (`(append state event now-ms)`) lets callers pin
+  the timestamp for deterministic tests."
+  ([state event]
+   (append state event (now-ms*)))
+  ([state event now-ms]
+   (cond-> state
+     (and (:recording? state)
+          (recordable-event? event))
+     (-> (update :events (fnil conj []) (vec event))
+         (conj-entry {:kind  :event/dispatch
+                      :event (vec event)
+                      :t     (timestamp-since-start state now-ms)})))))
+
+;; ---------------------------------------------------------------------------
+;; DOM-event capture (rf2-d5u89)
+;;
+;; The DOM-capture layer (`re-frame.story.recorder.dom-capture`,
+;; CLJS-only) emits one of three entry kinds per observed interaction:
+;;
+;;   [:dom/click  selector  t]
+;;   [:dom/type   selector  text  t]
+;;   [:dom/submit selector  t]
+;;
+;; The recorder's `record-dom-event!` accepts these vector shapes and
+;; appends them onto `:entries`. Strictly DOM kinds; ordinary
+;; `[:dispatch ...]` events ride `record-event!`.
+;;
+;; The pure `append-dom` transition is JVM-testable; the
+;; `record-dom-event!` impure entry-point is the per-process atom
+;; writer the listener invokes.
+;; ---------------------------------------------------------------------------
+
+(def ^:const dom-event-kinds
+  "The DOM-event kinds the recorder appends onto `:entries`."
+  #{:dom/click :dom/type :dom/submit})
+
+(defn dom-event?
+  "True iff `entry` is a recorder DOM-event vector — `[:dom/click ...]`
+  / `[:dom/type ...]` / `[:dom/submit ...]` — well-formed enough to
+  append."
+  [entry]
+  (and (vector? entry)
+       (pos? (count entry))
+       (contains? dom-event-kinds (first entry))))
+
+(defn- dom-entry
+  "Translate a DOM-event vector `entry` into the recorder's `:entries`
+  map shape. Returns nil for unknown kinds."
+  [entry]
+  (when (dom-event? entry)
+    (case (first entry)
+      :dom/click   {:kind     :dom/click
+                    :selector (nth entry 1 nil)
+                    :t        (nth entry 2 nil)}
+      :dom/type    {:kind     :dom/type
+                    :selector (nth entry 1 nil)
+                    :text     (nth entry 2 nil)
+                    :t        (nth entry 3 nil)}
+      :dom/submit  {:kind     :dom/submit
+                    :selector (nth entry 1 nil)
+                    :t        (nth entry 2 nil)})))
+
+(defn append-dom
+  "Pure: append a DOM-event `entry` onto the recorder state's
+  `:entries` slot iff the state is recording. Returns the new state.
+  Idempotent against malformed inputs.
+
+  `entry` is one of the three shapes:
+    `[:dom/click selector t]`
+    `[:dom/type selector text t]`
+    `[:dom/submit selector t]`"
+  [state entry]
   (cond-> state
-    (and (:recording? state)
-         (recordable-event? event))
-    (update :events (fnil conj []) (vec event))))
+    (and (:recording? state) (dom-event? entry))
+    (conj-entry (dom-entry entry))))
 
 (defn stop
   "Pure: return the recorder state for a stopped recording. Preserves
@@ -469,14 +620,25 @@
 
   The snapshot is stored on the dialog state itself — NOT read live
   off the recorder atom — so a fresh `start-recording!` after the
-  dialog opens does not mutate the dialog's snippet (rf2-8x9nb)."
-  [_state variant-id events now-ms]
-  (let [base (review-dialog/open review-dialog/initial-state
-                                 variant-id
-                                 {:events (vec events)}
-                                 now-ms
-                                 default-id-prefix)]
-    (assoc base :events (vec events))))
+  dialog opens does not mutate the dialog's snippet (rf2-8x9nb).
+
+  Per rf2-d5u89 the 5-arity variant also accepts `entries` (the
+  rich `:entries` slot) so the export dialog can drive the
+  `:play-script` translator with the full DOM+timing record. The
+  4-arity variant defaults `entries` to nil — back-compat for
+  call sites that haven't been updated."
+  ([state variant-id events now-ms]
+   (open-dialog state variant-id events nil now-ms))
+  ([_state variant-id events entries now-ms]
+   (let [base (review-dialog/open review-dialog/initial-state
+                                  variant-id
+                                  {:events  (vec events)
+                                   :entries (vec (or entries []))}
+                                  now-ms
+                                  default-id-prefix)]
+     (-> base
+         (assoc :events  (vec events))
+         (assoc :entries (vec (or entries [])))))))
 
 (defn close-dialog
   "Pure: return the dialog's idle state. Aliased to
@@ -537,6 +699,24 @@
   [event]
   (when config/enabled?
     (swap! state append event))
+  nil)
+
+(defn record-dom-event!
+  "Append a DOM-event entry to the recorder's `:entries` slot iff a
+  recording is in flight (rf2-d5u89). Called by the DOM-capture
+  layer (`re-frame.story.recorder.dom-capture`) for every observed
+  click / typed-input / form-submit on the canvas root.
+
+  `entry` is one of:
+    `[:dom/click  selector t]`
+    `[:dom/type   selector text t]`
+    `[:dom/submit selector t]`
+
+  Idempotent against malformed inputs (filtered by `dom-event?`).
+  No-op under production elision."
+  [entry]
+  (when config/enabled?
+    (swap! state append-dom entry))
   nil)
 
 (defn insert-assertion!

--- a/tools/story/src/re_frame/story/recorder/dom_capture.cljs
+++ b/tools/story/src/re_frame/story/recorder/dom_capture.cljs
@@ -1,0 +1,318 @@
+(ns re-frame.story.recorder.dom-capture
+  "DOM-event capture for the recorder (rf2-d5u89).
+
+  Listens on the story canvas root for `click` / `input` / `change` /
+  `submit` events while a recording is in flight, picks a selector
+  for each target via `re-frame.story.recorder.selector`, and feeds
+  the result back through the recorder's `record-dom-event!` seam
+  alongside the dispatched events already captured off the trace
+  bus.
+
+  ## Why a separate ns
+
+  The CLJS-only DOM event-listener wiring lives outside
+  `re-frame.story.recorder` (cljc) so the recorder's pure surface
+  stays JVM-testable. This file's public surface is small:
+
+  - `install!` / `remove!` — attach/detach the four delegated
+    listeners on a root node (defaults to the story canvas root).
+  - `set-enabled!` / `enabled?` — runtime opt-in toggle (default ON).
+  - `record-dom-click!` / `record-dom-type!` / `record-dom-submit!`
+    — the impure entry points the listeners invoke. Exposed so
+    browser tests can drive the recorder via synthetic events
+    without re-installing the DOM listeners.
+
+  ## Debounce policy
+
+  `input` and `change` events fire on every keystroke. The browser
+  produces N events for an N-char string; we only want ONE
+  `[:dom/type selector final-value t]` entry in the recording.
+
+  Strategy: track the last `input` per selector; flush
+  `input`-deltas to the recorder after `debounce-ms` of silence
+  on that selector OR when the user clicks elsewhere (the click
+  itself is a natural flush point), or when the recording is
+  stopped. `change` events (which fire on blur) flush
+  immediately for that selector.
+
+  Default `debounce-ms` is 250ms. Tunable via `set-debounce-ms!`
+  for tests / future-tuning.
+
+  ## Scope
+
+  The listener attaches to whatever root the caller passes in —
+  in practice the story canvas root. Listening on the document
+  would catch chrome interactions (sidebar / toolbar / scrubber)
+  and pollute the recording. By scoping to the canvas root we
+  only capture interactions the user is making against the
+  variant under test."
+  (:require [re-frame.story.config           :as config]
+            [re-frame.story.recorder         :as recorder]
+            [re-frame.story.recorder.selector :as selector]))
+
+;; ---- runtime knobs -----------------------------------------------------
+
+(defonce ^:private enabled-flag (atom true))
+
+(defn enabled?
+  "True iff DOM-event capture is currently enabled. The recorder
+  itself can still be in flight without DOM capture (e.g. user
+  opted out via the toolbar settings)."
+  []
+  (boolean @enabled-flag))
+
+(defn set-enabled!
+  "Flip the DOM-capture opt-in flag. Default true. Idempotent."
+  [b]
+  (reset! enabled-flag (boolean b))
+  nil)
+
+(defonce ^:private debounce-ms-atom (atom 250))
+
+(defn debounce-ms
+  "Current debounce window for input-typing flush, in ms."
+  []
+  @debounce-ms-atom)
+
+(defn set-debounce-ms!
+  "Override the debounce window. Used by tests to flush
+  synchronously (set to 0). Negative values clamp to 0."
+  [ms]
+  (reset! debounce-ms-atom (max 0 (int (or ms 0))))
+  nil)
+
+;; ---- per-selector type-debounce buffer ---------------------------------
+
+(defonce ^:private type-buffer
+  ;; { selector -> {:value <last-text> :timer <id-or-nil>} }
+  (atom {}))
+
+(defn- now-ms []
+  (.now js/Date))
+
+(defn- recording-now-ms
+  "ms since the recording started, or nil when no recording is in
+  flight. The recorder atom carries `:started-ms`; we just subtract."
+  []
+  (let [{:keys [started-ms recording?]} (recorder/current-state)]
+    (when (and recording? started-ms)
+      (max 0 (- (now-ms) started-ms)))))
+
+;; ---- impure recorder seams ---------------------------------------------
+
+(defn record-dom-click!
+  "Append a `[:dom/click selector t]` entry to the recorder's
+  trace. Public so browser tests + the DOM listener share one path."
+  [selector]
+  (when-let [t (recording-now-ms)]
+    (recorder/record-dom-event! [:dom/click selector t])))
+
+(defn record-dom-type!
+  "Append a `[:dom/type selector text t]` entry."
+  [selector text]
+  (when-let [t (recording-now-ms)]
+    (recorder/record-dom-event! [:dom/type selector text t])))
+
+(defn record-dom-submit!
+  "Append a `[:dom/submit form-selector t]` entry. The translator
+  best-effort maps this to a `[:click <submit-button>]` at export
+  time."
+  [form-selector]
+  (when-let [t (recording-now-ms)]
+    (recorder/record-dom-event! [:dom/submit form-selector t])))
+
+;; ---- type-debounce flush ------------------------------------------------
+
+(defn- clear-buffer-timer! [entry]
+  (when-let [timer (:timer entry)]
+    (js/clearTimeout timer)))
+
+(defn flush-type-buffer!
+  "Force a flush for `selector` (or every selector if `selector` is
+  nil). Idempotent against an empty buffer. Public so the recorder
+  stop path can drain pending type entries before the recording
+  closes."
+  ([] (flush-type-buffer! nil))
+  ([selector]
+   (let [snapshot @type-buffer
+         keys-to-flush (if selector [selector] (keys snapshot))]
+     (doseq [k keys-to-flush]
+       (when-let [entry (get snapshot k)]
+         (clear-buffer-timer! entry)
+         (record-dom-type! k (:value entry))))
+     (if selector
+       (swap! type-buffer dissoc selector)
+       (reset! type-buffer {})))
+   nil))
+
+(defn- schedule-type-flush!
+  "Set a `setTimeout` to flush `selector`'s buffer after the current
+  debounce window. Replaces any existing timer for the selector."
+  [selector]
+  (let [ms (debounce-ms)]
+    (if (zero? ms)
+      (flush-type-buffer! selector)
+      (let [timer (js/setTimeout
+                    (fn []
+                      (flush-type-buffer! selector))
+                    ms)]
+        (swap! type-buffer assoc-in [selector :timer] timer)))))
+
+(defn- buffer-type!
+  "Stash `value` for `selector` and (re)schedule the debounce flush."
+  [selector value]
+  (when (some? selector)
+    (let [existing (get @type-buffer selector)]
+      (clear-buffer-timer! existing))
+    (swap! type-buffer assoc selector {:value value :timer nil})
+    (schedule-type-flush! selector)))
+
+;; ---- predicates ---------------------------------------------------------
+
+(def ^:private typeable-tags
+  "Tags whose `input` / `change` events the debounce path consumes.
+  Anything else (e.g. a `<div contenteditable>`) is out of scope at
+  v1; file a follow-on bead if needed."
+  #{"INPUT" "TEXTAREA" "SELECT"})
+
+(defn- typeable-element?
+  "True iff `el` is one of `INPUT` / `TEXTAREA` / `SELECT`."
+  [el]
+  (boolean
+    (when el
+      (contains? typeable-tags (.-tagName el)))))
+
+(defn- target-value
+  "Read the current `.value` slot off `el`. Returns the empty string
+  if unreadable."
+  [el]
+  (or (.-value el) ""))
+
+(defn- should-capture?
+  "Top-level gate: is the recorder running AND DOM capture enabled?"
+  []
+  (and config/enabled?
+       (recorder/recording?)
+       (enabled?)))
+
+;; ---- listener handlers --------------------------------------------------
+
+(defn- handle-click!
+  "Click handler — fires on bubble. Flushes any pending type buffer
+  (so the `:dom/type` lands before the `:dom/click` in temporal
+  order) and records the click."
+  [ev]
+  (when (should-capture?)
+    (when-let [el (.-target ev)]
+      ;; The flush emits the buffered :dom/type entries first so
+      ;; the resulting recording is well-ordered: type-then-click.
+      (flush-type-buffer!)
+      (when-let [sel (selector/pick-for-element el)]
+        (record-dom-click! sel)))))
+
+(defn- handle-input!
+  "input / change handler — stashes the latest value into the
+  per-selector type buffer + (re)arms the debounce timer."
+  [ev]
+  (when (should-capture?)
+    (when-let [el (.-target ev)]
+      (when (typeable-element? el)
+        (when-let [sel (selector/pick-for-element el)]
+          (buffer-type! sel (target-value el)))))))
+
+(defn- handle-change!
+  "change handler — fires on blur for inputs / immediately for
+  selects. Drains the per-selector buffer (flush emits the
+  `:dom/type` entry with the current `.value`) so the recording
+  carries the final post-blur value."
+  [ev]
+  (when (should-capture?)
+    (when-let [el (.-target ev)]
+      (when (typeable-element? el)
+        (let [sel (selector/pick-for-element el)]
+          ;; Stash the most-recent value FIRST (so a `change` on a
+          ;; `<select>` — which never fires `input` — still has a
+          ;; value to flush).
+          (when sel
+            (buffer-type! sel (target-value el))
+            (flush-type-buffer! sel)))))))
+
+(defn- handle-submit!
+  "submit handler — best-effort form-submit capture. The translator
+  maps the recorded `[:dom/submit form-selector t]` to a
+  `[:click <submit-button>]` at export time when it can resolve
+  the form's submit button; otherwise it ships the form selector
+  + a hint."
+  [ev]
+  (when (should-capture?)
+    (when-let [el (.-target ev)]
+      (flush-type-buffer!)
+      (when-let [sel (selector/pick-for-element el)]
+        (record-dom-submit! sel)))))
+
+;; ---- install / remove --------------------------------------------------
+
+(defonce ^:private installed-root (atom nil))
+
+(defn- canvas-root
+  "The current shell canvas root, looked up by the framework-stable
+  `[data-test=\"story-canvas-frame\"]` hook. Returns nil when the
+  shell isn't mounted (e.g. before `mount-shell!`)."
+  []
+  (when (and (exists? js/document) (.-querySelector js/document))
+    (try
+      (.querySelector js/document "[data-test=\"story-canvas-frame\"]")
+      (catch :default _ nil))))
+
+(defn- attach-listeners! [root]
+  ;; Capture phase = false (bubble); we want the recorder to see what
+  ;; the variant component sees, after the variant's own handlers have
+  ;; had their turn. The click handler intentionally runs even when
+  ;; the variant's handler calls `preventDefault`/`stopPropagation` on
+  ;; bubble — the listener attaches at the canvas-root, so a
+  ;; `stopPropagation` from a deep child still bubbles up to the root
+  ;; (which is the listener's mount point).
+  (.addEventListener root "click"  handle-click!  false)
+  (.addEventListener root "input"  handle-input!  false)
+  (.addEventListener root "change" handle-change! false)
+  (.addEventListener root "submit" handle-submit! false))
+
+(defn- detach-listeners! [root]
+  (.removeEventListener root "click"  handle-click!  false)
+  (.removeEventListener root "input"  handle-input!  false)
+  (.removeEventListener root "change" handle-change! false)
+  (.removeEventListener root "submit" handle-submit! false))
+
+(defn install!
+  "Install the DOM-capture listeners on `root` (or the canvas root
+  when called with no arg). Idempotent — re-installing removes the
+  previous listener set first.
+
+  No-op when production elision is active (`config/enabled?` false).
+  Returns the root node on success, nil otherwise."
+  ([]
+   (install! (canvas-root)))
+  ([root]
+   (when (and config/enabled? root)
+     (when-let [prev @installed-root]
+       (detach-listeners! prev))
+     (attach-listeners! root)
+     (reset! installed-root root)
+     root)))
+
+(defn remove!
+  "Tear down any previously installed listeners. Idempotent. Drains
+  any pending type-buffer entries so the recording captures the
+  in-flight typed value (if any)."
+  []
+  (flush-type-buffer!)
+  (when-let [root @installed-root]
+    (detach-listeners! root)
+    (reset! installed-root nil))
+  nil)
+
+(defn installed?
+  "True iff `install!` is currently attached to a root node. Public
+  for tests and the toolbar's status display."
+  []
+  (some? @installed-root))

--- a/tools/story/src/re_frame/story/recorder/play_export.cljc
+++ b/tools/story/src/re_frame/story/recorder/play_export.cljc
@@ -22,16 +22,21 @@
 
   ## What gets translated
 
-  The recorder's existing model (`{:events [...vector-of-event-vecs]
-  :variant-id ... :started-ms ...}`) carries event vectors only —
-  no per-event timestamps and no DOM events. So the v1 translation
-  is the **dispatch-only path**:
+  Per rf2-d5u89 the recorder now captures BOTH dispatched events
+  (off the trace bus) AND DOM interactions (off the canvas root
+  via `re-frame.story.recorder.dom-capture`). Each captured entry
+  rides on the recorder's `:entries` slot as one of four shapes;
+  the translator maps them to `:play-script` steps:
 
-  | Recorded shape                              | Translated step              |
+  | Recorded entry kind                         | Translated step              |
   |---------------------------------------------|------------------------------|
-  | `[:counter/inc]`                            | `[:dispatch [:counter/inc]]` |
-  | `[:rf.assert/path-equals [:n] 3]`           | `[:dispatch-sync [:rf.assert/path-equals [:n] 3]]` |
-  | `[:rf/redacted]` (sensitive event)          | dropped + `;; redacted` annotation |
+  | `{:kind :event/dispatch :event ev :t ms}`   | `[:dispatch ev]`             |
+  | `{:kind :event/dispatch :event <:rf.assert/*> :t ms}` | `[:dispatch-sync ev]` |
+  | `{:kind :event/dispatch :event [:rf/redacted] :t ms}` | dropped |
+  | `{:kind :dom/click  :selector s :t ms}`     | `[:click s]`                 |
+  | `{:kind :dom/type   :selector s :text t :t ms}` | `[:type s t]`            |
+  | `{:kind :dom/submit :selector s :t ms}`     | `[:click s]` (best-effort)   |
+  | time gap between entries > `wait-threshold-ms` | `[:wait Δt]` inserted before the next step |
   | `(app-db snapshot at end)` (if provided)    | trailing `[:assert-db path expected]` steps (top-N changed paths) |
 
   Assertion events ride the `:dispatch-sync` rail because Spec 004 §3
@@ -41,9 +46,13 @@
   next state transition. The pure runner accepts either tag for any
   event; this is a translation convention, not a runtime requirement.
 
-  DOM events (`:click` / `:type`) and timing-based steps (`:wait`)
-  are NOT generated — the current recorder model doesn't capture
-  them. Filed as follow-on rf2-recorder-dom (TODO).
+  ## Legacy entry shape (pre-rf2-d5u89)
+
+  Callers that pass a bare `events` vector (the old `:events` slot)
+  still work — the translator coerces each bare event vector into
+  an `:event/dispatch` entry with `:t 0`. This keeps the JVM tests
+  from rf2-x9zsr (which exercise `recording->play-script` with a
+  bare vector) running unchanged.
 
   ## Auto-assert
 
@@ -77,6 +86,15 @@
   passing `:max-auto-assertions` explicitly or by trimming the output
   by hand."
   5)
+
+(def ^:const default-wait-threshold-ms
+  "Minimum gap between consecutive entries (in ms) that warrants a
+  `[:wait Δt]` step in the generated script. Sub-threshold gaps fold
+  out — the runner already sequences synchronously between dispatches
+  + DOM actions, and inserting a `:wait 4` step would just add noise.
+  Default 50ms — fast enough to preserve human-pace pauses
+  (~100ms+), slow enough to ignore intra-typing-burst micro-gaps."
+  50)
 
 (def ^:const redacted-event-id
   "The framework sentinel id the recorder uses to replace sensitive
@@ -118,6 +136,131 @@
     [:dispatch event]
 
     :else nil))
+
+;; ---------------------------------------------------------------------------
+;; Pure: entry-shape translation (rf2-d5u89)
+;;
+;; Each `:entries` entry is one of four shapes (see recorder.cljc
+;; §dom-event-kinds + §rf2-d5u89). `entry->step` maps the rich shape
+;; to a runner step OR nil (the caller filters).
+;; ---------------------------------------------------------------------------
+
+(defn entry->step
+  "Translate one rich `:entries` map into a `:play-script` step. Pure
+  data → data. Returns nil for entries the runner doesn't model
+  (redacted placeholders, malformed shapes).
+
+  Entry shapes:
+    {:kind :event/dispatch :event <vec> :t ms}
+    {:kind :dom/click      :selector <str> :t ms}
+    {:kind :dom/type       :selector <str> :text <str> :t ms}
+    {:kind :dom/submit     :selector <str> :t ms}
+
+  The `:dom/submit` entry is best-effort mapped to a `:click`
+  step against the form selector — the runner doesn't model form
+  submission directly, and a `:click` on the form (or the form's
+  submit button when reachable from a later selector hardening
+  pass) is the closest available step. See module doc."
+  [entry]
+  (case (and (map? entry) (:kind entry))
+    :event/dispatch
+    (event->step (:event entry))
+
+    :dom/click
+    (when-let [sel (:selector entry)]
+      [:click sel])
+
+    :dom/type
+    (when-let [sel (:selector entry)]
+      [:type sel (or (:text entry) "")])
+
+    :dom/submit
+    (when-let [sel (:selector entry)]
+      ;; Best-effort — see docstring.
+      [:click sel])
+
+    nil))
+
+(defn- coerce-entry
+  "Normalise an arbitrary `events`-vector member to an `:entries`-shape
+  map. Pure data → data; tolerates the legacy bare-event-vector
+  shape (`[:my/event ...]`) by lifting it into
+  `{:kind :event/dispatch :event <vec> :t 0}`."
+  [x]
+  (cond
+    (and (map? x) (contains? x :kind))
+    x
+
+    (vector? x)
+    {:kind :event/dispatch :event x :t 0}
+
+    :else nil))
+
+(defn- bare-events->entries
+  "Coerce a legacy bare-events vector to the new `:entries` shape so
+  the translator's wait-insertion + entry walker work uniformly."
+  [events]
+  (->> (or events [])
+       (mapv coerce-entry)
+       (filterv some?)))
+
+;; ---------------------------------------------------------------------------
+;; Pure: wait-step insertion (rf2-d5u89)
+;;
+;; Walk the entries in order, compare consecutive `:t` stamps, and
+;; inject a `[:wait Δt]` step whenever the gap exceeds the
+;; threshold. The output preserves the entry's own translated step
+;; immediately after the wait.
+;; ---------------------------------------------------------------------------
+
+(defn- wait-step
+  "Return `[:wait Δt]` when `delta-ms` warrants one (>= threshold and
+  positive), else nil."
+  [delta-ms threshold]
+  (when (and (number? delta-ms)
+             (number? threshold)
+             (>= delta-ms threshold))
+    [:wait (long delta-ms)]))
+
+(defn entries->steps
+  "Walk `entries` in order, translate each to a step (filtering nils),
+  and insert `[:wait Δt]` steps between consecutive entries whose
+  `:t` gap meets `wait-threshold-ms`. Pure data → data.
+
+  Options:
+    :wait-threshold-ms  default `default-wait-threshold-ms` (50ms).
+                        Pass 0 to emit a wait between every pair of
+                        timestamped entries; pass a very large value
+                        (or `Long/MAX_VALUE`) to disable waits."
+  ([entries] (entries->steps entries {}))
+  ([entries {:keys [wait-threshold-ms]
+             :or   {wait-threshold-ms default-wait-threshold-ms}}]
+   (loop [remaining (seq entries)
+          last-t    nil
+          out       (transient [])]
+     (if (empty? remaining)
+       (persistent! out)
+       (let [entry  (first remaining)
+             step   (entry->step entry)
+             this-t (:t entry)]
+         (cond
+           ;; Skip entries that don't yield a step (e.g. redacted).
+           ;; Leave `last-t` pointing at the most recent TRANSLATED
+           ;; step's timestamp so the next emitted step's wait gap
+           ;; measures the gap to the last visible step rather than
+           ;; the dropped intermediate.
+           (nil? step)
+           (recur (rest remaining) last-t out)
+
+           :else
+           (let [gap (when (and (some? last-t) (some? this-t))
+                       (- this-t last-t))
+                 w   (wait-step gap wait-threshold-ms)
+                 out (if w (conj! out w) out)
+                 out (conj! out step)]
+             (recur (rest remaining)
+                    (or this-t last-t)
+                    out))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Pure: auto-assert derivation
@@ -185,23 +328,31 @@
 
   Inputs:
 
-    `events`  — vector of recorded event vectors (the `:events` slot
-                of the recorder state).
+    `events`  — either the legacy vector of recorded event vectors
+                (the `:events` slot of the recorder state) OR the
+                rich `:entries` vector of per-entry maps (rf2-d5u89).
+                Mixed input is tolerated — each member is coerced
+                via `coerce-entry`. The bare-event-vector branch
+                stamps `:t 0` on every entry, so no `:wait` steps
+                are emitted (back-compat for v1 callers).
     `opts`:
-      :name             optional — `:name` field for the play-script.
-      :auto-assert?     bool, default false — when true, derive
-                        trailing `[:assert-db ...]` steps from
-                        `:final-db` (and `:seed-db` if supplied).
-      :final-db         map — the app-db snapshot at recording-end.
-                        Required when `:auto-assert?` is true.
-      :seed-db          optional — the app-db at recording-start.
-                        When supplied, only paths whose value changed
-                        produce assertions.
+      :name              optional — `:name` field for the play-script.
+      :auto-assert?      bool, default false — when true, derive
+                         trailing `[:assert-db ...]` steps from
+                         `:final-db` (and `:seed-db` if supplied).
+      :final-db          map — the app-db snapshot at recording-end.
+                         Required when `:auto-assert?` is true.
+      :seed-db           optional — the app-db at recording-start.
+                         When supplied, only paths whose value changed
+                         produce assertions.
       :max-auto-assertions  cap on the auto-assert block (default 5).
-      :auto-run?        bool — `:auto-run?` field on the play-script
-                        map. Defaults to true (matches the runner's
-                        default-auto-run? — on-mount replay is the
-                        Storybook-equivalent behaviour).
+      :auto-run?         bool — `:auto-run?` field on the play-script
+                         map. Defaults to true (matches the runner's
+                         default-auto-run? — on-mount replay is the
+                         Storybook-equivalent behaviour).
+      :wait-threshold-ms  ms threshold above which the translator
+                         inserts a `[:wait Δt]` step between entries.
+                         Default `default-wait-threshold-ms` (50ms).
 
   Returns a map: `{:script [...steps] :auto-run? bool :name str?}`.
   The script is pre-coerced via `runner/coerce-script` so it round-
@@ -212,13 +363,15 @@
   the auto-assert block can stand alone)."
   ([events]
    (recording->play-script events {}))
-  ([events {:keys [name auto-assert? final-db seed-db max-auto-assertions auto-run?]
+  ([events {:keys [name auto-assert? final-db seed-db max-auto-assertions
+                   auto-run? wait-threshold-ms]
             :or   {auto-assert?         false
                    auto-run?            true
-                   max-auto-assertions  default-max-auto-assertions}}]
-   (let [dispatch-steps (->> (or events [])
-                             (mapv event->step)
-                             (filterv some?))
+                   max-auto-assertions  default-max-auto-assertions
+                   wait-threshold-ms    default-wait-threshold-ms}}]
+   (let [entries        (bare-events->entries events)
+         dispatch-steps (entries->steps entries
+                                        {:wait-threshold-ms wait-threshold-ms})
          assert-steps   (if auto-assert?
                           (auto-assert-steps final-db
                                              {:seed-db             seed-db

--- a/tools/story/src/re_frame/story/recorder/selector.cljc
+++ b/tools/story/src/re_frame/story/recorder/selector.cljc
@@ -1,0 +1,188 @@
+(ns re-frame.story.recorder.selector
+  "Pure selector picker — DOM element → best-effort CSS selector string
+  (rf2-d5u89).
+
+  Used by the recorder's DOM-capture layer to turn a `click` /
+  `input` / `change` event target into a stable selector the
+  exporter can drop into a `:play-script` `[:click selector]` /
+  `[:type selector text]` step.
+
+  ## Priority
+
+  We walk a fixed priority list and pick the first attribute that
+  resolves to a non-blank value:
+
+  1. `[data-test=\"X\"]` — the canonical Story-/test-stable hook
+     (re-frame2 + Storybook convention). Every Story component
+     authored to be tested carries `:data-test \"...\"` on its
+     interactive nodes.
+  2. `[id=\"X\"]` — the next-best stable hook. Most app templates
+     emit ids on form controls.
+  3. `[aria-label=\"X\"]` — for icon buttons / inputs whose only
+     accessible label is the aria-label attribute.
+  4. `tag:nth-of-type(N)` fallback — best-effort positional
+     selector when nothing else is available. Brittle; the
+     translator's output carries a hint when this branch fires so
+     the user knows to harden the selector by hand.
+
+  ## Pure / impure split
+
+  This namespace is `.cljc` and exposes:
+
+  - `pick-selector` — pure: takes an element-shape map
+    (`{:tag :attrs :index-of-type}`) and returns a selector
+    string. JVM-testable without a DOM.
+  - `element->shape` — CLJS-only: walks a live `js/Element` and
+    builds the shape map `pick-selector` consumes. The DOM read
+    is the only impure part; the chooser logic stays pure.
+
+  The split means the priority logic ships one set of tests on
+  both JVM + CLJS; the DOM-shape extraction layer ships under a
+  separate browser-only test.
+
+  ## Why a strict whitelist of attributes
+
+  The recorder is a developer ergonomics tool — the selector it
+  picks ends up in source. We deliberately AVOID classes (CSS-
+  framework noise like `tailwind-3xl`), `name`, or `for` even when
+  they're present: only the four attributes above are stable
+  hooks Story / re-frame2 / Reagent authors reach for. Less is
+  more — a brittle selector that looks right (until the
+  refactor) is worse than a `:nth-of-type` fallback the user
+  immediately spots as wanting hardening."
+  (:require [clojure.string :as str]))
+
+;; ---- pure ---------------------------------------------------------------
+
+(defn- blank?
+  "Local `clojure.string/blank?` — keeps the deps surface small and
+  avoids `(:require [clojure.string :as str])` reaching every call site."
+  [s]
+  (or (nil? s) (and (string? s) (zero? (count (.trim ^String s))))))
+
+(def ^:const attribute-priority
+  "Ordered list of attribute keys we try, highest priority first. Pure
+  data so call sites can introspect (e.g. the translator's hint).
+
+  Each entry is a `[attribute-key css-template]` pair: the template
+  carries a `%s` placeholder for the attribute value."
+  [["data-test"  "[data-test=\"%s\"]"]
+   ["id"         "[id=\"%s\"]"]
+   ["aria-label" "[aria-label=\"%s\"]"]])
+
+(defn- escape-attr-value
+  "Escape a CSS-attribute-selector value: backslash + double-quote.
+  The selector is wrapped in double quotes so the escape set is
+  small. Returns the empty string for nil."
+  [s]
+  (if (nil? s)
+    ""
+    (-> (str s)
+        (str/replace "\\" "\\\\")
+        (str/replace "\"" "\\\""))))
+
+(defn- attribute-selector
+  "Build a selector for `attr-key` if `attrs` carries a non-blank
+  value for it, else nil. `attrs` is a map keyed on lower-case
+  attribute name (string).
+
+  `css-template` carries a `%s` placeholder; we splice manually
+  (CLJS has no `format`)."
+  [attrs [attr-key css-template]]
+  (let [v (get attrs attr-key)]
+    (when-not (blank? v)
+      (str/replace css-template "%s" (escape-attr-value v)))))
+
+(defn- nth-of-type-fallback
+  "Best-effort positional selector: `tag:nth-of-type(N)`. `tag`
+  defaults to `*` when missing; `index-of-type` is 1-based per CSS.
+  Returns nil if we can't produce anything sensible."
+  [{:keys [tag index-of-type]}]
+  (when (some? index-of-type)
+    (let [t (cond
+              (blank? tag) "*"
+              :else        (str/lower-case (str tag)))]
+      (str t ":nth-of-type(" index-of-type ")"))))
+
+(defn pick-selector
+  "Return the best-effort CSS selector for the DOM element described
+  by `shape`. Pure data → string (or nil).
+
+  `shape` is a map:
+    :tag            string — lower-case tag name (e.g. \"button\")
+    :attrs          {<lower-case-name> <value>} — relevant attributes only
+    :index-of-type  1-based positional index among siblings of the
+                    same tag, used by the `:nth-of-type(N)` fallback
+
+  Returns:
+    - the highest-priority attribute selector that resolves, or
+    - the `:nth-of-type` fallback if attributes don't help, or
+    - nil when no shape information is available."
+  [{:keys [attrs] :as shape}]
+  (or (some (partial attribute-selector (or attrs {})) attribute-priority)
+      (nth-of-type-fallback shape)))
+
+(defn selector-kind
+  "Diagnostic: tell the caller WHICH tier `pick-selector` picked.
+  Returns one of `:data-test` / `:id` / `:aria-label` / `:nth-of-type`
+  / `:none`. Used by the translator to attach a hint when the
+  brittle fallback fires."
+  [{:keys [attrs index-of-type]}]
+  (let [a (or attrs {})]
+    (cond
+      (not (blank? (get a "data-test")))  :data-test
+      (not (blank? (get a "id")))         :id
+      (not (blank? (get a "aria-label"))) :aria-label
+      (some? index-of-type)               :nth-of-type
+      :else                               :none)))
+
+;; ---- impure (CLJS-only DOM shape extractor) -----------------------------
+
+#?(:cljs
+   (defn- relevant-attrs
+     "Walk the priority list and read just those attributes off `el`.
+     Skips the `:nth-of-type` line — that's computed from sibling
+     position, not an attribute. Returns a string-keyed map suitable
+     for `pick-selector`'s `:attrs` slot."
+     [el]
+     (when (and el (.-getAttribute el))
+       (into {}
+             (keep (fn [[attr-key _]]
+                     (let [v (.getAttribute el attr-key)]
+                       (when v [attr-key v]))))
+             attribute-priority))))
+
+#?(:cljs
+   (defn- index-of-type
+     "1-based index among same-tag siblings under the same parent.
+     Returns nil when `el` has no parent (root / disconnected).
+     The implementation walks `previousElementSibling` so we don't
+     allocate a full sibling array."
+     [el]
+     (when-let [parent (.-parentElement el)]
+       (let [tag (.-tagName el)]
+         (loop [sib (.-previousElementSibling el) idx 1]
+           (cond
+             (nil? sib)               idx
+             (= (.-tagName sib) tag)  (recur (.-previousElementSibling sib)
+                                             (inc idx))
+             :else                    (recur (.-previousElementSibling sib)
+                                             idx)))))))
+
+#?(:cljs
+   (defn element->shape
+     "Read the priority-relevant slice of `el` into a shape map
+     `pick-selector` understands. Returns nil for nil input."
+     [el]
+     (when el
+       {:tag           (some-> (.-tagName el) str str/lower-case)
+        :attrs         (relevant-attrs el)
+        :index-of-type (index-of-type el)})))
+
+#?(:cljs
+   (defn pick-for-element
+     "Convenience: `element->shape` → `pick-selector`. The hot path the
+     DOM-capture layer reaches for on every observed click / change.
+     Returns nil if no usable selector can be derived."
+     [el]
+     (some-> el element->shape pick-selector)))

--- a/tools/story/src/re_frame/story/ui/recorder.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder.cljs
@@ -65,6 +65,7 @@
             [reagent.core :as r]
             [re-frame.story.config                       :as config]
             [re-frame.story.recorder                     :as recorder]
+            [re-frame.story.recorder.dom-capture         :as recorder-dom]
             [re-frame.story.review-dialog                :as review-dialog]
             [re-frame.story.ui.recorder-export-dialog    :as export-dialog]
             [re-frame.story.ui.state                     :as state]))
@@ -317,11 +318,16 @@
 (defn- open-dialog!
   "Open the save-as-variant dialog against `source-variant-id` with
   the captured `events` snapshot. `now-ms` defaults to the current
-  wall-clock; tests pass an explicit stamp."
+  wall-clock; tests pass an explicit stamp. Per rf2-d5u89 the
+  captured `:entries` are snapshotted alongside `:events` so the
+  export dialog drives the `:play-script` translator with the rich
+  DOM-event + timing record."
   ([source-variant-id events]
-   (open-dialog! source-variant-id events (.now js/Date)))
+   (open-dialog! source-variant-id events (recorder/recorded-entries) (.now js/Date)))
   ([source-variant-id events now-ms]
-   (swap! ui-dialog recorder/open-dialog source-variant-id events now-ms)))
+   (open-dialog! source-variant-id events (recorder/recorded-entries) now-ms))
+  ([source-variant-id events entries now-ms]
+   (swap! ui-dialog recorder/open-dialog source-variant-id events entries now-ms)))
 
 (defn- close-dialog! []
   (swap! ui-dialog recorder/close-dialog))
@@ -359,10 +365,19 @@
         on-click   (fn [_]
                      (cond
                        (and (not rec?) target)
-                       (recorder/start-recording! target)
+                       (do
+                         ;; rf2-d5u89: re-attach DOM-capture listeners to
+                         ;; the current canvas root. The shell's mount-
+                         ;; time install handles the common case, but mode
+                         ;; switches (Docs / Test → Canvas) re-mount the
+                         ;; canvas DOM and we want capture wired to the
+                         ;; live node before recording starts. Idempotent.
+                         (recorder-dom/install!)
+                         (recorder/start-recording! target))
 
                        rec?
-                       (let [{:keys [variant-id events]} (recorder/stop-recording!)]
+                       (let [_     (recorder-dom/flush-type-buffer!)
+                             {:keys [variant-id events]} (recorder/stop-recording!)]
                          (when (seq events)
                            (open-dialog! variant-id events)))))]
     [:button
@@ -561,13 +576,26 @@
                 :on-click  (fn [_] (insert!))}
                "insert"]]]))]])))
 
+;; rf2-d5u89: Reagent-mirror of the DOM-capture enabled flag so the
+;; overlay chip re-renders when the user toggles capture. The flag
+;; lives in the dom-capture ns; here we just mirror it.
+
+(defonce ui-dom-capture-enabled? (r/atom (recorder-dom/enabled?)))
+
+(defn- toggle-dom-capture! []
+  (let [new-val (not @ui-dom-capture-enabled?)]
+    (recorder-dom/set-enabled! new-val)
+    (reset! ui-dom-capture-enabled? new-val)))
+
 (defn recording-overlay
   "Fixed-position banner that floats at the top-right of the shell
   while a recording is in flight. Surfaces the target variant + the
   running event count + a `+ assert` button for mid-recording
-  assertion insertion (rf2-39u9e)."
+  assertion insertion (rf2-39u9e). Per rf2-d5u89 the overlay also
+  exposes a `DOM` toggle for opting in/out of DOM-event capture."
   []
-  (let [{:keys [recording? variant-id events]} @ui-state]
+  (let [{:keys [recording? variant-id events]} @ui-state
+        dom-on? @ui-dom-capture-enabled?]
     (when recording?
       [:div
        {:style       (:overlay styles)
@@ -581,6 +609,18 @@
        [:span {:style {:color "#9a9a9a"}}
         (str (count events) " event" (when (not= 1 (count events)) "s"))]
        [:button
+        {:style       (if dom-on?
+                        (assoc (:assert-btn styles) :background "#0e639c")
+                        (assoc (:btn-muted styles)  :opacity     "0.6"))
+         :data-test   "story-recorder-toggle-dom"
+         :data-enabled (if dom-on? "true" "false")
+         :title       (if dom-on?
+                        "DOM-event capture ON — click + type are recorded. Click to disable."
+                        "DOM-event capture OFF — only dispatched events are recorded. Click to enable.")
+         :aria-pressed (if dom-on? "true" "false")
+         :on-click    (fn [_] (toggle-dom-capture!))}
+        (if dom-on? "DOM on" "DOM off")]
+       [:button
         {:style     (:assert-btn styles)
          :data-test "story-recorder-add-assertion"
          :title     "Insert a :rf.assert/* assertion into the captured :play body"
@@ -590,6 +630,10 @@
         {:style    (:btn-muted styles)
          :data-test "story-recorder-stop"
          :on-click (fn [_]
+                     ;; rf2-d5u89: drain pending typed-input buffer
+                     ;; before sealing the recording so the final
+                     ;; :dom/type entry lands in the script.
+                     (recorder-dom/flush-type-buffer!)
                      (let [{:keys [variant-id events]} (recorder/stop-recording!)]
                        (when (seq events)
                          (open-dialog! variant-id events))))}
@@ -611,8 +655,8 @@
   snapshot was taken at `open-dialog!` time so a subsequent
   `start-recording!` cannot mutate the visible snippet (rf2-8x9nb)."
   []
-  (let [dialog                          @ui-dialog
-        {:keys [events source-id]}      dialog]
+  (let [dialog                                  @ui-dialog
+        {:keys [events entries source-id]}      dialog]
     (when (:open? dialog)
       (let [draft-id (:draft-id dialog)
             snippet  (recorder/gen-play-snippet
@@ -640,6 +684,7 @@
            :on-export         (fn []
                                 (export-dialog/open-from-recorder-dialog!
                                   {:events    events
+                                   :entries   entries
                                    :source-id source-id}))
            :on-close          close-dialog!
            :data-test-prefix  "story-recorder"})))))

--- a/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
+++ b/tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs
@@ -66,7 +66,8 @@
   state` carries plus the export-specific options."
   {:open?               false
    :source-id           nil   ; the recorded variant-id (rides into :extends)
-   :events              []    ; captured events snapshot
+   :events              []    ; captured events snapshot (legacy)
+   :entries             []    ; rich :entries snapshot (rf2-d5u89)
    :variant-id          nil   ; the new variant id (user-editable)
    :name                ""    ; optional :name field on the play-script
    :auto-assert?        true
@@ -84,19 +85,24 @@
   "Open the export dialog. `opts`:
 
     :source-id        — the recorded variant-id (rides into `:extends`).
-    :events           — captured events snapshot.
+    :events           — captured events snapshot (legacy bare-vectors).
+    :entries          — rich :entries snapshot (rf2-d5u89). When
+                        non-empty, the translator consumes this in
+                        preference to `:events` so DOM-events + per-
+                        event timestamps flow through to the script.
     :variant-id       — default new-variant id (user-editable inline).
     :final-db         — optional app-db snapshot at recording-end;
                         consumed by the auto-assert option.
 
   Idempotent — opening twice replaces the in-flight state."
-  [{:keys [source-id events variant-id final-db]}]
+  [{:keys [source-id events entries variant-id final-db]}]
   (when config/enabled?
     (reset! ui-dialog
             (assoc initial-state
                    :open?      true
                    :source-id  source-id
                    :events     (vec (or events []))
+                   :entries    (vec (or entries []))
                    :variant-id (or variant-id
                                    (when (qualified-keyword? source-id)
                                      (keyword (namespace source-id)
@@ -122,15 +128,19 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- build-export-from-dialog
-  [{:keys [events source-id variant-id name auto-assert? final-db]}]
-  (export-events/build-export
-    events
-    (cond-> {:variant-id variant-id
-             :extends    source-id
-             :auto-run?  true}
-      (and (string? name) (seq name)) (assoc :name name)
-      auto-assert?                     (assoc :auto-assert? true
-                                              :final-db     final-db))))
+  [{:keys [events entries source-id variant-id name auto-assert? final-db]}]
+  ;; Prefer the rich :entries snapshot when it carries anything —
+  ;; that's where DOM-events + per-event timestamps live (rf2-d5u89).
+  ;; Fall back to the legacy :events vector for back-compat.
+  (let [src (if (seq entries) entries events)]
+    (export-events/build-export
+      src
+      (cond-> {:variant-id variant-id
+               :extends    source-id
+               :auto-run?  true}
+        (and (string? name) (seq name)) (assoc :name name)
+        auto-assert?                     (assoc :auto-assert? true
+                                                :final-db     final-db)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Replay
@@ -368,11 +378,15 @@
 (defn open-from-recorder-dialog!
   "Open the export dialog using the recorder save-dialog's captured
   snapshot. Reads the live frame db at click time so the auto-assert
-  option can derive assertions from real data."
-  [{:keys [events source-id]}]
+  option can derive assertions from real data. Per rf2-d5u89 the
+  caller threads the recorder's `:entries` (rich DOM-event + timing
+  record) alongside `:events` so the translator emits `:click` /
+  `:type` / `:wait` steps when DOM-events were captured."
+  [{:keys [events entries source-id]}]
   (when config/enabled?
     (open-dialog!
       {:source-id source-id
        :events    events
+       :entries   entries
        :final-db  (when source-id
                     (export-events/snapshot-frame-db source-id))})))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -59,6 +59,7 @@
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.play-status :as play-status]
+            [re-frame.story.recorder.dom-capture :as recorder-dom]
             [re-frame.story.ui.recorder :as recorder-ui]
             [re-frame.story.ui.recorder-export-dialog :as recorder-export-ui]
             [re-frame.story.ui.save-variant :as save-variant-ui]
@@ -633,6 +634,19 @@
          ;; it installed is free; we only need to make sure it
          ;; exists before the user clicks REC.
          (recorder-ui/install-trace-listener!)
+         ;; rf2-d5u89: install the recorder's DOM-capture listeners
+         ;; on the canvas root so :click / :input / :change / :submit
+         ;; events translate into [:dom/click ...] / [:dom/type ...]
+         ;; / [:dom/submit ...] entries on the recorder's :entries
+         ;; stream. Delegate to a one-tick `setTimeout` so the React
+         ;; tree has committed the `[data-test=\"story-canvas-frame\"]`
+         ;; root before the install tries to find it. The listener
+         ;; short-circuits when no recording is in flight, so the
+         ;; install is free even when REC is idle.
+         (js/setTimeout
+           (fn []
+             (recorder-dom/install!))
+           0)
          ;; rf2-one3t: install the save-as-variant dialog-open callback
          ;; against the pure ns so `save-variant/save-current-as-variant!`
          ;; can drive the modal without coupling the .cljc helper to
@@ -653,6 +667,9 @@
        (stop-hot-reload-poll!)
        (remove-selection-watcher!)
        (recorder-ui/remove-trace-listener!)
+       ;; rf2-d5u89: tear down DOM-capture listeners alongside the
+       ;; trace listener so we don't leak listeners across re-mounts.
+       (recorder-dom/remove!)
        (teardown-all-listeners!))
      :reagent-render
      (fn []

--- a/tools/story/test/re_frame/story/recorder/dom_capture_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/recorder/dom_capture_cljs_test.cljs
@@ -1,0 +1,260 @@
+(ns re-frame.story.recorder.dom-capture-cljs-test
+  "CLJS-only tests for the recorder's DOM-event capture layer
+  (rf2-d5u89). Exercises:
+
+  - Selector picking via real DOM nodes.
+  - The impure recorder seams (`record-dom-click!` etc.) appending
+    onto the recorder's `:entries` stream.
+  - Click handler captures with the right selector tier.
+  - Type debounce — rapid input + change yields a single :dom/type
+    entry with the final value.
+  - Form submit captures `[:dom/submit ...]`.
+
+  The corpus mounts a transient DOM root inside the test document
+  (`document.body`) for each test, installs the capture listeners
+  on it, drives synthetic events, and tears the root down on each
+  fixture exit.
+
+  ## Runtime gating
+
+  shadow-cljs's `:node-test` build picks up every `*_cljs_test.cljs`
+  under the classpath. Node doesn't carry a `js/document`, so every
+  deftest body below short-circuits via `dom-available?` when run
+  on node-test. Each test ships its real assertions only under the
+  `:browser-test` runner. The shared ns-regexp tier means the file
+  IS picked up under both; the gate keeps node-test green without
+  any per-test rename/exclude dance."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.story.recorder :as recorder]
+            [re-frame.story.recorder.dom-capture :as dom]
+            [re-frame.story.recorder.selector :as sel]))
+
+;; ---- runtime gate --------------------------------------------------------
+
+(defn- dom-available? []
+  (and (exists? js/document)
+       (some? (.-body js/document))))
+
+;; ---- transient DOM root --------------------------------------------------
+
+(def ^:private test-root (atom nil))
+
+(defn- mount-root! []
+  (let [el (.createElement js/document "div")]
+    (.setAttribute el "data-test" "story-canvas-frame")
+    (.appendChild (.-body js/document) el)
+    (reset! test-root el)
+    el))
+
+(defn- unmount-root! []
+  (when-let [el @test-root]
+    (when (.-parentNode el)
+      (.removeChild (.-parentNode el) el)))
+  (reset! test-root nil))
+
+(defn- reset-all! [f]
+  (if-not (dom-available?)
+    ;; node-test: skip the DOM fixture entirely. The individual
+    ;; deftest bodies short-circuit on `dom-available?` too.
+    (f)
+    (do
+      (recorder/clear!)
+      (dom/set-enabled! true)
+      (dom/set-debounce-ms! 0)
+      (let [_ (mount-root!)]
+        (dom/install! @test-root)
+        (try
+          (f)
+          (finally
+            (dom/remove!)
+            (unmount-root!)
+            (recorder/clear!)
+            (dom/set-debounce-ms! 250)))))))
+
+(use-fixtures :each reset-all!)
+
+;; ---- selector picking via real DOM elements ------------------------------
+
+(deftest pick-for-element-prefers-data-test
+  (when (dom-available?)
+    (testing "pick-for-element walks priority on a real DOM element"
+      (let [btn (.createElement js/document "button")]
+        (.setAttribute btn "data-test" "go")
+        (.setAttribute btn "id" "btn-1")
+        (is (= "[data-test=\"go\"]"
+               (sel/pick-for-element btn)))))))
+
+(deftest pick-for-element-falls-back-to-nth
+  (when (dom-available?)
+    (testing "no useful attributes → nth-of-type fallback"
+      (let [parent (.createElement js/document "div")
+            a (.createElement js/document "button")
+            b (.createElement js/document "button")
+            c (.createElement js/document "button")]
+        (.appendChild parent a)
+        (.appendChild parent b)
+        (.appendChild parent c)
+        (is (= "button:nth-of-type(2)"
+               (sel/pick-for-element b)))))))
+
+;; ---- impure recorder seams ----------------------------------------------
+
+(deftest record-dom-click-appends-entry
+  (when (dom-available?)
+    (recorder/start-recording! :story.x/y)
+    (dom/record-dom-click! "[data-test=\"go\"]")
+    (let [entries (recorder/recorded-entries)]
+      (is (= 1 (count entries)))
+      (let [{:keys [kind selector t]} (first entries)]
+        (is (= :dom/click kind))
+        (is (= "[data-test=\"go\"]" selector))
+        (is (number? t))))))
+
+(deftest record-dom-type-appends-entry
+  (when (dom-available?)
+    (recorder/start-recording! :story.x/y)
+    (dom/record-dom-type! "[id=\"name\"]" "alice")
+    (let [{:keys [kind selector text]} (first (recorder/recorded-entries))]
+      (is (= :dom/type kind))
+      (is (= "[id=\"name\"]" selector))
+      (is (= "alice" text)))))
+
+(deftest record-dom-submit-appends-entry
+  (when (dom-available?)
+    (recorder/start-recording! :story.x/y)
+    (dom/record-dom-submit! "[id=\"login\"]")
+    (is (= :dom/submit (:kind (first (recorder/recorded-entries)))))))
+
+(deftest noops-when-not-recording
+  (when (dom-available?)
+    (testing "DOM-event records drop when no recording is in flight"
+      (is (not (recorder/recording?)))
+      (dom/record-dom-click! "anywhere")
+      (dom/record-dom-type! "anywhere" "x")
+      (dom/record-dom-submit! "anywhere")
+      (is (= [] (recorder/recorded-entries))))))
+
+(deftest noops-when-dom-capture-disabled
+  (when (dom-available?)
+    (testing "DOM-event records drop when the toggle is off — even mid-recording"
+      (dom/set-enabled! false)
+      (recorder/start-recording! :story.x/y)
+      (let [btn (.createElement js/document "button")]
+        (.setAttribute btn "data-test" "go")
+        (.appendChild @test-root btn)
+        (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
+        (is (= [] (recorder/recorded-entries))
+            "no DOM entries captured while the toggle is off")))))
+
+;; ---- click handler via synthetic DOM events ------------------------------
+
+(deftest click-listener-captures-with-selector
+  (when (dom-available?)
+    (recorder/start-recording! :story.x/y)
+    (let [btn (.createElement js/document "button")]
+      (.setAttribute btn "data-test" "submit")
+      (.appendChild @test-root btn)
+      (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
+      (let [entries (recorder/recorded-entries)]
+        (is (= 1 (count entries)))
+        (is (= :dom/click (:kind (first entries))))
+        (is (= "[data-test=\"submit\"]" (:selector (first entries))))))))
+
+;; ---- type debounce (final-value semantics) ------------------------------
+
+(deftest rapid-typing-folds-to-single-entry
+  (when (dom-available?)
+    (testing "many input events on the same input → ONE :dom/type entry with the final value"
+      (recorder/start-recording! :story.x/y)
+      ;; Bump the debounce window high so the buffer holds the
+      ;; intermediate input values until we trigger a flush
+      ;; manually. The fixture's default debounce-ms (0) would
+      ;; cause each input event to flush synchronously — that's
+      ;; the path the click-as-flush-point test covers; this one
+      ;; verifies the debounce semantics itself.
+      (dom/set-debounce-ms! 5000)
+      (let [input (.createElement js/document "input")]
+        (.setAttribute input "id" "name")
+        (.appendChild @test-root input)
+        (doseq [v ["a" "al" "ali" "alic" "alice"]]
+          (set! (.-value input) v)
+          (.dispatchEvent input (js/Event. "input" #js {:bubbles true})))
+        ;; Flush manually; under real use this happens on debounce
+        ;; expiry / click / stop-recording.
+        (dom/flush-type-buffer!)
+        (let [type-entries (filterv #(= :dom/type (:kind %))
+                                    (recorder/recorded-entries))]
+          (is (= 1 (count type-entries))
+              "five input events fold to a single :dom/type entry")
+          (is (= "alice" (:text (first type-entries)))
+              "the entry carries the final typed value"))))))
+
+(deftest change-event-flushes-immediately
+  (when (dom-available?)
+    (testing "a `change` event drains the per-selector type buffer"
+      (recorder/start-recording! :story.x/y)
+      (let [input (.createElement js/document "input")]
+        (.setAttribute input "id" "name")
+        (.appendChild @test-root input)
+        (set! (.-value input) "alice")
+        (.dispatchEvent input (js/Event. "change" #js {:bubbles true}))
+        (let [type-entries (filterv #(= :dom/type (:kind %))
+                                    (recorder/recorded-entries))]
+          (is (= 1 (count type-entries)))
+          (is (= "alice" (:text (first type-entries)))))))))
+
+(deftest submit-listener-captures-form-selector
+  (when (dom-available?)
+    (recorder/start-recording! :story.x/y)
+    (let [form (.createElement js/document "form")]
+      (.setAttribute form "id" "login")
+      (.appendChild @test-root form)
+      (let [ev (js/Event. "submit" #js {:bubbles true :cancelable true})]
+        (.dispatchEvent form ev))
+      (let [submit-entries (filterv #(= :dom/submit (:kind %))
+                                    (recorder/recorded-entries))]
+        (is (= 1 (count submit-entries)))
+        (is (= "[id=\"login\"]" (:selector (first submit-entries))))))))
+
+(deftest click-flushes-pending-type
+  (when (dom-available?)
+    (testing "a click after typing flushes the type buffer first, preserving order"
+      (recorder/start-recording! :story.x/y)
+      (let [input (.createElement js/document "input")
+            btn   (.createElement js/document "button")]
+        (.setAttribute input "id" "name")
+        (.setAttribute btn "data-test" "save")
+        (.appendChild @test-root input)
+        (.appendChild @test-root btn)
+        (dom/set-debounce-ms! 5000)
+        (set! (.-value input) "alice")
+        (.dispatchEvent input (js/Event. "input" #js {:bubbles true}))
+        (.dispatchEvent btn (js/MouseEvent. "click" #js {:bubbles true}))
+        (let [entries (recorder/recorded-entries)
+              kinds   (mapv :kind entries)]
+          (is (= [:dom/type :dom/click] kinds)
+              "type lands before click")
+          (is (= "alice" (:text (first entries)))))))))
+
+;; ---- enabled? / set-enabled! --------------------------------------------
+
+(deftest set-enabled-roundtrips
+  (when (dom-available?)
+    (dom/set-enabled! false)
+    (is (not (dom/enabled?)))
+    (dom/set-enabled! true)
+    (is (dom/enabled?))))
+
+;; ---- timestamps ride through to entries ---------------------------------
+
+(deftest dom-entries-carry-relative-timestamps
+  (when (dom-available?)
+    (testing "the recorded :t is relative to the recording's :started-ms"
+      (recorder/start-recording! :story.x/y)
+      (dom/record-dom-click! "[data-test=\"a\"]")
+      (let [{:keys [t]} (first (recorder/recorded-entries))]
+        (is (number? t))
+        (is (>= t 0)
+            ":t is non-negative ms since :started-ms")
+        (is (< t 10000)
+            "sanity: not an absolute epoch")))))

--- a/tools/story/test/re_frame/story/recorder/play_export_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/play_export_test.cljc
@@ -243,3 +243,229 @@
                     :final-db     {:n 1 :who "alice"}})]
       (is (= [] (runner/validate-script (:script spec)))
           "no malformed steps"))))
+
+;; ===========================================================================
+;; rf2-d5u89 — :entries shape + DOM-events + wait-step insertion
+;; ===========================================================================
+
+;; ---- entry->step ---------------------------------------------------------
+
+(deftest entry-step-dispatch
+  (testing ":event/dispatch entry of an ordinary event → [:dispatch ev]"
+    (is (= [:dispatch [:counter/inc]]
+           (export/entry->step
+             {:kind :event/dispatch :event [:counter/inc] :t 0})))))
+
+(deftest entry-step-assertion-rides-dispatch-sync
+  (testing ":event/dispatch entry of an assertion event → [:dispatch-sync ev]"
+    (is (= [:dispatch-sync [:rf.assert/path-equals [:n] 1]]
+           (export/entry->step
+             {:kind :event/dispatch
+              :event [:rf.assert/path-equals [:n] 1]
+              :t 0})))))
+
+(deftest entry-step-dom-click
+  (testing ":dom/click entry → [:click selector]"
+    (is (= [:click "[data-test=\"submit\"]"]
+           (export/entry->step
+             {:kind :dom/click :selector "[data-test=\"submit\"]" :t 250})))))
+
+(deftest entry-step-dom-type
+  (testing ":dom/type entry → [:type selector text]"
+    (is (= [:type "[id=\"name\"]" "alice"]
+           (export/entry->step
+             {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 300})))
+    (is (= [:type "[id=\"x\"]" ""]
+           (export/entry->step
+             {:kind :dom/type :selector "[id=\"x\"]" :t 0}))
+        "missing :text defaults to empty string")))
+
+(deftest entry-step-dom-submit-maps-to-click
+  (testing ":dom/submit entry → best-effort [:click form-selector]"
+    (is (= [:click "[id=\"login-form\"]"]
+           (export/entry->step
+             {:kind :dom/submit :selector "[id=\"login-form\"]" :t 0})))))
+
+(deftest entry-step-redacted-dispatch-drops
+  (testing ":event/dispatch of a [:rf/redacted] placeholder yields nil"
+    (is (nil? (export/entry->step
+                {:kind :event/dispatch :event [:rf/redacted] :t 0})))))
+
+(deftest entry-step-unknown-kind-yields-nil
+  (testing "unknown entry kinds yield nil"
+    (is (nil? (export/entry->step {:kind :unknown :selector "x" :t 0})))
+    (is (nil? (export/entry->step nil)))
+    (is (nil? (export/entry->step {})))))
+
+(deftest entry-step-missing-selector-yields-nil
+  (testing "DOM-entry without a selector yields nil"
+    (is (nil? (export/entry->step {:kind :dom/click :t 0})))
+    (is (nil? (export/entry->step {:kind :dom/type :text "x" :t 0})))
+    (is (nil? (export/entry->step {:kind :dom/submit :t 0})))))
+
+;; ---- entries->steps + wait insertion -------------------------------------
+
+(deftest entries-translate-in-order
+  (testing "entries translate to steps in declared order"
+    (is (= [[:dispatch [:counter/inc]]
+            [:click "[data-test=\"x\"]"]
+            [:type "[id=\"name\"]" "alice"]]
+           (export/entries->steps
+             [{:kind :event/dispatch :event [:counter/inc] :t 0}
+              {:kind :dom/click :selector "[data-test=\"x\"]" :t 10}
+              {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 20}])))))
+
+(deftest wait-step-inserted-when-gap-exceeds-threshold
+  (testing "consecutive entries > threshold ms apart get a [:wait Δt] between them"
+    (is (= [[:click "[data-test=\"a\"]"]
+            [:wait 100]
+            [:click "[data-test=\"b\"]"]]
+           (export/entries->steps
+             [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
+              {:kind :dom/click :selector "[data-test=\"b\"]" :t 100}])))))
+
+(deftest no-wait-when-gap-below-threshold
+  (testing "sub-threshold gaps fold out (no :wait noise)"
+    (is (= [[:click "[data-test=\"a\"]"]
+            [:click "[data-test=\"b\"]"]]
+           (export/entries->steps
+             [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
+              {:kind :dom/click :selector "[data-test=\"b\"]" :t 25}])))))
+
+(deftest wait-threshold-override
+  (testing "the :wait-threshold-ms opt tunes the gap detector"
+    (is (= [[:click "[data-test=\"a\"]"]
+            [:wait 30]
+            [:click "[data-test=\"b\"]"]]
+           (export/entries->steps
+             [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
+              {:kind :dom/click :selector "[data-test=\"b\"]" :t 30}]
+             {:wait-threshold-ms 10})))))
+
+(deftest large-wait-threshold-disables-waits
+  (testing "an effectively-infinite threshold suppresses every wait"
+    (is (= [[:click "[data-test=\"a\"]"]
+            [:click "[data-test=\"b\"]"]]
+           (export/entries->steps
+             [{:kind :dom/click :selector "[data-test=\"a\"]" :t 0}
+              {:kind :dom/click :selector "[data-test=\"b\"]" :t 5000}]
+             {:wait-threshold-ms 999999})))))
+
+(deftest mixed-events-and-dom-translate-together
+  (testing "dispatched events + DOM events + waits compose"
+    (is (= [[:dispatch [:counter/inc]]
+            [:wait 100]
+            [:click "[data-test=\"submit\"]"]
+            [:type "[id=\"name\"]" "alice"]]
+           (export/entries->steps
+             [{:kind :event/dispatch :event [:counter/inc] :t 0}
+              {:kind :dom/click :selector "[data-test=\"submit\"]" :t 100}
+              {:kind :dom/type :selector "[id=\"name\"]" :text "alice" :t 120}])))))
+
+(deftest redacted-entries-do-not-leave-orphan-waits
+  (testing "a dropped (redacted) entry doesn't insert a wait for itself,
+            but later entries still compare against the most recent
+            translated step's timestamp"
+    (is (= [[:dispatch [:counter/inc]]
+            [:wait 200]
+            [:dispatch [:counter/dec]]]
+           (export/entries->steps
+             [{:kind :event/dispatch :event [:counter/inc]   :t 0}
+              {:kind :event/dispatch :event [:rf/redacted]   :t 100}
+              {:kind :event/dispatch :event [:counter/dec]   :t 200}])))))
+
+;; ---- recording->play-script with the rich :entries shape -----------------
+
+(deftest recording-from-entries
+  (testing "passing rich :entries vectors produces a full-fidelity script"
+    (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
+                   {:kind :dom/click :selector "[data-test=\"b\"]" :t 200}
+                   {:kind :dom/type  :selector "[id=\"x\"]" :text "hi" :t 220}]
+          spec    (export/recording->play-script entries)]
+      (is (= [[:dispatch [:counter/inc]]
+              [:wait 200]
+              [:click "[data-test=\"b\"]"]
+              [:type "[id=\"x\"]" "hi"]]
+             (:script spec))
+          "200ms gap → wait; 20ms gap → no wait"))))
+
+(deftest recording-from-entries-respects-wait-threshold-opt
+  (testing ":wait-threshold-ms opt threads through recording->play-script"
+    (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
+                   {:kind :event/dispatch :event [:counter/dec] :t 75}]
+          spec    (export/recording->play-script entries {:wait-threshold-ms 100})]
+      (is (= [[:dispatch [:counter/inc]]
+              [:dispatch [:counter/dec]]]
+             (:script spec))
+          "75ms gap < 100ms threshold — no :wait inserted"))))
+
+(deftest legacy-bare-events-still-translate-without-waits
+  (testing "callers that still pass bare event-vectors get the old behaviour
+            (no :wait steps emitted — all entries stamped :t 0)"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc] [:counter/inc] [:counter/dec]])]
+      (is (= [[:dispatch [:counter/inc]]
+              [:dispatch [:counter/inc]]
+              [:dispatch [:counter/dec]]]
+             (:script spec))))))
+
+(deftest mixed-bare-and-entry-input
+  (testing "an input vector mixing bare event vectors and rich entries
+            still coerces cleanly"
+    (let [spec (export/recording->play-script
+                 [[:counter/inc]
+                  {:kind :dom/click :selector "[data-test=\"b\"]" :t 100}])]
+      (is (= [[:dispatch [:counter/inc]]
+              [:wait 100]
+              [:click "[data-test=\"b\"]"]]
+             (:script spec))))))
+
+(deftest exported-rich-script-survives-runner-parse-spec
+  (testing "rich-entries-derived script passes runner/parse-spec + validate-script clean"
+    (let [entries [{:kind :event/dispatch :event [:counter/inc] :t 0}
+                   {:kind :dom/click :selector "[data-test=\"b\"]" :t 80}
+                   {:kind :dom/type  :selector "[id=\"x\"]" :text "hi" :t 200}]
+          spec    (export/recording->play-script entries {:name "round trip"})
+          parsed  (runner/parse-spec spec)]
+      (is (= (:script spec) (:script parsed))
+          "runner parses identically — no normalisation drift")
+      (is (every? runner/known-step? (:script parsed))
+          "every emitted step is a known runner step")
+      (is (every? runner/step-arity-ok? (:script parsed))
+          "every emitted step has a legal arity")
+      (is (= [] (runner/validate-script (:script parsed)))
+          "no malformed steps"))))
+
+(deftest dom-submit-survives-runner-validation
+  (testing "the :dom/submit best-effort translation produces a valid :click step"
+    (let [entries [{:kind :dom/submit :selector "[id=\"login-form\"]" :t 0}]
+          spec    (export/recording->play-script entries)]
+      (is (= [[:click "[id=\"login-form\"]"]] (:script spec)))
+      (is (= [] (runner/validate-script (:script spec)))))))
+
+;; ---- round-trip: 4-step recording → export → runner-parse → assert -------
+
+(deftest four-step-round-trip
+  (testing "a 4-step interaction (click → type → click → dispatch) survives
+            the full export + parse pipeline"
+    (let [entries [{:kind :dom/click :selector "[data-test=\"open\"]"  :t 0}
+                   {:kind :dom/type  :selector "[id=\"name\"]" :text "alice" :t 200}
+                   {:kind :dom/click :selector "[data-test=\"save\"]"  :t 600}
+                   {:kind :event/dispatch :event [:counter/inc] :t 1100}]
+          spec    (export/recording->play-script entries {:name "round trip"})
+          parsed  (runner/parse-spec spec)]
+      ;; Translation contract — every event lifts and waits insert.
+      (is (= [[:click "[data-test=\"open\"]"]
+              [:wait 200]
+              [:type "[id=\"name\"]" "alice"]
+              [:wait 400]
+              [:click "[data-test=\"save\"]"]
+              [:wait 500]
+              [:dispatch [:counter/inc]]]
+             (:script spec))
+          "all four entries translate; waits insert on each >50ms gap")
+      ;; Runner contract — every emitted step is well-formed.
+      (is (every? runner/known-step? (:script spec)))
+      (is (every? runner/step-arity-ok? (:script spec)))
+      (is (= [] (runner/validate-script (:script spec))))
+      (is (= "round trip" (:name parsed))))))

--- a/tools/story/test/re_frame/story/recorder/selector_test.cljc
+++ b/tools/story/test/re_frame/story/recorder/selector_test.cljc
@@ -1,0 +1,107 @@
+(ns re-frame.story.recorder.selector-test
+  "Pure unit tests for the recorder's selector picker (rf2-d5u89).
+
+  Covers:
+  - Priority tiers (data-test > id > aria-label > nth-of-type).
+  - Attribute-value escaping (backslash + double-quote).
+  - Nth-of-type fallback geometry.
+  - `selector-kind` diagnostic returns the right tier."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.recorder.selector :as sel]))
+
+;; ---- priority tiers ------------------------------------------------------
+
+(deftest data-test-wins
+  (testing "data-test attribute beats id / aria-label / nth-of-type"
+    (is (= "[data-test=\"submit-btn\"]"
+           (sel/pick-selector
+             {:tag "button"
+              :attrs {"data-test"  "submit-btn"
+                      "id"         "btn-1"
+                      "aria-label" "Submit"}
+              :index-of-type 3})))))
+
+(deftest id-when-no-data-test
+  (testing "id wins when data-test is absent"
+    (is (= "[id=\"counter-input\"]"
+           (sel/pick-selector
+             {:tag "input"
+              :attrs {"id"         "counter-input"
+                      "aria-label" "Counter"}
+              :index-of-type 2})))))
+
+(deftest aria-label-when-no-data-test-or-id
+  (testing "aria-label wins when data-test and id are absent"
+    (is (= "[aria-label=\"Close dialog\"]"
+           (sel/pick-selector
+             {:tag "button"
+              :attrs {"aria-label" "Close dialog"}
+              :index-of-type 1})))))
+
+(deftest nth-of-type-fallback
+  (testing "nth-of-type fires when no attribute matches"
+    (is (= "button:nth-of-type(3)"
+           (sel/pick-selector
+             {:tag "BUTTON"
+              :attrs {}
+              :index-of-type 3})))))
+
+(deftest nth-of-type-falls-back-to-star
+  (testing "nth-of-type uses * when tag is missing/blank"
+    (is (= "*:nth-of-type(2)"
+           (sel/pick-selector
+             {:tag nil
+              :attrs {}
+              :index-of-type 2})))))
+
+(deftest returns-nil-when-nothing-usable
+  (testing "no attributes + no index → nil"
+    (is (nil? (sel/pick-selector {:tag "div" :attrs {} :index-of-type nil})))
+    (is (nil? (sel/pick-selector {})))))
+
+(deftest blank-attribute-values-are-ignored
+  (testing "blank / whitespace attribute values fall through to next tier"
+    (is (= "[id=\"x\"]"
+           (sel/pick-selector
+             {:tag "input"
+              :attrs {"data-test" "   "  ; blank, skip
+                      "id"        "x"}})))
+    (is (= "*:nth-of-type(1)"
+           (sel/pick-selector
+             {:tag nil
+              :attrs {"data-test" ""
+                      "id"        nil
+                      "aria-label" "  "}
+              :index-of-type 1})))))
+
+;; ---- escaping ------------------------------------------------------------
+
+(deftest escapes-double-quotes
+  (testing "double-quote inside value is escaped"
+    (is (= "[id=\"he said \\\"hi\\\"\"]"
+           (sel/pick-selector
+             {:tag "div"
+              :attrs {"id" "he said \"hi\""}})))))
+
+(deftest escapes-backslashes
+  (testing "backslash inside value is escaped"
+    (is (= "[id=\"a\\\\b\"]"
+           (sel/pick-selector
+             {:tag "div"
+              :attrs {"id" "a\\b"}})))))
+
+;; ---- selector-kind diagnostic --------------------------------------------
+
+(deftest selector-kind-reports-tier
+  (is (= :data-test  (sel/selector-kind {:attrs {"data-test" "x"}})))
+  (is (= :id         (sel/selector-kind {:attrs {"id" "x"}})))
+  (is (= :aria-label (sel/selector-kind {:attrs {"aria-label" "x"}})))
+  (is (= :nth-of-type (sel/selector-kind {:attrs {} :index-of-type 2})))
+  (is (= :none       (sel/selector-kind {:attrs {} :index-of-type nil}))))
+
+;; ---- attribute-priority is the documented data ---------------------------
+
+(deftest priority-list-is-data-test-id-aria-label
+  (testing "the priority list order matches the documented contract"
+    (is (= ["data-test" "id" "aria-label"]
+           (mapv first sel/attribute-priority)))))

--- a/tools/story/test/re_frame/story_recorder_test.clj
+++ b/tools/story/test/re_frame/story_recorder_test.clj
@@ -247,6 +247,61 @@
       (is (some? play-str) "extractor found a :play vector substring")
       (is (= events (edn/read-string play-str))))))
 
+;; ---- rf2-d5u89: DOM-event entries + per-event timestamps ----------------
+
+(deftest append-dom-click-pure-shape
+  (testing "append-dom of a click vector lands an :entries entry"
+    (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+          s1 (recorder/append-dom s0 [:dom/click "[data-test=\"a\"]" 100])]
+      (is (= 1 (count (:entries s1))))
+      (is (= {:kind :dom/click :selector "[data-test=\"a\"]" :t 100}
+             (first (:entries s1)))))))
+
+(deftest append-dom-type-pure-shape
+  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+        s1 (recorder/append-dom s0 [:dom/type "[id=\"x\"]" "alice" 200])]
+    (is (= {:kind :dom/type :selector "[id=\"x\"]" :text "alice" :t 200}
+           (first (:entries s1))))))
+
+(deftest append-dom-submit-pure-shape
+  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)
+        s1 (recorder/append-dom s0 [:dom/submit "[id=\"login\"]" 300])]
+    (is (= {:kind :dom/submit :selector "[id=\"login\"]" :t 300}
+           (first (:entries s1))))))
+
+(deftest append-dom-rejects-malformed
+  (let [s0 (recorder/start recorder/initial-state :story.x/y 0)]
+    (is (= [] (:entries (recorder/append-dom s0 nil))))
+    (is (= [] (:entries (recorder/append-dom s0 []))))
+    (is (= [] (:entries (recorder/append-dom s0 [:not-a-dom-kind "x" 0]))))))
+
+(deftest append-dom-noop-when-not-recording
+  (testing "DOM-events drop on the floor when no recording is in flight"
+    (let [s0 recorder/initial-state
+          s1 (recorder/append-dom s0 [:dom/click "[data-test=\"x\"]" 0])]
+      (is (= [] (:entries s1))))))
+
+(deftest append-event-stamps-timestamp
+  (testing "(append state event now-ms) populates :entries[:t]"
+    (let [s0 (recorder/start recorder/initial-state :story.x/y 1000)
+          s1 (recorder/append s0 [:counter/inc] 1250)]
+      (is (= [[:counter/inc]] (:events s1)) ":events carries bare event")
+      (let [{:keys [kind event t]} (first (:entries s1))]
+        (is (= :event/dispatch kind))
+        (is (= [:counter/inc] event))
+        (is (= 250 t) ":t = now-ms - started-ms (1250 - 1000)")))))
+
+(deftest record-dom-event!-impure-entry
+  (testing "the impure record-dom-event! entry mutates the shared atom"
+    (recorder/clear!)
+    (recorder/start-recording! :story.x/y)
+    (recorder/record-dom-event! [:dom/click "[data-test=\"go\"]" 50])
+    (recorder/record-dom-event! [:dom/type "[id=\"x\"]" "hi" 100])
+    (let [entries (recorder/recorded-entries)]
+      (is (= 2 (count entries)))
+      (is (= :dom/click (:kind (first entries))))
+      (is (= :dom/type (:kind (second entries)))))))
+
 ;; ---- mid-recording assertion insertion (rf2-39u9e) ----------------------
 
 (deftest assertion-vocabulary-covers-canonical-seven
@@ -446,7 +501,19 @@
     (rf/dispatch-sync [:counter/dec] {:frame :story.recorder/v})
     (recorder/stop-recording!)
     (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
-           (recorder/recorded-events)))
+           (recorder/recorded-events))
+        "back-compat :events slot still carries bare event vectors")
+    ;; rf2-d5u89: parallel :entries slot carries the rich shape too.
+    (let [entries (recorder/recorded-entries)]
+      (is (= 3 (count entries))
+          ":entries mirrors :events one-for-one")
+      (is (every? #(= :event/dispatch (:kind %)) entries)
+          "each entry is an :event/dispatch shape")
+      (is (= [[:counter/inc] [:counter/inc] [:counter/dec]]
+             (mapv :event entries))
+          ":event slot on each entry is the bare event vector")
+      (is (every? #(number? (:t %)) entries)
+          "each entry carries a numeric :t timestamp"))
     (story/destroy-variant! :story.recorder/v)
     (recorder/remove-trace-listener!)))
 


### PR DESCRIPTION
## Summary

Closes the loop with the rf2-x9zsr recorder → `:play-script` export pipeline. The recorder now captures DOM interactions (clicks, typed input, form submits) + per-event timestamps in a parallel `:entries` stream; the translator turns the rich entries into the full `:play-script` DSL (`:click` / `:type` / `:wait`) rather than dispatch-only steps.

Bead: rf2-d5u89 (stays open after merge per dispatch protocol).

## Translation table

| Recorded entry kind                                | Translated step              |
|----------------------------------------------------|------------------------------|
| `{:kind :event/dispatch :event ev :t ms}`          | `[:dispatch ev]`             |
| `{:kind :event/dispatch :event :rf.assert/* :t ms}` | `[:dispatch-sync ev]`       |
| `{:kind :event/dispatch :event [:rf/redacted] :t ms}` | dropped                  |
| `{:kind :dom/click :selector s :t ms}`             | `[:click s]`                 |
| `{:kind :dom/type :selector s :text t :t ms}`      | `[:type s t]`                |
| `{:kind :dom/submit :selector s :t ms}`            | `[:click s]` (best-effort)   |
| gap between entries ≥ `wait-threshold-ms` (50ms)   | `[:wait Δt]` inserted        |

## Selector picker priority

`tools/story/src/re_frame/story/recorder/selector.cljc` — pure picker walks a fixed priority list:

1. `[data-test="X"]` — canonical Story-/test-stable hook.
2. `[id="X"]` — next-best stable hook for form controls.
3. `[aria-label="X"]` — for icon buttons / unlabelled inputs.
4. `tag:nth-of-type(N)` — best-effort positional fallback.

Tier 4 is brittle by design — `selector-kind` exposes the diagnostic so callers (or future surfaces) can flag fallbacks for manual hardening.

## Flow

```
+--------------------+    click/input/change/submit    +-------------------+
|  story canvas root | ------------------------------> | dom-capture       |
|  [data-test=       |  bubble-phase listeners         |  (selector +      |
|   "story-canvas-   |                                  |   debounce)      |
|   frame"]          |                                  +---------+--------+
+--------------------+                                            |
                                                                  | record-dom-event!
                                                                  v
                                                       +---------------------+
                                                       |  recorder.cljc      |
                                                       |  :events  (legacy)  |
                                                       |  :entries (rich)    |
                                                       +----------+----------+
                                                                  | stop / open dialog
                                                                  v
                                                       +---------------------+
                                                       | save-dialog → export|
                                                       |  threads :entries   |
                                                       +----------+----------+
                                                                  | recording->play-script
                                                                  v
                                                       +---------------------+
                                                       | :play-script map    |
                                                       |  + :click / :type / |
                                                       |    :wait / :dispatch|
                                                       +---------------------+
```

## New files
- `tools/story/src/re_frame/story/recorder/selector.cljc` — pure selector picker + CLJS DOM-shape extractor.
- `tools/story/src/re_frame/story/recorder/dom_capture.cljs` — canvas-root listener install/teardown + per-selector type-debounce.
- `tools/story/test/re_frame/story/recorder/selector_test.cljc` — every priority tier + escape rules.
- `tools/story/test/re_frame/story/recorder/dom_capture_cljs_test.cljs` — synthetic-DOM-event tests (gated on `dom-available?`).

## Modified files
- `tools/story/src/re_frame/story/recorder.cljc` — `:entries` slot + `append-dom` / `record-dom-event!` + per-event `:t` stamping.
- `tools/story/src/re_frame/story/recorder/play_export.cljc` — `entry->step`, `entries->steps`, wait-step insertion, `recording->play-script` accepts both legacy + rich shapes.
- `tools/story/src/re_frame/story/ui/recorder.cljs` — re-install DOM capture on start-recording, flush type-buffer on stop, "DOM on/off" toggle chip on the recording overlay, thread `:entries` into export.
- `tools/story/src/re_frame/story/ui/recorder_export_dialog.cljs` — accept + prefer `:entries` when present.
- `tools/story/src/re_frame/story/ui/shell.cljs` — mount/unmount DOM-capture alongside the trace listener.
- `tools/story/test/re_frame/story/recorder/play_export_test.cljc` — DOM-event fixtures, wait-step coverage, four-step round-trip.
- `tools/story/test/re_frame/story_recorder_test.clj` — pure `append-dom` + `record-dom-event!` tests + verify the parallel `:entries` slot mirrors `:events` end-to-end.

## Test plan
- [x] `scripts/test-fast-pr.sh` — PASS (CLJS node 2851 / 8108)
- [x] `cd tools/story && clojure -M:test` — PASS (695 / 2128)
- [x] `cd implementation && npm run test:browser` — PASS (2840 / 8057)
- [x] `cd implementation && npm run test:story-play-scripts` — PASS (CI runner unchanged)
- [ ] Manual: record a 4-step interaction in a live story canvas → click `[Export as :play-script]` → verify the snippet emits `:click` / `:type` / `:wait` steps and round-trips through Replay.

## Divergences + follow-ons
- `:dom/submit` best-effort maps to `[:click form-selector]`. Recommend a follow-on bead to resolve the form's submit button rather than the form itself; filing not yet done so a fresh-eyes pass can scope it after this lands.
- `:nth-of-type` fallback is brittle (acknowledged in module doc + `selector-kind` diagnostic). Hardening heuristics (text-content matching, ancestor-stable-id chains) are filed as follow-on candidates — same fresh-eyes scope note.