### PR TITLE
fix(causa): managed-fx tooltips no longer leak internal references

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -121,7 +121,6 @@
   [correlation-id]
   (when correlation-id
     [:span {:data-testid "rf-causa-managed-fx-correlation"
-            :title "Correlation id — :request-id / :invoke-id / :flow-id. F.6 stale-response detection rides this slot."
             :style {:padding       "1px 6px"
                     :margin-left   "8px"
                     :border-radius "3px"
@@ -162,7 +161,7 @@
   [stubbed?]
   (when stubbed?
     [:span {:data-testid "rf-causa-managed-fx-stub"
-            :title "An :fx-overrides redirect is active for this fx. Per Spec 002 §:fx-overrides."
+            :title "Stubbed — this effect is redirected by an :fx-overrides entry instead of running for real."
             :style {:padding       "1px 6px"
                     :margin-left   "8px"
                     :border-radius "3px"
@@ -190,7 +189,6 @@
                           :font-size     "12px"
                           :color         (:text-primary tokens)}}
    [:span {:data-testid (str "rf-causa-managed-fx-surface-" (name surface))
-           :title (str "Managed-effects surface: " (name surface) ". Per spec/Managed-Effects.md")
            :style {:display       "inline-flex"
                    :align-items   "center"
                    :gap           "4px"
@@ -314,7 +312,7 @@
                     :font-family mono-stack
                     :font-size "11px"
                     :margin-bottom "4px"}}
-      "⚠ STATUS :ok but no app-db paths changed — possible F.4"]
+      "⚠ STATUS :ok but no app-db paths changed — app-db wasn't updated"]
      [:div {:style {:color (:text-tertiary tokens) :font-style "italic"}}
       "The handler dispatched but did not write a slice. Likely a "
       "missing :db assoc or a guard that no-op'd."]]

--- a/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_template_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/managed_fx_template_cljs_test.cljs
@@ -142,23 +142,96 @@
 (deftest records-list-nil-for-empty-records
   (is (nil? (template/records-list []))))
 
-;; ---- F.4 highlight: OK status + empty paths-touched -------------------
+;; ---- "app-db wasn't updated" highlight: OK status + empty paths-touched ----
+
+(defn- visible-text
+  "Walk a hiccup tree and concatenate every string node. Used to
+  assert on the rendered prose without booting a DOM."
+  [node]
+  (let [acc  (atom [])
+        walk (fn walk [n]
+               (cond
+                 (string? n) (swap! acc conj n)
+                 (vector? n) (doseq [c (drop 1 n)] (walk c))
+                 (seq? n)    (doseq [c n] (walk c))))]
+    (walk node)
+    (apply str @acc)))
+
+(defn- tooltip-text
+  "Walk a hiccup tree and concatenate every :title / :aria-label /
+  :data-tooltip attribute value. Used to assert tooltips don't leak
+  internal references (bead IDs, spec citations, F-codes)."
+  [node]
+  (let [acc  (atom [])
+        walk (fn walk [n]
+               (cond
+                 (and (vector? n) (map? (second n)))
+                 (let [attrs (second n)]
+                   (doseq [k [:title :aria-label :data-tooltip]]
+                     (when-let [v (get attrs k)]
+                       (swap! acc conj v)))
+                   (doseq [c (drop 2 n)] (walk c)))
+
+                 (vector? n) (doseq [c (drop 1 n)] (walk c))
+                 (seq? n)    (doseq [c n] (walk c))))]
+    (walk node)
+    (str/join " " @acc)))
 
 (deftest app-db-section-flags-empty-slice-on-ok-status
-  (testing "Per spec/019 §2.4 F.4 — when status is :ok but
-            paths-touched is empty, the panel renders the F.4 warning
-            heuristic instead of the bare '(no changes)' caption"
-    (let [r   (record {:surface :http :fx-id :rf.http/managed
+  (testing "When status is :ok but paths-touched is empty, the panel
+            renders the 'app-db wasn't updated' warning instead of the
+            bare '(no changes)' caption."
+    (let [r        (record {:surface :http :fx-id :rf.http/managed
+                            :status :ok :http-status 200
+                            :paths []})
+          combined (visible-text (template/record-panel r))]
+      (is (str/includes? combined "app-db wasn't updated"))
+      ;; silent-by-default: no internal F-code in user-visible prose
+      (is (not (re-find #"F\.\d" combined))
+          "user-visible warning text leaks an internal F-code"))))
+
+;; ---- chrome leak guard: no bead IDs / spec citations in user-facing text ----
+;;
+;; Per rf2-6lp7k + the silent-by-default policy (Conventions.md
+;; §Silent-by-default), no internal reference (bead IDs `rf2-*`,
+;; F-codes `F.\d`, "Spec N" citations, "spec/0NN" paths) may appear
+;; in user-facing chrome (rendered text or tooltips). These tests
+;; render every surface variant + the canonical edge cases and
+;; assert the negative.
+
+(def ^:private internal-ref-patterns
+  [[#"rf2-[a-z0-9]+"  "bead id"]
+   [#"F\.\d"          "F-code"]
+   [#"Spec \d"        "Spec citation"]
+   [#"spec/0\d\d"     "spec-path citation"]])
+
+(defn- assert-no-internal-refs!
+  [label text]
+  (doseq [[pat kind] internal-ref-patterns]
+    (is (not (re-find pat text))
+        (str label " leaks an internal " kind ": " (pr-str (re-find pat text))))))
+
+(deftest user-facing-text-carries-no-internal-refs
+  (let [recs [(record {:surface :http :fx-id :rf.http/managed
                        :status :ok :http-status 200
-                       :paths []})
-          out (template/record-panel r)
-          ;; Walk the hiccup tree for the F.4 warning text
-          txt (atom [])
-          walk (fn walk [node]
-                 (cond
-                   (string? node) (swap! txt conj node)
-                   (vector? node) (doseq [c (drop 1 node)] (walk c))
-                   (seq? node)    (doseq [c node] (walk c))))]
-      (walk out)
-      (let [combined (apply str @txt)]
-        (is (str/includes? combined "F.4"))))))
+                       :handler [:user/loaded] :paths [[:users 42]]})
+              (record {:surface :http :fx-id :rf.http/managed
+                       :status :ok :http-status 200
+                       :paths []})   ;; app-db-wasn't-updated warning path
+              (assoc (record {:surface :http :fx-id :rf.http/managed
+                              :status :error :http-status 500})
+                     :failure {:kind :rf.http/http-5xx
+                               :tags {:status 500}})
+              (record {:surface :websocket :fx-id :rf.ws/connect :status :ok})
+              (record {:surface :machine-invoke :fx-id :rf.machine/spawn :status :ok})
+              (record {:surface :ssr-fx :fx-id :rf.server/set-status :status :ok})
+              (record {:surface :flow :fx-id :rf.fx/reg-flow :status :ok})
+              (-> (record {:surface :http :fx-id :rf.http/managed :status :ok :http-status 200})
+                  (assoc :stubbed? true))
+              (-> (record {:surface :http :fx-id :rf.http/managed :status :cancelled})
+                  (assoc :cancel-cause :upstream-cancelled))]]
+    (doseq [r recs]
+      (let [panel (template/record-panel r)
+            label (str (:surface r) "/" (:status r))]
+        (assert-no-internal-refs! (str "visible-text[" label "]") (visible-text panel))
+        (assert-no-internal-refs! (str "tooltip-text[" label "]") (tooltip-text panel))))))


### PR DESCRIPTION
## Bug class

Managed-fx panel tooltips and one body-text warning leaked internal-only references (bead IDs, F-codes, Spec citations) into production chrome. Two policy lenses converge on the same fix:

- **Text audit (rf2-yn86j)** — flagged `rf2-6lp7k` as the surfacing-task for this class on managed-fx.
- **Silent-by-default policy (rf2-g3ghh / `Conventions.md §Silent-by-default`)** — UI text must earn its keep; "F.6 stale-response detection rides this slot" earns nothing for a hovering user.

PR #1422 (managed-fx wire-boundary diff) shipped this content before either policy was in force. This PR closes the gap.

## Before / after

| Where | Before | After |
| --- | --- | --- |
| `correlation-pill` `:title` | `Correlation id — :request-id / :invoke-id / :flow-id. F.6 stale-response detection rides this slot.` | _(removed — the pill already shows `correlation: <id>`)_ |
| `stub-pill` `:title` | `An :fx-overrides redirect is active for this fx. Per Spec 002 §:fx-overrides.` | `Stubbed — this effect is redirected by an :fx-overrides entry instead of running for real.` |
| Surface badge `:title` | `Managed-effects surface: <name>. Per spec/Managed-Effects.md` | _(removed — the badge already shows `MANAGED FX [<LABEL>]`)_ |
| `app-db-slice-section` body text | `⚠ STATUS :ok but no app-db paths changed — possible F.4` | `⚠ STATUS :ok but no app-db paths changed — app-db wasn't updated` |

Two of four call sites are dropped entirely (icon + adjacent label already carry the meaning); the other two are rewritten in user-facing language. No `:title`, `:aria-label`, or `:data-tooltip` in the panel now references `rf2-*`, an `F.\d` code, a `Spec N` citation, or a `spec/0NN` path.

## Test plan

- [x] Updated the existing F.4 assertion to the new wording.
- [x] Added a chrome-leak regression test (`user-facing-text-carries-no-internal-refs`) that renders every surface variant (`:http`, `:websocket`, `:machine-invoke`, `:ssr-fx`, `:flow`) plus the edge cases (stubbed, cancelled, app-db-wasn't-updated warning, failure) and asserts the negative against the four leak patterns over both visible text and tooltip attributes.
- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `cd tools/causa && clojure -M:test` — 923 tests / 2671 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 3129 tests / 9020 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 3120 tests / 8973 assertions / 0 failures
- [ ] Visual smoke (suggested manual): hover the managed-fx variants in panel-gallery and confirm tooltips read naturally.

## Scope

- Source comments and docstrings remain unchanged — they're maintainer-facing and still useful.
- The companion `managed_fx_subs.cljs` / `managed_fx_helpers.cljc` files only carry the same references in docstrings, so they aren't touched.

Bead `rf2-6lp7k` left open per dispatch instructions.