### PR TITLE
fix(causa): no aggregate-all-events state — [<] on first event is a true no-op

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -342,20 +342,29 @@
                    :border-radius  "4px"
                    :font-family    sans-stack
                    :font-size      (:body type-scale)}
-        dim       {:color (:text-tertiary tokens) :cursor "default"}]
+        ;; Per rf2-fzbrw the visual + a11y signal must match the
+        ;; functional signal: `cursor: not-allowed` so the mouse
+        ;; pointer telegraphs the no-op, plus `aria-disabled` for
+        ;; screen readers (the native `:disabled` attribute already
+        ;; blocks click events at the DOM layer).
+        dim       {:color (:text-tertiary tokens) :cursor "not-allowed"}]
     [:div {:data-testid "rf-causa-ribbon-nav"
            :style {:display "flex" :align-items "center" :gap "4px"}}
-     [:button {:data-testid "rf-causa-nav-prev"
-               :on-click    #(rf/dispatch [:rf.causa/focus-cascade-prev] {:frame :rf/causa})
-               :disabled    (boolean at-tail?)
-               :title       "Step to previous event (j)"
-               :style       (merge btn-style (when at-tail? dim))}
+     [:button {:data-testid   "rf-causa-nav-prev"
+               :on-click      (when-not at-tail?
+                                #(rf/dispatch [:rf.causa/focus-cascade-prev] {:frame :rf/causa}))
+               :disabled      (boolean at-tail?)
+               :aria-disabled (boolean at-tail?)
+               :title         "Step to previous event (j)"
+               :style         (merge btn-style (when at-tail? dim))}
       "◀"]
-     [:button {:data-testid "rf-causa-nav-next"
-               :on-click    #(rf/dispatch [:rf.causa/focus-cascade-next] {:frame :rf/causa})
-               :disabled    (boolean at-head?)
-               :title       "Step to next event (k)"
-               :style       (merge btn-style (when at-head? dim))}
+     [:button {:data-testid   "rf-causa-nav-next"
+               :on-click      (when-not at-head?
+                                #(rf/dispatch [:rf.causa/focus-cascade-next] {:frame :rf/causa}))
+               :disabled      (boolean at-head?)
+               :aria-disabled (boolean at-head?)
+               :title         "Step to next event (k)"
+               :style         (merge btn-style (when at-head? dim))}
       "▶"]
      [:button {:data-testid "rf-causa-nav-head"
                :on-click    #(rf/dispatch [:rf.causa/follow-head] {:frame :rf/causa})
@@ -512,7 +521,18 @@
         redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
         filters         @(rf/subscribe [:rf.causa/active-filters])
         focused-id      (:dispatch-id focus)
-        ids             (mapv :dispatch-id cascades)
+        ;; Per rf2-fzbrw: the boundary predicates must align with the
+        ;; user-visible event list. The L2 list filters `:ungrouped`
+        ;; (registry-time emits / lifecycle / REPL evals) via
+        ;; `cascade-has-event?`; if the ribbon walked the raw cascade
+        ;; vector instead, a buffer containing one real event PLUS the
+        ;; `:ungrouped` bucket would compute `at-tail?` against
+        ;; `:ungrouped` (= false) and leave `[<]` ENABLED on what the
+        ;; user sees as the first (only) event — clicking it would
+        ;; pin focus to the `:ungrouped` bucket and degrade the L4
+        ;; panels into an aggregate-across-all-events render.
+        event-cascades  (filterv cascade-has-event? cascades)
+        ids             (mapv :dispatch-id event-cascades)
         at-head?        (or (empty? ids)
                             (= focused-id (last ids))
                             (nil? focused-id))

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -49,6 +49,28 @@
 
 ;; ---- pure helpers --------------------------------------------------------
 
+(defn focusable-cascades
+  "Per rf2-fzbrw — the spine's invariant is 'one focused event at a
+  time'. The `:ungrouped` bucket produced by `projection/group-cascades`
+  for registry-time emits / frame lifecycle outside a drain / REPL
+  evals carries no event vector and is therefore NOT a valid focus
+  target: pinning to it leaves every event-detail / app-db / views
+  panel with no cascade to render, which degrades into the unwanted
+  'all subs / all handlers' aggregate look.
+
+  Strip the bucket before any spine walk so:
+    - the head/tail boundary predicates align with what the user sees
+      in the L2 event list (which already filters via
+      `shell/cascade-has-event?`);
+    - stepping past a real event cannot land focus on `:ungrouped`;
+    - `compose-focus` cannot resolve an effective dispatch-id to
+      `:ungrouped` for a stored slot that was already pointing there.
+
+  Pure data; JVM-runnable; idempotent (re-filtering a cleaned vector
+  is a no-op)."
+  [cascades]
+  (filterv #(not= :ungrouped (:dispatch-id %)) cascades))
+
 (defn head-cascade
   "The latest cascade in the projected list — the cascade whose
   `:dispatch-id` is the spine's 'head'. Returns nil when the list is
@@ -160,44 +182,65 @@
   `:paused?` suspends the auto-track — when paused, the focus stays
   on the stored slot-id so the user can inspect a cascade without
   losing it as new traffic arrives. Resuming (`follow-head` /
-  `toggle-live-pause`) snaps back to head."
+  `toggle-live-pause`) snaps back to head.
+
+  ## No-aggregate-state invariant (rf2-fzbrw)
+
+  The spine walks `focusable-cascades` (the `:ungrouped` bucket is
+  stripped) — so the head/tail boundary and any retro-pin operation
+  resolves against the user-visible cascade list. The composer
+  additionally snaps to head whenever the stored slot is nil OR
+  points at `:ungrouped` OR points at an evicted cascade. Combined
+  with the LIVE auto-follow above this makes 'buffer non-empty +
+  effective :dispatch-id nil' structurally unreachable — the L4
+  panels never have to handle the 'no cascade' degraded render."
   [focus cascades]
-  (let [head-id    (head-dispatch-id cascades)
+  (let [focusable  (focusable-cascades cascades)
+        head-id    (head-dispatch-id focusable)
         slot-id    (:dispatch-id focus)
         slot-frame (:frame focus)
         paused?    (boolean (:paused? focus))
+        ;; rf2-fzbrw — a slot pointing at nil OR the :ungrouped bucket
+        ;; is NOT a valid focus pin. (Evicted ids are still a valid
+        ;; pin: the event-detail panel surfaces its orphaned-state
+        ;; copy off them, so we don't conflate "evicted" with "never
+        ;; valid".)
+        slot-pinnable? (and slot-id (not= :ungrouped slot-id))
         mode       (or (:mode focus)
                        (if (or (nil? slot-id) (= slot-id head-id))
                          :live
                          :retro))
         eff-id  (cond
-                  ;; Live + unpaused — track head, regardless of slot-id.
-                  ;; This is the rf2-s0s5x Phase A change: previously the
-                  ;; stored slot-id won here, so once `focus-step-reducer`
-                  ;; landed on head the slot pinned to that id and never
-                  ;; auto-advanced as newer cascades arrived. Pre-alpha
-                  ;; the LIVE pill's contract is unambiguous — head IS
-                  ;; the focus.
+                  ;; rf2-fzbrw — slot is nil / :ungrouped while a
+                  ;; focusable buffer exists. Snap to head regardless
+                  ;; of mode so the unreachable "focus nil + buffer
+                  ;; non-empty" state stays unreachable. (Evicted retro
+                  ;; ids flow through to the :else branch so the
+                  ;; orphaned-state UX survives.)
+                  (and (some? head-id) (not slot-pinnable?))
+                  head-id
+                  ;; Live + unpaused — track head, regardless of
+                  ;; slot-id (rf2-s0s5x Phase A). Previously the
+                  ;; stored slot-id won here, so once
+                  ;; focus-step-reducer landed on the then-head the
+                  ;; slot pinned to that id and never auto-advanced
+                  ;; as newer cascades arrived. The LIVE pill's
+                  ;; contract is unambiguous — head IS the focus.
                   (and (= :live mode) (not paused?))
                   head-id
-                  ;; Live but paused — slot-id wins (frozen inspection);
-                  ;; if the stored id has been evicted from the buffer,
-                  ;; snap to head so the inspector doesn't dangle on a
-                  ;; nonexistent cascade.
+                  ;; Live + paused — slot-id wins (frozen inspection);
+                  ;; if the stored id has been evicted from the
+                  ;; buffer, snap to head so the inspector doesn't
+                  ;; dangle on a nonexistent cascade.
                   (and (= :live mode) paused?)
-                  (if (cascade-by-id cascades slot-id slot-frame) slot-id head-id)
-                  ;; Retro — slot-id wins UNCONDITIONALLY (even when
-                  ;; evicted). The event-detail panel's orphaned-state
-                  ;; branch surfaces "this id is no longer in the
-                  ;; buffer" copy off the evicted slot-id; auto-snapping
-                  ;; to head in retro would hide that signal. Empty
-                  ;; slot-id (initial state) does snap to head per §4
-                  ;; Defaults.
-                  (nil? slot-id)
-                  head-id
+                  (if (cascade-by-id focusable slot-id slot-frame)
+                    slot-id
+                    head-id)
+                  ;; Retro — slot-id wins. Evicted ids preserve the
+                  ;; orphaned-state surface in the event-detail panel.
                   :else
                   slot-id)
-        cascade (cascade-by-id cascades eff-id slot-frame)]
+        cascade (cascade-by-id focusable eff-id slot-frame)]
     {:dispatch-id eff-id
      :epoch-id    (:epoch-id focus)
      :frame       (or (:frame cascade) (:frame focus))
@@ -259,6 +302,15 @@
   pressing `j` (prev) from LIVE steps back one from the CURRENT head
   rather than from a stale stored id.
 
+  Per rf2-fzbrw the walk runs over `focusable-cascades` so the
+  `:ungrouped` bucket (registry-time emits / lifecycle / REPL evals)
+  is never a step target — pinning to it would degrade the L4 panels
+  into the unwanted 'all subs / all handlers' aggregate look. When
+  the buffer carries no focusable cascades, OR the step would land on
+  the current focus (already at a boundary), the reducer returns `db`
+  unchanged — a true no-op so `[<]` on the first event (or `[>]` on
+  the latest event) cannot clear or shuffle focus.
+
   The 3-arg arity (back-compat for callers that don't have the epoch
   buffer handy) treats `epoch-history` as empty so `:epoch-id`
   resolves to nil. Production callers in `install!` go through the
@@ -266,25 +318,38 @@
   ([db cascades delta]
    (focus-step-reducer db cascades [] delta))
   ([db cascades epoch-history delta]
-   (let [current-id (:dispatch-id (compose-focus (get db :focus) cascades))
-         new-id     (step-dispatch-id cascades current-id delta)
-         head-id    (head-dispatch-id cascades)
-         new-mode   (if (= new-id head-id) :live :retro)
-         cascade    (cascade-by-id cascades new-id)
-         frame-id   (:frame cascade)
-         epoch-id   (epoch-id-for-cascade epoch-history new-id)]
-     (cond-> db
-       true     (update :focus (fnil assoc {})
-                        :dispatch-id new-id
-                        :epoch-id    epoch-id
-                        :mode new-mode
-                        :previewing? false
-                        :paused? false)
-       frame-id (assoc-in [:focus :frame] frame-id)
-       true     (assoc :selected-dispatch-id new-id
-                       :selected-epoch-id    epoch-id
-                       :selected-dispatch    (cond-> {:dispatch-id new-id}
-                                               frame-id (assoc :frame frame-id)))))))
+   (let [focusable  (focusable-cascades cascades)
+         ;; rf2-s0s5x Phase A: resolve current-id through the same
+         ;; composer the spine sub uses, so in LIVE mode `j` steps
+         ;; back from the CURRENT head rather than from a stale
+         ;; stored id.
+         current-id (:dispatch-id (compose-focus (get db :focus) cascades))
+         new-id     (step-dispatch-id focusable current-id delta)
+         head-id    (head-dispatch-id focusable)]
+     (if (or (nil? new-id)
+             ;; rf2-fzbrw — boundary no-op. Stepping past either edge
+             ;; resolved to the same id we already hold; return db
+             ;; unchanged so the ribbon's `:disabled` contract is
+             ;; honoured at the reducer layer too. A keyboard j/k at
+             ;; the edge has no observable effect.
+             (and (some? current-id) (= new-id current-id)))
+       db
+       (let [new-mode (if (= new-id head-id) :live :retro)
+             cascade  (cascade-by-id focusable new-id)
+             frame-id (:frame cascade)
+             epoch-id (epoch-id-for-cascade epoch-history new-id)]
+         (cond-> db
+           true     (update :focus (fnil assoc {})
+                            :dispatch-id new-id
+                            :epoch-id    epoch-id
+                            :mode new-mode
+                            :previewing? false
+                            :paused? false)
+           frame-id (assoc-in [:focus :frame] frame-id)
+           true     (assoc :selected-dispatch-id new-id
+                           :selected-epoch-id    epoch-id
+                           :selected-dispatch    (cond-> {:dispatch-id new-id}
+                                                   frame-id (assoc :frame frame-id)))))))))
 
 (defn follow-head-reducer
   "Pure reducer for `:rf.causa/follow-head`. Snaps the spine to LIVE,

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -510,6 +510,106 @@
         (is (not (nav-head-disabled? tree)) "⏭ stays enabled")))))
 
 ;; -------------------------------------------------------------------------
+;; (4a-bis) rf2-fzbrw — ribbon nav at the boundary is a TRUE no-op
+;;
+;; The bead: 'When I'm on the first event and I click [<] I am still
+;; taken to a state where I see all subs, all handlers, etc.' Three
+;; fix layers in concert:
+;;   (A) ribbon's at-tail? / at-head? predicates walk the user-visible
+;;       (event-only) cascade vector, not the raw projection that
+;;       includes the :ungrouped bucket — so a buffer of 1 real event
+;;       plus :ungrouped still reports at-tail? = true on the only row.
+;;   (B) the disabled button drops its `:on-click` entirely AND carries
+;;       `cursor: not-allowed` + `aria-disabled` — defense in depth on
+;;       top of the native `:disabled` block.
+;;   (C) (covered in spine-cljs-test §10) — the spine reducer is a true
+;;       no-op at the edge so a keyboard j/k that bypasses the ribbon
+;;       cannot bypass the invariant either.
+;; -------------------------------------------------------------------------
+
+(deftest ribbon-prev-disabled-on-single-event-with-ungrouped-bucket
+  (testing "rf2-fzbrw — buffer has 1 real event PLUS the :ungrouped
+            bucket (registry-time emits, lifecycle, REPL evals). The
+            ribbon's at-tail? predicate must align with the user-visible
+            L2 list (which filters :ungrouped) — clicking [<] on the
+            only event must NOT pin focus to the :ungrouped bucket."
+    (causa-setup!)
+    ;; one real cascade …
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    ;; … plus an :ungrouped trace event (no :dispatch-id tag)
+    (trace-bus/collect-trace! {:id 50 :op-type :registry
+                               :operation :sub/registered
+                               :tags {:sub-id :foo/bar}})
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (is (nav-prev-disabled? tree)
+            "◀ DISABLED — focus is on the only real event; :ungrouped
+             is not a step target")
+        (is (nav-next-disabled? tree)
+            "▶ DISABLED — focus is also at head (single real event)")))))
+
+(deftest ribbon-prev-disabled-button-has-no-onclick-and-not-allowed-cursor
+  (testing "rf2-fzbrw — the disabled button drops its :on-click and
+            paints cursor: not-allowed plus aria-disabled. The native
+            :disabled attribute already blocks clicks at the DOM layer
+            but the visual + a11y signal must match the functional
+            signal — silent-by-default the user must NOT see a hand
+            cursor on a button that won't fire."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            prev (find-by-testid tree "rf-causa-nav-prev")
+            attrs (second prev)]
+        (is (true? (:disabled attrs)) "native :disabled set")
+        (is (true? (:aria-disabled attrs)) "aria-disabled set for a11y")
+        (is (nil? (:on-click attrs))
+            "no :on-click handler attached — pure no-op")
+        (is (= "not-allowed" (get-in attrs [:style :cursor]))
+            "cursor: not-allowed telegraphs the no-op")))))
+
+(deftest ribbon-prev-click-on-first-event-does-not-dispatch
+  (testing "rf2-fzbrw — exercise the disabled-button no-op path. Even
+            if a synthetic click somehow fires the on-click slot, it
+            must not dispatch any spine event because the slot is nil."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree (shell/shell-view)
+                prev (find-by-testid tree "rf-causa-nav-prev")
+                handler (:on-click (second prev))]
+            (is (nil? handler)
+                "disabled prev button has no on-click slot")
+            (when handler (handler nil)))))
+      (is (empty? (filter #(or (= [:rf.causa/focus-cascade-prev] %)
+                               (= :rf.causa/focus-cascade-prev (first %)))
+                          @dispatches))
+          "no :rf.causa/focus-cascade-prev dispatched"))))
+
+(deftest ribbon-prev-keyboard-equivalent-on-first-event-is-noop
+  (testing "rf2-fzbrw layer C — keyboard j (the [<] equivalent) routes
+            through the spine reducer. At the boundary the reducer
+            returns db unchanged, so focus persists on the first event
+            and never slides into nil / :ungrouped."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    ;; Spine auto-snaps focus to the only event in :live mode.
+    (rf/with-frame :rf/causa
+      (let [focus-before @(rf/subscribe [:rf.causa/focus])]
+        (is (= 1 (:dispatch-id focus-before)) "focus on the only event")
+        ;; Fire the keyboard-equivalent event — must be a no-op.
+        (rf/dispatch-sync [:rf.causa/focus-cascade-prev])
+        (let [focus-after @(rf/subscribe [:rf.causa/focus])]
+          (is (= 1 (:dispatch-id focus-after))
+              "focus unchanged — boundary no-op")
+          (is (some? (:dispatch-id focus-after))
+              "focus never goes nil with a non-empty buffer"))))))
+
+;; -------------------------------------------------------------------------
 ;; (4b) Row density + inline event-vector rendering — rf2-htik0 Bug 2 + 3
 ;; -------------------------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -638,3 +638,108 @@
           r  (spine/follow-head-reducer db)]
       (is (nil? (get-in r [:focus :epoch-id])))
       (is (nil? (:selected-epoch-id r))))))
