### PR TITLE
fix(causa): default-focus last event on Causa mount + suppress '<no event>' placeholder

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -88,6 +88,25 @@
     selection
     {:dispatch-id selection}))
 
+(defn- cascade-has-event?
+  "True iff `cascade` carries a real `:event` vector. The `:ungrouped`
+  bucket produced by `re-frame.trace.projection/group-cascades` for
+  registry-time emits / frame lifecycle outside a drain / REPL evals
+  carries no event vector. Per rf2-639lc head-cascade selection skips
+  this bucket so the L4 default-focus lands on the most recent ROUTED
+  cascade, not the projection's internal bucket."
+  [cascade]
+  (vector? (:event cascade)))
+
+(defn- default-head-cascade
+  "Pick the head (most recent) routed cascade from the cascade vector,
+  or nil when none exist. `:ungrouped` cascades are filtered out so a
+  registry-time emit can never become the default-focused row.
+  Cascades are oldest-first per group-cascades' contract; `last`
+  returns the head."
+  [cascades]
+  (last (filterv cascade-has-event? cascades)))
+
 (defn- cascade-matches-selection?
   [{:keys [dispatch-id frame]} selection]
   (let [{selected-id :dispatch-id selected-frame :frame} (selected-ref selection)]
@@ -460,20 +479,35 @@
     ;; when either changes. The `:<-` chain is the only sub-
     ;; registration form in v2 (per Spec 002 §Subscriptions composing
     ;; — reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
+    ;;
+    ;; Per rf2-639lc Bug 2: when the user has not explicitly selected a
+    ;; cascade (legacy `:selected-dispatch-id` slot nil), default-focus
+    ;; the head cascade so the L4 Event tab renders cascade DETAIL on
+    ;; first mount rather than the cascade-LIST landing view (the L2
+    ;; event list is the list affordance under the 4-layer chrome;
+    ;; rf2-lv9bc folded the panel-internal list into a landing
+    ;; placeholder, but on first mount with a populated buffer the
+    ;; user expects the detail of the latest event). The head-fallback
+    ;; lives at the composite layer (not the view) so consumers of
+    ;; `:rf.causa/event-detail` (the panel + its tests) all see the
+    ;; same effective selection.
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/selected-dispatch-id]
     :<- [:rf.causa/selected-dispatch-frame]
     (fn [[cascades selected-id selected-frame] _query]
-      (let [selection (when selected-id
-                        {:dispatch-id selected-id
-                         :frame       selected-frame})
+      (let [head      (when (nil? selected-id) (default-head-cascade cascades))
+            eff-id    (or selected-id (:dispatch-id head))
+            eff-frame (or selected-frame (:frame head))
+            selection (when eff-id
+                        {:dispatch-id eff-id
+                         :frame       eff-frame})
             by-id     (when selection
                         (some #(when (cascade-matches-selection? % selection) %)
                               cascades))]
-        {:cascades             cascades
-         :selected-dispatch-id selected-id
-         :selected-dispatch-frame selected-frame
-         :selected-cascade     by-id})))
+        {:cascades                cascades
+         :selected-dispatch-id    eff-id
+         :selected-dispatch-frame eff-frame
+         :selected-cascade        by-id})))
 
   ;; Spine shim (rf2-adve5) — `:rf.causa/select-dispatch-id` is the
   ;; legacy entry point used by causality / machine-inspector /

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -187,6 +187,16 @@
     (when (vector? ev)
       (first ev))))
 
