### PR TITLE
fix(causa): remove fake Telemetry section — no broken claims in chrome

### DIFF
--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -182,9 +182,14 @@ the `default-settings` block in `config.cljc`:
 {:general   {:text-size           13          ; px; slider range 10–18
              :panel-position      :right-rail ; :right-rail | :popout | :fullscreen
              :auto-open-on-error? false}
- :theme     :dark                              ; :dark | :light
- :telemetry {:opt-in?             false}}
+ :theme     :dark}                             ; :dark | :light
 ```
+
+> Note (rf2-jh9ws): a `:telemetry` slot shipped briefly with the
+> initial popup landing (rf2-9poxq) but was removed — Causa
+> transmits no telemetry. Legacy `:telemetry` keys in persisted
+> payloads or in `(configure! {:settings ...})` calls are silently
+> dropped by the per-section merge.
 
 | Value | Meaning |
 |---|---|

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -281,12 +281,15 @@ backfills what v1 actually ships.
 | **General** (default) | Text-size slider (range 10–18 px; writes the `--rf-causa-text-size` CSS custom property on the shell root + `<html>`) · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen` — routes to `mount/open!` / `mount/popout!` / `mount/open-overlay!` via the browser API exports) · "Auto-open Causa when an issue is observed" checkbox |
 | **Filters** | Pointer into the auto-filter pills feature. When the `day8.re-frame2-causa.filters` ns is on the classpath the tab renders an "Open auto-filter UI" button that dispatches `:rf.causa.filters/open`; otherwise it shows the "install the feature first" hint. The full pill management surface lives in the ribbon (per [`018-Event-Spine.md`](./018-Event-Spine.md) §7) — this tab is a discoverability handle. |
 | **Theme** | Dark (default) / Light radio. Toggles the `rf-causa-theme-{dark,light}` class on the shell root + `<html>`. Accent picker deferred. |
-| **Telemetry** | Single "Send anonymous usage telemetry" checkbox, **default OFF** (opt-in). No telemetry endpoint exists in v1 — the toggle round-trips to localStorage so a future endpoint lands with the user's preference already persisted. |
 
-**v1 ships:** four tabs (General / Filters / Theme / Telemetry). The
-fuller [`018-Event-Spine.md`](./018-Event-Spine.md) §9 catalogue
+**v1 ships:** three tabs (General / Filters / Theme). The fuller
+[`018-Event-Spine.md`](./018-Event-Spine.md) §9 catalogue
 (Keybindings, Buffer, Popout, Actions) is deferred to follow-on
-beads.
+beads. A Telemetry tab shipped briefly in the initial popup landing
+(rf2-9poxq) but was removed (rf2-jh9ws) — Causa transmits no
+telemetry, and a toggle pretending to control a non-existent
+endpoint was a broken affordance per the text audit (rf2-yn86j).
+When telemetry actually ships, the tab returns with real wiring.
 
 ### Defaults
 
@@ -296,7 +299,6 @@ beads.
 | `:general :panel-position` | `:right-rail` | Matches the existing `:layout/host-selector` inline-host posture per [`015-Configuration.md`](./015-Configuration.md). |
 | `:general :auto-open-on-error?` | `false` | The user is in their app, not asking Causa to interrupt them. |
 | `:theme` | `:dark` | Causa is a dev tool; the canvas-and-chrome palette in `theme/tokens.cljc` is the dark one. |
-| `:telemetry :opt-in?` | `false` | Opt-in; no payloads sent. |
 
 ### Persistence
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -850,16 +850,17 @@ The browser feature gate that asserts I1 + I3 + I4 together is the canonical iso
 
 ### v1 ships
 
