### PR TITLE
fix(causa): L2 event-list — nav button state + tighter density + real [:event-id ...] rendering

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -188,6 +188,85 @@
     (when (vector? ev)
       (first ev))))
 
+(def event-vector-inline-cap
+  "Max character count for the L2 row's inline event-vector rendering
+  (rf2-htik0). Cascades that pr-str longer than this collapse to
+  `<head>…]` so the row stays single-line. Click the row → the L4
+  Event tab shows the full vector (no truncation there).
+
+  ~80 chars is enough for `[:cart/add-item {:item-id \"apple\" :qty 2}]`
+  plus a touch of slack for typical event-handler signatures, and
+  short enough to keep the L2 list scannable in a stack of rows."
+  80)
+
+(defn truncate-event-vector
+  "Truncate a pr-str'd event vector to `cap` chars with `…]` suffix
+  when over the cap. Pure string utility — caller already has the
+  pr-str result.
+
+  Always preserves the trailing `]` so the rendered form still reads
+  as a vector at a glance (e.g. `[:foo/bar {:a 1 :b 2 :c…]`)."
+  [s cap]
+  (if (<= (count s) cap)
+    s
+    (str (subs s 0 (max 0 (- cap 2))) "…]")))
+
+(defn render-event-vector-inline
+  "Render an event vector as `[event-id payload…]` hiccup for the L2
+  event-list row (rf2-htik0).
+
+  - Empty payload (1-element vector) renders as `[:counter/inc]` — no
+    map, no `{}` placeholder.
+  - Non-empty payload pr-str's the full vector then truncates to
+    `event-vector-inline-cap` with `…]` suffix so the row stays
+    single-line.
+  - `event-id` (the first element) gets the keyword accent colour so
+    it pops out of the row; the rest renders in the row's default
+    text colour.
+
+  Returns hiccup (a `[:span … ]` tree). When the cascade carries no
+  event vector, falls back to a `<no event>` chip in the secondary
+  text colour so unrouted cascades stay visible."
+  [event-vec]
+  (cond
+    (not (vector? event-vec))
+    [:span {:style {:color (:text-secondary tokens)
+                    :font-style "italic"}}
+     "<no event>"]
+
+    (= 1 (count event-vec))
+    [:span {:style {:display "inline-flex" :align-items "baseline"}}
+     [:span {:style {:color (:text-tertiary tokens)}} "["]
+     [:span {:style {:color (:accent-violet tokens)}}
+      (pr-str (first event-vec))]
+     [:span {:style {:color (:text-tertiary tokens)}} "]"]]
+
+    :else
+    (let [event-id   (first event-vec)
+          id-str     (pr-str event-id)
+          full-str   (pr-str event-vec)
+          truncated  (truncate-event-vector full-str event-vector-inline-cap)
+          ;; Strip the leading `[id-str ` from the truncated body so we
+          ;; can colour the event-id separately. When truncation chopped
+          ;; into the id (shouldn't happen with cap >> typical id), fall
+          ;; back to rendering the whole truncated string in default colour.
+          id-prefix  (str "[" id-str " ")
+          tail       (when (and (> (count truncated) (count id-prefix))
+                                (= id-prefix (subs truncated 0 (count id-prefix))))
+                       (subs truncated (count id-prefix)))]
+      (if tail
+        [:span {:style {:display "inline-flex" :align-items "baseline"
+                        :overflow "hidden" :text-overflow "ellipsis"}}
+         [:span {:style {:color (:text-tertiary tokens)}} "["]
+         [:span {:style {:color (:accent-violet tokens)}} id-str]
+         [:span {:style {:color (:text-primary tokens)
+                         :margin-left "4px"}}
+          tail]]
+        ;; Defensive fallback — render the whole truncated string in one
+        ;; span so a pathological event-id (with embedded space?) still
+        ;; surfaces something useful.
+        [:span {:style {:color (:text-primary tokens)}} truncated]))))
+
 (defn gutter-glyph
   "Pick the gutter glyph per spec/018 §4 Row anatomy. The selected row
   gets `◉`; an errored row gets `x`; a wholly-redacted row gets `▥`;
@@ -228,8 +307,19 @@
   "Nav cluster — `◀ ▶ ⏭` per spec/018 §3. Buttons dispatch
   `:rf.causa/focus-cascade-prev` / `-next` / `:rf.causa/follow-head`.
 
-  `at-head?` / `at-tail?` come from the spine sub so the buttons can
-  disable themselves at the boundary."
+  `at-head?` (focus = most recent event) and `at-tail?` (focus = first
+  event in buffer) come from the spine sub so the buttons can disable
+  themselves at the boundary:
+
+  - `◀` (back / prev) — disabled when `at-tail?` (no older event to
+    step to).
+  - `▶` (forward / next) — disabled when `at-head?` (already at the
+    most recent event).
+  - `⏭` (live / fast-forward) — never disabled; pressing it always
+    snaps focus to head + resumes LIVE.
+
+  (rf2-htik0 P1 — earlier wiring had the head/tail boundaries flipped
+  so the disabled glyph dimmed the wrong button.)"
   [{:keys [at-head? at-tail?]}]
   (let [btn-style {:background     "transparent"
                    :border         (str "1px solid " (:border-default tokens))
@@ -244,15 +334,15 @@
            :style {:display "flex" :align-items "center" :gap "4px"}}
      [:button {:data-testid "rf-causa-nav-prev"
                :on-click    #(rf/dispatch [:rf.causa/focus-cascade-prev] {:frame :rf/causa})
-               :disabled    (boolean at-head?)
+               :disabled    (boolean at-tail?)
                :title       "Step to previous event (j)"
-               :style       (merge btn-style (when at-head? dim))}
+               :style       (merge btn-style (when at-tail? dim))}
       "◀"]
      [:button {:data-testid "rf-causa-nav-next"
                :on-click    #(rf/dispatch [:rf.causa/focus-cascade-next] {:frame :rf/causa})
-               :disabled    (boolean at-tail?)
+               :disabled    (boolean at-head?)
                :title       "Step to next event (k)"
-               :style       (merge btn-style (when at-tail? dim))}
+               :style       (merge btn-style (when at-head? dim))}
       "▶"]
      [:button {:data-testid "rf-causa-nav-head"
                :on-click    #(rf/dispatch [:rf.causa/follow-head] {:frame :rf/causa})
@@ -457,6 +547,7 @@
         glyph     (gutter-glyph cascade focused-id)
         badges    (row-badges cascade)
         ev-id     (event-id-of-cascade cascade)
+        event-vec (:event cascade)
         glyph-col (cond
                     focused?                                (:cyan tokens)
                     (= "x" glyph)                           (:red tokens)
@@ -466,6 +557,10 @@
         border    (if focused?
                     (str "1px solid " (:cyan tokens))
                     "1px solid transparent")]
+    ;; Density (rf2-htik0 Bug 2): height 22px + padding "1px 6px" tightens
+    ;; the row from the earlier 28px / "4px 8px" spec-baseline. Causa is
+    ;; info-dense; keeps clickable hit-area while letting ~10 rows fit in
+    ;; the same vertical budget the old 8 rows used.
     [:li {:data-testid (str "rf-causa-event-row-" (str id))
           :on-click    #(rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
                                      {:frame :rf/causa})
@@ -477,9 +572,10 @@
                                  {:frame :rf/causa})))
           :style {:display       "flex"
                   :align-items   "center"
-                  :gap           "8px"
-                  :padding       "4px 8px"
-                  :height        "28px"
+                  :gap           "6px"
+                  :padding       "1px 6px"
+                  :height        "22px"
+                  :line-height   "20px"
                   :cursor        "pointer"
                   :background    bg
                   :border        border
@@ -490,13 +586,17 @@
                   :white-space   "nowrap"
                   :overflow      "hidden"
                   :text-overflow "ellipsis"}}
-     [:span {:style {:width "16px" :color glyph-col :flex-shrink 0
+     [:span {:style {:width "14px" :color glyph-col :flex-shrink 0
                      :text-align "center"}}
       glyph]
-     [:span {:style {:flex "1 1 auto" :overflow "hidden"
+     ;; Bug 3 (rf2-htik0): render the real event vector inline —
+     ;; `[:cart/add-item {:item-id "apple"}]`, NOT just `:cart/add-item`.
+     ;; Truncates at ~80 chars with `…]` suffix to keep the row single-line.
+     [:span {:data-testid "rf-causa-row-event-vector"
+             :style {:flex "1 1 auto" :overflow "hidden"
                      :text-overflow "ellipsis"
-                     :color (:accent-violet tokens)}}
-      (str (or ev-id "<no event>"))]
+                     :min-width "0"}}
+      (render-event-vector-inline event-vec)]
      (when (seq badges)
        [:span {:data-testid "rf-causa-row-badges"
                :style {:display "flex" :gap "4px" :flex-shrink 0
@@ -507,7 +607,14 @@
 
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
-  latest-on-bottom, 8 visible at default 28px row height ≈ 224px.
+  latest-on-bottom, ~8 visible at the tightened 22px row height
+  (rf2-htik0 Bug 2 — was 28px row × 224px container; Causa is
+  info-dense and the earlier rhythm wasted vertical canvas).
+
+  Container height: 8 rows × 22px + 7 × 2px gap + 8px outer padding
+  ≈ 200px. `min-height` drops to 48px (2 rows + chrome) so the
+  native vertical-resize handle can still squeeze the list down to
+  the L2/L3 drag spec minimum.
 
   Per spec/018 §6 sub-graph + rf2-ak4ms: reads `:rf.causa/filtered-
   cascades` (NOT raw `:rf.causa/cascades`) so the L1 ribbon's IN/OUT
@@ -522,8 +629,8 @@
         focus      @(rf/subscribe [:rf.causa/focus])
         focused-id (:dispatch-id focus)]
     [:div {:data-testid "rf-causa-event-list"
-           :style {:height        "224px"   ; 8 rows × 28px
-                   :min-height    "56px"    ; 2 rows minimum per spec
+           :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
+                   :min-height    "48px"    ; 2 rows minimum
                    :overflow-y    "auto"
                    :overflow-x    "hidden"
                    :background    (:bg-2 tokens)

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -387,6 +387,204 @@
           ":rf.causa/focus-cascade fired with the cascade's dispatch-id"))))
 
 ;; -------------------------------------------------------------------------
+;; (4a) Ribbon nav button enable/disable state — rf2-htik0 Bug 1
+;; -------------------------------------------------------------------------
+;;
+;; The nav cluster's ◀ / ▶ buttons disable themselves at the boundaries
+;; of the cascade list so the user can see at-a-glance whether stepping
+;; further is meaningful. The ⏭ live button is always enabled (pressing
+;; it always advances focus to head + resumes LIVE; idempotent at head).
+;;
+;; `at-head?` = focus is on the most recent (latest) cascade ⟹ ▶ disabled.
+;; `at-tail?` = focus is on the oldest cascade in the buffer ⟹ ◀ disabled.
+
+(defn- nav-prev-disabled? [tree]
+  (boolean (:disabled (second (find-by-testid tree "rf-causa-nav-prev")))))
+
+(defn- nav-next-disabled? [tree]
+  (boolean (:disabled (second (find-by-testid tree "rf-causa-nav-next")))))
+
+(defn- nav-head-disabled? [tree]
+  (boolean (:disabled (second (find-by-testid tree "rf-causa-nav-head")))))
+
+(deftest ribbon-nav-buttons-disabled-on-cold-start
+  (testing "empty cascade list → no boundary to walk. Both prev and
+            next disable; live button stays enabled (idempotent snap
+            to head)."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (nav-prev-disabled? tree) "◀ disabled when no events")
+        (is (nav-next-disabled? tree) "▶ disabled when no events")
+        (is (not (nav-head-disabled? tree)) "⏭ always enabled")))))
+
+(deftest ribbon-nav-buttons-at-head-disable-forward
+  (testing "rf2-htik0 Bug 1 — focus on the most recent event ⟹
+            ▶ disabled, ◀ enabled (older events exist), ⏭ enabled."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:newer/event]))
+    ;; Fresh focus auto-snaps to head (id 2). Sanity-check + assert.
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            focus @(rf/subscribe [:rf.causa/focus])]
+        (is (= 2 (:dispatch-id focus)) "focus snapped to head (id 2)")
+        (is (nav-next-disabled? tree)
+            "▶ DISABLED at head — no newer event to step to")
+        (is (not (nav-prev-disabled? tree))
+            "◀ ENABLED at head — id 1 is older and reachable")
+        (is (not (nav-head-disabled? tree)) "⏭ stays enabled")))))
+
+(deftest ribbon-nav-buttons-at-tail-disable-back
+  (testing "rf2-htik0 Bug 1 — focus on the oldest event in the buffer
+            ⟹ ◀ disabled, ▶ enabled (newer events exist), ⏭ enabled."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:newer/event]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade 1]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (nav-prev-disabled? tree)
+            "◀ DISABLED at tail — no older event to step back to")
+        (is (not (nav-next-disabled? tree))
+            "▶ ENABLED at tail — id 2 is newer and reachable")
+        (is (not (nav-head-disabled? tree)) "⏭ stays enabled")))))
+
+(deftest ribbon-nav-buttons-mid-list-both-enabled
+  (testing "focus on a middle event ⟹ both ◀ and ▶ enabled."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:middle/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 3 [:newer/event]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade 2]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (not (nav-prev-disabled? tree))
+            "◀ ENABLED — older event (1) reachable")
+        (is (not (nav-next-disabled? tree))
+            "▶ ENABLED — newer event (3) reachable")
+        (is (not (nav-head-disabled? tree)) "⏭ stays enabled")))))
+
+;; -------------------------------------------------------------------------
+;; (4b) Row density + inline event-vector rendering — rf2-htik0 Bug 2 + 3
+;; -------------------------------------------------------------------------
+
+(deftest event-row-density-tight
+  (testing "rf2-htik0 Bug 2 — row height tightens to 22px so Causa's
+            info-dense L2 list reclaims vertical canvas. Padding stays
+            generous enough to keep the row clickable."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            row  (find-by-testid tree "rf-causa-event-row-1")
+            style (:style (second row))]
+        (is (some? row) "row renders")
+        (is (= "22px" (:height style))
+            "row height is the tightened 22px (was 28px)")
+        (is (= "1px 6px" (:padding style))
+            "row padding is the tightened 1px 6px (was 4px 8px)")))))
+
+(deftest event-list-container-height-matches-tight-rows
+  (testing "rf2-htik0 Bug 2 — container height stays at ~8 rows of the
+            new 22px row × 2px gap + padding (≈200px, was 224px)."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree  (shell/shell-view)
+            list  (find-by-testid tree "rf-causa-event-list")
+            style (:style (second list))]
+        (is (= "200px" (:height style))
+            "list container is ~8 rows × 22px + gaps + padding")))))
+
+(deftest event-row-renders-real-event-vector
+  (testing "rf2-htik0 Bug 3 — each L2 row shows the dispatched event
+            vector inline (`[:cart/add-item {:item-id \"apple\"}]`),
+            not just the event-id."
+    (causa-setup!)
+    (trace-bus/collect-trace!
+      (dispatch-trace-ev 1 [:cart/add-item {:item-id "apple" :qty 2}]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            row  (find-by-testid tree "rf-causa-event-row-1")
+            vec-node (find-by-testid tree "rf-causa-row-event-vector")
+            text (text-nodes vec-node)]
+        (is (some? row) "row renders")
+        (is (some? vec-node) "row carries the event-vector slot")
+        (is (re-find #":cart/add-item" text)
+            "event-id surfaces in the row text")
+        (is (re-find #":item-id" text)
+            "payload key surfaces in the row text")
+        (is (re-find #"apple" text)
+            "payload value surfaces in the row text")))))
+
+(deftest event-row-empty-payload-renders-as-bare-vector
+  (testing "rf2-htik0 Bug 3 — events with no payload render as
+            `[:counter/inc]` — no `{}` placeholder."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:counter/inc]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            vec-node (find-by-testid tree "rf-causa-row-event-vector")
+            text (text-nodes vec-node)]
+        (is (some? vec-node))
+        (is (re-find #":counter/inc" text)
+            "event-id renders")
+        (is (not (re-find #"\{" text))
+            "no `{}` placeholder for empty payload")
+        (is (not (re-find #"\}" text))
+            "no `{}` placeholder for empty payload")))))
+
+(deftest event-row-long-payload-truncates
+  (testing "rf2-htik0 Bug 3 — long event vectors collapse to head + `…]`
+            so the row stays single-line."
+    (causa-setup!)
+    (let [big-vec [:something/big {:a "alpha-beta-gamma-delta"
+                                   :b "epsilon-zeta-eta-theta"
+                                   :c "iota-kappa-lambda-mu"
+                                   :d "nu-xi-omicron-pi"}]]
+      (trace-bus/collect-trace! (dispatch-trace-ev 1 big-vec))
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              vec-node (find-by-testid tree "rf-causa-row-event-vector")
+              text (text-nodes vec-node)]
+          (is (some? vec-node))
+          (is (re-find #":something/big" text)
+              "head (event-id) preserved through truncation")
+          (is (re-find #"…\]$" text)
+              "trailing `…]` marks the truncation"))))))
+
+(deftest truncate-event-vector-helper
+  (testing "rf2-htik0 Bug 3 — pure truncator preserves short strings
+            and clips long ones with `…]` suffix"
+    (is (= "[:x]" (shell/truncate-event-vector "[:x]" 80))
+        "below cap → pass-through")
+    (is (= "[:x 1]" (shell/truncate-event-vector "[:x 1]" 80))
+        "below cap → pass-through")
+    (let [long-str (apply str "[:x " (repeat 100 "y"))
+          out      (shell/truncate-event-vector long-str 20)]
+      (is (= 20 (count out)) "output respects cap")
+      (is (re-find #"…\]$" out) "suffix is `…]`")
+      (is (re-find #"^\[:x" out) "head preserved"))))
+
+(deftest render-event-vector-inline-empty-payload
+  (testing "rf2-htik0 Bug 3 — render-event-vector-inline of a 1-element
+            vector returns hiccup containing just the event-id, no `{}`."
+    (let [hiccup (shell/render-event-vector-inline [:counter/inc])
+          text   (text-nodes hiccup)]
+      (is (re-find #":counter/inc" text))
+      (is (not (re-find #"\{" text)))
+      (is (not (re-find #"\}" text))))))
+
+(deftest render-event-vector-inline-nil-cascade
+  (testing "rf2-htik0 Bug 3 — render-event-vector-inline of non-vector
+            input returns the `<no event>` fallback chip."
+    (let [hiccup (shell/render-event-vector-inline nil)
+          text   (text-nodes hiccup)]
+      (is (re-find #"no event" text)))))
+
+;; -------------------------------------------------------------------------
 ;; (5) REDACTED indicator (preserved from pre-refactor — relocated to L1)
 ;; -------------------------------------------------------------------------
 


### PR DESCRIPTION
P1 fix for **bead rf2-htik0** — three foundational L2 event-list issues Mike hit on the live shell.

## Bug 1 — Nav buttons enable/disable wiring was flipped

The L1 ribbon's `[◀ ▶ ⏭]` cluster had `at-head?` and `at-tail?` wired to the wrong buttons.

| | Before | After |
|---|---|---|
| `◀` (prev/back) | disabled when `at-head?` (newest event) | disabled when `at-tail?` (oldest event) |
| `▶` (forward/next) | disabled when `at-tail?` (oldest event) | disabled when `at-head?` (newest event) |
| `⏭` (live) | always enabled | always enabled (unchanged) |

The corrected semantics: `◀` should be disabled when there's no older event to step to; `▶` should be disabled when there's no newer event to step to. Docstring rewritten to spell out the boundary conditions so this doesn't drift again.

## Bug 2 — L2 row density was too loose

Causa is information-dense; the spec-baseline 28px row height with `4px 8px` padding wasted vertical canvas.

| | Before | After |
|---|---|---|
| Row height | 28px | **22px** |
| Row padding | `4px 8px` | `1px 6px` |
| Row gap | 8px | 6px |
| Container height | 224px | **200px** (8 × 22px + gaps + padding) |
| Container min-height | 56px | 48px (2-row minimum) |

22px matches the spec's named "compact" density option (`spec/018 §View settings` table) — making it the default rather than wiring the not-yet-built density toggle. Hit-area stays clickable; line-height tuned to 20px so the text sits centred in the row.

## Bug 3 — Rows now show the real event vector inline

Before each row showed only the event-id keyword (`:cart/add-item`). After, each row renders the actual dispatched vector:

```
[:cart/add-item {:item-id "apple" :qty 2}]
```

Behaviour:
- Empty payload renders as bare `[:counter/inc]` — no `{}` placeholder.
- Long vectors truncate at 80 chars with `…]` suffix so the row stays single-line. Full vector is still visible by clicking the row → L4 Event tab.
- Event-id coloured with the accent-violet keyword token so it pops out of the payload visually.
- Non-vector input falls back to an italic `<no event>` chip in the secondary text colour.

Reusable pure helpers (`truncate-event-vector`, `render-event-vector-inline`) added so other panels (or a future settings density tier) can share the same renderer.

## Test plan

- [x] `scripts/test-fast-pr.sh` — `Ran 3163 tests containing 9095 assertions. 0 failures, 0 errors.`
- [x] `cd tools/causa && clojure -M:test` — `Ran 930 tests containing 2686 assertions. 0 failures, 0 errors.`
- [x] `cd implementation && npm run test:browser` — `Browser tests: Ran 3154 tests containing 9050 assertions. 0 failures, 0 errors.`
- [x] New deftests in `shell_cljs_test.cljs`:
  - `ribbon-nav-buttons-disabled-on-cold-start` — empty buffer → both `◀` and `▶` disabled
  - `ribbon-nav-buttons-at-head-disable-forward` — focus on newest → `▶` disabled, `◀` enabled
  - `ribbon-nav-buttons-at-tail-disable-back` — focus on oldest → `◀` disabled, `▶` enabled
  - `ribbon-nav-buttons-mid-list-both-enabled` — focus in the middle → both enabled
  - `event-row-density-tight` — asserts 22px height + `1px 6px` padding
  - `event-list-container-height-matches-tight-rows` — asserts 200px container
  - `event-row-renders-real-event-vector` — event-id + payload key + payload value all surface in row text
  - `event-row-empty-payload-renders-as-bare-vector` — no `{}` in 1-element vectors
  - `event-row-long-payload-truncates` — head preserved, `…]` suffix appears
  - `truncate-event-vector-helper` + `render-event-vector-inline-*` — pure-helper coverage

## Files

- `tools/causa/src/day8/re_frame2_causa/shell.cljs` — fixes + new helpers
- `tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs` — new coverage

Bead `rf2-htik0` stays open per dispatch instructions.