### PR TITLE
fix(causa): palette + causality popover dispatch-routing fix

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -25,7 +25,30 @@
   cursor, Enter invokes, Ctrl+Enter (or Cmd+Enter on mac) invokes
   in a pop-out, ESC closes. The shell-level Cmd/Ctrl+K listener
   handles open; ESC inside the input also closes so the user does
-  not need to drop modifier hands."
+  not need to drop modifier hands.
+
+  ## Why every dispatch carries `{:frame :rf/causa}` (rf2-w8lxg)
+
+  Subscribes resolve through the React-context tier at RENDER time —
+  React's `_currentValue` for the `frame-context` is set to `:rf/causa`
+  while the body of the `frame-provider`'s children is rendering, so
+  `(rf/subscribe …)` from inside the palette picks up the right frame
+  with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-change` / `:on-key-down` /
+  `:on-mouse-enter` fire LATER — after render commits and React has
+  POPPED `_currentValue` back to the context's default (`:rf/default`).
+  At click time the 3-tier frame resolution chain (dynamic var →
+  React-context tier → `:rf/default`) falls all the way through, the
+  dispatch lands on `:rf/default`'s router, and the `:rf.causa/palette-*`
+  handler reduces `:rf/default`'s db — leaving Causa's `:palette-*`
+  slots untouched. Symptom: palette appears frozen — arrow keys,
+  Enter, click on a row, ESC, backdrop click all no-op. Sister fix
+  to rf2-smvvz (Settings popup, PR #1465).
+
+  The fix is mechanical: every `rf/dispatch` from a deferred handler
+  carries `{:frame :rf/causa}` so the envelope's `:frame` is set at
+  call time and never depends on the click-time React-context read."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.palette.sources :as sources]
             [day8.re-frame2-causa.theme.tokens
@@ -171,8 +194,10 @@
         :data-active  (str active?)
         :on-click     #(rf/dispatch
                          [:rf.causa/palette-invoke item
-                          (boolean (or (.-ctrlKey %) (.-metaKey %)))])
-        :on-mouse-enter #(rf/dispatch [:rf.causa/palette-cursor-set idx])
+                          (boolean (or (.-ctrlKey %) (.-metaKey %)))]
+                         {:frame :rf/causa})
+        :on-mouse-enter #(rf/dispatch [:rf.causa/palette-cursor-set idx]
+                                      {:frame :rf/causa})
         :style        (row-style active?)}
    [:span {:style (icon-style source)} icon]
    [:span {:style {:flex             1
@@ -201,19 +226,25 @@
     (case k
       "ArrowDown" (do (.preventDefault e)
                       (rf/dispatch
-                        [:rf.causa/palette-cursor-down (dec count)]))
+                        [:rf.causa/palette-cursor-down (dec count)]
+                        {:frame :rf/causa}))
       "ArrowUp"   (do (.preventDefault e)
-                      (rf/dispatch [:rf.causa/palette-cursor-up]))
+                      (rf/dispatch [:rf.causa/palette-cursor-up]
+                                   {:frame :rf/causa}))
       "Enter"     (when active
                     (.preventDefault e)
                     (rf/dispatch
-                      [:rf.causa/palette-invoke active (boolean ctrl?)]))
+                      [:rf.causa/palette-invoke active (boolean ctrl?)]
+                      {:frame :rf/causa}))
       "Escape"    (do (.preventDefault e)
-                      (rf/dispatch [:rf.causa/palette-close]))
+                      (rf/dispatch [:rf.causa/palette-close]
+                                   {:frame :rf/causa}))
       "Home"      (do (.preventDefault e)
-                      (rf/dispatch [:rf.causa/palette-cursor-set 0]))
+                      (rf/dispatch [:rf.causa/palette-cursor-set 0]
+                                   {:frame :rf/causa}))
       "End"       (do (.preventDefault e)
-                      (rf/dispatch [:rf.causa/palette-cursor-set (dec count)]))
+                      (rf/dispatch [:rf.causa/palette-cursor-set (dec count)]
+                                   {:frame :rf/causa}))
       nil)))
 
 ;; ---- main view ---------------------------------------------------------
@@ -227,7 +258,8 @@
         results @(rf/subscribe [:rf.causa/palette-results])
         cursor  @(rf/subscribe [:rf.causa/palette-cursor])]
     [:div {:data-testid "rf-causa-palette-backdrop"
-           :on-click    #(rf/dispatch [:rf.causa/palette-close])
+           :on-click    #(rf/dispatch [:rf.causa/palette-close]
+                                      {:frame :rf/causa})
            :style       (backdrop-style)}
      [:div {:data-testid "rf-causa-palette-dialog"
             :data-rf-causa-mode "palette"
@@ -242,7 +274,8 @@
                 :placeholder  "Search panels, events, frames, commands…"
                 :on-change    #(rf/dispatch
                                  [:rf.causa/palette-set-query
-                                  (.. % -target -value)])
+                                  (.. % -target -value)]
+                                 {:frame :rf/causa})
                 :on-key-down  #(handle-input-keydown % results)
                 :style        (input-style)}]
        [:span {:data-testid "rf-causa-palette-result-count"

--- a/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality.cljs
@@ -29,7 +29,33 @@
   Per spec §10 §Layout direction the v1 ships TB as the default
   (descendants tree dominates the visual weight). The footer carries
   a toggle button that flips between LR and TB. The chosen direction
-  persists per session in Causa's app-db at `:causality-popover-layout`."
+  persists per session in Causa's app-db at `:causality-popover-layout`.
+
+  ## Why every dispatch carries `{:frame :rf/causa}` (rf2-w8lxg)
+
+  Subscribes resolve through the React-context tier at RENDER time —
+  React's `_currentValue` for the `frame-context` is set to `:rf/causa`
+  while the body of the `frame-provider`'s children is rendering, so
+  `(rf/subscribe …)` from inside the popover picks up the right frame
+  with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-key-down` fire LATER — after
+  render commits and React has POPPED `_currentValue` back to the
+  context's default (`:rf/default`). At click time the 3-tier frame
+  resolution chain (dynamic var → React-context tier → `:rf/default`)
+  falls all the way through, the dispatch lands on `:rf/default`'s
+  router, and the `:rf.causa/causality-popover-*` handler reduces
+  `:rf/default`'s db — leaving Causa's `:causality-popover-*` slots
+  untouched. Symptom: backdrop click, ✕ button, Esc, LR/TB toggle
+  all silently no-op. Sister fix to rf2-smvvz (Settings popup, PR
+  #1465).
+
+  The fix is mechanical: every `rf/dispatch` from a deferred handler
+  carries `{:frame :rf/causa}` so the envelope's `:frame` is set at
+  call time and never depends on the click-time React-context read.
+  The dispatches in `causality_graph.cljs` (node click / list-row
+  click → focus-cascade + popover-close) carry the same opt for the
+  same reason."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.popover.causality-events :as events]
             [day8.re-frame2-causa.popover.causality-subs   :as subs]
@@ -133,7 +159,8 @@
   (when (= "Escape" (.-key e))
     (.preventDefault e)
     (.stopPropagation e)
-    (rf/dispatch [:rf.causa/causality-popover-close])))
+    (rf/dispatch [:rf.causa/causality-popover-close]
+                 {:frame :rf/causa})))
 
 ;; ---- view ----------------------------------------------------------------
 
