### PR TITLE
feat(causa): drag-to-resize the Causa panel — standard devtool UX

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -75,6 +75,32 @@
   at 420px; 560px reads much better for the Event Detail panel)."
   "560px")
 
+(def default-panel-width-px
+  "Default panel width in pixels (rf2-x8h9y). Mirrors
+  `default-layout-host-width` (`\"560px\"`) without the unit so the
+  numeric Settings slot, the resize handle's drag math, and the
+  double-click reset can compose against one source of truth. The
+  resize handle writes the live value back through
+  `--rf-causa-inline-width` so the inline-host contract above (the
+  documented `var(--rf-causa-inline-width, 560px)` cascade) keeps
+  working unchanged — drag is simply a UX surface that drives that
+  same CSS custom property reactively."
+  560)
+
+(def min-panel-width-px
+  "Lower clamp for the resize handle (rf2-x8h9y). 320px matches the
+  inline-host snippet's `min-width: 320px` floor — below this the
+  L1 ribbon clusters start to wrap and the chrome becomes unusable."
+  320)
+
+(def max-panel-width-fraction
+  "Upper clamp for the resize handle expressed as a fraction of the
+  viewport width (rf2-x8h9y). 0.9 leaves a 10% sliver for the host
+  app so the user always has a visual anchor back to their content;
+  full-viewport coverage is the dedicated `:fullscreen` panel-position
+  rather than a side-effect of dragging the handle off the left edge."
+  0.9)
+
 (def default-accent-css-var
   "Name of the CSS custom property carrying Causa's brand-accent
   colour (the violet `#7C5CFF` from `theme/tokens.cljc` /
@@ -587,9 +613,25 @@
   the parent passes a new fn every time."
   {:general   {:text-size           13              ; px — slider range 10–18
                :panel-position      :right-rail     ; :right-rail | :popout | :fullscreen
+               :panel-width-px      default-panel-width-px ; rf2-x8h9y resize handle
                :auto-open-on-error? false}
    :theme     :dark                                  ; :dark | :light
    :diff      {:highlight-fn-ref-changes? false}})
+
+(defn clamp-panel-width-px
+  "Pure helper: clamp `px` to the resize handle's [min, viewport×0.9]
+  range (rf2-x8h9y). Pass `viewport-width-px` explicitly so the helper
+  stays CLJC-pure and JVM-testable (no implicit `window.innerWidth`
+  reach). Non-numeric input falls back to `default-panel-width-px` so
+  a malformed persisted payload never leaves the panel at an unusable
+  size."
+  [px viewport-width-px]
+  (if-not (number? px)
+    default-panel-width-px
+    (let [max-px (long (* (or viewport-width-px 2000) max-panel-width-fraction))
+          floor  min-panel-width-px
+          ceil   (max floor max-px)]
+      (long (-> px (max floor) (min ceil))))))
 
 (defonce
   ^{:doc "Atom holding the live settings map. Seeded with

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -32,11 +32,13 @@
   resolves `:<-` chains lazily at subscribe time, not register time."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.popover.causality :as causality-popover]
+            [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
@@ -177,6 +179,60 @@
       {:rf.trace/no-emit? true}
       (fn [db [_ positioning]]
         (assoc db :modal-positioning (or positioning :fixed))))
+
+    ;; ---- Panel width (rf2-x8h9y horizontal resize handle) -------
+    ;;
+    ;; The shell's left-edge resize handle drags the panel width.
+    ;; `:rf.causa/panel-width-px` reads from the settings map (the
+    ;; popup's `:rf.causa/setting` sub composes against the same
+    ;; slot — one source of truth); the value flows into the
+    ;; recommended `[data-rf-causa-host]` snippet via
+    ;; `--rf-causa-inline-width` (host CSS reads
+    ;; `var(--rf-causa-inline-width, 560px)` for its `flex-basis`).
+    ;;
+    ;; `:rf.causa/set-panel-width-px` is the drag handle's write
+    ;; surface — clamps to [min, viewport×0.9], persists through the
+    ;; same Settings round-trip every other `:rf.causa/settings-
+    ;; update` uses, AND applies the CSS var to the host immediately
+    ;; via `settings-effects/apply-panel-width!`. `:rf.trace/no-emit?`
+    ;; matches the modal-positioning handler — drag events fire at
+    ;; mousemove cadence (one dispatch per pixel of drag) and emitting
+    ;; them would flood the trace buffer with shape that no panel
+    ;; consumes. The clamp is applied at write-time so the persisted
+    ;; payload is always in-range — a future viewport-resize that
+    ;; would re-clamp would land on the next paint via the
+    ;; `panel-width-px` sub.
+    (rf/reg-sub :rf.causa/panel-width-px
+      (fn [db _query]
+        (or (get-in db [:settings :general :panel-width-px])
+            (config/get-setting :general :panel-width-px)
+            config/default-panel-width-px)))
+
+    (rf/reg-event-db :rf.causa/set-panel-width-px
+      {:rf.trace/no-emit? true}
+      (fn [db [_ px]]
+        (let [viewport (or (when (exists? js/window)
+                             (.-innerWidth js/window))
+                           2000)
+              clamped  (config/clamp-panel-width-px px viewport)]
+          ;; Dual-write: same pattern the settings-update event uses
+          ;; (config atom drives localStorage round-trip; app-db slot
+          ;; drives reactive re-render). Then push the CSS var so the
+          ;; layout host's `flex-basis` re-evaluates this paint.
+          (config/update-setting! :general :panel-width-px clamped)
+          (settings-effects/apply-panel-width! clamped)
+          (assoc-in db [:settings :general :panel-width-px] clamped))))
+
+    ;; Reset to default — bound to the resize handle's double-click.
+    ;; Routes through the same write surface so persistence + DOM
+    ;; cascade stay consistent. Separate event id so the palette /
+    ;; key-binding affordance can wire to it without re-implementing
+    ;; the clamp + persist logic.
+    (rf/reg-event-fx :rf.causa/reset-panel-width
+      {:rf.trace/no-emit? true}
+      (fn [_ _event]
+        {:fx [[:dispatch [:rf.causa/set-panel-width-px
+                          config/default-panel-width-px]]]}))
 
     ;; ---- 4-layer chrome — active filter pills (rf2-xy4yb / spec/018 §7) ----
     ;;

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -1,0 +1,228 @@
+(ns day8.re-frame2-causa.resize-handle
+  "Left-edge horizontal resize handle for the Causa shell (rf2-x8h9y).
+
+  ## What this is
+
+  A 6px-wide vertical strip pinned to the LEFT edge of the shell in
+  `:right-rail` (`:inline`) mode. The user drags it to widen / narrow
+  the panel; the live width persists through the Settings round-trip
+  and survives reload via localStorage. Double-click resets to
+  `config/default-panel-width-px` (560px).
+
+  ## Drag mechanics (global mouse capture)
+
+  `onMouseDown` records the starting mouse-X + starting panel width,
+  then attaches `mousemove` + `mouseup` listeners on
+  `js/document` (NOT the handle element). Document-level capture is
+  the standard devtool pattern — without it, drags faster than the
+  pointer-event cadence escape the handle's hit-test box and the
+  drag stalls. The handle's own `mousemove` only fires while the
+  cursor is over the 6px strip; the document's fires everywhere.
+
+  The same pattern is used by every browser's split-pane resizer,
+  Chrome devtools, VS Code's panel boundary, etc. — it's the
+  reference UX.
+
+  ## Width derivation
+
+  The panel currently lives to the RIGHT of the host app (per
+  `config/default-layout-host-snippet`'s flex layout — `<main>`
+  first, `<aside data-rf-causa-host>` second). Dragging the handle
+  to the LEFT widens the panel; dragging RIGHT narrows it. So the
+  delta is `(start-x - current-x)`:
+
+      width = start-width + (start-x - current-x)
+
+  Clamp at write-time via the registry's
+  `:rf.causa/set-panel-width-px` handler (which reaches
+  `config/clamp-panel-width-px`); the handle's UI math is naive
+  delta — the source of truth for the clamp lives in one place.
+
+  ## Coexistence with `:panel-position`
+
+  - `:right-rail` (default) — handle on LEFT edge of panel.
+    Rendered.
+  - `:popout` — separate window; browser-native window resize.
+    NOT rendered (the inline shell is hidden anyway).
+  - `:fullscreen` — full viewport overlay; resize is N/A.
+    NOT rendered.
+
+  The shell-view passes `mode` through; `Handle` renders nil for
+  any non-`:inline` mode.
+
+  ## Pure hiccup discipline (rf2-tijr)
+
+  Per shell.cljs §Pure hiccup the view code is plain hiccup with
+  no Reagent imports. Hover-state visual feedback would require a
+  Reagent ratom or a re-frame dispatch on every mouse-enter/leave
+  (cheap, but pollutes the trace); we ship without hover-state
+  highlight — the always-visible 1px accent stripe + cursor change
+  on hover (via inline `:cursor`) carry the affordance. While
+  dragging the body's cursor is overridden to `col-resize`
+  globally so the user reads the operation as continuous."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+
+;; ---- drag state ---------------------------------------------------------
+
+(defonce ^:private drag-state
+  ;; Holds the active drag's snapshot:
+  ;;   {:start-x       <Number>   ; pageX at mousedown
+  ;;    :start-width   <Number>   ; px at mousedown (from sub)
+  ;;    :on-move       <fn>       ; bound document handler (for cleanup)
+  ;;    :on-up         <fn>       ; bound document handler (for cleanup)
+  ;;    :prev-cursor   <string>}  ; body cursor pre-drag (for restore)
+  ;; nil when no drag is in progress. defonce so a shadow-cljs
+  ;; :after-load mid-drag doesn't strand a half-installed listener
+  ;; (the next mousedown re-installs cleanly).
+  (atom nil))
+
+(defn dragging?
+  "Test seam — true iff a drag is in progress. Pure read of the
+  drag-state atom. Used by `shell_resize_handle_cljs_test` to assert
+  the start/stop lifecycle."
+  []
+  (some? @drag-state))
+
+(defn- detach-document-listeners! []
+  (when-let [{:keys [on-move on-up prev-cursor]} @drag-state]
+    (when (and (exists? js/document) (.-removeEventListener js/document))
+      (try (.removeEventListener js/document "mousemove" on-move)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "mouseup" on-up)
+           (catch :default _ nil)))
+    ;; Restore the body cursor so the col-resize override doesn't
+    ;; linger after mouseup (the document drag overrides whatever
+    ;; the cursor was hovering, so we need to restore explicitly).
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor)
+            (or prev-cursor "")))
+    (reset! drag-state nil)))
+
+(defn- on-document-move [^js e]
+  (when-let [{:keys [start-x start-width]} @drag-state]
+    ;; Page-relative X so a drag that moves through a parent with
+    ;; CSS transforms still tracks the pointer.
+    (let [dx        (- start-x (.-pageX e))
+          new-width (+ start-width dx)]
+      (rf/dispatch [:rf.causa/set-panel-width-px new-width]
+                   {:frame :rf/causa}))))
+
+(defn- on-document-up [^js _e]
+  (detach-document-listeners!))
+
+(defn start-drag!
+  "Capture the drag start position + width snapshot, then attach the
+  document-level move + up listeners that drive the live update.
+  Pre-existing drag state is torn down first so a stuck listener
+  from a failed prior drag doesn't double-fire.
+
+  Exposed for the shell view's `:on-mouse-down` handler AND for the
+  test suite, which drives the drag lifecycle without a real DOM."
+  [^js e current-width]
+  ;; Defensive: clear any stale state from a prior aborted drag.
+  (detach-document-listeners!)
+  (let [start-x     (.-pageX e)
+        prev-cursor (when (and (exists? js/document)
+                               (.-body js/document))
+                      (-> js/document .-body .-style .-cursor))
+        on-move     on-document-move
+        on-up       on-document-up]
+    (reset! drag-state {:start-x     start-x
+                        :start-width (or current-width 560)
+                        :on-move     on-move
+                        :on-up       on-up
+                        :prev-cursor prev-cursor})
+    ;; Override the body cursor so the col-resize indicator persists
+    ;; through the drag even when the cursor moves off the 6px handle
+    ;; (which it will the moment the panel resizes wider than the
+    ;; original pointer position).
+    (when (and (exists? js/document) (.-body js/document))
+      (set! (-> js/document .-body .-style .-cursor) "col-resize"))
+    (when (and (exists? js/document) (.-addEventListener js/document))
+      (try (.addEventListener js/document "mousemove" on-move)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "mouseup" on-up)
+           (catch :default _ nil)))
+    ;; preventDefault swallows the native text-selection that begins
+    ;; on mousedown over a non-input element — without it a drag
+    ;; visually selects every piece of text the cursor crosses.
+    (try (.preventDefault e) (catch :default _ nil))))
+
+;; Test seam — directly drive the document-level handlers without
+;; needing a real DOM event listener attached. The view's
+;; `start-drag!` installs the handlers AND captures the snapshot;
+;; tests can replicate that by calling start-drag! with a stub event
+;; and then driving simulate-move! / simulate-up! to step the
+;; mouse without touching `js/document.dispatchEvent`.
+(defn simulate-move!
+  "Test-only: drive the document-level mousemove handler with a
+  page-X coordinate. No-op when no drag is in progress."
+  [page-x]
+  (when @drag-state
+    (on-document-move #js {:pageX page-x})))
+
+(defn simulate-up!
+  "Test-only: drive the document-level mouseup handler. No-op when no
+  drag is in progress."
+  []
+  (when @drag-state
+    (on-document-up nil)))
+
+;; ---- view ---------------------------------------------------------------
+
+(def ^:private base-width-px 6)
+
+(defn- handle-style []
+  ;; Left-edge stripe. `position: absolute; left: 0; top: 0;
+  ;; bottom: 0` pins the handle to the left edge of the shell-view's
+  ;; outer flex container (which is `position: relative` in `:inline`
+  ;; mode per shell.cljs §inline). The strip is 6px wide; a 1px
+  ;; accent stripe inset on the left edge sits at all times so the
+  ;; affordance is always visible (per pure-hiccup discipline we
+  ;; can't pseudo-class :hover; the always-visible accent + the
+  ;; col-resize cursor are the affordance). During drag the body
+  ;; cursor flips to col-resize globally so the operation reads as
+  ;; continuous even when the pointer leaves the strip.
+  {:position         "absolute"
+   :left             0
+   :top              0
+   :bottom           0
+   :width            (str base-width-px "px")
+   :cursor           "col-resize"
+   :background       "transparent"
+   ;; Hairline guide on the leftmost pixel so the affordance is
+   ;; visible against any host-app background.
+   :box-shadow       (str "inset 1px 0 0 0 " (:accent-violet tokens) "55")
+   ;; Above the chrome's panels but below the modals; modals use
+   ;; max-int z-index so we won't fight them.
+   :z-index          1000
+   ;; Touch / pointer hints — disable selection so a drag does not
+   ;; lasso text in adjacent panels.
+   :touch-action     "none"
+   :user-select      "none"})
+
+(rf/reg-view Handle
+  "Render the resize handle when `mode` is `:inline` (the right-rail
+  default). Other modes render nil — `:popout` is a separate window
+  the user resizes via the OS, `:fullscreen` is full-viewport and
+  has no width to drag.
+
+  `reg-view`-wrapped per rf2-in6l2 so the inner subscribe routes
+  through React-context to `:rf/causa` (the shell wraps the whole
+  chrome in `frame-provider {:frame :rf/causa}`)."
+  [mode]
+  (when (= mode :inline)
+    (let [current-width @(rf/subscribe [:rf.causa/panel-width-px])]
+      [:div {:data-testid     "rf-causa-resize-handle"
+             :role            "separator"
+             :aria-orientation "vertical"
+             :aria-label      "Resize Causa panel"
+             :title           "Drag to resize · double-click to reset"
+             :on-mouse-down   (fn [^js e]
+                                (start-drag! e current-width))
+             :on-double-click (fn [^js _e]
+                                (rf/dispatch
+                                  [:rf.causa/reset-panel-width]
+                                  {:frame :rf/causa}))
+             :style           (handle-style)}])))

--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -169,6 +169,43 @@
         (try (.add cl klass) (catch :default _ nil)))))
   nil)
 
