### PR TITLE
feat(causa): Machines tab canonical lens — silent OR topology + transition + guards + actions for the focused event

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/chart/svg.cljc
@@ -44,19 +44,23 @@
 ;; ---- helpers ------------------------------------------------------------
 
 (defn- node-fill
-  [{:keys [highlight? sim?]}]
+  [{:keys [highlight? sim? from-highlight? to-highlight?]}]
   (cond
-    sim?       "rgba(251, 191, 36, 0.18)"   ;; amber tint (Sim mode)
-    highlight? "rgba(67, 195, 208, 0.18)"   ;; cyan tint (live)
-    :else      "#1c2030"))
+    sim?            "rgba(251, 191, 36, 0.18)"   ;; amber tint (Sim mode)
+    to-highlight?   "rgba(67, 195, 208, 0.22)"   ;; brighter cyan (focused-event lens: landing state)
+    from-highlight? "rgba(132, 110, 230, 0.14)"  ;; violet tint (focused-event lens: origin state)
+    highlight?      "rgba(67, 195, 208, 0.18)"   ;; cyan tint (live)
+    :else           "#1c2030"))
 
 (defn- node-stroke
-  [{:keys [highlight? sim? final?]}]
+  [{:keys [highlight? sim? final? from-highlight? to-highlight?]}]
   (cond
-    sim?       (:yellow tokens/tokens)
-    highlight? (:cyan tokens/tokens)
-    final?     (:green tokens/tokens)
-    :else      (:border-default tokens/tokens)))
+    sim?            (:yellow tokens/tokens)
+    to-highlight?   (:cyan tokens/tokens)
+    from-highlight? (:accent-violet tokens/tokens)
+    highlight?      (:cyan tokens/tokens)
+    final?          (:green tokens/tokens)
+    :else           (:border-default tokens/tokens)))
 
 (defn compound-containers
   "rf2-m7co9 Phase 4 — compute the bounding box of each compound state
@@ -187,16 +191,27 @@
 
 (defn- render-node
   [{:keys [x y width height label final? compound? node-id path] :as n}
-   {:keys [highlight-id sim? on-state-click]}]
-  (let [active?    (= node-id highlight-id)
-        styled     (assoc n
-                          :highlight? active?
-                          :sim?       (and active? sim?))
-        fill       (node-fill styled)
-        stroke     (node-stroke styled)
-        stroke-w   (if active? highlight-stroke-width stroke-width)]
+   {:keys [highlight-id from-highlight-id to-highlight-id sim? on-state-click]}]
+  (let [active?         (= node-id highlight-id)
+        from-highlight? (= node-id from-highlight-id)
+        to-highlight?   (= node-id to-highlight-id)
+        ;; The focused-event lens's TO node wins over both the FROM
+        ;; node and the live highlight; the FROM node is dashed so the
+        ;; eye reads transition-direction; the live highlight is the
+        ;; fallback for picker-driven modes.
+        emphasised?     (or active? from-highlight? to-highlight?)
+        styled          (assoc n
+                               :highlight?      active?
+                               :from-highlight? from-highlight?
+                               :to-highlight?   to-highlight?
+                               :sim?            (and active? sim?))
+        fill            (node-fill styled)
+        stroke          (node-stroke styled)
+        stroke-w        (if emphasised? highlight-stroke-width stroke-width)]
     [:g {:data-testid (str "rf-causa-chart-node-" node-id)
          :data-active (str active?)
+         :data-from-highlight (str from-highlight?)
+         :data-to-highlight (str to-highlight?)
          :data-state-path (pr-str path)
          :on-click (when on-state-click
                      (fn [_ev] (on-state-click path)))
@@ -223,7 +238,11 @@
              :rx corner-radius
              :fill fill
              :stroke stroke
-             :stroke-width stroke-w}]
+             :stroke-width stroke-w
+             ;; FROM node draws with a dashed stroke so the eye reads
+             ;; the transition direction (origin → landing).
+             :stroke-dasharray (when (and from-highlight? (not to-highlight?))
+                                 "4 2")}]
      ;; Label
      ;; rf2-gz7vi — state-label tuned 11 → 9 (follow-up to rf2-isgqu's
      ;; 12 → 11 — diagram still didn't fit at default width). Vertical
@@ -234,8 +253,8 @@
              :text-anchor "middle"
              :font-family font-stack
              :font-size 9
-             :font-weight (if active? 600 400)
-             :fill (if active?
+             :font-weight (if emphasised? 600 400)
+             :fill (if emphasised?
                      (:text-primary tokens/tokens)
                      (:text-secondary tokens/tokens))}
       label]
@@ -303,13 +322,21 @@
 (defn- render-edge
   [{:keys [event-label points guard from-id to-id]
     :as _edge}
-   {:keys [highlight-id]}]
-  (let [active? (or (= from-id highlight-id)
-                    (= to-id   highlight-id))
-        stroke  (if active?
+   {:keys [highlight-id from-highlight-id to-highlight-id]}]
+  (let [active?         (or (= from-id highlight-id)
+                            (= to-id   highlight-id))
+        ;; Focused-event lens: when both endpoints match the
+        ;; from/to highlight pair, the edge IS the transition that
+        ;; fired — emphasise it.
+        focused-edge?   (and (some? from-highlight-id)
+                             (some? to-highlight-id)
+                             (= from-id from-highlight-id)
+                             (= to-id   to-highlight-id))
+        emphasised?     (or active? focused-edge?)
+        stroke  (if emphasised?
                   (:cyan tokens/tokens)
                   (:border-default tokens/tokens))
-        marker  (if active?
+        marker  (if emphasised?
                   "url(#rf-causa-chart-arrow-highlight)"
                   "url(#rf-causa-chart-arrow)")
         [lx ly] (edge-label-position points)
@@ -319,11 +346,12 @@
                      event-label)]
     [:g {:data-testid (str "rf-causa-chart-edge-" from-id "-to-" to-id)
          :data-event event-label
-         :data-active (str active?)}
+         :data-active (str active?)
+         :data-focused-edge (str focused-edge?)}
      [:path {:d (path-from-points points)
              :fill "none"
              :stroke stroke
-             :stroke-width (if active? highlight-stroke-width stroke-width)
+             :stroke-width (if emphasised? highlight-stroke-width stroke-width)
              :marker-end marker}]
      (when (seq full-label)
        [:g
@@ -354,19 +382,28 @@
 
   Options:
 
-    :highlight-id     — node-id to render as the active state (cyan
-                        when `:sim?` is false, amber when true)
-    :sim?             — flips the highlight palette to amber
-                        (UC1 sim mode — follow-on bead wires this)
-    :on-state-click   — `(fn [path] ...)` called when a node is clicked
-                        (Causa wires this to its source-coord jump)
-    :testid           — overrides the root SVG data-testid
+    :highlight-id        — node-id to render as the active state (cyan
+                           when `:sim?` is false, amber when true)
+    :from-highlight-id   — node-id for the focused-event lens's origin
+                           state (rf2-a9cke). Dashed accent-violet
+                           border; the edge between FROM and TO is
+                           emphasised cyan when both are set.
+    :to-highlight-id     — node-id for the focused-event lens's
+                           landing state (rf2-a9cke). Bold cyan
+                           border; wins over `:highlight-id` when set.
+    :sim?                — flips the highlight palette to amber
+                           (UC1 sim mode — follow-on bead wires this)
+    :on-state-click      — `(fn [path] ...)` called when a node is
+                           clicked (Causa wires this to its source-
+                           coord jump)
+    :testid              — overrides the root SVG data-testid
 
   Returns a stable hiccup form. Empty graphs (no nodes) render an
   inline note so the panel never sees an empty SVG container."
   ([positioned] (render positioned {}))
   ([{:keys [nodes edges width height] :as positioned}
-    {:keys [highlight-id sim? on-state-click testid]}]
+    {:keys [highlight-id from-highlight-id to-highlight-id
+            sim? on-state-click testid]}]
    (if (empty? nodes)
      [:div {:data-testid (or testid "rf-causa-chart-empty")
             :style {:padding "16px"
@@ -381,6 +418,8 @@
            containers (compound-containers nodes)]
        [:svg {:data-testid (or testid "rf-causa-chart-svg")
               :data-highlight-id (or highlight-id "")
+              :data-from-highlight-id (or from-highlight-id "")
+              :data-to-highlight-id (or to-highlight-id "")
               :viewBox (str "0 0 " width " " height)
               :width "100%"
               :preserveAspectRatio "xMidYMin meet"
@@ -400,15 +439,19 @@
               (for [edge edges]
                 ^{:key (str (:from-id edge) "->" (:to-id edge)
                             "/" (:event-label edge))}
-                (render-edge edge {:highlight-id highlight-id})))
+                (render-edge edge {:highlight-id      highlight-id
+                                   :from-highlight-id from-highlight-id
+                                   :to-highlight-id   to-highlight-id})))
         (render-initial-marker initial-node)
         (into [:g {:data-testid "rf-causa-chart-nodes"}]
               (for [node nodes]
                 ^{:key (:node-id node)}
                 (render-node node
-                             {:highlight-id   highlight-id
-                              :sim?           sim?
-                              :on-state-click on-state-click})))]))))
+                             {:highlight-id      highlight-id
+                              :from-highlight-id from-highlight-id
+                              :to-highlight-id   to-highlight-id
+                              :sim?              sim?
+                              :on-state-click    on-state-click})))]))))
 
 (defn render-from-definition
   "Convenience: lay out + render in one call. Useful for the panel

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -555,28 +555,41 @@
   "Combine the auto-classification with the user's forced selection.
   Pure fn for unit-testability.
 
-  `forced` is one of `:mode-a / :mode-b / :mode-c / nil`. Nil falls
-  back to `view-mode`. When a force is set but instance-count = 0 the
-  resolver still honours the user's pick so the cluster view remains
-  reachable in the empty-population case (useful for the test
-  override path + future spawn workflow)."
-  [instance-count forced]
+  `forced` is one of `:focused-event / :mode-a / :mode-b / :mode-c /
+  nil`. Per rf2-a9cke the canonical lens-on-focused-event is the panel
+  default — when nothing is explicitly forced, the focused-event lens
+  wins. The picker-driven Mode A/B/C exploration is opt-in via the
+  mode-strip click. The cluster-helpers' `mode-c-suggested?` threshold
+  for the auto-switch hint is computed separately by the mode-tab
+  strip and surfaced as a visual nudge, not as an auto-mode switch.
+
+  When a force is set but instance-count = 0 the resolver still
+  honours the user's pick so the cluster view remains reachable in
+  the empty-population case (useful for the test override path +
+  future spawn workflow)."
+  [_instance-count forced]
   (if (some? forced)
     forced
-    (view-mode instance-count)))
+    ;; Default: focused-event lens (rf2-a9cke). The lens itself is
+    ;; silent-by-default when the focused event triggered no machine
+    ;; transitions, so this never forces noisy chrome.
+    :focused-event))
 
 ;; ---- mode tab strip (UC2 Mode A | B | C selector) ---------------------
 
 (defn- mode-tab-strip
-  "Three-tab strip across the header that lets the user force Mode A
-  (definition), Mode B (instance tabs), or Mode C (cluster view) per
-  spec/003-Machine-Inspector.md §UC2. Auto-classification still drives
-  the default; clicking a tab sets a forced mode that overrides the
-  auto pick. Clicking the active tab clears the force (back to auto)."
+  "Four-tab strip across the header that lets the user pick the
+  canonical focused-event lens (rf2-a9cke; default) or force the
+  picker-driven Mode A (definition), Mode B (instance tabs), or
+  Mode C (cluster view) per spec/003-Machine-Inspector.md §UC2.
+  Clicking a tab sets a forced mode that overrides the default.
+  Clicking the active forced tab clears the force back to the
+  focused-event default."
   [resolved-mode forced-mode instance-count]
-  (let [tabs [{:id :mode-a :label "Definition"}
-              {:id :mode-b :label "Instances"}
-              {:id :mode-c :label "Cluster"}]
+  (let [tabs [{:id :focused-event :label "Focused event"}
+              {:id :mode-a        :label "Definition"}
+              {:id :mode-b        :label "Instances"}
+              {:id :mode-c        :label "Cluster"}]
         suggest-c? (ch/mode-c-suggested? instance-count)]
     [:div {:data-testid "rf-causa-machine-inspector-mode-strip"
            :data-resolved-mode (name resolved-mode)
@@ -639,6 +652,234 @@
                        :font-size "10px"}}
         (str instance-count
              " instances — Cluster view recommended")])]))
