### PR TITLE
chore(causa): text-audit cluster — drop 7 unearned-text patterns (rf2-yn86j)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
@@ -90,7 +90,7 @@
                                 [:rf.causa/open-edit-popup
                                  {:source :pill :mode mode :idx idx :pill pill}]
                                 {:frame :rf/causa})
-               :title        "Click to edit"
+               :title        "Edit"
                :style {:background  "transparent"
                        :border      "none"
                        :color       tone

--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -149,7 +149,7 @@
 
 (defn- empty-message [query]
   (if (seq query)
-    (str "No matches for " (pr-str query) " — try a shorter query.")
+    (str "No matches for " (pr-str query) ".")
     "Type to search. ↑↓ navigate · Enter invokes · Ctrl+Enter pops out · ESC closes."))
 
 (defn- empty-row []

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -50,11 +50,7 @@
                     :font-weight 600
                     :margin      0
                     :color       (:text-primary tokens)}}
-       "App-db diff"]
-      [:p {:style {:font-size "12px"
-                   :color     (:text-tertiary tokens)
-                   :margin    "4px 0 0 0"}}
-       "Structural diff for this epoch, grouped into path-headed sections."]]
+       "App-db diff"]]
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond
         focused-path

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
@@ -163,7 +163,7 @@
                   :font-family sans-stack
                   :font-size "12px"
                   :margin 0}}
-      "No epochs in the current ring buffer touched this path."]
+      "No epochs touched this path."]
      (into [:ul {:data-testid "rf-causa-app-db-diff-focus-hits"
                  :style {:list-style "none"
                          :margin 0

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
@@ -23,7 +23,7 @@
      (str target-frame)]
     " is at the boot value."]
    [:p {:style {:margin 0}}
-    "No diffs yet — every dispatch will land here with the slices it touched."]])
+    "No diffs yet."]])
 
 (defn- value-block
   [label value tone path]

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -305,20 +305,12 @@
                    :text-align "center"}}
      (case kind
        :no-trigger
-       [:div
-        [:p {:style {:margin "0 0 6px 0"}}
-         "No cancellation cascade in the trace window."]
-        [:p {:style {:margin 0 :font-size "11px"}}
-         "Cancellation cascades land here when a parent machine "
-         "destroys a child while in-flight effects are running."]]
+       [:p {:style {:margin 0}}
+        "No cancellation cascade in the trace window."]
 
        :no-aborts
-       [:div
-        [:p {:style {:margin "0 0 6px 0"}}
-         "Destroy fired — no in-flight effects to abort."]
-        [:p {:style {:margin 0 :font-size "11px"}}
-         "The cascade ran cleanly: the child machine was torn down "
-         "without any HTTP / WS / timer / invoke cleanup."]]
+       [:p {:style {:margin 0}}
+        "Destroy fired — no in-flight effects to abort."]
 
        [:p {:style {:margin 0}} "No cascade data."])]))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -399,7 +399,7 @@
           [:code {:style {:color (:accent-violet tokens)
                           :font-family mono-stack}}
            (str target-frame)]]
-         "No hydration mismatches recorded. This panel activates when SSR detects one.")]]
+         "No hydration mismatches recorded.")]]
      (cond
        (and has-mismatch? detail)
        [:div {:style {:flex 1 :display "flex" :flex-direction "column" :overflow "hidden"}}

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -34,8 +34,7 @@
 
   Per the bead's contract:
 
-    :no-issues  → 'No issues observed in this session.' with the
-                  '✓ All clear' badge — the desired state.
+    :no-issues  → '✓ All clear' badge — the desired state.
     :no-matches → issues exist but the active filters hide them
                   all. Carries a 'Clear filters' affordance.
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -283,8 +283,8 @@
 ;; ---- empty states -------------------------------------------------------
 
 (defn- empty-state-no-issues
-  "Per the bead's contract — the desired state. 'No issues observed
-  in this session.' with the '✓ All clear' badge."
+  "Per the bead's contract — the desired state. The `✓ All clear`
+  badge alone is the line."
   []
   [:div {:data-testid "rf-causa-issues-empty-no-issues"
          :style       {:padding     "24px"
@@ -294,18 +294,14 @@
                        :color       (:text-secondary tokens)}}
    [:div {:style {:display "flex"
                   :align-items "center"
-                  :gap "10px"
-                  :margin-bottom "8px"}}
+                  :gap "10px"}}
     [:span {:style {:color       (:green tokens)
                     :font-size   "16px"
                     :font-weight 700}}
      "✓"]
     [:span {:style {:color       (:green tokens)
                     :font-weight 600}}
-     "All clear"]]
-   [:p {:style {:margin 0
-                :color  (:text-tertiary tokens)}}
-    "No issues observed in this session."]])
+     "All clear"]]])
 
 (defn- empty-state-no-matches
   "Issues exist but the active filters hide them all. Carries a

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -312,7 +312,7 @@
                           :color (:text-tertiary tokens)
                           :font-family sans-stack
                           :font-size "12px"}}
