### PR TITLE
fix(story): ? help button -> top-left (REC chip unobscured)

### DIFF
--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -215,7 +215,7 @@
    [:ul {:style (:list styles)}
     [:li {:style (:list-item styles)}
      "Click the " [:span {:style (:kw styles)} "?"]
-     " in the top-right anytime."]]])
+     " in the top-left anytime."]]])
 
 (defn- on-key-down
   "Escape closes the overlay. Bound to a window listener while open."

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -697,7 +697,10 @@
            [right-panel]]
           ;; rf2-381i: first-time help overlay + persistent re-open chip.
           ;; The chip lives in a fixed-position slot so it floats above the
-          ;; right inspector pane regardless of which panels are visible.
+          ;; chrome regardless of which panels are visible. Per rf2-pxeko
+          ;; the slot is top-LEFT — the top-right corner is reserved for
+          ;; the Test-Codegen REC chip + recording-overlay banner; a
+          ;; floating `?` on the right occluded the REC affordance.
           [:div {:style (:help-slot styles)}
            [help/help-button]]
           [help/help-host]

--- a/tools/story/src/re_frame/story/ui/shell_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/shell_styles.cljs
@@ -66,7 +66,15 @@
                 :background "#1e1e1e"
                 :border-bottom "1px solid #1e1e1e"
                 :margin-bottom "-1px"}
+   ;; rf2-pxeko — `?` help-button chip lives top-LEFT of the viewport.
+   ;; The top-RIGHT corner is reserved for the Test-Codegen REC chip
+   ;; (`recorder/rec-chip` in the toolbar) plus the recording-overlay
+   ;; banner (`recorder/recording-overlay` at top:44px right:12px); a
+   ;; floating `?` on the right occluded the REC affordance. Top-left
+   ;; sits over the toolbar's first axis-label only — no fixed-position
+   ;; conflict with the sidebar (which is part of the flex layout, not
+   ;; fixed-positioned) or any other chrome affordance.
    :help-slot {:position "fixed"
                :top      "8px"
-               :right    "12px"
+               :left     "12px"
                :z-index  1500}})


### PR DESCRIPTION
## Bug (rf2-pxeko)

The Story playground's floating `?` help-button chip lived at `position: fixed; top: 8px; right: 12px` — directly atop the Test-Codegen `REC` chip (which sits at the right end of the toolbar bar) and the recording-overlay banner (`top: 44px; right: 12px`). Users couldn't reach REC without the `?` getting in the way.

## Fix

Move the `?` chip to the top-LEFT of the viewport (`top: 8px; left: 12px`). The right corner of the chrome is reserved for the recorder affordances; the left has no fixed-position competitors (the sidebar is part of the flex layout, not fixed-positioned). The `?` overlays only the toolbar's first axis-label, which is the same visual footprint pattern the right corner had — but without the REC collision.

Sibling updates:
- `shell_styles.cljs` — flip `:right` to `:left` in `:help-slot`; add a comment pinning the reservation contract (`?` top-left, REC top-right).
- `help.cljs` — overlay copy now reads "Click the `?` in the top-left anytime."
- `shell.cljs` — comment on the `:help-slot` div records the rf2-pxeko reservation.

## Chrome corners — before/after

```
BEFORE                                AFTER
+-----------------------------------+  +-----------------------------------+
| [chips ...] ... [REC] [reset] [?] |  | [?] [chips ...] ... [REC] [reset] |
+-----------------------------------+  +-----------------------------------+
| (? overlapped REC)                |  | (? top-left; REC unobstructed)    |
+-----------------------------------+  +-----------------------------------+
```

The `?` is a 24x22px floating chip; on the right it sat ON TOP of the toolbar's REC chip (same z-stack, same coords). On the left it sits over the empty space before the toolbar's first axis-label — no functional collision.

## Tests

- `scripts/test-fast-pr.sh` — PASS (3060 CLJS + 572 JVM tests; 0 failures)
- `cd tools/story && clojure -M:test` — PASS (696 tests, 2132 assertions; 0 failures)
- `cd implementation && npm run test:browser` — PASS (3049 tests, 8730 assertions)
- `cd implementation && npm run test:story-feature-load` — PASS (2 specs, 0 failures)

The recorder review-dialog `aria-pressed` count assertion (`story_feature_load.cjs:60` + `:196`) scopes to `[data-test="story-toolbar"]`, and the `?` button is rendered OUTSIDE the toolbar in the shell — it carries no `aria-pressed` attribute either, so position changes can't perturb that gate.

## Conflicts on top-left

None. The sidebar is part of the flex body layout (not fixed-positioned), and no other shell affordance occupies a fixed-position slot in the top-left corner.