### PR TITLE
feat(story): multi-play — named scripts per story + run-all

### DIFF
--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -1,32 +1,41 @@
 #!/usr/bin/env node
 /*
- * Story `:play-script` CI-as-test runner (rf2-3qcxk).
+ * Story `:play-script` CI-as-test runner (rf2-3qcxk + rf2-tl7zk).
  *
  * Compiles the counter-with-stories Story testbed, serves it, opens
  * the Story shell in Playwright, enumerates every registered variant
- * whose body carries a non-empty `:play-script` (via the
- * `window.__rf2_story_ci` global installed by
+ * whose body carries a non-empty `:play-script` or `:plays` slot (via
+ * the `window.__rf2_story_ci` global installed by
  * `re-frame.story.play.ci-runner/install-ci-hooks!`), navigates the
- * shell to each variant, waits for the auto-run's terminal status
- * chip (`:pass` / `:fail`), and prints a per-variant report.
+ * shell to each variant, waits for each play's terminal status
+ * (`:pass` / `:fail`), and prints a per-play report.
+ *
+ * rf2-tl7zk multi-play
+ * --------------------
+ * The runner consumes `ciContext().rows` — one row per PLAY. A variant
+ * declaring `:plays` of size N produces N rows; a single-script
+ * `:play-script` variant produces ONE row. The runner navigates once
+ * per variant, then triggers each non-auto-run play via the CI hook's
+ * `runPlay(variantId, playKey)` entry-point. Per-play terminal state
+ * is read via `readPlayRunState(variantId, playKey)`.
  *
  * EXPECTED-FAIL contract
  * ----------------------
- * Authoring a deliberately-failing variant is the normal way to gate
- * Story's failure path under CI. The runner reads the expected status
- * from the per-variant body via the CI hook's `ciContext()` and
- * inverts the assertion accordingly:
+ * Authoring a deliberately-failing variant / play is the normal way
+ * to gate Story's failure path under CI. The runner reads the expected
+ * status from the variant id AND the play key — either token can mark
+ * the row as expected-fail:
  *
- *   - any variant id whose name contains `failing` / `expected-fail`
+ *   - any variant id or play-key containing `failing` / `expected-fail`
  *     is treated as expected-fail; the runner asserts `:fail`
  *   - everything else asserts `:pass`
  *
- * The two seeded fixtures in the testbed:
- *   :story.counter-play-script/passing   → expects :pass
- *   :story.counter-play-script/failing   → expects :fail
+ * The seeded fixtures in the testbed:
+ *   :story.counter-play-script/passing            → expects :pass
+ *   :story.counter-play-script/failing            → expects :fail
  *
- * Exit code: 0 if every variant matched its expected status; 1 if
- * any variant deviated.
+ * Exit code: 0 if every play matched its expected status; 1 if any
+ * play deviated.
  */
 
 'use strict';
@@ -117,17 +126,23 @@ function stageTestbedHtml() {
 }
 
 /**
- * Classify the expected terminal status for a variant id. Authors mark
- * a fixture as expected-fail by including `failing` or `expected-fail`
- * in the variant name; everything else defaults to expected-pass.
+ * Classify the expected terminal status for a (variant-id, play-key)
+ * pair. Authors mark a fixture as expected-fail by including `failing`
+ * or `expected-fail` in the variant id OR the play's :name; everything
+ * else defaults to expected-pass.
  *
  * Symmetric with re-frame.story.play.ci-runner/play-script-summary:
- * the classification is over the variant id, not body content, so the
+ * the classification is over identifiers (not body content), so the
  * runner can pre-compute the verdict before the Story shell boots.
+ *
+ * rf2-tl7zk: accepts an optional `playKey` so multi-play rows can
+ * mark a specific play as expected-fail without forcing the entire
+ * variant id to carry the marker.
  */
-function expectedStatusFor(variantId) {
-  const name = String(variantId).toLowerCase();
-  if (/(?:failing|expected[-_]fail)/.test(name)) return 'fail';
+function expectedStatusFor(variantId, playKey) {
+  const re = /(?:failing|expected[-_]fail)/;
+  if (re.test(String(variantId).toLowerCase())) return 'fail';
+  if (playKey && re.test(String(playKey).toLowerCase())) return 'fail';
   return 'pass';
 }
 
@@ -178,6 +193,24 @@ async function readRunStateOnce(page, variantId) {
   }, variantIdToKw(variantId));
 }
 
