### PR TITLE
feat(machines): emit guard + action traces (rf2-2nwfd)

### DIFF
--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -147,6 +147,41 @@
       (f data event {:state (:state snapshot) :meta (:meta snapshot)})
       (f data event))))
 
+;; ---- guard / action evaluation traces -------------------------------------
+;;
+;; Per Spec 009 §Instrumentation and rf2-2nwfd: every user-declared guard
+;; evaluation emits `:rf.machine/guard-evaluated`; every user-declared
+;; action invocation emits `:rf.machine/action-ran`. Both traces ride
+;; through the standard trace bus, so `*handler-scope*` auto-stamps
+;; `:dispatch-id` into `:tags` — downstream cascade-correlation (e.g.
+;; Causa's `:rf.causa/machine-transitions-for-focused-event` sub) groups
+;; them with the originating event without any explicit threading here.
+;;
+;; The synthesised `(constantly true)` returned by `resolve-guard` for a
+;; nil guard-ref, and the synthesised `(constantly nil)` returned by
+;; `resolve-action` for a nil action-ref, are NOT user-declared
+;; evaluations — `evaluate-guard` / `run-action` only emit when
+;; `guard-ref` / `action-ref` is non-nil.
+
+(defn- evaluate-guard
+  "Resolve and invoke a user-declared guard, emitting
+  `:rf.machine/guard-evaluated` for cascade-discoverability. Returns the
+  guard's boolean outcome. When `guard-ref` is nil the guard is the
+  synthesised always-true — skip the trace (it is not a user-declared
+  evaluation) and return true."
+  [machine guard-ref snapshot event]
+  (if (nil? guard-ref)
+    true
+    (let [g       (resolve-guard machine guard-ref)
+          outcome (boolean (call-guard g snapshot event))]
+      (trace/emit! :machine :rf.machine/guard-evaluated
+                   {:machine-id (or (:rf/parent-id machine) (:id machine))
+                    :guard-id   guard-ref
+                    :input      {:data  (:data snapshot)
+                                 :event event}
+                    :outcome    (if outcome :pass :fail)})
+      outcome)))
+
 ;; ---- spawn-id allocator (in-snapshot) -------------------------------------
 ;;
 ;; Per Spec 005 §Declarative :invoke (sugar over spawn) and rf2-gr8q: on
@@ -370,10 +405,7 @@
                  :current-epoch   current-epoch}
                 (let [tspec     (if (keyword? t) {:target t} t)
                       guard-ref (:guard tspec)
-                      pass?     (if guard-ref
-                                  (let [g (resolve-guard machine guard-ref)]
-                                    (boolean (call-guard g snapshot event)))
-                                  true)]
+                      pass?     (evaluate-guard machine guard-ref snapshot event)]
                   (if pass?
                     {:transition tspec
                      :decl-path  prefix
@@ -420,8 +452,8 @@
                         (or (get-in n [:on event-id])
                             (get-in n [:on :*])))
                 hit   (some (fn [t]
-                              (let [g (resolve-guard machine (:guard t))]
-                                (when (call-guard g snapshot event) t)))
+                              (when (evaluate-guard machine (:guard t) snapshot event)
+                                t))
                             cands)]
             (when hit
               {:transition hit :decl-path prefix})))))))
@@ -457,14 +489,35 @@
 (defn- run-action
   "Run one action ref and return either a plain effects map (success) or a
   `result/fail` Result (the action threw). Successful actions may return
-  `nil` (treated as `{}`)."
+  `nil` (treated as `{}`).
+
+  Per rf2-2nwfd: every user-declared action invocation emits
+  `:rf.machine/action-ran` with the action-ref, the canonical input
+  `{:data :event}`, and an outcome — the action's return value on
+  success (or `:ok` when the action returned nil), or
+  `:rf.error/action-threw` on the exceptional path. The synthesised
+  no-op for `nil` action-ref is not user-declared — skip the trace."
   [machine snap action-ref event]
   (if action-ref
-    (let [f (resolve-action machine action-ref)]
+    (let [f         (resolve-action machine action-ref)
+          parent-id (or (:rf/parent-id machine) (:id machine))]
       (try
         (let [r (call-action f snap event)]
+          (trace/emit! :machine :rf.machine/action-ran
+                       {:machine-id parent-id
+                        :action-id  action-ref
+                        :input      {:data  (:data snap)
+                                     :event event}
+                        :outcome    (if (nil? r) :ok r)})
           (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
+          (trace/emit! :machine :rf.machine/action-ran
+                       {:machine-id parent-id
+                        :action-id  action-ref
+                        :input      {:data  (:data snap)
+                                     :event event}
+                        :outcome    :rf.error/action-threw
+                        :exception  e})
           (result/fail {:action-ref action-ref
                         :exception  e}))))
     {}))
@@ -1096,8 +1149,8 @@
                      (vector? always) always
                      :else            [always])
             hit    (some (fn [t]
-                           (let [g (resolve-guard machine (:guard t))]
-                             (when (call-guard g snapshot nil) t)))
+                           (when (evaluate-guard machine (:guard t) snapshot nil)
+                             t))
                          always)]
         (when hit
           {:transition (assoc hit :decl-path prefix) :decl-path prefix})))))

