### PR TITLE
fix(story): :play-script :pred accepts fn-direct — advanced-CLJS-safe

### DIFF
--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -30,7 +30,7 @@
   | `[:dispatch-sync event-vec]`       | `rf/dispatch-sync` (synchronous) into the frame               |
   | `[:wait ms]`                       | Sleep N ms (`setTimeout` CLJS / `Thread/sleep` JVM)            |
   | `[:assert-db path value]`          | Assert `(= (get-in @app-db path) value)`                      |
-  | `[:assert-db path :pred fn-sym]`   | Assert custom predicate (resolve via the framework registrar) |
+  | `[:assert-db path :pred fn-or-sym]`| Assert custom predicate — `fn` is preferred (works under advanced CLJS); `symbol` is the JVM/dev escape hatch (resolved at run time, fragile under advanced CLJS munging) |
   | `[:assert-dom selector :visible]`  | Assert selector resolves to a visible DOM node                |
   | `[:assert-dom selector :hidden]`   | Assert selector resolves to nothing (or hidden node)          |
   | `[:assert-dom selector :text txt]` | Assert selector's text-content matches `txt`                  |
@@ -112,10 +112,14 @@
                       (and (>= (count step) 3)
                            (vector? (nth step 1))
                            (or
-                             ;; :pred form is 4-arity: [:assert-db path :pred fn-sym]
+                             ;; :pred form is 4-arity: [:assert-db path :pred ref]
+                             ;; where `ref` is EITHER a fn (preferred — works
+                             ;; under advanced CLJS) OR a symbol (JVM escape
+                             ;; hatch via `requiring-resolve`).
                              (and (= 4 (count step))
                                   (= :pred (nth step 2))
-                                  (symbol? (nth step 3)))
+                                  (let [r (nth step 3)]
+                                    (or (fn? r) (symbol? r))))
                              ;; equality form is 3-arity: [:assert-db path value]
                              ;; ANY value (including nil) is legal — but :pred is
                              ;; reserved as a discriminator and would be ambiguous.
@@ -461,8 +465,13 @@
     :wait           (str "wait " (second step) "ms")
     :assert-db      (cond
                       (and (= 4 (count step)) (= :pred (nth step 2)))
-                      (str "assert-db " (pr-str (second step))
-                           " :pred " (pr-str (nth step 3)))
+                      (let [ref (nth step 3)]
+                        (str "assert-db " (pr-str (second step))
+                             " :pred "
+                             (cond
+                               (symbol? ref) (pr-str ref)
+                               (fn? ref)     "<fn>"
+                               :else         (pr-str ref))))
                       :else
                       (str "assert-db " (pr-str (second step))
                            " = " (pr-str (nth step 2))))
@@ -547,13 +556,22 @@
 
 (defn step-assert-db
   "Decompose an `:assert-db` step into `{:path <vec> :mode :equals|:pred
-  :expected <val> :pred-sym <sym>}`. The `:pred` form is 4-arity
-  (`[:assert-db path :pred fn-sym]`); the equality form is 3-arity."
+  :expected <val> :pred-ref <fn-or-sym> :pred-fn? <bool>}`.
+
+  The `:pred` form is 4-arity (`[:assert-db path :pred ref]`) where
+  `ref` is EITHER a fn (preferred — works under advanced CLJS) OR a
+  symbol (resolved via `requiring-resolve` on JVM, best-effort
+  `goog.global` walk on CLJS — fragile under advanced). The
+  equality form is 3-arity (`[:assert-db path value]`).
+
+  `:pred-fn?` discriminates so the runner can skip resolution when the
+  caller already handed in a callable."
   [step]
   (when (= :assert-db (step-type step))
     (let [path (nth step 1)]
       (if (and (= 4 (count step)) (= :pred (nth step 2)))
-        {:path path :mode :pred   :pred-sym (nth step 3)}
+        (let [ref (nth step 3)]
+          {:path path :mode :pred :pred-ref ref :pred-fn? (fn? ref)})
         {:path path :mode :equals :expected (nth step 2)}))))
 
 (defn step-assert-dom

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -9,8 +9,11 @@
     against the variant's frame.
   - `:wait` ms → JS `setTimeout` (CLJS) or `Thread/sleep` (JVM).
   - `:assert-db` path value → read from `rf/get-frame-db` and compare.
-  - `:assert-db` path :pred fn-sym → resolve the predicate via the
-    framework registrar (`re-frame.story.predicates`) and invoke.
+  - `:assert-db` path :pred fn-or-sym → invoke the predicate. A FN
+    handed in directly is called as-is (advanced-CLJS-safe); a SYMBOL
+    is resolved at run time via `requiring-resolve` (JVM) or a
+    best-effort `goog.global` walk (CLJS — fragile under advanced
+    compilation, see rf2-inbad).
   - `:click` / `:type` / `:assert-dom` → delegate to
     `re-frame.story.play.dom` (no-op on JVM / no-DOM).
 
@@ -280,10 +283,15 @@
   munged dotted names (works for fns reachable from a global ns
   like `js/cljs.user.my_pred`). Returns nil on miss.
 
-  CLJS resolution is best-effort — advanced-compiled fns have their
-  namespace mangled, so author fns referenced via `:pred` should be
-  defined `^:export`'d or under `js/window.<...>` for cross-target
-  parity. JVM tests cover the common case end-to-end."
+  CLJS symbol resolution is BEST-EFFORT and FRAGILE under advanced
+  compilation — the closure compiler mangles author namespace names,
+  so the munged-dotted-name walk won't find them. The advanced-safe
+  authoring path is to pass the predicate as a FN DIRECTLY in the
+  `:assert-db [path] :pred <fn>` step; the runner short-circuits the
+  resolver in that case (see `exec-assert-db!`).
+
+  rf2-inbad: this fn remains for the symbol-form escape hatch (JVM
+  tests + :dev CLJS) but is NOT the primary authoring path."
   [sym]
   (when sym
     (try
@@ -305,9 +313,20 @@
                    :else       (recur (aget obj (first ks)) (rest ks))))))))
       (catch #?(:clj Throwable :cljs :default) _ nil))))
 
+(defn- pred-label
+  "Human-readable label for a `:pred` ref — the symbol literal when
+  the author handed a symbol, the marker `<fn>` when they handed a
+  fn directly. Used in failure messages so authors can spot which
+  predicate failed without leaking compiler-munged identifiers."
+  [ref]
+  (cond
+    (symbol? ref) (str ref)
+    (fn? ref)     "<fn>"
+    :else         (pr-str ref)))
+
 (defn- exec-assert-db!
   [frame-id idx step]
-  (let [{:keys [path mode expected pred-sym]} (runner/step-assert-db step)
+  (let [{:keys [path mode expected pred-ref pred-fn?]} (runner/step-assert-db step)
         db (read-frame-db frame-id)]
     (case mode
       :equals
@@ -322,26 +341,32 @@
                                             ", got " (pr-str actual))})))
 
       :pred
-      (let [pred-fn (resolve-predicate pred-sym)
+      ;; rf2-inbad: prefer the fn-direct path (advanced-CLJS-safe). Fall
+      ;; back to symbol resolution for the JVM / :dev CLJS escape hatch.
+      (let [pred-fn (if pred-fn? pred-ref (resolve-predicate pred-ref))
+            label   (pred-label pred-ref)
             actual  (get-in db path)]
         (cond
           (nil? pred-fn)
           (runner/step-fail idx step
                             {:message (str "assert-db :pred — could not resolve "
-                                           pred-sym " in the predicates registry")})
+                                           label
+                                           " (symbol resolution is fragile under"
+                                           " advanced CLJS; pass the predicate as a"
+                                           " fn directly to avoid this)")})
 
           :else
           (try
             (if (pred-fn actual)
               (runner/step-pass idx step)
               (runner/step-fail idx step
-                                {:expected (str "predicate " pred-sym " returns truthy")
+                                {:expected (str "predicate " label " returns truthy")
                                  :actual   actual
                                  :message  (str "assert-db " (pr-str path)
-                                                " — predicate " pred-sym " returned false")}))
+                                                " — predicate " label " returned false")}))
             (catch #?(:clj Throwable :cljs :default) e
               (runner/step-fail idx step
-                                {:message (str "assert-db :pred " pred-sym " threw — "
+                                {:message (str "assert-db :pred " label " threw — "
                                                #?(:clj (.getMessage ^Throwable e)
                                                   :cljs (str e)))}))))))))
 

