### PR TITLE
feat(story): element-level click-to-code inspector (rf2-h0jc0)

### DIFF
--- a/tools/story/src/re_frame/story/ui/element_inspector.cljc
+++ b/tools/story/src/re_frame/story/ui/element_inspector.cljc
@@ -1,0 +1,466 @@
+(ns re-frame.story.ui.element-inspector
+  "Element-level click-to-code (rf2-h0jc0) — React-Devtools-style.
+
+  Story's per-variant Open-in-editor chip opens the *story-spec* source;
+  this inspector extends the same gesture to *every rendered element on
+  the canvas*: toggle inspect mode, hover any DOM element, click → open
+  the view-fn that produced it at the exact line.
+
+  ## The DOM contract
+
+  re-frame2's `reg-view` macro injects
+  `data-rf2-source-coord=\"<ns>:<sym>:<line>:<col>\"` on the rendered
+  root of every registered view (per Spec 006 §Source-coord annotation
+  / rf2-z7f7 / rf2-z9n1). The annotation is dev-only; production
+  builds elide via the universal `interop/debug-enabled?` gate. This
+  inspector reads that attribute off the hovered / clicked DOM node
+  (walking ancestor chain when the literal target doesn't carry one —
+  view-fn boundaries are the granularity, not every hiccup element).
+
+  The four colon-separated segments are a **public, parseable contract**:
+  `<ns>` and `<sym>` together form the registered handler-id keyword;
+  `<line>`/`<col>` are the source coords captured at `reg-view` macro-
+  expansion time. We split on `:` to recover them, then look up
+  `(rf/handler-meta :view <id>)` for the `:file` slot (the DOM attribute
+  carries line/col only — see `docs/causa/05-click-to-source.md`).
+
+  ## Inspector mode
+
+  - **Toggle**: a toolbar chip flips a per-process atom. `aria-haspopup`
+    not `aria-pressed` per the rf2-zll4h reset-gate convention (the
+    recorder's reset assertion counts `[aria-pressed=\"true\"]` and we
+    don't want the inspect chip to trip it).
+  - **Hover**: a `mousemove` listener on the canvas root walks up from
+    the event target to the nearest `[data-rf2-source-coord]` ancestor.
+    The overlay component draws an absolute-positioned outline +
+    tooltip at the ancestor's `getBoundingClientRect`. Hover state is
+    throttled via `requestAnimationFrame` so a fast mouse doesn't
+    thrash the React tree.
+  - **Click**: when inspect mode is on, the click handler intercepts
+    (capture-phase, `stopPropagation` + `preventDefault`) so the
+    variant's own onClick handlers don't fire. The resolved coord is
+    handed to `open-in-editor/open-source-coord!` — same launcher the
+    chip uses.
+  - **Esc**: a keydown listener exits inspect mode + clears hover state.
+
+  ## Why not a re-frame fx
+
+  The inspector's state is per-process transient UI hover state — not
+  app-db material. Keeping it in a defonce'd atom (mirrors
+  `recorder/dom-capture/installed-root`) avoids the latency + overhead
+  of routing every mousemove through dispatch. Click DOES route through
+  `open-in-editor/open-source-coord!` so the launcher + allowlist gate
+  stay the single source of truth.
+
+  ## Bundle isolation + production elision
+
+  This ns is Story-side; production builds elide the entire Story UI
+  shell at the `mount-shell!` call site (per Story config/enabled?), so
+  the inspector ns is reachable only when Story is enabled. The DOM
+  attribute it reads is itself dev-only (elides via
+  `interop/debug-enabled?`) — under prod the inspector would find no
+  matches and click would no-op. Per Spec 009 §Production builds."
+  (:require [clojure.string :as str]
+            #?@(:cljs [[reagent.core :as r]
+                       [re-frame.core :as rf]
+                       [re-frame.source-coords :as source-coords]
+                       [re-frame.story.ui.open-in-editor :as open-in-editor]])))
+
+;; ---- per-process state ---------------------------------------------------
+;;
+;; The inspector's mode flag + hover snapshot live in a single atom so
+;; the overlay component watches one ratom (mirrors recorder's defonce
+;; install/state pattern). Two separate atoms would race — the mode
+;; toggle fires on a different tick from the mousemove tick.
+;;
+;; `:active?` — inspect mode on/off
+;; `:hover`   — nil OR `{:coord-attr <string> :rect #js{...} :handler-id <kw>}`
+
+#?(:cljs
+   (defonce ^{:doc "Reagent ratom holding `{:active? bool :hover ...}`.
+                    CLJS-only — JVM consumers exercise the pure helpers
+                    below without touching this state."}
+     state
+     (r/atom {:active? false :hover nil})))
+
+#?(:cljs
+   (defn active?
+     "Predicate — true iff inspect mode is on."
+     []
+     (boolean (:active? @state))))
+
+;; ---- pure: parse + resolve coord ----------------------------------------
+
+(defn parse-coord
+  "Parse a `data-rf2-source-coord` attribute value into
+  `{:ns :handler-id :line :col}` or nil. Per Spec 006 §Attribute value
+  format — `<ns>:<sym>:<line>:<col>`, with `?` for missing coords.
+
+  Mirrors the parser in `skills/re-frame-pair2/.../runtime.cljs` (the
+  pair2 nREPL consumer that does the same DOM → id walk). Returns nil
+  for malformed input (too few / too many segments, empty ns or
+  handler-id, non-string input). Never throws."
+  [attr-val]
+  (when (and (string? attr-val) (seq attr-val))
+    (let [parts (str/split attr-val #":")]
+      (when (= 4 (count parts))
+        (let [[ns-part sym-part line-part col-part] parts
+              parse-int (fn [s]
+                          (when (and (string? s) (re-matches #"\d+" s))
+                            #?(:cljs (js/parseInt s 10)
+                               :clj  (Long/parseLong s))))]
+          (when (and (seq ns-part) (seq sym-part))
+            {:ns         ns-part
+             :handler-id sym-part
+             :line       (parse-int line-part)
+             :col        (parse-int col-part)}))))))
+
+(defn coord->handler-keyword
+  "Build the registered view id keyword from a parsed coord. Returns nil
+  when either segment is missing."
+  [{:keys [ns handler-id]}]
+  (when (and ns handler-id)
+    (keyword ns handler-id)))
+
+#?(:cljs
+   (defn resolve-source-coord
+     "Walk parsed coord + the live registrar to produce the full
+     source-coord map `editor-uri/editor-uri` expects (`{:file :line
+     :column}`). The DOM attribute carries line + col; the `:file` slot
+     comes from the registered view's metadata (see
+     `re-frame.source-coords` / `docs/causa/05-click-to-source.md`).
+
+     Falls back to the always-on `error-coords-by-id` registry
+     (rf2-3un2g) when the public meta has been stripped by production
+     elision — that registry survives `:advanced` + `goog.DEBUG=false`
+     and keeps the `:file` slot reachable for tooling."
+     [parsed]
+     (when-let [view-id (coord->handler-keyword parsed)]
+       (let [meta (rf/handler-meta :view view-id)
+             err  (source-coords/error-coords-for :view view-id)
+             file (or (:file meta) (:file err))]
+         {:file   file
+          :line   (or (:line parsed) (:line meta) (:line err) 1)
+          :column (or (:col parsed) (:column meta) (:column err) 1)
+          :ns     (or (:ns parsed) (some-> meta :ns str))}))))
+
+;; ---- DOM helpers ---------------------------------------------------------
+
+#?(:cljs
+   (defn- nearest-source-coord-ancestor
+     "Walk `el` and its ancestors looking for the first
+     `[data-rf2-source-coord]` attribute. Returns the ancestor element,
+     or nil when none is found within the DOM root (so a click outside
+     any registered view's tree is a no-op).
+
+     Bounded by `root` — the walk stops once it crosses `root`'s parent
+     so the inspector never resolves to an element outside the canvas."
+     [el root]
+     (loop [n el]
+       (cond
+         (or (nil? n) (= n root)) nil
+         (and (.-getAttribute n)
+              (.getAttribute n "data-rf2-source-coord"))
+         n
+         :else
+         (recur (.-parentElement n))))))
+
+#?(:cljs
+   (defn- rect->map
+     "Convert a `getBoundingClientRect` DOMRect into a plain Clojure
+     map. Decouples the React overlay component from the DOMRect
+     prototype so test rebinds can stub the snapshot."
+     [rect]
+     {:top    (.-top rect)
+      :left   (.-left rect)
+      :width  (.-width rect)
+      :height (.-height rect)}))
+
+;; ---- mode toggle ---------------------------------------------------------
+
+#?(:cljs
+   (defn- set-cursor!
+     "Toggle the document body's cursor between `crosshair` (inspect mode
+     on) and the prior value (inspect mode off). The prior cursor is
+     stashed on `state` so we restore exactly what was there — a plain
+     `\"\"` reset would clobber a host-app stylesheet that sets a custom
+     cursor on body."
+     [on?]
+     (when (and (exists? js/document) (.-body js/document))
+       (let [body (.-body js/document)
+             cur  @state]
+         (if on?
+           (do
+             (swap! state assoc :prev-cursor (.. body -style -cursor))
+             (set! (.. body -style -cursor) "crosshair"))
+           (do
+             (set! (.. body -style -cursor) (or (:prev-cursor cur) ""))
+             (swap! state dissoc :prev-cursor)))))))
+
+#?(:cljs
+   (defn set-active!
+     "Programmatic mode toggle. Public so tests + toolbar can drive without
+     going through the DOM."
+     [on?]
+     (set-cursor! on?)
+     (swap! state
+            (fn [s] (cond-> (assoc s :active? (boolean on?))
+                     (not on?) (assoc :hover nil))))))
+
+#?(:cljs
+   (defn toggle!
+     "Flip the inspect-mode flag. Wired from the toolbar chip."
+     []
+     (set-active! (not (active?)))))
+
+;; ---- event handlers ------------------------------------------------------
+;;
+;; All three handlers gate on `(active?)` so leaving them installed is
+;; free — same pattern as `recorder/dom-capture`.
+
+#?(:cljs (defonce ^:private rAF-handle (atom nil)))
+
+#?(:cljs
+   (defn- schedule-hover-update!
+     "rAF-throttle hover updates so a fast mouse doesn't thrash the React
+     tree (the overlay subscribes to `state` — every snapshot triggers
+     one render). Coalesces multiple mousemoves between two animation
+     frames into a single state write."
+     [f]
+     (when @rAF-handle
+       (.cancelAnimationFrame js/window @rAF-handle))
+     (reset! rAF-handle
+             (.requestAnimationFrame js/window
+               (fn [_]
+                 (reset! rAF-handle nil)
+                 (f))))))
+
+#?(:cljs
+   (defn- handle-mousemove!
+     "Mousemove handler on the canvas root. Walks ancestors to find the
+     nearest `[data-rf2-source-coord]` element; writes a snapshot to
+     `state :hover`. No-op when inspect mode is off (the listener stays
+     installed for cheapness; gating happens here)."
+     [root ev]
+     (when (active?)
+       (schedule-hover-update!
+         (fn []
+           (let [el      (.-target ev)
+                 ancestor (nearest-source-coord-ancestor el root)]
+             (if ancestor
+               (let [attr  (.getAttribute ancestor "data-rf2-source-coord")
+                     rect  (.getBoundingClientRect ancestor)
+                     parsed (parse-coord attr)]
+                 (swap! state assoc
+                        :hover {:coord-attr attr
+                                :handler-id (coord->handler-keyword parsed)
+                                :parsed     parsed
+                                :rect       (rect->map rect)}))
+               (swap! state assoc :hover nil))))))))
+
+#?(:cljs
+   (defn- handle-click!
+     "Click handler on the canvas root. When inspect mode is on, this
+     fires CAPTURE-PHASE so the variant's own onClick handlers do not
+     run (we don't want to commit a button submit while picking).
+     Resolves the click target → nearest `[data-rf2-source-coord]`
+     ancestor → source-coord → editor URI → `open!`."
+     [root ev]
+     (when (active?)
+       (.stopPropagation ev)
+       (.preventDefault ev)
+       (let [el (.-target ev)]
+         (when-let [ancestor (nearest-source-coord-ancestor el root)]
+           (let [attr   (.getAttribute ancestor "data-rf2-source-coord")
+                 parsed (parse-coord attr)]
+             (when-let [coord (resolve-source-coord parsed)]
+               (open-in-editor/open-source-coord! coord)))))
+       ;; Exit inspect mode after a successful pick — matches React
+       ;; Devtools' "pick once" gesture. The user re-clicks the chip
+       ;; to start another pick.
+       (set-active! false))))
+
+#?(:cljs
+   (defn- handle-keydown!
+     "Esc exits inspect mode + clears hover. Listener lives on
+     `js/document` (not the canvas root) so the user can hit Esc with
+     focus anywhere."
+     [ev]
+     (when (and (active?) (= "Escape" (.-key ev)))
+       (.preventDefault ev)
+       (set-active! false))))
+
+;; ---- install / remove ----------------------------------------------------
+;;
+;; Mirrors `recorder/dom-capture/install!`'s shape: defonce'd ref to
+;; the currently-installed root, attach/detach via the same key. Caller
+;; (shell) drives install at mount-time, remove at unmount.
+
+#?(:cljs (defonce ^:private installed-root (atom nil)))
+#?(:cljs (defonce ^:private bound-handlers (atom nil)))
+
+#?(:cljs
+   (defn- canvas-root
+     "The shell canvas root, looked up via the framework-stable
+     `[data-test=\"story-canvas-frame\"]` hook (same selector
+     `recorder/dom-capture` uses)."
+     []
+     (when (and (exists? js/document) (.-querySelector js/document))
+       (try
+         (.querySelector js/document "[data-test=\"story-canvas-frame\"]")
+         (catch :default _ nil)))))
+
+#?(:cljs
+   (defn- attach-listeners! [root]
+     (let [on-move (fn [ev] (handle-mousemove! root ev))
+           on-clk  (fn [ev] (handle-click! root ev))
+           on-key  handle-keydown!]
+       (reset! bound-handlers {:move on-move :click on-clk :key on-key})
+       ;; mousemove on root — bubble is fine; we always walk up to find
+       ;; the ancestor.
+       (.addEventListener root "mousemove" on-move false)
+       ;; click in CAPTURE phase — fire before the variant's own onClick
+       ;; gets a chance to react.
+       (.addEventListener root "click" on-clk true)
+       (.addEventListener js/document "keydown" on-key false))))
+
+#?(:cljs
+   (defn- detach-listeners! [root]
+     (when-let [h @bound-handlers]
+       (.removeEventListener root "mousemove" (:move h) false)
+       (.removeEventListener root "click" (:click h) true)
+       (.removeEventListener js/document "keydown" (:key h) false)
+       (reset! bound-handlers nil))))
+
+#?(:cljs
+   (defn install!
+     "Install the inspector listeners on `root` (or the canvas root when
+     called with no arg). Idempotent. Returns the root on success, nil
+     otherwise."
+     ([] (install! (canvas-root)))
+     ([root]
+      (when root
+        (when-let [prev @installed-root]
+          (detach-listeners! prev))
+        (attach-listeners! root)
+        (reset! installed-root root)
+        root))))
+
+#?(:cljs
+   (defn remove!
+     "Tear down any installed listeners. Idempotent. Also flips inspect
+     mode off — a re-mount mid-pick would otherwise leave the cursor
+     stuck on `crosshair`."
+     []
+     (when-let [root @installed-root]
+       (detach-listeners! root)
+       (reset! installed-root nil))
+     (set-active! false)
+     nil))
+
+(defn installed?
+  "True iff `install!` has attached listeners. Public for tests."
+  []
+  #?(:cljs (some? @installed-root)
+     :clj  false))
+
+;; ---- overlay component + chip --------------------------------------------
+
+(def ^:private overlay-styles
+  {:outline {:position       "fixed"
+             :pointer-events "none"
+             :z-index        "999999"
+             :border         "2px solid #61dafb"   ;; React-Devtools-ish blue
+             :background     "rgba(97, 218, 251, 0.15)"
+             :box-sizing     "border-box"
+             :border-radius  "2px"
+             :transition     "none"}
+   :tooltip {:position       "fixed"
+             :pointer-events "none"
+             :z-index        "1000000"
+             :background     "#1e1e1e"
+             :color          "#cccccc"
+             :border         "1px solid #444"
+             :border-radius  "3px"
+             :padding        "3px 8px"
+             :font-family    "monospace"
+             :font-size      "11px"
+             :white-space    "nowrap"
+             :box-shadow     "0 2px 8px rgba(0,0,0,0.4)"}
+   :chip-on    {:padding         "3px 8px"
+                :background      "#0e639c"
+                :color           "white"
+                :border          "none"
+                :border-radius   "10px"
+                :cursor          "pointer"
+                :font-family     "monospace"
+                :font-size       "11px"
+                :user-select     "none"}
+   :chip-off   {:padding         "3px 8px"
+                :background      "#37373d"
+                :color           "#cccccc"
+                :border          "none"
+                :border-radius   "10px"
+                :cursor          "pointer"
+                :font-family     "monospace"
+                :font-size       "11px"
+                :user-select     "none"}})
+
+#?(:cljs
+   (defn overlay
+     "The hover-overlay component. Mounted once by the shell; subscribes
+     to `state` and renders nothing when inspect mode is off OR when
+     `:hover` is nil. Renders an absolute-positioned outline + tooltip
+     when both are present.
+
+     Tooltip placement: above the hovered element when there's room
+     (top - 22px), below otherwise. Mirrors React Devtools' tooltip
+     placement heuristic."
+     []
+     (let [s          @state
+           {:keys [active? hover]} s]
+       (when (and active? hover)
+         (let [{:keys [coord-attr handler-id rect parsed]} hover
+               {:keys [top left width height]} rect
+               above? (> top 26)
+               tip-top (if above? (- top 24) (+ top height 4))]
+           [:div {:data-test "story-element-inspector-overlay"}
+            ;; The outline
+            [:div {:style (merge (:outline overlay-styles)
+                                 {:top    (str top "px")
+                                  :left   (str left "px")
+                                  :width  (str width "px")
+                                  :height (str height "px")})}]
+            ;; The tooltip
+            [:div {:style       (merge (:tooltip overlay-styles)
+                                       {:top  (str tip-top "px")
+                                        :left (str left "px")})
+                   :data-test   "story-element-inspector-tooltip"
+                   :data-handler-id (str handler-id)}
+             (str (or handler-id coord-attr)
+                  (when (:line parsed) (str " @ " (:line parsed)
+                                            (when (:col parsed) (str ":" (:col parsed))))))]])))))
+
+#?(:cljs
+   (defn inspect-chip
+     "The toolbar chip. Click → toggle inspect mode. Uses
+     `aria-haspopup`/`aria-expanded` (NOT `aria-pressed`) per the
+     rf2-zll4h reset-gate convention — the toolbar's reset assertion
+     in the e2e suite counts `[aria-pressed=\"true\"]` and we don't
+     want the inspect chip to trip it.
+
+     Hidden when production-elided: the chip lives in the Story bundle
+     and the entire shell ns is gated on `config/enabled?`."
+     []
+     (let [on? (boolean (:active? @state))]
+       [:button {:style (if on?
+                          (:chip-on overlay-styles)
+                          (:chip-off overlay-styles))
+                 :data-test "story-toolbar-inspect"
+                 :aria-haspopup "true"
+                 :aria-expanded (str on?)
+                 :title (if on?
+                          "Element inspector ON — hover any element, click to open its view-fn"
+                          "Element inspector — click any element to open its view-fn source")
+                 :on-click (fn [_] (toggle!))}
+        (if on? "Inspect ●" "Inspect")])))

