### PR TITLE
feat(causa): sub-output structural diff in Views panel

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/views.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views.cljs
@@ -29,6 +29,7 @@
   `subscriptions.cljs`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.views-events :as events]
+            [day8.re-frame2-causa.panels.views-sub-diff-subs :as sub-diff-subs]
             [day8.re-frame2-causa.panels.views-subs :as subs]
             [day8.re-frame2-causa.panels.views-view :as view]))
 
@@ -41,8 +42,15 @@
 
 (defn install!
   "Idempotent install for the Views panel's Causa-side registrations.
-  Returns nil per the facade convention."
+  Returns nil per the facade convention.
+
+  Order: `subs/install!` registers `:rf.causa/views-focused-cascade-
+  pair`; `sub-diff-subs/install!` (rf2-xjhhp Phase 2) registers the
+  sub-output structural-diff composite that depends on it. Re-frame's
+  lazy `:<-` resolution makes the order cosmetic, but the dependency
+  chain reads top-down here for clarity."
   []
   (subs/install!)
+  (sub-diff-subs/install!)
   (events/install!)
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff.cljs
@@ -1,0 +1,117 @@
+(ns day8.re-frame2-causa.panels.views-sub-diff
+  "Sub-output structural-diff drilldown for the Views panel
+  (rf2-xjhhp — Phase 2 of rf2-abts7).
+
+  Renders the records vector produced by
+  `:rf.causa/views-sub-diff-for-focused-event` (see
+  `views_sub_diff_subs.cljs`) using the Phase 1 sections-per-cluster
+  renderer (`diff.render/render-sections`).
+
+  ## What this ships
+
+    - One stacked block per recomputed sub.
+    - Per-block header: `:sub-id` + `:query-v` (formatted via
+      `app-db-diff-format/format-edn`).
+    - Per-block body: either the `render-sections` output (value
+      changed) or a single 'unchanged' chip (value identical pre/post —
+      framework cache-hit fast path means `:sub-runs` rarely contains
+      these, but it's defensive).
+
+  ## Surface key
+
+  The Phase 1 renderer takes a `surface` string used to namespace
+  per-node expand state. We compose
+  `view-sub-diff/<sub-id>/<query-v>` so each sub's expand state is
+  independent across drilldowns AND distinct from the app-db diff
+  surface."
+  (:require [day8.re-frame2-causa.diff.render :as diff-render]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- sub-header
+  "Per-sub header — sub-id, args, and a one-line summary."
+  [{:keys [sub-id query-v unchanged? diff-sections]}]
+  (let [args        (vec (rest query-v))
+        section-cnt (count diff-sections)]
+    [:header {:data-testid (str "rf-causa-views-sub-diff-header-"
+                                (pr-str sub-id))
+              :style {:display        "flex"
+                      :align-items    "baseline"
+                      :gap            "8px"
+                      :padding        "6px 0"
+                      :font-family    mono-stack
+                      :font-size      "12px"
+                      :color          (:text-primary tokens)
+                      :border-bottom  (str "1px solid "
+                                           (:border-subtle tokens))}}
+     [:span {:style {:color (:accent-violet tokens) :font-weight 600}}
+      (pr-str sub-id)]
+     (when (seq args)
+       [:span {:style {:color (:text-tertiary tokens)}}
+        (f/truncate (f/format-edn args) 48)])
+     [:span {:style {:flex 1}}]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-family sans-stack
+                     :font-size "11px"}}
+      (cond
+        unchanged?           "value unchanged"
+        (zero? section-cnt)  "no structural change"
+        (= 1 section-cnt)    "1 change cluster"
+        :else                (str section-cnt " change clusters"))]]))
+
+(defn sub-block
+  "Render one sub's diff block — header + sections (or 'unchanged'
+  chip)."
+  [{:keys [sub-id query-v unchanged? diff-sections] :as record}]
+  (let [surface (str "views-sub-diff/" (pr-str sub-id) "/" (pr-str query-v))]
+    [:section {:data-testid (str "rf-causa-views-sub-diff-block-"
+                                 (pr-str sub-id))
+               :style {:margin "8px 0"
+                       :padding "6px 8px"
+                       :background (:bg-2 tokens)
+                       :border (str "1px solid " (:border-subtle tokens))
+                       :border-radius "3px"}}
+     (sub-header record)
+     (cond
+       unchanged?
+       [:div {:data-testid (str "rf-causa-views-sub-diff-unchanged-"
+                                (pr-str sub-id))
+              :style {:padding "8px 4px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :font-style "italic"}}
+        "Value identical between db-before and db-after."]
+
+       (empty? diff-sections)
+       [:div {:data-testid (str "rf-causa-views-sub-diff-empty-"
+                                (pr-str sub-id))
+              :style {:padding "8px 4px"
+                      :color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :font-style "italic"}}
+        "No structural changes in the recomputed value."]
+
+       :else
+       (diff-render/render-sections diff-sections surface))]))
+
+(defn drilldown
+  "Top-level renderer — a stacked block per record."
+  [records]
+  [:div {:data-testid "rf-causa-views-sub-diff-drilldown"
+         :style {:display "flex"
+                 :flex-direction "column"
+                 :gap "4px"}}
+   (if (empty? records)
+     [:div {:data-testid "rf-causa-views-sub-diff-empty"
+            :style {:padding "8px 4px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "11px"
+                    :font-style "italic"}}
+      "No subs recomputed in this cascade."]
+     (for [record records]
+       ^{:key (str (pr-str (:sub-id record)) "/" (pr-str (:query-v record)))}
+       (sub-block record)))])

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff_subs.cljs
@@ -1,0 +1,186 @@
+(ns day8.re-frame2-causa.panels.views-sub-diff-subs
+  "Composite sub for the sub-output structural diff in the Views panel
+  (rf2-xjhhp — Phase 2 of rf2-abts7).
+
+  ## What this ships
+
+  One composite sub:
+
+      :rf.causa/views-sub-diff-for-focused-event
+        → {:dispatch-id <int>
+           :records [{:sub-id        <kw>
+                      :query-v       <vec>
+                      :diff-sections [<section> ...]
+                      :before-value  <v>
+                      :after-value   <v>
+                      :unchanged?    <bool>}
+                     ...]}
+
+  One record per `:sub-runs` entry in the focused cascade's
+  `:rf/epoch-record`. The records vector preserves the sub-runs order
+  the runtime captured (deepest dependency leaves recompute first; the
+  view consumes the order verbatim so the rendered drilldown matches
+  the cascade timeline).
+
+  ## How the diff is computed
+
+  Per the bead's Phase-2 scope: render the structural diff between
+  each sub's PRIOR cached value and its NEW value as sections-per-
+  cluster, reusing the Phase 1 engine
+  (`day8.re-frame2-causa.diff.annotated-tree` +
+  `.diff.section-grouping`).
+
+  The framework's `:sub-runs` projection carries `{:sub-id :query-v
+  :recomputed?}` — no value-before / value-after slot today
+  (`implementation/epoch/src/re_frame/epoch/capture.cljc` §`:sub-runs`).
+  To reconstruct the values without an instrumentation extension we
+  use `re-frame.core/compute-sub`:
+
+    - PRIOR value = `(compute-sub query-v (:db-before record))`
+    - NEW value   = `(compute-sub query-v (:db-after  record))`
+
+  `compute-sub` is the documented pure-compute form per
+  `spec/API.md` §Dispatch and subscribe — it bypasses the live
+  per-frame sub cache and runs the sub's handler-fn against the
+  supplied db snapshot. The result is stable per `(query-v, db)`
+  pair so the per-`:epoch-id` records cache is sound.
+
+  ### Why this beats reading the live cache
+
+  The live `rf/sub-cache` only holds the CURRENT cascade's value; the
+  PRIOR value is already evicted by the time the user clicks the
+  drilldown. The cascade pair sub already carries the prior cascade's
+  record (which carries its `:db-after`, which IS the current
+  cascade's `:db-before`), so the snapshots needed for the diff are
+  always reachable through the epoch ring buffer.
+
+  ### Divergence — `compute-sub` emits a `:sub/run` trace
+
+  Per `subs.cljc` §`compute-sub`, the pure compute form fires the
+  same `:sub/run` op-type the reactive recompute path emits — Causa
+  may observe its own diff-driven recomputes as extra `:sub/run`
+  entries in subsequent cascades. The trace pollution is bounded
+  (one emit per recomputed sub per drilldown render) and gated by
+  the user opening the drilldown; we document the cost here and
+  ship. A future bead can route the diff path through a
+  `:rf.trace/no-emit? true` flag if the noise becomes a problem.
+
+  ## Sentinel handling
+
+  Sub outputs may contain Spec 015 redacted / large sentinels — the
+  Phase 1 engine handles them uniformly (per
+  `annotated_tree.cljc` §Sentinel handling). When both sides are the
+  same redacted sentinel the structural `=` check returns true →
+  `:same`; when one side is a sentinel and the other is a real value
+  the walker emits a `:modified` leaf carrying both sides preserved.
+
+  ## N+1 sub recomputation cost
+
+  Worst case: a focused cascade with N recomputed subs that each
+  carry M-input `:<-` chains. `compute-sub` is N^2 on diamond
+  chains (the same input subs resolve once per consumer; no shared
+  cache across the recurse) — see `subs.cljc` §`compute-sub` §Cost.
+  The diff is computed twice per sub (once for before, once for
+  after), so the worst-case cost is `2 · N · M`. Bounded:
+
+    - N is typically < 10 per cascade (cascades touch a small
+      number of subs; the Views panel renders one drilldown per row
+      so the per-tick budget is one cascade × one row).
+    - Subs cache per `:epoch-id` so re-renders of the same drilldown
+      pay zero recompute after the first.
+
+  A follow-on bead can add a per-input memo across the recurse if
+  real-corpus profiling shows this matters."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.diff.annotated-tree :as at]
+            [day8.re-frame2-causa.diff.section-grouping :as sg]))
+
+(defonce sub-diff-cache
+  ;; Per-`:epoch-id` cache for the composite sub's `:records` vector.
+  ;; The cascade pair already pins the focused cascade's :epoch-id; we
+  ;; reuse that key so an inspector navigation away + back replays the
+  ;; same record vector without re-running compute-sub. Tests reset
+  ;; this atom between cases.
+  (atom {}))
+
+(defn- safe-compute-sub
+  "Wrap `rf/compute-sub` so a sub registered AFTER the cascade was
+  captured (or a sub that has been re-registered with a different
+  shape) doesn't blow up the diff composite. Returns the computed
+  value or nil on any exception. Per the framework contract
+  (`subs.cljc` §`compute-sub`) the inner handler invocation is
+  already wrapped in `try/catch`; this outer guard catches
+  registrar lookup failures (`(registrar/lookup :sub query-id)`
+  returning nil → the body still runs the trace/emit + body-fn
+  guarded path)."
+  [query-v db]
+  (try
+    (rf/compute-sub query-v db)
+    (catch :default _ nil)))
+
+(defn- sub-record
+  "Build one diff record for a `:sub-runs` entry. Returns
+    `{:sub-id <kw>
+      :query-v <vec>
+      :before-value <v>
+      :after-value  <v>
+      :diff-sections [<section> ...]
+      :unchanged? <bool>}`."
+  [sub-run db-before db-after]
+  (let [{:keys [sub-id query-v]} sub-run
+        before     (safe-compute-sub query-v db-before)
+        after      (safe-compute-sub query-v db-after)
+        annotated  (at/diff-tree before after)
+        sections   (sg/group-into-sections annotated)]
+    {:sub-id        sub-id
+     :query-v       query-v
+     :before-value  before
+     :after-value   after
+     :diff-sections sections
+     :unchanged?    (= :same (at/op-of annotated))}))
+
+(defn build-records
+  "Pure helper — given the current epoch record (carrying `:sub-runs`,
+  `:db-before`, `:db-after`), produce the records vector. Exposed for
+  unit testing without re-frame."
+  [current]
+  (let [sub-runs   (or (:sub-runs current) [])
+        db-before  (:db-before current)
+        db-after   (:db-after current)]
+    (mapv #(sub-record % db-before db-after) sub-runs)))
+
+(defn install!
+  "Idempotent install — register
+  `:rf.causa/views-sub-diff-for-focused-event`. Called from
+  `panels/views.cljs` facade's `install!`."
+  []
+  (rf/reg-sub :rf.causa/views-sub-diff-for-focused-event
+    :<- [:rf.causa/views-focused-cascade-pair]
+    :<- [:rf.causa/epoch-history]
+    (fn [[pair history] _query]
+      (let [current     (:current pair)
+            dispatch-id (:dispatch-id (:focus pair))
+            epoch-id    (:epoch-id current)]
+        (if-not current
+          {:dispatch-id dispatch-id
+           :records     []}
+          (let [cached (get @sub-diff-cache epoch-id ::miss)]
+            (if (not= ::miss cached)
+              {:dispatch-id dispatch-id
+               :records     cached}
+              (let [records (build-records current)
+                    ;; Prune the cache to epochs the ring buffer still
+                    ;; carries — same strategy as the app-db-diff
+                    ;; `:selected-epoch-diff` cache (see
+                    ;; `app_db_diff_subs.cljs`). Without the prune the
+                    ;; cache would grow without bound as the ring
+                    ;; buffer evicts old epochs.
+                    live-ids (into #{} (map :epoch-id) history)]
+                (swap! sub-diff-cache
+                       (fn [m]
+                         (-> m
+                             (select-keys live-ids)
+                             (assoc epoch-id records))))
+                {:dispatch-id dispatch-id
+                 :records     records})))))))
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -44,6 +44,7 @@
             ;; payloads. Per spec §Renderer the panel uses
             ;; `inspect-inline` for the one-line list cells and `inspect`
             ;; for the click-expand hero in the inline drilldown.
+            [day8.re-frame2-causa.panels.views-sub-diff :as sub-diff]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -205,15 +206,38 @@
 
 ;; ---- per-row body builders ---------------------------------------------
 
+(defn- relevant-sub-diff-records
+  "Filter the cascade-wide sub-diff records to subs in this row's
+  `invalidated-by` list. Sub-id match — args (`:query-v`) might
+  differ across consumers but the most common case is identical args
+  per row. Phase 2 v1 ships the cascade-wide records pre-filtered to
+  the row's invalidating subs; per-row sub-attribution lands when the
+  render-tracker emits `:owning-frame` (P17 wave)."
+  [records invalidated-by]
+  (let [wanted (set (keep :sub-id invalidated-by))]
+    (filterv (fn [rec] (contains? wanted (:sub-id rec))) records)))
+
 (defn- expanded-block
   "Inline expansion content per spec §Per-component drilldown — single-
   column block placed BELOW the row. v1 ships the structural
   scaffolding (props-diff section header, subs-consumed list,
   reason); the props-diff and React-fiber slots stay placeholder
-  until `theme/data_inspector.cljc` lands."
+  until `theme/data_inspector.cljc` lands.
+
+  ## Sub-output diff (rf2-xjhhp Phase 2)
+
+  Below the structural scaffolding we mount the sub-output structural
+  diff for the row's invalidating subs. Records come from
+  `:rf.causa/views-sub-diff-for-focused-event`; rendering goes
+  through the Phase 1 sections-per-cluster engine
+  (`day8.re-frame2-causa.diff.render/render-sections`) via the
+  thin `views-sub-diff/drilldown` wrapper."
   [item]
   (let [r (:render item)
-        invalidated-by (:invalidated-by item)]
+        invalidated-by (:invalidated-by item)
+        sub-diff-data @(rf/subscribe [:rf.causa/views-sub-diff-for-focused-event])
+        sub-records   (relevant-sub-diff-records (:records sub-diff-data)
+                                                 invalidated-by)]
     [:div {:data-testid "rf-causa-views-row-expanded"
            :style {:padding "8px 16px 12px 32px"
                    :background (:bg-1 tokens)
@@ -238,6 +262,12 @@
      (when (seq invalidated-by)
        [:div [:strong "Subs consumed"]
         (invalidated-by-list invalidated-by)])
+     ;; rf2-xjhhp Phase 2 — sub-output structural diff for the row's
+     ;; invalidating subs. The renderer ships an empty-state chip when
+     ;; no records remain after filtering (e.g. for parent-forced
+     ;; re-renders where no sub invalidated the row).
+     [:div [:strong "Sub-output diff"]
+      (sub-diff/drilldown sub-records)]
      [:div [:strong "Reason"]
       [:p {:style {:margin "4px 0"}}
        (cond

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_cljs_test.cljs
@@ -1,0 +1,94 @@
+(ns day8.re-frame2-causa.panels.views-sub-diff-cljs-test
+  "Smoke test for the sub-output structural-diff drilldown view
+  (rf2-xjhhp Phase 2 of rf2-abts7).
+
+  Hiccup-level walk over `views-sub-diff/drilldown` — asserts the
+  drilldown's data-testid hooks ship + the empty-state chip renders
+  when records is empty."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.diff.annotated-tree :as at]
+            [day8.re-frame2-causa.diff.section-grouping :as sg]
+            [day8.re-frame2-causa.panels.views-sub-diff :as view]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- expand-fn [node]
+  (if (and (vector? node) (fn? (first node)))
+    (try (apply (first node) (rest node))
+         (catch :default _ node))
+    node))
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(deftest drilldown-empty-records-shows-empty-chip
+  (testing "no records → the drilldown renders the empty-state chip
+            so the caller can tell 'no subs recomputed' from a
+            mounting bug"
+    (let [tree (view/drilldown [])]
+      (is (has-testid? tree "rf-causa-views-sub-diff-drilldown")
+          "drilldown container renders")
+      (is (has-testid? tree "rf-causa-views-sub-diff-empty")
+          "empty-state chip renders"))))
+
+(deftest drilldown-with-records-renders-blocks
+  (testing "records → one block per record with the sub-id testid hook"
+    (let [records [{:sub-id        :test/counter
+                    :query-v       [:test/counter]
+                    :before-value  0
+                    :after-value   1
+                    :diff-sections []
+                    :unchanged?    false}
+                   {:sub-id        :test/items
+                    :query-v       [:test/items]
+                    :before-value  []
+                    :after-value   [{:x 1}]
+                    :diff-sections []
+                    :unchanged?    false}]
+          tree    (view/drilldown records)]
+      (is (has-testid? tree "rf-causa-views-sub-diff-drilldown"))
+      (is (has-testid? tree "rf-causa-views-sub-diff-block-:test/counter"))
+      (is (has-testid? tree "rf-causa-views-sub-diff-block-:test/items")))))
+
+(deftest drilldown-unchanged-record-renders-unchanged-chip
+  (testing "an :unchanged? record renders its 'value identical' chip
+            instead of the sections renderer"
+    (let [records [{:sub-id        :test/counter
+                    :query-v       [:test/counter]
+                    :before-value  1
+                    :after-value   1
+                    :diff-sections []
+                    :unchanged?    true}]
+          tree    (view/drilldown records)]
+      (is (has-testid? tree "rf-causa-views-sub-diff-unchanged-:test/counter")
+          "the per-sub unchanged chip renders for an unchanged record"))))
+
+(deftest sub-block-renders-with-sections
+  (testing "a record with diff-sections falls through to the Phase 1
+            renderer; we assert the section block ships its testid
+            (the renderer's own hook from `diff/render.cljs`)"
+    (let [;; Build a minimal annotated subtree from the Phase 1 engine
+          ;; via diff-tree so the renderer's per-section markup is
+          ;; well-formed.
+          before    {:cart {:total 10}}
+          after     {:cart {:total 12}}
+          annotated (at/diff-tree before after)
+          sections  (sg/group-into-sections annotated)
+          record    {:sub-id        :test/cart
+                     :query-v       [:test/cart]
+                     :before-value  before
+                     :after-value   after
+                     :diff-sections sections
+                     :unchanged?    false}
+          tree      (view/sub-block record)]
+      (is (has-testid? tree "rf-causa-views-sub-diff-block-:test/cart")
+          "the per-sub block renders + the per-sub header testid")
+      (is (has-testid? tree "rf-causa-views-sub-diff-header-:test/cart")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_subs_cljs_test.cljs
@@ -1,0 +1,195 @@
+(ns day8.re-frame2-causa.panels.views-sub-diff-subs-cljs-test
+  "Per-leaf tests for `views-sub-diff-subs` (rf2-xjhhp Phase 2 of
+  rf2-abts7).
+
+  Exercises:
+
+    - The pure `build-records` helper against synthetic epoch records
+      (no re-frame runtime needed).
+    - The composite sub `:rf.causa/views-sub-diff-for-focused-event`
+      end-to-end through Causa's umbrella registry — install
+      Causa's handlers, allocate the `:rf/causa` frame, write the
+      epoch-history slot + focus the cascade via the spine, then read
+      the composite via `subscribe`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.views-sub-diff-subs :as subs]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (reset! subs/sub-diff-cache {}))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- pure helper -----------------------------------------------------------
+
+(deftest build-records-empty-sub-runs
+  (testing "no sub-runs in the current epoch → empty records vector"
+    (is (= [] (subs/build-records {:sub-runs   []
+                                   :db-before  {}
+                                   :db-after   {}})))))
+
+(deftest build-records-three-recomputed-subs
+  (testing "three sub-runs against a host-registered sub graph → three
+            records, each with its sub-id + query-v preserved + a
+            diff-sections vector from the Phase 1 engine"
+    ;; Register three host-frame subs against the global registrar so
+    ;; `compute-sub` can run them against `:db-before` / `:db-after`.
+    (rf/reg-sub :test/counter      (fn [db _] (get db :counter)))
+    (rf/reg-sub :test/items        (fn [db _] (get db :items)))
+    (rf/reg-sub :test/user-profile (fn [db _] (get db :user)))
+    (let [db-before {:counter 0
+                     :items   [{:id 1 :qty 2}]
+                     :user    {:name "Alice" :email "a@x"}}
+          db-after  {:counter 1
+                     :items   [{:id 1 :qty 3} {:id 2 :qty 1}]
+                     :user    {:name "Alice" :email "alice@x"}}
+          current   {:sub-runs  [{:sub-id :test/counter
+                                  :query-v [:test/counter]
+                                  :recomputed? true}
+                                 {:sub-id :test/items
+                                  :query-v [:test/items]
+                                  :recomputed? true}
+                                 {:sub-id :test/user-profile
+                                  :query-v [:test/user-profile]
+                                  :recomputed? true}]
+                     :db-before db-before
+                     :db-after  db-after}
+          records   (subs/build-records current)]
+      (is (= 3 (count records)))
+      (is (= [:test/counter :test/items :test/user-profile]
+             (mapv :sub-id records)))
+      ;; Counter went 0 → 1 — scalar :modified at root.
+      (let [counter-rec (first records)]
+        (is (= 0 (:before-value counter-rec)))
+        (is (= 1 (:after-value counter-rec)))
+        (is (false? (:unchanged? counter-rec))))
+      ;; Items grew an item AND mutated an existing :qty.
+      (let [items-rec (nth records 1)]
+        (is (= [{:id 1 :qty 2}] (:before-value items-rec)))
+        (is (= [{:id 1 :qty 3} {:id 2 :qty 1}] (:after-value items-rec)))
+        (is (seq (:diff-sections items-rec))
+            "non-empty diff-sections for changed vector"))
+      ;; User profile mutated :email but kept :name.
+      (let [user-rec (nth records 2)]
+        (is (false? (:unchanged? user-rec)))
+        (is (seq (:diff-sections user-rec)))))))
+
+(deftest build-records-unchanged-sub-flagged
+  (testing "a sub-run whose value did not change (e.g. db slice didn't
+            mutate the slot this sub reads) → :unchanged? true with
+            empty :diff-sections"
+    (rf/reg-sub :test/unchanged (fn [db _] (get db :unchanged)))
+    (let [db-before {:unchanged {:x 1 :y 2} :counter 0}
+          db-after  {:unchanged {:x 1 :y 2} :counter 1}
+          current   {:sub-runs  [{:sub-id :test/unchanged
+                                  :query-v [:test/unchanged]
+                                  :recomputed? true}]
+                     :db-before db-before
+                     :db-after  db-after}
+          [rec]     (subs/build-records current)]
+      (is (true? (:unchanged? rec))
+          "value identical pre/post → :unchanged?")
+      (is (= [] (:diff-sections rec)))
+      (is (= {:x 1 :y 2} (:before-value rec)))
+      (is (= {:x 1 :y 2} (:after-value rec))))))
+
+(deftest build-records-sentinel-handling
+  (testing "Spec 015 sentinels (`:rf/redacted` / `:rf/large`) in sub
+            outputs: identical sentinels collapse to :unchanged?;
+            sentinel ↔ real-value diverges as a :modified leaf with
+            both sides preserved (Phase 1 engine contract)"
+    (rf/reg-sub :test/sentinel-passthrough
+      (fn [db _] (get db :slot)))
+    ;; Case A — both sides equal-sentinel → unchanged.
+    (let [db-before {:slot {:value :rf/redacted}}
+          db-after  {:slot {:value :rf/redacted}}
+          current   {:sub-runs  [{:sub-id  :test/sentinel-passthrough
+                                  :query-v [:test/sentinel-passthrough]
+                                  :recomputed? true}]
+                     :db-before db-before
+                     :db-after  db-after}
+          [rec]     (subs/build-records current)]
+      (is (true? (:unchanged? rec))
+          "identical sentinels → :unchanged? per the Phase 1 contract"))
+    ;; Case B — sentinel on one side, real value on the other → diff.
+    (let [db-before {:slot {:value :rf/redacted}}
+          db-after  {:slot {:value 42}}
+          current   {:sub-runs  [{:sub-id  :test/sentinel-passthrough
+                                  :query-v [:test/sentinel-passthrough]
+                                  :recomputed? true}]
+                     :db-before db-before
+                     :db-after  db-after}
+          [rec]     (subs/build-records current)]
+      (is (false? (:unchanged? rec))
+          "sentinel ↔ real value → :modified, NOT :unchanged?")
+      (is (seq (:diff-sections rec))
+          "diff-sections carry the change point"))))
+
+;; ---- leaf install / catalogue --------------------------------------------
+
+(deftest leaf-install-registers-the-sub
+  (subs/install!)
+  (is (some? (registrar/handler :sub :rf.causa/views-sub-diff-for-focused-event))))
+
+(deftest cache-atom-is-leaf-level
+  (is (some? subs/sub-diff-cache))
+  (is (map? @subs/sub-diff-cache)))
+
+;; ---- composite sub end-to-end --------------------------------------------
+
+(defn- seed-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(deftest composite-returns-empty-when-no-cascade-focused
+  (testing "with no cascade focused + empty epoch-history → empty
+            records (defensive contract: composite never throws on a
+            dormant frame)"
+    (seed-causa!)
+    (rf/with-frame :rf/causa
+      (let [out @(rf/subscribe [:rf.causa/views-sub-diff-for-focused-event])]
+        (is (= [] (:records out))
+            "no current cascade → empty records")))))
+
+(deftest composite-populates-records-from-focused-cascade
+  (testing "with an epoch in history carrying :sub-runs + :db-before /
+            :db-after AND the spine focused on the cascade, the
+            composite produces one record per sub-run with the diff
+            sections populated"
+    (seed-causa!)
+    ;; Register a host sub the cascade's sub-runs will reference.
+    (rf/reg-sub :test/total (fn [db _] (get db :total)))
+    (let [epoch {:epoch-id    :e1
+                 :dispatch-id 7
+                 :event-id    7
+                 :db-before   {:total 10}
+                 :db-after    {:total 12}
+                 :sub-runs    [{:sub-id :test/total
+                                :query-v [:test/total]
+                                :recomputed? true}]
+                 :renders     []}]
+      (rf/with-frame :rf/causa
+        ;; Seed Causa's app-db: epoch-history + focus pinned to the
+        ;; cascade. `:rf.causa/sync-epoch-history` is the test-friendly
+        ;; entry-point time-travel-events ships.
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [epoch]])
+        ;; Pin focus to the cascade (mode flips to :retro).
+        (rf/dispatch-sync [:rf.causa/focus-cascade 7 nil])
+        (let [out @(rf/subscribe [:rf.causa/views-sub-diff-for-focused-event])]
+          (is (= 1 (count (:records out)))
+              "one sub-run → one record")
+          (let [rec (first (:records out))]
+            (is (= :test/total (:sub-id rec)))
+            (is (= 10 (:before-value rec)))
+            (is (= 12 (:after-value rec)))
+            (is (false? (:unchanged? rec)))))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -242,7 +242,11 @@
    :rf.causa/views-expanded-rows
    :rf.causa/views-focused-cascade-pair
    :rf.causa/views-group-by
-   :rf.causa/views-heatmap?])
+   :rf.causa/views-heatmap?
+   ;; rf2-xjhhp Phase 2 — sub-output structural-diff composite for the
+   ;; Views row drilldown. Reuses the Phase 1 engine
+   ;; (`diff.annotated_tree` + `diff.section_grouping`).
+   :rf.causa/views-sub-diff-for-focused-event])
 
 (def ^:private all-event-names
   ;; Issues-ribbon panel-internal events (rf2-nmc1f) — nested under
@@ -545,7 +549,9 @@
     ;;   :rf.causa/selected-epoch-sections.
     ;; + 1 modal positioning (rf2-om6fa):
     ;;   :rf.causa/modal-positioning — Story-aware modal positioning opt.
-    (is (= 125 (count all-sub-names)))
+    ;; + 1 sub-output structural-diff composite (rf2-xjhhp Phase 2):
+    ;;   :rf.causa/views-sub-diff-for-focused-event.
+    (is (= 126 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -1617,7 +1623,11 @@
                       :rf.causa/performance-data
                       :rf.causa/machine-inspector-data
                       :rf.causa/schema-violation-timeline
-                      :rf.causa/views-data]]
+                      :rf.causa/views-data
+                      ;; rf2-xjhhp Phase 2 — sub-output structural diff
+                      ;; composite. Empty-frame contract: returns
+                      ;; `{:dispatch-id nil :records []}`.
+                      :rf.causa/views-sub-diff-for-focused-event]]
         (is (some? @(rf/subscribe [sub-id]))
             (str sub-id " must not throw on an empty frame"))))))
 


### PR DESCRIPTION
## Bug class

> "What changed about THIS sub's return value during the cascade?"

When a sub recomputed during a focused cascade, the developer could see THAT it ran (the Views panel surfaced the row in the Re-rendered group with an `Invalidated by` chip) but not WHAT changed in its output. The before/after values were either left to the eye against two cljs-devtools trees or skipped entirely — the same shape problem rf2-gfxmk Phase 1 solved for app-db diffs.

Phase 2 (rf2-xjhhp) reuses the Phase 1 annotated-tree + section-grouping engine + the sections-per-cluster renderer to surface the structural diff between each recomputed sub's PRIOR and NEW value, mounted inline under the Views row drilldown.

## Screenshot-equivalent ASCII

Row click expands to:

```
┌─ <CartTotal> · expanded ──────────────────────────────────────────────┐
│ Render entry (raw)     {…}                                            │
│ Subs consumed                                                         │
│   ✱ :cart/subtotal                                                    │
│   · :cart/items                                                       │
│                                                                       │
│ Sub-output diff                                                       │
│   ┌─────────────────────────────────────────────────────────────┐    │
│   │ :cart/subtotal                                  1 change    │    │
│   │ ─────────────────────────────────────────────────────────── │    │
│   │ ╔═ (root) ◴ 1 change ════════════════════════════════════╗  │    │
│   │ │ ~ 42.00 → 47.50                                        │  │    │
│   │ ╚════════════════════════════════════════════════════════╝  │    │
│   └─────────────────────────────────────────────────────────────┘    │
│   ┌─────────────────────────────────────────────────────────────┐    │
│   │ :cart/items                                  1 change cluster│    │
│   │ ─────────────────────────────────────────────────────────── │    │
│   │ ╔═ [:0 :qty] ◴ 1 change ═════════════════════════════════╗  │    │
│   │ │ ~ 2 → 3                                                │  │    │
│   │ ╚════════════════════════════════════════════════════════╝  │    │
│   └─────────────────────────────────────────────────────────────┘    │
│                                                                       │
│ Reason   Re-render triggered by :cart/subtotal                        │
│ Render timing   elapsed 0.18ms                                        │
└───────────────────────────────────────────────────────────────────────┘
```

## Summary

- New composite sub `:rf.causa/views-sub-diff-for-focused-event` returns one record per `:sub-runs` entry in the focused cascade. Each record carries `:sub-id`, `:query-v`, `:before-value`, `:after-value`, the Phase 1 `:diff-sections` vector, and an `:unchanged?` flag for value-equality fast-path renders.
- New drilldown view `views_sub_diff.cljs` stacks one block per record, reusing the Phase 1 `diff/render/render-sections` renderer.
- Views row `expanded-block` mounts the drilldown filtered to the row's invalidated-by subs (per spec/012 §Per-component drilldown).
- Per-`:epoch-id` cache (mirrors the app-db-diff cache contract) so drilldown re-renders pay zero recompute after the first read.

## Value reconstruction

The framework's `:sub-runs` projection carries `{:sub-id :query-v :recomputed?}` only — no value slot today (`implementation/epoch/src/re_frame/epoch/capture.cljc` §`:sub-runs`). We reconstruct via `re-frame.core/compute-sub` against the cascade's `:db-before` / `:db-after` (the documented pure-compute form per `spec/API.md` §Dispatch and subscribe). The cascade-pair sub already pins both snapshots through the epoch ring buffer, so no new instrumentation is needed.

## Sentinel handling

Identical sentinels (e.g. `:rf/redacted` on both sides) collapse to `:unchanged?` via the Phase 1 engine's structural-`=` short-circuit; sentinel ↔ real-value diverges as `:modified` with both sides preserved. Verified with a dedicated test.

## Divergence

- `compute-sub` emits a `:sub/run` trace per recomputed value (`subs.cljc` §`compute-sub`). The trace pollution is bounded (one emit per recomputed sub per drilldown open) and gated by the user opening the row. A follow-on bead can route through `:rf.trace/no-emit?` if the noise becomes a problem.
- Per-row sub-attribution (which sub belongs to which render) ships best-effort by `sub-id` membership in `:invalidated-by` — the per-render `:owning-frame` tag (P17 wave) will let us refine this once it lands.

## New files

- `tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff_subs.cljs`
- `tools/causa/src/day8/re_frame2_causa/panels/views_sub_diff.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_subs_cljs_test.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/views_sub_diff_cljs_test.cljs`

## Modified files

- `tools/causa/src/day8/re_frame2_causa/panels/views.cljs` (chain new install)
- `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs` (mount drilldown)
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` (catalogue +1)

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `cd tools/causa && clojure -M:test` — PASS (890 tests, 2583 assertions)
- [x] `cd implementation && npm run test:cljs` — PASS (3072 tests, 8819 assertions)
- [x] `cd implementation && npm run test:browser` — PASS (3048 tests, 8717 assertions)
- [x] New `views_sub_diff_subs_cljs_test`: empty cascade, 3 recomputed subs, unchanged-sub flagging, sentinel handling, install / cache, composite end-to-end
- [x] New `views_sub_diff_cljs_test`: drilldown empty-state, multi-record rendering, unchanged-chip, sections fallthrough