+
+;; ---- focused-event lens (rf2-a9cke) ------------------------------------
+;;
+;; Per Mike's canonical Machines design (rf2-si9o5): when an L2 event is
+;; focused, the Machines panel renders one section per machine that
+;; transitioned in that event's cascade — chart with FROM/TO highlights,
+;; the transition-edge, guards list, actions list. Silent when no
+;; machine activity (per rf2-g3ghh silent-by-default policy).
+
+(defn- guards-list
+  "Render the per-transition Guards section. Empty list = no surface
+  (silent-by-default per rf2-g3ghh). Each row carries `:guard-id`,
+  `:input`, `:outcome` (`:pass` / `:fail` / nil)."
+  [guards]
+  (when (seq guards)
+    [:div {:data-testid "rf-causa-machine-focused-event-guards"
+           :style {:padding "8px 12px"
+                   :background (:bg-1 tokens)
+                   :border-top (str "1px solid " (:border-subtle tokens))}}
+     [:div {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :margin-bottom "4px"}}
+      "Guards"]
+     (into [:ul {:style {:list-style "none"
+                         :margin 0
+                         :padding 0
+                         :font-family mono-stack
+                         :font-size "11px"
+                         :color (:text-primary tokens)}}]
+           (for [{:keys [guard-id input outcome]} guards]
+             ^{:key (str guard-id)}
+             [:li {:data-testid (str "rf-causa-machine-focused-event-guard-"
+                                     (when guard-id (name guard-id)))
+                   :style {:display "flex"
+                           :align-items "center"
+                           :gap "8px"
+                           :padding "2px 0"}}
+              [:span {:style {:color (case outcome
+                                       :pass (:green tokens)
+                                       :fail (:red tokens)
+                                       (:text-tertiary tokens))
+                              :font-weight 600}}
+               (case outcome
+                 :pass "✓"
+                 :fail "✗"
+                 "?")]
+              [:span (str guard-id)]
+              (when input
+                [:span {:style {:color (:text-tertiary tokens)}}
+                 (pr-str input)])]))]))
+
+(defn- actions-list
+  "Render the per-transition Actions section. Empty list = no surface."
+  [actions]
+  (when (seq actions)
+    [:div {:data-testid "rf-causa-machine-focused-event-actions"
+           :style {:padding "8px 12px"
+                   :background (:bg-1 tokens)
+                   :border-top (str "1px solid " (:border-subtle tokens))}}
+     [:div {:style {:color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :margin-bottom "4px"}}
+      "Actions"]
+     (into [:ul {:style {:list-style "none"
+                         :margin 0
+                         :padding 0
+                         :font-family mono-stack
+                         :font-size "11px"
+                         :color (:text-primary tokens)}}]
+           (for [{:keys [action-id input outcome]} actions]
+             ^{:key (str action-id)}
+             [:li {:data-testid (str "rf-causa-machine-focused-event-action-"
+                                     (when action-id (name action-id)))
+                   :style {:display "flex"
+                           :align-items "center"
+                           :gap "8px"
+                           :padding "2px 0"}}
+              [:span {:style {:color (case outcome
+                                       :ok   (:green tokens)
+                                       :fail (:red tokens)
+                                       (:text-tertiary tokens))
+                              :font-weight 600}}
+               (case outcome
+                 :ok   "✓"
+                 :fail "✗"
+                 "•")]
+              [:span (str action-id)]
+              (when input
+                [:span {:style {:color (:text-tertiary tokens)}}
+                 (pr-str input)])]))]))
+
+(defn- focused-event-section
+  "Render one section per transitioned machine. Header → chart →
+  guards → actions. The chart's FROM/TO highlights drive the visual
+  read of the transition: dashed accent-violet origin, bold cyan
+  landing, the connecting edge emphasised."
+  [{:keys [machine-id from-state to-state on-event event microstep?
+           definition guards actions]}]
+  (let [from-id    (when from-state
+                     (chart-layout/highlight-id from-state))
+        to-id      (when to-state
+                     (chart-layout/highlight-id to-state))
+        direction  :tb
+        positioned (when definition
+                     (elk-layout/layout-or-fallback definition direction))
+        engine     (if (and definition
+                            (some? (elk-layout/cached-layout
+                                     definition direction)))
+                     "elk"
+                     "layered")
+        ;; Kick the loader so the next render swaps the layered
+        ;; fallback for ELK once it resolves.
+        _          (when definition
+                     (elk-layout/ensure-elk!
+                       (fn [_inst]
+                         (when (and (= :ready (elk-layout/elk-status))
+                                    (nil? (elk-layout/cached-layout
+                                            definition direction)))
+                           (elk-layout/compute-layout!
+                             definition direction
+                             (fn [chart-layout]
+                               (when chart-layout
+                                 (rf/dispatch
+                                   [:rf.causa/machine-chart-layout-pulse]
+                                   {:frame :rf/causa}))))))))]
+    [:section
+     {:data-testid (str "rf-causa-machine-focused-event-section-"
+                        (when machine-id
+                          ;; Full namespaced/name pair so the testid
+                          ;; round-trips :auth/login → "auth/login"
+                          ;; (collides cleanly with the
+                          ;; `find-all-by-testid-prefix` walker that
+                          ;; tests use to count sections).
+                          (subs (str machine-id) 1)))
+      :data-machine-id (str machine-id)
+      :data-from-state (str from-state)
+      :data-to-state (str to-state)
+      :data-on-event (str on-event)
+      :data-microstep (str (boolean microstep?))
+      :style {:margin "12px"
+              :border (str "1px solid " (:border-default tokens))
+              :border-radius "4px"
+              :background (:bg-2 tokens)}}
+     [:header {:data-testid "rf-causa-machine-focused-event-header"
+               :style {:padding "10px 12px"
+                       :display "flex"
+                       :align-items "center"
+                       :gap "10px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :background (:bg-3 tokens)
+                       :font-family mono-stack
+                       :font-size "12px"
+                       :color (:text-primary tokens)}}
+      (when microstep?
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-size "10px"}}
+         "↳"])
+      [:strong {:style {:color (:accent-violet tokens)}}
+       (h/format-machine-id machine-id)]
+      [:span {:style {:color (:text-secondary tokens)}}
+       (h/format-state from-state)]
+      [:span {:style {:color (:cyan tokens)}}
+       "→"]
+      [:span {:style {:color (:text-primary tokens)
+                      :font-weight 600}}
+       (h/format-state to-state)]
+      (when event
+        [:span {:style {:color (:text-tertiary tokens)
+                        :font-size "11px"
+                        :margin-left "auto"}}
+         (h/format-event event)])]
+     (cond
+       (nil? definition)
+       [:div {:data-testid "rf-causa-machine-focused-event-no-definition"
+              :style {:padding "12px"
+                      :font-family sans-stack
+                      :font-size "11px"
+                      :color (:text-tertiary tokens)}}
+        "No introspectable definition — chart cannot render."]
+
+       :else
+       [:div {:data-testid "rf-causa-machine-focused-event-chart"
+              :data-layout-engine engine
+              :data-machine-id (str machine-id)
+              :data-from-highlight-id (or from-id "")
+              :data-to-highlight-id (or to-id "")
+              :style {:padding "12px"
+                      :background (:bg-1 tokens)
+                      :overflow "auto"}}
+        (chart-svg/render
+          positioned
+          {:from-highlight-id from-id
+           :to-highlight-id   to-id
+           :on-state-click    (fn [path]
+                                (rf/dispatch
+                                  [:rf.causa/machine-state-clicked
+                                   {:machine-id machine-id
+                                    :path       path}]
+                                  {:frame :rf/causa}))})])
+     (guards-list guards)
+     (actions-list actions)]))
+
+(defn- focused-event-view
+  "Top-level focused-event lens. Reads the
+  `:rf.causa/machine-transitions-for-focused-event` composite sub.
+  Silent (returns nil) when no machine transitioned in the focused
+  event's cascade — the panel renders only the header chrome in that
+  case."
+  []
+  (let [records @(rf/subscribe
+                   [:rf.causa/machine-transitions-for-focused-event])]
+    (when (seq records)
+      (into [:div {:data-testid "rf-causa-machine-focused-event"
+                   :data-section-count (count records)
+                   :style {:display "flex"
+                           :flex-direction "column"}}]
+            (for [rec records]
+              ^{:key (str (:machine-id rec) "-"
+                          (:id rec) "-"
+                          (:from-state rec) "-"
+                          (:to-state rec))}
+              (focused-event-section rec))))))
 
 ;; ---- empty state --------------------------------------------------------
 
