### PR TITLE
fix+feat(causa): Event panel EFFECTS rendering bug + Live mode auto-follows head

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -214,22 +214,78 @@
     [:div (inspector/inspect (:tags ev) "event-detail/fx-tags")]
     (coord-line ev)]])
 
+(defn- db-changed-events
+  "Pluck the `:event/db-changed` traces from a cascade's `:other`
+  bucket. Per Spec 002 §Drain-loop pseudocode every `:db` commit
+  emits one `:event/db-changed` trace; the projection routes those
+  to `:other` (they don't fit a domino slot per Spec 009
+  §`:op-type` vocabulary). For the EFFECTS row this is the only
+  cascade-side signal that the handler returned a `:db` effect — no
+  `:rf.fx/handled` is emitted for `:db` because the commit happens
+  in the interceptor chain, not in the fx walk."
+  [other]
+  (filter (fn [ev]
+            (and (= :event (:op-type ev))
+                 (= :event/db-changed (:operation ev))))
+          other))
+
+(defn effects-entries
+  "Build the EFFECTS row's display entries from a cascade. Combines:
+
+    1. `:event/db-changed` traces (if any) — surfaced as a virtual
+       `:db` entry per rf2-s0s5x Phase A so events that committed
+       only a `:db` effect (the common `reg-event-db` case) don't
+       lie with `EFFECTS (none)`.
+    2. `:op-type :fx` traces from the `:effects` slot — every fx
+       handler invocation (`:rf.fx/handled` /
+       `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform`).
+
+  Returns a sequence of `{:fx-id <kw> :operation <kw> :id <int>}`
+  display rows in cascade order (`:db` first, then fx vector
+  entries). Empty when neither signal is present."
+  [cascade]
+  (let [db-rows (for [ev (db-changed-events (:other cascade))]
+                  {:fx-id     :db
+                   :operation (:operation ev)
+                   :id        (:id ev)
+                   :ev        ev})
+        fx-rows (for [ev (:effects cascade)]
+                  {:fx-id     (get-in ev [:tags :fx-id])
+                   :operation (:operation ev)
+                   :id        (:id ev)
+                   :ev        ev})]
+    (concat db-rows fx-rows)))
+
 (defn- effects-row
-  "Fourth domino: every `:op-type :fx` event (one per fx handler
-  invocation). Renders as a stacked list — fx-id + status — under a
-  single label cell."
-  [effects]
-  [domino-row {:label "effects" :tone :green}
-   (if (empty? effects)
-     [:span {:style {:color (:text-tertiary tokens)}} "(none)"]
-     (into [:div]
-           (for [ev effects]
-             ^{:key (:id ev)}
-             [:div {:style {:padding "2px 0"}}
-              [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
-               (str (get-in ev [:tags :fx-id]))]
-              [:span {:style {:color (:text-secondary tokens)}}
-               (str (:operation ev))]])))])
+  "Fourth domino: the effects the cascade actually committed. Renders
+  a stacked list of fx-id + operation, with a virtual `:db` row when
+  the cascade emitted `:event/db-changed` (the cascade-side signal
+  for the `:db` effect — see `db-changed-events`).
+
+  Per rf2-s0s5x Phase A: previously this row read only the
+  projection's `:effects` slot (built from `:op-type :fx` events),
+  which left pure `reg-event-db` handlers showing `(none)` even
+  though `:db` had been committed — the EFFECTS lie the bead calls
+  out. The composite `effects-entries` folds in `:event/db-changed`
+  from the `:other` bucket so the row reflects the cascade's actual
+  outcome."
+  [cascade]
+  (let [entries (effects-entries cascade)]
+    [domino-row {:label "effects" :tone :green}
+     (if (empty? entries)
+       [:span {:data-testid "rf-causa-event-detail-effects-none"
+               :style {:color (:text-tertiary tokens)}}
+        "(none)"]
+       (into [:div {:data-testid "rf-causa-event-detail-effects"}]
+             (for [{:keys [fx-id operation id]} entries]
+               ^{:key id}
+               [:div {:data-testid (str "rf-causa-event-detail-effects-row-"
+                                        (name (or fx-id :unknown)))
+                      :style {:padding "2px 0"}}
+                [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
+                 (str fx-id)]
+                [:span {:style {:color (:text-secondary tokens)}}
+                 (str operation)]])))]))
 
 (defn- subs-row
   "Fifth domino: subscription work (`:sub/run` + `:sub/create`)."
@@ -338,7 +394,7 @@
   wire-boundary diff template (rf2-uyp86 / F-C2) mounts below the
   six-domino window as an inline `<div>` per record. Cascades without
   managed-fx invocations render unchanged."
-  [{:keys [dispatch-id frame event handler fx effects subs renders other] :as cascade}]
+  [{:keys [dispatch-id frame event handler fx subs renders other] :as cascade}]
   (let [managed-fx-records (managed-fx-h/cascade->managed-fx-records cascade)]
     [:div {:data-testid "rf-causa-event-detail-cascade"
            :data-dispatch-id (str dispatch-id)
@@ -354,7 +410,7 @@
       [event-row event (trigger-handler-coord (or handler fx))]
       (when handler [handler-row handler])
       (when fx [fx-row fx])
-      [effects-row effects]
+      [effects-row cascade]
       [subs-row subs]
       [renders-row renders]
       (other-row other)]
@@ -454,22 +510,35 @@
   ;; The projection runs against the live buffer on every recompute.
   ;; Per spec/007-UX-IA.md §Performance budget the panel renders at
   ;; most ~200 cascades; the projection is O(n) over the buffer.
+  ;;
+  ;; ## Spine-driven focus (rf2-s0s5x Phase A)
+  ;;
+  ;; The composite reads the EFFECTIVE focused dispatch-id off the
+  ;; spine sub (`:rf.causa/focus`) rather than the legacy
+  ;; `:selected-dispatch-id` slot. The spine composer auto-advances
+  ;; the effective id to head in `:live` mode (rf2-s0s5x §Live
+  ;; auto-follow); reading the legacy slot would leave this panel
+  ;; pinned to a stale id that `focus-cascade-reducer` last wrote.
+  ;; The legacy slot remains as a shim for older direct readers (the
+  ;; orphaned-branch caption, MCP probes) but the focused-cascade
+  ;; computation here is canonically off the spine.
   (rf/reg-sub :rf.causa/event-detail
     ;; Signal layer: depend on the shared `:rf.causa/cascades`
-    ;; projection + selected-dispatch-id so this composite recomputes
+    ;; projection + the spine focus so this composite recomputes
     ;; when either changes. The `:<-` chain is the only sub-
     ;; registration form in v2 (per Spec 002 §Subscriptions composing
     ;; — reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
     :<- [:rf.causa/cascades]
-    :<- [:rf.causa/selected-dispatch-id]
-    :<- [:rf.causa/selected-dispatch-frame]
-    (fn [[cascades selected-id selected-frame] _query]
-      (let [selection (when selected-id
-                        {:dispatch-id selected-id
-                         :frame       selected-frame})
-            by-id     (when selection
-                        (some #(when (cascade-matches-selection? % selection) %)
-                              cascades))]
+    :<- [:rf.causa/focus]
+    (fn [[cascades focus] _query]
+      (let [selected-id    (:dispatch-id focus)
+            selected-frame (:frame focus)
+            selection      (when selected-id
+                             {:dispatch-id selected-id
+                              :frame       selected-frame})
+            by-id          (when selection
+                             (some #(when (cascade-matches-selection? % selection) %)
+                                   cascades))]
         {:cascades             cascades
          :selected-dispatch-id selected-id
          :selected-dispatch-frame selected-frame
@@ -490,8 +559,15 @@
     (fn [db [_ dispatch-id frame-id]]
       (spine/focus-cascade-reducer db dispatch-id frame-id)))
 
+  ;; Programmatic clear of the focused cascade. Resets the spine focus
+  ;; back to LIVE (head-tracking) per the rf2-s0s5x Phase A semantics —
+  ;; clearing means "go back to following the live stream", same
+  ;; outcome the user gets by clicking the LIVE pill.
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
       (-> db
           (dissoc :selected-dispatch :selected-dispatch-id)
-          (assoc-in [:focus :dispatch-id] nil)))))
+          (update :focus (fnil assoc {})
+                  :dispatch-id nil
+                  :mode :live
+                  :previewing? false)))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -559,6 +559,7 @@
     ;; lives at the composite layer (not the view) so consumers of
     ;; `:rf.causa/event-detail` (the panel + its tests) all see the
     ;; same effective selection.
+    :<- [:rf.causa/cascades]
     :<- [:rf.causa/focus]
     (fn [[cascades focus] _query]
       ;; Phase A spine wiring: read the EFFECTIVE focused id off the

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -64,10 +64,27 @@
 
 (defn cascade-by-id
   "Find a cascade in `cascades` by its `:dispatch-id`. Returns nil when
-  no match (id refers to an evicted cascade, or a fresh session)."
-  [cascades dispatch-id]
-  (when dispatch-id
-    (some #(when (= dispatch-id (:dispatch-id %)) %) cascades)))
+  no match (id refers to an evicted cascade, or a fresh session).
+
+  The 3-arity prefers a cascade matching `:frame` when supplied —
+  multiple cascades can share a dispatch-id across frames (Spec 002
+  §Frame isolation + rf2-g6ih4: dispatch-id uniqueness is per-frame,
+  not process-global). When no frame-matching cascade exists the
+  lookup falls back to a dispatch-id-only match so a stale stored
+  frame (e.g. a user-frame the cascade was re-emitted from) doesn't
+  hide an otherwise-valid cascade — the cascade's own `:frame` is
+  treated as authoritative."
+  ([cascades dispatch-id]
+   (cascade-by-id cascades dispatch-id nil))
+  ([cascades dispatch-id frame-id]
+   (when dispatch-id
+     (or (when frame-id
+           (some #(when (and (= dispatch-id (:dispatch-id %))
+                             (= frame-id (:frame %)))
+                    %)
+                 cascades))
+         (some #(when (= dispatch-id (:dispatch-id %)) %)
+               cascades)))))
 
 (defn step-dispatch-id
   "Compute the new `:dispatch-id` when stepping by `delta` (-1 for
@@ -98,20 +115,60 @@
 
   In `:live` mode an unset (or evicted) dispatch-id snaps to head so
   a fresh session opens already pointing at the latest cascade per
-  §4 Defaults."
+  §4 Defaults.
+
+  ## Live auto-follow (rf2-s0s5x Phase A)
+
+  In `:live` mode the effective `:dispatch-id` is ALWAYS the current
+  head — even when a stored `slot-id` exists and is still in the
+  buffer. Previously the composer honoured the stored slot-id once it
+  was set (so `focus-step-reducer` landing on the then-head left
+  `:dispatch-id` pinned to that id even after newer cascades arrived);
+  the user observed focus 'stuck' even though the LIVE pill said it
+  was tracking. Spec/018 §3 says the LIVE pill auto-tracks head; this
+  composer is the canonical site that derives that behaviour.
+
+  `:paused?` suspends the auto-track — when paused, the focus stays
+  on the stored slot-id so the user can inspect a cascade without
+  losing it as new traffic arrives. Resuming (`follow-head` /
+  `toggle-live-pause`) snaps back to head."
   [focus cascades]
-  (let [head-id (head-dispatch-id cascades)
-        slot-id (:dispatch-id focus)
-        mode    (or (:mode focus)
-                    (if (or (nil? slot-id) (= slot-id head-id))
-                      :live
-                      :retro))
-        eff-id  (if (and (= :live mode)
-                         (or (nil? slot-id)
-                             (nil? (cascade-by-id cascades slot-id))))
+  (let [head-id    (head-dispatch-id cascades)
+        slot-id    (:dispatch-id focus)
+        slot-frame (:frame focus)
+        paused?    (boolean (:paused? focus))
+        mode       (or (:mode focus)
+                       (if (or (nil? slot-id) (= slot-id head-id))
+                         :live
+                         :retro))
+        eff-id  (cond
+                  ;; Live + unpaused — track head, regardless of slot-id.
+                  ;; This is the rf2-s0s5x Phase A change: previously the
+                  ;; stored slot-id won here, so once `focus-step-reducer`
+                  ;; landed on head the slot pinned to that id and never
+                  ;; auto-advanced as newer cascades arrived. Pre-alpha
+                  ;; the LIVE pill's contract is unambiguous — head IS
+                  ;; the focus.
+                  (and (= :live mode) (not paused?))
                   head-id
+                  ;; Live but paused — slot-id wins (frozen inspection);
+                  ;; if the stored id has been evicted from the buffer,
+                  ;; snap to head so the inspector doesn't dangle on a
+                  ;; nonexistent cascade.
+                  (and (= :live mode) paused?)
+                  (if (cascade-by-id cascades slot-id slot-frame) slot-id head-id)
+                  ;; Retro — slot-id wins UNCONDITIONALLY (even when
+                  ;; evicted). The event-detail panel's orphaned-state
+                  ;; branch surfaces "this id is no longer in the
+                  ;; buffer" copy off the evicted slot-id; auto-snapping
+                  ;; to head in retro would hide that signal. Empty
+                  ;; slot-id (initial state) does snap to head per §4
+                  ;; Defaults.
+                  (nil? slot-id)
+                  head-id
+                  :else
                   slot-id)
-        cascade (cascade-by-id cascades eff-id)]
+        cascade (cascade-by-id cascades eff-id slot-frame)]
     {:dispatch-id eff-id
      :epoch-id    (:epoch-id focus)
      :frame       (or (:frame cascade) (:frame focus))
@@ -119,7 +176,7 @@
      :head?       (or (nil? eff-id)
                       (= eff-id head-id))
      :previewing? (boolean (:previewing? focus))
-     :paused?     (boolean (:paused? focus))}))
+     :paused?     paused?}))
 
 ;; ---- pure reducers exposed for direct unit testing ----------------------
 
@@ -146,10 +203,15 @@
   the `:dispatch-id` through the cascade vector by `delta` (-1 or
   +1), updates the legacy shim slot, and flips mode based on the
   step's outcome — stepping back from head → :retro; stepping
-  forward back to head → :live (the user has scrubbed home)."
+  forward back to head → :live (the user has scrubbed home).
+
+  Per rf2-s0s5x Phase A — `compose-focus` now treats `:live` mode as
+  always tracking head, so the stored slot-id can lag the actual
+  focused cascade. Compute `current-id` through the same composer so
+  pressing `j` (prev) from LIVE steps back one from the CURRENT head
+  rather than from a stale stored id."
   [db cascades delta]
-  (let [current-id (or (get-in db [:focus :dispatch-id])
-                       (:selected-dispatch-id db))
+  (let [current-id (:dispatch-id (compose-focus (get db :focus) cascades))
         new-id     (step-dispatch-id cascades current-id delta)
         head-id    (head-dispatch-id cascades)
         new-mode   (if (= new-id head-id) :live :retro)

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -142,29 +142,32 @@
             node))
         (hiccup-seq tree)))
 
-;; ---- (1) empty state: cascade list --------------------------------------
+;; ---- (1) initial state: LIVE auto-focuses head (rf2-s0s5x Phase A) ------
+;;
+;; Pre-rf2-s0s5x the panel landed on a cascade-list 'empty state' until
+;; the user clicked a row. Phase A makes the panel spine-driven —
+;; `:rf.causa/event-detail` reads its `:selected-dispatch-id` off the
+;; spine `:rf.causa/focus` sub. With no stored focus, the spine
+;; composer returns LIVE + head; the panel renders the head cascade's
+;; detail. The cascade-list landing page only renders when the buffer
+;; is empty (no head to focus on).
 
-(deftest empty-state-renders-cascade-list
-  (testing "with cascades in the buffer but no selection, the panel
-            renders the cascade list"
+(deftest live-focus-renders-head-cascade-detail
+  (testing "with cascades in the buffer + no explicit selection, the
+            spine LIVE-tracks head and the panel renders the head
+            cascade's detail (rf2-s0s5x Phase A)"
     (seed-buffer! (concat (cascade-evs 100 [:user/login {:id 42}] 0)
                           (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container present")
-        (is (some? (find-by-testid tree "rf-causa-cascade-list"))
-            "cascade list container present")
-        (is (some? (find-by-testid tree "rf-causa-cascade-row-100"))
-            "cascade 100 has a clickable row")
-        (is (some? (find-by-testid tree "rf-causa-cascade-row-200"))
-            "cascade 200 has a clickable row")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail container absent when no selection")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
+            "cascade-detail container renders for the head cascade")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
+            "no empty-state container when there's a head to focus on")))))
 
 (deftest empty-state-renders-with-no-cascades
   (testing "with an empty buffer + no selection the panel still
-            renders the empty-state container"
+            renders the empty-state container — no head to focus on"
     (seed-buffer! [])
     (rf/with-frame :rf/causa
       (let [tree (event-detail/Panel)]
@@ -244,17 +247,21 @@
       (is (nil? (:selected-dispatch-id default-db))
           "selection did NOT leak into :rf/default"))))
 
-(deftest clear-selected-dispatch-id-returns-to-empty-state
-  (testing "after select + clear the panel renders the empty state"
+(deftest clear-selected-dispatch-id-snaps-to-live-head
+  (testing "after select + clear the panel snaps back to LIVE
+            head-tracking (rf2-s0s5x Phase A). Clearing the
+            selection means 'resume following the live stream' —
+            the spine resets to :live and the panel renders the
+            head cascade's detail."
     (seed-buffer! (cascade-evs 100 [:user/login {:id 42}] 0))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (rf/dispatch-sync [:rf.causa/clear-selected-dispatch-id])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container present after clear")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail container absent after clear")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
+            "head cascade's detail renders after clear (LIVE auto-tracks head)")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
+            "no empty-state container — LIVE is focused on the head cascade")))))
 
 ;; ---- (4) defaults / wiring ----------------------------------------------
 
@@ -522,3 +529,95 @@
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
         (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+
+;; ---- (7) EFFECTS row — non-lying empty state (rf2-s0s5x Phase A) -------
+;;
+;; Per the bead's Bug 1: the EFFECTS row previously showed `(none)` on
+;; cascades whose handler returned only `:db` — `:event/db-changed`
+;; lives in the projection's `:other` bucket (no `:op-type :fx` is
+;; emitted for the framework-driven `:db` commit), so the row's
+;; `(empty? effects)` branch fired even though the user clearly saw
+;; the state change. The fix folds `:event/db-changed` in as a virtual
+;; `:db` entry alongside the standard fx-handled traces; the row now
+;; shows `(none)` only when neither signal is present (true silence).
+
+(defn- cascade-evs-db-only
+  "Pure-db cascade — like `cascade-evs` but instead of the two
+  `:rf.fx/handled` rows it emits one `:event/db-changed` so the
+  projection bucketises `:effects` as empty AND surfaces the db
+  commit in `:other`. Mirrors what `reg-event-db` produces in
+  production (the cart-total testbed's `:cart/add-item` is the
+  canonical repro)."
+  [dispatch-id event-vec id-base]
+  [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+    :tags {:dispatch-id dispatch-id :event event-vec}}
+   {:id (+ id-base 2) :op-type :event :operation :event
+    :tags {:dispatch-id dispatch-id :phase :run-end}}
+   {:id (+ id-base 3) :op-type :event :operation :event/db-changed
+    :tags {:dispatch-id dispatch-id :event-id (first event-vec)}}
+   {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+    :tags {:dispatch-id dispatch-id}}])
+
+(deftest effects-row-renders-db-when-db-changed-emitted
+  (testing "rf2-s0s5x Phase A — a reg-event-db cascade emits
+            `:event/db-changed` but no `:rf.fx/handled`; the EFFECTS
+            row surfaces a virtual `:db` entry so the panel doesn't
+            lie with `(none)` when the cascade committed a `:db`
+            effect"
+    (seed-buffer! (cascade-evs-db-only 400 [:counter/inc] 400))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 400])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects"))
+            "EFFECTS row renders the entries list, not the (none) span")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-db"))
+            "db row carries a stable testid")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects-none"))
+            "no (none) caption when an effect was committed")))))
+
+(deftest effects-row-renders-fx-entries-when-handled
+  (testing "an fx-bearing cascade emits one `:rf.fx/handled` per fx
+            handler invocation; the EFFECTS row lists each by fx-id +
+            operation. Same fixture as `cascade-detail-renders-six-
+            dominoes` — two :rf.fx/handled entries (`:fx-id :db` and
+            `:fx-id :dispatch`)."
+    (seed-buffer! (cascade-evs 401 [:counter/inc] 400))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 401])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects")))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-db"))
+            "fx-id :db row present (from the cascade-evs fixture)")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-dispatch"))
+            "fx-id :dispatch row present")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects-none")))))))
+
+(deftest effects-row-shows-none-when-truly-empty
+  (testing "a cascade with no fx-handled traces AND no db-changed
+            trace renders `(none)` — the empty-state is only a lie
+            when there's actual cascade work; the silent path stays
+            silent."
+    (seed-buffer! [{:id 1 :op-type :event :operation :event/dispatched
+                    :tags {:dispatch-id 500 :event [:noop]}}
+                   {:id 2 :op-type :event :operation :event
+                    :tags {:dispatch-id 500 :phase :run-end}}
+                   {:id 3 :op-type :event :operation :event/do-fx
+                    :tags {:dispatch-id 500}}])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 500])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-none"))
+            "(none) caption renders for a truly empty cascade")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects")))))))
+
+(deftest effects-entries-orders-db-first
+  (testing "the entries fn surfaces db before fx-vector entries —
+            matches the runtime ordering (db commit precedes the fx
+            walk per Spec 002 §Drain-loop pseudocode)"
+    (let [cascade {:effects [{:id 5 :op-type :fx :operation :rf.fx/handled
+                              :tags {:fx-id :dispatch}}]
+                   :other   [{:id 3 :op-type :event :operation :event/db-changed
+                              :tags {}}]}
+          entries (event-detail/effects-entries cascade)]
+      (is (= [:db :dispatch] (mapv :fx-id entries))
+          "db row first (cascade order), then fx vector entries"))))

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -218,11 +218,18 @@
     (is (= :live (get-in r [:focus :mode]))
         "stepping back to head implicitly re-engages LIVE")))
 
