### PR TITLE
fix(causa): Views tab honours focused-event invariant — uses :epoch-id from spine

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/views_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_subs.cljs
@@ -20,21 +20,23 @@
 
 (defn- find-cascade-index
   "Walk `epoch-history` (a vector of epoch records) and return the
-  index of the record whose `:event-id` / cascade discriminator
-  matches `dispatch-id`. The spine carries `:dispatch-id`; the epoch
-  record carries `:event-id` per Spec-Schemas — Tool-Pair's time-
-  travel slot is keyed on event-id, but per spec/018 §6 the
-  user-facing 'cascade id' the spine pins is the cascade's root
-  dispatch-id. The renderer needs both signals to align — we look
-  for either match (`:event-id` first, then `:trigger-event` head)
-  so the projection works against both the live cascade list and
-  legacy epoch records that key on event-id alone."
-  [epoch-history dispatch-id]
-  (when (and dispatch-id (seq epoch-history))
+  index of the record whose `:epoch-id` matches `epoch-id`.
+
+  Per spec/018 §6 Spine events the spine sub `:rf.causa/focus`
+  carries `:epoch-id` (the per-frame primary key into the epoch ring
+  buffer) alongside `:dispatch-id`. The spine resolves the linkage
+  for us via `epoch-id-for-cascade` (`spine.cljs`); panels just look
+  up by `:epoch-id` directly — there is no second-level join needed
+  here. This is the spec-canonical lookup.
+
+  Returns nil when the focus has no resolved `:epoch-id` (cold start,
+  ungrouped frame, mid-build cascade) or when the matching epoch has
+  been evicted from the ring buffer — the composite then falls back
+  to head so the panel stays useful."
+  [epoch-history epoch-id]
+  (when (and epoch-id (seq epoch-history))
     (some (fn [[idx record]]
-            (when (or (= dispatch-id (:event-id record))
-                      (= dispatch-id (:dispatch-id record))
-                      (= dispatch-id (first (:trigger-event record))))
+            (when (= epoch-id (:epoch-id record))
               idx))
           (map-indexed vector epoch-history))))
 
@@ -73,8 +75,9 @@
     :<- [:rf.causa/epoch-history]
     (fn [[focus history] _query]
       (let [history (vec history)
-            idx     (or (find-cascade-index history (:dispatch-id focus))
-                        ;; LIVE / no explicit focus → fall back to head.
+            idx     (or (find-cascade-index history (:epoch-id focus))
+                        ;; LIVE / no explicit focus (or evicted from ring)
+                        ;; → fall back to head.
                         (when (seq history) (dec (count history))))
             current (when idx (nth history idx nil))
             prior   (when (and idx (pos? idx)) (nth history (dec idx) nil))]

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_subs_cljs_test.cljs
@@ -1,0 +1,149 @@
+(ns day8.re-frame2-causa.panels.views-subs-cljs-test
+  "Regression test for the Views panel's focused-cascade lookup
+  (rf2-w15el; rf2-ak3ty prereq).
+
+  Per `ai/findings/2026-05-18-tab-focus-invariant-audit.md` §Views the
+  Views composite previously looked up the focused cascade in the
+  epoch ring buffer by `:dispatch-id` against `:event-id` /
+  `:trigger-event` head — none of which match in production because
+  `:dispatch-id` is an opaque router counter and the epoch record
+  carries an unrelated `:event-id` (event keyword) + `:epoch-id`
+  (per-frame counter). The lookup always fell through to head; the
+  panel-gallery testbed masked the bug by setting
+  `:epoch-id == :dispatch-id` in fixtures.
+
+  After rf2-ak3ty the spine's `:rf.causa/focus` sub now carries
+  `:epoch-id`, and `views_subs.cljs/find-cascade-index` honours it
+  directly. This test pins the invariant: focusing event A vs event B
+  in the L2 list MUST change which cascade record the composite
+  surfaces — never the head fallback when a different cascade is
+  focused."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-test-support/reset-all!}))
+
+(defn- seed-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- epoch
+  "Build a minimal epoch record with distinct `:epoch-id` and
+  `:dispatch-id` — the production shape the audit identified as
+  failing under the old lookup."
+  [{:keys [epoch-id dispatch-id event-id renders sub-runs]}]
+  {:epoch-id      epoch-id
+   :dispatch-id   dispatch-id
+   :event-id      event-id
+   :trigger-event [event-id]
+   :renders       (vec (or renders []))
+   :sub-runs      (vec (or sub-runs []))
+   :committed-at  (* 1000 epoch-id)
+   :db-before     {}
+   :db-after      {}
+   :trace-events  [{:op-type     :event/dispatched
+                    :dispatch-id dispatch-id
+                    :event-v     [event-id]}]})
+
+(deftest focused-cascade-pair-resolves-by-epoch-id
+  (testing "Focus pinned via `:rf.causa/focus-cascade` resolves the
+            focused cascade by `:epoch-id` (not head) — distinct
+            :epoch-id / :dispatch-id pair, two cascades, focus on the
+            EARLIER one → composite surfaces the earlier cascade's
+            :renders / :sub-runs, not the head's."
+    (seed-causa!)
+    (let [earlier (epoch {:epoch-id     10
+                          :dispatch-id  100
+                          :event-id     :counter/inc
+                          :renders      [{:render-key [:counter/badge :tok-A]
+                                          :elapsed-ms 3}]
+                          :sub-runs     [{:sub-id      :counter/value
+                                          :query-v     [:counter/value]
+                                          :recomputed? true
+                                          :elapsed-ms  1}]})
+          head    (epoch {:epoch-id     11
+                          :dispatch-id  101
+                          :event-id     :counter/dec
+                          :renders      [{:render-key [:counter/badge :tok-B]
+                                          :elapsed-ms 5}]
+                          :sub-runs     [{:sub-id      :counter/value
+                                          :query-v     [:counter/value]
+                                          :recomputed? true
+                                          :elapsed-ms  2}]})]
+      (rf/with-frame :rf/causa
+        ;; Seed the ring buffer.
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [earlier head]])
+        ;; Pin focus to the EARLIER cascade by its dispatch-id; the
+        ;; spine resolves the corresponding :epoch-id from the buffer.
+        (rf/dispatch-sync [:rf.causa/focus-cascade 100 nil])
+        (let [pair  @(rf/subscribe [:rf.causa/views-focused-cascade-pair])
+              focus (:focus pair)]
+          (is (= 100 (:dispatch-id focus))
+              "focus carries the dispatch-id we pinned")
+          (is (= 10 (:epoch-id focus))
+              "spine resolved :epoch-id from :rf.causa/focus-cascade
+               (rf2-ak3ty)")
+          (is (= 0 (:index pair))
+              "composite indexed the EARLIER cascade, not the head
+               (regression for rf2-w15el — pre-fix this was 1)")
+          (is (= 10 (:epoch-id (:current pair)))
+              "current cascade is the focused (earlier) record")
+          (is (= [{:render-key [:counter/badge :tok-A]
+                   :elapsed-ms 3}]
+                 (:renders (:current pair)))
+              "current cascade's :renders are the focused-event's
+               renders, not the head's"))))))
+
+(deftest focused-cascade-pair-falls-back-to-head-in-live-mode
+  (testing "In LIVE mode with no explicit focus, `:epoch-id` is nil
+            and the composite falls back to head — same behaviour the
+            gallery relies on, preserved post-fix."
+    (seed-causa!)
+    (let [e1 (epoch {:epoch-id     20
+                     :dispatch-id  200
+                     :event-id     :counter/inc
+                     :renders      [{:render-key [:counter/badge :tok-1]
+                                     :elapsed-ms 1}]})
+          e2 (epoch {:epoch-id     21
+                     :dispatch-id  201
+                     :event-id     :counter/dec
+                     :renders      [{:render-key [:counter/badge :tok-2]
+                                     :elapsed-ms 2}]})]
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [e1 e2]])
+        ;; No focus-cascade event → spine stays in LIVE mode.
+        (let [pair (-> @(rf/subscribe [:rf.causa/views-focused-cascade-pair]))]
+          (is (= 1 (:index pair))
+              "LIVE mode → head fallback (last index)")
+          (is (= 21 (:epoch-id (:current pair)))
+              "current cascade is the head (e2)"))))))
+
+(deftest focused-cascade-pair-falls-back-to-head-when-epoch-evicted
+  (testing "Focus pins an epoch-id that is no longer in the ring
+            buffer (evicted) → composite falls back to head rather
+            than rendering empty. Defensive contract: stale focus
+            never blanks the panel."
+    (seed-causa!)
+    (let [live (epoch {:epoch-id     31
+                       :dispatch-id  301
+                       :event-id     :counter/inc
+                       :renders      [{:render-key [:counter/badge :tok-X]
+                                       :elapsed-ms 1}]})]
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [live]])
+        ;; Pin focus to a dispatch-id NOT in the buffer — :epoch-id
+        ;; resolves to nil; composite falls back to head.
+        (rf/dispatch-sync [:rf.causa/focus-cascade 999 nil])
+        (let [pair @(rf/subscribe [:rf.causa/views-focused-cascade-pair])]
+          (is (nil? (:epoch-id (:focus pair)))
+              "no :epoch-id resolution for an evicted/unknown cascade")
+          (is (= 31 (:epoch-id (:current pair)))
+              "fallback to head when focus can't be resolved"))))))


### PR DESCRIPTION
## Summary

Closes the one-line bridge between the spec/018 spine fix (rf2-ak3ty, PR #1453) and the Views tab's focused-cascade-pair sub. Pre-rf2-ak3ty the spine carried no `:epoch-id` and Views' `find-cascade-index` tried to match `:dispatch-id` against three slots — none of which match in production. Post-rf2-ak3ty the spine resolves `:epoch-id` from the buffer for every focus-cascade event; Views just needed to use it.

### What changed

- **`tools/causa/src/.../panels/views_subs.cljs`** — `find-cascade-index` now matches `(:epoch-id focus)` against record `:epoch-id`. Single, spec-canonical lookup (per spec/018 §6 Spine events). Call site updated; head fallback preserved for LIVE mode and evicted/stale focus.
- **`tools/causa/test/.../panels/views_subs_cljs_test.cljs`** (new) — regression test pinning the invariant against the production id shape (distinct `:epoch-id` ≠ `:dispatch-id`):
  - Focus pinned to the EARLIER of two cascades → composite surfaces the earlier record, not head.
  - LIVE mode with no explicit focus → head fallback.
  - Focus pinned to a dispatch-id not in the ring buffer → head fallback (defensive).

### Why

Per [`ai/findings/2026-05-18-tab-focus-invariant-audit.md`](https://github.com/day8/re-frame2/blob/main/ai/findings/2026-05-18-tab-focus-invariant-audit.md) §Views, the old lookup couldn't ever match an opaque router counter (`:dispatch-id`) against the unrelated keyword `:event-id` or per-frame `:epoch-id` counter. Clicking a row in the L2 event list left Views always rendering the head cascade. The panel-gallery testbed masked the bug because `fixtures_views.cljs` set `:epoch-id = :dispatch-id`. After this fix the fixtures keep working — `:epoch-id` is now legitimately on the focus map, and the lookup matches by the same field the fixtures already populate.

## Bead

- **rf2-w15el** — Views tab honours focused-event invariant (do NOT close on merge).
- **Prereq:** rf2-ak3ty (PR #1453) — spine `focus-cascade-reducer` computes `:epoch-id`. Merged; this branch is based on it.

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] `cd tools/causa && clojure -M:test` — 930 tests, 0 failures
- [x] `cd implementation && npm run test:cljs` — 3178 tests, 0 failures (includes the new 3 regression cases)
- [x] `cd implementation && npm run test:browser` — 3169 tests, 0 failures
- [x] `cd implementation && npm run test:causa-feature-gate` — 13 scenarios, 0 failures