+/**
+ * rf2-tl7zk: per-play state read for multi-play rows.
+ */
+async function readPlayRunStateOnce(page, variantId, playKey) {
+  return page.evaluate(
+    ({ vid, pk }) => {
+      const ci = window.__rf2_story_ci;
+      if (!ci || typeof ci.readPlayRunState !== 'function') return null;
+      try {
+        return ci.readPlayRunState(vid, pk || '');
+      } catch (e) {
+        return { error: String(e && e.message ? e.message : e) };
+      }
+    },
+    { vid: variantIdToKw(variantId), pk: playKey || '' },
+  );
+}
+
 async function waitForTerminalState(page, variantId) {
   const deadline = Date.now() + TERMINAL_TIMEOUT_MS;
   let last = null;
@@ -189,6 +222,42 @@ async function waitForTerminalState(page, variantId) {
     await new Promise((r) => setTimeout(r, 100));
   }
   return last;
+}
+
+/**
+ * rf2-tl7zk: wait for the per-(variantId, playKey) terminal state.
+ */
+async function waitForPlayTerminalState(page, variantId, playKey) {
+  const deadline = Date.now() + TERMINAL_TIMEOUT_MS;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await readPlayRunStateOnce(page, variantId, playKey);
+    if (last && (last.status === 'pass' || last.status === 'fail')) {
+      return last;
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return last;
+}
+
+/**
+ * rf2-tl7zk: trigger a specific play to run. The CI hook's `runPlay`
+ * picks the spec off the variant body and drives the runner.
+ */
+async function triggerPlay(page, variantId, playKey) {
+  return page.evaluate(
+    ({ vid, pk }) => {
+      const ci = window.__rf2_story_ci;
+      if (!ci || typeof ci.runPlay !== 'function') return false;
+      try {
+        ci.runPlay(vid, pk || '');
+        return true;
+      } catch (e) {
+        return false;
+      }
+    },
+    { vid: variantIdToKw(variantId), pk: playKey || '' },
+  );
 }
 
 async function discoverVariants(page) {
@@ -238,7 +307,10 @@ function summariseResults(results) {
   for (const r of results) {
     const tag = r.matched ? 'OK  ' : 'MISS';
     const actual = (r.runState && r.runState.status) || 'no-state';
-    lines.push(`${tag} ${r.variantId}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`);
+    const playLabel = r.playKey ? `[${r.playKey}]` : '';
+    lines.push(
+      `${tag} ${r.variantId}${playLabel}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`,
+    );
     if (!r.matched) {
       const fails = (r.runState && r.runState.results) || [];
       for (const stepR of fails) {
@@ -250,9 +322,23 @@ function summariseResults(results) {
   }
   lines.push('');
   lines.push(
-    `Ran ${results.length} :play-script variants. ${failures.length} unexpected outcomes.`,
+    `Ran ${results.length} :play-script row(s). ${failures.length} unexpected outcomes.`,
   );
   return { lines: lines.join('\n'), failures };
+}
+
+/**
+ * rf2-tl7zk: group ci-rows by variant id so we navigate ONCE per
+ * variant and then drive each row's play locally.
+ */
+function groupRowsByVariant(rows) {
+  const grouped = new Map();
+  for (const row of rows) {
+    const vid = row['variant-id'];
+    if (!grouped.has(vid)) grouped.set(vid, []);
+    grouped.get(vid).push(row);
+  }
+  return grouped;
 }
 
 async function runAllVariants(browser, baseUrl) {
@@ -273,42 +359,75 @@ async function runAllVariants(browser, baseUrl) {
       throw new Error(`variant discovery failed: ${discovery.error || JSON.stringify(discovery)}`);
     }
     const variants = discovery.variants;
-    log(`Discovered ${variants.length} variant(s) with :play-script`);
+    // rf2-tl7zk: prefer the per-play `rows` enumeration; fall back to
+    // the legacy per-variant shape when the CI hook is older.
+    const rows =
+      discovery.context && Array.isArray(discovery.context.rows)
+        ? discovery.context.rows
+        : variants.map((vid) => ({ 'variant-id': vid, 'play-key': null, name: null }));
+    log(
+      `Discovered ${variants.length} variant(s) with :play-script / :plays — ${rows.length} play row(s) total`,
+    );
     if (VERBOSE) {
-      for (const s of (discovery.context && discovery.context.summaries) || []) {
-        log(`  - ${s['variant-id']}  steps=${s['script-len']}  name=${s.name || '(unnamed)'}`);
+      for (const r of rows) {
+        log(
+          `  - ${r['variant-id']}  play=${r['play-key'] || '(default)'}  steps=${r['script-len']}  auto=${r['auto-run?']}`,
+        );
       }
     }
-    if (variants.length === 0) {
-      // No fixtures with :play-script — exit clean. The npm gate
-      // is fail-loud only on UNEXPECTED outcomes; zero variants
-      // means no signal either way.
-      log('No :play-script variants registered. Nothing to assert.');
+    if (rows.length === 0) {
+      // No fixtures with :play-script / :plays — exit clean. The npm gate
+      // is fail-loud only on UNEXPECTED outcomes; zero rows means no
+      // signal either way.
+      log('No :play-script / :plays rows registered. Nothing to assert.');
       return 0;
     }
 
     const results = [];
-    for (const vid of variants) {
-      const expected = expectedStatusFor(vid);
+    const grouped = groupRowsByVariant(rows);
+    for (const [vid, variantRows] of grouped.entries()) {
+      let navOk = true;
       try {
         await navigateToVariant(page, baseUrl, vid);
       } catch (err) {
+        navOk = false;
+        for (const row of variantRows) {
+          results.push({
+            variantId: vid,
+            playKey: row['play-key'],
+            expected: expectedStatusFor(vid, row['play-key']),
+            matched: false,
+            runState: { status: 'navigate-error', message: err.message },
+          });
+        }
+      }
+      if (!navOk) continue;
+
+      // For each play row on this variant: if it auto-ran, just wait
+      // for the terminal state; otherwise, trigger it then wait.
+      for (const row of variantRows) {
+        const playKey = row['play-key'];
+        const expected = expectedStatusFor(vid, playKey);
+
+        if (!row['auto-run?']) {
+          // Manual play — trigger it explicitly. The CI hook routes
+          // through runner-events/run-play! which sets the active
+          // play + drives the runner; we read per-play state below.
+          await triggerPlay(page, vid, playKey);
+        }
+
+        const runState = playKey
+          ? await waitForPlayTerminalState(page, vid, playKey)
+          : await waitForTerminalState(page, vid);
+        const actual = (runState && runState.status) || null;
         results.push({
           variantId: vid,
+          playKey,
           expected,
-          matched: false,
-          runState: { status: 'navigate-error', message: err.message },
+          matched: actual === expected,
+          runState,
         });
-        continue;
       }
-      const runState = await waitForTerminalState(page, vid);
-      const actual = (runState && runState.status) || null;
-      results.push({
-        variantId: vid,
-        expected,
-        matched: actual === expected,
-        runState,
-      });
     }
 
     const { lines, failures } = summariseResults(results);

--- a/tools/story/src/re_frame/story/play/ci_runner.cljc
+++ b/tools/story/src/re_frame/story/play/ci_runner.cljc
@@ -65,18 +65,36 @@
       (map? body)    (pos? (count (:script body [])))
       :else          false)))
 
+(defn has-plays?
+  "True iff `variant-body` carries a non-empty `:plays` vector.
+  rf2-tl7zk multi-play. Pure data → data."
+  [variant-body]
+  (let [plays (:plays variant-body)]
+    (boolean (and (vector? plays) (pos? (count plays))))))
+
+(defn has-any-play?
+  "True iff `variant-body` carries EITHER a non-empty `:play-script`
+  or a non-empty `:plays` vector. rf2-tl7zk multi-play."
+  [variant-body]
+  (or (has-play-script? variant-body)
+      (has-plays? variant-body)))
+
 (defn variants-with-play-scripts
   "Return a SORTED vector of variant ids whose body carries a non-empty
-  `:play-script` slot. Pure data → data; reads the Story registrar's
-  variant side-table.
+  `:play-script` or `:plays` slot. Pure data → data; reads the Story
+  registrar's variant side-table.
 
   Sorted so the CI runner walks variants in a deterministic order —
-  helpful when comparing run logs across runs / branches."
+  helpful when comparing run logs across runs / branches.
+
+  rf2-tl7zk: the name kept its `play-scripts` plural for back-compat;
+  it now includes `:plays`-carrying variants too. The CI runner uses
+  `ci-rows` to enumerate per-PLAY rows."
   ([]
    (variants-with-play-scripts (registrar/registrations :variant)))
   ([variant-registrations]
    (->> variant-registrations
-        (filter (fn [[_ body]] (has-play-script? body)))
+        (filter (fn [[_ body]] (has-any-play? body)))
         (map first)
         (sort)
         (vec))))
@@ -89,23 +107,72 @@
       {:variant-id <kw>
        :name       <string or nil>     ; from `:play-script` `:name`
        :script-len <int>               ; number of steps (post-coerce)
-       :auto-run?  <bool>}"
+       :auto-run?  <bool>}
+
+  rf2-tl7zk: for variants carrying `:plays` (multi-play), the summary
+  reports the FIRST play (the toolbar's default selection). Use
+  `ci-rows` for the per-play enumeration."
   [variant-id]
-  (let [body (registrar/handler-meta :variant variant-id)
-        spec (runner/parse-spec (:play-script body))]
+  (let [body  (registrar/handler-meta :variant variant-id)
+        plays (runner/variant-body->plays body)
+        spec  (or (first plays)
+                  ;; Defensive: no play surface registered — return the
+                  ;; empty-script shape (mirrors the historical contract).
+                  (runner/parse-spec nil))]
     {:variant-id variant-id
      :name       (:name spec)
      :script-len (count (:script spec))
      :auto-run?  (boolean (:auto-run? spec))}))
 
+(defn ci-rows
+  "rf2-tl7zk multi-play: enumerate the CI runner's per-row catalogue.
+  Each row is one play; a variant with `:plays` of size N yields N
+  rows; a single-script `:play-script` variant yields ONE row.
+
+  Pure data → data.
+
+  Shape (one entry per row):
+      {:variant-id <kw>
+       :play-key   <string or nil>     ; play's :name (nil for legacy)
+       :name       <string or nil>     ; same as :play-key, for parity
+       :script-len <int>
+       :auto-run?  <bool>}
+
+  The CI runner uses this to drive one Playwright assertion per row.
+  Stable order: variants sorted alphabetically, plays in declaration
+  order within each variant."
+  ([]
+   (ci-rows (registrar/registrations :variant)))
+  ([variant-registrations]
+   (let [vids (variants-with-play-scripts variant-registrations)]
+     (vec
+       (mapcat
+         (fn [vid]
+           (let [body  (get variant-registrations vid)
+                 plays (runner/variant-body->plays body)]
+             (map (fn [spec]
+                    {:variant-id vid
+                     :play-key   (:name spec)
+                     :name       (:name spec)
+                     :script-len (count (:script spec))
+                     :auto-run?  (boolean (:auto-run? spec))})
+                  plays)))
+         vids)))))
+
 (defn ci-context
-  "Build the full CI catalogue: every variant with a `:play-script`
+  "Build the full CI catalogue: every variant with a play surface
   paired with its summary metadata. Pure data → data. Used by the
-  Playwright runner via `install-ci-hooks!`."
+  Playwright runner via `install-ci-hooks!`.
+
+  rf2-tl7zk multi-play: adds `:rows` — the per-play enumeration the
+  multi-play runner uses to drive its per-play assertions. The legacy
+  `:summaries` keeps the per-VARIANT shape (first play of multi-play)
+  for back-compat with consumers that haven't migrated."
   []
   (let [vids (variants-with-play-scripts)]
-    {:variants vids
-     :summaries (mapv play-script-summary vids)}))
+    {:variants  vids
+     :summaries (mapv play-script-summary vids)
+     :rows      (ci-rows)}))
 
 ;; ---- terminal-state helpers ---------------------------------------------
 
@@ -183,18 +250,57 @@
      (->js (ci-context))))
 
 #?(:cljs
+   (defn- ->variant-id
+     "Coerce a `variant-id-str` of the form `\"story.foo/bar\"` back into
+     the keyword `:story.foo/bar`."
+     [variant-id-str]
+     (let [s (str variant-id-str)
+           slash (.indexOf s "/")]
+       (if (pos? slash)
+         (keyword (subs s 0 slash) (subs s (inc slash)))
+         (keyword s)))))
+
+#?(:cljs
    (defn- read-run-state-js
      "Read the current `:rf.story.play/run-state` slot for `variant-id`
      (passed as a fully-qualified string) and return the projected
-     shape as JSON-safe JS. Returns nil when no run has been started."
+     shape as JSON-safe JS. Returns nil when no run has been started.
+
+     rf2-tl7zk: this reads the LATEST run-state for the variant —
+     whichever play was most recently driven. CI runners that want a
+     specific play's outcome should use `readPlayRunState`."
      [variant-id-str]
-     (let [vid   (let [s (str variant-id-str)
-                       slash (.indexOf s "/")]
-                   (if (pos? slash)
-                     (keyword (subs s 0 slash) (subs s (inc slash)))
-                     (keyword s)))
+     (let [vid   (->variant-id variant-id-str)
            state (runner-events/current-state vid)]
        (->js (project-state state)))))
+
+#?(:cljs
+   (defn- read-play-run-state-js
+     "rf2-tl7zk multi-play: read the per-(variant, play-key) run state.
+     `play-key-str` is the play's `:name` string, or null/empty for the
+     single-script `:play-script` slot. Returns the projected JSON-safe
+     shape, or nil when no run has been started for that play."
+     [variant-id-str play-key-str]
+     (let [vid (->variant-id variant-id-str)
+           pk  (when (and play-key-str
+                          (not= "" play-key-str))
+                 (str play-key-str))
+           state (runner-events/current-state-for-play vid pk)]
+       (->js (project-state state)))))
+
+#?(:cljs
+   (defn- run-play-js
+     "rf2-tl7zk multi-play: trigger a run for `(variant-id, play-key)`.
+     Used by the CI runner when the auto-run default doesn't fire the
+     intended play (e.g. the second play of a multi-play variant whose
+     `:auto-run?` defaults to false)."
+     [variant-id-str play-key-str]
+     (let [vid (->variant-id variant-id-str)
+           pk  (when (and play-key-str
+                          (not= "" play-key-str))
+                 (str play-key-str))]
+       (runner-events/run-play! vid pk)
+       nil)))
 
 #?(:cljs
    (defn install-ci-hooks!
@@ -206,11 +312,18 @@
      on a CI-only init path (e.g. a testbed's `core/run` checks
      `window.location.search` for a `ci=1` flag, or simply always
      install when re-frame.story.config/enabled? is true since the
-     hook is inert until polled)."
+     hook is inert until polled).
+
+     rf2-tl7zk multi-play: the hook object grows two new entry points:
+     - `readPlayRunState(variantId, playKey)` — per-play state read.
+     - `runPlay(variantId, playKey)` — trigger a run for a specific
+       play (used by the CI runner for non-auto-run plays)."
      []
      (let [hooks (js-obj
-                   "listVariants" list-variants-js
-                   "ciContext"    ci-context-js
-                   "readRunState" read-run-state-js)]
+                   "listVariants"     list-variants-js
+                   "ciContext"        ci-context-js
+                   "readRunState"     read-run-state-js
+                   "readPlayRunState" read-play-run-state-js
+                   "runPlay"          run-play-js)]
        (aset js/window "__rf2_story_ci" hooks)
        nil)))

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -199,6 +199,109 @@
     (cond-> {:script script :auto-run? auto-run?}
       nm (assoc :name nm))))
 
