### PR TITLE
feat(causa): cancellation cascade visualiser — single waterfall for rf2-wvkn cancellation

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -1,0 +1,486 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade
+  "Cancellation-cascade visualiser (rf2-59e7k, parent rf2-5aw5v).
+
+  Per `tools/causa/spec/019-Cross-Cutting-Insight.md` §M.3 / the
+  cancellation-cascade section: when a parent machine decision triggers
+  a destroy, every in-flight effect the child held aborts (per Spec
+  014 §Abort on actor destroy / rf2-wvkn). Today those traces scatter
+  through the Trace tab as a flurry; this visualiser folds them into
+  ONE vertical waterfall:
+
+      PARENT DECISION
+        └─ [destroy-child] dispatched at 1234ms by :auth/logout
+      CHILD TEARDOWN
+        └─ child:user-session destroying at 1240ms (5 in-flight fxs)
+      EFFECT ABORTS (in order)
+        ├─ HTTP GET /api/profile  aborted at 1242ms (:actor-destroyed)
+        ├─ HTTP POST /api/log     aborted at 1242ms (:actor-destroyed)
+        ├─ WS send :heartbeat     aborted at 1243ms (:actor-destroyed)
+        ├─ :after timer fire      aborted at 1243ms (:actor-destroyed)
+        └─ machine-invoke fetch   aborted at 1244ms (:actor-destroyed)
+
+  Each row is clickable → jumps to the underlying trace entry via the
+  spine shim (`:rf.causa/select-dispatch-id`).
+
+  ## Two mounts
+
+    1. **Machines tab side-panel** — when the focused machine had a
+       cancellation-anchor in the trace window, the visualiser mounts
+       inline beside the chart. Reads
+       `:rf.causa/cancellation-cascade-for-focused-machine`.
+
+    2. **Popover** — opened from anywhere via
+       `:rf.causa/cancellation-cascade-open` (e.g. a Trace row's
+       'Show cancellation cascade' affordance). Reads
+       `:rf.causa/cancellation-cascade-for-focused-event` (composes
+       popover-focus → spine focus).
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — no Reagent / UIx /
+  Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.cancellation-cascade-events :as events]
+            [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as h]
+            [day8.re-frame2-causa.panels.cancellation-cascade-subs :as subs]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack type-scale]]))
+
+;; ---- row styling primitives ----------------------------------------------
+
+(def ^:private row-glyph
+  {:parent-decision "●"
+   :child-teardown  "└─"
+   :effect-abort    "├─"
+   :effect-abort-last "└─"})
+
+(defn- row-colour
+  "Per the bead's contract: decision = blue, teardown = orange,
+  abort = red. Reads tokens off the theme map so the visualiser
+  follows the active theme."
+  [kind]
+  (case kind
+    :parent-decision (:cyan tokens)              ; blue-ish in the dark theme
+    :child-teardown  (or (:accent-orange tokens)
+                         (:warning-amber tokens)
+                         (:yellow tokens))
+    :effect-abort    (or (:red tokens)
+                         (:error-red tokens)
+                         (:danger tokens))
+    (:text-secondary tokens)))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  "Top strip — title + the cascade summary + close button (popover
+  mount only). `close-fn` is the on-click for the close button; nil
+  in the side-panel mount."
+  [cascade close-fn]
+  [:div {:data-testid "rf-causa-cancellation-cascade-header"
+         :style {:display "flex"
+                 :align-items "center"
+                 :justify-content "space-between"
+                 :gap "12px"
+                 :padding "10px 14px"
+                 :background (:bg-2 tokens)
+                 :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:div
+    [:div {:style {:font-family sans-stack
+                   :font-size (:body type-scale)
+                   :font-weight 600
+                   :color (:text-primary tokens)}}
+     "Cancellation cascade"]
+    [:div {:data-testid "rf-causa-cancellation-cascade-summary"
+           :style {:font-family sans-stack
+                   :font-size "11px"
+                   :color (:text-tertiary tokens)
+                   :margin-top "2px"}}
+     (h/cascade-summary cascade)]]
+   (when close-fn
+     [:button {:data-testid "rf-causa-cancellation-cascade-close"
+               :on-click    close-fn
+               :style       {:background  "transparent"
+                             :border      "none"
+                             :color       (:text-secondary tokens)
+                             :cursor      "pointer"
+                             :font-family mono-stack
+                             :font-size   "14px"}}
+      "×"])])
+
+;; ---- parent-decision row ------------------------------------------------
+
+(defn- parent-decision-row
+  "Render the parent-decision row at the top of the waterfall."
+  [decision]
+  (let [clickable? (boolean (:dispatch-id decision))]
+    [:div {:data-testid "rf-causa-cancellation-cascade-decision-row"
+           :on-click    (when clickable?
+                          (fn [_]
+                            (rf/dispatch
+                              [:rf.causa/focus-trace-entry
+                               {:dispatch-id (:dispatch-id decision)
+                                :trace-id    (:trace-id decision)}]
+                              {:frame :rf/causa})))
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :gap           "8px"
+                   :padding       "8px 14px"
+                   :cursor        (if clickable? "pointer" "default")
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:span {:style {:color (row-colour :parent-decision)
+                     :font-weight 700}}
+      (:parent-decision row-glyph)]
+     [:span {:style {:color       (:text-tertiary tokens)
+                     :font-size   "10px"
+                     :min-width   "70px"
+                     :white-space "nowrap"}}
+      (h/format-time-ms (:t decision))]
+     [:span {:style {:color (:text-secondary tokens)
+                     :text-transform "uppercase"
+                     :font-size "9px"
+                     :letter-spacing "0.5px"}}
+      "DECISION"]
+     [:span {:style {:color (:text-primary tokens)
+                     :flex 1
+                     :overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space "nowrap"}}
+      (h/format-event-vec (:event-vec decision))]
+     (when-let [m (:machine-id decision)]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :white-space "nowrap"}}
+        (str " by " m)])]))
+
+;; ---- teardown row --------------------------------------------------------
+
+(defn- teardown-row
+  [{:keys [child-id t inflight-count reason dispatch-id trace-id]}]
+  (let [clickable? (boolean dispatch-id)]
+    [:div {:data-testid (str "rf-causa-cancellation-cascade-teardown-row-"
+                             (str child-id))
+           :on-click    (when clickable?
+                          (fn [_]
+                            (rf/dispatch
+                              [:rf.causa/focus-trace-entry
+                               {:dispatch-id dispatch-id
+                                :trace-id    trace-id}]
+                              {:frame :rf/causa})))
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :gap           "8px"
+                   :padding       "6px 14px 6px 28px"
+                   :cursor        (if clickable? "pointer" "default")
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:span {:style {:color (row-colour :child-teardown)
+                     :font-weight 700}}
+      (:child-teardown row-glyph)]
+     [:span {:style {:color       (:text-tertiary tokens)
+                     :font-size   "10px"
+                     :min-width   "70px"
+                     :white-space "nowrap"}}
+      (h/format-time-ms t)]
+     [:span {:style {:color (row-colour :child-teardown)
+                     :text-transform "uppercase"
+                     :font-size "9px"
+                     :letter-spacing "0.5px"}}
+      "TEARDOWN"]
+     [:span {:style {:color (:text-primary tokens)
+                     :flex 1
+                     :overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space "nowrap"}}
+      (str child-id)]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :white-space "nowrap"}}
+      (str inflight-count
+           (if (= 1 inflight-count)
+             " in-flight fx"
+             " in-flight fxs"))]
+     (when reason
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :white-space "nowrap"}}
+        (str " · " reason)])]))
+
+;; ---- abort row -----------------------------------------------------------
+
+(defn- abort-row
+  [{:keys [fx t cancel-cause url correlation-id
+           dispatch-id trace-id]
+    :as row}
+   last?]
+  (let [clickable? (boolean dispatch-id)]
+    [:div {:data-testid (str "rf-causa-cancellation-cascade-abort-row-"
+                             (str (or trace-id correlation-id)))
+           :data-cancel-cause (str cancel-cause)
+           :data-fx           (name (or fx :unknown))
+           :on-click    (when clickable?
+                          (fn [_]
+                            (rf/dispatch
+                              [:rf.causa/focus-trace-entry
+                               {:dispatch-id dispatch-id
+                                :trace-id    trace-id}]
+                              {:frame :rf/causa})))
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :gap           "8px"
+                   :padding       "6px 14px 6px 42px"
+                   :cursor        (if clickable? "pointer" "default")
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [:span {:style {:color (row-colour :effect-abort)
+                     :font-weight 700}}
+      (if last?
+        (:effect-abort-last row-glyph)
+        (:effect-abort row-glyph))]
+     [:span {:style {:color       (:text-tertiary tokens)
+                     :font-size   "10px"
+                     :min-width   "70px"
+                     :white-space "nowrap"}}
+      (h/format-time-ms t)]
+     [:span {:style {:color (row-colour :effect-abort)
+                     :text-transform "uppercase"
+                     :font-size "9px"
+                     :letter-spacing "0.5px"}}
+      "ABORT"]
+     [:span {:style {:color (:text-primary tokens)
+                     :flex 1
+                     :overflow "hidden"
+                     :text-overflow "ellipsis"
+                     :white-space "nowrap"}}
+      (h/format-fx-label row)]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :white-space "nowrap"}}
+      (str cancel-cause)]]))
+
+;; ---- collapsed expander row ---------------------------------------------
+
+(defn- expand-button
+  "Renders the 'Show all N' / 'Collapse' affordance under the abort
+  list when collapse is active."
+  [collapsed-count total-count expanded?]
+  [:div {:data-testid "rf-causa-cancellation-cascade-expander"
+         :style {:padding "8px 14px"
+                 :text-align "center"
+                 :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [:button {:data-testid "rf-causa-cancellation-cascade-expand-toggle"
+             :on-click    (fn [_]
+                            (rf/dispatch
+                              [:rf.causa/cancellation-cascade-toggle-expand]
+                              {:frame :rf/causa}))
+             :style       {:background "transparent"
+                           :border (str "1px solid " (:border-default tokens))
+                           :color (:accent-violet tokens)
+                           :font-family sans-stack
+                           :font-size "11px"
+                           :padding "3px 10px"
+                           :border-radius "10px"
+                           :cursor "pointer"}}
+    (if expanded?
+      (str "Collapse · showing " total-count)
+      (str "Show all " total-count " · "
+           collapsed-count " hidden"))]])
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  "Empty-state body — branches on the cascade's `:empty-kind`."
+  [cascade]
+  (let [kind (:empty-kind cascade)]
+    [:div {:data-testid (str "rf-causa-cancellation-cascade-empty-"
+                             (name (or kind :no-trigger)))
+           :style {:padding "16px"
+                   :color (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size "13px"
+                   :text-align "center"}}
+     (case kind
+       :no-trigger
+       [:div
+        [:p {:style {:margin "0 0 6px 0"}}
+         "No cancellation cascade in the trace window."]
+        [:p {:style {:margin 0 :font-size "11px"}}
+         "Cancellation cascades land here when a parent machine "
+         "destroys a child while in-flight effects are running."]]
+
+       :no-aborts
+       [:div
+        [:p {:style {:margin "0 0 6px 0"}}
+         "Destroy fired — no in-flight effects to abort."]
+        [:p {:style {:margin 0 :font-size "11px"}}
+         "The cascade ran cleanly: the child machine was torn down "
+         "without any HTTP / WS / timer / invoke cleanup."]]
+
+       [:p {:style {:margin 0}} "No cascade data."])]))
+
+;; ---- the body (waterfall list) -----------------------------------------
+
+(defn- body
+  "Render the waterfall body — decision + teardown rows + abort rows.
+  Reads `:rf.causa/cancellation-cascade-expanded?` to decide whether
+  the abort list is collapsed."
+  [cascade]
+  (let [{:keys [parent-decision child-teardowns effect-aborts]} cascade
+        expanded? @(rf/subscribe [:rf.causa/cancellation-cascade-expanded?])
+        collapse? (h/should-collapse? cascade)
+        visible-aborts (cond
+                         (not collapse?) effect-aborts
+                         expanded?       effect-aborts
+                         :else           (vec (take 5 effect-aborts)))
+        hidden-count   (- (count effect-aborts) (count visible-aborts))]
+    [:div {:data-testid "rf-causa-cancellation-cascade-body"
+           :data-collapsed (str (and collapse? (not expanded?)))
+           :data-aborts-shown (str (count visible-aborts))
+           :data-aborts-total (str (count effect-aborts))
+           :style {:flex 1
+                   :overflow "auto"
+                   :background (:bg-2 tokens)}}
+     (when parent-decision
+       (parent-decision-row parent-decision))
+     (when (seq child-teardowns)
+       [:div {:data-testid "rf-causa-cancellation-cascade-teardowns"}
+        (doall
+          (for [t child-teardowns]
+            ^{:key (str "teardown-" (or (:trace-id t)
+                                        (:child-id t)))}
+            (teardown-row t)))])
+     (when (seq visible-aborts)
+       [:div {:data-testid "rf-causa-cancellation-cascade-aborts"}
+        (doall
+          (map-indexed
+            (fn [idx row]
+              (let [last? (= idx (dec (count visible-aborts)))]
+                ^{:key (str "abort-" (or (:trace-id row)
+                                         (:correlation-id row)
+                                         idx))}
+                (abort-row row last?)))
+            visible-aborts))])
+     (when (and collapse? (pos? hidden-count) (not expanded?))
+       (expand-button hidden-count (count effect-aborts) expanded?))
+     (when (and collapse? expanded?)
+       (expand-button 0 (count effect-aborts) expanded?))]))
+
+;; ---- public views --------------------------------------------------------
+
+(defn render-cascade
+  "Render the cascade as a self-contained block. `cascade` is the
+  helpers/extract-cascade record; `close-fn` is optional (popover
+  mount passes a close handler; side-panel mount passes nil).
+
+  Always renders SOMETHING — the empty-state branches still render
+  so the mount point can place this unconditionally."
+  [cascade close-fn]
+  [:section {:data-testid "rf-causa-cancellation-cascade"
+             :data-empty-kind (when (:empty-kind cascade)
+                                (name (:empty-kind cascade)))
+             :style {:display "flex"
+                     :flex-direction "column"
+                     :height "100%"
+                     :background (:bg-2 tokens)
+                     :color (:text-primary tokens)
+                     :font-family sans-stack
+                     :border (str "1px solid " (:border-subtle tokens))
+                     :border-radius "4px"
+                     :overflow "hidden"}}
+   (header cascade close-fn)
+   (if (:empty-kind cascade)
+     (empty-state cascade)
+     (body cascade))])
+
+(rf/reg-view SidePanel
+  "Machines-tab side-panel mount. Reads
+  `:rf.causa/cancellation-cascade-for-focused-machine` and renders
+  only when the cascade is non-empty (i.e. the focused machine had a
+  destroy in the trace window). Closed-state cost is one subscribe
+  + a when-gate."
+  []
+  (let [cascade @(rf/subscribe [:rf.causa/cancellation-cascade-for-focused-machine])]
+    ;; The bead's contract: mount in the side-rail WHEN a destroy
+    ;; lands. Empty `:no-trigger` cascades render nothing so the
+    ;; mount stays dormant most of the time.
+    (when-not (= :no-trigger (:empty-kind cascade))
+      (render-cascade cascade nil))))
+
+;; ---- popover (overlay) ---------------------------------------------------
+
+(defn- backdrop-style []
+  {:position         "fixed"
+   :top              0
+   :left             0
+   :right            0
+   :bottom           0
+   :background       "rgba(0,0,0,0.18)"
+   :display          "flex"
+   :align-items      "center"
+   :justify-content  "center"
+   :z-index          2147483644})
+
+(defn- dialog-style []
+  {:width            "720px"
+   :max-width        "92vw"
+   :height           "520px"
+   :max-height       "82vh"
+   :display          "flex"
+   :flex-direction   "column"
+   :background       (:bg-1 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "8px"
+   :box-shadow       "rgba(0,0,0,0.6) 0 24px 64px"
+   :overflow         "hidden"
+   :font-family      sans-stack
+   :color            (:text-primary tokens)})
+
+(defn- handle-popover-keydown
+  [^js e]
+  (when (= "Escape" (.-key e))
+    (.preventDefault e)
+    (.stopPropagation e)
+    (rf/dispatch [:rf.causa/cancellation-cascade-close]
+                 {:frame :rf/causa})))
+
+(rf/reg-view Popover
+  "Overlay popover mount. Reads
+  `:rf.causa/cancellation-cascade-popover-open?` and short-circuits to
+  nil when closed (one subscribe + when-gate). When open, reads
+  `:rf.causa/cancellation-cascade-for-focused-event` and renders the
+  cascade body inside the dialog."
+  []
+  (when @(rf/subscribe [:rf.causa/cancellation-cascade-popover-open?])
+    (let [cascade @(rf/subscribe [:rf.causa/cancellation-cascade-for-focused-event])
+          close   (fn [_]
+                    (rf/dispatch [:rf.causa/cancellation-cascade-close]
+                                 {:frame :rf/causa}))]
+      [:div {:data-testid "rf-causa-cancellation-cascade-popover-backdrop"
+             :on-click    close
+             :on-key-down handle-popover-keydown
+             :tab-index   -1
+             :style       (backdrop-style)}
+       [:div {:data-testid "rf-causa-cancellation-cascade-popover-dialog"
+              :on-click    #(.stopPropagation %)
+              :on-key-down handle-popover-keydown
+              :tab-index   0
+              :style       (dialog-style)}
+        (render-cascade cascade close)]])))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the visualiser's sub/event registrations.
+  Called from `registry.cljs`'s `register-causa-handlers!` fan-out.
+
+  The view-side `reg-view`s above are picked up at ns-load (the
+  `reg-view` macro registers eagerly); this `install!` only registers
+  the subs + events under the orchestrator's idempotency sentinel."
+  []
+  (subs/install!)
+  (events/install!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_events.cljs
@@ -1,0 +1,85 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade-events
+  "Events for the Cancellation-cascade visualiser (rf2-59e7k).
+
+  Per the bead's contract the visualiser has three event surfaces:
+
+    `:rf.causa/cancellation-cascade-open`    ; popover open (anchor focus)
+    `:rf.causa/cancellation-cascade-close`   ; popover close
+    `:rf.causa/cancellation-cascade-toggle-expand` ; show-all-N toggle
+    `:rf.causa/focus-trace-entry`            ; jump-to-trace from a row
+    `:rf.causa/cancellation-cascade-set-collapse-default`
+       ; per-panel collapse default override (test hook)
+
+  All events run against Causa's `:rf/causa` frame; the storage slots
+  live at `:cancellation-cascade-popover-open?`,
+  `:cancellation-cascade-popover-focus` (the `{:kind :dispatch-id | :machine-id
+  :id <id>}` map the visualiser uses to pick its anchor), and
+  `:cancellation-cascade-expanded?`.
+
+  `:rf.causa/focus-trace-entry` is a small jump-event the visualiser
+  rows dispatch when clicked — it delegates into the existing
+  `:rf.causa/select-dispatch-id` spine shim when a dispatch-id is
+  present, otherwise no-ops. The slot is the bead's contract for
+  'click a row → jump to the trace entry'."
+  (:require [re-frame.core :as rf]))
+
+(defn install!
+  "Install the cancellation-cascade visualiser's events. Idempotent
+  under re-frame's replace-in-place registrar — second + subsequent
+  calls are harmless beyond the `:rf.warning/handler-replaced` trace
+  which the orchestrator's `registered?` sentinel already protects
+  against."
+  []
+
+  ;; ---- popover open / close --------------------------------------------
+
+  (rf/reg-event-db :rf.causa/cancellation-cascade-open
+    (fn [db [_ focus]]
+      (-> db
+          (assoc :cancellation-cascade-popover-open? true)
+          (assoc :cancellation-cascade-popover-focus focus))))
+
+  (rf/reg-event-db :rf.causa/cancellation-cascade-close
+    (fn [db _event]
+      (assoc db :cancellation-cascade-popover-open? false)))
+
+  ;; ---- show-all / collapse toggle --------------------------------------
+
+  (rf/reg-event-db :rf.causa/cancellation-cascade-toggle-expand
+    (fn [db _event]
+      (update db :cancellation-cascade-expanded? not)))
+
+  (rf/reg-event-db :rf.causa/cancellation-cascade-set-expanded
+    (fn [db [_ expanded?]]
+      (assoc db :cancellation-cascade-expanded? (boolean expanded?))))
+
+  ;; ---- focus-trace-entry: row-click jump --------------------------------
+  ;;
+  ;; Per the bead's contract: clicking any row in the visualiser
+  ;; surfaces the underlying trace entry. The row carries the dispatch-id
+  ;; (when the trace event was emitted during a drain); we delegate into
+  ;; the legacy spine shim `:rf.causa/select-dispatch-id` so the
+  ;; existing event-detail panel takes the focus pivot.
+  (rf/reg-event-fx :rf.causa/focus-trace-entry
+    (fn [_ctx [_ {:keys [dispatch-id frame trace-id]}]]
+      ;; trace-id rides through for the future per-event focus surface
+      ;; (rf2-pending event-row direct focus); today the dispatch-id is
+      ;; the only addressable axis the spine accepts. When no dispatch-id
+      ;; is available (e.g. an actor-destroy abort outside a drain), the
+      ;; event becomes a no-op — the visualiser still has the trace-id
+      ;; pinned via the row's data-testid so the user can grep on it.
+      {:fx (cond-> []
+             dispatch-id
+             (conj [:dispatch [[:rf.causa/select-dispatch-id
+                                dispatch-id frame]
+                               {:frame :rf/causa}]])
+             dispatch-id
+             (conj [:dispatch [[:rf.causa/select-panel :event-detail]
+                               {:frame :rf/causa}]])
+             ;; Also close the popover when a row jump fires — the
+             ;; user has navigated away.
+             true
+             (conj [:dispatch [[:rf.causa/cancellation-cascade-close]
+                               {:frame :rf/causa}]]))}))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_helpers.cljc
@@ -1,0 +1,575 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade-helpers
+  "Pure-data helpers for Causa's Cancellation-cascade visualiser
+  (rf2-59e7k, parent rf2-5aw5v).
+
+  ## What this is
+
+  Per `tools/causa/spec/019-Cross-Cutting-Insight.md` §M.3 — when a
+  parent machine destroys a child (`:invoke` exit, `:after` fire,
+  `:invoke-all` cancel-on-decision, explicit `[:rf.machine/destroy <id>]`,
+  or parent-frame teardown), every in-flight `:rf.http/managed` request
+  the child held aborts. Each abort emits a
+  `:rf.http/aborted-on-actor-destroy` trace event (per Spec 014 §Abort
+  on actor destroy / rf2-wvkn). In today's Trace tab these scatter
+  through the firehose alongside the `:rf.machine.lifecycle/destroyed`
+  emit and the `:rf.machine/destroyed` enrichment — devs cannot
+  reconstruct which abort came from which destroy.
+
+  This namespace folds those scattered trace events into ONE record:
+
+      {:parent-decision  {:event-vec <vec> :t <ms> :machine-id <id>
+                          :dispatch-id <id>}
+       :child-teardowns  [{:child-id <id> :t <ms>
+                           :reason   <keyword> :inflight-count <int>}
+                          ...]
+       :effect-aborts    [{:fx <:http | :ws | :after | :machine-invoke>
+                           :req {<...>}  ;; per-fx detail
+                           :t <ms>
+                           :cancel-cause <keyword>  ;; :actor-destroyed etc
+                           :request-id <id-or-nil>
+                           :url <str-or-nil>
+                           :actor-id <id-or-nil>
+                           :correlation-id <id-or-nil>
+                           :trace-id <id>           ;; the trace event :id
+                           :dispatch-id <id-or-nil>}
+                          ...]
+       :total-elapsed-ms <int-or-nil>
+       :empty-kind       <nil | :no-trigger | :no-aborts>}
+
+  `:total-elapsed-ms` is the wall-clock span from the parent decision
+  to the last abort (nil if either endpoint is missing). `:empty-kind`
+  is `:no-trigger` when no parent decision could be located,
+  `:no-aborts` when a decision exists but no abort traces ride with
+  it.
+
+  ## Why a separate .cljc
+
+  Same dual-target pattern every other panel helper uses (the JVM
+  test target drives the algebra without a CLJS runtime). The view in
+  `cancellation_cascade.cljs` is a thin renderer over this record.
+
+  ## Detection strategy
+
+  The cascade pivots on a single anchor: a `:rf.machine.lifecycle/
+  destroyed` or `:rf.machine/destroyed` trace event whose `:reason`
+  is one of the cancellation reasons (`:explicit`,
+  `:parent-unmount-cascade`, `:parent-frame-destroyed`). The anchor's
+  `:dispatch-id` (when present) is the cascade boundary; aborts that
+  share the same `:dispatch-id` (or land within a small wall-clock
+  window of the anchor for the actor-destroy case where the abort
+  emits run outside the originating drain) are gathered into the
+  visualiser.
+
+  The decision row (\"parent decision\") is the most-recent
+  `:event/dispatched` trace event within the cascade that the anchor
+  belongs to — typically `[:auth/logout]`, `[:checkout/cancel]`, etc.
+
+  Best-effort heuristic when the trace events lack the runtime tags
+  we'd ideally read: fall back to a small wall-clock window
+  (`+default-actor-destroy-window-ms+`) around the anchor; group every
+  `:rf.http/aborted-on-actor-destroy` trace inside the window into the
+  cascade. Divergence note: today's traces don't all carry
+  `:cancel-cause`; we lift it off `:reason` / `:tags :reason` when
+  available and default to `:actor-destroyed` for
+  `:rf.http/aborted-on-actor-destroy` events (the canonical case).
+
+  ## What this does NOT do
+
+    - Rendering — the view ns does the SVG/hiccup work.
+    - Cross-frame causality — single-cascade-anchor scope only.
+    - Multi-anchor merging — each call returns ONE cascade. The subs
+      pick which anchor to focus (focused-machine or focused-event)."
+  (:require [clojure.string :as str]))
+
+;; ---- canonical operation sets -------------------------------------------
+
+(def ^:private destroy-operations
+  "Trace operations that signal a machine-instance teardown. Per Spec
+  009 §Trace events both pairs land on a destroy:
+
+    - `:rf.machine.lifecycle/destroyed` (frame.cljc + lifecycle_fx)
+    - `:rf.machine/destroyed` (fx.cljc on the destroy fx-id path)
+
+  The pair is intentionally symmetric so consumers can subscribe to
+  either; we accept either as a cascade anchor."
+  #{:rf.machine.lifecycle/destroyed
+    :rf.machine/destroyed})
+
+(def ^:private abort-operations
+  "Trace operations that signal an in-flight effect being cancelled.
+
+    - `:rf.http/aborted-on-actor-destroy` (Spec 014 §Abort on actor destroy)
+    - `:rf.http/aborted` (failure category, when `:reason` is one of
+      the cascade reasons; rarer)
+    - `:rf.ws/aborted-on-actor-destroy` (Pattern-WebSocket; defensive —
+      not all installs ship this)
+    - `:rf.machine.timer/cancelled-on-resolution` (per Spec 005 §after
+      timer lifecycle)
+    - `:rf.machine.invoke/cancelled-on-join-resolution` (per Spec 005
+      §Cancel-on-decision)"
+  #{:rf.http/aborted-on-actor-destroy
+    :rf.http/aborted
+    :rf.ws/aborted-on-actor-destroy
+    :rf.machine.timer/cancelled-on-resolution
+    :rf.machine.invoke/cancelled-on-join-resolution})
+
+(def ^:private cancellation-reasons
+  "Reasons that classify a destroy as part of a cancellation cascade
+  (per Spec 009 §Trace events L110-L119). `:rf.machine/finished` is
+  excluded — it represents a natural termination, not a cancellation."
+  #{:explicit
+    :parent-unmount-cascade
+    :parent-frame-destroyed
+    :rf.machine/cancelled
+    :actor-destroyed})
+
+(def ^:const default-actor-destroy-window-ms
+  "Best-effort wall-clock window (ms) around the anchor's `:time` for
+  associating abort traces that lack a `:dispatch-id` link. Per the
+  bead's divergence allowance: until the substrate stamps
+  `:cancel-cause` + a back-link on every abort event, proximity is
+  the structural fallback."
+  100)
+
+;; ---- predicates ---------------------------------------------------------
+
+(defn destroy-event?
+  "True iff `ev` is a machine-destroy trace event."
+  [ev]
+  (and (map? ev)
+       (contains? destroy-operations (:operation ev))))
+
+(defn abort-event?
+  "True iff `ev` is an effect-abort trace event."
+  [ev]
+  (and (map? ev)
+       (contains? abort-operations (:operation ev))))
+
+(defn dispatched-event?
+  "True iff `ev` is an `:event/dispatched` trace event."
+  [ev]
+  (and (map? ev)
+       (= :event/dispatched (:operation ev))))
+
+(defn- destroy-reason
+  "Lift the cancellation `:reason` off the destroy trace event. Per
+  Spec 009 the runtime stamps `:tags :reason` on both
+  `:rf.machine/destroyed` (lifecycle_fx) and `:rf.machine.lifecycle/
+  destroyed` (frame.cljc) emit sites. nil when absent."
+  [ev]
+  (get-in ev [:tags :reason]))
+
+(defn cancellation-anchor?
+  "True iff `ev` is a destroy event whose `:reason` marks it as part
+  of a cancellation cascade (vs. a natural `:rf.machine/finished`)."
+  [ev]
+  (and (destroy-event? ev)
+       (contains? cancellation-reasons (destroy-reason ev))))
+
+;; ---- fx-id classification -----------------------------------------------
+
+(defn classify-fx
+  "Classify an abort trace event into one of the abort-row :fx tags
+  the visualiser displays. Pure fn of the event."
+  [ev]
+  (case (:operation ev)
+    :rf.http/aborted-on-actor-destroy        :http
+    :rf.http/aborted                         :http
+    :rf.ws/aborted-on-actor-destroy          :ws
+    :rf.machine.timer/cancelled-on-resolution :after
+    :rf.machine.invoke/cancelled-on-join-resolution :machine-invoke
+    :unknown))
+
+;; ---- cancel-cause projection --------------------------------------------
+
+(defn cancel-cause
+  "Project the `:cancel-cause` for an abort trace event. Per the
+  divergence allowance: the substrate may or may not stamp this slot
+  today. We fall back to a structural default derived from the abort's
+  identity:
+
+    - `:rf.http/aborted-on-actor-destroy` → `:actor-destroyed`
+    - `:rf.ws/aborted-on-actor-destroy`   → `:actor-destroyed`
+    - `:rf.machine.timer/cancelled-*`     → `:join-resolved`
+    - `:rf.machine.invoke/cancelled-*`    → `:join-resolved`
+    - any other abort with `:reason` tag  → that reason
+    - otherwise                           → `:unknown`"
+  [ev]
+  (or (get-in ev [:tags :cancel-cause])
+      (get-in ev [:tags :reason])
+      (case (:operation ev)
+        :rf.http/aborted-on-actor-destroy        :actor-destroyed
+        :rf.ws/aborted-on-actor-destroy          :actor-destroyed
+        :rf.machine.timer/cancelled-on-resolution :join-resolved
+        :rf.machine.invoke/cancelled-on-join-resolution :join-resolved
+        :unknown)))
+
+;; ---- row projection -----------------------------------------------------
+
+(defn- abort-row
+  "Build one abort-row from an abort trace event."
+  [ev]
+  (let [tags (:tags ev)]
+    {:fx             (classify-fx ev)
+     :req            (select-keys tags [:request-id :url :method
+                                        :timer-id :child-id :spawned-id
+                                        :invoke-id])
+     :t              (:time ev)
+     :cancel-cause   (cancel-cause ev)
+     :request-id     (:request-id tags)
+     :url            (:url tags)
+     :actor-id       (or (:actor-id tags) (:machine-id tags) (:spawned-id tags))
+     :correlation-id (or (:request-id tags) (:correlation-id tags))
+     :trace-id       (:id ev)
+     :dispatch-id    (:dispatch-id tags)}))
+
+(defn- teardown-row
+  "Build one child-teardown row from a destroy trace event."
+  [ev]
+  (let [tags (:tags ev)]
+    {:child-id       (or (:machine-id tags) (:spawned-id tags))
+     :spawned-id     (:spawned-id tags)
+     :parent-id      (:parent-id tags)
+     :invoke-id      (:invoke-id tags)
+     :t              (:time ev)
+     :reason         (destroy-reason ev)
+     :last-state     (:last-state tags)
+     :inflight-count nil  ;; populated downstream from the gathered aborts
+     :trace-id       (:id ev)
+     :dispatch-id    (:dispatch-id tags)}))
+
+(defn- decision-row
+  "Build the parent-decision row from a `:event/dispatched` trace
+  event. nil when the input isn't a dispatched event."
+  [ev]
+  (when (dispatched-event? ev)
+    (let [tags (:tags ev)]
+      {:event-vec   (:event tags)
+       :t           (:time ev)
+       :machine-id  (or (:machine-id tags) (:handler-id tags))
+       :dispatch-id (:dispatch-id tags)
+       :trace-id    (:id ev)})))
+
+;; ---- cascade extraction -------------------------------------------------
+
+(defn- find-anchor
+  "Locate the cascade anchor in `trace-buffer`. The anchor is either:
+
+    1. The destroy event matching `focus-id` (when `focus-kind`
+       = `:machine-id`).
+    2. The most-recent destroy event in the cascade identified by
+       `focus-id` (when `focus-kind` = `:dispatch-id`).
+    3. The most-recent cancellation-anchor in the buffer (when
+       `focus-kind` = nil — the 'just show me the latest cascade' path).
+
+  Returns the trace event map, or nil when no anchor can be found."
+  [trace-buffer focus-kind focus-id]
+  (let [evs (or trace-buffer [])]
+    (case focus-kind
+      :machine-id
+      (->> evs
+           (filter #(and (cancellation-anchor? %)
+                         (let [tags (:tags %)]
+                           (or (= focus-id (:machine-id tags))
+                               (= focus-id (:spawned-id tags))
+                               (= focus-id (:parent-id tags))))))
+           (sort-by :time)
+           last)
+
+      :dispatch-id
+      (->> evs
+           (filter #(and (cancellation-anchor? %)
+                         (= focus-id (get-in % [:tags :dispatch-id]))))
+           (sort-by :time)
+           last)
+
+      ;; default: latest cancellation-anchor in the buffer
+      (->> evs
+           (filter cancellation-anchor?)
+           (sort-by :time)
+           last))))
+
+(defn- gather-related-aborts
+  "Pull every abort trace event that should be grouped under the
+  anchor. Two paths in order of preference:
+
+    1. Same `:dispatch-id` as the anchor (the strict structural link).
+    2. Wall-clock window around the anchor's `:time`
+       (`+default-actor-destroy-window-ms+`) — the best-effort fallback
+       for when the actor-destroy abort fires outside the originating
+       drain and so carries no `:dispatch-id` link.
+
+  Sorted oldest-first by `:time`."
+  [trace-buffer anchor]
+  (let [evs           (or trace-buffer [])
+        anchor-t      (:time anchor)
+        anchor-disp   (get-in anchor [:tags :dispatch-id])
+        anchor-actor  (or (get-in anchor [:tags :machine-id])
+                          (get-in anchor [:tags :spawned-id]))
+        window        default-actor-destroy-window-ms
+        by-dispatch   (when anchor-disp
+                        (filter #(and (abort-event? %)
+                                      (= anchor-disp
+                                         (get-in % [:tags :dispatch-id])))
+                                evs))
+        ;; Wall-clock fallback — include if the trace lacks the
+        ;; dispatch-id link but lands inside the window AND either
+        ;; mentions the actor or is an actor-destroy-shaped abort.
+        by-window     (filter
+                        (fn [ev]
+                          (and (abort-event? ev)
+                               (number? (:time ev))
+                               (number? anchor-t)
+                               (<= 0 (- (:time ev) anchor-t) window)
+                               (let [ev-disp (get-in ev [:tags :dispatch-id])
+                                     ev-actor (or (get-in ev [:tags :actor-id])
+                                                  (get-in ev [:tags :machine-id]))]
+                                 (and (or (nil? ev-disp)
+                                          (not= ev-disp anchor-disp))
+                                      (or (nil? anchor-actor)
+                                          (nil? ev-actor)
+                                          (= anchor-actor ev-actor)
+                                          ;; actor-destroy-shaped abort with
+                                          ;; no actor link — fold it in
+                                          (= :rf.http/aborted-on-actor-destroy
+                                             (:operation ev)))))))
+                        evs)
+        all           (concat by-dispatch by-window)
+        ;; Dedup by trace-id; preserve order; sort oldest-first.
+        unique        (->> all
+                           (reduce (fn [{:keys [seen acc]} ev]
+                                     (let [k (:id ev)]
+                                       (if (and k (contains? seen k))
+                                         {:seen seen :acc acc}
+                                         {:seen (if k (conj seen k) seen)
+                                          :acc  (conj acc ev)})))
+                                   {:seen #{} :acc []})
+                           :acc)]
+    (->> unique
+         (sort-by (fn [ev] [(or (:time ev) 0) (or (:id ev) 0)])))))
+
+(defn- gather-related-teardowns
+  "Pull every destroy trace event that rides with the anchor (same
+  cascade or wall-clock window). The anchor itself is included. Each
+  carries `:inflight-count` derived from the aborts that target the
+  same actor.
+
+  Sorted oldest-first by `:time`."
+  [trace-buffer anchor aborts]
+  (let [evs           (or trace-buffer [])
+        anchor-t      (:time anchor)
+        anchor-disp   (get-in anchor [:tags :dispatch-id])
+        window        default-actor-destroy-window-ms
+        by-dispatch   (when anchor-disp
+                        (filter #(and (cancellation-anchor? %)
+                                      (= anchor-disp
+                                         (get-in % [:tags :dispatch-id])))
+                                evs))
+        by-window     (filter
+                        (fn [ev]
+                          (and (cancellation-anchor? ev)
+                               (number? (:time ev))
+                               (number? anchor-t)
+                               (<= 0
+                                   (Math/abs (- (:time ev) anchor-t))
+                                   window)
+                               (let [ev-disp (get-in ev [:tags :dispatch-id])]
+                                 (or (nil? ev-disp)
+                                     (nil? anchor-disp)
+                                     (not= ev-disp anchor-disp)))))
+                        evs)
+        all           (concat by-dispatch by-window [anchor])
+        seen          (volatile! #{})
+        unique        (vec
+                        (keep (fn [ev]
+                                (let [k [(:operation ev) (:id ev)]]
+                                  (when (and (not (contains? @seen k))
+                                             (vswap! seen conj k))
+                                    ev)))
+                              all))
+        ;; Build a count of aborts per actor id.
+        counts-by-actor
+        (reduce (fn [acc abort-ev]
+                  (let [tags  (:tags abort-ev)
+                        actor (or (:actor-id tags)
+                                  (:machine-id tags)
+                                  (:spawned-id tags))]
+                    (if actor
+                      (update acc actor (fnil inc 0))
+                      acc)))
+                {}
+                (or aborts []))]
+    (->> unique
+         (sort-by (fn [ev] [(or (:time ev) 0) (or (:id ev) 0)]))
+         (mapv (fn [ev]
+                 (let [row    (teardown-row ev)
+                       actor  (or (:child-id row) (:spawned-id row))
+                       found  (when actor (get counts-by-actor actor))]
+                   (assoc row :inflight-count (or found 0))))))))
+
+(defn- find-decision
+  "Locate the parent decision — the most-recent `:event/dispatched`
+  trace event within the cascade defined by the anchor's
+  `:dispatch-id`. Falls back to the most-recent dispatched event
+  before the anchor's `:time` when the anchor has no `:dispatch-id`."
+  [trace-buffer anchor]
+  (let [evs         (or trace-buffer [])
+        anchor-t    (:time anchor)
+        anchor-disp (get-in anchor [:tags :dispatch-id])
+        by-dispatch (when anchor-disp
+                      (->> evs
+                           (filter #(and (dispatched-event? %)
+                                         (= anchor-disp
+                                            (get-in % [:tags :dispatch-id]))))
+                           (sort-by :time)
+                           first))]
+    (or by-dispatch
+        (when (number? anchor-t)
+          (->> evs
+               (filter #(and (dispatched-event? %)
+                             (number? (:time %))
+                             (<= (:time %) anchor-t)))
+               (sort-by :time)
+               last)))))
+
+(defn extract-cascade
+  "Project a cancellation-cascade record from the trace buffer. Pure
+  data → data.
+
+  Inputs:
+    `trace-buffer` — vector of trace events (Causa's mirror slot or
+      a fixture). nil-safe.
+    `focus`        — `{:kind <:machine-id | :dispatch-id | nil>
+                       :id   <value-or-nil>}` or nil.
+
+      `:kind :machine-id`  → anchor is the latest cancellation-destroy
+                             for that machine-id.
+      `:kind :dispatch-id` → anchor is the destroy with that
+                             dispatch-id.
+      `:kind nil` (or focus nil) → most-recent cancellation-destroy
+                                   in the buffer.
+
+  Returns the cascade record described in the ns docstring, or a
+  shaped empty-state record when no anchor / aborts are present."
+  ([trace-buffer]
+   (extract-cascade trace-buffer nil))
+  ([trace-buffer focus]
+   (let [{:keys [kind id]} (or focus {})
+         anchor   (find-anchor trace-buffer kind id)]
+     (if (nil? anchor)
+       {:parent-decision  nil
+        :child-teardowns  []
+        :effect-aborts    []
+        :total-elapsed-ms nil
+        :empty-kind       :no-trigger}
+       (let [aborts        (gather-related-aborts trace-buffer anchor)
+             teardowns     (gather-related-teardowns trace-buffer anchor aborts)
+             decision-ev   (find-decision trace-buffer anchor)
+             decision      (decision-row decision-ev)
+             abort-rows    (mapv abort-row aborts)
+             ;; Total elapsed: earliest event-time (decision when
+             ;; present, else first teardown) → latest abort/teardown.
+             start-t       (or (:t decision)
+                               (some-> teardowns first :t)
+                               (:time anchor))
+             end-t         (or (some->> abort-rows
+                                        (keep :t)
+                                        seq
+                                        (apply max))
+                               (some->> teardowns
+                                        (keep :t)
+                                        seq
+                                        (apply max))
+                               (:time anchor))
+             elapsed       (when (and (number? start-t) (number? end-t))
+                             (max 0 (- end-t start-t)))]
+         {:parent-decision  decision
+          :child-teardowns  teardowns
+          :effect-aborts    abort-rows
+          :total-elapsed-ms elapsed
+          :empty-kind       (if (empty? abort-rows) :no-aborts nil)})))))
+
+;; ---- cascade summarisers ------------------------------------------------
+
+(defn cascade-summary
+  "One-line summary line for the visualiser footer / collapsed header.
+  Pure data → string."
+  [cascade]
+  (let [teardowns (count (:child-teardowns cascade))
+        aborts    (count (:effect-aborts cascade))
+        elapsed   (:total-elapsed-ms cascade)
+        elapsed-s (when elapsed (str elapsed "ms"))]
+    (cond
+      (= :no-trigger (:empty-kind cascade))
+      "No cancellation cascade in the trace window."
+
+      (= :no-aborts (:empty-kind cascade))
+      (str teardowns " child destroyed"
+           (when (not= 1 teardowns) "s")
+           " · 0 effects aborted")
+
+      :else
+      (str/join " · "
+                (cond-> [(str teardowns " child"
+                              (when (not= 1 teardowns) "ren")
+                              " destroyed")
+                         (str aborts " effect"
+                              (when (not= 1 aborts) "s")
+                              " aborted")]
+                  elapsed-s (conj (str elapsed-s " elapsed")))))))
+
+(defn group-by-cancel-cause
+  "Group `:effect-aborts` by `:cancel-cause`. Returns a map
+  cause → vector-of-rows. Order within a group is input order."
+  [cascade]
+  (->> (:effect-aborts cascade)
+       (group-by :cancel-cause)))
+
+(def ^:const default-collapse-threshold
+  "Per the bead's contract — collapse aborts by default when there are
+  more than N. The view exposes a 'Show all N' expander."
+  10)
+
+(defn should-collapse?
+  "True when the abort list should be collapsed by default. Pure fn
+  for unit testability."
+  ([cascade] (should-collapse? cascade default-collapse-threshold))
+  ([cascade threshold]
+   (> (count (:effect-aborts cascade)) threshold)))
+
+;; ---- formatters (view-side, kept in .cljc for test reuse) --------------
+
+(defn format-time-ms
+  "Render a wall-clock `:time` value as a short label. Best-effort —
+  if `t` is nil returns `\"—\"`."
+  [t]
+  (if (number? t)
+    (str t "ms")
+    "—"))
+
+(defn format-event-vec
+  "Pretty-print an event vector for display in the parent-decision row."
+  [event-vec]
+  (cond
+    (nil? event-vec) "—"
+    (vector? event-vec)
+    (try (pr-str event-vec) (catch #?(:clj Throwable :cljs :default) _ (str event-vec)))
+    :else (str event-vec)))
+
+(defn format-fx-label
+  "Human label for an abort row's `:fx` tag. Includes the request
+  method/URL when present."
+  [{:keys [fx req url]}]
+  (let [method (some-> (:method req) name str/upper-case)
+        u      (or url (:url req))]
+    (case fx
+      :http           (str "HTTP " (or method "") (when u " ") (or u ""))
+      :ws             (str "WS send" (when (:event req)
+                                       (str " " (pr-str (:event req)))))
+      :after          (str ":after timer fire"
+                           (when (:timer-id req)
+                             (str " " (pr-str (:timer-id req)))))
+      :machine-invoke (str "machine-invoke"
+                           (when (:child-id req)
+                             (str " " (pr-str (:child-id req)))))
+      (str (name (or fx :unknown))))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_subs.cljs
@@ -1,0 +1,77 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade-subs
+  "Composite subs for the Cancellation-cascade visualiser (rf2-59e7k).
+
+  Three reactive surfaces:
+
+    `:rf.causa/cancellation-cascade-popover-open?`
+    `:rf.causa/cancellation-cascade-popover-focus`
+    `:rf.causa/cancellation-cascade-expanded?`
+
+  Two cascade-projection composites:
+
+    `:rf.causa/cancellation-cascade-for-focused-machine`
+       ; project the cascade for the focused machine's most-recent
+       ; cancellation-anchor (if any in the trace window).
+
+    `:rf.causa/cancellation-cascade-for-focused-event`
+       ; project the cascade for the focused cascade's dispatch-id
+       ; (if its drain contained a cancellation-anchor).
+
+  Both composites are pure-data → pure-data; the heavy lifting lives
+  in `cancellation_cascade_helpers/extract-cascade`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as h]))
+
+(defn install!
+  "Install the cancellation-cascade visualiser's subs. Idempotent."
+  []
+
+  ;; ---- popover slots --------------------------------------------------
+
+  (rf/reg-sub :rf.causa/cancellation-cascade-popover-open?
+    (fn [db _query]
+      (boolean (get db :cancellation-cascade-popover-open?))))
+
+  (rf/reg-sub :rf.causa/cancellation-cascade-popover-focus
+    (fn [db _query]
+      (get db :cancellation-cascade-popover-focus)))
+
+  (rf/reg-sub :rf.causa/cancellation-cascade-expanded?
+    (fn [db _query]
+      (boolean (get db :cancellation-cascade-expanded?))))
+
+  ;; ---- cascade for focused machine ------------------------------------
+  ;;
+  ;; The Machines tab side-panel mount reads this. We compose against
+  ;; the existing `:rf.causa/selected-machine-id` (the picker's
+  ;; selection) + the trace buffer. When no machine is selected the
+  ;; composite returns a `:no-trigger` shape so the view can branch
+  ;; cleanly.
+
+  (rf/reg-sub :rf.causa/cancellation-cascade-for-focused-machine
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/selected-machine-id]
+    (fn [[buffer machine-id] _query]
+      (h/extract-cascade buffer
+                         (when machine-id
+                           {:kind :machine-id :id machine-id}))))
+
+  ;; ---- cascade for focused event --------------------------------------
+  ;;
+  ;; The Trace popover (and any caller passing an explicit
+  ;; dispatch-id focus) reads this. We compose against the
+  ;; popover-focus slot first (explicit user-driven focus), falling
+  ;; back to the spine's `:rf.causa/focus` so a 'just show me the
+  ;; cancellation for the current focus' subscribe stays useful.
+
+  (rf/reg-sub :rf.causa/cancellation-cascade-for-focused-event
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/cancellation-cascade-popover-focus]
+    :<- [:rf.causa/focus]
+    (fn [[buffer popover-focus spine-focus] _query]
+      (let [focus (or popover-focus
+                      (when-let [d (:dispatch-id spine-focus)]
+                        {:kind :dispatch-id :id d}))]
+        (h/extract-cascade buffer focus))))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -77,6 +77,7 @@
             [day8.re-frame2-causa.chart.layout :as chart-layout]
             [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-causa.panels.machine-inspector-cluster :as cluster]
             [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers :as ch]