+;; ---- panel width (rf2-x8h9y resize handle) ------------------------------
+
+(def panel-width-css-var
+  "Name of the CSS custom property the resize handle drives. Mirrors
+  `config/default-layout-host-css-var` — the inline-host snippet
+  reads `var(--rf-causa-inline-width, 560px)` for its `flex-basis`,
+  so writing to this property on `:root` (and the host element)
+  resizes the panel in lockstep. Published here as a constant so the
+  apply fn + tests reference one spelling."
+  "--rf-causa-inline-width")
+
+(defn- layout-host-element
+  "Resolve the configured layout host element if Causa is mounted in
+  the right-rail. Falls back to nil under :overlay/:popout/test
+  runtimes — `apply-panel-width!` then writes to `:root` only, which
+  is harmless because the host element doesn't exist in those modes."
+  []
+  (when (and (exists? js/document) (.-querySelector js/document))
+    (try
+      (.querySelector js/document (config/get-layout-host-selector))
+      (catch :default _ nil))))
+
+(defn apply-panel-width!
+  "Write `px` as the value of `--rf-causa-inline-width` on both the
+  configured layout host (so the host's `flex-basis` re-evaluates
+  immediately) and the `<html>` root (so the cascade still resolves
+  for any consumer reading `var(--rf-causa-inline-width, 560px)`
+  further up the tree). No-op when neither element is present —
+  matches the apply-text-size! / apply-theme! pattern."
+  [px]
+  (let [value (str (long (or px config/default-panel-width-px)) "px")]
+    (when-let [host (layout-host-element)]
+      (.setProperty (.-style host) panel-width-css-var value))
+    (when-let [html (html-root-element)]
+      (.setProperty (.-style html) panel-width-css-var value)))
+  nil)
+
 ;; ---- panel position -----------------------------------------------------
 
 (defn apply-panel-position!
@@ -296,8 +333,14 @@
   individually no-op-safe pre-mount."
   []
   (let [s (config/get-settings)]
-    (apply-text-size! (get-in s [:general :text-size]))
-    (apply-theme!     (get s :theme))
+    (apply-text-size!  (get-in s [:general :text-size]))
+    (apply-theme!      (get s :theme))
+    ;; rf2-x8h9y — restore the persisted panel width so the user's
+    ;; saved drag survives reload BEFORE first paint. No-op-safe
+    ;; pre-mount (writes to `<html>` only when the layout host hasn't
+    ;; mounted yet; the host pickup happens at next paint via the
+    ;; var cascade).
+    (apply-panel-width! (get-in s [:general :panel-width-px]))
     ;; Panel-position is intentionally NOT applied at boot — the
     ;; preload's auto-open already handles the default `:right-rail`
     ;; case, and reopening into the saved position would surprise a

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -95,6 +95,9 @@
         (and (= section :general) (= key :panel-position))
         (effects/apply-panel-position! value)
 
+        (and (= section :general) (= key :panel-width-px))
+        (effects/apply-panel-width! value)
+
         (and (= section :theme) (nil? key))
         (effects/apply-theme! value)
 

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -176,9 +176,10 @@
 ;; ---- section: General ---------------------------------------------------
 
 (defn- general-section []
-  (let [text-size      @(rf/subscribe [:rf.causa/setting :general :text-size])
-        panel-position @(rf/subscribe [:rf.causa/setting :general :panel-position])
-        auto-open?     @(rf/subscribe [:rf.causa/setting :general :auto-open-on-error?])]
+  (let [text-size       @(rf/subscribe [:rf.causa/setting :general :text-size])
+        panel-position  @(rf/subscribe [:rf.causa/setting :general :panel-position])
+        panel-width-px  @(rf/subscribe [:rf.causa/panel-width-px])
+        auto-open?      @(rf/subscribe [:rf.causa/setting :general :auto-open-on-error?])]
     [:div {:data-testid "rf-causa-settings-section-general"}
      [:h2 {:style (section-heading-style)} "General"]
 
@@ -204,6 +205,43 @@
                              :min-width   "32px"
                              :text-align  "right"}}
         (str (or text-size 13) "px")]]]
+
+     ;; ── Panel width (rf2-x8h9y resize handle numeric override) ─
+     [:div {:style (field-style)}
+      [:label {:style (label-style)} "Panel width (px)"]
+      [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
+       [:input {:data-testid "rf-causa-settings-panel-width-input"
+                :type        "number"
+                :min         "320"
+                :step        "10"
+                :value       (str (or panel-width-px 560))
+                :on-change   (fn [^js e]
+                               (let [n (js/parseInt (.. e -target -value) 10)]
+                                 (when-not (js/isNaN n)
+                                   (rf/dispatch
+                                     [:rf.causa/set-panel-width-px n]))))
+                :style       {:width        "120px"
+                              :padding      "4px 8px"
+                              :background   (:bg-2 tokens)
+                              :color        (:text-primary tokens)
+                              :border       (str "1px solid " (:border-default tokens))
+                              :border-radius "4px"
+                              :font-family  mono-stack}}]
+       [:button {:data-testid "rf-causa-settings-panel-width-reset"
+                 :title       "Reset to default (560px)"
+                 :on-click    #(rf/dispatch [:rf.causa/reset-panel-width])
+                 :style       {:background "transparent"
+                               :border     (str "1px solid " (:border-default tokens))
+                               :color      (:text-secondary tokens)
+                               :cursor     "pointer"
+                               :padding    "4px 10px"
+                               :border-radius "4px"
+                               :font-family sans-stack
+                               :font-size  (:body type-scale)}}
+        "Reset"]]
+      [:p {:style (hint-style)}
+       "Drag the left edge of the Causa panel to resize, or set "
+       "an exact pixel width here. Double-click the handle to reset."]]
 
      ;; ── Panel position radio ────────────────────────────────────
      [:div {:style (field-style)}

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -98,6 +98,7 @@
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.popover.causality :as causality-popover]
+            [day8.re-frame2-causa.resize-handle :as resize-handle]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.share-modal :as share-modal]
             [day8.re-frame2-causa.theme.tokens :refer [tokens type-scale layout sans-stack mono-stack]]))
