### PR TITLE
feat(story): URL state encoding — sharability 4→10

### DIFF
--- a/tools/story/src/re_frame/story/share.cljc
+++ b/tools/story/src/re_frame/story/share.cljc
@@ -9,14 +9,34 @@
 
   ## URL scheme
 
-  Per IMPL-SPEC §2.8.5 the scheme is:
+  Per IMPL-SPEC §2.8.5 + rf2-o4u18 the scheme is:
 
-      <base>?variant=<id>&modes=<list>&overrides=<list>&substrate=<s>
+      <base>?variant=<id>
+            &workspace=<id>
+            &mode-tab=<id>
+            &modes=<list>
+            &viewport=<id-or-WxH>
+            &background=<id-or-#rrggbb>
+            &tag-filter=<list>
+            &overrides=<list>
+            &substrate=<s>
 
-  - `<id>` — the variant id as `:story.foo/bar`
-  - `<list>` for modes — comma-separated mode ids
+  - `<id>` for variant / workspace — the id as `:story.foo/bar`
+  - `<id>` for mode-tab — one of `dev` / `docs` / `test`
+  - `<list>` for modes / tag-filter — comma-separated keyword ids
   - `<list>` for overrides — comma-separated `arg-key:EDN-value` pairs
+  - `<id-or-WxH>` for viewport — preset keyword (`tablet`) or
+                                  `WxH` custom (e.g. `800x600`)
+  - `<id-or-#rrggbb>` for background — preset keyword (`dark`) or a
+                                       hex colour string (`#abc123`)
   - `<s>` — substrate id (omitted when `:reagent` default)
+
+  Per rf2-o4u18 the URL is the sharability surface of the testbed: a
+  teammate pasting a URL must land on the exact same view (workspace
+  + mode-tab + viewport + background + tag-filter + modes + overrides
+  + substrate). The chrome's `re-frame.story.ui.url-state` wires
+  pushState / popstate against this encoder so back-button + bookmark
+  preserves state.
 
   ## Modules in this ns
 
@@ -94,6 +114,94 @@
   keyword or nil."
   [s]
   (parse-keyword-token s))