@@ -776,7 +777,13 @@
          (when (= :mode-c mode)
            [cluster/ClusterView])
          (when sim-active?
-           [sim/SimSideRail])]
+           [sim/SimSideRail])
+         ;; Cancellation-cascade visualiser (rf2-59e7k) — mounts in the
+         ;; Machines tab side-rail when the focused machine had a
+         ;; destroy-with-cancellation-reason in the trace window. The
+         ;; SidePanel reg-view short-circuits to nil otherwise, so the
+         ;; mount is dormant in the common case.
+         [cancellation-cascade/SidePanel]]
         (transition-ribbon transitions)])]))
 
 ;; ---- registration entry --------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -60,6 +60,7 @@
   `trace_helpers.cljc` so the algebra runs under the JVM unit-test
   target."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
@@ -272,7 +273,12 @@
            source-coord dispatch-id]
     :as row}]
   (let [row-test-id (str "rf-causa-trace-row-" id)
-        dot-colour  (h/op-type-colour op-type)]
+        dot-colour  (h/op-type-colour op-type)
+        ;; rf2-59e7k — destroy-event rows surface a 'Show cancellation
+        ;; cascade' action button next to the source-coord cell. The
+        ;; classifier mirrors helpers/destroy-operations so the trace
+        ;; ns has no upward dep on the cascade view.
+        destroy?    (cch/destroy-event? {:operation operation})]
     [:li {:key         (h/row-key row)
           :data-testid row-test-id
           :on-click    (fn []
@@ -281,9 +287,17 @@
                                          dispatch-id frame] {:frame :rf/causa})
                            (rf/dispatch [:rf.causa/select-panel
                                          :event-detail] {:frame :rf/causa})))
