### PR TITLE
fix(causa): Settings popup dismissal + tab nav restored (rf2-smvvz)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -5,7 +5,33 @@
   it in `reg-view` so subscribes route to `:rf/causa`. Visual style
   mirrors the palette modal (dim backdrop, centred dialog,
   `tokens/bg-1` body) so the user gets a consistent affordance
-  class for transient overlays."
+  class for transient overlays.
+
+  ## Why every dispatch carries `{:frame :rf/causa}` (rf2-smvvz)
+
+  Subscribes resolve through the React-context tier at RENDER time —
+  React's `_currentValue` for the `frame-context` is set to `:rf/causa`
+  while the body of the `frame-provider`'s children is rendering, so
+  `(rf/subscribe …)` from inside the popup picks up the right frame
+  with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire
+  LATER — after render commits and React has POPPED `_currentValue`
+  back to the context's default (`:rf/default`). At click time the
+  3-tier frame resolution chain (dynamic var → React-context tier →
+  `:rf/default`) falls all the way through, the dispatch lands on
+  `:rf/default`'s router, and the `:rf.causa/settings-*` handler
+  reduces `:rf/default`'s db — leaving Causa's `:settings-open?` flag
+  untouched. Symptom: X button does nothing, tabs do not switch, Esc
+  does not close — the modal is stuck. Same shape as the
+  `filters/edit_popup.cljs` + `share_modal.cljs` fix that already
+  passes the opt explicitly.
+
+  The fix is mechanical: every `rf/dispatch` from a deferred handler
+  carries `{:frame :rf/causa}` so the envelope's `:frame` is set at
+  call time and never depends on the click-time React-context read.
+  Sister modals (palette + causality popover) carry the same bug;
+  fixed separately under their own beads to keep this PR scoped."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
@@ -169,7 +195,8 @@
 (defn- tab-button [{:keys [id label]} active?]
   [:button {:data-testid (str "rf-causa-settings-tab-" (name id))
             :data-active (str active?)
-            :on-click    #(rf/dispatch [:rf.causa/settings-select-tab id])
+            :on-click    #(rf/dispatch [:rf.causa/settings-select-tab id]
+                                       {:frame :rf/causa})
             :style       (tab-style active?)}
    label])
 
@@ -197,7 +224,8 @@
                                (let [n (js/parseInt (.. e -target -value) 10)]
                                  (when-not (js/isNaN n)
                                    (rf/dispatch [:rf.causa/settings-update
-                                                 :general :text-size n]))))
+                                                 :general :text-size n]
+                                                {:frame :rf/causa}))))
                 :style       {:flex 1}}]
        [:span {:data-testid "rf-causa-settings-text-size-value"
                :style       {:font-family mono-stack
@@ -219,7 +247,8 @@
                                (let [n (js/parseInt (.. e -target -value) 10)]
                                  (when-not (js/isNaN n)
                                    (rf/dispatch
-                                     [:rf.causa/set-panel-width-px n]))))
+                                     [:rf.causa/set-panel-width-px n]
+                                     {:frame :rf/causa}))))
                 :style       {:width        "120px"
                               :padding      "4px 8px"
                               :background   (:bg-2 tokens)
@@ -229,7 +258,8 @@
                               :font-family  mono-stack}}]
        [:button {:data-testid "rf-causa-settings-panel-width-reset"
                  :title       "Reset to default (560px)"
-                 :on-click    #(rf/dispatch [:rf.causa/reset-panel-width])
+                 :on-click    #(rf/dispatch [:rf.causa/reset-panel-width]
+                                            {:frame :rf/causa})
                  :style       {:background "transparent"
                                :border     (str "1px solid " (:border-default tokens))
                                :color      (:text-secondary tokens)
@@ -259,7 +289,8 @@
                   :name        "rf-causa-settings-panel-position"
                   :checked     (= panel-position pos)
                   :on-change   #(rf/dispatch [:rf.causa/settings-update
-                                              :general :panel-position pos])}]
+                                              :general :panel-position pos]
+                                             {:frame :rf/causa})}]
          label])]
 
      ;; ── Auto-open-on-error checkbox ─────────────────────────────
@@ -274,7 +305,8 @@
                 :on-change   #(rf/dispatch
                                 [:rf.causa/settings-update
                                  :general :auto-open-on-error?
-                                 (boolean (.. % -target -checked))])}]
+                                 (boolean (.. % -target -checked))]
+                                {:frame :rf/causa})}]
        "Auto-open Causa when an issue is observed"]]]))
 
 ;; ---- section: Filters ---------------------------------------------------