@@ -160,12 +187,14 @@
     "Layout:"]
    [:button {:data-testid "rf-causa-popover-layout-lr"
              :on-click    #(when (not= :lr layout)
-                             (rf/dispatch [:rf.causa/causality-popover-toggle-layout]))
+                             (rf/dispatch [:rf.causa/causality-popover-toggle-layout]
+                                          {:frame :rf/causa}))
              :style       (toggle-button-style (= :lr layout))}
     "LR"]
    [:button {:data-testid "rf-causa-popover-layout-tb"
              :on-click    #(when (not= :tb layout)
-                             (rf/dispatch [:rf.causa/causality-popover-toggle-layout]))
+                             (rf/dispatch [:rf.causa/causality-popover-toggle-layout]
+                                          {:frame :rf/causa}))
              :style       (toggle-button-style (= :tb layout))}
     "TB"]])
 
@@ -178,7 +207,8 @@
         positioning @(rf/subscribe [:rf.causa/modal-positioning])]
     [:div {:data-testid "rf-causa-popover-backdrop"
            :data-rf-causa-modal-positioning (name (or positioning :fixed))
-           :on-click    #(rf/dispatch [:rf.causa/causality-popover-close])
+           :on-click    #(rf/dispatch [:rf.causa/causality-popover-close]
+                                      {:frame :rf/causa})
            :on-key-down handle-popover-keydown
            :tab-index   -1
            :style       (backdrop-style positioning)}