--- a/implementation/machines/test/re_frame/guard_action_traces_test.clj
+++ b/implementation/machines/test/re_frame/guard_action_traces_test.clj
@@ -1,0 +1,221 @@
+(ns re-frame.guard-action-traces-test
+  "Per rf2-2nwfd: the machines substrate emits two cascade-discoverable
+  traces around every transition:
+
+    :rf.machine/guard-evaluated
+      {:guard-id <kw-or-fn>
+       :input    {:data <data> :event <event-vec>}
+       :outcome  :pass | :fail}
+
+    :rf.machine/action-ran
+      {:action-id <kw-or-fn>
+       :input     {:data <data> :event <event-vec>}
+       :outcome   <action-return> | :ok | :rf.error/action-threw}
+
+  Both traces ride the standard trace bus, so `*handler-scope*`
+  auto-stamps `:dispatch-id` under `:tags` — downstream cascade
+  correlation (Causa's `:rf.causa/machine-transitions-for-focused-event`
+  sub) groups them with the originating event without explicit
+  threading from the substrate.
+
+  Locked invariants exercised here:
+    - one guard-evaluated trace per user-declared guard evaluation
+      (no trace for the synthesised always-true when no `:guard` is set)
+    - first-fail short-circuits guard evaluation (no trace for unreached
+      candidate guards), but the failing one IS observed
+    - one action-ran trace per user-declared action invocation, in
+      cascade order (exit → action → entry)
+    - `:dispatch-id` matches the originating event's dispatch-id across
+      both trace operations, enabling Causa to group by cascade
+    - exceptional path: the throwing action emits `action-ran` with
+      `:outcome :rf.error/action-threw` AND carries the exception"
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- record-traces!
+  "Register a trace listener for the duration of `body-fn`, returning
+  the captured trace vec."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- ops [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+;; ---- guard-evaluated: pass + fail outcomes --------------------------------
+
+(deftest guard-evaluated-pass-and-fail-outcomes
+  (testing "user-declared guard fires once per evaluation; outcome marker
+   matches the guard's boolean return"
+    (rf/reg-machine :ga/guard-outcomes
+      {:initial :idle
+       :data    {:ready? false}
+       :guards  {:ready? (fn [data _ev] (:ready? data))}
+       :states  {:idle  {:on {:go [{:guard :ready? :target :done}]}}
+                 :done  {}}})
+    ;; First dispatch: :ready? is false → guard fails.
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/guard-outcomes [:go]])))
+          gs  (ops evs :rf.machine/guard-evaluated)]
+      (is (= 1 (count gs)) "exactly one guard-evaluated trace")
+      (let [g (first gs)]
+        (is (= :ready? (-> g :tags :guard-id)) "guard-id is the keyword ref")
+        (is (= :fail   (-> g :tags :outcome))  ":fail outcome marker")
+        (is (= {:ready? false} (-> g :tags :input :data))
+            "input :data carries the snapshot's :data slot")
+        (is (= [:go] (-> g :tags :input :event))
+            "input :event carries the originating event vec")))))
+
+(deftest guard-evaluated-pass-outcome
+  (testing "guard returning true emits :pass outcome and the transition fires"
+    (rf/reg-machine :ga/guard-pass
+      {:initial :idle
+       :data    {:ready? true}
+       :guards  {:ready? (fn [data _ev] (:ready? data))}
+       :states  {:idle  {:on {:go [{:guard :ready? :target :done}]}}
+                 :done  {}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/guard-pass [:go]])))
+          gs  (ops evs :rf.machine/guard-evaluated)]
+      (is (= 1 (count gs)) "exactly one guard-evaluated trace")
+      (is (= :pass (-> gs first :tags :outcome)) ":pass outcome marker"))))
+
+;; ---- guard short-circuit: failed guard observed; unreached ones silent ----
+
+(deftest guard-evaluation-short-circuits-on-first-pass
+  (testing "the deepest-wins first-pass walker stops at the first guard
+   that returns true; later candidates are NOT traced (they did not run)"
+    (rf/reg-machine :ga/short-circuit
+      {:initial :idle
+       :data    {:a? false :b? true :c? true}
+       :guards  {:a? (fn [d _] (:a? d))
+                 :b? (fn [d _] (:b? d))
+                 :c? (fn [d _] (:c? d))}
+       :states  {:idle {:on {:go [{:guard :a? :target :A}
+                                  {:guard :b? :target :B}
+                                  {:guard :c? :target :C}]}}
+                 :A    {}
+                 :B    {}
+                 :C    {}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/short-circuit [:go]])))
+          gs  (ops evs :rf.machine/guard-evaluated)
+          ids (mapv #(-> % :tags :guard-id) gs)
+          outs (mapv #(-> % :tags :outcome) gs)]
+      (is (= [:a? :b?] ids)
+          ":a? failed, :b? passed, :c? never ran (no trace for unreached)")
+      (is (= [:fail :pass] outs)
+          ":a? :fail, :b? :pass — outcome markers reflect short-circuit semantics"))))
+
+;; ---- guard with no :guard slot: no trace (synthesised always-true) --------
+
+(deftest guard-evaluated-skipped-for-no-guard-clause
+  (testing "a transition with no `:guard` is the synthesised always-true —
+   not a user-declared evaluation, so no trace fires"
+    (rf/reg-machine :ga/no-guard
+      {:initial :idle
+       :states  {:idle {:on {:go {:target :done}}}
+                 :done {}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/no-guard [:go]])))
+          gs  (ops evs :rf.machine/guard-evaluated)]
+      (is (empty? gs)
+          "no guard-evaluated trace when the transition omits `:guard`"))))
+
+;; ---- action-ran: success path with :ok marker ------------------------------
+
+(deftest action-ran-success-with-ok-marker
+  (testing "a transition's :action that returns nil emits action-ran with :outcome :ok"
+    (let [calls (atom 0)]
+      (rf/reg-machine :ga/action-ok
+        {:initial :idle
+         :actions {:tap (fn [_data _ev] (swap! calls inc) nil)}
+         :states  {:idle {:on {:go {:target :done :action :tap}}}
+                   :done {}}})
+      (let [evs (record-traces!
+                  (fn [] (rf/dispatch-sync [:ga/action-ok [:go]])))
+            as  (ops evs :rf.machine/action-ran)]
+        (is (= 1 @calls) "action ran exactly once")
+        (is (= 1 (count as)) "exactly one action-ran trace")
+        (let [a (first as)]
+          (is (= :tap (-> a :tags :action-id)) ":action-id is the keyword ref")
+          (is (= :ok  (-> a :tags :outcome))   ":ok marker for nil-returning action")
+          (is (= [:go] (-> a :tags :input :event)) ":input :event present"))))))
+
+;; ---- action-ran: cascade order — exit → action → entry --------------------
+
+(deftest action-ran-cascade-order
+  (testing "exit cascade → transition :action → entry cascade — action-ran
+   traces fire in cascade order"
+    (rf/reg-machine :ga/cascade
+      {:initial :idle
+       :actions {:exit-idle  (fn [_ _] nil)
+                 :do-go      (fn [_ _] nil)
+                 :enter-done (fn [_ _] nil)}
+       :states  {:idle {:exit :exit-idle
+                        :on   {:go {:target :done :action :do-go}}}
+                 :done {:entry :enter-done}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/cascade [:go]])))
+          as  (ops evs :rf.machine/action-ran)
+          ids (mapv #(-> % :tags :action-id) as)]
+      (is (= [:exit-idle :do-go :enter-done] ids)
+          "three action-ran traces in exit → action → entry order"))))
+
+;; ---- action-ran: exception path ------------------------------------------
+
+(deftest action-ran-exception-path
+  (testing "throwing action emits action-ran with :outcome :rf.error/action-threw
+   AND carries the exception in :tags"
+    (rf/reg-machine :ga/throws
+      {:initial :idle
+       :actions {:boom (fn [_ _] (throw (ex-info "boom" {})))}
+       :states  {:idle {:on {:go {:target :done :action :boom}}}
+                 :done {}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/throws [:go]])))
+          as  (ops evs :rf.machine/action-ran)]
+      (is (= 1 (count as)) "exactly one action-ran trace for the throwing action")
+      (let [a (first as)]
+        (is (= :boom (-> a :tags :action-id)) ":action-id captured")
+        (is (= :rf.error/action-threw (-> a :tags :outcome))
+            ":outcome carries the throw marker")
+        (is (instance? Throwable (-> a :tags :exception))
+            ":exception slot carries the thrown Throwable")))))
+
+;; ---- cascade correlation: :dispatch-id rides both traces -----------------
+
+(deftest cascade-correlation-dispatch-id-rides-both-traces
+  (testing "guard-evaluated and action-ran both ride the standard trace bus,
+   so `*handler-scope*` auto-stamps `:dispatch-id` under `:tags` — Causa's
+   per-event grouping works without any explicit threading"
+    (rf/reg-machine :ga/correlate
+      {:initial :idle
+       :data    {:ready? true}
+       :guards  {:ready? (fn [d _] (:ready? d))}
+       :actions {:tap (fn [_ _] nil)}
+       :states  {:idle {:on {:go [{:guard :ready? :target :done :action :tap}]}}
+                 :done {}}})
+    (let [evs (record-traces!
+                (fn [] (rf/dispatch-sync [:ga/correlate [:go]])))
+          g   (first (ops evs :rf.machine/guard-evaluated))
+          a   (first (ops evs :rf.machine/action-ran))
+          ;; :event/dispatched is the cascade anchor; its :dispatch-id is
+          ;; the canonical id that flows through `*handler-scope*` into
+          ;; every nested emit. Cross-reference it directly here.
+          disp (first (ops evs :event/dispatched))
+          cascade-id (-> disp :tags :dispatch-id)]
+      (is (some? cascade-id) "the originating cascade has a dispatch-id")
+      (is (= cascade-id (-> g :tags :dispatch-id))
+          "guard-evaluated picks up the cascade dispatch-id from *handler-scope*")
+      (is (= cascade-id (-> a :tags :dispatch-id))
+          "action-ran picks up the same cascade dispatch-id"))))


