### PR TITLE
feat(causa): hydration mismatch bisector adopts hiccup engine — structural-diff epic complete

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs
@@ -60,22 +60,38 @@
   All pure-data logic — `classify-divergence`, `first-divergence-path`,
   `mismatch-detail`, `re-root` — lives in
   `hydration_debugger_helpers.cljc` so the algebra runs under the JVM
-  unit-test target."
+  unit-test target.
+
+  ## Phase 4 (rf2-1mcax) — hiccup-engine adoption
+
+  Per Phase 4 of epic rf2-abts7 the side-by-side panes consume the
+  Phase 3 hiccup-diff micro-engine
+  (`day8.re-frame2-causa.diff.hiccup`) through the perspective-aware
+  renderer in `day8.re-frame2-causa.panels.hydration-pane-render`. The
+  raw `pr-str` rendering kept in Phase 5 is replaced by a structural
+  diff: server-only nodes render red on the server pane and as
+  greyed-out `[absent]` chips on the client pane; client-only nodes do
+  the mirror; shared elements surface their attr deltas inline; the
+  fn-prop opaque rule + the `:highlight-fn-ref-changes?` toggle from
+  Phase 3 apply uniformly.
+
+  The drilldown header surfaces the `:rf.causa/first-divergent-path`
+  text — a single line like `:div > :section.cart > :p` derived from
+  the bisector path (see `h/first-divergent-header-text`)."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.hydration-debugger-helpers :as h]
+            ;; rf2-1mcax Phase 4 — adopt the Phase 3 hiccup-diff
+            ;; micro-engine for per-pane annotation. The pane renderer
+            ;; below consumes the annotated tree once + renders it
+            ;; twice (one perspective per side).
+            [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.panels.hydration-pane-render
+             :as pane-render]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
 ;; ---- pure-data render helpers -------------------------------------------
-
-(defn- format-edn
-  "Best-effort EDN-like format. Used to render the path + hash + tree
-  scalars in the mono columns."
-  [v]
-  (try
-    (pr-str v)
-    (catch :default _ (str v))))
 
 (defn- path-segments
   "Render a path vector as `:a > :b > :c` — used in the mismatch list
@@ -205,38 +221,46 @@
    (str "#" (subs (str hash) 0 (min 6 (count (str hash)))))])
 
 (defn- tree-pane
-  "Render one side of the side-by-side view. `chips` is the bisector
-  chip list for this side; `divergent-path` is the bisection path
-  (used to mark the chip at that path as divergent). `tree` is the
-  full hiccup subtree to display in EDN form."
-  [{:keys [side label tree chips divergent-path]}]
-  [:section {:data-testid (str "rf-causa-hydration-tree-pane-" (name side))
-             :style       {:flex   1
-                           :min-width 0
-                           :background (:bg-2 tokens)
-                           :border-right (when (= side :server)
-                                           (str "1px solid " (:border-default tokens)))
-                           :overflow "auto"}}
-   [:header {:style {:padding "8px 12px"
-                     :border-bottom (str "1px solid " (:border-subtle tokens))
-                     :font-family sans-stack
-                     :font-size "12px"
-                     :font-weight 600
-                     :color (:text-secondary tokens)}}
-    [:span (str (name side) " render")]
-    (into [:span {:style {:margin-left "8px"}}]
-          (map (fn [chip]
-                 (hash-chip chip (= (:path chip) divergent-path)))
-               chips))]
-   [:pre {:data-testid (str "rf-causa-hydration-tree-content-" (name side))
-          :style       {:margin       0
-                        :padding      "12px"
-                        :font-family  mono-stack
-                        :font-size    "12px"
-                        :color        (:text-primary tokens)
-                        :white-space  "pre-wrap"
-                        :word-break   "break-word"}}
-    (format-edn tree)]])
+  "Render one side of the side-by-side view.
+
+  Phase 4 (rf2-1mcax): rather than `pr-str` over the tree, this consumes
+  the pre-computed Phase-3 annotated diff and routes it through the
+  perspective-aware renderer (`hydration-pane-render/render-pane`). The
+  pane shows structural diff annotations from `side`'s POV — server-
+  only nodes red on the server pane / `[absent]` on the client pane;
+  client-only nodes mirror; shared elements surface their attr deltas
+  inline.
+
+  `chips` is the bisector chip list (rendered in the header); `annotated`
+  is the diff node from `hiccup/diff-hiccup-node`; `mismatch-id` enters
+  the surface key so per-pane expand state is per-selection."
+  [{:keys [side annotated chips divergent-path mismatch-id]}]
+  (let [surface (str "hydration/" (pr-str mismatch-id))]
+    [:section {:data-testid (str "rf-causa-hydration-tree-pane-" (name side))
+               :style       {:flex   1
+                             :min-width 0
+                             :background (:bg-2 tokens)
+                             :border-right (when (= side :server)
+                                             (str "1px solid " (:border-default tokens)))
+                             :overflow "auto"}}
+     [:header {:style {:padding "8px 12px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack
+                       :font-size "12px"
+                       :font-weight 600
+                       :color (:text-secondary tokens)
+                       :display "flex"
+                       :align-items "baseline"
+                       :gap "8px"
+                       :flex-wrap "wrap"}}
+      [:span {:data-testid (str "rf-causa-hydration-pane-label-" (name side))}
+       (str (name side) " render")]
+      (into [:span {:style {:margin-left "8px"}}]
+            (map (fn [chip]
+                   (hash-chip chip (= (:path chip) divergent-path)))
+                 chips))]
+     [:div {:data-testid (str "rf-causa-hydration-tree-content-" (name side))}
+      (pane-render/render-pane annotated side surface)]]))
 
 (defn- divergent-marker
   "Per spec §Layout the divergent node is flagged with `⚠`. Rendered
@@ -315,15 +339,65 @@
                             :title "Source-coord fallback — exact view coord unavailable; using handler coord."}}
              "(?)"])])])))
 
