### PR TITLE
feat(causa): view-hiccup diff micro-engine + opt-in fn-ref toggle

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -564,12 +564,24 @@
   "Default settings map — the shape `configure! :settings` / the
   `settings/popup` modal / the `:rf.causa/setting` sub all read
   against. See the comment block above for the rationale on each
-  default."
+  default.
+
+  ## :diff section (rf2-i39w2 — hiccup-diff micro-engine, Phase 3 of
+  rf2-abts7)
+
+  `:highlight-fn-ref-changes?` — opt-in toggle for the hiccup-diff
+  engine's fn-ref classification (`ai/findings/2026-05-18-difftastic-
+  in-causa.md` §4.5). Default `false`: function-valued props with
+  identity-different references render as `:same` so idiomatic fresh-
+  per-render closures don't drown the actual hiccup diff. Flip to
+  `true` when diagnosing memoization issues — child re-renders because
+  the parent passes a new fn every time."
   {:general   {:text-size           13              ; px — slider range 10–18
                :panel-position      :right-rail     ; :right-rail | :popout | :fullscreen
                :auto-open-on-error? false}
    :theme     :dark                                  ; :dark | :light
-   :telemetry {:opt-in? false}})
+   :telemetry {:opt-in? false}
+   :diff      {:highlight-fn-ref-changes? false}})
 
 (defonce
   ^{:doc "Atom holding the live settings map. Seeded with
@@ -692,7 +704,8 @@
                          (update :general merge (:general parsed))
                          (assoc  :theme  (or (:theme parsed)
                                              (:theme default-settings)))
-                         (update :telemetry merge (:telemetry parsed)))))))
+                         (update :telemetry merge (:telemetry parsed))
+                         (update :diff      merge (:diff parsed)))))))
        (catch :default _ nil))
      nil))
 
@@ -888,7 +901,8 @@
                   (update :general merge (:general settings))
                   (assoc  :theme  (or (:theme settings)
                                       (:theme default-settings)))
-                  (update :telemetry merge (:telemetry settings))))
+                  (update :telemetry merge (:telemetry settings))
+                  (update :diff      merge (:diff settings))))
       #?(:cljs (write-storage!))))
   ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
   ;; seed so a host that overrides both in one call gets the seed

--- a/tools/causa/src/day8/re_frame2_causa/diff/hiccup.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/diff/hiccup.cljc
@@ -1,0 +1,506 @@
+(ns day8.re-frame2-causa.diff.hiccup
+  "Hiccup-tree-diff micro-engine (rf2-i39w2 Phase 3 of rf2-abts7).
+
+  Design source-of-truth:
+  `ai/findings/2026-05-18-difftastic-in-causa.md` §3.3 + §4.
+
+  ## Why a separate engine
+
+  The generic annotated-tree walker (Phase 1) treats hiccup as a plain
+  vector — `[tag attrs? & children]` — which produces noisy output for
+  rendered hiccup:
+
+    1. Slot 1 (the attrs map) deserves its own diff treatment so a
+       single attribute change reads as one delta, not a 'slot 1
+       modified' with the whole map stacked.
+    2. Children should be tracked by `:key` metadata when present so a
+       reordered keyed child surfaces as `:element-moved`, not as N
+       modifications.
+    3. Text children are leaves; element children recurse. The generic
+       walker doesn't know the difference and recurses into strings as
+       sequences (CLJS treats strings as seqable).
+    4. **Function-valued props would flag every re-render as a diff.**
+       Anonymous event handlers are created fresh per render; treating
+       their reference change as `:modified` drowns the actual signal.
+       Per §4.5 — opaque-by-default rule.
+
+  ## Output shape
+
+  Returns annotated nodes the renderer dispatches on via `::op`:
+
+      {::op :same         :value v}
+      {::op :added        :value v}
+      {::op :removed      :value v}
+      {::op :modified     :before bv :after av}
+      {::op :element-changed
+       :tag t
+       :attrs-diff   <annotated-attrs-node>
+       :children-diff <vector-of-annotated-children>}
+      {::op :element-moved
+       :value v
+       :from-index N
+       :to-index   M
+       :key        k}
+      {::op :fn-ref-changed
+       :before bv
+       :after  av}
+
+  Each child of an element-changed carries either `:index` (positional
+  children) or `:key` (keyed children) so the renderer can label the
+  position.
+
+  ## Opaque-by-default rule (§4.5 — load-bearing)
+
+  Function-valued props are opaque. The vast majority of `:on-click` /
+  `:on-change` / `:ref` handlers are anonymous fns created fresh per
+  render; treating their reference change as `:modified` would drown
+  the actual signal. The classifier returns `:same` for the
+  (opaque, opaque) case by default. The opt-in toggle promotes that
+  case to `:fn-ref-changed` for memoisation-issue diagnosis.
+
+  Other opaque shapes covered by the same rule: channels, promises,
+  atoms (CLJS Atom / Volatile), DOM nodes, React class components.
+
+  ## Pure data → data
+
+  CLJC so the JVM unit-test target picks it up. No runtime dependency
+  on the substrate.
+
+  ## Divergences from the design doc
+
+  - Vector reorder detection on positional children: deferred per the
+    bead's divergence allowance. Positional children diff as
+    add/remove/modified by index; only KEYED children get
+    :element-moved. Follow-on bead for LCS-driven move detection on
+    positional children.
+  - Per-attr-key fn-ref opt-in (§4.5 detection nuance): v1 ships one
+    global toggle; per-attr-key granularity is a follow-on bead."
+  (:require [clojure.set :as set]))
+
+;; ---- predicates --------------------------------------------------------
+
+(defn hiccup-vector?
+  "True when `x` is a hiccup vector — a vector whose first element is a
+  keyword tag (`:div`, `:span`, `:<>`, etc) or a function (Reagent
+  functional component) or a Reagent class component.
+
+  Per design §4.3 — Reagent functional components are treated as
+  opaque (slot 0 is a fn); the predicate treats them as element-shape
+  so the engine routes through the element-diff path. Mismatched
+  shapes (`fn` vs keyword tag) end up as `:modified`."
+  [x]
+  (and (vector? x)
+       (pos? (count x))
+       (or (keyword? (nth x 0))
+           (fn?      (nth x 0))
+           (symbol?  (nth x 0)))))
+
+(defn fragment?
+  "True when `x` is a hiccup `[:<> ...]` fragment vector. Per design
+  §4.3 — fragment children flatten into the parent's children-vec
+  before diffing."
+  [x]
+  (and (hiccup-vector? x) (= :<> (nth x 0))))
+
+(defn- attrs-map?
+  "True when slot 1 of a hiccup vector is an attribute map. Hiccup
+  optionally omits attrs; this discriminates `[:span 'text']` from
+  `[:span {} 'text']`. Records ARE maps but are typically passed as
+  payload (not as attrs); treat records as non-attrs."
+  [x]
+  (and (map? x) (not (record? x))))
+
+(defn split-attrs+children
+  "Return `[attrs children-vec]` for a hiccup element vector. Attrs is
+  `{}` when absent; children-vec is `[]` when there are no children."
+  [v]
+  (when (hiccup-vector? v)
+    (let [tail (subvec v 1)]
+      (if (and (seq tail) (attrs-map? (first tail)))
+        [(first tail) (vec (rest tail))]
+        [{}           (vec tail)]))))
+
+(defn- get-tag [v]
+  (when (hiccup-vector? v) (nth v 0)))
+
+;; ---- opaque predicate (§4.5) -------------------------------------------
+
+(defn opaque?
+  "True when `v` is treated as opaque for hiccup-diff purposes.
+
+  Per design §4.5 — function-valued props are the headline case, but
+  the same logic extends to:
+
+    - channels (`cljs.core.async/chan`)
+    - promises / Deferred / atoms (mutable references)
+    - DOM nodes (rare but possible)
+    - React component classes / fragments
+
+  All default to `(opaque)` rendering with reference-change suppressed
+  unless the opt-in toggle is on.
+
+  The predicate is intentionally conservative — false-positive flags
+  on values the user wanted to deep-diff are recoverable (the renderer
+  shows the value); false negatives (treating a fn as not opaque)
+  would drown signal in re-render noise."
+  [v]
+  (cond
+    (nil? v)     false
+    (fn? v)      true
+    #?@(:cljs
+        [(satisfies? IDeref v)              true   ; atoms, Volatiles, Reagent reactions
+         (instance? js/Promise v)           true
+         ;; DOM nodes — `nodeType` is the cross-browser marker.
+         (and (object? v)
+              (.-nodeType v))               true])
+    #?@(:clj
+        [(instance? clojure.lang.IDeref v)  true
+         (instance? java.util.concurrent.CompletionStage v) true])
+    :else        false))
+
+;; ---- node constructors -------------------------------------------------
+
+(defn- same-node    [v]              {::op :same     :value v})
+(defn- added-node   [v]              {::op :added    :value v})
+(defn- removed-node [v]              {::op :removed  :value v})
+(defn- modified-node
+  [bv av]
+  {::op :modified :before bv :after av})
+
+(defn- element-changed-node
+  [tag attrs-diff children-diff]
+  {::op :element-changed
+   :tag tag
+   :attrs-diff   attrs-diff
+   :children-diff children-diff})
+
+(defn- element-moved-node
+  [v key from-index to-index]
+  {::op :element-moved
+   :value v
+   :key   key
+   :from-index from-index
+   :to-index   to-index})
+
+(defn- fn-ref-changed-node
+  [bv av]
+  {::op :fn-ref-changed :before bv :after av})
+
+;; ---- per-prop classifier (§4.5) ----------------------------------------
+
+(declare diff-hiccup-node)
+
+(defn classify-prop
+  "Diff a single hiccup prop value. The fn-ref toggle is consulted ONLY
+  for the (opaque, opaque) case; all other cases are unaffected.
+
+  Per design §4.5 — the load-bearing rule. Function-valued props honour
+  opaque-by-default; the opt-in toggle promotes the reference-changed
+  case to `:fn-ref-changed` for memoisation diagnosis."
+  [before after {:keys [highlight-fn-ref-changes?] :as opts}]
+  (cond
+    ;; Both opaque (functions, atoms, channels, promises, DOM nodes).
+    (and (opaque? before) (opaque? after))
+    (if (and highlight-fn-ref-changes?
+             (not (identical? before after)))
+      (fn-ref-changed-node before after)
+      (same-node after))
+
+    ;; Opaque removed (was a fn, now nil).
+    (and (opaque? before) (nil? after))
+    (removed-node before)
+
+    ;; Opaque added (was nil, now a fn).
+    (and (nil? before) (opaque? after))
+    (added-node after)
+
+    ;; Type-shift: opaque → non-opaque or vice versa. The value type
+    ;; changed; that's a real `:modified`.
+    (or (and (opaque? before) (not (opaque? after)))
+        (and (not (opaque? before)) (opaque? after)))
+    (modified-node before after)
+
+    ;; Both nil / both equal — `:same`.
+    (= before after)
+    (same-node after)
+
+    ;; Otherwise delegate to the generic value-diff (style maps,
+    ;; class strings, nested data). For props, the children-aware
+    ;; hiccup walker isn't appropriate (a prop value is rarely a
+    ;; hiccup tree); we use the modified-node leaf form here.
+    :else
+    (modified-node before after)))
+
+;; ---- attrs-map diff ----------------------------------------------------
+
+(defn- diff-attrs
+  "Diff two attribute maps. Returns a node tagged `::op :attrs` whose
+  `:children` is a vector of per-attr annotated nodes (each carrying
+  a `:key` slot for the attr name). Each prop value is routed through
+  `classify-prop` (§4.5) before being placed under its key."
+  [attrs-before attrs-after opts]
+  (let [bks   (set (keys attrs-before))
+        aks   (set (keys attrs-after))
+        all   (into bks aks)
+        sks   (try (sort all)
+                   (catch #?(:clj Exception :cljs :default) _ all))
+        per-key
+        (mapv
+          (fn [k]
+            (let [in-b? (contains? attrs-before k)
+                  in-a? (contains? attrs-after k)
+                  bv    (when in-b? (get attrs-before k))
+                  av    (when in-a? (get attrs-after k))]
+              (cond
+                (and in-a? (not in-b?))
+                (assoc (added-node av) :key k)
+
+                (and in-b? (not in-a?))
+                (assoc (removed-node bv) :key k)
+
+                :else
+                (assoc (classify-prop bv av opts) :key k))))
+          sks)
+        summary (reduce (fn [acc child]
+                          (update acc (::op child) (fnil inc 0)))
+                        {}
+                        per-key)]
+    {::op :attrs
+     :children per-key
+     :child-summary summary}))
+
+(defn- attrs-has-changes?
+  "True when the attrs-diff carries at least one non-`:same` child."
+  [attrs-diff]
+  (let [s (:child-summary attrs-diff)]
+    (boolean (or (pos? (:added s 0))
+                 (pos? (:removed s 0))
+                 (pos? (:modified s 0))
+                 (pos? (:fn-ref-changed s 0))))))
+
+;; ---- children flattening + keying --------------------------------------
+
+(defn- flatten-children
+  "Flatten `[:<> ...]` fragments + realise lazy seqs into a single
+  vector of children. Per design §4.3 — fragments are diff-transparent
+  (the children diff against the parent's children directly).
+
+  Lazy seqs cap at `cap` items so a non-realising producer doesn't
+  hang the differ; per design §4.3 the cap matches the §007 perf
+  budget of 200."
+  ([xs] (flatten-children xs 200))
+  ([xs cap]
+   (vec
+     (mapcat
+       (fn [c]
+         (cond
+           (fragment? c)
+           (let [[_ children] (split-attrs+children c)]
+             (flatten-children children cap))
+
+           (and (seq? c) (not (vector? c)))
+           (flatten-children (vec (take cap c)) cap)
+
+           :else
+           [c]))
+       xs))))
+
+(defn- child-key
+  "Read the `:key` slot from a hiccup element's attrs, or nil. The
+  presence of `:key` is the move-tracking signal — design §4.1 ties
+  identity to it."
+  [c]
+  (when (hiccup-vector? c)
+    (let [[attrs _] (split-attrs+children c)]
+      (get attrs :key))))
+
+(defn- all-keyed?
+  "True when EVERY element of `xs` is a hiccup vector whose attrs map
+  carries a `:key`. Per design §4.1 — only the all-keyed case triggers
+  identity-tracked diff; a mixed-keyed list falls back to positional."
+  [xs]
+  (and (seq xs)
+       (every? (fn [c]
+                 (and (hiccup-vector? c)
+                      (some? (child-key c))))
+               xs)))
+
+;; ---- children diff: keyed ---------------------------------------------
+
+(defn- index-by-key
+  "Map `:key` → index for a vector of keyed hiccup children. Earlier
+  occurrences of a duplicate key win (a duplicate is a bug in the
+  user's hiccup; we don't try to repair it)."
+  [xs]
+  (reduce
+    (fn [acc [i c]]
+      (let [k (child-key c)]
+        (if (contains? acc k) acc (assoc acc k i))))
+    {}
+    (map-indexed vector xs)))
+
+(defn- diff-children-keyed
+  "Both sides have :keyed children. Match by :key; emit per-child:
+
+    :element-changed (or :same / :modified) — present in both,
+                     diffed via diff-hiccup-node
+    :element-moved   — present in both, key matches but index changed
+    :added           — present in after only
+    :removed         — present in before only"
+  [bxs axs opts]
+  (let [bidx (index-by-key bxs)
+        aidx (index-by-key axs)
+        bkeys (set (keys bidx))
+        akeys (set (keys aidx))
+        all-keys (vec (concat
+                        ;; Preserve order: keys of `after` (their new
+                        ;; positions) then deletions trailing.
+                        (for [k (map child-key axs)] k)
+                        (filter #(not (contains? akeys %)) (map child-key bxs))))]
+    (vec
+      (for [k all-keys]
+        (let [bi (get bidx k)
+              ai (get aidx k)
+              bc (when bi (nth bxs bi nil))
+              ac (when ai (nth axs ai nil))]
+          (cond
+            ;; In after only.
+            (and ac (not bc))
+            (assoc (added-node ac) :key k :index ai)
+
+            ;; In before only.
+            (and bc (not ac))
+            (assoc (removed-node bc) :key k :index bi)
+
+            ;; In both, same index, same content (pointer or =).
+            (and (= bi ai) (or (identical? bc ac) (= bc ac)))
+            (assoc (same-node ac) :key k :index ai)
+
+            ;; In both, same index, content differs.
+            (= bi ai)
+            (assoc (diff-hiccup-node bc ac opts) :key k :index ai)
+
+            ;; In both, different index — moved. If the content also
+            ;; differs, the renderer paints both the move chip + the
+            ;; inner diff; we attach the inner diff as `:inner-diff`.
+            :else
+            (let [inner (when-not (or (identical? bc ac) (= bc ac))
+                          (diff-hiccup-node bc ac opts))]
+              (cond-> (element-moved-node ac k bi ai)
+                inner (assoc :inner-diff inner)))))))))
+
+;; ---- children diff: positional ----------------------------------------
+
+(defn- diff-children-positional
+  "Positional walk: pairwise per index. The longer side carries
+  leftover children as `:added` / `:removed`. Per the divergence
+  allowance — no LCS / move-detection on positional children; a
+  follow-on bead handles that.
+
+  Strings + numbers + nil are scalar leaves (`:same` / `:modified` /
+  `:added` / `:removed`); hiccup vectors recurse via diff-hiccup-node."
+  [bxs axs opts]
+  (let [n (max (count bxs) (count axs))]
+    (vec
+      (for [i (range n)]
+        (let [in-b? (< i (count bxs))
+              in-a? (< i (count axs))
+              b     (when in-b? (nth bxs i))
+              a     (when in-a? (nth axs i))]
+          (cond
+            (and in-a? (not in-b?))
+            (assoc (added-node a) :index i)
+
+            (and in-b? (not in-a?))
+            (assoc (removed-node b) :index i)
+
+            (or (identical? b a) (= b a))
+            (assoc (same-node a) :index i)
+
+            :else
+            (assoc (diff-hiccup-node b a opts) :index i)))))))
+
+;; ---- top-level walker --------------------------------------------------
+
+(defn diff-hiccup-node
+  "Diff two hiccup nodes — scalar (string / number / nil), hiccup
+  element vector, or a fragment.
+
+  `opts` keys:
+
+    :highlight-fn-ref-changes?  (default false) — when true, opaque
+                                  function references with different
+                                  identity surface as
+                                  `:fn-ref-changed` instead of `:same`."
+  ([before after] (diff-hiccup-node before after {}))
+  ([before after opts]
+   (cond
+     ;; Pointer-equality short-circuit. The most common case — a
+     ;; render that returned identical hiccup to its previous render.
+     (identical? before after)
+     (same-node after)
+
+     (= before after)
+     (same-node after)
+
+     ;; Both scalar (string / number / nil / keyword / boolean — anything
+     ;; that's not a hiccup vector). At this point we know they're not
+     ;; equal; emit a leaf-modified.
+     (and (not (hiccup-vector? before)) (not (hiccup-vector? after)))
+     (modified-node before after)
+
+     ;; One side hiccup, the other a scalar — shape mismatch; the
+     ;; renderer paints both sides.
+     (not (and (hiccup-vector? before) (hiccup-vector? after)))
+     (modified-node before after)
+
+     :else
+     (let [btag (get-tag before)
+           atag (get-tag after)]
+       (cond
+         ;; Different tags — whole element is :modified (we don't try
+         ;; to align attrs+children of different elements).
+         (not= btag atag)
+         (modified-node before after)
+
+         ;; Same tag — diff attrs + children. Fragments (`:<>`) are
+         ;; transparent containers; their attrs are typically empty,
+         ;; their children flatten into the parent. Here we treat
+         ;; same-tag fragments as element-changed with the standard
+         ;; diff applied (flattening happens inside children-diff).
+         :else
+         (let [[battrs bchildren] (split-attrs+children before)
+               [aattrs achildren] (split-attrs+children after)
+               bch (flatten-children bchildren)
+               ach (flatten-children achildren)
+               attrs-diff    (diff-attrs battrs aattrs opts)
+               children-diff (if (and (all-keyed? bch) (all-keyed? ach))
+                               (diff-children-keyed     bch ach opts)
+                               (diff-children-positional bch ach opts))]
+           (element-changed-node atag attrs-diff children-diff)))))))
+
+;; ---- changed? helper ---------------------------------------------------
+
+(defn changed?
+  "True when the annotated node represents any non-`:same` op.
+
+  For an `:element-changed` container, the node is `changed?` only
+  when it carries at least one non-`:same` attr or child — a synthetic
+  empty container with all-same kids degrades to `false` so callers
+  can use this as a cheap 'should I render the diff chrome' gate."
+  [node]
+  (let [op (::op node)]
+    (cond
+      (= op :same) false
+
+      (= op :element-changed)
+      (or (attrs-has-changes? (:attrs-diff node))
+          (boolean (some (fn [c] (not= :same (::op c)))
+                         (:children-diff node))))
+
+      :else true)))
+
+(defn op-of
+  "Read the op of an annotated node."
+  [node]
+  (::op node))

--- a/tools/causa/src/day8/re_frame2_causa/diff/hiccup_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/hiccup_render.cljs
@@ -1,0 +1,385 @@
+(ns day8.re-frame2-causa.diff.hiccup-render
+  "Renderer for the hiccup-tree-diff micro-engine
+  (rf2-i39w2 Phase 3 of rf2-abts7).
+
+  Design source-of-truth:
+  `ai/findings/2026-05-18-difftastic-in-causa.md` §3.3 + §4.2 + §5.4.
+
+  ## What this renders
+
+  Input: an annotated hiccup node produced by
+  `diff.hiccup/diff-hiccup-node` — either a scalar leaf
+  (`:added`/`:removed`/`:modified`/`:same`) OR one of the three
+  hiccup-specific shapes:
+
+    - `:element-changed`  → render `[:div.row {…}]` header + attrs-diff
+                            inline + recurse into children-diff
+    - `:element-moved`    → render `↻` chip with from/to index +
+                            optionally recurse into :inner-diff
+    - `:fn-ref-changed`   → render distinct violet `(fn ref changed)`
+                            chip (only emitted when toggle on)
+
+  Output is a hiccup tree the caller drops into any DOM-ish surface
+  (the Views panel drilldown, the hydration debugger pane, etc.).
+
+  ## Colour tokens (§5.4)
+
+  Element-moved + fn-ref-changed both use `:accent-violet` (distinct
+  from `:modified`'s `:yellow`) so the eye reads 'this is something
+  other than a plain modification'."
+  (:require [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- node-key helper ---------------------------------------------------
+
+(defn- node-key-for
+  "Stable per-node expand-state key combining the surface + path."
+  [surface path]
+  (str surface "/hiccup" "/" (pr-str (vec path))))
+
+(defn- key-or-index-label
+  "Inline `[index]` or `{:key k}` label that prefixes a per-child diff
+  row. The renderer reads `:index` and `:key` slots set by the engine."
+  [node]
+  (cond
+    (some? (:key node))
+    [:span {:style {:color       (:accent-violet tokens)
+                    :font-family mono-stack
+                    :font-size   "11px"
+                    :margin-right "6px"}}
+     (str ":key " (pr-str (:key node)))]
+
+    (some? (:index node))
+    [:span {:style {:color       (:text-tertiary tokens)
+                    :font-family mono-stack
+                    :font-size   "11px"
+                    :margin-right "6px"}}
+     (str "[" (:index node) "]")]
+
+    :else nil))
+
+(defn- inspect-value
+  [v node-key]
+  (inspector/inspect (f/display-value v) node-key))
+
+(defn- gutter
+  "Coloured-glyph + left-border wrapper for an annotated row."
+  [glyph tone body]
+  [:div {:style {:display      "flex"
+                 :align-items  "flex-start"
+                 :gap          "4px"
+                 :padding      "2px 0"
+                 :padding-left "6px"
+                 :border-left  (str "3px solid " tone)}}
+   [:span {:style {:flex          "0 0 14px"
+                   :color         tone
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :font-weight   700
+                   :text-align    "center"
+                   :user-select   "none"}}
+    glyph]
+   [:div {:style {:flex 1 :min-width 0}}
+    body]])
+
+;; ---- annotated-attrs rendering -----------------------------------------
+
+(declare render-hiccup-annotated)
+
+(defn- render-attr-row
+  "Render one attr from the attrs-diff. The attr key prefixes the
+  value rendering; ops dispatch to coloured-gutter cells."
+  [attr-node parent-key]
+  (let [op    (hd/op-of attr-node)
+        k     (:key attr-node)
+        nkey  (str parent-key "/attr/" (pr-str k))]
+    (case op
+      :same
+      [:div {:style {:display "flex" :gap "6px"
+                     :color (:text-tertiary tokens)
+                     :font-family mono-stack :font-size "12px"}}
+       [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+       (inspect-value (:value attr-node) nkey)]
+
+      :added
+      (gutter "+" (:green tokens)
+              [:div {:style {:display "flex" :gap "6px"}}
+               [:span {:style {:color (:accent-violet tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (pr-str k)]
+               [:span {:style {:color (:green tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (inspect-value (:value attr-node) nkey)]])
+
+      :removed
+      (gutter "-" (:red tokens)
+              [:div {:style {:display "flex" :gap "6px"
+                             :text-decoration "line-through"}}
+               [:span {:style {:color (:accent-violet tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (pr-str k)]
+               [:span {:style {:color (:red tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (inspect-value (:value attr-node) nkey)]])
+
+      :modified
+      (gutter "~" (:yellow tokens)
+              [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                             :align-items "baseline"}}
+               [:span {:style {:color (:accent-violet tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (pr-str k)]
+               [:span {:style {:color (:text-tertiary tokens)
+                               :font-family mono-stack
+                               :font-size "12px"
+                               :text-decoration "line-through"}}
+                (inspect-value (:before attr-node) (str nkey "/before"))]
+               [:span {:style {:color (:text-tertiary tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                "→"]
+               [:span {:style {:color (:yellow tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (inspect-value (:after attr-node) (str nkey "/after"))]])
+
+      :fn-ref-changed
+      (gutter "◴" (:accent-violet tokens)
+              [:div {:style {:display "flex" :gap "6px"
+                             :align-items "baseline"}}
+               [:span {:style {:color (:accent-violet tokens)
+                               :font-family mono-stack
+                               :font-size "12px"}}
+                (pr-str k)]
+               [:span {:data-testid "rf-causa-diff-fn-ref-changed-chip"
+                       :style {:color (:accent-violet tokens)
+                               :font-family mono-stack
+                               :font-size "11px"
+                               :font-style "italic"}}
+                "(fn ref changed)"]])
+
+      ;; Fallback — unknown op (defensive).
+      [:span {:style {:color (:red tokens)}}
+       (str "unknown attr op: " (pr-str op))])))
+
+(defn- render-attrs-diff
+  "Render an attrs-diff node — render only non-`:same` rows by
+  default; collapse pure-:same attrs into nothing (the attrs map
+  rendering on the element header carries the same-value info)."
+  [attrs-diff parent-key]
+  (let [kids   (:children attrs-diff)
+        changed (filter #(not= :same (hd/op-of %)) kids)]
+    (when (seq changed)
+      (into [:div {:data-testid "rf-causa-diff-hiccup-attrs"
+                   :style {:padding-left "12px"
+                           :margin "2px 0"}}]
+            (for [c changed]
+              ^{:key (pr-str (:key c))}
+              (render-attr-row c parent-key))))))
+
+;; ---- children diff rendering ------------------------------------------
+
+(defn- render-children-diff
+  "Render a vector of children-diff nodes. Recurses for elements;
+  shows scalar diffs inline."
+  [children-diff surface parent-path depth]
+  (when (seq children-diff)
+    (into [:div {:data-testid "rf-causa-diff-hiccup-children"
+                 :style {:padding-left "12px"
+                         :border-left (str "1px solid "
+                                           (:border-subtle tokens))
+                         :margin "2px 0"}}]
+          (map-indexed
+            (fn [i c]
+              (let [k    (or (:key c) (:index c) i)
+                    path (conj parent-path k)]
+                ^{:key (pr-str k)}
+                (render-hiccup-annotated c surface path (inc depth))))
+            children-diff))))
+
+;; ---- element header (the `[:div.row {…}]` line) ------------------------
+
+(defn- element-header
+  "Render `[tag attrs-summary …]` as the per-element row label. The
+  attrs detail rolls out below."
+  [tag attrs-count children-count node-label]
+  [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
+                 :font-family mono-stack :font-size "12px"
+                 :color (:text-primary tokens)}}
+   (when node-label node-label)
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (str "[" (pr-str tag)
+         (when (pos? attrs-count) " {…}")
+         (when (pos? children-count) " …")
+         "]")]])
+
+;; ---- element-changed --------------------------------------------------
+
+(defn- render-element-changed
+  [node surface path depth]
+  (let [{:keys [tag attrs-diff children-diff]} node
+        nkey         (node-key-for surface path)
+        attrs-count  (count (:children attrs-diff))
+        kids-count   (count children-diff)
+        any-changes? (or (some #(not= :same (hd/op-of %)) (:children attrs-diff))
+                         (some #(not= :same (hd/op-of %)) children-diff))]
+    [:div {:data-testid (str "rf-causa-diff-hiccup-element-" nkey)
+           :style {:display "flex"
+                   :flex-direction "column"
+                   :margin "2px 0"}}
+     [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
+                    :font-family mono-stack :font-size "12px"
+                    :color (:text-primary tokens)}}
+      (key-or-index-label node)
+      (element-header tag attrs-count kids-count nil)
+      (when any-changes?
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "11px"}}
+         "◴ changed"])]
+     (render-attrs-diff attrs-diff nkey)
+     (render-children-diff children-diff surface path depth)]))
+
+;; ---- element-moved ----------------------------------------------------
+
+(defn- render-element-moved
+  [node surface path depth]
+  (let [{:keys [value key from-index to-index inner-diff]} node
+        nkey (node-key-for surface path)]
+    [:div {:data-testid "rf-causa-diff-hiccup-moved"
+           :style {:display "flex"
+                   :flex-direction "column"
+                   :margin "2px 0"}}
+     (gutter "↻" (:accent-violet tokens)
+             [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                            :align-items "baseline"
+                            :font-family mono-stack :font-size "12px"}}
+              (key-or-index-label node)
+              [:span {:style {:color (:accent-violet tokens)
+                              :font-weight 600}}
+               (str "moved")]
+              [:span {:style {:color (:text-tertiary tokens)
+                              :font-size "11px"
+                              :font-style "italic"}}
+               (str "(was at index " from-index ", now at " to-index ")")]
+              [:span {:style {:color (:text-secondary tokens)}}
+               (inspect-value value nkey)]])
+     (when inner-diff
+       (render-hiccup-annotated inner-diff surface
+                                (conj path :inner) (inc depth)))]))
+
+;; ---- scalar dispatch (re-uses existing colour palette) ----------------
+
+(defn- render-same-leaf
+  [node nkey]
+  [:div {:style {:display "flex" :gap "6px"
+                 :color (:text-tertiary tokens)
+                 :font-family mono-stack :font-size "12px"}}
+   (key-or-index-label node)
+   (inspect-value (:value node) nkey)])
+
+(defn- render-added-leaf
+  [node nkey]
+  (gutter "+" (:green tokens)
+          [:div {:style {:display "flex" :gap "6px"}}
+           (key-or-index-label node)
+           [:span {:style {:color (:green tokens)
+                           :font-family mono-stack
+                           :font-size "12px"}}
+            (inspect-value (:value node) nkey)]]))
+
+(defn- render-removed-leaf
+  [node nkey]
+  (gutter "-" (:red tokens)
+          [:div {:style {:display "flex" :gap "6px"
+                         :text-decoration "line-through"}}
+           (key-or-index-label node)
+           [:span {:style {:color (:red tokens)
+                           :font-family mono-stack
+                           :font-size "12px"}}
+            (inspect-value (:value node) nkey)]]))
+
+(defn- render-modified-leaf
+  [node nkey]
+  (gutter "~" (:yellow tokens)
+          [:div {:style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                         :align-items "baseline"}}
+           (key-or-index-label node)
+           [:span {:style {:color (:text-tertiary tokens)
+                           :font-family mono-stack
+                           :font-size "12px"
+                           :text-decoration "line-through"}}
+            (inspect-value (:before node) (str nkey "/before"))]
+           [:span {:style {:color (:text-tertiary tokens)
+                           :font-family mono-stack
+                           :font-size "12px"}}
+            "→"]
+           [:span {:style {:color (:yellow tokens)
+                           :font-family mono-stack
+                           :font-size "12px"}}
+            (inspect-value (:after node) (str nkey "/after"))]]))
+
+(defn- render-fn-ref-changed-leaf
+  [node nkey]
+  (gutter "◴" (:accent-violet tokens)
+          [:div {:data-testid "rf-causa-diff-fn-ref-changed-chip"
+                 :style {:display "flex" :gap "6px"
+                         :align-items "baseline"
+                         :font-family mono-stack
+                         :font-size "12px"
+                         :color (:accent-violet tokens)
+                         :font-style "italic"}}
+           (key-or-index-label node)
+           "(fn ref changed)"]))
+
+;; ---- public dispatch ---------------------------------------------------
+
+(defn render-hiccup-annotated
+  "Dispatch on the hiccup-diff `::op` and render the annotated node.
+
+  Three hiccup-specific cases:
+
+    `:element-changed` — render element header + attrs-diff +
+                         children-diff (recursive)
+    `:element-moved`   — render `↻` chip with from/to index, optional
+                         inner-diff
+    `:fn-ref-changed`  — render distinct violet `(fn ref changed)`
+                         chip (only emitted when toggle on)
+
+  Plus the generic scalar cases (`:same` / `:added` / `:removed` /
+  `:modified`)."
+  [node surface path depth]
+  (let [op   (hd/op-of node)
+        nkey (node-key-for surface path)]
+    (case op
+      :element-changed (render-element-changed node surface path depth)
+      :element-moved   (render-element-moved   node surface path depth)
+      :fn-ref-changed  (render-fn-ref-changed-leaf node nkey)
+      :same            (render-same-leaf     node nkey)
+      :added           (render-added-leaf    node nkey)
+      :removed         (render-removed-leaf  node nkey)
+      :modified        (render-modified-leaf node nkey)
+      ;; Fallback — shouldn't happen for well-formed input.
+      [:span {:style {:color (:red tokens)}}
+       (str "unknown hiccup op: " (pr-str op))])))
+
+(defn render-root
+  "Top-level entry for a hiccup-diff render. Wraps the dispatch in a
+  testable container with a stable `data-testid`."
+  ([annotated surface]
+   (render-root annotated surface []))
+  ([annotated surface path]
+   [:div {:data-testid "rf-causa-diff-hiccup-root"
+          :style {:font-family mono-stack
+                  :font-size "12px"
+                  :color (:text-primary tokens)
+                  :line-height "1.5"}}
+    (render-hiccup-annotated annotated surface path 0)]))

--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -43,6 +43,12 @@
   reveal."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.diff.annotated-tree :as at]
+            ;; Phase 3 (rf2-i39w2) — hiccup-diff micro-engine renderer.
+            ;; Additive dispatch: when this renderer encounters a
+            ;; hiccup-diff op (`:element-changed`/`:element-moved`/
+            ;; `:fn-ref-changed`) it delegates to the hiccup-specific
+            ;; renderer; the generic ops still resolve here.
+            [day8.re-frame2-causa.diff.hiccup-render :as hd-render]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
@@ -349,20 +355,38 @@
     - `:modified` → inline `before → after`
     - `:added` / `:removed` → coloured-gutter leaf
 
+  Hiccup-engine ops (`:element-changed` / `:element-moved` /
+  `:fn-ref-changed`, rf2-i39w2 Phase 3) carry the parallel `::hd/op`
+  key — when a section subtree is a hiccup-diff (e.g. a future Views-
+  panel section), this dispatch detects and delegates to the
+  hiccup-specific renderer in `diff.hiccup-render`. Today the Views
+  panel calls `hd-render/render-root` directly; this branch keeps the
+  generic section pipeline forward-compatible.
+
   `:same` rendered via greyed-out inspector pass."
   [node section-path sub-path surface depth]
   (let [node-key (node-key-for surface section-path sub-path)
-        op       (at/op-of node)]
-    (case op
-      :children (render-children-container node section-path sub-path
-                                           surface depth)
-      :modified (gutter :modified (render-modified-leaf node node-key))
-      :added    (gutter :added    (render-added-leaf    node node-key))
-      :removed  (gutter :removed  (render-removed-leaf  node node-key))
-      :same     (render-same-inline node node-key)
-      ;; Fallback — shouldn't happen for well-formed input.
-      [:span {:style {:color (:red tokens)}}
-       (str "unknown op: " (pr-str op))])))
+        op       (at/op-of node)
+        hd-op    (get node :day8.re-frame2-causa.diff.hiccup/op)]
+    (cond
+      ;; Hiccup-engine op short-circuit — delegate. Path conjoins
+      ;; section-path + sub-path to preserve the unique node-key contract.
+      (#{:element-changed :element-moved :fn-ref-changed} hd-op)
+      (hd-render/render-hiccup-annotated node surface
+                                         (vec (concat section-path sub-path))
+                                         depth)
+
+      :else
+      (case op
+        :children (render-children-container node section-path sub-path
+                                             surface depth)
+        :modified (gutter :modified (render-modified-leaf node node-key))
+        :added    (gutter :added    (render-added-leaf    node node-key))
+        :removed  (gutter :removed  (render-removed-leaf  node node-key))
+        :same     (render-same-inline node node-key)
+        ;; Fallback — shouldn't happen for well-formed input.
+        [:span {:style {:color (:red tokens)}}
+         (str "unknown op: " (pr-str op))]))))
 
 ;; ---- section + panel ---------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -46,6 +46,14 @@
             ;; for the click-expand hero in the inline drilldown.
             [day8.re-frame2-causa.panels.views-sub-diff :as sub-diff]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            ;; rf2-i39w2 Phase 3 — hiccup-diff micro-engine + renderer.
+            ;; Lit up in the Re-rendered row drilldown when the render
+            ;; entry carries `:hiccup-before` + `:hiccup-after`. The
+            ;; render-tracker capture for these slots is a follow-on
+            ;; (P17 wave); the drilldown is forward-compatible — when
+            ;; the slots appear, the diff renders without further code.
+            [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.diff.hiccup-render :as hd-render]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -217,6 +225,41 @@
   (let [wanted (set (keep :sub-id invalidated-by))]
     (filterv (fn [rec] (contains? wanted (:sub-id rec))) records)))
 
+(defn- hiccup-diff-block
+  "rf2-i39w2 Phase 3 — render the view-hiccup diff drilldown when the
+  render entry carries `:hiccup-before` + `:hiccup-after`. Reads the
+  `:rf.causa/diff-opts` sub for the opt-in `:highlight-fn-ref-changes?`
+  toggle. The render-tracker capture for these slots is a follow-on
+  (P17 wave); until then this block returns nil and the drilldown
+  shows only the raw render entry. Forward-compatible — when the
+  slots appear, the diff lights up without further code."
+  [r]
+  (when (and (contains? r :hiccup-before)
+             (contains? r :hiccup-after))
+    (let [opts  @(rf/subscribe [:rf.causa/diff-opts])
+          before (:hiccup-before r)
+          after  (:hiccup-after r)
+          node  (hd/diff-hiccup-node before after opts)]
+      [:div {:data-testid "rf-causa-views-row-hiccup-diff"
+             :style {:margin-top "4px"
+                     :padding    "6px 8px"
+                     :background (:bg-2 tokens)
+                     :border-left (str "3px solid " (:accent-violet tokens))
+                     :border-radius "2px"
+                     :font-family mono-stack
+                     :font-size "12px"}}
+       [:div {:style {:color (:text-tertiary tokens)
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :margin-bottom "4px"}}
+        (if (hd/changed? node)
+          "View hiccup diff"
+          "Hiccup unchanged (wasted re-render — view returned identical hiccup)")]
+       (when (hd/changed? node)
+         (hd-render/render-root
+           node
+           (str "views/" (pr-str (:render-key r)))))])))
+
 (defn- expanded-block
   "Inline expansion content per spec §Per-component drilldown — single-
   column block placed BELOW the row. v1 ships the structural
@@ -231,7 +274,14 @@
   `:rf.causa/views-sub-diff-for-focused-event`; rendering goes
   through the Phase 1 sections-per-cluster engine
   (`day8.re-frame2-causa.diff.render/render-sections`) via the
-  thin `views-sub-diff/drilldown` wrapper."
+  thin `views-sub-diff/drilldown` wrapper.
+
+  ## View hiccup diff (rf2-i39w2 Phase 3)
+
+  `hiccup-diff-block` renders below the raw entry when the render-
+  tracker captures `:hiccup-before` + `:hiccup-after` on the entry.
+  Forward-compatible — the block returns nil until that capture
+  lands."
   [item]
   (let [r (:render item)
         invalidated-by (:invalidated-by item)
@@ -258,7 +308,8 @@
       ;; click through to the render-key, triggered-by, elapsed-ms.
       ;; Props-diff renders as a structured tree the moment the runtime
       ;; emits per-render `:props-before` / `:props-after` slots.
-      (inspector/inspect r (str "views/" (pr-str (:render-key r))))]
+      (inspector/inspect r (str "views/" (pr-str (:render-key r))))
+      (hiccup-diff-block r)]
      (when (seq invalidated-by)
        [:div [:strong "Subs consumed"]
         (invalidated-by-list invalidated-by)])

--- a/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
@@ -48,4 +48,18 @@
     (fn [db _query]
       (or (get db :settings) (config/get-settings))))
 
+  ;; rf2-i39w2 Phase 3 — convenience sub for the diff opts map the
+  ;; hiccup-diff engine consumes via `classify-prop`. Reads the
+  ;; `:diff` slot of the settings map (in app-db when seeded, the
+  ;; atom otherwise) and reshapes to the engine's opts vocabulary.
+  ;; A single sub means subs that compose against the diff engine
+  ;; read one canonical map rather than per-knob `:rf.causa/setting`
+  ;; calls.
+  (rf/reg-sub :rf.causa/diff-opts
+    (fn [db _query]
+      (let [diff (or (get-in db [:settings :diff])
+                     (:diff (config/get-settings)))]
+        {:highlight-fn-ref-changes? (boolean
+                                      (:highlight-fn-ref-changes? diff))})))
+
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -150,12 +150,14 @@
 
 (def ^:private tabs
   "Ordered tab list. Per the bead's contract the modal carries four
-  sections (General | Filters | Theme | Telemetry). Tab id matches
-  the `:rf.causa/settings-update` `section` for sections that map
-  1:1 to a settings slot."
+  sections (General | Filters | Theme | Telemetry); rf2-i39w2 Phase 3
+  adds a fifth (Diff) for the hiccup-diff micro-engine's opt-in
+  fn-ref-changes toggle. Tab id matches the `:rf.causa/settings-update`
+  `section` for sections that map 1:1 to a settings slot."
   [{:id :general   :label "General"}
    {:id :filters   :label "Filters"}
    {:id :theme     :label "Theme"}
+   {:id :diff      :label "Diff"}
    {:id :telemetry :label "Telemetry"}])
 
 (defn- tab-button [{:keys [id label]} active?]
@@ -299,6 +301,42 @@
        "Light / dark only for v1. Accent picker arrives in a later "
        "release."]]]))
 
+;; ---- section: Diff (rf2-i39w2 Phase 3) ----------------------------------
+
+(defn- diff-section []
+  (let [highlight? @(rf/subscribe [:rf.causa/setting :diff :highlight-fn-ref-changes?])]
+    [:div {:data-testid "rf-causa-settings-section-diff"}
+     [:h2 {:style (section-heading-style)} "Diff"]
+     [:p {:style {:color (:text-secondary tokens)
+                  :line-height 1.5
+                  :margin "0 0 16px 0"}}
+      "Controls for the structural-diff engine that powers App-DB Diff, "
+      "Sub-output diff, and the View-hiccup diff drilldown in the Views "
+      "panel."]
+
+     ;; ── Highlight fn-ref changes ────────────────────────────────
+     [:div {:style (field-style)}
+      [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                       :cursor "pointer"
+                       :font-size (:body type-scale)
+                       :color (:text-primary tokens)}}
+       [:input {:data-testid "rf-causa-settings-diff-highlight-fn-ref"
+                :type        "checkbox"
+                :checked     (boolean highlight?)
+                :on-change   #(rf/dispatch
+                                [:rf.causa/settings-update
+                                 :diff :highlight-fn-ref-changes?
+                                 (boolean (.. % -target -checked))])}]
+       "Highlight function-ref changes in view hiccup"]
+      [:p {:style (hint-style)}
+       "Off by default. The hiccup-diff engine treats function-valued "
+       "props (`:on-click`, `:on-change`, `:ref`, …) as opaque — "
+       "anonymous fns created fresh per render do NOT surface as a "
+       "diff. Flip this on when diagnosing memoization issues (a "
+       "child re-renders because the parent passes a new fn every "
+       "time); identity-different fns will surface as a distinct "
+       "violet `(fn ref changed)` chip."]]]))
+
 ;; ---- section: Telemetry -------------------------------------------------
 
 (defn- telemetry-section []
@@ -383,5 +421,6 @@
          :general   (general-section)
          :filters   (filters-section)
          :theme     (theme-section)
+         :diff      (diff-section)
          :telemetry (telemetry-section)
          (general-section))]]]))

--- a/tools/causa/test/day8/re_frame2_causa/diff/hiccup_render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/diff/hiccup_render_cljs_test.cljs
@@ -1,0 +1,112 @@
+(ns day8.re-frame2-causa.diff.hiccup-render-cljs-test
+  "Smoke tests for the hiccup-diff renderer (rf2-i39w2 Phase 3 of
+  rf2-abts7).
+
+  Each public render path is invoked once and the load-bearing
+  `data-testid` hooks asserted present in the produced hiccup."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.diff.hiccup-render :as hd-render]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter}))
+
+;; ---- helpers -----------------------------------------------------------
+
+(defn- has-testid? [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(defn- any-testid-prefix? [tree prefix]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (let [tid (:data-testid (second node))]
+                 (and tid (.startsWith tid prefix)))))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+;; ---- element-changed root ----------------------------------------------
+
+(deftest renders-element-changed-root
+  (testing "an :element-changed annotated node renders with the hiccup
+            root testid + an element testid"
+    (let [n      (hd/diff-hiccup-node [:div {:class "a"} "k"]
+                                      [:div {:class "b"} "k"])
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-root"))
+      (is (any-testid-prefix? hiccup "rf-causa-diff-hiccup-element-"))
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-attrs")))))
+
+;; ---- element-moved ----------------------------------------------------
+
+(deftest renders-element-moved-chip
+  (testing "keyed reorder produces an :element-moved subtree with the
+            rf-causa-diff-hiccup-moved testid"
+    (let [before [:ul
+                  [:li {:key 1} "one"]
+                  [:li {:key 2} "two"]]
+          after  [:ul
+                  [:li {:key 2} "two"]
+                  [:li {:key 1} "one"]]
+          n      (hd/diff-hiccup-node before after)
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-moved")))))
+
+;; ---- fn-ref-changed (toggle on) ---------------------------------------
+
+(deftest renders-fn-ref-changed-chip-when-toggle-on
+  (testing "with :highlight-fn-ref-changes? on, an opaque fn whose
+            reference changed renders with the fn-ref-changed chip
+            testid"
+    (let [f1 (fn [_e] :one)
+          f2 (fn [_e] :two)
+          before [:button {:on-click f1 :class "a"} "Click"]
+          after  [:button {:on-click f2 :class "b"} "Click"]
+          n      (hd/diff-hiccup-node before after
+                                      {:highlight-fn-ref-changes? true})
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (has-testid? hiccup "rf-causa-diff-fn-ref-changed-chip")))))
+
+(deftest no-fn-ref-chip-when-toggle-off
+  (testing "with default opts, an opaque fn whose reference changed does
+            NOT render the fn-ref-changed chip"
+    (let [f1 (fn [_e] :one)
+          f2 (fn [_e] :two)
+          before [:button {:on-click f1 :class "a"} "Click"]
+          after  [:button {:on-click f2 :class "b"} "Click"]
+          n      (hd/diff-hiccup-node before after)  ; no toggle
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (not (has-testid? hiccup "rf-causa-diff-fn-ref-changed-chip"))))))
+
+;; ---- scalar leaves ----------------------------------------------------
+
+(deftest renders-modified-leaf-fallback
+  (testing ":modified scalar (e.g. text child) → renders inside the
+            root container; the gutter+inspector call returns hiccup"
+    (let [n      (hd/diff-hiccup-node "hi" "ho")
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-root")))))
+
+;; ---- deep tree ---------------------------------------------------------
+
+(deftest renders-deep-element-changed-tree
+  (testing "nested change: row [span 'qty 1'] → [span 'qty 2']"
+    (let [before [:div.row
+                  [:span.id "22"]
+                  [:span.qty "1"]
+                  [:span.added-at "..."]]
+          after  [:div.row
+                  [:span.id "22"]
+                  [:span.qty "2"]
+                  [:span.added-at "..."]]
+          n      (hd/diff-hiccup-node before after)
+          hiccup (hd-render/render-root n "view-hiccup")]
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-root"))
+      (is (any-testid-prefix? hiccup "rf-causa-diff-hiccup-element-"))
+      (is (has-testid? hiccup "rf-causa-diff-hiccup-children")))))

--- a/tools/causa/test/day8/re_frame2_causa/diff/hiccup_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/diff/hiccup_test.cljc
@@ -1,0 +1,316 @@
+(ns day8.re-frame2-causa.diff.hiccup-test
+  "Tests for the hiccup-tree-diff micro-engine (rf2-i39w2 Phase 3 of
+  rf2-abts7). Pure data → data so the JVM target picks them up via
+  `.cljc`. Per design `ai/findings/2026-05-18-difftastic-in-causa.md`
+  §3.3 + §4."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.diff.hiccup :as h]))
+
+;; ---- shape-level scalar cases ------------------------------------------
+
+(deftest identical-pointers-short-circuit
+  (testing "pointer-equal short-circuit → :same with the same value"
+    (let [v [:div {:class "x"} "hello"]
+          n (h/diff-hiccup-node v v)]
+      (is (= :same   (h/op-of n)))
+      (is (= v       (:value n))))))
+
+(deftest equal-values-collapse-to-same
+  (testing "structurally equal but pointer-different → :same"
+    (let [a [:div {:class "x"} "hello"]
+          b [:div {:class "x"} "hello"]
+          n (h/diff-hiccup-node a b)]
+      (is (= :same (h/op-of n))))))
+
+(deftest both-scalars-not-equal-modified
+  (testing "both sides scalars, different → :modified"
+    (let [n (h/diff-hiccup-node "hi" "ho")]
+      (is (= :modified (h/op-of n)))
+      (is (= "hi" (:before n)))
+      (is (= "ho" (:after n))))))
+
+(deftest scalar-vs-hiccup-modified
+  (testing "shape mismatch → :modified (no recursion)"
+    (let [n (h/diff-hiccup-node "hi" [:span "hi"])]
+      (is (= :modified (h/op-of n))))))
+
+(deftest different-tags-modified
+  (testing "different tags → whole element :modified"
+    (let [n (h/diff-hiccup-node [:div "x"] [:span "x"])]
+      (is (= :modified (h/op-of n))))))
+
+;; ---- attrs diff --------------------------------------------------------
+
+(deftest attrs-add-remove-change
+  (testing "attrs map diffs key-by-key: added / removed / modified"
+    (let [n (h/diff-hiccup-node [:div {:class "a" :id "x"} "k"]
+                                [:div {:class "b" :data-test "y"} "k"])]
+      (is (= :element-changed (h/op-of n)))
+      (is (= :div (:tag n)))
+      (let [attrs (:attrs-diff n)
+            kids  (:children attrs)
+            by-key (into {} (map (juxt :key identity) kids))]
+        (is (= :modified (h/op-of (by-key :class))))
+        (is (= "a" (:before (by-key :class))))
+        (is (= "b" (:after  (by-key :class))))
+        (is (= :removed (h/op-of (by-key :id))))
+        (is (= :added   (h/op-of (by-key :data-test))))))))
+
+(deftest attrs-unchanged-children-changed
+  (testing "attrs unchanged, children change → only :children-diff
+            carries non-:same entries"
+    (let [n (h/diff-hiccup-node [:div {:class "row"} [:span "1"]]
+                                [:div {:class "row"} [:span "2"]])]
+      (is (= :element-changed (h/op-of n)))
+      ;; attrs all :same
+      (let [attrs (:attrs-diff n)
+            kids  (:children attrs)]
+        (is (every? (fn [c] (= :same (h/op-of c))) kids))))))
+
+;; ---- children diff: positional ----------------------------------------
+
+(deftest positional-add-at-end
+  (testing "positional child added at end → :added with :index"
+    (let [n (h/diff-hiccup-node [:ul [:li "a"]]
+                                [:ul [:li "a"] [:li "b"]])
+          cdiff (:children-diff n)]
+      (is (= 2 (count cdiff)))
+      (is (= :same  (h/op-of (nth cdiff 0))))
+      (is (= :added (h/op-of (nth cdiff 1))))
+      (is (= 1      (:index (nth cdiff 1)))))))
+
+(deftest positional-remove-at-end
+  (testing "positional child removed at end → :removed with :index"
+    (let [n (h/diff-hiccup-node [:ul [:li "a"] [:li "b"]]
+                                [:ul [:li "a"]])
+          cdiff (:children-diff n)]
+      (is (= 2 (count cdiff)))
+      (is (= :same    (h/op-of (nth cdiff 0))))
+      (is (= :removed (h/op-of (nth cdiff 1)))))))
+
+(deftest positional-text-child-modified
+  (testing "text child differs → :modified leaf at :index"
+    (let [n (h/diff-hiccup-node [:span "1"] [:span "2"])
+          cdiff (:children-diff n)]
+      (is (= 1 (count cdiff)))
+      (is (= :modified (h/op-of (nth cdiff 0))))
+      (is (= "1" (:before (nth cdiff 0))))
+      (is (= "2" (:after  (nth cdiff 0)))))))
+
+;; ---- children diff: keyed identity-tracked reorder ---------------------
+
+(deftest keyed-reorder-no-false-positives
+  (testing "keyed children reordered → :element-moved per item; no
+            false-positive :modified on identity-preserved content"
+    (let [before [:ul
+                  [:li {:key 7}  "seven"]
+                  [:li {:key 22} "twenty-two"]
+                  [:li {:key 91} "ninety-one"]]
+          after  [:ul
+                  [:li {:key 22} "twenty-two"]
+                  [:li {:key 7}  "seven"]
+                  [:li {:key 91} "ninety-one"]]
+          n     (h/diff-hiccup-node before after)
+          cdiff (:children-diff n)
+          by-key (into {} (map (juxt :key identity) cdiff))]
+      (is (= :element-changed (h/op-of n)))
+      (is (= :element-moved (h/op-of (by-key 22))))
+      (is (= 1 (:from-index (by-key 22))))
+      (is (= 0 (:to-index   (by-key 22))))
+      (is (= :element-moved (h/op-of (by-key 7))))
+      (is (= 0 (:from-index (by-key 7))))
+      (is (= 1 (:to-index   (by-key 7))))
+      ;; 91 stayed at index 2 → :same
+      (is (= :same (h/op-of (by-key 91)))))))
+
+(deftest keyed-insert-at-front
+  (testing "keyed insert at index 0 → :added for new key, others stay
+            :same (their key→content didn't change even though their
+            positional index shifted; this is the React reconciliation
+            contract)"
+    (let [before [:ul
+                  [:li {:key 7} "seven"]
+                  [:li {:key 9} "nine"]]
+          after  [:ul
+                  [:li {:key 1} "one"]
+                  [:li {:key 7} "seven"]
+                  [:li {:key 9} "nine"]]
+          n     (h/diff-hiccup-node before after)
+          cdiff (:children-diff n)
+          by-key (into {} (map (juxt :key identity) cdiff))]
+      (is (= :added (h/op-of (by-key 1))))
+      ;; 7 moved from index 0 to 1, 9 moved from index 1 to 2.
+      (is (= :element-moved (h/op-of (by-key 7))))
+      (is (= :element-moved (h/op-of (by-key 9)))))))
+
+(deftest keyed-remove-from-middle
+  (testing "keyed remove from middle → :removed for missing key,
+            others detect their new position"
+    (let [before [:ul
+                  [:li {:key 1} "one"]
+                  [:li {:key 2} "two"]
+                  [:li {:key 3} "three"]]
+          after  [:ul
+                  [:li {:key 1} "one"]
+                  [:li {:key 3} "three"]]
+          n     (h/diff-hiccup-node before after)
+          cdiff (:children-diff n)
+          by-key (into {} (map (juxt :key identity) cdiff))]
+      (is (= :removed       (h/op-of (by-key 2))))
+      (is (= :same          (h/op-of (by-key 1))))
+      ;; 3 moved from index 2 to 1.
+      (is (= :element-moved (h/op-of (by-key 3)))))))
+
+(deftest keyed-content-changes-without-move
+  (testing "keyed child stays at same index but content changes →
+            :element-changed (or :modified) at that key"
+    (let [before [:ul [:li {:key 7} "before"]]
+          after  [:ul [:li {:key 7} "after"]]
+          n     (h/diff-hiccup-node before after)
+          cdiff (:children-diff n)
+          c     (first cdiff)]
+      ;; The child is at the same index, content differs → element-changed
+      ;; for the inner :li (the :key stays as the slot).
+      (is (= :element-changed (h/op-of c)))
+      (is (= 7 (:key c))))))
+
+;; ---- fragment flattening ----------------------------------------------
+
+(deftest fragments-flatten-into-parent
+  (testing "[:<> ...] fragment children flatten so the diff sees the
+            inner children as direct children of the parent"
+    (let [before [:ul
+                  [:<>
+                   [:li "a"]
+                   [:li "b"]]]
+          after  [:ul
+                  [:li "a"]
+                  [:li "b"]]
+          n (h/diff-hiccup-node before after)]
+      ;; After flattening, both sides have the same two children → :same.
+      (is (= :element-changed (h/op-of n)))
+      (let [cdiff (:children-diff n)]
+        (is (= 2 (count cdiff)))
+        (is (every? (fn [c] (= :same (h/op-of c))) cdiff))))))
+
+;; ---- opaque fn props: same-by-default (§4.5) ---------------------------
+
+(deftest opaque-fn-prop-same-by-default
+  (testing "function-valued prop both sides → :same (not :modified)
+            even when the fn IDENTITY changed (fresh per-render closure)"
+    (let [f1     (fn [_e] :one)
+          f2     (fn [_e] :two)  ; different identity, same purpose
+          before [:button {:on-click f1} "Click"]
+          after  [:button {:on-click f2} "Click"]
+          n      (h/diff-hiccup-node before after)
+          attrs  (:attrs-diff n)
+          per-key (into {} (map (juxt :key identity) (:children attrs)))]
+      (is (= :element-changed (h/op-of n)))
+      (is (= :same (h/op-of (per-key :on-click))))
+      ;; And children/attrs together carry NO non-:same entries.
+      (is (every? (fn [c] (= :same (h/op-of c))) (:children attrs))))))
+
+(deftest opaque-fn-prop-with-toggle-on-surfaces-fn-ref-changed
+  (testing "with :highlight-fn-ref-changes? true, identity-different
+            opaque fns surface as :fn-ref-changed"
+    (let [f1 (fn [_e] :one)
+          f2 (fn [_e] :two)
+          before [:button {:on-click f1} "Click"]
+          after  [:button {:on-click f2} "Click"]
+          n      (h/diff-hiccup-node before after
+                                     {:highlight-fn-ref-changes? true})
+          attrs  (:attrs-diff n)
+          per-key (into {} (map (juxt :key identity) (:children attrs)))]
+      (is (= :fn-ref-changed (h/op-of (per-key :on-click)))))))
+
+(deftest opaque-fn-prop-identical-stays-same-under-toggle
+  (testing "with toggle on, identical fn references still surface :same
+            (force a real attrs diff via :class so the element-changed
+            path runs and we can inspect the :on-click per-attr classify)"
+    (let [f1     (fn [_e] :one)
+          before [:button {:on-click f1 :class "a"} "Click"]
+          after  [:button {:on-click f1 :class "b"} "Click"]
+          n      (h/diff-hiccup-node before after
+                                     {:highlight-fn-ref-changes? true})
+          attrs  (:attrs-diff n)
+          per-key (into {} (map (juxt :key identity) (:children attrs)))]
+      (is (= :element-changed (h/op-of n)))
+      (is (= :same (h/op-of (per-key :on-click))))
+      (is (= :modified (h/op-of (per-key :class)))))))
+
+(deftest opaque-fn-prop-added-removed
+  (testing "fn prop added / removed surface correctly"
+    (let [f1     (fn [_e] :one)
+          ;; Removed: was a fn, now nil/absent.
+          n-rm   (h/diff-hiccup-node [:button {:on-click f1} "x"]
+                                     [:button {} "x"])
+          ;; Added: was absent, now a fn.
+          n-add  (h/diff-hiccup-node [:button {} "x"]
+                                     [:button {:on-click f1} "x"])
+          by-key (fn [n]
+                   (into {} (map (juxt :key identity)
+                                 (:children (:attrs-diff n)))))]
+      (is (= :removed (h/op-of (get (by-key n-rm) :on-click))))
+      (is (= :added   (h/op-of (get (by-key n-add) :on-click)))))))
+
+(deftest opaque-prop-type-mismatch-modified
+  (testing "opaque → non-opaque (fn replaced by a string handler URL)
+            surfaces :modified (real type change)"
+    (let [f1     (fn [_e] :one)
+          before [:a {:on-click f1} "x"]
+          after  [:a {:on-click "javascript:void(0)"} "x"]
+          n      (h/diff-hiccup-node before after)
+          attrs  (:attrs-diff n)
+          per-key (into {} (map (juxt :key identity) (:children attrs)))]
+      (is (= :modified (h/op-of (per-key :on-click)))))))
+
+;; ---- mixed opaque shapes (§4.5 other opaque values) -------------------
+
+(deftest opaque-other-shapes-are-same-by-default
+  (testing "non-fn opaque shapes (atom, IDeref) also default to :same"
+    (let [a1 (atom :one)
+          a2 (atom :two)  ; different identity, both atoms
+          before [:input {:ref a1}]
+          after  [:input {:ref a2}]
+          n      (h/diff-hiccup-node before after)
+          attrs  (:attrs-diff n)
+          per-key (into {} (map (juxt :key identity) (:children attrs)))]
+      (is (= :same (h/op-of (per-key :ref)))))))
+
+(deftest opaque-classifier-handles-atoms-and-fns-uniformly
+  (testing "classify-prop direct: (atom, atom) → :same; (fn, fn) →
+            :same; (fn, fn) with toggle → :fn-ref-changed"
+    (let [a1 (atom :one) a2 (atom :two)
+          f1 (fn [] 1)   f2 (fn [] 2)]
+      (is (= :same (h/op-of (h/classify-prop a1 a2 {}))))
+      (is (= :same (h/op-of (h/classify-prop f1 f2 {}))))
+      (is (= :fn-ref-changed
+             (h/op-of (h/classify-prop f1 f2 {:highlight-fn-ref-changes? true})))))))
+
+;; ---- nil children / scalar shapes -------------------------------------
+
+(deftest nil-children-no-recursion-bug
+  (testing "nil children handled as scalar leaves (not as a seqable)"
+    (let [n (h/diff-hiccup-node [:div nil] [:div "x"])
+          c (first (:children-diff n))]
+      (is (= :modified (h/op-of c))))))
+
+;; ---- changed? helper ---------------------------------------------------
+
+(deftest changed-detects-non-same
+  (testing "changed? returns true for :modified / :added / :removed /
+            :element-changed (with at least one non-same child)"
+    (is (false? (h/changed? {::h/op :same :value 1})))
+    (is (true?  (h/changed? {::h/op :modified :before 1 :after 2})))
+    (is (true?  (h/changed? {::h/op :added :value 1})))
+    (is (true?  (h/changed? (h/diff-hiccup-node [:div {:class "a"}]
+                                                [:div {:class "b"}])))))
+  (testing "changed? returns false for an element-changed with all-same
+            attrs + all-same children (degenerate; shouldn't normally
+            arise because identical/equal short-circuits earlier)"
+    (let [synthetic {::h/op :element-changed
+                     :tag :div
+                     :attrs-diff {::h/op :attrs :children []
+                                  :child-summary {}}
+                     :children-diff []}]
+      (is (false? (h/changed? synthetic))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -121,6 +121,8 @@
    :rf.causa/causality-popover-open?
    :rf.causa/causality-popover-layout
    :rf.causa/causality-popover-payload
+   ;; rf2-i39w2 Phase 3 — hiccup-diff micro-engine opt-in toggle.
+   :rf.causa/diff-opts
    :rf.causa/edit-popup-draft
    :rf.causa/edit-popup-open?
    :rf.causa/edit-popup-trigger
@@ -551,7 +553,11 @@
     ;;   :rf.causa/modal-positioning — Story-aware modal positioning opt.
     ;; + 1 sub-output structural-diff composite (rf2-xjhhp Phase 2):
     ;;   :rf.causa/views-sub-diff-for-focused-event.
-    (is (= 126 (count all-sub-names)))
+    ;; + 1 hiccup-diff opts (rf2-i39w2 Phase 3 of rf2-abts7):
+    ;;   :rf.causa/diff-opts — wraps the Settings → Diff section's
+    ;;   `:highlight-fn-ref-changes?` slot in the shape the hiccup-diff
+    ;;   engine's `classify-prop` consumes.
+    (is (= 127 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):


### PR DESCRIPTION
## Summary

Bead **rf2-i39w2** — Phase 3 of the structural-diff epic (rf2-abts7). Hiccup-specific structural-diff micro-engine for the Views panel re-render drilldown, plus the opaque-by-default rule for function-valued props + opt-in toggle for memoisation-issue diagnosis.

Per `ai/findings/2026-05-18-difftastic-in-causa.md` §3.3 + §4.

## Bug class addressed

Without a hiccup-aware diff, the generic `annotated-tree` walker on rendered hiccup produces noise:

1. The attrs map appears as a single 'slot 1 modified' with the whole map stacked, not as per-attr deltas.
2. Reordered keyed children surface as N modifications instead of one `:element-moved` per key.
3. Strings/text children get recursed-into as seqables (CLJS treats strings as seqable).
4. **Function-valued props would flag every re-render as a diff** — anonymous handlers are created fresh per render; the generic walker would mark every `:on-click` as `:modified` on every re-render, drowning the actual signal.

## ASCII sketches

### Keyed reorder — no false positives

```
▼ <CartList>  ◴ hiccup changed
│
│  ▼ [:ul {…}]
│  │ ↻ :key 22  [:li …]   moved (was at index 1, now at 0)
│  │ ↻ :key 7   [:li …]   moved (was at index 0, now at 1)
│  │   :key 91  [:li …]   (unchanged at 2)
```

Two keys moved; zero re-rendered. Without key-aware identity tracking this surfaces as "slot 0 modified, slot 1 modified" — false alarms.

### Fn-prop opaque vs toggle-on

```
Default (toggle OFF):
▼ <Button>  hiccup unchanged
│  (idiomatic fresh-per-render :on-click closure ignored)