--- a/tools/story/src/re_frame/story/ui/open_in_editor.cljs
+++ b/tools/story/src/re_frame/story/ui/open_in_editor.cljs
@@ -133,10 +133,13 @@
     (reset! navigator f)
     prev))
 
-(defn- open!
+(defn open!
   "Navigate `js/window.location` to `uri` via the configured navigator
   seam (default `Location.assign`). Custom URI schemes hand off to
   the OS handler chain. Returns nothing.
+
+  Public so the element-inspector (rf2-h0jc0) can share the exact same
+  click-time gate the chip uses — one launcher, one allowlist seam.
 
   Per rf2-vwcsq: `uri` is the return of `editor-uri/editor-uri`, which
   already rejects `javascript:` / `data:` / `vbscript:` schemes by
@@ -222,6 +225,29 @@
                              (.preventDefault e)
                              (open! uri))}
           "open"])))))
+
+(defn open-source-coord!
+  "Resolve `source-coord` to an editor URI via the current Story config
+  (`config/get-editor` + `config/get-project-root`) and hand it off to
+  `open!`. Returns true when the launcher was invoked with an allowed
+  URI, false otherwise (missing :file, forbidden scheme, or scheme
+  outside the rf2-cm93v allowlist).
+
+  This is the imperative path the element-inspector (rf2-h0jc0) uses
+  when the user clicks a DOM element while inspector mode is on. The
+  chip's `:on-click` (above) takes the same shape: build URI via
+  `editor-uri`, gate via `allowed-uri?`, hand to `open!`.
+
+  `source-coord` shape: `{:file :line :column}` per
+  `re-frame.source-coords`."
+  [source-coord]
+  (when (editor-uri/has-source? source-coord)
+    (let [editor (config/get-editor)
+          opts   {:project-root (config/get-project-root)}
+          uri    (editor-uri/editor-uri editor source-coord opts)]
+      (when (and uri (editor-uri/allowed-uri? uri))
+        (open! uri)
+        true))))
 
 (defn open-chip-for-variant
   "Render an open-chip for a variant — reads the source-coord off the

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -55,6 +55,7 @@
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.dispatch-console :as dispatch-console]
             [re-frame.story.ui.docs :as docs]