+;; ---- :plays multi-play resolution (rf2-tl7zk) ----------------------------
+
+(defn- parse-named-play
+  "Normalise ONE `:plays` entry. Auto-run defaults differ for the first
+  vs subsequent plays — the first entry mirrors the single-play default
+  (auto-run? true) so deep-linking to a multi-play variant 'just works';
+  subsequent entries default to false so the page doesn't run every
+  scenario back-to-back on mount."
+  [first? entry]
+  (let [script    (coerce-script (get entry :script []))
+        auto-run? (if (contains? entry :auto-run?)
+                    (boolean (:auto-run? entry))
+                    first?)
+        nm        (when-let [n (:name entry)] (str n))]
+    (cond-> {:script script :auto-run? auto-run?}
+      nm (assoc :name nm))))
+
+(defn parse-plays
+  "Normalise a `:plays` vector into a vector of `{:script :auto-run?
+  :name}` maps. Pure data → data.
+
+  Each entry is run through the same coercion as `parse-spec` so bare
+  event vectors lift to `[:dispatch ...]`, and `:auto-run?` defaults to
+  true for the FIRST entry / false for the rest (matching the
+  single-play `:play-script` deep-link behaviour). Authors override
+  the per-play default by setting `:auto-run?` explicitly."
+  [plays]
+  (let [v (cond
+            (nil?    plays) []
+            (vector? plays) plays
+            :else           [])]
+    (->> v
+         (map-indexed (fn [idx entry] (parse-named-play (zero? idx) entry)))
+         vec)))
+
+(defn variant-body->plays
+  "Resolve a variant body's play surface into a CANONICAL vector of
+  parsed plays. Pure data → data.
+
+  Resolution order (mutual-exclusion handled at the schema layer; this
+  fn is tolerant in case the schema gate is elided):
+
+  - Both `:plays` and `:play-script` present → prefer `:plays` (the
+    runtime warning is emitted by the runner-events ns at resolve time).
+  - `:plays` present → return parsed plays.
+  - `:play-script` present → wrap in a single-entry vector. The wrapped
+    entry inherits the script's `:name` (or nil), and `:auto-run?` from
+    `parse-spec`.
+  - Neither → empty vector.
+
+  Every returned entry carries `{:script :auto-run? :name}` (the same
+  shape as `parse-spec`). An entry's `:name` is nil only for the
+  single-script wrap-up of `:play-script` when the script body omits
+  `:name`."
+  [variant-body]
+  (cond
+    (and (some? variant-body) (contains? variant-body :plays))
+    (parse-plays (:plays variant-body))
+
+    (and (some? variant-body) (contains? variant-body :play-script))
+    [(parse-spec (:play-script variant-body))]
+
+    :else
+    []))
+
+(defn play-key
+  "Stable key for ONE play within a variant. The empty / single-script
+  shape uses `nil` (the legacy `:play-script` slot has no per-play
+  identifier). Multi-play entries use the play's `:name` string.
+
+  Used by the runner-events ns to key per-(variant, play) run-state
+  and by the UI's chip dropdown / CI runner to identify a play
+  unambiguously."
+  [play]
+  (when play (:name play)))
+
+(defn find-play
+  "Return the play at `play-key` (a name string) in `plays`, or nil.
+  `play-key` of nil matches the single-entry case (the legacy
+  `:play-script` wrap)."
+  [plays play-key]
+  (when (seq plays)
+    (if (nil? play-key)
+      (first plays)
+      (some (fn [p] (when (= play-key (:name p)) p)) plays))))
+
+(defn default-play-key
+  "Return the default play key for `plays`. For multi-play this is the
+  name of the first play (the toolbar starts focused there); for the
+  single-play case this is `nil`."
+  [plays]
+  (when (seq plays)
+    (let [first-name (:name (first plays))]
+      ;; Single-script :play-script wrap leaves :name nil → keep nil.
+      ;; Multi-play entries always carry a :name (enforced by schema).
+      first-name)))
+
+(defn multi?
+  "True iff `plays` carries more than one entry — i.e. the variant
+  declared `:plays` with N >= 2 (or the schema gate was bypassed)."
+  [plays]
+  (boolean (and (vector? plays) (> (count plays) 1))))
+
 ;; ---- run-state state machine ---------------------------------------------
 
 (def ^:const status-idle    :idle)

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -45,8 +45,33 @@
   ^{:doc "frame-id → runner-state map. The UI's play-status chip derefs
          this atom and renders the per-variant status. The driver
          swaps the slot on every step transition. CLJS uses a Reagent
-         ratom (so UI re-renders observe it); JVM uses a plain atom."}
+         ratom (so UI re-renders observe it); JVM uses a plain atom.
+
+         rf2-tl7zk multi-play: the stored state carries a `:play-key`
+         slot (the play's `:name` for `:plays` variants, nil for the
+         single-script `:play-script` slot). The chip uses this to
+         show which play was last run; per-play history lives in
+         `runs-by-play` for finer-grained queries."}
   run-state
+  #?(:cljs (r/atom {})
+     :clj  (atom  {})))
+
+(defonce
+  ^{:doc "[frame-id play-key] → runner-state. rf2-tl7zk: per-play
+         history so the toolbar dropdown can show each play's last
+         outcome and the CI runner can read per-play terminal state.
+         For single-script (`:play-script`) variants the only key is
+         `[variant-id nil]`. CLJS uses a Reagent ratom."}
+  runs-by-play
+  #?(:cljs (r/atom {})
+     :clj  (atom  {})))
+
+(defonce
+  ^{:doc "frame-id → play-key. rf2-tl7zk: the play the toolbar is
+         currently focused on. Default is the first play's name (or
+         nil for single-script variants). Changed by the dropdown's
+         `select-play!`. Reagent ratom on CLJS."}
+  active-play
   #?(:cljs (r/atom {})
      :clj  (atom  {})))
 
@@ -55,21 +80,48 @@
   [frame-id]
   (get @run-state frame-id))
 
+(defn current-state-for-play
+  "Read the run-state for `(frame-id, play-key)`, or nil. rf2-tl7zk:
+  exposes per-play state for the dropdown's per-row status badges +
+  the CI runner's per-play outcome read."
+  [frame-id play-key]
+  (get @runs-by-play [frame-id play-key]))
+
+(defn active-play-key
+  "Return the play-key the toolbar is currently focused on for
+  `frame-id`, or nil. rf2-tl7zk multi-play."
+  [frame-id]
+  (get @active-play frame-id))
+
+(defn set-active-play!
+  "Set the toolbar's focused play for `frame-id`. rf2-tl7zk multi-play.
+  Idempotent — re-setting the same key is a no-op."
+  [frame-id play-key]
+  (swap! active-play assoc frame-id play-key)
+  nil)
+
 (defn clear-state!
   "Wipe the run-state for `frame-id`. Called from frame teardown +
   before each fresh run."
   [frame-id]
   (swap! run-state dissoc frame-id)
+  (swap! runs-by-play (fn [m]
+                        (into {} (remove (fn [[[fid _]] _]
+                                           (= fid frame-id)) m))))
+  (swap! active-play dissoc frame-id)
   nil)
 
 (defn- update-state!
-  [frame-id f & args]
+  [frame-id play-key f & args]
   (swap! run-state update frame-id #(apply f % args))
+  (swap! runs-by-play update [frame-id play-key] #(apply f % args))
   nil)
 
 (defn- set-state!
-  [frame-id state]
-  (swap! run-state assoc frame-id state)
+  [frame-id play-key state]
+  (let [tagged (assoc state :play-key play-key)]
+    (swap! run-state    assoc frame-id tagged)
+    (swap! runs-by-play assoc [frame-id play-key] tagged))
   nil)
 
 ;; ---- wall-clock probe ----------------------------------------------------
@@ -90,11 +142,77 @@
 (defn variant-play-script
   "Resolve the `:play-script` body on `variant-id` and parse it. Returns
   the normalised spec map per `runner/parse-spec`. Variants without
-  `:play-script` return `{:script [] :auto-run? true}`."
+  `:play-script` return `{:script [] :auto-run? true}`.
+
+  Note (rf2-tl7zk): variants declaring `:plays` resolve to the FIRST
+  play's spec — preserves legacy single-script call sites + matches the
+  toolbar's 'default play' behaviour. Callers that need the full plays
+  vector should use `variant-plays` instead."
   [variant-id]
-  (runner/parse-spec
-    (when-let [body (handler-meta variant-id)]
-      (:play-script body))))
+  (let [body  (handler-meta variant-id)
+        plays (runner/variant-body->plays body)]
+    (cond
+      ;; Multi-play (:plays slot) — default to the first play.
+      (and (seq plays) (contains? body :plays))
+      (first plays)
+
+      ;; Single-script (:play-script slot) — legacy path.
+      :else
+      (runner/parse-spec (when body (:play-script body))))))
+
+;; ---- multi-play warning (one-shot) ---------------------------------------
+
+(defonce ^:private ^{:doc "Set of variant ids that have already received
+                          the both-:play-script-and-:plays console
+                          warning. One warning per variant per page
+                          lifetime keeps the console quiet."}
+  warned-both-slots
+  (atom #{}))
+
+(defn- warn-both-slots-once!
+  [variant-id]
+  (when (and variant-id (not (contains? @warned-both-slots variant-id)))
+    (swap! warned-both-slots conj variant-id)
+    #?(:cljs
+       (try
+         (js/console.warn
+           (str "[re-frame.story.play] " (pr-str variant-id)
+                " declares BOTH :play-script and :plays — preferring :plays."
+                " Pick one per variant to silence this warning."))
+         (catch :default _ nil))
+       :clj
+       (binding [*out* *err*]
+         (println (str "[re-frame.story.play] " (pr-str variant-id)
+                       " declares BOTH :play-script and :plays — preferring :plays."
+                       " Pick one per variant to silence this warning."))))))
+
+(defn variant-plays
+  "Resolve the canonical vector of parsed plays for `variant-id`. Pure
+  data → data; works on JVM + CLJS. rf2-tl7zk multi-play.
+
+  - `:plays` present → returns the parsed plays vector (size >= 1).
+  - `:play-script` present → returns a single-entry vector wrapping the
+    parsed single-script spec.
+  - Both present → warns once, prefers `:plays`.
+  - Neither → returns `[]`."
+  [variant-id]
+  (let [body (handler-meta variant-id)]
+    (when (and body
+               (contains? body :play-script)
+               (contains? body :plays))
+      (warn-both-slots-once! variant-id))
+    (runner/variant-body->plays body)))
+
+(defn resolve-play
+  "Resolve a `(variant-id, play-key)` pair to the parsed play spec, or
+  nil. `play-key` may be nil — meaning 'the default play' (first
+  entry for multi-play, the single script for `:play-script`).
+  rf2-tl7zk multi-play."
+  [variant-id play-key]
+  (let [plays (variant-plays variant-id)]
+    (if (nil? play-key)
+      (first plays)
+      (runner/find-play plays play-key))))
 
 ;; ---- trace emission ------------------------------------------------------
 
@@ -302,18 +420,18 @@
 (defn- record-result!
   "Append `result` to the run-state for `frame-id` and emit the trace
   event."
-  [frame-id name idx step result]
-  (update-state! frame-id runner/record-step-result result)
+  [frame-id play-key name idx step result]
+  (update-state! frame-id play-key runner/record-step-result result)
   (emit-trace! frame-id name idx step result)
   nil)
 
 (defn- finish!
   "Transition the run-state to `:pass` / `:fail` and resolve `done-cb`
   with the final state."
-  [frame-id done-cb]
-  (update-state! frame-id runner/finish (now-ms))
+  [frame-id play-key done-cb]
+  (update-state! frame-id play-key runner/finish (now-ms))
   (when done-cb
-    (try (done-cb (current-state frame-id))
+    (try (done-cb (current-state-for-play frame-id play-key))
          (catch #?(:clj Throwable :cljs :default) _ nil))))
 
 (defn- run-loop!
@@ -321,15 +439,15 @@
   to the scheduler and resume from the wait time onwards.
 
   `done-cb` is invoked with the final run-state once the loop ends."
-  [frame-id done-cb]
-  (let [state (current-state frame-id)]
+  [frame-id play-key done-cb]
+  (let [state (current-state-for-play frame-id play-key)]
     (cond
       ;; abort if state has gone missing (frame torn down mid-run)
       (nil? state)
       nil
 
       (runner/done? state)
-      (finish! frame-id done-cb)
+      (finish! frame-id play-key done-cb)
 
       :else
       (let [idx  (:step-idx state)
@@ -338,8 +456,8 @@
         (cond
           (= :wait (runner/step-type step))
           (let [ms (runner/step-wait-ms step)]
-            (record-result! frame-id nm idx step (runner/step-skip idx step))
-            (schedule! (or ms 0) #(run-loop! frame-id done-cb)))
+            (record-result! frame-id play-key nm idx step (runner/step-skip idx step))
+            (schedule! (or ms 0) #(run-loop! frame-id play-key done-cb)))
 
           :else
           (let [result (try
@@ -348,12 +466,12 @@
                            (runner/step-exception idx step
                                                   #?(:clj  (.getMessage ^Throwable e)
                                                      :cljs (str e)))))]
-            (record-result! frame-id nm idx step result)
+            (record-result! frame-id play-key nm idx step result)
             ;; Tail-call into the loop. On CLJS we yield via a 0-ms
             ;; setTimeout so a long async script doesn't blow the stack
             ;; and the UI gets a chance to repaint between steps.
-            #?(:cljs (js/setTimeout #(run-loop! frame-id done-cb) 0)
-               :clj  (recur frame-id done-cb))))))))
+            #?(:cljs (js/setTimeout #(run-loop! frame-id play-key done-cb) 0)
+               :clj  (recur frame-id play-key done-cb))))))))
 
 ;; ---- public driver -------------------------------------------------------
 
@@ -369,36 +487,139 @@
 
   Idempotent w.r.t. concurrent runs — calling `run!` while a previous
   run is in flight cancels the previous run's `done-cb` (the new one
-  takes over the run-state slot)."
+  takes over the run-state slot).
+
+  Arities:
+  - `[variant-id]`                — run the default play (rf2-tl7zk:
+                                    the first play of `:plays`, or the
+                                    single `:play-script`).
+  - `[variant-id done-cb]`        — as above + completion callback.
+  - `[variant-id spec done-cb]`   — legacy: drive an explicit spec.
+                                    The play-key is read off the spec's
+                                    `:name` (nil for unnamed scripts).
+  - `[variant-id play-key spec done-cb]` — rf2-tl7zk multi-play form:
+                                    drive a specific play. `play-key`
+                                    is the play's `:name` string (or
+                                    nil for the single-script case)."
   ([variant-id]
-   (run! variant-id nil nil))
+   (run! variant-id nil nil nil))
   ([variant-id done-cb]
-   (run! variant-id nil done-cb))
+   ;; Legacy two-arity: variant-id + done-cb. Picks the default play.
+   (run! variant-id nil nil done-cb))
   ([variant-id spec done-cb]
-   (let [spec  (or spec (variant-play-script variant-id))
+   ;; Legacy three-arity: variant-id + spec + done-cb. The play-key is
+   ;; derived from the spec's :name (nil for unnamed scripts). Preserved
+   ;; for back-compat with callers that hand-build a spec.
+   (run! variant-id (when spec (:name spec)) spec done-cb))
+  ([variant-id play-key spec done-cb]
+   (let [spec  (or spec
+                   (resolve-play variant-id play-key)
+                   ;; Fall back to the legacy single-script path so the
+                   ;; default play of a `:play-script` variant Just Works.
+                   (variant-play-script variant-id))
+         pk    (or play-key (:name spec))
          init  (runner/initial-state spec)
-         start (runner/start init (now-ms))]
-     (set-state! variant-id start)
-     (run-loop! variant-id done-cb)
-     start)))
+         started (runner/start init (now-ms))]
+     (set-state! variant-id pk started)
+     (set-active-play! variant-id pk)
+     (run-loop! variant-id pk done-cb)
+     started)))
 
 (defn re-run!
   "Re-run the play script for `variant-id`. Convenience wrapper around
   `run!` — distinct fn name so the toolbar's `[Re-run]` button has a
-  one-call API."
+  one-call API.
+
+  rf2-tl7zk: with no explicit `play-key`, re-runs the currently active
+  play (set by the dropdown). For single-script variants the active
+  play is nil, so this matches the legacy behaviour."
   ([variant-id]
    (re-run! variant-id nil))
   ([variant-id done-cb]
-   (run! variant-id done-cb)))
+   (let [pk (active-play-key variant-id)]
+     (run! variant-id pk nil done-cb))))
+
+(defn run-play!
+  "rf2-tl7zk multi-play: run the play identified by `play-key` (a
+  play's `:name`) for `variant-id`. Passing nil picks the default
+  play (first entry for multi-play, the single script for
+  `:play-script`)."
+  ([variant-id play-key]
+   (run-play! variant-id play-key nil))
+  ([variant-id play-key done-cb]
+   (run! variant-id play-key nil done-cb)))
+
+(defn select-play!
+  "rf2-tl7zk: set `variant-id`'s active play to `play-key` WITHOUT
+  running it. Used by the toolbar dropdown when the user picks a play
+  but the user hasn't pressed Re-run yet."
+  [variant-id play-key]
+  (set-active-play! variant-id play-key))
+
+(declare run-plays-sequentially!)
 
 (defn auto-run!
   "Run the play script if `:auto-run?` is true. Called from the shell
   after the variant mounts. No-op when the variant has no
-  `:play-script` slot or `:auto-run?` is false."
+  `:play-script` / `:plays` slot or no play declares `:auto-run? true`.
+
+  rf2-tl7zk multi-play: every play with `:auto-run? true` is run in
+  ORDER (sequentially) so they don't race against the same frame. By
+  the per-play default (first play true, rest false) only the first
+  play auto-runs on mount; subsequent plays opt in explicitly."
   ([variant-id]
    (auto-run! variant-id nil))
   ([variant-id done-cb]
    (when config/enabled?
-     (let [spec (variant-play-script variant-id)]
-       (when (and (:auto-run? spec) (seq (:script spec)))
-         (run! variant-id spec done-cb))))))
+     (let [plays      (variant-plays variant-id)
+           auto-plays (filterv (fn [p] (and (:auto-run? p)
+                                            (seq (:script p))))
+                               plays)]
+       (cond
+         (empty? auto-plays)
+         nil
+
+         ;; Single auto-run play — direct fire so the legacy
+         ;; single-script callers keep their existing run shape.
+         (= 1 (count auto-plays))
+         (let [spec (first auto-plays)]
+           (run! variant-id (:name spec) spec done-cb))
+
+         ;; Multiple auto-run plays — sequence them so a later play
+         ;; doesn't trample the frame mid-run.
+         :else
+         (run-plays-sequentially! variant-id auto-plays done-cb))))))
+
+;; ---- run-all (sequential) — rf2-tl7zk ------------------------------------
+
+(defn- run-plays-sequentially!
+  "Internal: run `plays` against `variant-id` one after another.
+  Resolves `done-cb` with a vector of terminal states once every play
+  has finished (or the loop is interrupted by a missing frame)."
+  [variant-id plays done-cb]
+  (let [acc (atom [])]
+    (letfn [(step! [remaining]
+              (if (empty? remaining)
+                (when done-cb
+                  (try (done-cb @acc)
+                       (catch #?(:clj Throwable :cljs :default) _ nil)))
+                (let [spec (first remaining)
+                      pk   (:name spec)]
+                  (run! variant-id pk spec
+                        (fn [final]
+                          (swap! acc conj final)
+                          (step! (rest remaining)))))))]
+      (step! plays))))
+
+(defn run-all-plays!
+  "rf2-tl7zk multi-play: run every play declared on `variant-id` in
+  order, sequentially. Calls `done-cb` with a vector of per-play
+  terminal states once every play has completed. Returns nil.
+
+  No-op when the variant carries no plays."
+  ([variant-id]
+   (run-all-plays! variant-id nil))
+  ([variant-id done-cb]
+   (let [plays (variant-plays variant-id)]
+     (when (seq plays)
+       (run-plays-sequentially! variant-id (vec plays) done-cb)))))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -379,6 +379,35 @@
     [:auto-run? {:optional true} :boolean]
     [:name      {:optional true} :string]]])
 
+;; ---- :plays — multi-play extension (rf2-tl7zk) ---------------------------
+
+(def NamedPlaySpec
+  "A single entry in a `:plays` vector. Same shape as `PlaySpec` (map
+  form) but `:name` is REQUIRED — multi-play needs a stable label per
+  play so the toolbar dropdown + the CI runner can identify each
+  play unambiguously.
+
+  Example:
+      {:name      \"happy path\"
+       :auto-run? true
+       :script    [[:dispatch-sync [:counter/initialise 3]]
+                   [:assert-db [:count] 3]]}"
+  [:map
+   [:name      :string]
+   [:script    PlayScript]
+   [:auto-run? {:optional true} :boolean]])
+
+(def PlaysSpec
+  "A vector of named play specs. At least one entry; every entry MUST
+  carry a `:name` so the toolbar dropdown + CI rows can identify it."
+  [:and
+   [:vector NamedPlaySpec]
+   [:fn {:error/message ":plays must contain at least one named play"}
+    (fn [v] (and (vector? v) (pos? (count v))))]
+   [:fn {:error/message ":plays entries must have unique :name values"}
+    (fn [v] (or (empty? v)
+                (= (count v) (count (distinct (map :name v))))))]])
+
 (def Variant
   "Schema for the body of `reg-variant`.
 
@@ -388,41 +417,66 @@
 
   Open shape — Story-defined keys are validated; downstream tools may add
   their own keys without registration ceremony (per Spec-Schemas's
-  open-by-default convention)."
-  [:map
-   [:doc                   {:optional true} :string]
-   [:extends               {:optional true} :keyword]
-   [:events                {:optional true} [:vector EventVector]]
-   [:play                  {:optional true} [:vector EventVector]]
-   ;; rf2-8i2a9 — the rich Storybook-style play script. Coexists with
-   ;; `:play` (the existing phase-4 plain-event-vector sequence).
-   ;; `:play-script` is interpreted post-mount by the play runner; each
-   ;; step is a tagged vector (`[:dispatch ...]`, `[:wait ms]`,
-   ;; `[:assert-db path value]`, etc.). See `PlaySpec`.
-   [:play-script           {:optional true} PlaySpec]
-   [:args                  {:optional true} ArgMap]
-   [:argtypes              {:optional true} ArgtypesMap]
-   [:tags                  {:optional true} TagSet]
-   [:decorators            {:optional true} DecoratorRefs]
-   [:loaders               {:optional true} [:vector EventVector]]
-   [:loaders-complete-when {:optional true}
-    [:or
-     :keyword                                ; registered predicate-event id
-     [:vector EventVector]]]                 ; literal data form
-   [:args->events          {:optional true} [:map-of :keyword :keyword]]
-   [:platforms             {:optional true} PlatformSet]
-   [:substrates            {:optional true} SubstrateSet]
-   [:modes                 {:optional true} ModeRefSet]
-   ;; rf2-q9kv5: per-variant overrides for the dispatch-console panel +
-   ;; Causa preset. A variant may opt out of the dispatch-console panel
-   ;; (default true at story level) or carry a Causa preset that
-   ;; overrides the parent story's preset.
-   [:dispatch-console?     {:optional true} :boolean]
-   [:causa                 {:optional true} CausaPreset]
-   ;; rf2-zll4h — viewport + background per-variant overrides. Resolved
-   ;; with variant-first, then story-level, then chrome toolbar.
-   [:viewport              {:optional true} ViewportSlot]
-   [:background            {:optional true} BackgroundSlot]])
+  open-by-default convention).
+
+  ## Multi-play (rf2-tl7zk)
+
+  A variant may declare ONE of two play surfaces:
+
+  - `:play-script` — a single named play (the simple case).
+  - `:plays`       — a vector of named plays (multiple scenarios).
+
+  These slots are mutually exclusive. If both are present the runner
+  prefers `:plays` and emits a one-time console warning."
+  [:and
+   [:map
+    [:doc                   {:optional true} :string]
+    [:extends               {:optional true} :keyword]
+    [:events                {:optional true} [:vector EventVector]]
+    [:play                  {:optional true} [:vector EventVector]]
+    ;; rf2-8i2a9 — the rich Storybook-style play script. Coexists with
+    ;; `:play` (the existing phase-4 plain-event-vector sequence).
+    ;; `:play-script` is interpreted post-mount by the play runner; each
+    ;; step is a tagged vector (`[:dispatch ...]`, `[:wait ms]`,
+    ;; `[:assert-db path value]`, etc.). See `PlaySpec`.
+    [:play-script           {:optional true} PlaySpec]
+    ;; rf2-tl7zk — multi-play: a vector of named plays. Mutually
+    ;; exclusive with `:play-script` (validated by the `:fn` clause
+    ;; below). The toolbar surfaces a dropdown when `:plays` has more
+    ;; than one entry; the CI runner enumerates each play as its own
+    ;; result row. See `PlaysSpec`.
+    [:plays                 {:optional true} PlaysSpec]
+    [:args                  {:optional true} ArgMap]
+    [:argtypes              {:optional true} ArgtypesMap]
+    [:tags                  {:optional true} TagSet]
+    [:decorators            {:optional true} DecoratorRefs]
+    [:loaders               {:optional true} [:vector EventVector]]
+    [:loaders-complete-when {:optional true}
+     [:or
+      :keyword                                ; registered predicate-event id
+      [:vector EventVector]]]                 ; literal data form
+    [:args->events          {:optional true} [:map-of :keyword :keyword]]
+    [:platforms             {:optional true} PlatformSet]
+    [:substrates            {:optional true} SubstrateSet]
+    [:modes                 {:optional true} ModeRefSet]
+    ;; rf2-q9kv5: per-variant overrides for the dispatch-console panel +
+    ;; Causa preset. A variant may opt out of the dispatch-console panel
+    ;; (default true at story level) or carry a Causa preset that
+    ;; overrides the parent story's preset.
+    [:dispatch-console?     {:optional true} :boolean]
+    [:causa                 {:optional true} CausaPreset]
+    ;; rf2-zll4h — viewport + background per-variant overrides. Resolved
+    ;; with variant-first, then story-level, then chrome toolbar.
+    [:viewport              {:optional true} ViewportSlot]
+    [:background            {:optional true} BackgroundSlot]]
+   ;; rf2-tl7zk — mutual-exclusion check. Authors pick ONE play surface
+   ;; per variant; mixing them is a schema-level error so the rejection
+   ;; lands at `reg-variant*` rather than surprising the runner.
+   [:fn {:error/message
+         ":play-script and :plays are mutually exclusive — pick one per variant"}
+    (fn [body]
+      (not (and (contains? body :play-script)
+                (contains? body :plays))))]])
 
 ;; ---- :rf/workspace --------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/play_status.cljs
+++ b/tools/story/src/re_frame/story/ui/play_status.cljs
@@ -17,8 +17,28 @@
 
   Both components deref `runner-events/run-state` so Reagent re-renders
   observe every step transition. Production CLJS builds DCE the file
-  entirely via `re-frame.story.config/enabled?`."
-  (:require [re-frame.story.config           :as config]
+  entirely via `re-frame.story.config/enabled?`.
+
+  ## Multi-play (rf2-tl7zk)
+
+  Variants that declare `:plays` (a vector of named plays) get a
+  dropdown affordance inside the chip:
+
+      [Play: happy path - PASS  v]  [Re-run]
+                                 ^^^ click to open the dropdown
+        +--------------------------+
+        | happy path     - PASS   |
+        | error path     - FAIL   |
+        | edge case: 0   - IDLE   |
+        | -------------------- |
+        | Run all plays           |
+        +--------------------------+
+
+  Clicking a play row selects + runs it. Clicking 'Run all plays'
+  runs every play sequentially, updating the chip as each one
+  completes."
+  (:require [reagent.core                    :as r]
+            [re-frame.story.config           :as config]
             [re-frame.story.play.dom         :as dom]
             [re-frame.story.play.runner      :as runner]
             [re-frame.story.play.runner-events :as runner-events]))
@@ -37,7 +57,8 @@
                  :user-select     "none"
                  :display         "inline-flex"
                  :align-items     "center"
-                 :gap             "6px"}
+                 :gap             "6px"
+                 :position        "relative"}
    :chip-idle    {}
    :chip-running {:background "#3a3a00"
                   :color      "#fae766"}
@@ -55,6 +76,63 @@
                   :font-family     "monospace"
                   :font-size       "10px"
                   :margin-left     "4px"}
+   :dropdown-btn {:padding         "0 4px"
+                  :background      "transparent"
+                  :color           "inherit"
+                  :border          "none"
+                  :cursor          "pointer"
+                  :font-family     "monospace"
+                  :font-size       "10px"
+                  :line-height     "1"}
+   :dropdown-panel {:position       "absolute"
+                    :top            "100%"
+                    :left           "0"
+                    :margin-top     "4px"
+                    :background     "#1e1e1e"
+                    :color          "#cccccc"
+                    :border         "1px solid #3c3c3c"
+                    :border-radius  "4px"
+                    :font-family    "monospace"
+                    :font-size      "11px"
+                    :min-width      "220px"
+                    :max-width      "320px"
+                    :z-index        "2147483646"
+                    :box-shadow     "0 4px 12px rgba(0,0,0,0.5)"
+                    :overflow       "hidden"}
+   :dropdown-row {:padding         "6px 10px"
+                  :cursor          "pointer"
+                  :display         "flex"
+                  :justify-content "space-between"
+                  :align-items     "center"
+                  :gap             "10px"
+                  :border          "none"
+                  :background      "transparent"
+                  :color           "inherit"
+                  :width           "100%"
+                  :text-align      "left"
+                  :font-family     "monospace"
+                  :font-size       "11px"}
+   :dropdown-row-active {:background "#264f78"
+                         :color      "white"}
+   :dropdown-row-name   {:overflow      "hidden"
+                         :text-overflow "ellipsis"
+                         :white-space   "nowrap"
+                         :flex          "1 1 auto"}
+   :dropdown-row-status {:flex          "0 0 auto"
+                         :font-size     "9px"
+                         :text-transform "uppercase"
+                         :opacity       "0.85"}
+   :dropdown-divider    {:height "1px" :background "#3c3c3c"}
+   :dropdown-run-all    {:padding         "6px 10px"
+                         :cursor          "pointer"
+                         :display         "block"
+                         :width           "100%"
+                         :text-align      "left"
+                         :border          "none"
+                         :background      "transparent"
+                         :color           "#7bbcff"
+                         :font-family     "monospace"
+                         :font-size       "11px"}
    :banner       {:background     "#5a1d1d"
                   :color          "#fde0e0"
                   :padding        "8px 14px"
@@ -108,6 +186,34 @@
     "Play: IDLE"
     (str "Play: " (runner/progress-str state))))
 
+(defn chip-label-multi
+  "Pure helper — render the chip's text for a multi-play variant. The
+  active play's name is included so the chip says which play the
+  status reflects.
+
+  Format: `Play <name> | IDLE|RUNNING|PASS|FAIL`.
+
+  Exposed for unit tests."
+  [state play-name]
+  (let [status-str (if (nil? state)
+                     "IDLE"
+                     (runner/progress-str state))
+        nm         (or play-name "(default)")]
+    (str "Play " nm " | " status-str)))
+
+(defn dropdown-row-status
+  "Pure helper — render the per-row status badge text in the dropdown.
+  Used by both the dropdown row and the unit-tests."
+  [state]
+  (if (nil? state)
+    "IDLE"
+    (case (:status state)
+      :idle     "IDLE"
+      :running  "RUN"
+      :pass     "PASS"
+      :fail     "FAIL"
+      (str (:status state)))))
+
 ;; ---- click-to-highlight ---------------------------------------------------
 
 (defn- highlight-failure-node!
@@ -130,31 +236,111 @@
 
 ;; ---- chip component -------------------------------------------------------
 
-(defn chip
-  "Render the play-status chip for `variant-id`. Form-1 component; the
-  outer `runner-events/run-state` deref drives re-renders. Tagged with
-  `data-test=\"story-play-status\"` for browser tests."
-  [variant-id]
-  (let [state  (get @runner-events/run-state variant-id)
-        status (or (:status state) :idle)
-        label  (chip-label state)]
-    [:span {:style      (chip-style-for status)
-            :data-test  "story-play-status"
-            :data-variant (pr-str variant-id)
-            :data-status  (name status)
-            :title      (str "Play status — " label)
-            :role       "status"
-            :aria-live  "polite"}
-     [:span {:style (:chip-icon styles)} (chip-icon status)]
-     [:span label]
+(defn- dropdown-panel
+  "Render the dropdown listing each play + a 'Run all' option. CLJS-only;
+  caller passes a fn `close!` to dismiss the panel + the active play
+  key + the plays vector."
+  [variant-id plays active-key close!]
+  [:div {:style     (:dropdown-panel styles)
+         :data-test "story-play-status-dropdown"
+         :role      "menu"
+         :on-click  (fn [e] (.stopPropagation e))}
+   (for [[idx spec] (map-indexed vector plays)
+         :let [pk     (:name spec)
+               state  (runner-events/current-state-for-play variant-id pk)
+               status (or (:status state) :idle)
+               active? (= active-key pk)]]
+     ^{:key (str pk "-" idx)}
      [:button
-      {:style     (:re-run-btn styles)
-       :data-test "story-play-status-re-run"
-       :title     "Re-run the play script"
-       :on-click  (fn [e]
-                    (.stopPropagation e)
-                    (runner-events/re-run! variant-id))}
-      "Re-run"]]))
+      {:style       (merge (:dropdown-row styles)
+                           (chip-style-for status)
+                           (when active? (:dropdown-row-active styles)))
+       :data-test   "story-play-status-dropdown-row"
+       :data-play   (str pk)
+       :data-status (name status)
+       :role        "menuitem"
+       :title       (str "Run play: " (or pk "(default)"))
+       :on-click    (fn [e]
+                      (.stopPropagation e)
+                      (close!)
+                      (runner-events/run-play! variant-id pk))}
+      [:span {:style (:dropdown-row-name styles)} (or pk "(unnamed)")]
+      [:span {:style (:dropdown-row-status styles)} (dropdown-row-status state)]])
+   [:div {:style (:dropdown-divider styles)}]
+   [:button
+    {:style     (:dropdown-run-all styles)
+     :data-test "story-play-status-run-all"
+     :role      "menuitem"
+     :title     "Run every play in order"
+     :on-click  (fn [e]
+                  (.stopPropagation e)
+                  (close!)
+                  (runner-events/run-all-plays! variant-id))}
+    (str "Run all (" (count plays) ")")]])
+
+(defn chip
+  "Render the play-status chip for `variant-id`. Form-2 component; the
+  outer `runner-events/run-state` deref drives re-renders. Tagged with
+  `data-test=\"story-play-status\"` for browser tests.
+
+  rf2-tl7zk multi-play: when the variant declares `:plays` (more than
+  one), the chip grows a `[v]` dropdown affordance that opens a panel
+  listing each play with its per-play status + a 'Run all' option."
+  [variant-id]
+  (let [open? (r/atom false)]
+    (fn [variant-id]
+      (let [plays      (runner-events/variant-plays variant-id)
+            multi?     (runner/multi? plays)
+            active-key (or (runner-events/active-play-key variant-id)
+                           (runner/default-play-key plays))
+            ;; In multi-play mode, the chip's state reflects the
+            ;; ACTIVE play's per-(variant, play) row; in single-play
+            ;; mode it reflects the legacy single-script state.
+            state      (if multi?
+                         (runner-events/current-state-for-play variant-id active-key)
+                         (get @runner-events/run-state variant-id))
+            status     (or (:status state) :idle)
+            active-spec (runner/find-play plays active-key)
+            active-name (when active-spec (:name active-spec))
+            label      (if multi?
+                         (chip-label-multi state active-name)
+                         (chip-label state))
+            close!     (fn [] (reset! open? false))]
+        [:span {:style      (chip-style-for status)
+                :data-test  "story-play-status"
+                :data-variant (pr-str variant-id)
+                :data-status  (name status)
+                :data-multi   (str multi?)
+                :data-play    (str active-key)
+                :title      (str "Play status — " label)
+                :role       "status"
+                :aria-live  "polite"}
+         [:span {:style (:chip-icon styles)} (chip-icon status)]
+         [:span label]
+         (when multi?
+           [:button
+            {:style    (:dropdown-btn styles)
+             :data-test "story-play-status-dropdown-toggle"
+             :title    "Pick a play"
+             :aria-haspopup "menu"
+             :aria-expanded (str @open?)
+             :on-click (fn [e]
+                         (.stopPropagation e)
+                         (swap! open? not))}
+            (if @open? "^" "v")])
+         (when (and multi? @open?)
+           [dropdown-panel variant-id plays active-key close!])
+         [:button
+          {:style     (:re-run-btn styles)
+           :data-test "story-play-status-re-run"
+           :title     (str "Re-run "
+                           (if multi?
+                             (str "play: " (or active-name "(default)"))
+                             "the play script"))
+           :on-click  (fn [e]
+                        (.stopPropagation e)
+                        (runner-events/re-run! variant-id))}
+          "Re-run"]]))))
 
 ;; ---- failure banner -------------------------------------------------------
 
