### PR TITLE
feat(causa): multi-frame testbed — 3-frame interactive testbed for Causa

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -132,6 +132,17 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'cart_total', 'index.html'),
     outDir: path.join(OUT_ROOT, 'cart-total'),
   },
+  // Multi-frame Causa testbed (rf2-2vgog) — three named frames
+  // (:cart-frame, :checkout-frame, :admin-frame) coexisting; one
+  // cross-frame coordination scenario. The companion spec at
+  // tools/causa/testbeds/multi_frame_causa/spec.cjs exercises frame
+  // scoping, cascade isolation, the cross-frame hop, and Causa's
+  // frame picker enumerating all three frames.
+  {
+    build: 'examples/multi-frame-causa',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'multi_frame_causa', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'multi-frame-causa'),
+  },
   {
     build: 'examples/temperature',
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', '7Guis', 'temperature', 'temperature.html'),

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -435,6 +435,27 @@
    :modules    {:main {:init-fn cart-total.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
+  ;; Multi-frame Causa testbed (rf2-2vgog) — three richly-domain'd
+  ;; frames (:cart-frame, :checkout-frame, :admin-frame) coexisting on
+  ;; one page; one cross-frame coordination scenario (cart's
+  ;; Send-to-checkout fans out to :checkout-frame via a bridge fx).
+  ;; Sources live under tools/causa/testbeds/multi_frame_causa/. The
+  ;; Causa preload is wired so the frame picker enumerates all three
+  ;; frames and a Causa user can step through scope-per-frame /
+  ;; cascade-isolation / cross-frame causality scenarios.
+  ;;
+  ;; Distinct from the top-level testbeds/multi_frame/ surface (build
+  ;; id `:testbeds/multi-frame` — rf2-kzcim shared framework-behavior
+  ;; testbed with three minimal counters). This Causa-owned variant
+  ;; is domain-rich and panel-rich; the shared one is stark and
+  ;; minimal-by-design (Causa, Story, and pair2-mcp all consume it).
+  :examples/multi-frame-causa
+  {:target     :browser
+   :output-dir "out/examples/multi-frame-causa"
+   :asset-path "."
+   :modules    {:main {:init-fn multi-frame-causa.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
   ;; Causa panel-gallery testbed (rf2-1o7mp) — visual gallery of Causa
   ;; panels under varying state magnitude. Sources live under
   ;; tools/causa/testbeds/panel_gallery/ alongside the stories ns.

--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -271,10 +271,10 @@ coverage matrix at [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage
 reports `covered` across every row at the unit/helper/view tier.
 
 Browser testbeds live under `tools/causa/testbeds/` — `cart_total`,
-`counter-driven`, `feature_matrix`, `inline_resize`, `panel_gallery`,
-`perf_counter`, `rigorous` — covering the shell, panels,
-sensitive/large redaction, performance, popout, and the
-production-elision probe.
+`counter-driven`, `feature_matrix`, `inline_resize`, `multi_frame_causa`,
+`panel_gallery`, `perf_counter`, `rigorous` — covering the shell,
+panels, sensitive/large redaction, performance, popout, multi-frame
+isolation + cross-frame coordination, and the production-elision probe.
 
 The sibling `tools/causa-mcp/` artefact ships the agent surface (18
 tools across five bands; catalogue formally pinned at

--- a/tools/causa/testbeds/multi_frame_causa/README.md
+++ b/tools/causa/testbeds/multi_frame_causa/README.md
@@ -1,0 +1,64 @@
+# `tools/causa/testbeds/multi_frame_causa/`
+
+Multi-frame Causa testbed (rf2-2vgog) — three richly-domain'd frames coexisting on one page, with one deliberate cross-frame coordination scenario. The point: exercise *Causa's* frame picker, scope-per-frame, cascade isolation, and cross-frame causality against three named frames a Causa user would actually want to inspect.
+
+This testbed is distinct from the top-level [`testbeds/multi_frame/`](../../../../testbeds/multi_frame/) (rf2-kzcim) — that one is three minimal counters proving the framework's per-frame partitioning contract, shared across Causa / Story / pair2-mcp consumers. This Causa-owned variant is domain-rich and panel-rich, designed for the Causa devtools workflow.
+
+## The three frames
+
+| Frame              | Events                                                  | Subs                                                       | Panel             |
+|--------------------|---------------------------------------------------------|------------------------------------------------------------|-------------------|
+| `:cart-frame`      | `:cart/add-item`, `:cart/remove-item`, `:cart/clear`, `:cart/send-to-checkout` | `:cart/items`, `:cart/total`                               | Cart UI           |
+| `:checkout-frame`  | `:checkout/start`, `:checkout/pay`, `:checkout/reset`   | `:checkout/items`, `:checkout/total`, `:checkout/status`   | Checkout UI       |
+| `:admin-frame`     | `:admin/refund`, `:admin/audit`                         | `:admin/transactions`, `:admin/refund-count`, `:admin/audit-count` | Admin panel       |
+
+Each frame's `app-db` carries only its own slot. No shared root, no app-global keys.
+
+## The cross-frame coordination scenario
+
+Clicking **Send to checkout** on `:cart-frame` dispatches `:cart/send-to-checkout`. The handler snapshots `:cart/items`, clears the local slot, and fans out `[:checkout/start <items>]` to `:checkout-frame` via a tiny bridge fx (`::dispatch-to-frame`) that calls `rf/dispatch` with explicit `{:frame :checkout-frame}` opts.
+
+Reserved `:dispatch` is intra-frame by contract — same pattern as the shared multi-frame testbed.
+
+## What Causa users observe
+
+- **Frame picker** — `ribbon-frame-picker` enumerates all three frames after any cross-frame click.
+- **Per-frame scoping** — selecting a frame in the picker scopes the L2 event list + downstream panels to that frame's cascade.
+- **Cascade isolation** — events fired against `:admin-frame` don't appear in `:cart-frame`'s or `:checkout-frame`'s L2 list.
+- **Cross-frame causality** — the Send-to-checkout click produces an envelope-rooted sequence: the originating `:cart/send-to-checkout` (on `:cart-frame`) and the resulting `:checkout/start` (on `:checkout-frame`) land in the same drain.
+
+## Files
+
+- `core.cljs` — registers the three frames, their events / subs / views; mounts the root component with three `rf/frame-provider`-wrapped panels.
+- `fixtures.cljs` — deterministic per-frame event vectors (cart seed, cross-frame handoff, admin traffic) for the Playwright smoke and future Story variants.
+- `index.html` — static host with the standard `[data-rf-causa-host]` aside so the Causa preload auto-mounts inline.
+- `spec.cjs` — Playwright smoke asserting initial-state, frame-scoped isolation, the cross-frame hop, Causa shell mount, and frame picker enumeration.
+
+## Running
+
+From `implementation/`:
+
+```bash
+npx shadow-cljs watch :examples/multi-frame-causa
+```
+
+Browse to `http://localhost:9630/build/multi-frame-causa/dashboard` (or open the served `index.html` from `out/examples/multi-frame-causa/`). Press **Ctrl+Shift+C** to toggle Causa.
+
+From repo root, the testbed is also picked up by the examples orchestrator:
+
+```bash
+cd implementation
+npm run test:examples              # full sweep including this testbed
+npm run test:examples:realworld -- --filter multi-frame-causa
+```
+
+## Build target
+
+`:examples/multi-frame-causa` (defined in [`implementation/shadow-cljs.edn`](../../../../implementation/shadow-cljs.edn)). The Causa preload (`day8.re-frame2-causa.preload`) is wired so the shell auto-mounts inline on every dev build.
+
+## Cross-references
+
+- [`spec/002-Frames.md` §What lives in a frame](../../../../spec/002-Frames.md) — the per-frame `app-db` / router-queue / sub-cache partitioning contract.
+- [`spec/002-Frames.md` §Dispatches issued from inside a handler body](../../../../spec/002-Frames.md) — the cross-frame `:dispatch` semantics this testbed exercises via the bridge fx.
+- [`tools/causa/spec/018-Event-Spine.md` §3 Frame dropdown](../../spec/018-Event-Spine.md) — the frame-picker contract this testbed populates with three frames.
+- [`testbeds/multi_frame/`](../../../../testbeds/multi_frame/) — the sibling shared framework-behavior surface (minimal counters, three consumers).

--- a/tools/causa/testbeds/multi_frame_causa/core.cljs
+++ b/tools/causa/testbeds/multi_frame_causa/core.cljs
@@ -1,0 +1,424 @@
+(ns multi-frame-causa.core
+  "Multi-frame Causa testbed (rf2-2vgog) — three richly-domain'd frames
+  living in one page, each carrying its own events / subs / app-db slot,
+  with one deliberate cross-frame coordination scenario.
+
+  Unlike the shared framework-behavior `testbeds/multi_frame/` surface
+  (top-level; rf2-kzcim) — which is three minimal counters proving
+  per-frame partitioning of `app-db` / sub-cache / epoch ring — this
+  Causa-owned testbed is domain-rich: a cart, a checkout, an admin
+  panel, each with its own button cluster and its own slice of state.
+  The point is to exercise *Causa's* frame picker, frame-scoped panels,
+  and cross-frame causality popover against three distinct, named
+  frames a Causa user would actually want to inspect.
+
+  ## The three frames
+
+      :cart-frame      — add-item / remove-item / send-to-checkout
+                         buttons; subs :cart/items, :cart/total.
+      :checkout-frame  — start / pay buttons; subs :checkout/items,
+                         :checkout/total, :checkout/status.
+      :admin-frame     — refund / audit buttons; sub :admin/transactions.
+
+  Each frame's `app-db` carries only its own slot — no shared keys, no
+  app-global root. The framework keeps the three `app-db`s
+  partitioned per [spec/002 §What lives in a frame].
+
+  ## The cross-frame coordination scenario
+
+  Clicking *Send to checkout* on `:cart-frame` dispatches
+  `[:checkout/start <items>]` against `:checkout-frame` via a tiny
+  bridge fx (`::dispatch-to-frame`) — same pattern as the shared
+  multi-frame testbed. The reserved `:dispatch` fx is intra-frame by
+  contract, so cross-frame fan-out goes through `rf/dispatch` with
+  `{:frame ...}` opts.
+
+  In Causa: the click produces two `:event/dispatched` traces in one
+  drain — one on `:cart-frame` (the originating `:cart/send-to-checkout`)
+  and one on `:checkout-frame` (the resulting `:checkout/start`). The
+  frame picker shows both frames; selecting `:cart-frame` scopes the
+  L2 list and downstream panels to the cart's cascade only. Selecting
+  `:checkout-frame` scopes to the checkout's cascade.
+
+  ## What Causa users observe
+
+  - **Frame picker** (`ribbon-frame-picker` in shell.cljs) enumerates
+    the three frames + `:rf/default` (and `:rf/causa` under the dev
+    toggle). After one cross-frame click, all three frames carry
+    at least one event in their ring buffer.
+  - **L2 event list** scopes per the selected frame.
+  - **Cascade isolation** — events in `:cart-frame`'s cascade don't
+    appear in `:admin-frame`'s L2 list.
+  - **Cross-frame causality** — the *Send to checkout* click produces
+    an envelope-rooted sequence: cart-frame's `:cart/send-to-checkout`
+    is the source, the cross-frame `:dispatch-to-frame` fx fires, and
+    checkout-frame's `:checkout/start` lands in the same drain."
+  (:require [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; FRAME IDs — referenced from handler bodies + provider props
+;; ============================================================================
+
+(def frame-cart     :cart-frame)
+(def frame-checkout :checkout-frame)
+(def frame-admin    :admin-frame)
+
+;; ============================================================================
+;; Catalogue — tiny three-row table referenced by :cart/add-item.
+;; Same shape as the shared cart-total testbed but distinct prices so
+;; they don't pun across testbeds (prices in cents — exact arithmetic).
+;; ============================================================================
+
+(def catalogue
+  {:apple   {:id :apple   :name "Apple"   :price 100}
+   :bread   {:id :bread   :name "Bread"   :price 300}
+   :coffee  {:id :coffee  :name "Coffee"  :price 500}})
+
+;; ============================================================================
+;; PER-FRAME app-db INITIALISERS
+;; ============================================================================
+;;
+;; Each frame registers a distinct init handler so the `:on-create`
+;; entry on `reg-frame` runs the right seed for the frame's shape. The
+;; handler ids carry their frame prefix as documentation.
+
+(rf/reg-event-db :cart/init
+  (fn [_db _ev]
+    {:cart/items []}))
+
+(rf/reg-event-db :checkout/init
+  (fn [_db _ev]
+    {:checkout/items  []
+     :checkout/status :idle}))                ;; :idle | :paid
+
+(rf/reg-event-db :admin/init
+  (fn [_db _ev]
+    {:admin/transactions []}))
+
+;; ============================================================================
+;; :cart-frame EVENTS + SUBS
+;; ============================================================================
+
+(rf/reg-event-db :cart/add-item
+  (fn [db [_ item-id]]
+    (let [item        (get catalogue item-id)
+          existing-ix (->> (:cart/items db)
+                           (keep-indexed (fn [ix line]
+                                           (when (= item-id (:id line)) ix)))
+                           first)]
+      (if existing-ix
+        (update-in db [:cart/items existing-ix :qty] inc)
+        (update db :cart/items (fnil conj []) (assoc item :qty 1))))))
+
+(rf/reg-event-db :cart/remove-item
+  (fn [db [_ item-id]]
+    (update db :cart/items
+            (fn [lines]
+              (vec (remove #(= item-id (:id %)) lines))))))
+
+(rf/reg-event-db :cart/clear
+  (fn [db _ev]
+    (assoc db :cart/items [])))
+
+(rf/reg-sub :cart/items (fn [db _] (:cart/items db)))
+
+(rf/reg-sub :cart/total
+  :<- [:cart/items]
+  (fn [items _]
+    (reduce + 0 (map (fn [{:keys [price qty]}] (* price qty)) items))))
+
+;; ============================================================================
+;; :checkout-frame EVENTS + SUBS
+;; ============================================================================
+;;
+;; :checkout/start ACCEPTS a payload (the items snapshot from the
+;; originating cart-frame cascade) so the cross-frame hop carries
+;; data across — proving the framework passes the dispatch payload
+;; through to the target frame's handler intact.
+
+(rf/reg-event-db :checkout/start
+  (fn [db [_ items]]
+    (-> db
+        (assoc :checkout/items  (vec items))
+        (assoc :checkout/status :idle))))
+
+(rf/reg-event-db :checkout/pay
+  (fn [db _ev]
+    (assoc db :checkout/status :paid)))
+
+(rf/reg-event-db :checkout/reset
+  (fn [db _ev]
+    (-> db
+        (assoc :checkout/items  [])
+        (assoc :checkout/status :idle))))
+
+(rf/reg-sub :checkout/items  (fn [db _] (:checkout/items db)))
+(rf/reg-sub :checkout/status (fn [db _] (:checkout/status db)))
+
+(rf/reg-sub :checkout/total
+  :<- [:checkout/items]
+  (fn [items _]
+    (reduce + 0 (map (fn [{:keys [price qty]}] (* price qty)) items))))
+
+;; ============================================================================
+;; :admin-frame EVENTS + SUBS
+;; ============================================================================
+;;
+;; Admin is a passive log frame — refund + audit each append a row to
+;; :admin/transactions. No cross-frame coordination originates here.
+;; Its purpose in the Causa walkthrough: a frame whose L2 list stays
+;; empty when the cart/checkout buttons fire, demonstrating cascade
+;; isolation. Clicking the admin-only buttons populates ONLY this
+;; frame's ring buffer.
+
+(rf/reg-event-db :admin/refund
+  (fn [db [_ amount]]
+    (update db :admin/transactions (fnil conj [])
+            {:kind   :refund
+             :amount amount
+             :at     (count (:admin/transactions db))})))
+
+(rf/reg-event-db :admin/audit
+  (fn [db _ev]
+    (update db :admin/transactions (fnil conj [])
+            {:kind :audit
+             :at   (count (:admin/transactions db))})))
+
+(rf/reg-sub :admin/transactions (fn [db _] (:admin/transactions db)))
+
+(rf/reg-sub :admin/refund-count
+  :<- [:admin/transactions]
+  (fn [txs _]
+    (count (filter #(= :refund (:kind %)) txs))))
+
+(rf/reg-sub :admin/audit-count
+  :<- [:admin/transactions]
+  (fn [txs _]
+    (count (filter #(= :audit (:kind %)) txs))))
+
+;; ============================================================================
+;; CROSS-FRAME BRIDGE — :cart-frame → :checkout-frame
+;; ============================================================================
+;;
+;; The reserved `:dispatch` fx is intra-frame by contract: a handler
+;; running on :cart-frame returning `[:dispatch [:checkout/start ...]]`
+;; would queue against :cart-frame and fail at handler-resolve time
+;; (no :checkout/start handler is registered on :cart-frame's local
+;; lookup path — handlers are global, but the dispatch envelope's
+;; :frame still gates which app-db is passed in).
+;;
+;; The bridge fx (`::dispatch-to-frame`) calls public `rf/dispatch`
+;; with explicit `{:frame ...}` opts so the target frame's router
+;; queue receives the envelope. Same pattern as the shared
+;; multi-frame testbed.
+
+(rf/reg-fx ::dispatch-to-frame
+  (fn [_ctx {:keys [event frame]}]
+    (rf/dispatch event {:frame frame})))
+
+(rf/reg-event-fx :cart/send-to-checkout
+  (fn [{:keys [db]} _ev]
+    ;; Snapshot the cart's items into the cross-frame dispatch payload,
+    ;; then clear the cart locally — same shape a real checkout-flow
+    ;; would use.
+    (let [items (:cart/items db)]
+      {:db (assoc db :cart/items [])
+       :fx [[::dispatch-to-frame {:event [:checkout/start items]
+                                  :frame frame-checkout}]]})))
+
+;; ============================================================================
+;; VIEWS — three panels, one per frame
+;; ============================================================================
+;;
+;; Each panel mounts under its frame-provider; the reg-view-injected
+;; `dispatch` / `subscribe` resolve to the surrounding frame. The
+;; *Send to checkout* button sits in :cart-frame because the
+;; originating event is `:cart/send-to-checkout` (which then fans out
+;; to :checkout-frame via the bridge fx).
+
+(defn- format-money [cents]
+  (let [dollars (quot cents 100)
+        change  (mod cents 100)]
+    (str "$" dollars "." (if (< change 10) (str "0" change) change))))
+
+(reg-view cart-panel []
+  (let [items @(subscribe [:cart/items])
+        total @(subscribe [:cart/total])]
+    [:section {:data-testid "cart-frame-panel"
+               :style {:border "1px solid #2b7" :border-radius "6px"
+                       :padding "1em 1.5em" :background "#f7fff9"
+                       :min-width "260px" :flex 1}}
+     [:h3 {:style {:margin-top 0 :color "#1a5"}} "Cart " [:small "(:cart-frame)"]]
+     [:div {:style {:margin-bottom "0.75em" :display "flex" :gap "6px" :flex-wrap "wrap"}}
+      [:button {:data-testid "cart-add-apple"
+                :on-click    #(dispatch [:cart/add-item :apple])}
+       "+ Apple"]
+      [:button {:data-testid "cart-add-bread"
+                :on-click    #(dispatch [:cart/add-item :bread])}
+       "+ Bread"]
+      [:button {:data-testid "cart-add-coffee"
+                :on-click    #(dispatch [:cart/add-item :coffee])}
+       "+ Coffee"]
+      [:button {:data-testid "cart-clear"
+                :on-click    #(dispatch [:cart/clear])
+                :style       {:margin-left "8px"}}
+       "Clear cart"]]
+     (if (seq items)
+       [:table {:style {:border-collapse "collapse" :width "100%"
+                        :font-size "13px" :margin-bottom "0.5em"}}
+        [:tbody
+         (for [{:keys [id name qty price]} items]
+           ^{:key id}
+           [:tr {:data-testid (str "cart-line-" (clojure.core/name id))}
+            [:td {:style {:padding "2px 8px"}} name]
+            [:td {:style {:padding "2px 8px"}} (str "× " qty)]
+            [:td {:style {:padding "2px 8px" :text-align "right"}}
+             (format-money (* price qty))]
+            [:td {:style {:padding "2px 8px"}}
+             [:button {:data-testid (str "cart-remove-" (clojure.core/name id))
+                       :on-click    #(dispatch [:cart/remove-item id])
+                       :style       {:font-size "11px"}}
+              "remove"]]])]]
+       [:p {:style {:color "#666" :font-style "italic" :margin "0.5em 0"}}
+        "Cart is empty."])
+     [:div {:style {:border-top "1px solid #cee"
+                    :padding-top "6px" :margin-top "6px"
+                    :display "flex" :justify-content "space-between"
+                    :font-weight "bold"}}
+      [:span "Cart total"]
+      [:span {:data-testid "cart-total"} (format-money total)]]
+     [:button {:data-testid "cart-send-to-checkout"
+               :on-click    #(dispatch [:cart/send-to-checkout])
+               :disabled    (empty? items)
+               :style       {:margin-top "0.75em"
+                             :padding "6px 12px"
+                             :background (if (seq items) "#1a5" "#aaa")
+                             :color "#fff" :border "none"
+                             :border-radius "4px"
+                             :cursor (if (seq items) "pointer" "default")}}
+      "Send to checkout (cross-frame → :checkout-frame)"]]))
+
+(reg-view checkout-panel []
+  (let [items  @(subscribe [:checkout/items])
+        total  @(subscribe [:checkout/total])
+        status @(subscribe [:checkout/status])]
+    [:section {:data-testid "checkout-frame-panel"
+               :style {:border "1px solid #36c" :border-radius "6px"
+                       :padding "1em 1.5em" :background "#f5f8ff"
+                       :min-width "260px" :flex 1}}
+     [:h3 {:style {:margin-top 0 :color "#249"}} "Checkout " [:small "(:checkout-frame)"]]
+     [:div {:style {:margin-bottom "0.75em" :display "flex" :gap "6px" :flex-wrap "wrap"}}
+      [:button {:data-testid "checkout-pay"
+                :on-click    #(dispatch [:checkout/pay])
+                :disabled    (or (empty? items) (= :paid status))}
+       "Pay"]
+      [:button {:data-testid "checkout-reset"
+                :on-click    #(dispatch [:checkout/reset])
+                :style       {:margin-left "8px"}}
+       "Reset"]]
+     (if (seq items)
+       [:table {:style {:border-collapse "collapse" :width "100%"
+                        :font-size "13px" :margin-bottom "0.5em"}}
+        [:tbody
+         (for [{:keys [id name qty price]} items]
+           ^{:key id}
+           [:tr {:data-testid (str "checkout-line-" (clojure.core/name id))}
+            [:td {:style {:padding "2px 8px"}} name]
+            [:td {:style {:padding "2px 8px"}} (str "× " qty)]
+            [:td {:style {:padding "2px 8px" :text-align "right"}}
+             (format-money (* price qty))]])]]
+       [:p {:style {:color "#666" :font-style "italic" :margin "0.5em 0"}}
+        "No items in checkout yet. Click "
+        [:em "Send to checkout"] " on the cart."])
+     [:div {:style {:border-top "1px solid #cce"
+                    :padding-top "6px" :margin-top "6px"
+                    :display "flex" :justify-content "space-between"
+                    :font-weight "bold"}}
+      [:span "Checkout total"]
+      [:span {:data-testid "checkout-total"} (format-money total)]]
+     [:div {:style {:margin-top "0.5em" :font-size "12px" :color "#444"}}
+      "status: "
+      [:span {:data-testid "checkout-status"
+              :style {:font-weight "bold"
+                      :color (case status :paid "#1a5" "#666")}}
+       (str status)]]]))
+
+(reg-view admin-panel []
+  (let [txs           @(subscribe [:admin/transactions])
+        refund-count  @(subscribe [:admin/refund-count])
+        audit-count   @(subscribe [:admin/audit-count])]
+    [:section {:data-testid "admin-frame-panel"
+               :style {:border "1px solid #c63" :border-radius "6px"
+                       :padding "1em 1.5em" :background "#fff8f3"
+                       :min-width "260px" :flex 1}}
+     [:h3 {:style {:margin-top 0 :color "#a40"}} "Admin " [:small "(:admin-frame)"]]
+     [:div {:style {:margin-bottom "0.75em" :display "flex" :gap "6px" :flex-wrap "wrap"}}
+      [:button {:data-testid "admin-refund"
+                :on-click    #(dispatch [:admin/refund 250])}
+       "Issue refund ($2.50)"]
+      [:button {:data-testid "admin-audit"
+                :on-click    #(dispatch [:admin/audit])}
+       "Run audit"]]
+     [:p {:style {:margin "0.25em 0" :font-size "13px"}}
+      "refunds=" [:span {:data-testid "admin-refund-count"} refund-count]
+      " · audits=" [:span {:data-testid "admin-audit-count"} audit-count]
+      " · total=" [:span {:data-testid "admin-tx-count"} (count txs)]]
+     (if (seq txs)
+       [:ul {:data-testid "admin-tx-list"
+             :style {:max-height "10em" :overflow :auto
+                     :font-size "12px" :font-family "monospace"
+                     :background "#fff" :border "1px solid #f2dcc4"
+                     :border-radius "4px" :padding "4px 12px"}}
+        (for [[idx tx] (map-indexed vector txs)]
+          ^{:key idx}
+          [:li {:data-testid (str "admin-tx-" idx)} (pr-str tx)])]
+       [:p {:style {:color "#666" :font-style "italic" :margin "0.5em 0"}}
+        "No admin transactions yet."])]))
+
+(reg-view root []
+  [:div {:data-testid "multi-frame-causa-root"
+         :style {:font-family "system-ui, sans-serif" :padding "1em"
+                 :max-width "1100px" :margin "0 auto"}}
+   [:h2 {:style {:margin-top 0}} "Multi-frame Causa testbed"]
+   [:p {:style {:color "#444" :margin "0.25em 0 1em 0"}}
+    "Three frames coexist on this page: "
+    [:code ":cart-frame"] ", "
+    [:code ":checkout-frame"] ", "
+    [:code ":admin-frame"] ". "
+    "Each carries its own events, subs, and "
+    [:code "app-db"] " slot. "
+    "Most clicks stay scoped to one frame; "
+    [:em "Send to checkout"] " is the cross-frame coordination scenario — "
+    "the cart-frame handler fans out to the checkout-frame via a bridge fx."]
+   [:p {:style {:color "#666" :font-size "12px" :margin "0 0 1em 0"}}
+    "Open Causa (Ctrl+Shift+C). The frame picker should enumerate all three "
+    "frames. Selecting a frame scopes the L2 event list + downstream panels "
+    "to that frame's cascade."]
+   [:div {:style {:display "flex" :gap "1em" :flex-wrap "wrap"
+                  :align-items "flex-start"}}
+    [rf/frame-provider {:frame frame-cart}
+     [cart-panel]]
+    [rf/frame-provider {:frame frame-checkout}
+     [checkout-panel]]
+    [rf/frame-provider {:frame frame-admin}
+     [admin-panel]]]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the three frames before any dispatch. The `:on-create`
+  ;; entries seed each frame's `app-db` synchronously.
+  (rf/reg-frame frame-cart     {:on-create [:cart/init]})
+  (rf/reg-frame frame-checkout {:on-create [:checkout/init]})
+  (rf/reg-frame frame-admin    {:on-create [:admin/init]})
+  (rdc/render react-root [root]))

--- a/tools/causa/testbeds/multi_frame_causa/fixtures.cljs
+++ b/tools/causa/testbeds/multi_frame_causa/fixtures.cljs
@@ -1,0 +1,44 @@
+(ns multi-frame-causa.fixtures
+  "Per-frame deterministic event vectors for the multi-frame Causa
+  testbed. Each fixture is a sequence of `[event-vec opts-map]` pairs
+  where `opts-map` carries the `{:frame ...}` opts that route the
+  dispatch to its target frame.
+
+  These are NOT auto-replayed at boot — the testbed app starts in the
+  empty state for every frame, so a Causa user steps through clicks
+  directly. The fixtures exist for the Playwright smoke + future Story
+  variants to seed deterministic shapes."
+  (:require [re-frame.core :as rf]))
+
+(def cart-frame     :cart-frame)
+(def checkout-frame :checkout-frame)
+(def admin-frame    :admin-frame)
+
+(def cart-seed-events
+  "Apple ×2 + Bread ×1 in :cart-frame."
+  [[[:cart/add-item :apple] {:frame cart-frame}]
+   [[:cart/add-item :apple] {:frame cart-frame}]
+   [[:cart/add-item :bread] {:frame cart-frame}]])
+
+(def cross-frame-handoff-events
+  "Seed the cart, then click Send-to-checkout. After this the
+  checkout-frame's :checkout/items carries the snapshot and the
+  cart-frame's :cart/items is empty."
+  (conj cart-seed-events
+        [[:cart/send-to-checkout] {:frame cart-frame}]))
+
+(def admin-traffic-events
+  "Two admin events firing on :admin-frame only — used by the
+  cascade-isolation spec to prove they don't appear in
+  :cart-frame or :checkout-frame's L2 list."
+  [[[:admin/audit] {:frame admin-frame}]
+   [[:admin/refund 250] {:frame admin-frame}]])
+
+(defn dispatch-sync-events!
+  "Replay a fixture vector through `dispatch-sync` so the resulting
+  cascades land synchronously (suitable for tests that need a fully-
+  resolved app-db before asserting)."
+  [events]
+  (doseq [[event opts] events]
+    (rf/dispatch-sync event opts))
+  nil)

--- a/tools/causa/testbeds/multi_frame_causa/index.html
+++ b/tools/causa/testbeds/multi_frame_causa/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: multi-frame (Causa)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
+       give the user a browser-native drag handle on the host (rf2-e07yk). */
+    :root { --rf-causa-accent: #7C5CFF; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-causa-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/causa/testbeds/multi_frame_causa/spec.cjs
+++ b/tools/causa/testbeds/multi_frame_causa/spec.cjs
@@ -1,0 +1,151 @@
+/*
+ * Multi-frame Causa testbed — browser smoke (rf2-2vgog).
+ *
+ * Three frames coexist on the page — :cart-frame, :checkout-frame,
+ * :admin-frame — each owning its own events / subs / app-db slot. One
+ * deliberate cross-frame coordination scenario: the cart's
+ * `Send to checkout` button dispatches `:cart/send-to-checkout` on
+ * :cart-frame; the handler fans out a `[:checkout/start <items>]`
+ * envelope at :checkout-frame via the testbed bridge fx.
+ *
+ * This spec asserts:
+ *
+ *   1. All three frame panels render and start empty.
+ *
+ *   2. Frame-scoped events stay local: clicking buttons in one frame's
+ *      panel mutates only that frame's app-db (the other two frames'
+ *      visible state stays put).
+ *
+ *   3. Cross-frame coordination: clicking Send-to-checkout on
+ *      :cart-frame drains items into :checkout-frame's view, leaves
+ *      :cart-frame empty, and never touches :admin-frame.
+ *
+ *   4. Causa shell mounted via the preload — the ribbon's frame picker
+ *      enumerates all three named frames (plus :rf/default that the
+ *      runtime always exposes).
+ *
+ *   5. Switching the picker to each frame in turn keeps Causa's chrome
+ *      stable (no errors, the L4 detail panel stays mounted) — the
+ *      minimum-viable signal that the framework's per-frame trace
+ *      ring buffers exist and are readable.
+ */
+
+const {
+  expectTextEquals,
+  expectVisible,
+  expectCount,
+} = require('../../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'multi-frame (Causa)',
+  url:  '/multi-frame-causa/',
+  run:  async (page) => {
+    // --- 0. Wait for first paint ---------------------------------------------
+    await expectVisible(page.locator('[data-testid="multi-frame-causa-root"]'), 10000);
+    await expectVisible(page.locator('[data-testid="cart-frame-panel"]'), 5000);
+    await expectVisible(page.locator('[data-testid="checkout-frame-panel"]'), 5000);
+    await expectVisible(page.locator('[data-testid="admin-frame-panel"]'), 5000);
+
+    // Initial state — every frame's slot is empty / zero.
+    await expectTextEquals(page.locator('[data-testid="cart-total"]'),     '$0.00');
+    await expectTextEquals(page.locator('[data-testid="checkout-total"]'), '$0.00');
+    await expectTextEquals(page.locator('[data-testid="admin-tx-count"]'), '0');
+    await expectTextEquals(page.locator('[data-testid="checkout-status"]'), ':idle');
+
+    // --- 1. Frame-scoped events stay local ------------------------------------
+    //
+    // Click +Apple (cart) +Bread (cart) +Coffee (cart) → cart-frame's
+    // :cart/items grows; checkout and admin slots are unchanged.
+    await page.locator('[data-testid="cart-add-apple"]').click();
+    await page.locator('[data-testid="cart-add-bread"]').click();
+    await page.locator('[data-testid="cart-add-coffee"]').click();
+    // Apple ($1.00) + Bread ($3.00) + Coffee ($5.00) = $9.00.
+    await expectTextEquals(page.locator('[data-testid="cart-total"]'),     '$9.00');
+    await expectTextEquals(page.locator('[data-testid="checkout-total"]'), '$0.00');
+    await expectTextEquals(page.locator('[data-testid="admin-tx-count"]'), '0');
+
+    // Click admin-refund + admin-audit → admin-frame populates; cart +
+    // checkout slots stay frozen at their current values.
+    await page.locator('[data-testid="admin-refund"]').click();
+    await page.locator('[data-testid="admin-audit"]').click();
+    await expectTextEquals(page.locator('[data-testid="admin-refund-count"]'), '1');
+    await expectTextEquals(page.locator('[data-testid="admin-audit-count"]'),  '1');
+    await expectTextEquals(page.locator('[data-testid="admin-tx-count"]'),     '2');
+    // Cart + checkout — unchanged.
+    await expectTextEquals(page.locator('[data-testid="cart-total"]'),     '$9.00');
+    await expectTextEquals(page.locator('[data-testid="checkout-total"]'), '$0.00');
+
+    // --- 2. Cross-frame coordination ------------------------------------------
+    //
+    // Send-to-checkout on :cart-frame drains the cart's items into
+    // :checkout-frame via the bridge fx. After the click:
+    //   - :cart-frame  → :cart/items empty, total $0.00
+    //   - :checkout-frame → carries the snapshot, total $9.00
+    //   - :admin-frame → unchanged (cascade isolation)
+    await page.locator('[data-testid="cart-send-to-checkout"]').click();
+    await expectTextEquals(page.locator('[data-testid="cart-total"]'),     '$0.00');
+    await expectTextEquals(page.locator('[data-testid="checkout-total"]'), '$9.00');
+    await expectTextEquals(page.locator('[data-testid="admin-tx-count"]'), '2');
+
+    // Checkout lines materialised — three distinct testids, one per item.
+    await expectVisible(page.locator('[data-testid="checkout-line-apple"]'),  5000);
+    await expectVisible(page.locator('[data-testid="checkout-line-bread"]'),  5000);
+    await expectVisible(page.locator('[data-testid="checkout-line-coffee"]'), 5000);
+
+    // The :cart-frame's line testids are gone — cart was cleared by
+    // :cart/send-to-checkout before the cross-frame dispatch.
+    await expectCount(page.locator('[data-testid^="cart-line-"]'), 0);
+
+    // Pay → :checkout/status flips to :paid. Local to :checkout-frame;
+    // cart / admin slots stay put.
+    await page.locator('[data-testid="checkout-pay"]').click();
+    await expectTextEquals(page.locator('[data-testid="checkout-status"]'), ':paid');
+    await expectTextEquals(page.locator('[data-testid="cart-total"]'),     '$0.00');
+    await expectTextEquals(page.locator('[data-testid="admin-tx-count"]'), '2');
+
+    // --- 3. Causa shell mounted via the preload -------------------------------
+    //
+    // The :testbeds/multi-frame build wires day8.re-frame2-causa.preload
+    // in `:devtools/:preloads` — Causa auto-mounts inline against the
+    // page's `[data-rf-causa-host]` aside without a Ctrl+Shift+C
+    // toggle. Bring up the ribbon to read the frame picker.
+    await expectVisible(page.locator('[data-testid="rf-causa-shell"]'),  10000);
+    await expectVisible(page.locator('[data-testid="rf-causa-ribbon"]'),  5000);
+
+    // --- 4. Frame picker enumerates all three frames --------------------------
+    //
+    // After the clicks above each of :cart-frame, :checkout-frame, and
+    // :admin-frame has at least one event in its ring buffer, so the
+    // picker's `distinct-frames` produces ≥ 3 entries — well above the
+    // single-entry collapse-to-label branch in `ribbon-frame-picker`.
+    const picker = page.locator('[data-testid="rf-causa-ribbon-frame-picker"]');
+    await expectVisible(picker, 5000);
+
+    const optionValues = await picker.locator('option').evaluateAll((els) =>
+      els.map((el) => el.value),
+    );
+    const requiredFrames = [':cart-frame', ':checkout-frame', ':admin-frame'];
+    for (const f of requiredFrames) {
+      if (!optionValues.includes(f)) {
+        throw new Error(
+          `Frame picker missing ${f}. Got options: ${JSON.stringify(optionValues)}`,
+        );
+      }
+    }
+
+    // --- 5. Switching frames keeps Causa chrome stable ------------------------
+    //
+    // For each named frame, select it via the picker and confirm the
+    // L4 detail panel stays mounted (it rebinds per-tab — the default
+    // landing tab is :event). This is the minimum-viable signal that
+    // the framework's per-frame trace ring buffers are readable and
+    // panel rendering scoped per the selection doesn't blow up.
+    for (const f of requiredFrames) {
+      await picker.selectOption(f);
+      await expectVisible(
+        page.locator('[data-testid="rf-causa-detail-panel-event"]'),
+        5000,
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary

Closes the testbed gap from **rf2-2vgog**: today's interactive testbeds (cart-total, counter-driven, rigorous) are all single-frame. This PR adds an interactive multi-frame testbed under `tools/causa/testbeds/multi_frame_causa/` so Causa's frame picker, per-frame scoping, cascade isolation, and cross-frame causality can be exercised against a real domain-rich application.

## Design — three frames + one cross-frame scenario

Three named frames coexist on one page, each with its own events / subs / app-db slot:

| Frame              | Events                                                            | Subs                                                                | Visible component |
|--------------------|-------------------------------------------------------------------|---------------------------------------------------------------------|-------------------|
| `:cart-frame`      | `:cart/add-item`, `:cart/remove-item`, `:cart/clear`, `:cart/send-to-checkout` | `:cart/items`, `:cart/total`                                        | Cart UI           |
| `:checkout-frame`  | `:checkout/start`, `:checkout/pay`, `:checkout/reset`             | `:checkout/items`, `:checkout/total`, `:checkout/status`            | Checkout UI       |
| `:admin-frame`     | `:admin/refund`, `:admin/audit`                                   | `:admin/transactions`, `:admin/refund-count`, `:admin/audit-count`  | Admin panel       |

**Cross-frame coordination scenario**: clicking *Send to checkout* on `:cart-frame` dispatches `:cart/send-to-checkout`; the handler snapshots the cart items, clears the local slot, and fans out `[:checkout/start <items>]` against `:checkout-frame` via a tiny bridge fx (`::dispatch-to-frame`) that calls `rf/dispatch` with `{:frame :checkout-frame}` opts. Same pattern as the shared multi-frame testbed (reserved `:dispatch` is intra-frame by contract).

Distinct from the top-level [`testbeds/multi_frame/`](https://github.com/day8/re-frame2/blob/main/testbeds/multi_frame/) (rf2-kzcim) — that one is three minimal counters proving framework partitioning, shared across Causa / Story / pair2-mcp. This Causa variant is domain-rich and panel-rich, designed for the Causa devtools workflow.

## Files

- `tools/causa/testbeds/multi_frame_causa/core.cljs` (424 LoC) — three frames + cross-frame bridge + three panels under `frame-provider`s
- `tools/causa/testbeds/multi_frame_causa/fixtures.cljs` (44 LoC) — per-frame deterministic event vectors
- `tools/causa/testbeds/multi_frame_causa/index.html` (27 LoC) — standard Causa-host shell
- `tools/causa/testbeds/multi_frame_causa/spec.cjs` (151 LoC) — Playwright smoke
- `tools/causa/testbeds/multi_frame_causa/README.md` (64 LoC)
- `implementation/shadow-cljs.edn` — adds `:examples/multi-frame-causa` build (Causa preload wired)
- `examples/scripts/serve-and-run-examples-tests.cjs` — adds the orchestrator entry
- `tools/causa/README.md` — lists the new testbed

## Running

From `implementation/`:

```bash
npx shadow-cljs watch :examples/multi-frame-causa
# then open out/examples/multi-frame-causa/index.html in a browser
# (Causa auto-mounts inline; Ctrl+Shift+C toggles)
```

The testbed is also picked up automatically by:

```bash
cd implementation
npm run test:examples              # full sweep including this testbed
```

## What it tests in Causa

- **Frame picker** (`rf-causa-ribbon-frame-picker`) enumerates `:cart-frame`, `:checkout-frame`, `:admin-frame` after any cross-frame click (all three frames carry events in their ring buffer).
- **Per-frame scoping** — selecting a frame in the picker scopes the L2 event list + downstream panels to that frame's cascade.
- **Cascade isolation** — events fired against one frame don't appear in another frame's L2 list (the spec asserts the visible-DOM signal of this: admin clicks don't change cart / checkout totals, cart clicks don't change admin counts).
- **Cross-frame coordination** — Send-to-checkout produces an envelope-rooted sequence: `:cart/send-to-checkout` on `:cart-frame` originating, `:checkout/start` on `:checkout-frame` resulting, in the same drain.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 3242 tests, 0 failures
- [x] `cd implementation && npm run test:browser` — 3233 tests, 0 failures
- [x] `cd tools/causa && clojure -M:test` — 945 tests / 2740 assertions, 0 failures
- [x] `cd implementation && npx shadow-cljs compile :examples/multi-frame-causa` — clean compile (no new warnings)
- [x] `cd implementation && npx shadow-cljs compile :testbeds/multi-frame` — pre-existing top-level testbed still compiles
- [x] `cd implementation && npm run test:examples` — `PASS  multi-frame (Causa)` (the one pre-existing `FAIL causa-inline-resize` is unrelated CSS-variable propagation in a different testbed)

Bead **rf2-2vgog** intentionally left **open** (this is the foundational drop; further panel-by-panel Causa scenarios against the testbed are follow-on work).