### PR TITLE
fix(story): variant-row click clears :selected-workspace — workspace mode is no longer one-way

### DIFF
--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -379,11 +379,11 @@
          ;;
          ;; Per rf2-9la06: also stamp `data-test-variant` with the
          ;; active variant id so Playwright specs can scope selectors
-         ;; to the canvas of a specific variant — disambiguates the
-         ;; canvas from sibling workspace cells whose state may not yet
-         ;; have torn down (sidebar `:selected-variant` and
-         ;; `:selected-workspace` are independent slots; clicking a
-         ;; variant doesn't clear a previously-selected workspace).
+         ;; to the canvas of a specific variant.
+         ;; (Per rf2-hscut clicking a variant in the sidebar now clears
+         ;; `:selected-workspace`, so the canvas no longer competes with
+         ;; a stale workspace pane for the main slot. The stamp is
+         ;; retained for cross-route test scoping.)
         [:section (cond-> {:style      (:wrap styles)
                            :aria-label "Variant canvas"
                            :tab-index  "0"}

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -241,8 +241,16 @@
                              (when selected? (:variant-row-active styles)))
          :data-test   "story-sidebar-variant-row"
          :data-variant (str variant-id)
-         :on-click    (fn [_] (state/swap-state!
-                                state/select-variant variant-id))}
+         ;; rf2-hscut — symmetric escape from workspace mode. Selecting a
+         ;; variant clears any previously-selected workspace so the
+         ;; canvas's ws-id short-circuit (`shell.cljs` `main-pane`) yields
+         ;; to the variant branch. Mirror of the workspace-row click
+         ;; below, which clears `:selected-variant`.
+         :on-click    (fn [_]
+                        (state/swap-state!
+                          (fn [s] (-> s
+                                      (state/select-variant variant-id)
+                                      (state/select-workspace nil)))))}
    (when testable? [status-dot status])
    [:span (str "/" (name variant-id))]
    [tag-badges tags]])

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -202,9 +202,10 @@
            errors         (:errors decorator-pack)]
        ;; Per rf2-9la06: stamp `data-test-variant` on each cell so
        ;; Playwright specs can disambiguate workspace cells from each
-       ;; other and from the canvas's variant when both are mounted
-       ;; (sidebar `:selected-variant` and `:selected-workspace` are
-       ;; independent slots; one doesn't clear the other on selection).
+       ;; other and from the canvas's variant when both are mounted.
+       ;; (Per rf2-hscut the sidebar variant/workspace clicks now clear
+       ;; each other's slot, but the `data-test-variant` stamp remains
+       ;; useful for snapshot/test scoping while a workspace is active.)
        [:div {:style (:cell styles)
               :data-test-variant (pr-str variant-id)}
         [:div {:style (:cell-title styles)}

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -76,6 +76,35 @@
     (state/swap-state! state/select-variant :story.foo/bar)
     (is (= :story.foo/bar (:selected-variant (state/get-state))))))
 
+;; rf2-hscut — variant-row click clears the workspace slot so workspace
+;; mode is no longer a one-way door. `main-pane` in `shell.cljs` short-
+;; circuits on `:selected-workspace`, so a variant click that does NOT
+;; clear it is invisible from the canvas. This is the symmetric mirror
+;; of the workspace-row handler which clears `:selected-variant`.
+;;
+;; The click handler lives inline in the private `variant-row` reagent
+;; component (`sidebar.cljs`), so we exercise the same pure swap-state!
+;; composition the closure runs — that is the unit of behaviour the bug
+;; fix codifies.
+(deftest variant-click-clears-workspace-rf2-hscut
+  (testing "selecting a variant from the sidebar clears any selected workspace"
+    (state/swap-state! state/select-workspace :Workspace.nav/all)
+    (is (= :Workspace.nav/all (:selected-workspace (state/get-state))))
+    (state/swap-state!
+      (fn [s] (-> s
+                  (state/select-variant :story.nav/v1)
+                  (state/select-workspace nil))))
+    (is (= :story.nav/v1 (:selected-variant (state/get-state))))
+    (is (nil? (:selected-workspace (state/get-state)))))
+  (testing "mirror of workspace-row click — both row handlers are symmetric"
+    (state/swap-state! state/select-variant :story.nav/v1)
+    (state/swap-state!
+      (fn [s] (-> s
+                  (state/select-workspace :Workspace.nav/all)
+                  (state/select-variant nil))))
+    (is (= :Workspace.nav/all (:selected-workspace (state/get-state))))
+    (is (nil? (:selected-variant (state/get-state))))))
+
 (deftest toggle-tag-filter-flips
   (testing "toggle-tag-filter adds + removes a tag"
     (state/swap-state! state/toggle-tag-filter :dev)

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -73,6 +73,29 @@
       (is (= :Workspace.demo/y (:selected-workspace s2)))
       (is (= :story.a/x (:selected-variant s2))))))
 