@@ -200,12 +386,16 @@
 
 (defn chip-when-enabled
   "Render `chip` only when the Story config is enabled AND the variant
-  has a `:play-script` body. Used by the toolbar so production builds
-  + variants without a script don't render the chip at all."
+  has a `:play-script` OR `:plays` body. Used by the toolbar so
+  production builds + variants without a play surface don't render
+  the chip at all.
+
+  rf2-tl7zk: checks both single-script + multi-play surfaces via
+  `variant-plays` (which resolves both)."
   [variant-id]
   (when (and config/enabled? variant-id)
-    (let [spec (runner-events/variant-play-script variant-id)]
-      (when (seq (:script spec))
+    (let [plays (runner-events/variant-plays variant-id)]
+      (when (some (fn [p] (seq (:script p))) plays)
         [chip variant-id]))))
 
 (defn banner-when-enabled
@@ -215,6 +405,6 @@
   spec-presence layer."
   [variant-id]
   (when (and config/enabled? variant-id)
-    (let [spec (runner-events/variant-play-script variant-id)]
-      (when (seq (:script spec))
+    (let [plays (runner-events/variant-plays variant-id)]
+      (when (some (fn [p] (seq (:script p))) plays)
         [banner variant-id]))))

--- a/tools/story/test/re_frame/story/play/ci_runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/ci_runner_test.cljc
@@ -179,3 +179,91 @@
 
 (deftest project-state-nil-yields-nil
   (is (nil? (ci/project-state nil))))
+
+;; ---- multi-play (rf2-tl7zk) ----------------------------------------------
+
+(deftest has-plays?-recognises-non-empty-plays
+  (is (false? (ci/has-plays? {})))
+  (is (false? (ci/has-plays? {:plays []})))
+  (is (true?  (ci/has-plays? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
+
+(deftest has-any-play?-or-of-both
+  (is (false? (ci/has-any-play? {})))
+  (is (true?  (ci/has-any-play? {:play-script [[:dispatch [:a]]]})))
+  (is (true?  (ci/has-any-play? {:plays [{:name "p" :script [[:dispatch [:a]]]}]}))))
+
+(deftest discovery-includes-plays-variants
+  (testing "variants-with-play-scripts picks up :plays-carrying bodies"
+    (let [regs {:story.a/single  {:play-script [[:dispatch [:a]]]}
+                :story.b/multi   {:plays [{:name "p1" :script [[:dispatch [:b1]]]}
+                                          {:name "p2" :script [[:dispatch [:b2]]]}]}
+                :story.c/none    {:events []}}]
+      (is (= [:story.a/single :story.b/multi]
+             (ci/variants-with-play-scripts regs))))))
+
+(deftest ci-rows-enumerates-plays-per-variant
+  (testing "ci-rows produces one row per play; single-script variants produce one row"
+    (let [regs {:story.a/single
+                {:play-script {:name "single-named"
+                               :script [[:dispatch [:a]]]}}
+
+                :story.b/multi
+                {:plays [{:name "happy" :script [[:dispatch [:b1]]]}
+                         {:name "error" :script [[:dispatch [:b2]]]
+                          :auto-run? true}]}
+
+                :story.c/no-play {:events []}}
+          rows (ci/ci-rows regs)]
+      (is (= 3 (count rows))
+          "single + multi(2) = 3 rows total")
+      (is (= [[:story.a/single "single-named"]
+              [:story.b/multi  "happy"]
+              [:story.b/multi  "error"]]
+             (mapv (fn [r] [(:variant-id r) (:play-key r)]) rows))
+          "rows preserve declaration order within a variant")
+      (let [error-row (last rows)]
+        (is (= "error" (:play-key error-row)))
+        (is (true? (:auto-run? error-row))
+            "row carries the per-play auto-run? flag")))))
+
+(deftest ci-rows-handles-bare-play-script
+  (testing "a bare :play-script (no :name) yields a row with :play-key nil"
+    (let [regs {:story.x/bare {:play-script [[:dispatch [:a]]]}}
+          rows (ci/ci-rows regs)]
+      (is (= 1 (count rows)))
+      (is (nil? (:play-key (first rows))))
+      (is (= 1   (:script-len (first rows))))
+      (is (true? (:auto-run? (first rows)))
+          "bare scripts default :auto-run? to true (legacy contract)"))))
+
+(deftest ci-context-includes-rows
+  (testing "ci-context exposes the per-play rows alongside :variants + :summaries"
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.ctx/multi]
+           {:plays [{:name "a" :script [[:dispatch [:foo]]]}
+                    {:name "b" :script [[:dispatch [:bar]]]}]})
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.ctx/single]
+           {:play-script {:name "lone" :script [[:dispatch [:baz]]]}})
+    (let [ctx (ci/ci-context)]
+      (is (= [:story.ctx/multi :story.ctx/single] (:variants ctx)))
+      ;; summaries are per-VARIANT (multi-play uses its first play).
+      (is (= 2 (count (:summaries ctx))))
+      ;; rows are per-PLAY — multi(2) + single(1) = 3 rows.
+      (is (= 3 (count (:rows ctx))))
+      (is (= [[:story.ctx/multi  "a"]
+              [:story.ctx/multi  "b"]
+              [:story.ctx/single "lone"]]
+             (mapv (fn [r] [(:variant-id r) (:play-key r)]) (:rows ctx)))))))
+
+(deftest summary-from-plays-uses-first-play
+  (testing "play-script-summary on a :plays variant reports the first play"
+    (swap! registrar/kind->id->body assoc-in
+           [:variant :story.s/multi]
+           {:plays [{:name "first-play"  :script [[:dispatch [:a]] [:wait 0]]}
+                    {:name "second-play" :script [[:dispatch [:b]]]}]})
+    (let [s (ci/play-script-summary :story.s/multi)]
+      (is (= :story.s/multi   (:variant-id s)))
+      (is (= "first-play"     (:name s)))
+      (is (= 2                (:script-len s)))
+      (is (true?              (:auto-run? s))))))

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -288,3 +288,204 @@
              results (:results final)]
          (is (= :fail (:status final)))
          (is (every? (fn [r] (or (:skipped? r) (true? (:passed? r)))) results))))))