+;; ---- first-divergent header (Phase 4) -----------------------------------
+
+(defn- first-divergent-header
+  "Phase 4 (rf2-1mcax) — surface the path to the first divergent node
+  as a single line at the top of the drilldown. Uses the bisector path
+  computed by the projection plus the (possibly re-rooted) server tree
+  to render readable tag segments."
+  [{:keys [tree bisector-path view-id]}]
+  [:div {:data-testid "rf-causa-hydration-first-divergent-header"
+         :style       {:padding       "6px 12px"
+                       :background    (:bg-3 tokens)
+                       :border-bottom (str "1px solid "
+                                           (:border-default tokens))
+                       :font-family   sans-stack
+                       :font-size     "12px"
+                       :color         (:text-primary tokens)
+                       :display       "flex"
+                       :align-items   "baseline"
+                       :gap           "8px"
+                       :flex-wrap     "wrap"}}
+   [:span {:style {:color (:cyan tokens)
+                   :font-family mono-stack
+                   :font-size "11px"
+                   :text-transform "uppercase"}}
+    "first divergent"]
+   [:code {:data-testid "rf-causa-hydration-first-divergent-path"
+           :style       {:color       (:accent-violet tokens)
+                         :font-family mono-stack
+                         :font-size   "12px"}}
+    (h/first-divergent-header-text tree bisector-path)]
+   (when view-id
+     [:span {:style {:margin-left "auto"
+                     :color (:text-tertiary tokens)
+                     :font-size "11px"}}
+      "in "
+      [:code {:style {:color (:cyan tokens)
+                      :font-family mono-stack}}
+       (str view-id)]])])
+
 ;; ---- mismatch detail composite view -------------------------------------
 
 (defn- mismatch-detail
   "Per spec §Layout — the side-by-side server / client render-tree
-  view with the bisector path highlighted + the hypothesis below."
-  [{:keys [detail source-coord re-root-path] :as _data}]
+  view with the bisector path highlighted + the hypothesis below.
+
+  Phase 4 (rf2-1mcax): runs the Phase 3 hiccup-diff micro-engine once
+  over the (possibly re-rooted) server vs client subtrees, then routes
+  the annotated tree through the per-pane renderer. Each pane sees the
+  same diff but flips `:added` / `:removed` semantics so the eye reads
+  'this side has this, the other side does not'.
+
+  The hiccup-diff opts (e.g. `:highlight-fn-ref-changes?`) come from
+  the shared `:rf.causa/diff-opts` sub — same source the Views panel
+  uses for its drilldown diff. The two panels now share the same
+  toggle state."
+  [{:keys [detail source-coord re-root-path diff-opts] :as _data}]
   (let [{:keys [server-tree client-tree
                 server-chips client-chips
-                bisector-path view-id]} detail
+                bisector-path view-id id]} detail
         ;; If the user has re-rooted (clicked a hash chip), apply the
         ;; re-root to both trees; otherwise render the full subtree.
         server-tree' (if (seq re-root-path)
@@ -331,12 +405,19 @@
                        server-tree)
         client-tree' (if (seq re-root-path)
                        (h/re-root client-tree re-root-path)
-                       client-tree)]
+                       client-tree)
+        ;; Phase 4 — run the diff once; render twice (one perspective
+        ;; per pane). The opts map flows through `classify-prop`'s
+        ;; opaque-fn rule per Phase 3 §4.5.
+        annotated    (hd/diff-hiccup-node server-tree' client-tree' (or diff-opts {}))]
     [:div {:data-testid "rf-causa-hydration-mismatch-detail"
            :style       {:flex          1
                          :display       "flex"
                          :flex-direction "column"
                          :overflow      "hidden"}}
+     (first-divergent-header {:tree          server-tree'
+                              :bisector-path bisector-path
+                              :view-id       view-id})
      (hypothesis-row detail)
      (source-coord-row source-coord view-id)
      (divergent-marker)
@@ -345,15 +426,15 @@
                     :flex-direction "row"
                     :overflow "hidden"}}
       (tree-pane {:side           :server
-                  :label          "server render"
-                  :tree           server-tree'
+                  :annotated      annotated
                   :chips          server-chips
-                  :divergent-path bisector-path})
+                  :divergent-path bisector-path
+                  :mismatch-id    id})
       (tree-pane {:side           :client
-                  :label          "client render"
-                  :tree           client-tree'
+                  :annotated      annotated
                   :chips          client-chips
-                  :divergent-path bisector-path})]]))
+                  :divergent-path bisector-path
+                  :mismatch-id    id})]]))
 
 ;; ---- public view --------------------------------------------------------
 
@@ -373,7 +454,12 @@
                 selected-mismatch-id detail
                 source-coord re-root-path target-frame]
          :as data}
-        @(rf/subscribe [:rf.causa/hydration-debugger-data])]
+        @(rf/subscribe [:rf.causa/hydration-debugger-data])
+        ;; Phase 4 (rf2-1mcax) — same diff-opts sub the Views panel
+        ;; uses. The two panels share the `:highlight-fn-ref-changes?`
+        ;; toggle from Settings → Diff so users get one mental model
+        ;; for opaque-prop rendering across the tool.
+        diff-opts @(rf/subscribe [:rf.causa/diff-opts])]
     [:section {:data-testid "rf-causa-hydration-debugger"
                :style       {:height         "100%"
                              :display        "flex"
@@ -406,7 +492,8 @@
         (mismatch-list mismatch-summary selected-mismatch-id)
         (mismatch-detail {:detail        detail
                           :source-coord  source-coord
-                          :re-root-path  re-root-path})]
+                          :re-root-path  re-root-path
+                          :diff-opts     diff-opts})]
 
        has-mismatch?
        ;; Edge case — mismatches exist but no detail (selection

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger_helpers.cljc
@@ -49,7 +49,21 @@
   The hypothesis is **a hint, not an answer**; the panel surfaces it
   with the appropriate panel pivot link. The classification fn is
   pure → callers (tests + view) consume it without any reactive
-  context."
+  context.
+
+  ## Phase 4 hiccup-engine adoption (rf2-1mcax)
+
+  Per `tools/causa/spec/006-Hydration-Debugger.md` §Layout the panel
+  renders the divergent subtree side-by-side. Phase 4 of rf2-abts7
+  composes the Phase 3 hiccup-diff micro-engine
+  (`day8.re-frame2-causa.diff.hiccup`) so each pane shows structural
+  diff annotations rather than raw `pr-str` output. The annotated
+  tree is computed **once** (the diff is symmetric) and the renderer
+  consumes it with a `:perspective` flag that picks which side's
+  value to surface and which `::op` semantics to flip.
+
+  See `bisector-path-segments` for the human-readable first-divergent
+  header and `first-divergent-header-text` for the title bar text."
   (:require [clojure.string :as str]))
 
 ;; ---- mismatch projection ------------------------------------------------