--- a/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_events_cljs_test.cljc
@@ -146,6 +146,49 @@
          (is (false? (:passed? (nth results 1))))))))
 
 #?(:clj
+   (deftest assert-db-pred-fn-direct
+     (testing ":assert-db :pred accepts a fn directly (rf2-inbad — advanced-CLJS-safe)"
+       (rf/reg-event-db :rt/set-n
+         (fn [db [_ v]] (assoc db :n v)))
+       (story/reg-variant :story.runner/pred-fn
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/set-n 7]]
+                                    [:assert-db [:n] :pred pos?]
+                                    [:assert-db [:n] :pred neg?]
+                                    [:assert-db [:n] :pred (fn [x] (= x 7))]]}})
+       (async/deref-blocking (story/run-variant :story.runner/pred-fn) 5000)
+       (let [final   (run-blocking :story.runner/pred-fn)
+             results (filterv #(= :assert-db (:type %)) (:results final))]
+         (is (= :fail (:status final))
+             "neg? against 7 fails — overall status is :fail")
+         (is (= 3 (count results)))
+         (is (true?  (:passed? (nth results 0))) "pos? against 7 passes")
+         (is (false? (:passed? (nth results 1))) "neg? against 7 fails")
+         (is (true?  (:passed? (nth results 2))) "anonymous fn passes")
+         (is (re-find #"<fn>" (:message (nth results 1)))
+             "failure message renders fn ref as <fn> — no compiler-munged leakage")))))
+
+#?(:clj
+   (deftest assert-db-pred-bogus-symbol-fails-gracefully
+     (testing ":assert-db :pred with an unresolvable symbol fails gracefully (rf2-inbad)"
+       (rf/reg-event-db :rt/set-n
+         (fn [db [_ v]] (assoc db :n v)))
+       (story/reg-variant :story.runner/pred-bogus
+         {:events      []
+          :play-script {:auto-run? false
+                        :script    [[:dispatch-sync [:rt/set-n 7]]
+                                    [:assert-db [:n] :pred 'no.such.ns/missing-pred]]}})
+       (async/deref-blocking (story/run-variant :story.runner/pred-bogus) 5000)
+       (let [final   (run-blocking :story.runner/pred-bogus)
+             results (filterv #(= :assert-db (:type %)) (:results final))]
+         (is (= :fail (:status final)))
+         (is (= 1 (count results)))
+         (is (false? (:passed? (first results))))
+         (is (re-find #"could not resolve" (:message (first results)))
+             "user-facing message mentions resolution failure")))))
+
+#?(:clj
    (deftest run-records-results-in-order
      (testing "results vector reflects step order"
        (rf/reg-event-db :rt/touch

--- a/tools/story/test/re_frame/story/play/runner_test.cljc
+++ b/tools/story/test/re_frame/story/play/runner_test.cljc
@@ -55,7 +55,11 @@
     (is (true?  (runner/step-arity-ok? [:assert-db [:k] 1])))
     (is (true?  (runner/step-arity-ok? [:assert-db [:a :b] nil])))
     (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred 'my-ns/pos-int?])))
-    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred "not-a-sym"])))
+    ;; rf2-inbad: fn-direct is the advanced-CLJS-safe authoring path.
+    (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred pos?])))
+    (is (true?  (runner/step-arity-ok? [:assert-db [:k] :pred (fn [_] true)])))
+    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred "not-a-sym-or-fn"])))
+    (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred 42])))
     (is (false? (runner/step-arity-ok? [:assert-db [:k]])))
     (is (false? (runner/step-arity-ok? [:assert-db "not-a-vec" 1])))
     (is (false? (runner/step-arity-ok? [:assert-db [:k] :pred])))))