+            [re-frame.story.ui.element-inspector :as element-inspector]
             [re-frame.story.ui.help :as help]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
@@ -700,7 +701,16 @@
          ;; install is free even when REC is idle.
          (js/setTimeout
            (fn []
-             (recorder-dom/install!))
+             (recorder-dom/install!)
+             ;; rf2-h0jc0: element-level click-to-code inspector. Hooks
+             ;; mousemove / click / keydown on the same canvas root the
+             ;; recorder uses. Listener gates on `(inspector/active?)`
+             ;; so the install is free when the chip is off — install
+             ;; once at shell-mount, gate per-event at the listener
+             ;; head. Same one-tick `setTimeout` discipline as the
+             ;; recorder so the React tree has committed the canvas-
+             ;; frame DOM node before the install tries to find it.
+             (element-inspector/install!))
            0)
          ;; rf2-one3t: install the save-as-variant dialog-open callback
          ;; against the pure ns so `save-variant/save-current-as-variant!`
@@ -725,6 +735,10 @@
        ;; rf2-d5u89: tear down DOM-capture listeners alongside the
        ;; trace listener so we don't leak listeners across re-mounts.
        (recorder-dom/remove!)
+       ;; rf2-h0jc0: tear down the element-inspector listeners +
+       ;; reset its mode flag. Mirrors the recorder-dom shape — both
+       ;; rides the canvas-root listener install lifecycle.
+       (element-inspector/remove!)
        ;; rf2-o4u18: drop popstate + shell-state URL watchers so a
        ;; re-mount doesn't accumulate listeners.
        (url-state/tear-down! state/shell-state-atom)
