### PR TITLE
fix(causa): remaining broken-fix-it strings from text audit

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -180,7 +180,7 @@
      (cond
        sim-active?
        (str (h/format-machine-id machine-id)
-            " — sim mode active; clicks walk the topology against a clone")
+            " — sim mode active")
 
        (zero? (or instance-count 0))
        (str (h/format-machine-id machine-id)

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
@@ -186,7 +186,7 @@
                        :font-size "11px"
                        :font-weight 600
                        :margin-bottom "8px"}}
-   "SIMULATING — no live data; clicks walk the topology"])
+   "SIMULATING — no live data"])
 
 (defn- sim-current-state-row
   [sim]

--- a/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/performance.cljs
@@ -221,7 +221,7 @@
                              :font-size   "10px"
                              :font-weight 700
                              :text-align  "right"}
-               :title       "Over budget — click to inspect"}
+               :title       "Over budget"}
         "▲ over"]
        [:span {:style {:color     (:text-tertiary tokens)
                        :font-size "10px"


### PR DESCRIPTION
## Summary

The text audit (`ai/findings/2026-05-18-causa-text-audit.md`) enumerated 6 "broken-fix-it" strings — UI promises whose backing affordance the source doesn't actually wire. By the time this bead landed:

- 2 were already shipped (rf2-o09bu app-db slice subhead, rf2-u3qm1 popout "— stubbed" tag)
- 3 more were swept by cluster #1439 (rf2-bmyii, rf2-nvy10, rf2-4rqre — heatmap segment, causality popover footer, drilldown caption)
- 1 was always **K** verdict in the audit (the chart-fallback message — distinct-but-related to the banner explainer + button tooltip; not strictly a lie, just triplicated)

So the original 6 were effectively cleared. Per the prompt's fallback instruction ("use the same predicate to sweep the panels we touched in #1439 + audit-listed surfaces for other lies"), this PR finds and fixes 3 fresh broken-fix-its using the predicate "does the source dispatch what the text claims?"

## Per-string verdicts

| # | Location | String | Verdict | Rationale |
|---|---|---|---|---|
| 1 | `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs:183` | `<machine> — sim mode active; clicks walk the topology against a clone` | **deleted "clicks walk" clause** | The chart's `:on-state-click` dispatches `:rf.causa/machine-state-clicked` — but that handler is a no-op stub (line 948-950: `(fn [db [_ _payload]] db)`). Topology walking in sim mode happens via the Step button in the sub-rail, not via chart-node clicks. The bare `sim mode active` banner is the load-bearing mode indicator and stays. |
| 2 | `tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs:189` | `SIMULATING — no live data; clicks walk the topology` | **deleted "clicks walk" tail** | Same lie. The `SIMULATING — no live data` banner is load-bearing (chart highlights mean something different in sim mode); the tail is the broken promise. |
| 3 | `tools/causa/src/day8/re_frame2_causa/panels/performance.cljs:224` | `Over budget — click to inspect` (tooltip on the over-budget glyph) | **deleted "— click to inspect" tail** | The glyph `:span` itself has no `:on-click` — only the parent row does. Per audit P3 ("Click X to Y" narration is banned) and the "silent by default" policy (rf2-g3ghh, just landed), the row's `cursor:pointer` + visual selection state are the affordance. Tooltip becomes simply `Over budget`. |

Two-of-three are the same lie surfaced on two surfaces (the sim-mode banner appears both in the main panel banner and in the side-rail banner). The third is a "Click X to Y" tooltip on a non-click target.

## Method

- Re-verified each of the original 6 audit-listed broken-fix-its against current source — confirmed 5 swept by #1439 + earlier fixes; 1 was always **K**.
- Grep'd `tools/causa/src` for `:title "[^"]*Click[^"]*"`, `"clicks walk"`, `"Click "/"click "` patterns + tooltip claims.
- For each candidate, verified the source dispatches what the text claims (`:on-click` handlers + their `reg-event-*` registration + the handler body).
- Found these 3 substantive lies (and 1 borderline case at `machine_inspector.cljs:189` — "(toggle Sim ▶︎ to walk topology)" — which the audit kept as **K**; left alone to honor the audit).
- Confirmed no test pins any of the deleted strings.

## Out of scope

- `tools/causa/spec/003-Machine-Inspector.md:98` still includes the old "SIMULATING — no live data; clicks walk the topology" wording in a design mockup. That belongs in a spec/UX update bead, not this rendered-UI fix.
- The chart-fallback / banner / button-tooltip triplication flagged in the audit ("No introspectable definition available — chart cannot render.") is a single-source refactor opportunity; the three surfaces say genuinely different things and aren't a lie per se. Leaving for a separate ticket if desired.

## Test plan

- [x] `scripts/test-fast-pr.sh` — passes (3132 tests, 0 failures)
- [x] `cd tools/causa && clojure -M:test` — passes (923 tests, 2671 assertions, 0 failures)
- [x] `cd implementation && npm run test:browser` — passes (3123 tests, 8908 assertions, 0 failures)
- [ ] Visual check: open Causa machine-inspector in sim mode and confirm the banner reads `<machine> — sim mode active` and the sub-rail banner reads `SIMULATING — no live data`
- [ ] Visual check: open Causa performance panel with an over-budget cascade and confirm the `▲ over` tooltip reads `Over budget`