+
+;; ---- multi-play (rf2-tl7zk) ----------------------------------------------
+
+#?(:clj
+   (defn- run-play-blocking
+     "Drive a specific play via `run-play!` and block until terminal."
+     ([variant-id play-key] (run-play-blocking variant-id play-key 5000))
+     ([variant-id play-key timeout-ms]
+      (let [done (atom nil)]
+        (re/run-play! variant-id play-key (fn [s] (reset! done s)))
+        (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+          (loop []
+            (cond
+              @done @done
+              (> (System/currentTimeMillis) deadline)
+              (throw (ex-info "run-play-blocking timeout"
+                              {:variant-id variant-id
+                               :play-key   play-key}))
+              :else (do (Thread/sleep 5) (recur)))))))))
+
+#?(:clj
+   (deftest variant-plays-resolves-plays-vector
+     (testing "variant-plays returns a vector of parsed plays"
+       (rf/reg-event-db :rt/inc
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/two
+         {:events []
+          :plays  [{:name "happy"
+                    :auto-run? false
+                    :script    [[:dispatch-sync [:rt/inc]]
+                                [:assert-db [:n] 1]]}
+                   {:name "error"
+                    :auto-run? false
+                    :script    [[:dispatch-sync [:rt/inc]]
+                                [:assert-db [:n] 99]]}]})
+       (let [plays (re/variant-plays :story.multi/two)]
+         (is (= 2 (count plays)))
+         (is (= ["happy" "error"] (mapv :name plays)))
+         ;; First play's auto-run? was explicitly false here, so no
+         ;; positional default applies.
+         (is (every? false? (map :auto-run? plays)))))))
+
+#?(:clj
+   (deftest variant-plays-wraps-legacy-play-script
+     (testing "variant-plays wraps a legacy :play-script body in a one-entry vector"
+       (story/reg-variant :story.multi/legacy
+         {:events []
+          :play-script {:name "lone" :script [[:dispatch [:a]]]}})
+       (let [plays (re/variant-plays :story.multi/legacy)]
+         (is (= 1 (count plays)))
+         (is (= "lone" (:name (first plays))))))))
+
+#?(:clj
+   (deftest run-play-keys-state-per-play
+     (testing "running each play stores state under [variant-id play-key]"
+       (rf/reg-event-db :rt/inc
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/keyed
+         {:events []
+          :plays  [{:name "first"  :auto-run? false
+                    :script [[:dispatch-sync [:rt/inc]]
+                             [:assert-db [:n] 1]]}
+                   {:name "second" :auto-run? false
+                    :script [[:dispatch-sync [:rt/inc]]
+                             [:assert-db [:n] 2]]}]})
+       (async/deref-blocking (story/run-variant :story.multi/keyed) 5000)
+       (let [first-state  (run-play-blocking :story.multi/keyed "first")
+             second-state (run-play-blocking :story.multi/keyed "second")]
+         (is (= :pass (:status first-state)))
+         (is (= :pass (:status second-state)))
+         ;; Per-play state preserved.
+         (is (= :pass (:status (re/current-state-for-play :story.multi/keyed "first"))))
+         (is (= :pass (:status (re/current-state-for-play :story.multi/keyed "second"))))
+         ;; The latest run-state slot tracks the most recent run.
+         (let [latest (re/current-state :story.multi/keyed)]
+           (is (= :pass (:status latest)))
+           (is (= "second" (:play-key latest))))))))
+
+#?(:clj
+   (deftest run-play-sets-active-play
+     (testing "run-play! also sets the active-play key the toolbar reads"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/active
+         {:events []
+          :plays  [{:name "alpha" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]]}
+                   {:name "beta"  :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]]}]})
+       (async/deref-blocking (story/run-variant :story.multi/active) 5000)
+       (run-play-blocking :story.multi/active "beta")
+       (is (= "beta" (re/active-play-key :story.multi/active))))))
+
+#?(:clj
+   (deftest select-play-without-running
+     (testing "select-play! changes the active key but does not run"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/select
+         {:events []
+          :plays  [{:name "one" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]]}
+                   {:name "two" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]]}]})
+       (async/deref-blocking (story/run-variant :story.multi/select) 5000)
+       (re/select-play! :story.multi/select "two")
+       (is (= "two" (re/active-play-key :story.multi/select)))
+       ;; No run-state slot was populated by select-play! alone.
+       (is (nil? (re/current-state-for-play :story.multi/select "two"))))))
+
+#?(:clj
+   (deftest run-all-plays-sequences-runs
+     (testing "run-all-plays! drives every play and resolves with per-play results"
+       (rf/reg-event-db :rt/touch
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/all
+         {:events []
+          :plays  [{:name "a" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]
+                             [:assert-db [:n] 1]]}
+                   {:name "b" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]
+                             [:assert-db [:n] 2]]}
+                   {:name "c" :auto-run? false
+                    :script [[:dispatch-sync [:rt/touch]]
+                             [:assert-db [:n] 3]]}]})
+       (async/deref-blocking (story/run-variant :story.multi/all) 5000)
+       (let [done    (atom nil)
+             _       (re/run-all-plays! :story.multi/all
+                                        (fn [final] (reset! done final)))
+             deadline (+ (System/currentTimeMillis) 5000)]
+         (loop []
+           (cond
+             (some? @done) nil
+             (> (System/currentTimeMillis) deadline)
+             (throw (ex-info "run-all-plays timeout" {}))
+             :else (do (Thread/sleep 5) (recur))))
+         (let [results @done]
+           (is (= 3 (count results)))
+           (is (every? #(= :pass (:status %)) results))
+           (is (= ["a" "b" "c"] (mapv :play-key results))))))))
+
+#?(:clj
+   (deftest auto-run-multi-runs-only-opted-in-plays
+     (testing "auto-run! runs only plays whose :auto-run? is true (per-position defaults)"
+       (rf/reg-event-db :rt/inc
+         (fn [db _] (update db :n (fnil inc 0))))
+       (story/reg-variant :story.multi/auto
+         {:events []
+          :plays  [{:name "first-default-true"
+                    ;; :auto-run? omitted → first defaults to true
+                    :script [[:dispatch-sync [:rt/inc]]
+                             [:assert-db [:n] 1]]}
+                   {:name "second-default-false"
+                    :script [[:dispatch-sync [:rt/inc]]
+                             [:assert-db [:n] 99]]}
+                   {:name "third-opted-in"
+                    :auto-run? true
+                    :script [[:dispatch-sync [:rt/inc]]]}]})
+       (async/deref-blocking (story/run-variant :story.multi/auto) 5000)
+       (let [done (atom nil)]
+         ;; Multi-play auto-run sequences the opted-in plays + resolves
+         ;; the done-cb ONCE with the per-play terminal-state vector.
+         (re/auto-run! :story.multi/auto (fn [final] (reset! done final)))
+         (let [deadline (+ (System/currentTimeMillis) 5000)]
+           (loop []
+             (cond
+               (some? @done) nil
+               (> (System/currentTimeMillis) deadline)
+               (throw (ex-info "auto-run multi timeout" {:done @done}))
+               :else (do (Thread/sleep 5) (recur)))))
+         (let [results @done]
+           (is (= 2 (count results))
+               "first + third auto-ran; second did not")
+           (is (= ["first-default-true" "third-opted-in"]
+                  (mapv :play-key results))))
+         ;; second play was NOT auto-run — its state slot stays empty.
+         (is (nil? (re/current-state-for-play :story.multi/auto
+                                              "second-default-false")))))))
+
+#?(:clj
+   (deftest mutual-exclusion-warning-emits-once
+     (testing "variants declaring BOTH :play-script and :plays warn ONCE per variant"
+       ;; Bypass schema validation by writing directly into the side-table.
+       (require '[re-frame.story.registrar :as registrar])
+       (let [registrar (resolve 're-frame.story.registrar/kind->id->body)]
+         (swap! @registrar assoc-in
+                [:variant :story.multi/both]
+                {:play-script [[:dispatch [:legacy]]]
+                 :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
+         ;; First read warns; the call returns the :plays-derived plays vector.
+         (let [out1 (with-out-str
+                      (binding [*err* *out*]
+                        (re/variant-plays :story.multi/both)))
+               out2 (with-out-str
+                      (binding [*err* *out*]
+                        (re/variant-plays :story.multi/both)))]
+           (is (re-find #":play-script.*:plays" out1)
+               "first read prints the both-slots warning")
+           (is (empty? out2)
+               "subsequent reads stay silent — warning is one-shot per variant"))))))

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -315,3 +315,107 @@
                 {:results [{:passed? true} {:passed? false}]})))
   (is (true?  (runner/any-failure?
                 {:results [{:exception true :passed? false}]}))))
+
+;; ---- multi-play (rf2-tl7zk) ----------------------------------------------
+
+(deftest parse-plays-empty
+  (testing "parse-plays of nil / [] returns []"
+    (is (= [] (runner/parse-plays nil)))
+    (is (= [] (runner/parse-plays [])))))
+
+(deftest parse-plays-first-auto-runs-by-default
+  (testing "the first entry defaults :auto-run? to true; subsequent entries default to false"
+    (let [plays (runner/parse-plays
+                  [{:name "happy" :script [[:dispatch [:a]]]}
+                   {:name "error" :script [[:dispatch [:b]]]}
+                   {:name "edge"  :script [[:dispatch [:c]]]}])]
+      (is (= 3 (count plays)))
+      (is (true?  (:auto-run? (nth plays 0))))
+      (is (false? (:auto-run? (nth plays 1))))
+      (is (false? (:auto-run? (nth plays 2)))))))
+
+(deftest parse-plays-respects-explicit-auto-run
+  (testing "explicit :auto-run? overrides the per-position default"
+    (let [plays (runner/parse-plays
+                  [{:name "first" :auto-run? false :script [[:dispatch [:a]]]}
+                   {:name "second" :auto-run? true :script [[:dispatch [:b]]]}])]
+      (is (false? (:auto-run? (nth plays 0))))
+      (is (true?  (:auto-run? (nth plays 1)))))))
+
+(deftest parse-plays-coerces-bare-event-vectors
+  (testing "bare event vectors inside a play's :script lift to [:dispatch ...]"
+    (let [plays (runner/parse-plays
+                  [{:name "p" :script [[:foo/bar 1] [:wait 0]]}])]
+      (is (= [[:dispatch [:foo/bar 1]] [:wait 0]]
+             (:script (first plays)))))))
+
+(deftest parse-plays-preserves-name
+  (let [plays (runner/parse-plays
+                [{:name "happy path" :script [[:dispatch [:a]]]}])]
+    (is (= "happy path" (:name (first plays))))))
+
+(deftest variant-body->plays-prefers-plays-over-play-script
+  (testing "if both :plays and :play-script are present, :plays wins"
+    (let [body  {:play-script [[:dispatch [:legacy]]]
+                 :plays       [{:name "p1" :script [[:dispatch [:plays]]]}]}
+          plays (runner/variant-body->plays body)]
+      (is (= 1 (count plays)))
+      (is (= "p1" (:name (first plays))))
+      (is (= [[:dispatch [:plays]]] (:script (first plays)))))))
+
+(deftest variant-body->plays-wraps-play-script
+  (testing "a :play-script-only variant produces a single-entry vector"
+    (let [body  {:play-script {:name "single" :script [[:dispatch [:a]]]}}
+          plays (runner/variant-body->plays body)]
+      (is (= 1 (count plays)))
+      (is (= "single" (:name (first plays))))
+      (is (= [[:dispatch [:a]]] (:script (first plays)))))))
+
+(deftest variant-body->plays-bare-play-script-without-name
+  (testing "a bare :play-script without a :name produces a one-entry vector with :name nil"
+    (let [body  {:play-script [[:dispatch [:a]]]}
+          plays (runner/variant-body->plays body)]
+      (is (= 1 (count plays)))
+      (is (nil? (:name (first plays)))))))
+
+(deftest variant-body->plays-empty
+  (testing "no play surface yields an empty vector"
+    (is (= [] (runner/variant-body->plays nil)))
+    (is (= [] (runner/variant-body->plays {})))
+    (is (= [] (runner/variant-body->plays {:events []})))))
+
+(deftest find-play-by-name
+  (let [plays (runner/parse-plays
+                [{:name "happy" :script [[:dispatch [:a]]]}
+                 {:name "error" :script [[:dispatch [:b]]]}])]
+    (is (= "happy" (:name (runner/find-play plays "happy"))))
+    (is (= "error" (:name (runner/find-play plays "error"))))
+    (is (nil? (runner/find-play plays "missing")))))
+
+(deftest find-play-nil-key-returns-first
+  (let [plays (runner/parse-plays
+                [{:name "first" :script [[:dispatch [:a]]]}
+                 {:name "second" :script [[:dispatch [:b]]]}])]
+    (is (= "first" (:name (runner/find-play plays nil))))))
+
+(deftest default-play-key-shape
+  (let [multi  (runner/parse-plays
+                 [{:name "alpha" :script [[:dispatch [:a]]]}
+                  {:name "beta"  :script [[:dispatch [:b]]]}])
+        single-bare (runner/variant-body->plays {:play-script [[:dispatch [:a]]]})
+        single-named (runner/variant-body->plays {:play-script {:name "n" :script [[:dispatch [:a]]]}})]
+    (is (= "alpha" (runner/default-play-key multi)))
+    ;; Single-script wrap preserves the original :name (nil for bare, "n" for named).
+    (is (nil? (runner/default-play-key single-bare)))
+    (is (= "n" (runner/default-play-key single-named)))
+    (is (nil? (runner/default-play-key [])))))
+
+(deftest multi?-predicate
+  (is (false? (runner/multi? [])))
+  (is (false? (runner/multi? [{:name "one"}])))
+  (is (true?  (runner/multi? [{:name "one"} {:name "two"}]))))
+
+(deftest play-key-extraction
+  (is (= "p" (runner/play-key {:name "p"})))
+  (is (nil?  (runner/play-key {:name nil})))
+  (is (nil?  (runner/play-key nil))))

--- a/tools/story/test/re_frame/story/ui/play_status_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/play_status_cljs_test.cljc
@@ -105,3 +105,35 @@
           summ   (runner/fail-summary failed)]
       (is (= 1 (:count summ)))
       (is (= 1 (:idx (:first summ)))))))