@@ -771,6 +785,12 @@
           [recorder-ui/recording-overlay]
           [recorder-ui/assertion-picker]
           [recorder-ui/save-dialog]
+          ;; rf2-h0jc0: element-inspector hover overlay. Self-elides
+          ;; when inspect mode is off OR no element is currently
+          ;; hovered. Lives in the chrome layer (fixed positioning)
+          ;; so it floats above the three-pane layout regardless of
+          ;; which panels are visible.
+          [element-inspector/overlay]
           ;; rf2-x9zsr — Test Codegen :play-script export dialog. Opens
           ;; off the recorder save-dialog's [export as :play-script]
           ;; button; stacks above via a higher z-index. Lives in its own

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -50,6 +50,7 @@
             [clojure.string :as str]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
+            [re-frame.story.ui.element-inspector :as element-inspector]
             [re-frame.story.ui.play-status :as play-status]
             [re-frame.story.ui.recorder :as ui-recorder]
             [re-frame.story.ui.state :as state]
@@ -379,6 +380,15 @@
      ;; tripped by viewport / background state.
      [viewport-switcher/chip-when-enabled]
      [backgrounds-switcher/chip-when-enabled]
+     ;; rf2-h0jc0 — element-level click-to-code inspector chip. Toggles
+     ;; the React-Devtools-style pick mode that hovers / highlights any
+     ;; rendered DOM element and opens its view-fn source on click.
+     ;; Lives between the viewport / backgrounds dropdowns and the REC
+     ;; chip so the chrome reads left-to-right as a "what you see, how
+     ;; you see it, who rendered it, what you do with it" cluster. Uses
+     ;; `aria-haspopup` (not `aria-pressed`) per rf2-zll4h convention so
+     ;; the reset gate is unaffected.
+     [element-inspector/inspect-chip]
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
      ;; affordance so the chrome-wide recorder is reachable regardless of
      ;; which variant the user has focused.

