### PR TITLE
fix(causa): machines chart font smaller — diagram fits at default width

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs
@@ -176,8 +176,10 @@
 
 ;; ---- definition → ELK graph (pure) -------------------------------------
 
-(def ^:private default-node-width 140)
-(def ^:private default-node-height 48)
+;; rf2-gz7vi — kept in lock-step with layout/node-width / node-height
+;; so ELK + the layered fallback render at the same physical size.
+(def ^:private default-node-width 120)
+(def ^:private default-node-height 40)
 
 (defn ->elk-graph
   "Project a parsed machine-definition into the ELK JSON graph shape:

--- a/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/layout.cljc
@@ -44,7 +44,7 @@
     2. **Stratify** nodes into rank-buckets; within each bucket
        sort by id for determinism.
     3. **Place** each rank as a horizontal row, centred; row spacing
-       is 100px, node spacing 40px, node size 140x48.
+       is 100px, node spacing 40px, node size 120x40.
     4. **Route** edges as straight lines from source-bottom to
        target-top (simple — no orthogonal routing, no obstacle
        avoidance). Self-loops render as a small arc above the node
@@ -75,8 +75,12 @@
 
 ;; ---- layout constants ---------------------------------------------------
 
-(def node-width 140)
-(def node-height 48)
+;; rf2-gz7vi — node-size trimmed (140×48 → 120×40) to track the
+;; rf2-isgqu/rf2-gz7vi font-shrink cascade. Smaller labels were
+;; rattling around in oversized boxes; the new dims keep the chart
+;; dense and fit at default panel width.
+(def node-width 120)
+(def node-height 40)
 (def rank-gap 100)             ;; vertical gap between ranks
 (def node-gap 40)              ;; horizontal gap between same-rank nodes
 (def chart-margin 32)          ;; outer margin around the layout

--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -225,28 +225,28 @@
              :stroke stroke
              :stroke-width stroke-w}]
      ;; Label
-     ;; rf2-isgqu — state-label tuned 12 → 11 so labels stop swamping
-     ;; the chart and match the surrounding L4 detail rhythm. Vertical
-     ;; baseline tweak (+4 → +3) keeps the glyphs visually centred at
+     ;; rf2-gz7vi — state-label tuned 11 → 9 (follow-up to rf2-isgqu's
+     ;; 12 → 11 — diagram still didn't fit at default width). Vertical
+     ;; baseline tweak (+3 → +2) keeps the glyphs visually centred at
      ;; the smaller size.
      [:text {:x (+ x (quot width 2))
-             :y (+ y (quot height 2) 3)
+             :y (+ y (quot height 2) 2)
              :text-anchor "middle"
              :font-family font-stack
-             :font-size 11
+             :font-size 9
              :font-weight (if active? 600 400)
              :fill (if active?
                      (:text-primary tokens/tokens)
                      (:text-secondary tokens/tokens))}
       label]
      ;; Final-state check glyph
-     ;; rf2-isgqu — track the state-label tune (11 → 10) so the corner
-     ;; check scales with its neighbour.
+     ;; rf2-gz7vi — corner check tuned 10 → 9 to track the state-label
+     ;; reduction (rf2-isgqu followed 12 → 11; this PR follows 11 → 9).
      (when final?
-       [:text {:x (+ x width -10)
-               :y (+ y 14)
+       [:text {:x (+ x width -9)
+               :y (+ y 13)
                :font-family font-stack
-               :font-size 10
+               :font-size 9
                :fill (:green tokens/tokens)}
         "✓"])]))
 
@@ -327,22 +327,23 @@
              :marker-end marker}]
      (when (seq full-label)
        [:g
-        ;; rf2-isgqu — edge-label tuned 10 → 9 (keeps state > edge by
-        ;; ~2px so the visual hierarchy still reads). Pill geometry
-        ;; shrinks proportionally: 4/8 → 3.5/7 char-width, height
-        ;; 14 → 12, vertical offset 9 → 8 to match the smaller glyph.
+        ;; rf2-gz7vi — edge-label tuned 9 → 7 (rf2-isgqu went 10 → 9;
+        ;; chart still crowded). Keeps state > edge by ~2px so the
+        ;; visual hierarchy still reads. Pill geometry shrinks
+        ;; proportionally: 3.5/7 → 2.75/5.5 char-width, height
+        ;; 12 → 10, vertical offset 8 → 7 to match the smaller glyph.
         ;; Background pill for legibility
-        [:rect {:x (- lx (long (* 3.5 (count full-label))))
-                :y (- ly 8)
-                :width (* 7 (count full-label))
-                :height 12
+        [:rect {:x (- lx (long (* 2.75 (count full-label))))
+                :y (- ly 7)
+                :width (long (* 5.5 (count full-label)))
+                :height 10
                 :rx 3
                 :fill (:bg-2 tokens/tokens)
                 :opacity 0.85}]
-        [:text {:x lx :y (+ ly 1)
+        [:text {:x lx :y ly
                 :text-anchor "middle"
                 :font-family font-stack
-                :font-size 9
+                :font-size 7
                 :fill (:text-secondary tokens/tokens)}
          full-label]])]))
 


### PR DESCRIPTION
## Bug

Mike re-reported (bead **rf2-gz7vi**, P1) that the chart in Causa's Machines tab was still absurdly large after **rf2-isgqu** (#1442) — the diagram doesn't fit at default panel width. Labels needed another reduction, and the oversized node-boxes were leaving a lot of empty real estate around the now-smaller glyphs.

## Fix

Another shrink pass on the SVG font sizes, and a proportional reduction of the node-box dims (which were still sized for the original 12px label).

## Sizes

| Element              | Before (rf2-isgqu) | After (rf2-gz7vi) |
|----------------------|-------------------:|------------------:|
| state label          | 11                 |  9                |
| final-state glyph    | 10                 |  9                |
| edge label           |  9                 |  7                |
| node-width           | 140                | 120               |
| node-height          |  48                |  40               |

Edge-label pill geometry shrinks proportionally so the legibility background stays snug to the smaller glyph: char-width 3.5 → 2.75, width-mult 7 → 5.5, height 12 → 10, y-offset 8 → 7, baseline +1 → 0.

`elk_layout.cljs` `default-node-width / default-node-height` kept in lock-step with `layout/node-width / node-height` so both the layered fallback and the ELK adapter emit the same physical node size.

## Files touched

- `tools/causa/src/day8/re_frame2_causa/chart/svg.cljc` — font + pill tweaks
- `tools/causa/src/day8/re_frame2_causa/chart/layout.cljc` — node-width/height constants
- `tools/causa/src/day8/re_frame2_causa/chart/elk_layout.cljs` — kept ELK defaults in sync

## Gates

- `scripts/test-fast-pr.sh` — PASS (3154 tests, 0 failures)
- `cd tools/causa && clojure -M:test` — PASS (930 tests, 0 failures)
- `cd implementation && npm run test:browser` — PASS (3145 tests, 0 failures)