+;; rf2-hscut — sidebar variant-row click composes select-variant with
+;; select-workspace nil so workspace mode is no longer a one-way door.
+;; The click handler is a private Reagent closure inside `sidebar.cljs`;
+;; we exercise the same pure composition the closure performs so the
+;; JVM corpus catches a regression without booting Reagent.
+(deftest variant-row-click-symmetric-clear-rf2-hscut
+  (testing "variant-row pipeline sets variant AND clears workspace"
+    (let [s  (-> state/default-shell-state
+                 (state/select-workspace :Workspace.nav/all))
+          s1 (-> s
+                 (state/select-variant :story.nav/v1)
+                 (state/select-workspace nil))]
+      (is (= :story.nav/v1 (:selected-variant s1)))
+      (is (nil? (:selected-workspace s1)))))
+  (testing "mirror — workspace-row pipeline sets workspace AND clears variant"
+    (let [s  (-> state/default-shell-state
+                 (state/select-variant :story.nav/v1))
+          s1 (-> s
+                 (state/select-workspace :Workspace.nav/all)
+                 (state/select-variant nil))]
+      (is (= :Workspace.nav/all (:selected-workspace s1)))
+      (is (nil? (:selected-variant s1))))))
+
 (deftest toggle-tag-filter-pure
   (testing "toggle-tag-filter adds and removes"
     (let [s  state/default-shell-state


### PR DESCRIPTION
## Summary

Bead **rf2-hscut** — 4-line P0 bug fix. Closes the asymmetric escape path documented in `ai/findings/2026-05-18-story-workspace-variant-navigation.md §B`.

Workspace mode in Story was a one-way door: once a user clicked a workspace in the sidebar, the variant-row click handler wrote `:selected-variant` but never cleared `:selected-workspace`. `main-pane` (`shell.cljs:580-589`) short-circuits on `ws-id` first, so the canvas kept showing the workspace and there was no escape gesture anywhere in the UI.

The fix mirrors the workspace-row click handler (which already explicitly clears `:selected-variant`). The pure transition composition matches the same pattern used by `command_palette/view.cljs`.

## The 4-line fix

`tools/story/src/re_frame/story/ui/sidebar.cljs` — variant-row `:on-click`:

```clojure
;; Before:
:on-click (fn [_] (state/swap-state! state/select-variant variant-id))

;; After:
:on-click (fn [_]
            (state/swap-state!
              (fn [s] (-> s
                          (state/select-variant variant-id)
                          (state/select-workspace nil)))))
```

## Navigation flow — before / after

```
BEFORE (one-way door)                  AFTER (symmetric escape)

sidebar variant click                  sidebar variant click
  → :selected-variant = vid              → :selected-variant = vid
  → :selected-workspace UNCHANGED        → :selected-workspace = nil
                                                       ↓
main-pane (cond ws-id …)               main-pane (cond ws-id …)
  ws-id wins → workspace pane            ws-id nil → variant branch
  canvas shows OLD workspace             canvas shows new variant
  user is TRAPPED                        ✓ escape gesture works
```

## What changed

- `tools/story/src/re_frame/story/ui/sidebar.cljs` — variant-row click now clears workspace (the fix).
- `tools/story/src/re_frame/story/ui/workspace.cljc` — known-and-unfixed comment at L205-207 updated.
- `tools/story/src/re_frame/story/ui/canvas.cljs` — known-and-unfixed comment at L382-386 updated.
- `tools/story/test/re_frame/story_ui_test.clj` — JVM test asserts the symmetric pure transition.
- `tools/story/test/re_frame/story_ui_cljs_test.cljs` — CLJS test asserts the round-trip through `swap-state!`.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 2943 tests, 0 failures
- [x] `cd tools/story && clojure -M:test` — 696 tests, 0 failures
- [x] `cd implementation && npm run test:browser` — 2932 tests, 0 failures
- [ ] Manual: pick a workspace in the sidebar → click a variant row → canvas shows the variant (not the workspace)
- [ ] Manual: pick a variant → click a workspace row → canvas shows the workspace (regression check for the inverse)