### PR TITLE
fix(causa): click on head event stays LIVE

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -611,9 +611,15 @@
   ;; keeps reading what it always has — the shim is transparent.
   (rf/reg-event-db :rf.causa/select-dispatch-id
     (fn [db [_ dispatch-id frame-id]]
-      (let [history (get db :epoch-history [])
-            epoch-id (spine/epoch-id-for-cascade history dispatch-id)]
-        (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id))))
+      (let [history  (get db :epoch-history [])
+            epoch-id (spine/epoch-id-for-cascade history dispatch-id)
+            ;; rf2-xzzih: clicking the head cascade should stay LIVE
+            ;; (auto-follow new arrivals); only non-head clicks pin
+            ;; to RETRO. Compute head off the same focusable filter
+            ;; the L2 list uses so the spine's notion of 'head'
+            ;; agrees with what the user sees as the latest row.
+            head-id  (spine/focusable-head-id (spine/db->cascades db))]
+        (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
 
   ;; Programmatic clear of the focused cascade. Resets the spine focus
   ;; back to LIVE (head-tracking) per the rf2-s0s5x Phase A semantics —

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -85,6 +85,18 @@
   [cascades]
   (:dispatch-id (head-cascade cascades)))
 
+(defn focusable-head-id
+  "The `:dispatch-id` of the head focusable cascade — i.e. the latest
+  row the user actually sees in the L2 event list. Returns nil when
+  no focusable cascades exist.
+
+  Used for click-on-head detection (rf2-xzzih): clicking the visible
+  head event should stay LIVE; the raw `head-dispatch-id` would treat
+  an `:ungrouped` bucket as the head if it sorted last, which the
+  user never sees as a focusable row."
+  [cascades]
+  (head-dispatch-id (focusable-cascades cascades)))
+
 (defn cascade-by-id
   "Find a cascade in `cascades` by its `:dispatch-id`. Returns nil when
   no match (id refers to an evicted cascade, or a fresh session).
@@ -254,13 +266,22 @@
 
 (defn focus-cascade-reducer
   "Pure reducer for the `:rf.causa/focus-cascade <id>` event. Writes
-  `:dispatch-id` into the `:focus` slot, flips to `:retro` mode,
+  `:dispatch-id` into the `:focus` slot, picks the spine `:mode`,
   stamps `:epoch-id` (the cascade's settling epoch primary key per
   spec/018 §6 Spine events), and shims the legacy
   `:selected-dispatch-id` / `:selected-dispatch` / `:selected-epoch-
   id` slots so the existing event-detail / causality / machine-
   inspector / app-db / time-travel panels keep rendering without per-
   panel change.
+
+  ## Mode selection (rf2-xzzih)
+
+  When the caller supplies `head-id` (the 5-arg arity) the reducer
+  picks the new mode head-aware: clicking the head event keeps the
+  spine LIVE so new arrivals continue to auto-advance; clicking any
+  non-head event pins to RETRO. Without `head-id` (legacy 3-arg /
+  4-arg arities) the mode defaults to RETRO — preserves the rf2-
+  s0s5x Phase A contract for callers that don't yet pass the head.
 
   Per spec/018 §6 the spine sub `:rf.causa/focus` carries `:epoch-id`
   as a first-class slot; consumers (Views' focused-cascade-pair sub,
@@ -272,20 +293,23 @@
   rebinds on `:dispatch-id`, but the epoch-keyed surfaces will not
   pivot until a 4-arg call lands."
   ([db dispatch-id frame-id]
-   (focus-cascade-reducer db dispatch-id frame-id nil))
+   (focus-cascade-reducer db dispatch-id frame-id nil nil))
   ([db dispatch-id frame-id epoch-id]
-   (cond-> db
-     true       (update :focus (fnil assoc {})
-                        :dispatch-id dispatch-id
-                        :epoch-id    epoch-id
-                        :mode :retro
-                        :previewing? false)
-     frame-id   (assoc-in [:focus :frame] frame-id)
-     ;; Legacy shim — panels reading these slots stay live.
-     true       (assoc :selected-dispatch-id dispatch-id
-                       :selected-epoch-id    epoch-id
-                       :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
-                                               frame-id (assoc :frame frame-id))))))
+   (focus-cascade-reducer db dispatch-id frame-id epoch-id nil))
+  ([db dispatch-id frame-id epoch-id head-id]
+   (let [mode (if (and head-id (= dispatch-id head-id)) :live :retro)]
+     (cond-> db
+       true       (update :focus (fnil assoc {})
+                          :dispatch-id dispatch-id
+                          :epoch-id    epoch-id
+                          :mode        mode
+                          :previewing? false)
+       frame-id   (assoc-in [:focus :frame] frame-id)
+       ;; Legacy shim — panels reading these slots stay live.
+       true       (assoc :selected-dispatch-id dispatch-id
+                         :selected-epoch-id    epoch-id
+                         :selected-dispatch    (cond-> {:dispatch-id dispatch-id}
+                                                 frame-id (assoc :frame frame-id)))))))
 
 (defn focus-step-reducer
   "Pure reducer for `:rf.causa/focus-cascade-prev` / `-next`. Steps
@@ -404,13 +428,17 @@
 
 ;; ---- registration --------------------------------------------------------
 
-(defn- db->cascades
+(defn db->cascades
   "Read the cascade vector by re-running the projection against the
   Causa app-db's `:trace-buffer` slot (falling back to the trace-bus
   atom for pre-mount callers). Used by the step events that need to
   walk the cascade list inside an event-db handler — the equivalent
   reactive path inside the `:rf.causa/focus` sub uses the
-  `:rf.causa/cascades` chain."
+  `:rf.causa/cascades` chain.
+
+  Public so legacy spine-shim events (e.g. `:rf.causa/select-
+  dispatch-id` in event_detail.cljs) can reuse the same projection
+  when they need head-id (rf2-xzzih)."
   [db]
   (let [buffer (or (get db :trace-buffer) (trace-bus/buffer))]
     (projection/group-cascades buffer)))
@@ -450,8 +478,10 @@
 
   (rf/reg-event-db :rf.causa/focus-cascade
     (fn [db [_ dispatch-id frame-id]]
-      (let [epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
-        (focus-cascade-reducer db dispatch-id frame-id epoch-id))))
+      (let [cascades (db->cascades db)
+            head-id  (focusable-head-id cascades)
+            epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
+        (focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
 
   (rf/reg-event-db :rf.causa/focus-cascade-prev
     (fn [db _event]

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -743,3 +743,109 @@
       (is (= :c3 (:dispatch-id r))
           "nil slot-id + non-empty buffer + :retro → snap to head")
       (is (true? (:head? r))))))
+
+;; -------------------------------------------------------------------------
+;; (12) Click on head stays LIVE (rf2-xzzih)
+;;
+;; Phase A (rf2-s0s5x / PR #1452) made any L2 click flip mode → :retro.
+;; But clicking the latest event (head) shouldn't pin the user to RETRO —
+;; they're still at head, so new arrivals should continue to auto-advance.
+;; The fix: the click-handler reducer is now head-aware. Mike's quote:
+;; "If I'm on the last event (the most recent one) and another event
+;; comes in, I should change to that new event. Ie. I'm live."
+;; -------------------------------------------------------------------------
+
+(deftest focusable-head-id-skips-ungrouped
+  (testing "focusable-head-id returns the latest focusable cascade —
+            not the literal last entry if that's the :ungrouped bucket"
+    (is (= :c3 (spine/focusable-head-id fixture-cascades)))
+    (is (= :c2 (spine/focusable-head-id
+                 fixture-cascades-with-ungrouped))
+        ":ungrouped sorts last (first-id sentinel) but focusable head
+         is the latest real cascade — :c2 not :ungrouped")
+    (is (nil? (spine/focusable-head-id [])))
+    (is (nil? (spine/focusable-head-id
+                [{:dispatch-id :ungrouped :frame nil}])))))
+
+(deftest focus-cascade-reducer-5-arg-head-stays-live
+  (testing "rf2-xzzih — when dispatch-id == head-id the reducer picks
+            :live so subsequent arrivals auto-advance"
+    (let [r (spine/focus-cascade-reducer {} :c3 :rf/default :e3 :c3)]
+      (is (= :c3 (get-in r [:focus :dispatch-id])))
+      (is (= :live (get-in r [:focus :mode]))
+          "head click → :live (auto-follow continues)")
+      (is (= :c3 (:selected-dispatch-id r)))
+      (is (= :e3 (get-in r [:focus :epoch-id]))))))
+
+(deftest focus-cascade-reducer-5-arg-non-head-pins-retro
+  (testing "rf2-xzzih — clicking a non-head cascade still pins to :retro"
+    (let [r (spine/focus-cascade-reducer {} :c1 :rf/default :e1 :c3)]
+      (is (= :c1 (get-in r [:focus :dispatch-id])))
+      (is (= :retro (get-in r [:focus :mode]))
+          "non-head click → :retro (auto-follow suspended)"))))
+
+(deftest focus-cascade-reducer-nil-head-id-defaults-retro
+  (testing "rf2-xzzih — the 4-arg back-compat path (no head-id supplied)
+            preserves the pre-fix :retro default. Keeps existing
+            callers' contract intact."
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default :e2 nil)]
+      (is (= :retro (get-in r [:focus :mode]))))
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default :e2)]
+      (is (= :retro (get-in r [:focus :mode]))
+          "4-arg arity defaults to retro"))
+    (let [r (spine/focus-cascade-reducer {} :c2 :rf/default)]
+      (is (= :retro (get-in r [:focus :mode]))
+          "3-arg arity defaults to retro"))))
+
+(deftest focus-cascade-event-clicking-head-stays-live
+  (testing "rf2-xzzih end-to-end — dispatching :rf.causa/focus-cascade
+            on the head cascade keeps spine in :live so a subsequent
+            arrival auto-advances the focus"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c3 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (= :live (:mode r))
+          "head click → mode stays :live")
+      (is (true? (:head? r))))
+    ;; A new cascade arrives — focus must auto-advance to the new head.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (let [r (focus-sub)]
+      (is (= :c4 (:dispatch-id r))
+          "new arrival auto-advances because mode stayed :live")
+      (is (= :live (:mode r)))
+      (is (true? (:head? r))))))
+
+(deftest focus-cascade-event-clicking-non-head-pins-retro
+  (testing "rf2-xzzih — clicking a non-head cascade pins :retro and
+            blocks auto-advance through subsequent arrivals"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c1 (:dispatch-id r)))
+      (is (= :retro (:mode r)) "non-head click → :retro"))
+    ;; New cascade arrives — :retro must NOT auto-advance.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (let [r (focus-sub)]
+      (is (= :c1 (:dispatch-id r))
+          ":retro pins focus through arrivals")
+      (is (= :retro (:mode r))))))
+
+(deftest legacy-select-dispatch-id-clicking-head-stays-live
+  (testing "rf2-xzzih — the legacy `:rf.causa/select-dispatch-id`
+            event (the spine-shim entry used by causality / machine
+            / cancellation panels) shares the head-aware mode pick
+            so clicks from those panels onto the head cascade also
+            keep :live"
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id :c3 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r)))
+      (is (= :live (:mode r))
+          "legacy click on head → :live (parity with focus-cascade event)"))))