+(defn cascade-has-event?
+  "True iff `cascade` carries a real `:event` vector (`(first :event)`
+  resolves to a non-nil event-id). False for the `:ungrouped` bucket
+  produced by `re-frame.trace.projection/group-cascades` for registry-
+  time emits / frame lifecycle outside a drain / REPL evals — those
+  carry no event vector. Per rf2-639lc the L2 event list filters this
+  bucket out so the user never sees a `<no event>` placeholder row."
+  [cascade]
+  (some? (event-id-of-cascade cascade)))
+
 (defn gutter-glyph
   "Pick the gutter glyph per spec/018 §4 Row anatomy. The selected row
   gets `◉`; an errored row gets `x`; a wholly-redacted row gets `▥`;
@@ -515,11 +525,21 @@
   the same filtered list (per spec/018 §6 'Atomicity contract').
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/causa`."
+  `:rf/causa`.
+
+  Per rf2-639lc the list filters out `:ungrouped` cascades (those
+  with no `:event` vector — registry-time emits / frame lifecycle
+  outside a drain / REPL evals). Without the filter the L2 list
+  rendered a leading `<no event>` placeholder row that leaked the
+  projection's internal bucket into the user-facing event timeline.
+  Other panels (Causality Graph, Performance, etc.) keep reading
+  `:rf.causa/cascades` directly so the bucket remains available where
+  it is meaningful."
   []
-  (let [cascades   @(rf/subscribe [:rf.causa/filtered-cascades])
-        focus      @(rf/subscribe [:rf.causa/focus])
-        focused-id (:dispatch-id focus)]
+  (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
+        focus          @(rf/subscribe [:rf.causa/focus])
+        focused-id     (:dispatch-id focus)
+        event-cascades (filterv cascade-has-event? cascades)]
     [:div {:data-testid "rf-causa-event-list"
            :style {:height        "224px"   ; 8 rows × 28px
                    :min-height    "56px"    ; 2 rows minimum per spec
@@ -529,7 +549,7 @@
                    :border-bottom (str "1px solid " (:border-subtle tokens))
                    :resize        "vertical"   ; native vertical resize for the L2/L3 drag handle
                    :padding       "4px"}}
-     (if (empty? cascades)
+     (if (empty? event-cascades)
        [:div {:data-testid "rf-causa-event-list-empty"
               :style {:padding   "16px"
                       :color     (:text-secondary tokens)
@@ -539,7 +559,7 @@
        (into [:ul {:style {:list-style "none" :margin 0 :padding 0
                            :display "flex" :flex-direction "column"
                            :gap "2px"}}]
-             (for [cascade cascades]
+             (for [cascade event-cascades]
                ^{:key (str (:dispatch-id cascade))}
                [event-row {:cascade cascade :focused-id focused-id}])))]))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -3,11 +3,14 @@
 
   ## Three contracts under test
 
-  1. **Cascade list when nothing is selected.** With trace events in
-     the buffer but no selected dispatch-id, the panel's
-     `:rf.causa/event-detail` composite sub returns every cascade and
-     the view renders the empty-state list. Clicking a cascade row
-     fires `:rf.causa/select-dispatch-id`.
+  1. **Default-focus head cascade on cold start.** With trace events
+     in the buffer but no explicit selection (rf2-639lc Bug 2), the
+     panel's `:rf.causa/event-detail` composite sub defaults
+     `:selected-dispatch-id` to the head (most recent routed)
+     cascade so the view renders cascade DETAIL on first mount.
+     The pre-rf2-639lc landing-list behaviour was redundant under the
+     4-layer chrome — the L2 event list is always visible alongside
+     L4 so the panel-internal list never carried weight (rf2-lv9bc).
 
   2. **Cascade detail when something is selected.** With a selection
      set via `:rf.causa/select-dispatch-id`, the composite sub returns
@@ -15,8 +18,8 @@
      rows.
 
   3. **Clear selection.** Dispatching `:rf.causa/clear-selected-
-     dispatch-id` empties the selection and the view returns to the
-     cascade list.
+     dispatch-id` empties the explicit selection; the panel
+     default-focuses the head cascade again per (1).
 
   ## Pure-data scope
 
@@ -142,36 +145,61 @@
             node))
         (hiccup-seq tree)))
 
-;; ---- (1) empty state: cascade list --------------------------------------
+;; ---- (1) default-focus head cascade on cold start (rf2-639lc Bug 2) -----
 
