### PR TITLE
fix(causa): drop '← Events' back-link (pre-chrome leftover)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -372,11 +372,16 @@
   "The hero panel's root view. Subscribes to
   `:rf.causa/event-detail` and renders either the cascade-detail
   layout (when a dispatch-id is selected) or the cascade-list empty
-  state (when not)."
+  state (when not).
+
+  Note: this panel has no internal back-link affordance — under the
+  4-layer chrome (rf2-lv9bc) the L2 event list is always visible
+  alongside the L4 detail, so a 'back to events' affordance is
+  meaningless. Selection is cleared by clicking a different cascade
+  row, or programmatically via `:rf.causa/clear-selected-dispatch-id`."
   []
   (let [{:keys [selected-dispatch-id selected-dispatch-frame selected-cascade cascades]}
-        @(rf/subscribe [:rf.causa/event-detail])
-        has-selection? (boolean selected-dispatch-id)]
+        @(rf/subscribe [:rf.causa/event-detail])]
     [:section {:data-testid "rf-causa-event-detail"
                :style       {:height         "100%"
                              :display        "flex"
@@ -386,17 +391,6 @@
                              :font-family    sans-stack
                              :font-size      "14px"}}
      [:header {:style {:padding "16px 16px 8px 16px"}}
-      (when has-selection?
-        [:button {:data-testid "rf-causa-event-detail-back"
-                  :on-click    #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
-                  :style       {:background  "transparent"
-                                :border      "none"
-                                :color       (:text-secondary tokens)
-                                :padding     "0 0 6px 0"
-                                :cursor      "pointer"
-                                :font-family sans-stack
-                                :font-size   "12px"}}
-         "← Events"])
       [:h1 {:style {:font-size   "16px"
                     :font-weight 600
                     :margin      0
@@ -418,26 +412,14 @@
                              :color   (:text-tertiary tokens)
                              :font-family sans-stack
                              :font-size "13px"}}
-       "Selected dispatch-id "
-        [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+         "Selected dispatch-id "
+         [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
           (str selected-dispatch-id)]
-        (when selected-dispatch-frame
-          [:span " in frame "
-           [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
-            (str selected-dispatch-frame)]])
-         " is no longer in the trace buffer. "
-         [:button {:data-testid "rf-causa-event-detail-orphaned-back"
-                   :on-click #(rf/dispatch [:rf.causa/clear-selected-dispatch-id] {:frame :rf/causa})
-                   :style    {:margin-left "8px"
-                              :background  "transparent"
-                              :border      (str "1px solid " (:border-default tokens))
-                              :color       (:text-secondary tokens)
-                              :padding     "2px 8px"
-                              :border-radius "4px"
-                              :cursor      "pointer"
-                              :font-family sans-stack
-                              :font-size   "11px"}}
-          "← Events"]]
+         (when selected-dispatch-frame
+           [:span " in frame "
+            [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
+             (str selected-dispatch-frame)]])
+         " is no longer in the trace buffer. Pick another cascade from the event list."]
 
         :else
         (cascade-list cascades))]]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -186,8 +186,15 @@
             "cascade-detail container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container absent once a selection is set")