--- a/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc
@@ -1,0 +1,238 @@
+(ns re-frame.story.ui.element-inspector-cljs-test
+  "Tests for the element-level click-to-code inspector (rf2-h0jc0).
+
+  Runs on both the JVM (cognitect.test-runner via `clojure -M:test`)
+  and the CLJS node-test build (shadow's `:node-test` target picks up
+  the `cljs-test$` ns-regex). The pure helpers — coord parsing,
+  handler-keyword reconstruction — are CLJC; the side-effectful
+  install/remove/toggle paths are CLJS-only.
+
+  ## Coverage
+
+  - **Pure data** (JVM + CLJS):
+    - `parse-coord` round-trips the `<ns>:<sym>:<line>:<col>` DOM
+      attribute into `{:ns :handler-id :line :col}` with malformed-
+      input safety (mirror of skills/re-frame-pair2's parser tests so
+      format drift surfaces here too).
+    - `coord->handler-keyword` reconstructs the registered view id.
+
+  - **CLJS-only side-effects**:
+    - `toggle!` / `set-active!` flip the mode flag.
+    - `resolve-source-coord` walks parsed coord + the registry's
+      handler-meta to produce a launchable source-coord map.
+    - The toolbar chip renders the right shape (data-test attr,
+      `aria-haspopup`/`aria-expanded` per rf2-zll4h convention,
+      label flips on toggle).
+    - The overlay component renders nothing when inspect mode is off
+      or no element is hovered; renders the outline + tooltip when
+      both are set."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            #?@(:cljs [[re-frame.core :as rf]
+                       [re-frame.source-coords :as source-coords]])
+            [re-frame.story.ui.element-inspector :as inspector]))
+
+;; ---- pure: parse-coord (JVM + CLJS) -------------------------------------
+
+(deftest parse-coord-canonical
+  (testing "canonical 4-segment shape — the same contract the DOM attr
+            ships in re-frame2 dev builds (Spec 006 §Source-coord
+            annotation)"
+    (is (= {:ns "counter.core" :handler-id "counter-buttons"
+            :line 47 :col 11}
+           (inspector/parse-coord "counter.core:counter-buttons:47:11")))))
+
+(deftest parse-coord-dotted-and-hyphenated
+  (testing "dotted ns + hyphenated handler-id parse cleanly"
+    (is (= {:ns "my-app.cart.view" :handler-id "apply-coupon-button"
+            :line 125 :col 4}
+           (inspector/parse-coord
+             "my-app.cart.view:apply-coupon-button:125:4")))))
+
+(deftest parse-coord-degraded
+  (testing "programmatic registration emits `?:?` for missing line/col;
+            parser surfaces them as nil"
+    (is (= {:ns "rf.src-coord-test" :handler-id "programmatic"
+            :line nil :col nil}
+           (inspector/parse-coord "rf.src-coord-test:programmatic:?:?")))))
+
+(deftest parse-coord-malformed-too-few-segments
+  (testing "fewer than 4 segments → nil"
+    (is (nil? (inspector/parse-coord "ns:view:42")))
+    (is (nil? (inspector/parse-coord "ns:view")))
+    (is (nil? (inspector/parse-coord "")))
+    (is (nil? (inspector/parse-coord nil)))))
+
+(deftest parse-coord-malformed-too-many-segments
+  (testing "more than 4 segments → nil (strict 4-segment contract)"
+    (is (nil? (inspector/parse-coord "a:b:c:d:e")))))
+
+(deftest parse-coord-empty-segments
+  (testing "empty `<ns>` or `<handler-id>` → nil"
+    (is (nil? (inspector/parse-coord ":handler:1:2")))
+    (is (nil? (inspector/parse-coord "ns::1:2")))))
+
+(deftest parse-coord-non-string-input
+  (testing "non-string input → nil (never throws)"
+    (is (nil? (inspector/parse-coord 42)))
+    (is (nil? (inspector/parse-coord :keyword)))
+    (is (nil? (inspector/parse-coord ["v" "e" "c"])))))
+
+(deftest coord->handler-keyword-shape
+  (testing "parsed coord round-trips to the registered view-id keyword"
+    (is (= :counter.core/counter-buttons
+           (inspector/coord->handler-keyword
+             {:ns "counter.core" :handler-id "counter-buttons"
+              :line 47 :col 11}))))
+  (testing "missing :ns or :handler-id → nil"
+    (is (nil? (inspector/coord->handler-keyword {:handler-id "x"})))
+    (is (nil? (inspector/coord->handler-keyword {:ns "x"})))
+    (is (nil? (inspector/coord->handler-keyword nil)))))
+
+;; ---- CLJS-only: mode toggle + chip + overlay ----------------------------
+
+#?(:cljs
+   (defn reset-inspector! []
+     (inspector/set-active! false)
+     (reset! inspector/state {:active? false :hover nil})))
+
+#?(:cljs
+   (use-fixtures :each {:before reset-inspector!
+                        :after  reset-inspector!}))
+
+#?(:cljs
+   (deftest mode-toggle-flips-active-flag
+     (testing "set-active! + toggle! drive the active? predicate"
+       (is (false? (inspector/active?)))
+       (inspector/set-active! true)
+       (is (true? (inspector/active?)))
+       (inspector/toggle!)
+       (is (false? (inspector/active?)))
+       (inspector/toggle!)
+       (is (true? (inspector/active?))))))
+
+#?(:cljs
+   (deftest set-active-false-clears-hover
+     (testing "turning the inspector OFF must clear any pending hover
+               snapshot so a stale outline doesn't survive the toggle"
+       (swap! inspector/state assoc
+              :active? true
+              :hover {:coord-attr "x:y:1:1"
+                      :handler-id :x/y
+                      :rect {:top 0 :left 0 :width 10 :height 10}})
+       (inspector/set-active! false)
+       (is (false? (inspector/active?)))
+       (is (nil? (:hover @inspector/state))))))
+
+#?(:cljs
+   (deftest inspect-chip-renders-toggle-state
+     (testing "chip renders with `aria-haspopup` (not aria-pressed) per
+               rf2-zll4h reset-gate convention"
+       (let [hiccup (inspector/inspect-chip)
+             props  (second hiccup)]
+         (is (= :button (first hiccup)))
+         (is (= "story-toolbar-inspect" (:data-test props)))
+         (is (= "true" (:aria-haspopup props))
+             "aria-haspopup must be present — the toolbar reset assertion
+              counts [aria-pressed=\"true\"] and we don't want this chip
+              to trip it")
+         (is (= "false" (:aria-expanded props))
+             "off-state aria-expanded")
+         (is (not (contains? props :aria-pressed))
+             "MUST NOT use aria-pressed — see rf2-zll4h")
+         (is (fn? (:on-click props)))))))
+
+#?(:cljs
+   (deftest inspect-chip-renders-on-state
+     (testing "chip's data attrs flip after toggle"
+       (inspector/set-active! true)
+       (let [hiccup (inspector/inspect-chip)
+             props  (second hiccup)]
+         (is (= "true" (:aria-expanded props)))))))
+
+#?(:cljs
+   (deftest overlay-renders-nothing-when-off
+     (testing "overlay returns nil when inspector mode is off"
+       (is (nil? (inspector/overlay))))))
+
+#?(:cljs
+   (deftest overlay-renders-nothing-when-no-hover
+     (testing "active but no hover → no outline"
+       (inspector/set-active! true)
+       (is (nil? (inspector/overlay))))))
+
+#?(:cljs
+   (deftest resolve-source-coord-pulls-file-from-handler-meta
+     (testing "the DOM attribute carries line+col; `:file` lives on the
+               registered view's meta. `resolve-source-coord` walks the
+               registry to produce the full source-coord shape
+               `editor-uri/editor-uri` expects."
+       (let [view-id :rf.inspector-test/sample-view]
+         ;; Seed the always-on error-coord registry so the resolver finds
+         ;; a :file even when handler-meta is unset (mirrors the
+         ;; production-elided dev meta case).
+         (source-coords/remember-error-coords!
+           :view view-id
+           {:ns "rf.inspector-test" :file "src/sample.cljs"
+            :line 12 :column 4})
+         (let [parsed   (inspector/parse-coord
+                          "rf.inspector-test:sample-view:42:7")
+               resolved (inspector/resolve-source-coord parsed)]
+           (is (= "src/sample.cljs" (:file resolved))
+               ":file pulled from the error-coords registry fallback")
+           (is (= 42 (:line resolved))
+               "DOM-side line beats meta-side line (the attr is the
+                most-recent ground truth)")
+           (is (= 7 (:column resolved))
+               "DOM-side col beats meta-side col")
+           (source-coords/forget-error-coords!))))))
+
+#?(:cljs
+   (deftest resolve-source-coord-defaults-when-attr-degraded
+     (testing "programmatic-registration coords arrive as `?:?` — the
+               resolver falls through to meta-side line/col when both
+               are present, else 1/1"
+       (let [view-id :rf.inspector-test/degraded]
+         (source-coords/remember-error-coords!
+           :view view-id
+           {:ns "rf.inspector-test" :file "src/d.cljs"
+            :line 99 :column 3})
+         (let [parsed   (inspector/parse-coord
+                          "rf.inspector-test:degraded:?:?")
+               resolved (inspector/resolve-source-coord parsed)]
+           (is (= 99 (:line resolved))
+               "meta-side line fills in when DOM-side is nil")
+           (is (= 3 (:column resolved))
+               "meta-side column fills in when DOM-side is nil")
+           (source-coords/forget-error-coords!))))))
+
+#?(:cljs
+   (deftest overlay-renders-outline-and-tooltip-when-hovering
+     (testing "active + hover snapshot present → outline + tooltip
+               hiccup with the right test attrs"
+       (swap! inspector/state assoc
+              :active? true
+              :hover {:coord-attr "counter.core:counter:47:11"
+                      :handler-id :counter.core/counter
+                      :parsed     {:ns "counter.core"
+                                   :handler-id "counter"
+                                   :line 47 :col 11}
+                      :rect       {:top 100 :left 200
+                                   :width 300 :height 40}})
+       (let [root (inspector/overlay)]
+         (is (vector? root))
+         (is (= :div (first root)))
+         (is (= "story-element-inspector-overlay"
+                (:data-test (second root))))
+         ;; Two children: outline + tooltip
+         (is (= 4 (count root))
+             "root + props + outline + tooltip = 4 elements")
+         (let [outline (nth root 2)
+               tooltip (nth root 3)]
+           (is (= :div (first outline)))
+           (is (= "story-element-inspector-tooltip"
+                  (:data-test (second tooltip))))
+           (is (= ":counter.core/counter"
+                  (:data-handler-id (second tooltip))))
+           ;; The tooltip text carries the handler id + line:col so the
+           ;; user can sanity-check before clicking.
+           (is (clojure.string/includes? (nth tooltip 2) "47")))))))

