### PR TITLE
fix(causa): Trace tab cascade-scoped by default

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -38,12 +38,28 @@
   ride a follow-on bead for the UI (drag-zoom on the time-axis,
   expression input).
 
+  ## Cascade-scope (rf2-ycoct)
+
+  Per spec/018 §6 every L4 panel is a lens on the spine's focused
+  event, not a global ribbon. The trace tab pre-filters its ribbon
+  to events in the focused cascade's window via the
+  `:rf.causa/focus` sub (composed by the spine in `spine.cljs`). User
+  chip filters AND with the cascade scope; the chip rows continue to
+  reflect user state only — the cascade-scope is a system-level
+  invariant, not a user narrowing. Clicking a different cascade in
+  the L2 event list re-binds the spine and the ribbon re-renders
+  with the new cascade's events.
+
   ## Empty states
 
   Per the bead's contract:
 
     :no-events   → 'No events.' Once the trace bus starts flowing
                    this clears immediately.
+    :no-focus    → defensive: buffer is non-empty but the spine has
+                   no `:dispatch-id`. Per rf2-639lc default-focus
+                   should always land on a real cascade, so this
+                   should never render in practice.
     :no-matches  → events exist but the active filters hide them
                    all. 'No events match current filters' + Clear.
 
@@ -414,6 +430,23 @@
                 :color  (:text-tertiary tokens)}}
     "No events."]])
 
