### PR TITLE
fix(causa): Trace tab — drop redundant frame-filter chip

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -27,10 +27,18 @@
 
   ## Filter axes (Spec 009 §Filter vocabulary)
 
-  All 9 named axes the vocabulary enumerates are surfaced:
+  The 8 named axes the vocabulary enumerates that the chip-row UI
+  surfaces:
 
-      :op-type      :severity     :source      :origin       :frame
+      :op-type      :severity     :source      :origin
       :operation    :event-id     :handler-id  :dispatch-id
+
+  `:frame` is in the Spec-009 vocabulary but intentionally omitted
+  from the chip-row UI — post-rf2-ycoct the Trace tab is cascade-
+  scoped, so every visible row already shares the focused event's
+  frame; a frame chip would offer to filter on the only value
+  present. The filter algebra still accepts `:frame` if a dispatcher
+  sets it programmatically.
 
   Each axis is set via `:rf.causa/set-trace-filter` (axis, value);
   `nil` clears the axis. The numeric `:since` / `:since-ms` /
@@ -88,12 +96,16 @@
 (def ^:private axis-labels
   "Human-readable label for each filter axis. The view uses these
   for the chip-row headers and for the 'active filter' badges in the
-  header strip."
+  header strip.
+
+  `:frame` is intentionally absent — post-rf2-ycoct the Trace tab is
+  cascade-scoped, so a frame-filter chip on top of the cascade scope
+  is redundant (the focused event has exactly one frame). See
+  `trace-helpers/filter-axes` for the full rationale."
   {:op-type     "op-type"
    :severity    "severity"
    :source      "source"
    :origin      "origin"
-   :frame       "frame"
    :operation   "operation"
    :event-id    "event-id"
    :handler-id  "handler-id"
@@ -352,11 +364,14 @@
                            :white-space   "nowrap"}
              :title       description}
       description]