@@ -292,7 +324,8 @@
       "ribbon; this section is the management surface."]
      (if present?
        [:button {:data-testid "rf-causa-settings-filters-open"
-                 :on-click    #(rf/dispatch [:rf.causa.filters/open])
+                 :on-click    #(rf/dispatch [:rf.causa.filters/open]
+                                            {:frame :rf/causa})
                  :style       (primary-button-style)}
         "Open auto-filter UI"]
        [:div {:data-testid "rf-causa-settings-filters-install-hint"
@@ -330,7 +363,8 @@
                   :checked     (= theme t)
                   :on-change   #(rf/dispatch
                                   [:rf.causa/settings-update
-                                   :theme nil t])}]
+                                   :theme nil t]
+                                  {:frame :rf/causa})}]
          label])]]))
 
 ;; ---- section: Diff (rf2-i39w2 Phase 3) ----------------------------------
@@ -358,7 +392,8 @@
                 :on-change   #(rf/dispatch
                                 [:rf.causa/settings-update
                                  :diff :highlight-fn-ref-changes?
-                                 (boolean (.. % -target -checked))])}]
+                                 (boolean (.. % -target -checked))]
+                                {:frame :rf/causa})}]
        "Highlight function-ref changes in view hiccup"]
       [:p {:style (hint-style)}
        "Off by default. The hiccup-diff engine treats function-valued "
@@ -376,7 +411,8 @@
   (case (.-key e)
     "Escape" (do (.preventDefault e)
                  (.stopPropagation e)
-                 (rf/dispatch [:rf.causa/settings-close]))
+                 (rf/dispatch [:rf.causa/settings-close]
+                              {:frame :rf/causa}))
     nil))
 
 ;; ---- public view --------------------------------------------------------
@@ -391,7 +427,8 @@
         positioning @(rf/subscribe [:rf.causa/modal-positioning])]
     [:div {:data-testid "rf-causa-settings-backdrop"
            :data-rf-causa-modal-positioning (name (or positioning :fixed))
-           :on-click    #(rf/dispatch [:rf.causa/settings-close])
+           :on-click    #(rf/dispatch [:rf.causa/settings-close]
+                                      {:frame :rf/causa})
            :on-key-down handle-keydown
            :style       (backdrop-style positioning)}
      [:div {:data-testid "rf-causa-settings-dialog"
@@ -408,7 +445,10 @@
         "Settings"]
        [:button {:data-testid "rf-causa-settings-close"
                  :title       "Close settings (Esc)"
-                 :on-click    #(rf/dispatch [:rf.causa/settings-close])
+                 :on-click    (fn [^js e]
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/settings-close]
+                                             {:frame :rf/causa}))
                  :style       (close-button-style)}
         "✕"]]
       ;; Tab strip

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
@@ -7,6 +7,12 @@
   - Each section renders
   - Tab strip switches sections
 
+  Click-time frame-routing tests (rf2-smvvz — the X button / backdrop /
+  Esc / tab-button must close the modal even when the dispatch fires
+  outside `:rf/causa`'s React-context tier) live in
+  `popup_dispatch_routing_cljs_test.cljs` — separate ns because they
+  use `cljs.test/async` which requires a different `use-fixtures` shape.
+
   Uses the same hiccup-walk + plain-atom-fixture pattern as
   `shell_cljs_test.cljs` so the test surface stays Reagent-free
   on the assertion side."
@@ -231,3 +237,4 @@
         (is (= "absolute"
                (:data-rf-causa-modal-positioning (second backdrop)))
             "data attribute echoes the resolved positioning")))))