+(defn- empty-state-no-focus
+  "Defensive empty-state — the buffer has events but the spine focus
+  has no `:dispatch-id`. Per rf2-639lc the default-focus rule should
+  always land on a real cascade, so this branch should never render
+  in practice; the terse copy + testid here let us spot a regression
+  when it does."
+  []
+  [:div {:data-testid "rf-causa-trace-empty-no-focus"
+         :style       {:padding     "24px"
+                       :font-family sans-stack
+                       :font-size   "13px"
+                       :line-height 1.5
+                       :color       (:text-secondary tokens)}}
+   [:p {:style {:margin 0
+                :color  (:text-tertiary tokens)}}
+    "No focused event."]])
+
 (defn- active-filter-pill
   "Per rf2-vu0mp — one pill in the no-matches empty state's 'narrowing
   on' strip. Clicking removes the axis from the filter map. Orphan
@@ -531,6 +564,7 @@
      [:div {:style {:flex 1 :overflow "auto"}}
       (case empty-kind
         :no-events  (empty-state-no-events)
+        :no-focus   (empty-state-no-focus)
         :no-matches (empty-state-no-matches {:active-filters active-filters})
         nil         (overflow/capped-list
                       rows
@@ -606,15 +640,37 @@
 
   ;; Composite — produces every slot the view consumes. Reactive
   ;; surface: trace-feed-state (incrementally maintained) + filter
-  ;; state. The helper's `project-feed-from-state` does the read-
-  ;; side work: a single reverse-then-filter walk over already-
-  ;; projected rows. Filter-only changes still O(rows) but with no
-  ;; per-event `project-row` cost.
+  ;; state + spine focus. The helper's `project-feed-from-state` does
+  ;; the read-side work: a single reverse-then-filter walk over
+  ;; already-projected rows. Filter-only changes still O(rows) but
+  ;; with no per-event `project-row` cost.
+  ;;
+  ;; ## Cascade-scope by default (rf2-ycoct)
+  ;;
+  ;; Per spec/018 §6 every L4 panel is a lens on the spine's focused
+  ;; event, not a global ribbon. The trace tab pre-filters to events
+  ;; in the focused cascade's window using the focus sub's
+  ;; `:dispatch-id` (which the spine composer auto-resolves to the
+  ;; head cascade in LIVE mode per rf2-s0s5x, or pins to the retro
+  ;; selection in RETRO mode). User chip filters still apply AND-wise
+  ;; on top of the cascade scope.
+  ;;
+  ;; The cascade-scope is a SYSTEM-level invariant (not a user
+  ;; narrowing), so the `:rf.causa/trace-filters` map and the chip
+  ;; rows continue to reflect user state only. A user click on a
+  ;; `:dispatch-id` chip becomes redundant when it matches the
+  ;; focused id (both filters yield the same set) and acts as an
+  ;; AND-wise narrower when it doesn't — but the typical workflow is
+  ;; to focus via L2 and let the panel auto-scope.
   (rf/reg-sub :rf.causa/trace-feed
     :<- [:rf.causa/trace-feed-state]
     :<- [:rf.causa/trace-filters]
-    (fn [[state filters] _query]
-      (h/project-feed-from-state state filters)))
+    :<- [:rf.causa/focus]
+    (fn [[state filters focus] _query]
+      (h/project-feed-from-state
+        state
+        filters
+        {:cascade-dispatch-id (:dispatch-id focus)})))
 
   ;; Set or clear one axis. Passing nil-value clears that axis;
   ;; setting a value replaces any existing value on that axis (the

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -627,43 +627,121 @@
   per-event `project-row` cost) and stops at `cap` matches so the
   view never sees more than its render-cap rows. The buffer's full
   size is reflected by `:total`; the panel's overflow indicator
-  surfaces 'hidden N' from the cap-rows helper downstream."
-  [state filters]
-  (let [normalised (normalise-filters filters)
-        passes?    (trace-bus/build-filter-predicate normalised)
-        rows       (:projected-rows state)
-        total      (:total state)
-        rev-rows   (rseq rows)
-        rendered+rows
-        (if (empty? normalised)
-          [(count rows) (vec rev-rows)]
-          (loop [remain rev-rows
-                 rendered 0
-                 acc      (transient [])]
-            (if (nil? (seq remain))
-              [rendered (persistent! acc)]
-              (let [row (first remain)
-                    ev  (:raw row)]
-                (if (passes? ev)
-                  (recur (next remain) (inc rendered) (conj! acc row))
-                  (recur (next remain) rendered acc))))))
-        [rendered display-rows] rendered+rows
-        empty-kind (cond
-                     (zero? total)    :no-events
-                     (zero? rendered) :no-matches
-                     :else            nil)
-        active-filters (active-filters-summary normalised (:seen state))]
-    {:rows           display-rows
-     :total          total
-     :rendered       rendered
-     :distinct       (effective-distinct (:distinct state)
-                                         (:seen state)
-                                         normalised)
-     :counts         (:counts state)
-     :filters        normalised
-     :any-filter?    (boolean (seq normalised))
-     :empty-kind     empty-kind
-     :active-filters active-filters}))
+  surfaces 'hidden N' from the cap-rows helper downstream.
+
+  ## Cascade-scope (rf2-ycoct)
+
+  The optional 3-arity takes `opts` with `:cascade-dispatch-id`. When
+  the spine has a focus, the projection pre-filters rows to those
+  belonging to the focused cascade — honouring spec/018 §6 (every L4
+  panel is a lens on the spine's focused event, not a global ribbon).
+  User chip filters still apply AND-wise on top of the cascade scope.
+
+  Scope semantics:
+
+    - `nil`         — no spine focus (cold start with an empty buffer
+                      or a broken default-focus rule). Empty buffer is
+                      classified `:no-events`; non-empty buffer with
+                      nil focus is the defensive `:no-focus` branch
+                      (rf2-639lc says default-focus should land on
+                      head, so this should never occur in practice).
+    - `:ungrouped`  — the projection's catch-all bucket for events
+                      without a dispatch-id (registry-time emits,
+                      frame lifecycle outside a drain). The scope
+                      matches rows whose `:dispatch-id` is nil — the
+                      same rows the `:ungrouped` cascade groups.
+    - `<id>`        — match rows whose `:dispatch-id` equals `<id>`.
+
+  Cascade-scope is independent of the user filter map (it is enforced
+  regardless of whether `:dispatch-id` is in the user's chip filter)
+  so `:any-filter?` / `:filters` continue to reflect the USER state
+  only — the cascade-scope is a system-level invariant, not a user
+  narrowing.
+
+  Returned shape adds:
+
+    :cascade-dispatch-id — the resolved scope value (nil when
+                           unscoped) — the view uses it to label the
+                           cascade-scope chip in the header.
+    :empty-kind          — adds the `:no-focus` branch on top of the
+                           existing `:no-events` / `:no-matches` /
+                           nil cases."
+  ([state filters]
+   (project-feed-from-state state filters nil))
+  ([state filters opts]
+   (let [{:keys [cascade-dispatch-id]} opts
+         ;; Spine wiring presence — the caller passing an `opts` map
+         ;; signals that the panel is now spine-aware. When `opts` is
+         ;; absent (the 2-arity bridge, callers that pre-date the
+         ;; rf2-ycoct cascade-scope wiring, headless test rigs that
+         ;; build state directly) we behave as a global ribbon — no
+         ;; cascade-scope, no `:no-focus` defensive branch.
+         spine-aware? (some? opts)
+         normalised (normalise-filters filters)
+         passes?    (trace-bus/build-filter-predicate normalised)
+         total      (:total state)
+         no-focus?  (and spine-aware?
+                         (nil? cascade-dispatch-id)
+                         (pos? total))
+         in-scope?  (cond
+                      no-focus?
+                      (constantly false)
+
+                      (= :ungrouped cascade-dispatch-id)
+                      (fn [row] (nil? (:dispatch-id row)))
+
+                      (some? cascade-dispatch-id)
+                      (fn [row] (= cascade-dispatch-id (:dispatch-id row)))
+
+                      :else
+                      (constantly true))
+         scoped?    (or no-focus? (some? cascade-dispatch-id))
+         no-user-filters? (empty? normalised)
+         rows       (:projected-rows state)
+         rev-rows   (rseq rows)
+         rendered+rows
+         (cond
+           ;; Defensive no-focus path: short-circuit to empty rows
+           ;; without walking the buffer.
+           no-focus?
+           [0 []]
+
+           ;; Fast path: no user filters AND no cascade-scope → every
+           ;; row passes; just reverse the vector.
+           (and no-user-filters? (not scoped?))
+           [(count rows) (vec rev-rows)]
+
+           :else
+           (loop [remain rev-rows
+                  rendered 0
+                  acc      (transient [])]
+             (if (nil? (seq remain))
+               [rendered (persistent! acc)]
+               (let [row (first remain)
+                     ev  (:raw row)]
+                 (if (and (in-scope? row)
+                          (or no-user-filters? (passes? ev)))
+                   (recur (next remain) (inc rendered) (conj! acc row))
+                   (recur (next remain) rendered acc))))))
+         [rendered display-rows] rendered+rows
+         empty-kind (cond
+                      (zero? total)    :no-events
+                      no-focus?        :no-focus
+                      (zero? rendered) :no-matches
+                      :else            nil)
+         active-filters (active-filters-summary normalised (:seen state))]
+     {:rows                display-rows
+      :total               total
+      :rendered            rendered
+      :distinct            (effective-distinct (:distinct state)
+                                               (:seen state)
+                                               normalised)
+      :counts              (:counts state)
+      :filters             normalised
+      :any-filter?         (boolean (seq normalised))
+      :empty-kind          empty-kind
+      :active-filters      active-filters
+      :cascade-dispatch-id cascade-dispatch-id})))
 
 ;; ---- React keys ---------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -777,3 +777,99 @@
   (let [state (h/rebuild-feed-state (events-fixture))
         feed  (h/project-feed-from-state state {})]
     (is (= [] (:active-filters feed)))))
+
+;; ---- (7) cascade-scope (rf2-ycoct) -------------------------------------
+;;
+;; Mike's call on rf2-ycoct: the Trace tab is cascade-scoped by default
+;; (audit findings 2026-05-18). project-feed-from-state's 3-arity takes
+;; `{:cascade-dispatch-id <id-or-:ungrouped-or-nil>}` and pre-filters
+;; rows to the focused cascade. User chip filters AND on top.
+
+(deftest project-feed-from-state-cascade-scope-narrows-to-cascade
+  (testing "rf2-ycoct: cascade-scope filters rows to those whose
+            :dispatch-id matches the focused cascade's id"
+    (let [evs   (events-fixture)
+          state (h/rebuild-feed-state evs)
+          ;; Fixture has dispatch-ids 10, 11, 12. Scope to 10 → rows 1, 2, 4.
+          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 10})]
+      (is (= 5 (:total feed))
+          ":total reflects entire buffer, not the scoped subset")
+      (is (= 3 (:rendered feed))
+          "three rows belong to cascade 10")
+      (is (= #{1 2 4} (set (mapv :id (:rows feed))))
+          "exactly cascade 10's events surface")
+      (is (= 10 (:cascade-dispatch-id feed))
+          ":cascade-dispatch-id rides on the result"))))
+
+(deftest project-feed-from-state-cascade-scope-ands-with-user-filter
+  (testing "rf2-ycoct: user chip filter AND-wise with cascade-scope"
+    (let [evs    (events-fixture)
+          state  (h/rebuild-feed-state evs)
+          ;; Cascade 10 has 3 rows (ids 1, 2, 4). Of those, op-type :error
+          ;; is only row 2. AND-wise: cascade 10 ∩ op-type :error = {2}.
+          feed   (h/project-feed-from-state state
+                                            {:op-type :error}
+                                            {:cascade-dispatch-id 10})]
+      (is (= 1 (:rendered feed)))
+      (is (= [2] (mapv :id (:rows feed)))))))
+
+(deftest project-feed-from-state-cascade-scope-no-overlap-empty
+  (testing "rf2-ycoct: scope on a cascade not in the buffer renders
+            zero rows and reports :no-matches"
+    (let [evs   (events-fixture)
+          state (h/rebuild-feed-state evs)
+          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 99999})]
+      (is (= 0 (:rendered feed)))
+      (is (= :no-matches (:empty-kind feed)))
+      (is (= 99999 (:cascade-dispatch-id feed))))))
+
+(deftest project-feed-from-state-cascade-scope-ungrouped-matches-nil-dispatch-id
+  (testing "rf2-ycoct: scope :ungrouped matches rows whose :dispatch-id
+            is nil (the projection's catch-all bucket)"
+    (let [evs   [(ev {:id 1 :op-type :event :operation :event/dispatched
+                      :time 100 :source :ui})           ; no dispatch-id
+                 (ev {:id 2 :op-type :event :operation :event/dispatched
+                      :time 200 :source :ui :dispatch-id 10})
+                 (ev {:id 3 :op-type :info  :operation :rf/lifecycle
+                      :time 300 :source :ui})]          ; no dispatch-id
+          state (h/rebuild-feed-state evs)
+          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id :ungrouped})]
+      (is (= 2 (:rendered feed))
+          "rows 1 and 3 have no :dispatch-id → they belong to :ungrouped")
+      (is (= #{1 3} (set (mapv :id (:rows feed))))))))
+
+(deftest project-feed-from-state-no-focus-defensive-empty-state
+  (testing "rf2-ycoct defensive: opts passed with nil :cascade-dispatch-id
+            and a non-empty buffer triggers :no-focus (the default-focus
+            rule from rf2-639lc should prevent this in production)"
+    (let [evs   (events-fixture)
+          state (h/rebuild-feed-state evs)
+          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id nil})]
+      (is (= :no-focus (:empty-kind feed)))
+      (is (= 0 (:rendered feed)))
+      (is (= [] (:rows feed)))
+      (is (= 5 (:total feed))
+          ":total reflects the buffer (the state is broken, not the data)"))))
+
+(deftest project-feed-from-state-2-arity-preserves-global-ribbon-shape
+  (testing "rf2-ycoct: the 2-arity (no opts) keeps the pre-rf2-ycoct
+            global-ribbon behaviour — no cascade-scope, no :no-focus
+            defensive branch. Headless test rigs / callers that pre-
+            date the spine wiring continue to work."
+    (let [evs   (events-fixture)
+          state (h/rebuild-feed-state evs)
+          feed  (h/project-feed-from-state state {})]
+      (is (= 5 (:rendered feed))
+          "every buffered row renders — no cascade-scope applied")
+      (is (nil? (:empty-kind feed)))
+      (is (nil? (:cascade-dispatch-id feed))
+          "the scope key is nil (no scope was passed)"))))
+
+(deftest project-feed-from-state-cascade-scope-empty-buffer
+  (testing "rf2-ycoct: with an empty buffer, :no-events wins regardless
+            of the cascade-scope value (the buffer is empty FIRST,
+            scoping is a no-op)"
+    (let [state (h/init-feed-state)
+          feed  (h/project-feed-from-state state {} {:cascade-dispatch-id 100})]
+      (is (= :no-events (:empty-kind feed))
+          ":no-events takes precedence over :no-focus when total = 0"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -50,7 +50,8 @@
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.test-support :as causa-test-support]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
-            [day8.re-frame2-causa.panels.trace :as trace]))
+            [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.panels.trace-helpers :as h]))
 
 ;; ---- fixtures -----------------------------------------------------------
 
@@ -224,11 +225,15 @@
 
 (deftest empty-state-no-matches-renders-when-filters-hide-all
   (testing "with events present but a filter that matches nothing the
-            panel renders the :no-matches empty-state with clear button"
+            panel renders the :no-matches empty-state with clear button.
+            The event carries `:dispatch-id 1` so the spine has a
+            focusable cascade (rf2-fzbrw strips :ungrouped from the
+            focusable list; without a focusable cascade the panel
+            would render :no-focus, not :no-matches)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui}))
+                              :source :ui :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :no-such-source])
       (let [tree (trace/Panel)]
         (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches"))
@@ -265,13 +270,16 @@
           "every filter axis cleared"))))
 
 (deftest filter-by-source-narrows-rendered-rows
-  (testing "setting :source narrows the feed to events with that source"
+  (testing "setting :source narrows the feed to events with that source.
+            All events share `:dispatch-id 1` so the rf2-ycoct cascade-
+            scope is a no-op for this axis-in-isolation assertion (the
+            spine's head cascade is 1, every row is in scope)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
                               :source :ui :dispatch-id 1}))
       (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                              :source :timer :dispatch-id 2}))