-        (is (some? (find-by-testid tree "rf-causa-event-detail-back"))
-            "back-to-events button is rendered in the panel header")))))
+        ;; Per rf2-lv9bc — the panel-internal '← Events' back-link was
+        ;; a pre-4-layer-chrome leftover. Under the 4-layer chrome the
+        ;; L2 event list is always visible alongside the L4 detail, so
+        ;; the affordance is meaningless. Assert positively that no
+        ;; back-link is rendered in either the header (cascade view)
+        ;; or the orphaned branch.
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-back"))
+            "no internal '← Events' back-link in the header — L2 event
+             list is always visible alongside L4 detail (rf2-lv9bc)")))))
 
 (deftest selecting-non-existent-dispatch-id-shows-orphaned-state
   (testing "selecting a dispatch-id that's not in the buffer surfaces
@@ -202,7 +209,14 @@
         (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
             "orphaned-selection container present")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail absent when the id has no matching cascade")))))
+            "cascade-detail absent when the id has no matching cascade")
+        ;; rf2-lv9bc — the orphaned branch's '← Events' button was the
+        ;; same pre-4-layer-chrome leftover; under the chrome the L2
+        ;; list is always visible so the user picks another cascade
+        ;; directly. The handler (`:rf.causa/clear-selected-dispatch-id`)
+        ;; is retained for programmatic clear.
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-orphaned-back"))
+            "no '← Events' button in the orphaned branch (rf2-lv9bc)")))))
 
 (deftest frame-qualified-selection-renders-the-matching-cascade
   (testing "same dispatch-id in two frames resolves to the selected frame's cascade"

--- a/tools/causa/testbeds/rigorous/spec.cjs
+++ b/tools/causa/testbeds/rigorous/spec.cjs
@@ -440,12 +440,25 @@ module.exports = {
     // mount per the bare event-detail panel's reg-event-db. Force a
     // known-empty starting point in case an earlier walk left a
     // selection in place.
-    {
-      const lingeringBack = page.locator('[data-testid="rf-causa-event-detail-back"]');
-      if ((await lingeringBack.count()) > 0) {
-        await lingeringBack.first().click();
-      }
-    }
+    //
+    // rf2-lv9bc: the panel-internal '← Events' back-link was dropped
+    // (pre-4-layer-chrome leftover). Clear selection programmatically
+    // by dispatching `:rf.causa/clear-selected-dispatch-id` on the
+    // :rf/causa frame — same handler the deleted button fired.
+    await page.evaluate(() => {
+      const cljs = window.cljs.core;
+      const rf   = window.re_frame.core;
+      const kw   = (n) => cljs.keyword(n);
+      const frameOpts = cljs.PersistentArrayMap.fromArray(
+        [kw('frame'), kw('rf/causa')], true, false,
+      );
+      rf.dispatch_sync_STAR_(
+        cljs.PersistentVector.fromArray([
+          kw('rf.causa/clear-selected-dispatch-id'),
+        ], true),
+        frameOpts,
+      );
+    });
     await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);
     const cascadeRows = page.locator('[data-testid^="rf-causa-cascade-row-"]');
     await waitForCondition(
@@ -472,13 +485,28 @@ module.exports = {
       `cascade-detail data-dispatch-id=${clickedDispatchId}`,
       5000,
     );
-    // Click ← Events — back to the list. The detail goes away and
-    // the empty-state list reappears.
-    await page.locator('[data-testid="rf-causa-event-detail-back"]').click();
+    // Clear selection — under rf2-lv9bc the panel's '← Events' back-
+    // link was dropped (pre-4-layer-chrome leftover); fire the same
+    // handler the button used to fire so the detail unmounts and the
+    // empty-state list reappears.
+    await page.evaluate(() => {
+      const cljs = window.cljs.core;
+      const rf   = window.re_frame.core;
+      const kw   = (n) => cljs.keyword(n);
+      const frameOpts = cljs.PersistentArrayMap.fromArray(
+        [kw('frame'), kw('rf/causa')], true, false,
+      );
+      rf.dispatch_sync_STAR_(
+        cljs.PersistentVector.fromArray([
+          kw('rf.causa/clear-selected-dispatch-id'),
+        ], true),
+        frameOpts,
+      );
+    });
     await waitForCondition(
       async () => page.locator('[data-testid="rf-causa-event-detail-cascade"]').count(),
       (count) => count === 0,
-      'cascade-detail to unmount after ← Events',
+      'cascade-detail to unmount after :rf.causa/clear-selected-dispatch-id',
       5000,
     );
     await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);
@@ -3837,13 +3865,25 @@ module.exports = {
       await clickSidebar(page, 'event-detail', 'rf-causa-event-detail');
       // Force list-mode so the cascade-row inventory below reads a
       // populated list (cascade-detail mounts hide the list).
-      {
-        const lingeringBack = page.locator('[data-testid="rf-causa-event-detail-back"]');
-        if ((await lingeringBack.count()) > 0) {
-          await lingeringBack.first().click();
-          await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);
-        }
-      }
+      //
+      // rf2-lv9bc: the panel-internal '← Events' back-link was dropped
+      // (pre-4-layer-chrome leftover). Clear selection programmatically
+      // by dispatching the underlying handler.
+      await page.evaluate(() => {
+        const cljs = window.cljs.core;
+        const rf   = window.re_frame.core;
+        const kw   = (n) => cljs.keyword(n);
+        const frameOpts = cljs.PersistentArrayMap.fromArray(
+          [kw('frame'), kw('rf/causa')], true, false,
+        );
+        rf.dispatch_sync_STAR_(
+          cljs.PersistentVector.fromArray([
+            kw('rf.causa/clear-selected-dispatch-id'),
+          ], true),
+          frameOpts,
+        );
+      });
+      await expectVisible(page.locator('[data-testid="rf-causa-event-detail-empty"]'), 5000);
 
       // Capture the host counter's pre-stress baseline.
       const counterValueLocator = page.locator('#app [data-testid="counter-value"]');


### PR DESCRIPTION
## Summary

Drops the panel-internal `← Events` back-link from the Causa Event Detail panel — both instances (cascade-detail header + orphaned-selection branch). Pre-4-layer-chrome leftover: under the current chrome the L2 event list is always visible alongside the L4 detail, so 'back to events' is meaningless. The user just clicks another row in the always-visible L2 list.

Bead: **rf2-lv9bc** (do NOT close on merge per bead protocol).

## Text-audit citation

The affordance was a **broken affordance** in the post-chrome layout — its visual model ('go back to the previous view') doesn't match the actual layout ('the list is right there'). Surfaced as part of the Causa text-audit pass on dead/leftover chrome from pre-4-layer-chrome (Causa hero-panel era).

## Files changed

- `tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs` — delete both `← Events` buttons + their styling. The handler `:rf.causa/clear-selected-dispatch-id` is **retained** (still listed in `spec/014-Registry-Catalogue.md`, still dispatched directly from tests + rigorous testbed).
- `tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs` — drop the affordance assertion in `cascade-detail-renders-six-dominoes`; assert positively that neither testid (`-back`, `-orphaned-back`) is in the tree.
- `tools/causa/testbeds/rigorous/spec.cjs` — replace three back-link-button clicks with `page.evaluate()` calls that dispatch the same clear event the button used to fire.

## ASCII before / after

### Cascade-detail header

Before:
```
+----------------------------------------------+
| ← Events                                     |
| Event detail                                 |
| Pick a dispatch from the cascade list ...    |
+----------------------------------------------+
| [cascade-detail six-domino rows]             |
| ...                                          |
+----------------------------------------------+
```

After:
```
+----------------------------------------------+
| Event detail                                 |
| Pick a dispatch from the cascade list ...    |
+----------------------------------------------+
| [cascade-detail six-domino rows]             |
| ...                                          |
+----------------------------------------------+
```

### Orphaned-selection branch

Before:
```
+----------------------------------------------+
| Selected dispatch-id `42` is no longer in    |
| the trace buffer. [ ← Events ]               |
+----------------------------------------------+
```

After:
```
+----------------------------------------------+
| Selected dispatch-id `42` is no longer in    |
| the trace buffer. Pick another cascade from  |
| the event list.                              |
+----------------------------------------------+
```

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS (3072 cljs tests, 8820 assertions, 0 failures)
- [x] `cd tools/causa && clojure -M:test` — PASS (890 tests, 2583 assertions, 0 failures)
- [x] `cd implementation && npm run test:browser` — PASS (3061 tests, 8769 assertions, 0 failures)
- [x] Event-detail test suite: existing focus/cascade tests still pass; new negative assertions confirm neither back-link testid renders.