-**v1 ships four sections, NOT six** (rf2-9poxq): **General**,
-**Filters**, **Theme**, **Telemetry** — a top tab strip (not left-rail
-nav) drives which body section renders. Defaults: telemetry OFF
-(opt-in), auto-open-on-error OFF, panel-position `:right-rail`,
-theme `:dark`, text-size 13 px. Storage key
-`re-frame2.causa.settings.v1` (single nested map, one round-trip
-through `pr-str`). Full per-knob inventory + persistence rationale +
-auto-open-watcher semantics are in
+**v1 ships three sections, NOT six** (rf2-9poxq + rf2-jh9ws):
+**General**, **Filters**, **Theme** — a top tab strip (not left-rail
+nav) drives which body section renders. Defaults: auto-open-on-error
+OFF, panel-position `:right-rail`, theme `:dark`, text-size 13 px.
+Storage key `re-frame2.causa.settings.v1` (single nested map, one
+round-trip through `pr-str`). Full per-knob inventory + persistence
+rationale + auto-open-watcher semantics are in
 [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Settings popup
-— v1 ships.
+— v1 ships. (A Telemetry tab shipped briefly with the initial popup
+landing but was removed per rf2-jh9ws — Causa transmits no telemetry
+and the toggle was a broken affordance.)
 
 The Keybindings, Buffer, Popout, and Actions sections (the bottom
 four rows of the table above) are the **full §9 catalogue intent**

--- a/tools/causa/spec/Principles.md
+++ b/tools/causa/spec/Principles.md
@@ -95,7 +95,10 @@ does not.
 The privacy bet beats the utility bet. The user's runtime may
 contain sensitive data; Causa stores nothing it doesn't need to.
 
-Settings → Telemetry has a section explaining we ship none.
+Causa ships no telemetry — nothing is sent to Day8, Anthropic, or
+anywhere. (A Settings tab labelled "Telemetry" briefly carried an
+opt-in toggle but was removed per rf2-jh9ws — chrome must not
+pretend to control something that does not exist.)
 
 ## Animation communicates, not decorates
 

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -526,10 +526,10 @@
 ;; ---- settings popup defaults + persistence (rf2-9poxq) ------------------
 ;;
 ;; The Settings popup modal (`settings/popup.cljs`) reads + writes a
-;; settings map carrying user preferences for general / theme /
-;; telemetry knobs. Defaults are catalogued here; the live values
-;; round-trip through localStorage under the key below so they survive
-;; reload (CLJS only — the JVM target reads/writes the in-memory atom).
+;; settings map carrying user preferences for general / theme knobs.
+;; Defaults are catalogued here; the live values round-trip through
+;; localStorage under the key below so they survive reload (CLJS only
+;; — the JVM target reads/writes the in-memory atom).
 ;;
 ;; ## Why a single nested map
 ;;
@@ -540,9 +540,8 @@
 ;; subscription contract) folds onto `get-in` / `assoc-in` over the
 ;; same shape.
 ;;
-;; ## Locked decisions (rf2-9poxq R3)
+;; ## Locked decisions (rf2-9poxq R3, rf2-jh9ws)
 ;;