+                              :source :timer :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 2 (:total feed)))
@@ -279,12 +287,19 @@
         (is (= [1] (mapv :id (:rows feed))))))))
 
 (deftest filter-by-op-type-narrows-rendered-rows
-  (testing "setting :op-type narrows the feed to events with that op-type"
+  (testing "setting :op-type narrows the feed to events with that op-type.
+            All events share `:dispatch-id 1` so the rf2-ycoct cascade-
+            scope is a no-op (rf2-fzbrw strips :ungrouped from focusable
+            cascades — events without :dispatch-id would otherwise leave
+            the spine with no focusable cascade and trigger :no-focus)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched}))
-      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw}))
-      (push-trace! (mk-trace {:id 3 :op-type :fx    :operation :rf.fx/handled}))
+      (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                              :dispatch-id 1}))
+      (push-trace! (mk-trace {:id 2 :op-type :error :operation :rf.error/handler-threw
+                              :dispatch-id 1}))
+      (push-trace! (mk-trace {:id 3 :op-type :fx    :operation :rf.fx/handled
+                              :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :op-type :error])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 1 (:rendered feed)))
@@ -292,15 +307,16 @@
 
 (deftest filter-axes-compose-and-wise
   (testing "two filter axes compose AND-wise — only rows matching both
-            survive"
+            survive. All events share `:dispatch-id 1` so the rf2-ycoct
+            cascade-scope is a no-op for this composition assertion."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui    :frame :rf/default}))
+                              :source :ui    :frame :rf/default :dispatch-id 1}))
       (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                              :source :ui    :frame :rf/causa}))
