### PR TITLE
fix(causa): remove Pop-out '— stubbed' from shell chrome

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -250,17 +250,15 @@
 
     ;; Ribbon right-icon stubs — wired to events so the click round-
     ;; trips through the registry surface even though the user-facing
-    ;; modals / popout / close behaviours are follow-on work.
+    ;; close behaviour is follow-on work. Per rf2-u3qm1 the pop-out
+    ;; ribbon button + `:rf.causa/popout` stub are gone — pop-out is
+    ;; programmatic-only via `(causa/popout!)` until the second-window
+    ;; UX lands (spec/011-Launch-Modes.md). No broken-claim button in
+    ;; chrome (silent-by-default — rf2-g3ghh / rf2-yn86j).
     (rf/reg-event-db :rf.causa/open-settings
       (fn [db _event]
         ;; Settings popup lands behind rf2-pending-settings-modal.
         (assoc db :settings-open? true)))
-
-    (rf/reg-event-db :rf.causa/popout
-      (fn [db _event]
-        ;; Popout dispatch is symbolic until the popout window handle
-        ;; lands; the slot signals intent.
-        (assoc db :popout-requested? true)))
 
     (rf/reg-event-db :rf.causa/close-shell
       (fn [db _event]

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -35,7 +35,9 @@
     + trailing `[+]` add-pill. Click any pill → edit popup.
   - **Mode pill** — `● LIVE` / `◐ RETRO` / `● LIVE (paused)` dual-
     purpose indicator + toggle. Carries the REDACTED-count tooltip.
-  - **Right icons** — `⚙` settings · `⛶` popout · `✕` close.
+  - **Right icons** — `⚙` settings · `✕` close. (Pop-out is a
+    programmatic API only — `(causa/popout!)` — no ribbon affordance
+    until the second-window UX lands per spec/011-Launch-Modes.md.)
 
   ## Event list (L2)
 
@@ -107,9 +109,9 @@
 (def ^:private internal-frames
   "Frames Causa filters out of the picker by default per spec/018 §8 I1.
   `:rf/causa` is Causa's own state; `:rf/pair2` is the future MCP-pair
-  frame. The Settings 'Show tool frames in picker' toggle re-includes
-  them under a `── Power user ──` divider (settings UI is stubbed
-  pending follow-on work)."
+  frame. A future Settings 'Show tool frames in picker' toggle will
+  re-include them under a `── Power user ──` divider; the toggle UI
+  is not built yet, so the picker is hardcoded to exclude them."
   #{:rf/causa :rf/pair2})
 
 (def ^:private tabs
@@ -361,12 +363,16 @@
      (str "● REDACTED " redacted-count)]))
 
 (defn- ribbon-right-icons
-  "Right-icons cluster — `⚙` settings · `⛶` popout · `✕` close per
-  spec/018 §3 Right-icon behaviour. Settings opens the Settings popup
-  modal (rf2-9poxq) via `:rf.causa/settings-open`; popout is stubbed
-  (popout dispatches the existing toggle for symmetry). Close
-  dispatches `:rf.causa/close-shell` (handled by mount.cljs in
-  production)."
+  "Right-icons cluster — `⚙` settings · `✕` close. Per spec/018 §3
+  Right-icon behaviour the pop-out (`⛶`) slot is reserved for the
+  second-window UX (spec/011-Launch-Modes.md); the ribbon affordance
+  is omitted until that lands rather than showing a broken-claim
+  button (silent-by-default — rf2-g3ghh / rf2-yn86j). The programmatic
+  `(causa/popout!)` API remains the supported pop-out path.
+
+  Settings opens the Settings popup modal (rf2-9poxq) via
+  `:rf.causa/settings-open`; close dispatches `:rf.causa/close-shell`
+  (handled by mount.cljs in production)."
   []
   (let [icon-style {:background     "transparent"
                     :border         "none"
@@ -382,11 +388,6 @@
                :on-click    #(rf/dispatch [:rf.causa/settings-open] {:frame :rf/causa})
                :style       icon-style}
       "⚙"]
-     [:button {:data-testid "rf-causa-icon-popout"
-               :title       "Pop out (o) — stubbed"
-               :on-click    #(rf/dispatch [:rf.causa/popout] {:frame :rf/causa})
-               :style       icon-style}
-      "⛶"]
      [:button {:data-testid "rf-causa-icon-close"
                :title       "Close (Ctrl+Shift+C)"
                :on-click    #(rf/dispatch [:rf.causa/close-shell] {:frame :rf/causa})
@@ -402,7 +403,7 @@
   [_props]
   (let [focus           @(rf/subscribe [:rf.causa/focus])
         cascades        @(rf/subscribe [:rf.causa/cascades])
-        show-tool?      false   ; Power-user toggle stubbed pending Settings modal
+        show-tool?      false   ; Hardcoded — Power-user toggle UI not built yet
         frames          (distinct-frames cascades show-tool?)
         redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
         filters         @(rf/subscribe [:rf.causa/active-filters])

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -331,7 +331,6 @@
    :rf.causa/palette-toggle
    :rf.causa/pin-current
    :rf.causa/pin-slice
-   :rf.causa/popout
    :rf.causa/preview-cascade
    :rf.causa/remove-filter
    :rf.causa/rename-pin
@@ -578,8 +577,12 @@
     ;;   views-set-component-filter, views-set-group-by,
     ;;   views-set-heatmap?, views-toggle-cluster, views-toggle-heatmap,
     ;;   views-toggle-row.
-    ;; + 6 4-layer chrome (rf2-xy4yb): select-tab + add-filter +
-    ;;   remove-filter + open-settings + popout + close-shell
+    ;; + 5 4-layer chrome (rf2-xy4yb): select-tab + add-filter +
+    ;;   remove-filter + open-settings + close-shell
+    ;;   (popout dropped per rf2-u3qm1 — the ribbon `⛶` button + its
+    ;;   stub `:rf.causa/popout` event were broken-claim chrome; pop-
+    ;;   out is programmatic-only via `(causa/popout!)` until the
+    ;;   second-window UX lands).
     ;; + 6 sim sub-mode (rf2-v869p Phase 2):
     ;;   :rf.causa/sim-start / sim-step / sim-reset / sim-stop /
     ;;   sim-set-pending-event / sim-set-pending-data
@@ -621,7 +624,7 @@
     ;;   pin for the CLJS-side test surface).
     ;; + 1 modal positioning (rf2-om6fa):
     ;;   :rf.causa/set-modal-positioning — Story-aware shell-view opt.
-    (is (= 144 (count all-event-names)))
+    (is (= 143 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -201,6 +201,27 @@
         (is (some? (find-by-testid tree "rf-causa-ribbon-icons"))
             "right-icons cluster present")))))
 
+(deftest ribbon-omits-popout-button
+  (testing "rf2-u3qm1 — the right-icons cluster mounts only Settings +
+            Close. The legacy `⛶` pop-out (`rf-causa-icon-popout`) was
+            a broken-claim affordance (`title 'Pop out (o) — stubbed'`)
+            and is removed. Pop-out is programmatic-only via
+            `(causa/popout!)` until the second-window UX lands per
+            spec/011-Launch-Modes.md."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            icons (find-by-testid tree "rf-causa-ribbon-icons")]
+        (is (some? icons) "right-icons cluster still mounts")
+        (is (some? (find-by-testid tree "rf-causa-icon-settings"))
+            "Settings icon still present")
+        (is (some? (find-by-testid tree "rf-causa-icon-close"))
+            "Close icon still present")
+        (is (nil? (find-by-testid tree "rf-causa-icon-popout"))
+            "pop-out ribbon button is absent (silent-by-default)")
+        (is (not (re-find #"stubbed" (text-nodes icons)))
+            "no `stubbed` copy in the right-icons cluster")))))
+
 (deftest ribbon-nav-buttons-dispatch-spine-events
   (testing "spec/018 §3 — ribbon `◀ ▶ ⏭` dispatch focus-cascade-prev /
             -next / follow-head"


### PR DESCRIPTION
## Summary

Per **rf2-u3qm1**: `tools/causa/src/day8/re_frame2_causa/shell.cljs` mounted a ribbon button whose `title` literally read `Pop out (o) — stubbed`. Documenting in user-facing chrome that an affordance does not work is a broken claim and violates silent-by-default (rf2-g3ghh) and no-broken-claims (rf2-yn86j). The handler dispatched a no-op `:rf.causa/popout` stub that wrote `:popout-requested? true` to app-db — symbolic only; nothing observed it.

## Bug class

Broken claim documented in chrome — the UI itself confessed the feature was non-functional. Decision per the bead: **remove the affordance entirely** rather than fake an implementation. Pop-out remains a programmatic-only API via `(causa/popout!)` until the second-window UX lands per `spec/011-Launch-Modes.md`.

## Files changed

- `tools/causa/src/day8/re_frame2_causa/shell.cljs`
  - Removed the `⛶` button (`rf-causa-icon-popout` testid) + its tooltip + the `:rf.causa/popout` dispatch from `ribbon-right-icons`.
  - Updated the ns docstring (`Right icons` bullet) and `ribbon-right-icons` docstring to document the silent-by-default decision + reference the programmatic path.
  - Cleaned two adjacent stale comments per the bead's audit instruction:
    - `internal-frames` docstring no longer says "settings UI is stubbed pending follow-on work" (the Settings popup is built — rf2-9poxq). Wording now reflects the still-unbuilt power-user toggle UI honestly.
    - `ribbon` view comment `; Power-user toggle stubbed pending Settings modal` → `; Hardcoded — Power-user toggle UI not built yet`.
- `tools/causa/src/day8/re_frame2_causa/registry.cljs`
  - Removed the `(reg-event-db :rf.causa/popout ...)` stub handler. Updated the surrounding comment to cite rf2-u3qm1 and explain why the slot is gone.
- `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs`
  - Dropped `:rf.causa/popout` from `all-event-names`; event-count assertion 144 → 143; comment trail updated (`6 4-layer chrome` → `5 4-layer chrome`).
- `tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs`
  - New `ribbon-omits-popout-button` test — asserts `rf-causa-icon-popout` is absent, the Settings + Close icons remain, and no `stubbed` copy appears in the right-icons cluster.

## Keybinding

The `o` keybinding was **not** registered. `tools/causa/src/day8/re_frame2_causa/keybinding.cljs` binds only Space / L / G / j / k / c (plus Ctrl+Shift+C and Cmd/Ctrl+K). Nothing to deactivate.

## Gates

- `scripts/test-fast-pr.sh` — 3134 tests / 9032 assertions, 0 failures, 0 errors
- `cd tools/causa && clojure -M:test` — 923 tests / 2671 assertions, 0 failures, 0 errors
- `cd implementation && npm run test:browser` — 3125 tests / 8985 assertions, 0 failures, 0 errors

## Bead

Do **not** close `rf2-u3qm1`; the mayor closes after merge.