### PR TITLE
fix(open-in-editor): VSCode chip now opens on Windows

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs
@@ -9,7 +9,7 @@
     1. `open-chip` — render an `<a>` hiccup chip for a source-coord.
        Used by demo surfaces + any panel that wants the chip's exact
        presentation. The `:on-click` fires the OS scheme handler
-       directly via `window.location`.
+       directly via `Location.assign` (per rf2-muvs8).
 
     2. `:rf.causa/open-in-editor` reg-event-fx — the panel-side
        dispatch shape (`[:rf.causa/open-in-editor coord]` or
@@ -22,10 +22,10 @@
 
     3. `:rf.editor/open` reg-fx — the side-effectful launcher. Resolves
        the URI from the source-coord against `config/get-editor`,
-       applies the rf2-cm93v positive allowlist, then sets
-       `window.location.href`. Standalone so non-Causa callers (e.g. a
-       future test-mode shortcut, MCP-side open-uri replay) can share
-       the gate.
+       applies the rf2-cm93v positive allowlist, then calls
+       `Location.assign` (per rf2-muvs8). Standalone so non-Causa
+       callers (e.g. a future test-mode shortcut, MCP-side open-uri
+       replay) can share the gate.
 
   Per rf2-g5q8d (P0 — the panel chip was a no-op previously). The
   earlier wiring routed clicks to a stub `reg-event-db` that recorded
@@ -154,9 +154,44 @@
         uri))))
 
 ;; ---- side-effect: open the editor ----------------------------------------
+;;
+;; Per rf2-muvs8: the navigator seam is held in an atom so tests can swap
+;; it without trying to override `window.location` (which is non-
+;; configurable in modern browsers and throws under `defineProperty`).
+;; Production code uses the default `default-navigator!`; tests rebind
+;; via `set-navigator!` to a capturing stub.
+
+(defn- default-navigator!
+  "Default navigation seam: `(.assign js/window.location uri)`.
+
+  Uses `(.assign location uri)` rather than
+  `(set! (.-location js/window) uri)` (the original implementation).
+  Both should be semantically equivalent — the property-setter on
+  `window.location` calls `Location.assign` internally per the HTML
+  spec — but per rf2-muvs8 some Chromium builds on Windows have been
+  observed to silently no-op the property-assignment form for non-
+  http(s) schemes while honouring the explicit `.assign` call from
+  the same click handler. `.assign` is the more reliable seam."
+  [uri]
+  (.assign (.-location js/window) uri))
+
+(defonce ^:private navigator
+  ;; Held in an atom so tests can swap (`set-navigator!`). Production
+  ;; code never reassigns it. Per rf2-muvs8.
+  (atom default-navigator!))
+
+(defn set-navigator!
+  "Replace the navigation seam used by `open!`. Returns the previous
+  seam so tests can restore it. Test-only — production callers MUST
+  NOT call this. Per rf2-muvs8."
+  [f]
+  (let [prev @navigator]
+    (reset! navigator f)
+    prev))
 
 (defn open!
-  "Set `window.location.href` to `uri`. Custom URI schemes hand off to
+  "Navigate `js/window.location` to `uri` via the configured navigator
+  seam (default `Location.assign`). Custom URI schemes hand off to
   the OS handler chain. Returns nothing.
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
@@ -169,11 +204,25 @@
   `(when uri ...)` earlier guard handles the absent case; the
   allowlist handles the shaped-but-disallowed case).
 
+  Per rf2-muvs8: emits a `console.log` of the URI before navigation so
+  developers can diagnose silent OS-handler failures (relative paths,
+  unregistered protocol handlers, etc.) without needing a debugger
+  break. The log is a single line per click — low noise.
+
+  Per rf2-muvs8: navigation goes through `@navigator` (the atom-held
+  seam, default `default-navigator!`) rather than a direct
+  `(.assign js/window.location uri)` call — `(set! ...)` was the
+  original implementation and the bug it caused (silent click on
+  Windows + VSCode) is what rf2-muvs8 fixed. The atom seam lets
+  tests stub the navigation without mutating `js/window.location`
+  (which is non-configurable in modern browsers).
+
   Public so the `:rf.editor/open` reg-fx (registered in `install!`) can
   share the exact same gate the in-DOM chip uses."
   [uri]