@@ -194,7 +224,8 @@
                :style {:color (:text-primary tokens)}}
         (header-title payload)]
        [:button {:data-testid "rf-causa-popover-close"
-                 :on-click    #(rf/dispatch [:rf.causa/causality-popover-close])
+                 :on-click    #(rf/dispatch [:rf.causa/causality-popover-close]
+                                            {:frame :rf/causa})
                  :style       (close-button-style)}
         "×"]]
       ;; Body

--- a/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/popover/causality_graph.cljs
@@ -28,7 +28,17 @@
 
   The view is pure hiccup per rf2-tijr — the substrate's `rf/render`
   walks the tree. The reactive surface is one subscribe to
-  `:rf.causa/causality-popover-payload` + one to `-layout`."
+  `:rf.causa/causality-popover-payload` + one to `-layout`.
+
+  ## Why dispatches carry `{:frame :rf/causa}` (rf2-w8lxg)
+
+  Same root cause as the popover facade — `:on-click` handlers on the
+  SVG nodes + fallback-list rows fire AFTER React has popped
+  `_currentValue` for the `frame-context` back to `:rf/default`. At
+  click time the 3-tier frame resolution chain falls through to
+  `:rf/default`'s router, the dispatch lands on the wrong frame, and
+  the spine-rebind / popover-close pair silently no-op. Every
+  dispatch from a deferred handler passes `{:frame :rf/causa}`."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.popover.causality-graph-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
@@ -216,8 +226,12 @@
                      ;; sees as an app-db write through the popover's
                      ;; toggle-layout-noop slot — or rather, we re-use
                      ;; the existing layout slot's nil → same write to