-(deftest empty-state-renders-cascade-list
-  (testing "with cascades in the buffer but no selection, the panel
-            renders the cascade list"
+(deftest cold-start-default-focuses-head-cascade
+  (testing "with cascades in the buffer but no explicit selection
+            (rf2-639lc Bug 2), the panel default-focuses the HEAD
+            (most recent routed) cascade and renders its cascade
+            DETAIL — not the legacy panel-internal cascade list"
     (seed-buffer! (concat (cascade-evs 100 [:user/login {:id 42}] 0)
                           (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
+      ;; Composite sub: effective selection is the head's dispatch-id.
+      (let [data @(rf/subscribe [:rf.causa/event-detail])]
+        (is (= 200 (:selected-dispatch-id data))
+            "head cascade (200, latest) is the default selection"))
+      ;; View: cascade-detail container renders for the head, not the
+      ;; landing list.
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container present")
-        (is (some? (find-by-testid tree "rf-causa-cascade-list"))
-            "cascade list container present")
-        (is (some? (find-by-testid tree "rf-causa-cascade-row-100"))
-            "cascade 100 has a clickable row")
-        (is (some? (find-by-testid tree "rf-causa-cascade-row-200"))
-            "cascade 200 has a clickable row")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail container absent when no selection")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
+            "cascade-detail container present for the head cascade")
+        (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
+            "panel-internal cascade list NOT rendered on default-focus
+             — the L2 event list (rf-causa-event-list) is the list
+             affordance under the 4-layer chrome (rf2-lv9bc)")))))
 
-(deftest empty-state-renders-with-no-cascades
+(deftest cold-start-with-no-cascades-renders-empty-container
   (testing "with an empty buffer + no selection the panel still
-            renders the empty-state container"
+            renders the empty-state container (no cascade list)"
     (seed-buffer! [])
     (rf/with-frame :rf/causa
       (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
             "empty-state container present even with an empty buffer")
         (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
-            "no cascade list when there are zero cascades")))))
+            "no cascade list when there are zero cascades")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
+            "no cascade-detail when there is nothing to default-focus")))))
+
+(deftest cold-start-default-focus-skips-ungrouped-bucket
+  (testing "per rf2-639lc Bug 1 the head-fallback ignores the
+            `:ungrouped` cascade (registry-time emits / frame
+            lifecycle outside a drain). Synthesise a trace with a
+            real cascade plus a stray registry-time emit (no
+            :dispatch-id tag — lands in the :ungrouped bucket); the
+            default focus must land on the real cascade's id."
+    (seed-buffer!
+      (concat (cascade-evs 100 [:user/login] 0)
+              ;; Stray emit with no :dispatch-id — group-cascades
+              ;; routes this to the :ungrouped bucket.
+              [{:id 50 :op-type :registry :operation :sub/registered
+                :tags {:sub-id :foo/bar}}]))
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/event-detail])]
+        (is (= 100 (:selected-dispatch-id data))
+            "default-focus picks the routed cascade (100), not the
+             :ungrouped bucket")))))
 
 ;; ---- (2) cascade-detail when a dispatch-id is selected ------------------
 
@@ -244,17 +272,21 @@
       (is (nil? (:selected-dispatch-id default-db))
           "selection did NOT leak into :rf/default"))))
 
-(deftest clear-selected-dispatch-id-returns-to-empty-state
-  (testing "after select + clear the panel renders the empty state"
-    (seed-buffer! (cascade-evs 100 [:user/login {:id 42}] 0))
+(deftest clear-selected-dispatch-id-falls-back-to-head-default-focus
+  (testing "after select + clear the panel default-focuses the head
+            cascade again (rf2-639lc Bug 2) — clearing the explicit
+            selection lets the composite's head-fallback fire."
+    (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
+                          (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (rf/dispatch-sync [:rf.causa/clear-selected-dispatch-id])
-      (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container present after clear")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail container absent after clear")))))
+      (let [data @(rf/subscribe [:rf.causa/event-detail])
+            tree (event-detail/Panel)]
+        (is (= 200 (:selected-dispatch-id data))
+            "after clear the default-focus snaps back to the head (200)")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
+            "cascade-detail container renders for the head after clear")))))
 
 ;; ---- (4) defaults / wiring ----------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -367,6 +367,48 @@
         (is (= 2 (count rows))
             "one row per cascade")))))
 