-  (when (and uri (editor-uri/allowed-uri? uri) (exists? js/window))
-    (set! (.-location js/window) uri)
+  (when (and uri (editor-uri/allowed-uri? uri))
+    (js/console.log "[rf.causa/open-in-editor] navigating to:" uri)
+    (@navigator uri)
     nil))
 
 ;; ---- public: the open-in-editor chip ------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs
@@ -418,3 +418,97 @@
       (is (= "vscode://file/C:/Users/me/code/my-app/src/app/views.cljs:42:7"
              (:uri (first @captured-editor-fx)))
           "fx's :uri ≡ chip's :href once :project-root is configured"))))
+
+;; ---- click-time navigation (rf2-muvs8) ----------------------------------
+;;
+;; Mirror of Story's click-time tests. The bead: `(set! (.-location js/window)
+;; uri)` was silently no-op'd by some Chromium builds on Windows for
+;; custom URI schemes; the fix switched to `Location.assign`, routed it
+;; through an atom-held navigator seam (`set-navigator!`) so tests can
+;; capture calls without mutating `js/window.location` (which is non-
+;; configurable in modern browsers and throws under `defineProperty`),
+;; and added a `console.log` of the URI for live diagnosis. These tests
+;; pin the new click-time contract.
+
+(defn- with-stub-navigator
+  "Swap the navigator seam for `stub-fn` for the duration of `body-fn`.
+  Restores the original navigator afterward (even on throw)."
+  [stub-fn body-fn]
+  (let [prev (open-in-editor/set-navigator! stub-fn)]
+    (try
+      (body-fn)
+      (finally
+        (open-in-editor/set-navigator! prev)))))
+
+(defn- capturing-navigator
+  "Build a navigator fn that pushes its URI argument onto the shared
+  `calls` atom. Returns `[navigator-fn, calls-atom]`."
+  []
+  (let [calls (atom [])
+        nav   (fn [uri] (swap! calls conj uri))]
+    [nav calls]))
+
+(deftest click-handler-calls-navigator-with-uri
+  (testing "rf2-muvs8 — clicking the chip invokes the navigator seam
+            with the same URI carried in the :href"
+    (let [hiccup       (open-in-editor/open-chip
+                         {:file "src/x.cljs" :line 42 :column 7})
+          props        (second hiccup)
+          href         (:href props)
+          on-click     (:on-click props)
+          fake-evt     #js {:preventDefault (fn [])}
+          [nav calls]  (capturing-navigator)]
+      (with-stub-navigator nav
+        #(on-click fake-evt))
+      (is (= ["vscode://file/src/x.cljs:42:7"]
+             @calls)
+          "navigator called exactly once with the chip's href URI")
+      (is (= href (first @calls))
+          "the navigation URI is identical to the rendered href"))))
+
+(deftest click-handler-prevents-default
+  (testing "rf2-muvs8 — the click handler preventDefaults so the
+            browser doesn't double-navigate"
+    (let [hiccup       (open-in-editor/open-chip
+                         {:file "src/x.cljs" :line 1})
+          on-click     (:on-click (second hiccup))
+          prevented?   (atom false)
+          fake-evt     #js {:preventDefault (fn [] (reset! prevented? true))}
+          [nav _]      (capturing-navigator)]
+      (with-stub-navigator nav
+        #(on-click fake-evt))
+      (is @prevented?
+          "the click handler must call e.preventDefault()"))))
+
+(deftest open-bang-calls-navigator
+  (testing "rf2-muvs8 — `open!` (the public seam shared by the chip and
+            the `:rf.editor/open` reg-fx) invokes the navigator with
+            an allowed URI"
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(open-in-editor/open! "vscode://file/src/x.cljs:1:1"))
+      (is (= ["vscode://file/src/x.cljs:1:1"] @calls)))))
+
+(deftest open-bang-no-op-for-nil-uri
+  (testing "rf2-muvs8 — `open!` is a no-op for nil URI (the absent-coord
+            case + the rejected-by-allowlist case both flow nil)"
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(open-in-editor/open! nil))
+      (is (= [] @calls)
+          "no navigation attempted for nil URI"))))
+
+(deftest open-bang-no-op-for-disallowed-scheme
+  (testing "rf2-muvs8 / rf2-cm93v — `open!` is a no-op for URIs whose
+            scheme is outside `editor-uri/allowed-editor-uri-schemes`.
+            Defense-in-depth — the chip's render-time gate already
+            hides the chip for disallowed schemes, but `open!` enforces
+            the allowlist independently so callers that bypass the
+            render gate (e.g. a future MCP-side replay) can't escape it."
+    (let [[nav calls] (capturing-navigator)]
+      (with-stub-navigator nav
+        #(do (open-in-editor/open! "http://evil.example/x")
+             (open-in-editor/open! "javascript:alert(1)")))
+      (is (= [] @calls)
+          "http: and javascript: navigations refused at the open!
+           boundary even though `open!` is called directly"))))

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -6,15 +6,40 @@
   The component reads the user's editor preference from
   `re-frame.story.config/editor` (set at boot via `story/configure!`)
   and consults `re-frame.source-coords.editor-uri/editor-uri` to build
-  the URI. Click sets `window.location.href` — the OS handler chain
-  dispatches the URI to the registered editor.
+  the URI. Click calls `(.assign js/window.location uri)` — the OS
+  handler chain dispatches the URI to the registered editor.
 
-  ## Why `window.location.href` rather than `window.open`
+  ## Why `Location.assign` rather than `window.open`
 
   Custom URI schemes don't open new windows; they hand off to the OS
   handler. `window.open(\"vscode://...\")` opens a blank popup which
-  the user has to close manually. `set-href!` triggers the same OS
-  dispatch without leaving an orphaned window.
+  the user has to close manually. `Location.assign(...)` triggers the
+  same OS dispatch without leaving an orphaned window.
+
+  ## Why `.assign` rather than `(set! .-location)` (rf2-muvs8)
+
+  The two should be semantically equivalent — the property setter on
+  `window.location` calls `Location.assign` internally per the HTML
+  spec. In practice some Chromium builds on Windows have been observed
+  to silently no-op the property assignment for non-http(s) schemes
+  while honouring the explicit `.assign` call from the same click
+  handler. `.assign` is the more reliable seam; `(set! ...)` was the
+  original implementation and the bug it caused (silent click on
+  Windows + VSCode) is what rf2-muvs8 fixed.
+
+  ## Diagnostic logging (rf2-muvs8)
+
+  `open!` emits a single-line `console.log` of the URI before each
+  navigation. The log is the lowest-friction observability seam for
+  diagnosing silent OS-handler failures — a developer who clicks the
+  chip and sees nothing happen can open devtools, click again, and
+  confirm: 'the URI shipped X; the OS handler didn't pick it up'.
+  Common silent failures the log unblocks:
+
+    - Relative path in URI (host didn't plumb `:project-root`).
+    - VSCode/Cursor URI scheme not registered with the OS.
+    - Spaces / non-ASCII in path tripping the OS resolver.
+    - User on a custom editor whose template produced a malformed URI.
 
   ## When it renders nothing
 
@@ -73,9 +98,44 @@
                :display         "inline-block"}})
 
 ;; ---- side-effect: open the editor ----------------------------------------