+          :on-context-menu (when destroy?
+                             (fn [e]
+                               (.preventDefault e)
+                               (.stopPropagation e)
+                               (rf/dispatch
+                                 [:rf.causa/cancellation-cascade-open
+                                  {:kind :dispatch-id :id dispatch-id}]
+                                 {:frame :rf/causa})))
           :style       {:display       "grid"
                         :grid-template-columns
-                        "84px 14px minmax(140px, 1fr) 2fr auto auto"
+                        "84px 14px minmax(140px, 1fr) 2fr auto auto auto"
                         :gap           "10px"
                         :align-items   "center"
                         :padding       "6px 16px"
@@ -355,7 +369,34 @@
         source-coord]
        [:span {:style {:color (:text-tertiary tokens)
                        :font-size "10px"}}
-        "—"])]))
+        "—"])
+     ;; rf2-59e7k cancellation-cascade action (destroy rows only).
+     ;; Opens the popover focused on this row's dispatch-id. Right-
+     ;; clicking the row anywhere is the same action — this button is
+     ;; the visible affordance for the same shortcut.
+     (if destroy?
+       [:button {:data-testid (str row-test-id "-cancellation-cascade")
+                 :title       "Show cancellation cascade"
+                 :on-click    (fn [e]
+                                (.stopPropagation e)
+                                (rf/dispatch
+                                  [:rf.causa/cancellation-cascade-open
+                                   {:kind :dispatch-id :id dispatch-id}]
+                                  {:frame :rf/causa}))
+                 :style       {:background  "transparent"
+                               :color       (or (:red tokens)
+                                                (:text-secondary tokens))
+                               :border      (str "1px solid " (:border-subtle tokens))
+                               :padding     "1px 6px"
+                               :border-radius "3px"
+                               :cursor      "pointer"
+                               :font-family mono-stack
+                               :font-size   "10px"}}
+        "⟲ cascade"]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-size "10px"
+                       :min-width "10px"}}
+        ""])]))
 
 ;; ---- empty states -------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -41,6 +41,7 @@
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.effects :as effects]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.flows :as flows]
@@ -444,6 +445,13 @@
     ;; chain reads top-down) but re-frame's lazy :<- resolution makes
     ;; the registration order incidental.
     (causality-popover/install!)