@@ -762,33 +1003,55 @@
        (empty-state)
        [:div {:style {:flex 1 :display "flex" :flex-direction "column"
                       :overflow "hidden"}}
-        [machine-picker machines selected-id]
+        ;; Mode strip is the ONLY persistent chrome across modes — it
+        ;; lets the user toggle out of the focused-event lens into the
+        ;; picker-driven exploration surfaces. The picker + instance
+        ;; tabs ride below ONLY in the picker-driven modes; the
+        ;; focused-event lens has its own per-section header instead.
         [mode-tab-strip mode forced-mode instance-count]
-        [instance-tabs (or selected {}) instance-count mode]
-        [:div {:style {:flex 1 :overflow "auto"}}
-         (placeholder-banner
-           {:machine-id     (:machine-id selected)
-            :state          (:state selected)
-            :instance-count instance-count
-            :definition     (:definition selected)
-            :sim-active?    sim-active?})
-         (placeholder-chart chart-props sim-snapshot arc-highlight)
-         ;; Phase 5: scrubber strip beneath the chart. Visible whenever
-         ;; the arc has at least one step (i.e. ≥1 transition or an
-         ;; initial-state-only arc).
-         (when arc-active?
-           [scrubber/ScrubberStrip])
-         (when (= :mode-c mode)
-           [cluster/ClusterView])
-         (when sim-active?
-           [sim/SimSideRail])
-         ;; Cancellation-cascade visualiser (rf2-59e7k) — mounts in the
-         ;; Machines tab side-rail when the focused machine had a
-         ;; destroy-with-cancellation-reason in the trace window. The
-         ;; SidePanel reg-view short-circuits to nil otherwise, so the
-         ;; mount is dormant in the common case.
-         [cancellation-cascade/SidePanel]]
-        (transition-ribbon transitions)])]))
+        (cond
+          (= :focused-event mode)
+          ;; rf2-a9cke canonical lens. Silent (renders nothing) when no
+          ;; machine transitioned in the focused event's cascade — per
+          ;; rf2-g3ghh's silent-by-default policy.
+          [:div {:data-testid "rf-causa-machine-inspector-focused-event-host"
+                 :style {:flex 1 :overflow "auto"}}
+           [focused-event-view]]
+
+          :else
+          ;; Picker-driven exploration modes (Mode A definition view /
+          ;; Mode B instance tabs / Mode C cluster). Preserved verbatim
+          ;; from the pre-rf2-a9cke surface so existing flows
+          ;; (instrumented tests, the Sim sub-mode, the arc + scrubber)
+          ;; keep working when the user opts out of the focused-event
+          ;; lens.
+          [:<>
+           [machine-picker machines selected-id]
+           [instance-tabs (or selected {}) instance-count mode]
+           [:div {:style {:flex 1 :overflow "auto"}}
+            (placeholder-banner
+              {:machine-id     (:machine-id selected)
+               :state          (:state selected)
+               :instance-count instance-count
+               :definition     (:definition selected)
+               :sim-active?    sim-active?})
+            (placeholder-chart chart-props sim-snapshot arc-highlight)
+            ;; Phase 5: scrubber strip beneath the chart. Visible whenever
+            ;; the arc has at least one step (i.e. ≥1 transition or an
+            ;; initial-state-only arc).
+            (when arc-active?
+              [scrubber/ScrubberStrip])
+            (when (= :mode-c mode)
+              [cluster/ClusterView])
+            (when sim-active?
+              [sim/SimSideRail])
+            ;; Cancellation-cascade visualiser (rf2-59e7k) — mounts in
+            ;; the Machines tab side-rail when the focused machine had
+            ;; a destroy-with-cancellation-reason in the trace window.
+            ;; The SidePanel reg-view short-circuits to nil otherwise,
+            ;; so the mount is dormant in the common case.
+            [cancellation-cascade/SidePanel]]
+           (transition-ribbon transitions)])])]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -929,6 +1192,55 @@
         (h/project-data
           machines snapshots definitions buffer selected-id target-frame))))
 