+                              :source :ui    :frame :rf/causa   :dispatch-id 1}))
       (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                              :source :timer :frame :rf/default}))
+                              :source :timer :frame :rf/default :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
       (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/default])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
@@ -309,7 +325,14 @@
         (is (= [1] (mapv :id (:rows feed))))))))
 
 (deftest filter-by-dispatch-id-collapses-cascade
-  (testing "setting :dispatch-id slices the feed to one cascade's events"
+  (testing "setting :dispatch-id slices the feed to one cascade's events.
+            Per rf2-ycoct the panel is cascade-scoped to the focused
+            cascade by default; here we explicitly focus 42, then the
+            user's `:dispatch-id` chip-filter narrows to the same id
+            (redundant in this case — both filters land on the same
+            set, which is the expected workflow when the user clicks
+            the dispatch-id chip on a row of the already-focused
+            cascade)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
@@ -318,6 +341,10 @@
                               :dispatch-id 42}))
       (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
                               :dispatch-id 99}))
+      ;; Focus cascade 42 (the spine's LIVE auto-snap would land on 99 —
+      ;; the head — so we pin to 42 explicitly to assert the axis
+      ;; filter algebra in isolation from the auto-scope).
+      (rf/dispatch-sync [:rf.causa/focus-cascade 42])
       (rf/dispatch-sync [:rf.causa/set-trace-filter :dispatch-id 42])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 2 (:rendered feed)))
@@ -464,7 +491,11 @@
             :key of any previously-rendered <li>. Same input row → same
             React key → React's reconciler reuses the DOM node instead
             of unmounting + remounting it. Mirrors rf2-kgn0c's
-            v:<variant-id> discipline in the story workspace."
+            v:<variant-id> discipline in the story workspace.
+
+            All six events share `:dispatch-id 1` so the rf2-ycoct
+            cascade-scope is a no-op for this key-stability assertion
+            (the spine's head cascade stays 1, every row is in scope)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Seed three rows.
@@ -482,14 +513,15 @@
             "every initial row carries a React :key")
         (is (= 3 (count (distinct (vals keys-1))))
             "initial row keys are distinct")