### PR DESCRIPTION
## Summary

Bead: rf2-2nwfd.

Add two cascade-discoverable traces from the machines substrate so Causa's Machines lens lights up its **Guards** and **Actions** lists automatically. The consumer side (PR #1462 — Causa Machines canonical lens) already shipped and is forward-compatible with these shapes; once this merges the lists populate without further Causa work.

### Trace shapes

```
:rf.machine/guard-evaluated
  {:guard-id <kw-or-fn>
   :input    {:data <data> :event <event>}
   :outcome  :pass | :fail}
```

```
:rf.machine/action-ran
  {:action-id <kw-or-fn>
   :input     {:data <data> :event <event>}
   :outcome   <return> | :ok | :rf.error/action-threw
   :exception <Throwable>  ;; throw path only}
```

### Implementation notes

- Single new helper `evaluate-guard` used at all three guard call sites — `pick-transition`, `pick-after-transition`, `pick-always-transition` — so wiring stays uniform.
- Only user-declared guards/actions emit; the synthesised always-true / no-op for `nil` refs are skipped (they're not user-observable evaluations).
- Guard first-fail short-circuit semantics preserved — unreached candidate guards do **not** emit (they did not run).
- Action throw path emits one trace with `:rf.error/action-threw` + the `:exception` before propagating the failure Result via `collect-actions`'s `reduced` short-circuit; subsequent cascade actions do not run, matching the existing 'cascade halts on first throw' semantic in Spec 005 §Errors.
- Both traces flow through `trace/emit!`, so `*handler-scope*` auto-stamps `:dispatch-id` under `:tags`. Causa's `:rf.causa/machine-transitions-for-focused-event` sub composes guard/action evaluations with the originating event without any explicit threading from the substrate.

### Files changed

- `implementation/machines/src/re_frame/machines/transition.cljc` — `evaluate-guard` helper + `run-action` extension; three guard call sites switched to the helper.
- `implementation/machines/test/re_frame/guard_action_traces_test.clj` — eight new JVM tests.

### Tests added

| Test | What it locks |
|---|---|
| `guard-evaluated-pass-and-fail-outcomes` | one trace per evaluation; `:guard-id`/`:outcome`/`:input` shape |
| `guard-evaluated-pass-outcome` | `:pass` marker for true-returning guard |
| `guard-evaluation-short-circuits-on-first-pass` | failing guard observed; later candidates silent |
| `guard-evaluated-skipped-for-no-guard-clause` | no trace for the synthesised always-true |
| `action-ran-success-with-ok-marker` | `:ok` marker for nil-returning action |
| `action-ran-cascade-order` | exit → action → entry order |
| `action-ran-exception-path` | `:rf.error/action-threw` + `:exception` slot |
| `cascade-correlation-dispatch-id-rides-both-traces` | `:dispatch-id` matches `:event/dispatched`'s id across both ops |

## Test plan

- [x] `cd implementation/machines && clojure -M:test` — 206 tests / 731 assertions / 0 failures / 0 errors
- [x] `cd implementation && npm run test:cljs` — 3255 tests / 9362 assertions / 0 failures / 0 errors
- [x] `scripts/test-fast-pr.sh` — PASS