### PR TITLE
fix(causa): spine focus computes :epoch-id — unblocks Views focus + fixes App-db pivot

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -522,10 +522,13 @@
   ;; keeps reading what it always has — the shim is transparent.
   (rf/reg-event-db :rf.causa/select-dispatch-id
     (fn [db [_ dispatch-id frame-id]]
-      (spine/focus-cascade-reducer db dispatch-id frame-id)))
+      (let [history (get db :epoch-history [])
+            epoch-id (spine/epoch-id-for-cascade history dispatch-id)]
+        (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id))))
 
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
       (-> db
-          (dissoc :selected-dispatch :selected-dispatch-id)
-          (assoc-in [:focus :dispatch-id] nil)))))
+          (dissoc :selected-dispatch :selected-dispatch-id :selected-epoch-id)
+          (assoc-in [:focus :dispatch-id] nil)
+          (assoc-in [:focus :epoch-id] nil)))))

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -44,6 +44,7 @@
   future spine-aware list updates the legacy slots."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- pure helpers --------------------------------------------------------
@@ -90,6 +91,34 @@
                             (min (dec n)))]
         (:dispatch-id (nth cascades new-idx))))))
 
+(defn epoch-id-for-cascade
+  "Return the `:epoch-id` of the epoch record in `epoch-history` whose
+  settling cascade is `dispatch-id`, or nil when no match is found
+  (the cascade is mid-build, was evicted from the ring, or the focus
+  pins `:ungrouped`).
+
+  Per spec/018 §6 Spine events the spine sub `:rf.causa/focus` carries
+  both `:dispatch-id` (cascade root, opaque router counter) and
+  `:epoch-id` (per-frame settling counter, primary key into the epoch
+  ring buffer). The two are semantically the same identity — a
+  cascade settles into exactly one epoch record — but they're
+  separate counter spaces, so the linkage is a per-cascade lookup
+  against the buffer.
+
+  The lookup leans on the existing `common/dispatch-id-of-epoch`
+  helper, which walks an epoch record's `:trace-events` for the first
+  `:dispatch-id` tag. Synthetic test epochs that omit `:trace-events`
+  but carry a literal `:dispatch-id` slot are matched directly so
+  fixture rigs that pre-date the spec/018 spine wiring continue to
+  resolve. Pure data; JVM-runnable."
+  [epoch-history dispatch-id]
+  (when (and dispatch-id (seq epoch-history))
+    (some (fn [record]
+            (when (or (= dispatch-id (common/dispatch-id-of-epoch record))
+                      (= dispatch-id (:dispatch-id record)))
+              (:epoch-id record)))
+          epoch-history)))
+
 (defn compose-focus
   "Derive the public `:rf.causa/focus` map from a stored `:focus` slot
   and the live cascade vector. Always re-derives `:head?` and the
@@ -125,61 +154,92 @@
 
 (defn focus-cascade-reducer
   "Pure reducer for the `:rf.causa/focus-cascade <id>` event. Writes
-  `:dispatch-id` into the `:focus` slot, flips to `:retro` mode, and
-  shims the legacy `:selected-dispatch-id` / `:selected-dispatch`
-  slots so the existing event-detail / causality / machine-inspector
-  panels keep rendering without per-panel change."
-  [db dispatch-id frame-id]
-  (cond-> db
-    true       (update :focus (fnil assoc {})
-                       :dispatch-id dispatch-id
-                       :mode :retro
-                       :previewing? false)
-    frame-id   (assoc-in [:focus :frame] frame-id)
-    ;; Legacy shim — panels reading these slots stay live.
-    true       (assoc :selected-dispatch-id dispatch-id
-                      :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
-                                              frame-id (assoc :frame frame-id)))))
+  `:dispatch-id` into the `:focus` slot, flips to `:retro` mode,
+  stamps `:epoch-id` (the cascade's settling epoch primary key per
+  spec/018 §6 Spine events), and shims the legacy
+  `:selected-dispatch-id` / `:selected-dispatch` / `:selected-epoch-
+  id` slots so the existing event-detail / causality / machine-
+  inspector / app-db / time-travel panels keep rendering without per-
+  panel change.
+
+  Per spec/018 §6 the spine sub `:rf.causa/focus` carries `:epoch-id`
+  as a first-class slot; consumers (Views' focused-cascade-pair sub,
+  App-db's selected-epoch-* sub chain) pivot on it. The 4-arg arity
+  takes a resolved `epoch-id`; event handlers resolve it from the
+  Causa `:epoch-history` slot via `epoch-id-for-cascade` before
+  calling. The 3-arg arity (back-compat for callers that don't have
+  the buffer handy) leaves `:epoch-id` nil — the focus sub still
+  rebinds on `:dispatch-id`, but the epoch-keyed surfaces will not
+  pivot until a 4-arg call lands."
+  ([db dispatch-id frame-id]
+   (focus-cascade-reducer db dispatch-id frame-id nil))
+  ([db dispatch-id frame-id epoch-id]
+   (cond-> db
+     true       (update :focus (fnil assoc {})
+                        :dispatch-id dispatch-id
+                        :epoch-id    epoch-id
+                        :mode :retro
+                        :previewing? false)
+     frame-id   (assoc-in [:focus :frame] frame-id)
+     ;; Legacy shim — panels reading these slots stay live.
+     true       (assoc :selected-dispatch-id dispatch-id
+                       :selected-epoch-id    epoch-id
+                       :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
+                                               frame-id (assoc :frame frame-id))))))
 
 (defn focus-step-reducer
   "Pure reducer for `:rf.causa/focus-cascade-prev` / `-next`. Steps
   the `:dispatch-id` through the cascade vector by `delta` (-1 or
-  +1), updates the legacy shim slot, and flips mode based on the
-  step's outcome — stepping back from head → :retro; stepping
-  forward back to head → :live (the user has scrubbed home)."
-  [db cascades delta]
-  (let [current-id (or (get-in db [:focus :dispatch-id])
-                       (:selected-dispatch-id db))
-        new-id     (step-dispatch-id cascades current-id delta)
-        head-id    (head-dispatch-id cascades)
-        new-mode   (if (= new-id head-id) :live :retro)
-        cascade    (cascade-by-id cascades new-id)
-        frame-id   (:frame cascade)]
-    (cond-> db
-      true     (update :focus (fnil assoc {})
-                       :dispatch-id new-id
-                       :mode new-mode
-                       :previewing? false
-                       :paused? false)
-      frame-id (assoc-in [:focus :frame] frame-id)
-      true     (assoc :selected-dispatch-id new-id
-                      :selected-dispatch    (cond-> {:dispatch-id new-id}
-                                              frame-id (assoc :frame frame-id))))))
+  +1), resolves the cascade's settling `:epoch-id` from
+  `epoch-history` (per spec/018 §6 Spine events), updates the legacy
+  shim slots, and flips mode based on the step's outcome — stepping
+  back from head → :retro; stepping forward back to head → :live (the
+  user has scrubbed home).
+
+  The 4-arg arity (back-compat for callers that don't have the epoch
+  buffer handy) treats `epoch-history` as empty so `:epoch-id`
+  resolves to nil. Production callers in `install!` go through the
+  5-arg arity."
+  ([db cascades delta]
+   (focus-step-reducer db cascades [] delta))
+  ([db cascades epoch-history delta]
+   (let [current-id (or (get-in db [:focus :dispatch-id])
+                        (:selected-dispatch-id db))
+         new-id     (step-dispatch-id cascades current-id delta)
+         head-id    (head-dispatch-id cascades)
+         new-mode   (if (= new-id head-id) :live :retro)
+         cascade    (cascade-by-id cascades new-id)
+         frame-id   (:frame cascade)
+         epoch-id   (epoch-id-for-cascade epoch-history new-id)]
+     (cond-> db
+       true     (update :focus (fnil assoc {})
+                        :dispatch-id new-id
+                        :epoch-id    epoch-id
+                        :mode new-mode
+                        :previewing? false
+                        :paused? false)
+       frame-id (assoc-in [:focus :frame] frame-id)
+       true     (assoc :selected-dispatch-id new-id
+                       :selected-epoch-id    epoch-id
+                       :selected-dispatch    (cond-> {:dispatch-id new-id}
+                                               frame-id (assoc :frame frame-id)))))))
 
 (defn follow-head-reducer
   "Pure reducer for `:rf.causa/follow-head`. Snaps the spine to LIVE,
   clears the pinned id (`:dispatch-id nil` means 'track head'), and
   clears `:paused?` so the LIVE buffer flow resumes. Also clears the
-  legacy `:selected-dispatch-id` so the event-detail panel returns to
-  the cascade-list landing view."
+  legacy `:selected-dispatch-id` / `:selected-epoch-id` slots in
+  lockstep so the event-detail / app-db / time-travel panels return
+  to their LIVE-tracking landing views."
   [db]
   (-> db
       (update :focus (fnil assoc {})
               :dispatch-id nil
+              :epoch-id    nil
               :mode :live
               :paused? false
               :previewing? false)
-      (dissoc :selected-dispatch :selected-dispatch-id)))
+      (dissoc :selected-dispatch :selected-dispatch-id :selected-epoch-id)))
 
 (defn toggle-live-pause-reducer
   "Pure reducer for `:rf.causa/toggle-live-pause`. Toggles `:paused?`
@@ -228,6 +288,14 @@
   (let [buffer (or (get db :trace-buffer) (trace-bus/buffer))]
     (projection/group-cascades buffer)))
 