-                     ;; pulse the reactive graph.
-                     (rf/dispatch [:rf.causa/causality-popover-layout-pulse]))))
+                     ;; pulse the reactive graph. `{:frame :rf/causa}`
+                     ;; explicit (rf2-w8lxg) — this Promise `.then`
+                     ;; resolves AFTER render so the React-context tier
+                     ;; would otherwise route the pulse to `:rf/default`.
+                     (rf/dispatch [:rf.causa/causality-popover-layout-pulse]
+                                  {:frame :rf/causa}))))
           (.catch (fn [_e]
                     ;; Treat layout failure as a transient — the
                     ;; fallback render is still active. The next
@@ -252,8 +266,10 @@
                   (str (subs s 0 (max 0 (dec n))) "…")))]
     [:g {:data-testid (str "rf-causa-popover-node-" dispatch-id)
          :on-click    (fn []
-                        (rf/dispatch [:rf.causa/focus-cascade dispatch-id])
-                        (rf/dispatch [:rf.causa/causality-popover-close]))
+                        (rf/dispatch [:rf.causa/focus-cascade dispatch-id]
+                                     {:frame :rf/causa})
+                        (rf/dispatch [:rf.causa/causality-popover-close]
+                                     {:frame :rf/causa}))
          :style       {:cursor "pointer"}}
      [:rect {:x            x
              :y            y
@@ -348,8 +364,10 @@
                    (catch :default _ (str event)))]
     [:li {:data-testid (str "rf-causa-popover-list-row-" dispatch-id)
           :on-click    (fn []
-                         (rf/dispatch [:rf.causa/focus-cascade dispatch-id])
-                         (rf/dispatch [:rf.causa/causality-popover-close]))
+                         (rf/dispatch [:rf.causa/focus-cascade dispatch-id]
+                                      {:frame :rf/causa})
+                         (rf/dispatch [:rf.causa/causality-popover-close]
+                                      {:frame :rf/causa}))
           :style       {:padding         "6px 12px"
                         :cursor          "pointer"
                         :display         "flex"

--- a/tools/causa/test/day8/re_frame2_causa/palette/dispatch_routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/palette/dispatch_routing_cljs_test.cljs
@@ -1,0 +1,254 @@
+(ns day8.re-frame2-causa.palette.dispatch-routing-cljs-test
+  "Click-time frame-routing tests for the Causa command palette
+  (rf2-w8lxg). Sibling of rf2-smvvz's settings popup fix (PR #1465).
+
+  ## The bug these tests defend against
+
+  The palette modal mounts via `[rf/frame-provider {:frame :rf/causa}
+  …]` in the shell. Subscribes inside the palette resolve through
+  React context — at RENDER time, React's `_currentValue` for the
+  `frame-context` is set to `:rf/causa` while the body of the
+  frame-provider's children is rendering, so `(rf/subscribe …)`
+  picks up the right frame with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-change` / `:on-key-down` /
+  `:on-mouse-enter` fire LATER — after render commits and React has
+  POPPED `_currentValue` back to the context's default
+  (`:rf/default`). At click time the 3-tier frame resolution chain
+  (dynamic var → React-context tier → `:rf/default`) falls all the
+  way through, the dispatch lands on `:rf/default`'s router, and the
+  `:rf.causa/palette-*` handler reduces `:rf/default`'s db — leaving
+  Causa's palette slots untouched. Symptom: backdrop click does not
+  close, arrow keys do not move the cursor, Esc does not close, input
+  text does not update the query — the palette appears frozen.
+
+  The fix in `palette/view.cljs` is mechanical: every `rf/dispatch`
+  from a deferred handler carries `{:frame :rf/causa}` so the
+  envelope's `:frame` is set at call time and never depends on the
+  click-time React-context read.
+
+  ## How these tests reproduce the click-time path
+
+  Each test plucks the handler off the rendered hiccup and invokes
+  it OUTSIDE any `with-frame` binding — simulating the browser's
+  click-fires-after-render reality. Click handlers use queued
+  `rf/dispatch` (not `dispatch-sync`); the router drain is async via
+  `goog.async.nextTick`. Tests use `test-support/poll-until` to await
+  the drain before asserting."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.palette :as palette]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-settings!)
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- teardown-runtime! []
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- hiccup walker (mirrors popup_dispatch_routing test) ---------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- click-time helpers ------------------------------------------------
+
+(defn- on-click [node] (:on-click (second node)))
+(defn- on-key-down [node] (:on-key-down (second node)))
+(defn- on-change [node] (:on-change (second node)))
+
+(defn- fake-event []
+  #js {:preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- fake-key-event [key]
+  #js {:key             key
+       :ctrlKey         false
+       :metaKey         false
+       :preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- fake-change-event [value]
+  #js {:target          #js {:value value}
+       :preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- await-causa-db
+  "Poll until `pred` of `:rf/causa`'s app-db returns truthy."
+  [pred label]
+  (test-support/poll-until
+    #(pred (rf/get-frame-db :rf/causa))
+    {:label label :timeout-ms 1000}))
+
+(defn- render-open-palette []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open]))
+  (rf/with-frame :rf/causa (palette/Modal)))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest backdrop-click-closes-palette-from-default-frame-context
+  (testing "rf2-w8lxg — clicking the backdrop from OUTSIDE the
+            :rf/causa frame-provider's render context still closes the
+            palette. Without the explicit `{:frame :rf/causa}` opt the
+            click would land on :rf/default and the palette would stay
+            open."
+    (let [rendered (render-open-palette)
+          backdrop (find-by-testid rendered "rf-causa-palette-backdrop")
+          handler  (on-click backdrop)]
+      (is (some? handler) "backdrop exposes an :on-click handler")
+      ;; Pre-condition — palette is open on :rf/causa.
+      (is (true? (boolean (:palette-open? (rf/get-frame-db :rf/causa)))))
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:palette-open? %)))
+                            "palette-open? flips false after backdrop click")
+            (.then (fn [_]
+                     (is (false? (boolean (:palette-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :palette-open? flips to false")
+                     (is (nil? (:palette-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest esc-keydown-closes-palette-from-default-frame-context
+  (testing "rf2-w8lxg — Esc keydown on the palette input from OUTSIDE
+            the :rf/causa frame-provider's render context still closes
+            the palette."
+    (let [rendered (render-open-palette)
+          input    (find-by-testid rendered "rf-causa-palette-input")
+          handler  (on-key-down input)]
+      (is (some? handler) "input exposes an :on-key-down handler")
+      (handler (fake-key-event "Escape"))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:palette-open? %)))
+                            "palette-open? flips false after Esc")
+            (.then (fn [_]
+                     (is (false? (boolean (:palette-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :palette-open? flips to false")
+                     (is (nil? (:palette-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by Esc dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest arrow-down-keydown-moves-cursor-from-default-frame-context
+  (testing "rf2-w8lxg — ArrowDown keydown on the palette input from
+            OUTSIDE the :rf/causa frame-provider's render context still
+            updates :rf/causa's :palette-cursor. Without the explicit
+            frame opt the dispatch would land on :rf/default and the
+            cursor would never move."
+    (let [rendered (render-open-palette)
+          input    (find-by-testid rendered "rf-causa-palette-input")
+          handler  (on-key-down input)]
+      (is (some? handler) "input exposes an :on-key-down handler")
+      ;; Pre-condition — cursor at 0.
+      (is (= 0 (:palette-cursor (rf/get-frame-db :rf/causa))))
+      (handler (fake-key-event "ArrowDown"))
+      (async done
+        (-> (await-causa-db #(pos? (or (:palette-cursor %) 0))
+                            "palette-cursor advances past 0 after ArrowDown")
+            (.then (fn [_]
+                     (is (pos? (or (:palette-cursor (rf/get-frame-db :rf/causa)) 0))
+                         ":rf/causa's :palette-cursor advances after ArrowDown")
+                     (is (nil? (:palette-cursor (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the cursor dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest arrow-up-keydown-routes-to-causa-frame
+  (testing "rf2-w8lxg — ArrowUp keydown also routes through the
+            explicit frame opt. Move cursor to 2 first, then ArrowUp
+            should bring it back toward 0 against :rf/causa's db."
+    (let [_ (rf/with-frame :rf/causa
+              (rf/dispatch-sync [:rf.causa/palette-open])
+              (rf/dispatch-sync [:rf.causa/palette-cursor-set 2]))
+          rendered (rf/with-frame :rf/causa (palette/Modal))
+          input    (find-by-testid rendered "rf-causa-palette-input")
+          handler  (on-key-down input)]
+      (is (= 2 (:palette-cursor (rf/get-frame-db :rf/causa))))
+      (handler (fake-key-event "ArrowUp"))
+      (async done
+        (-> (await-causa-db #(< (or (:palette-cursor %) 0) 2)
+                            "palette-cursor decrements after ArrowUp")
+            (.then (fn [_]
+                     (is (< (or (:palette-cursor (rf/get-frame-db :rf/causa)) 0) 2)
+                         ":rf/causa's :palette-cursor decrements after ArrowUp")
+                     (is (nil? (:palette-cursor (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by ArrowUp")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest input-on-change-updates-query-from-default-frame-context
+  (testing "rf2-w8lxg — typing into the palette input from OUTSIDE the
+            :rf/causa frame-provider's render context still updates
+            :rf/causa's :palette-query. Without the explicit frame opt
+            every keystroke would land on :rf/default and the
+            displayed query would freeze."
+    (let [rendered (render-open-palette)
+          input    (find-by-testid rendered "rf-causa-palette-input")
+          handler  (on-change input)]
+      (is (some? handler) "input exposes an :on-change handler")
+      (handler (fake-change-event "search"))
+      (async done
+        (-> (await-causa-db #(= "search" (:palette-query %))
+                            "palette-query flips to 'search' after on-change")
+            (.then (fn [_]
+                     (is (= "search" (:palette-query (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :palette-query reflects the typed text")
+                     (is (nil? (:palette-query (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by typing")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))

--- a/tools/causa/test/day8/re_frame2_causa/popover/causality_dispatch_routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/popover/causality_dispatch_routing_cljs_test.cljs
@@ -1,0 +1,221 @@
+(ns day8.re-frame2-causa.popover.causality-dispatch-routing-cljs-test
+  "Click-time frame-routing tests for the Causality popover
+  (rf2-w8lxg). Sibling of rf2-smvvz's settings popup fix (PR #1465).
+
+  ## The bug these tests defend against
+
+  The popover mounts via `[rf/frame-provider {:frame :rf/causa} …]`
+  in the shell. Subscribes inside the popover resolve through React
+  context — at RENDER time, React's `_currentValue` for the
+  `frame-context` is set to `:rf/causa` while the body of the
+  frame-provider's children is rendering, so `(rf/subscribe …)`
+  picks up the right frame with no explicit opt.
+
+  Dispatches from `:on-click` / `:on-key-down` fire LATER — after
+  render commits and React has POPPED `_currentValue` back to the
+  context's default (`:rf/default`). At click time the 3-tier frame
+  resolution chain (dynamic var → React-context tier → `:rf/default`)
+  falls all the way through, the dispatch lands on `:rf/default`'s
+  router, and the `:rf.causa/causality-popover-*` handler reduces
+  `:rf/default`'s db — leaving Causa's `:causality-popover-*` slots
+  untouched. Symptom: backdrop click, ✕ button, Esc, LR/TB toggle
+  all silently no-op.
+
+  The fix in `popover/causality.cljs` (+ `causality_graph.cljs`) is
+  mechanical: every `rf/dispatch` from a deferred handler carries
+  `{:frame :rf/causa}` so the envelope's `:frame` is set at call time
+  and never depends on the click-time React-context read.
+
+  ## How these tests reproduce the click-time path
+
+  Each test plucks the handler off the rendered hiccup and invokes
+  it OUTSIDE any `with-frame` binding — simulating the browser's
+  click-fires-after-render reality. Click handlers use queued
+  `rf/dispatch` (not `dispatch-sync`); the router drain is async via
+  `goog.async.nextTick`. Tests use `test-support/poll-until` to await
+  the drain before asserting."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.popover.causality :as popover]
+            [day8.re-frame2-causa.popover.causality-graph :as pop-graph]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (pop-graph/reset-elk-state-for-test!)
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- teardown-runtime! []
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- hiccup walker -----------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- click-time helpers ------------------------------------------------
+
+(defn- on-click [node] (:on-click (second node)))
+(defn- on-key-down [node] (:on-key-down (second node)))
+
+(defn- fake-event []
+  #js {:preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- fake-key-event [key]
+  #js {:key             key
+       :preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- await-causa-db
+  "Poll until `pred` of `:rf/causa`'s app-db returns truthy."
+  [pred label]
+  (test-support/poll-until
+    #(pred (rf/get-frame-db :rf/causa))
+    {:label label :timeout-ms 1000}))
+
+(defn- render-open-popover []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/causality-popover-open]))
+  (rf/with-frame :rf/causa (popover/Popover)))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest close-button-click-closes-popover-from-default-frame-context
+  (testing "rf2-w8lxg — clicking the ✕ button from OUTSIDE the
+            :rf/causa frame-provider's render context still flips
+            :rf/causa's :causality-popover-open? to false. Without the
+            explicit `{:frame :rf/causa}` opt on the dispatch, the
+            click would land on :rf/default and the popover would
+            stay open."
+    (let [rendered  (render-open-popover)
+          close-btn (find-by-testid rendered "rf-causa-popover-close")
+          handler   (on-click close-btn)]
+      (is (some? handler) "close button exposes an :on-click handler")
+      (is (true? (boolean (:causality-popover-open? (rf/get-frame-db :rf/causa))))
+          "pre-condition: popover open on :rf/causa")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:causality-popover-open? %)))
+                            "causality-popover-open? flips false after ✕ click")
+            (.then (fn [_]
+                     (is (false? (boolean (:causality-popover-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :causality-popover-open? flips to false")
+                     (is (nil? (:causality-popover-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest backdrop-click-closes-popover-from-default-frame-context
+  (testing "rf2-w8lxg — clicking the backdrop from OUTSIDE the
+            :rf/causa frame-provider's render context still closes the
+            popover."
+    (let [rendered (render-open-popover)
+          backdrop (find-by-testid rendered "rf-causa-popover-backdrop")
+          handler  (on-click backdrop)]
+      (is (some? handler) "backdrop exposes an :on-click handler")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:causality-popover-open? %)))
+                            "causality-popover-open? flips false after backdrop click")
+            (.then (fn [_]
+                     (is (false? (boolean (:causality-popover-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :causality-popover-open? flips to false")
+                     (is (nil? (:causality-popover-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by backdrop click")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest esc-keydown-closes-popover-from-default-frame-context
+  (testing "rf2-w8lxg — Esc keydown from OUTSIDE the :rf/causa frame-
+            provider's render context still closes the popover."
+    (let [rendered (render-open-popover)
+          dialog   (find-by-testid rendered "rf-causa-popover-dialog")
+          handler  (on-key-down dialog)]
+      (is (some? handler) "dialog exposes an :on-key-down handler")
+      (handler (fake-key-event "Escape"))
+      (async done
+        (-> (await-causa-db #(false? (boolean (:causality-popover-open? %)))
+                            "causality-popover-open? flips false after Esc")
+            (.then (fn [_]
+                     (is (false? (boolean (:causality-popover-open? (rf/get-frame-db :rf/causa))))
+                         ":rf/causa's :causality-popover-open? flips to false")
+                     (is (nil? (:causality-popover-open? (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by Esc dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest lr-toggle-click-flips-layout-from-default-frame-context
+  (testing "rf2-w8lxg — clicking the LR toggle from OUTSIDE the
+            :rf/causa frame-provider's render context still flips
+            :rf/causa's :causality-popover-layout from :tb (default)
+            to :lr. Without the explicit frame opt the dispatch
+            would land on :rf/default and the layout would stay
+            frozen on :tb."
+    (let [rendered (render-open-popover)
+          lr-btn   (find-by-testid rendered "rf-causa-popover-layout-lr")
+          handler  (on-click lr-btn)]
+      (is (some? handler) "LR button exposes an :on-click handler")
+      (is (= :tb (:causality-popover-layout (rf/get-frame-db :rf/causa)))
+          "pre-condition: default layout is :tb on :rf/causa")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(= :lr (:causality-popover-layout %))
+                            "layout flips :lr after LR click")
+            (.then (fn [_]
+                     (is (= :lr (:causality-popover-layout (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :causality-popover-layout flips to :lr")
+                     (is (nil? (:causality-popover-layout (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the layout dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))


### PR DESCRIPTION
## Summary

Sibling fix to rf2-smvvz (PR #1465). Same React `_currentValue` pop bug in two additional Causa-frame-provider-mounted surfaces — every `rf/dispatch` from a deferred handler (`:on-click`, `:on-change`, `:on-key-down`, `:on-mouse-enter`) now carries an explicit `{:frame :rf/causa}` opt.

## Root cause

The palette + causality popover both mount under `[rf/frame-provider {:frame :rf/causa} …]` in the Causa shell. Subscribes resolve through the React-context tier during render — React's `_currentValue` on the shared `frame-context` is set to `:rf/causa` while children render, so `(rf/subscribe …)` picks up the right frame with no explicit opt.

Dispatches fire LATER — after render commits and React has popped `_currentValue` back to `:rf/default`. At click time the 3-tier frame resolution chain falls through to `:rf/default`, the dispatch lands on the wrong frame's router, and the `:rf.causa/*` handler reduces `:rf/default`'s db — leaving Causa's slots untouched.

Symptoms (per bead rf2-w8lxg):
- **Palette** — backdrop click does not close, arrow keys do not move cursor, Esc does not close, typing does not update query
- **Causality popover** — ✕ button does nothing, backdrop does nothing, LR/TB toggle does not flip, Esc does not close

Same shape as PR #1465; fix is mechanical.

## Call sites updated

- `tools/causa/src/.../palette/view.cljs` — 10 sites (backdrop on-click, on-change input, 6 key-handler branches, row on-click, row on-mouse-enter)
- `tools/causa/src/.../popover/causality.cljs` — 5 sites (Esc keydown, LR/TB toggle pair, backdrop on-click, ✕ button on-click)
- `tools/causa/src/.../popover/causality_graph.cljs` — 5 sites (SVG node on-click pair, fallback list-row on-click pair, ELK layout-pulse `.then`)

## Tests

Two new dispatch-routing test namespaces modeled on PR #1465's `popup_dispatch_routing_cljs_test.cljs`. Each plucks the handler off the rendered hiccup and invokes it OUTSIDE any `with-frame` binding (simulating the browser's click-fires-after-render reality), then asserts both:

1. The expected `:rf/causa` slot flips
2. `:rf/default`'s db is NOT polluted

## Test plan

- [x] `scripts/test-fast-pr.sh` — passes
- [x] `cd tools/causa && clojure -M:test` — 945 tests / 2740 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 3251 tests / 9351 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 3242 tests / 9306 assertions / 0 failures