-      "No machine selected — nothing to chart."]
+      "No machine selected."]
 
      (nil? (:definition props))
      (chart-fallback props)
@@ -479,7 +479,7 @@
                       :color (:text-tertiary tokens)
                       :font-family sans-stack
                       :font-size "12px"}}
-        "No transitions recorded for this machine yet."]
+        "No transitions yet."]
        (into [:ul {:data-testid "rf-causa-machine-inspector-ribbon-list"
                    :style {:list-style "none"
                            :margin 0
@@ -660,8 +660,7 @@
     "Register a machine with "
     [:code {:style {:font-family mono-stack :color (:accent-violet tokens)}}
      "rf/reg-machine"]
-    " and it will appear here with its live state, transition history, "
-    "and any :after countdowns."]])
+    " to populate this panel."]])
 
 ;; ---- public view --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -753,11 +753,7 @@
                      :font-weight 600
                      :margin 0
                      :color (:text-primary tokens)}}
-        "Machine inspector"]
-       [:p {:style {:font-size "12px"
-                    :color     (:text-tertiary tokens)
-                    :margin    "4px 0 0 0"}}
-        "Pick a machine to inspect its current state and recent transitions."]]
+        "Machine inspector"]]
       ;; Share button — visible whenever the panel has more than empty
       ;; state. Empty-state branch hides the whole inner div below so
       ;; the button only appears when there's something to share.

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
@@ -525,7 +525,7 @@
                       :font-family sans-stack
                       :font-size "12px"
                       :font-style "italic"}}
-        "No instances for the selected cluster-by."]
+        "No instances for this cluster-by."]
        (into [:ul {:data-testid "rf-causa-mode-c-cluster-list"
                    :style {:list-style "none"
                            :margin 0

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
@@ -515,9 +515,7 @@
       (str (count clusters) " cluster"
            (when (not= 1 (count clusters)) "s")
            " · " (reduce + 0 (map :count clusters)) " instance"
-           (when (not= 1 (reduce + 0 (map :count clusters))) "s")
-           " · "
-           "Shift+click to compare")]
+           (when (not= 1 (reduce + 0 (map :count clusters))) "s"))]
      (if (empty? clusters)
        [:div {:data-testid "rf-causa-mode-c-empty"
               :style {:padding "12px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
@@ -467,7 +467,7 @@
                     :font-family sans-stack
                     :font-size "11px"
                     :font-style "italic"}}
-      "No steps yet. Pick an event above and click Step."]
+      "No steps yet."]
      (into [:ol {:data-testid "rf-causa-machine-inspector-sim-audit-list"
                  :style {:list-style "none" :padding 0 :margin 0}}]
            (for [[idx row] (map-indexed vector trail)]

--- a/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_feed.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/mcp_server_feed.cljs
@@ -113,18 +113,7 @@
      "⌬"]
     [:span {:style {:color       (:text-primary tokens)
                     :font-weight 600}}
-     "No agent activity"]]
-   [:p {:style {:margin "0 0 8px 0" :color (:text-tertiary tokens)}}
-    "Causa-MCP (the agent server) tags every operation it performs "
-    "with " [:code {:style {:font-family mono-stack
-                            :color (:causa-mcp-cyan tokens)}}
-             ":origin :causa-mcp"]
-    ". Nothing tagged that way has landed in the buffer this session."]
-   [:p {:style {:margin 0 :color (:text-tertiary tokens)
-                :font-size "12px"
-                :font-style "italic"}}
-    "Once an agent connects via the causa-mcp jar and performs an op, "
-    "this feed lights up."]])
+     "No agent activity."]]])
 
 (defn empty-state-no-matches
   "Events exist but the active filters hide them all."

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -240,14 +240,10 @@
                        :font-size   "13px"
                        :line-height 1.5
                        :color       (:text-secondary tokens)}}
