### PR TITLE
fix(causa): hard-filter Causa internal events from data layer — Causa no longer instruments itself in user-facing panels

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -260,10 +260,27 @@
     ;; downstream composite declares the dependency via `:<-` so the
     ;; reactive graph stays correct (and idle composites still don't pay
     ;; for the projection).
+    ;;
+    ;; Per rf2-g1pt8 the projection ALSO hard-filters Causa-internal
+    ;; cascades (any cascade whose event-id is in the `rf.causa`
+    ;; namespace) at this single point so every downstream consumer
+    ;; — `:rf.causa/filtered-cascades`, the L2 event list, the spine,
+    ;; the causality popover, the Trace / Issues / Event / Views
+    ;; tabs — inherits the filter automatically. The ingest-side
+    ;; `trace-bus/causa-internal-event?` guard (rf2-xs8vu) catches
+    ;; self-emitted sub-reads + view-renders inside Causa's frame
+    ;; scope, but `:rf.causa/*` events dispatched WITHOUT a
+    ;; `{:frame :rf/causa}` option (palette quick-actions, the
+    ;; causality popover's node click, headless helpers) land on the
+    ;; host frame and slip past the ingest filter. This filter
+    ;; closes that hole structurally without forcing every call site
+    ;; to thread `:frame`. Pre-alpha posture: no opt-out toggle —
+    ;; Causa's internals are not user-facing.
     (rf/reg-sub :rf.causa/cascades
       :<- [:rf.causa/trace-buffer]
       (fn [buffer _query]
-        (projection/group-cascades buffer)))
+        (let [cascades (projection/group-cascades buffer)]
+          (into [] (remove trace-bus/causa-internal-cascade?) cascades))))
 
     ;; Cross-panel sidebar selection. Legacy slot kept alive for tests
     ;; that still address the pre-refactor sidebar contract.

--- a/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/trace_bus.cljc
@@ -235,6 +235,71 @@
   [event]
   (= :rf/causa (or (:frame event) (get-in event [:tags :frame]))))
 
+;; ---- causa-internal event-id guard (rf2-g1pt8) --------------------------
+;;
+;; The ingest-side `causa-internal-event?` predicate above filters trace
+;; events by `:frame`. It catches every emit that originates inside a
+;; `(rf/with-frame :rf/causa ...)` scope — the dominant self-noise case
+;; (panel re-render `:sub/run` + `:view/render` floods).
+;;
+;; But it misses one cleanup pattern: Causa-internal events (`:rf.causa/
+;; focus-cascade`, `:rf.causa/select-tab`, `:rf.causa/open-settings`,
+;; etc.) dispatched WITHOUT a `:frame :rf/causa` option. Those land on
+;; the host's `:rf/default` frame (re-frame chain-resolution per
+;; rf2-higwg), so the trace envelope carries `:frame :rf/default` —
+;; the ingest filter waves them through into Causa's buffer, and the
+;; L2 event list shows Causa instrumenting itself in the user-facing
+;; cascade list. Concrete sites (as of this fix): the causality popover
+;; node click in `popover/causality_graph.cljs:255`, the palette's
+;; `:palette/select-panel` dispatch in `palette/events.cljs:175`, and
+;; the headless `core/select-panel!` helper.
+;;
+;; Tightening every call site to pass `{:frame :rf/causa}` would be a
+;; manual sweep with no structural guarantee. The data-layer guard
+;; here is the single point of truth: cascades whose event vector's
+;; head is in the `rf.causa` namespace are filtered out of the shared
+;; `:rf.causa/cascades` sub, and every downstream consumer (the
+;; filtered-cascades facade, the L2 event list, the spine, the
+;; causality popover, performance / event-detail / trace / issues
+;; tabs) inherits the filter automatically. Single point of truth;
+;; readers stay simple.
+;;
+;; Pre-alpha posture mirrors `causa-internal-event?`: drop
+;; unconditionally, no opt-out toggle. Causa's internals are
+;; structurally invisible to the user.
+
+(defn causa-internal-event-id?
+  "True when `event-id` is a keyword in the `rf.causa` namespace
+  (spec/Conventions.md §Reserved namespaces — Causa's canonical
+  devtool prefix).
+
+  Pure-data + JVM-runnable; nil-safe.
+
+  Examples:
+    (causa-internal-event-id? :rf.causa/focus-cascade)  ;; true
+    (causa-internal-event-id? :rf.causa/select-tab)     ;; true
+    (causa-internal-event-id? :cart/add-item)           ;; false
+    (causa-internal-event-id? :rf/init)                 ;; false
+    (causa-internal-event-id? nil)                      ;; false
+    (causa-internal-event-id? \"rf.causa/x\")           ;; false (non-kw)"
+  [event-id]
+  (and (keyword? event-id)
+       (= "rf.causa" (namespace event-id))))
+
+(defn causa-internal-cascade?
+  "True when `cascade`'s `:event` vector's head is a Causa-internal
+  event-id (see `causa-internal-event-id?`). False for cascades whose
+  event vector is absent (e.g. the `:ungrouped` bucket — those are
+  filtered separately by `cascade-has-event?` at the L2 boundary).
+
+  Pure-data + JVM-runnable. Used by the `:rf.causa/cascades` sub to
+  hard-filter Causa's own events out of every downstream consumer
+  per rf2-g1pt8."
+  [cascade]
+  (let [ev (:event cascade)]
+    (and (vector? ev)
+         (causa-internal-event-id? (first ev)))))
+
 ;; ---- collector --------------------------------------------------------
 
 (defn collect-trace!

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -850,6 +850,95 @@
       (finally
         (trace-bus/set-buffer-depth! 1000)))))
 