+
+;; ---- multi-play helpers (rf2-tl7zk) -------------------------------------
+
+#?(:cljs
+   (deftest chip-label-multi-idle
+     (testing "nil state with a play name renders 'Play <name> | IDLE'"
+       (is (= "Play happy path | IDLE"
+              (ps/chip-label-multi nil "happy path"))))))
+
+#?(:cljs
+   (deftest chip-label-multi-no-name-uses-default
+     (testing "no play name falls back to (default)"
+       (is (= "Play (default) | IDLE"
+              (ps/chip-label-multi nil nil))))))
+
+#?(:cljs
+   (deftest chip-label-multi-running
+     (testing "running state shows progress alongside the play name"
+       (let [s (-> (runner/parse-spec {:script [[:wait 1] [:wait 2]]})
+                   runner/initial-state
+                   (assoc :status :running :step-idx 1))]
+         (is (= "Play error path | RUNNING (step 2/2)"
+                (ps/chip-label-multi s "error path")))))))
+
+#?(:cljs
+   (deftest dropdown-row-status-shapes
+     (testing "dropdown-row-status renders short status badges"
+       (is (= "IDLE" (ps/dropdown-row-status nil)))
+       (is (= "IDLE" (ps/dropdown-row-status {:status :idle})))
+       (is (= "RUN"  (ps/dropdown-row-status {:status :running})))
+       (is (= "PASS" (ps/dropdown-row-status {:status :pass})))
+       (is (= "FAIL" (ps/dropdown-row-status {:status :fail}))))))

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -111,6 +111,63 @@
         (is (= :rf.error/story-panel-shape (:rf.error (ex-data e))))))))
 
 ;; ===========================================================================