@@ -734,6 +735,15 @@
                             :min-width  "560px"
                             :z-index    2147483000
                             :box-shadow "rgba(0, 0, 0, 0.4) -8px 0 24px"}))}
+    ;; Left-edge horizontal resize handle (rf2-x8h9y) — only renders
+    ;; in `:inline` (right-rail) mode. Position-absolute pins it to
+    ;; the LEFT edge of this flex container; the outer div is
+    ;; `position: relative` in :inline so the handle's anchor
+    ;; resolves correctly. The handle's drag math writes through
+    ;; `:rf.causa/set-panel-width-px`, which clamps + persists +
+    ;; pushes `--rf-causa-inline-width` onto the layout host so the
+    ;; host's `flex-basis` re-evaluates this paint.
+    [resize-handle/Handle mode]
     ;; L1 — top ribbon (scope controls)
     [ribbon {}]
     ;; L2 — event list (the spine timeline)

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -229,6 +229,66 @@
   (config/configure! {:editor :cursor})
   (is (= "myhost.filters" (config/get-filters-storage-key))))
 
+;; ---- panel-width (rf2-x8h9y resize handle) -----------------------------
+
+(deftest default-panel-width-px-published
+  (testing "config publishes a default panel width — the resize handle's
+            double-click reset target. 560px mirrors the inline-host
+            snippet's documented `var(--rf-causa-inline-width, 560px)`
+            so reset reads the same value the host CSS falls back to."
+    (is (= 560 config/default-panel-width-px))))
+
+(deftest default-settings-include-panel-width-px
+  (testing "the default settings map carries `:general :panel-width-px`
+            so the persistence round-trip + the Settings popup's reads
+            never see a nil"
+    (is (= config/default-panel-width-px
+           (get-in config/default-settings [:general :panel-width-px])))))
+
+(deftest clamp-panel-width-px-floor
+  (testing "min-clamp is published as `min-panel-width-px` (320) and a
+            sub-floor input snaps to the floor"
+    (is (= 320 config/min-panel-width-px))
+    (is (= 320 (config/clamp-panel-width-px 100 2000)))
+    (is (= 320 (config/clamp-panel-width-px 320 2000)))
+    (is (= 321 (config/clamp-panel-width-px 321 2000)))))
+
+(deftest clamp-panel-width-px-ceil
+  (testing "ceil is viewport × 0.9 — a wider request snaps down"
+    (is (= 1800 (config/clamp-panel-width-px 5000 2000))
+        "2000 × 0.9 = 1800")
+    (is (= 1800 (config/clamp-panel-width-px 1800 2000)))
+    (is (= 1799 (config/clamp-panel-width-px 1799 2000)))))
+
+(deftest clamp-panel-width-px-non-numeric-falls-back-to-default
+  (testing "malformed persisted payload (string, nil, NaN) shouldn't
+            leave the panel at an unusable size — fall back to default"
+    (is (= config/default-panel-width-px
+           (config/clamp-panel-width-px nil 2000)))
+    (is (= config/default-panel-width-px
+           (config/clamp-panel-width-px "wide" 2000)))))
+
+(deftest clamp-panel-width-px-narrow-viewport-still-floors
+  (testing "if viewport is narrower than the floor (mobile / odd
+            test runtime), the floor still wins over the ceil — the
+            panel never collapses below 320px"
+    (is (= 320 (config/clamp-panel-width-px 200 300))
+        "300 × 0.9 = 270 < 320 floor; floor wins")
+    (is (= 320 (config/clamp-panel-width-px 999 300))
+        "even a wide request clamps to the floor when the viewport
+         is too narrow for the floor to cleanly fit")))
+
+(deftest update-setting-round-trips-panel-width
+  (testing "the standard settings round-trip drives the panel-width
+            slot — same surface text-size + theme go through. After
+            the round-trip get-setting reads the new value."
+    (config/reset-settings!)
+    (config/update-setting! :general :panel-width-px 720)
+    (is (= 720 (config/get-setting :general :panel-width-px)))
+    (config/update-setting! :general :panel-width-px 480)
+    (is (= 480 (config/get-setting :general :panel-width-px)))
+    (config/reset-settings!)))
+
 (deftest editor-uri-project-root-regression-rf2-5m5n2
   (testing "regression: the relative source-coord case the editor's
             OS handler used to reject ('Path does not exist') now

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -204,6 +204,8 @@
    :rf.causa/selected-mismatch-id
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/modal-positioning
+   ;; rf2-x8h9y — horizontal resize handle width.
+   :rf.causa/panel-width-px
    :rf.causa/selected-panel
    :rf.causa/selected-route-id
    :rf.causa/selected-tab
@@ -337,6 +339,8 @@
    :rf.causa/rename-pin
    :rf.causa/reorder-pinned-slices
    :rf.causa/reroot-tree-view
+   ;; rf2-x8h9y — resize-handle double-click reset.
+   :rf.causa/reset-panel-width
    :rf.causa/reset-suppressed-counters
    :rf.causa/reset-to-epoch
    :rf.causa/reset-to-pinned
@@ -363,6 +367,8 @@
    :rf.causa/set-mode-c-context-key
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/set-modal-positioning
+   ;; rf2-x8h9y — resize-handle live update event.
+   :rf.causa/set-panel-width-px
    ;; rf2-7hwwe — `:after` countdown rings now-ms override (test-only).
    :rf.causa/set-now-ms-override-for-test
    :rf.causa/set-performance-budget-ms
@@ -557,7 +563,9 @@
     ;;   :rf.causa/diff-opts — wraps the Settings → Diff section's
     ;;   `:highlight-fn-ref-changes?` slot in the shape the hiccup-diff
     ;;   engine's `classify-prop` consumes.
-    (is (= 127 (count all-sub-names)))
+    ;; + 1 resize handle (rf2-x8h9y):
+    ;;   :rf.causa/panel-width-px — drag-to-resize panel width slot.
+    (is (= 128 (count all-sub-names)))
     ;; Includes panel-local Causa events and internal mirror/tick events
     ;; that still occupy the public registrar namespace.
     ;; 67 baseline + 8 palette (rf2-wm7z4):
@@ -621,7 +629,10 @@
     ;;   pin for the CLJS-side test surface).
     ;; + 1 modal positioning (rf2-om6fa):
     ;;   :rf.causa/set-modal-positioning — Story-aware shell-view opt.
-    (is (= 144 (count all-event-names)))
+    ;; + 2 resize handle (rf2-x8h9y):
+    ;;   :rf.causa/set-panel-width-px (drag live update) +
+    ;;   :rf.causa/reset-panel-width (double-click reset).
+    (is (= 146 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,

--- a/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
@@ -1,0 +1,269 @@
+(ns day8.re-frame2-causa.resize-handle-cljs-test
+  "CLJS tests for the Causa shell's horizontal resize handle (rf2-x8h9y).
+
+  Asserts:
+    1. `Handle` mounts on `:inline` mode and short-circuits to nil on
+       `:popout` / `:fullscreen`.
+    2. The shell-view tree carries the handle when in default
+       `:inline` mode.
+    3. Drag lifecycle — `start-drag!` flips `dragging?` to true,
+       `simulate-up!` flips it back. `simulate-move!` dispatches the
+       set-panel-width-px event with the start + delta.
+    4. Clamp at write-time — the registry's set-panel-width-px event
+       clamps to [320, viewport×0.9] before persisting.
+    5. Double-click handler dispatches `:rf.causa/reset-panel-width`
+       which dispatches set-panel-width-px with the default value.
+    6. `apply-panel-width!` writes the CSS custom property on the
+       host element.
+    7. `apply-all!` restores the persisted width on boot.
+    8. Reload survival — `update-setting!` round-trips through
+       localStorage (covered indirectly by config + effects)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.resize-handle :as resize-handle]
+            [day8.re-frame2-causa.settings.effects :as settings-effects]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-settings!)
+  ;; Force-cleanup any stale drag-state from a previous test (the
+  ;; module-level defonce atom survives fixture reset).
+  (resize-handle/simulate-up!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- hiccup walker (mirrors shell_cljs_test) ---------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- mount on :inline / short-circuit on others ------------------------
+
+(deftest handle-renders-on-inline-mode
+  (setup!)
+  (rf/with-frame :rf/causa
+    (let [tree (resize-handle/Handle :inline)]
+      (is (some? tree)
+          "Handle returns a hiccup tree when mode is :inline")
+      (is (= "rf-causa-resize-handle" (:data-testid (second tree)))
+          "the testid is the documented contract"))))
+
+(deftest handle-short-circuits-on-popout
+  (setup!)
+  (rf/with-frame :rf/causa
+    (is (nil? (resize-handle/Handle :popout))
+        "popout mode has no handle — the OS-window's chrome handles resize")))
+
+(deftest handle-short-circuits-on-fullscreen
+  (setup!)
+  (rf/with-frame :rf/causa
+    (is (nil? (resize-handle/Handle :fullscreen))
+        "fullscreen mode has no resize — the panel fills the viewport")))
+
+;; ---- shell mounts the handle in :inline mode ---------------------------
+
+(deftest shell-mounts-resize-handle
+  (testing "the resize handle is present in the shell tree when mode
+            is :inline (the default for the production right-rail
+            mount)"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view {:mode :inline})]
+        (is (some? (find-by-testid tree "rf-causa-resize-handle"))
+            "resize handle present in :inline mode")))))
+
+(deftest shell-omits-resize-handle-in-popout
+  (testing "popout mode hides the handle — separate OS window owns resize"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view {:mode :popout})]
+        (is (nil? (find-by-testid tree "rf-causa-resize-handle"))
+            "resize handle absent in :popout mode")))))
+
+;; ---- drag lifecycle ----------------------------------------------------
+
+(defn- stub-event
+  "Build a stub MouseEvent-shaped JS object carrying just the slots
+  the handle reads. `preventDefault` is a no-op stub so start-drag!
+  can call it without throwing in the test runner."
+  [page-x]
+  #js {:pageX          page-x
+       :preventDefault (fn [])})
+
+(deftest start-drag-flips-state
+  (setup!)
+  (is (false? (resize-handle/dragging?))
+      "no drag in progress at fixture start")
+  (resize-handle/start-drag! (stub-event 1000) 480)
+  (is (true? (resize-handle/dragging?))
+      "start-drag! installed the global capture")
+  (resize-handle/simulate-up!)
+  (is (false? (resize-handle/dragging?))
+      "simulate-up! tore down the capture"))
+
+(deftest drag-move-dispatches-set-width
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/start-drag! (stub-event 1000) 480)
+      ;; Drag LEFT by 50px (pageX 950 < start-x 1000) — panel widens
+      ;; by 50px → 530px target. The view's `dx = start-x - now-x`,
+      ;; so dx = 50, new-width = 530.
+      (resize-handle/simulate-move! 950)
+      (resize-handle/simulate-up!))
+    (let [width-events (filter #(= :rf.causa/set-panel-width-px (first %))
+                               @dispatches)]
+      (is (seq width-events)
+          "set-panel-width-px was dispatched at least once")
+      (is (some #(= 530 (second %)) width-events)
+          "drag left by 50px dispatched 530 (start 480 + 50 delta)"))))
+
+(deftest drag-right-narrows-panel
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/start-drag! (stub-event 1000) 800)
+      ;; Drag RIGHT by 100px — pageX 1100 > start-x 1000 → dx = -100,
+      ;; new-width = 700.
+      (resize-handle/simulate-move! 1100)
+      (resize-handle/simulate-up!))
+    (let [width-events (filter #(= :rf.causa/set-panel-width-px (first %))
+                               @dispatches)]
+      (is (some #(= 700 (second %)) width-events)
+          "drag right narrows: 800 - 100 = 700"))))
+
+;; ---- clamp at write-time (event handler) -------------------------------
+
+(deftest set-panel-width-event-clamps-to-floor
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-panel-width-px 100]))
+  ;; 100 < 320 floor → clamps to 320.
+  (is (= 320 (config/get-setting :general :panel-width-px))
+      "sub-floor request snaps to min-panel-width-px"))
+
+(deftest set-panel-width-event-persists-in-range-value
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-panel-width-px 720]))
+  (is (= 720 (config/get-setting :general :panel-width-px))
+      "in-range value persists verbatim through the round-trip"))
+
+;; ---- double-click reset -------------------------------------------------
+
+(deftest reset-event-restores-default
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-panel-width-px 720]))
+  (is (= 720 (config/get-setting :general :panel-width-px))
+      "panel-width-px is 720 after explicit set")
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/reset-panel-width]))
+  (is (= config/default-panel-width-px
+         (config/get-setting :general :panel-width-px))
+      "reset event restored the default"))
+
+(deftest double-click-handler-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (rf/with-frame :rf/causa
+        (let [tree    (resize-handle/Handle :inline)
+              handler (:on-double-click (second tree))]
+          (is (fn? handler)
+              "the handle node carries on-double-click")
+          (handler nil))))
+    (is (some #(= [:rf.causa/reset-panel-width] %) @dispatches)
+        "double-click dispatched the reset event")))
+
+;; ---- apply-panel-width! (CSS var write) --------------------------------
+
+(defn- ensure-stub-shell-root! []
+  (when (and (exists? js/document) (.-createElement js/document))
+    (when-not (.getElementById js/document "rf-causa-root")
+      (let [el (.createElement js/document "div")]
+        (set! (.-id el) "rf-causa-root")
+        (when (.-body js/document)
+          (.appendChild (.-body js/document) el))))))
+
+(deftest apply-panel-width-writes-css-var-on-html
+  (ensure-stub-shell-root!)
+  (settings-effects/apply-panel-width! 700)
+  (when-let [html (and (exists? js/document)
+                       (.-documentElement js/document))]
+    (is (= "700px"
+           (.getPropertyValue (.-style html) "--rf-causa-inline-width"))
+        "<html> CSS var carries the value so the cascade resolves")))
+
+(deftest apply-panel-width-handles-missing-root
+  ;; Even without a layout host present, the call should not throw.
+  (is (nil? (settings-effects/apply-panel-width! 480))
+      "no-op safe pre-mount"))
+
+;; ---- panel-width-px sub --------------------------------------------------
+
+(deftest panel-width-px-sub-defaults-to-published-default
+  (setup!)
+  (rf/with-frame :rf/causa
+    (let [width @(rf/subscribe [:rf.causa/panel-width-px])]
+      (is (= config/default-panel-width-px width)
+          "fresh sub returns the published default"))))
+
+(deftest panel-width-px-sub-tracks-update
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-panel-width-px 600]))
+  (rf/with-frame :rf/causa
+    (let [width @(rf/subscribe [:rf.causa/panel-width-px])]
+      (is (= 600 width)
+          "sub reflects the latest update"))))