-     ;; Per-row chip-filters — the bead's contract. We surface the four
+     ;; Per-row chip-filters — the bead's contract. We surface the
      ;; commonly-grepped axes that ride on the row directly (source,
-     ;; origin, frame). The op-type / severity chips ride the dot;
-     ;; clicking the dot itself is a future affordance — for v1 the
-     ;; chip-row in the header is the op-type entry point.
+     ;; origin). The op-type / severity chips ride the dot; clicking
+     ;; the dot itself is a future affordance — for v1 the chip-row in
+     ;; the header is the op-type entry point. `:frame` is omitted —
+     ;; post-rf2-ycoct the Trace tab is cascade-scoped, so every visible
+     ;; row already shares the focused event's frame; a frame chip on
+     ;; the row would offer to filter on the only value present.
      [:span {:data-testid (str row-test-id "-row-chips")
              :style       {:display "flex"
                            :align-items "center"
@@ -364,9 +379,7 @@
       (row-chip {:axis :source :value source
                  :test-id (str row-test-id "-source-chip")})
       (row-chip {:axis :origin :value origin
-                 :test-id (str row-test-id "-origin-chip")})
-      (row-chip {:axis :frame :value frame
-                 :test-id (str row-test-id "-frame-chip")})]
+                 :test-id (str row-test-id "-origin-chip")})]
      ;; Source-coord (when present)
      (if source-coord
        [:button {:data-testid (str row-test-id "-source-coord")

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace_helpers.cljc
@@ -54,12 +54,20 @@
 (def filter-axes
   "The canonical filter-vocabulary axes Spec 009 §Filter vocabulary
   enumerates. Render order for the chip rows in the panel — most-
-  commonly-used axes first. Source/Origin/Frame/Severity ride the
+  commonly-used axes first. Source/Origin/Severity ride the
   enumerable-as-chips path; everything else (:dispatch-id, :event-id,
   :handler-id, :operation, :op-type) is per-row click-to-filter; the
   numeric axes (:since, :since-ms, :between) and :pred ride a
-  follow-on bead."
-  [:op-type :severity :source :origin :frame
+  follow-on bead.
+
+  Note: `:frame` is NOT a chip-row axis. Post-rf2-ycoct the Trace tab
+  is cascade-scoped to the spine's focused event — and the focused
+  event has exactly ONE frame — so a frame-filter chip on top of the
+  cascade scope is doubly redundant (the user has already selected a
+  frame by selecting an event). The underlying filter algebra in
+  `trace-bus/build-filter-predicate` still accepts `:frame` as a
+  vocabulary primitive; we just don't surface a UI for it."
+  [:op-type :severity :source :origin
    :operation :event-id :handler-id :dispatch-id])
 
 ;; ---- short-description ---------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_helpers_cljs_test.cljc
@@ -288,7 +288,10 @@
     (is (contains? (:distinct feed) :op-type))
     (is (contains? (:distinct feed) :severity))
     (is (contains? (:distinct feed) :origin))
-    (is (contains? (:distinct feed) :frame))))
+    (is (not (contains? (:distinct feed) :frame))
+        ":frame is not enumerated as a chip-row axis post-rf2-ycoct
+         (the Trace tab is cascade-scoped so every visible row
+         already shares the focused event's frame)")))
 
 (deftest project-feed-filters-pass-through-normalised
   (let [feed (h/project-feed (events-fixture)
@@ -376,17 +379,26 @@
 
 (deftest filter-axes-cover-the-bead-contract
   (testing "the panel surfaces every named axis from Spec 009
-            §Filter vocabulary that has a chip-row presentation"
+            §Filter vocabulary that has a chip-row presentation.
+
+            Note: `:frame` is intentionally NOT in `filter-axes` —
+            post-rf2-ycoct the Trace tab is cascade-scoped, so the
+            focused event has exactly one frame and a frame chip on
+            top of the scope is redundant. The underlying algebra in
+            `trace-bus/build-filter-predicate` still accepts `:frame`
+            as a vocabulary primitive (covered by `filter-by-frame`
+            below); we just don't enumerate it as a chip-row axis."
     (let [axes (set h/filter-axes)]
       (is (contains? axes :op-type))
       (is (contains? axes :severity))
       (is (contains? axes :source))
       (is (contains? axes :origin))
-      (is (contains? axes :frame))
       (is (contains? axes :operation))
       (is (contains? axes :event-id))
       (is (contains? axes :handler-id))
-      (is (contains? axes :dispatch-id)))))
+      (is (contains? axes :dispatch-id))
+      (is (not (contains? axes :frame))
+          ":frame is not a chip-row axis post-rf2-ycoct cascade-scope"))))
 
 ;; ---- (13) row-key — rf2-z4fza (sibling of rf2-kgn0c) -------------------
 ;;
@@ -526,21 +538,21 @@
 (deftest active-filters-summary-marks-present-and-orphaned
   (let [seen-map {:op-type #{:event :error}
                   :source  #{:ui}
-                  :frame   #{:rf/default}}
+                  :origin  #{:app}}
         summary  (h/active-filters-summary
                    {:op-type :error
                     :source  :timer    ;; orphan
-                    :frame   :rf/default}
+                    :origin  :app}
                    seen-map)]
     (testing "every active axis has an entry"
       (is (= 3 (count summary))))
     (testing "iteration follows filter-axes order (op-type, severity,
-              source, origin, frame, ...)"
-      (is (= [:op-type :source :frame] (mapv :axis summary))))
+              source, origin, ...)"
+      (is (= [:op-type :source :origin] (mapv :axis summary))))
     (testing "present? is true when value is in seen"
       (is (true?  (:present? (some #(when (= :op-type (:axis %)) %) summary))))
       (is (false? (:present? (some #(when (= :source  (:axis %)) %) summary))))
-      (is (true?  (:present? (some #(when (= :frame   (:axis %)) %) summary)))))
+      (is (true?  (:present? (some #(when (= :origin  (:axis %)) %) summary)))))
     (testing "value is preserved verbatim for the empty-state render"
       (is (= :timer (:value (some #(when (= :source (:axis %)) %) summary)))))))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -264,7 +264,7 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame :rf/default])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
       (rf/dispatch-sync [:rf.causa/clear-trace-filters])
       (is (= {} @(rf/subscribe [:rf.causa/trace-filters]))
           "every filter axis cleared"))))
@@ -312,13 +312,13 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (push-trace! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                              :source :ui    :frame :rf/default :dispatch-id 1}))
+                              :source :ui    :origin :app  :dispatch-id 1}))
       (push-trace! (mk-trace {:id 2 :op-type :event :operation :event/dispatched
-                              :source :ui    :frame :rf/causa   :dispatch-id 1}))
+                              :source :ui    :origin :pair :dispatch-id 1}))
       (push-trace! (mk-trace {:id 3 :op-type :event :operation :event/dispatched
-                              :source :timer :frame :rf/default :dispatch-id 1}))
+                              :source :timer :origin :app  :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/default])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :app])
       (let [feed @(rf/subscribe [:rf.causa/trace-feed])]
         (is (= 1 (:rendered feed))
             "only the row matching both axes survives")
@@ -630,10 +630,10 @@
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default
+                             :source :ui :origin :app
                              :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :timer])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame :rf/missing])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :rf/missing-origin])
       (let [dispatches (atom [])]
         (with-redefs [rf/dispatch* (fn
                                      ([ev]      (swap! dispatches conj ev) nil)
@@ -650,32 +650,37 @@
 (deftest empty-state-active-filter-pill-marks-present-vs-orphan
   (testing "rf2-vu0mp: a present axis pill (the value still exists in
             the buffer) is styled differently from an orphan pill — the
-            data-driven marker on the chip label. Event carries
+            data-driven marker on the chip label.
+
+            Post-rf2-ycoct `:frame` is no longer a chip-row axis (the
+            Trace tab is cascade-scoped so the focused event already
+            pins one frame). We exercise the orphan path with `:origin`
+            instead — same algebra; different axis. Event carries
             `:dispatch-id 1` so the spine has a focusable cascade
             (rf2-fzbrw)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       ;; Push :ui-sourced events; then add TWO filters: source = :ui
       ;; (present, but combined with the second filter renders zero
-      ;; rows) AND frame = :rf/missing (orphan).
+      ;; rows) AND origin = :rf/missing-origin (orphan).
       (sync-push! (mk-trace {:id 1 :op-type :event :operation :event/dispatched
-                             :source :ui :frame :rf/default
+                             :source :ui :origin :app
                              :dispatch-id 1}))
       (rf/dispatch-sync [:rf.causa/set-trace-filter :source :ui])
-      (rf/dispatch-sync [:rf.causa/set-trace-filter :frame  :rf/missing])
+      (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :rf/missing-origin])
       (let [tree         (trace/Panel)
             source-pill  (find-by-testid tree "rf-causa-trace-empty-active-source")
-            frame-pill   (find-by-testid tree "rf-causa-trace-empty-active-frame")
+            origin-pill  (find-by-testid tree "rf-causa-trace-empty-active-origin")
             label-of     (fn [node]
                            (->> (hiccup-seq node)
                                 (filter string?)
                                 (apply str)))]
         (is (some? source-pill) "present axis pill renders")
-        (is (some? frame-pill)  "orphan axis pill renders")
+        (is (some? origin-pill)  "orphan axis pill renders")
         (testing "present pill has no orphan marker"
           (is (not (re-find #"orphaned" (label-of source-pill)))))
         (testing "orphan pill carries the orphan marker"
-          (is (re-find #"orphaned" (label-of frame-pill))))))))
+          (is (re-find #"orphaned" (label-of origin-pill))))))))
 
 ;; ---- (10) incremental projection wiring — rf2-44vzy --------------------
 ;;


### PR DESCRIPTION
## Summary

The Trace tab's frame-filter chip is redundant after rf2-ycoct cascade-scoping (PR #1459) lands. Mike: *"Trace allows you to filter on a frame but that makes no sense given you have to select both a frame and an event to even be seeing anything in the trace panel."*

Post-cascade-scope the Trace tab only shows events in the focused event's cascade. The focused event has exactly ONE frame. A frame-filter chip on top of the cascade scope is doubly redundant — the user has already selected a frame by selecting an event.

This PR removes the frame chip from the chip strip and the per-row frame chip; the rest of the chip vocabulary (severity / source / origin / op-type / event-id / handler-id / dispatch-id / operation) is unchanged and still ANDs orthogonally with the cascade scope.

## Changes

- `tools/causa/src/.../panels/trace_helpers.cljc` — drop `:frame` from `filter-axes` (header chip-row + per-axis snapshot machinery). The `frame-of` helper and the `:frame` slot on the projected row stay — they're used downstream by `:rf.causa/select-dispatch-id` to route to event-detail. The framework's `trace-bus/build-filter-predicate` still accepts `:frame` as a Spec 009 vocabulary primitive; we just don't surface a UI for it.
- `tools/causa/src/.../panels/trace.cljs` — drop `:frame` from `axis-labels` (no header chip-row to label); drop the per-row `:frame` row-chip.
- Tests — pin the absence; swap `:frame`-as-witness to `:origin`-as-witness in tests that incidentally used `:frame` as a generic axis value.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 930 tests, 0 failures
- [x] `bash scripts/test-fast-pr.sh` — 3199 tests, 0 failures (core JVM + CLJS node-test + helpers)
- [x] `cd implementation && npm run test:browser` — 3190 tests, 0 failures
- [x] Cascade-scope contract (rf2-ycoct) preserved — `:frame` slot on the projected row + `frame-of` helper are unchanged.