-        ;; Push three more events — under the broken positional-key
-        ;; shape, this would shift every existing key.
+        ;; Push three more events in the SAME cascade — under the
+        ;; broken positional-key shape, this would shift every
+        ;; existing key.
         (sync-push! (mk-trace {:id 4 :op-type :event :operation :event/dispatched
-                               :time 400 :dispatch-id 2}))
+                               :time 400 :dispatch-id 1}))
         (sync-push! (mk-trace {:id 5 :op-type :fx    :operation :rf.fx/handled
-                               :time 500 :dispatch-id 2}))
+                               :time 500 :dispatch-id 1}))
         (sync-push! (mk-trace {:id 6 :op-type :error :operation :rf.error/handler-threw
-                               :time 600 :dispatch-id 2}))
+                               :time 600 :dispatch-id 1}))
         (let [tree-2 (trace/Panel)
               keys-2 {1 (:key (second (row-li-by-id tree-2 1)))
                       2 (:key (second (row-li-by-id tree-2 2)))
@@ -568,14 +600,18 @@
 (deftest orphan-empty-state-surfaces-active-filter-strip
   (testing "rf2-vu0mp: the :no-matches empty state surfaces an
             'narrowing on:' strip listing each active axis=value pair
-            so the user always sees what is filtering the ribbon"
+            so the user always sees what is filtering the ribbon.
+            Events carry `:dispatch-id 1` so the spine has a focusable
+            cascade (rf2-fzbrw)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push two events that won't match the filter.
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app :frame :rf/default}))
+                             :source :ui :origin :app :frame :rf/default
+                             :dispatch-id 1}))
       (sync-push! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                             :source :ui :origin :app :frame :rf/default}))