+;; ---- :rf.causa/cascades — causa-internal filter (rf2-g1pt8) ------------
+
+(defn- mk-cascade
+  "Build a minimal cascade record for the data-layer filter test —
+  matches the shape `re-frame.trace.projection/group-cascades`
+  returns (`:dispatch-id` + `:event` vector)."
+  [dispatch-id event-vec]
+  {:dispatch-id dispatch-id
+   :event       event-vec
+   :other       []})
+
+(defn- seed-buffer-with-dispatched-events!
+  "Push synthetic `:event/dispatched` trace events into Causa's trace
+  buffer so `group-cascades` produces one cascade per event. Each
+  trace event needs `:operation :event/dispatched`, `:op-type :event`,
+  a unique `:dispatch-id` (cascade-grouping key), and the event vector
+  under `:tags :event`."
+  [events]
+  (doseq [{:keys [dispatch-id event-vec]} events]
+    (trace-bus/collect-trace!
+      {:operation   :event/dispatched
+       :op-type     :event
+       :id          dispatch-id
+       :time        (* dispatch-id 1000)
+       :tags        {:dispatch-id dispatch-id
+                     :event       event-vec
+                     :event-id    (first event-vec)
+                     :frame       :rf/default}})))
+
+(deftest sub-cascades-filters-causa-internal-events
+  (testing "per rf2-g1pt8 — `:rf.causa/cascades` hard-filters cascades
+            whose event-id is in the `rf.causa` namespace at the
+            data-layer so every downstream consumer (filtered-cascades,
+            L2 event list, spine, popovers, all tabs) inherits the
+            filter automatically. Synthetic dispatched-event mix: 2
+            user-app + 3 Causa-internal → sub returns only the 2
+            user-app cascades."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-buffer-with-dispatched-events!
+        [{:dispatch-id 1 :event-vec [:cart/add-item {:item-id "apple"}]}
+         {:dispatch-id 2 :event-vec [:rf.causa/focus-cascade 99]}
+         {:dispatch-id 3 :event-vec [:checkout/start]}
+         {:dispatch-id 4 :event-vec [:rf.causa/select-tab :event]}
+         {:dispatch-id 5 :event-vec [:rf.causa/open-settings]}])
+      (let [cascades @(rf/subscribe [:rf.causa/cascades])
+            event-ids (mapv #(first (:event %)) cascades)]
+        (is (= 2 (count cascades))
+            "the 3 :rf.causa/* cascades are filtered; the 2 user-app cascades survive")
+        (is (= [:cart/add-item :checkout/start] event-ids)
+            "the surviving cascades carry the user-app event-ids in oldest-first order")
+        (is (every? (complement trace-bus/causa-internal-cascade?) cascades)
+            "no Causa-internal cascade leaks past the data-layer filter")))))
+
+(deftest sub-cascades-filter-also-applies-to-filtered-cascades
+  (testing "per rf2-g1pt8 — because `:rf.causa/filtered-cascades`
+            composes against `:rf.causa/cascades`, the data-layer
+            filter propagates automatically. Synthetic Causa-internal
+            cascades are gone before the auto-filter facade even sees
+            them, so the L2 list (which subscribes to filtered-
+            cascades) shows only user-app rows."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-buffer-with-dispatched-events!
+        [{:dispatch-id 1 :event-vec [:cart/add-item]}
+         {:dispatch-id 2 :event-vec [:rf.causa/select-tab :machines]}
+         {:dispatch-id 3 :event-vec [:checkout/start]}])
+      (let [filtered @(rf/subscribe [:rf.causa/filtered-cascades])
+            event-ids (mapv #(first (:event %)) filtered)]
+        (is (= [:cart/add-item :checkout/start] event-ids)
+            "the :rf.causa/select-tab cascade is filtered out at the data-layer")))))
+
+(deftest sub-cascades-pure-user-app-pass-through
+  (testing "per rf2-g1pt8 — a buffer with only user-app cascades is
+            untouched by the data-layer filter (count + ordering
+            preserved). Symmetry guard: the filter is narrow, not a
+            blanket rejection."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-buffer-with-dispatched-events!
+        [{:dispatch-id 1 :event-vec [:cart/add-item {:item-id "apple"}]}
+         {:dispatch-id 2 :event-vec [:cart/remove-item {:item-id "apple"}]}
+         {:dispatch-id 3 :event-vec [:checkout/start]}])
+      (let [cascades @(rf/subscribe [:rf.causa/cascades])]
+        (is (= 3 (count cascades))
+            "user-app-only buffer is untouched by the filter")
+        (is (= [:cart/add-item :cart/remove-item :checkout/start]
+               (mapv #(first (:event %)) cascades)))))))
+
 (deftest sub-suppressed-sensitive-count-reads-app-db
   (testing ":rf.causa/suppressed-sensitive-count reads from Causa's
             app-db at `:suppressed-counters` (rf2-0vxdn) — first deref

--- a/tools/causa/test/day8/re_frame2_causa/trace_bus_self_noise_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/trace_bus_self_noise_cljs_test.cljc
@@ -188,3 +188,79 @@
           :tags {:sub-id :user/some-sub :frame :rf/default}})
        (is (= 1 (count (trace-bus/buffer)))
            "non-Causa :sub/run events flow through normally"))))
+
+;; ---- causa-internal event-id guard (rf2-g1pt8) --------------------------
+;;
+;; Pure-data sibling of `causa-internal-event?`. The ingest filter above
+;; catches every trace event emitted INSIDE `(rf/with-frame :rf/causa
+;; ...)`. The data-layer filter below catches every CASCADE whose
+;; event-id is in the `rf.causa` namespace — covering :rf.causa/* events
+;; dispatched WITHOUT `:frame :rf/causa` (those land on the host frame
+;; and slip past the ingest filter; the data-layer guard at the
+;; `:rf.causa/cascades` sub closes the hole structurally).
+;;
+;; Predicate tests run under both CLJ + CLJS (pure data, no
+;; collect-trace! plumbing).
+
+(deftest causa-internal-event-id?-keyword-namespace
+  (testing "true iff event-id is a keyword in the `rf.causa` namespace"
+    (is (true?  (trace-bus/causa-internal-event-id? :rf.causa/focus-cascade)))
+    (is (true?  (trace-bus/causa-internal-event-id? :rf.causa/select-tab)))
+    (is (true?  (trace-bus/causa-internal-event-id? :rf.causa/open-settings)))
+    (is (true?  (trace-bus/causa-internal-event-id? :rf.causa/select-panel)))
+    (is (true?  (trace-bus/causa-internal-event-id? :rf.causa/sync-trace-buffer)))
+    (testing "user-app events stay false"
+      (is (false? (trace-bus/causa-internal-event-id? :cart/add-item)))
+      (is (false? (trace-bus/causa-internal-event-id? :checkout/start)))
+      (is (false? (trace-bus/causa-internal-event-id? :user/click))))
+    (testing "framework + sibling reserved namespaces stay false"
+      ;; The filter is narrow: only `rf.causa`. Sibling reserved
+      ;; namespaces (`:rf/init`, `:rf.epoch/*`) are NOT Causa-internal
+      ;; — they're framework / epoch surface and must remain visible
+      ;; in the user-facing cascade list.
+      (is (false? (trace-bus/causa-internal-event-id? :rf/init)))
+      (is (false? (trace-bus/causa-internal-event-id? :rf.epoch/begin)))
+      (is (false? (trace-bus/causa-internal-event-id? :rf.story/something))))
+    (testing "nil-safe + non-keyword inputs"
+      (is (false? (trace-bus/causa-internal-event-id? nil)))
+      (is (false? (trace-bus/causa-internal-event-id? "rf.causa/foo")))
+      (is (false? (trace-bus/causa-internal-event-id? :unnamespaced)))
+      (is (false? (trace-bus/causa-internal-event-id? 42))))
+    (testing "namespace prefix collision guard"
+      ;; A keyword whose namespace STARTS with `rf.causa` but is not
+      ;; exactly `rf.causa` (e.g. `:rf.causal/x`, `:rf.causal-link/y`)
+      ;; must NOT match. The contract is namespace equality, not
+      ;; prefix matching.
+      (is (false? (trace-bus/causa-internal-event-id? :rf.causal/x)))
+      (is (false? (trace-bus/causa-internal-event-id? :rf.causal-link/y))))))
+
+(deftest causa-internal-cascade?-event-vector-head
+  (testing "true iff the cascade's :event vector's head is causa-internal"
+    (is (true?  (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 1
+                   :event       [:rf.causa/focus-cascade 99]})))
+    (is (true?  (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 2
+                   :event       [:rf.causa/select-tab :event]})))
+    (is (true?  (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 3
+                   :event       [:rf.causa/open-settings]}))
+        "single-element event vector (no payload) still classifies"))
+  (testing "user-app cascades stay false"
+    (is (false? (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 4
+                   :event       [:cart/add-item {:item-id "apple"}]})))
+    (is (false? (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 5
+                   :event       [:user/click]}))))
+  (testing ":ungrouped + event-less cascades stay false"
+    ;; `cascade-has-event?` (rf2-639lc) handles the :ungrouped bucket
+    ;; at the L2 boundary; the causa-internal filter sits orthogonal.
+    (is (false? (trace-bus/causa-internal-cascade?
+                  {:dispatch-id :ungrouped :event nil})))
+    (is (false? (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 6 :event []}))))
+  (testing "malformed shapes don't throw"
+    (is (false? (trace-bus/causa-internal-cascade? {})))
+    (is (false? (trace-bus/causa-internal-cascade?
+                  {:dispatch-id 7 :event "not-a-vector"})))))


### PR DESCRIPTION
## Bug (rf2-g1pt8)

Mike: "I see Causa events flowing into Causa."

Causa's own `:rf.causa/*` events (`focus-cascade`, `select-tab`, `open-settings`, etc.) were leaking into the user-facing L2 event list. The panel was showing Causa instrumenting itself — recursion noise that drowns the host events the developer is actually trying to inspect.

## Root cause

The ingest-side `trace-bus/causa-internal-event?` guard (rf2-xs8vu) drops trace events whose `:frame` slot is `:rf/causa` — covering the dominant self-noise case (panel-re-render `:sub/run` + `:view/render` floods).

But it misses one cleanup pattern: `:rf.causa/*` events dispatched **without** a `{:frame :rf/causa}` option (e.g. the causality popover's node click in `popover/causality_graph.cljs:255`, the palette's `:palette/select-panel` dispatch in `palette/events.cljs:175`, the headless `core/select-panel!` helper). Those land on the host's `:rf/default` frame (re-frame chain-resolution per rf2-higwg), so the trace envelope carries `:frame :rf/default` — the ingest filter waves them through into Causa's buffer, and the L2 event list shows them as if they were user-app cascades.

## Fix — data-layer, single point of truth

Tightening every call site to thread `{:frame :rf/causa}` would be a manual sweep with no structural guarantee. The fix lands at the **data layer**:

- `trace_bus.cljc` — adds `causa-internal-event-id?` + `causa-internal-cascade?` pure-data predicates (JVM-runnable). `causa-internal-event-id?` matches keywords whose namespace equals `"rf.causa"`; the narrow equality check (not a prefix match) prevents accidental classification of sibling namespaces like `:rf.causal/x`.
- `registry.cljs` — applies `(remove causa-internal-cascade?)` at the `:rf.causa/cascades` sub. Every downstream consumer — `:rf.causa/filtered-cascades`, the L2 event list, the spine, the causality popover, the Event / Trace / Issues / Views / Machines tabs — composes against `:rf.causa/cascades` via `:<-` and inherits the filter automatically. No per-consumer change.

Pre-alpha posture mirrors the existing rf2-xs8vu ingest filter: drop unconditionally, no opt-out toggle. Causa's internals are structurally invisible to the developer using Causa. If Causa needs to introspect its own machinery later, that's a separate feature surface (parallel internal buffer), not an opt-out on the user-facing trace feed.

## Tests

- `trace_bus_self_noise_cljs_test.cljc` — two new pure-data deftest blocks covering the new predicates: keyword namespace match, namespace-collision guard (`:rf.causal/x` stays unmatched), nil-safety + non-keyword inputs, sibling reserved namespaces (`:rf/init`, `:rf.epoch/*`) preserved, cascade `:event` head extraction including `:ungrouped` + malformed shapes.
- `registry_cljs_test.cljs` — three new sub-level deftests against `:rf.causa/cascades` + `:rf.causa/filtered-cascades`: a mixed synthetic buffer (2 user-app + 3 Causa-internal) returns only the user-app cascades; the data-layer filter propagates through `:rf.causa/filtered-cascades`; pure user-app buffers pass through unchanged (symmetry guard).

## Gates

- `scripts/test-fast-pr.sh` — PASS (572 JVM + 3204 CLJS)
- `cd tools/causa && clojure -M:test` — PASS (932 / 2712)
- `cd implementation && npm run test:browser` — PASS (3195 / 9170)