### PR TITLE
feat(causa): :after timer countdown rings — wall-clock time visible at last

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -418,6 +418,127 @@
 ;; padded into the box. Empty / all-zero samples collapse to a centred
 ;; baseline so the visual lane stays consistent across cluster rows.
 
+;; ---- countdown ring primitive (rf2-7hwwe) ------------------------------
+;;
+;; A partial-circle SVG glyph drawn AROUND a chart state-node when an
+;; `:after` timer is armed for that state. The ring sweeps from a full
+;; circle (just armed) to empty (about to fire); colour shifts from
+;; green (fresh) through amber (mid-cycle) to red (firing-soon).
+;;
+;; Implementation: SVG `<circle stroke-dasharray>` trick. A circle's
+;; circumference is `2πr`; setting `stroke-dasharray` to
+;; `[arc-len, (2πr - arc-len)]` produces a partial sweep. Rotating the
+;; circle -90° puts the sweep's origin at 12 o'clock (the conventional
+;; clock face).
+;;
+;; Pure data → hiccup; JVM-runnable so the rings-helpers tests can
+;; assert against the shape without a CLJS runtime.
+
+(def ^:private ring-color->token
+  "Semantic colour-tier keywords (from
+  `machine_after_rings_helpers.cljc/ring-color`) → tokens-table
+  keywords. Centralised here so the SVG primitive stays decoupled
+  from the helpers ns."
+  {:green :green
+   :amber :yellow
+   :red   :red
+   :gray  :text-tertiary})
+
+(defn countdown-ring
+  "Render a single `:after`-timer countdown ring around `(cx, cy)`
+  with radius `r`. Pure fn — produces hiccup.
+
+  Options:
+
+    :cx           — node centre x  (required)
+    :cy           — node centre y  (required)
+    :r            — ring radius    (required)
+    :fraction     — 0.0..1.0; portion of the ring to FILL (= the
+                    portion of countdown REMAINING). nil renders the
+                    ring as a faded full circle (degenerate cases:
+                    no resolvable duration, sub-vec mid-resolution).
+    :color        — semantic tier `:green / :amber / :red / :gray`
+                    (defaults to `:gray`).
+    :cancelled?   — when true the ring renders gray + a diagonal
+                    cross-line through it (the timer was cancelled
+                    by state exit or sub-resolution).
+    :stroke-width — defaults to 2.5 (chunky enough to read at chart-
+                    scale, thin enough to not obscure the node).
+    :testid       — overrides the root data-testid (used by the panel
+                    to stamp `(machine-id, state)` for hit-testing).
+    :tooltip      — when present, wraps a native SVG `<title>` so a
+                    hover shows browser-default chrome.
+
+  Returns a hiccup `[:g ...]` form. The outer `<g>` carries
+  `:pointer-events :all` and is sized to the bounding box of the
+  circle so the ring is hover-targetable across its full sweep.
+
+  ## Why a single SVG primitive (not three sub-components)
+
+  Both the live ring + the cancelled ring + the degenerate full-circle
+  ring share the same outer geometry — only the dasharray + stroke
+  colour + the cross-overlay change. Folding the three states into one
+  fn keeps the data → hiccup mapping trivial for tests."
+  [{:keys [cx cy r fraction color cancelled? stroke-width testid tooltip]
+    :or   {color        :gray
+           stroke-width 2.5}}]
+  (let [sw        stroke-width
+        circ      (* 2 Math/PI r)
+        ;; Clamp the fraction inside `[0, 1]`. Nil → full ring (the
+        ;; degenerate-data fallback already renders gray via colour).
+        f         (cond
+                    (nil? fraction)        1.0
+                    (< fraction 0.0)       0.0
+                    (> fraction 1.0)       1.0
+                    :else                  (double fraction))
+        arc-len   (* f circ)
+        gap-len   (- circ arc-len)
+        token-key (get ring-color->token color :text-tertiary)
+        stroke    (get tokens/tokens token-key)
+        opacity   (if cancelled? 0.4 0.85)]
+    [:g {:data-testid    (or testid "rf-causa-chart-countdown-ring")
+         :data-color     (name color)
+         :data-cancelled (str (boolean cancelled?))
+         :data-fraction  (when fraction (str fraction))
+         :pointer-events "all"}
+     ;; Underlay: a faint full circle so the user reads the "track"
+     ;; the ring sweeps along. Without it the partial ring looks like
+     ;; an arc fragment.
+     [:circle {:cx cx :cy cy :r r
+               :fill "none"
+               :stroke (:border-subtle tokens/tokens)
+               :stroke-width (* 0.6 sw)
+               :opacity 0.4
+               :pointer-events "none"}]
+     ;; The countdown sweep itself. Rotate -90° around (cx, cy) so
+     ;; the dasharray origin sits at 12 o'clock.
+     [:circle {:cx cx :cy cy :r r
+               :fill "none"
+               :stroke stroke
+               :stroke-width sw
+               :stroke-linecap "round"
+               :stroke-dasharray (str arc-len " " gap-len)
+               :stroke-dashoffset 0
+               :opacity opacity
+               :transform (str "rotate(-90 " cx " " cy ")")
+               :pointer-events "stroke"}]
+     ;; Cancelled-ring diagonal cross — a single line at 45° through
+     ;; the circle's bounding box. Renders ABOVE the ring so it reads
+     ;; as a kill-mark.
+     (when cancelled?
+       (let [diag (long (* 0.707 r))]   ;; r / sqrt(2)
+         [:line {:x1 (- cx diag) :y1 (- cy diag)
+                 :x2 (+ cx diag) :y2 (+ cy diag)
+                 :stroke (:red tokens/tokens)
+                 :stroke-width (* 0.8 sw)
+                 :stroke-linecap "round"
+                 :opacity 0.7
+                 :pointer-events "none"}]))
+     ;; Tooltip (native SVG `<title>`) — zero-cost accessible chrome
+     ;; that the browser surfaces on hover; no JS handlers required.
+     (when tooltip
+       [:title tooltip])]))
+
 (defn sparkline
   "Inline SVG glyph for `samples` — a vector of non-negative integers,
   oldest-first. Used by the Mode C cluster view to show recent

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
@@ -1,0 +1,333 @@
+(ns day8.re-frame2-causa.panels.machine-after-rings
+  "Machine Inspector `:after` timer countdown rings — mount + tick driver
+  (rf2-7hwwe, parent rf2-2tkza).
+
+  Closes the wall-clock-time visualisation gap on the chart per
+  `spec/019-Cross-Cutting-Insight.md` §Wall-clock time is under-served:
+  every armed `:after` timer draws a countdown ring AROUND its bearing
+  state-node. In live mode the ring sweeps from full → empty in real
+  time; in retrospective mode (scrubber not at `:present`) it freezes
+  at the position it occupied when the scrubber was paused.
+
+  ## Architecture
+
+    1. **Helpers (`machine_after_rings_helpers.cljc`)** — pure
+       projection from the trace buffer into a vector of timer
+       records + the ring-fraction maths. JVM-runnable.
+    2. **This ns** — installs the sub/event family + mounts the SVG
+       overlay + drives the rAF tick loop that re-renders the rings
+       in live mode.
+    3. **`chart/svg.cljc`** — owns the `countdown-ring` primitive (a
+       pure-data SVG hiccup builder). The view here positions one ring
+       per active timer over the chart's positioned graph.
+
+  ## Subs/events surface
+
+    `:rf.causa/active-timers-for-focused-machine` — composite sub over
+                                                     trace buffer +
+                                                     selected machine.
+    `:rf.causa/timer-tick`                         — bumps a tick-
+                                                     counter on app-db
+                                                     to drive a re-
+                                                     render.
+    `:rf.causa/timer-hover`                        — set the hovered
+                                                     timer for tooltip
+                                                     state (v1 uses
+                                                     native SVG <title>,
+                                                     so the slot is
+                                                     plumbed for
+                                                     follow-on
+                                                     rich-tooltip
+                                                     beads).
+    `:rf.causa/now-ms`                             — current wall-clock,
+                                                     bumped per tick so
+                                                     subscribers re-fire
+                                                     reactively.
+    `:rf.causa/set-now-ms-override-for-test`       — test hook to pin
+                                                     `now-ms` to a
+                                                     deterministic
+                                                     value.
+
+  ## rAF tick driver
+
+  A single `requestAnimationFrame` loop ticks at the browser's natural
+  frame rate (~60fps). On each tick we bump `:rf.causa/now-ms` —
+  every consumer of the ring-fraction sub re-fires on the standard
+  reactive path. The loop self-gates: when there are no armed timers
+  OR the scrubber is in retrospective mode, the next rAF is not
+  scheduled; the loop resumes when a fresh `:scheduled` event arrives
+  (the panel re-evaluates `needs-ticking?` on every render and kicks
+  the loop when truthy).
+
+  Per the bead's divergence allowances: if rAF creates perf issues
+  under many concurrent timers, the throttle knob lives in
+  `*tick-min-delta-ms*` — bump it to skip-frame when fractional delta
+  is below threshold. v1 ships at ~60fps with no skip-frame because
+  the typical-app `:after`-timer count is small (1-3).
+
+  ## Pure hiccup
+
+  Same contract as every other Causa panel — the view is pure hiccup,
+  no Reagent / UIx / Helix references. Frame isolation comes from the
+  enclosing `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [day8.re-frame2-causa.chart.layout :as chart-layout]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-causa.panels.machine-after-rings-helpers
+             :as rings-h]
+            [day8.re-frame2-causa.panels.machine-inspector-arc-helpers
+             :as arc-h]))
+
+;; ---- wall-clock reader (overridable for tests) -------------------------
+
+(defn- now-ms
+  "Wall-clock ms. Tests rebind via `with-redefs` or the
+  `:rf.causa/set-now-ms-override-for-test` event slot."
+  []
+  (.now js/Date))
+
+;; ---- subs ---------------------------------------------------------------
+
+(defn install-subs!
+  "Register the rings sub family. Idempotent."
+  []
+  ;; ---- now-ms surface --------------------------------------------------
+  ;;
+  ;; The wall-clock `now-ms` is the reactive driver for the ring
+  ;; animation. The rAF tick loop dispatches `:rf.causa/timer-tick`
+  ;; per frame; the handler writes the fresh timestamp into the
+  ;; `:rings/now-ms` slot; every consumer (ring-fraction / tooltip)
+  ;; re-fires on the standard reactive path.
+  ;;
+  ;; Tests pin a deterministic `now-ms` via the override slot so
+  ;; ring-fraction calcs don't drift between assertion + capture.
+  (rf/reg-sub :rf.causa/now-ms
+    (fn [db _query]
+      (or (get db :rings/now-ms-override)
+          (get db :rings/now-ms))))
+
+  ;; ---- active-timers-for-focused-machine ------------------------------
+  ;;
+  ;; Composes:
+  ;;   - the trace buffer (rings-helpers folds timer events into a
+  ;;     timer-table)
+  ;;   - the selected machine (resolves via the inspector's composite
+  ;;     so we honour first-row default + picker focus)
+  ;;   - now-ms (so the projection's zombie-eviction is reactive)
+  ;;
+  ;; Returns a vector of timer records — `:armed` for live rings +
+  ;; `:cancelled` for the fading-out + crossed-out rings.
+  (rf/reg-sub :rf.causa/active-timers-for-focused-machine
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/machine-inspector-data]
+    :<- [:rf.causa/now-ms]
+    (fn [[buffer mi-data now] _query]
+      (let [machine-id (:selected-id mi-data)]
+        (rings-h/active-timers-for-machine buffer machine-id now))))
+
+  ;; ---- timer-hover slot ----------------------------------------------
+  ;;
+  ;; Used by the view to surface the hovered timer's full tooltip in
+  ;; the side-rail (follow-on; v1 uses native SVG <title>). The slot
+  ;; is plumbed today so a follow-on bead lifts the hover into a rich
+  ;; tooltip without touching subscriber wiring.
+  (rf/reg-sub :rf.causa/timer-hover
+    (fn [db _query]
+      (get db :rings/hover))))
+
+;; ---- events -------------------------------------------------------------
+
+(defn install-events!
+  "Register the rings event family. Idempotent."
+  []
+  (rf/reg-event-db :rf.causa/timer-tick
+    ;; Per rf2-qsjda — `:rf.trace/no-emit?` keeps the rAF tick from
+    ;; bombing Causa's own trace buffer 60 times per second. The tick
+    ;; is an internal animation pulse, not user-visible signal.
+    {:rf.trace/no-emit? true}
+    (fn [db [_ t]]
+      (assoc db :rings/now-ms (or t (.now js/Date)))))
+
+  (rf/reg-event-db :rf.causa/timer-hover
+    (fn [db [_ payload]]
+      (if (nil? payload)
+        (dissoc db :rings/hover)
+        (assoc db :rings/hover payload))))
+
+  ;; Test-only override for `now-ms` — the JVM helpers tests don't
+  ;; need it (pure fn) but the CLJS test surface uses it to pin a
+  ;; deterministic timestamp into the projection.
+  (rf/reg-event-db :rf.causa/set-now-ms-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rings/now-ms-override)
+        (assoc db :rings/now-ms-override ov)))))
+
+;; ---- rAF tick driver ----------------------------------------------------
+;;
+;; A single rAF loop that bumps `:rf.causa/timer-tick` per frame when
+;; `needs-ticking?` says so. The loop self-gates so it stops when:
+;;
+;;   - all timers are cancelled / fired
+;;   - the scrubber leaves `:present`
+;;   - the panel un-mounts (no callers means the next dispatched
+;;     `:rings/now-ms` isn't read; the next render's `kick-tick!`
+;;     call won't fire because the panel isn't on screen)
+;;
+;; Per the bead's divergence allowances the throttle knob lives in
+;; `*tick-min-delta-ms*`. v1 sets it to 0 (no skip-frame); a follow-on
+;; can tune up if many-timer scenarios show jank.
+
+(defonce ^:private tick-state
+  ;; `{:running? bool :last-now-ms long}`
+  ;;   :running? — true while a rAF is queued and undrained.
+  ;;   :last-now-ms — last bumped value; the next tick can skip-frame
+  ;;     if (- now last) < *tick-min-delta-ms*.
+  (atom {:running?    false
+         :last-now-ms 0}))
+
+(def ^:dynamic *tick-min-delta-ms*
+  "Minimum gap (ms) between consecutive `:rf.causa/timer-tick`
+  dispatches. 0 = un-throttled (~60fps). Bump to 16/33 to skip-frame
+  if many-timer scenarios show jank. Dynamic so tests can rebind."
+  0)
+
+(defn- raf!
+  "Schedule a callback at the next animation frame. `js/requestAnimationFrame`
+  in CLJS; the test surface stubs it via `set!`. Falls back to
+  `interop/next-tick` when rAF is unavailable (jsdom under node-test
+  where `requestAnimationFrame` may be a no-op or absent — the test
+  fixture pins `now-ms` via the override slot anyway, so the fallback
+  doesn't drive any real animation, only keeps the dispatch ladder
+  alive)."
+  [f]
+  (cond
+    (exists? js/requestAnimationFrame) (js/requestAnimationFrame f)
+    :else                              (interop/next-tick f)))
+
+(defn- tick-loop!
+  "One iteration of the rAF tick loop. Reads the active-timers sub +
+  scrubber sub; bumps `now-ms` when ticking is warranted; re-schedules
+  itself iff still needed.
+
+  The two app-db reads inside the body are deliberately NOT
+  `rf/subscribe`-mediated — the loop is a side-effect driver, not a
+  view; using `subscribe` here would create a reactive dependency on
+  Causa's own frame from outside the view's reactive context, which is
+  the same self-noise hazard the trace-bus avoids. We reach through
+  `rf/frame-app-db-value` (the JVM-runnable read; CLJS impl reads off
+  the frame's app-db atom) directly."
+  []
+  (try
+    (let [timers   @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
+          scrub    @(rf/subscribe [:rf.causa/machine-scrubber-position])
+          now      (now-ms)
+          last-now (:last-now-ms @tick-state)
+          due?     (or (zero? *tick-min-delta-ms*)
+                       (>= (- now last-now) *tick-min-delta-ms*))]
+      (when due?
+        (rf/dispatch [:rf.causa/timer-tick now] {:frame :rf/causa})
+        (swap! tick-state assoc :last-now-ms now))
+      (if (rings-h/needs-ticking? timers scrub)
+        (raf! tick-loop!)
+        (swap! tick-state assoc :running? false)))
+    (catch :default _e
+      ;; Defensive: a frame error must not strand the loop in
+      ;; `:running? true` (would block future kicks).
+      (swap! tick-state assoc :running? false))))
+
+(defn kick-tick!
+  "Start the rAF tick loop iff not already running. Idempotent —
+  callers (the rings overlay component, mounted per render) call this
+  on every render; the `:running?` sentinel prevents duplicate loops."
+  []
+  (when (compare-and-set!
+          tick-state
+          (assoc @tick-state :running? false)
+          (assoc @tick-state :running? true))
+    (raf! tick-loop!)))
+
+(defn stop-tick!
+  "Force-stop the rAF tick loop. Tests use this to reset between
+  fixtures; production code never calls this directly (the loop
+  self-gates on `needs-ticking?`)."
+  []
+  (swap! tick-state assoc :running? false))
+
+;; ---- view: SVG ring overlay --------------------------------------------
+
+(defn AfterRingsOverlay
+  "Renders the focused machine's `:after` countdown rings as an SVG
+  overlay positioned over the chart's `<svg>` viewport. Takes the
+  chart's positioned graph (so it can resolve timer states to node-
+  centres + radii) as the only arg; subscribes to the timers + now-ms
+  internally.
+
+  Returns nil when the projection has no active timers (the SVG layer
+  drops out of the chart so unrelated chart hover handlers aren't
+  shadowed)."
+  [{:keys [nodes width height]}]
+  (let [timers   @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
+        now      @(rf/subscribe [:rf.causa/now-ms])
+        scrub    @(rf/subscribe [:rf.causa/machine-scrubber-position])
+        node-idx (arc-h/nodes->index nodes)
+        ;; Kick the rAF loop iff ticking is needed (live mode + at
+        ;; least one armed timer). Cheap to call per render — the
+        ;; `:running?` sentinel collapses duplicate kicks.
+        _        (when (rings-h/needs-ticking? timers scrub)
+                   (kick-tick!))
+        rings    (rings-h/timers->ring-positions
+                   timers node-idx chart-layout/highlight-id)]
+    (when (seq rings)
+      [:svg {:data-testid "rf-causa-machine-inspector-after-rings-overlay"
+             :data-timer-count (count rings)
+             :viewBox (str "0 0 " (or width 0) " " (or height 0))
+             :width "100%"
+             :preserveAspectRatio "xMidYMin meet"
+             :style {:position "absolute"
+                     :top 0
+                     :left 0
+                     :width "100%"
+                     :height "100%"
+                     :pointer-events "none"   ;; rings opt in below
+                     :overflow "visible"}}
+       (into [:g {:data-testid "rf-causa-machine-inspector-after-rings"
+                  :style {:pointer-events "all"}}]
+             (for [{:keys [timer cx cy r]} rings
+                   :let [fraction (rings-h/ring-fraction timer now)
+                         color    (rings-h/timer-color timer now)
+                         cancelled? (= :cancelled (:status timer))
+                         tooltip  (rings-h/format-timer-tooltip timer now)
+                         state-id (if (keyword? (:state timer))
+                                    (name (:state timer))
+                                    (pr-str (:state timer)))
+                         testid   (str "rf-causa-machine-inspector-after-ring-"
+                                       state-id)]]
+               ^{:key (str (:state timer) "/" (:epoch timer))}
+               [:g {:on-mouse-enter
+                    (fn [_]
+                      (rf/dispatch [:rf.causa/timer-hover
+                                    {:machine-id (:machine-id timer)
+                                     :state      (:state timer)
+                                     :epoch      (:epoch timer)}]
+                                   {:frame :rf/causa}))
+                    :on-mouse-leave
+                    (fn [_]
+                      (rf/dispatch [:rf.causa/timer-hover nil]
+                                   {:frame :rf/causa}))}
+                (chart-svg/countdown-ring
+                  {:cx cx :cy cy :r r
+                   :fraction fraction
+                   :color    color
+                   :cancelled? cancelled?
+                   :testid   testid
+                   :tooltip  tooltip})]))])))
+
+;; ---- public install entry -----------------------------------------------
+
+(defn install!
+  "Idempotent install — called by `machine_inspector/install!`."
+  []
+  (install-subs!)
+  (install-events!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings_helpers.cljc
@@ -1,0 +1,479 @@
+(ns day8.re-frame2-causa.panels.machine-after-rings-helpers
+  "Pure-data helpers for the Machine Inspector `:after` timer countdown
+  rings (rf2-7hwwe).
+
+  ## What this owns
+
+  Translates Causa's trace ring buffer into a vector of *armed* `:after`
+  timer records the chart can overlay as countdown rings around state
+  nodes — the wall-clock-time visualisation arc per
+  `spec/019-Cross-Cutting-Insight.md`.
+
+  Each timer record:
+
+      {:machine-id  <kw>      ;; the machine the timer belongs to
+       :state       <kw|vec>  ;; the bearing state-node
+       :armed-at    <int>     ;; trace event time (ms epoch)
+       :fires-at    <int>     ;; armed-at + duration-ms
+       :duration-ms <int>     ;; resolved delay
+       :epoch       <int>     ;; the machine's :after-epoch when scheduled
+       :status      <kw>      ;; :armed | :fired | :stale | :cancelled | :skipped
+       :delay-key   <any>     ;; the original :after map key (literal/sub-vec/fn)
+       :sub-id      <kw|nil>} ;; subscription id when :delay-source = :sub
+
+  ## Source events (per Spec 005 §Delayed :after transitions)
+
+  The runtime emits these on the trace bus:
+
+    - `:rf.machine.timer/scheduled`             — arms a timer
+    - `:rf.machine.timer/fired` (`:fired? true`)— normal expiry
+    - `:rf.machine.timer/fired` (`:fired? false`)— guard-suppressed
+    - `:rf.machine.timer/stale-after`           — epoch mismatch
+    - `:rf.machine.timer/cancelled-on-resolution`— sub-vec re-resolution
+    - `:rf.machine.timer/skipped-on-server`     — SSR no-op
+
+  ## Folding algorithm
+
+  Walk the trace buffer oldest-first. Each `scheduled` event opens a
+  timer keyed by `(machine-id, state, epoch)`; a later `fired` /
+  `stale-after` / `cancelled-on-resolution` event for the same key
+  closes it. The latest event wins so re-schedules at the same key
+  replace the prior record (matches the runtime's idempotent
+  `cancel-after-timer-entry!` shape).
+
+  ## Ring geometry
+
+  Live mode: `(ring-fraction timer now-ms) → [0.0 .. 1.0]`
+  - 1.0 = just armed
+  - 0.0 = about to fire
+  - <0.0 = past deadline (delayed firing, clamped to 0)
+
+  Retrospective: caller passes the scrubber's anchor-time as `now-ms`;
+  the ring freezes at the position it occupied at that instant.
+
+  ## Colours
+
+  Map the fraction to a semantic colour tier:
+
+    - 0.66..1.0  → :green   (fresh)
+    - 0.33..0.66 → :amber   (mid-cycle)
+    - 0.0..0.33  → :red     (firing-soon / past-deadline)
+
+  Final states (`:fired`, `:stale`, `:skipped`) → :gray.
+  `:cancelled` → :gray with a fade + diagonal cross drawn by the view.
+
+  ## Why a separate .cljc
+
+  Same dual-target pattern every panel helper uses (the JVM test
+  target drives the algebra without a CLJS runtime). The CLJS-only
+  surfaces (raf tick driver, dispatch) live in
+  `machine_after_rings.cljs`."
+  (:require [clojure.string :as str]))
+
+;; ---- canonical operation taxonomy ---------------------------------------
+
+(def timer-operations
+  "Trace operations the rings helper consumes. Defined as a set so
+  `transition-event?`-style predicates can compose without repeating
+  the literal-keyword list at every call site."
+  #{:rf.machine.timer/scheduled
+    :rf.machine.timer/fired
+    :rf.machine.timer/stale-after
+    :rf.machine.timer/cancelled-on-resolution
+    :rf.machine.timer/skipped-on-server})
+
+(defn timer-event?
+  "True iff `ev` carries one of the recognised timer operations."
+  [ev]
+  (and (map? ev)
+       (contains? timer-operations (:operation ev))))
+
+(defn- machine-id-of
+  "Per Spec 009 the timer events stamp `:machine-id` under `:tags`. The
+  `:scheduled` event has it at the top of the `:tags` map; the `:fired`
+  / `:stale-after` events emit only the state (per
+  `emit-pick-traces!` — the parent machine-id is implicit in the
+  cascade context). The fallback walks `:tags :handler-id` (which the
+  pure-transition emit DOES carry for fired events when present) and
+  finally drops down to whatever the trace projection layer left in
+  the top-level `:frame` slot.
+
+  Returns nil when no machine-id can be resolved — the caller
+  filters those out before folding."
+  [ev]
+  (or (get-in ev [:tags :machine-id])
+      (get-in ev [:tags :handler-id])))
+
+;; ---- timer key resolution -----------------------------------------------
+
+(defn- timer-key
+  "Composite key for the timer-table fold. `(machine-id, state, epoch)`
+  is the runtime's identity tuple — re-scheduling at the same state
+  bumps the epoch (per `re-frame.machines.transition/pick-after-
+  transition`), so a fresh epoch ALWAYS starts a new record. Within an
+  epoch the latest event wins (the runtime's invariant: at most one
+  in-flight timer per (state, epoch)).
+
+  When the closing trace event lacks an `:epoch` (the `:cancelled-on-
+  resolution` shape historically didn't stamp epoch — it sent the
+  cancellation reason instead), we fall back to `(machine-id, state,
+  :*)` so closures match the most recent open record."
+  [machine-id state epoch]
+  {:machine-id machine-id
+   :state      state
+   :epoch      (or epoch :*)})
+
+;; ---- public: project active timers --------------------------------------
+
+(defn- update-or-cancel
+  "Match a closing event against the open timer-table. When `epoch` is
+  provided, exact match; when nil, match the most recent open record
+  for `(machine-id, state)`. Returns `[k record-or-nil]` — `nil`
+  record means no open entry to update.
+
+  Pure fn — JVM-runnable."
+  [open machine-id state epoch]
+  (let [exact-k (timer-key machine-id state epoch)
+        exact   (get open exact-k)]
+    (if exact
+      [exact-k exact]
+      ;; Fall back to the latest open record for the (machine-id, state)
+      ;; pair — the closing event didn't stamp epoch so we trust the
+      ;; ordering of the buffer.
+      (let [matches (filter (fn [[k _v]]
+                              (and (= machine-id (:machine-id k))
+                                   (= state      (:state k))))
+                            open)]
+        (if (seq matches)
+          ;; Pick the most-recently-armed one. The open record's
+          ;; `:armed-at` is monotonic per `(machine-id, state)`.
+          (let [[k v] (apply max-key (fn [[_ v]] (or (:armed-at v) 0))
+                             matches)]
+            [k v])
+          [exact-k nil])))))
+
+(defn fold-timer-events
+  "Reduce a sequence of timer events (oldest-first) into the final
+  timer table — `{<k> <record>}`. The table tracks every timer the
+  buffer has seen, with each record stamped with its current
+  `:status`. Pure fn — JVM-runnable.
+
+  The fold guarantees:
+
+    - Every `:scheduled` opens / refreshes a record at its `(machine-
+      id, state, epoch)` key with `:status :armed`.
+    - A `:fired` event flips the matching record's `:status` to
+      `:fired` (or `:guard-suppressed` when `:fired? false`).
+    - A `:stale-after` flips it to `:stale`.
+    - A `:cancelled-on-resolution` flips it to `:cancelled` and
+      retains the `:armed-at` / `:fires-at` so the view can render
+      the ring at its last position with the crossed-out overlay.
+    - `:skipped-on-server` (`:platform :server`) flips to `:skipped`.
+
+  The caller filters down to the entries it wants to render (typically
+  `:armed` for live rings + recently-closed for fading-out states)."
+  [events]
+  (reduce
+    (fn [open ev]
+      (let [op         (:operation ev)
+            tags       (get ev :tags {})
+            machine-id (machine-id-of ev)
+            state      (or (:state tags) (:to tags) (:to-state tags))
+            epoch      (:epoch tags)
+            t          (:time ev)
+            delay      (:delay tags)
+            delay-src  (:delay-source tags)
+            delay-key  (:delay-key tags)
+            sub-id     (:sub-id tags)]
+        (cond
+          (nil? machine-id) open
+          (nil? state)      open
+
+          (= :rf.machine.timer/scheduled op)
+          (assoc open (timer-key machine-id state epoch)
+                 {:machine-id  machine-id
+                  :state       state
+                  :armed-at    t
+                  :fires-at    (when (and t (number? delay)) (+ t delay))
+                  :duration-ms (when (number? delay) delay)
+                  :epoch       epoch
+                  :status      :armed
+                  :delay-source delay-src
+                  :delay-key   delay-key
+                  :sub-id      sub-id})
+
+          (= :rf.machine.timer/fired op)
+          (let [[k v] (update-or-cancel open machine-id state epoch)]
+            (if v
+              (assoc open k
+                     (assoc v
+                            :status (if (false? (:fired? tags))
+                                      :guard-suppressed
+                                      :fired)
+                            :closed-at t))
+              open))
+
+          (= :rf.machine.timer/stale-after op)
+          (let [;; stale-after emits `:scheduled-epoch` (the timer's epoch)
+                ;; + `:current-epoch` (the machine's epoch when the timer
+                ;; fired) — we close the scheduled-epoch record.
+                stale-epoch (or (:scheduled-epoch tags) epoch)
+                [k v] (update-or-cancel open machine-id state stale-epoch)]
+            (if v
+              (assoc open k (assoc v :status :stale :closed-at t))
+              open))
+
+          (= :rf.machine.timer/cancelled-on-resolution op)
+          (let [[k v] (update-or-cancel open machine-id state epoch)]
+            (if v
+              (assoc open k (assoc v :status :cancelled :closed-at t))
+              open))
+
+          (= :rf.machine.timer/skipped-on-server op)
+          (assoc open (timer-key machine-id state epoch)
+                 {:machine-id  machine-id
+                  :state       state
+                  :armed-at    t
+                  :fires-at    nil
+                  :duration-ms (when (number? delay) delay)
+                  :epoch       epoch
+                  :status      :skipped
+                  :delay-source delay-src
+                  :delay-key   delay-key
+                  :sub-id      sub-id})
+
+          :else open)))
+    {}
+    (or events [])))
+
+(defn project-timers
+  "Project Causa's trace buffer into a flat vector of timer records
+  for `machine-id`. Sorted oldest-first by `:armed-at` for stable
+  hover-region ordering.
+
+  Returns `[]` when `machine-id` is nil. Pure fn — JVM-runnable."
+  [trace-buffer machine-id]
+  (if (nil? machine-id)
+    []
+    (let [events (->> (or trace-buffer [])
+                      (filter timer-event?)
+                      (filter (fn [ev] (= machine-id (machine-id-of ev))))
+                      ;; Oldest first — the fold relies on chronological
+                      ;; order so a later cancellation overrides an earlier
+                      ;; arming.
+                      (sort-by (fn [ev] (or (:id ev) (:time ev) 0))))
+          table  (fold-timer-events events)]
+      (vec
+        (sort-by (fn [r] (or (:armed-at r) 0))
+                 (vals table))))))
+
+(defn active-timers-for-machine
+  "Return the timer records the chart should render rings for. Filters
+  the projection to:
+
+    - `:armed`        — countdown is in progress.
+    - `:cancelled`    — show fade + diagonal cross until evicted (the
+                        view decides retention; the helper returns the
+                        record so the renderer has the data).
+
+  Closed-state timers (`:fired`, `:stale`, `:guard-suppressed`,
+  `:skipped`) drop out — the ring's purpose is to show wall-clock-
+  pressure on the chart; a fired ring is just chart noise.
+
+  `now-ms` is optional; when supplied, `:armed` records whose
+  `:fires-at` is more than 5s in the past are dropped — protects
+  against zombie projections when a `:fired` trace event was elided
+  from the buffer (e.g. ring-buffer eviction)."
+  ([trace-buffer machine-id]
+   (active-timers-for-machine trace-buffer machine-id nil))
+  ([trace-buffer machine-id now-ms]
+   (let [zombie-threshold-ms 5000
+         records (project-timers trace-buffer machine-id)]
+     (vec
+       (keep
+         (fn [r]
+           (case (:status r)
+             :armed
+             (cond
+               (and now-ms (:fires-at r)
+                    (> (- now-ms (:fires-at r)) zombie-threshold-ms))
+               nil
+               :else r)
+
+             :cancelled r
+             nil))
+         records)))))
+
+;; ---- ring geometry ------------------------------------------------------
+
+(defn ring-fraction
+  "Compute the remaining-time fraction for `timer` at wall-clock
+  instant `now-ms`. Returns a double in `[0.0, 1.0]`:
+
+    - 1.0  = just armed (full ring)
+    - 0.5  = halfway through the countdown
+    - 0.0  = about to fire / past deadline
+    - nil  = the timer has no resolvable duration (literal delay
+             missing / unresolved sub) — caller renders without a ring
+             progress arc.
+
+  Pure fn — JVM-runnable."
+  [{:keys [armed-at fires-at duration-ms]} now-ms]
+  (cond
+    (or (nil? armed-at) (nil? fires-at) (nil? duration-ms)
+        (not (pos? duration-ms))
+        (nil? now-ms))
+    nil
+
+    :else
+    (let [remaining (- fires-at now-ms)
+          frac      (/ (double remaining) (double duration-ms))]
+      (cond
+        (<= frac 0.0) 0.0
+        (>= frac 1.0) 1.0
+        :else         frac))))
+
+(defn ring-color
+  "Map a ring `fraction` to the design-token keyword the SVG primitive
+  + view consume. Pure fn.
+
+    - >= 0.66        → :green   (plenty of headroom)
+    - 0.33..0.66     → :amber   (mid-cycle)
+    - 0.0..0.33      → :red     (firing-soon / past-deadline)
+    - past deadline  → :red     (we clamp `ring-fraction` at 0 already)
+    - nil            → :gray    (no progress data — degenerate ring)"
+  [fraction]
+  (cond
+    (nil? fraction)    :gray
+    (>= fraction 0.66) :green
+    (>= fraction 0.33) :amber
+    :else              :red))
+
+(defn timer-color
+  "Resolve the colour for a `timer` record at instant `now-ms`. Combines
+  `ring-fraction` + `ring-color` with status-based overrides:
+
+    - `:cancelled` → `:gray` (the view also draws the diagonal cross)
+    - `:fired` / `:stale` / `:guard-suppressed` / `:skipped` → `:gray`
+    - `:armed` → fraction-driven (`ring-color`)
+
+  Pure fn — JVM-runnable. Used by both the SVG renderer and the JVM
+  test suite."
+  [timer now-ms]
+  (case (:status timer)
+    :cancelled        :gray
+    :fired            :gray
+    :stale            :gray
+    :guard-suppressed :gray
+    :skipped          :gray
+    :armed            (ring-color (ring-fraction timer now-ms))
+    :gray))
+
+(defn ms-remaining
+  "Convenience for the hover tooltip. nil for non-armed timers and
+  unresolved-duration timers."
+  [{:keys [fires-at] :as _timer} now-ms]
+  (when (and fires-at now-ms)
+    (max 0 (- fires-at now-ms))))
+
+(defn format-timer-tooltip
+  "Human-readable tooltip for a ring hover. Pure fn — used by the
+  `<title>` element in the SVG (zero-cost accessible tooltip).
+
+    `:armed`        → 'state · 1234ms remaining · fires @5678'
+    `:cancelled`    → 'state · cancelled · last @1234'
+    `:fired`        → 'state · fired @1234'
+    `:stale`        → 'state · stale (epoch mismatch)'
+    `:skipped`      → 'state · skipped (server-side)'
+    `:guard-suppressed` → 'state · fired but guard suppressed'"
+  [{:keys [state status fires-at duration-ms closed-at] :as timer}
+   now-ms]
+  (let [state-s (if (keyword? state) (str state) (pr-str state))
+        dur     (when duration-ms (str " (" duration-ms "ms)"))]
+    (case status
+      :armed
+      (let [remaining (ms-remaining timer now-ms)
+            fires-s   (when fires-at (str " · fires @" fires-at))]
+        (str state-s
+             (when remaining (str " · " remaining "ms remaining"))
+             fires-s
+             dur))
+
+      :cancelled
+      (str state-s " · cancelled"
+           (when closed-at (str " @" closed-at))
+           dur)
+
+      :fired
+      (str state-s " · fired"
+           (when closed-at (str " @" closed-at))
+           dur)
+
+      :stale
+      (str state-s " · stale (epoch mismatch)" dur)
+
+      :skipped
+      (str state-s " · skipped (server-side)" dur)
+
+      :guard-suppressed
+      (str state-s " · fired (guard suppressed)"
+           (when closed-at (str " @" closed-at))
+           dur)
+
+      (str state-s " · " (when status (name status))))))
+
+;; ---- geometry for the chart overlay -------------------------------------
+
+(defn state-node-center
+  "Resolve the `[cx cy r]` triple for a chart-node corresponding to
+  `state`. `id-fn` is `chart.layout/highlight-id` (passed in to avoid
+  a compile-time dep from this ns into the chart layout); `node-index`
+  is the `{node-id node}` map produced by `arc-h/nodes->index`.
+
+  The radius is half the longer node dimension + a small breathing
+  gap so the ring sits OUTSIDE the node rectangle. Returns nil when
+  the state has no corresponding node in the positioned graph."
+  [state node-index id-fn]
+  (when (and state id-fn node-index)
+    (let [nid (id-fn state)
+          n   (get node-index nid)]
+      (when n
+        (let [cx (+ (:x n) (quot (:width n) 2))
+              cy (+ (:y n) (quot (:height n) 2))
+              ;; Radius = half-diagonal + a 4px breathing gap so the
+              ;; ring sits clearly outside the node's stroke.
+              w  (:width n)
+              h  (:height n)
+              r  (+ 4 (quot (long (Math/ceil (Math/sqrt
+                                               (+ (* w w) (* h h))))) 2))]
+          [cx cy r])))))
+
+(defn timers->ring-positions
+  "For each armed/cancelled `timer`, resolve its centre + radius via
+  `state-node-center`. Returns a vec of `{:timer <r> :cx :cy :r}` —
+  the view maps over this to render each ring. Pure fn.
+
+  Drops timers whose state has no corresponding chart node (e.g. a
+  compound parent without leaves in the projected graph)."
+  [timers node-index id-fn]
+  (vec
+    (keep
+      (fn [t]
+        (when-let [[cx cy r] (state-node-center (:state t) node-index id-fn)]
+          {:timer t :cx cx :cy cy :r r}))
+      (or timers []))))
+
+;; ---- tick driver gating -------------------------------------------------
+
+(defn needs-ticking?
+  "True when the rings panel should run its rAF tick driver. False when:
+
+    - There are no armed timers (`:cancelled` rings are static).
+    - The scrubber is NOT at `:present` (retrospective mode freezes
+      every ring at the scrubber's anchor time).
+
+  Pure fn — keeps the rAF gate testable. The view passes the result
+  to a side-effect that starts / stops the loop."
+  [timers scrubber-position]
+  (and (= :present scrubber-position)
+       (some (fn [t] (= :armed (:status t))) (or timers []))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -82,6 +82,7 @@
             [day8.re-frame2-causa.panels.machine-inspector-cluster-helpers :as ch]
             [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]
             [day8.re-frame2-causa.panels.machine-inspector-arc :as arc]
+            [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]
             [day8.re-frame2-causa.panels.machine-inspector-scrubber :as scrubber]
             [day8.re-frame2-causa.share :as share]
             [day8.re-frame2-causa.theme.tokens
@@ -395,7 +396,15 @@
         ;; Phase 5: per-instance arc overlay. Hidden in sim mode (the
         ;; arc represents the LIVE trajectory; sim is a clone walk).
         (when (not sim?)
-          [arc/ArcOverlay positioned])]))))
+          [arc/ArcOverlay positioned])
+        ;; rf2-7hwwe: `:after` countdown rings — drawn AROUND every
+        ;; state-node that currently has an armed `:after` timer. Live
+        ;; mode animates from full → empty; retrospective freezes at
+        ;; the scrubber's anchor time. Hidden in sim mode for the same
+        ;; reason the arc is — sim is a clone walk, not the live
+        ;; trajectory whose timers the trace bus reflects.
+        (when (not sim?)
+          [after-rings/AfterRingsOverlay positioned])]))))
 
 ;; ---- transition history ribbon ------------------------------------------
 
@@ -1000,6 +1009,19 @@
   ;; panel reads. The arc-helper algebra is JVM-runnable and lives in
   ;; `machine_inspector_arc_helpers.cljc`.
   (arc/install!)
+
+  ;; ---- rf2-7hwwe — `:after` timer countdown rings ----------------
+  ;;
+  ;; The rings sub/event family lives in
+  ;; `panels/machine_after_rings.cljs`. The install fn registers
+  ;; `:rf.causa/active-timers-for-focused-machine` +
+  ;; `:rf.causa/timer-tick` + `:rf.causa/timer-hover` +
+  ;; `:rf.causa/now-ms` (+ the test-only override) against the same
+  ;; `:rf/causa` frame the panel reads. Pure projection lives in
+  ;; `machine_after_rings_helpers.cljc`. MUST install AFTER the arc
+  ;; install! above because the rings overlay consumes the scrubber-
+  ;; position sub the arc family registers.
+  (after-rings/install!)
 
   ;; ---- Phase 5 (rf2-nqw0v) — Share affordance --------------------
   ;;

--- a/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc
@@ -189,3 +189,74 @@
     (let [{:keys [nodes]} (layout/layout compound-machine)
           [c]              (chart-svg/compound-containers nodes)]
       (is (= "authenticated" (:label c))))))
+
+;; ---- countdown-ring primitive (rf2-7hwwe) -------------------------------
+;;
+;; Pure-data tests for the SVG ring primitive. The view-side (rings
+;; overlay mounted on the chart) is tested in
+;; `panels/machine_after_rings_view_cljs_test.cljs`.
+
+(deftest countdown-ring-emits-base-shape
+  (let [tree (chart-svg/countdown-ring
+               {:cx 100 :cy 100 :r 30 :fraction 0.5 :color :amber})]
+    (is (vector? tree))
+    (is (= :g (first tree)))
+    (let [attrs (second tree)]
+      (is (= "amber"        (:data-color attrs)))
+      (is (= "false"        (:data-cancelled attrs)))
+      (is (= "0.5"          (:data-fraction attrs))))
+    (let [circles (filter (fn [n] (and (vector? n) (= :circle (first n))))
+                          (hiccup-seq tree))]
+      (is (>= (count circles) 2)
+          "underlay track + countdown sweep circles render"))))
+
+(deftest countdown-ring-fraction-drives-dasharray
+  (testing "fraction 1.0 → arc covers (most of) the circumference;
+            fraction 0.0 → arc covers nothing (full gap)"
+    (let [full   (chart-svg/countdown-ring
+                   {:cx 0 :cy 0 :r 10 :fraction 1.0 :color :green})
+          empty  (chart-svg/countdown-ring
+                   {:cx 0 :cy 0 :r 10 :fraction 0.0 :color :red})
+          sweeps (fn [tree]
+                   (->> (hiccup-seq tree)
+                        (filter (fn [n] (and (vector? n) (= :circle (first n)))))
+                        (filter (fn [n] (some? (:stroke-dasharray (second n)))))))
+          full-dash  (-> full sweeps first second :stroke-dasharray)
+          empty-dash (-> empty sweeps first second :stroke-dasharray)]
+      (is (string? full-dash))
+      (is (string? empty-dash))
+      (is (not= full-dash empty-dash)))))
+
+(deftest countdown-ring-cancelled-renders-cross-line
+  (let [tree (chart-svg/countdown-ring
+               {:cx 50 :cy 50 :r 20 :fraction 0.3 :color :gray
+                :cancelled? true})
+        lines (filter (fn [n] (and (vector? n) (= :line (first n))))
+                      (hiccup-seq tree))]
+    (is (= "true" (-> tree second :data-cancelled)))
+    (is (= 1 (count lines))
+        "the cancelled overlay draws exactly one diagonal cross line")))
+
+(deftest countdown-ring-tooltip-wraps-title
+  (let [tree (chart-svg/countdown-ring
+               {:cx 0 :cy 0 :r 10 :fraction 0.5 :color :amber
+                :tooltip ":idle · 1500ms remaining"})
+        titles (filter (fn [n] (and (vector? n) (= :title (first n))))
+                       (hiccup-seq tree))]
+    (is (= 1 (count titles)))
+    (is (re-find #"1500ms remaining" (last (first titles))))))
+
+(deftest countdown-ring-respects-custom-testid
+  (let [tree (chart-svg/countdown-ring
+               {:cx 0 :cy 0 :r 10 :fraction 1.0 :color :green
+                :testid "rf-test-custom"})]
+    (is (= "rf-test-custom" (-> tree second :data-testid)))))
+
+(deftest countdown-ring-nil-fraction-renders-full-track
+  (testing "nil fraction (degenerate / unresolvable duration) still
+            renders a stable shape — the colour mapping has already
+            been resolved upstream to :gray"
+    (let [tree (chart-svg/countdown-ring
+                 {:cx 0 :cy 0 :r 10 :fraction nil :color :gray})]
+      (is (vector? tree))
+      (is (nil? (-> tree second :data-fraction))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
@@ -1,0 +1,258 @@
+(ns day8.re-frame2-causa.panels.machine-after-rings-cljs-test
+  "CLJS-side wiring tests for Causa's Machine Inspector `:after`
+  countdown rings (rf2-7hwwe).
+
+  Covers:
+
+    1. Registry wires the rings sub family + the tick/hover/now-ms
+       event family.
+    2. `:rf.causa/active-timers-for-focused-machine` composes trace
+       buffer + selected machine + now-ms into an active-timers vector.
+    3. `:rf.causa/now-ms` is driven by the timer-tick event AND by the
+       test-only override slot.
+    4. `:rf.causa/timer-hover` writes / clears the slot.
+    5. The rings overlay component emits a stable SVG hiccup tree
+       (renders nothing without active timers; renders one ring per
+       active timer).
+    6. The rAF tick loop's `needs-ticking?` gate stops the loop when
+       no armed timers are present."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (after-rings/stop-tick!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- override-machines! [machines]
+  (rf/dispatch-sync
+    [:rf.causa/set-registered-machines-override-for-test machines]))
+
+(defn- override-definitions! [definitions]
+  (rf/dispatch-sync
+    [:rf.causa/set-machine-definitions-override-for-test definitions]))
+
+(defn- pin-now-ms! [ms]
+  (rf/dispatch-sync [:rf.causa/set-now-ms-override-for-test ms]))
+
+(defn- push-scheduled!
+  [id machine-id state delay epoch]
+  (trace-bus/collect-trace!
+    {:id id :time id
+     :operation :rf.machine.timer/scheduled
+     :tags {:machine-id machine-id
+            :state state
+            :delay delay
+            :delay-source :literal
+            :epoch epoch}}))
+
+(defn- push-fired!
+  [id machine-id state epoch]
+  (trace-bus/collect-trace!
+    {:id id :time id
+     :operation :rf.machine.timer/fired
+     :tags {:machine-id machine-id
+            :state state
+            :epoch epoch
+            :fired? true}}))
+
+(def ^:private fixture-definition
+  {:initial :idle
+   :states  {:idle    {:on    {:start :authing}
+                       :after {5000 :timeout}}
+             :authing {:on {:ok :done}}
+             :timeout {:on {:retry :idle}}
+             :done    {:final? true}}})
+
+;; ---- (1) registry wiring -----------------------------------------------
+
+(deftest registry-installs-rings-handlers
+  (testing "register-causa-handlers! installs the rings sub + event family"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/active-timers-for-focused-machine)))
+    (is (some? (registrar/handler :sub :rf.causa/now-ms)))
+    (is (some? (registrar/handler :sub :rf.causa/timer-hover)))
+    (is (some? (registrar/handler :event :rf.causa/timer-tick)))
+    (is (some? (registrar/handler :event :rf.causa/timer-hover)))
+    (is (some? (registrar/handler :event :rf.causa/set-now-ms-override-for-test)))))
+
+;; ---- (2) active-timers composite ---------------------------------------
+
+(deftest active-timers-empty-when-no-selection
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines! [])
+    (is (= [] @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])))))
+
+(deftest active-timers-folds-scheduled-into-armed
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 2000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (let [active @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])]
+      (is (= 1 (count active)))
+      (is (= :armed (-> active first :status)))
+      (is (= :idle  (-> active first :state)))
+      (is (= 6000   (-> active first :fires-at))))))
+
+(deftest active-timers-drops-fired
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 7000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (push-fired!     6000 :auth/login :idle 0)
+    (is (empty? @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])))))
+
+;; ---- (3) now-ms surface ------------------------------------------------
+
+(deftest now-ms-override-overrides-tick
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/timer-tick 10000])
+    (is (= 10000 @(rf/subscribe [:rf.causa/now-ms])))
+    (pin-now-ms! 9999)
+    (is (= 9999 @(rf/subscribe [:rf.causa/now-ms]))
+        "override slot wins over the tick-bumped value")))
+
+(deftest timer-tick-event-writes-now-ms
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/timer-tick 12345])
+    (is (= 12345 @(rf/subscribe [:rf.causa/now-ms])))))
+
+;; ---- (4) timer-hover ---------------------------------------------------
+
+(deftest timer-hover-writes-and-clears
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa/timer-hover])))
+    (rf/dispatch-sync [:rf.causa/timer-hover {:machine-id :auth/login
+                                              :state :idle
+                                              :epoch 0}])
+    (is (= {:machine-id :auth/login :state :idle :epoch 0}
+           @(rf/subscribe [:rf.causa/timer-hover])))
+    (rf/dispatch-sync [:rf.causa/timer-hover nil])
+    (is (nil? @(rf/subscribe [:rf.causa/timer-hover])))))
+
+;; ---- (5) overlay view --------------------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(def ^:private fixture-positioned
+  ;; `node-id` is the STRING the chart-layout primitive mints from a
+  ;; state path (per `chart.layout/node-id`). The rings overlay
+  ;; resolves a timer's `:state` keyword to this id via
+  ;; `chart-layout/highlight-id`; mismatching the shape silently
+  ;; drops every ring.
+  {:nodes [{:node-id "idle"    :x 100 :y 100 :width 140 :height 48
+            :path [:idle] :depth 0 :initial? true}
+           {:node-id "authing" :x 300 :y 100 :width 140 :height 48
+            :path [:authing] :depth 1}
+           {:node-id "timeout" :x 500 :y 100 :width 140 :height 48
+            :path [:timeout] :depth 2}
+           {:node-id "done"    :x 700 :y 100 :width 140 :height 48
+            :path [:done] :depth 2}]
+   :edges []
+   :width 900
+   :height 250
+   :initial-id "idle"})
+
+(deftest overlay-returns-nil-with-no-active-timers
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 1000)
+    (is (nil? (after-rings/AfterRingsOverlay fixture-positioned)))))
+
+(deftest overlay-renders-one-ring-per-active-timer
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 2000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (let [tree (after-rings/AfterRingsOverlay fixture-positioned)
+          ;; The svg overlay container.
+          overlay (find-by-testid tree
+                    "rf-causa-machine-inspector-after-rings-overlay")]
+      (is (some? overlay))
+      (is (= "1" (str (-> overlay second :data-timer-count))))
+      ;; One ring with the state-id stamped.
+      (is (some? (find-by-testid tree
+                   "rf-causa-machine-inspector-after-ring-idle"))))))
+
+(deftest overlay-stops-rendering-fired-timers
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 7000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (push-fired!     6000 :auth/login :idle 0)
+    (is (nil? (after-rings/AfterRingsOverlay fixture-positioned))
+        "fired timers are filtered out of the active projection — the
+         whole overlay drops out")))
+
+(deftest overlay-renders-rings-for-multiple-concurrent-timers
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 2000)
+    (push-scheduled! 1000 :auth/login :idle    5000 0)
+    (push-scheduled! 1500 :auth/login :authing 3000 0)
+    (let [tree (after-rings/AfterRingsOverlay fixture-positioned)]
+      (is (= "2" (str (-> (find-by-testid tree
+                            "rf-causa-machine-inspector-after-rings-overlay")
+                          second :data-timer-count))))
+      (is (some? (find-by-testid tree
+                   "rf-causa-machine-inspector-after-ring-idle")))
+      (is (some? (find-by-testid tree
+                   "rf-causa-machine-inspector-after-ring-authing"))))))
+
+;; ---- (6) frame isolation ----------------------------------------------
+
+(deftest now-ms-lives-on-causa-frame
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/timer-tick 42]))
+  (let [causa-db   (frame/frame-app-db-value :rf/causa)
+        default-db (frame/frame-app-db-value :rf/default)]
+    (is (= 42 (:rings/now-ms causa-db)))
+    (is (nil? (:rings/now-ms default-db))
+        "host frame is untouched")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_helpers_cljs_test.cljc
@@ -1,0 +1,384 @@
+(ns day8.re-frame2-causa.panels.machine-after-rings-helpers-cljs-test
+  "Pure-data tests for Causa's Machine Inspector `:after` timer
+  countdown-rings helpers (rf2-7hwwe).
+
+  Dual-target via the `_cljs_test.cljc` extension — Cognitect's CLJ
+  test-runner picks the ns up via the `.*-test$` regex; Shadow's
+  `:node-test` build picks it up via `cljs-test$`. Same pattern every
+  Causa helper test uses.
+
+  ## What's under test
+
+    1. `timer-event?` / `fold-timer-events` — the projection state
+       machine.
+    2. `project-timers`                     — full pipeline over a
+                                              trace buffer.
+    3. `active-timers-for-machine`          — armed + cancelled filter.
+    4. `ring-fraction`                      — boundary cases (just-
+                                              armed / about-to-fire /
+                                              past-deadline /
+                                              uncomputable).
+    5. `ring-color` / `timer-color`         — colour tier mapping +
+                                              status-based overrides.
+    6. `format-timer-tooltip`               — per-status messages.
+    7. `state-node-center` / `timers->ring-positions` — node geometry.
+    8. `needs-ticking?`                     — rAF tick driver gate.
+    9. `ms-remaining`                       — tooltip-ms calc."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.machine-after-rings-helpers
+             :as h]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- scheduled
+  ([id machine-id state delay epoch]
+   (scheduled id machine-id state delay epoch :literal))
+  ([id machine-id state delay epoch source]
+   {:id id :time id
+    :operation :rf.machine.timer/scheduled
+    :tags {:machine-id   machine-id
+           :state        state
+           :delay        delay
+           :delay-source source
+           :epoch        epoch}}))
+
+(defn- fired
+  [id machine-id state epoch & {:keys [fired?] :or {fired? true}}]
+  {:id id :time id
+   :operation :rf.machine.timer/fired
+   :tags {:machine-id machine-id
+          :state      state
+          :epoch      epoch
+          :fired?     fired?}})
+
+(defn- stale-after
+  [id machine-id state scheduled-epoch current-epoch]
+  {:id id :time id
+   :operation :rf.machine.timer/stale-after
+   :tags {:machine-id      machine-id
+          :state           state
+          :scheduled-epoch scheduled-epoch
+          :current-epoch   current-epoch
+          :recovery        :replaced-with-default}})
+
+(defn- cancelled-on-resolution
+  [id machine-id state epoch sub-id]
+  {:id id :time id
+   :operation :rf.machine.timer/cancelled-on-resolution
+   :tags {:machine-id machine-id
+          :state      state
+          :epoch      epoch
+          :reason     :sub-changed
+          :sub-id     sub-id}})
+
+(defn- skipped-on-server
+  [id machine-id state delay epoch]
+  {:id id :time id
+   :operation :rf.machine.timer/skipped-on-server
+   :tags {:machine-id machine-id
+          :state      state
+          :delay      delay
+          :delay-source :literal
+          :epoch      epoch
+          :platform   :server
+          :recovery   :skipped}})
+
+(defn- other-event
+  [id]
+  {:id id :time id :operation :rf.machine/transition
+   :tags {:machine-id :auth/login :from :idle :to :authing}})
+
+;; ---- (1) timer-event? ---------------------------------------------------
+
+(deftest timer-event?-recognises-each-operation
+  (is (h/timer-event? (scheduled 1 :auth/login :idle 1000 0)))
+  (is (h/timer-event? (fired 2 :auth/login :idle 0)))
+  (is (h/timer-event? (stale-after 3 :auth/login :idle 0 1)))
+  (is (h/timer-event? (cancelled-on-resolution 4 :auth/login :idle 0 :delay-ms)))
+  (is (h/timer-event? (skipped-on-server 5 :auth/login :idle 1000 0))))
+
+(deftest timer-event?-rejects-non-timer-and-nil
+  (is (not (h/timer-event? nil)))
+  (is (not (h/timer-event? {})))
+  (is (not (h/timer-event? (other-event 1))))
+  (is (not (h/timer-event? "scheduled"))))
+
+;; ---- (2) fold-timer-events ----------------------------------------------
+
+(deftest fold-empty
+  (is (= {} (h/fold-timer-events []))))
+
+(deftest fold-scheduled-opens-armed-record
+  (let [t (h/fold-timer-events [(scheduled 1000 :auth/login :idle 5000 0)])
+        r (-> t vals first)]
+    (is (= 1 (count t)))
+    (is (= :armed (:status r)))
+    (is (= 1000   (:armed-at r)))
+    (is (= 6000   (:fires-at r)))
+    (is (= 5000   (:duration-ms r)))
+    (is (= 0      (:epoch r)))
+    (is (= :idle  (:state r)))
+    (is (= :auth/login (:machine-id r)))))
+
+(deftest fold-fired-closes-matching-record
+  (let [t (h/fold-timer-events
+            [(scheduled 1000 :auth/login :idle 5000 0)
+             (fired     6000 :auth/login :idle 0)])
+        r (-> t vals first)]
+    (is (= :fired (:status r)))
+    (is (= 6000   (:closed-at r)))))
+
+(deftest fold-fired-guard-suppressed-flips-to-guard-suppressed
+  (let [t (h/fold-timer-events
+            [(scheduled 1000 :auth/login :idle 5000 0)
+             (fired     6000 :auth/login :idle 0 :fired? false)])
+        r (-> t vals first)]
+    (is (= :guard-suppressed (:status r)))))
+
+(deftest fold-stale-after-uses-scheduled-epoch
+  (let [t (h/fold-timer-events
+            [(scheduled   1000 :auth/login :idle 5000 0)
+             (stale-after 6500 :auth/login :idle 0 1)])
+        r (-> t vals first)]
+    (is (= :stale (:status r)))
+    (is (= 0      (:epoch r))
+        "epoch is preserved from the scheduled record")))
+
+(deftest fold-cancelled-on-resolution-flips-to-cancelled
+  (let [t (h/fold-timer-events
+            [(scheduled              1000 :auth/login :idle 5000 0 :sub)
+             (cancelled-on-resolution 3000 :auth/login :idle 0 :delay-ms)])
+        r (-> t vals first)]
+    (is (= :cancelled (:status r)))
+    (is (= 3000       (:closed-at r)))
+    (is (= 1000       (:armed-at r))
+        "armed-at survives so the view can render the ring at its last
+         position with the diagonal cross overlay")))
+
+(deftest fold-skipped-on-server-flips-to-skipped
+  (let [t (h/fold-timer-events
+            [(skipped-on-server 1000 :auth/login :idle 5000 0)])
+        r (-> t vals first)]
+    (is (= :skipped (:status r)))))
+
+(deftest fold-reschedule-same-state-bumps-epoch
+  (testing "the runtime guarantees epoch monotonicity per (machine, state)
+            so a fresh schedule always opens a new record"
+    (let [t (h/fold-timer-events
+              [(scheduled 1000 :auth/login :idle 5000 0)
+               (fired     6000 :auth/login :idle 0)
+               (scheduled 7000 :auth/login :idle 5000 1)])]
+      (is (= 2 (count t)))
+      (let [armed (some #(when (= :armed (:status %)) %) (vals t))
+            fired (some #(when (= :fired (:status %)) %) (vals t))]
+        (is (= 1 (:epoch armed)))
+        (is (= 0 (:epoch fired)))))))
+
+(deftest fold-ignores-events-without-machine-id-or-state
+  (let [bad-machine {:id 1 :time 1
+                     :operation :rf.machine.timer/scheduled
+                     :tags {:state :idle :delay 1000 :epoch 0}}
+        bad-state   {:id 2 :time 2
+                     :operation :rf.machine.timer/scheduled
+                     :tags {:machine-id :x :delay 1000 :epoch 0}}]
+    (is (= {} (h/fold-timer-events [bad-machine bad-state])))))
+
+;; ---- (3) project-timers + active-timers-for-machine --------------------
+
+(deftest project-timers-returns-empty-on-nil-id
+  (is (= [] (h/project-timers
+              [(scheduled 1 :auth/login :idle 1000 0)] nil))))
+
+(deftest project-timers-filters-by-machine-id
+  (let [buf [(scheduled 1 :auth/login   :idle 1000 0)
+             (scheduled 2 :other/machine :foo  2000 0)]]
+    (is (= 1 (count (h/project-timers buf :auth/login))))
+    (is (= 1 (count (h/project-timers buf :other/machine))))))
+
+(deftest project-timers-orders-by-armed-at
+  (let [buf [(scheduled 3000 :auth/login :foo 1000 0)
+             (scheduled 1000 :auth/login :bar 1000 0)
+             (scheduled 2000 :auth/login :baz 1000 0)]]
+    (is (= [1000 2000 3000]
+           (mapv :armed-at (h/project-timers buf :auth/login))))))
+
+(deftest active-timers-keeps-armed-and-cancelled
+  (let [buf [(scheduled                1000 :auth/login :idle    5000 0)
+             (scheduled                1500 :auth/login :authing 5000 0 :sub)
+             (cancelled-on-resolution  2000 :auth/login :authing 0 :delay)
+             (scheduled                3000 :auth/login :done    5000 0)
+             (fired                    4000 :auth/login :done    0)
+             (skipped-on-server        5000 :auth/login :ssr     5000 0)]
+        active (h/active-timers-for-machine buf :auth/login)
+        statuses (set (map :status active))]
+    (is (contains? statuses :armed))
+    (is (contains? statuses :cancelled))
+    (is (not (contains? statuses :fired)))
+    (is (not (contains? statuses :skipped)))))
+
+(deftest active-timers-drops-zombie-armed
+  (testing "an armed timer whose fires-at is >5s in the past is dropped —
+            protects against trace-buffer eviction of the fired event"
+    (let [buf [(scheduled 1000 :auth/login :idle 1000 0)]   ;; fires-at = 2000
+          ;; now = 2000 + 5001 (just past threshold)
+          active (h/active-timers-for-machine buf :auth/login (+ 2000 5001))]
+      (is (empty? active))))
+  (testing "an armed timer fresh past its fires-at is KEPT (the colour
+            already maps to :red so the past-deadline state is visible)"
+    (let [buf [(scheduled 1000 :auth/login :idle 1000 0)]
+          active (h/active-timers-for-machine buf :auth/login 3000)]
+      (is (= 1 (count active))))))
+
+;; ---- (4) ring-fraction --------------------------------------------------
+
+(deftest ring-fraction-just-armed-is-near-1
+  (let [t {:armed-at 1000 :fires-at 6000 :duration-ms 5000}]
+    (is (= 1.0 (h/ring-fraction t 1000)))))
+
+(deftest ring-fraction-halfway
+  (let [t {:armed-at 1000 :fires-at 6000 :duration-ms 5000}]
+    (is (= 0.5 (h/ring-fraction t 3500)))))
+
+(deftest ring-fraction-about-to-fire
+  (let [t {:armed-at 1000 :fires-at 6000 :duration-ms 5000}]
+    (is (= 0.0 (h/ring-fraction t 6000)))))
+
+(deftest ring-fraction-past-deadline-clamps-to-zero
+  (let [t {:armed-at 1000 :fires-at 6000 :duration-ms 5000}]
+    (is (= 0.0 (h/ring-fraction t 9000)))))
+
+(deftest ring-fraction-degenerate-cases-return-nil
+  (testing "nil duration / nil fires-at / nil now-ms / zero duration"
+    (is (nil? (h/ring-fraction {} 1000)))
+    (is (nil? (h/ring-fraction {:armed-at 1000} 2000)))
+    (is (nil? (h/ring-fraction {:armed-at 1000 :fires-at 2000} 1500))
+        "nil duration-ms blocks a meaningful fraction")
+    (is (nil? (h/ring-fraction {:armed-at 1000 :fires-at 2000
+                                :duration-ms 0} 1500)))
+    (is (nil? (h/ring-fraction {:armed-at 1000 :fires-at 2000
+                                :duration-ms 1000} nil)))))
+
+;; ---- (5) ring-color / timer-color --------------------------------------
+
+(deftest ring-color-tiers
+  (is (= :green (h/ring-color 1.0)))
+  (is (= :green (h/ring-color 0.66)))
+  (is (= :amber (h/ring-color 0.65)))
+  (is (= :amber (h/ring-color 0.33)))
+  (is (= :red   (h/ring-color 0.32)))
+  (is (= :red   (h/ring-color 0.0)))
+  (is (= :gray  (h/ring-color nil))))
+
+(deftest timer-color-status-overrides
+  (let [armed {:armed-at 1000 :fires-at 6000 :duration-ms 5000
+               :status :armed}
+        canc  (assoc armed :status :cancelled)
+        fire  (assoc armed :status :fired)
+        stale (assoc armed :status :stale)
+        skip  (assoc armed :status :skipped)
+        sup   (assoc armed :status :guard-suppressed)]
+    (is (= :green (h/timer-color armed 1500))
+        "fresh armed → green tier off the fraction")
+    (is (= :red   (h/timer-color armed 5800))
+        "about-to-fire → red")
+    (is (= :gray  (h/timer-color canc  1500)))
+    (is (= :gray  (h/timer-color fire  9000)))
+    (is (= :gray  (h/timer-color stale 9000)))
+    (is (= :gray  (h/timer-color skip  9000)))
+    (is (= :gray  (h/timer-color sup   9000)))))
+
+;; ---- (6) format-timer-tooltip ------------------------------------------
+
+(deftest format-timer-tooltip-armed-shows-remaining-and-fires-at
+  (let [t {:state :idle :status :armed
+           :armed-at 1000 :fires-at 6000 :duration-ms 5000}
+        tip (h/format-timer-tooltip t 3000)]
+    (is (re-find #":idle"            tip))
+    (is (re-find #"3000ms remaining" tip))
+    (is (re-find #"fires @6000"      tip))
+    (is (re-find #"5000ms"           tip))))
+
+(deftest format-timer-tooltip-cancelled-and-stale-and-fired
+  (is (re-find #"cancelled"
+               (h/format-timer-tooltip
+                 {:state :idle :status :cancelled :duration-ms 5000
+                  :closed-at 2000} 3000)))
+  (is (re-find #"fired"
+               (h/format-timer-tooltip
+                 {:state :idle :status :fired :duration-ms 5000
+                  :closed-at 2000} 3000)))
+  (is (re-find #"stale"
+               (h/format-timer-tooltip
+                 {:state :idle :status :stale :duration-ms 5000} 3000)))
+  (is (re-find #"skipped"
+               (h/format-timer-tooltip
+                 {:state :idle :status :skipped :duration-ms 5000} 3000)))
+  (is (re-find #"guard suppressed"
+               (h/format-timer-tooltip
+                 {:state :idle :status :guard-suppressed :duration-ms 5000
+                  :closed-at 2000} 3000))))
+
+;; ---- (7) state-node-center / timers->ring-positions --------------------
+
+(def ^:private fixture-nodes
+  ;; Two flat nodes — a chart of `:idle / :authing`.
+  [{:node-id :idle    :x 100 :y 100 :width 140 :height 48}
+   {:node-id :authing :x 300 :y 100 :width 140 :height 48}])
+
+(def ^:private fixture-node-index
+  ;; { :idle <node> :authing <node> }
+  (into {} (map (fn [n] [(:node-id n) n]) fixture-nodes)))
+
+(defn- id-fn
+  "Stub the chart-layout/highlight-id resolver — flat keywords map to
+  themselves."
+  [state]
+  (cond
+    (keyword? state) state
+    (vector?  state) (first state)
+    :else            nil))
+
+(deftest state-node-center-returns-cx-cy-r
+  (let [[cx cy r] (h/state-node-center :idle fixture-node-index id-fn)]
+    (is (= 170 cx)  "x + width/2")
+    (is (= 124 cy)  "y + height/2")
+    (is (pos? r)    "radius is positive (half-diagonal + 4px gap)")))
+
+(deftest state-node-center-nil-when-state-not-in-graph
+  (is (nil? (h/state-node-center :ghost fixture-node-index id-fn))))
+
+(deftest state-node-center-nil-on-nil-state
+  (is (nil? (h/state-node-center nil fixture-node-index id-fn))))
+
+(deftest timers-ring-positions-maps-each-armed-timer
+  (let [timers [{:state :idle    :status :armed}
+                {:state :authing :status :cancelled}
+                {:state :ghost   :status :armed}]   ;; dropped — no node
+        rings  (h/timers->ring-positions timers fixture-node-index id-fn)]
+    (is (= 2 (count rings)))
+    (is (every? (every-pred :cx :cy :r :timer) rings))))
+
+;; ---- (8) needs-ticking? -------------------------------------------------
+
+(deftest needs-ticking?-true-when-armed-and-at-present
+  (is (h/needs-ticking? [{:status :armed}] :present)))
+
+(deftest needs-ticking?-falsy-when-no-armed
+  (is (not (h/needs-ticking? [{:status :cancelled}] :present)))
+  (is (not (h/needs-ticking? [] :present))))
+
+(deftest needs-ticking?-falsy-when-scrubbed-back
+  (is (not (h/needs-ticking? [{:status :armed}] 3)))
+  (is (not (h/needs-ticking? [{:status :armed}] 0))))
+
+;; ---- (9) ms-remaining ---------------------------------------------------
+
+(deftest ms-remaining-armed-returns-non-negative
+  (is (= 3000 (h/ms-remaining {:fires-at 6000} 3000)))
+  (is (= 0    (h/ms-remaining {:fires-at 6000} 9000))
+      "past deadline clamps to zero so tooltip doesn't show a negative"))
+
+(deftest ms-remaining-nil-cases
+  (is (nil? (h/ms-remaining {} 1000)))
+  (is (nil? (h/ms-remaining {:fires-at 6000} nil))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -100,6 +100,8 @@
   "Every :rf.causa/* sub registered by `register-causa-handlers!`. Sorted
   for stable iteration in the smoke block."
   [:rf.causa/active-filters
+   ;; rf2-7hwwe — Machine Inspector `:after` countdown rings.
+   :rf.causa/active-timers-for-focused-machine
    :rf.causa/active-route-slice
    :rf.causa/active-route-slice-override
    :rf.causa/app-db-diff
@@ -153,6 +155,8 @@
    :rf.causa/mcp-filters
    :rf.causa/mcp-origin-filter-enabled?
    :rf.causa/mcp-server
+   ;; rf2-7hwwe — `:after` ring tick driver wall-clock surface + hover slot.
+   :rf.causa/now-ms
    :rf.causa/performance-budget-ms
    :rf.causa/performance-data
    :rf.causa/pin-store
@@ -211,6 +215,8 @@
    :rf.causa/target-frame
    :rf.causa/target-frame-db
    :rf.causa/time-travel
+   ;; rf2-7hwwe — `:after` countdown ring hover slot (rich tooltip lifecycle).
+   :rf.causa/timer-hover
    :rf.causa/trace-buffer
    :rf.causa/trace-feed
    :rf.causa/trace-filters
@@ -328,6 +334,8 @@
    :rf.causa/set-mcp-since-seconds
    :rf.causa/set-mode-c-cluster-by
    :rf.causa/set-mode-c-context-key
+   ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).
+   :rf.causa/set-now-ms-override-for-test
    :rf.causa/set-performance-budget-ms
    :rf.causa/set-registered-flows-override-for-test
    :rf.causa/set-registered-fxs-override-for-test
@@ -359,6 +367,12 @@
    :rf.causa/sync-epoch-history
    :rf.causa/sync-trace-buffer
    :rf.causa/time-travel-set-label-input
+   ;; rf2-7hwwe — `:after` countdown rings event family. timer-tick
+   ;; is the rAF pulse; timer-hover writes the per-ring hovered slot
+   ;; (v1 surfaces the tooltip via native SVG <title>; the slot is
+   ;; plumbed for a follow-on rich-tooltip).
+   :rf.causa/timer-hover
+   :rf.causa/timer-tick
    :rf.causa/toggle-live-pause
    :rf.causa/toggle-mcp-op-type
    :rf.causa/toggle-mcp-origin-filter
@@ -493,7 +507,11 @@
     ;;   share-url + share-copy-status.
     ;; + 1 managed-fx wire-boundary diff (rf2-uyp86):
     ;;   :rf.causa/managed-fx-for-focused-event composite sub.
-    (is (= 114 (count all-sub-names)))
+    ;; + 3 `:after` countdown rings (rf2-7hwwe):
+    ;;   :rf.causa/active-timers-for-focused-machine + :rf.causa/now-ms
+    ;;   + :rf.causa/timer-hover. The rings overlay rides the same
+    ;;   composite + scrubber wiring the arc does (no new scrubber sub).
+    (is (= 117 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -545,7 +563,12 @@
     ;;   correct count rises by 8 events; subs add another 9.
     ;; + 1 managed-fx cross-link (rf2-uyp86):
     ;;   :rf.causa/focus-event — HANDLER DISPATCHED row pivots the spine.
-    (is (= 135 (count all-event-names)))
+    ;; + 3 `:after` countdown rings (rf2-7hwwe):
+    ;;   :rf.causa/timer-tick (rAF pulse) + :rf.causa/timer-hover
+    ;;   (rich-tooltip lifecycle slot) +
+    ;;   :rf.causa/set-now-ms-override-for-test (deterministic timestamp
+    ;;   pin for the CLJS-side test surface).
+    (is (= 138 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Bug class (rf2-7hwwe; per `spec/019-Cross-Cutting-Insight.md` §Wall-clock time is under-served)

> Machines using `:after` timers (retry backoffs, debounce windows, timeout guards) have invisible countdowns. Devs can't see "how long until next fire?", can't visually confirm throttling, miss "why didn't this fire?" until silent failure.

## What Causa shows now

A countdown ring is drawn AROUND each state-node that has an armed `:after` timer:

```
   ┌─────────────────┐
   │                 │
   │     ╭─ ─ ╮      │      ← faint track (full circle)
   │   ╭─╯    ╰─╮    │
   │  │  ┌────┐  │   │
   │  │  │idle│  │   │      ← state node (with cyan live-highlight)
   │  │  └────┘  │   │
   │   ╰─╮    ╭─╯    │
   │     ╰────╯      │      ← amber sweep at ~50% (mid-cycle)
   │                 │
   └─────────────────┘

Cancelled ring:                Fired / stale / skipped:
   ╭───╮ ╲                       (no ring — closed states drop out)
   │   │  ╲
   │   │   ╲
   ╰───╯
   gray + diagonal cross
```

## Live vs retrospective

- **Live mode (scrubber at `:present`)** — a single rAF loop bumps `:rf.causa/now-ms` at ~60fps; every ring's stroke-dasharray re-renders against the fresh wall-clock. The loop self-gates: it stops when no armed timers remain OR the scrubber leaves `:present`.
- **Retrospective mode (scrubber not at `:present`)** — the rings freeze at the position they occupied at the scrubber's anchor time. The fraction is computed against the scrubber-time, not now.

## Colours

| Fraction      | Tier      |
| ------------- | --------- |
| `1.0..0.66`   | `:green`  |
| `0.66..0.33`  | `:amber`  |
| `0.33..0.0`   | `:red`    |
| past deadline | `:red`    |
| cancelled / fired / stale / skipped | `:gray` |

## New files

- `tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs` — sub/event install + rAF tick driver + SVG overlay component
- `tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings_helpers.cljc` — pure projection from trace bus → timer records + ring-fraction maths (JVM-runnable)
- `tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_helpers_cljs_test.cljc` — 36 helper deftests
- `tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs` — CLJS wiring tests (registry, composite sub, tick event, hover slot, overlay render paths)

## Modified files

- `tools/causa/src/day8/re_frame2_causa/chart/svg.cljc` — `countdown-ring` SVG primitive (pure data → hiccup; SVG `stroke-dasharray` trick; cancelled-cross overlay)
- `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs` — wire `after-rings/install!` + mount `[after-rings/AfterRingsOverlay positioned]` alongside the existing arc overlay (both hidden in sim mode)
- `tools/causa/test/day8/re_frame2_causa/chart/svg_cljs_test.cljc` — 6 deftests for the ring primitive
- `tools/causa/test/day8/re_frame2_causa/panels/registry_cljs_test.cljs` — catalogue updated (117 subs, 138 events)

## Substrate-contract assumptions

Reads these trace events emitted by `re-frame.machines.{transition,timer}`:

- `:rf.machine.timer/scheduled`                 — arms a record at `(machine-id, state, epoch)` → `:armed`
- `:rf.machine.timer/fired` (`:fired? true`)    — closes record → `:fired`
- `:rf.machine.timer/fired` (`:fired? false`)   — closes record → `:guard-suppressed`
- `:rf.machine.timer/stale-after`               — closes record → `:stale` (uses `:scheduled-epoch`)
- `:rf.machine.timer/cancelled-on-resolution`   — closes record → `:cancelled` (sub-vec re-resolution)
- `:rf.machine.timer/skipped-on-server`         — `:skipped` (SSR no-op)

No substrate change needed; the rings ride existing trace shapes.

## Divergences from bead spec

- **Hover tooltip ships as native SVG `<title>` (v1)** per the bead's divergence allowance. The `:rf.causa/timer-hover` event + slot are plumbed today so a follow-on bead can lift the hover into a rich tooltip without touching subscriber wiring.
- **rAF throttle knob lives in `*tick-min-delta-ms*`** (defaults to 0 = un-throttled). v1 ships at ~60fps because the typical-app `:after`-timer count is small (1-3); a follow-on can tune up if many-timer scenarios show jank.
- **Zombie-eviction backstop**: an armed timer whose `:fires-at` is >5s in the past is dropped from the projection (protects against trace-buffer eviction of the closing `:fired` event).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 821 tests, 0 failures
- [x] `scripts/test-fast-pr.sh` — passes (CLJS node + JVM core + script-helpers + elision + bundle-isolation)
- [x] `cd implementation && npm run test:browser` — 2946 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2957 tests, 8447 assertions, 0 failures
- [x] `cd implementation && npm run test:elision` — production / control bundle sentinels match
- [x] `cd implementation && npm run test:bundle-isolation` — no tools/ leak into production bundles