+
+;; -------------------------------------------------------------------------
+;; (11) rf2-fzbrw — no aggregate-all-events state
+;;
+;; The spine's invariant is 'one focused event at a time'. Two specific
+;; reachable states would otherwise break that invariant:
+;;
+;;   (i)  Stepping prev from the first event lands focus on the
+;;        `:ungrouped` bucket (registry-time emits / lifecycle / REPL
+;;        evals) — the L4 panels reading the focused cascade then have
+;;        no event to render and degrade into an aggregate look.
+;;   (ii) The composed `:rf.causa/focus` sub returns
+;;        `:dispatch-id nil` while the buffer carries real events —
+;;        same downstream effect.
+;;
+;; The fix has three layers; this section covers the spine ones (B
+;; and C in the bead's fix sketch).
+;; -------------------------------------------------------------------------
+
+(def ^:private fixture-cascades-with-ungrouped
+  "Two real cascades + the `:ungrouped` bucket the projection emits
+  for events that carry no `:dispatch-id` tag. The bucket sorts to
+  the head by `first-id`'s `MAX_SAFE_INTEGER` sentinel; for the spine
+  walk we treat the bucket as not present, so the walkable head is
+  still the latest real cascade (`:c2` here)."
+  [(cascade :c1 :rf/default)
+   (cascade :c2 :rf/default)
+   (cascade :ungrouped nil)])
+
+(deftest focusable-cascades-drops-ungrouped-bucket
+  (testing "rf2-fzbrw — :ungrouped is filtered out of the spine walk
+            (it carries no event vector → not a valid focus target)"
+    (is (= 2 (count (spine/focusable-cascades
+                      fixture-cascades-with-ungrouped))))
+    (is (every? #(not= :ungrouped (:dispatch-id %))
+                (spine/focusable-cascades
+                  fixture-cascades-with-ungrouped)))
+    (is (= fixture-cascades
+           (spine/focusable-cascades fixture-cascades))
+        "no :ungrouped → no-op")))
+
+(deftest focus-step-reducer-prev-on-first-event-is-no-op
+  (testing "rf2-fzbrw — [<] on the first (oldest) real event returns db
+            unchanged. The boundary is a true no-op so focus cannot
+            shuffle into the :ungrouped bucket or any other aggregate
+            state."
+    (let [db {:focus {:dispatch-id :c1 :mode :retro}
+              :selected-dispatch-id :c1}
+          r  (spine/focus-step-reducer db
+                                       fixture-cascades-with-ungrouped
+                                       -1)]
+      (is (= db r) "db unchanged — boundary no-op"))))
+
+(deftest focus-step-reducer-next-on-head-is-no-op
+  (testing "rf2-fzbrw — [>] on the head (newest real event) returns db
+            unchanged. Symmetric counterpart of the [<] boundary."
+    (let [db {:focus {:dispatch-id :c2 :mode :live}
+              :selected-dispatch-id :c2}
+          r  (spine/focus-step-reducer db
+                                       fixture-cascades-with-ungrouped
+                                       +1)]
+      (is (= db r) "db unchanged at head"))))
+
+(deftest focus-step-reducer-prev-from-real-skips-ungrouped
+  (testing "rf2-fzbrw — stepping prev from the only real-event focus
+            never lands on :ungrouped. With a single real cascade plus
+            the bucket, [<] at the only real event is a no-op."
+    (let [cascades [(cascade :ungrouped nil)
+                    (cascade :only-real :rf/default)]
+          db       {:focus {:dispatch-id :only-real :mode :live}
+                    :selected-dispatch-id :only-real}
+          r        (spine/focus-step-reducer db cascades -1)]
+      (is (= db r)
+          "single real event → [<] is a no-op, not a slide into :ungrouped"))))
+
+(deftest focus-step-reducer-empty-focusable-buffer-is-no-op
+  (testing "buffer carries only the :ungrouped bucket (no real events
+            yet) → stepping is a no-op; the reducer cannot manufacture
+            a focusable cascade out of nothing."
+    (let [cascades [(cascade :ungrouped nil)]
+          db       {}
+          r        (spine/focus-step-reducer db cascades -1)]
+      (is (= db r)))))
+
+(deftest compose-focus-snaps-to-head-when-slot-id-is-ungrouped
+  (testing "rf2-fzbrw — even in :retro, a stored slot pointing at
+            :ungrouped (or a no-longer-present cascade) snaps to head.
+            The spine MUST NOT surface nil :dispatch-id while focusable
+            cascades exist."
+    (let [r (spine/compose-focus {:dispatch-id :ungrouped :mode :retro}
+                                 fixture-cascades-with-ungrouped)]
+      (is (= :c2 (:dispatch-id r))
+          "stored :ungrouped → effective head (:c2)")
+      (is (true? (:head? r))))))
+
+(deftest compose-focus-snaps-to-head-when-slot-id-nil-in-retro
+  (testing "rf2-fzbrw — even in :retro mode, nil slot-id with a
+            non-empty focusable buffer snaps to head. The unreachable
+            state 'buffer non-empty + focus nil' is structurally
+            blocked at the compose layer."
+    (let [r (spine/compose-focus {:dispatch-id nil :mode :retro}
+                                 fixture-cascades)]
+      (is (= :c3 (:dispatch-id r))
+          "nil slot-id + non-empty buffer + :retro → snap to head")
+      (is (true? (:head? r))))))