### PR DESCRIPTION
## Summary

Phase A (rf2-s0s5x / #1452) made any L2 row click flip the spine to `:retrospective`. But clicking the head (latest) event shouldn't pin the user — they're still at head, so new arrivals should continue to auto-advance.

> Mike: "If I'm on the last event (the most recent one) and another event comes in, I should change to that new event. Ie. I'm live. At the moment, in Causa, you stay on the event one you were on."

## Fix

`focus-cascade-reducer` is now head-aware:

- **Click head event** (`dispatch-id == head-id`) → mode `:live` (auto-follow continues).
- **Click non-head event** (`dispatch-id != head-id`) → mode `:retro` (auto-follow paused).

The 5-arg arity carries `head-id`; the 3-arg / 4-arg back-compat arities default to `:retro` so existing callers' contract is unchanged.

Both the new `:rf.causa/focus-cascade` event and the legacy `:rf.causa/select-dispatch-id` shim (used by causality / machine / cancellation panels) compute `head-id` via `focusable-head-id` so a click on the head from any panel keeps the spine LIVE. The focusable filter (rf2-fzbrw) strips the `:ungrouped` bucket so the spine's notion of head agrees with what the user sees as the latest row in the L2 event list.

## Bead

rf2-xzzih (still open — Mike to close after landing).

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass
- [x] `tools/causa` JVM tests (`clojure -M:test`) — 930 tests / 2686 assertions / 0 failures
- [x] `implementation` CLJS tests (`npm run test:cljs`) — 3206 tests / 9208 assertions / 0 failures
- [x] `implementation` browser tests (`npm run test:browser`) — 3197 tests / 9163 assertions / 0 failures
- [x] New unit + integration coverage:
  - `focus-cascade-reducer-5-arg-head-stays-live` — head click → `:live`
  - `focus-cascade-reducer-5-arg-non-head-pins-retro` — non-head → `:retro`
  - `focus-cascade-reducer-nil-head-id-defaults-retro` — back-compat arities
  - `focus-cascade-event-clicking-head-stays-live` — end-to-end auto-advance after head click
  - `focus-cascade-event-clicking-non-head-pins-retro` — `:retro` pins through arrivals
  - `legacy-select-dispatch-id-clicking-head-stays-live` — shim parity