--- a/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
@@ -227,3 +227,17 @@
   (when-let [el (shell-root)]
     (is (= "12px" (.getPropertyValue (.-style el) "--rf-causa-text-size")))
     (is (true? (.contains (.-classList el) "rf-causa-theme-light")))))
+
+;; ---- panel width (rf2-x8h9y) -------------------------------------------
+
+(deftest apply-all-restores-panel-width
+  (testing "rf2-x8h9y — boot path restores the persisted panel width
+            so the user's saved drag survives reload BEFORE first
+            paint. The CSS var lands on `<html>` (the cascade reaches
+            the layout host's flex-basis even pre-mount)."
+    (config/update-setting! :general :panel-width-px 700)
+    (effects/apply-all!)
+    (when-let [html (html-root)]
+      (is (= "700px"
+             (.getPropertyValue (.-style html) "--rf-causa-inline-width"))
+          "<html> --rf-causa-inline-width carries the persisted value"))))


### PR DESCRIPTION
## Summary

Causa panel now carries a left-edge horizontal resize handle (rf2-x8h9y). Standard devtool UX — drag the edge to widen / narrow; double-click to reset.

- **Bug class** — UX gap. Mike hit the need on first open of Causa in the cart-total testbed. Fixed-width devtool panels are an anti-pattern; every Chrome/Firefox/VS Code devtool surfaces drag-to-resize as the primary affordance.

- **Drag mechanics** — document-level mouse capture. `onMouseDown` on the 6px handle records `start-x` + `start-width`, then attaches `mousemove` / `mouseup` listeners on `js/document` (NOT the handle element). Fast drags don't escape the hit-test box; the body cursor flips to `col-resize` globally for the duration so the operation reads as continuous. This is the same pattern Chrome devtools / browser split-pane resizers use.

- **Clamp + persistence** — written through the registry's `:rf.causa/set-panel-width-px` handler. Clamp `[min: 320px, max: viewport × 0.9]` applied at write-time (`config/clamp-panel-width-px`, a pure CLJC helper covered by 5 JVM tests). Persists via the existing Settings round-trip (localStorage `re-frame2.causa.settings.v1`) — survives reload.

- **Double-click reset** — handle's `:on-double-click` dispatches `:rf.causa/reset-panel-width`, which routes back through `set-panel-width-px` with `config/default-panel-width-px` (560px, matching the documented `var(--rf-causa-inline-width, 560px)` host CSS fallback).

- **Settings → General numeric input** — a width input + Reset button alongside the text-size slider and panel-position radio, so the preference is discoverable + addressable for users who want pixel-exact sizing.

- **`:panel-position` coexistence** — handle renders only in `:right-rail` (`:inline`) mode. `:popout` mode is a separate OS window the user resizes via the OS; `:fullscreen` is a full-viewport overlay. `resize-handle/Handle` short-circuits to nil for both — covered by tests.

### Handle anatomy

```
  ┌─[L1 ribbon]──────────────────────────────────┐
  │║                                              │
  │║  6px col-resize strip, pinned position:      │
  │║  absolute; left: 0; top: 0; bottom: 0;       │
  │║                                              │
  │║  hairline accent stripe always visible       │
  │║  (inset 1px box-shadow, accent-violet 33%)   │
  │║                                              │
  │║  on mousedown:                               │
  │║   - capture start-x + start-width            │
  │║   - attach document mousemove + mouseup      │
  │║   - body.style.cursor = col-resize           │
  │║                                              │
  │║  on document mousemove:                      │
  │║   - dispatch :rf.causa/set-panel-width-px    │
  │║       (start-width + (start-x - now-x))      │
  │║                                              │
  │║  on document mouseup:                        │
  │║   - detach listeners; restore body cursor    │
  │║                                              │
  │║  on dblclick:                                │
  │║   - dispatch :rf.causa/reset-panel-width     │
  │║                                              │
  └──────────────────────────────────────────────┘
```

## Files

- `tools/causa/src/.../config.cljc` — `:panel-width-px` slot in `default-settings`; `default-panel-width-px`/`min-panel-width-px`/`max-panel-fraction` constants; `clamp-panel-width-px` CLJC pure helper.
- `tools/causa/src/.../resize_handle.cljs` — new ns. `Handle` reg-view + drag lifecycle + document listeners + simulate-move/up test seams.
- `tools/causa/src/.../shell.cljs` — mounts `[resize-handle/Handle mode]` as the first child of the shell's flex container.
- `tools/causa/src/.../settings/effects.cljs` — `apply-panel-width!` writes the CSS var on the host + `<html>`; `apply-all!` boot path restores it pre-paint.
- `tools/causa/src/.../settings/events.cljs` — wired into the `:rf.causa/settings-update` event handler.
- `tools/causa/src/.../settings/view.cljs` — Settings → General numeric input + Reset button.
- `tools/causa/src/.../registry.cljs` — `:rf.causa/panel-width-px` sub; `:rf.causa/set-panel-width-px` (clamp + persist + push CSS var) + `:rf.causa/reset-panel-width` events. Both `:rf.trace/no-emit? true` (drag fires at mousemove cadence; flooding the trace with the same shape no panel consumes would be wasteful).

## Test plan

- [x] JVM `clojure -M:test` (tools/causa) — `clamp-panel-width-px` floor / ceil / non-numeric / narrow-viewport / round-trip
- [x] CLJS `npm run test:cljs` — `Handle` mounts on `:inline` / nil on `:popout` and `:fullscreen`; drag lifecycle; left-drag widens, right-drag narrows; clamp at write-time; double-click reset; `apply-panel-width!` writes CSS var; `apply-all!` restores; `:rf.causa/panel-width-px` sub tracks updates; registry catalogue tests updated for the 1 new sub + 2 new events
- [x] CLJS `npm run test:browser` — full browser-runtime sweep
- [x] `scripts/test-fast-pr.sh` — full fast PR spine green