### PR DESCRIPTION
## Bug class

> Mike: 'When I'm on the first event and I click [<] I am still taken to a state where I see all subs, all handlers, etc.'

Causa's invariant is **one focused event at a time; panels are lenses on that event**. The aggregate-across-all-events state should not be reachable.

## Root cause

The L1 ribbon's `at-tail?` / `at-head?` boundary predicates walked the raw `:rf.causa/cascades` projection, which includes the `:ungrouped` bucket (registry-time emits / lifecycle / REPL evals). On a buffer of one real event PLUS `:ungrouped` the ribbon saw 2 ids and computed `at-tail? = (= real-id (first ids)) = FALSE` because the first id was `:ungrouped`. `[<]` stayed enabled on what the user saw as the only event; clicking it stepped focus to `:ungrouped` — the L4 panels then had no cascade to render and degraded into the aggregate look.

## Fix — three layers

**(A) Ribbon walks event-only cascades** (`shell.cljs`)
- `ribbon` reg-view filters via `cascade-has-event?` before computing `at-head?` / `at-tail?` so the boundary aligns with what the user sees in the L2 event list.
- The disabled prev/next buttons also drop their `:on-click` slot entirely and carry `cursor: not-allowed` + `aria-disabled` — visual + a11y signal matches the functional signal.