-(deftest focus-step-reducer-from-empty-slot-uses-legacy
-  (let [db {:selected-dispatch-id :c2}
-        r  (spine/focus-step-reducer db fixture-cascades -1)]
-    (is (= :c1 (get-in r [:focus :dispatch-id]))
-        "stepping reads current-id from legacy when :focus is empty")))
+(deftest focus-step-reducer-from-empty-slot-snaps-to-head-then-steps
+  (testing "rf2-s0s5x Phase A — with an empty `:focus` slot the
+            current-id is derived through `compose-focus` (which
+            snaps to head in :live), not lifted off the legacy
+            `:selected-dispatch-id` slot. The legacy slot is a
+            shim-write-target now, not a read source — keeping
+            spine as the canonical source of truth."
+    (let [db {:selected-dispatch-id :c2}
+          r  (spine/focus-step-reducer db fixture-cascades -1)]
+      (is (= :c2 (get-in r [:focus :dispatch-id]))
+          "step prev: empty :focus → composer derives head (c3) → prev
+           lands on c2 (one step back from head)"))))
 
 ;; -------------------------------------------------------------------------
 ;; (5) follow-head-reducer
@@ -403,3 +410,112 @@
   (let [r (focus-sub)]
     (is (true? (:paused? r)))
     (is (= :live (:mode r)))))
+
+;; -------------------------------------------------------------------------
+;; (9) Live auto-follow head (rf2-s0s5x Phase A)
+;; -------------------------------------------------------------------------
+;;
+;; Per the bead's Phase A acceptance: when `:mode :live` and a new
+;; cascade arrives, the effective focus auto-advances. Previously
+;; `compose-focus` honoured a non-nil stored slot-id even in :live
+;; mode (so stepping back to head with `k` left the slot pinned and
+;; later head arrivals went unfollowed). The composer now treats
+;; LIVE as 'always head' unless paused — and the legacy slot writes
+;; are still honoured for paused/retro selections.
+
+(deftest compose-focus-live-with-stored-id-tracks-head
+  (testing "rf2-s0s5x Phase A — LIVE always tracks head, even when a
+            stored slot-id exists and matches the previous head. The
+            stored id might be the previous head pinned by
+            focus-step-reducer landing back on head; once a fresher
+            cascade arrives, focus auto-advances."
+    (let [r (spine/compose-focus {:dispatch-id :c2 :mode :live}
+                                 fixture-cascades)]
+      (is (= :c3 (:dispatch-id r))
+          "LIVE mode → effective id is the current head, not the stored id")
+      (is (true? (:head? r))))))
+
+(deftest compose-focus-paused-live-preserves-stored-id
+  (testing "rf2-s0s5x Phase A — when paused, LIVE auto-follow is
+            suspended so the user can inspect a pinned cascade
+            without losing it as new traffic arrives. The composer
+            falls back to slot-id behaviour."
+    (let [r (spine/compose-focus {:dispatch-id :c1 :mode :live :paused? true}
+                                 fixture-cascades)]
+      (is (= :c1 (:dispatch-id r))
+          "paused LIVE → stored slot-id wins")
+      (is (true? (:paused? r))))))
+
+(deftest compose-focus-paused-live-with-evicted-id-snaps-head
+  (testing "paused LIVE + the stored id has been evicted from the
+            buffer → snap to head (no orphan focus). Matches the
+            non-paused eviction fallback."
+    (let [r (spine/compose-focus {:dispatch-id :gone :mode :live :paused? true}
+                                 fixture-cascades)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (true? (:head? r))))))
+
+(deftest focus-sub-live-auto-follows-new-head
+  (testing "rf2-s0s5x Phase A acceptance — user is in LIVE on c3
+            (head); a new cascade c4 arrives; focus auto-advances to
+            c4 without the user clicking the LIVE pill."
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    ;; Initial state — LIVE, focused on head c3 (implicit, slot-id nil).
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (= :live (:mode r))))
+    ;; User steps prev then next — lands on c3 again, slot-id is now :c3.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade-prev])
+      (rf/dispatch-sync [:rf.causa/focus-cascade-next]))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (= :live (:mode r))
+          "stepping back to head re-engages LIVE per focus-step-reducer"))
+    ;; A new cascade c4 arrives — head shifts.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (let [r (focus-sub)]
+      (is (= :c4 (:dispatch-id r))
+          "LIVE auto-follows the new head — focus advances to c4")
+      (is (true? (:head? r))))))
+
+(deftest focus-sub-retro-does-not-auto-follow
+  (testing "in :retro the focus stays pinned even when new cascades
+            arrive — the user has explicitly opted out of LIVE."
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c1 (:dispatch-id r)))
+      (is (= :retro (:mode r))))
+    ;; New cascade arrives. Focus stays on c1.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (let [r (focus-sub)]
+      (is (= :c1 (:dispatch-id r))
+          ":retro pins the focus through arrivals")
+      (is (= :retro (:mode r))))))
+
+(deftest focus-sub-paused-live-does-not-auto-follow
+  (testing "paused LIVE freezes auto-follow — user paused to inspect,
+            so new arrivals don't pull focus away."
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      ;; Get into :live mode with slot-id pinned on c2 (paused inspection
+      ;; of a non-head cascade — possible via focus-step then pause).
+      (rf/dispatch-sync [:rf.causa/focus-cascade-prev])
+      (rf/dispatch-sync [:rf.causa/focus-cascade-next]))
+    ;; Now slot-id = :c3, mode = :live. Pause.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/toggle-live-pause]))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (true? (:paused? r))))
+    ;; New cascade arrives. Paused LIVE stays put.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r))
+          "paused LIVE pins focus through arrivals")
+      (is (true? (:paused? r))))))