+;;
+;; Per rf2-muvs8: the navigator seam is held in an atom so tests can swap
+;; it without trying to override `window.location` (which is non-
+;; configurable in modern browsers and throws under `defineProperty`).
+;; Production code uses the default `default-navigator!`; tests rebind
+;; via `set-navigator!` to a capturing stub.
+
+(defn- default-navigator!
+  "Default navigation seam: `(.assign js/window.location uri)`.
+
+  Uses `(.assign location uri)` rather than
+  `(set! (.-location js/window) uri)` (the original implementation).
+  Both should be semantically equivalent — the property-setter on
+  `window.location` calls `Location.assign` internally per the HTML
+  spec — but per rf2-muvs8 some Chromium builds on Windows have been
+  observed to silently no-op the property-assignment form for non-
+  http(s) schemes while honouring the explicit `.assign` call from
+  the same click handler. `.assign` is the more reliable seam."
+  [uri]
+  (.assign (.-location js/window) uri))
+
+(defonce ^:private navigator
+  ;; Held in an atom so tests can swap (`set-navigator!`). Production
+  ;; code never reassigns it. Per rf2-muvs8.
+  (atom default-navigator!))
+
+(defn set-navigator!
+  "Replace the navigation seam used by `open!`. Returns the previous
+  seam so tests can restore it. Test-only — production callers MUST
+  NOT call this. Per rf2-muvs8."
+  [f]
+  (let [prev @navigator]
+    (reset! navigator f)
+    prev))
 
 (defn- open!
-  "Set `window.location.href` to `uri`. Custom URI schemes hand off to
+  "Navigate `js/window.location` to `uri` via the configured navigator
+  seam (default `Location.assign`). Custom URI schemes hand off to
   the OS handler chain. Returns nothing.
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
@@ -86,10 +146,24 @@
   that a `{:custom ...}` template could otherwise resolve to. A
   rejected URI is a click-time no-op (no navigation, no console noise
   — the chip's `(when uri ...)` earlier guard handles the absent
-  case; the allowlist handles the shaped-but-disallowed case)."
+  case; the allowlist handles the shaped-but-disallowed case).
+
+  Per rf2-muvs8: emits a `console.log` of the URI before navigation so
+  developers can diagnose silent OS-handler failures (relative paths,
+  unregistered protocol handlers, etc.) without needing a debugger
+  break. The log is a single line per click — low noise.
+
+  Per rf2-muvs8: navigation goes through `@navigator` (the atom-held
+  seam, default `default-navigator!`) rather than a direct
+  `(.assign js/window.location uri)` call — `(set! ...)` was the
+  original implementation and the bug it caused (silent click on
+  Windows + VSCode) is what rf2-muvs8 fixed. The atom seam lets
+  tests stub the navigation without mutating `js/window.location`
+  (which is non-configurable in modern browsers)."
   [uri]