-   [:p {:style {:margin "0 0 8px 0"
+   [:p {:style {:margin 0
                 :color  (:text-primary tokens)
                 :font-weight 600}}
-    "No performance data yet"]
-   [:p {:style {:margin 0
-                :color  (:text-tertiary tokens)}}
-    "Perform actions in the app to capture cascades. Each dispatch lands "
-    "as one row with a per-step duration breakdown."]])
+    "No performance data yet."]])
 
 ;; ---- public view --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routes.cljs
@@ -121,11 +121,7 @@
                    :color (:text-tertiary tokens)
                    :font-family sans-stack
                    :font-size "12px"}}
-     "No active route. Navigate the host app to populate "
-     [:code {:style {:font-family mono-stack
-                     :color       (:accent-violet tokens)}}
-      ":rf/route"]
-     "."]
+     "No active route."]
     (let [{:keys [route-id params query fragment transition]} active]
       [:div {:data-testid "rf-causa-routes-active"
              :style {:padding "10px 16px"
@@ -325,11 +321,7 @@
                           :color   (:text-tertiary tokens)
                           :font-family sans-stack
                           :font-size "12px"}}
-      "No navigations recorded yet. The feed populates on every "
-      [:code {:style {:font-family mono-stack
-                      :color       (:accent-violet tokens)}}
-       ":rf.route/navigate"]
-      " or browser back/forward event."]
+      "No navigations recorded yet."]
      (into [:ul {:style {:list-style "none"
                          :margin 0
                          :padding 0}}]
@@ -359,11 +351,7 @@
     [:code {:style {:font-family mono-stack
                     :color       (:accent-violet tokens)}}
      "rf/reg-route"]
-    " — the panel populates as routes register. See "
-    [:code {:style {:font-family mono-stack
-                    :color       (:accent-violet tokens)}}
-     "spec/012-Routing.md"]
-    "."]])
+    " to populate this panel."]])
 
 ;; ---- public view --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/time_travel.cljs
@@ -13,7 +13,7 @@
    "No epoch history for "
    [:code {:style {:color (:accent-violet tokens) :font-family mono-stack}}
     (str target-frame)]
-   " yet. Trigger a dispatch in the host app and the scrubber will populate."])
+   "."])
 
 (defn- chip-view
   [{:keys [pin attached] :as _chip-state}]

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -42,8 +42,8 @@
 
   Per the bead's contract:
 
-    :no-events   → 'No events observed in this session.' Once the
-                   trace bus starts flowing this clears immediately.
+    :no-events   → 'No events.' Once the trace bus starts flowing
+                   this clears immediately.
     :no-matches  → events exist but the active filters hide them
                    all. 'No events match current filters' + Clear.
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -435,9 +435,9 @@
               :on-click    #(rf/dispatch [:rf.causa/set-trace-filter
                                           axis nil] {:frame :rf/causa})
               :title       (if present?
-                             (str "click to drop the " axis-name " filter")
+                             (str "Drop " axis-name " filter")
                              (str axis-name " = " value-str
-                                  " — value aged out of the buffer; click to drop"))
+                                  " — value aged out of the buffer"))
               :style       {:background    (if present?
                                              (:bg-active tokens)
                                              "transparent")
@@ -492,9 +492,6 @@
                             :align-items "baseline"}}]
             (for [{:keys [axis] :as pill} active-filters]
               ^{:key axis} [active-filter-pill pill]))])