@@ -220,6 +224,10 @@
   (is (= "assert-db [:k] = 1" (runner/step-summary [:assert-db [:k] 1])))
   (is (= "assert-db [:k] :pred my/pred?"
          (runner/step-summary [:assert-db [:k] :pred 'my/pred?])))
+  ;; rf2-inbad: fn-direct refs render as <fn> so messages don't leak
+  ;; compiler-munged identifiers under advanced CLJS.
+  (is (= "assert-db [:k] :pred <fn>"
+         (runner/step-summary [:assert-db [:k] :pred pos?])))
   (is (= "assert-dom \"sel\" visible"
          (runner/step-summary [:assert-dom "sel" :visible])))
   (is (= "click \"sel\""  (runner/step-summary [:click "sel"])))
@@ -282,8 +290,15 @@
 (deftest step-assert-db-decomposition
   (is (= {:path [:k] :mode :equals :expected 1}
          (runner/step-assert-db [:assert-db [:k] 1])))
-  (is (= {:path [:a :b] :mode :pred :pred-sym 'my/pos?}
-         (runner/step-assert-db [:assert-db [:a :b] :pred 'my/pos?]))))
+  (testing "symbol ref decomposes to :pred-ref + :pred-fn? false"
+    (is (= {:path [:a :b] :mode :pred :pred-ref 'my/pos? :pred-fn? false}
+           (runner/step-assert-db [:assert-db [:a :b] :pred 'my/pos?]))))
+  (testing "fn ref decomposes to :pred-ref + :pred-fn? true (rf2-inbad)"
+    (let [decomp (runner/step-assert-db [:assert-db [:a :b] :pred pos?])]
+      (is (= [:a :b] (:path decomp)))
+      (is (= :pred (:mode decomp)))
+      (is (true? (:pred-fn? decomp)))
+      (is (identical? pos? (:pred-ref decomp))))))
 
 (deftest step-assert-dom-decomposition
   (is (= {:selector "x" :mode :visible}

--- a/tools/story/testbeds/counter_with_stories/stories.cljs
+++ b/tools/story/testbeds/counter_with_stories/stories.cljs
@@ -601,6 +601,26 @@
      :tags       #{:dev :test :internal}
      :substrates #{:reagent}})
 
+  ;; rf2-inbad fn-direct :pred fixture — verifies the advanced-CLJS-safe
+  ;; authoring path for `:assert-db :pred` (a fn reference handed in
+  ;; directly instead of a symbol). The fixture pairs an in-line
+  ;; anonymous predicate with a top-level clojure.core predicate so both
+  ;; cases land in the browser-side play-script runner.
+  (story/reg-variant :story.counter-play-script/pred-fn-direct
+    {:doc        "rf2-inbad CI fixture — `:assert-db :pred` with fn
+                 references handed in directly. Survives advanced CLJS
+                 because no symbol resolution is performed at run time."
+     :args       {:label "Play-script :pred fn-direct"}
+     :events     []
+     :play-script
+     {:name      "pred-fn-direct-passes"
+      :auto-run? true
+      :script    [[:dispatch-sync [:counter/initialise 3]]
+                  [:assert-db [:count] :pred pos?]
+                  [:assert-db [:count] :pred (fn [n] (= n 3))]]}
+     :tags       #{:dev :test :internal}
+     :substrates #{:reagent}})
+
   ;; rf2-e0kof DOM-step fixtures — live-browser coverage of the rich-DSL
   ;; `:click` / `:type` / `:assert-dom` steps. The pure-step + JVM
   ;; coverage in tools/story/test/re_frame/story/play/ exercises the


### PR DESCRIPTION
## Bug (rf2-inbad)

Story's `:play-script` `[:assert-db [path] :pred ref]` step required `ref` to be a SYMBOL — resolved at run time via `requiring-resolve` (JVM) or a best-effort `goog.global` walk (CLJS).

Under advanced compilation the closure compiler mangles author namespace names, so the CLJS goog-walk resolver can't find author predicates. The step's `:dev` path works; the `:advanced` path silently fails to resolve.

## Options considered

(a) Require `^:export` on every predicate + walk `goog.global`.
    Fragile, leaks compiler concerns into authoring.

(b) Build a registry (`reg-play-pred :id fn`) + reference by keyword.
    Works under advanced, but adds a registrar API authors must remember and a lookup per assert.

(c) Accept the fn DIRECTLY in the step — no resolution needed.
    Keep symbol form as the JVM/`:dev` escape hatch.

## Chosen approach — (c)

Most flexible, zero new API, advanced-CLJS-safe by construction. The runner short-circuits the resolver when `(fn? ref)` is true; otherwise it falls back to symbol resolution.

### Changes

- `runner/step-arity-ok?` accepts `fn?` OR `symbol?` in the `:pred` slot.
- `runner/step-assert-db` decomposes to `{:mode :pred :pred-ref <ref> :pred-fn? <bool>}` (renamed from `:pred-sym`).
- `runner-events/exec-assert-db!` calls `pred-ref` directly when `:pred-fn?` is true; otherwise resolves the symbol.
- `runner/step-summary` renders fn refs as `<fn>` so failure messages don't leak compiler-munged identifiers.
- New `:story.counter-play-script/pred-fn-direct` fixture exercises the fn-direct path end-to-end through the browser play-script CI runner.
- JVM integration tests cover fn-direct PASS, fn-direct FAIL, and graceful failure when a symbol can't be resolved.

### Authoring example

```clojure
;; Advanced-CLJS-safe (preferred):
[:assert-db [:count] :pred pos?]
[:assert-db [:count] :pred (fn [n] (= n 42))]

;; JVM / :dev escape hatch — works on JVM via `requiring-resolve`;
;; fragile on :advanced CLJS:
[:assert-db [:count] :pred 'my-ns/pos?]
```

## Test plan

- [x] `scripts/test-fast-pr.sh` — green (3185 CLJS tests)
- [x] `cd tools/story && clojure -M:test` — green (792 tests)
- [x] `cd implementation && npm run test:browser` — green (3176 tests)
- [x] `cd implementation && npm run test:story-play-scripts` — green (8 rows, including new `pred-fn-direct` fixture)

Does NOT close `rf2-inbad` — mayor reviews + closes.