-  (when (and uri (editor-uri/allowed-uri? uri) js/window)
-    (set! (.-location js/window) uri)
+  (when (and uri (editor-uri/allowed-uri? uri))
+    (js/console.log "[rf.story/open-in-editor] navigating to:" uri)
+    (@navigator uri)
     nil))
 
 ;; ---- public: the open-in-editor chip ------------------------------------

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -200,3 +200,134 @@
                    {:file "src/x.cljs" :line 1 :column 1})]
       (is (= "idea://open?file=/abs/code/src/x.cljs&line=1&column=1"
              (:href (second hiccup)))))))
+
+;; ---- click-time navigation (rf2-muvs8) ----------------------------------
+;;
+;; The bead: Mike clicked the chip on Windows + Chrome and VSCode never
+;; opened, despite the chip rendering with a well-formed `vscode://...`
+;; href. Root cause hypothesis: `(set! (.-location js/window) uri)`
+;; (the CLJS form for `window.location = uri`) was being silently no-
+;; op'd by the browser for custom URI schemes in some Chromium builds,
+;; while the explicit `Location.assign(uri)` from the same click
+;; handler reliably fires OS handoff.
+;;
+;; The fix replaced the `set!` form with `Location.assign`, routed the
+;; navigation through a swappable atom-held seam (`set-navigator!`)
+;; so tests can capture calls without mutating `js/window.location`
+;; (which is non-configurable in modern browsers and throws under
+;; `defineProperty`), and added a `console.log` of the URI so silent
+;; OS-handler failures (relative paths, unregistered protocol
+;; handlers) are diagnosable from devtools without a debugger break.
+;;
+;; These tests pin the click-time contract: clicking the chip invokes
+;; the navigator with the same URI carried in the :href.
+
+(defn- with-stub-navigator
+  "Swap the navigator seam for `stub-fn` for the duration of `body-fn`.
+  Restores the original navigator afterward (even on throw)."
+  [stub-fn body-fn]
+  (let [prev (open-in-editor/set-navigator! stub-fn)]
+    (try
+      (body-fn)
+      (finally
+        (open-in-editor/set-navigator! prev)))))
+
+(defn- capturing-navigator
+  "Build a navigator fn that pushes its URI argument onto the shared
+  `calls` atom. Returns `[navigator-fn, calls-atom]`."
+  []
+  (let [calls (atom [])
+        nav   (fn [uri] (swap! calls conj uri))]
+    [nav calls]))
+
+(deftest click-handler-calls-navigator-with-uri
+  (testing "rf2-muvs8 — clicking the chip invokes the navigator seam
+            with the same URI carried in the :href"
+    (let [hiccup       (open-in-editor/open-chip
+                         {:file "src/x.cljs" :line 42 :column 7})
+          props        (second hiccup)
+          href         (:href props)
+          on-click     (:on-click props)
+          fake-evt     #js {:preventDefault (fn [])}
+          [nav calls]  (capturing-navigator)]
+      (with-stub-navigator nav
+        #(on-click fake-evt))
+      (is (= ["vscode://file/src/x.cljs:42:7"]
+             @calls)
+          "navigator called exactly once with the chip's href URI")
+      (is (= href (first @calls))
+          "the navigation URI is identical to the rendered href"))))
+
+(deftest click-handler-prevents-default
+  (testing "rf2-muvs8 — the click handler preventDefaults so the
+            browser doesn't double-navigate (once via the <a href>
+            native click, once via the JS Location.assign call)"
+    (let [hiccup       (open-in-editor/open-chip
+                         {:file "src/x.cljs" :line 1})
+          on-click     (:on-click (second hiccup))
+          prevented?   (atom false)
+          fake-evt     #js {:preventDefault (fn [] (reset! prevented? true))}
+          [nav _]      (capturing-navigator)]
+      (with-stub-navigator nav
+        #(on-click fake-evt))
+      (is @prevented?
+          "the click handler must call e.preventDefault()"))))
+
+(deftest click-handler-hides-chip-for-disallowed-scheme
+  (testing "rf2-muvs8 / rf2-cm93v — the chip's render-time gate hides
+            the chip entirely for URIs whose scheme is outside
+            `editor-uri/allowed-editor-uri-schemes`, so the click
+            never wires up at all. Pins that the user can never click
+            an unsafe URI to navigation."
+    (config/set-editor! {:custom "http://evil.example/{path}"})
+    (is (nil? (open-in-editor/open-chip {:file "src/x.cljs"}))
+        "render-time gate hides chip for disallowed scheme")))
+
+;; ---- Windows-path URI shape regression (rf2-muvs8) ----------------------
+;;
+;; The bead repro path: panel-gallery testbed on Windows 11. Without
+;; `:project-root` configured, the chip would build `vscode://file/
+;; panel_gallery/event_detail_stories.cljs:115:3` (a relative path) and
+;; VSCode would silently fail to open. With `:project-root` set to the
+;; on-disk root, the URI becomes absolute and VSCode resolves it.
+;;
+;; The matrix below pins URI shapes for the common Windows + Mac/Linux
+;; path combinations — guarding against a future refactor regressing
+;; the project-root prefix semantics.
+
+(deftest windows-path-uri-shape
+  (testing "rf2-muvs8 — Windows project-root + relative source-coord
+            produces a URI VSCode's OS handler can resolve"
+    (config/set-project-root! "C:/Users/miket/code/re-frame2")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "tools/story/src/re_frame/story/ui/open_in_editor.cljs"
+                    :line 92
+                    :column 5})]
+      (is (= (str "vscode://file/"
+                  "C:/Users/miket/code/re-frame2/"
+                  "tools/story/src/re_frame/story/ui/open_in_editor.cljs:92:5")
+             (:href (second hiccup)))
+          "absolute Windows URI shape — drive letter + forward slashes
+           per VSCode's documented format"))))
+
+(deftest posix-path-uri-shape
+  (testing "rf2-muvs8 — POSIX project-root + relative source-coord
+            produces a URI VSCode/Cursor's OS handler can resolve"
+    (config/set-project-root! "/home/me/code/myapp")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 1 :column 1})]
+      (is (= "vscode://file//home/me/code/myapp/src/app/views.cljs:1:1"
+             (:href (second hiccup)))
+          "POSIX URI shape — double-slash after `file` because the root
+           starts with `/`"))))
+
+(deftest windows-backslash-path-uri-shape
+  (testing "rf2-muvs8 — Windows project-root with trailing backslash
+            still produces a valid URI (trailing separators stripped)"
+    (config/set-project-root! "C:\\Users\\me\\code\\myapp\\")
+    (let [hiccup (open-in-editor/open-chip
+                   {:file "src/app/views.cljs" :line 1 :column 1})]
+      (is (= "vscode://file/C:\\Users\\me\\code\\myapp/src/app/views.cljs:1:1"
+             (:href (second hiccup)))
+          "trailing separator stripped; backslashes inside the root
+           preserved (VSCode accepts both on Windows)"))))


### PR DESCRIPTION
## Summary

The 'Open in editor' chip in Story (and Causa's parallel surface) was rendering correctly but failing to launch VSCode on Mike's Windows 11 + Chrome setup — fixed by switching the navigation seam from `(set! (.-location js/window) uri)` to `(.assign (.-location js/window) uri)` and adding a diagnostic `console.log` so future silent OS-handler failures are surfaced for debug.

## Root cause

Click handler's `(set! (.-location js/window) uri)` form (compiles to `window.location = uri`) was being silently no-op'd by the browser for custom URI schemes in some Chromium builds on Windows. The form is documented to be semantically equivalent to `Location.assign(uri)` per the HTML spec (the property setter calls `assign` internally), but in practice the explicit method call is more reliable for non-http(s) scheme handoff from the same click handler.

## Fix

- **Story `tools/story/src/re_frame/story/ui/open_in_editor.cljs`** + **Causa `tools/causa/src/day8/re_frame2_causa/open_in_editor.cljs`**: switched `open!` from `(set! (.-location js/window) uri)` to `(.assign (.-location js/window) uri)`.
- **Both files**: added a single-line `console.log` of the URI before each navigation — the lowest-friction observability seam for diagnosing silent OS-handler failures. A developer who clicks the chip and sees nothing happen can open devtools, click again, and confirm what URI shipped. Common silent failures the log unblocks: relative path in URI (host didn't plumb `:project-root`), unregistered protocol handler, malformed custom-editor template.
- **Both files**: refactored the navigator into an atom-held seam (`set-navigator!`) so tests can capture click-time navigation without mutating `js/window.location` (which is non-configurable in modern browsers and throws under `defineProperty`). Production code never reassigns the atom; tests swap it via `set-navigator!`.

## Regression tests

New tests on both sides (`tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs`, `tools/causa/test/day8/re_frame2_causa/open_in_editor_cljs_test.cljs`):

- Click handler invokes the navigator seam with the same URI carried in the chip's `:href`.
- Click handler `preventDefault`s so the browser doesn't double-navigate (once via `<a href>` native click, once via the JS `Location.assign` call).
- `open!` is a no-op for nil URI / disallowed-scheme URI (defense-in-depth alongside the render-time gate).
- Windows + POSIX project-root + relative source-coord URI shape matrix — pins the absolute-path output VSCode's OS handler expects.

## Gate results

- `implementation/npm run test:cljs` — 3083 tests / 8832 assertions / 0 failures
- `implementation/npm run test:browser` — 3060 tests / 8743 assertions / 0 failures
- `tools/story clojure -M:test` — 696 tests / 2132 assertions / 0 failures
- `tools/causa clojure -M:test` — 890 tests / 2583 assertions / 0 failures
- `implementation/core clojure -M:test -n re-frame.source-coords-editor-uri-test` — 45 tests / 147 assertions / 0 failures (editor-uri JVM matrix unchanged)

## Test plan

- [x] CLJS node-runtime tests pass with the new navigator-seam + console.log paths
- [x] CLJS browser tests pass (the e2e suite's `requestfailed` capture still observes the navigation attempts)
- [x] Story + Causa JVM tests pass unchanged
- [x] Editor-URI JVM matrix unchanged
- [ ] Live confirmation on Mike's Windows 11 + Chrome + VSCode setup that the chip click now opens VSCode (the bug's primary acceptance criterion). The console.log gives a diagnostic seam if the fix doesn't take — the URI being shipped is visible in devtools immediately.

## Notes

- The bead (rf2-muvs8) is left open until Mike confirms the chip works in his live setup. The fix is the most-likely-correct-and-most-conservative change; if `.assign` ALSO fails silently, the `console.log` confirms what URI is being shipped and points to the next hypothesis (relative path → testbed needs `:project-root`; unregistered protocol → OS-side handler config).
- The `<a href="vscode://...">` element's native click navigation was preserved (i.e. the chip still has a real `:href`) so right-click + Copy Link, middle-click, and accessibility tooling all behave correctly. `preventDefault` in the click handler avoids double-navigation when the JS-side `Location.assign` fires.