### PR TITLE
fix(causa): Story-aware modal positioning — workspace popups no longer kill window

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -50,22 +50,28 @@
              :refer [tokens type-scale sans-stack mono-stack]]))
 
 ;; ---- styles --------------------------------------------------------------
+;;
+;; Backdrop honours `:rf.causa/modal-positioning` (rf2-om6fa). `:fixed`
+;; (production default) keeps the full-viewport overlay with max-int
+;; z-index (one above the palette so an edit popup opened over an
+;; open palette wins focus — palette is z 2147483646 per rf2-wm7z4).
+;; `:absolute` (Story testbeds) confines the backdrop to the shell
+;; cell and drops the z-index to a sane in-cell layer.
 
-(defn- backdrop-style []
-  {:position         "fixed"
-   :top              0
-   :left             0
-   :right            0
-   :bottom           0
-   :background       "rgba(0,0,0,0.55)"
-   :backdrop-filter  "blur(2px)"
-   :display          "flex"
-   :align-items      "flex-start"
-   :justify-content  "center"
-   :padding-top      "12vh"
-   ;; One above the palette so an edit popup opened over an open
-   ;; palette wins focus; the palette is z 2147483646 (rf2-wm7z4).
-   :z-index          2147483647})
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.55)"
+     :backdrop-filter  "blur(2px)"
+     :display          "flex"
+     :align-items      "flex-start"
+     :justify-content  "center"
+     :padding-top      (if absolute? "8%" "12vh")
+     :z-index          (if absolute? 101 2147483647)}))
 
 (defn- dialog-style []
   {:width            "420px"
@@ -251,21 +257,23 @@
   "The popup body. Caller (`filters/Modal`) gates the mount on
   `:rf.causa/edit-popup-open?`."
   []
-  (let [trigger @(rf/subscribe [:rf.causa/edit-popup-trigger])
-        draft   @(rf/subscribe [:rf.causa/edit-popup-draft])
-        mode    (or (:mode draft) :in)
-        scope   (or (:scope draft) #{:event-id})
-        editing? (= :pill (:source trigger))
-        title    (case (:source trigger)
-                   :pill    "Edit filter"
-                   :context "Add filter for this event"
-                   "Add filter")
+  (let [trigger     @(rf/subscribe [:rf.causa/edit-popup-trigger])
+        draft       @(rf/subscribe [:rf.causa/edit-popup-draft])
+        positioning @(rf/subscribe [:rf.causa/modal-positioning])
+        mode        (or (:mode draft) :in)
+        scope       (or (:scope draft) #{:event-id})
+        editing?    (= :pill (:source trigger))
+        title       (case (:source trigger)
+                      :pill    "Edit filter"
+                      :context "Add filter for this event"
+                      "Add filter")
         ;; Apply is enabled when the pattern is non-blank.
-        can-apply? (let [p (:pattern draft)]
-                     (and (string? p) (seq (clojure.string/trim p))))]
+        can-apply?  (let [p (:pattern draft)]
+                      (and (string? p) (seq (clojure.string/trim p))))]
     [:div {:data-testid "rf-causa-edit-popup-backdrop"
+           :data-rf-causa-modal-positioning (name (or positioning :fixed))
            :on-click    #(rf/dispatch [:rf.causa/close-edit-popup] {:frame :rf/causa})
-           :style       (backdrop-style)}
+           :style       (backdrop-style positioning)}
      [:div {:data-testid "rf-causa-edit-popup-dialog"
             :on-click    #(.stopPropagation %)
             :style       (dialog-style)}

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -411,18 +411,24 @@
       (render-cascade cascade nil))))
 
 ;; ---- popover (overlay) ---------------------------------------------------
+;;
+;; Backdrop honours `:rf.causa/modal-positioning` (rf2-om6fa).
+;; `:fixed` (production default) — full-viewport overlay. `:absolute`
+;; (Story testbeds) — backdrop confined to the shell cell with a
+;; sane in-cell z-index.
 
-(defn- backdrop-style []
-  {:position         "fixed"
-   :top              0
-   :left             0
-   :right            0
-   :bottom           0
-   :background       "rgba(0,0,0,0.18)"
-   :display          "flex"
-   :align-items      "center"
-   :justify-content  "center"
-   :z-index          2147483644})
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.18)"
+     :display          "flex"
+     :align-items      "center"
+     :justify-content  "center"
+     :z-index          (if absolute? 97 2147483644)}))
 
 (defn- dialog-style []
   {:width            "720px"
@@ -455,15 +461,17 @@
   cascade body inside the dialog."
   []
   (when @(rf/subscribe [:rf.causa/cancellation-cascade-popover-open?])
-    (let [cascade @(rf/subscribe [:rf.causa/cancellation-cascade-for-focused-event])
-          close   (fn [_]
-                    (rf/dispatch [:rf.causa/cancellation-cascade-close]
-                                 {:frame :rf/causa}))]
+    (let [cascade     @(rf/subscribe [:rf.causa/cancellation-cascade-for-focused-event])
+          positioning @(rf/subscribe [:rf.causa/modal-positioning])
+          close       (fn [_]
+                        (rf/dispatch [:rf.causa/cancellation-cascade-close]
+                                     {:frame :rf/causa}))]
       [:div {:data-testid "rf-causa-cancellation-cascade-popover-backdrop"
+             :data-rf-causa-modal-positioning (name (or positioning :fixed))
              :on-click    close
              :on-key-down handle-popover-keydown
              :tab-index   -1
-             :style       (backdrop-style)}
+             :style       (backdrop-style positioning)}
        [:div {:data-testid "rf-causa-cancellation-cascade-popover-dialog"
               :on-click    #(.stopPropagation %)
               :on-key-down handle-popover-keydown

--- a/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
@@ -38,18 +38,25 @@
              :refer [tokens sans-stack mono-stack type-scale]]))
 
 ;; ---- styles --------------------------------------------------------------
+;;
+;; Backdrop honours `:rf.causa/modal-positioning` (rf2-om6fa).
+;; `:fixed` (production default) — full-viewport 15% dim per spec §10.
+;; `:absolute` (Story testbeds) — backdrop confined to the shell
+;; cell with a sane in-cell z-index so workspace cells don't paint
+;; over each other.
 
-(defn- backdrop-style []
-  {:position         "fixed"
-   :top              0
-   :left             0
-   :right            0
-   :bottom           0
-   :background       "rgba(0,0,0,0.15)"     ; spec §10 — 15% dim
-   :display          "flex"
-   :align-items      "center"
-   :justify-content  "center"
-   :z-index          2147483645})
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.15)"     ; spec §10 — 15% dim
+     :display          "flex"
+     :align-items      "center"
+     :justify-content  "center"
+     :z-index          (if absolute? 99 2147483645)}))
 
 (defn- dialog-style []
   {:width            "640px"      ; spec §10 — default 640×480
@@ -166,13 +173,15 @@
   "The hiccup for the open popover. Caller has gated on
   `:rf.causa/causality-popover-open?` already."
   []
-  (let [payload @(rf/subscribe [:rf.causa/causality-popover-payload])
-        layout  @(rf/subscribe [:rf.causa/causality-popover-layout])]
+  (let [payload     @(rf/subscribe [:rf.causa/causality-popover-payload])
+        layout      @(rf/subscribe [:rf.causa/causality-popover-layout])
+        positioning @(rf/subscribe [:rf.causa/modal-positioning])]
     [:div {:data-testid "rf-causa-popover-backdrop"
+           :data-rf-causa-modal-positioning (name (or positioning :fixed))
            :on-click    #(rf/dispatch [:rf.causa/causality-popover-close])
            :on-key-down handle-popover-keydown
            :tab-index   -1
-           :style       (backdrop-style)}
+           :style       (backdrop-style positioning)}
      [:div {:data-testid "rf-causa-popover-dialog"
             :data-rf-causa-mode "popover"
             :on-click    #(.stopPropagation %)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -152,6 +152,32 @@
       (fn [db _query]
         (get db :selected-tab :event)))
 
+    ;; ---- Modal positioning (rf2-om6fa) ----
+    ;;
+    ;; Every Causa modal (Settings popup, auto-filter edit popup,
+    ;; Causality popover, Share modal, Cancellation cascade popover)
+    ;; defaults to `position: fixed; inset: 0; z-index: 2_147_483_64x`
+    ;; — the right shape for production where the shell covers the
+    ;; host app. In a Story testbed where multiple shell instances
+    ;; render side-by-side in workspace cells, that geometry escapes
+    ;; the cell and paints over the whole Story shell ("popup kills
+    ;; window"). Story testbeds pass `:modal-positioning :absolute`
+    ;; on `shell-view` so each cell's modals stay inside the cell.
+    ;;
+    ;; The opt lands here in app-db so every modal can read it via
+    ;; one sub regardless of where in the tree it mounts (popovers
+    ;; opened from keybindings, modals opened from imperative
+    ;; dispatches, etc.). Default `:fixed` preserves production
+    ;; behaviour; `:absolute` is the testbed-scoped containment mode.
+    (rf/reg-sub :rf.causa/modal-positioning
+      (fn [db _query]
+        (get db :modal-positioning :fixed)))
+
+    (rf/reg-event-db :rf.causa/set-modal-positioning
+      {:rf.trace/no-emit? true}
+      (fn [db [_ positioning]]
+        (assoc db :modal-positioning (or positioning :fixed))))
+
     ;; ---- 4-layer chrome — active filter pills (rf2-xy4yb / spec/018 §7) ----
     ;;
     ;; The ribbon's filter cluster reads `:rf.causa/active-filters` —

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -27,20 +27,29 @@
   (boolean (find-ns 'day8.re-frame2-causa.filters)))
 
 ;; ---- styles --------------------------------------------------------------
+;;
+;; The backdrop's `:position` and `:z-index` honour the
+;; `:rf.causa/modal-positioning` opt published by `shell-view` (rf2-om6fa).
+;; `:fixed` (default, production) — full-viewport overlay at the
+;; chrome's max-int stacking layer. `:absolute` (Story testbeds) —
+;; contained to the nearest positioned ancestor (the shell's outer
+;; `<div>` is `position: relative` in `:inline` mode) with a sane
+;; z-index so the cell's modals never paint over Story chrome.
 
-(defn- backdrop-style []
-  {:position         "fixed"
-   :top              0
-   :left             0
-   :right            0
-   :bottom           0
-   :background       "rgba(0,0,0,0.55)"
-   :backdrop-filter  "blur(2px)"
-   :display          "flex"
-   :align-items      "flex-start"
-   :justify-content  "center"
-   :padding-top      "8vh"
-   :z-index          2147483646})
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.55)"
+     :backdrop-filter  "blur(2px)"
+     :display          "flex"
+     :align-items      "flex-start"
+     :justify-content  "center"
+     :padding-top      (if absolute? "5%" "8vh")
+     :z-index          (if absolute? 100 2147483646)}))
 
 (defn- dialog-style []
   {:width            "600px"
@@ -338,11 +347,13 @@
   and always renders. ESC closes; click outside the dialog closes;
   the ✕ button in the header closes."
   []
-  (let [active-tab @(rf/subscribe [:rf.causa/settings-active-tab])]
+  (let [active-tab  @(rf/subscribe [:rf.causa/settings-active-tab])
+        positioning @(rf/subscribe [:rf.causa/modal-positioning])]
     [:div {:data-testid "rf-causa-settings-backdrop"
+           :data-rf-causa-modal-positioning (name (or positioning :fixed))
            :on-click    #(rf/dispatch [:rf.causa/settings-close])
            :on-key-down handle-keydown
-           :style       (backdrop-style)}
+           :style       (backdrop-style positioning)}
      [:div {:data-testid "rf-causa-settings-dialog"
             :data-rf-causa-mode "settings"
             :on-click    #(.stopPropagation %)

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -25,19 +25,25 @@
              :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- view helpers -------------------------------------------------------
+;;
+;; Backdrop honours `:rf.causa/modal-positioning` (rf2-om6fa).
+;; `:fixed` (production default) — full-viewport overlay. `:absolute`
+;; (Story testbeds) — backdrop confined to the shell cell with a
+;; sane in-cell z-index.
 
-(defn- backdrop-style []
-  {:position        "fixed"
-   :top             0
-   :left            0
-   :right           0
-   :bottom          0
-   :background      "rgba(8, 9, 12, 0.65)"
-   :backdrop-filter "blur(2px)"
-   :display         "flex"
-   :align-items     "center"
-   :justify-content "center"
-   :z-index         2147483100})
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position        (if absolute? "absolute" "fixed")
+     :top             0
+     :left            0
+     :right           0
+     :bottom          0
+     :background      "rgba(8, 9, 12, 0.65)"
+     :backdrop-filter "blur(2px)"
+     :display         "flex"
+     :align-items     "center"
+     :justify-content "center"
+     :z-index         (if absolute? 98 2147483100)}))
 
 (defn- dialog-style []
   {:background    (:bg-1 tokens)
@@ -249,8 +255,10 @@
   resolve through the React-context tier to `:rf/causa`."
   []
   (when @(rf/subscribe [:rf.causa/share-modal-open?])
-    [:div {:data-testid "rf-causa-share-modal-backdrop"
-           :on-click    #(rf/dispatch [:rf.causa/share-modal-close]
-                                      {:frame :rf/causa})
-           :style       (backdrop-style)}
-     (share-dialog)]))
+    (let [positioning @(rf/subscribe [:rf.causa/modal-positioning])]
+      [:div {:data-testid "rf-causa-share-modal-backdrop"
+             :data-rf-causa-modal-positioning (name (or positioning :fixed))
+             :on-click    #(rf/dispatch [:rf.causa/share-modal-close]
+                                        {:frame :rf/causa})
+             :style       (backdrop-style positioning)}
+       (share-dialog)])))

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -655,8 +655,46 @@
   provider (it's the mount root) so React-context inside `shell-view`'s
   body still resolves to the default — every subscribing child is its
   own reg-view component so the surrounding `:rf/causa` Provider
-  reaches them via React context."
-  [& [{:keys [mode] :or {mode :inline}}]]
+  reaches them via React context.
+
+  ## `:modal-positioning` opt (rf2-om6fa)
+
+  Default `:fixed` — modal backdrops use `position: fixed; inset: 0`
+  with max-int z-indexes so they cover the entire host viewport. The
+  right shape for production where the shell IS the global overlay.
+
+  Story testbeds that mount N shell cells side-by-side pass
+  `:modal-positioning :absolute` so each cell's modals stay confined
+  to the cell (backdrop becomes `position: absolute; inset: 0` with
+  a sane z-index of 100). The cell wrapper must establish a
+  positioning context (`position: relative`) for the absolute backdrop
+  to be contained — `:inline` mode already sets that on the shell's
+  outer `<div>`, so the contract is satisfied out of the box.
+
+  Note: with `:absolute` positioning the modals are visually contained
+  per-cell, but the open-state flags (`:rf.causa/<modal>-open?`)
+  still live in the process-global `:rf/causa` frame. Opening Settings
+  in one cell opens Settings in every cell that mounts the shell
+  against the same frame. Frame-scoping is the follow-on fix —
+  see the bead trail."
+  [& [{:keys [mode modal-positioning]
+       :or   {mode :inline modal-positioning :fixed}}]]
+  ;; Idempotent app-db write so every modal can read the positioning
+  ;; via the `:rf.causa/modal-positioning` sub. Guarded against
+  ;; re-dispatch by comparing the current slot to the prop — once the
+  ;; slot matches the prop, the `when` short-circuits and the render
+  ;; quiesces. `dispatch-sync` so the slot lands BEFORE the modal
+  ;; children mount and read the sub on this same render pass; without
+  ;; sync the first paint of a fresh shell would render every modal's
+  ;; backdrop at the default `:fixed` before the async router drains.
+  ;; Sub + dispatch route via `:rf/causa` so the read/write lands on
+  ;; Causa's app-db (`shell-view` itself sits OUTSIDE the
+  ;; `frame-provider` in the tree below — the React-context tier
+  ;; doesn't reach this call site, hence the explicit frame arg).
+  (let [current-positioning @(rf/subscribe :rf/causa [:rf.causa/modal-positioning])]
+    (when (not= current-positioning modal-positioning)
+      (rf/dispatch-sync [:rf.causa/set-modal-positioning modal-positioning]
+                        {:frame :rf/causa})))
   [rf/frame-provider {:frame :rf/causa}
    [:div {:data-testid "rf-causa-shell"
           ;; Per rf2-zkfiz Q1-9 the spec-published mode axis is
@@ -665,6 +703,10 @@
           ;; was a duplicate axis and is gone — tests + testbeds read
           ;; the rf-causa-prefixed name everywhere.
           :data-rf-causa-mode (name mode)
+          ;; rf2-om6fa — the positioning attribute is published on the
+          ;; shell root for testbed assertions; the modals read the
+          ;; sub directly rather than via DOM lookup.
+          :data-rf-causa-modal-positioning (name modal-positioning)
           :style       (merge
                          {:width            "100%"
                           :height           "100%"

--- a/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/edit_popup_cljs_test.cljs
@@ -269,3 +269,66 @@
   (let [filters (frame-sub [:rf.causa/active-filters])]
     (is (= [{:pattern :mouse-move}] (:out filters)))
     (is (= [] (:in filters)))))
+
+;; -------------------------------------------------------------------------
+;; (8) Modal positioning (rf2-om6fa)
+;; -------------------------------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (tree-seq (some-fn vector? seq?) seq (expand-tree tree))))
+
+(deftest backdrop-defaults-to-fixed-positioning
+  (testing "with no :rf.causa/modal-positioning slot set, the edit
+            popup backdrop renders position: fixed at the production
+            z-index"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (rf/with-frame :rf/causa
+      (let [rendered (filters/Modal)
+            backdrop (find-by-testid rendered "rf-causa-edit-popup-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "fixed" (:position style)))
+        (is (= 2147483647 (:z-index style))
+            "production z-index unchanged — one above the palette")
+        (is (= "fixed"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+(deftest backdrop-honours-absolute-positioning
+  (testing "after `:rf.causa/set-modal-positioning :absolute` the
+            backdrop switches to position: absolute"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/open-edit-popup {:source :add :mode :in}])
+    (frame-dispatch [:rf.causa/set-modal-positioning :absolute])
+    (rf/with-frame :rf/causa
+      (let [rendered (filters/Modal)
+            backdrop (find-by-testid rendered "rf-causa-edit-popup-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "absolute" (:position style)))
+        (is (< (:z-index style) 1000)
+            "z-index drops to a sane in-cell value")
+        (is (= "absolute"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
@@ -273,3 +273,40 @@
       (let [db @(rf/subscribe [:rf/app-db])]
         (is (not (contains? db :cancellation-cascade-popover-open?))
             "no leak into the host's :rf/default frame")))))
+
+;; ---- (7) Modal positioning (rf2-om6fa) -------------------------------
+
+(deftest popover-backdrop-defaults-to-fixed-positioning
+  (testing "with no :rf.causa/modal-positioning slot set, the
+            cancellation-cascade popover backdrop renders position:
+            fixed at the production z-index"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open nil]))
+    (rf/with-frame :rf/causa
+      (let [tree     (cc/Popover)
+            backdrop (find-by-testid tree "rf-causa-cancellation-cascade-popover-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "fixed" (:position style)))
+        (is (= 2147483644 (:z-index style)))
+        (is (= "fixed"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+(deftest popover-backdrop-honours-absolute-positioning
+  (testing "after `:rf.causa/set-modal-positioning :absolute` the
+            cancellation-cascade backdrop switches to position:
+            absolute with a sane in-cell z-index"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open nil])
+      (rf/dispatch-sync [:rf.causa/set-modal-positioning :absolute]))
+    (rf/with-frame :rf/causa
+      (let [tree     (cc/Popover)
+            backdrop (find-by-testid tree "rf-causa-cancellation-cascade-popover-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "absolute" (:position style)))
+        (is (< (:z-index style) 1000))
+        (is (= "absolute"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))

--- a/tools/causa/test/day8/re_frame2_causa/popover/causality_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/popover/causality_cljs_test.cljs
@@ -249,3 +249,41 @@
       (let [tree (popover/Popover)]
         (is (some? (find-by-testid tree "rf-causa-popover-empty"))
             "the empty-state surface renders inside the body slot")))))
+
+;; ---- Modal positioning (rf2-om6fa) -------------------------------------
+
+(deftest backdrop-defaults-to-fixed-positioning
+  (testing "with no :rf.causa/modal-positioning slot set, the
+            causality popover backdrop renders position: fixed at the
+            production z-index"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/causality-popover-open]))
+    (rf/with-frame :rf/causa
+      (let [tree     (popover/Popover)
+            backdrop (find-by-testid tree "rf-causa-popover-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "fixed" (:position style)))
+        (is (= 2147483645 (:z-index style)))
+        (is (= "fixed"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+(deftest backdrop-honours-absolute-positioning
+  (testing "after `:rf.causa/set-modal-positioning :absolute` the
+            causality backdrop switches to position: absolute with a
+            sane in-cell z-index"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/causality-popover-open])
+      (rf/dispatch-sync [:rf.causa/set-modal-positioning :absolute]))
+    (rf/with-frame :rf/causa
+      (let [tree     (popover/Popover)
+            backdrop (find-by-testid tree "rf-causa-popover-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "absolute" (:position style)))
+        (is (< (:z-index style) 1000)
+            "z-index drops to a sane in-cell value")
+        (is (= "absolute"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -200,6 +200,8 @@
    :rf.causa/selected-fx-id
    :rf.causa/selected-machine-id
    :rf.causa/selected-mismatch-id
+   ;; rf2-om6fa — Story-aware modal positioning opt.
+   :rf.causa/modal-positioning
    :rf.causa/selected-panel
    :rf.causa/selected-route-id
    :rf.causa/selected-tab
@@ -353,6 +355,8 @@
    :rf.causa/set-mcp-since-seconds
    :rf.causa/set-mode-c-cluster-by
    :rf.causa/set-mode-c-context-key
+   ;; rf2-om6fa — Story-aware modal positioning opt.
+   :rf.causa/set-modal-positioning
    ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).
    :rf.causa/set-now-ms-override-for-test
    :rf.causa/set-performance-budget-ms
@@ -485,7 +489,7 @@
           (str "expected :fx handler for " fx-id)))))
 
 (deftest registry-counts-match-bead
-  (testing "registry holds exactly 119 subs + 140 events + 7 fxs"
+  (testing "registry holds exactly 125 subs + 144 events + 7 fxs"
     ;; 66 baseline + 6 palette (rf2-wm7z4, post-co-pilot-removal rf2-s3vx5):
     ;;   palette-active-item / palette-cursor / palette-index /
     ;;   palette-open? / palette-query / palette-results
@@ -539,7 +543,9 @@
     ;; + 2 structural-diff engine (rf2-gfxmk Phase 1):
     ;;   :rf.causa/selected-epoch-annotated-tree +
     ;;   :rf.causa/selected-epoch-sections.
-    (is (= 124 (count all-sub-names)))
+    ;; + 1 modal positioning (rf2-om6fa):
+    ;;   :rf.causa/modal-positioning — Story-aware modal positioning opt.
+    (is (= 125 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -601,7 +607,9 @@
     ;;   (rich-tooltip lifecycle slot) +
     ;;   :rf.causa/set-now-ms-override-for-test (deterministic timestamp
     ;;   pin for the CLJS-side test surface).
-    (is (= 143 (count all-event-names)))
+    ;; + 1 modal positioning (rf2-om6fa):
+    ;;   :rf.causa/set-modal-positioning — Story-aware shell-view opt.
+    (is (= 144 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
@@ -200,3 +200,45 @@
   (rf/with-frame :rf/causa
     (rf/dispatch-sync [:rf.causa/settings-toggle]))
   (is (false? (boolean (:settings-open? (rf/get-frame-db :rf/causa))))))
+
+;; ---- Modal positioning (rf2-om6fa) -------------------------------------
+
+(deftest backdrop-defaults-to-fixed-positioning
+  (testing "with no :rf.causa/modal-positioning slot set, backdrop
+            renders position: fixed at the production z-index"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (rf/with-frame :rf/causa
+      (let [rendered (popup/Modal)
+            backdrop (find-by-testid rendered "rf-causa-settings-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "fixed" (:position style))
+            ":position is :fixed by default")
+        (is (= 2147483646 (:z-index style))
+            "production z-index unchanged")
+        (is (= "fixed"
+               (:data-rf-causa-modal-positioning (second backdrop)))
+            "data attribute echoes the resolved positioning")))))
+
+(deftest backdrop-honours-absolute-positioning
+  (testing "after `:rf.causa/set-modal-positioning :absolute` the
+            backdrop switches to position: absolute with a sane
+            in-cell z-index"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open])
+      (rf/dispatch-sync [:rf.causa/set-modal-positioning :absolute]))
+    (rf/with-frame :rf/causa
+      (let [rendered (popup/Modal)
+            backdrop (find-by-testid rendered "rf-causa-settings-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "absolute" (:position style))
+            ":position is :absolute under the testbed opt")
+        (is (< (:z-index style) 1000)
+            "z-index drops to a sane in-cell value")
+        (is (= "absolute"
+               (:data-rf-causa-modal-positioning (second backdrop)))
+            "data attribute echoes the resolved positioning")))))

--- a/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/share_cljs_test.cljs
@@ -21,9 +21,10 @@
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.share :as share]
+            [day8.re-frame2-causa.share-modal :as share-modal]
             [day8.re-frame2-causa.test-support :as causa-test-support]
-            [day8.re-frame2-causa.trace-bus :as trace-bus]
-            [day8.re-frame2-causa.share :as share]))
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -263,3 +264,62 @@
         "modal-open flag lands on Causa")
     (is (nil? (:share/modal-open? default-db))
         "host frame is untouched")))
+
+;; ---- Modal positioning (rf2-om6fa) -------------------------------------
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (tree-seq (some-fn vector? seq?) seq (expand-tree tree))))
+
+(deftest share-modal-backdrop-defaults-to-fixed-positioning
+  (testing "with no :rf.causa/modal-positioning slot set, the share
+            modal backdrop renders position: fixed at the production
+            z-index"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/share-modal-open]))
+    (rf/with-frame :rf/causa
+      (let [tree     (share-modal/Modal)
+            backdrop (find-by-testid tree "rf-causa-share-modal-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "fixed" (:position style)))
+        (is (= 2147483100 (:z-index style)))
+        (is (= "fixed"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+(deftest share-modal-backdrop-honours-absolute-positioning
+  (testing "after `:rf.causa/set-modal-positioning :absolute` the
+            share modal backdrop switches to position: absolute"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/share-modal-open])
+      (rf/dispatch-sync [:rf.causa/set-modal-positioning :absolute]))
+    (rf/with-frame :rf/causa
+      (let [tree     (share-modal/Modal)
+            backdrop (find-by-testid tree "rf-causa-share-modal-backdrop")
+            style    (:style (second backdrop))]
+        (is (some? backdrop))
+        (is (= "absolute" (:position style)))
+        (is (< (:z-index style) 1000))
+        (is (= "absolute"
+               (:data-rf-causa-modal-positioning (second backdrop))))))))

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -543,3 +543,57 @@
   (is (= :foo/bar (shell/event-id-of-cascade {:event [:foo/bar {:x 1}]})))
   (is (nil? (shell/event-id-of-cascade {:event nil}))
       "missing event → nil"))
+
+;; -------------------------------------------------------------------------
+;; (9) :modal-positioning opt — rf2-om6fa
+;; -------------------------------------------------------------------------
+;;
+;; The opt threads through `shell-view` into `:rf/causa`'s app-db so every
+;; modal can read it via the `:rf.causa/modal-positioning` sub. Default
+;; `:fixed` preserves production behaviour; `:absolute` is the testbed-
+;; scoped containment mode (Story workspaces).
+
+(deftest modal-positioning-defaults-to-fixed
+  (testing "shell-view with no opt renders :fixed on the shell-root
+            attribute. Slot stays unwritten (sub falls back to :fixed
+            via `(get db :modal-positioning :fixed)`) — no dispatch
+            fires because the sub already matches the default prop."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            shell (find-by-testid tree "rf-causa-shell")]
+        (is (some? shell))
+        (is (= "fixed" (:data-rf-causa-modal-positioning (second shell)))
+            "default attribute is :fixed")))
+    (rf/with-frame :rf/causa
+      (is (= :fixed @(rf/subscribe [:rf.causa/modal-positioning]))
+          "sub resolves to :fixed default"))))
+
+(deftest modal-positioning-absolute-opt-publishes-attribute
+  (testing "shell-view with :modal-positioning :absolute seeds the
+            slot via dispatch-sync and writes
+            data-rf-causa-modal-positioning=\"absolute\" on the shell
+            root"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree  (shell/shell-view {:modal-positioning :absolute})
+            shell (find-by-testid tree "rf-causa-shell")]
+        (is (some? shell))
+        (is (= "absolute" (:data-rf-causa-modal-positioning (second shell)))
+            "explicit attribute is :absolute"))
+      (is (= :absolute @(rf/subscribe [:rf.causa/modal-positioning]))
+          "sub returns :absolute after the first render"))))
+
+(deftest modal-positioning-toggle-round-trips
+  (testing "flipping the opt re-seeds the slot — render with :absolute,
+            then render with :fixed (no opt) settles back to :fixed"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (shell/shell-view {:modal-positioning :absolute}))
+    (rf/with-frame :rf/causa
+      (is (= :absolute @(rf/subscribe [:rf.causa/modal-positioning]))))
+    (rf/with-frame :rf/causa
+      (shell/shell-view))
+    (rf/with-frame :rf/causa
+      (is (= :fixed @(rf/subscribe [:rf.causa/modal-positioning]))
+          "no-opt render re-defaults the slot to :fixed"))))

--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -87,26 +87,32 @@ function waitForReady(url, timeoutMs) {
     // The chrome workspace uses :layout :tabs (not :variants-grid)
     // so it isn't subject to the same shared-cell concern as the
     // grid workspaces; we walk it last as a round-trip target.
-    // The chrome-follow-on workspaces (rf2-mpn8m settings popup,
-    // rf2-kbrkx auto-filter edit-popup, rf2-pt1e1 causality popover)
-    // are deliberately excluded from this single-session walk. They
-    // mount the chrome shell which writes to `:rf/causa` AND opens
-    // a global modal whose backdrop covers the entire viewport. The
-    // modal state lives in the process-global `:rf/causa` frame, so
-    // it persists across workspace switches (Story tears down the
-    // variant tree but the frame state survives). The sibling
-    // `_smoke.cjs` covers these workspaces on FRESH pages where the
-    // shared-state caveat is harmless; the rf2-kgn0c IDeref-null
-    // regression that THIS smoke pins is orthogonal to modal state.
+    //
+    // Per rf2-om6fa: the chrome-follow-on workspaces (settings
+    // popup, auto-filter edit-popup, causality popover) used to be
+    // excluded from this walk because their modals mounted at
+    // `position: fixed; inset: 0` with max-int z-index, stacking
+    // N full-viewport backdrops over the Story shell. The
+    // `:modal-positioning :absolute` opt threaded through
+    // `chrome-shell` confines each cell's modals to the cell's
+    // positioning context with a sane in-cell z-index, so they
+    // can now ride the single-session walk without painting over
+    // each other. Modal open-state still lives in the process-
+    // global `:rf/causa` frame (per-frame scoping is a follow-on
+    // — see the bead trail) but the visual contract is now
+    // contained per cell.
     const walk = [
-      { name: 'Workspace.causa.event/all',    expectedAtLeast: 12 },
-      { name: 'Workspace.causa.app-db/all',   expectedAtLeast: 12 },
-      { name: 'Workspace.causa.views/all',    expectedAtLeast: 7  },
-      { name: 'Workspace.causa.trace/all',    expectedAtLeast: 10 },
-      { name: 'Workspace.causa.machines/all', expectedAtLeast: 6  },
-      { name: 'Workspace.causa.issues/all',   expectedAtLeast: 11 },
-      { name: 'Workspace.causa.event/all',    expectedAtLeast: 12 }, // round-trip
-      { name: 'Workspace.causa.app-db/all',   expectedAtLeast: 12 }, // round-trip
+      { name: 'Workspace.causa.event/all',           expectedAtLeast: 12 },
+      { name: 'Workspace.causa.app-db/all',          expectedAtLeast: 12 },
+      { name: 'Workspace.causa.views/all',           expectedAtLeast: 7  },
+      { name: 'Workspace.causa.trace/all',           expectedAtLeast: 10 },
+      { name: 'Workspace.causa.machines/all',        expectedAtLeast: 6  },
+      { name: 'Workspace.causa.issues/all',          expectedAtLeast: 11 },
+      { name: 'Workspace.causa.settings-popup/all',  expectedAtLeast: 4  },
+      { name: 'Workspace.causa.filters/all',         expectedAtLeast: 5  },
+      { name: 'Workspace.causa.causality-popover/all', expectedAtLeast: 4 },
+      { name: 'Workspace.causa.event/all',           expectedAtLeast: 12 }, // round-trip
+      { name: 'Workspace.causa.app-db/all',          expectedAtLeast: 12 }, // round-trip
     ];
 
     // Per rf2-sszlr: the rf2-kgn0c regression gate this smoke pins is

--- a/tools/causa/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/panel_views.cljs
@@ -65,8 +65,16 @@
 (def ^:private card-style
   "Card chrome around an embedded panel — gives the variants-grid a
   consistent visual shell with a labelled border so a reviewer can
-  spot the panel boundary."
-  {:height          "520px"
+  spot the panel boundary.
+
+  `:position :relative` (rf2-om6fa) — establishes the positioning
+  context for `:modal-positioning :absolute` modal backdrops mounted
+  inside the chrome shell. The shell's `:inline` mode already sets
+  its outer `<div>` to `position: relative`, but pinning it on the
+  card too keeps containment robust against future tweaks to the
+  shell's outer styling."
+  {:position        "relative"
+   :height          "520px"
    :width           "100%"
    :display         "flex"
    :flex-direction  "column"
@@ -134,11 +142,25 @@
   per spec/018-Event-Spine.md §2. The shell sits inside its own
   `[frame-provider {:frame :rf/causa}]` (per shell.cljs); variant
   seed events therefore dispatch with `{:frame :rf/causa}` so the
-  reads land where the shell reads."
+  reads land where the shell reads.
+
+  ## `:modal-positioning :absolute` (rf2-om6fa)
+
+  Story workspaces mount multiple chrome cells side-by-side. With
+  the production default `:fixed` positioning every cell's modal
+  backdrop would paint over the entire viewport at max-int z-index
+  (`position: fixed; inset: 0`), and a workspace of N cells would
+  stack N full-viewport backdrops over the Story shell — popup
+  kills window. `:absolute` confines each cell's modals to the
+  cell's positioning context (the card's `:position :relative`
+  established by `chrome-card-style` / `card-style`) with a sane
+  in-cell z-index, so per-cell modals can be opened, dismissed, and
+  inspected without leaking into the Story chrome."
   [_args]
   [:div {:style       chrome-card-style
          :data-testid "panel-gallery-chrome-card"}
-   [shell/shell-view {:mode :inline}]])
+   [shell/shell-view {:mode :inline
+                      :modal-positioning :absolute}]])
 
 ;; ---- registration --------------------------------------------------------
 


### PR DESCRIPTION
## Bug class

`:rf/causa` is a process-global frame; every chrome cell in a Story workspace shares one `:rf.causa/<modal>-open?` flag, and each modal backdrop mounts at `position: fixed; inset: 0` with max-int z-index. Workspaces that render multiple chrome cells side-by-side (settings popup, auto-filter edit popup, causality popover, share modal, cancellation cascade popover) stack N full-viewport backdrops over the entire Story shell. Sidebar, toolbar, right-rail — everything unclickable. Closing the topmost backdrop reveals the next one; state survives workspace teardown because the global frame outlives the React unmount. Documented in `ai/findings/2026-05-18-story-workspace-variant-navigation.md` §A.

## Opt design

New `:modal-positioning` opt on `shell-view`:
- **`:fixed`** (default, production) — backdrops use `position: fixed; inset: 0` with max-int z-index. Unchanged from today.
- **`:absolute`** (Story testbeds) — backdrops use `position: absolute; inset: 0` with a sane in-cell z-index (97–101). Per-cell modals stay confined to the cell's positioning context.

The opt threads through Causa's app-db via a new `:rf.causa/modal-positioning` sub + `:rf.causa/set-modal-positioning` event. `shell-view` seeds the slot via `dispatch-sync` (guarded against re-dispatch); each modal reads the sub and dispatches its backdrop style.

Story testbeds pass `:modal-positioning :absolute` on `shell-view` and pin the gallery card to `position: relative` so the absolute backdrop has a containment ancestor.

## Before / after

- **Before**: opening Settings (or any of the five modals) in a `:variants-grid` workspace painted N full-viewport overlays over the Story shell. `_workspace_switch_smoke.cjs` excluded the chrome-popover workspaces to keep CI green; runtime users hit the bug Mike reported.
- **After**: per-cell modals stay inside their cell. The smoke test now visits all chrome-follow-on workspaces in one session and passes with zero fatal page errors.

## Frame-scoping decision

The modal *open-state* flags (`:rf.causa/<modal>-open?`) still live in the process-global `:rf/causa` frame, so opening Settings in cell A opens Settings in every cell that mounts the shell against the same frame. Per-frame scoping (per-cell `:rf/causa-<variant-id>` frames) is a larger architectural change called out in `ai/findings/2026-05-18-story-workspace-variant-navigation.md` §A.5 "Fix 2". The bead description (rf2-om6fa) authorises shipping positioning ahead of frame-scoping with a divergence note. **Frame-scoping is deliberately deferred to a follow-on bead.**

Visible impact of the divergence: in a workspace, opening Settings in one cell makes the Settings backdrop appear in every cell. Each backdrop is properly contained (no longer paints over the Story shell), so the divergence is workable — the user sees N copies of the same modal, dismisses any one, all close. Acceptable scope for the positioning fix.

## Files

- `tools/causa/src/.../shell.cljs` — accept opt; seed `:rf.causa/modal-positioning` via guarded `dispatch-sync`; publish on shell root as `data-rf-causa-modal-positioning`.
- `tools/causa/src/.../registry.cljs` — new sub `:rf.causa/modal-positioning` + event `:rf.causa/set-modal-positioning`.
- `tools/causa/src/.../settings/view.cljs` — backdrop reads sub.
- `tools/causa/src/.../filters/edit_popup.cljs` — same.
- `tools/causa/src/.../popover/causality.cljs` — same.
- `tools/causa/src/.../share_modal.cljs` — same.
- `tools/causa/src/.../panels/cancellation_cascade.cljs` (Popover) — same.
- `tools/causa/testbeds/panel_gallery/panel_views.cljs` — pass `:modal-positioning :absolute`; pin card to `position: relative`.
- `tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` — remove chrome-popover exclusion; walk now covers all workspaces in one session.
- Tests across all five modals + shell-view + registry smoke + registry count surface.

## Test plan

- [x] `scripts/test-fast-pr.sh` — passes (CLJS node 3060 tests · 8781 assertions)
- [x] `cd tools/causa && clojure -M:test` — passes (847 tests · 2445 assertions)
- [x] `cd implementation && npm run test:browser` — passes (2997 tests · 8569 assertions)
- [x] `node tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs` — passes WITHOUT the previously-excluded chrome-popover workspaces (settings-popup/all, filters/all, causality-popover/all) being skipped
- [ ] Manual: open `http://localhost:8765/#/stories` → click `:Workspace.causa.settings-popup/all` → confirm modals stay inside cells, sidebar/toolbar remain clickable