+  ;; ---- rf2-a9cke — focused-event lens composite sub ---------------
+  ;;
+  ;; Per Mike's canonical Machines design (rf2-si9o5) the panel's
+  ;; default surface is a lens on the FOCUSED event — one section per
+  ;; machine that transitioned in that event's cascade, silent
+  ;; otherwise. This composite folds the spine `:rf.causa/focus`'s
+  ;; `:epoch-id` (per spec/018 §6 Spine events) + the per-frame
+  ;; `:rf.causa/epoch-history`'s `:trace-events` window + the
+  ;; registered machine-definitions into the per-transition record
+  ;; vector the view consumes.
+  ;;
+  ;; Returns `[]` when the focused event triggered no machine
+  ;; transitions — the silent-by-default branch the view honours per
+  ;; rf2-g3ghh.
+
+  (rf/reg-sub :rf.causa/machine-transitions-for-focused-event
+    :<- [:rf.causa/focus]
+    :<- [:rf.causa/epoch-history]
+    :<- [:rf.causa/machine-definitions]
+    (fn [[focus history definitions] _query]
+      (let [record (h/focused-epoch-record history focus)
+            events (when record (:trace-events record))]
+        (h/project-focused-event-transitions events definitions))))
+
+  ;; Test-only overrides for the rf2-a9cke focused-event composite.
+  ;; The two surfaces this composite reads (`:rf.causa/epoch-history`,
+  ;; the spine's `:rf.causa/focus`) live OUTSIDE this panel's
+  ;; install — `:epoch-history` is owned by time-travel-subs +
+  ;; epoch-capture, `:focus` lives on the spine. Tests want a one-stop
+  ;; override that doesn't reach across those module boundaries, so we
+  ;; register two hooks that write directly to Causa's app-db slots
+  ;; (`:epoch-history` is the slot the time-travel sub reads; `:focus
+  ;; :epoch-id` is the slot the spine's compose-focus reads). Mirrors
+  ;; the existing test-override pattern (snapshots / definitions /
+  ;; registered-machines) so JVM + node-test suites can drive the
+  ;; focused-event lens without booting a host with a live machine
+  ;; transition + epoch capture path.
+  (rf/reg-event-db :rf.causa/set-epoch-history-for-test
+    (fn [db [_ history]]
+      (if (nil? history)
+        (dissoc db :epoch-history)
+        (assoc db :epoch-history (vec history)))))
+
+  (rf/reg-event-db :rf.causa/set-focus-epoch-id-for-test
+    (fn [db [_ epoch-id]]
+      (if (nil? epoch-id)
+        (update db :focus dissoc :epoch-id)
+        (update db :focus (fnil assoc {}) :epoch-id epoch-id))))
+
   ;; ---- Machine Inspector panel events ----------------------------
 
   (rf/reg-event-db :rf.causa/select-machine-id
@@ -979,7 +1291,7 @@
   (rf/reg-event-db :rf.causa/set-forced-machine-mode
     (fn [db [_ mode]]
       (if (or (nil? mode)
-              (contains? #{:mode-a :mode-b :mode-c} mode))
+              (contains? #{:focused-event :mode-a :mode-b :mode-c} mode))
         (if (nil? mode)
           (dissoc db :machine-inspector/forced-mode)
           (assoc db :machine-inspector/forced-mode mode))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
@@ -353,3 +353,243 @@
       (pr-str event)
       (catch #?(:clj Throwable :cljs :default) _
         (str event)))))
+
+;; ---- focused-event lens (rf2-a9cke) -------------------------------------
+;;
+;; Per Mike's canonical Machines design (rf2-si9o5): when the user focuses
+;; an L2 event, the Machines panel becomes a lens on THAT event's machine
+;; activity:
+;;
+;;   - If the event triggered no machine transitions → render nothing
+;;     (silent-by-default per rf2-g3ghh).
+;;   - If the event triggered ≥1 machine transitions → render one section
+;;     per machine, each carrying the topology + current state + new
+;;     state + the transition-edge + any guards + any actions that ran.
+;;
+;; The helper folds the focused epoch record's `:trace-events` (per
+;; spec/Spec-Schemas §`:rf/epoch-record`) into a vector of per-machine
+;; transition records the view consumes. Each record carries enough data
+;; for the view to highlight the chart + render the guards/actions lists
+;; without further trace-walking.
+;;
+;; ## Trace-shape coverage
+;;
+;; Today's substrate (implementation/machines/) emits:
+;;
+;;   - `:rf.machine/transition` — outer transition; tags carry
+;;     `:before` + `:after` snapshots + `:event` + `:machine-id`.
+;;   - `:rf.machine.microstep/transition` — `:always`-driven microstep;
+;;     same tag shape (some tests use `:from`/`:to` tag fallbacks).
+;;
+;; The substrate does NOT yet emit `:rf.machine/guard-evaluated` or
+;; `:rf.machine/action-ran` per-step traces. The helper looks for those
+;; ops anyway (set in `guard-operations` / `action-operations`) so when
+;; the substrate gains them, the lens lights up without further work.
+;; In the meantime guards/actions render as empty lists per transition.
+;;
+;; Per spec/005-StateMachines.md the guard / action functions are
+;; resolved off the transition object on the machine definition; we
+;; surface their refs so the view can label them as `:guards` /
+;; `:actions` lists even when no per-step trace fired.
+
+(def guard-operations
+  "Trace operations the focused-event lens treats as guard evaluations.
+  Today's substrate doesn't emit any of these; the set is the
+  forward-compatible vocabulary so when the runtime gains the trace
+  shape the lens lights up without code changes (rf2-a9cke
+  divergence-allowance note)."
+  #{:rf.machine/guard-evaluated
+    :rf.machine.guard/evaluated})
+
+(def action-operations
+  "Trace operations the focused-event lens treats as action runs.
+  Forward-compatible vocabulary — same posture as `guard-operations`."
+  #{:rf.machine/action-ran
+    :rf.machine.action/ran
+    :rf.machine/action-executed})
+
+(defn guard-event?
+  "True iff `ev` is one of the guard-evaluation operations."
+  [ev]
+  (and (map? ev)
+       (contains? guard-operations (:operation ev))))
+
+(defn action-event?
+  "True iff `ev` is one of the action-run operations."
+  [ev]
+  (and (map? ev)
+       (contains? action-operations (:operation ev))))
+
+(defn- transition-record-from-trace
+  "Project a single `:rf.machine/transition` trace event into the
+  view-consumed record shape. The trace carries `:before` / `:after`
+  snapshots (per registration.cljc's commit-or-finalize) so we can read
+  the from-state / to-state directly off the snapshot pair. Falls back
+  to the legacy `:from`/`:to` tag slots when present (test fixtures)."
+  [ev]
+  (let [tags  (get ev :tags {})
+        before (:before tags)
+        after  (:after  tags)
+        from-state (cond
+                     (some? before) (:state before)
+                     :else          (or (:from tags) (:from-state tags)))
+        to-state   (cond
+                     (some? after)  (:state after)
+                     :else          (or (:to tags) (:to-state tags)))
+        event-v    (or (:event tags) (:event-v tags))
+        ;; The on-event keyword that fired the transition is the
+        ;; head of the event vector. nil-safe so a microstep that
+        ;; lacks the event tag still surfaces a stable record.
+        on-event   (when (vector? event-v) (first event-v))]
+    {:machine-id   (machine-id-of ev)
+     :from-state   from-state
+     :to-state     to-state
+     :on-event     on-event
+     :event        event-v
+     :time         (:time ev)
+     :id           (:id ev)
+     :dispatch-id  (get-in ev [:tags :dispatch-id])
+     :microstep?   (= :rf.machine.microstep/transition (:operation ev))
+     ;; Guards/actions filled in by `attach-guards-and-actions` —
+     ;; default empty so the record shape is stable.
+     :guards       []
+     :actions      []}))
+
+(defn- guard-record
+  "Project a guard-evaluated trace event into the record the view
+  renders inside the per-transition Guards section."
+  [ev]
+  (let [tags (get ev :tags {})]
+    {:guard-id (or (:guard-id tags) (:guard tags))
+     :input    (or (:input tags) (:args tags))
+     :outcome  (cond
+                 (contains? tags :outcome) (:outcome tags)
+                 (contains? tags :pass?)   (if (:pass? tags) :pass :fail)
+                 (contains? tags :passed?) (if (:passed? tags) :pass :fail)
+                 :else                     nil)
+     :time     (:time ev)}))
+
+(defn- action-record
+  "Project an action-ran trace event into the record the view renders
+  inside the per-transition Actions section."
+  [ev]
+  (let [tags (get ev :tags {})]
+    {:action-id (or (:action-id tags) (:action tags))
+     :input     (or (:input tags) (:args tags))
+     :outcome   (cond
+                  (contains? tags :outcome)   (:outcome tags)
+                  (contains? tags :exception) :fail
+                  :else                       :ok)
+     :time      (:time ev)}))
+
+(defn- attach-guards-and-actions
+  "Attach the guard/action records that fired against `transition-record`
+  to the record. Walks the cascade-window trace events and matches by
+  `:machine-id` + time-window (event :time between transition.start and
+  transition.end). Since today's substrate doesn't emit guard/action
+  traces this is forward-compatible — when the runtime gains them, the
+  per-transition lists populate without code changes.
+
+  The match-window v1 is loose — any guard/action trace for the same
+  machine inside the cascade attributes to the only-or-first transition
+  for that machine. When the substrate ships explicit
+  `:transition-id` / `:decl-path` tags on guard/action traces a
+  follow-on bead tightens the attribution."
+  [transition-record events]
+  (let [mid       (:machine-id transition-record)
+        guards    (->> events
+                       (filter (fn [ev]
+                                 (and (guard-event? ev)
+                                      (= mid (machine-id-of ev)))))
+                       (mapv guard-record))
+        actions   (->> events
+                       (filter (fn [ev]
+                                 (and (action-event? ev)
+                                      (= mid (machine-id-of ev)))))
+                       (mapv action-record))]
+    (cond-> transition-record
+      (seq guards)  (assoc :guards guards)
+      (seq actions) (assoc :actions actions))))
+
+(defn project-focused-event-transitions
+  "Project the focused epoch's cascade window into a vector of
+  per-machine-transition records the Machines panel's focused-event
+  lens consumes.
+
+  Inputs:
+
+    `trace-events` — the focused epoch record's `:trace-events` vector
+                     (per spec/Spec-Schemas §`:rf/epoch-record`). nil-safe.
+    `definitions`  — `{machine-id <machine-definition>}` map (from
+                     `:rf.causa/machine-definitions`). nil-safe; used
+                     to surface the registered definition on each
+                     record so the view can render the topology
+                     without re-resolving.
+
+  Returns a vector of records, oldest-first (cascade-document-order),
+  one per `:rf.machine/transition` / `:rf.machine.microstep/transition`
+  event in the cascade:
+
+      {:machine-id   <kw>
+       :from-state   <kw|vec|nil>
+       :to-state     <kw|vec|nil>
+       :on-event     <kw|nil>
+       :event        <event-vec|nil>
+       :time         <int|nil>
+       :id           <int|nil>
+       :dispatch-id  <id|nil>
+       :microstep?   <bool>
+       :definition   <machine-def-or-nil>
+       :guards       [<guard-record>...]
+       :actions      [<action-record>...]}
+
+  Returns `[]` when no machine-transition trace fired in the cascade —
+  the silent-by-default branch the view honours per rf2-g3ghh.
+
+  Pure fn — JVM-runnable."
+  ([trace-events]
+   (project-focused-event-transitions trace-events nil))
+  ([trace-events definitions]
+   (let [defs (or definitions {})
+         events (or trace-events [])]
+     (->> events
+          (filter transition-event?)
+          ;; Stable cascade order — :id is monotonic per Spec 009;
+          ;; fall back to :time, then 0.
+          (sort-by (fn [ev] (or (:id ev) (:time ev) 0)))
+          (map (fn [ev]
+                 (let [base (transition-record-from-trace ev)
+                       mid  (:machine-id base)
+                       defn-> (get defs mid)]
+                   (cond-> (attach-guards-and-actions base events)
+                     defn-> (assoc :definition defn->)))))
+          ;; Drop records whose machine-id couldn't be resolved — a
+          ;; malformed trace shouldn't surface a section with no
+          ;; identity. nil :machine-id matches no chart definition so
+          ;; the row would be unrenderable anyway.
+          (filter :machine-id)
+          vec))))
+
+(defn focused-epoch-record
+  "Resolve the epoch record whose `:epoch-id` matches `focus`'s
+  `:epoch-id`. The spine sub `:rf.causa/focus` carries the focused
+  cascade's settling `:epoch-id` per spec/018 §6 (Spine events); the
+  record's `:trace-events` is the cascade window the lens reads.
+
+  Falls back to the head record when the focused epoch-id is nil
+  (LIVE mode default; matches the views-focused-cascade-pair fallback
+  pattern). Returns nil when the buffer is empty.
+
+  Pure fn — JVM-runnable."
+  [epoch-history focus]
+  (let [history (vec (or epoch-history []))]
+    (cond
+      (empty? history) nil
+      (some? (:epoch-id focus))
+      (or (some (fn [r] (when (= (:epoch-id focus) (:epoch-id r)) r))
+                history)
+          ;; Focused epoch-id not in buffer (evicted) → fall back to
+          ;; head so the panel renders something rather than going
+          ;; silent on what is really a buffer-eviction event.
+          (peek history))
+      :else (peek history))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
@@ -137,11 +137,15 @@
 
 ;; ---- (2) Mode C activation threshold ------------------------------------
 
-(deftest resolve-mode-honours-auto-classification
-  (testing "with no forced override, resolve-mode == view-mode"
-    (is (= :mode-a (machine-inspector/resolve-mode 0   nil)))
-    (is (= :mode-b (machine-inspector/resolve-mode 1   nil)))
-    (is (= :mode-c (machine-inspector/resolve-mode 100 nil)))))
+(deftest resolve-mode-defaults-to-focused-event-lens
+  (testing "per rf2-a9cke the panel default is the focused-event lens —
+            with no forced override, resolve-mode returns :focused-event
+            regardless of instance count. The picker-driven Mode A/B/C
+            classifier remains available via `view-mode` for callers
+            that want to hint at the auto pick."
+    (is (= :focused-event (machine-inspector/resolve-mode 0   nil)))
+    (is (= :focused-event (machine-inspector/resolve-mode 1   nil)))
+    (is (= :focused-event (machine-inspector/resolve-mode 100 nil)))))
 
 (deftest resolve-mode-honours-user-force
   (testing "with a forced override, resolve-mode returns it directly"

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
@@ -333,3 +333,140 @@
 (deftest format-event-handles-nil-and-vector
   (is (= "" (h/format-event nil)))
   (is (= "[:auth/submit]" (h/format-event [:auth/submit]))))
+
+;; ---- (10) focused-event lens (rf2-a9cke) --------------------------------
+
+(defn- t-event
+  "Build a `:rf.machine/transition` trace event with the
+  registration.cljc shape — `:before`/`:after` snapshots in `:tags`."
+  ([id mid from to ev]
+   (t-event id mid from to ev :rf.machine/transition))
+  ([id mid from to ev op]
+   {:id        id
+    :time      (* id 10)
+    :operation op
+    :tags      {:machine-id  mid
+                :before      {:state from :data {}}
+                :after       {:state to   :data {}}
+                :event       ev
+                :dispatch-id (str "d-" id)}}))
+
+(deftest project-focused-event-empty-for-no-events
+  (is (= [] (h/project-focused-event-transitions nil)))
+  (is (= [] (h/project-focused-event-transitions []))))
+
+(deftest project-focused-event-empty-for-no-machine-traces
+  (testing "a cascade with no machine traces yields the silent-by-default
+            empty vector"
+    (let [events [{:id 1 :operation :event/dispatched
+                   :tags {:event [:foo]}}
+                  {:id 2 :operation :sub/run
+                   :tags {:sub-id ::bar}}]]
+      (is (= [] (h/project-focused-event-transitions events))))))
+
+(deftest project-focused-event-projects-one-record-per-transition
+  (let [events [(t-event 1 :auth/login :idle    :authing [:auth/submit])
+                (t-event 2 :auth/login :authing :done    [:auth/ok])]
+        records (h/project-focused-event-transitions events)]
+    (is (= 2 (count records)))
+    (is (= [:auth/login :auth/login] (mapv :machine-id records)))
+    (is (= [:idle :authing]          (mapv :from-state records)))
+    (is (= [:authing :done]          (mapv :to-state records)))
+    (is (= [:auth/submit :auth/ok]   (mapv :on-event records)))))
+
+(deftest project-focused-event-preserves-cascade-order
+  (testing "records are oldest-first (cascade document order) regardless
+            of buffer-insertion order"
+    (let [events [(t-event 2 :auth/login :authing :done    [:auth/ok])
+                  (t-event 1 :auth/login :idle    :authing [:auth/submit])]
+          records (h/project-focused-event-transitions events)]
+      (is (= [:idle :authing] (mapv :from-state records))))))
+
+(deftest project-focused-event-multi-machine
+  (testing "a cascade triggering ≥ 1 transitions across multiple machines
+            yields one record per transition, document-order"
+    (let [events [(t-event 1 :auth/login    :idle   :ok    [:bootstrap])
+                  (t-event 2 :checkout/flow :idle   :paying [:cart/sync])
+                  (t-event 3 :session/clock :tick-0 :tick-1 [:tick])]
+          records (h/project-focused-event-transitions events)]
+      (is (= 3 (count records)))
+      (is (= [:auth/login :checkout/flow :session/clock]
+             (mapv :machine-id records))))))
+
+(deftest project-focused-event-surfaces-microstep-flag
+  (let [events [(t-event 1 :auth/login :idle    :authing [:auth/submit])
+                (t-event 2 :auth/login :authing :done    [:always]
+                          :rf.machine.microstep/transition)]
+        records (h/project-focused-event-transitions events)]
+    (is (= [false true] (mapv :microstep? records)))))
+
+(deftest project-focused-event-attaches-definition-when-present
+  (let [definitions {:auth/login {:initial :idle
+                                  :states  {:idle    {:on {:submit :authing}}
+                                            :authing {:on {:ok :done}}
+                                            :done    {:final? true}}}}
+        events [(t-event 1 :auth/login :idle :authing [:auth/submit])]
+        records (h/project-focused-event-transitions events definitions)]
+    (is (= 1 (count records)))
+    (is (= (get definitions :auth/login)
+           (-> records first :definition)))))
+
+(deftest project-focused-event-drops-records-without-machine-id
+  (testing "a malformed trace lacking :machine-id is dropped rather
+            than rendered as an identityless section"
+    (let [events [{:id 1 :time 1 :operation :rf.machine/transition
+                   :tags {:before {:state :a :data {}}
+                          :after  {:state :b :data {}}}}]]
+      (is (= [] (h/project-focused-event-transitions events))))))
+
+(deftest project-focused-event-attaches-guard-and-action-traces
+  (testing "when the substrate emits guard-evaluated / action-ran traces,
+            they attach to the per-transition record by machine-id"
+    (let [events [(t-event 1 :auth/login :idle :authing [:auth/submit])
+                  {:id 2 :time 11 :operation :rf.machine/guard-evaluated
+                   :tags {:machine-id :auth/login
+                          :guard-id   :user-has-credentials?
+                          :input      {:user "ada"}
+                          :outcome    :pass}}
+                  {:id 3 :time 12 :operation :rf.machine/action-ran
+                   :tags {:machine-id :auth/login
+                          :action-id  :issue-token
+                          :input      {:user "ada"}
+                          :outcome    :ok}}]
+          records (h/project-focused-event-transitions events)]
+      (is (= 1 (count records)))
+      (let [rec (first records)]
+        (is (= 1 (count (:guards rec))))
+        (is (= :user-has-credentials? (-> rec :guards first :guard-id)))
+        (is (= :pass                  (-> rec :guards first :outcome)))
+        (is (= 1 (count (:actions rec))))
+        (is (= :issue-token (-> rec :actions first :action-id)))
+        (is (= :ok          (-> rec :actions first :outcome)))))))
+
+;; ---- (11) focused-epoch-record (rf2-a9cke) ------------------------------
+
+(deftest focused-epoch-record-empty-history
+  (is (nil? (h/focused-epoch-record nil  {:epoch-id 7})))
+  (is (nil? (h/focused-epoch-record []   {:epoch-id 7}))))
+
+(deftest focused-epoch-record-matches-by-epoch-id
+  (let [history [{:epoch-id 5 :trace-events []}
+                 {:epoch-id 7 :trace-events [:x]}
+                 {:epoch-id 9 :trace-events []}]]
+    (is (= 7 (:epoch-id (h/focused-epoch-record history {:epoch-id 7}))))))
+
+(deftest focused-epoch-record-falls-back-to-head-for-live-focus
+  (testing "LIVE focus carries nil :epoch-id → fall back to head (the
+            most recent settling epoch in the history)"
+    (let [history [{:epoch-id 5 :trace-events []}
+                   {:epoch-id 7 :trace-events []}]]
+      (is (= 7 (:epoch-id (h/focused-epoch-record history nil))))
+      (is (= 7 (:epoch-id (h/focused-epoch-record history {:epoch-id nil})))))))
+
+(deftest focused-epoch-record-falls-back-to-head-when-evicted
+  (testing "Focused :epoch-id no longer in the buffer → fall back to head
+            so the panel renders SOMETHING rather than going silent on a
+            buffer-eviction event"
+    (let [history [{:epoch-id 5 :trace-events []}
+                   {:epoch-id 7 :trace-events []}]]
+      (is (= 7 (:epoch-id (h/focused-epoch-record history {:epoch-id 99})))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
@@ -121,6 +121,15 @@
   (rf/dispatch-sync
     [:rf.causa/set-machine-definitions-override-for-test definitions]))
 
+(defn- force-picker-mode!
+  "Force the panel out of the rf2-a9cke focused-event default into the
+  picker-driven Mode A (definition) so the chart / sim chrome / sim
+  side-rail this test ns exercises mounts. The sim sub-mode is
+  picker-driven by design — the focused-event lens is the canonical
+  lens but doesn't surface the sim sub-mode chrome."
+  []
+  (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-a]))
+
 (def ^:private ok-result
   {:re-frame.machines.result/tag :ok
    :re-frame.machines.result/snap {:state :authing :data {:counter 1}}
@@ -300,6 +309,7 @@
 (deftest chart-flips-sim-active-when-sim-on
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-snapshots!   {:auth/login {:state :idle :data {}}})
     (override-definitions! {:auth/login fixture-definition})
@@ -322,6 +332,7 @@
             from the sim snapshot, not the production snapshot"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
+      (force-picker-mode!)
       (override-machines!    [:auth/login])
       ;; The production snapshot says :authing — but sim's snapshot
       ;; starts at :idle (the definition's :initial). The chart should
@@ -340,6 +351,7 @@
 (deftest chart-highlight-follows-sim-step
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -360,6 +372,7 @@
 (deftest side-rail-mounts-when-sim-active
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -384,6 +397,7 @@
 (deftest side-rail-renders-available-transitions
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -403,6 +417,7 @@
 (deftest side-rail-renders-audit-trail-after-step
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -427,6 +442,7 @@
 (deftest side-rail-surfaces-error-on-fail
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -447,6 +463,7 @@
 (deftest toggle-button-enabled-when-definition-present
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (let [tree   (machine-inspector/Panel)
@@ -459,6 +476,7 @@
 (deftest toggle-button-disabled-without-definition
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines! [:auth/login])
     ;; No definitions override — Causa has no way to clone.
     (let [tree   (machine-inspector/Panel)
@@ -470,6 +488,7 @@
 (deftest toggle-button-dispatches-sim-start-and-stop
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
@@ -491,6 +510,7 @@
 (deftest toggle-button-stops-sim-when-active
   (setup-causa-frame!)
   (rf/with-frame :rf/causa
+    (force-picker-mode!)
     (override-machines!    [:auth/login])
     (override-definitions! {:auth/login fixture-definition})
     (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -106,6 +106,13 @@
   (rf/dispatch-sync
     [:rf.causa/set-machine-definitions-override-for-test definitions]))
 
+(defn- force-mode!
+  "Force the panel out of the rf2-a9cke focused-event default into one
+  of the picker-driven exploration modes for tests that pin the
+  picker / chart / ribbon chrome that only renders under those modes."
+  [mode]
+  (rf/dispatch-sync [:rf.causa/set-forced-machine-mode mode]))
+
 (def ^:private fixture-definition
   {:initial :idle
    :states  {:idle    {:on {:start :authing}}
@@ -187,16 +194,33 @@
 ;; ---- (3) picker ---------------------------------------------------------
 
 (deftest picker-renders-with-machines
-  (testing "with the override populated the picker renders the dropdown"
+  (testing "with the override populated the picker renders the dropdown
+            under any picker-driven exploration mode (rf2-a9cke: Mode A
+            here; the focused-event default has its own per-section
+            header instead)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login :checkout/flow])
+      (force-mode! :mode-a)
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-picker"))
             "picker container present")
         (is (some? (find-by-testid
                      tree "rf-causa-machine-inspector-picker-select"))
             "picker dropdown present")))))
+
+(deftest picker-hidden-in-focused-event-default-mode
+  (testing "the rf2-a9cke focused-event default has its own per-section
+            header chrome; the picker is opt-in via the mode strip"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login :checkout/flow])
+      (let [tree (machine-inspector/Panel)
+            root (find-by-testid tree "rf-causa-machine-inspector")]
+        (is (= "focused-event" (:data-view-mode (second root)))
+            "default mode is rf2-a9cke focused-event lens")
+        (is (nil? (find-by-testid tree "rf-causa-machine-inspector-picker"))
+            "picker chrome is hidden in the focused-event default")))))
 
 (deftest select-machine-id-event-writes-to-causa-frame
   (testing ":rf.causa/select-machine-id stores the machine-id on the Causa frame"
@@ -226,10 +250,13 @@
 
 (deftest placeholder-banner-renders-with-selection
   (testing "the placeholder banner calls out the deferred machines-viz
-            impl whenever a machine is selected"
+            impl whenever a machine is selected (picker-driven Mode A;
+            the rf2-a9cke focused-event default has its own per-section
+            chrome)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
+      (force-mode! :mode-a)
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid
                      tree "rf-causa-machine-inspector-placeholder-banner"))
@@ -238,11 +265,14 @@
 (deftest placeholder-falls-back-to-prop-summary-without-definition
   (testing "when no machine-definition is available (no introspection
             metadata), the panel falls back to the prop-summary
-            view so the panel still renders something useful"
+            view so the panel still renders something useful (picker-
+            driven Mode B; the rf2-a9cke focused-event default has its
+            own no-definition fallback)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!  [:auth/login])
       (override-snapshots! {:auth/login {:state :authing :data {}}})
+      (force-mode! :mode-b)
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-placeholder")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-prop-machine-id")))
@@ -250,12 +280,15 @@
 
 (deftest chart-renders-when-definition-is-available
   (testing "with the definitions override populated, the panel renders
-            the live SVG chart instead of the prop-summary fallback"
+            the live SVG chart instead of the prop-summary fallback
+            (picker-driven Mode B; the rf2-a9cke focused-event default
+            renders its own chart per section)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!    [:auth/login])
       (override-snapshots!   {:auth/login {:state :authing :data {}}})
       (override-definitions! {:auth/login fixture-definition})
+      (force-mode! :mode-b)
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-chart"))
             "the chart container replaces the prop-summary fallback")
@@ -265,12 +298,14 @@
             "the fallback is suppressed when a definition is available")))))
 
 (deftest chart-highlights-active-state-from-snapshot
-  (testing "the chart's root data-highlight-id matches the snapshot's :state"
+  (testing "the chart's root data-highlight-id matches the snapshot's :state
+            (picker-driven Mode B)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!    [:auth/login])
       (override-snapshots!   {:auth/login {:state :authing :data {}}})
       (override-definitions! {:auth/login fixture-definition})
+      (force-mode! :mode-b)
       (let [tree (machine-inspector/Panel)
             chart (find-by-testid tree "rf-causa-machine-inspector-chart")]
         (is (some? chart))
@@ -281,20 +316,26 @@
 
 (deftest ribbon-renders-empty-when-no-transitions
   (testing "with no transition events in the buffer the ribbon shows
-            its empty branch"
+            its empty branch (picker-driven Mode A — the ribbon is
+            scoped to a single picker-selected machine; the rf2-a9cke
+            focused-event default surfaces transitions via per-section
+            sections instead)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
+      (force-mode! :mode-a)
       (let [tree (machine-inspector/Panel)]
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon")))
         (is (some? (find-by-testid tree "rf-causa-machine-inspector-ribbon-empty")))))))
 
 (deftest ribbon-renders-entries-when-transitions-present
   (testing "with transition events in the buffer for the selected machine
-            the ribbon renders one entry per transition"
+            the ribbon renders one entry per transition (picker-driven
+            Mode A)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
+      (force-mode! :mode-a)
       ;; Push two transition events into the Causa trace buffer via
       ;; the production `collect-trace!` path (per rf2-e9s81 the
       ;; sub thunks the trace-bus atom).
@@ -314,10 +355,12 @@
 
 (deftest ribbon-entry-click-pivots-to-event-detail
   (testing "clicking a ribbon entry dispatches :rf.causa/select-dispatch-id
-            (parity with the Issues ribbon + Trace panel cross-panel jump)"
+            (parity with the Issues ribbon + Trace panel cross-panel jump;
+            picker-driven Mode A)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines! [:auth/login])
+      (force-mode! :mode-a)
       ;; Push a transition event via `collect-trace!` (per rf2-e9s81
       ;; the sub thunks the trace-bus atom).
       (trace-bus/collect-trace!
@@ -344,8 +387,11 @@
 ;; ---- (5b) Mode A / Mode B (UC2 dynamic instance modes) ----------------
 
 (deftest view-mode-helper-routes-by-instance-count
-  (testing "the view-mode classifier returns :mode-a / :mode-b / :mode-c
-            per spec/003-Machine-Inspector.md §UC2"
+  (testing "the view-mode auto-classifier returns :mode-a / :mode-b /
+            :mode-c per spec/003-Machine-Inspector.md §UC2. Note that
+            per rf2-a9cke `view-mode` is now only the AUTO classifier
+            for the picker-driven modes; the panel default is
+            :focused-event (see resolve-mode below)"
     (is (= :mode-a (machine-inspector/view-mode 0)))
     (is (= :mode-a (machine-inspector/view-mode nil)))
     (is (= :mode-b (machine-inspector/view-mode 1)))
@@ -353,13 +399,32 @@
     (is (= :mode-c (machine-inspector/view-mode 4)))
     (is (= :mode-c (machine-inspector/view-mode 100)))))
 
-(deftest mode-a-renders-when-no-snapshot-state
-  (testing "with a registered machine but no snapshot :state, the panel
-            renders in Mode A (definition view; instance-tabs hidden)"
+(deftest resolve-mode-defaults-to-focused-event
+  (testing "per rf2-a9cke the panel's default mode is :focused-event
+            (the canonical lens-on-focused-event). The picker-driven
+            Mode A/B/C explorations are opt-in via the mode strip."
+    (is (= :focused-event (machine-inspector/resolve-mode 0 nil)))
+    (is (= :focused-event (machine-inspector/resolve-mode 5 nil)))
+    (is (= :focused-event (machine-inspector/resolve-mode nil nil)))))
+
+(deftest resolve-mode-honours-forced-pick
+  (testing "a forced-mode override pins the resolved mode regardless of
+            instance-count"
+    (is (= :mode-a (machine-inspector/resolve-mode 0 :mode-a)))
+    (is (= :mode-b (machine-inspector/resolve-mode 0 :mode-b)))
+    (is (= :mode-c (machine-inspector/resolve-mode 100 :mode-c)))
+    (is (= :focused-event
+           (machine-inspector/resolve-mode 100 :focused-event)))))
+
+(deftest mode-a-renders-when-forced
+  (testing "with a registered machine + the picker-driven Mode A forced,
+            the panel renders in Mode A (definition view; instance-tabs
+            hidden)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!    [:auth/login])
       (override-definitions! {:auth/login fixture-definition})
+      (force-mode! :mode-a)
       (let [tree (machine-inspector/Panel)
             root (find-by-testid tree "rf-causa-machine-inspector")]
         (is (= "mode-a" (:data-view-mode (second root))))
@@ -368,14 +433,16 @@
                     tree "rf-causa-machine-inspector-instance-tabs"))
             "instance-tabs strip is hidden in Mode A")))))
 
-(deftest mode-b-renders-instance-tabs-when-snapshot-present
-  (testing "with a registered machine + a live snapshot, the panel
-            renders in Mode B (instance tabs visible above the chart)"
+(deftest mode-b-renders-instance-tabs-when-forced
+  (testing "with a registered machine + a live snapshot + Mode B forced,
+            the panel renders in Mode B (instance tabs visible above
+            the chart)"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (override-machines!    [:auth/login])
       (override-snapshots!   {:auth/login {:state :authing :data {}}})
       (override-definitions! {:auth/login fixture-definition})
+      (force-mode! :mode-b)
       (let [tree (machine-inspector/Panel)
             root (find-by-testid tree "rf-causa-machine-inspector")
             tabs (find-by-testid
@@ -384,6 +451,144 @@
         (is (= 1 (:data-instance-count (second root))))
         (is (some? tabs) "instance-tabs strip is present in Mode B")
         (is (= "mode-b" (:data-mode (second tabs))))))))
+
+;; ---- (5c) focused-event lens (rf2-a9cke) ------------------------------
+
+(defn- override-epoch-history!
+  "Write an epoch-history slot so the focused-event lens has cascade
+  windows to walk. Used by the rf2-a9cke wiring tests; mirrors the
+  existing `override-*` pattern but writes the slot directly since
+  the panel's existing test-overrides cover registered-machines /
+  snapshots / definitions only."
+  [history]
+  (rf/dispatch-sync
+    [:rf.causa/set-epoch-history-for-test history]))
+
+(defn- focus-epoch!
+  "Pin the spine's focus to a specific :epoch-id by writing through
+  `:rf.causa/focus-cascade` (which the spine reduces to also stamp
+  :epoch-id when resolvable). Tests that want explicit control of
+  the focused epoch write the slot directly via the event below."
+  [epoch-id]
+  (rf/dispatch-sync
+    [:rf.causa/set-focus-epoch-id-for-test epoch-id]))
+
+(deftest focused-event-mode-is-the-default
+  (testing "the panel's default mode is :focused-event per rf2-a9cke
+            (no forced-mode → focused-event lens wins)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (let [tree (machine-inspector/Panel)
+            root (find-by-testid tree "rf-causa-machine-inspector")]
+        (is (= "focused-event" (:data-view-mode (second root))))
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-inspector-focused-event-host"))
+            "the focused-event host is mounted at the default surface")))))
+
+(deftest focused-event-lens-is-silent-when-no-machine-traces
+  (testing "per rf2-g3ghh silent-by-default: an empty cascade window
+            renders the host but NO focused-event sections"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (let [tree (machine-inspector/Panel)
+            host (find-by-testid
+                   tree "rf-causa-machine-inspector-focused-event-host")]
+        (is (some? host) "host present (the chrome always mounts)")
+        (is (nil? (find-by-testid tree "rf-causa-machine-focused-event"))
+            "no inner focused-event surface when no machine transitions")))))
+
+(deftest focused-event-lens-renders-one-section-per-transition
+  (testing "an epoch whose :trace-events carry ≥ 1 :rf.machine/transition
+            events yields one focused-event-section per record (rf2-a9cke
+            canonical design)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1 :trace-events []}
+         {:epoch-id 2
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit]
+                   :dispatch-id "d-1"}}]}])
+      (focus-epoch! 2)
+      (let [tree (machine-inspector/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-machine-focused-event"))
+            "the focused-event surface mounts when the cascade has a transition")
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-focused-event-section-auth/login"))
+            "one section per transitioned machine")
+        (is (some? (find-by-testid
+                     tree "rf-causa-machine-focused-event-chart"))
+            "the section renders the topology chart")))))
+
+(deftest focused-event-lens-renders-multi-machine-cascade
+  (testing "a cascade triggering transitions across multiple machines
+            yields one section per machine, document-order (rf2-a9cke
+            multi-machine acceptance)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login :checkout/flow :session/clock])
+      (override-definitions! {:auth/login    fixture-definition
+                              :checkout/flow fixture-definition
+                              :session/clock fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 7
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :dispatch-id "d-1"}}
+           {:id 2 :time 11 :operation :rf.machine/transition
+            :tags {:machine-id :checkout/flow
+                   :before     {:state :idle :data {}}
+                   :after      {:state :done :data {}}
+                   :event      [:cart/sync] :dispatch-id "d-1"}}
+           {:id 3 :time 12 :operation :rf.machine/transition
+            :tags {:machine-id :session/clock
+                   :before     {:state :idle :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:tick] :dispatch-id "d-1"}}]}])
+      (focus-epoch! 7)
+      (let [tree     (machine-inspector/Panel)
+            sections (find-all-by-testid-prefix
+                       tree "rf-causa-machine-focused-event-section-")]
+        (is (= 3 (count sections))
+            "three sections — one per transitioned machine")
+        (is (= [":auth/login" ":checkout/flow" ":session/clock"]
+               (mapv #(:data-machine-id (second %)) sections))
+            "sections appear in cascade document order")))))
+
+(deftest focused-event-section-emits-from-and-to-highlight-ids
+  (testing "the per-section chart carries data-from/to-highlight-id so
+            the chart's render path applies the dashed-origin + bold-
+            landing visual grammar"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (override-epoch-history!
+        [{:epoch-id 1
+          :trace-events
+          [{:id 1 :time 10 :operation :rf.machine/transition
+            :tags {:machine-id :auth/login
+                   :before     {:state :idle    :data {}}
+                   :after      {:state :authing :data {}}
+                   :event      [:auth/submit] :dispatch-id "d-1"}}]}])
+      (focus-epoch! 1)
+      (let [tree   (machine-inspector/Panel)
+            chart  (find-by-testid
+                     tree "rf-causa-machine-focused-event-chart")]
+        (is (some? chart))
+        (is (= "idle"    (:data-from-highlight-id (second chart))))
+        (is (= "authing" (:data-to-highlight-id   (second chart))))))))
 
 ;; ---- (6) frame isolation ------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -375,6 +375,9 @@
    :rf.causa/set-registered-fxs-override-for-test
    :rf.causa/set-registered-machines-override-for-test
    :rf.causa/set-arc-hover
+   ;; rf2-a9cke — focused-event lens test overrides (Machine Inspector).
+   :rf.causa/set-epoch-history-for-test
+   :rf.causa/set-focus-epoch-id-for-test
    :rf.causa/set-registered-routes-override-for-test
    :rf.causa/set-schema-filter
    :rf.causa/set-scrubber-position
@@ -635,7 +638,11 @@
     ;; + 2 resize handle (rf2-x8h9y):
     ;;   :rf.causa/set-panel-width-px (drag live update) +
     ;;   :rf.causa/reset-panel-width (double-click reset).
-    (is (= 145 (count all-event-names)))
+    ;; + 2 rf2-a9cke focused-event lens test overrides:
+    ;;   :rf.causa/set-epoch-history-for-test (writes the epoch-history
+    ;;   slot the lens walks) + :rf.causa/set-focus-epoch-id-for-test
+    ;;   (pins the spine focus's :epoch-id to a known cascade).
+    (is (= 147 (count all-event-names)))
     ;; 4 baseline (`:rf.causa.fx/copy-to-clipboard`,
     ;; `:rf.causa.fx/reset-frame-db!`, `:rf.causa.fx/restore-epoch`,
     ;; `:rf.editor/open`) + 1 palette (`:rf.causa.palette.fx/popout`,


### PR DESCRIPTION
## Summary
- Implements Mike's canonical Machines design (rf2-si9o5) and closes the audit follow-on (rf2-omdal / rf2-a9cke). The Machines tab is now a lens on the FOCUSED event: silent when the event triggered no machine transitions; one section per transitioned machine otherwise — each section showing the topology with FROM (dashed accent-violet) and TO (bold cyan) state highlights, the connecting transition-edge emphasised, plus per-transition Guards and Actions lists.
- The focused-event lens is the new default mode. Picker-driven exploration (Mode A definition / Mode B instance tabs / Mode C cluster + UC1 Sim sub-mode + Phase 5 arc/scrubber/share + cancellation-cascade) is preserved verbatim and accessible via the now-four-tab mode strip: `[Focused event] [Definition] [Instances] [Cluster]`.

## What landed
- **New composite sub** `:rf.causa/machine-transitions-for-focused-event` — composes the spine focus (`:epoch-id` per spec/018 §6), the per-frame epoch-history (cascade window via `:trace-events`), and the registered machine definitions. Returns a vector of per-machine transition records oldest-first; empty when no machine transitioned in the focused cascade.
- **Chart primitive extension** — `chart/svg.cljc`'s `render` accepts `:from-highlight-id` / `:to-highlight-id` for the two-node highlight grammar. Existing single `:highlight-id` channel is unchanged for picker-driven modes.
- **New view** — `focused-event-view` + per-section renderer in `machine_inspector.cljs`. Pure hiccup, frame-isolated to `:rf/causa`.
- **Pure helpers** — `project-focused-event-transitions` + `focused-epoch-record` + the canonical guard/action operation taxonomies in `machine_inspector_helpers.cljc`. All JVM-runnable.

## Substrate gap (divergence allowance, as the dispatch noted)
Today's `re-frame.machines.*` substrate emits `:rf.machine/transition` and `:rf.machine.microstep/transition` (carrying `:before`/`:after` snapshots) — but no per-step `:rf.machine/guard-evaluated` or `:rf.machine/action-ran` traces. The helper looks for those operation keys anyway (forward-compatible vocabulary in `guard-operations` / `action-operations`); when the runtime gains them the per-transition Guards and Actions sections light up without code changes. Until then the sections render only when guard/action traces are present. Follow-on bead recommended to add those trace emissions to `re-frame.machines.transition` / `lifecycle-fx.registration` for the action invocations and guard evaluations.

## Test plan
- [x] `cd tools/causa && clojure -M:test` — 943 tests, 0 failures (JVM helpers exercised under both CLJ + CLJS via `_cljs_test.cljc` extension).
- [x] `cd implementation && npm run test:cljs` — 3220 tests, 0 failures (CLJS node-test build; covers the new view + sub wiring + composite + the picker-driven sim/cluster/scrubber tests pinned via `force-mode!`).
- [x] `bash scripts/test-fast-pr.sh` — PASS fast PR spine.
- [x] `cd implementation && npm run test:browser` — 3197 tests, 0 failures (browser-side chart rendering smoke).

## Preserved modes (Mode A/B/C, Sim, arc/scrubber/share, cancellation-cascade)
- Mode strip is the persistent chrome across modes; clicking the active forced tab clears the force (back to focused-event default).
- All picker-driven view tests (chart, sim toggle, sim rail, ribbon, instance tabs, cluster view) pinned via the new `force-mode!` helper that dispatches `:rf.causa/set-forced-machine-mode :mode-a/b/c` — explicit per-test mode forcing keeps the existing surfaces honest.

## Cites
- Design: rf2-si9o5 (Mike's canonical Machines panel design)
- Audit: rf2-omdal (focus-invariant audit; rf2-a9cke is the Machines-tab follow-on)
- Silent-by-default policy: rf2-g3ghh
- Spine `:epoch-id` prereq (shipped): rf2-ak3ty (PR #1453)
- ELK layout primitive: rf2-m7co9 (PR #1410)
- Compact chart fonts: rf2-gz7vi