+(defn- db->epoch-history
+  "Read the Causa app-db's `:epoch-history` slot — the per-frame
+  epoch ring buffer (per `tools/causa/spec/018-Event-Spine.md` §5.2)
+  used to resolve `:dispatch-id → :epoch-id` for spine focus events.
+  Empty vector when the slot is absent (cold start, pre-mount)."
+  [db]
+  (get db :epoch-history []))
+
 (defn install!
   "Idempotent install — register the `:rf.causa/focus` sub + its
   driving events. Called from `registry.cljs`'s
@@ -255,15 +323,16 @@
 
   (rf/reg-event-db :rf.causa/focus-cascade
     (fn [db [_ dispatch-id frame-id]]
-      (focus-cascade-reducer db dispatch-id frame-id)))
+      (let [epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
+        (focus-cascade-reducer db dispatch-id frame-id epoch-id))))
 
   (rf/reg-event-db :rf.causa/focus-cascade-prev
     (fn [db _event]
-      (focus-step-reducer db (db->cascades db) -1)))
+      (focus-step-reducer db (db->cascades db) (db->epoch-history db) -1)))
 
   (rf/reg-event-db :rf.causa/focus-cascade-next
     (fn [db _event]
-      (focus-step-reducer db (db->cascades db) +1)))
+      (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1)))
 
   (rf/reg-event-db :rf.causa/follow-head
     (fn [db _event]

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -403,3 +403,122 @@
   (let [r (focus-sub)]
     (is (true? (:paused? r)))
     (is (= :live (:mode r)))))
+
+;; -------------------------------------------------------------------------
+;; (9) :epoch-id resolution — rf2-ak3ty
+;;
+;; Spec/018 §6 Spine events says `:rf.causa/focus-cascade <id>` MUST
+;; "compute `:epoch-id` from cascades". The reducer takes a resolved
+;; epoch-id (the event handler in `install!` resolves it from the
+;; Causa `:epoch-history` slot via `epoch-id-for-cascade`), then
+;; stamps both the `:focus :epoch-id` slot and the legacy
+;; `:selected-epoch-id` shim slot the App-db diff panel reads.
+;; -------------------------------------------------------------------------
+
+(defn- epoch
+  "Build a minimal `:rf/epoch-record` carrying the slots
+  `epoch-id-for-cascade` looks at — a `:trace-events` vector with one
+  dispatch-id-tagged event, plus the literal `:dispatch-id` slot the
+  test fallback honours."
+  [epoch-id dispatch-id]
+  {:epoch-id     epoch-id
+   :dispatch-id  dispatch-id
+   :trace-events [{:id 1 :op-type :event :operation :event/dispatched
+                   :tags {:dispatch-id dispatch-id}}]})
+
+(deftest epoch-id-for-cascade-walks-trace-events
+  (testing "resolves :epoch-id from an epoch's :trace-events :dispatch-id tag"
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]]
+      (is (= :e2 (spine/epoch-id-for-cascade history :c2)))
+      (is (= :e3 (spine/epoch-id-for-cascade history :c3))))))
+
+(deftest epoch-id-for-cascade-falls-back-to-literal-dispatch-id
+  (testing "synthetic test epochs without :trace-events resolve via
+            literal :dispatch-id slot"
+    (let [history [{:epoch-id :e1 :dispatch-id 7}
+                   {:epoch-id :e2 :dispatch-id 8}]]
+      (is (= :e2 (spine/epoch-id-for-cascade history 8))))))
+
+(deftest epoch-id-for-cascade-missing-returns-nil
+  (testing "no matching epoch → nil (cascade evicted from ring buffer,
+            or mid-build before its epoch record commits)"
+    (is (nil? (spine/epoch-id-for-cascade [] :c1)))
+    (is (nil? (spine/epoch-id-for-cascade [(epoch :e1 :c1)] :c-gone)))
+    (is (nil? (spine/epoch-id-for-cascade nil :c1)))
+    (is (nil? (spine/epoch-id-for-cascade [(epoch :e1 :c1)] nil)))))
+
+(deftest focus-cascade-reducer-4-arg-writes-epoch-id
+  (testing "the 4-arg reducer writes :epoch-id into the :focus slot AND
+            the legacy :selected-epoch-id shim slot — App-db pivots
+            from L2-list clicks once this lands (rf2-ak3ty)"
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default :e2)]
+      (is (= :e2 (get-in r [:focus :epoch-id])))
+      (is (= :e2 (:selected-epoch-id r))
+          "legacy slot the App-db panel reads pivots in lockstep")
+      (is (= :c2 (get-in r [:focus :dispatch-id])))
+      (is (= :c2 (:selected-dispatch-id r))))))
+
+(deftest focus-cascade-reducer-3-arg-leaves-epoch-id-nil
+  (testing "the back-compat 3-arg reducer leaves :epoch-id nil — the
+            focus sub still rebinds on :dispatch-id, but epoch-keyed
+            surfaces won't pivot until a 4-arg call lands"
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default)]
+      (is (nil? (get-in r [:focus :epoch-id])))
+      (is (nil? (:selected-epoch-id r))))))
+
+(deftest focus-cascade-event-resolves-epoch-id-from-history
+  (testing "the registered :rf.causa/focus-cascade event resolves
+            :epoch-id from the Causa app-db's :epoch-history slot —
+            end-to-end the spine focus now carries both ids in
+            lockstep (rf2-ak3ty)"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]])
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c2 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c2 (:dispatch-id r)))
+      (is (= :e2 (:epoch-id r))
+          "spine sub carries the resolved epoch-id — the
+           load-bearing prereq for rf2-w15el (Views) and the
+           App-db pivot fix"))))
+
+(deftest focus-cascade-event-writes-selected-epoch-id-legacy-slot
+  (testing "App-db's :rf.causa/selected-epoch-id sub pivots on L2-list
+            click — proves the spine writes through the legacy shim
+            so App-db (and Time-Travel highlight) rebind from a row
+            click without any per-panel change"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]])
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+    (let [legacy (rf/with-frame :rf/causa
+                   @(rf/subscribe [:rf.causa/selected-epoch-id]))]
+      (is (= :e1 legacy)
+          "App-db's :selected-epoch-id sub rebinds to the focused
+           cascade's epoch — pivot now works from L2 list clicks"))))
+
+(deftest focus-step-reducer-4-arg-writes-epoch-id
+  (testing "step events resolve :epoch-id for the new dispatch-id"
+    (let [db       {:focus {:dispatch-id :c3 :mode :live}
+                    :selected-dispatch-id :c3}
+          history  [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
+          r        (spine/focus-step-reducer db fixture-cascades history -1)]
+      (is (= :c2 (get-in r [:focus :dispatch-id])))
+      (is (= :e2 (get-in r [:focus :epoch-id])))
+      (is (= :e2 (:selected-epoch-id r))))))
+
+(deftest follow-head-reducer-clears-selected-epoch-id
+  (testing "follow-head clears the App-db legacy slot in lockstep with
+            the dispatch-id slot — the panel returns to its landing
+            view"
+    (let [db {:focus                {:dispatch-id :c1 :epoch-id :e1
+                                     :mode :retro}
+              :selected-dispatch-id :c1
+              :selected-epoch-id    :e1}
+          r  (spine/follow-head-reducer db)]
+      (is (nil? (get-in r [:focus :epoch-id])))
+      (is (nil? (:selected-epoch-id r))))))


### PR DESCRIPTION
## Summary

Closes the spec/018 §6 Spine events gap pinned at L544: `:rf.causa/focus-cascade` MUST "compute `:epoch-id` from cascades". The reducer was only writing `:dispatch-id`, leaving `:epoch-id` nil on every L2-list click — the load-bearing prereq for **rf2-ak3ty** (this PR), **rf2-w15el** (Views focus, now a one-liner), and the App-db pivot bug surfaced by the [tab focus-invariant audit](https://github.com/day8/re-frame2/tree/main/ai/findings) (rf2-omdal).

### Root cause (per the audit)

- `spine.cljs` `focus-cascade-reducer` wrote `:dispatch-id` / `:mode` / `:previewing?` / `:frame` — **never `:epoch-id`**. It also wrote legacy `:selected-dispatch-id` but **not** `:selected-epoch-id`.
- Production cascade `:dispatch-id` is an opaque router counter (`router.cljc` `next-dispatch-id`); production epoch `:epoch-id` is a per-frame counter (`assembly.cljc` `state/next-epoch-id`). The two share no projection in the framework, so Views' `find-cascade-index` always fell back to head and App-db's `:selected-epoch-id` sub never pivoted from L2 clicks.

### Fix

- New pure helper `epoch-id-for-cascade [epoch-history dispatch-id]` in `spine.cljs` — uses the existing `common-helpers/dispatch-id-of-epoch` (which walks an epoch record's `:trace-events` for its root `:dispatch-id` tag) so the link is consumed without a schema change.
- `focus-cascade-reducer` gains a 4-arg arity that takes a resolved `epoch-id`; the 3-arg arity is preserved for back-compat (leaves `:epoch-id` nil).
- `focus-step-reducer` gains a 4-arg arity that takes `epoch-history`; the 3-arg arity is preserved.
- `follow-head-reducer` clears the new slot in lockstep.
- Event handlers in `install!` read `:epoch-history` from db and feed the resolved epoch-id through.
- `:rf.causa/select-dispatch-id` shim (in `event_detail.cljs`) gets the same wiring so causality-graph / machine-inspector / issues-ribbon / performance / routes clicks pivot App-db too. Its `clear-selected-dispatch-id` companion clears the new slot.

### Downstream beads unblocked

- **rf2-w15el** (Views tab focus) — `views_subs.cljs` `find-cascade-index` becomes a one-line change to look up by `:epoch-id`.
- **App-db pivot from L2 list clicks** — no separate bead needed; falls out of the legacy `:selected-epoch-id` shim write.

### Spec citation

[`tools/causa/spec/018-Event-Spine.md`](tools/causa/spec/018-Event-Spine.md) §6 Spine events L544:
> `:rf.causa/focus-cascade <id>` ... Sets `:dispatch-id <id>`, **computes `:epoch-id` from cascades**, flips `:mode → :retro`

No spec change — the spec was already correct; this PR closes the implementation gap.

### Fixture-shape audit

The audit flagged that `tools/causa/testbeds/panel_gallery/fixtures_views.cljs:61` equates `:epoch-id` and `:dispatch-id` per-record, masking the bug. With the fix those fixtures continue to resolve: `epoch-id-for-cascade` checks the literal `:dispatch-id` slot as a fallback for synthetic test records that omit `:trace-events`. **No fixture changes required** — green tests revealed no divergence.

## Test plan

- [x] `clojure -M:test` (causa JVM, 930 tests / 2686 assertions / 0 failures)
- [x] `npm run test:cljs` (node CLJS, 3163 tests / 9082 assertions / 0 failures)
- [x] `npm run test:browser` (Playwright browser, 3154 tests / 9037 assertions / 0 failures)
- [x] `node implementation/scripts/serve-and-run-causa-feature-gate.cjs` (13 scenarios / 0 failures)
- [x] `scripts/test-fast-pr.sh` (PASS fast PR spine)
- [x] New tests in `spine_cljs_test.cljs §9` cover: pure helper resolution (trace-events + literal-slot fallback + nil paths), both reducer arities, registered event end-to-end (focus sub carries `:epoch-id`; `:rf.causa/selected-epoch-id` sub pivots), step-event resolution, follow-head clearing the legacy slot.

Refs: rf2-ak3ty (this) · rf2-omdal (parent audit) · rf2-w15el (follow-on, Views one-liner)