### PR TITLE
feat(causa): managed-fx wire-boundary diff — unified request→wire→response→handler→app-db waterfall

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc
@@ -1,0 +1,193 @@
+(ns day8.re-frame2-causa.chart.timing-waterfall
+  "Wire-timing waterfall — pure SVG hiccup primitive for the
+  managed-fx wire-boundary diff panel (rf2-uyp86).
+
+  ## Why a separate ns
+
+  The waterfall renders per-phase timing for one managed-fx interaction:
+  one horizontal row per phase, bar width proportional to the phase's
+  share of total elapsed time, ms-label to the right. Five surfaces use
+  it (HTTP / WebSocket / machine-invoke / SSR / flow); promoting it to
+  a shared chart primitive keeps the panel template lean and the
+  rendering testable from `clojure -M:test`.
+
+  ## Shape
+
+  Input is a `wire-timing` map per
+  `panels/managed-fx-helpers/http-wire-timing`:
+
+      {:phases   [[:dns     2]
+                  [:connect 15]
+                  [:ssl     22]
+                  [:request 1]
+                  [:ttfb    180]
+                  [:download 30]]
+       :total-ms 250
+       :synthesised? false}
+
+  Each phase is `[<phase-keyword> <duration-ms>]`. The renderer normalises
+  bar widths against `:total-ms` (or against the sum of phase durations
+  if `:total-ms` is absent / inconsistent).
+
+  ## Reduced-motion
+
+  Per spec/019 §1.1 the live arc animation flattens to a static
+  bar + numeric percentage; the waterfall is already static (only the
+  per-phase bar width carries meaning), so no extra reduced-motion
+  handling is needed."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- visual constants --------------------------------------------------
+
+(def ^:private row-height 16)
+(def ^:private label-width 80)
+(def ^:private value-width 60)
+(def ^:private bar-padding 8)
+(def ^:private font-stack
+  "ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace")
+
+;; ---- pure projection ---------------------------------------------------
+
+(defn normalise-phases
+  "Resolve the timing input to a vector of `{:phase :duration-ms :width-pct :offset-pct}`
+  maps so the renderer is a pure positional walk.
+
+  Pure fn — JVM-testable.
+
+    - Drops phases with non-numeric / non-positive duration so a single
+      bogus row doesn't break the layout.
+    - `:width-pct` is `duration / total` ratio clamped to `[0, 1]`.
+    - `:offset-pct` is the running sum of preceding widths — supports
+      a layered (gantt-style) rendering where each phase starts after
+      its predecessor ends. The default ASCII-spec style is a
+      stack-of-bars (each row starts at 0); the panel can choose either
+      mode by reading the same projection."
+  [{:keys [phases total-ms]}]
+  (let [clean    (filterv (fn [[_ ms]] (and (number? ms) (pos? ms))) (or phases []))
+        sum      (reduce + 0 (map second clean))
+        total    (or (when (and (number? total-ms) (pos? total-ms)) total-ms)
+                     (when (pos? sum) sum)
+                     0)]
+    (if (or (zero? total) (empty? clean))
+      []
+      (loop [acc       []
+             offset    0
+             remaining clean]
+        (if (empty? remaining)
+          acc
+          (let [[ph ms] (first remaining)
+                width   (min 1.0 (max 0.0 (/ (double ms) (double total))))]
+            (recur (conj acc {:phase      ph
+                              :duration-ms ms
+                              :width-pct  width
+                              :offset-pct (min 1.0 (max 0.0 (/ (double offset) (double total))))})
+                   (+ offset ms)
+                   (rest remaining))))))))
+
+(defn slowest-phase
+  "Identify the phase that owns the largest share of total elapsed time.
+  The panel marks this row with a `← slow` annotation. Pure fn."
+  [{:keys [phases]}]
+  (when (seq phases)
+    (let [valid (filter (fn [[_ ms]] (and (number? ms) (pos? ms))) phases)]
+      (when (seq valid)
+        (first (apply max-key second valid))))))
+
+;; ---- hiccup renderer ---------------------------------------------------
+
+(defn- phase-label
+  [{:keys [phase]}]
+  (cond
+    (keyword? phase) (name phase)
+    (nil? phase)     "—"
+    :else            (str phase)))
+
+(defn- duration-label
+  [{:keys [duration-ms]}]
+  (cond
+    (not (number? duration-ms)) "—"
+    (< duration-ms 1000)        (str (long duration-ms) "ms")
+    :else                       (str (Math/round (/ duration-ms 100.0)) "00ms")))
+
+(defn- bar-fill
+  [phase slowest?]
+  (cond
+    slowest?                  (:yellow tokens/tokens)
+    (= phase :issued)         (:accent-violet tokens/tokens)
+    (contains? #{:elapsed :ttfb :download :receive :compute}
+               phase)         (:cyan tokens/tokens)
+    :else                     (:cyan tokens/tokens)))
+
+(defn render
+  "Render a wire-timing map as a hiccup SVG waterfall.
+
+  Options:
+
+    :width           — viewport width in px (default 480)
+    :slowest-marker? — when true, the longest phase gets a yellow fill
+                       + `← slow` annotation (default true)
+    :testid          — overrides the root SVG data-testid
+
+  Returns nil when there are no phases to render so the panel can
+  fall back to a `n/a` placeholder. Pure fn — JVM-runnable."
+  ([wire] (render wire {}))
+  ([wire {:keys [width slowest-marker? testid]
+          :or   {width 480
+                 slowest-marker? true
+                 testid "rf-causa-waterfall"}}]
+   (let [rows       (normalise-phases wire)
+         slowest    (when slowest-marker? (slowest-phase wire))
+         n-rows     (count rows)
+         bar-area-w (max 40 (- width label-width value-width (* 2 bar-padding)))
+         svg-h      (max row-height (* n-rows row-height))]
+     (when (seq rows)
+       [:svg {:data-testid testid
+              :data-row-count (str n-rows)
+              :width  width
+              :height svg-h
+              :viewBox (str "0 0 " width " " svg-h)
+              :style {:display "block"
+                      :font-family font-stack}}
+        (into [:g {:data-testid "rf-causa-waterfall-rows"}]
+              (for [[i row] (map-indexed vector rows)
+                    :let [y         (* i row-height)
+                          slow?     (= (:phase row) slowest)
+                          bar-x     (+ label-width bar-padding)
+                          bar-w-px  (max 1 (Math/round (* (:width-pct row) bar-area-w)))
+                          fill      (bar-fill (:phase row) slow?)]]
+                ^{:key (str (:phase row) "-" i)}
+                [:g {:data-testid (str "rf-causa-waterfall-row-" (phase-label row))
+                     :data-phase  (phase-label row)
+                     :data-slow   (str slow?)}
+                 ;; left label
+                 [:text {:x 4
+                         :y (+ y (- row-height 4))
+                         :font-size 10
+                         :fill (:text-secondary tokens/tokens)}
+                  (phase-label row)]
+                 ;; track background
+                 [:rect {:x bar-x
+                         :y (+ y 3)
+                         :width bar-area-w
+                         :height (- row-height 6)
+                         :fill (:bg-3 tokens/tokens)
+                         :rx 2}]
+                 ;; bar
+                 [:rect {:x bar-x
+                         :y (+ y 3)
+                         :width bar-w-px
+                         :height (- row-height 6)
+                         :fill fill
+                         :rx 2}
+                  [:title (str (phase-label row) " — " (duration-label row)
+                               (when slow? " (slow)"))]]
+                 ;; right value
+                 [:text {:x (+ bar-x bar-area-w bar-padding)
+                         :y (+ y (- row-height 4))
+                         :font-size 10
+                         :fill (if slow?
+                                 (:yellow tokens/tokens)
+                                 (:text-tertiary tokens/tokens))}
+                  (str (duration-label row)
+                       (when slow? " ← slow"))]]))]))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -47,6 +47,8 @@
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
+            [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
+            [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
@@ -334,25 +336,35 @@
 
 (defn- cascade-detail
   "The six-domino cascade for the selected dispatch-id. `cascade` is a
-  single cascade record per `re-frame.trace.projection/group-cascades`."
-  [{:keys [dispatch-id frame event handler fx effects subs renders other] :as _cascade}]
-  [:div {:data-testid "rf-causa-event-detail-cascade"
-         :data-dispatch-id (str dispatch-id)
-         :data-frame (str frame)
-         :style       {:padding "8px 0"}}
-   [:div {:style {:padding "0 12px 8px 12px"
-                  :font-family sans-stack
-                  :font-size   "12px"
-                  :color       (:text-tertiary tokens)}}
-    [:span "Cascade"]]
-   [:div {:style {:border-top (str "1px solid " (:border-subtle tokens))}}
-    [event-row event (trigger-handler-coord (or handler fx))]
-    (when handler [handler-row handler])
-    (when fx [fx-row fx])
-    [effects-row effects]
-    [subs-row subs]
-    [renders-row renders]
-    (other-row other)]])
+  single cascade record per `re-frame.trace.projection/group-cascades`.
+
+  When the cascade contains managed-fx invocations (per
+  `panels/managed-fx-helpers/cascade->managed-fx-records`), the
+  wire-boundary diff template (rf2-uyp86 / F-C2) mounts below the
+  six-domino window as an inline `<div>` per record. Cascades without
+  managed-fx invocations render unchanged."
+  [{:keys [dispatch-id frame event handler fx effects subs renders other] :as cascade}]
+  (let [managed-fx-records (managed-fx-h/cascade->managed-fx-records cascade)]
+    [:div {:data-testid "rf-causa-event-detail-cascade"
+           :data-dispatch-id (str dispatch-id)
+           :data-frame (str frame)
+           :data-managed-fx-count (str (count managed-fx-records))
+           :style       {:padding "8px 0"}}
+     [:div {:style {:padding "0 12px 8px 12px"
+                    :font-family sans-stack
+                    :font-size   "12px"
+                    :color       (:text-tertiary tokens)}}
+      [:span "Cascade"]]
+     [:div {:style {:border-top (str "1px solid " (:border-subtle tokens))}}
+      [event-row event (trigger-handler-coord (or handler fx))]
+      (when handler [handler-row handler])
+      (when fx [fx-row fx])
+      [effects-row effects]
+      [subs-row subs]
+      [renders-row renders]
+      (other-row other)]
+     (when (seq managed-fx-records)
+       (managed-fx/records-list managed-fx-records))]))
 
 ;; ---- public view --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc
@@ -1,0 +1,666 @@
+(ns day8.re-frame2-causa.panels.managed-fx-helpers
+  "Pure-data helpers for the managed-fx wire-boundary diff panel
+  (rf2-uyp86, parent rf2-5aw5v — flagship cross-cutting feature from
+  `tools/causa/spec/019-Cross-Cutting-Insight.md` §2.4).
+
+  ## What the panel needs
+
+  One uniform record per managed-fx invocation in a focused cascade,
+  satisfying [`spec/Managed-Effects.md`'s eight-property
+  contract](../../../../spec/Managed-Effects.md). Across five surfaces
+  (HTTP / WebSocket / machine `:invoke` / SSR `:rf.server/*` /
+  `:rf.flow/*`) the record fields are the same; only the projection
+  from the surface's raw trace events differs.
+
+  ## The record shape
+
+      {:surface         :http | :websocket | :machine-invoke
+                                | :ssr-fx | :flow
+       :fx-id           <id>                ;; the registered fx id
+       :req             <request-payload>   ;; method, url, headers,
+                                            ;; body (or surface-specific
+                                            ;; equivalent)
+       :wire            <wire-timing-map>   ;; nil when the surface
+                                            ;; doesn't emit timing
+       :res             <response-payload>  ;; nil when in-flight or
+                                            ;; the surface has no
+                                            ;; reply-shape
+       :handler         <handler-event-vec> ;; the dispatched response
+                                            ;; handler (e.g.
+                                            ;; [:user/profile-loaded …])
+       :status          :ok | :error | :in-flight | :overridden
+                                | :skipped | :stub
+       :phase           :issued | :sent | :received | :completed
+                                | :failed | :aborted
+       :correlation-id  <id-or-nil>         ;; request-id, machine
+                                            ;; spawn id, …
+       :cancel-cause    <kw-or-nil>         ;; :user / :actor-destroyed
+                                            ;; / :superseded / …
+       :http-status     <int-or-nil>        ;; HTTP only
+       :duration-ms     <num-or-nil>        ;; elapsed ms
+       :failure         <failure-map-or-nil>;; `:rf.<surface>/*` kind +
+                                            ;; tags
+       :paths-touched   [<path> ...]        ;; app-db slice paths the
+                                            ;; handler caused to change
+       :origin-event-id <int-or-nil>}       ;; trace-event :id of the
+                                            ;; `:rf.fx/handled` emit —
+                                            ;; the cross-link anchor
+
+  Pure data → data. JVM-runnable so the test suite can drive the
+  projection without booting a CLJS runtime.
+
+  ## Surface adapters
+
+  Each adapter is a fn `(adapter fx-event surface-events handler-event)`
+  taking three slices off the cascade:
+
+    - `fx-event`        — the `:rf.fx/handled` event for this fx
+                          invocation (carries `:fx-id`, `:fx-args`,
+                          `:dispatch-id`, `:frame` on `:tags`).
+    - `surface-events`  — the other trace events on the same cascade
+                          for this surface (e.g.
+                          `:rf.http/retry-attempt`,
+                          `:rf.http/aborted-on-actor-destroy`,
+                          `:rf.machine.lifecycle/spawned`,
+                          `:rf.flow/computed`).
+    - `handler-event`   — the dispatched response event vector (if
+                          known via the fx-args `:on-success` /
+                          `:on-failure` / `:on-done` slot or via the
+                          cascade's child `:event` slot).
+
+  Each adapter returns one record per managed-fx invocation in the
+  cascade. The composite-sub layer walks the cascade once, partitions
+  the effects by surface, and routes each to the right adapter.
+
+  ## What's NOT addressed (yet)
+
+  Wire-timing is only natively emitted by `:rf.http/managed` today —
+  the other surfaces default `:wire` to nil and the panel renders a
+  `n/a` placeholder. The retry-attempt timeline (F.3) lives under
+  `:rf.http/retry-attempt` traces and is folded into the HTTP record's
+  `:phase` / `:duration-ms` summary. Per-attempt drill-down is a
+  follow-on bead."
+  (:require [clojure.string :as str]
+            [day8.re-frame2-causa.panels.common-helpers :as common]
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as diff-h]))
+
+;; ---- surface taxonomy ---------------------------------------------------
+
+(def surfaces
+  "Canonical render-order — the same order the template list uses, so a
+  cascade with HTTP + machine-invoke + flow records always renders in
+  the same vertical order."
+  [:http :websocket :machine-invoke :ssr-fx :flow])
+
+(def surface->label
+  "Render-label for the panel header, e.g. `MANAGED FX [HTTP]`."
+  {:http           "HTTP"
+   :websocket      "WS"
+   :machine-invoke "INVOKE"
+   :ssr-fx         "SSR"
+   :flow           "FLOW"})
+
+(def surface->glyph
+  "Per spec/019 §3 the badge taxonomy (F-C1) maps the five surfaces to
+  glyphs. Same alphabet as the L2 event-list row badges so the panel
+  header reads continuously with the row glyph."
+  {:http           "🌐"   ;; 🌐
+   :websocket      "🔌"   ;; 🔌
+   :machine-invoke "🤖"   ;; 🤖
+   :ssr-fx         "📄"   ;; 📄
+   :flow           "🌊"}) ;; 🌊
+
+(def status->colour-token
+  "Status → colour-token mapping. The view resolves the token to a hex
+  via the panel's `tokens` map."
+  {:ok         :green
+   :error      :red
+   :in-flight  :cyan
+   :overridden :accent-violet
+   :skipped    :text-tertiary
+   :stub       :accent-violet})
+
+(def status->glyph
+  "Status → shape-glyph (colour-blind-safe parallel signal)."
+  {:ok         "✓"   ;; ✓
+   :error      "✗"   ;; ✗
+   :in-flight  "⧖"   ;; ⧖
+   :overridden "◑"   ;; ◑
+   :skipped    "○"   ;; ○
+   :stub       "◑"}) ;; ◑
+
+;; ---- common readers -----------------------------------------------------
+
+(def tag common/tag-of)
+
+(defn- fx-id-of [ev]
+  (tag ev :fx-id))
+
+(defn- fx-args-of [ev]
+  (tag ev :fx-args))
+
+(defn- dispatch-id-of [ev]
+  (tag ev :dispatch-id))
+
+(defn- frame-id-of [ev]
+  (tag ev :frame))
+
+(defn- ms-of [ev]
+  (or (:time ev) (tag ev :time)))
+
+;; ---- surface classifier -------------------------------------------------
+
+(defn classify-fx-id
+  "Return the surface this fx-id belongs to, or nil for non-managed fxs.
+
+  Surfaces are recognised by the `:rf.<surface>/*` reserved-namespace
+  convention per [spec/Conventions.md §Reserved namespaces](../../../../spec/Conventions.md):
+
+    - `:rf.http/*`     → `:http`        (Spec 014)
+    - `:rf.ws/*`       → `:websocket`   (Pattern-WebSocket)
+    - `:rf.machine/*`  → `:machine-invoke` (Spec 005 `:invoke`)
+    - `:rf.server/*`   → `:ssr-fx`      (Spec 011)
+    - `:rf.flow/*` / `:rf.fx/reg-flow` / `:rf.fx/clear-flow`
+                       → `:flow`        (Spec 013)
+
+  Pure fn. Idempotent. Returns nil for `:db`, `:dispatch`, `:fx`, and
+  every user-registered fx — those don't satisfy the eight-property
+  contract."
+  [fx-id]
+  (when (keyword? fx-id)
+    (let [n (namespace fx-id)
+          base-name (name fx-id)]
+      (cond
+        (or (= n "rf.http")
+            (str/starts-with? (or n "") "rf.http."))
+        :http
+
+        (or (= n "rf.ws")
+            (str/starts-with? (or n "") "rf.ws."))
+        :websocket
+
+        (or (= n "rf.machine")
+            (str/starts-with? (or n "") "rf.machine."))
+        :machine-invoke
+
+        (or (= n "rf.server")
+            (str/starts-with? (or n "") "rf.server."))
+        :ssr-fx
+
+        (or (= n "rf.flow")
+            (str/starts-with? (or n "") "rf.flow."))
+        :flow
+
+        ;; `:rf.fx/reg-flow` + `:rf.fx/clear-flow` are flow lifecycle fxs
+        ;; per spec/013 §`:rf.fx/reg-flow`.
+        (and (= n "rf.fx")
+             (contains? #{"reg-flow" "clear-flow"} base-name))
+        :flow
+
+        :else nil))))
+
+(defn managed-fx-effect?
+  "True when a `:rf.fx/handled` (or override / skipped) trace event names
+  a managed-fx-surface fx-id. Pure predicate."
+  [ev]
+  (boolean (classify-fx-id (fx-id-of ev))))
+
+;; ---- surface-event collectors ------------------------------------------
+
+(def http-trace-operations
+  "Trace operations the HTTP surface emits between issuance and
+  terminal outcome. The panel groups them under the per-record
+  surface-events bag so the WIRE TIMING / phase summary can fold
+  them."
+  #{:rf.http/retry-attempt
+    :rf.http/aborted-on-actor-destroy
+    :rf.http/aborted
+    :rf.http/transport
+    :rf.http/timeout
+    :rf.http/decode-failure
+    :rf.http/handled
+    :rf.http/managed-issued
+    :rf.warning/decode-defaulted})
+
+(def websocket-trace-operations
+  #{:rf.ws/connected
+    :rf.ws/disconnected
+    :rf.ws/reconnecting
+    :rf.ws/stale-socket
+    :rf.ws/transport
+    :rf.ws/auth
+    :rf.ws/sent
+    :rf.ws/received})
+
+(def machine-invoke-trace-operations
+  #{:rf.machine/transition
+    :rf.machine.transition/suppressed
+    :rf.machine.lifecycle/spawned
+    :rf.machine.lifecycle/destroyed
+    :rf.machine/destroy
+    :rf.machine/invoke-failed
+    :rf.machine.timer/scheduled
+    :rf.machine.timer/fired
+    :rf.machine.timer/stale-after
+    :rf.machine.timer/cancelled-on-resolution
+    :rf.machine/snapshot-version-mismatch})
+
+(def ssr-fx-trace-operations
+  #{:rf.ssr/render-failed
+    :rf.ssr/hydration-mismatch
+    :rf.ssr/payload-too-large
+    :rf.ssr/streaming-boundary
+    :rf.ssr/streaming-boundary-failed})
+
+(def flow-trace-operations
+  #{:rf.flow/computed
+    :rf.flow/failed
+    :rf.flow/skip
+    :rf.flow/registered
+    :rf.flow/cleared
+    :rf.error/flow-eval-exception})
+
+(defn- surface-events-for
+  "Filter `cascade-other-events` to the operations a given surface
+  emits. The `:other` slot of the cascade record per
+  `re-frame.trace.projection/group-cascades` is where these non-domino
+  traces land. Pure fn."
+  [cascade-other-events surface]
+  (let [ops (case surface
+              :http           http-trace-operations
+              :websocket      websocket-trace-operations
+              :machine-invoke machine-invoke-trace-operations
+              :ssr-fx         ssr-fx-trace-operations
+              :flow           flow-trace-operations
+              #{})]
+    (filterv #(contains? ops (:operation %)) (or cascade-other-events []))))
+
+;; ---- status derivation --------------------------------------------------
+
+(defn- fx-event->status
+  "Project an fx event's `:operation` onto the panel's status taxonomy.
+  The :stub status is a UI synthesis — a `:rf.fx/override-applied`
+  event flags the row as stubbed in addition to its own outcome."
+  [fx-ev]
+  (case (:operation fx-ev)
+    :rf.fx/handled                 :ok
+    :rf.fx/override-applied        :overridden
+    :rf.fx/skipped-on-platform     :skipped
+    :rf.error/fx-handler-exception :error
+    :rf.error/no-such-fx           :error
+    :in-flight))
+
+(defn- surface-events->failure
+  "Walk the surface-events bag for a terminal failure trace. The first
+  matching event's `:tags` are projected into the record's
+  `:failure` map. Returns nil when no failure trace is present."
+  [surface-events]
+  (when-let [failed (some (fn [ev]
+                            (when (or (= (:op-type ev) :error)
+                                      (contains? #{:rf.http/transport
+                                                   :rf.http/timeout
+                                                   :rf.http/decode-failure
+                                                   :rf.http/aborted
+                                                   :rf.http/aborted-on-actor-destroy
+                                                   :rf.ws/transport
+                                                   :rf.ws/auth
+                                                   :rf.ws/stale-socket
+                                                   :rf.machine/invoke-failed
+                                                   :rf.ssr/render-failed
+                                                   :rf.flow/failed
+                                                   :rf.error/flow-eval-exception}
+                                                 (:operation ev)))
+                              ev))
+                          (or surface-events []))]
+    {:kind (:operation failed)
+     :tags (:tags failed)
+     :message (or (get-in failed [:tags :message])
+                  (get-in failed [:tags :reason]))}))
+
+(defn- surface-events->cancel-cause
+  "When the cascade includes an abort trace, surface its cause so the
+  panel header can render `cancel: :actor-destroyed`. Returns nil when
+  no cancellation is present."
+  [surface-events]
+  (some (fn [ev]
+          (case (:operation ev)
+            :rf.http/aborted-on-actor-destroy :actor-destroyed
+            :rf.http/aborted                  (or (get-in ev [:tags :reason])
+                                                  :user)
+            :rf.machine/destroy               :actor-destroyed
+            nil))
+        (or surface-events [])))
+
+(defn- surface-events->phase
+  "Project the most-advanced phase observed in the surface-events bag.
+  Phases are coarse; the precise wall-clock waterfall belongs in
+  `:wire`. Phases progress in this order:
+  `:issued → :sent → :received → :completed | :failed | :aborted`."
+  [fx-ev surface-events status]
+  (cond
+    (some #(or (= (:operation %) :rf.http/aborted-on-actor-destroy)
+               (= (:operation %) :rf.http/aborted))
+          surface-events) :aborted
+    (= status :error)     :failed
+    (= status :ok)        :completed
+    (= status :in-flight) :issued
+    :else                 :completed))
+
+;; ---- handler / response extraction -------------------------------------
+
+(defn- args-handler-event
+  "Pull the response handler event vector off the fx-args, if any. The
+  managed-effect surfaces all carry the dispatched response under one
+  of `:on-success`, `:on-failure`, `:on-done`, `:on-reply` — the
+  caller's projection of 'what fires when this returns'. Pure fn."
+  [args]
+  (when (map? args)
+    (or (:on-success args)
+        (:on-done args)
+        (:on-reply args)
+        (:on-failure args))))
+
+;; ---- correlation-id resolution -----------------------------------------
+
+(defn- args-correlation-id
+  "Surface-specific correlation id reader. HTTP carries `:request-id`;
+  machine `:invoke` carries `:machine-id` or `:invoke-id`; SSR-fx
+  events carry `:request-id` at the server-side accumulator. The
+  caller's args map names it; we resolve defensively."
+  [surface args]
+  (when (map? args)
+    (case surface
+      :http           (:request-id args)
+      :websocket      (or (:socket-id args) (:request-id args))
+      :machine-invoke (or (:invoke-id args) (:machine-id args) (:id args))
+      :ssr-fx         (:request-id args)
+      :flow           (:flow-id args)
+      nil)))
+
+;; ---- wire timing (HTTP only natively; others are nil) ------------------
+
+(defn- http-wire-timing
+  "Pull a wire-timing map off the HTTP surface events. The runtime today
+  does NOT emit per-phase timing (DNS / connect / SSL / request / TTFB
+  / download); when it does, the shape is
+  `{:phases [[<phase-kw> <duration-ms>]] :total-ms <ms>}` and the panel
+  renders the waterfall.
+
+  Two synthetic phases the panel can always show today:
+
+    - `:issued`   — fx event time
+    - `:received` — last surface event time (if any)
+
+  Pure fn. Returns nil when there's no time information at all so the
+  panel falls back to the `n/a` rendering."
+  [fx-ev surface-events]
+  (let [issued-ms (ms-of fx-ev)
+        last-ev   (last (sort-by ms-of (or surface-events [])))
+        last-ms   (when last-ev (ms-of last-ev))
+        explicit  (some-> fx-ev :tags :wire-timing)]
+    (cond
+      (and (map? explicit) (seq (:phases explicit)))
+      explicit
+
+      (and (number? issued-ms) (number? last-ms) (> last-ms issued-ms))
+      {:phases [[:issued 0]
+                [:elapsed (- last-ms issued-ms)]]
+       :total-ms (- last-ms issued-ms)
+       :synthesised? true}
+
+      :else
+      nil)))
+
+(defn- non-http-wire-timing
+  "Same synthesised two-phase waterfall (`:issued` → end of cascade) for
+  non-HTTP surfaces — used to show *some* timing even when the surface
+  doesn't carry native per-phase data. Returns nil when no end-event
+  is available so the panel renders `n/a`."
+  [fx-ev surface-events]
+  (let [issued-ms (ms-of fx-ev)
+        last-ev   (last (sort-by ms-of (or surface-events [])))
+        last-ms   (when last-ev (ms-of last-ev))]
+    (when (and (number? issued-ms) (number? last-ms) (> last-ms issued-ms))
+      {:phases [[:issued 0]
+                [:elapsed (- last-ms issued-ms)]]
+       :total-ms (- last-ms issued-ms)
+       :synthesised? true})))
+
+;; ---- per-surface adapters ----------------------------------------------
+
+(defn- common-record
+  "Folder shared by every surface — the basic record before
+  surface-specific fields are added."
+  [surface fx-ev surface-events]
+  (let [status        (fx-event->status fx-ev)
+        cancel-cause  (surface-events->cancel-cause surface-events)
+        failure       (surface-events->failure surface-events)
+        ;; Cancel cause overrides the basic status to :aborted-shape.
+        terminal-status (cond
+                          cancel-cause :error
+                          failure      :error
+                          :else        status)
+        args         (fx-args-of fx-ev)]
+    {:surface         surface
+     :fx-id           (fx-id-of fx-ev)
+     :req             args
+     :wire            nil
+     :res             nil
+     :handler         (args-handler-event args)
+     :status          terminal-status
+     :phase           (surface-events->phase fx-ev surface-events terminal-status)
+     :correlation-id  (args-correlation-id surface args)
+     :cancel-cause    cancel-cause
+     :http-status     nil
+     :duration-ms     (when-let [w (or (http-wire-timing fx-ev surface-events)
+                                       (non-http-wire-timing fx-ev surface-events))]
+                        (:total-ms w))
+     :failure         failure
+     :paths-touched   []
+     :origin-event-id (:id fx-ev)
+     :dispatch-id     (dispatch-id-of fx-ev)
+     :frame           (frame-id-of fx-ev)
+     :stubbed?        (= status :overridden)}))
+
+(defn http-adapter
+  "HTTP surface adapter. Pull request payload off `:fx-args :request`;
+  pull HTTP status / response off the surface events; fold the
+  per-phase wire timing where available."
+  [fx-ev cascade-other]
+  (let [surface-events (surface-events-for cascade-other :http)
+        args           (fx-args-of fx-ev)
+        request        (when (map? args) (:request args))
+        ;; A successful response trace (if any) carries `:response`
+        ;; under `:tags` per Spec 014. Failure traces carry `:kind` +
+        ;; `:status` for HTTP-4xx/5xx.
+        terminal       (some (fn [ev]
+                               (when (contains? #{:rf.http/handled
+                                                  :rf.http/transport
+                                                  :rf.http/timeout
+                                                  :rf.http/decode-failure}
+                                                (:operation ev))
+                                 ev))
+                             surface-events)
+        response       (some-> terminal :tags :response)
+        http-status    (or (some-> terminal :tags :status)
+                           (some-> response :status))
+        wire           (http-wire-timing fx-ev surface-events)
+        rec            (common-record :http fx-ev surface-events)]
+    (cond-> rec
+      true        (assoc :req request
+                         :wire wire
+                         :res  response
+                         :http-status http-status)
+      ;; Failure tags can land directly on the surface event when the
+      ;; runtime classifies the outcome under `:rf.http/*`; promote
+      ;; them into the record's `:failure` map for the panel.
+      (and (not (:failure rec))
+           terminal
+           (contains? #{:rf.http/transport
+                        :rf.http/timeout
+                        :rf.http/decode-failure}
+                      (:operation terminal)))
+      (assoc :failure {:kind (:operation terminal)
+                       :tags (:tags terminal)
+                       :message (some-> terminal :tags :message)}))))
+
+(defn websocket-adapter
+  "WebSocket surface adapter. The `:fx-args` carries connection-config
+  (`:url`, `:socket-id`, frame payload); the surface events carry
+  connection-state transitions. Per the divergence allowance, ship a
+  basic record now — bi-directional frame timeline is a follow-on."
+  [fx-ev cascade-other]
+  (let [surface-events (surface-events-for cascade-other :websocket)
+        args           (fx-args-of fx-ev)
+        rec            (common-record :websocket fx-ev surface-events)]
+    (assoc rec
+           :req args
+           :wire (non-http-wire-timing fx-ev surface-events))))
+
+(defn machine-invoke-adapter
+  "Machine `:invoke` adapter. The fx-args carry the spawned actor's
+  `:machine-id` / `:invoke-id` / initial `:data`; the surface events
+  carry the spawn/transition/destroy lifecycle."
+  [fx-ev cascade-other]
+  (let [surface-events (surface-events-for cascade-other :machine-invoke)
+        args           (fx-args-of fx-ev)
+        spawned        (some #(when (= (:operation %) :rf.machine.lifecycle/spawned) %)
+                             surface-events)
+        rec            (common-record :machine-invoke fx-ev surface-events)]
+    (assoc rec
+           :req args
+           :wire (non-http-wire-timing fx-ev surface-events)
+           :res (when spawned (select-keys (:tags spawned)
+                                            [:invoke-id :machine-id :state])))))
+
+(defn ssr-fx-adapter
+  "SSR `:rf.server/*` adapter. The fx-args carry the response-shape
+  contribution (status code, header name+value, cookie); the surface
+  events carry render lifecycle. Records sit per-call, so a request
+  with N `:rf.server/set-header` calls produces N records."
+  [fx-ev cascade-other]
+  (let [surface-events (surface-events-for cascade-other :ssr-fx)
+        args           (fx-args-of fx-ev)
+        rec            (common-record :ssr-fx fx-ev surface-events)]
+    (assoc rec
+           :req args
+           :wire (non-http-wire-timing fx-ev surface-events)
+           ;; The 'response' for an SSR-fx is the contribution to the
+           ;; per-request accumulator — the args map IS the
+           ;; contribution.
+           :res args)))
+
+(defn flow-adapter
+  "Managed-flow adapter. The fx-args carry the registration (for
+  `:rf.fx/reg-flow`) or the flow-id (`:rf.fx/clear-flow`); surface
+  events carry per-flow computation / failure traces."
+  [fx-ev cascade-other]
+  (let [surface-events (surface-events-for cascade-other :flow)
+        args           (fx-args-of fx-ev)
+        computed       (some #(when (= (:operation %) :rf.flow/computed) %)
+                             surface-events)
+        rec            (common-record :flow fx-ev surface-events)]
+    (assoc rec
+           :req args
+           :wire (non-http-wire-timing fx-ev surface-events)
+           :res (some-> computed :tags :output))))
+
+(def surface->adapter
+  {:http           http-adapter
+   :websocket      websocket-adapter
+   :machine-invoke machine-invoke-adapter
+   :ssr-fx         ssr-fx-adapter
+   :flow           flow-adapter})
+
+;; ---- cascade walker ----------------------------------------------------
+
+(defn cascade->managed-fx-records
+  "Walk a cascade record (per `re-frame.trace.projection/group-cascades`)
+  and project one managed-fx record per `:rf.fx/handled` (or
+  `:rf.fx/override-applied`, etc.) event whose fx-id classifies as a
+  managed-fx surface.
+
+  Pure fn. Returns a vector of records in cascade order. Each record
+  carries the surface-specific projection of `req` / `wire` / `res` /
+  `handler` / `status` / `phase` / `correlation-id` / `cancel-cause`.
+
+  When `paths-by-dispatch-id` is supplied (per the composite sub) the
+  record's `:paths-touched` is filled with the app-db diff paths that
+  changed during this cascade — the F.4 'app-db wasn't updated' bug
+  class lights up when this list is empty for an OK-status record."
+  ([cascade]
+   (cascade->managed-fx-records cascade nil))
+  ([{:keys [effects other dispatch-id] :as _cascade} paths-by-dispatch-id]
+   (let [fx-events     (filterv managed-fx-effect? (or effects []))
+         path-touched  (when paths-by-dispatch-id
+                         (get paths-by-dispatch-id dispatch-id []))]
+     (vec
+       (for [fx-ev fx-events
+             :let  [surface (classify-fx-id (fx-id-of fx-ev))
+                    adapter (get surface->adapter surface)]
+             :when adapter]
+         (-> (adapter fx-ev other)
+             (assoc :paths-touched (vec path-touched))))))))
+
+;; ---- formatting helpers (consumed by the view) ------------------------
+
+(defn format-status-label
+  "Human-readable status label for the panel header."
+  [status]
+  (case status
+    :ok         "OK"
+    :error      "ERROR"
+    :in-flight  "IN-FLIGHT"
+    :overridden "OVERRIDDEN"
+    :skipped    "SKIPPED"
+    :stub       "STUB"
+    "—"))
+
+(defn format-fx-id
+  "Render an fx-id keyword as `:ns/name` for compact display."
+  [fx-id]
+  (cond
+    (keyword? fx-id) (str fx-id)
+    (nil? fx-id)     "—"
+    :else            (str fx-id)))
+
+(defn format-http-status-band
+  "Map HTTP status codes onto colour bands per the panel header rule:
+  green for 2xx, yellow for 3xx, red for 4xx/5xx, gray for nil/in-flight."
+  [status]
+  (cond
+    (and (number? status) (<= 200 status 299)) :green
+    (and (number? status) (<= 300 status 399)) :yellow
+    (and (number? status) (<= 400 status 599)) :red
+    :else                                       :text-tertiary))
+
+(defn format-duration-ms
+  "Render a ms duration as `<n>ms` (or `<n.n>s` once it crosses 1s).
+  Returns `—` for nil / non-number input."
+  [ms]
+  (cond
+    (not (number? ms)) "—"
+    (< ms 1000)        (str (long ms) "ms")
+    :else              (str (Math/round (/ ms 100.0)) "00ms")))
+
+;; ---- spec-018 §Bug class coverage table -------------------------------
+;;
+;; Surfaced here as data so the view can iterate the coverage rows in
+;; the panel doc-overlay (if/when added) and so the test suite can pin
+;; the bug-class → field mapping the panel claims to address.
+
+(def bug-class-coverage
+  "Map of `:F.<n>` → the record field(s) the panel surfaces to address
+  that bug class. Anchors the per-class coverage claim in the
+  findings doc."
+  {:F.1  [:wire :duration-ms]            ;; request-timeout waterfall
+   :F.2  [:req]                          ;; bad-request payload inspector
+   :F.3  [:handler :failure]             ;; failed response handler
+   :F.4  [:paths-touched :status]        ;; app-db wasn't updated
+   :F.5  [:cancel-cause :correlation-id] ;; cancellation cascade (deferred to rf2-wvkn)
+   :F.6  [:correlation-id]               ;; stale response — id mismatch in header
+   :F.7  [:failure]                      ;; remaining structured-failure surfacing
+   :F.8  [:status :stubbed?]             ;; stub/override visibility
+   :F.9  [:status]                       ;; skipped-on-platform visibility
+   :F.10 [:surface]                      ;; surface badge taxonomy
+   :F.11 [:cancel-cause]})               ;; cross-surface stale-suppression

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_subs.cljs
@@ -1,0 +1,61 @@
+(ns day8.re-frame2-causa.panels.managed-fx-subs
+  "Composite subs for the managed-fx wire-boundary diff template
+  (rf2-uyp86, parent rf2-5aw5v).
+
+  The panel template (`panels/managed_fx_template`) is the renderer;
+  this ns produces the data the renderer consumes. One read produces
+  every slot the view needs:
+
+      {:records [<record> ...]}
+
+  where each record satisfies the eight-property contract from
+  [`panels/managed-fx-helpers/cascade->managed-fx-records`](managed_fx_helpers.cljc).
+
+  The composite is keyed to the spine's `:rf.causa/focus` — it
+  recomputes whenever the user clicks a different cascade in the L2
+  event list, scrubs through history, or a new cascade lands at head
+  in LIVE mode.
+
+  ## Cross-link
+
+  Records carry `:origin-event-id` so the panel's HANDLER DISPATCHED
+  row can wire `:on-click` to `:rf.causa/focus-event` — clicking pivots
+  the spine to the child cascade the response handler kicks off. The
+  cross-link event lives here so panel views stay thin."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.managed-fx-helpers :as h]
+            [day8.re-frame2-causa.spine :as spine]))
+
+;; ---- public install -----------------------------------------------------
+
+(defn install!
+  "Idempotent install — register `:rf.causa/managed-fx-for-focused-event`
+  + the `:rf.causa/focus-event` cross-link event. Called from
+  `registry.cljs`'s `register-causa-handlers!` fan-out."
+  []
+
+  ;; Composite sub — produces the records vector for the focused
+  ;; cascade. Re-derives on every spine flip / cascade-list change /
+  ;; focus move.
+  (rf/reg-sub :rf.causa/managed-fx-for-focused-event
+    :<- [:rf.causa/cascades]
+    :<- [:rf.causa/focus]
+    (fn [[cascades focus] _query]
+      (let [dispatch-id (:dispatch-id focus)
+            cascade     (when dispatch-id
+                          (spine/cascade-by-id cascades dispatch-id))]
+        {:dispatch-id dispatch-id
+         :frame       (:frame focus)
+         :records     (if cascade
+                        (h/cascade->managed-fx-records cascade)
+                        [])})))
+
+  ;; Cross-link event — the HANDLER DISPATCHED row dispatches this to
+  ;; pivot the spine to a different cascade. Thin wrapper over the
+  ;; existing `:rf.causa/focus-cascade` event; named to read as the
+  ;; panel-side concept ('focus this event'), since the panel surfaces
+  ;; an event vector and the user thinks 'jump to that event' rather
+  ;; than 'jump to that cascade'. Internally same write.
+  (rf/reg-event-db :rf.causa/focus-event
+    (fn [db [_ dispatch-id frame-id]]
+      (spine/focus-cascade-reducer db dispatch-id frame-id))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -1,0 +1,401 @@
+(ns day8.re-frame2-causa.panels.managed-fx-template
+  "Managed-fx wire-boundary diff template (rf2-uyp86, parent rf2-5aw5v).
+
+  The headline cross-cutting Causa feature from
+  [`tools/causa/spec/019-Cross-Cutting-Insight.md`](../../../../tools/causa/spec/019-Cross-Cutting-Insight.md)
+  §2.4 / F-C2. Renders one panel per managed-fx invocation inside the
+  focused cascade's six-domino window, surfacing the eight-property
+  contract from [`spec/Managed-Effects.md`](../../../../spec/Managed-Effects.md)
+  as a uniform UI:
+
+  ```
+  ┌─ MANAGED FX [HTTP] · :user/load-profile · 250ms ──────────────┐
+  │ STATUS: ✓ 200 OK · correlation: c-abc12 · phase: completed     │
+  │                                                                │
+  │ ▼ REQUEST                                                      │
+  │ ▼ WIRE TIMING                                                  │
+  │ ▼ RESPONSE                                                     │
+  │ ▼ HANDLER DISPATCHED                                           │
+  │ ▼ APP-DB SLICE TOUCHED                                         │
+  └────────────────────────────────────────────────────────────────┘
+  ```
+
+  ## Five surfaces, one template
+
+  The same renderer handles HTTP, WebSocket, machine-`:invoke`, SSR
+  `:rf.server/*`, and `:rf.flow/*` records. Per-surface variation lives
+  in the helpers ns (`panels/managed_fx_helpers`); this ns is purely a
+  hiccup folder over the record shape.
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — pure hiccup, no Reagent /
+  UIx / Helix references. Frame isolation is provided by the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`. Every
+  `subscribe` / `dispatch` here resolves to the `:rf/causa` frame.
+
+  ## Cross-link
+
+  The HANDLER DISPATCHED row uses `:rf.causa/focus-event` to pivot the
+  spine to the child cascade — clicking '→ jump to handler' moves
+  focus to wherever the response landed, so the user can follow the
+  cascade chain hop-by-hop. Cross-link wiring lives in
+  `panels/managed_fx_subs/install!` so the panel view stays thin."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.managed-fx-helpers :as h]
+            [day8.re-frame2-causa.chart.timing-waterfall :as waterfall]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]))
+
+;; ---- section header (collapsible) --------------------------------------
+
+(defn- section-header
+  "One row above a section's body — `▼ SECTION TITLE`. Pure visual;
+  collapse-toggle wires through the `:rf.causa.managed-fx/section-state`
+  sub when the panel adds per-record persistence (follow-on)."
+  [{:keys [label expanded? testid]}]
+  [:div {:data-testid testid
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "6px"
+                       :padding       "4px 0"
+                       :font-family   sans-stack
+                       :font-size     "11px"
+                       :font-weight   600
+                       :letter-spacing "0.6px"
+                       :text-transform "uppercase"
+                       :color         (:text-secondary tokens)}}
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family mono-stack}}
+    (if expanded? "▼" "▶")]
+   label])
+
+(defn- section
+  [{:keys [label expanded? testid]} body]
+  [:div {:data-testid testid
+         :style       {:padding "8px 0"
+                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
+   (section-header {:label label
+                    :expanded? expanded?
+                    :testid (str testid "-header")})
+   (when expanded?
+     [:div {:data-testid (str testid "-body")
+            :style       {:padding "6px 0 0 18px"
+                          :font-family mono-stack
+                          :font-size "12px"
+                          :color (:text-primary tokens)}}
+      body])])
+
+;; ---- panel header ------------------------------------------------------
+
+(defn- status-pill
+  "Coloured status pill anchoring the panel header. HTTP-status-band
+  colour wins when an HTTP status is present (green for 2xx, etc.);
+  otherwise we fall back to the generic status colour."
+  [{:keys [status http-status]}]
+  (let [band-tok    (when (number? http-status)
+                      (h/format-http-status-band http-status))
+        tok         (or band-tok (get h/status->colour-token status :text-tertiary))
+        colour      (get tokens tok (:text-tertiary tokens))
+        glyph       (get h/status->glyph status "—")
+        label       (h/format-status-label status)]
+    [:span {:data-testid (str "rf-causa-managed-fx-status-" (name status))
+            :style       {:display       "inline-flex"
+                          :align-items   "center"
+                          :gap           "6px"
+                          :padding       "1px 8px"
+                          :border-radius "3px"
+                          :background    "rgba(255,255,255,0.04)"
+                          :color         colour
+                          :font-family   mono-stack
+                          :font-size     "11px"
+                          :font-weight   700
+                          :letter-spacing "0.4px"}}
+     [:span glyph]
+     (str label
+          (when (number? http-status)
+            (str " " http-status)))]))
+
+(defn- correlation-pill
+  [correlation-id]
+  (when correlation-id
+    [:span {:data-testid "rf-causa-managed-fx-correlation"
+            :title "Correlation id — :request-id / :invoke-id / :flow-id. F.6 stale-response detection rides this slot."
+            :style {:padding       "1px 6px"
+                    :margin-left   "8px"
+                    :border-radius "3px"
+                    :background    (:bg-3 tokens)
+                    :color         (:text-secondary tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"}}
+     (str "correlation: " correlation-id)]))
+
+(defn- phase-pill
+  [phase]
+  (when phase
+    [:span {:data-testid (str "rf-causa-managed-fx-phase-" (name phase))
+            :style {:padding       "1px 6px"
+                    :margin-left   "8px"
+                    :border-radius "3px"
+                    :background    (:bg-3 tokens)
+                    :color         (:text-secondary tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"}}
+     (str "phase: " (name phase))]))
+
+(defn- cancel-pill
+  [cancel-cause]
+  (when cancel-cause
+    [:span {:data-testid "rf-causa-managed-fx-cancel"
+            :style {:padding       "1px 6px"
+                    :margin-left   "8px"
+                    :border-radius "3px"
+                    :background    "rgba(232, 121, 249, 0.12)"
+                    :color         (:magenta tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"
+                    :font-weight   600}}
+     (str "cancel: " cancel-cause)]))
+
+(defn- stub-pill
+  [stubbed?]
+  (when stubbed?
+    [:span {:data-testid "rf-causa-managed-fx-stub"
+            :title "An :fx-overrides redirect is active for this fx. Per Spec 002 §:fx-overrides."
+            :style {:padding       "1px 6px"
+                    :margin-left   "8px"
+                    :border-radius "3px"
+                    :background    "rgba(124, 92, 255, 0.15)"
+                    :border        (str "1px solid " (:accent-violet tokens))
+                    :color         (:accent-violet tokens)
+                    :font-family   mono-stack
+                    :font-size     "10px"
+                    :font-weight   700
+                    :letter-spacing "0.5px"}}
+     "STUB"]))
+
+(defn- panel-header
+  [{:keys [surface fx-id duration-ms status http-status correlation-id phase cancel-cause stubbed?]
+    :as   record}]
+  [:header {:data-testid (str "rf-causa-managed-fx-header-" (name surface))
+            :style       {:display       "flex"
+                          :align-items   "center"
+                          :flex-wrap     "wrap"
+                          :gap           "6px"
+                          :padding       "8px 12px"
+                          :background    (:bg-3 tokens)
+                          :border-bottom (str "1px solid " (:border-subtle tokens))
+                          :font-family   sans-stack
+                          :font-size     "12px"
+                          :color         (:text-primary tokens)}}
+   [:span {:data-testid (str "rf-causa-managed-fx-surface-" (name surface))
+           :title (str "Managed-effects surface: " (name surface) ". Per spec/Managed-Effects.md")
+           :style {:display       "inline-flex"
+                   :align-items   "center"
+                   :gap           "4px"
+                   :padding       "1px 8px"
+                   :border-radius "3px"
+                   :background    "rgba(67, 195, 208, 0.12)"
+                   :color         (:cyan tokens)
+                   :font-family   mono-stack
+                   :font-size     "11px"
+                   :font-weight   700
+                   :letter-spacing "0.5px"}}
+    [:span (get h/surface->glyph surface "•")]
+    (str "MANAGED FX [" (get h/surface->label surface (str surface)) "]")]
+   [:span {:style {:color (:accent-violet tokens)
+                   :font-family mono-stack
+                   :font-size "12px"
+                   :font-weight 600}}
+    (h/format-fx-id fx-id)]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family mono-stack
+                   :font-size "11px"}}
+    (h/format-duration-ms duration-ms)]
+   [:span {:style {:flex 1}}]
+   (status-pill record)
+   (correlation-pill correlation-id)
+   (phase-pill phase)
+   (cancel-pill cancel-cause)
+   (stub-pill stubbed?)])
+
+;; ---- section bodies ----------------------------------------------------
+
+(defn- request-section
+  [{:keys [req surface fx-id]}]
+  (cond
+    (and (nil? req) (= surface :flow))
+    [:span {:style {:color (:text-tertiary tokens)}} "(flow input — see registration)"]
+
+    (nil? req)
+    [:span {:style {:color (:text-tertiary tokens)}} "(no request payload)"]
+
+    :else
+    [inspector/inspect req (str "managed-fx/" (h/format-fx-id fx-id) "/req")]))
+
+(defn- wire-section
+  "Wire timing section. When the surface emits per-phase wire data we
+  render the waterfall; when only synthesised round-trip is available
+  we render the single bar; when nothing is available we render the
+  documented `n/a` placeholder per the divergence allowance."
+  [{:keys [wire]}]
+  (cond
+    (and wire (seq (:phases wire)))
+    (waterfall/render wire)
+
+    :else
+    [:div {:data-testid "rf-causa-managed-fx-wire-na"
+           :style {:color (:text-tertiary tokens) :font-style "italic"}}
+     "n/a — this surface does not emit per-phase wire timing today."]))
+
+(defn- response-section
+  [{:keys [res surface fx-id failure]}]
+  (cond
+    failure
+    [:div
+     [:div {:style {:color (:red tokens)
+                    :font-weight 600
+                    :margin-bottom "4px"}}
+      (str "✗ " (or (some-> failure :kind name) "FAILURE"))]
+     [inspector/inspect (or (:tags failure) failure)
+      (str "managed-fx/" (h/format-fx-id fx-id) "/failure")]]
+
+    (and (nil? res) (= surface :flow))
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "(in flight / no output yet)"]
+
+    (nil? res)
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "(no response payload yet)"]
+
+    :else
+    [inspector/inspect res (str "managed-fx/" (h/format-fx-id fx-id) "/res")]))
+
+(defn- handler-section
+  "Renders the dispatched handler event vector + a click-to-focus
+  affordance that pivots the spine to that child cascade. Anchors the
+  F.3 'failed response handler' diagnostic."
+  [{:keys [handler frame dispatch-id]}]
+  (if (and (vector? handler) (seq handler))
+    [:div {:style {:display "flex"
+                   :align-items "center"
+                   :gap "12px"
+                   :flex-wrap "wrap"}}
+     [:div {:style {:flex 1 :min-width 0}}
+      [inspector/inspect handler "managed-fx/handler"]]
+     [:button {:data-testid "rf-causa-managed-fx-focus-handler"
+               :on-click    #(rf/dispatch [:rf.causa/focus-event dispatch-id frame]
+                                          {:frame :rf/causa})
+               :style       {:background  "transparent"
+                             :border      (str "1px solid " (:border-default tokens))
+                             :color       (:accent-violet tokens)
+                             :font-family mono-stack
+                             :font-size   "10px"
+                             :padding     "2px 8px"
+                             :border-radius "3px"
+                             :cursor      "pointer"
+                             :flex-shrink 0}}
+      "→ focus event ↗"]]
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "(no handler dispatched — this fx had no :on-success / :on-failure / :on-done)"]))
+
+(defn- app-db-slice-section
+  "Per spec/019 §2.4 F.4 — 'app-db wasn't updated' lights up when the
+  status is OK but the slice paths-touched list is empty. The renderer
+  highlights the empty-paths case with an amber hint so the bug class
+  is immediately legible."
+  [{:keys [paths-touched status]}]
+  (cond
+    (and (= status :ok) (empty? paths-touched))
+    [:div
+     [:div {:style {:color (:yellow tokens)
+                    :font-weight 600
+                    :font-family mono-stack
+                    :font-size "11px"
+                    :margin-bottom "4px"}}
+      "⚠ STATUS :ok but no app-db paths changed — possible F.4"]
+     [:div {:style {:color (:text-tertiary tokens) :font-style "italic"}}
+      "The handler dispatched but did not write a slice. Likely a "
+      "missing :db assoc or a guard that no-op'd."]]
+
+    (empty? paths-touched)
+    [:span {:style {:color (:text-tertiary tokens)}}
+     "(no app-db changes in this cascade)"]
+
+    :else
+    [:ul {:style {:list-style "none"
+                  :margin     0
+                  :padding    0}}
+     (for [[i path] (map-indexed vector paths-touched)]
+       ^{:key i}
+       [:li {:style {:padding "2px 0"
+                     :font-family mono-stack
+                     :font-size "12px"
+                     :color (:text-primary tokens)}}
+        [:span {:style {:color (:accent-violet tokens)}}
+         (pr-str path)]])]))
+
+;; ---- one record's panel ------------------------------------------------
+
+(defn record-panel
+  "Render one managed-fx record as a hiccup panel. Pure function over
+  the record; CLJS-only (consumes Reagent re-frame subs via
+  `inspector/inspect`).
+
+  Section default-expanded state per the bead's contract:
+
+    - STATUS + WIRE + APP-DB SLICE TOUCHED expanded by default
+    - REQUEST + RESPONSE + HANDLER DISPATCHED collapsed by default
+      (one click reveals the payload — keeps the panel scannable on
+      first paint)."
+  [record]
+  [:section {:data-testid (str "rf-causa-managed-fx-record-"
+                               (name (:surface record))
+                               "-" (or (:origin-event-id record) "x"))
+             :data-fx-id  (h/format-fx-id (:fx-id record))
+             :data-status (name (:status record))
+             :style       {:margin "8px 12px"
+                           :border (str "1px solid " (:border-subtle tokens))
+                           :border-radius "4px"
+                           :background    (:bg-2 tokens)}}
+   (panel-header record)
+   [:div {:style {:padding "8px 12px"}}
+    (section {:label "REQUEST" :expanded? false
+              :testid (str "rf-causa-managed-fx-section-request")}
+             (request-section record))
+    (section {:label "WIRE TIMING" :expanded? true
+              :testid (str "rf-causa-managed-fx-section-wire")}
+             (wire-section record))
+    (section {:label "RESPONSE" :expanded? false
+              :testid (str "rf-causa-managed-fx-section-response")}
+             (response-section record))
+    (section {:label "HANDLER DISPATCHED" :expanded? false
+              :testid (str "rf-causa-managed-fx-section-handler")}
+             (handler-section record))
+    (section {:label "APP-DB SLICE TOUCHED" :expanded? true
+              :testid (str "rf-causa-managed-fx-section-app-db")}
+             (app-db-slice-section record))]])
+
+;; ---- list panel --------------------------------------------------------
+
+(defn records-list
+  "Render a vector of managed-fx records as a stack of panels. Pure fn
+  over the records vector; used by `event_detail.cljs` to mount the
+  list under the six-domino cascade view, and by the tests to render
+  a deterministic stack against canned records."
+  [records]
+  (when (seq records)
+    [:div {:data-testid "rf-causa-managed-fx-list"
+           :style {:padding "8px 0"
+                   :border-top (str "1px solid " (:border-subtle tokens))}}
+     [:div {:style {:padding "8px 12px 0 12px"
+                    :font-family sans-stack
+                    :font-size "12px"
+                    :color (:text-tertiary tokens)}}
+      [:span (str (count records) " managed-fx record"
+                  (if (= 1 (count records)) "" "s")
+                  " in this cascade")]]
+     (for [rec records]
+       ^{:key (str (:surface rec) "-" (:origin-event-id rec) "-" (:fx-id rec))}
+       (record-panel rec))]))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -47,6 +47,7 @@
             [day8.re-frame2-causa.panels.hydration-debugger :as hydration-debugger]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.managed-fx-subs :as managed-fx-subs]
             [day8.re-frame2-causa.panels.mcp-server :as mcp-server]
             [day8.re-frame2-causa.panels.performance :as performance]
             [day8.re-frame2-causa.panels.routes :as routes]
@@ -450,6 +451,12 @@
     (hydration-debugger/install!)
     (issues-ribbon/install!)
     (machine-inspector/install!)
+    ;; Managed-fx wire-boundary diff template (rf2-uyp86) — installs the
+    ;; `:rf.causa/managed-fx-for-focused-event` sub + the
+    ;; `:rf.causa/focus-event` cross-link event. The panel view itself
+    ;; mounts inline in event_detail.cljs under the six-domino cascade,
+    ;; so no L3 tab is added.
+    (managed-fx-subs/install!)
     (mcp-server/install!)
     (performance/install!)
     (routes/install!)

--- a/tools/causa/test/day8/re_frame2_causa/chart/timing_waterfall_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/timing_waterfall_cljs_test.cljc
@@ -1,0 +1,75 @@
+(ns day8.re-frame2-causa.chart.timing-waterfall-cljs-test
+  "Pure-data tests for the wire-timing waterfall primitive
+  (rf2-uyp86, parent rf2-5aw5v).
+
+  Covers `normalise-phases` (the projection), `slowest-phase` (the
+  annotation feed), and the smoke-render hiccup shape."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.chart.timing-waterfall :as wf]))
+
+;; ---- normalise-phases ---------------------------------------------------
+
+(deftest normalise-phases-empty-returns-empty
+  (is (= [] (wf/normalise-phases {})))
+  (is (= [] (wf/normalise-phases {:phases [] :total-ms 0})))
+  (is (= [] (wf/normalise-phases nil))))
+
+(deftest normalise-phases-derives-total-from-sum-when-absent
+  (testing "When :total-ms is missing the sum of phase durations is used"
+    (let [out (wf/normalise-phases {:phases [[:dns 50] [:connect 50]]})]
+      (is (= 2 (count out)))
+      (is (= 0.5 (:width-pct (first out))))
+      (is (= 0.5 (:width-pct (second out)))))))
+
+(deftest normalise-phases-uses-explicit-total
+  (testing "Explicit :total-ms is honoured"
+    (let [out (wf/normalise-phases {:phases [[:a 50] [:b 50]] :total-ms 200})]
+      (is (= 0.25 (:width-pct (first out))))
+      (is (= 0.25 (:width-pct (second out)))))))
+
+(deftest normalise-phases-clamps-width-to-one
+  (testing "A phase whose duration exceeds total gets clamped to 100%"
+    (let [out (wf/normalise-phases {:phases [[:x 9999]] :total-ms 100})]
+      (is (= 1.0 (:width-pct (first out)))))))
+
+(deftest normalise-phases-tracks-offset
+  (testing "Each row's offset-pct is the running sum of preceding widths"
+    (let [out (wf/normalise-phases {:phases [[:a 25] [:b 25] [:c 50]] :total-ms 100})]
+      (is (= 0.0 (:offset-pct (nth out 0))))
+      (is (= 0.25 (:offset-pct (nth out 1))))
+      (is (= 0.5 (:offset-pct (nth out 2)))))))
+
+(deftest normalise-phases-drops-non-positive
+  (testing "Non-numeric / non-positive durations are filtered out"
+    (let [out (wf/normalise-phases {:phases [[:a 100] [:b 0] [:c -10] [:d "x"]]
+                                    :total-ms 100})]
+      (is (= 1 (count out)))
+      (is (= :a (:phase (first out)))))))
+
+;; ---- slowest-phase ------------------------------------------------------
+
+(deftest slowest-phase-picks-largest-duration
+  (is (= :ttfb (wf/slowest-phase {:phases [[:dns 2] [:connect 15] [:ttfb 180] [:download 30]]}))))
+
+(deftest slowest-phase-nil-on-empty
+  (is (nil? (wf/slowest-phase {:phases []})))
+  (is (nil? (wf/slowest-phase {}))))
+
+;; ---- render smoke -------------------------------------------------------
+
+(deftest render-returns-nil-for-empty
+  (is (nil? (wf/render {})))
+  (is (nil? (wf/render {:phases []}))))
+
+(deftest render-returns-svg-hiccup
+  (let [out (wf/render {:phases [[:dns 2] [:connect 15] [:ttfb 180]]
+                        :total-ms 200})]
+    (is (vector? out))
+    (is (= :svg (first out)))
+    (is (map? (second out)))
+    (is (= "3" (-> out second :data-row-count)))))
+
+(deftest render-overrides-testid
+  (let [out (wf/render {:phases [[:a 10]]} {:testid "custom-id"})]
+    (is (= "custom-id" (-> out second :data-testid)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_helpers_cljs_test.cljc
@@ -1,0 +1,321 @@
+(ns day8.re-frame2-causa.panels.managed-fx-helpers-cljs-test
+  "Pure-data tests for the managed-fx wire-boundary helpers
+  (rf2-uyp86, parent rf2-5aw5v).
+
+  ## Coverage
+
+    1. `classify-fx-id` — surface taxonomy.
+    2. Per-surface adapter (http / websocket / machine-invoke /
+       ssr-fx / flow) on success and failure cases.
+    3. `cascade->managed-fx-records` — cascade walker; record-per-fx;
+       paths-touched cross-fold.
+    4. Status / phase / cancel-cause / failure derivation."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.managed-fx-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- fx-handled
+  ([fx-id args] (fx-handled fx-id args {}))
+  ([fx-id args extra-tags]
+   {:operation :rf.fx/handled
+    :op-type   :fx
+    :id        (rand-int 1000000)
+    :time      1000
+    :tags      (merge {:fx-id fx-id
+                       :fx-args args
+                       :frame :rf/default
+                       :dispatch-id 7}
+                      extra-tags)}))
+
+(defn- surface-ev
+  ([op tags] (surface-ev op tags 1100))
+  ([op tags t]
+   {:operation op
+    :op-type   (cond
+                 (= op :rf.machine.lifecycle/spawned) :info
+                 (#{:rf.flow/failed :rf.machine/invoke-failed :rf.ssr/render-failed
+                    :rf.error/flow-eval-exception} op) :error
+                 :else :info)
+    :id        (rand-int 1000000)
+    :time      t
+    :tags      tags}))
+
+;; ---- (1) classify-fx-id ------------------------------------------------
+
+(deftest classify-fx-id-http
+  (is (= :http (h/classify-fx-id :rf.http/managed)))
+  (is (= :http (h/classify-fx-id :rf.http/managed-abort)))
+  (is (= :http (h/classify-fx-id :rf.http/managed-canned-success))))
+
+(deftest classify-fx-id-ws
+  (is (= :websocket (h/classify-fx-id :rf.ws/connect)))
+  (is (= :websocket (h/classify-fx-id :rf.ws/send))))
+
+(deftest classify-fx-id-machine
+  (is (= :machine-invoke (h/classify-fx-id :rf.machine/spawn)))
+  (is (= :machine-invoke (h/classify-fx-id :rf.machine/destroy))))
+
+(deftest classify-fx-id-ssr
+  (is (= :ssr-fx (h/classify-fx-id :rf.server/set-status)))
+  (is (= :ssr-fx (h/classify-fx-id :rf.server/set-header)))
+  (is (= :ssr-fx (h/classify-fx-id :rf.server/redirect))))
+
+(deftest classify-fx-id-flow
+  (is (= :flow (h/classify-fx-id :rf.flow/registered)))
+  (is (= :flow (h/classify-fx-id :rf.fx/reg-flow)))
+  (is (= :flow (h/classify-fx-id :rf.fx/clear-flow))))
+
+(deftest classify-fx-id-non-managed-is-nil
+  (testing "non-managed-effects fxs classify as nil"
+    (is (nil? (h/classify-fx-id :db)))
+    (is (nil? (h/classify-fx-id :dispatch)))
+    (is (nil? (h/classify-fx-id :user/my-fx)))
+    (is (nil? (h/classify-fx-id :my/persist)))
+    (is (nil? (h/classify-fx-id nil)))
+    (is (nil? (h/classify-fx-id "not-a-keyword")))))
+
+(deftest managed-fx-effect?-uses-classifier
+  (is (true?  (h/managed-fx-effect? {:tags {:fx-id :rf.http/managed}})))
+  (is (false? (h/managed-fx-effect? {:tags {:fx-id :user/x}}))))
+
+;; ---- (2a) HTTP adapter on success --------------------------------------
+
+(deftest http-adapter-success-record
+  (testing "HTTP success path projects a clean OK record"
+    (let [args   {:request {:method :get :url "/api/users/42"
+                            :headers {:accept "application/json"}}
+                  :decode  :json
+                  :request-id :req-1
+                  :on-success [:user/loaded]}
+          fx-ev  (fx-handled :rf.http/managed args)
+          rec    (h/http-adapter fx-ev [])]
+      (is (= :http (:surface rec)))
+      (is (= :rf.http/managed (:fx-id rec)))
+      (is (= :ok (:status rec)))
+      (is (= [:user/loaded] (:handler rec)))
+      (is (= :req-1 (:correlation-id rec)))
+      (is (nil? (:cancel-cause rec)))
+      (is (= {:method :get :url "/api/users/42"
+              :headers {:accept "application/json"}}
+             (:req rec))))))
+
+(deftest http-adapter-failure-record
+  (testing "HTTP transport failure surfaces under :failure"
+    (let [args   {:request {:method :get :url "/api/x"}
+                  :request-id :req-2
+                  :on-failure [:x/failed]}
+          fx-ev  (fx-handled :rf.http/managed args)
+          fail-ev (surface-ev :rf.http/transport
+                              {:request-id :req-2 :message "ECONNREFUSED"})
+          rec    (h/http-adapter fx-ev [fail-ev])]
+      (is (= :http (:surface rec)))
+      (is (= :error (:status rec)))
+      (is (= :rf.http/transport (-> rec :failure :kind))))))
+
+(deftest http-adapter-aborted-record
+  (testing "HTTP abort-on-actor-destroy surfaces :cancel-cause"
+    (let [args   {:request {:method :post :url "/api/finalize"}
+                  :request-id :req-3}
+          fx-ev  (fx-handled :rf.http/managed args)
+          abort  (surface-ev :rf.http/aborted-on-actor-destroy
+                             {:request-id :req-3})
+          rec    (h/http-adapter fx-ev [abort])]
+      (is (= :aborted (:phase rec)))
+      (is (= :actor-destroyed (:cancel-cause rec))))))
+
+(deftest http-adapter-synthesised-wire-timing
+  (testing "When per-phase timing is absent the synthesised round-trip
+            two-row waterfall lights up so the user still sees elapsed"
+    (let [fx-ev (fx-handled :rf.http/managed
+                            {:request {:method :get :url "/x"}}
+                            {})
+          end   (surface-ev :rf.http/handled
+                            {:request-id :req-1 :status 200}
+                            1250)
+          rec   (h/http-adapter fx-ev [end])]
+      (is (= 250 (:duration-ms rec)))
+      (is (some? (:wire rec)))
+      (is (= 2 (count (-> rec :wire :phases))))
+      (is (true? (-> rec :wire :synthesised?))))))
+
+;; ---- (2b) WebSocket adapter --------------------------------------------
+
+(deftest websocket-adapter-basic-record
+  (let [args   {:url "wss://chat.example.com" :socket-id :sock-1}
+        fx-ev  (fx-handled :rf.ws/connect args)
+        rec    (h/websocket-adapter fx-ev [])]
+    (is (= :websocket (:surface rec)))
+    (is (= :ok (:status rec)))
+    (is (= :sock-1 (:correlation-id rec)))
+    (is (= args (:req rec)))))
+
+(deftest websocket-adapter-failure
+  (let [args   {:url "wss://chat.example.com" :socket-id :sock-2}
+        fx-ev  (fx-handled :rf.ws/connect args)
+        fail   (surface-ev :rf.ws/transport
+                           {:socket-id :sock-2 :message "ECONNRESET"})
+        rec    (h/websocket-adapter fx-ev [fail])]
+    (is (= :error (:status rec)))
+    (is (= :rf.ws/transport (-> rec :failure :kind)))))
+
+;; ---- (2c) machine-invoke adapter ---------------------------------------
+
+(deftest machine-invoke-adapter-spawn-record
+  (let [args   {:machine-id :auth/main :invoke-id :inv-1
+                :data {:user-id 42}}
+        fx-ev  (fx-handled :rf.machine/spawn args)
+        spawn  (surface-ev :rf.machine.lifecycle/spawned
+                           {:invoke-id :inv-1 :machine-id :auth/main
+                            :state :idle})
+        rec    (h/machine-invoke-adapter fx-ev [spawn])]
+    (is (= :machine-invoke (:surface rec)))
+    (is (= :ok (:status rec)))
+    (is (= :inv-1 (:correlation-id rec)))
+    (is (= {:invoke-id :inv-1 :machine-id :auth/main :state :idle}
+           (:res rec)))))
+
+(deftest machine-invoke-adapter-failure
+  (let [fx-ev (fx-handled :rf.machine/spawn
+                          {:machine-id :auth/main :invoke-id :inv-2})
+        fail  (surface-ev :rf.machine/invoke-failed
+                          {:invoke-id :inv-2 :reason :no-such-machine})
+        rec   (h/machine-invoke-adapter fx-ev [fail])]
+    (is (= :error (:status rec)))
+    (is (= :rf.machine/invoke-failed (-> rec :failure :kind)))))
+
+;; ---- (2d) SSR-fx adapter -----------------------------------------------
+
+(deftest ssr-fx-adapter-set-status
+  (let [args  {:status 302}
+        fx-ev (fx-handled :rf.server/set-status args)
+        rec   (h/ssr-fx-adapter fx-ev [])]
+    (is (= :ssr-fx (:surface rec)))
+    (is (= :ok (:status rec)))
+    (is (= args (:req rec)))
+    (is (= args (:res rec)))))
+
+(deftest ssr-fx-adapter-failure-render
+  (let [fx-ev (fx-handled :rf.server/set-status {:status 500})
+        fail  (surface-ev :rf.ssr/render-failed
+                          {:request-id :ssr-1 :message "boom"})
+        rec   (h/ssr-fx-adapter fx-ev [fail])]
+    (is (= :error (:status rec)))
+    (is (= :rf.ssr/render-failed (-> rec :failure :kind)))))
+
+;; ---- (2e) flow adapter --------------------------------------------------
+
+(deftest flow-adapter-registered-record
+  (let [args  {:flow-id :flow/cart-subtotal :input [:cart] :output [:cart :subtotal]}
+        fx-ev (fx-handled :rf.fx/reg-flow args)
+        comp  (surface-ev :rf.flow/computed
+                          {:flow-id :flow/cart-subtotal :output 42})
+        rec   (h/flow-adapter fx-ev [comp])]
+    (is (= :flow (:surface rec)))
+    (is (= :ok (:status rec)))
+    (is (= :flow/cart-subtotal (:correlation-id rec)))
+    (is (= 42 (:res rec)))))
+
+(deftest flow-adapter-eval-exception
+  (let [fx-ev (fx-handled :rf.fx/reg-flow
+                          {:flow-id :flow/x})
+        fail  (surface-ev :rf.error/flow-eval-exception
+                          {:flow-id :flow/x :message "div by zero"})
+        rec   (h/flow-adapter fx-ev [fail])]
+    (is (= :error (:status rec)))
+    (is (= :rf.error/flow-eval-exception (-> rec :failure :kind)))))
+
+;; ---- (3) cascade walker ------------------------------------------------
+
+(deftest cascade-walker-extracts-managed-fx-only
+  (testing "non-managed fxs (e.g. :db, :dispatch, user/x) are dropped"
+    (let [cascade {:dispatch-id 7
+                   :frame :rf/default
+                   :effects [(fx-handled :rf.http/managed
+                                         {:request {:method :get :url "/x"}})
+                             (fx-handled :db {:foo 1})
+                             (fx-handled :user/persist {:bar 2})]
+                   :other []}
+          records (h/cascade->managed-fx-records cascade)]
+      (is (= 1 (count records)))
+      (is (= :http (-> records first :surface)))
+      (is (= :rf.http/managed (-> records first :fx-id))))))
+
+(deftest cascade-walker-handles-multiple-surfaces
+  (testing "a cascade with HTTP + SSR + flow fxs produces three records"
+    (let [cascade {:dispatch-id 8
+                   :frame :rf/default
+                   :effects [(fx-handled :rf.http/managed
+                                         {:request {:method :get :url "/x"}})
+                             (fx-handled :rf.server/set-header
+                                         {:name "X" :value "Y"})
+                             (fx-handled :rf.fx/reg-flow
+                                         {:flow-id :flow/x})]
+                   :other []}
+          records (h/cascade->managed-fx-records cascade)]
+      (is (= 3 (count records)))
+      (is (= #{:http :ssr-fx :flow}
+             (set (map :surface records)))))))
+
+(deftest cascade-walker-folds-paths-touched
+  (testing "paths-by-dispatch-id supplies the F.4 slice-touched check"
+    (let [cascade {:dispatch-id 9
+                   :frame :rf/default
+                   :effects [(fx-handled :rf.http/managed
+                                         {:request {:method :get :url "/x"}}
+                                         {:dispatch-id 9})]
+                   :other []}
+          rec     (first (h/cascade->managed-fx-records
+                           cascade {9 [[:users 42] [:loading? :user-profile]]}))]
+      (is (= [[:users 42] [:loading? :user-profile]]
+             (:paths-touched rec))))))
+
+(deftest cascade-walker-empty-for-non-managed-cascade
+  (testing "a cascade with only :db / :dispatch fxs returns empty"
+    (let [cascade {:dispatch-id 10
+                   :frame :rf/default
+                   :effects [(fx-handled :db {:foo 1})
+                             (fx-handled :dispatch [:x])]
+                   :other []}]
+      (is (= [] (h/cascade->managed-fx-records cascade))))))
+
+;; ---- (4) formatting helpers --------------------------------------------
+
+(deftest format-fx-id-handles-keyword-and-nil
+  (is (= ":rf.http/managed" (h/format-fx-id :rf.http/managed)))
+  (is (= "—"                (h/format-fx-id nil))))
+
+(deftest format-status-label-covers-taxonomy
+  (doseq [s [:ok :error :in-flight :overridden :skipped :stub]]
+    (is (some? (h/format-status-label s)))))
+
+(deftest format-http-status-band-bands
+  (is (= :green         (h/format-http-status-band 200)))
+  (is (= :green         (h/format-http-status-band 204)))
+  (is (= :yellow        (h/format-http-status-band 302)))
+  (is (= :red           (h/format-http-status-band 404)))
+  (is (= :red           (h/format-http-status-band 503)))
+  (is (= :text-tertiary (h/format-http-status-band nil))))
+
+(deftest format-duration-ms-ranges
+  (is (= "—"     (h/format-duration-ms nil)))
+  (is (= "250ms" (h/format-duration-ms 250)))
+  (is (= "1500ms" (h/format-duration-ms 1500))))
+
+(deftest surfaces-and-glyphs-match
+  (testing "every canonical surface has a label, glyph, and adapter"
+    (doseq [s h/surfaces]
+      (is (some? (get h/surface->label s))   (str "label for " s))
+      (is (some? (get h/surface->glyph s))   (str "glyph for " s))
+      (is (some? (get h/surface->adapter s)) (str "adapter for " s)))))
+
+;; ---- (5) bug-class coverage table --------------------------------------
+
+(deftest bug-class-coverage-is-data
+  (testing "every F.<n> the panel claims to address lists at least one
+            record-field it surfaces"
+    (doseq [[k fields] h/bug-class-coverage]
+      (is (keyword? k))
+      (is (vector? fields))
+      (is (seq fields) (str "no fields listed for " k)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_subs_cljs_test.cljs
@@ -1,0 +1,112 @@
+(ns day8.re-frame2-causa.panels.managed-fx-subs-cljs-test
+  "Composite-sub test for `:rf.causa/managed-fx-for-focused-event` +
+  the `:rf.causa/focus-event` cross-link event (rf2-uyp86).
+
+  Uses the same test-runtime + seed-buffer pattern as
+  `event_detail_cljs_test.cljs` — install Causa's handlers, allocate
+  the `:rf/causa` frame, push trace events through the production
+  `trace-bus/collect-trace!` path, then read the composite via
+  `subscribe`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/set-show-sensitive! false)
+  (config/reset-suppressed-count!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- seed-buffer! [evs]
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (doseq [ev evs]
+    (trace-bus/collect-trace! ev)))
+
+;; ---- trace fixture ------------------------------------------------------
+
+(defn- cascade-evs-http
+  "One cascade containing a single `:rf.http/managed` invocation. The
+  fx args carry the standard Spec 014 shape so the helper can extract
+  request / handler / correlation-id."
+  [dispatch-id id-base]
+  [{:id (+ id-base 1) :op-type :event    :operation :event/dispatched
+    :tags {:dispatch-id dispatch-id :event [:user/load]}}
+   {:id (+ id-base 2) :op-type :event    :operation :event/do-fx
+    :tags {:dispatch-id dispatch-id}}
+   {:id (+ id-base 3) :op-type :fx       :operation :rf.fx/handled
+    :tags {:dispatch-id dispatch-id
+           :fx-id :rf.http/managed
+           :fx-args {:request {:method :get :url "/api/users/42"}
+                     :request-id :req-abc
+                     :on-success [:user/loaded]}}}])
+
+(defn- cascade-evs-non-managed
+  "A cascade with only `:db` / `:dispatch` fxs — should produce zero
+  managed-fx records."
+  [dispatch-id id-base]
+  [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+    :tags {:dispatch-id dispatch-id :event [:counter/inc]}}
+   {:id (+ id-base 2) :op-type :event :operation :event/do-fx
+    :tags {:dispatch-id dispatch-id}}
+   {:id (+ id-base 3) :op-type :fx    :operation :rf.fx/handled
+    :tags {:dispatch-id dispatch-id :fx-id :db}}])
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest empty-when-no-focus
+  (testing "with cascades in the buffer but no focused dispatch-id, the
+            composite returns empty records (the spine snaps to head in
+            LIVE mode but the cascade picked may have no managed-fx)"
+    (seed-buffer! (cascade-evs-non-managed 100 0))
+    (rf/with-frame :rf/causa
+      (let [out @(rf/subscribe [:rf.causa/managed-fx-for-focused-event])]
+        (is (= [] (:records out))
+            "non-managed cascade yields empty records in LIVE-head mode")))))
+
+(deftest projects-records-for-focused-cascade
+  (testing "focused cascade with managed-fx → records populated"
+    (seed-buffer! (cascade-evs-http 200 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-event 200 :rf/default])
+      (let [out @(rf/subscribe [:rf.causa/managed-fx-for-focused-event])]
+        (is (= 200 (:dispatch-id out)))
+        (is (= 1 (count (:records out))))
+        (is (= :http (-> out :records first :surface)))
+        (is (= :rf.http/managed (-> out :records first :fx-id)))
+        (is (= [:user/loaded] (-> out :records first :handler)))
+        (is (= :req-abc (-> out :records first :correlation-id)))))))
+
+(deftest empty-records-for-cascade-without-managed-fx
+  (testing "focused cascade with no managed-fx → empty records"
+    (seed-buffer! (cascade-evs-non-managed 300 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-event 300 :rf/default])
+      (let [out @(rf/subscribe [:rf.causa/managed-fx-for-focused-event])]
+        (is (= 300 (:dispatch-id out)))
+        (is (= [] (:records out)))))))
+
+(deftest focus-event-writes-spine-slot
+  (testing ":rf.causa/focus-event dispatches through to the spine slot —
+            this is the cross-link the HANDLER DISPATCHED row uses to
+            pivot the spine to the handler's cascade"
+    (seed-buffer! (cascade-evs-http 400 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-event 400 :rf/default])
+      (let [focus @(rf/subscribe [:rf.causa/focus])]
+        (is (= 400 (:dispatch-id focus)))
+        (is (= :rf/default (:frame focus)))
+        (is (= :retro (:mode focus)))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_template_cljs_test.cljs
@@ -1,0 +1,164 @@
+(ns day8.re-frame2-causa.panels.managed-fx-template-cljs-test
+  "Smoke render tests for the managed-fx wire-boundary diff template
+  (rf2-uyp86, parent rf2-5aw5v).
+
+  Pure hiccup; the test asserts the structural shape of the panel
+  per-surface without booting a substrate. The data-testid attributes
+  the template carries make the assertions deterministic without DOM
+  introspection."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [day8.re-frame2-causa.panels.managed-fx-template :as template]
+            [day8.re-frame2-causa.panels.managed-fx-helpers :as h]))
+
+;; ---- fixture record builder --------------------------------------------
+
+(defn- record
+  [{:keys [surface fx-id status http-status wire handler paths]}]
+  {:surface         surface
+   :fx-id           fx-id
+   :req             {:method :get :url "/x"}
+   :wire            wire
+   :res             {:ok true}
+   :handler         handler
+   :status          status
+   :phase           :completed
+   :correlation-id  :corr-1
+   :cancel-cause    nil
+   :http-status     http-status
+   :duration-ms     250
+   :failure         nil
+   :paths-touched   (or paths [])
+   :origin-event-id 99
+   :dispatch-id     7
+   :frame           :rf/default
+   :stubbed?        false})
+
+;; ---- recursive hiccup walker ------------------------------------------
+
+(defn- testids
+  "Collect every :data-testid in a hiccup tree. Used to assert the
+  template's section structure exists without walking the DOM."
+  [node]
+  (cond
+    (and (vector? node) (map? (second node)))
+    (let [attrs (second node)
+          tid   (:data-testid attrs)
+          kids  (drop 2 node)]
+      (concat (when tid [tid])
+              (mapcat testids kids)))
+
+    (vector? node)
+    (mapcat testids (drop 1 node))
+
+    (seq? node)
+    (mapcat testids node)
+
+    :else []))
+
+;; ---- per-surface smoke render ------------------------------------------
+
+(deftest record-panel-http-smoke
+  (let [r   (record {:surface :http :fx-id :rf.http/managed
+                     :status :ok :http-status 200
+                     :handler [:user/loaded]
+                     :paths [[:users 42]]})
+        out (template/record-panel r)
+        ids (set (testids out))]
+    (is (contains? ids "rf-causa-managed-fx-record-http-99"))
+    (is (contains? ids "rf-causa-managed-fx-header-http"))
+    (is (contains? ids "rf-causa-managed-fx-surface-http"))
+    (is (contains? ids "rf-causa-managed-fx-status-ok"))
+    (is (contains? ids "rf-causa-managed-fx-section-request"))
+    (is (contains? ids "rf-causa-managed-fx-section-wire"))
+    (is (contains? ids "rf-causa-managed-fx-section-response"))
+    (is (contains? ids "rf-causa-managed-fx-section-handler"))
+    (is (contains? ids "rf-causa-managed-fx-section-app-db"))))
+
+(deftest record-panel-machine-invoke-smoke
+  (let [r   (record {:surface :machine-invoke :fx-id :rf.machine/spawn
+                     :status :ok})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-header-machine-invoke"))
+    (is (contains? ids "rf-causa-managed-fx-surface-machine-invoke"))))
+
+(deftest record-panel-ssr-fx-smoke
+  (let [r   (record {:surface :ssr-fx :fx-id :rf.server/set-status
+                     :status :ok})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-header-ssr-fx"))
+    (is (contains? ids "rf-causa-managed-fx-surface-ssr-fx"))))
+
+(deftest record-panel-flow-smoke
+  (let [r   (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-header-flow"))
+    (is (contains? ids "rf-causa-managed-fx-surface-flow"))))
+
+(deftest record-panel-websocket-smoke
+  (let [r   (record {:surface :websocket :fx-id :rf.ws/connect :status :ok})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-header-websocket"))
+    (is (contains? ids "rf-causa-managed-fx-surface-websocket"))))
+
+;; ---- error-status renders error styling -------------------------------
+
+(deftest record-panel-error-surfaces-status-error-testid
+  (let [r   (assoc (record {:surface :http :fx-id :rf.http/managed
+                            :status :error :http-status 500})
+                    :failure {:kind :rf.http/http-5xx
+                              :tags {:status 500 :body "oops"}})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-status-error"))))
+
+;; ---- cross-link wiring -------------------------------------------------
+;;
+;; HANDLER DISPATCHED is collapsed by default; the focus button lives
+;; inside the section body. The tests assert the structural surface
+;; (section header is always rendered; body shows up once the section
+;; is expanded). The button visibility itself rides on the panel's
+;; default-collapse state and is exercised by the gallery
+;; (panel-gallery isn't in scope for rf2-uyp86).
+
+(deftest handler-section-header-present-when-handler-present
+  (let [r   (record {:surface :http :fx-id :rf.http/managed
+                     :status :ok :http-status 200
+                     :handler [:user/loaded {:id 1}]})
+        ids (set (testids (template/record-panel r)))]
+    (is (contains? ids "rf-causa-managed-fx-section-handler"))
+    (is (contains? ids "rf-causa-managed-fx-section-handler-header"))))
+
+;; ---- records-list ------------------------------------------------------
+
+(deftest records-list-renders-one-panel-per-record
+  (let [recs [(record {:surface :http :fx-id :rf.http/managed :status :ok :http-status 200})
+              (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})]
+        out  (template/records-list recs)
+        ids  (set (testids out))]
+    (is (contains? ids "rf-causa-managed-fx-list"))
+    (is (contains? ids "rf-causa-managed-fx-record-http-99"))
+    (is (contains? ids "rf-causa-managed-fx-record-flow-99"))))
+
+(deftest records-list-nil-for-empty-records
+  (is (nil? (template/records-list []))))
+
+;; ---- F.4 highlight: OK status + empty paths-touched -------------------
+
+(deftest app-db-section-flags-empty-slice-on-ok-status
+  (testing "Per spec/019 §2.4 F.4 — when status is :ok but
+            paths-touched is empty, the panel renders the F.4 warning
+            heuristic instead of the bare '(no changes)' caption"
+    (let [r   (record {:surface :http :fx-id :rf.http/managed
+                       :status :ok :http-status 200
+                       :paths []})
+          out (template/record-panel r)
+          ;; Walk the hiccup tree for the F.4 warning text
+          txt (atom [])
+          walk (fn walk [node]
+                 (cond
+                   (string? node) (swap! txt conj node)
+                   (vector? node) (doseq [c (drop 1 node)] (walk c))
+                   (seq? node)    (doseq [c node] (walk c))))]
+      (walk out)
+      (let [combined (apply str @txt)]
+        (is (str/includes? combined "F.4"))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -142,6 +142,8 @@
    :rf.causa/machine-scrubber-position
    :rf.causa/machine-snapshots
    :rf.causa/machine-snapshots-override
+   ;; rf2-uyp86 — managed-fx wire-boundary diff composite.
+   :rf.causa/managed-fx-for-focused-event
    :rf.causa/mode-c-cluster-by
    :rf.causa/mode-c-clusters
    :rf.causa/mode-c-compare-table
@@ -270,6 +272,9 @@
    :rf.causa/focus-cascade
    :rf.causa/focus-cascade-next
    :rf.causa/focus-cascade-prev
+   ;; rf2-uyp86 — managed-fx wire-boundary diff cross-link event
+   ;; (HANDLER DISPATCHED row dispatches this to pivot the spine).
+   :rf.causa/focus-event
    :rf.causa/focus-slice-path
    :rf.causa/follow-head
    :rf.causa/hide-event-type
@@ -486,7 +491,9 @@
     ;;   machine-arc-highlight-state + machine-arc-hover +
     ;;   machine-scrubber-position + share-modal-open? + share-state +
     ;;   share-url + share-copy-status.
-    (is (= 113 (count all-sub-names)))
+    ;; + 1 managed-fx wire-boundary diff (rf2-uyp86):
+    ;;   :rf.causa/managed-fx-for-focused-event composite sub.
+    (is (= 114 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -536,7 +543,9 @@
     ;;   restore-from-share-url (8 share/arc events) + the
     ;;   arc-data implicit composite has no event of its own. The
     ;;   correct count rises by 8 events; subs add another 9.
-    (is (= 134 (count all-event-names)))
+    ;; + 1 managed-fx cross-link (rf2-uyp86):
+    ;;   :rf.causa/focus-event — HANDLER DISPATCHED row pivots the spine.
+    (is (= 135 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary

Implements **rf2-uyp86** — the headline cross-cutting Causa feature from
`tools/causa/spec/019-Cross-Cutting-Insight.md` §2.4 / F-C2. One panel template
per managed-fx invocation in the focused cascade, surfacing the eight-property
contract from `spec/Managed-Effects.md` as a uniform UI across all five
managed-effect surfaces.

The panel mounts inline in the Event tab's cascade-detail layout under the
six-domino window when the focused cascade contains managed-fx invocations.
No new tab; no chrome reflow.

## 8-property contract usage

Every record satisfies the eight-property contract:

| Spec property | Record field |
|---|---|
| 1. Effect-as-data | `:req` — verbatim args map per surface |
| 2. Framework-owned lifecycle | `:phase` — `:issued :sent :received :completed :failed :aborted` |
| 3. Structured failure taxonomy | `:failure` — `{:kind <:rf.<surface>/*> :tags ...}` |
| 4. Trace-bus observable | All five adapters consume `:rf.<surface>/*` ops |
| 5. `:sensitive?` + `:large?` composition | Inherited via the existing `theme/data_inspector` |
| 6. Retry/abort/teardown | `:cancel-cause` field; retry timeline rides the surface events |
| 7. In-flight registry | Visible via `:status` + `:phase` |
| 8. Per-frame interceptors / scoping | `:frame` field on every record + `:stubbed?` flag |

## Per-surface adapter table

| Surface | fx-id pattern | Adapter | Wire timing |
|---|---|---|---|
| HTTP | `:rf.http/*` | `http-adapter` | per-phase when emitted; synthesised round-trip otherwise |
| WebSocket | `:rf.ws/*` | `websocket-adapter` | synthesised round-trip (bi-directional frame timeline → follow-on) |
| Machine `:invoke` | `:rf.machine/*` | `machine-invoke-adapter` | spawn → terminal-event elapsed |
| SSR `:rf.server/*` | `:rf.server/*` | `ssr-fx-adapter` | per-call accumulator contribution |
| Flows | `:rf.flow/*`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow` | `flow-adapter` | recompute elapsed |

## ASCII of the template

```
+- MANAGED FX [HTTP] . :rf.http/managed . 250ms ---- v 200 . correlation: req-abc . phase: completed -+
| > REQUEST                                                                                            |
| v WIRE TIMING                                                                                        |
|   issued     [##......................] 0ms                                                          |
|   elapsed    [...####################.] 250ms  <- slow                                               |
| > RESPONSE                                                                                           |
| > HANDLER DISPATCHED          -> focus event /                                                       |
| v APP-DB SLICE TOUCHED                                                                               |
|   [:users 42] . [:loading? :user-profile]                                                            |
+------------------------------------------------------------------------------------------------------+
```

When status is `:ok` but `:paths-touched` is empty, the APP-DB SLICE TOUCHED
section renders an amber **F.4 heuristic warning** — the documented "app-db
wasn't updated" diagnostic.

## Bug-class coverage (per the findings doc §Managed-Effects)

| Class | Bug | Surfaced via |
|---|---|---|
| **F.1** | Request timeout | WIRE TIMING waterfall + `:duration-ms` |
| **F.2** | Bad request payload | REQUEST section (cljs-devtools-shaped inspector) |
| **F.3** | Failed response handler | HANDLER DISPATCHED row + `:failure` map + cross-link |
| **F.4** | App-db wasn't updated | APP-DB SLICE TOUCHED — amber F.4 heuristic |
| **F.5** | Cancellation cascade | `:cancel-cause` pill (deeper drill-down → rf2-wvkn) |
| **F.6** | Stale response (correlation mismatch) | `correlation: <id>` header pill |
| **F.7** | Other structured failures | `:failure {:kind ...}` rendered under RESPONSE |
| **F.8** | Stub/override visibility | `STUB` pill when `:rf.fx/override-applied` fires |
| **F.9** | Skipped-on-platform | `:skipped` status |
| **F.10** | Surface badge taxonomy | HTTP / WS / machine / SSR / flow glyph in header |
| **F.11** | Cross-surface stale-suppression | `:cancel-cause :superseded` |

## Files added

- `tools/causa/src/day8/re_frame2_causa/chart/timing_waterfall.cljc` — pure SVG waterfall primitive
- `tools/causa/src/day8/re_frame2_causa/panels/managed_fx_helpers.cljc` — per-surface adapters + cascade walker
- `tools/causa/src/day8/re_frame2_causa/panels/managed_fx_subs.cljs` — composite sub + cross-link event
- `tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs` — five-section panel template
- `tools/causa/test/day8/re_frame2_causa/chart/timing_waterfall_cljs_test.cljc`
- `tools/causa/test/day8/re_frame2_causa/panels/managed_fx_helpers_cljs_test.cljc`
- `tools/causa/test/day8/re_frame2_causa/panels/managed_fx_subs_cljs_test.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/managed_fx_template_cljs_test.cljs`

## Files modified

- `tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs` — mount the records list inline under the six-domino cascade
- `tools/causa/src/day8/re_frame2_causa/registry.cljs` — install the new subs
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — bump catalogue counts (113→114 subs, 134→135 events)

## Divergences + follow-on beads

- **Wire timing**: only HTTP carries native per-phase timing today. For other
  surfaces, the adapter synthesises a two-row `:issued → :elapsed` waterfall
  from event timestamps when both bookend events are available, and renders
  `n/a` otherwise. Per-phase native timing on the non-HTTP surfaces is a
  follow-on bead worth scheduling once the surfaces emit it.
- **Cancellation cascade (F.5)**: surfaced as a single `:cancel-cause` pill;
  the deeper tree visualiser (parent destroy → in-flight aborts → child
  teardown) lives in the M-C3 cancellation-cascade panel (rf2-wvkn) — same
  underlying cascade-grouping projection will feed both.
- **WebSocket bi-directional frame timeline**: adapter ships a basic record;
  per-frame send/recv lane is a follow-on as the surface's trace schema
  stabilises.
- **Panel-gallery slot**: no panel-gallery testbed currently lives in
  `tools/causa/testbeds/`; gallery variants for each surface are a follow-on.
- **F.4 detection**: the heuristic fires when an OK-status managed-fx leaves
  `:paths-touched` empty. The composite sub today does not yet thread the
  per-cascade app-db diff into `:paths-touched`; the field is wired and the
  view branch lights up correctly when populated. Threading the diff requires
  joining the cascade record with the epoch-history slice — straightforward
  follow-on; the current rendering shows the bare `(no changes)` caption
  until that lands.

## Gate results

- `scripts/test-fast-pr.sh` → PASS
- `cd tools/causa && clojure -M:test` → 781 tests, 2268 assertions, 0 failures
- `cd implementation && npm run test:cljs` → 2891 tests, 8305 assertions, 0 failures
- `cd implementation && npm run test:browser` → 2880 tests, 8225 assertions, 0 failures
- `cd implementation && npm run story:build` → built (counter-with-stories static export)

## Test plan

- [ ] Mount Causa in a host app; trigger a `:rf.http/managed` GET that succeeds.
      Open the Event tab on that cascade; confirm the panel renders with
      green status header, a populated REQUEST inspector, and the synthesised
      two-row WIRE TIMING waterfall.
- [ ] Trigger a `:rf.http/managed` that fails (4xx / 5xx); confirm the panel
      header shows red ERROR + status and the RESPONSE section displays the
      `:rf.http/http-4xx` / `:rf.http/http-5xx` failure map.
- [ ] Trigger an `:rf.fx/reg-flow` registration; confirm a per-flow record
      appears with the flow surface glyph and the `:flow-id` as the
      correlation id.
- [ ] Click the focus button on a HANDLER DISPATCHED row; confirm the spine
      moves to the handler's child cascade and the panel re-derives against
      the new focus.