--- a/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs
@@ -78,6 +78,56 @@
     (is (nil? (open-in-editor/open-chip-for-variant {:events []})))
     (is (nil? (open-in-editor/open-chip-for-variant nil)))))
 
+;; ---- open-source-coord! (rf2-h0jc0) --------------------------------------
+;;
+;; The element-inspector uses this helper to resolve a source-coord →
+;; URI through Story config and hand it to `open!`. One launcher across
+;; the chip + the inspector — same allowlist gate, same navigator seam.
+
+(deftest open-source-coord!-fires-navigator-with-resolved-uri
+  (testing "open-source-coord! resolves through Story config + the
+            navigator seam — same path the chip uses"
+    (let [calls (atom [])
+          nav   (fn [uri] (swap! calls conj uri))
+          prev  (open-in-editor/set-navigator! nav)]
+      (try
+        (open-in-editor/open-source-coord!
+          {:file "src/app.cljs" :line 17 :column 3})
+        (is (= ["vscode://file/src/app.cljs:17:3"] @calls)
+            "navigator invoked once with the resolved vscode:// URI")
+        (finally
+          (open-in-editor/set-navigator! prev))))))
+
+(deftest open-source-coord!-no-op-without-file
+  (testing "open-source-coord! returns nil when source-coord lacks :file"
+    (let [calls (atom [])
+          nav   (fn [uri] (swap! calls conj uri))
+          prev  (open-in-editor/set-navigator! nav)]
+      (try
+        (is (nil? (open-in-editor/open-source-coord! nil)))
+        (is (nil? (open-in-editor/open-source-coord! {:line 10})))
+        (is (= [] @calls)
+            "no navigation attempted when :file is absent")
+        (finally
+          (open-in-editor/set-navigator! prev))))))
+
+(deftest open-source-coord!-respects-editor-preference
+  (testing "the URI shipped by open-source-coord! reflects the live
+            editor + project-root config — same source of truth the
+            chip's :href reads"
+    (config/set-editor! :cursor)
+    (config/set-project-root! "C:/Users/me/code/my-app")
+    (let [calls (atom [])
+          nav   (fn [uri] (swap! calls conj uri))
+          prev  (open-in-editor/set-navigator! nav)]
+      (try
+        (open-in-editor/open-source-coord!
+          {:file "src/app.cljs" :line 17 :column 3})
+        (is (= ["cursor://file/C:/Users/me/code/my-app/src/app.cljs:17:3"]
+               @calls))
+        (finally
+          (open-in-editor/set-navigator! prev))))))
+
 (deftest open-chip-title-attribute-shape
   (testing "the chip's :title attr surfaces file:line for hover"
     (let [hiccup (open-in-editor/open-chip


### PR DESCRIPTION
## Summary

Adds a React-Devtools-style **inspect mode** to Story's toolbar: toggle the chip, hover any rendered canvas element to highlight + tooltip the view-fn that produced it, click to open its source in the configured editor.

- Reuses the existing `data-rf2-source-coord` annotation (already shipped across Reagent/UIx/Helix per Spec 006 §Source-coord annotation, rf2-z7f7 / rf2-z9n1).
- Reuses `editor-uri/editor-uri` + the rf2-cm93v positive-scheme allowlist (no new URI infrastructure).
- Reuses Story's existing navigator seam from the per-variant Open-in-editor chip (rf2-muvs8).
- View-fn boundary granularity (per the bead's Option B) — the macro-side injection across all three adapters was already shipped, this bead consumes the contract.

## Architecture

| Surface | What's there | What this PR ships |
|---|---|---|
| Macro: inject `data-rf2-source-coord` on view-fn boundary | Already shipped: `views/source_coord_annotation.cljs` (Reagent inline) + spine's `wrap-view` (UIx/Helix `cloneElement`). Production-elided via universal `interop/debug-enabled?` gate (per Spec 009 §Production builds). | nothing — already covered |
| Editor URI dispatch | `editor-uri/editor-uri` + `allowed-editor-uri-schemes` shared between Story + Causa | nothing — already covered |
| Causa "view source" per trace row | Already in `panels/trace.cljs` dispatching `:rf.causa/open-in-editor` | nothing — already covered |
| **Story inspector toggle + overlay + click handler** | — | **new** |

The bead's three other deliverables (macro injection, editor URI dispatch, Causa trace-row chip) were already in place; only the Story-side inspector UI was missing. This PR ships exactly that.

## What's in the diff

**New** (660 LoC):
- `tools/story/src/re_frame/story/ui/element_inspector.cljc` — toggle, mousemove/click/keydown listeners (gated on per-process `active?` atom for free install cost), rAF-throttled hover snapshot, hover overlay (outline + tooltip), toolbar chip (uses `aria-haspopup` not `aria-pressed` per rf2-zll4h reset-gate convention).
- `tools/story/test/re_frame/story/ui/element_inspector_cljs_test.cljc` — JVM + CLJS test ns. Pure-data parser tests run on both runtimes (mirrors the skills/re-frame-pair2 parser tests so format drift surfaces here too); CLJS tests cover mode toggle, chip shape, overlay render states, and the registry-driven `resolve-source-coord` walk that falls back through the always-on error-coords registry (rf2-3un2g) when public meta is production-stripped.

**Modified** (152 LoC):
- `tools/story/src/re_frame/story/ui/open_in_editor.cljs` — lift `open!` to public + add `open-source-coord!` helper. One launcher across the chip + the inspector.
- `tools/story/src/re_frame/story/ui/toolbar.cljs` — wire the inspect chip into the toolbar strip (after viewport/backgrounds, before REC).
- `tools/story/src/re_frame/story/ui/shell.cljs` — mount overlay in the chrome float layer (next to recorder overlay), install listeners alongside recorder-dom in `component-did-mount`, tear down in `component-will-unmount`.
- `tools/story/test/re_frame/story_open_in_editor_cljs_test.cljs` — three new tests for `open-source-coord!`.

## Adapter coverage

3/3 — Reagent / UIx / Helix all benefit. The inspector reads the `data-rf2-source-coord` DOM attribute (framework-stable contract) so it's adapter-agnostic. No per-adapter changes needed; the macro-side injection was already in place across all three.

## Production elision

Verified via existing gates:
- `npm run test:elision`: production bundle still 31/31 sentinels absent (the DOM attribute and the whole `interop/debug-enabled?` branch DCE under `:advanced` + `goog.DEBUG=false`).
- `npm run test:bundle-isolation`: all 3 allow-list budgets ok. Inspector lives in the Story bundle, which is itself elided at the `mount-shell!` call site via `config/enabled?`.

## UX gestures

- **Toggle**: click the "Inspect" chip in the toolbar (between backgrounds switcher and the REC chip).
- **Hover**: mousemove highlights the nearest `[data-rf2-source-coord]` ancestor with a React-Devtools-style blue outline + a tooltip showing the registered view-id + line:col.
- **Click**: opens the view-fn source in the configured editor (same URI seam the chip uses). Click capture-phase + `stopPropagation` so the variant's own onClick handlers don't fire while picking.
- **Esc**: exits inspect mode.
- After a successful pick the mode auto-exits (matches React Devtools' "pick once" gesture).

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `tools/story && clojure -M:test -n re-frame.story.ui.element-inspector-cljs-test` — 8/8 tests, 17 assertions, 0 failures
- [x] `implementation && npm run test:cljs` — 3113 tests, 0 failures
- [x] `implementation && npm run test:browser` — 3105 tests, 0 failures
- [x] `implementation && npm run test:elision` — production 31/31 absent
- [x] `implementation && npm run test:bundle-isolation` — 11 artefact entries, 26 sentinels absent, 3 allow-list budgets ok
- [x] `implementation && npm run test:examples` — 40 specs, 0 failures, 1 skipped (unrelated rf2-xy4yb)

## Divergences / follow-ons

None required. The bead's Option B (view-fn boundary granularity) was already met by the existing macro-side infrastructure, so no per-adapter changes were needed. The `:rf.editor/open` reg-fx already exists in Causa; Story's inspector uses the direct `open!` seam (same allowlist, same navigator) rather than dispatching the fx — kept Causa's contract intact.

Closes rf2-h0jc0 once merged.