### PR TITLE
docs(causa): document Causa panel resize affordance

### DIFF
--- a/docs/causa/02-panel-tour.md
+++ b/docs/causa/02-panel-tour.md
@@ -102,6 +102,12 @@ See [chapter 7](07-hydration.md).
 
 ---
 
+## Resizing Causa
+
+Drag the left edge of the Causa panel to resize horizontally. Width persists across reloads (per-Causa-instance, stored in localStorage). Double-click the handle to reset to default width.
+
+For full-screen inspection, change `Settings → General → Panel position` to `fullscreen`. For an out-of-window view, change it to `popout` — the browser's window controls then govern size.
+
 ## How the panels share state
 
 Every panel reads the same store. Selecting an event in *Event detail* highlights the corresponding row in *Trace* and pins the *App-DB* diff to that epoch. Dragging the time-travel scrubber retargets every panel at the historical epoch. Clicking a sub in *Subscriptions* opens its source in your editor (next chapter), pins it in *App-DB*, and highlights its incoming edge in the static sub-graph.

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -88,17 +88,22 @@ right-side host to the app layout (DOM order: `<main>` first, host
 #app { flex: 1; min-width: 0; }
 ```
 
-Two complementary resize mechanisms ship together — both
-browser-native, both JS-free:
+Three complementary resize mechanisms ship together:
 
 - **CSS variable** (host-owned). Override `--rf-causa-inline-width`
   anywhere up the cascade (e.g.
   `:root { --rf-causa-inline-width: 720px; }`) to set the initial
   width.
-- **Browser-native drag** (user-controlled). `resize: horizontal` +
+- **Browser-native drag** (host-CSS fallback). `resize: horizontal` +
   `overflow: auto` give the host a drag-handle in the bottom corner;
   the variable seeds the initial size, a drag overrides it for the
   page lifetime.
+- **Causa drag handle** (user-controlled, persisted). Drag the panel's
+  outer edge (left edge when docked `:right-rail`) to resize. Width
+  clamps to `[320px, 90vw]` and persists across reloads via
+  `configure! :settings :general :panel-width-px`. Double-click the
+  handle to reset to default. See
+  [`spec/007-UX-IA.md` §Resize affordance](./spec/007-UX-IA.md#resize-affordance).
 
 If the host is missing, Causa logs an actionable `console.error` and
 exposes the same state through `window.day8.re_frame2_causa.status()`.

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -139,6 +139,29 @@ as `day8.re-frame2-causa.config/default-layout-host-css-var` /
 without forking the string. Full contract + drag mechanics in
 [`011-Launch-Modes.md`](./011-Launch-Modes.md).
 
+### Resize affordance
+
+Causa's panel SHALL be horizontally resizable via a drag handle on the
+panel's outer edge (left edge when docked `:right-rail`; the default per
+`Settings → General → Panel position`). The handle SHALL:
+
+- Show `cursor: col-resize` on hover
+- Drag-to-update width with global mouse-capture
+- Clamp width to `[320px, 90vw]`
+- Persist via `configure! :settings :general :panel-width-px`
+  (see [`015-Configuration.md`](./015-Configuration.md))
+- Reset to default width on double-click
+
+No textual affordance accompanies the handle (cursor change is sufficient
+signal per [`Conventions.md`](./Conventions.md) §UI text — silent by
+default). The resize handle is a worked example of "non-obvious
+affordance with iconographic alternative": discovery is via cursor
+change on edge hover, not via prose label.
+
+In `:popout` panel-position the browser's window controls govern size
+(no in-panel handle renders). In `:fullscreen` position the handle is
+suppressed — the panel fills the viewport.
+
 ## The L1 ribbon
 
 Five clusters, fixed order left to right:

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -181,9 +181,18 @@ the `default-settings` block in `config.cljc`:
 ```clojure
 {:general   {:text-size           13          ; px; slider range 10–18
              :panel-position      :right-rail ; :right-rail | :popout | :fullscreen
+             :panel-width-px      480         ; number; clamped [320, 0.9 × viewport-width-px]
              :auto-open-on-error? false}
  :theme     :dark}                             ; :dark | :light
 ```
+
+The `:panel-width-px` slot (rf2-x8h9y) drives the
+`:right-rail` panel's horizontal width. The Causa drag handle (per
+[`007-UX-IA.md` §Resize affordance](./007-UX-IA.md#resize-affordance))
+writes through to this slot on drag-end; the slot persists via the
+existing `re-frame2.causa.settings.v1` localStorage key so width survives
+reloads. Default `480`. Ignored in `:popout` (window owns size) and
+`:fullscreen` (viewport owns size) positions.
 
 > Note (rf2-jh9ws): a `:telemetry` slot shipped briefly with the
 > initial popup landing (rf2-9poxq) but was removed — Causa

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -278,7 +278,7 @@ backfills what v1 actually ships.
 
 | Tab | What it carries |
 |---|---|
-| **General** (default) | Text-size slider (range 10–18 px; writes the `--rf-causa-text-size` CSS custom property on the shell root + `<html>`) · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen` — routes to `mount/open!` / `mount/popout!` / `mount/open-overlay!` via the browser API exports) · "Auto-open Causa when an issue is observed" checkbox |
+| **General** (default) | Text-size slider (range 10–18 px; writes the `--rf-causa-text-size` CSS custom property on the shell root + `<html>`) · Panel-position radio (`:right-rail` / `:popout` / `:fullscreen` — routes to `mount/open!` / `mount/popout!` / `mount/open-overlay!` via the browser API exports) · Panel-width-px slot (number; default 480; written by the resize handle per [`007-UX-IA.md` §Resize affordance](./007-UX-IA.md#resize-affordance); no in-popup widget — the panel's drag handle is the affordance) · "Auto-open Causa when an issue is observed" checkbox |
 | **Filters** | Pointer into the auto-filter pills feature. When the `day8.re-frame2-causa.filters` ns is on the classpath the tab renders an "Open auto-filter UI" button that dispatches `:rf.causa.filters/open`; otherwise it shows the "install the feature first" hint. The full pill management surface lives in the ribbon (per [`018-Event-Spine.md`](./018-Event-Spine.md) §7) — this tab is a discoverability handle. |
 | **Theme** | Dark (default) / Light radio. Toggles the `rf-causa-theme-{dark,light}` class on the shell root + `<html>`. Accent picker deferred. |
 
@@ -297,6 +297,7 @@ When telemetry actually ships, the tab returns with real wiring.
 |---|---|---|
 | `:general :text-size` | `13` (px) | Matches `theme/tokens.cljc :type-scale :body`. |
 | `:general :panel-position` | `:right-rail` | Matches the existing `:layout/host-selector` inline-host posture per [`015-Configuration.md`](./015-Configuration.md). |
+| `:general :panel-width-px` | `480` | Matches the default inline-host `--rf-causa-inline-width` band. Clamped `[320, 0.9 × viewport-width-px]` on every write. Set by the drag handle (rf2-x8h9y); double-click resets to this default. |
 | `:general :auto-open-on-error?` | `false` | The user is in their app, not asking Causa to interrupt them. |
 | `:theme` | `:dark` | Causa is a dev tool; the canvas-and-chrome palette in `theme/tokens.cljc` is the dark one. |
 

--- a/tools/causa/spec/Conventions.md
+++ b/tools/causa/spec/Conventions.md
@@ -221,6 +221,13 @@ Prose appears only when:
 2. The user is in **a state they couldn't otherwise know about** (e.g.
    "filter is hiding 12 events" — invisible from the data alone).
 
+Worked example of "non-obvious affordance with iconographic alternative":
+the panel resize handle (rf2-x8h9y; spec at
+[`007-UX-IA.md` §Resize affordance](./007-UX-IA.md#resize-affordance))
+ships with no label, no tooltip, no "drag to resize" prose. Discovery is
+via `cursor: col-resize` on hover — the cursor change is the
+iconographic signal, and prose would be redundant chrome.
+
 ### Banned phrasings
 
 - **Panel subheads** that restate the panel title.


### PR DESCRIPTION
Companion to bead **rf2-x8h9y** (Causa panel horizontal resize handle — impl PR lands separately).

## Summary

Documents the horizontal resize affordance across the Causa docs surface: user-facing tutorial paragraph, normative spec section, configure! schema slot, settings popup entry, and a Conventions worked-example.

## Files updated

- `docs/causa/02-panel-tour.md` — user-facing "Resizing Causa" paragraph (drag-to-resize, double-click reset, panel-position interaction).
- `tools/causa/README.md` — extends the "Add The Layout Host" three-mechanism overview to include Causa's drag handle (was: 2 browser-native mechanisms; now: + the rf2-x8h9y persisted drag handle).
- `tools/causa/spec/007-UX-IA.md` — new §Resize affordance normative subsection (cursor `col-resize`, clamp `[320px, 90vw]`, persist via configure!, dbl-click reset).
- `tools/causa/spec/015-Configuration.md` — adds `:panel-width-px` to the `:settings :general` block with cross-link to 007-UX-IA.
- `tools/causa/spec/016-Auxiliary-Panels.md` — extends the Settings popup General tab inventory + defaults table to include the panel-width slot.
- `tools/causa/spec/Conventions.md` — uses the resize handle as the worked example of "non-obvious affordance with iconographic alternative" (cursor change is the signal; no prose label).

## Gates

- `mkdocs build --strict`: 0 new warnings introduced (baseline 72 unchanged; all pre-existing under guide/24-* and skills/ pointing at spec/* targets outside the docs tree).

## Notes

- Does NOT change source — the impl PR handles that.
- Does NOT close rf2-x8h9y — the impl PR will trigger the close.

## Test plan

- [ ] Verify mkdocs build succeeds against this branch in CI.
- [ ] Visual confirmation that `tools/causa/spec/007-UX-IA.md#resize-affordance` anchor renders and is reachable from cross-links in 015 / 016 / Conventions / README.