@@ -411,6 +425,94 @@
         (if (and (< idx (count children)))
           (recur (nth children idx) (rest remaining))
           node)))))
+
+;; ---- Phase 4 (rf2-1mcax) — first-divergent header ---------------------
+
+(defn- node-display-tag
+  "Render a node as a short readable tag for the bisector header. Hiccup
+  vectors collapse to `:tag`; text leaves render via `pr-str` (truncated
+  to keep the header on one line). Pure data → string."
+  [node]
+  (cond
+    (hiccup-vector? node)
+    (let [tag    (tag-of node)
+          attrs  (attrs-of node)
+          id     (when attrs (get attrs :id))
+          cls    (when attrs (get attrs :class))]
+      (cond-> (str tag)
+        id  (str "#" id)
+        cls (str (if (string? cls) (str "." (str/replace cls " " "."))
+                                   (str "." cls)))))
+
+    (text-node? node)
+    (let [s (pr-str node)]
+      (if (> (count s) 24) (str (subs s 0 21) "...") s))
+
+    :else
+    (let [s (pr-str node)]
+      (if (> (count s) 24) (str (subs s 0 21) "...") s))))
+
+(defn bisector-path-segments
+  "Walk a tree along the bisector path (vector of integer child indices)
+  and return a vector of short readable segments, one per node from the
+  root down to the first divergent node. Used to render the
+  'first divergent' header per Phase 4.
+
+  Example:
+
+      (bisector-path-segments
+        [:div [:section.cart [:p \"3 items\"]]]
+        [0 0])
+      ;; => [\":div\" \":section.cart\" \":p\"]
+
+  Pure data → vector of strings. JVM-runnable."
+  [tree bisector-path]
+  (loop [segments [(node-display-tag tree)]
+         node     tree
+         remaining bisector-path]
+    (if (empty? remaining)
+      segments
+      (let [idx      (first remaining)
+            children (vec (children-of node))
+            sub      (when (< idx (count children))
+                       (nth children idx))]
+        (if (nil? sub)
+          segments
+          (recur (conj segments (node-display-tag sub))
+                 sub
+                 (rest remaining)))))))
+
+(defn first-divergent-header-text
+  "Render the first-divergent path as a single-line header string for
+  the panel's drilldown header (per Phase 4). Joins segments with `>`.
+
+      \":div > :section.cart > :p\"
+
+  Returns `(root)` when the bisector path is empty (root divergence)."
+  [tree bisector-path]
+  (let [segs (bisector-path-segments tree bisector-path)]
+    (if (= 1 (count segs))
+      (first segs)
+      (str/join " > " segs))))
+
+;; ---- Phase 4 (rf2-1mcax) — hiccup-engine pane diff -------------------
+
+(defn pane-diff-input
+  "Return a map suitable for per-pane rendering by the Phase 4 pane
+  renderer in `hydration_debugger.cljs`:
+
+      {:server-tree   <original>
+       :client-tree   <original>
+       :bisector-path <path>}
+
+  The hiccup-engine diff is computed lazily inside the renderer (it
+  requires the runtime `:diff-opts` map fed from the settings sub).
+  This helper exists so the projection is JVM-testable shape-wise
+  without depending on the engine ns from the .cljc target."
+  [{:keys [server-tree client-tree bisector-path] :as _detail}]
+  {:server-tree   server-tree
+   :client-tree   client-tree
+   :bisector-path (or bisector-path [])})
 
 ;; ---- source-coord resolution (Lock #11 fallback) ------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs
@@ -1,0 +1,473 @@
+(ns day8.re-frame2-causa.panels.hydration-pane-render
+  "Per-pane hiccup-diff renderer for Causa's Hydration Debugger panel
+  (Phase 4, rf2-1mcax — completes the structural-diff epic rf2-abts7).
+
+  ## What this does
+
+  Wraps the Phase 3 hiccup-diff micro-engine + renderer
+  (`day8.re-frame2-causa.diff.hiccup` + `.hiccup-render`) for use as
+  per-pane annotation in the hydration side-by-side. The hydration
+  side-by-side is symmetric — the same annotated tree underlies both
+  panes — but each pane surfaces the diff from its own perspective:
+
+    - **Server pane** — the SERVER side's value is canonical.
+      `:added` (present-after-only / client-only) is suppressed to
+      `[absent]` ghost rows. `:removed` (server-only) renders in red
+      as 'present in server but not client' (the server pane's POV).
+
+    - **Client pane** — mirror image. `:removed` (server-only) is
+      suppressed; `:added` (client-only) renders in green.
+
+  Shared elements / shared attrs render identically on both sides
+  (the `:modified` / `:element-changed` paths surface the divergent
+  attrs inline). The fn-prop opaque rule + the `:highlight-fn-ref-
+  changes?` toggle from Phase 3 apply uniformly — the opts map
+  passed in flows straight through `classify-prop`.
+
+  ## Why a separate ns
+
+  The generic `hiccup-render` is symmetric — it shows both sides of
+  every diff (the cljs-devtools-style before/after). The hydration
+  panel needs per-side rendering — each pane shows only its own side
+  of the diff with the diverging slots highlighted. The translation
+  is a thin pattern-match over the `::op` keys; bolting it onto the
+  generic renderer would tax every other consumer (Views drilldown,
+  app-db diff) with a perspective flag they don't need.
+
+  ## Pure hiccup
+
+  Per the Causa convention — the renderer returns hiccup, no Reagent /
+  UIx / Helix references."
+  (:require [day8.re-frame2-causa.diff.hiccup :as hd]
+            [day8.re-frame2-causa.diff.hiccup-render :as hd-render]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- node-key + small helpers ------------------------------------------
+
+(defn- node-key-for
+  "Stable per-node expand-state key combining surface + perspective +
+  path. The perspective enters the key so server / client panes have
+  independent expand state for the same path."
+  [surface perspective path]
+  (str surface "/hydration/" (name perspective) "/" (pr-str (vec path))))
+
+(defn- inspect-value
+  [v node-key]
+  (inspector/inspect (f/display-value v) node-key))
+
+(defn- inspect-inline
+  [v]
+  (inspector/inspect-inline (f/display-value v)))
+
+;; ---- absent / present chips --------------------------------------------
+
+(defn- absent-chip
+  "Render the 'this side does not have this node' chip. Used when the
+  pane's perspective is server and the engine emitted `:added`
+  (client-only), or when the perspective is client and the engine
+  emitted `:removed` (server-only)."
+  [label]
+  [:span {:data-testid "rf-causa-hydration-pane-absent"
+          :style {:display       "inline-block"
+                  :padding       "0 6px"
+                  :margin        "1px 0"
+                  :border        (str "1px dashed " (:border-default tokens))
+                  :border-radius "2px"
+                  :background    (:bg-3 tokens)
+                  :color         (:text-tertiary tokens)
+                  :font-family   mono-stack
+                  :font-size     "11px"
+                  :font-style    "italic"}}
+   (str "absent on this side · was " label)])
+
+(defn- present-chip
+  "Render the 'present only on this side' annotation. The colour signals
+  perspective — green when this pane has it and the other does not."
+  [tone label value nkey]
+  [:div {:data-testid "rf-causa-hydration-pane-only-here"
+         :style {:display       "flex"
+                 :align-items   "baseline"
+                 :gap           "4px"
+                 :padding       "2px 0"
+                 :padding-left  "6px"
+                 :border-left   (str "3px solid " tone)}}
+   [:span {:style {:flex          "0 0 14px"
+                   :color         tone
+                   :font-family   mono-stack
+                   :font-size     "12px"
+                   :font-weight   700}}
+    label]
+   [:span {:style {:color (:text-primary tokens)
+                   :font-family mono-stack
+                   :font-size "12px"}}
+    (inspect-value value nkey)]])
+
+(defn- key-or-index-label
+  "Same label as the generic hiccup-render — but kept local so we don't
+  reach into private vars in `hiccup-render`."
+  [node]
+  (cond
+    (some? (:key node))
+    [:span {:style {:color (:accent-violet tokens)
+                    :font-family mono-stack
+                    :font-size "11px"
+                    :margin-right "6px"}}
+     (str ":key " (pr-str (:key node)))]
+
+    (some? (:index node))
+    [:span {:style {:color (:text-tertiary tokens)
+                    :font-family mono-stack
+                    :font-size "11px"
+                    :margin-right "6px"}}
+     (str "[" (:index node) "]")]
+
+    :else nil))
+
+;; ---- attrs renderer ----------------------------------------------------
+
+(declare render-pane-node)
+
+(defn- render-attr-row
+  "Render one attr from the attrs-diff, perspective-aware. Same colour
+  vocabulary as the generic hiccup renderer for `:modified` (both
+  sides differ) + `:fn-ref-changed`; `:added` / `:removed` are flipped
+  per perspective."
+  [attr-node perspective parent-key]
+  (let [op   (hd/op-of attr-node)
+        k    (:key attr-node)
+        nkey (str parent-key "/attr/" (pr-str k))]
+    (case op
+      :same
+      [:div {:style {:display "flex" :gap "6px"
+                     :color (:text-tertiary tokens)
+                     :font-family mono-stack :font-size "12px"}}
+       [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+       (inspect-value (:value attr-node) nkey)]
+
+      ;; :added = attr present on CLIENT only. Server pane shows it as
+      ;; 'absent on this side'; client pane shows it in green.
+      :added
+      (case perspective
+        :server
+        [:div {:data-testid (str "rf-causa-hydration-attr-server-absent-" (pr-str k))
+               :style {:display "flex" :gap "6px"
+                       :color (:text-tertiary tokens)
+                       :font-family mono-stack :font-size "12px"
+                       :opacity 0.6}}
+         [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+         (absent-chip (pr-str (:value attr-node)))]
+
+        :client
+        [:div {:data-testid (str "rf-causa-hydration-attr-client-only-" (pr-str k))
+               :style {:display "flex" :gap "6px"
+                       :padding-left "6px"
+                       :border-left (str "3px solid " (:green tokens))}}
+         [:span {:style {:color (:accent-violet tokens)
+                         :font-family mono-stack :font-size "12px"}}
+          (pr-str k)]
+         [:span {:style {:color (:green tokens)
+                         :font-family mono-stack :font-size "12px"}}
+          (inspect-value (:value attr-node) nkey)]])
+
+      ;; :removed = attr present on SERVER only.
+      :removed
+      (case perspective
+        :server
+        [:div {:data-testid (str "rf-causa-hydration-attr-server-only-" (pr-str k))
+               :style {:display "flex" :gap "6px"
+                       :padding-left "6px"
+                       :border-left (str "3px solid " (:red tokens))}}
+         [:span {:style {:color (:accent-violet tokens)
+                         :font-family mono-stack :font-size "12px"}}
+          (pr-str k)]
+         [:span {:style {:color (:red tokens)
+                         :font-family mono-stack :font-size "12px"}}
+          (inspect-value (:value attr-node) nkey)]]
+
+        :client
+        [:div {:data-testid (str "rf-causa-hydration-attr-client-absent-" (pr-str k))
+               :style {:display "flex" :gap "6px"
+                       :color (:text-tertiary tokens)
+                       :font-family mono-stack :font-size "12px"
+                       :opacity 0.6}}
+         [:span {:style {:color (:accent-violet tokens)}} (pr-str k)]
+         (absent-chip (pr-str (:value attr-node)))])
+
+      :modified
+      [:div {:data-testid (str "rf-causa-hydration-attr-modified-" (pr-str k))
+             :style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                     :align-items "baseline"
+                     :padding-left "6px"
+                     :border-left (str "3px solid " (:yellow tokens))}}
+       [:span {:style {:color (:accent-violet tokens)
+                       :font-family mono-stack :font-size "12px"}}
+        (pr-str k)]
+       [:span {:style {:color (:yellow tokens)
+                       :font-family mono-stack :font-size "12px"}}
+        (inspect-value
+          (case perspective
+            :server (:before attr-node)
+            :client (:after  attr-node))
+          (str nkey "/" (name perspective)))]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-family mono-stack :font-size "11px"
+                       :font-style "italic"}}
+        (case perspective
+          :server (str "(client: " (pr-str (:after  attr-node)) ")")
+          :client (str "(server: " (pr-str (:before attr-node)) ")"))]]
+
+      :fn-ref-changed
+      [:div {:data-testid (str "rf-causa-hydration-attr-fn-ref-changed-" (pr-str k))
+             :style {:display "flex" :gap "6px"
+                     :align-items "baseline"
+                     :padding-left "6px"
+                     :border-left (str "3px solid " (:accent-violet tokens))}}
+       [:span {:style {:color (:accent-violet tokens)
+                       :font-family mono-stack :font-size "12px"}}
+        (pr-str k)]
+       [:span {:style {:color (:accent-violet tokens)
+                       :font-family mono-stack :font-size "11px"
+                       :font-style "italic"}}
+        "(fn ref changed)"]]
+
+      ;; Defensive fallback.
+      [:span {:style {:color (:red tokens)}}
+       (str "unknown attr op: " (pr-str op))])))
+
+(defn- render-attrs-diff
+  "Render the per-attr rows for a pane. Pure-:same attrs collapse into
+  nothing — same as the generic renderer."
+  [attrs-diff perspective parent-key]
+  (let [kids    (:children attrs-diff)
+        changed (filter #(not= :same (hd/op-of %)) kids)]
+    (when (seq changed)
+      (into [:div {:data-testid (str "rf-causa-hydration-pane-attrs-" (name perspective))
+                   :style {:padding-left "12px"
+                           :margin "2px 0"}}]
+            (for [c changed]
+              ^{:key (pr-str (:key c))}
+              (render-attr-row c perspective parent-key))))))
+
+;; ---- children renderer -------------------------------------------------
+
+(defn- render-children-diff
+  [children-diff perspective surface parent-path depth]
+  (when (seq children-diff)
+    (into [:div {:data-testid (str "rf-causa-hydration-pane-children-" (name perspective))
+                 :style {:padding-left "12px"
+                         :border-left (str "1px solid " (:border-subtle tokens))
+                         :margin "2px 0"}}]
+          (map-indexed
+            (fn [i c]
+              (let [k    (or (:key c) (:index c) i)
+                    path (conj parent-path k)]
+                ^{:key (pr-str k)}
+                (render-pane-node c perspective surface path (inc depth))))
+            children-diff))))
+
+;; ---- element header ----------------------------------------------------
+
+(defn- element-header
+  [tag attrs-count children-count node-label]
+  [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
+                 :font-family mono-stack :font-size "12px"
+                 :color (:text-primary tokens)}}
+   (when node-label node-label)
+   [:span {:style {:color (:text-tertiary tokens)}}
+    (str "[" (pr-str tag)
+         (when (pos? attrs-count) " {…}")
+         (when (pos? children-count) " …")
+         "]")]])
+
+;; ---- per-op renderers --------------------------------------------------
+
+(defn- render-element-changed
+  [node perspective surface path depth]
+  (let [{:keys [tag attrs-diff children-diff]} node
+        nkey         (node-key-for surface perspective path)
+        attrs-count  (count (:children attrs-diff))
+        kids-count   (count children-diff)
+        any-changes? (or (some #(not= :same (hd/op-of %)) (:children attrs-diff))
+                         (some #(not= :same (hd/op-of %)) children-diff))]
+    [:div {:data-testid (str "rf-causa-hydration-pane-element-" nkey)
+           :style {:display "flex"
+                   :flex-direction "column"
+                   :margin "2px 0"}}
+     [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
+                    :font-family mono-stack :font-size "12px"
+                    :color (:text-primary tokens)}}
+      (key-or-index-label node)
+      (element-header tag attrs-count kids-count nil)
+      (when any-changes?
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "11px"}}
+         "◴ changed"])]
+     (render-attrs-diff attrs-diff perspective nkey)
+     (render-children-diff children-diff perspective surface path depth)]))
+
+(defn- render-element-moved
+  "Element moved (same key, different index). Same render on both sides
+  — the move is symmetric."
+  [node perspective surface path depth]
+  (let [{:keys [value from-index to-index inner-diff]} node
+        nkey (node-key-for surface perspective path)]
+    [:div {:data-testid "rf-causa-hydration-pane-moved"
+           :style {:display "flex"
+                   :flex-direction "column"
+                   :margin "2px 0"}}
+     [:div {:style {:display "flex" :align-items "baseline" :gap "6px"
+                    :padding-left "6px"
+                    :border-left (str "3px solid " (:accent-violet tokens))
+                    :font-family mono-stack :font-size "12px"}}
+      (key-or-index-label node)
+      [:span {:style {:color (:accent-violet tokens)
+                      :font-weight 600}}
+       "moved"]
+      [:span {:style {:color (:text-tertiary tokens)
+                      :font-size "11px"
+                      :font-style "italic"}}
+       (str "(was at index " from-index ", now at " to-index ")")]
+      [:span {:style {:color (:text-secondary tokens)}}
+       (inspect-value value nkey)]]
+     (when inner-diff
+       (render-pane-node inner-diff perspective surface
+                         (conj path :inner) (inc depth)))]))
+
+(defn- render-same-leaf
+  [node perspective surface path]
+  (let [nkey (node-key-for surface perspective path)]
+    [:div {:style {:display "flex" :gap "6px"
+                   :color (:text-tertiary tokens)
+                   :font-family mono-stack :font-size "12px"}}
+     (key-or-index-label node)
+     (inspect-value (:value node) nkey)]))
+
+(defn- render-added-leaf
+  "`:added` = present-on-CLIENT-only. Server pane shows absent; client
+  pane shows green."
+  [node perspective surface path]
+  (let [nkey (node-key-for surface perspective path)]
+    (case perspective
+      :server
+      [:div {:data-testid "rf-causa-hydration-pane-server-absent"
+             :style {:display "flex" :gap "6px"
+                     :color (:text-tertiary tokens)
+                     :font-family mono-stack :font-size "12px"
+                     :opacity 0.6}}
+       (key-or-index-label node)
+       (absent-chip (pr-str (:value node)))]
+
+      :client
+      (present-chip (:green tokens) "+" (:value node) nkey))))
+
+(defn- render-removed-leaf
+  "`:removed` = present-on-SERVER-only. Server pane shows red; client
+  pane shows absent."
+  [node perspective surface path]
+  (let [nkey (node-key-for surface perspective path)]
+    (case perspective
+      :server
+      (present-chip (:red tokens) "-" (:value node) nkey)
+
+      :client
+      [:div {:data-testid "rf-causa-hydration-pane-client-absent"
+             :style {:display "flex" :gap "6px"
+                     :color (:text-tertiary tokens)
+                     :font-family mono-stack :font-size "12px"
+                     :opacity 0.6}}
+       (key-or-index-label node)
+       (absent-chip (pr-str (:value node)))])))
+
+(defn- render-modified-leaf
+  "`:modified` = both sides have a value; values differ. Show this
+  side's value with the other side's value as a faint annotation."
+  [node perspective surface path]
+  (let [nkey (node-key-for surface perspective path)
+        mine (case perspective
+               :server (:before node)
+               :client (:after  node))
+        theirs (case perspective
+                 :server (:after  node)
+                 :client (:before node))]
+    [:div {:data-testid (str "rf-causa-hydration-pane-modified-" (name perspective))
+           :style {:display "flex" :flex-wrap "wrap" :gap "6px"
+                   :align-items "baseline"
+                   :padding-left "6px"
+                   :border-left (str "3px solid " (:yellow tokens))}}
+     (key-or-index-label node)
+     [:span {:style {:color (:yellow tokens)
+                     :font-family mono-stack
+                     :font-size "12px"}}
+      (inspect-value mine (str nkey "/mine"))]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-family mono-stack
+                     :font-size "11px"
+                     :font-style "italic"}}
+      (str "(" (case perspective :server "client" :client "server") ": "
+           (pr-str theirs) ")")]]))
+
+(defn- render-fn-ref-changed-leaf
+  [node perspective _surface _path]
+  [:div {:data-testid (str "rf-causa-hydration-pane-fn-ref-changed-" (name perspective))
+         :style {:display "flex" :gap "6px"
+                 :align-items "baseline"
+                 :padding-left "6px"
+                 :border-left (str "3px solid " (:accent-violet tokens))
+                 :font-family mono-stack
+                 :font-size "12px"
+                 :color (:accent-violet tokens)
+                 :font-style "italic"}}
+   (key-or-index-label node)
+   "(fn ref changed)"])
+
+;; ---- public dispatch ---------------------------------------------------
+
+(defn render-pane-node
+  "Dispatch on the hiccup-diff `::op` and render the annotated node
+  from `perspective`'s POV (`:server` or `:client`).
+
+  Per Phase 4 (rf2-1mcax) — each pane shows the SAME annotated tree
+  but flips `:added` ↔ `:removed` semantics based on perspective."
+  [node perspective surface path depth]
+  (let [op (hd/op-of node)]
+    (case op
+      :element-changed (render-element-changed node perspective surface path depth)
+      :element-moved   (render-element-moved   node perspective surface path depth)
+      :fn-ref-changed  (render-fn-ref-changed-leaf node perspective surface path)
+      :same            (render-same-leaf       node perspective surface path)
+      :added           (render-added-leaf      node perspective surface path)
+      :removed         (render-removed-leaf    node perspective surface path)
+      :modified        (render-modified-leaf   node perspective surface path)
+      ;; Defensive fallback — shouldn't happen for well-formed input.
+      [:span {:style {:color (:red tokens)}}
+       (str "unknown hiccup op: " (pr-str op))])))
+
+(defn render-pane
+  "Top-level entry for a per-pane hydration render. Takes the annotated
+  tree (already diffed), a `:server` / `:client` perspective, a stable
+  `surface` string for expand state, and returns a hiccup tree the
+  caller drops into its layout.
+
+  When the diff returns `::op :same` (both sides identical at this
+  subtree), renders a 'no structural difference' chip."
+  [annotated perspective surface]
+  [:div {:data-testid (str "rf-causa-hydration-pane-render-" (name perspective))
+         :style {:font-family mono-stack
+                 :font-size "12px"
+                 :color (:text-primary tokens)
+                 :line-height "1.5"
+                 :padding "12px"}}
+   (if (and (= :same (hd/op-of annotated))
+            (not (hd/changed? annotated)))
+     [:div {:data-testid (str "rf-causa-hydration-pane-no-diff-" (name perspective))
+            :style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "11px"
+                    :font-style "italic"}}
+      (str "No structural difference at this subtree from the "
+           (name perspective) " perspective.")]
+     (render-pane-node annotated perspective surface [] 0))])

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_cljs_test.cljc
@@ -295,3 +295,83 @@
     (let [ev (mismatch-ev 1 [] [:p] [:p])]
       (is (= {:coord nil :annotation nil}
              (h/source-coord-for-mismatch ev))))))