**(B) Spine step reducer skips `:ungrouped` + boundary no-op** (`spine.cljs` `focus-step-reducer`)
- New `focusable-cascades` helper strips the `:ungrouped` bucket before any spine walk.
- `step-dispatch-id` runs over the cleaned vector → stepping past a real event cannot land focus on `:ungrouped`.
- At the boundary (`new-id == current-id`, or empty focusable buffer) the reducer returns `db` unchanged — keyboard `j` / `k` at the edge has no observable effect either.

**(C) `compose-focus` snaps to head when slot is nil / `:ungrouped`** (`spine.cljs`)
- New `slot-pinnable?` guard treats nil and `:ungrouped` slot-ids as non-pinnable.
- With a non-empty focusable buffer the composer snaps to head **regardless of mode**. Combined with the LIVE auto-follow (rf2-s0s5x Phase A) this makes 'buffer non-empty + effective `:dispatch-id` nil' structurally unreachable.
- Evicted retro slot-ids still flow through to preserve the event-detail panel's orphaned-state surface.

## Test plan

- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `cd tools/causa && clojure -M:test` — PASS (930 tests)
- [x] `cd implementation && npm run test:cljs` — PASS (3199 tests)
- [x] `cd implementation && npm run test:browser` — PASS (3187 tests)

New tests:
- `shell_cljs_test` §4a-bis 'rf2-fzbrw — ribbon nav at the boundary is a TRUE no-op'
- `spine_cljs_test` §11 'rf2-fzbrw — no aggregate-all-events state'