+    ;; Cancellation-cascade visualiser (rf2-59e7k) — installs the
+    ;; subs + events for the Machines tab side-panel + the trace-row
+    ;; popover. The view-side `reg-view`s are picked up at ns-load.
+    ;; Order: registers AFTER spine + cascades (composes against
+    ;; `:rf.causa/focus` + `:rf.causa/trace-buffer`); registry order is
+    ;; cosmetic since re-frame resolves `:<-` chains lazily.
+    (cancellation-cascade/install!)
     (effects/install!)
     (event-detail/install!)
     (flows/install!)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -90,6 +90,7 @@
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
@@ -724,6 +725,14 @@
     ;; the palette Modal: closed-state is one subscribe + when-gate,
     ;; so the dormant cost is negligible.
     [causality-popover/Popover]
+    ;; Cancellation-cascade popover (rf2-59e7k) — single waterfall view
+    ;; of the rf2-wvkn cancellation contract. Opened from the Trace tab
+    ;; (right-click a destroy-event row → 'Show cancellation cascade')
+    ;; or imperatively via `:rf.causa/cancellation-cascade-open`. Same
+    ;; mount discipline as the other popovers: shell-root mount so
+    ;; subscribes resolve through the `:rf/causa` frame-provider;
+    ;; closed-state cost is one subscribe + a when-gate.
+    [cancellation-cascade/Popover]
     ;; Share modal (rf2-nqw0v Phase 5) — encodes the current Causa
     ;; state (focused machine + mode + scrubber + tab) into a URL the
     ;; user can paste anywhere. Same mount discipline as the other