+                             :source :ui :origin :app :frame :rf/default
+                             :dispatch-id 1}))
       ;; Narrow on a value the buffer doesn't carry — orphan.
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
       (let [tree (trace/Panel)]
@@ -589,11 +625,13 @@
 (deftest active-filter-pill-click-drops-the-axis
   (testing "rf2-vu0mp: clicking an active-filter pill drops that axis
             from the filter map (lets the user clear an orphan without
-            hunting through the header)"
+            hunting through the header). Event carries `:dispatch-id 1`
+            so the spine has a focusable cascade (rf2-fzbrw)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default}))
+                             :source :ui :frame :rf/default
+                             :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
       (rf/dispatch-sync [:rf.causa/set-trace-filter :frame :rf/missing])
       (let [dispatches (atom [])]
@@ -612,14 +650,17 @@
 (deftest empty-state-active-filter-pill-marks-present-vs-orphan
   (testing "rf2-vu0mp: a present axis pill (the value still exists in
             the buffer) is styled differently from an orphan pill — the
-            data-driven marker on the chip label."
+            data-driven marker on the chip label. Event carries
+            `:dispatch-id 1` so the spine has a focusable cascade
+            (rf2-fzbrw)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push :ui-sourced events; then add TWO filters: source = :ui
       ;; (present, but combined with the second filter renders zero
       ;; rows) AND frame = :rf/missing (orphan).
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default}))
+                             :source :ui :frame :rf/default
+                             :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
       (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/missing])
       (let [tree         (trace/Panel)
@@ -735,4 +776,165 @@
         (is (contains? feed :any-filter?))
         (is (contains? feed :empty-kind))
         (is (contains? feed :active-filters)
-            "rf2-vu0mp adds :active-filters for the empty-state strip")))))
+            "rf2-vu0mp adds :active-filters for the empty-state strip")
+        (is (contains? feed :cascade-dispatch-id)
+            "rf2-ycoct adds :cascade-dispatch-id for the spine-scoped
+             view")))))
+
+;; ---- (11) cascade-scope (focused-event invariant) — rf2-ycoct ----------
+;;
+;; Per spec/018 §6 every L4 panel is a lens on the spine's focused event,
+;; not a global ribbon. Mike's call (audit findings 2026-05-18) on
+;; rf2-ycoct: the Trace tab is cascade-scoped by default. The composite
+;; reads :rf.causa/focus and pre-filters rows to the focused cascade's
+;; events; user chip filters AND on top of the scope.
+
+(deftest trace-feed-cascade-scoped-to-focused-event
+  (testing "rf2-ycoct: with two cascades in the buffer, focusing one
+            scopes the feed to that cascade's events. Switching focus
+            to the other re-renders with the other cascade's events."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Cascade A: dispatch-id 100, events 1+2.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 100 :frame :rf/default}))
+      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                             :time 110 :dispatch-id 100 :frame :rf/default}))
+      ;; Cascade B: dispatch-id 200, events 3+4+5.
+      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                             :time 200 :dispatch-id 200 :frame :rf/default}))
+      (sync-push! (mk-trace {:id 4 :op-type :fx    :operation :rf.fx/handled
+                             :time 210 :dispatch-id 200 :frame :rf/default}))
+      (sync-push! (mk-trace {:id 5 :op-type :error :operation :rf.error/x
+                             :time 220 :dispatch-id 200 :frame :rf/default}))
+      ;; Focus cascade A.
+      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 5 (:total feed))
+            ":total reflects the ENTIRE buffer (unscoped count) —
+             cascade-scope narrows what RENDERS, not what's in the
+             buffer")
+        (is (= 2 (:rendered feed))
+            "only the two events in cascade A are rendered")
+        (is (= #{1 2} (set (mapv :id (:rows feed))))
+            "rows are exactly cascade A's events")
+        (is (= 100 (:cascade-dispatch-id feed))
+            "the scope value rides on the feed shape"))
+      ;; Pivot focus to cascade B.
+      (rf/dispatch-sync [:rf.causa/focus-cascade 200])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 3 (:rendered feed))
+            "rendered count flips to cascade B's three events")
+        (is (= #{3 4 5} (set (mapv :id (:rows feed))))
+            "rows are exactly cascade B's events")
+        (is (= 200 (:cascade-dispatch-id feed)))))))
+
+(deftest trace-feed-user-chip-filter-ands-with-cascade-scope
+  (testing "rf2-ycoct: user chip filters AND on top of the cascade
+            scope — the panel is a lens AND a filterable ribbon."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Cascade A: two events, mixed sources.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 100 :source :ui}))
+      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                             :time 110 :dispatch-id 100 :source :timer}))
+      ;; Cascade B: one :ui-sourced event (would survive a global
+      ;; :source :ui filter if scope were not applied).
+      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                             :time 200 :dispatch-id 200 :source :ui}))
+      ;; Focus cascade A, then narrow on :source :ui — the AND-wise
+      ;; result must be cascade-A AND :source :ui = event 1 only.
+      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 1 (:rendered feed))
+            "AND-wise: cascade-A ∩ :source :ui = event 1 only")
+        (is (= [1] (mapv :id (:rows feed))))
+        (is (true? (:any-filter? feed))
+            ":any-filter? reflects USER filter state (cascade-scope is
+             a system invariant, not a user narrowing)")))))
+
+(deftest trace-feed-live-mode-auto-tracks-head-cascade
+  (testing "rf2-ycoct + rf2-s0s5x: in LIVE mode the spine auto-tracks
+            the head cascade, so a new cascade landing rebinds the
+            scope automatically. No explicit focus event needed — the
+            panel ALWAYS shows the latest cascade by default."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Cascade A — head while it's alone.
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 100}))
+      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                             :time 110 :dispatch-id 100}))
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 2 (:rendered feed))
+            "with one cascade, LIVE auto-scope shows that cascade")
+        (is (= 100 (:cascade-dispatch-id feed))))
+      ;; Cascade B lands — head pivots, LIVE auto-tracks.
+      (sync-push! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
+                             :time 200 :dispatch-id 200}))
+      (sync-push! (mk-trace {:id 4 :op-type :fx    :operation :rf.fx/handled
+                             :time 210 :dispatch-id 200}))
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (= 2 (:rendered feed))
+            "scope auto-pivoted to cascade B (the new head)")
+        (is (= #{3 4} (set (mapv :id (:rows feed)))))
+        (is (= 200 (:cascade-dispatch-id feed)))))))
+
+(deftest trace-feed-cascade-scope-no-match-renders-no-matches
+  (testing "rf2-ycoct: when the focused cascade is in the buffer but
+            user filters reduce it to zero rendered rows, the
+            :no-matches empty-state renders (not :no-events)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :time 100 :dispatch-id 100 :source :ui}))
+      (sync-push! (mk-trace {:id 2 :op-type :fx    :operation :rf.fx/handled
+                             :time 110 :dispatch-id 100 :source :ui}))
+      (rf/dispatch-sync [:rf.causa/focus-cascade 100])
+      ;; Narrow on a source that doesn't exist in cascade A.
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])
+            tree (trace/Panel)]
+        (is (= :no-matches (:empty-kind feed)))
+        (is (some? (find-by-testid tree "rf-causa-trace-empty-no-matches")))))))
+
+(deftest trace-feed-defensive-no-focus-empty-state
+  (testing "rf2-ycoct defensive branch: when the buffer is non-empty
+            but the spine's focus has no :dispatch-id (default-focus
+            rule from rf2-639lc broken / not yet applied), the panel
+            renders the terse :no-focus empty state.
+
+            We construct this state directly via the helper to pin the
+            contract — the spine's LIVE auto-snap normally prevents
+            this state from arising in the running app."
+    (let [state  (h/rebuild-feed-state
+                   [(mk-trace {:id 1 :op-type :event
+                               :operation :event/dispatched
+                               :dispatch-id 100})])
+          feed   (h/project-feed-from-state
+                   state {} {:cascade-dispatch-id nil})]
+      (is (= :no-focus (:empty-kind feed)))
+      (is (= 0 (:rendered feed))
+          "no rows render in the no-focus defensive branch")
+      (is (= 1 (:total feed))
+          ":total still reflects the buffer (the state is broken,
+           not the data)"))))
+
+(deftest panel-spine-auto-snap-guards-against-no-focus-in-production
+  (testing "rf2-ycoct + rf2-s0s5x guard: in LIVE mode with cascades
+            present, the spine ALWAYS snaps focus to head — the
+            defensive :no-focus state should never arise in production.
+            This pins the contract: a regression in the spine's auto-
+            snap behaviour that left :dispatch-id nil with a non-empty
+            buffer would fail this assertion."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
+                             :dispatch-id 100}))
+      (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
+        (is (not= :no-focus (:empty-kind feed))
+            "LIVE auto-snap → focus has :dispatch-id 100 → no :no-focus")
+        (is (= 100 (:cascade-dispatch-id feed))
+            "scope landed on the head cascade automatically")))))

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -703,19 +703,31 @@ async function pushSyntheticTraceEvents(page, count) {
         ? cljs.keyword.call(null, trimmed)
         : cljs.keyword(trimmed);
     }