+(deftest event-list-suppresses-ungrouped-cascade-placeholder
+  (testing "per rf2-639lc Bug 1 the L2 list filters out the `:ungrouped`
+            cascade produced by group-cascades for registry-time emits /
+            frame lifecycle outside a drain / REPL evals. Without the
+            filter the list rendered a leading `<no event>` placeholder
+            row that leaked the projection's internal bucket into the
+            user-facing event timeline.
+
+            Synthesise a real cascade plus a stray registry-time emit
+            (no :dispatch-id tag → :ungrouped bucket). The L2 list
+            renders exactly one row (the real cascade) and no row
+            carries the `<no event>` text."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! {:id 50 :op-type :registry
+                               :operation :sub/registered
+                               :tags {:sub-id :foo/bar}})
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            rows (find-all-by-testid-prefix tree "rf-causa-event-row-")
+            text (text-nodes tree)]
+        (is (= 1 (count rows))
+            "exactly one event row — the :ungrouped bucket is filtered out")
+        (is (not (re-find #"<no event>" text))
+            "no `<no event>` placeholder leaks into the rendered list")))))
+
+(deftest event-list-empty-when-only-ungrouped-cascades
+  (testing "per rf2-639lc Bug 1 a buffer that carries ONLY :ungrouped
+            cascades (no routed events) collapses to the empty-state
+            container — the `<no event>` placeholder is never the
+            user's first impression of the L2 list."
+    (causa-setup!)
+    (trace-bus/collect-trace! {:id 50 :op-type :registry
+                               :operation :sub/registered
+                               :tags {:sub-id :foo/bar}})
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (some? (find-by-testid tree "rf-causa-event-list-empty"))
+            "empty-state container present when only :ungrouped cascades exist")
+        (is (empty? (find-all-by-testid-prefix tree "rf-causa-event-row-"))
+            "no event rows render — the :ungrouped bucket is filtered out")))))
+
 (deftest event-row-click-dispatches-focus-cascade
   (testing "spec/018 §6 — row click dispatches :rf.causa/focus-cascade,
             spine flips to :retro, every dependent surface rebinds"

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -790,7 +790,13 @@ async function readLaunchModeProjection(page) {
         selectedDispatchId: cascade ? cascade.getAttribute('data-dispatch-id') : null,
         selectedFrame: cascade ? cascade.getAttribute('data-frame') : null,
         cascadeText: text(root, '[data-testid="rf-causa-event-detail-cascade"]'),
-        cascadeRows: count(root, '[data-testid^="rf-causa-cascade-row-"]'),
+        // Per rf2-639lc the L4 Event panel default-focuses the head
+        // cascade on mount — the cascade-detail container is the
+        // primary surface. The legacy `rf-causa-cascade-row-*` list
+        // only renders in the empty-state branch (no routable
+        // cascades). `cascadeRows` is 1 when cascade-detail is
+        // rendered, 0 when the empty container or orphaned branch is.
+        cascadeRows: count(root, '[data-testid="rf-causa-event-detail-cascade"]'),
         traceRows: count(root, '[data-testid^="rf-causa-trace-row-"]'),
         traceCountsText: text(root, '[data-testid="rf-causa-trace-counts"]'),
       };
@@ -880,10 +886,15 @@ async function runShellFeatureSweep(page) {
   await clickHostButtonByLabel(page, '-');
 
   await clickTab(page, 'event', 'rf-causa-event-detail');
+  // Per rf2-639lc the L4 Event panel default-focuses the head cascade
+  // on mount, so the panel renders `rf-causa-event-detail-cascade`
+  // (six-domino detail) directly — no click-into-list step required.
+  // The legacy `rf-causa-cascade-row-*` empty-state rows only appear
+  // when the panel has no routable cascade to default-focus on.
   await waitForValue(
-    () => page.locator('[data-testid^="rf-causa-cascade-row-"]').count(),
+    () => page.locator('[data-testid="rf-causa-event-detail-cascade"]').count(),
     (count) => count > 0,
-    { timeoutMs: 5000, description: 'event-detail cascade rows' },
+    { timeoutMs: 5000, description: 'event-detail cascade default-focus' },
   );
 
   await clickTab(page, 'trace', 'rf-causa-trace');
@@ -1052,22 +1063,21 @@ async function runHttpToggle(page) {
 
   // Post rf2-xy4yb: the dedicated Effects (fx) panel was dropped.
   // Per spec/018 §5 fx-handlers-ran now lands as an `fx` + `effects`
-  // domino row inside the cascade-detail of the Event tab. Pick the
-  // first cascade row and assert its rendered detail carries an fx
-  // row (the `:rf.fx/handled` emits for the dispatched `:go` event
-  // are projected into the `effects` block).
+  // domino row inside the cascade-detail of the Event tab. Per
+  // rf2-639lc the L4 panel default-focuses the head (most-recent)
+  // cascade on mount — so opening the tab after the last `:go`
+  // dispatch already surfaces its cascade-detail. Assert the rendered
+  // detail carries an fx row (the `:rf.fx/handled` emits for the
+  // dispatched `:go` event are projected into the `effects` block).
   await clickTab(page, 'event', 'rf-causa-event-detail');
-  const firstCascade = await waitForValue(
-    () => page.locator('[data-testid^="rf-causa-cascade-row-"]').first().getAttribute('data-testid'),
-    (id) => typeof id === 'string' && id.length > 0,
-    { timeoutMs: 5000, description: 'first cascade row in event tab' },
-  );
-  await page.locator(`[data-testid="${firstCascade}"]`).click();
   await expectVisible(page.locator('[data-testid="rf-causa-event-detail-cascade"]'), 5000);
   const cascadeText = ((await page.locator('[data-testid="rf-causa-event-detail-cascade"]').textContent()) || '').toLowerCase();
   if (!cascadeText.includes('effects') && !cascadeText.includes('fx')) {
+    const dispatchId = await page
+      .locator('[data-testid="rf-causa-event-detail-cascade"]')
+      .getAttribute('data-dispatch-id');
     failWithDetails('Event-tab cascade-detail did not surface the fx/effects domino rows', {
-      firstCascade,
+      dispatchId,
       cascadeText: cascadeText.slice(0, 800),
     });
   }
@@ -1326,10 +1336,13 @@ async function runTwentyEventLoad(page, state) {
   );
   const elapsedMs = Date.now() - start;
   await clickTab(page, 'event', 'rf-causa-event-detail');
+  // Per rf2-639lc the L4 panel default-focuses the head cascade on
+  // mount — assert the cascade-detail surface rendered (proves the
+  // spine pipeline emitted routable cascades visible to L4).
   await waitForValue(
-    () => page.locator('[data-testid^="rf-causa-cascade-row-"]').count(),
+    () => page.locator('[data-testid="rf-causa-event-detail-cascade"]').count(),
     (count) => count > 0,
-    { timeoutMs: 5000, description: 'event-detail cascade rows after load' },
+    { timeoutMs: 5000, description: 'event-detail cascade default-focus after load' },
   );
   // Post rf2-xy4yb: the Causality Graph panel was dropped (planned
   // future popover via `c` key — not yet wired). The 20-event


### PR DESCRIPTION
## Summary

P1 fix for two foundational UX bugs Mike hit on first-mount of Causa (bead rf2-639lc).

### Bug 1 — `<no event>` placeholder leaks into L2 event list

**Before:** four events show on first mount and the first is `<no event>`.

**Root cause:** `re-frame.trace.projection/group-cascades` always synthesises an `:ungrouped` cascade for registry-time emits / frame lifecycle outside a drain / REPL evals (events with no `:dispatch-id` tag — see `projection.cljc` §`first-id` sentinel). The L2 list rendered one row per cascade; `shell/event-id-of-cascade` returned `nil` for the ungrouped one and the row body fell back to `(str (or ev-id \"<no event>\"))`.

**Fix:** filter `:ungrouped` cascades out at the L2 view layer (new `shell/cascade-has-event?` helper). Other consumers (Causality Graph, Performance, etc.) keep reading `:rf.causa/cascades` directly so the bucket remains available where it is meaningful.

### Bug 2 — L4 Event tab renders cascade-LIST on first mount, not detail

**Before:** L4 Event tab landed on the panel-internal cascade-list, not the cascade DETAIL of the most recent event.

**Root cause:** the `:rf.causa/event-detail` composite read the legacy `:selected-dispatch-id` slot directly. On first mount that slot is nil (no click yet), so the panel fell back to the cascade-list landing branch. Under the 4-layer chrome (rf2-lv9bc) the L2 event list is always visible alongside L4, so the panel-internal list was redundant — and worse, hid the head cascade's six-domino detail the user expected to see.

**Fix:** in `:rf.causa/event-detail`, default-fall-back to the head (most recent routed) cascade's dispatch-id when no explicit selection exists. Reuses the same `:ungrouped` filter so default-focus never lands on the projection's internal bucket. Explicit selection paths (click row, `:rf.causa/select-dispatch-id`, orphaned-id branch) remain unchanged.

## Files changed

- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — `cascade-has-event?` helper + filter applied to L2 `event-list`.
- `tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs` — `default-head-cascade` helper + composite-sub head-fallback.
- `tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs` — two new Bug 1 tests.
- `tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs` — three new Bug 2 tests; updated `clear-selected-dispatch-id-falls-back-to-head-default-focus` to match new semantics.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 3137 CLJS tests, 0 failures.
- [x] `cd tools/causa && clojure -M:test` — 923 tests, 0 failures.
- [x] `cd implementation && npm run test:browser` — 3127 tests, 0 failures.
- [x] New tests cover: empty buffer + first mount → empty container (no `<no event>`); non-empty buffer + first mount → focus set to head, cascade renders in L4; clicking any L2 event → L4 updates to its cascade; head-fallback skips `:ungrouped` bucket.