+
+;; ---- (8) Phase 4 (rf2-1mcax) — first-divergent header -------------------
+
+(deftest bisector-path-segments-empty-path-is-root
+  (testing "bisector-path-segments with [] returns one segment — the
+            tree's root tag"
+    (is (= [":div"]
+           (h/bisector-path-segments [:div [:p "hi"]] [])))))
+
+(deftest bisector-path-segments-walks-down-tree
+  (testing "bisector-path-segments walks the bisector path and returns
+            short readable tag strings, one per node"
+    (let [tree [:div
+                [:section
+                 [:p "match"]
+                 [:p [:em "server"]]]]]
+      (is (= [":div" ":section" ":p" ":em"]
+             (h/bisector-path-segments tree [0 1 0]))))))
+
+(deftest bisector-path-segments-renders-id-and-class
+  (testing "bisector-path-segments surfaces :id and :class for readability"
+    (let [tree [:div {:id "app" :class "layout"}
+                [:section {:class "cart"}
+                 [:p "x"]]]]
+      (let [segs (h/bisector-path-segments tree [0 0])]
+        (is (= 3 (count segs)))
+        (is (re-find #"^:div" (first segs)))
+        (is (re-find #"#app" (first segs)))
+        (is (re-find #"\.layout" (first segs)))
+        (is (re-find #":section" (nth segs 1)))
+        (is (re-find #"\.cart" (nth segs 1)))
+        (is (= ":p" (nth segs 2)))))))
+
+(deftest bisector-path-segments-handles-text-leaf
+  (testing "bisector-path-segments walks into a text leaf at the tail"
+    (let [tree [:p "hello"]]
+      (let [segs (h/bisector-path-segments tree [0])]
+        (is (= 2 (count segs)))
+        (is (= ":p" (first segs)))
+        (is (= "\"hello\"" (second segs)))))))
+
+(deftest bisector-path-segments-truncates-long-text
+  (testing "bisector-path-segments truncates long text leaves to keep
+            the header on one line"
+    (let [tree [:p (apply str (repeat 100 "x"))]
+          segs (h/bisector-path-segments tree [0])
+          leaf (second segs)]
+      (is (= ":p" (first segs)))
+      (is (<= (count leaf) 24))
+      (is (re-find #"\.\.\.$" leaf)))))
+
+(deftest first-divergent-header-text-renders-single-line
+  (testing "first-divergent-header-text joins segments with ' > '"
+    (let [tree [:div [:section [:p "x"]]]]
+      (is (= ":div > :section > :p"
+             (h/first-divergent-header-text tree [0 0]))))))
+
+(deftest first-divergent-header-text-empty-path-renders-root
+  (testing "first-divergent-header-text with [] just renders the root"
+    (is (= ":div"
+           (h/first-divergent-header-text [:div [:p "x"]] [])))))
+
+;; ---- (9) pane-diff-input shape ------------------------------------------
+
+(deftest pane-diff-input-shape
+  (testing "pane-diff-input surfaces the slots the per-pane renderer
+            consumes from the mismatch-detail"
+    (let [detail {:server-tree   [:p "3 items"]
+                  :client-tree   [:p "0 items"]
+                  :bisector-path [0]}
+          pane   (h/pane-diff-input detail)]
+      (is (= [:p "3 items"] (:server-tree pane)))
+      (is (= [:p "0 items"] (:client-tree pane)))
+      (is (= [0] (:bisector-path pane))))))
+
+(deftest pane-diff-input-defaults-bisector-path
+  (testing "pane-diff-input defaults missing bisector-path to []"
+    (is (= [] (:bisector-path
+                (h/pane-diff-input {:server-tree [:p]
+                                    :client-tree [:p]}))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs
@@ -361,3 +361,129 @@
         (is (= 1 (count (:mismatch-summary data)))
             "only the :rf/default mismatch surfaces by default")
         (is (= [1] (mapv :id (:mismatch-summary data))))))))
+
+;; ---- (6) Phase 4 (rf2-1mcax) — hiccup-engine adoption -------------------
+;;
+;; Phase 4 of epic rf2-abts7 wires the Phase 3 hiccup-diff micro-engine
+;; into the side-by-side panes. The tests below assert:
+;;   - The first-divergent header surfaces a readable path line.
+;;   - Per-pane render mounts (one container per perspective).
+;;   - Server-only / client-only nodes route through perspective-aware
+;;     chrome — `:added` flips between green-on-client and absent-on-
+;;     server, and the converse for `:removed`.
+;;   - Shared elements surface modified-attr deltas inline.
+
+(deftest view-renders-first-divergent-header
+  (testing "with a mismatch present, the drilldown surfaces the
+            first-divergent header + the readable path line"
+    (seed-buffer! [(mismatch-ev 1 [:div :main]
+                                [:div [:section [:p "3 items"]]]
+                                [:div [:section [:p "0 items"]]])])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/Panel)]
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-first-divergent-header"))
+            "first-divergent header present")
+        (let [path-el (find-by-testid tree
+                                      "rf-causa-hydration-first-divergent-path")
+              txt     (when path-el
+                        (->> (hiccup-seq path-el)
+                             (filter string?)
+                             (apply str)))]
+          (is (some? path-el))
+          (is (re-find #":div.*:section.*:p" txt)
+              "path is rendered with > separators down to the divergent leaf"))))))
+
+(deftest view-renders-perspective-aware-pane-containers
+  (testing "each pane mounts its perspective-aware render container"
+    (seed-buffer! [(mismatch-ev 1 [] [:p "x"] [:p "y"])])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/Panel)]
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-pane-render-server"))
+            "server pane render container present")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-pane-render-client"))
+            "client pane render container present")
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-pane-label-server")))
+        (is (some? (find-by-testid tree
+                                   "rf-causa-hydration-pane-label-client")))))))
+
+(deftest view-surfaces-server-only-element-as-absent-on-client-pane
+  (testing "an element present only on the server renders red on the
+            server pane and as an [absent] chip on the client pane"
+    ;; Server has [:p ...], client has empty subtree at that slot.
+    (seed-buffer! [(mismatch-ev 1 []
+                                [:div [:span "kept"] [:p "server-only"]]
+                                [:div [:span "kept"]])])
+    (rf/with-frame :rf/causa
+      (let [tree         (hydration/Panel)
+            server-pane  (find-by-testid tree
+                                         "rf-causa-hydration-pane-render-server")
+            client-pane  (find-by-testid tree
+                                         "rf-causa-hydration-pane-render-client")
+            client-abs   (find-all-by-testid-prefix
+                           client-pane "rf-causa-hydration-pane-client-absent")]
+        (is (some? server-pane))
+        (is (some? client-pane))
+        (is (pos? (count client-abs))
+            "client pane shows at least one [absent] chip for the server-only :p")))))
+
+(deftest view-surfaces-client-only-element-as-absent-on-server-pane
+  (testing "an element present only on the client mirrors — green on
+            client pane, [absent] chip on server pane"
+    (seed-buffer! [(mismatch-ev 1 []
+                                [:div [:span "kept"]]
+                                [:div [:span "kept"] [:p "client-only"]])])
+    (rf/with-frame :rf/causa
+      (let [tree        (hydration/Panel)
+            server-pane (find-by-testid tree
+                                        "rf-causa-hydration-pane-render-server")
+            server-abs  (find-all-by-testid-prefix
+                          server-pane "rf-causa-hydration-pane-server-absent")]
+        (is (pos? (count server-abs))
+            "server pane shows at least one [absent] chip for the client-only :p")))))
+
+(deftest view-surfaces-modified-attr-on-both-panes
+  (testing "a shared element whose attr differs surfaces a `:modified`
+            row on both panes (each pane shows ITS value with the other
+            value as a faint annotation)"
+    (seed-buffer! [(mismatch-ev 1 []
+                                [:a {:href "/server"} "go"]
+                                [:a {:href "/client"} "go"])])
+    (rf/with-frame :rf/causa
+      (let [tree         (hydration/Panel)
+            server-pane  (find-by-testid tree
+                                         "rf-causa-hydration-pane-render-server")
+            client-pane  (find-by-testid tree
+                                         "rf-causa-hydration-pane-render-client")
+            server-mods  (find-all-by-testid-prefix
+                           server-pane "rf-causa-hydration-attr-modified-")
+            client-mods  (find-all-by-testid-prefix
+                           client-pane "rf-causa-hydration-attr-modified-")]
+        (is (pos? (count server-mods))
+            "server pane surfaces the modified :href row")
+        (is (pos? (count client-mods))
+            "client pane surfaces the modified :href row")))))
+
+(deftest view-no-structural-difference-collapses-to-chip
+  (testing "if the bisector flagged a mismatch but both subtrees are
+            structurally identical after re-rooting, the per-pane
+            renderer shows a 'no structural difference' chip (defensive
+            against malformed traces and re-root edge cases)"
+    ;; Stash two identical trees. The classify-divergence path returns
+    ;; :unknown / nil for equal trees but the panel still mounts the
+    ;; detail.
+    (seed-buffer! [(mismatch-ev 1 []
+                                [:p "same"]
+                                [:p "same"])])
+    (rf/with-frame :rf/causa
+      (let [tree (hydration/Panel)]
+        ;; The chip mounts on at least one pane (both, in this case
+        ;; since the subtrees are equal).
+        (is (or (some? (find-by-testid tree
+                                       "rf-causa-hydration-pane-no-diff-server"))
+                (some? (find-by-testid tree
+                                       "rf-causa-hydration-pane-no-diff-client")))
+            "no-difference chip surfaces when both subtrees match")))))


### PR DESCRIPTION
## Summary

Phase 4 of the structural-diff epic (**rf2-abts7**) — **the epic now ships complete**. The hydration debugger's side-by-side panes adopt the Phase 3 hiccup-diff micro-engine for per-pane annotation, replacing the raw `pr-str` rendering that landed in the Phase 5 panel ship (rf2-pzxsr).

Closes the structural-diff vision per [`tools/causa/spec/006-Hydration-Debugger.md`](../blob/main/tools/causa/spec/006-Hydration-Debugger.md) §Layout + §Render-tree hash bisector and the hero SSR feature called out in [`tools/causa/spec/019-Cross-Cutting-Insight.md`](../blob/main/tools/causa/spec/019-Cross-Cutting-Insight.md) §2.3.

## Bug class quoted

> Body / head hydration mismatch. The server-rendered tree and the client first-render tree disagree at a node. The `:rf.ssr/hydration-mismatch` trace fires with `:first-diff-path`. The console error is one line; the divergent node is rarely the one the error points to. SSR debugging is **uniformly opaque** in every framework — React's "hydration error" message tells you a node mismatched but gives you nothing about WHY the upstream state diverged.
>
> — `tools/causa/spec/006-Hydration-Debugger.md` §Bug class

The Phase 4 panel now answers WHERE (bisector path), WHAT (per-pane structural diff with attr-level granularity), and points toward WHY (hypothesis row + deferred sub-attribution).

## Side-by-side panes

```
┌─ FIRST DIVERGENT :div.app > :section.cart > :p     in cart-summary-view ─┐
├──────────────────────────────────────────────────────────────────────────┤
│ HYPOTHESIS  App-db state differs between server and client.              │
│             Check the slice that feeds this view.   (different-text)     │
├──────────────────────────────────────────────────────────────────────────┤
│ Divergent view: cart-summary-view  Registered at: src/cart/views.cljs:42 │
├──────────────────────────────────────────────────────────────────────────┤
│                              ⚠ Divergent node                            │
├─────────────── server render ────────────────┬───── client render ───────┤
│  #abc                                        │ #def                      │
│  [:div]                                      │ [:div]                    │
│  │ [:section.cart]                           │ │ [:section.cart]         │
│  │ │ [:p]                                    │ │ │ [:p]                  │
│  │ │ │ - "3 items"   (client: "0 items")     │ │ │ │ "0 items"  (server: │
│  │ │                                         │ │ │ │            "3 items")
│  │ │ [:button "Checkout"]                    │ │ │ [:button "Checkout"]  │
│  │ │   [absent on this side · was            │ │ │   {:on-click ...}     │
│  │ │    {:on-click ...}]    (server pane)    │ │ │   (client-only attr)  │
└──────────────────────────────────────────────┴───────────────────────────┘
```

Each pane consumes the SAME annotated tree from `diff.hiccup/diff-hiccup-node`; the new `hydration-pane-render/render-pane` walks the diff with a `:perspective` flag (`:server` or `:client`) and flips `:added` ↔ `:removed` semantics so the eye reads "this side has this, the other side does not." Modified attrs surface inline on both panes with the other-side's value as a faint annotation. The fn-prop opaque rule from Phase 3 §4.5 applies uniformly — `:rf.causa/diff-opts` is now the shared toggle state for Views + Hydration.

## New + modified files

**New**

- `tools/causa/src/day8/re_frame2_causa/panels/hydration_pane_render.cljs` (473 LoC) — perspective-aware hiccup-diff renderer for hydration side-by-side panes.

**Modified**

- `tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger.cljs` (+193 / -54) — drops `pr-str` tree rendering; wires the hiccup engine + per-pane renderer + first-divergent header + shared `:rf.causa/diff-opts` toggle.
- `tools/causa/src/day8/re_frame2_causa/panels/hydration_debugger_helpers.cljc` (+104) — new `bisector-path-segments`, `first-divergent-header-text`, `pane-diff-input` helpers. Pure data → data, JVM-runnable.
- `tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_cljs_test.cljc` (+80) — 9 new helper tests covering the bisector header + pane-diff-input shape.
- `tools/causa/test/day8/re_frame2_causa/panels/hydration_debugger_view_cljs_test.cljs` (+126) — 6 new view tests covering first-divergent header, per-pane perspective rendering, server-only / client-only / modified-attr cases, no-difference chip.

## Deferred — sub-attribution (rf2-sg8xe)

Per the bead's divergence allowance, sub-attribution defers behind a substrate change: the SSR pipeline does not yet emit per-side `:rf.ssr/sub-run` traces during hydration, so the panel cannot match server-side sub-runs against client-side sub-runs by `[sub-id query-v]` yet. Filed **rf2-sg8xe** (blocked on rf2-1mcax) to track once Spec 011 extends with the per-side trace.

## Epic rf2-abts7 — complete

- Phase 1 (PR #1426): annotated-tree walker + section-grouping.
- Phase 2 (PR #1430): sub-output diff in Views (95% Phase 1 reuse).
- Phase 3 (PR #1434): hiccup micro-engine + opt-in fn-ref toggle.
- **Phase 4 (this PR): hydration debugger adopts hiccup engine.**

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS (572 core-JVM + 3128 CLJS-node tests, 0 failures)
- [x] `cd tools/causa && clojure -M:test` — PASS (923 tests, 2671 assertions, 0 failures; +9 new helper assertions over Phase 5 baseline)
- [x] `cd implementation && npm run test:browser` — PASS (3119 tests, 8900 assertions, 0 failures)
- [x] `npm run test:bundle-isolation` — PASS (Causa stays out of production bundles)