### PR TITLE
fix(causa): drop stale 'pick a dispatch from cascade list' empty-state (silent by default)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -305,21 +305,16 @@
 (defn- cascade-list
   "Empty-state list of cascades for the user to click into. Until the
   actions panel lands (rf2-5yriz) this is the primary way to select a
-  dispatch-id."
+  dispatch-id.
+
+  Silent-by-default (rf2-b9f6z) — no prose; the panel reflects the L2
+  event-list focus like every other panel. When the buffer has
+  cascades, the list itself is the only affordance; when the buffer is
+  empty, the container renders empty."
   [cascades]
   [:div {:data-testid "rf-causa-event-detail-empty"
          :style       {:padding "16px"}}
-   [:p {:style {:font-family sans-stack
-                :font-size   "13px"
-                :color       (:text-secondary tokens)
-                :margin      "0 0 12px 0"}}
-    "Click a cascade below to inspect its dispatch."]
-   (if (empty? cascades)
-     [:p {:style {:font-family sans-stack
-                  :font-size   "13px"
-                  :color       (:text-tertiary tokens)
-                  :margin      0}}
-      "No cascades yet. Trigger a dispatch in the host app to populate."]
+   (when (seq cascades)
      (overflow/capped-list
        cascades
        {:panel-id "event-detail"
@@ -401,12 +396,7 @@
                     :font-weight 600
                     :margin      0
                     :color       (:text-primary tokens)}}
-       "Event detail"]
-      [:p {:style {:font-size "12px"
-                   :color     (:text-tertiary tokens)
-                   :margin    "4px 0 0 0"}}
-       "Pick a dispatch from the cascade list to see its handler, "
-       "effects, subscriptions, and source coord."]]
+       "Event detail"]]
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond
         (and selected-dispatch-id selected-cascade)

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -304,14 +304,16 @@
 (deftest no-selection-empty-buffer-renders-default-landing-view
   (testing "per spec/007-UX-IA.md §Default landing view, the panel's
             initial state (no selection, no events) renders the empty-
-            state container with the 'no cascades yet' placeholder copy"
+            state container silently — per rf2-b9f6z the panel reflects
+            the L2 event-list focus like every other panel, so the
+            empty container carries no prose"
     (seed-buffer! [])
     (rf/with-frame :rf/causa
       (let [tree    (event-detail/Panel)
             empty   (find-by-testid tree "rf-causa-event-detail-empty")
             ;; Flatten every text node under the empty-state container
-            ;; so the assertion is agnostic to the placeholder paragraph's
-            ;; exact hiccup nesting.
+            ;; so the silent-by-default assertion is agnostic to the
+            ;; container's exact hiccup nesting.
             text    (->> (hiccup-seq empty)
                          (filter string?)
                          (apply str))]
@@ -323,8 +325,9 @@
             "no cascade-detail container in the initial state")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-orphaned"))
             "no orphaned-state container in the initial state")
-        (is (re-find #"No cascades yet" text)
-            "placeholder copy guides the user to trigger a dispatch")))))
+        (is (= "" text)
+            "silent-by-default — empty-state container carries no prose
+             (rf2-b9f6z: drop pre-spine 'pick from cascade list' wording)")))))
 
 (deftest sensitive-redacted-cascade-renders-orphaned-and-bumps-count
   (testing "when the privacy gate drops a :sensitive? cascade entirely,

--- a/tools/causa/testbeds/panel_gallery/gallery_event.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_event.cljs
@@ -66,9 +66,9 @@
 
   ;; ----- 1. empty cascade buffer ---------------------------------------
   (story/reg-variant :story.causa.event/empty-cascade
-    {:doc        "No cascades in the buffer. Panel renders the
-                 'No cascades yet' empty-state copy alongside the
-                 cascade-list container."
+    {:doc        "No cascades in the buffer. Panel renders the silent
+                 empty-state container (rf2-b9f6z — no prose; the L2
+                 event-list is the focus surface)."
      :events     [[:rf.causa/sync-trace-buffer (fixtures/empty-buffer)]]
      :tags       #{:dev :state/empty}
      :substrates #{:reagent}})


### PR DESCRIPTION
Closes part of rf2-b9f6z (bead stays open — Mike to confirm/close).

## Summary

The Event Detail panel header carried a pre-spine prose line:

> "Pick a dispatch from the cascade list to see its handler, effects, subscriptions, and source coord."

This pre-dates the L2 event-list focus model. Per Mike's invariant, every panel reflects the event chosen in the event list; the panel-local "pick from cascade list" affordance the prose described no longer fits. Per the text-audit silent-by-default pattern, the empty state becomes literally silent.

## Before / after

**`tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs`**

Header — before:
```clojure
[:h1 ... "Event detail"]
[:p {:style {...}}
 "Pick a dispatch from the cascade list to see its handler, "
 "effects, subscriptions, and source coord."]
```

Header — after:
```clojure
[:h1 ... "Event detail"]
```

`cascade-list` empty-state — before: two `<p>` blocks ("Click a cascade below..." and "No cascades yet. Trigger a dispatch in the host app to populate.") plus the conditional list.

`cascade-list` empty-state — after: silent container; the click-through list renders when cascades exist, the container is empty otherwise.

## Sibling stale strings swept

- `gallery_event.cljs` story doc-string referenced the deleted "No cascades yet" copy — updated to describe the silent container.
- Two remaining hits for "from the cascade list" are inside source-file docstrings/comments describing the underlying data structure (`spine.cljs:96`, `popover/causality_graph_helpers.cljc:217`) — they reference "cascade list" as a domain term, not as user-facing UI prose. Left as-is.

## Focus flow verified

The L2 event-list → Event Detail focus flow goes through `:rf.causa/focus-cascade` → `spine/focus-cascade-reducer`. The legacy `:rf.causa/select-dispatch-id` event-db (used by the panel's own cascade rows) also writes through the same reducer per the rf2-adve5 spine shim, so both paths land at the same `:selected-dispatch-id` / `:focus` slots. The cascade-detail renders correctly when focus is set; no separate focus-routing bug was discovered.

## Files changed

- `tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs`
- `tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs` — updated `no-selection-empty-buffer-renders-default-landing-view` to assert silent-by-default (`(= "" text)`) instead of the old placeholder copy.
- `tools/causa/testbeds/panel_gallery/gallery_event.cljs` — story doc-string for `:story.causa.event/empty-cascade`.

## Test plan

- [x] `cd tools/causa && clojure -M:test` → 890 tests, 0 failures
- [x] `scripts/test-fast-pr.sh` (includes `implementation && npm run test:cljs`, which runs `day8.re-frame2-causa.panels.event-detail-cljs-test`) → 3077 tests, 0 failures
- [x] `cd implementation && npm run test:browser` → 3068 tests, 0 failures