### PR TITLE
fix(causa): L2 event-list auto-scrolls in LIVE mode + slim scrollbar

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -560,6 +560,118 @@
 
 ;; ---- L2 event list -------------------------------------------------------
 
+;; ---- L2 scrollbar styling (rf2-ieg6d Bug 2) ------------------------------
+;;
+;; The default browser scrollbar is chunky (16-17px) and stylistically loud
+;; — wrong rhythm for an info-dense devtools panel. Firefox accepts the
+;; standardised `scrollbar-width` / `scrollbar-color` inline (set on the
+;; container's `:style`). WebKit/Blink still ship the legacy `::-webkit-
+;; scrollbar` pseudo-elements which can ONLY be reached via a real CSS
+;; stylesheet (no React inline-style equivalent), so we inject a one-shot
+;; `<style>` tag scoped to `[data-testid="rf-causa-event-list"]` at
+;; namespace load. The scope keeps the slim chrome confined to the L2
+;; list — no global page-level webkit-scrollbar override (would conflict
+;; with host-app stylesheets).
+;;
+;; `defonce` + idempotent DOM probe keeps shadow-cljs `:after-load` from
+;; double-injecting; the guard skips the side-effect entirely under node-
+;; test where `js/document` does not exist.
+
+(def ^:private scrollbar-style-id
+  "rf-causa-event-list-scrollbar")
+
+(def ^:private scrollbar-css
+  "Webkit/Blink slim-scrollbar rules scoped to the L2 event-list container.
+  Mirror of the inline Firefox `scrollbar-width`/`-color` props so all
+  browsers land on the same visual rhythm.
+
+  Colours echo `(:border-subtle tokens)` / `(:text-tertiary tokens)` —
+  hardcoded as hex/rgba here because the rule lives in a string outside
+  the hiccup tree where the tokens map isn't directly available."
+  (str "[data-testid=\"rf-causa-event-list\"]::-webkit-scrollbar"
+       " { width: 6px; height: 6px; }"
+       "[data-testid=\"rf-causa-event-list\"]::-webkit-scrollbar-track"
+       " { background: transparent; }"
+       "[data-testid=\"rf-causa-event-list\"]::-webkit-scrollbar-thumb"
+       " { background: rgba(107, 112, 128, 0.4); border-radius: 3px; }"
+       "[data-testid=\"rf-causa-event-list\"]::-webkit-scrollbar-thumb:hover"
+       " { background: rgba(107, 112, 128, 0.7); }"))
+
+(defonce ^:private scrollbar-style-injected?
+  ;; defonce so shadow-cljs `:after-load` doesn't re-inject; the `<style>`
+  ;; node itself is identified by `id` so even a fresh load reusing this
+  ;; symbol would not double-inject.
+  (atom false))
+
+(defn- inject-scrollbar-style!
+  "Idempotent one-shot injection of the slim-scrollbar CSS into
+  `<head>`. No-op when `js/document` is absent (node-test) or the
+  style node is already present."
+  []
+  (when (and (not @scrollbar-style-injected?)
+             (exists? js/document)
+             (.-head js/document)
+             (.-createElement js/document))
+    (let [existing (when (.-getElementById js/document)
+                     (.getElementById js/document scrollbar-style-id))]
+      (when-not existing
+        (let [node (.createElement js/document "style")]
+          (set! (.-id node) scrollbar-style-id)
+          (.appendChild node (.createTextNode js/document scrollbar-css))
+          (.appendChild (.-head js/document) node))))
+    (reset! scrollbar-style-injected? true)))
+
+;; ---- L2 auto-scroll on focus change (rf2-ieg6d Bug 1) --------------------
+;;
+;; When a new event arrives + mode=:live + focus auto-advances to head,
+;; the focused row may render below the L2 list's visible window. The
+;; LIVE pill says "tracking head" but the user can't see the head row
+;; — defeats the LIVE UX. Fix: a `:ref` callback on the focused row
+;; that calls `scrollIntoView` when (a) we just landed on a new id and
+;; (b) the spine is in :live mode at head (the auto-tracking branch).
+;;
+;; RETRO clicks already place the focused row where the user clicked
+;; (it's already visible — they just clicked it), so we deliberately
+;; skip scroll-into-view in RETRO to avoid stealing the cursor.
+
+(defonce ^:private last-scrolled-focus-id
+  ;; Closure atom keyed by focused dispatch-id. The ref callback fires
+  ;; once per attached DOM element; we scroll only when the id changes
+  ;; relative to this atom (otherwise React's normal re-renders would
+  ;; re-trigger scroll on every parent rerender).
+  (atom ::never))
+
+(defn- scroll-focused-row-into-view!
+  "Imperative scroll. Called from the focused row's `:ref` callback
+  when a new focus id lands in LIVE+head. Guarded against test
+  environments where the DOM element is a hand-rolled stub without
+  `.scrollIntoView`."
+  [^js el]
+  (when (and el (.-scrollIntoView el))
+    (.scrollIntoView el #js {:behavior "auto" :block "nearest"})))
+
+(defn- focused-row-ref
+  "Build the `:ref` callback for a row that is BOTH focused AND in the
+  auto-tracking branch (LIVE + head). Returns nil when not in the
+  auto-tracking branch — non-nil rows always get a ref attachment
+  cycle on first mount, which would otherwise scroll on every initial
+  RETRO render too.
+
+  The callback compares `id` against `last-scrolled-focus-id` and
+  scrolls + updates the atom only on transition. nil-element calls
+  (React's unmount signal) reset the atom so a re-mount of the same
+  id will scroll again (covers the toggle-off/on case)."
+  [id auto-track?]
+  (when auto-track?
+    (fn [el]
+      (cond
+        (nil? el)
+        (reset! last-scrolled-focus-id ::never)
+
+        (not= id @last-scrolled-focus-id)
+        (do (reset! last-scrolled-focus-id id)
+            (scroll-focused-row-into-view! el))))))
+
 (defn- event-row
   "One row in the L2 event list. Single line per spec/018 §4 Row
   anatomy. Gutter glyph + event-id + right-anchored badge cluster +
@@ -574,7 +686,7 @@
   multi-item menu lands behind a follow-on bead); preventing the
   browser context menu keeps the affordance discoverable on first
   right-click."
-  [{:keys [cascade focused-id]}]
+  [{:keys [cascade focused-id auto-track?]}]
   (let [id        (:dispatch-id cascade)
         focused?  (= id focused-id)
         glyph     (gutter-glyph cascade focused-id)
@@ -589,36 +701,41 @@
         bg        (if focused? (:bg-active tokens) "transparent")
         border    (if focused?
                     (str "1px solid " (:cyan tokens))
-                    "1px solid transparent")]
+                    "1px solid transparent")
+        ;; rf2-ieg6d Bug 1 — only the focused row in the LIVE-at-head
+        ;; auto-tracking branch carries a ref. RETRO and non-focused rows
+        ;; get nil (no DOM-side scroll work, no per-render cost).
+        ref-fn    (when focused? (focused-row-ref id auto-track?))]
     ;; Density (rf2-htik0 Bug 2): height 22px + padding "1px 6px" tightens
     ;; the row from the earlier 28px / "4px 8px" spec-baseline. Causa is
     ;; info-dense; keeps clickable hit-area while letting ~10 rows fit in
     ;; the same vertical budget the old 8 rows used.
-    [:li {:data-testid (str "rf-causa-event-row-" (str id))
-          :on-click    #(rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
-                                     {:frame :rf/causa})
-          :on-context-menu (fn [^js e]
-                             (when ev-id
-                               (.preventDefault e)
-                               (rf/dispatch
-                                 [:rf.causa/hide-event-type ev-id]
-                                 {:frame :rf/causa})))
-          :style {:display       "flex"
-                  :align-items   "center"
-                  :gap           "6px"
-                  :padding       "1px 6px"
-                  :height        "22px"
-                  :line-height   "20px"
-                  :cursor        "pointer"
-                  :background    bg
-                  :border        border
-                  :border-radius "2px"
-                  :font-family   mono-stack
-                  :font-size     (:mono-body type-scale)
-                  :color         (:text-primary tokens)
-                  :white-space   "nowrap"
-                  :overflow      "hidden"
-                  :text-overflow "ellipsis"}}
+    [:li (cond-> {:data-testid (str "rf-causa-event-row-" (str id))
+                  :on-click    #(rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
+                                             {:frame :rf/causa})
+                  :on-context-menu (fn [^js e]
+                                     (when ev-id
+                                       (.preventDefault e)
+                                       (rf/dispatch
+                                         [:rf.causa/hide-event-type ev-id]
+                                         {:frame :rf/causa})))
+                  :style {:display       "flex"
+                          :align-items   "center"
+                          :gap           "6px"
+                          :padding       "1px 6px"
+                          :height        "22px"
+                          :line-height   "20px"
+                          :cursor        "pointer"
+                          :background    bg
+                          :border        border
+                          :border-radius "2px"
+                          :font-family   mono-stack
+                          :font-size     (:mono-body type-scale)
+                          :color         (:text-primary tokens)
+                          :white-space   "nowrap"
+                          :overflow      "hidden"
+                          :text-overflow "ellipsis"}}
+           ref-fn (assoc :ref ref-fn))
      [:span {:style {:width "14px" :color glyph-col :flex-shrink 0
                      :text-align "center"}}
       glyph]
@@ -665,11 +782,33 @@
   projection's internal bucket into the user-facing event timeline.
   Other panels (Causality Graph, Performance, etc.) keep reading
   `:rf.causa/cascades` directly so the bucket remains available where
-  it is meaningful."
+  it is meaningful.
+
+  Per rf2-ieg6d Bug 1 the focused row carries a `:ref` callback that
+  scrolls it into view when (a) focus has just moved to a new id AND
+  (b) the spine is in LIVE+head mode (i.e. the auto-tracking branch
+  from `spine/compose-focus`). RETRO clicks place the row where the
+  user clicked, so the scroll-into-view is suppressed there to avoid
+  stealing the cursor. Per rf2-ieg6d Bug 2 the container carries
+  Firefox's standardised `scrollbar-width`/`-color`; WebKit/Blink
+  rules ship via a one-shot `<style>` injection (see
+  `inject-scrollbar-style!`)."
   []
+  ;; rf2-ieg6d Bug 2 — idempotent stylesheet injection. Lives in the
+  ;; reg-view body so it runs on first paint of the L2 list (which is
+  ;; mounted by the shell-view); defonce + DOM guards keep it a
+  ;; no-op everywhere it matters.
+  (inject-scrollbar-style!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
         focus          @(rf/subscribe [:rf.causa/focus])
         focused-id     (:dispatch-id focus)
+        ;; LIVE+head+not-paused = the auto-tracking branch from
+        ;; spine/compose-focus. Only here do we want scroll-into-view
+        ;; to fire on focus change; RETRO + paused-LIVE leave the
+        ;; user's scroll position alone.
+        auto-track?    (and (= :live (:mode focus))
+                            (:head? focus)
+                            (not (:paused? focus)))
         event-cascades (filterv cascade-has-event? cascades)]
     [:div {:data-testid "rf-causa-event-list"
            :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
@@ -679,7 +818,13 @@
                    :background    (:bg-2 tokens)
                    :border-bottom (str "1px solid " (:border-subtle tokens))
                    :resize        "vertical"   ; native vertical resize for the L2/L3 drag handle
-                   :padding       "4px"}}
+                   :padding       "4px"
+                   ;; rf2-ieg6d Bug 2 — Firefox standardised props for the
+                   ;; slim scrollbar. WebKit/Blink pseudo-element rules ship
+                   ;; via the `inject-scrollbar-style!` <style> tag above —
+                   ;; pseudo-elements can't be set via React inline-style.
+                   :scrollbar-width "thin"
+                   :scrollbar-color "rgba(107, 112, 128, 0.4) transparent"}}
      (if (empty? event-cascades)
        [:div {:data-testid "rf-causa-event-list-empty"
               :style {:padding   "16px"
@@ -692,7 +837,9 @@
                            :gap "2px"}}]
              (for [cascade event-cascades]
                ^{:key (str (:dispatch-id cascade))}
-               [event-row {:cascade cascade :focused-id focused-id}])))]))
+               [event-row {:cascade     cascade
+                           :focused-id  focused-id
+                           :auto-track? auto-track?}])))]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -429,6 +429,124 @@
           ":rf.causa/focus-cascade fired with the cascade's dispatch-id"))))
 
 ;; -------------------------------------------------------------------------
+;; (4b) L2 event-list polish — slim scrollbar + auto-scroll (rf2-ieg6d)
+;; -------------------------------------------------------------------------
+;;
+;; Bug 2 — the L2 container `:style` carries the Firefox standardised
+;; `scrollbar-width`/`scrollbar-color` props (the WebKit/Blink pseudo-
+;; element rules ship via a one-shot `<style>` injection — node-test
+;; has no `js/document` so we only assert the inline-style branch here).
+;;
+;; Bug 1 — in LIVE+head mode the focused row carries a `:ref` callback
+;; that calls `scrollIntoView` when the focused id transitions. The
+;; callback is suppressed in RETRO (user clicked → already visible)
+;; and in paused-LIVE (user inspecting a frozen cascade).
+
+(deftest event-list-carries-slim-scrollbar-style
+  (testing "rf2-ieg6d Bug 2 — the L2 container :style includes the
+            Firefox slim-scrollbar props. WebKit rules ship via a
+            <style> injection (DOM-side, not assertable in node-test)."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            list-el (find-by-testid tree "rf-causa-event-list")
+            style  (:style (second list-el))]
+        (is (some? list-el) "event-list container present")
+        (is (= "thin" (:scrollbar-width style))
+            ":scrollbar-width is thin (Firefox slim)")
+        (is (string? (:scrollbar-color style))
+            ":scrollbar-color is set (Firefox slim, thumb + track)")))))
+
+(deftest event-list-focused-row-carries-ref-in-live-head
+  (testing "rf2-ieg6d Bug 1 — in LIVE+head the focused row's hiccup
+            map carries a callable `:ref`. Cold-start auto-snaps to
+            head in :live mode (per spec/018 §4 Defaults), so the only
+            row rendered is also the focused-LIVE-head row."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [focus @(rf/subscribe [:rf.causa/focus])
+            tree  (shell/shell-view)
+            row   (find-by-testid tree "rf-causa-event-row-1")]
+        (is (= :live (:mode focus)) "spine starts in :live mode")
+        (is (:head? focus) "focus is on head")
+        (is (some? row) "focused row renders")
+        (is (fn? (:ref (second row)))
+            ":ref callback present on the LIVE+head focused row")))))
+
+(deftest event-list-focused-row-omits-ref-in-retro
+  (testing "rf2-ieg6d Bug 1 — clicking a row flips spine to :retro.
+            The focused row in RETRO must NOT carry a `:ref` callback
+            (the user clicked → already visible; scrolling would
+            steal the cursor)."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:newer/event]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade 1]))
+    (rf/with-frame :rf/causa
+      (let [focus @(rf/subscribe [:rf.causa/focus])
+            tree  (shell/shell-view)
+            row   (find-by-testid tree "rf-causa-event-row-1")]
+        (is (= :retro (:mode focus)) "spine is in :retro after focus-cascade")
+        (is (some? row) "focused row renders")
+        (is (nil? (:ref (second row)))
+            ":ref absent on the RETRO focused row")))))
+
+(deftest event-list-non-focused-row-has-no-ref
+  (testing "rf2-ieg6d Bug 1 — only the focused row gets a `:ref`. Non-
+            focused rows must not carry one (would scroll on every
+            attachment cycle)."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:older/event]))
+    (trace-bus/collect-trace! (dispatch-trace-ev 2 [:newer/event]))
+    ;; Focus auto-snaps to head (id 2). Row 1 is the non-focused row.
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            row1 (find-by-testid tree "rf-causa-event-row-1")
+            row2 (find-by-testid tree "rf-causa-event-row-2")]
+        (is (some? row1) "row 1 present")
+        (is (some? row2) "row 2 (focused head) present")
+        (is (nil? (:ref (second row1)))
+            "non-focused row 1 carries no :ref")
+        (is (fn? (:ref (second row2)))
+            "focused-head row 2 carries the :ref callback")))))
+
+(deftest focused-row-ref-scrolls-on-focus-change-only
+  (testing "rf2-ieg6d Bug 1 — the ref callback fires `scrollIntoView`
+            once when called with a new id, no-ops when called with
+            the same id (so React's normal re-render cycles don't
+            re-scroll). Drive the callback directly with a stub DOM
+            element that records `scrollIntoView` calls."
+    (let [scroll-calls (atom 0)
+          stub-el      #js {:scrollIntoView (fn [_opts]
+                                              (swap! scroll-calls inc))}
+          ;; Reset the module-level atom so this test is hermetic.
+          _            (reset! @#'shell/last-scrolled-focus-id ::reset-marker)
+          ref-fn       (#'shell/focused-row-ref 42 true)]
+      (is (fn? ref-fn) "ref-fn is a function when auto-track? is true")
+      ;; First call → scroll.
+      (ref-fn stub-el)
+      (is (= 1 @scroll-calls) "first attachment scrolls")
+      ;; Second call with same id → no scroll.
+      (ref-fn stub-el)
+      (is (= 1 @scroll-calls) "repeat attachment for same id does NOT re-scroll")
+      ;; New focus id (simulating a fresh focused-row-ref for a new
+      ;; focus). The atom is shared; a different ref-fn for a new id
+      ;; should re-scroll.
+      (let [ref-fn-2 (#'shell/focused-row-ref 99 true)]
+        (ref-fn-2 stub-el)
+        (is (= 2 @scroll-calls) "new focus id triggers a fresh scroll")))))
+
+(deftest focused-row-ref-nil-when-not-auto-tracking
+  (testing "rf2-ieg6d Bug 1 — `focused-row-ref` returns nil when the
+            spine is NOT in the auto-tracking branch. The row's hiccup
+            map then omits `:ref` (cond->) and React attaches no
+            callback."
+    (is (nil? (#'shell/focused-row-ref 42 false))
+        "auto-track? false → nil ref")))
+
+;; -------------------------------------------------------------------------
 ;; (4a) Ribbon nav button enable/disable state — rf2-htik0 Bug 1
 ;; -------------------------------------------------------------------------
 ;;


### PR DESCRIPTION
## Summary

rf2-ieg6d — two L2 polish bugs.

**Bug 1: auto-scroll in LIVE.** When a new event arrived and focus auto-advanced to head, the new focused row rendered offscreen — the `LIVE` pill claimed to be tracking but the user had to scroll to see it. Fix: focused row carries a `:ref` callback (only in the LIVE+head+not-paused auto-tracking branch) that calls `scrollIntoView({behavior:'auto', block:'nearest'})` once per focus-id transition. RETRO and paused-LIVE deliberately skip the scroll (the user is already looking — scrolling would steal the cursor).

**Bug 2: slim scrollbar.** Default chunky browser scrollbar replaced with the slim themed pattern that matches Causa's info-density. Firefox: `:scrollbar-width "thin"` + `:scrollbar-color` set inline on the L2 container's `:style`. WebKit/Blink: a one-shot `<style>` injection scoped to `[data-testid="rf-causa-event-list"]` (pseudo-elements can't ride React inline-style). `defonce` + DOM-existence guards keep it idempotent and node-test safe.

## Test plan

- [x] `cd tools/causa && clojure -M:test` → 930 tests, 0 failures
- [x] `scripts/test-fast-pr.sh` → green, including the new CLJS shell tests
- [x] `cd implementation && npm run test:cljs` → 3205 tests, 0 failures (6 new from this bead)
- [x] `cd implementation && npm run test:browser` → 3185 tests, 0 failures
- [ ] Smoke in the panel-gallery testbed (mayor — visual verify of slim scrollbar + auto-scroll on a real LIVE feed)

## New test cases (`shell_cljs_test.cljs`)

- `event-list-carries-slim-scrollbar-style` — Firefox `scrollbar-width`/`-color` pinned on the container
- `event-list-focused-row-carries-ref-in-live-head` — `:ref` present in the auto-tracking branch
- `event-list-focused-row-omits-ref-in-retro` — `:ref` absent after a row click flips to RETRO
- `event-list-non-focused-row-has-no-ref` — only the focused row carries the ref
- `focused-row-ref-scrolls-on-focus-change-only` — ref callback scrolls once per id transition, no-op on repeats
- `focused-row-ref-nil-when-not-auto-tracking` — nil ref when `auto-track?` is false