--- a/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
@@ -1,0 +1,275 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade-cljs-test
+  "CLJS-side wiring + view tests for Causa's Cancellation-cascade
+  visualiser (rf2-59e7k).
+
+  ## What's under test (in addition to the pure-data tests in
+  `cancellation_cascade_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the composite subs and events** under
+       `:rf.causa/cancellation-cascade-*` ids.
+    2. **Empty-state render** — `SidePanel` short-circuits when no
+       cancellation-anchor is present; `Popover` is gated by
+       `:rf.causa/cancellation-cascade-popover-open?`.
+    3. **Populated render** — with a seeded trace buffer the cascade
+       view renders the decision + teardown + abort rows.
+    4. **Click handlers dispatch the right events** — the row's
+       on-click dispatches `:rf.causa/focus-trace-entry`; the close
+       button dispatches `:rf.causa/cancellation-cascade-close`.
+    5. **Collapse / expand affordance** — under the default
+       threshold the expander appears and the toggle event flips
+       `:rf.causa/cancellation-cascade-expanded?`.
+
+  ## Pure hiccup
+
+  Same approach as `flows_view_cljs_test` — walk the view's hiccup
+  tree by `data-testid` rather than mounting to the DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cc]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror other view tests) ---------------------------
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (apply (first node) (rest node))
+    node))
+
+(defn- hiccup-seq [tree]
+  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree))
+       (map expand-fn-component)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- seed-trace! [events]
+  ;; Seed Causa's app-db trace-buffer slot directly via the registry's
+  ;; sync event. Avoids the trace-bus collector loop entirely; the
+  ;; subs read off `:trace-buffer` regardless of how the slot got
+  ;; populated.
+  (rf/dispatch-sync [:rf.causa/sync-trace-buffer (vec events)]))
+
+;; ---- minimal fixture events ---------------------------------------------
+
+(def ^:private cancel-cascade-buffer
+  "One decision + one cancellation-anchor + two HTTP aborts."
+  [{:id 1 :operation :event/dispatched :op-type :event
+    :time 1000
+    :tags {:event [:auth/logout] :dispatch-id 7 :frame :rf/default}}
+   {:id 2 :operation :rf.machine/destroyed :op-type :rf.machine
+    :time 1010
+    :tags {:machine-id :user-session :reason :explicit
+           :dispatch-id 7 :frame :rf/default}}
+   {:id 3 :operation :rf.http/aborted-on-actor-destroy :op-type :rf.http
+    :severity :info :time 1020
+    :tags {:request-id :r1 :url "/api/profile" :actor-id :user-session
+           :dispatch-id 7 :frame :rf/default}}
+   {:id 4 :operation :rf.http/aborted-on-actor-destroy :op-type :rf.http
+    :severity :info :time 1021
+    :tags {:request-id :r2 :url "/api/log" :actor-id :user-session
+           :dispatch-id 7 :frame :rf/default}}])
+
+;; ---- (1) registry wires the composite subs + events --------------------
+
+(deftest registry-installs-cancellation-cascade-handlers
+  (testing "register-causa-handlers! installs every sub + event the
+            visualiser depends on"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/cancellation-cascade-popover-open?)))
+    (is (some? (registrar/handler :sub :rf.causa/cancellation-cascade-popover-focus)))
+    (is (some? (registrar/handler :sub :rf.causa/cancellation-cascade-expanded?)))
+    (is (some? (registrar/handler :sub :rf.causa/cancellation-cascade-for-focused-machine)))
+    (is (some? (registrar/handler :sub :rf.causa/cancellation-cascade-for-focused-event)))
+    (is (some? (registrar/handler :event :rf.causa/cancellation-cascade-open)))
+    (is (some? (registrar/handler :event :rf.causa/cancellation-cascade-close)))
+    (is (some? (registrar/handler :event :rf.causa/cancellation-cascade-toggle-expand)))
+    (is (some? (registrar/handler :event :rf.causa/focus-trace-entry)))))
+
+;; ---- (2) empty-state renders -------------------------------------------
+
+(deftest side-panel-empty-when-no-cascade
+  (testing "with an empty trace buffer the SidePanel reg-view returns
+            nil (mount stays dormant)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [out (cc/SidePanel)]
+        (is (nil? out)
+            "no rendered hiccup when no cancellation cascade is present")))))
+
+(deftest popover-empty-when-closed
+  (testing "Popover short-circuits to nil when the open? slot is false"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (is (nil? (cc/Popover))))))
+
+(deftest popover-renders-empty-state-when-open-with-no-cascade
+  (testing "Popover renders the no-trigger empty state when open but
+            the trace buffer carries no cascade"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open nil])
+      (let [tree (cc/Popover)]
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-popover-dialog")))
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-empty-no-trigger")))))))
+
+;; ---- (3) populated render ----------------------------------------------
+
+(deftest side-panel-renders-when-machine-cascade-present
+  (testing "with a cancellation cascade in the trace buffer for the
+            focused machine the SidePanel renders the waterfall"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-trace! cancel-cascade-buffer)
+      ;; Pick the machine that had the destroy
+      (rf/dispatch-sync [:rf.causa/select-machine-id :user-session])
+      (let [tree (cc/SidePanel)]
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade"))
+            "section root rendered")
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-decision-row"))
+            "decision row rendered")
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-summary"))
+            "summary line rendered")
+        (let [aborts (find-all-by-testid-prefix
+                       tree "rf-causa-cancellation-cascade-abort-row-")]
+          (is (= 2 (count aborts))
+              "two abort rows rendered, one per fixture event"))))))
+
+(deftest popover-renders-cascade-for-focused-event
+  (testing "Popover opened with a dispatch-id focus pulls the cascade
+            for that dispatch and renders the body"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-trace! cancel-cascade-buffer)
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open
+                         {:kind :dispatch-id :id 7}])
+      (let [tree (cc/Popover)]
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-popover-dialog")))
+        (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-decision-row")))
+        (is (= 2 (count (find-all-by-testid-prefix
+                          tree "rf-causa-cancellation-cascade-abort-row-"))))))))
+
+;; ---- (4) click handlers ------------------------------------------------
+
+(deftest close-button-dispatches-close-event
+  (testing "the close button's on-click dispatches
+            :rf.causa/cancellation-cascade-close, flipping the
+            popover-open? slot to false"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open nil])
+      (is (true? @(rf/subscribe [:rf.causa/cancellation-cascade-popover-open?])))
+      ;; Fire the close event directly to assert the reducer's
+      ;; round-trip — the on-click is a thin wrapper over this dispatch.
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-close])
+      (is (false? @(rf/subscribe [:rf.causa/cancellation-cascade-popover-open?]))))))
+
+(deftest focus-trace-entry-event-shape
+  (testing "the row-click event accepts a `:dispatch-id` and dispatches
+            without throwing — production path flips through the spine
+            shim and panel-select"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-trace! cancel-cascade-buffer)
+      ;; No throw is enough — the event handler delegates via :fx so
+      ;; the side-effecting half routes through the spine shim, which
+      ;; we've already covered in the spine tests.
+      (rf/dispatch-sync [:rf.causa/focus-trace-entry
+                         {:dispatch-id 7 :frame :rf/default :trace-id 1}])
+      (is (true? true)))))
+
+;; ---- (5) collapse / expand ---------------------------------------------
+
+(deftest expander-toggles-expanded-slot
+  (testing "the expand-toggle event flips the `:expanded?` slot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (is (false? @(rf/subscribe [:rf.causa/cancellation-cascade-expanded?])))
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-toggle-expand])
+      (is (true?  @(rf/subscribe [:rf.causa/cancellation-cascade-expanded?])))
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-toggle-expand])
+      (is (false? @(rf/subscribe [:rf.causa/cancellation-cascade-expanded?]))))))
+
+(deftest expander-renders-when-aborts-exceed-threshold
+  (testing "with > default-collapse-threshold aborts the expander
+            appears under the abort list"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [decision    {:id 1 :operation :event/dispatched :op-type :event
+                         :time 1000
+                         :tags {:event [:checkout/cancel]
+                                :dispatch-id 9 :frame :rf/default}}
+            destroy     {:id 2 :operation :rf.machine/destroyed
+                         :op-type :rf.machine :time 1010
+                         :tags {:machine-id :checkout :reason :explicit
+                                :dispatch-id 9 :frame :rf/default}}
+            many-aborts (for [n (range 15)]
+                          {:id        (+ 100 n)
+                           :operation :rf.http/aborted-on-actor-destroy
+                           :op-type   :rf.http
+                           :time      (+ 1020 n)
+                           :tags      {:request-id (keyword (str "r" n))
+                                       :url        (str "/api/x" n)
+                                       :actor-id   :checkout
+                                       :dispatch-id 9
+                                       :frame      :rf/default}})]
+        (seed-trace! (concat [decision destroy] many-aborts))
+        (rf/dispatch-sync [:rf.causa/cancellation-cascade-open
+                           {:kind :dispatch-id :id 9}])
+        (let [tree (cc/Popover)]
+          (is (some? (find-by-testid tree "rf-causa-cancellation-cascade-expander"))
+              "expander present when collapsed-by-default kicks in")
+          (let [shown-when-collapsed
+                (find-all-by-testid-prefix
+                  tree "rf-causa-cancellation-cascade-abort-row-")]
+            (is (<= (count shown-when-collapsed) 5)
+                "collapsed view shows at most 5 abort rows by default")))))))
+
+;; ---- (6) frame isolation ----------------------------------------------
+
+(deftest popover-state-isolated-on-rf-causa
+  (testing "the popover slot lives on :rf/causa, not on the default
+            frame — the host's app-db never sees these keys"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open nil])
+      (is (true? @(rf/subscribe [:rf.causa/cancellation-cascade-popover-open?]))
+          "open slot reads true under the :rf/causa frame"))
+    (rf/with-frame :rf/default
+      (let [db @(rf/subscribe [:rf/app-db])]
+        (is (not (contains? db :cancellation-cascade-popover-open?))
+            "no leak into the host's :rf/default frame")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_helpers_cljs_test.cljc
@@ -1,0 +1,381 @@
+(ns day8.re-frame2-causa.panels.cancellation-cascade-helpers-cljs-test
+  "Pure-data tests for Causa's Cancellation-cascade visualiser
+  helpers (rf2-59e7k).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as the other helper tests — Cognitect's
+  test-runner (CLJ) and Shadow's `:node-test` build both pick up
+  `(cljs-)?test$` ns names.
+
+  ## What's under test
+
+    1. Predicates (destroy-event? / abort-event? / cancellation-anchor?
+       / classify-fx / cancel-cause).
+    2. extract-cascade: six core fixtures (single abort, many aborts,
+       no aborts, nested destroys, mixed cancel-causes, correlation-id
+       pairing) plus the empty-state branches.
+    3. cascade-summary / group-by-cancel-cause / should-collapse?
+    4. Formatters."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- dispatched-ev
+  ([event] (dispatched-ev event {:dispatch-id 1 :time 1000}))
+  ([event {:keys [dispatch-id time id frame]
+           :or {dispatch-id 1 time 1000 id 100 frame :rf/default}}]
+   {:id        id
+    :operation :event/dispatched
+    :op-type   :event
+    :time      time
+    :tags      {:event       event
+                :dispatch-id dispatch-id
+                :frame       frame}}))
+
+(defn- destroy-ev
+  [{:keys [machine-id reason dispatch-id time id op spawned-id parent-id]
+    :or {reason       :explicit
+         dispatch-id  1
+         time         1010
+         id           200
+         op           :rf.machine/destroyed}}]
+  {:id        id
+   :operation op
+   :op-type   :rf.machine
+   :time      time
+   :tags      (cond-> {:machine-id  machine-id
+                       :reason      reason
+                       :dispatch-id dispatch-id}
+                spawned-id (assoc :spawned-id spawned-id)
+                parent-id  (assoc :parent-id parent-id))})
+
+(defn- http-abort-ev
+  [{:keys [request-id url actor-id dispatch-id time id sensitive?]
+    :or {request-id  :req-1
+         url         "/api/foo"
+         actor-id    :user-session
+         dispatch-id 1
+         time        1020
+         id          300}}]
+  {:id         id
+   :operation  :rf.http/aborted-on-actor-destroy
+   :op-type    :rf.http
+   :severity   :info
+   :time       time
+   :sensitive? (boolean sensitive?)
+   :tags       (cond-> {:request-id  request-id
+                        :url         url
+                        :actor-id    actor-id}
+                 dispatch-id (assoc :dispatch-id dispatch-id))})
+
+(defn- ws-abort-ev
+  [{:keys [event actor-id dispatch-id time id]
+    :or {event       [:heartbeat]
+         actor-id    :user-session
+         dispatch-id 1
+         time        1023
+         id          400}}]
+  {:id         id
+   :operation  :rf.ws/aborted-on-actor-destroy
+   :op-type    :rf.ws
+   :time       time
+   :tags       {:event       event
+                :actor-id    actor-id
+                :dispatch-id dispatch-id}})
+
+(defn- timer-cancel-ev
+  [{:keys [timer-id dispatch-id time id]
+    :or {timer-id    :debounce
+         dispatch-id 1
+         time        1024
+         id          500}}]
+  {:id         id
+   :operation  :rf.machine.timer/cancelled-on-resolution
+   :op-type    :rf.machine.timer
+   :time       time
+   :tags       {:timer-id    timer-id
+                :dispatch-id dispatch-id}})
+
+(defn- invoke-cancel-ev
+  [{:keys [child-id dispatch-id time id]
+    :or {child-id    :fetch
+         dispatch-id 1
+         time        1025
+         id          600}}]
+  {:id         id
+   :operation  :rf.machine.invoke/cancelled-on-join-resolution
+   :op-type    :rf.machine.invoke
+   :time       time
+   :tags       {:child-id    child-id
+                :dispatch-id dispatch-id}})
+
+;; ---- (1) predicates -----------------------------------------------------
+
+(deftest destroy-event?-positive
+  (is (true? (h/destroy-event? (destroy-ev {:machine-id :user-session}))))
+  (is (true? (h/destroy-event? {:operation :rf.machine.lifecycle/destroyed
+                                :tags {:reason :parent-frame-destroyed}}))))
+
+(deftest destroy-event?-negative
+  (is (false? (h/destroy-event? (dispatched-ev [:auth/logout]))))
+  (is (false? (h/destroy-event? (http-abort-ev {})))))
+
+(deftest abort-event?-positive
+  (is (true? (h/abort-event? (http-abort-ev {}))))
+  (is (true? (h/abort-event? (ws-abort-ev {}))))
+  (is (true? (h/abort-event? (timer-cancel-ev {}))))
+  (is (true? (h/abort-event? (invoke-cancel-ev {})))))
+
+(deftest abort-event?-negative
+  (is (false? (h/abort-event? (dispatched-ev [:auth/logout]))))
+  (is (false? (h/abort-event? (destroy-ev {:machine-id :x})))))
+
+(deftest cancellation-anchor?-true-for-cancel-reasons
+  (doseq [r [:explicit :parent-unmount-cascade :parent-frame-destroyed]]
+    (is (true? (h/cancellation-anchor?
+                 (destroy-ev {:machine-id :x :reason r}))))))
+
+(deftest cancellation-anchor?-false-for-natural-finish
+  (is (false? (h/cancellation-anchor?
+                (destroy-ev {:machine-id :x :reason :rf.machine/finished})))))
+
+(deftest classify-fx-maps-each-operation
+  (is (= :http   (h/classify-fx (http-abort-ev {}))))
+  (is (= :ws     (h/classify-fx (ws-abort-ev {}))))
+  (is (= :after  (h/classify-fx (timer-cancel-ev {}))))
+  (is (= :machine-invoke (h/classify-fx (invoke-cancel-ev {})))))
+
+(deftest cancel-cause-prefers-explicit-tag
+  (is (= :user-clicked-cancel
+         (h/cancel-cause
+           (assoc-in (http-abort-ev {}) [:tags :cancel-cause]
+                     :user-clicked-cancel)))))
+
+(deftest cancel-cause-defaults-by-operation
+  (is (= :actor-destroyed (h/cancel-cause (http-abort-ev {}))))
+  (is (= :actor-destroyed (h/cancel-cause (ws-abort-ev {}))))
+  (is (= :join-resolved   (h/cancel-cause (timer-cancel-ev {}))))
+  (is (= :join-resolved   (h/cancel-cause (invoke-cancel-ev {})))))
+
+;; ---- (2) extract-cascade: single abort ---------------------------------
+
+(deftest extract-single-abort
+  (testing "one parent decision → one teardown → one HTTP abort"
+    (let [buf [(dispatched-ev [:auth/logout]
+                              {:dispatch-id 1 :time 1000 :id 1})
+               (destroy-ev {:machine-id :user-session
+                            :dispatch-id 1 :time 1010 :id 2})
+               (http-abort-ev {:request-id  :req-1
+                               :url         "/api/profile"
+                               :actor-id    :user-session
+                               :dispatch-id 1
+                               :time        1020
+                               :id          3})]
+          c   (h/extract-cascade buf)]
+      (is (nil? (:empty-kind c)))
+      (is (= [:auth/logout] (-> c :parent-decision :event-vec)))
+      (is (= 1 (count (:child-teardowns c))))
+      (is (= :user-session (-> c :child-teardowns first :child-id)))
+      (is (= 1 (-> c :child-teardowns first :inflight-count)))
+      (is (= 1 (count (:effect-aborts c))))
+      (is (= :http (-> c :effect-aborts first :fx)))
+      (is (= :actor-destroyed (-> c :effect-aborts first :cancel-cause)))
+      (is (= 20 (:total-elapsed-ms c))))))
+
+;; ---- (2) extract-cascade: many aborts ----------------------------------
+
+(deftest extract-many-aborts-sorted
+  (testing "five aborts under one teardown, sorted by :time"
+    (let [buf [(dispatched-ev [:checkout/cancel]
+                              {:dispatch-id 9 :time 5000 :id 1})
+               (destroy-ev {:machine-id :checkout :dispatch-id 9
+                            :time 5010 :id 2})
+               (http-abort-ev {:request-id :r3 :url "/api/log"
+                               :dispatch-id 9 :time 5040 :id 5
+                               :actor-id :checkout})
+               (http-abort-ev {:request-id :r1 :url "/api/finalize"
+                               :dispatch-id 9 :time 5020 :id 3
+                               :actor-id :checkout})
+               (ws-abort-ev {:event [:heartbeat]
+                             :dispatch-id 9 :time 5030 :id 4
+                             :actor-id :checkout})
+               (timer-cancel-ev {:timer-id :debounce
+                                 :dispatch-id 9 :time 5050 :id 6})
+               (invoke-cancel-ev {:child-id :fetch
+                                  :dispatch-id 9 :time 5060 :id 7})]
+          c   (h/extract-cascade buf)]
+      (is (= 5 (count (:effect-aborts c))))
+      (is (= [5020 5030 5040 5050 5060]
+             (mapv :t (:effect-aborts c))))
+      (is (= [:http :ws :http :after :machine-invoke]
+             (mapv :fx (:effect-aborts c))))
+      (is (= 60 (:total-elapsed-ms c))))))
+
+;; ---- (2) extract-cascade: no aborts ------------------------------------
+
+(deftest extract-no-aborts
+  (testing "destroy fired but nothing aborted — empty-kind :no-aborts"
+    (let [buf [(dispatched-ev [:auth/logout]
+                              {:dispatch-id 1 :time 1000 :id 1})
+               (destroy-ev {:machine-id :user-session :dispatch-id 1
+                            :time 1010 :id 2})]
+          c   (h/extract-cascade buf)]
+      (is (= :no-aborts (:empty-kind c)))
+      (is (= 0 (count (:effect-aborts c))))
+      (is (= 1 (count (:child-teardowns c))))
+      (is (= 0 (-> c :child-teardowns first :inflight-count))))))
+
+;; ---- (2) extract-cascade: nested destroys ------------------------------
+
+(deftest extract-nested-destroys
+  (testing "parent destroy → two child destroys → aborts on each"
+    (let [buf [(dispatched-ev [:auth/logout]
+                              {:dispatch-id 1 :time 1000 :id 1})
+               (destroy-ev {:machine-id :parent :dispatch-id 1
+                            :time 1010 :id 2
+                            :spawned-id :parent
+                            :parent-id nil
+                            :reason :explicit})
+               (destroy-ev {:machine-id :child-a :dispatch-id 1
+                            :time 1011 :id 3
+                            :reason :parent-unmount-cascade})
+               (destroy-ev {:machine-id :child-b :dispatch-id 1
+                            :time 1012 :id 4
+                            :reason :parent-unmount-cascade})
+               (http-abort-ev {:request-id :r1 :actor-id :child-a
+                               :dispatch-id 1 :time 1020 :id 5})
+               (http-abort-ev {:request-id :r2 :actor-id :child-b
+                               :dispatch-id 1 :time 1021 :id 6})]
+          c   (h/extract-cascade buf)]
+      (is (= 3 (count (:child-teardowns c))))
+      (is (every? #(contains? #{0 1} %)
+                  (map :inflight-count (:child-teardowns c))))
+      (is (= 2 (count (:effect-aborts c)))))))
+
+;; ---- (2) extract-cascade: mixed cancel-causes --------------------------
+
+(deftest extract-mixed-cancel-causes
+  (testing "explicit :cancel-cause tags ride through"
+    (let [buf [(destroy-ev {:machine-id :s :dispatch-id 1
+                            :time 1000 :id 1})
+               (-> (http-abort-ev {:dispatch-id 1 :time 1010 :id 2})
+                   (assoc-in [:tags :cancel-cause] :user-clicked-cancel))
+               (-> (http-abort-ev {:dispatch-id 1 :time 1011 :id 3})
+                   (assoc-in [:tags :cancel-cause] :timeout))]
+          c   (h/extract-cascade buf)
+          grouped (h/group-by-cancel-cause c)]
+      (is (= 2 (count grouped)))
+      (is (contains? grouped :user-clicked-cancel))
+      (is (contains? grouped :timeout)))))
+
+;; ---- (2) extract-cascade: correlation-id pairing -----------------------
+
+(deftest extract-correlation-id-pairing
+  (testing "request-id rides through to :correlation-id on each row"
+    (let [buf [(destroy-ev {:machine-id :s :dispatch-id 1
+                            :time 1000 :id 1})
+               (http-abort-ev {:request-id :req-XYZ
+                               :url "/api/x"
+                               :dispatch-id 1 :time 1010 :id 2})]
+          c   (h/extract-cascade buf)
+          row (first (:effect-aborts c))]
+      (is (= :req-XYZ (:correlation-id row)))
+      (is (= :req-XYZ (:request-id row)))
+      (is (= "/api/x"  (:url row))))))
+
+;; ---- (2) extract-cascade: empty buffer ---------------------------------
+
+(deftest extract-empty-buffer
+  (let [c (h/extract-cascade [])]
+    (is (= :no-trigger (:empty-kind c)))
+    (is (nil? (:parent-decision c)))
+    (is (= [] (:child-teardowns c)))
+    (is (= [] (:effect-aborts c)))))
+
+(deftest extract-natural-finish-is-not-an-anchor
+  (testing "a :rf.machine/finished destroy is NOT a cancellation anchor"
+    (let [buf [(destroy-ev {:machine-id :x :dispatch-id 1 :time 1
+                            :reason :rf.machine/finished})]
+          c   (h/extract-cascade buf)]
+      (is (= :no-trigger (:empty-kind c))))))
+
+;; ---- (2) extract-cascade: focus by machine-id --------------------------
+
+(deftest extract-focus-by-machine-id
+  (testing "focus picks the latest destroy for that machine-id"
+    (let [buf [(destroy-ev {:machine-id :a :dispatch-id 1 :time 1000 :id 1})
+               (destroy-ev {:machine-id :b :dispatch-id 2 :time 2000 :id 2})
+               (http-abort-ev {:actor-id :a :dispatch-id 1
+                               :time 1005 :id 3})
+               (http-abort-ev {:actor-id :b :dispatch-id 2
+                               :time 2005 :id 4})]
+          c   (h/extract-cascade buf {:kind :machine-id :id :a})]
+      (is (= 1 (count (:effect-aborts c))))
+      (is (= :a (-> c :child-teardowns first :child-id))))))
+
+;; ---- (2) extract-cascade: best-effort wall-clock window ----------------
+
+(deftest extract-wall-clock-fallback
+  (testing "actor-destroy abort outside the originating drain (no
+            dispatch-id) is still folded in by wall-clock proximity"
+    (let [buf [(destroy-ev {:machine-id :user-session :dispatch-id 1
+                            :time 1000 :id 1})
+               ;; abort fires AFTER the anchor's drain — dispatch-id
+               ;; missing from tags; proximity gathers it.
+               (-> (http-abort-ev {:request-id :r1 :actor-id :user-session
+                                   :time 1015 :id 2})
+                   (update :tags dissoc :dispatch-id))]
+          c   (h/extract-cascade buf)]
+      (is (= 1 (count (:effect-aborts c)))))))
+
+;; ---- (3) summarisers ---------------------------------------------------
+
+(deftest cascade-summary-empty
+  (is (= "No cancellation cascade in the trace window."
+         (h/cascade-summary (h/extract-cascade [])))))
+
+(deftest cascade-summary-with-aborts
+  (let [buf [(destroy-ev {:machine-id :s :dispatch-id 1 :time 1000 :id 1})
+             (http-abort-ev {:dispatch-id 1 :time 1010 :id 2})
+             (http-abort-ev {:dispatch-id 1 :time 1011 :id 3
+                             :request-id :other})]
+        s   (h/cascade-summary (h/extract-cascade buf))]
+    (is (re-find #"2 effects aborted" s))
+    (is (re-find #"1 child destroyed" s))))
+
+(deftest should-collapse?-respects-threshold
+  (let [tiny  {:effect-aborts (vec (repeat 3 {}))}
+        big   {:effect-aborts (vec (repeat 50 {}))}]
+    (is (false? (h/should-collapse? tiny)))
+    (is (true?  (h/should-collapse? big)))
+    (is (true?  (h/should-collapse? tiny 2)))))
+
+(deftest group-by-cancel-cause-empty-cascade
+  (let [c (h/extract-cascade [])]
+    (is (= {} (h/group-by-cancel-cause c)))))
+
+;; ---- (4) formatters ----------------------------------------------------
+
+(deftest format-time-ms-handles-nil
+  (is (= "—" (h/format-time-ms nil)))
+  (is (= "1234ms" (h/format-time-ms 1234))))
+
+(deftest format-event-vec-handles-nil-and-vec
+  (is (= "—" (h/format-event-vec nil)))
+  (is (= "[:auth/logout]" (h/format-event-vec [:auth/logout]))))
+
+(deftest format-fx-label-shapes
+  (is (re-find #"HTTP"
+               (h/format-fx-label {:fx :http
+                                   :req {:method :post}
+                                   :url "/api/foo"})))
+  (is (re-find #"WS send"
+               (h/format-fx-label {:fx :ws :req {:event [:hb]}})))
+  (is (re-find #":after timer fire"
+               (h/format-fx-label {:fx :after :req {:timer-id :t1}})))
+  (is (re-find #"machine-invoke"
+               (h/format-fx-label {:fx :machine-invoke
+                                   :req {:child-id :c1}}))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -104,6 +104,14 @@
    :rf.causa/active-route-slice-override
    :rf.causa/app-db-diff
    :rf.causa/cascades
+   ;; rf2-59e7k — Cancellation-cascade visualiser subs (Machines
+   ;; tab side-panel + Trace popover). Per
+   ;; `tools/causa/spec/019-Cross-Cutting-Insight.md` §M.3.
+   :rf.causa/cancellation-cascade-expanded?
+   :rf.causa/cancellation-cascade-for-focused-event
+   :rf.causa/cancellation-cascade-for-focused-machine
+   :rf.causa/cancellation-cascade-popover-focus
+   :rf.causa/cancellation-cascade-popover-open?
    ;; :rf.causa/causality-graph-data removed with rf2-dqnuu — the
    ;; Causality panel was replaced by the c-key popover; the popover's
    ;; payload sub `:rf.causa/causality-popover-payload` stands in for
@@ -236,6 +244,12 @@
    :rf.causa.issues/toggle-severity
    :rf.causa/add-filter
    :rf.causa/bump-restore-epoch-tick
+   ;; rf2-59e7k — Cancellation-cascade visualiser events. Per
+   ;; `tools/causa/spec/019-Cross-Cutting-Insight.md` §M.3.
+   :rf.causa/cancellation-cascade-close
+   :rf.causa/cancellation-cascade-open
+   :rf.causa/cancellation-cascade-set-expanded
+   :rf.causa/cancellation-cascade-toggle-expand
    ;; Causality popover events (rf2-dqnuu) — replace the dropped
    ;; Causality tab. See spec/018-Event-Spine.md §10.
    :rf.causa/causality-popover-close
@@ -271,6 +285,9 @@
    :rf.causa/focus-cascade-next
    :rf.causa/focus-cascade-prev
    :rf.causa/focus-slice-path
+   ;; rf2-59e7k — Cancellation-cascade row-click jump (delegates into
+   ;; :rf.causa/select-dispatch-id via the spine shim).
+   :rf.causa/focus-trace-entry
    :rf.causa/follow-head
    :rf.causa/hide-event-type
    :rf.causa/hydrate-filters
@@ -486,7 +503,13 @@
     ;;   machine-arc-highlight-state + machine-arc-hover +
     ;;   machine-scrubber-position + share-modal-open? + share-state +
     ;;   share-url + share-copy-status.
-    (is (= 113 (count all-sub-names)))
+    ;; + 5 cancellation-cascade visualiser (rf2-59e7k):
+    ;;   :rf.causa/cancellation-cascade-popover-open? +
+    ;;   cancellation-cascade-popover-focus +
+    ;;   cancellation-cascade-expanded? +
+    ;;   cancellation-cascade-for-focused-machine +
+    ;;   cancellation-cascade-for-focused-event
+    (is (= 118 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -536,7 +559,12 @@
     ;;   restore-from-share-url (8 share/arc events) + the
     ;;   arc-data implicit composite has no event of its own. The
     ;;   correct count rises by 8 events; subs add another 9.
-    (is (= 134 (count all-event-names)))
+    ;; + 5 cancellation-cascade visualiser (rf2-59e7k):
+    ;;   :rf.causa/cancellation-cascade-open +
+    ;;   cancellation-cascade-close + cancellation-cascade-toggle-expand +
+    ;;   cancellation-cascade-set-expanded +
+    ;;   :rf.causa/focus-trace-entry (row-click jump shim).
+    (is (= 139 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Bug class (Cross-Cutting-Insight §M.3)

> Parent state exits; child's `:invoke` destroyed; child had N
> in-flight HTTP requests; each aborts. The author sees a flurry
> of `:rf.http/aborted-on-actor-destroy` traces in the firehose
> and one `:rf.machine.lifecycle/destroyed`. They cannot
> reconstruct the cascade.

The cancellation contract rides on rf2-wvkn (Spec 014 §Abort on
actor destroy + Spec 005 §Cancellation cascade), but until now
there was nowhere in Causa where the cascade reads as a coherent
unit. This PR adds the single-waterfall view that lifts those
scattered trace entries into one diagram.

## Waterfall

```
PARENT DECISION
  └─ [destroy-child] dispatched at 1234ms by :auth/logout
