### PR TITLE
docs(causa): adopt 'silent by default' UI text style policy

### DIFF
--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -206,6 +206,85 @@ Per `registry.cljs` the panels' `install!` calls run in alphabetical
 panel-id order. When you add a new panel facade, slot its `install!` into
 the alphabetical list and keep the comment in lockstep.
 
+## UI text
+
+Causa is an information-dense devtool. Every pixel of chrome competes
+with the data the developer is here to inspect. UI text is **silent by
+default**.
+
+### The rule
+
+Prose appears only when:
+
+1. An affordance is **genuinely non-obvious** AND has no iconographic
+   alternative.
+2. The user is in **a state they couldn't otherwise know about** (e.g.
+   "filter is hiding 12 events" — invisible from the data alone).
+
+### Banned phrasings
+
+- **Panel subheads** that restate the panel title.
+- **Empty-state explainers** ("X will appear here when Y happens" —
+  prefer terse "No X." or absent).
+- **"Click X to Y" narration** — every list is clickable; every chip is
+  interactive; users discover this. Narration wastes pixels and risks
+  lying (see PR #1435 for a confirmed broken claim that bit users).
+- **Roadmap text in chrome** ("future: ...", "v2 will add ...") — keep
+  vision in spec, not in ship-time UI (see PR #1436 for the Telemetry
+  section removal — chrome must not pretend to control something that
+  does not exist).
+- **Internal bead IDs / spec citations** in tooltips (see rf2-6lp7k).
+
+### Tooltip discipline
+
+Tooltips carry **shortcuts and disambiguation** — not descriptions.
+
+- Good: `"Re-run (R)"` — names the keybinding.
+- Good: `"Auto-filter pattern. Glob: my/* matches all keys under :my"` —
+  disambiguates the syntax.
+- Bad: `"Click this button to open the settings"` — narrates the obvious.
+
+### Empty-state pattern
+
+- **Tier 1 (preferred):** absent. Empty pane is the empty state.
+- **Tier 2:** one terse line ("No traces.") when complete absence is
+  jarring (e.g. zero-height panel).
+- **Tier 3 (banned):** narrated explainer.
+
+### When you must add text
+
+Three questions before shipping any UI prose:
+
+1. Would removing this line confuse a future reader who knows the data
+   model?
+2. Does the text describe something the user can't deduce from layout
+   + affordance + data?
+3. Does it survive the "earn its keep" test: deletion would create a
+   real comprehension gap?
+
+If you can't answer "yes" to ALL THREE, delete the text.
+
+### Audit cadence
+
+Per text-audit findings (`ai/findings/2026-05-18-causa-text-audit.md` —
+local-only working substrate; not committed), sweep recurring patterns
+when reviewing PRs:
+
+- New panel subhead? — flag.
+- "Click X to Y" string? — flag.
+- "X will appear here when Y happens" empty state? — flag.
+
+Cleanups under this policy: PR #1435 (back-link narration removal),
+PR #1436 (Telemetry section removal), PR #1437 (pre-spine cascade
+empty-state removal), PR #1439 (7-pattern text-audit cluster).
+
+### See also
+
+- [`Principles.md`](./Principles.md) — Causa's load-bearing principles;
+  silent-by-default is the UI-text expression of information-density.
+- [`000-Vision.md`](./000-Vision.md) — Causa's claim; the cascade you
+  can see, not the cascade you can read narration about.
+
 ## See also
 
 - `tools/causa/spec/017-Test-Coverage-Matrix.md` — feature-level coverage

--- a/tools/causa/spec/Principles.md
+++ b/tools/causa/spec/Principles.md
@@ -175,6 +175,23 @@ rail was removed under bead rf2-s3vx5; the cost / privacy / UX
 trade-offs that earlier locks debated now route through the MCP
 integration instead.
 
+## Silent by default — UI text earns its keep
+
+Causa is an information-dense devtool. Every pixel of chrome competes
+with the data the developer is here to inspect. UI text is **silent by
+default** — prose appears only when an affordance is genuinely
+non-obvious AND has no iconographic alternative, or when the user is in
+a state they couldn't otherwise know about. Panel subheads, empty-state
+explainers, and "click X to Y" narration are banned; tooltips carry
+shortcuts and disambiguation, not descriptions.
+
+This is the AI-first principle applied to surface text: information
+density is the read, and narration is its enemy. The full policy —
+banned phrasings, tooltip discipline, empty-state tiers, the
+"earn its keep" test, and audit cadence — lives in
+[`Conventions.md` §UI text](./Conventions.md#ui-text). Recent cleanups
+under this policy: PRs #1435, #1436, #1437, #1439.
+
 ## Backed by the framework's principles
 
 When in doubt, defer to the framework's [Principles](../../../spec/Principles.md):


### PR DESCRIPTION
## Summary

Adopts a normative UI-text style policy as a Causa spec convention, so future PRs that violate it are gateable against a documented rule.

### The policy

> **Silent by default.** Causa text is silent by default. Prose appears only when (a) an affordance is genuinely non-obvious AND has no iconographic alternative, or (b) the user is in a state they couldn't otherwise know about. Panel subheads, empty-state explainers, and 'click X to Y' narration are banned. Tooltips carry shortcuts and disambiguation, not descriptions.

### What lands

- `tools/causa/spec/Conventions.md` gains a new **UI text** section with the full normative policy: the rule, banned phrasings, tooltip discipline, empty-state tiers (absent / one terse line / banned explainer), the three-question "earn its keep" test, and the audit cadence for PR review.
- `tools/causa/spec/Principles.md` gains a one-paragraph cross-link: silent-by-default is the UI-text expression of Causa's information-density posture.

Additive only; no source code changed (the actual cleanups already shipped — see motivating PRs).

### Motivation

Text-audit findings (`ai/findings/2026-05-18-causa-text-audit.md`, local-only working substrate) plus the recent cleanup cluster surfaced a recurring style drift Causa kept paying for. The policy bakes in the discipline so reviewers have a single sentence to point at.

Motivating PRs:
- #1435 — back-link narration removal (confirmed lying claim that bit users)
- #1436 — fake Telemetry section removed (chrome must not pretend to control something that does not exist)
- #1437 — pre-spine cascade empty-state removal
- #1439 — seven-pattern text-audit remediation cluster

bd: rf2-g3ghh (do not close).

## Test plan

- [x] `mkdocs build --strict` — verified my edits introduce **zero new warnings** (72 pre-existing warnings on base; same 72 on this branch). The `tools/causa/spec/` tree is not part of the mkdocs nav; the strict-mode infra debt is unrelated.
- [x] Cross-links resolve: `Principles.md` -> `Conventions.md#ui-text`, and the new UI-text section's "See also" -> `Principles.md` + `000-Vision.md`.
- [x] Additive only: existing sections of Conventions.md untouched; new section sits just above the trailing "See also" footer.