### PR DESCRIPTION
## Summary

Two small wins from `ai/prompt/2026-05-18-event-panel-redesign.md` Phase A (bead **rf2-s0s5x**):

1. **Bug** — Event-detail's EFFECTS row showed `(none)` on `reg-event-db` cascades even though `:db` had clearly committed.
2. **Feature** — LIVE mode auto-follows head: when a new cascade arrives and the user is in `:live`, focus advances; mode-transitions across click / pause / pill follow the spec/018 table.

## EFFECTS bug — before / after

Repro: open cart-total testbed, click `+ Apple` (event-db handler returning only `:db`), focus the cascade.

| | EFFECTS row |
| --- | --- |
| **before** | `(none)` — projection's `:effects` slot is empty for db-only handlers (the framework emits `:event/db-changed`, not `:rf.fx/handled`, for `:db`) |
| **after** | `:db :event/db-changed` — `effects-entries` folds the `:event/db-changed` trace in as a virtual `:db` row; fx-vector entries still list as before |

`(none)` now renders **only** when the cascade neither committed `:db` nor walked any fx (true silence).

## LIVE auto-follow — mode-transition table

`spine/compose-focus` previously honoured the stored `slot-id` once set, so `focus-step-reducer` landing on head left the slot pinned and never auto-advanced as newer cascades arrived. Phase A: in `:live` (when not paused) the composer ALWAYS returns head-id.