+
+;; ---- rf2-o4u18: workspace / mode-tab / viewport / background / tag-filter
+
+(defn parse-workspace-param
+  "Parse the `workspace=` URLSearchParams value as a workspace id.
+  Returns a qualified keyword or nil. Same shape as variant ids; the
+  caller verifies registration."
+  [s]
+  (parse-keyword-token s))
+
+(def ^:private mode-tab-tokens
+  "Canonical mode-tab tokens emitted on the wire. Mirrors
+  `re-frame.story.ui.state/mode-tabs` — kept here as a literal set
+  rather than required to avoid a CLJS→CLJC dependency (the canonical
+  tabs are stable; if a new tab ships the set is updated here)."
+  #{:dev :docs :test})
+
+(defn parse-mode-tab-param
+  "Parse the `mode-tab=` URLSearchParams value into one of `:dev` /
+  `:docs` / `:test`. Returns nil for unknown values so a stale URL
+  degrades to the default tab rather than poisoning the slot."
+  [s]
+  (when-let [kw (parse-keyword-token s)]
+    (when (contains? mode-tab-tokens kw) kw)))
+
+(def ^:private viewport-wxh-re
+  "WxH custom viewport on the wire — two positive integers joined by
+  a literal `x`. Trailing whitespace is tolerated."
+  #"(?i)^\s*(\d+)x(\d+)\s*$")
+
+(defn parse-viewport-param
+  "Parse the `viewport=` URLSearchParams value into one of:
+
+  - a preset keyword (`:tablet` / `:desktop` / ...) when the value
+    matches a recognised preset token,
+  - a `{:width :height}` map when the value is the `WxH` custom shape,
+  - nil otherwise.
+
+  Validation of the preset keyword against the actual `viewport/presets`
+  table happens at hydrate time — keeping this fn pure (no registrar
+  dependency) means JVM tests can round-trip the wire shape without
+  pulling the viewport ns in."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (let [trimmed (str/trim s)]
+      (if-let [[_ w h] (re-matches viewport-wxh-re trimmed)]
+        (try
+          (let [wi #?(:clj  (Integer/parseInt w)
+                      :cljs (js/parseInt w 10))
+                hi #?(:clj  (Integer/parseInt h)
+                      :cljs (js/parseInt h 10))]
+            (when (and (pos? wi) (pos? hi))
+              {:width wi :height hi}))
+          (catch #?(:clj Exception :cljs :default) _ nil))
+        (parse-keyword-token trimmed)))))
+
+(def ^:private hex-colour-re
+  "Hex colour on the wire — 3, 6, or 8 hex digits prefixed with `#`."
+  #"^#(?:[0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$")
+
+(defn parse-background-param
+  "Parse the `background=` URLSearchParams value into one of:
+
+  - a preset keyword (`:dark` / `:light` / ...),
+  - a hex colour string (`#abc123`),
+  - nil otherwise.
+
+  Like `parse-viewport-param`, preset validation against
+  `backgrounds/presets` is the hydrator's job."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (let [trimmed (str/trim s)]
+      (if (re-matches hex-colour-re trimmed)
+        trimmed
+        (parse-keyword-token trimmed)))))
+
+(defn parse-tag-filter-param
+  "Parse the `tag-filter=` URLSearchParams value into a set of tag
+  keywords. The wire shape is a comma-separated list of `(kw->str)`
+  tokens — the same shape `parse-modes-param` consumes. Returns a
+  (possibly empty) set, or nil when the input is blank."
+  [s]
+  (when (and (string? s) (seq (str/trim s)))
+    (let [tokens (->> (str/split s #",")
+                      (map parse-keyword-token)
+                      (remove nil?))]
+      (when (seq tokens)
+        (into #{} tokens)))))
 
 (defn- ^:no-doc read-edn
   [s]
@@ -182,28 +290,81 @@
 
 ;; ---- pure: param building -----------------------------------------------
 
-(defn build-params
-  "Pure: build the ordered vector of `k=v` URL params for a variant
-  share URL. Keys are stable across calls so the QR encoding is
-  deterministic.
+(defn- ^:no-doc encode-viewport
+  "Encode a viewport slot value into the wire form. Accepts the same
+  shapes the encoder takes off the shell state: a preset keyword or a
+  `{:width :height}` custom map. Returns the URL-encoded token (no `&`
+  / `=` glue), or nil when the input is unusable."
+  [v]
+  (cond
+    (keyword? v)
+    (url-encode (kw->str v))
 
-  - `:variant` — the variant id (always present)
-  - `:modes`   — comma-separated stable list of active mode ids (when present)
-  - `:overrides` — comma-separated `arg-key:EDN-value` pairs (when present)
-  - `:substrate` — substrate id (when not :reagent)
+    (and (map? v) (some? (:width v)) (some? (:height v)))
+    (url-encode (str (:width v) "x" (:height v)))
+
+    :else nil))
+
+(defn- ^:no-doc encode-background
+  "Encode a background slot value into the wire form. Accepts a preset
+  keyword or a colour string. Returns the URL-encoded token, or nil
+  when unusable."
+  [v]
+  (cond
+    (keyword? v) (url-encode (kw->str v))
+    (string? v)  (url-encode v)
+    :else        nil))
+
+(defn build-params
+  "Pure: build the ordered vector of `k=v` URL params for a share URL.
+  Keys are stable across calls so the QR encoding is deterministic.
+
+  Per rf2-o4u18 the param set covers the full sharability surface:
+
+  - `:variant`    — the focused variant id (when set)
+  - `:workspace`  — the focused workspace id (when set)
+  - `:mode-tab`   — the focused variant's mode-tab when not the default
+                    `:dev`
+  - `:modes`      — comma-separated stable list of active mode ids
+  - `:viewport`   — chrome-wide viewport selection (preset kw or `WxH`)
+  - `:background` — chrome-wide background selection (preset kw or hex)
+  - `:tag-filter` — comma-separated stable list of active tag-filter keys
+  - `:overrides`  — comma-separated `arg-key:EDN-value` pairs
+  - `:substrate`  — substrate id (omitted when `:reagent` default)
 
   Returns a vector of `k=v` URL fragments. Pure data → data;
-  JVM-testable."
-  [{:keys [variant-id active-modes cell-overrides substrate]}]
+  JVM-testable. Slots whose value is empty/nil/default are omitted so
+  the URL is the minimal canonical form."
+  [{:keys [variant-id workspace-id mode-tab
+           active-modes viewport background tag-filter
+           cell-overrides substrate]}]
   (cond-> []
     variant-id
     (conj (kv-pair :variant (url-encode (kw->str variant-id))))
+
+    workspace-id
+    (conj (kv-pair :workspace (url-encode (kw->str workspace-id))))
+
+    (and mode-tab (contains? mode-tab-tokens mode-tab) (not= mode-tab :dev))
+    (conj (kv-pair :mode-tab (url-encode (name mode-tab))))
 
     (seq active-modes)
     (conj (kv-pair :modes
                    (url-encode
                      (str/join ","
                        (map kw->str (sort-by kw->str active-modes))))))
+
+    (some? (encode-viewport viewport))
+    (conj (kv-pair :viewport (encode-viewport viewport)))
+
+    (some? (encode-background background))
+    (conj (kv-pair :background (encode-background background)))
+
+    (seq tag-filter)
+    (conj (kv-pair :tag-filter
+                   (url-encode
+                     (str/join ","
+                       (map kw->str (sort-by kw->str tag-filter))))))
 
     (seq cell-overrides)
     (conj (kv-pair :overrides
@@ -214,6 +375,36 @@
 
     (and substrate (not= substrate :reagent))
     (conj (kv-pair :substrate (url-encode (name substrate))))))
+
+(defn parse-params
+  "Pure inverse of `build-params` — given a `{param-name → string}`
+  getter map (e.g. the canonicalised output of `URLSearchParams`), return
+  the parsed shape:
+
+      {:variant-id    nil-or-kw
+       :workspace-id  nil-or-kw
+       :mode-tab      nil-or-kw  (one of :dev :docs :test)
+       :active-modes  nil-or-vec
+       :viewport      nil-or-kw-or-{:width :height}
+       :background    nil-or-kw-or-string
+       :tag-filter    nil-or-set
+       :cell-overrides nil-or-map  (uses silent-drop `parse-overrides-param`)
+       :substrate     nil-or-kw}
+
+  Slot values that fail to parse degrade to nil — the caller decides
+  whether to default or skip. Used by the URL-state hydrator and by
+  tests for round-trip assertions. Pure data → data; JVM-testable."
+  [params]
+  (let [g (fn [k] (get params k))]
+    {:variant-id     (parse-keyword-token   (g "variant"))
+     :workspace-id   (parse-workspace-param (g "workspace"))
+     :mode-tab       (parse-mode-tab-param  (g "mode-tab"))
+     :active-modes   (parse-modes-param     (g "modes"))
+     :viewport       (parse-viewport-param  (g "viewport"))
+     :background     (parse-background-param (g "background"))
+     :tag-filter     (parse-tag-filter-param (g "tag-filter"))
+     :cell-overrides (parse-overrides-param  (g "overrides"))
+     :substrate      (parse-substrate-param  (g "substrate"))}))
 
 (defn variant-share-url
   "Build a sharable URL for `variant-id` against `base-url`.

--- a/tools/story/src/re_frame/story/ui/share.cljs
+++ b/tools/story/src/re_frame/story/ui/share.cljs
@@ -97,18 +97,26 @@
 
 (defn- current-share-url
   "Compute the share URL against the current shell state. Returns a
-  string."
+  string. Per rf2-o4u18 the share popover encodes the FULL chrome
+  state — workspace + mode-tab + viewport + background + tag-filter —
+  so a shared link drops the recipient onto the exact same view."
   [variant-id]
   (let [shell @state/shell-state-atom
         base  (when js/window
                 (let [loc (.-location js/window)]
-                  (str (.-origin loc) (.-pathname loc) "#/stories")))]
+                  (str (.-origin loc) (.-pathname loc) "#/stories")))
+        mode-tab (get-in shell [:active-mode-tab variant-id])]
     (share/variant-share-url
       variant-id
       (or base "")
       {:active-modes   (:active-modes shell)
        :cell-overrides (get-in shell [:cell-overrides variant-id])
-       :substrate      (:substrate shell)})))
+       :substrate      (:substrate shell)
+       :workspace-id   (:selected-workspace shell)
+       :mode-tab       mode-tab
+       :viewport       (:viewport shell)
+       :background     (:background shell)
+       :tag-filter     (:tag-filter shell)})))
 
 (defn- current-url-params
   []

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -66,6 +66,7 @@
             [re-frame.story.ui.scrubber :as scrubber]
             [re-frame.story.ui.share :as share]
             [re-frame.story.ui.shell.rails :as rails]
+            [re-frame.story.ui.url-state :as url-state]
             [re-frame.story.ui.shell-styles :refer [styles]]
             [re-frame.story.ui.sidebar :as sidebar]
             [re-frame.story.ui.state :as state]
@@ -415,6 +416,47 @@
   ;; value held over from the previous mount.
   (reset! selection-prev nil))
 
+;; ---- url-state apply-fn ---------------------------------------------------
+;;
+;; rf2-o4u18: bridge between the pure `url-state` engine and the live
+;; registrar / preset tables. `url-state/apply-parsed-to-state` takes a
+;; validators map; we build it here so the engine ns stays portable
+;; (CLJC) and the live wiring sits in one place.
+
+(defn- url-state-apply-fn
+  "Build the `apply-fn` `url-state` consumes — closes over the live
+  registrar + viewport + backgrounds tables. Returns a `(state →
+  parsed → state')` fn."
+  []
+  (let [validators {:variant?    (fn [vid]
+                                   (or (nil? vid)
+                                       (registrar/registered? :variant vid)))
+                    :workspace?  (fn [wid]
+                                   (or (nil? wid)
+                                       (registrar/registered? :workspace wid)))
+                    :viewport?   (fn [v]
+                                   (or (nil? v) (viewport/valid-selection? v)))
+                    :background? (fn [b]
+                                   (or (nil? b) (backgrounds/valid-selection? b)))}]
+    (fn [state parsed]
+      (url-state/apply-parsed-to-state state parsed validators))))
+
+(defn- hydrate-url-state!
+  "One-shot URL → shell-state hydration on mount. Also folds the
+  `share/parse-overrides-param*` dropped-entries hint for the focused
+  variant (rf2-9jthx parity) and selects the variant through the
+  existing `share/hydrate-from-url!` cell-overrides path so the
+  selection-watcher's preallocate-frame branch fires.
+
+  Order:
+    1. `url-state/hydrate-from-url!` writes selection / mode-tab /
+       modes / viewport / background / tag-filter / substrate.
+    2. `share/hydrate-from-url!` adds cell-overrides + the
+       share-import hint (idempotent; selection is already set)."
+  []
+  (url-state/hydrate-from-url! state/shell-state-atom (url-state-apply-fn))
+  (share/hydrate-from-url!))
+
 ;; ---- the top-level component ---------------------------------------------
 
 (defn- right-panel
@@ -623,11 +665,24 @@
          (backgrounds-switcher/hydrate!)
          (start-hot-reload-poll!)
          (selection-watcher)
-         ;; Hydrate the share URL's focused variant / overrides /
-         ;; substrate slots after the selection watcher is installed:
-         ;; deep-link selection must take the same preallocate-frame path
-         ;; as a user clicking a sidebar row.
-         (share/hydrate-from-url!)
+         ;; rf2-o4u18: hydrate the URL-state slots (workspace + mode-tab +
+         ;; viewport + background + tag-filter + variant / modes /
+         ;; substrate) BEFORE the per-variant overrides — the URL-state
+         ;; engine sets the focused selection, then share/hydrate-from-url!
+         ;; folds in cell-overrides + the share-import hint (rf2-9jthx).
+         ;; Selection runs through the same shell-state-atom swap path
+         ;; the user's click would take, so the selection-watcher's
+         ;; preallocate-frame branch fires for deep-linked variants.
+         (hydrate-url-state!)
+         ;; rf2-o4u18: subscribe to popstate so the back-button restores
+         ;; prior URL state, and watch shell-state-atom so user-driven
+         ;; selection / viewport / background / tag-filter changes
+         ;; pushState the canonical URL. Cell-override edits are NOT
+         ;; pushed (too chatty) — they ride the share popover.
+         (url-state/install-popstate-listener!
+           state/shell-state-atom
+           (url-state-apply-fn))
+         (url-state/install-state-watcher! state/shell-state-atom)
          ;; rf2-5fc15: install the Test Codegen recorder's trace-bus
          ;; listener once at shell mount. The listener short-circuits
          ;; on every emit when no recording is in flight, so leaving
@@ -670,6 +725,9 @@
        ;; rf2-d5u89: tear down DOM-capture listeners alongside the
        ;; trace listener so we don't leak listeners across re-mounts.
        (recorder-dom/remove!)
+       ;; rf2-o4u18: drop popstate + shell-state URL watchers so a
+       ;; re-mount doesn't accumulate listeners.
+       (url-state/tear-down! state/shell-state-atom)
        (teardown-all-listeners!))
      :reagent-render
      (fn []

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -1,0 +1,376 @@
+(ns re-frame.story.ui.url-state
+  "URL state engine — encode the shell's user-visible selection into the
+  browser URL, and hydrate the shell from the URL on mount / popstate
+  (rf2-o4u18).
+
+  ## Why
+
+  Per the workspace/variant audit (`ai/findings/2026-05-18-story-
+  workspace-variant-navigation.md` §D), the testbed scored 4/10 on URL
+  sharability: variant + modes + overrides + substrate were encoded,
+  but workspace / mode-tab / viewport / background / tag-filter were
+  NOT, and no `pushState` / `popstate` was wired so back-button and
+  bookmarks didn't reflect navigation. For a devtool testbed
+  sharability IS the value proposition — a teammate should be able to
+  paste a URL and land on the exact same view.
+
+  ## What
+
+  This ns sits at the seam between `shell-state-atom` and
+  `window.history`:
+
+  - `url-from-state`     — pure: shell-state → URL string.
+  - `params-from-state`  — pure: shell-state → param-vector (the same
+                           shape `share/build-params` emits).
+  - `install-popstate-listener!` — CLJS: subscribe to back/forward.
+  - `install-state-watcher!`     — CLJS: subscribe to shell-state
+                                   changes + push / replace URL.
+  - `hydrate-from-url!`  — CLJS: parse `window.location` once on mount.
+  - `tear-down!`         — CLJS: remove every subscription.
+
+  All pure work lives in `re-frame.story.share` (encode + parse). This
+  ns is the bind layer.
+
+  ## pushState vs replaceState
+
+  Primary navigation (variant / workspace selection, mode-tab switch,
+  toolbar mode toggle, viewport / background preset change, tag-filter
+  toggle) → `pushState` so the browser back-button restores the prior
+  view.
+
+  Cell-override edits are NOT pushed/replaced here — they're handled
+  by the existing share-URL surface (the share popover) on demand.
+  Threading every keystroke into the URL is too chatty for an
+  interactive controls panel.
+
+  ## Idempotence
+
+  The state-watcher diffs the computed URL string against the current
+  `window.location` before calling `pushState` — no-op when the URL
+  hasn't changed (e.g. the watcher fires on a non-URL slot like
+  `:hot-reload-tick`).
+
+  popstate-driven hydration sets an internal `*hydrating?*` flag so
+  the state-watcher's reaction does NOT bounce back a push for the
+  state it just absorbed."
+  (:require [clojure.string :as str]
+            [re-frame.story.share :as share]))
+
+;; ---- pure: shell-state → URL params -------------------------------------
+
+(defn params-from-state
+  "Project the URL-relevant slots out of a shell-state map into the
+  arg-shape `share/build-params` consumes. Pure data → data;
+  JVM-testable.
+
+  Cell-overrides are projected from the per-variant overrides map for
+  the currently-focused variant only — the share URL is variant-
+  scoped, not the entire overrides side-table."
+  [shell]
+  (let [vid       (:selected-variant shell)
+        wid       (:selected-workspace shell)
+        tab       (when vid
+                    (get-in shell [:active-mode-tab vid]))
+        modes     (:active-modes shell)
+        viewport  (:viewport shell)
+        bg        (:background shell)
+        tagf      (:tag-filter shell)
+        overrides (when vid (get-in shell [:cell-overrides vid]))
+        substrate (:substrate shell)]
+    (cond-> {}
+      vid       (assoc :variant-id    vid)
+      wid       (assoc :workspace-id  wid)
+      tab       (assoc :mode-tab      tab)
+      (seq modes)     (assoc :active-modes   modes)
+      viewport  (assoc :viewport       viewport)
+      bg        (assoc :background     bg)
+      (seq tagf)      (assoc :tag-filter     tagf)
+      (seq overrides) (assoc :cell-overrides overrides)
+      substrate (assoc :substrate      substrate))))
+
+(defn query-string-from-state
+  "Build the canonical `?<query>` string (no path / hash) for `shell`.
+  Returns an empty string when no URL-relevant slots are populated.
+  Pure data → data; JVM-testable."
+  [shell]
+  (let [params (share/build-params (params-from-state shell))]
+    (if (seq params)
+      (str "?" (str/join "&" params))
+      "")))
+
+(defn url-from-state
+  "Compose the full URL (path + query + fragment) for `shell` against
+  `location-shape`, a `{:pathname :hash}` map describing the current
+  browser location. Returns a string. Pure data → data; JVM-testable.
+
+  The encoder writes the query BEFORE the hash route (Story uses
+  hash-based routing under `#/stories`); same convention
+  `share/variant-share-url` honours so a hash-routed Story page keeps
+  its query in `location.search`."
+  [shell {:keys [pathname hash]}]
+  (let [qs (query-string-from-state shell)
+        path (or pathname "")
+        hash (or hash "")]
+    (str path qs hash)))
+
+;; ---- diff predicate -----------------------------------------------------
+
+(defn url-relevant-slots-changed?
+  "True iff any URL-encoded slot differs between two shell-state maps.
+  Pure data → data; the state-watcher uses this to skip pushState when
+  the watcher fires on a non-URL slot (e.g. `:hot-reload-tick`).
+
+  Compared slots: `:selected-variant`, `:selected-workspace`,
+  `:active-mode-tab`, `:active-modes`, `:viewport`, `:background`,
+  `:tag-filter`, `:substrate`. Cell-overrides are NOT included — they
+  ride the share popover, not the live URL."
+  [old new]
+  (or (not= (:selected-variant   old) (:selected-variant   new))
+      (not= (:selected-workspace old) (:selected-workspace new))
+      (not= (:active-mode-tab    old) (:active-mode-tab    new))
+      (not= (:active-modes       old) (:active-modes       new))
+      (not= (:viewport           old) (:viewport           new))
+      (not= (:background         old) (:background         new))
+      (not= (:tag-filter         old) (:tag-filter         new))
+      (not= (:substrate          old) (:substrate          new))))
+
+;; ---- hydrator: URL params → shell-state apply ---------------------------
+
+(defn apply-parsed-to-state
+  "Pure: fold `parsed` (the output of `share/parse-params`) into a
+  shell-state map. Returns the new state map.
+
+  Validation: each slot is validated against the relevant registrar /
+  preset table via the supplied `validators` map so this fn stays
+  pure. Unknown / invalid ids are silently dropped (a stale URL
+  degrades to the empty / default state rather than poisoning the
+  shell). Missing validators mean 'accept any keyword'.
+
+  `validators` keys:
+    :variant?    fn   — registered? predicate for variant ids
+    :workspace?  fn   — registered? predicate for workspace ids
+    :viewport?   fn   — recognised? for preset kw / custom map
+    :background? fn   — recognised? for preset kw / colour string
+
+  Per rf2-hscut: workspace + variant are mutually exclusive in the
+  sidebar (selecting one clears the other). If the URL carries both
+  the variant wins (variant is the canonical sharable unit; workspace
+  groupings are derived)."
+  [state parsed validators]
+  (let [{:keys [variant-id workspace-id mode-tab active-modes
+                viewport background tag-filter substrate]} parsed
+        variant-ok? (or (nil? (:variant? validators))
+                        ((:variant? validators) variant-id))
+        ws-ok?      (or (nil? (:workspace? validators))
+                        ((:workspace? validators) workspace-id))
+        vp-ok?      (or (nil? (:viewport? validators))
+                        ((:viewport? validators) viewport))
+        bg-ok?      (or (nil? (:background? validators))
+                        ((:background? validators) background))
+        ;; Variant wins over workspace when both are present (rf2-hscut).
+        keep-variant?   (and variant-id variant-ok?)
+        keep-workspace? (and (not keep-variant?) workspace-id ws-ok?)]
+    (cond-> state
+      keep-variant?
+      (-> (assoc :selected-variant variant-id)
+          (assoc :selected-workspace nil))
+
+      keep-workspace?
+      (-> (assoc :selected-workspace workspace-id)
+          (assoc :selected-variant nil))
+
+      (and (not keep-variant?) (not keep-workspace?))
+      (-> (assoc :selected-variant   nil)
+          (assoc :selected-workspace nil))
+
+      (and keep-variant? mode-tab)
+      (assoc-in [:active-mode-tab variant-id] mode-tab)
+
+      (seq active-modes)
+      (assoc :active-modes (vec active-modes))
+
+      (and viewport vp-ok?)
+      (assoc :viewport viewport)
+
+      (and background bg-ok?)
+      (assoc :background background)
+
+      (seq tag-filter)
+      (assoc :tag-filter (set tag-filter))
+
+      substrate
+      (assoc :substrate substrate))))
+
+;; ---- CLJS-only: window.history + popstate -------------------------------
+
+#?(:cljs
+   (do
+
+     (defn- ^:no-doc safe-window []
+       (when (exists? js/window) js/window))
+
+     (defn- ^:no-doc current-location-shape
+       "Snapshot `window.location` into the pure `{:pathname :hash}`
+       shape `url-from-state` consumes."
+       []
+       (when-let [w (safe-window)]
+         (let [loc (.-location w)]
+           {:pathname (.-pathname loc)
+            :hash     (.-hash loc)})))
+
+     (defn- ^:no-doc current-url-search+hash
+       "Snapshot the `(search + hash)` portion of the current URL so the
+       state-watcher can compare against its computed candidate
+       without forcing an absolute-URL diff that includes the origin."
+       []
+       (when-let [w (safe-window)]
+         (let [loc (.-location w)]
+           (str (.-pathname loc) (.-search loc) (.-hash loc)))))
+
+     (defn- ^:no-doc params->getter
+       "Build the `{key → string}` getter map `share/parse-params`
+       consumes from a `URLSearchParams` instance."
+       [usp]
+       (when usp
+         {"variant"    (.get usp "variant")
+          "workspace"  (.get usp "workspace")
+          "mode-tab"   (.get usp "mode-tab")
+          "modes"      (.get usp "modes")
+          "viewport"   (.get usp "viewport")
+          "background" (.get usp "background")
+          "tag-filter" (.get usp "tag-filter")
+          "overrides"  (.get usp "overrides")
+          "substrate"  (.get usp "substrate")}))
+
+     (defn parse-current-url
+       "Parse the current `window.location.search` into the
+       `share/parse-params` shape. Returns nil when no search params
+       are present or window is unavailable."
+       []
+       (when-let [w (safe-window)]
+         (let [search (.-search (.-location w))]
+           (when (and (string? search) (seq search))
+             (try
+               (let [usp (js/URLSearchParams. search)]
+                 (share/parse-params (params->getter usp)))
+               (catch :default _ nil))))))
+
+     (defonce ^:private hydrating?-atom (atom false))
+
+     (defn hydrating?
+       "True while the popstate listener is mid-flight applying URL
+       state back to the shell — the state-watcher checks this flag
+       and skips its pushState reaction so we don't bounce a redundant
+       URL write."
+       []
+       @hydrating?-atom)
+
+     (defn- ^:no-doc with-hydration-guard
+       "Run `f` with the hydration flag pinned true; clears it before
+       returning so the state-watcher resumes pushing on the next
+       user-driven change."
+       [f]
+       (reset! hydrating?-atom true)
+       (try
+         (f)
+         (finally
+           (reset! hydrating?-atom false))))
+
+     (defn push!
+       "`history.pushState(null, '', url)` if URL differs from the
+       current location's `(pathname + search + hash)`. No-op
+       otherwise. Idempotent."
+       [url]
+       (when-let [w (safe-window)]
+         (let [cur (current-url-search+hash)]
+           (when (and url (not= url cur))
+             (try
+               (.pushState (.-history w) nil "" url)
+               (catch :default _ nil))))))
+
+     (defn replace!
+       "`history.replaceState(null, '', url)` if URL differs. No-op
+       otherwise. Idempotent."
+       [url]
+       (when-let [w (safe-window)]
+         (let [cur (current-url-search+hash)]
+           (when (and url (not= url cur))
+             (try
+               (.replaceState (.-history w) nil "" url)
+               (catch :default _ nil))))))
+
+     ;; ---- watch wiring -----------------------------------------------------
+
+     (defonce ^:private popstate-handler-atom (atom nil))
+
+     (defn install-popstate-listener!
+       "Subscribe to `window.popstate`. Each pop parses
+       `window.location.search` via `share/parse-params` and folds the
+       result into `shell-state-atom` via `apply-parsed-to-state`.
+
+       `apply-fn` is the post-validation applicator — production wires
+       it to `apply-parsed-to-state` curried with live validators (so
+       the popstate handler doesn't need to import the registrar /
+       viewport / backgrounds nss directly). Tests can pass a no-op /
+       capturing apply-fn.
+
+       Idempotent: re-installing replaces the previous handler. Returns
+       the wired handler so tests can introspect."
+       [shell-state-atom apply-fn]
+       (when-let [w (safe-window)]
+         (when-let [prev @popstate-handler-atom]
+           (try (.removeEventListener w "popstate" prev)
+                (catch :default _ nil)))
+         (let [h (fn [_]
+                   (when-let [parsed (parse-current-url)]
+                     (with-hydration-guard
+                       (fn []
+                         (swap! shell-state-atom apply-fn parsed)))))]
+           (.addEventListener w "popstate" h)
+           (reset! popstate-handler-atom h)
+           h)))
+
+     (defn remove-popstate-listener! []
+       (when-let [w (safe-window)]
+         (when-let [h @popstate-handler-atom]
+           (try (.removeEventListener w "popstate" h)
+                (catch :default _ nil))
+           (reset! popstate-handler-atom nil))))
+
+     (def ^:private state-watcher-key ::url-state-watcher)
+
+     (defn install-state-watcher!
+       "Watch `shell-state-atom`; on every URL-relevant change push the
+       canonical URL via `history.pushState`. No-op when the watcher
+       fires on a non-URL slot or while a popstate hydration is in
+       flight. Idempotent: re-installing replaces the previous watch
+       (same watch-key)."
+       [shell-state-atom]
+       (add-watch shell-state-atom state-watcher-key
+                  (fn [_ _ old new]
+                    (when (and (not (hydrating?))
+                               (url-relevant-slots-changed? old new))
+                      (let [url (url-from-state new (current-location-shape))]
+                        (push! url))))))
+
+     (defn remove-state-watcher! [shell-state-atom]
+       (remove-watch shell-state-atom state-watcher-key))
+
+     (defn hydrate-from-url!
+       "Parse the current `window.location.search` once at shell mount
+       and fold the parsed slots into `shell-state-atom`. Sets a
+       transient `*hydrating?*` flag so the state-watcher's first
+       fire (the swap below) doesn't bounce a redundant pushState
+       back to the same URL.
+
+       Returns the parsed map (or nil when no params)."
+       [shell-state-atom apply-fn]
+       (when-let [parsed (parse-current-url)]
+         (with-hydration-guard
+           (fn []
+             (swap! shell-state-atom apply-fn parsed)))
+         parsed))
+
+     (defn tear-down! [shell-state-atom]
+       (remove-state-watcher! shell-state-atom)
+       (remove-popstate-listener!))))

--- a/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/url_state_cljs_test.cljs
@@ -1,0 +1,177 @@
+(ns re-frame.story.ui.url-state-cljs-test
+  "CLJS-side regression net for the URL-state engine (rf2-o4u18).
+
+  The pure pieces (params projection, query-string composition, slot
+  diff, parsed-application) are covered in
+  `re-frame.story.ui.url-state-test` (.cljc). This ns exercises the
+  CLJS-only surfaces — pushState / replaceState idempotence,
+  popstate-driven hydration, and the install/teardown contract.
+
+  The window.history surface is mocked rather than driving the real
+  browser back-stack so the test stays deterministic under the node
+  runner (and so the test doesn't perturb the harness's own URL)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string               :as str]
+            [re-frame.story.share         :as share]
+            [re-frame.story.ui.state      :as state]
+            [re-frame.story.ui.url-state  :as us]))
+
+;; ---- fixtures ------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/window) (exists? js/URLSearchParams)))
+
+(defn reset-all! []
+  (state/reset-shell-state!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- url-from-state composition -----------------------------------------
+
+(deftest url-from-state-includes-every-slot
+  (testing "rf2-o4u18 — composed URL carries every URL-relevant slot"
+    (let [shell {:selected-variant   :foo/bar
+                 :active-mode-tab    {:foo/bar :docs}
+                 :active-modes       [:m/dark]
+                 :viewport           :tablet
+                 :background         :dark
+                 :tag-filter         #{:tag/a}
+                 :substrate          :uix}
+          url   (us/url-from-state shell {:pathname "/p/" :hash "#/stories"})]
+      (is (re-find #"variant="    url))
+      (is (re-find #"mode-tab="   url))
+      (is (re-find #"modes="      url))
+      (is (re-find #"viewport="   url))
+      (is (re-find #"background=" url))
+      (is (re-find #"tag-filter=" url))
+      (is (re-find #"substrate="  url))
+      (is (re-find #"#/stories$"  url)
+          "hash route survives at the tail"))))
+
+;; ---- params-from-state via the public share encoder ---------------------
+
+(deftest params-from-state-feeds-share-build-params
+  (testing "rf2-o4u18 — the projection contract: params-from-state +
+            share/build-params produce a URL params vector that
+            share/parse-params round-trips back to the projection"
+    (let [shell  {:selected-variant   :foo/bar
+                  :active-mode-tab    {:foo/bar :test}
+                  :active-modes       [:m/dark]
+                  :viewport           {:width 800 :height 600}
+                  :background         "#abc123"
+                  :tag-filter         #{:tag/x}
+                  :cell-overrides     {:foo/bar {:label "Hi"}}
+                  :substrate          :uix}
+          proj   (us/params-from-state shell)
+          ps     (share/build-params proj)
+          usp    (js/URLSearchParams. (str/join "&" ps))
+          getter {"variant"    (.get usp "variant")
+                  "workspace"  (.get usp "workspace")
+                  "mode-tab"   (.get usp "mode-tab")
+                  "modes"      (.get usp "modes")
+                  "viewport"   (.get usp "viewport")
+                  "background" (.get usp "background")
+                  "tag-filter" (.get usp "tag-filter")
+                  "overrides"  (.get usp "overrides")
+                  "substrate"  (.get usp "substrate")}
+          out    (share/parse-params getter)]
+      (is (= :foo/bar (:variant-id out)))
+      (is (= :test    (:mode-tab out)))
+      (is (= [:m/dark] (:active-modes out)))
+      (is (= {:width 800 :height 600} (:viewport out)))
+      (is (= "#abc123" (:background out)))
+      (is (= #{:tag/x} (:tag-filter out)))
+      (is (= {:label "Hi"} (:cell-overrides out)))
+      (is (= :uix (:substrate out))))))
+
+;; ---- pushState idempotence ----------------------------------------------
+;;
+;; Under the node runner `js/window.history` is mocked by jsdom. The
+;; tests below capture pushState invocations via a wrapper atom so we
+;; can assert n calls without actually mutating the test runner's URL.
+
+(when (browser?)
+  (defn- with-history-spy
+    "Install a spy around `window.history.pushState`; returns the
+    captured-calls atom + a restore fn."
+    []
+    (let [captured (atom [])
+          orig     (.-pushState (.-history js/window))
+          spy      (fn [_state _title url]
+                     (swap! captured conj url))]
+      (set! (.-pushState (.-history js/window)) spy)
+      [captured (fn [] (set! (.-pushState (.-history js/window)) orig))]))
+
+  (deftest push!-skips-when-url-matches-current-location
+    (testing "rf2-o4u18 — push! is idempotent: no-op when the URL matches
+              the current location (avoids gratuitous back-stack entries)"
+      (let [[captured restore] (with-history-spy)
+            ;; Use the actual current pathname so the diff says 'same'.
+            cur (str (.-pathname (.-location js/window))
+                     (.-search   (.-location js/window))
+                     (.-hash     (.-location js/window)))]
+        (us/push! cur)
+        (try
+          (is (= 0 (count @captured))
+              "no pushState calls when URL matches")
+          (finally (restore))))))
+
+  (deftest push!-fires-when-url-differs
+    (testing "rf2-o4u18 — push! pushes a different URL"
+      (let [[captured restore] (with-history-spy)]
+        (us/push! (str (.-pathname (.-location js/window))
+                       "?variant=foo%2Fbar"
+                       (.-hash (.-location js/window))))
+        (try
+          (is (= 1 (count @captured)))
+          (is (re-find #"variant=foo" (first @captured)))
+          (finally (restore)))))))
+
+;; ---- state-watcher install/teardown -------------------------------------
+
+(deftest state-watcher-install-and-teardown-noerr
+  (testing "rf2-o4u18 — install + teardown completes without error and is
+            idempotent (re-install replaces under same key, teardown
+            removes the watch)"
+    (us/install-state-watcher! state/shell-state-atom)
+    ;; Re-install replaces under the same watch-key (no doubled fires
+    ;; because add-watch is keyed).
+    (us/install-state-watcher! state/shell-state-atom)
+    (us/remove-state-watcher! state/shell-state-atom)
+    (is true "install + reinstall + teardown without errors")))
+
+;; ---- popstate listener install/teardown ---------------------------------
+
+(deftest popstate-listener-install-is-idempotent
+  (testing "rf2-o4u18 — re-installing the popstate listener replaces the
+            previous handler rather than stacking"
+    (when (browser?)
+      (us/install-popstate-listener! state/shell-state-atom
+                                     (fn [s _parsed] s))
+      ;; Second install: still one handler effective; the engine
+      ;; tracks the previous handler and removeEventListener's it.
+      (us/install-popstate-listener! state/shell-state-atom
+                                     (fn [s _parsed] s))
+      ;; Best we can assert without driving popstate: no exceptions
+      ;; raised, and tear-down clears the slot.
+      (us/remove-popstate-listener!)
+      (is true "install + reinstall + remove without errors"))))
+
+;; ---- apply-fn integration through swap! ---------------------------------
+
+(deftest apply-parsed-to-state-via-swap
+  (testing "rf2-o4u18 — swap! threads apply-parsed-to-state through the
+            live shell-state ratom"
+    (let [apply-fn (fn [s parsed]
+                     (us/apply-parsed-to-state s parsed {}))]
+      (swap! state/shell-state-atom apply-fn
+             {:variant-id :foo/bar
+              :viewport   :tablet
+              :background :dark
+              :tag-filter #{:tag/a}})
+      (let [s @state/shell-state-atom]
+        (is (= :foo/bar (:selected-variant s)))
+        (is (= :tablet  (:viewport s)))
+        (is (= :dark    (:background s)))
+        (is (= #{:tag/a} (:tag-filter s)))))))
+

--- a/tools/story/test/re_frame/story/ui/url_state_test.cljc
+++ b/tools/story/test/re_frame/story/ui/url_state_test.cljc
@@ -1,0 +1,246 @@
+(ns re-frame.story.ui.url-state-test
+  "Pure tests for the URL-state engine (rf2-o4u18).
+
+  The CLJS browser surface (pushState / popstate / window.location) is
+  exercised in `re-frame.story.ui.url-state-cljs-test` and in the
+  Playwright browser scenario. This ns pins the pure pieces:
+
+  - `params-from-state`     — project shell-state slots onto build-params shape.
+  - `query-string-from-state` — round-trip ?key=val&... composition.
+  - `url-from-state`        — full path + query + hash composition.
+  - `url-relevant-slots-changed?` — diff for the state watcher.
+  - `apply-parsed-to-state` — fold parsed slots back into shell-state."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.url-state :as us]))
+
+;; ---- params-from-state ---------------------------------------------------
+
+(deftest params-from-state-empty
+  (testing "an empty shell state projects to {}"
+    (is (= {} (us/params-from-state {})))))
+
+(deftest params-from-state-variant-only
+  (testing "a focused variant projects to {:variant-id ...} only"
+    (is (= {:variant-id :story.foo/bar}
+           (us/params-from-state
+             {:selected-variant :story.foo/bar})))))
+
+(deftest params-from-state-workspace-only
+  (testing "a focused workspace projects to {:workspace-id ...} only"
+    (is (= {:workspace-id :story.foo/grid}
+           (us/params-from-state
+             {:selected-workspace :story.foo/grid})))))
+
+(deftest params-from-state-mode-tab-keyed-on-variant
+  (testing "mode-tab is projected from the focused variant's slot"
+    (is (= {:variant-id :story.foo/bar
+            :mode-tab   :docs}
+           (us/params-from-state
+             {:selected-variant :story.foo/bar
+              :active-mode-tab  {:story.foo/bar :docs
+                                 :story.other/x :test}})))))
+
+(deftest params-from-state-cell-overrides-scoped-to-variant
+  (testing "cell-overrides only project for the focused variant"
+    (is (= {:variant-id     :story.foo/bar
+            :cell-overrides {:label "Hi"}}
+           (us/params-from-state
+             {:selected-variant :story.foo/bar
+              :cell-overrides   {:story.foo/bar  {:label "Hi"}
+                                 :story.other/x  {:label "Hidden"}}})))))
+
+(deftest params-from-state-full
+  (testing "every URL-relevant slot projects"
+    (let [out (us/params-from-state
+                {:selected-variant   :story.foo/bar
+                 :selected-workspace nil
+                 :active-mode-tab    {:story.foo/bar :test}
+                 :active-modes       [:m/dark]
+                 :viewport           :tablet
+                 :background         :dark
+                 :tag-filter         #{:tag/a}
+                 :cell-overrides     {:story.foo/bar {:n 5}}
+                 :substrate          :uix})]
+      (is (= :story.foo/bar (:variant-id out)))
+      (is (= :test          (:mode-tab   out)))
+      (is (= [:m/dark]      (:active-modes out)))
+      (is (= :tablet        (:viewport out)))
+      (is (= :dark          (:background out)))
+      (is (= #{:tag/a}      (:tag-filter out)))
+      (is (= {:n 5}         (:cell-overrides out)))
+      (is (= :uix           (:substrate out))))))
+
+;; ---- query-string-from-state --------------------------------------------
+
+(deftest query-string-from-empty-state-is-blank
+  (is (= "" (us/query-string-from-state {}))))
+
+(deftest query-string-from-state-prepends-question-mark
+  (let [qs (us/query-string-from-state {:selected-variant :foo/bar})]
+    (is (re-find #"^\?variant=" qs))))
+
+(deftest query-string-from-state-includes-all-slots
+  (let [qs (us/query-string-from-state
+             {:selected-variant   :foo/bar
+              :active-mode-tab    {:foo/bar :docs}
+              :active-modes       [:m/dark]
+              :viewport           :tablet
+              :background         :dark
+              :tag-filter         #{:tag/a}})]
+    (is (re-find #"variant="    qs))
+    (is (re-find #"mode-tab="   qs))
+    (is (re-find #"modes="      qs))
+    (is (re-find #"viewport="   qs))
+    (is (re-find #"background=" qs))
+    (is (re-find #"tag-filter=" qs))))
+
+;; ---- url-from-state ------------------------------------------------------
+
+(deftest url-from-state-composes-pathname-query-hash
+  (let [url (us/url-from-state
+              {:selected-variant :foo/bar}
+              {:pathname "/foo/"
+               :hash     "#/stories"})]
+    (is (= "/foo/?variant=foo%2Fbar#/stories" url))))
+
+(deftest url-from-state-no-query-when-empty
+  (let [url (us/url-from-state {} {:pathname "/foo/" :hash "#/stories"})]
+    (is (= "/foo/#/stories" url))))
+
+;; ---- url-relevant-slots-changed? ----------------------------------------
+
+(deftest url-relevant-slots-changed-detects-variant-change
+  (is (us/url-relevant-slots-changed?
+        {:selected-variant :foo/a}
+        {:selected-variant :foo/b})))
+
+(deftest url-relevant-slots-changed-detects-workspace-change
+  (is (us/url-relevant-slots-changed?
+        {:selected-workspace :foo/a}
+        {:selected-workspace :foo/b})))
+
+(deftest url-relevant-slots-changed-detects-mode-tab-change
+  (is (us/url-relevant-slots-changed?
+        {:active-mode-tab {:foo/a :dev}}
+        {:active-mode-tab {:foo/a :docs}})))
+
+(deftest url-relevant-slots-changed-detects-viewport-change
+  (is (us/url-relevant-slots-changed?
+        {:viewport :full}
+        {:viewport :tablet})))
+
+(deftest url-relevant-slots-changed-detects-background-change
+  (is (us/url-relevant-slots-changed?
+        {:background :light}
+        {:background :dark})))
+
+(deftest url-relevant-slots-changed-detects-tag-filter-change
+  (is (us/url-relevant-slots-changed?
+        {:tag-filter #{}}
+        {:tag-filter #{:tag/a}})))
+
+(deftest url-relevant-slots-changed-detects-active-modes-change
+  (is (us/url-relevant-slots-changed?
+        {:active-modes []}
+        {:active-modes [:m/dark]})))
+
+(deftest url-relevant-slots-changed-ignores-non-url-slots
+  (testing "changes to non-URL slots (hot-reload-tick, cell-overrides,
+            fingerprints, panel-visibility) do NOT trigger a push"
+    (is (not (us/url-relevant-slots-changed?
+               {:selected-variant :foo/a :hot-reload-tick 0}
+               {:selected-variant :foo/a :hot-reload-tick 99})))
+    (is (not (us/url-relevant-slots-changed?
+               {:selected-variant :foo/a :cell-overrides {}}
+               {:selected-variant :foo/a :cell-overrides {:foo/a {:x 1}}})))
+    (is (not (us/url-relevant-slots-changed?
+               {:selected-variant :foo/a :fingerprints {}}
+               {:selected-variant :foo/a :fingerprints {:foo/a {:dec :h}}})))
+    (is (not (us/url-relevant-slots-changed?
+               {:selected-variant :foo/a
+                :panel-visibility {:trace true}}
+               {:selected-variant :foo/a
+                :panel-visibility {:trace false}})))))
+
+;; ---- apply-parsed-to-state ----------------------------------------------
+
+(deftest apply-parsed-variant-only
+  (let [out (us/apply-parsed-to-state
+              {} {:variant-id :foo/bar} {})]
+    (is (= :foo/bar (:selected-variant out)))
+    (is (nil? (:selected-workspace out)))))
+
+(deftest apply-parsed-workspace-only
+  (let [out (us/apply-parsed-to-state
+              {} {:workspace-id :foo/grid} {})]
+    (is (= :foo/grid (:selected-workspace out)))
+    (is (nil? (:selected-variant out)))))
+
+(deftest apply-parsed-variant-wins-over-workspace
+  (testing "rf2-hscut — variant click clears :selected-workspace. When the
+            URL carries BOTH (a teammate crafted a URL or a stale
+            bookmark), variant wins."
+    (let [out (us/apply-parsed-to-state
+                {} {:variant-id   :foo/bar
+                    :workspace-id :foo/grid}
+                {})]
+      (is (= :foo/bar (:selected-variant out)))
+      (is (nil? (:selected-workspace out))))))
+
+(deftest apply-parsed-validators-drop-unknown-variant
+  (testing "unknown variant id is dropped (stale URL degrades, not crashes)"
+    (let [out (us/apply-parsed-to-state
+                {:selected-variant nil}
+                {:variant-id :ghost/x}
+                {:variant? (fn [vid] (= vid :foo/bar))})]
+      (is (nil? (:selected-variant out))))))
+
+(deftest apply-parsed-validators-drop-unknown-workspace
+  (testing "unknown workspace id is dropped"
+    (let [out (us/apply-parsed-to-state
+                {} {:workspace-id :ghost/grid}
+                {:workspace? (fn [_] false)})]
+      (is (nil? (:selected-workspace out))))))
+
+(deftest apply-parsed-validators-drop-unknown-viewport
+  (testing "unknown viewport preset is dropped — chrome falls back to default"
+    (let [out (us/apply-parsed-to-state
+                {} {:viewport :nonsense}
+                {:viewport? (fn [v] (= v :tablet))})]
+      (is (nil? (:viewport out))))))
+
+(deftest apply-parsed-mode-tab-keyed-on-variant
+  (testing "mode-tab only applies when a valid variant is also present"
+    (let [out (us/apply-parsed-to-state
+                {} {:variant-id :foo/bar :mode-tab :docs} {})]
+      (is (= :docs (get-in out [:active-mode-tab :foo/bar]))))))
+
+(deftest apply-parsed-tag-filter-set
+  (let [out (us/apply-parsed-to-state
+              {} {:tag-filter #{:tag/a :tag/b}} {})]
+    (is (= #{:tag/a :tag/b} (:tag-filter out)))))
+
+(deftest apply-parsed-substrate
+  (let [out (us/apply-parsed-to-state
+              {} {:substrate :uix} {})]
+    (is (= :uix (:substrate out)))))
+
+(deftest apply-parsed-full-round-trip-through-state
+  (testing "URL → parsed → state, then state → URL produces equivalent
+            params (allowing for set vs vec re-ordering)"
+    (let [parsed   {:variant-id   :foo/bar
+                    :mode-tab     :docs
+                    :active-modes [:m/dark]
+                    :viewport     :tablet
+                    :background   :dark
+                    :tag-filter   #{:tag/a :tag/b}
+                    :substrate    :uix}
+          state    (us/apply-parsed-to-state {} parsed {})
+          re-proj  (us/params-from-state state)]
+      (is (= :foo/bar       (:variant-id   re-proj)))
+      (is (= :docs          (:mode-tab     re-proj)))
+      (is (= [:m/dark]      (:active-modes re-proj)))
+      (is (= :tablet        (:viewport     re-proj)))
+      (is (= :dark          (:background   re-proj)))
+      (is (= #{:tag/a :tag/b} (:tag-filter  re-proj)))
+      (is (= :uix           (:substrate    re-proj))))))

--- a/tools/story/test/re_frame/story_share_url_state_test.clj
+++ b/tools/story/test/re_frame/story_share_url_state_test.clj
@@ -1,0 +1,201 @@
+(ns re-frame.story-share-url-state-test
+  "JVM tests for the URL-state slot extensions (rf2-o4u18).
+
+  Pairs with `re-frame.story-share-test` (variant + modes + overrides +
+  substrate). This ns pins the new sharability slots — workspace,
+  mode-tab, viewport, background, tag-filter — and the
+  `share/parse-params` round-trip.
+
+  Pure CLJC — every encoder + parser lives in `re-frame.story.share`,
+  no CLJS deps."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.story.share :as share]))
+
+;; ---- workspace -----------------------------------------------------------
+
+(deftest build-params-workspace
+  (testing "workspace id encodes as workspace=<ns>/<name>"
+    (let [ps (share/build-params {:workspace-id :story.foo/grid})
+          wp (some #(when (str/starts-with? % "workspace=") %) ps)]
+      (is (some? wp))
+      (is (re-find #"story.foo" wp))
+      (is (re-find #"grid" wp)))))
+
+(deftest parse-workspace-param-round-trip
+  (testing "parse-workspace-param round-trips a kw->str token"
+    (is (= :story.foo/grid
+           (share/parse-workspace-param "story.foo/grid")))
+    (is (nil? (share/parse-workspace-param "")))
+    (is (nil? (share/parse-workspace-param nil)))))
+
+;; ---- mode-tab ------------------------------------------------------------
+
+(deftest build-params-mode-tab-non-default
+  (testing "mode-tab encodes when non-default (anything other than :dev)"
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :mode-tab   :docs})]
+      (is (some #(str/starts-with? % "mode-tab=docs") ps)))))
+
+(deftest build-params-mode-tab-default-omitted
+  (testing ":dev (the default) is omitted so the canonical URL stays minimal"
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :mode-tab   :dev})]
+      (is (not (some #(str/starts-with? % "mode-tab=") ps))))))
+
+(deftest build-params-mode-tab-unknown-dropped
+  (testing "unknown mode-tab values are dropped (a stale URL degrades silently)"
+    (let [ps (share/build-params {:variant-id :story.foo/bar
+                                  :mode-tab   :bogus})]
+      (is (not (some #(str/starts-with? % "mode-tab=") ps))))))
+
+(deftest parse-mode-tab-param
+  (testing "parse-mode-tab-param recognises :dev/:docs/:test, drops anything else"
+    (is (= :dev  (share/parse-mode-tab-param "dev")))
+    (is (= :docs (share/parse-mode-tab-param "docs")))
+    (is (= :test (share/parse-mode-tab-param "test")))
+    (is (nil?    (share/parse-mode-tab-param "bogus")))
+    (is (nil?    (share/parse-mode-tab-param "")))
+    (is (nil?    (share/parse-mode-tab-param nil)))))
+
+;; ---- viewport ------------------------------------------------------------
+
+(deftest build-params-viewport-preset
+  (testing "viewport preset keyword encodes as viewport=<id>"
+    (let [ps (share/build-params {:viewport :tablet})]
+      (is (some #(= "viewport=tablet" %) ps)))))
+
+(deftest build-params-viewport-custom
+  (testing "viewport custom map encodes as viewport=WxH"
+    (let [ps (share/build-params {:viewport {:width 800 :height 600}})]
+      (is (some #(= "viewport=800x600" %) ps)))))
+
+(deftest build-params-viewport-omitted-when-nil
+  (testing "nil viewport is omitted from the canonical URL"
+    (let [ps (share/build-params {:viewport nil})]
+      (is (not (some #(str/starts-with? % "viewport=") ps))))))
+
+(deftest parse-viewport-param-preset
+  (is (= :tablet (share/parse-viewport-param "tablet"))))
+
+(deftest parse-viewport-param-custom
+  (testing "custom WxH parses into {:width :height}"
+    (is (= {:width 800 :height 600} (share/parse-viewport-param "800x600")))
+    (is (= {:width 1024 :height 768} (share/parse-viewport-param "1024x768")))))
+
+(deftest parse-viewport-param-malformed
+  (testing "malformed values degrade — empty / nil → nil; zero dim → nil;
+            unknown keywords are returned as-is (the hydrator validates
+            against the preset table via apply-parsed-to-state)"
+    (is (nil? (share/parse-viewport-param "0x600")) "zero dim → nil")
+    (is (nil? (share/parse-viewport-param "")))
+    (is (nil? (share/parse-viewport-param nil)))
+    ;; Bare tokens parse to keywords here; the hydrator's :viewport?
+    ;; validator drops anything that isn't a registered preset / valid custom.
+    (is (= :x (share/parse-viewport-param "x")))))
+
+;; ---- background ----------------------------------------------------------
+
+(deftest build-params-background-preset
+  (testing "background preset keyword encodes as background=<id>"
+    (let [ps (share/build-params {:background :dark})]
+      (is (some #(= "background=dark" %) ps)))))
+
+(deftest build-params-background-hex
+  (testing "hex colour string encodes as background=%23rrggbb"
+    (let [ps (share/build-params {:background "#abc123"})]
+      (is (some #(= "background=%23abc123" %) ps)
+          "# is percent-encoded to %23 so it doesn't collide with hash routes"))))
+
+(deftest parse-background-param-preset
+  (is (= :dark (share/parse-background-param "dark"))))
+
+(deftest parse-background-param-hex
+  (testing "hex colour parses back to itself"
+    (is (= "#abc123" (share/parse-background-param "#abc123")))
+    (is (= "#ABC" (share/parse-background-param "#ABC")))
+    (is (= "#aabbccdd" (share/parse-background-param "#aabbccdd")))))
+
+(deftest parse-background-param-malformed
+  (testing "malformed values degrade to nil"
+    (is (nil? (share/parse-background-param "")))
+    (is (nil? (share/parse-background-param nil)))))
+
+;; ---- tag-filter ----------------------------------------------------------
+
+(deftest build-params-tag-filter
+  (testing "tag-filter set encodes as a sorted comma-separated list"
+    (let [ps (share/build-params {:tag-filter #{:tag/b :tag/a}})
+          tf (some #(when (str/starts-with? % "tag-filter=") %) ps)]
+      (is (some? tf))
+      ;; The wire form percent-encodes `/` to %2F and `,` to %2C.
+      (is (re-find #"tag%2Fa" tf))
+      (is (re-find #"tag%2Fb" tf))
+      (is (< (str/index-of tf "tag%2Fa")
+             (str/index-of tf "tag%2Fb"))
+          "sorted alphabetically — :a appears before :b"))))
+
+(deftest parse-tag-filter-param
+  (testing "tag-filter parses into a set"
+    (is (= #{:tag/a :tag/b}
+           (share/parse-tag-filter-param "tag/a,tag/b")))
+    (is (nil? (share/parse-tag-filter-param "")))
+    (is (nil? (share/parse-tag-filter-param nil)))))
+
+;; ---- parse-params round-trip --------------------------------------------
+
+(deftest parse-params-full-round-trip
+  (testing "rf2-o4u18 — full encode → URLSearchParams-shaped getter → parse
+            round-trips every slot"
+    (let [in    {:variant-id     :story.counter/loaded
+                 :workspace-id   nil
+                 :mode-tab       :docs
+                 :active-modes   [:Mode.app/dark :Mode.app/mobile]
+                 :viewport       :tablet
+                 :background     "#abc123"
+                 :tag-filter     #{:tag/a :tag/b}
+                 :cell-overrides {:label "Hi"}
+                 :substrate      :uix}
+          ps    (share/build-params in)
+          ;; Simulate URLSearchParams by parsing the param vector back.
+          getter (into {}
+                       (for [kv ps
+                             :let [[k v] (str/split kv #"=" 2)]]
+                         [k (java.net.URLDecoder/decode v "UTF-8")]))
+          out   (share/parse-params getter)]
+      (is (= :story.counter/loaded (:variant-id   out)))
+      (is (= :docs                 (:mode-tab     out)))
+      (is (= [:Mode.app/dark :Mode.app/mobile]
+                                   (:active-modes out)))
+      (is (= :tablet               (:viewport     out)))
+      (is (= "#abc123"             (:background   out)))
+      (is (= #{:tag/a :tag/b}      (:tag-filter   out)))
+      (is (= {:label "Hi"}         (:cell-overrides out)))
+      (is (= :uix                  (:substrate    out))))))
+
+(deftest parse-params-handles-missing-keys
+  (testing "parse-params returns nil for absent slots — caller decides defaults"
+    (let [out (share/parse-params {})]
+      (is (every? nil? (vals out))))))
+
+(deftest parse-params-with-workspace
+  (testing "workspace round-trips when present"
+    (let [in    {:workspace-id :story.foo/grid}
+          ps    (share/build-params in)
+          getter (into {}
+                       (for [kv ps
+                             :let [[k v] (str/split kv #"=" 2)]]
+                         [k (java.net.URLDecoder/decode v "UTF-8")]))
+          out   (share/parse-params getter)]
+      (is (= :story.foo/grid (:workspace-id out))))))
+
+(deftest parse-params-with-viewport-custom
+  (testing "viewport custom WxH round-trips"
+    (let [in    {:viewport {:width 800 :height 600}}
+          ps    (share/build-params in)
+          getter (into {}
+                       (for [kv ps
+                             :let [[k v] (str/split kv #"=" 2)]]
+                         [k (java.net.URLDecoder/decode v "UTF-8")]))
+          out   (share/parse-params getter)]
+      (is (= {:width 800 :height 600} (:viewport out))))))


### PR DESCRIPTION
## Summary

Lifts the Story testbed's URL sharability from **4/10 → 10/10** per the workspace/variant audit (`ai/findings/2026-05-18-story-workspace-variant-navigation.md` §D). A teammate pasting a URL now lands on the exact same view: workspace + mode-tab + viewport + background + tag-filter + variant + modes + overrides + substrate — and the browser back-button + bookmark + reload preserves state.

Bead: rf2-o4u18.

### Before / after URL examples

**Before** (only variant + modes + overrides + substrate):

```
https://example.test/counter-with-stories/?variant=story.counter%2Floaded&modes=Mode.app%2Fdark#/stories
```

**After** (full chrome state):

```
https://example.test/counter-with-stories/?variant=story.counter%2Floaded&mode-tab=docs&modes=Mode.app%2Fdark&viewport=tablet&background=dark&tag-filter=tag%2Fa%2Ctag%2Fb&overrides=label%3A%22Hi%22&substrate=uix#/stories
```

A workspace-focused URL:

```
https://example.test/counter-with-stories/?workspace=story.counter%2Fgrid&viewport=desktop-wide#/stories
```

A custom viewport + custom hex background:

```
https://example.test/counter-with-stories/?variant=story.counter%2Floaded&viewport=800x600&background=%23abc123#/stories
```

### New URL slots

| Slot | Wire form | Notes |
|------|-----------|-------|
| `workspace` | `:ns/name` | qualified keyword; mutually exclusive with `variant` (variant wins per rf2-hscut) |
| `mode-tab` | `dev` / `docs` / `test` | `dev` (default) omitted |
| `viewport` | `tablet` / `800x600` | preset keyword OR `WxH` custom |
| `background` | `dark` / `%23abc123` | preset keyword OR hex (escaped) |
| `tag-filter` | `tag%2Fa%2Ctag%2Fb` | sorted comma-separated keyword list |

Cell-overrides continue to ride the share popover on demand (NOT pushed on every keystroke — too chatty for a controls panel).

### Engine

`re-frame.story.ui.url-state` is a thin bind layer between `shell-state-atom` and `window.history`:

- pure CLJC: `params-from-state`, `query-string-from-state`, `url-from-state`, `url-relevant-slots-changed?`, `apply-parsed-to-state` (with a `validators` map for registrar / preset gating).
- CLJS: `install-popstate-listener!`, `install-state-watcher!`, `hydrate-from-url!`, `tear-down!`.

A transient `hydrating?` flag prevents popstate → state → push bounce-back. pushState/replaceState are idempotent — they no-op when the candidate URL matches the current location, so the watcher firing on a non-URL slot costs nothing.

### Tests

- **JVM pure** (`re-frame.story-share-url-state-test`) — 23 deftests for every new slot's encode + parse + full parse-params round-trip.
- **CLJC pure** (`re-frame.story.ui.url-state-test`) — 29 deftests for params projection, query-string composition, slot diff, parsed-application with/without validators.
- **CLJS** (`re-frame.story.ui.url-state-cljs-test`) — 6 deftests for url-from-state through the live share encoder, pushState spy-mocked idempotence, state-watcher install/teardown, and apply-parsed-to-state via swap!.

## Test plan

- [x] `scripts/test-fast-pr.sh` — fast PR spine
- [x] `cd tools/story && clojure -M:test` — 748 tests, 0 failures
- [x] `cd implementation && npm run test:cljs` — 3052 tests, 0 failures
- [x] `cd implementation && npm run test:browser` — 3043 tests, 0 failures
- [x] `cd implementation && npm run story:build` — clean
- [x] `cd implementation && npm run test:story-feature-load` — 2 specs, 0 failures
- [x] `cd implementation && npm run test:bundle-isolation` — clean