+;; rf2-tl7zk — :plays multi-play schema contract
+;; ===========================================================================
+
+(deftest reg-variant-plays-accepts-named-list
+  (testing ":plays with valid named entries is accepted"
+    (story/reg-variant :story.multi/named
+      {:events []
+       :plays  [{:name "happy path"
+                 :script [[:dispatch [:foo]]]}
+                {:name "error path"
+                 :script [[:dispatch [:bar]]]}]})
+    (let [body (story/handler-meta :variant :story.multi/named)]
+      (is (= 2 (count (:plays body)))))))
+
+(deftest reg-variant-plays-empty-rejected
+  (testing ":plays must contain at least one entry"
+    (try
+      (story/reg-variant :story.multi/empty
+        {:events []
+         :plays  []})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-variant-plays-without-name-rejected
+  (testing "each :plays entry must carry a :name"
+    (try
+      (story/reg-variant :story.multi/no-name
+        {:events []
+         :plays  [{:script [[:dispatch [:foo]]]}]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-variant-plays-duplicate-names-rejected
+  (testing ":plays entries must have unique :name values"
+    (try
+      (story/reg-variant :story.multi/dup
+        {:events []
+         :plays  [{:name "p" :script [[:dispatch [:a]]]}
+                  {:name "p" :script [[:dispatch [:b]]]}]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+
+(deftest reg-variant-play-script-and-plays-mutually-exclusive
+  (testing "a variant may not declare BOTH :play-script and :plays"
+    (try
+      (story/reg-variant :story.multi/both
+        {:events      []
+         :play-script [[:dispatch [:legacy]]]
+         :plays       [{:name "p" :script [[:dispatch [:plays]]]}]})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/variant-shape (:rf.error (ex-data e))))))))
+
+;; ===========================================================================
 ;; UNKNOWN-TAG CONTRACT — tag-vocab cross-check error carries the offending set
 ;; ===========================================================================
 

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -601,6 +601,31 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  ;; rf2-tl7zk multi-play fixture — three named plays on one variant.
+  ;; The first play (happy-path) auto-runs on mount per the per-position
+  ;; default; the other two run on demand (manual trigger via the
+  ;; toolbar dropdown OR the CI runner's `runPlay` hook). One play
+  ;; deliberately fails to keep the failure path under CI coverage.
+  (story/reg-variant :story.counter-play-script/multi
+    {:doc        "rf2-tl7zk CI fixture — multi-play variant with three
+                 named plays. The CI runner enumerates each play as its
+                 own row (per-play pass/fail) and matches the per-play
+                 expected status using `failing` / `expected-fail` name
+                 markers."
+     :args       {:label "Multi-play"}
+     :events     []
+     :plays      [{:name      "happy-path"
+                   :script    [[:dispatch-sync [:counter/initialise 5]]
+                               [:assert-db [:count] 5]]}
+                  {:name      "edge-case-zero"
+                   :script    [[:dispatch-sync [:counter/initialise 0]]
+                               [:assert-db [:count] 0]]}
+                  {:name      "deliberately-failing"
+                   :script    [[:dispatch-sync [:counter/initialise 2]]
+                               [:assert-db [:count] 99]]}]
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; -------------------------------------------------------------------------
   ;; reg-workspace — two workspaces, one per layout the v1 ships
   ;;


### PR DESCRIPTION
## Why

Completes the `:play-script` toolset (rf2-tl7zk).

The current `:play-script` slot carries ONE script per variant. Storybook lets authors register multiple named `play()` functions against one story so the toolbar exposes a dropdown. This PR adds the `:plays` plural slot — a vector of named plays.

The single-script `:play-script` slot stays as the simple case; `:plays` is the rich case. Authors pick ONE per variant (schema-level mutual exclusion).

## Schema

```clj
{:plays [{:name      "happy-path"
          :auto-run? true                ; per-position default for entry 0
          :script    [[:dispatch-sync [:counter/initialise 5]]
                      [:assert-db [:count] 5]]}
         {:name      "edge-case-zero"
          :script    [[:dispatch-sync [:counter/initialise 0]]
                      [:assert-db [:count] 0]]}
         {:name      "deliberately-failing"
          :script    [[:dispatch-sync [:counter/initialise 2]]
                      [:assert-db [:count] 99]]}]}
```

Rules:
- `:plays` and `:play-script` are mutually exclusive at the variant level — schema rejects both. Runtime resolver prefers `:plays` and emits a one-shot console warning when both are present (defensive).
- Every `:plays` entry needs `:name`; names must be unique within a variant.
- First entry defaults `:auto-run? true` (matches the legacy single-script deep-link contract); subsequent entries default to `false`. Authors override explicitly.

## UI

ASCII of the toolbar chip dropdown (multi-play variants):

```
[Play happy-path | PASS  v]  [Re-run]
                       ^^^ click to open the dropdown
  +------------------------------+
  | happy-path           PASS    |   <- click runs that play
  | edge-case-zero       IDLE    |
  | deliberately-failing FAIL    |
  | ---------------------------- |
  | Run all (3)                  |   <- sequences all plays
  +------------------------------+
```

- The chip becomes Form-2 (stateful) for multi-play. Single-script variants are unchanged.
- Clicking a row dispatches `run-play!`, sets the active play, and closes the dropdown.
- `Re-run` re-runs the currently active play (set by the dropdown).
- `Run all (N)` sequences every play in declaration order so they don't race the same frame.

`data-test` attrs added for browser tests: `story-play-status-dropdown-toggle`, `story-play-status-dropdown`, `story-play-status-dropdown-row`, `story-play-status-run-all`. The chip exposes `data-multi` + `data-play` for selector targeting.

## CI runner behaviour change

`re-frame.story.play.ci-runner/ci-context` now exposes a per-play `:rows` enumeration alongside the legacy `:variants` / `:summaries`. A variant with `:plays` of size 3 yields 3 rows; a `:play-script` variant yields 1 row.

The CI hook adds two new entry-points:
- `readPlayRunState(variantId, playKey)` — per-play terminal state read.
- `runPlay(variantId, playKey)` — trigger a specific play.

The Playwright harness (`examples/scripts/serve-and-run-story-play-scripts.cjs`) groups rows by variant, navigates once per variant, triggers non-auto-run plays explicitly, and asserts per-play. The expected-fail marker (`failing` / `expected-fail`) now matches against either the variant id OR the play's `:name`.

Sample output:

```
Discovered 3 variant(s) with :play-script / :plays — 5 play row(s) total

=== Story :play-script CI summary ===
OK   story.counter-play-script/failing[initialise-one-but-expect-nine]  expected=fail actual=fail  steps=2
OK   story.counter-play-script/multi[happy-path]                        expected=pass actual=pass  steps=2
OK   story.counter-play-script/multi[edge-case-zero]                    expected=pass actual=pass  steps=2
OK   story.counter-play-script/multi[deliberately-failing]              expected=fail actual=fail  steps=2
OK   story.counter-play-script/passing[initialise-three-and-assert-pass] expected=pass actual=pass  steps=2

Ran 5 :play-script row(s). 0 unexpected outcomes.
```

## New + modified files

Modified:
- `tools/story/src/re_frame/story/schemas.cljc` — `NamedPlaySpec`, `PlaysSpec`, `:plays` slot, mutual-exclusion `:fn`.
- `tools/story/src/re_frame/story/play/runner.cljc` — `parse-plays`, `variant-body->plays`, `find-play`, `default-play-key`, `play-key`, `multi?`.
- `tools/story/src/re_frame/story/play/runner_events.cljc` — `runs-by-play` atom, `active-play` atom, `run-play!`, `select-play!`, `run-all-plays!`, multi-play `auto-run!`, one-shot mutual-exclusion warning, `variant-plays`, `resolve-play`, `current-state-for-play`, `active-play-key`, `set-active-play!`.
- `tools/story/src/re_frame/story/play/ci_runner.cljc` — `has-plays?`, `has-any-play?`, `ci-rows`, new `readPlayRunState` + `runPlay` JS hooks; discovery includes `:plays`.
- `tools/story/src/re_frame/story/ui/play_status.cljs` — Form-2 `chip` with dropdown affordance; `chip-label-multi`, `dropdown-row-status`, dropdown panel renderer.
- `tools/story/test/re_frame/story/play/runner_test.cljc` — `parse-plays` / `variant-body->plays` / `find-play` / `default-play-key` / `multi?` / `play-key` tests.
- `tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc` — JVM integration: per-play state keying, `run-play!`, `select-play!`, `run-all-plays!`, multi-play auto-run, one-shot warning.
- `tools/story/test/re_frame/story/play/ci_runner_test.cljc` — `has-plays?`, `has-any-play?`, `ci-rows` enumeration, summary from `:plays` (first play), context shape.
- `tools/story/test/re_frame/story/ui/play_status_cljs_test.cljc` — `chip-label-multi`, `dropdown-row-status`.
- `tools/story/test/re_frame/story_authoring_validation_test.clj` — `:plays` schema: accepted shape, empty rejected, missing `:name` rejected, duplicate names rejected, mutual exclusion with `:play-script`.
- `tools/story/testbeds/counter_with_stories/stories.cljs` — `:story.counter-play-script/multi` 3-play fixture.
- `examples/scripts/serve-and-run-story-play-scripts.cjs` — per-play row driver.

## Test plan

- [x] `cd tools/story && clojure -M:test` — 790 tests, 2338 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 3117 tests, 8920 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 3108 tests, 8873 assertions, 0 failures
- [x] `cd implementation && npm run test:story-play-scripts` — 5 play rows, 0 unexpected outcomes
- [x] `cd implementation && npm run story:build` — release-build compiles cleanly (203 files compiled, 0 warnings)
- [x] `scripts/test-fast-pr.sh` — PASS

## Divergence notes

- **Schema-layer mutual exclusion.** Bead allowed runtime-only check; ship enforced it at registration time so authors get the error at `reg-variant` instead of at first run. Runtime warning still fires defensively for any code path that bypasses validation (direct registrar side-table writes).
- **Run-all sequential coordinator.** Bead allowed dropping run-all to a follow-on; ship includes it because the sequencing primitive was already needed for multi-play `auto-run!` (multiple `:auto-run? true` plays must not race).
- **CI runner extension.** Implemented in this PR; per-play assertions verified end-to-end against the new multi-play testbed fixture.

## Follow-ons

None identified. Bead stays OPEN as instructed.