CHILD TEARDOWN
  └─ child:user-session destroying at 1240ms (5 in-flight fxs)
EFFECT ABORTS (in order)
  ├─ HTTP GET /api/profile  aborted at 1242ms (:actor-destroyed)
  ├─ HTTP POST /api/log     aborted at 1242ms (:actor-destroyed)
  ├─ WS send :heartbeat     aborted at 1243ms (:actor-destroyed)
  ├─ :after timer fire      aborted at 1243ms (:actor-destroyed)
  └─ machine-invoke fetch   aborted at 1244ms (:actor-destroyed)
```

Each row is clickable → jumps to the underlying trace entry via
the existing spine shim (`:rf.causa/select-dispatch-id`).
Collapsed-by-default when there are more than 10 aborts with a
`Show all N` expander.

## Where it lives

- **Machines tab side-panel** — `cancellation-cascade/SidePanel`
  mounts inline next to the chart/cluster/sim rail. The
  `reg-view` short-circuits to nil when the focused machine has
  no cancellation-anchor in the trace window, so the dormant
  cost is one subscribe + a when-gate.
- **Trace tab** — every destroy-event row carries a right-click
  handler AND a visible `⟲ cascade` action button. Both
  dispatch `:rf.causa/cancellation-cascade-open` with the row's
  dispatch-id; the popover overlay (mounted at `shell-view`
  root, same as the Causality popover) renders the same body.

## New / modified files

**New:**
- `tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs`
- `tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_events.cljs`
- `tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_helpers.cljc`
- `tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade_subs.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_helpers_cljs_test.cljc`

**Modified:**
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs` — side-panel mount
- `tools/causa/src/day8/re_frame2_causa/panels/trace.cljs` — destroy-row action button + right-click
- `tools/causa/src/day8/re_frame2_causa/registry.cljs` — `install!` the new subs/events
- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — popover overlay mount
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` — catalog the 5 new subs + 5 new events; counts updated

## Substrate-contract note

Not every abort trace today carries `:cancel-cause` under `:tags`.
The visualiser synthesises the canonical value per operation
when missing (`:actor-destroyed` for
`:rf.http/aborted-on-actor-destroy`, `:join-resolved` for
`:rf.machine.timer/cancelled-on-resolution`, etc.) and prefers
any explicit substrate-stamped `:cancel-cause` when present.
This is best-effort by design — no follow-on bead opened, but
if the substrate later wants to stamp `:cancel-cause`
authoritatively (cleaner taxonomy, future-proofing), the
visualiser honours it without code change.

## Test plan

- [x] `clojure -M:test` from `tools/causa` — 767 tests / 2183 assertions / 0 failures
- [x] `npm run test:cljs` — 2874 tests / 8225 assertions / 0 failures
- [x] `npm run test:browser` — 2863 tests / 8145 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `npm run test:bundle-isolation` — PASS (no leak into production bundles)
- [ ] Manual smoke: open a host with `[:rf.machine/destroy <id>]` while inflight HTTP is running; visualiser should show in Machines tab side-panel; "⟲ cascade" button on the destroy row in Trace tab should pop the overlay