-   [:p {:style {:margin "0 0 12px 0"
-                :color (:text-tertiary tokens)}}
-    "Click a pill above to drop that axis, or use Clear filters to widen the ribbon."]
    [:button {:data-testid "rf-causa-trace-empty-clear-filters"
              :on-click    #(rf/dispatch [:rf.causa/clear-trace-filters] {:frame :rf/causa})
              :style       {:background "transparent"

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -412,8 +412,7 @@
                        :color       (:text-secondary tokens)}}
    [:p {:style {:margin 0
                 :color  (:text-tertiary tokens)}}
-    "No events observed in this session. "
-    "Once the host app dispatches anything the ribbon will fill."]])
+    "No events."]])
 
 (defn- active-filter-pill
   "Per rf2-vu0mp — one pill in the no-matches empty state's 'narrowing

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -462,18 +462,13 @@
    [:h1 {:style {:font-size "16px" :font-weight 600 :margin 0
                  :color (:text-primary tokens)}}
     "Views"]
-   [:p {:style {:font-size "12px" :color (:text-tertiary tokens)
-                :margin "4px 0 0 0"
-                :font-family sans-stack}}
-    (str "Per-view rows: mounted / re-rendered / unmounted. "
-         "Subs nest under each view (spec/012). "
-         "Cascade ms: " (format-ms (:cascade-ms (:totals data))))]
    (when-let [frame (:frame data)]
      [:p {:style {:font-size "11px" :color (:text-tertiary tokens)
                   :margin "2px 0 0 0"}}
       (str "Frame: " frame
            (when-let [did (:dispatch-id data)]
-             (str " · cascade " (pr-str did))))])])
+             (str " · cascade " (pr-str did)))
+           " · cascade ms: " (format-ms (:cascade-ms (:totals data))))])])
 
 (defn- bottom-controls
   [data]

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -514,8 +514,7 @@
      [:p "Select an event in the list to inspect its views."]
 
      :else
-     [:p "No views rendered this cascade. (The handler made no app-db "
-      "changes that any subscribed view depends on.)"])])
+     [:p "No views rendered this cascade."])])
 
 ;; ---- panel root --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -360,11 +360,7 @@
         [:span {:style {:color (:text-tertiary tokens) :font-size "11px"}}
          (format-ms (:elapsed-ms r))]
         [:span {:style {:color (:text-tertiary tokens) :font-size "11px"}}
-         (str "▾")]]
-       (when (and (= :rendered group) (= 1 (count invalidated-by)))
-         [:div {:style {:color (:text-tertiary tokens) :font-size "11px"
-                        :margin-top "2px"}}
-          "Click for inline drilldown"])]
+         (str "▾")]]]
       (when (= :rendered group)
         [:div {:style {:flex "1 1 60%" :min-width 0
                        :border-left (str "1px solid " (:border-subtle tokens))

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -511,7 +511,7 @@
                  :font-size "13px"}}
    (cond
      (nil? (:current (:focus data)))
-     [:p "Select an event in the list to inspect its views."]
+     [:p "No event focused."]
 
      :else
      [:p "No views rendered this cascade."])])
@@ -545,11 +545,7 @@
         (:heatmap? data)
         [:div {:style {:padding "12px 16px"}}
          (heatmap-bar (:segments (:heatmap data))
-                      (:total-ms (:heatmap data)))
-         [:p {:style {:margin "8px 0 0 0" :font-size "11px"
-                      :color (:text-tertiary tokens)}}
-          "Click a segment to filter the three groups and exit heatmap "
-          "mode. Hover for label."]]
+                      (:total-ms (:heatmap data)))]
 
         (zero? (+ (count (:mounted groups))
                   (count (:rendered groups))

--- a/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
@@ -203,9 +203,7 @@
        (graph/body payload layout)]
       ;; Footer
       [:div {:style (footer-style)}
-       (layout-toggle layout)
-       [:div {:style {:color (:text-tertiary tokens)}}
-        "Click a node to focus · Esc · c · click-outside to close"]]]]))
+       (layout-toggle layout)]]]))
 
 (rf/reg-view Popover
   "The Causality popover. Renders only when `:rf.causa/causality-

--- a/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
@@ -391,8 +391,7 @@
                          :color   (:text-secondary tokens)
                          :font-family sans-stack
                          :font-size "13px"}}
-     "No focused event — click a row in the event list to see its
-      causal graph."]
+     "No focused event."]
     (let [{:keys [ancestors focused descendants]} payload
           desc-nodes (:nodes descendants)
           all (concat ancestors [focused] desc-nodes)]

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -203,9 +203,7 @@
                              :color       (:text-secondary tokens)
                              :min-width   "32px"
                              :text-align  "right"}}
-        (str (or text-size 13) "px")]]
-      [:p {:style (hint-style)}
-       "Scales every Causa text surface. Slider range 10–18 px."]]
+        (str (or text-size 13) "px")]]]
 
      ;; ── Panel position radio ────────────────────────────────────
      [:div {:style (field-style)}
@@ -224,10 +222,7 @@
                   :checked     (= panel-position pos)
                   :on-change   #(rf/dispatch [:rf.causa/settings-update
                                               :general :panel-position pos])}]
-         label])
-      [:p {:style (hint-style)}
-       "Right-rail is the default inline mount; popout opens a window; "
-       "fullscreen mounts as an overlay."]]
+         label])]
 
      ;; ── Auto-open-on-error checkbox ─────────────────────────────
      [:div {:style (field-style)}
@@ -242,11 +237,7 @@
                                 [:rf.causa/settings-update
                                  :general :auto-open-on-error?
                                  (boolean (.. % -target -checked))])}]
