### PR TITLE
feat(story): :play-script DOM-step Playwright coverage

### DIFF
--- a/examples/scripts/serve-and-run-story-play-scripts.cjs
+++ b/examples/scripts/serve-and-run-story-play-scripts.cjs
@@ -312,10 +312,19 @@ function summariseResults(results) {
       `${tag} ${r.variantId}${playLabel}  expected=${r.expected} actual=${actual}  steps=${r.runState ? r.runState.total : '?'}`,
     );
     if (!r.matched) {
+      // The CLJS `project-state` serialises `:passed?` as the literal
+      // string key `"passed?"` (keyword → name preservation); read it
+      // via bracket-access so the `?` survives the JS identifier rules.
+      // Older drafts read `.passed` and silently dropped every failure
+      // line — leaving only the row-level MISS with no step diagnostic.
       const fails = (r.runState && r.runState.results) || [];
       for (const stepR of fails) {
-        if (stepR.passed === false) {
-          lines.push(`     step ${stepR.idx} ${stepR.type} — ${stepR.message || '(no message)'}`);
+        if (stepR['passed?'] === false) {
+          const expected = stepR.expected ? ` expected=${stepR.expected}` : '';
+          const actual   = stepR.actual   ? ` actual=${stepR.actual}`     : '';
+          lines.push(
+            `     step ${stepR.idx} ${stepR.type} — ${stepR.message || '(no message)'}${expected}${actual}`,
+          );
         }
       }
     }

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -601,6 +601,73 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  ;; rf2-e0kof DOM-step fixtures — live-browser coverage of the rich-DSL
+  ;; `:click` / `:type` / `:assert-dom` steps. The pure-step + JVM
+  ;; coverage in tools/story/test/re_frame/story/play/ exercises the
+  ;; parser + the JVM no-DOM branches; this fixture closes the gap by
+  ;; driving the actual DOM via the Story shell in the Playwright runner
+  ;; at examples/scripts/serve-and-run-story-play-scripts.cjs.
+  ;;
+  ;; The :counter-with-stories.views/counter-with-input view exposes
+  ;;   - [data-test=count-display] — read by `:assert-dom :text`
+  ;;   - [data-test=count-input]   — written by `:type`
+  ;;   - [data-test=set-button]    — clicked by `:click` (dispatches
+  ;;                                 :counter/set with the input value)
+  ;; The script: seed db → type "42" → click set → wait for re-render →
+  ;; assert app-db AND the rendered text both reflect 42. End-to-end
+  ;; coverage of every DOM-step type in one play.
+  (story/reg-variant :story.counter-play-script/dom
+    {:doc        "rf2-e0kof DOM-step fixture — exercises every
+                 rich-DSL DOM step (`:click` / `:type` / `:assert-dom`)
+                 end-to-end against a real browser DOM. Pairs with the
+                 expected-fail twin to keep the failure path under CI
+                 coverage too."
+     :component  :counter-with-stories.views/counter-with-input
+     :args       {:label "Play-script DOM"}
+     :events     []
+     :play-script
+     {:name      "type-click-and-assert-dom"
+      :auto-run? true
+      ;; A leading `:wait 300` gives React's first commit a chance to
+      ;; render the component before the first DOM assertion. The
+      ;; auto-run fires as soon as the lifecycle machine reaches
+      ;; `:ready`, which can race ahead of React's render flush.
+      :script    [[:dispatch-sync [:counter/initialise 0]]
+                  [:wait        300]
+                  [:assert-dom  "[data-test=count-display]" :text "0"]
+                  [:type        "[data-test=count-input]" "42"]
+                  [:click       "[data-test=set-button]"]
+                  ;; The click dispatches :counter/set synchronously
+                  ;; on Reagent; the wait ensures the next render cycle
+                  ;; has flushed before we read the DOM.
+                  [:wait        300]
+                  [:assert-db   [:count] 42]
+                  [:assert-dom  "[data-test=count-display]" :text "42"]
+                  [:assert-dom  "[data-test=set-button]"    :visible]]}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
+  (story/reg-variant :story.counter-play-script/dom-expected-fail
+    {:doc        "rf2-e0kof expected-fail twin — same DOM-step shape as
+                 :story.counter-play-script/dom but the FINAL
+                 `:assert-dom :text` expects '99' against an actual
+                 '42'. The CI runner reads `expected-fail` off the
+                 variant id and asserts the play reaches `:fail`."
+     :component  :counter-with-stories.views/counter-with-input
+     :args       {:label "Play-script DOM (expected-fail)"}
+     :events     []
+     :play-script
+     {:name      "type-click-and-assert-dom-wrong"
+      :auto-run? true
+      :script    [[:dispatch-sync [:counter/initialise 0]]
+                  [:wait          50]
+                  [:type          "[data-test=count-input]" "42"]
+                  [:click         "[data-test=set-button]"]
+                  [:wait          100]
+                  [:assert-dom    "[data-test=count-display]" :text "99"]]}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; rf2-tl7zk multi-play fixture — three named plays on one variant.
   ;; The first play (happy-path) auto-runs on mount per the per-position
   ;; default; the other two run on demand (manual trigger via the

--- a/tools/story/testbeds/counter_with_stories/views.cljs
+++ b/tools/story/testbeds/counter_with_stories/views.cljs
@@ -150,6 +150,69 @@
              :data-test "a11y-known-bad-action"}
     "Unlabelled image above"]])
 
+;; ---- counter-with-input — DOM-step play-script fixture (rf2-e0kof) -----
+;;
+;; A minimal counter variant whose user surface exposes the three DOM
+;; affordances the rich-DSL `:click` / `:type` / `:assert-dom` steps
+;; reach for:
+;;
+;;   - [data-test=count-input]   — text input the `:type` step writes into
+;;   - [data-test=set-button]    — button the `:click` step dispatches
+;;   - [data-test=count-display] — span the `:assert-dom :text` step reads
+;;
+;; The component owns local state for the input value (Reagent ratom);
+;; the button click commits it to app-db via `:counter/set`. Picking a
+;; distinct `[data-test=count-display]` selector (rather than
+;; `[data-test=count]` from counter-buttons) avoids cross-component
+;; selector collisions if a future variant composes both surfaces.
+;;
+;; The CI runner at examples/scripts/serve-and-run-story-play-scripts.cjs
+;; navigates to the matching variant and asserts the auto-run reaches
+;; `:pass` (or `:fail` for the expected-fail twin).
+
+(reg-view counter-with-input [{:keys [label]}]
+  [:div {:style {:padding         "1em 1.5em"
+                 :border          "1px solid #ddd"
+                 :border-radius   "6px"
+                 :background      "#fff"
+                 :display         "inline-flex"
+                 :flex-direction  "column"
+                 :gap             "0.5em"
+                 :font-family     "system-ui, sans-serif"}}
+   [:div {:style {:font-size "14px" :color "#666"}}
+    (or label "Counter (input)")]
+   [:div {:style {:display "flex" :align-items "center" :gap "0.5em"}}
+    [:span {:data-test "count-display"
+            :style     {:min-width "2em" :text-align "center"
+                        :font-weight "bold"}}
+     (str @(subscribe [:count]))]
+    ;; Uncontrolled input — `defaultValue ""` + no `:value` prop. Reads
+    ;; back from the DOM on click. The rich-DSL `:type` step sets
+    ;; `.value` directly (re_frame.story.play.dom/type!) and dispatches
+    ;; synthetic `input` + `change` events; a controlled input here
+    ;; would fight React's value-tracker (the tracker thinks the value
+    ;; is unchanged after a raw `.value =` write), so we read the DOM
+    ;; directly on click instead. This isolates the DOM-step spec from
+    ;; React controlled-input semantics — exactly what we want under
+    ;; test, where the step contract is "DOM node mutated; event fired".
+    [:input {:type          "text"
+             :data-test     "count-input"
+             :default-value ""}]
+    [:button {:type       "button"
+              :data-test  "set-button"
+              :aria-label "Set count from input"
+              :on-click
+              (fn [_]
+                (let [node (.querySelector js/document
+                             "[data-test=count-input]")
+                      raw  (when node (.-value node))
+                      n    (try
+                             (js/parseInt raw 10)
+                             (catch :default _ nil))]
+                  (when (and (number? n) (not (js/isNaN n)))
+                    (dispatch [:counter/set n]))))}
+     "Set"]]])
+
 (reg-view throwing-card [_args]
   [:div {:style {:background "#5a1d1d"
                  :color "#fff"


### PR DESCRIPTION
## Summary

P2 test-coverage close-out for **rf2-e0kof**: browser-side Playwright
coverage for `:play-script` DOM steps (`:click`, `:type`,
`:assert-dom`). Pure-step + JVM no-DOM coverage already existed; this
PR closes the live-browser gap.

## Bug class

`:click` / `:type` / `:assert-dom` steps were unit-tested (parser +
pure helper semantics) and JVM-tested (no-DOM `:skipped?` branch), but
no test driving them against a real browser DOM. Regressions in the
synthetic-event emitters, the `querySelector` plumbing, or the
runner's step dispatcher for DOM step types would slip past every
existing gate. This PR closes that.

## What changed

- **New testbed view** `:counter-with-stories.views/counter-with-input`
  exposes the three DOM affordances the rich-DSL DOM steps reach for:
  - `[data-test=count-display]` -- read by `:assert-dom :text`
  - `[data-test=count-input]`   -- written by `:type`
  - `[data-test=set-button]`    -- clicked by `:click` (dispatches
    `:counter/set` with the input's current value)

  Uncontrolled input (`defaultValue ""` + no `:value` prop) so the
  rich-DSL `:type` step's raw `.value =` writes don't fight React's
  controlled-input value-tracker; the `on-click` reads the DOM
  directly on commit.

- **New variant** `:story.counter-play-script/dom` auto-runs a
  script that exercises every rich-DSL step type end-to-end:

  ```
  [:dispatch-sync [:counter/initialise 0]]
  [:wait        300]
  [:assert-dom  "[data-test=count-display]" :text "0"]
  [:type        "[data-test=count-input]" "42"]
  [:click       "[data-test=set-button]"]
  [:wait        300]
  [:assert-db   [:count] 42]
  [:assert-dom  "[data-test=count-display]" :text "42"]
  [:assert-dom  "[data-test=set-button]"    :visible]
  ```

- **New expected-fail twin**
  `:story.counter-play-script/dom-expected-fail` -- same shape but the
  final `:assert-dom :text` expects `"99"` against actual `"42"`. The
  CI runner reads `expected-fail` off the variant id and asserts the
  play reaches `:fail`, keeping the failure path under coverage.

- **Fix latent reporting bug** in
  `examples/scripts/serve-and-run-story-play-scripts.cjs`'s failure
  formatter -- it read `stepR.passed` but the CLJS `project-state`
  serialises the key as the literal string `"passed?"` (keyword name
  preserved across `clj->js`). All step-failure lines were being
  silently dropped, leaving MISS rows with no diagnostic. Now each
  MISS prints the failing step's type, message, expected, and actual
  -- which is how I caught my own DOM-step timing issue mid-iteration.

## Variant count delta

- Before: 5 variants / 5 play rows (passing, failing, multi*3)
- After:  7 variants / 7 play rows (+ dom, dom-expected-fail)

## Test plan

- [x] `scripts/test-fast-pr.sh` -- PASS (3133 tests, 9028 assertions)
- [x] `cd tools/story && clojure -M:test` -- PASS (790 tests)
- [x] `cd implementation && npm run test:browser` -- PASS (3124 tests)
- [x] `cd implementation && npm run test:story-play-scripts` -- PASS
      (7 play rows, 0 unexpected outcomes; was 5 with multi-play)
- [x] `cd implementation && npm run story:build` -- PASS
- [x] `scripts/test-jvm-tools.sh` -- PASS

## Bead

`bd show rf2-e0kof` -- intentionally LEFT OPEN for mayor to close.