Toggle ON (Settings → Diff → highlight fn-ref changes):
▼ <Button>  ◴ hiccup changed
│  ▼ [:button {…}]
│  │ ◴ :on-click  (fn ref changed)        ← violet chip, distinct from :modified
│  │ ~ :class "a" → "b"                   ← yellow inline diff
```

### Element added / removed

```
▼ <CartList>  ◴ hiccup changed
│  ▼ [:ul {…}]
│  │   :key 1   [:li "one"]               (unchanged)
│  │ - :key 2   [:li "two"]               (removed)
│  │ + :key 3   [:li "three"]             (added)
```

## New files

| File | LoC |
|---|---|
| `tools/causa/src/day8/re_frame2_causa/diff/hiccup.cljc` | 506 (~340 code + ~170 docstrings) |
| `tools/causa/src/day8/re_frame2_causa/diff/hiccup_render.cljs` | 385 |
| `tools/causa/test/day8/re_frame2_causa/diff/hiccup_test.cljc` | 316 |
| `tools/causa/test/day8/re_frame2_causa/diff/hiccup_render_cljs_test.cljs` | 112 |

## Modified files

| File | Change |
|---|---|
| `tools/causa/src/day8/re_frame2_causa/config.cljc` | Add `:diff {:highlight-fn-ref-changes? false}` to `default-settings`; mirror in `load-settings-from-storage!` + `configure!`. |
| `tools/causa/src/day8/re_frame2_causa/diff/render.cljs` | Forward-compat dispatch: detect hiccup-engine ops by `::hd/op` key and delegate to `hiccup-render`. Generic ops still resolve in render.cljs. |
| `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs` | `expanded-block` calls new `hiccup-diff-block` — returns nil unless render entry carries `:hiccup-before` + `:hiccup-after` (render-tracker P17 follow-on). |
| `tools/causa/src/day8/re_frame2_causa/settings/subs.cljs` | Register `:rf.causa/diff-opts` sub — reshapes `:diff` settings slot into the engine's opts vocabulary. |
| `tools/causa/src/day8/re_frame2_causa/settings/view.cljs` | Add Diff tab + `diff-section` view with the highlight-fn-ref checkbox. |
| `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs` | Catalogue: add `:rf.causa/diff-opts`; bump sub count 126 → 127. |

## Toggle UX

Settings popup → **Diff** tab (new, 4th in the tab strip) → "Highlight function-ref changes in view hiccup" checkbox. Off by default. Round-trips via the existing settings persistence layer (localStorage in CLJS, in-memory atom for JVM tests).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 914 tests / 2650 assertions / 0 failures (includes 24 new hiccup-engine tests, 67 assertions)
- [x] `cd implementation && npm run test:cljs` — 3078 tests / 8831 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 3067 tests / 8780 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS

## Divergences from design (per bead allowances)

- **Positional vector reorder** deferred. Only keyed children get `:element-moved` (full React-style identity tracking); positional children diff as add/remove/modified by index. Follow-on bead for LCS-driven move detection on positional children.
- **Per-attr-key fn-ref opt-in** (§4.5 detection nuance) deferred. v1 ships one global toggle; per-attr-key granularity (e.g. opt-in for `:on-click` but not `:ref`) is a follow-on bead.
- **Fragment handling** is shipped — `flatten-children` flattens `[:<> ...]` children into the parent's children-vec before diffing. The test corpus exercises this.

## Phase 1 reuse

The hiccup engine is a fresh ~340-LoC micro-engine, NOT a wrapper around `annotated-tree`. Hiccup's structural rules (positional children + attrs-map at slot 1 + key reorder tracking + opaque-by-default fns) differ enough from generic data that fitting them through the generic engine costs more code than it saves — same conclusion the design doc reached in §3.3.

The **renderer** does share with Phase 1: colour-token palette (`tokens/`), inspector dispatch for value display, and the same gutter idiom. `render.cljs` gains a forward-compat dispatch that detects hiccup-engine ops via their `::hd/op` key so generic vs hiccup annotated trees coexist in the same section-pipeline.

## Follow-on beads to file

- LCS-driven move detection on positional (unkeyed) children
- Per-attr-key fn-ref opt-in granularity
- Render-tracker `:hiccup-before` / `:hiccup-after` capture (P17 wave) — lights up the drilldown