### PR TITLE
fix(causa): tune Machine Inspector chart font size — labels were too large

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -225,22 +225,28 @@
              :stroke stroke
              :stroke-width stroke-w}]
      ;; Label
+     ;; rf2-isgqu — state-label tuned 12 → 11 so labels stop swamping
+     ;; the chart and match the surrounding L4 detail rhythm. Vertical
+     ;; baseline tweak (+4 → +3) keeps the glyphs visually centred at
+     ;; the smaller size.
      [:text {:x (+ x (quot width 2))
-             :y (+ y (quot height 2) 4)
+             :y (+ y (quot height 2) 3)
              :text-anchor "middle"
              :font-family font-stack
-             :font-size 12
+             :font-size 11
              :font-weight (if active? 600 400)
              :fill (if active?
                      (:text-primary tokens/tokens)
                      (:text-secondary tokens/tokens))}
       label]
      ;; Final-state check glyph
+     ;; rf2-isgqu — track the state-label tune (11 → 10) so the corner
+     ;; check scales with its neighbour.
      (when final?
        [:text {:x (+ x width -10)
                :y (+ y 14)
                :font-family font-stack
-               :font-size 11
+               :font-size 10
                :fill (:green tokens/tokens)}
         "✓"])]))
 
@@ -321,18 +327,22 @@
              :marker-end marker}]
      (when (seq full-label)
        [:g
+        ;; rf2-isgqu — edge-label tuned 10 → 9 (keeps state > edge by
+        ;; ~2px so the visual hierarchy still reads). Pill geometry
+        ;; shrinks proportionally: 4/8 → 3.5/7 char-width, height
+        ;; 14 → 12, vertical offset 9 → 8 to match the smaller glyph.
         ;; Background pill for legibility
-        [:rect {:x (- lx (* 4 (count full-label)))
-                :y (- ly 9)
-                :width (* 8 (count full-label))
-                :height 14
+        [:rect {:x (- lx (long (* 3.5 (count full-label))))
+                :y (- ly 8)
+                :width (* 7 (count full-label))
+                :height 12
                 :rx 3
                 :fill (:bg-2 tokens/tokens)
                 :opacity 0.85}]
         [:text {:x lx :y (+ ly 1)
                 :text-anchor "middle"
                 :font-family font-stack
-                :font-size 10
+                :font-size 9
                 :fill (:text-secondary tokens/tokens)}
          full-label]])]))
 


### PR DESCRIPTION
## Bug

rf2-isgqu — Mike: 'the font size used in the diagram in the machines tab is way too big.' Causa is information-dense; the chart's state-node labels and edge-event labels were swamping the diagram, breaking the L4 detail rhythm of the surrounding panel chrome.

## Fix

Tuned the three font-sizes in `tools/causa/src/day8/re_frame2_causa/chart/svg.cljc`:

| Element                  | Before | After | Notes                                            |
|--------------------------|--------|-------|--------------------------------------------------|
| State-node label         | 12     | 11    | Primary glyph; baseline +4 → +3 to recentre.     |
| Final-state check glyph  | 11     | 10    | Tracks state-label down a step.                  |
| Edge-event label         | 10     | 9     | Floor; visual hierarchy still reads (state > edge by 2px). |
| Compound title strip     | 10     | 10    | Already at the small end; left alone.            |

Edge-label background pill shrinks proportionally so it still hugs the (now smaller) glyph:

- char-width assumption  4 / 8 → 3.5 / 7
- pill height            14   → 12
- vertical offset        −9   → −8

## ELK / layout sync

`elk.layout.nodeSize.fixedGraphSize` and friends are NOT in play — the layout layer uses pinned constants (`node-width 140`, `node-height 48` in both `layout.cljc` and `elk_layout.cljs`). Nothing in the layout pipeline reads font-size to estimate node sizes, so shrinking the rendered font does not leave nodes over-padded. No layout-side change required.

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass (3113 tests / 8912 assertions, 0 failures).
- [x] `cd tools/causa && clojure -M:test` — pass (914 tests / 2650 assertions, 0 failures).
- [x] `cd implementation && npm run test:browser` — pass (3104 tests / 8865 assertions, 0 failures).
- [x] No existing test asserts on the literal font-size numerics, so the snapshot story is untouched.
- [ ] Visual smoke recommended: render `gallery_machines` variants in the panel-gallery and eyeball legibility of state + edge labels.

## Acceptance (per bead)

- State labels now read at the L4 detail rhythm (matches surrounding panel chrome). ✅
- Edge labels slightly smaller; legible (9px floor). ✅
- No regression on the cluster Mode C overlay (sparkline + count badges live in `chart/svg.cljc`'s `sparkline` fn, untouched by this change). ✅

Bead `rf2-isgqu` stays open per the dispatch brief — Mike to close after eyeballing.