+    // Post rf2-ycoct: the Trace tab is cascade-scoped — it only
+    // renders rows belonging to the spine's focused cascade. To stress
+    // the per-cascade 200-row DOM budget we push every synthetic event
+    // under a SINGLE shared :dispatch-id so the buffer holds one
+    // focusable cascade containing all `eventCount` rows; LIVE mode
+    // auto-snaps focus to that head cascade and the trace ribbon ends
+    // up trying to render all 1000 — which the DOM budget then caps at
+    // 200 with the overflow indicator. (The earlier shape allocated a
+    // distinct :dispatch-id per event, producing 1000 single-row
+    // cascades; under cascade-scoping only the head cascade — a single
+    // row — would render, missing the budget assertion entirely.)
+    const sharedDispatchId = 500000;
     const now = Date.now();
     for (let i = 0; i < eventCount; i += 1) {
-      const dispatchId = 500000 + i;
+      const eventId = sharedDispatchId + i;
       const tags = cljs.hash_map(
         keyword(':frame'), keyword(':rf/default'),
         keyword(':event-id'), keyword(':causa.synthetic/load'),
         keyword(':event'), cljs.PersistentVector.fromArray([keyword(':causa.synthetic/load'), i], true),
-        keyword(':dispatch-id'), dispatchId,
+        keyword(':dispatch-id'), sharedDispatchId,
         keyword(':origin'), keyword(':app'),
         keyword(':source'), keyword(':synthetic'),
       );
       const ev = cljs.hash_map(
-        keyword(':id'), dispatchId,
+        keyword(':id'), eventId,
         keyword(':time'), now + i,
         keyword(':operation'), keyword(':event/dispatched'),
         keyword(':op-type'), keyword(':info'),

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -621,35 +621,118 @@ async function setCausaTraceFilter(page, axis, value) {
   }
 }
 
-async function clickTraceRowByFrame(page, { frame, event }) {
-  const result = await page.evaluate(({ targetFrame, targetEvent }) => {
-    const root = document.getElementById('rf-causa-root');
-    if (!root) return { clicked: false, reason: 'Causa root missing', candidates: [] };
-    const rows = Array.from(root.querySelectorAll('[data-testid^="rf-causa-trace-row-"]'));
-    const candidates = rows.map((row) => ({
-      testId: row.getAttribute('data-testid'),
-      text: (row.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240),
-    }));
-    const target = rows.find((row) => {
-      const text = (row.textContent || '').trim();
-      return text.includes(targetFrame) && text.includes(targetEvent);
-    });
-    if (!target) {
+/**
+ * Find the `:dispatch-id` of the bus trace event matching the given
+ * (`frame`, `eventId`) pair (an `:event/dispatched` record) and
+ * dispatch `:rf.causa/focus-cascade` to focus that cascade.
+ *
+ * Replaces the old `clickTraceRowByFrame` helper: post rf2-ycoct the
+ * Trace DOM is cascade-scoped and only renders rows for the currently
+ * focused cascade, so scanning trace rows to "find and click" a
+ * sibling cascade no longer works. The bus buffer is the canonical,
+ * unscoped source of (frame, event) → dispatch-id, and `:rf.causa/
+ * focus-cascade` is the same spine event the L2 event-row click
+ * dispatches — picking a cascade through this helper exercises the
+ * same focus → projection wiring without depending on the cascade-
+ * scoped Trace surface.
+ */
+async function focusCascadeByFrameEvent(page, { frame, eventId }) {
+  const result = await page.evaluate(({ targetFrame, targetEventId }) => {
+    const cljs = window.cljs && window.cljs.core;
+    const rf = window.re_frame && window.re_frame.core;
+    const bus = window.day8 &&
+      window.day8.re_frame2_causa &&
+      window.day8.re_frame2_causa.trace_bus;
+    const dispatch = rf && (rf.dispatch_STAR_ ||
+      (window.re_frame.router && window.re_frame.router.dispatch_BANG_));
+    if (!cljs || !bus || typeof bus.buffer !== 'function' ||
+        typeof dispatch !== 'function') {
       return {
-        clicked: false,
-        reason: `No trace row matched frame=${targetFrame} event=${targetEvent}`,
+        ok: false,
+        reason: 'cljs.core / trace_bus.buffer / re_frame dispatch unavailable',
+      };
+    }
+    function keyword(s) {
+      const trimmed = String(s).replace(/^:/, '');
+      const parts = trimmed.split('/');
+      if (parts.length === 2) {
+        return cljs.keyword.call
+          ? cljs.keyword.call(null, parts[0], parts[1])
+          : cljs.keyword(parts[0], parts[1]);
+      }
+      return cljs.keyword.call
+        ? cljs.keyword.call(null, trimmed)
+        : cljs.keyword(trimmed);
+    }
+    const kFrame      = keyword(':frame');
+    const kEvent      = keyword(':event');
+    const kTags       = keyword(':tags');
+    const kOperation  = keyword(':operation');
+    const kDispatchId = keyword(':dispatch-id');
+    const opDispatched   = keyword(':event/dispatched');
+    const targetFrameKw  = keyword(targetFrame);
+    const targetEventKw  = keyword(targetEventId);
+    // Walk bus buffer; first match wins (events are append-ordered so
+    // this is the originating `:event/dispatched` record). The raw
+    // framework trace puts the dispatched event vector under
+    // `:tags :event`; the event-id is `(first event-vector)`. We do
+    // NOT read `:tags :event-id` — Causa's projection materialises
+    // that field but the trace-bus's stored events do not carry it.
+    let s = cljs.seq(bus.buffer());
+    let match = null;
+    const candidates = [];
+    while (s) {
+      const ev   = cljs.first(s);
+      const op   = cljs.get(ev, kOperation);
+      const tags = cljs.get(ev, kTags);
+      const evFrame    = tags ? cljs.get(tags, kFrame)      : null;
+      const evVec      = tags ? cljs.get(tags, kEvent)      : null;
+      const dispatchId = tags ? cljs.get(tags, kDispatchId) : null;
+      const evEventId  = (evVec != null && cljs.seq(evVec)) ? cljs.first(evVec) : null;
+      if (op && cljs._EQ_(op, opDispatched)) {
+        candidates.push({
+          frame:     evFrame   ? cljs.pr_str(evFrame)   : null,
+          eventId:   evEventId ? cljs.pr_str(evEventId) : null,
+          dispatchId,
+        });
+        if (evFrame && evEventId &&
+            cljs._EQ_(evFrame, targetFrameKw) &&
+            cljs._EQ_(evEventId, targetEventKw)) {
+          match = { frame: evFrame, dispatchId };
+          break;
+        }
+      }
+      s = cljs.next(s);
+    }
+    if (!match) {
+      return {
+        ok: false,
+        reason: `No bus :event/dispatched record matched frame=${targetFrame} event-id=${targetEventId}`,
         candidates: candidates.slice(0, 20),
       };
     }
-    target.click();
+    const event = cljs.PersistentVector.fromArray([
+      keyword(':rf.causa/focus-cascade'),
+      match.dispatchId,
+      match.frame,
+    ], true);
+    const opts = cljs.hash_map(keyword(':frame'), keyword(':rf/causa'));
+    if (dispatch.cljs$core$IFn$_invoke$arity$2) {
+      dispatch.cljs$core$IFn$_invoke$arity$2(event, opts);
+    } else {
+      dispatch(event, opts);
+    }
     return {
-      clicked: true,
-      testId: target.getAttribute('data-testid'),
-      text: (target.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 240),
+      ok: true,
+      frame: targetFrame,
+      eventId: targetEventId,
+      dispatchId: match.dispatchId,
     };
-  }, { targetFrame: frame, targetEvent: event });
-  if (!result.clicked) {
-    failWithDetails('Could not select trace row by frame', { frame, event, observed: result });
+  }, { targetFrame: frame, targetEventId: eventId });
+  if (!result.ok) {
+    failWithDetails('Could not focus cascade by (frame, event-id)', {
+      frame, eventId, observed: result,
+    });
   }
   return result;
 }
@@ -1155,9 +1238,24 @@ async function runMultiFrame(page, state) {
     (count) => count > 0,
     { timeoutMs: 5000, description: 'multi-frame trace rows' },
   );
-  const selected = await clickTraceRowByFrame(page, {
+  // Post rf2-ycoct: the Trace tab is cascade-scoped — it only renders
+  // rows belonging to the spine's focused cascade. LIVE mode auto-
+  // snaps focus to the head cascade (the most recent dispatch), so
+  // unless the :counter/b :multi-frame.core/inc cascade happens to be
+  // the head the Trace DOM never contains that row. The old test
+  // scanned `[data-testid^="rf-causa-trace-row-"]` for it directly
+  // and failed under cascade-scoping.
+  //
+  // The test's intent — exercise the cascade-focus → event-detail
+  // wiring for a chosen :counter/b cascade — is preserved by focusing
+  // the cascade explicitly via the spine event `:rf.causa/focus-
+  // cascade` (the same event the L2 event-row click dispatches) and
+  // then asserting the event-detail projection. We look up the
+  // dispatch-id by walking the bus buffer for the (frame, event-id)
+  // pair, which is independent of the cascade-scoped Trace DOM.
+  const selected = await focusCascadeByFrameEvent(page, {
     frame: ':counter/b',
-    event: ':multi-frame.core/inc',
+    eventId: ':multi-frame.core/inc',
   });
   state.multiFrame.selectedTraceRow = selected;
   await clickTab(page, 'event', 'rf-causa-event-detail');
@@ -1174,7 +1272,7 @@ async function runMultiFrame(page, state) {
       };
     }),
     (projection) => projection.selectedCascadeFrame === ':counter/b',
-    { timeoutMs: 5000, description: 'event-detail projection after selecting B trace row' },
+    { timeoutMs: 5000, description: 'event-detail projection after focusing B cascade' },
   );
   state.multiFrame.eventDetailProjection = eventDetailProjection;
   if (eventDetailProjection.orphanedText ||


### PR DESCRIPTION
## Summary

Per Mike's call on **rf2-ycoct** (cascade-scoped by default) and the
audit findings in `ai/findings/2026-05-18-tab-focus-invariant-audit.md`
§Trace: the Trace tab now honours the focused-event invariant from
spec/018 §6 — it's a lens on the spine's focused event, not a global
ribbon.

- Trace composite sub subscribes to `:rf.causa/focus` and pre-filters
  rows to the focused cascade's events.
- User chip filters AND on top of the cascade scope (the chip rows
  continue to reflect user state only — cascade-scope is a system
  invariant, not a user narrowing).
- New defensive `:no-focus` empty state for the rf2-639lc-violation
  case (buffer non-empty but spine has no `:dispatch-id`) — the spine's
  LIVE auto-snap (rf2-s0s5x / rf2-fzbrw) is structurally guaranteed to
  prevent this, but the helper-level contract is pinned by tests.

## Files

- `tools/causa/src/day8/re_frame2_causa/panels/trace.cljs` — composite
  sub gains `:<- [:rf.causa/focus]`; panel view adds the `:no-focus`
  case branch.
- `tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc` —
  `project-feed-from-state` gains a 3-arity for `{:cascade-dispatch-id}`;
  returned shape adds `:cascade-dispatch-id` and the new `:no-focus`
  `:empty-kind`.
- `tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc`
  — seven new pure-data tests pin the cascade-scope contract.
- `tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs`
  — four new wiring tests (cascade narrows by focus, pivots on focus
  change, ANDs with user filter, LIVE auto-tracks head) + existing
  tests updated to give events a `:dispatch-id` so the spine has a
  focusable cascade (rf2-fzbrw strips `:ungrouped` from focusables).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 937 tests / 2705 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — 3212 tests / 9225 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 3203 tests / 9180 assertions / 0 failures