-       "Auto-open Causa when an issue is observed"]
-      [:p {:style (hint-style)}
-       "When ON, Causa opens itself the first time the issues feed "
-       "carries a non-empty entry. Off by default — you're in your "
-       "app, not asking Causa to interrupt you."]]]))
+       "Auto-open Causa when an issue is observed"]]]))
 
 ;; ---- section: Filters ---------------------------------------------------
 
@@ -302,10 +293,7 @@
                   :on-change   #(rf/dispatch
                                   [:rf.causa/settings-update
                                    :theme nil t])}]
-         label])
-      [:p {:style (hint-style)}
-       "Light / dark only for v1. Accent picker arrives in a later "
-       "release."]]]))
+         label])]]))
 
 ;; ---- section: Diff (rf2-i39w2 Phase 3) ----------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -534,8 +534,7 @@
                       :color     (:text-secondary tokens)
                       :font-family sans-stack
                       :font-size (:body type-scale)}}
-        "Click around your app — every dispatch will land here. "
-        "Press [c] for the causality graph."]
+        "No events."]
        (into [:ul {:style {:list-style "none" :margin 0 :padding 0
                            :display "flex" :flex-direction "column"
                            :gap "2px"}}]


### PR DESCRIPTION
## Summary

Cluster PR for the rf2-yn86j epic — applies seven small, high-impact text-audit cuts surfaced in `ai/findings/2026-05-18-causa-text-audit.md` (the 'every line earns its keep' UI audit). All cuts are deletions of redundant or self-narrating chrome. Net effect: ~85 fewer lines of UI prose; no functional or visual layout changes beyond the removed text.

## Beads (one commit each, in safe-to-revert order)

| Bead | Commit | What |
|---|---|---|
| **rf2-m7vhf** | `01bb2021` | Drop redundant L4 panel subheads (App-db diff, Views, Machine inspector — Event detail already done). Views keeps cascade-ms by folding it into the existing frame/cascade context row. |
| **rf2-bmyii** | `e7ecc59e` | Drop per-row 'Click for inline drilldown' caption — was the worst per-instance-cost violation (renders under every single-invalidator re-rendered row). |
| **rf2-euucc** | `c59f5255` | Collapse Trace + Issues empty-state explainers. Trace 'No events.'; Issues drops the redundant 'No issues observed…' paragraph — `✓ All clear` badge alone is the line. |
| **rf2-addv9** | `c6990034` | Drop four Settings popup hints (text-size, panel-position, auto-open, theme). |
| **rf2-nvy10** | `b1fb64d0` | Drop Causality popover footer hint ('Click a node to focus · Esc · c · click-outside to close'). |
| **rf2-jioeu** | `5495d381` | Sweep audit-pattern P2 — narrated empty states ('this will fill when…'). 14 files. |
| **rf2-4rqre** | `0e329ba6` | Sweep audit-pattern P3 — 'Click X to Y' narration of discoverable affordances. 5 files. |

Plus a tiny docstring sync (`c889ef5a`) bringing the `:no-events` / `:no-issues` contract docstrings in line with the rf2-euucc cuts.

## What was NOT deleted (defensible exceptions)

- Issues / MCP `Adjust the X / Y chips above to widen the feed.` — these are narrated-non-empty-states (filters are active), distinct from pure 'No <thing>' empty states. Audit verdict was S (shorten) not D — leaving for a follow-on if Mike wants the shortening.
- Sim 'No outgoing transitions declared on this state.' — audit's defensible exception: carries semantic info about the machine, not just absence.
- Filter edit popup `(pre-alpha: stored, not yet matched)` — defensible exception: the affordance literally doesn't work yet.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — **914 tests, 2650 assertions, 0 failures**
- [x] `cd implementation && npm run test:browser` — **3084 tests, 8815 assertions, 0 failures**
- [x] No test assertions on the deleted strings (verified via grep across tools/causa/test, implementation tests, testbeds). Tests that touch the affected empty-state surfaces assert on `data-testid` attributes only.

## Notes

- Per-commit so the PR can be partially reverted if needed.
- Mayor will close all 7 beads after merge.
- Source: ai/findings/2026-05-18-causa-text-audit.md (rf2-yn86j epic).