+

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_dispatch_routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_dispatch_routing_cljs_test.cljs
@@ -1,0 +1,222 @@
+(ns day8.re-frame2-causa.settings.popup-dispatch-routing-cljs-test
+  "Click-time frame-routing tests for the Causa Settings popup (rf2-smvvz).
+
+  Sibling to `popup_cljs_test.cljs`. Lives in a separate ns so the
+  `use-fixtures` map shape required by `cljs.test/async` does not
+  conflict with the fn-form `reset-runtime-fixture` the existing
+  render / open-state tests use.
+
+  ## The bug these tests defend against
+
+  The Settings popup mounts via `[rf/frame-provider {:frame :rf/causa}
+  …]` in the shell. Subscribes inside the popup resolve through React
+  context — at RENDER time, React's `_currentValue` for the
+  `frame-context` is set to `:rf/causa` while the body of the
+  frame-provider's children is rendering, so `(rf/subscribe …)` picks
+  up the right frame with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire
+  LATER — after render commits and React has POPPED `_currentValue`
+  back to the context's default (`:rf/default`). At click time the
+  3-tier frame resolution chain (dynamic var → React-context tier →
+  `:rf/default`) falls all the way through, the dispatch lands on
+  `:rf/default`'s router, and the `:rf.causa/settings-*` handler
+  reduces `:rf/default`'s db — leaving Causa's `:settings-open?` flag
+  untouched. Symptom: X button does nothing, tabs do not switch, Esc
+  does not close — the modal is stuck.
+
+  The fix in `view.cljs` is mechanical: every `rf/dispatch` from a
+  deferred handler carries `{:frame :rf/causa}` so the envelope's
+  `:frame` is set at call time and never depends on the click-time
+  React-context read.
+
+  ## How these tests reproduce the click-time path
+
+  Each test plucks the click handler off the rendered hiccup and
+  invokes it OUTSIDE any `with-frame` binding — simulating the
+  browser's click-fires-after-render reality. Click handlers use
+  queued `rf/dispatch` (not `dispatch-sync`); the router drain is
+  async via `goog.async.nextTick`. Tests use `test-support/poll-until`
+  to await the drain before asserting."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.settings.popup :as popup]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-settings!)
+  ;; Capture the framework registrar so we can restore it post-test,
+  ;; matching the body of `test-support/reset-runtime-fixture`.
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  ;; Causa's :rf.causa/* registrations + the :rf/causa frame.
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- teardown-runtime! []
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- hiccup walker (mirrors popup_cljs_test) ---------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- click-time helpers ------------------------------------------------
+
+(defn- on-click [node] (:on-click (second node)))
+(defn- on-key-down [node] (:on-key-down (second node)))
+
+(defn- fake-event []
+  ;; Minimal object covering the methods the handlers call
+  ;; (preventDefault, stopPropagation). Plain JS object so `(.x e)`
+  ;; / `(.. e -x)` reads work.
+  #js {:preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- fake-key-event [key]
+  #js {:key             key
+       :preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- await-causa-db
+  "Poll until `pred` of `:rf/causa`'s app-db returns truthy. Settles
+  the async router drain that queued click-dispatches go through."
+  [pred label]
+  (test-support/poll-until
+    #(pred (rf/get-frame-db :rf/causa))
+    {:label label :timeout-ms 1000}))
+
+(defn- render-open-modal []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/settings-open]))
+  (rf/with-frame :rf/causa (popup/Modal)))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest x-button-click-closes-modal-from-default-frame-context
+  (testing "rf2-smvvz — clicking the ✕ button from OUTSIDE the
+            :rf/causa frame-provider's render context still flips
+            :rf/causa's :settings-open? to false. Without the explicit
+            `{:frame :rf/causa}` opt on the dispatch, the click would
+            land on :rf/default and the modal would stay open."
+    (let [rendered  (render-open-modal)
+          close-btn (find-by-testid rendered "rf-causa-settings-close")
+          handler   (on-click close-btn)]
+      (is (some? handler) "close button exposes an :on-click handler")
+      (handler (fake-event)) ; outside any with-frame — same as a browser click
+      (async done
+        (-> (await-causa-db #(false? (boolean (:settings-open? %)))
+                            "settings-open? flips false after X click")
+            (.then (fn [_]
+                     (is (false? (boolean (:settings-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :settings-open? flips to false")
+                     (is (nil? (:settings-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest backdrop-click-closes-modal-from-default-frame-context
+  (testing "rf2-smvvz — clicking the backdrop from OUTSIDE the
+            :rf/causa frame-provider's render context still closes the
+            modal."
+    (let [rendered (render-open-modal)
+          backdrop (find-by-testid rendered "rf-causa-settings-backdrop")
+          handler  (on-click backdrop)]
+      (is (some? handler) "backdrop exposes an :on-click handler")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:settings-open? %)))
+                            "settings-open? flips false after backdrop click")
+            (.then (fn [_]
+                     (is (false? (boolean (:settings-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :settings-open? flips to false")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest esc-keydown-closes-modal-from-default-frame-context
+  (testing "rf2-smvvz — Esc keydown from OUTSIDE the :rf/causa frame-
+            provider's render context still closes the modal."
+    (let [rendered (render-open-modal)
+          dialog   (find-by-testid rendered "rf-causa-settings-dialog")
+          handler  (on-key-down dialog)]
+      (is (some? handler) "dialog exposes an :on-key-down handler")
+      (handler (fake-key-event "Escape"))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:settings-open? %)))
+                            "settings-open? flips false after Esc")
+            (.then (fn [_]
+                     (is (false? (boolean (:settings-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :settings-open? flips to false")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest tab-click-switches-section-from-default-frame-context
+  (testing "rf2-smvvz — clicking a tab button from OUTSIDE the
+            :rf/causa frame-provider's render context still updates
+            :rf/causa's :settings-active-tab. Without the explicit
+            frame opt, every tab click would land on :rf/default and
+            the popup would stay frozen on the :general default."
+    (let [rendered (render-open-modal)
+          tab-node (find-by-testid rendered "rf-causa-settings-tab-filters")
+          handler  (on-click tab-node)]
+      (is (some? handler) "filters tab exposes an :on-click handler")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(= :filters (:settings-active-tab %))
+                            "active-tab flips :filters after click")
+            (.then (fn [_]
+                     (is (= :filters (:settings-active-tab (rf/get-frame-db :rf/causa)))
+                         "tab click flips :settings-active-tab to :filters")
+                     (is (nil? (:settings-active-tab (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the tab dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))


### PR DESCRIPTION
## Summary

P0 bug: the Causa Settings popup was stuck — X button did nothing, tabs would not switch, Esc + backdrop clicks did not close the modal. Bead `rf2-smvvz`.

**Root cause** — click-time frame resolution falls through to `:rf/default`.

The popup mounts inside `shell-view`'s `[rf/frame-provider {:frame :rf/causa} …]`. Subscribes resolve through the React-context tier during render (React's `_currentValue` on the shared `frame-context` is set to `:rf/causa` while the frame-provider's children are rendering), so `(rf/subscribe …)` picks up the right frame with no explicit opt.

Dispatches from `:on-click` / `:on-change` / `:on-key-down` fire LATER — after render commits and React has popped `_currentValue` back to the context default (`:rf/default`). At click time the 3-tier frame resolution chain (dynamic var → React-context tier → `:rf/default`) falls all the way through, the dispatch lands on `:rf/default`'s router, and the `:rf.causa/settings-*` handler reduces `:rf/default`'s db. Causa's `:settings-open?` / `:settings-active-tab` slots stay frozen.

**Fix** — mechanical sweep across `settings/view.cljs`: 12 dispatch sites now pass `{:frame :rf/causa}` so the envelope's `:frame` is set at call time and never depends on the click-time React-context read. Same pattern already in `filters/edit_popup.cljs` + `share_modal.cljs`.

## Before / after

| Action | Before | After |
| --- | --- | --- |
| Click ✕ | nothing | modal closes |
| Click backdrop | nothing | modal closes |
| Press Esc inside dialog | nothing | modal closes |
| Click Filters / Theme / Diff tab | nothing | section switches |
| Move text-size slider | no effect | live re-render |
| Toggle auto-open / theme / diff checkbox | no effect | persisted + applied |
| Edit panel-width input or click Reset | no effect | live resize |

## Why not rf2-jh9ws / rf2-om6fa

Mike's bead notes cited the telemetry removal (rf2-jh9ws) and the modal-positioning patch (rf2-om6fa) as suspects. Neither broke the dispatch routing — the bug is older (since the popup landed in rf2-9poxq, c5e58ce4) but apparently only surfaced now under whatever Provider / sibling-render configuration the current shell sets up. The fix is the same regardless of which configuration tipped React into popping `_currentValue` reliably.

## Tests

New ns `popup_dispatch_routing_cljs_test.cljs` plucks the click handler off the rendered hiccup and invokes it OUTSIDE any `with-frame` binding — simulating the browser's click-fires-after-render reality. Four tests cover X button / backdrop / Esc / tab-button; each asserts `:rf/causa` state flips AND `:rf/default` db is NOT polluted (the negative control).

Lives in its own ns because `cljs.test/async` requires the `use-fixtures` map shape and the existing fn-form fixture in `popup_cljs_test.cljs` is the wrong shape — splitting per-fixture keeps both test surfaces clean.

## Follow-up

Bead `rf2-w8lxg` filed for the palette + causality popover modals — they share the same bug shape (no explicit `{:frame :rf/causa}` on dispatches) but were silent because the modals happened to ""work"" in some browsers / Provider configurations. Fix is mechanical; scope kept off this P0 to ship the user-blocking fix fast.

## Test plan

- [x] `scripts/test-fast-pr.sh` (fast PR spine: schemas-prod browser + bundle isolation + script policy + CLJS node integration — 3203 tests, 0 failures)
- [x] `cd tools/causa && clojure -M:test` (causa JVM tests — 930 tests, 0 failures)
- [x] `cd implementation && npm run test:browser` (3194 browser tests, 0 failures)
- [x] New click-time tests in `popup_dispatch_routing_cljs_test.cljs` pass and prove the routing
- [ ] Live verification (Mike): launch cart-total, open Settings (⚙), click ✕ / Esc / backdrop / each tab — every affordance should respond