-;; - telemetry default OFF (opt-in)
 ;; - auto-open-on-error default OFF (the user is in their app, not
 ;;   asking for Causa to interrupt them)
 ;; - panel-position default `:right-rail` (matches the existing
@@ -553,6 +552,16 @@
 ;;   :body` — the popup's slider is the one knob that scales every
 ;;   subsequent inline-style reads via the published CSS custom
 ;;   property `--rf-causa-text-size`).
+;;
+;; ## Migration (rf2-jh9ws)
+;;
+;; Settings persisted with `:telemetry` key from prior sessions
+;; should NOT break. `load-settings-from-storage!` deep-merges over
+;; `default-settings` per-known-section, so any legacy `:telemetry`
+;; key in the persisted payload is silently dropped (the merge target
+;; no longer carries the slot). Same for `update-setting!` —
+;; `valid-section-key?` rejects unknown `[section key]` paths so a
+;; rogue `[:telemetry :opt-in?]` write is a no-op + a tap>.
 
 (def settings-storage-key
   "localStorage key the settings round-trip uses. Versioned so a future
@@ -568,8 +577,7 @@
   {:general   {:text-size           13              ; px — slider range 10–18
                :panel-position      :right-rail     ; :right-rail | :popout | :fullscreen
                :auto-open-on-error? false}
-   :theme     :dark                                  ; :dark | :light
-   :telemetry {:opt-in? false}})
+   :theme     :dark})                                ; :dark | :light
 
 (defonce
   ^{:doc "Atom holding the live settings map. Seeded with
@@ -681,7 +689,13 @@
      deep-merge over the in-memory defaults. Idempotent — safe to call
      more than once. Failures (no window, no localStorage, malformed
      payload) degrade silently to the defaults the atom already holds.
-     Called from the preload's side-effect block on CLJS startup."
+     Called from the preload's side-effect block on CLJS startup.
+
+     Per rf2-jh9ws: legacy `:telemetry` keys (from sessions prior to
+     the Telemetry section's removal) are silently dropped — the
+     per-section merge below only knows about known slots, so any
+     unknown top-level key in the persisted payload falls on the
+     floor without throwing."
      []
      (try
        (when-let [raw (storage-get settings-storage-key)]
@@ -691,8 +705,7 @@
                      (-> default-settings
                          (update :general merge (:general parsed))
                          (assoc  :theme  (or (:theme parsed)
-                                             (:theme default-settings)))
-                         (update :telemetry merge (:telemetry parsed)))))))
+                                             (:theme default-settings))))))))
        (catch :default _ nil))
      nil))
 
@@ -881,14 +894,16 @@
   ;; NB: `settings` here is the destructured bulk-config map; the
   ;; in-namespace defonce atom is reached via the fully-qualified
   ;; symbol (`day8.re-frame2-causa.config/settings`) to disambiguate.
+  ;; rf2-jh9ws: legacy `:telemetry` keys in the bulk-config map are
+  ;; silently dropped — the per-section merge here only knows about
+  ;; known slots.
   (when (contains? opts :settings)
     (when (map? settings)
       (reset! day8.re-frame2-causa.config/settings
               (-> default-settings
                   (update :general merge (:general settings))
                   (assoc  :theme  (or (:theme settings)
-                                      (:theme default-settings)))
-                  (update :telemetry merge (:telemetry settings))))
+                                      (:theme default-settings)))))
       #?(:cljs (write-storage!))))
   ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
   ;; seed so a host that overrides both in one call gets the seed

--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -39,10 +39,6 @@
     would `(add-watch nil ...)` and throw under Story testbeds
     that never open Causa).
 
-  - **telemetry opt-in?** — no-op for v1. The setting still
-    round-trips so when the telemetry endpoint lands the value is
-    already persisted.
-
   ## Why a separate ns
 
   The popup's `events.cljs` writes through to the in-memory atom +

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -29,11 +29,11 @@
 
   ## Active tab
 
-  The modal's left-rail navigation (General | Filters | Theme |
-  Telemetry) tracks `:settings-active-tab` in app-db. Default is
-  `:general`. `:rf.causa/settings-open` resets the tab to `:general`
-  so each reopen starts in a predictable place (the modal is
-  transient per spec/018 §9 — the user is not 'browsing' it)."
+  The modal's top tab strip (General | Filters | Theme) tracks
+  `:settings-active-tab` in app-db. Default is `:general`.
+  `:rf.causa/settings-open` resets the tab to `:general` so each
+  reopen starts in a predictable place (the modal is transient per
+  spec/018 §9 — the user is not 'browsing' it)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.settings.effects :as effects]))
@@ -84,8 +84,7 @@
   ;;
   ;; After the dual-write, the matching side-effect lands so the
   ;; user sees the change immediately (text-size CSS var, theme
-  ;; class, panel-position route). Telemetry has no v1 side-effect
-  ;; — the toggle is round-tripped only.
+  ;; class, panel-position route).
   (rf/reg-event-db :rf.causa/settings-update
     (fn [db [_ section key value]]
       (config/update-setting! section key value)

--- a/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
@@ -8,13 +8,14 @@
   `:rf.causa/settings-open?` is false; closed-state cost is one
   subscribe + a `when`.
 
-  ## Sections (this bead — rf2-9poxq)
+  ## Sections (rf2-9poxq + rf2-jh9ws)
 
-  General | Filters | Theme | Telemetry — a top tab strip drives
-  which body section renders. The full spec/018 §9 catalogue
-  (Keybindings, Buffer, Popout, Actions) is deferred to follow-on
-  beads; this bead ships the four sections enumerated in the bead's
-  contract.
+  General | Filters | Theme — a top tab strip drives which body
+  section renders. The full spec/018 §9 catalogue (Keybindings,
+  Buffer, Popout, Actions) is deferred to follow-on beads. The
+  Telemetry tab was removed (rf2-jh9ws) — Causa ships no telemetry
+  endpoint and the v1 toggle was a broken affordance; per the text
+  audit (rf2-yn86j) the chrome must not pretend.
 
   ## Modal layer
 

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -149,14 +149,18 @@
 ;; ---- tab strip ----------------------------------------------------------
 
 (def ^:private tabs
-  "Ordered tab list. Per the bead's contract the modal carries four
-  sections (General | Filters | Theme | Telemetry). Tab id matches
-  the `:rf.causa/settings-update` `section` for sections that map
-  1:1 to a settings slot."
+  "Ordered tab list. The modal carries three sections
+  (General | Filters | Theme). Tab id matches the
+  `:rf.causa/settings-update` `section` for sections that map 1:1
+  to a settings slot.
+
+  Telemetry was removed (rf2-jh9ws): Causa ships no telemetry
+  endpoint, and the toggle in v1 was a broken affordance — silent
+  by default, no broken claims (per text-audit rf2-yn86j). When
+  telemetry actually ships, the tab returns with real wiring."
   [{:id :general   :label "General"}
    {:id :filters   :label "Filters"}
-   {:id :theme     :label "Theme"}
-   {:id :telemetry :label "Telemetry"}])
+   {:id :theme     :label "Theme"}])
 
 (defn- tab-button [{:keys [id label]} active?]
   [:button {:data-testid (str "rf-causa-settings-tab-" (name id))
@@ -299,36 +303,6 @@
        "Light / dark only for v1. Accent picker arrives in a later "
        "release."]]]))
 
-;; ---- section: Telemetry -------------------------------------------------
-
-(defn- telemetry-section []
-  (let [opt-in? @(rf/subscribe [:rf.causa/setting :telemetry :opt-in?])]
-    [:div {:data-testid "rf-causa-settings-section-telemetry"}
-     [:h2 {:style (section-heading-style)} "Telemetry"]
-     [:div {:style (field-style)}
-      [:label {:style {:display "flex" :align-items "center" :gap "8px"
-                       :cursor "pointer"
-                       :font-size (:body type-scale)
-                       :color (:text-primary tokens)}}
-       [:input {:data-testid "rf-causa-settings-telemetry-opt-in"
-                :type        "checkbox"
-                :checked     (boolean opt-in?)
-                :on-change   #(rf/dispatch
-                                [:rf.causa/settings-update
-                                 :telemetry :opt-in?
-                                 (boolean (.. % -target -checked))])}]
-       "Send anonymous usage telemetry to help improve Causa"]
-      [:p {:style (hint-style)}
-       "Off by default. When on, Causa sends panel-open counts and "
-       "feature-use frequency to the project. No event payloads, no "
-       "app-db contents — see "
-       [:a {:href   "https://github.com/day8/re-frame2/blob/main/tools/causa/spec/Conventions.md"
-            :target "_blank"
-            :rel    "noreferrer"
-            :style  {:color (:cyan tokens) :text-decoration "underline"}}
-        "the privacy doc"]
-       " for the exact list."]]]))
-
 ;; ---- key handling -------------------------------------------------------
 
 (defn- handle-keydown
@@ -383,5 +357,4 @@
          :general   (general-section)
          :filters   (filters-section)
          :theme     (theme-section)
-         :telemetry (telemetry-section)
          (general-section))]]]))

--- a/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/persistence_cljs_test.cljs
@@ -37,8 +37,7 @@
     (is (= :right-rail
               (config/get-setting :general :panel-position)))
     (is (= false  (config/get-setting :general :auto-open-on-error?)))
-    (is (= :dark  (config/get-setting :theme nil)))
-    (is (= false  (config/get-setting :telemetry :opt-in?)))))
+    (is (= :dark  (config/get-setting :theme nil)))))
 
 ;; ---- per-setting round-trip --------------------------------------------
 
@@ -75,12 +74,24 @@
   (config/load-settings-from-storage!)
   (is (= :light (config/get-setting :theme nil))))
 
-(deftest telemetry-opt-in-round-trips
-  (config/update-setting! :telemetry :opt-in? true)
-  (is (true? (config/get-setting :telemetry :opt-in?)))
+(deftest legacy-telemetry-key-is-silently-dropped
+  ;; rf2-jh9ws: settings persisted from prior sessions with a
+  ;; `:telemetry` key (the section was removed because no telemetry
+  ;; endpoint exists) must not break load. The per-section merge in
+  ;; `load-settings-from-storage!` only knows the surviving slots, so
+  ;; the legacy key falls on the floor without throwing.
+  (#'config/storage-set! config/settings-storage-key
+                         (pr-str {:general   {:text-size 15}
+                                  :theme     :light
+                                  :telemetry {:opt-in? true}}))
   (reset! config/settings config/default-settings)
   (config/load-settings-from-storage!)
-  (is (true? (config/get-setting :telemetry :opt-in?))))
+  (is (= 15 (config/get-setting :general :text-size))
+      "known slots load cleanly")
+  (is (= :light (config/get-setting :theme nil))
+      "known slots load cleanly")
+  (is (nil? (:telemetry @config/settings))
+      "legacy :telemetry key is silently dropped"))
 
 ;; ---- reset ------------------------------------------------------------
 
@@ -111,6 +122,9 @@
 ;; ---- bulk configure! :settings ----------------------------------------
 
 (deftest configure-settings-bulk-replaces
+  ;; rf2-jh9ws: legacy `:telemetry` key in the bulk-config map is
+  ;; silently dropped — known slots round-trip; unknown slots fall
+  ;; on the floor.
   (config/configure! {:settings {:general   {:text-size 15
                                              :panel-position :fullscreen
                                              :auto-open-on-error? true}
@@ -120,7 +134,8 @@
   (is (= :fullscreen (config/get-setting :general :panel-position)))
   (is (true? (config/get-setting :general :auto-open-on-error?)))
   (is (= :light (config/get-setting :theme nil)))
-  (is (true? (config/get-setting :telemetry :opt-in?)))
+  (is (nil? (:telemetry @config/settings))
+      "legacy :telemetry key dropped by per-section merge")
   (is (some? (storage-payload))
       "bulk configure round-trips to localStorage"))
 
@@ -130,5 +145,4 @@
   ;; Other general slots keep their defaults
   (is (= :right-rail (config/get-setting :general :panel-position)))
   (is (= false (config/get-setting :general :auto-open-on-error?)))
-  (is (= :dark (config/get-setting :theme nil)))
-  (is (= false (config/get-setting :telemetry :opt-in?))))
+  (is (= :dark (config/get-setting :theme nil))))

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
@@ -152,26 +152,15 @@
       (is (find-by-testid rendered "rf-causa-settings-theme-dark"))
       (is (find-by-testid rendered "rf-causa-settings-theme-light")))))
 
-(deftest telemetry-section-renders
-  (setup!)
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/settings-open])
-    (rf/dispatch-sync [:rf.causa/settings-select-tab :telemetry]))
-  (rf/with-frame :rf/causa
-    (let [rendered (popup/Modal)]
-      (is (find-by-testid rendered "rf-causa-settings-section-telemetry"))
-      (is (find-by-testid rendered "rf-causa-settings-telemetry-opt-in")))))
-
 ;; ---- Tab switching ------------------------------------------------------
 
 (deftest tab-switching-changes-section
   (setup!)
   (rf/with-frame :rf/causa
     (rf/dispatch-sync [:rf.causa/settings-open]))
-  (doseq [[tab-id section-testid] [[:general   "rf-causa-settings-section-general"]
-                                   [:filters   "rf-causa-settings-section-filters"]
-                                   [:theme     "rf-causa-settings-section-theme"]
-                                   [:telemetry "rf-causa-settings-section-telemetry"]]]
+  (doseq [[tab-id section-testid] [[:general "rf-causa-settings-section-general"]
+                                   [:filters "rf-causa-settings-section-filters"]
+                                   [:theme   "rf-causa-settings-section-theme"]]]
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/settings-select-tab tab-id]))
     (rf/with-frame :rf/causa

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -132,15 +132,17 @@ function waitForReady(url, timeoutMs) {
         cardTestid:  'panel-gallery-chrome-card',
         expectedAtLeast: 10,
       },
-      // Settings popup workspace (rf2-mpn8m) — 4 variants. Each
-      // cell mounts the chrome + opens the Settings popup on a
-      // different tab (General / Filters / Theme / Telemetry).
-      // Same shared :rf/causa caveat as the chrome workspace.
+      // Settings popup workspace (rf2-mpn8m, rf2-jh9ws) — 3
+      // variants. Each cell mounts the chrome + opens the Settings
+      // popup on a different tab (General / Filters / Theme). The
+      // Telemetry tab was removed (rf2-jh9ws) because no telemetry
+      // endpoint exists — chrome must not pretend. Same shared
+      // :rf/causa caveat as the chrome workspace.
       {
         id:          'settings-popup',
         workspaceRe: /Workspace\.causa\.settings-popup\/all/,
         cardTestid:  'panel-gallery-chrome-card',
-        expectedAtLeast: 4,
+        expectedAtLeast: 3,
       },
       // Auto-filter pill + edit-popup workspace (rf2-kbrkx) — 5
       // variants. Each cell mounts the chrome and either seeds

--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -108,7 +108,7 @@ function waitForReady(url, timeoutMs) {
       { name: 'Workspace.causa.trace/all',           expectedAtLeast: 10 },
       { name: 'Workspace.causa.machines/all',        expectedAtLeast: 6  },
       { name: 'Workspace.causa.issues/all',          expectedAtLeast: 11 },
-      { name: 'Workspace.causa.settings-popup/all',  expectedAtLeast: 4  },
+      { name: 'Workspace.causa.settings-popup/all',  expectedAtLeast: 3  },
       { name: 'Workspace.causa.filters/all',         expectedAtLeast: 5  },
       { name: 'Workspace.causa.causality-popover/all', expectedAtLeast: 4 },
       { name: 'Workspace.causa.event/all',           expectedAtLeast: 12 }, // round-trip

--- a/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
@@ -44,8 +44,10 @@
 
   (story/reg-tag :feature/causa-settings-popup
     {:axis :feature
-     :doc  "Causa Settings popup modal — 4-tab strip (General /
-            Filters / Theme / Telemetry) per spec/018-Event-Spine §9."})
+     :doc  "Causa Settings popup modal — 3-tab strip (General /
+            Filters / Theme) per spec/018-Event-Spine §9. Telemetry
+            tab removed per rf2-jh9ws (no endpoint exists; chrome
+            must not pretend)."})
 
   (story/reg-story :story.causa.settings-popup
     {:doc        "Visual gallery of the Causa Settings popup modal.
@@ -112,22 +114,8 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 4. Telemetry tab — opt-in checkbox checked.
-  (story/reg-variant :story.causa.settings-popup/telemetry-opt-in
-    {:doc        "Settings popup open on Telemetry tab with the
-                 anonymous-usage opt-in checkbox checked. v1
-                 ships the toggle round-tripped only (no live
-                 telemetry side-effect) — the popup contract is
-                 the user-facing surface."
-     :events     [[:panel-gallery.chrome/seed!
-                   {:trace-buffer (fixtures/n-cascades 3)
-                    :selected-tab :event
-                    :after-seeds
-                    [[:rf.causa/settings-update :telemetry :opt-in? true]
-                     [:rf.causa/settings-open]
-                     [:rf.causa/settings-select-tab :telemetry]]}]]
-     :tags       #{:dev :state/special}
-     :substrates #{:reagent}})
+  ;; (Telemetry tab removed per rf2-jh9ws — no endpoint exists,
+  ;; chrome must not pretend; section + variant deleted.)
 
   ;; ----- workspace ---------------------------------------------------
   ;;
@@ -136,7 +124,7 @@
   ;; The last variant to seed wins the shared interior; canvas-mode
   ;; (sidebar pick) is where per-variant fidelity is fully observable.
   (story/reg-workspace :Workspace.causa.settings-popup/all
-    {:doc      "All four Settings popup variants. The chrome
+    {:doc      "All three Settings popup variants. The chrome
                 internally wraps :rf/causa via a hardcoded frame-
                 provider, so workspace cells share interior state —
                 see canvas-mode (sidebar pick) for per-variant


### PR DESCRIPTION
## Bead: rf2-jh9ws

**Bug class:** broken-claim (per text-audit rf2-yn86j).

The Causa Settings popup (rf2-9poxq landing, PR #1405) shipped a
Telemetry tab carrying an opt-in toggle and the prose:

> Send anonymous usage telemetry to help improve Causa.

But Causa transmits no telemetry — there is no endpoint, no payload
emitter, no wiring of any kind. The toggle was a no-op stub; the
prose was a lie. Per rf2-yn86j (text-audit posture, established
across the Causa chrome): **silent by default, no broken claims.**
When telemetry actually ships, the tab returns with real wiring.

Settings popup tabs now go from 4 → 3: **General / Filters / Theme**.

## What changed

### Code

- `tools/causa/src/.../settings/view.cljs` — drop `:telemetry` tab
  entry from the tab strip, drop the `telemetry-section` fn, drop
  the `case` branch in `popup-view`.
- `tools/causa/src/.../settings/popup.cljs` — docstring updated;
  no behavioural change (no telemetry-specific subs/events existed).
- `tools/causa/src/.../settings/events.cljs` — docstrings cleaned
  of telemetry mentions; no event was telemetry-specific.
- `tools/causa/src/.../settings/effects.cljs` — drop the per-setting
  "telemetry opt-in?: no-op for v1" bullet from the ns docstring.
- `tools/causa/src/.../config.cljc` — drop `:telemetry` slot from
  `default-settings`; both `load-settings-from-storage!` and
  `configure!` per-section merges silently drop any legacy
  `:telemetry` key (migration: prior-session payloads do not break).

### Tests

- `popup_cljs_test.cljs` — drop `telemetry-section-renders`; trim
  tab-switching matrix to 3 tabs.
- `persistence_cljs_test.cljs` — drop `telemetry-opt-in-round-trips`
  and `:telemetry` asserts from defaults + bulk-configure tests;
  add a new `legacy-telemetry-key-is-silently-dropped` test that
  exercises the migration path (persisted payload carrying the
  legacy slot loads cleanly, slot falls on the floor).
- `panel_gallery/gallery_settings.cljs` — drop the telemetry
  Story variant; workspace doc + tag doc updated to 3 tabs.
- `_smoke.cjs` / `_workspace_switch_smoke.cjs` — settings-popup
  workspace `expectedAtLeast` 4 → 3.

### Spec

These describe what the popup ships; kept in sync so we don't
introduce spec-vs-code drift:

- `tools/causa/spec/016-Auxiliary-Panels.md` — v1 tab inventory
  table drops the Telemetry row; defaults table drops
  `:telemetry :opt-in?`; "v1 ships" claim is now three tabs with
  the removal rationale.
- `tools/causa/spec/018-Event-Spine.md` — "v1 ships four sections"
  becomes "v1 ships three sections".
- `tools/causa/spec/015-Configuration.md` — `:settings` shape no
  longer carries `:telemetry`; migration note added.
- `tools/causa/spec/Principles.md` — "Settings → Telemetry has a
  section explaining we ship none" replaced with prose stating the
  fact (the chrome no longer makes the claim).

## Migration

Settings persisted with `:telemetry` key from prior sessions do
NOT break. `load-settings-from-storage!` and `configure!` both
deep-merge per-known-section over `default-settings`; the legacy
`:telemetry` payload key falls on the floor without throwing. New
test asserts this explicitly.

## Don't

Per the bead's contract:

- **Did not** leave a "future: telemetry will live here" placeholder.
- **Did not** keep the toggle "for future use" — that's exactly the
  broken-claim pattern we're fixing.

## Test plan

- [x] `scripts/test-fast-pr.sh` (3076 tests / 8836 assertions, 0/0)
- [x] `cd tools/causa && clojure -M:test` (890 / 2583, 0/0)
- [x] `cd implementation && npm run test:browser` (3067 / 8789, 0/0)

Closes the broken affordance flagged by rf2-jh9ws; bead remains
open per the dispatch contract.