| start | event | end |
| --- | --- | --- |
| `:live` (any focus) | new cascade arrives | `:live`, focus = head |
| `:live` (any focus) | click non-head row | `:retro`, focus = clicked id |
| `:retro` | click LIVE pill (`:rf.causa/follow-head`) | `:live`, focus = head |
| `:retro` | new cascade arrives | `:retro` (unchanged) |
| `:live :paused?` | new cascade arrives | `:live :paused?` (unchanged) |

The `:rf.causa/event-detail` composite now reads its focused id off `:rf.causa/focus` (spine sub) rather than the legacy `:selected-dispatch-id` slot — so the panel re-renders in lockstep with spine auto-advances. The legacy slot is still written by `focus-cascade-reducer` for older readers; spine is canonical.

## Test coverage

- `effects-row-renders-db-when-db-changed-emitted` — reg-event-db cascade → virtual `:db` row visible, no `(none)`
- `effects-row-renders-fx-entries-when-handled` — fx-vector cascade → per-fx rows + `:db` row
- `effects-row-shows-none-when-truly-empty` — cascade with neither signal → `(none)` (silent path stays silent)
- `effects-entries-orders-db-first` — db row precedes fx entries (matches runtime ordering)
- `compose-focus-live-with-stored-id-tracks-head` — LIVE always head, regardless of stored slot
- `compose-focus-paused-live-preserves-stored-id` — pause suspends auto-track
- `compose-focus-paused-live-with-evicted-id-snaps-head` — paused + evicted → head fallback
- `focus-sub-live-auto-follows-new-head` — end-to-end: user on head → new cascade → focus advances
- `focus-sub-retro-does-not-auto-follow` — retro pins through arrivals
- `focus-sub-paused-live-does-not-auto-follow` — paused live pins through arrivals
- Three existing event-detail tests (`empty-state-renders-cascade-list`, `clear-selected-dispatch-id-returns-to-empty-state`, `focus-step-reducer-from-empty-slot-uses-legacy`) embodied the old cascade-list landing → updated to assert the new LIVE auto-focus semantics

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass (3161 tests)
- [x] `cd tools/causa && clojure -M:test` — pass (930 tests)
- [x] `cd implementation && npm run test:browser` — pass (3152 tests)

Citation: `ai/prompt/2026-05-18-event-panel-redesign.md`