### PR TITLE
feat(causa): section-header pin + show-me-when affordances (rf2-ykjl5)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -104,51 +104,164 @@
 
 ;; ---- breadcrumb -------------------------------------------------------
 
+(defn- subtree->after-value
+  "Extract the 'most-useful' value at the section's path for the
+  Copy-value affordance: prefer `:after` on a `:modified` leaf, then
+  `:value` for `:added` / `:children` / `:same`, then fall back to
+  `:value` on a `:removed` leaf (the removed value is the only one
+  available for a deleted slice)."
+  [subtree]
+  (case (at/op-of subtree)
+    :modified (:after subtree)
+    (:added :children :same) (:value subtree)
+    :removed  (:value subtree)
+    (:value subtree)))
+
+(defn- header-button
+  "Per-button hiccup factory for the breadcrumb's affordance row. Uses
+  the same chrome the slice-mini-panel used before rf2-gfxmk so the
+  visual language stays consistent."
+  [{:keys [testid label colour on-click]}]
+  [:button {:data-testid testid
+            :on-click    on-click
+            :style       {:background    "transparent"
+                          :color         (or colour (:text-secondary tokens))
+                          :border        (str "1px solid "
+                                              (:border-default tokens))
+                          :padding       "1px 6px"
+                          :border-radius "4px"
+                          :cursor        "pointer"
+                          :font-family   sans-stack
+                          :font-size     "10px"}}
+   label])
+
+(defn- breadcrumb-segments
+  "Render the section path as individual clickable segments. Plain click
+  copies the absolute path up to and including the clicked segment;
+  Cmd-click (or Ctrl-click on non-Mac) is the explicit modifier the
+  design (§5.1) calls out — both gestures dispatch
+  `:rf.causa/copy-path-to-clipboard` with the prefix path."
+  [section-path]
+  (if (empty? section-path)
+    [:span {:data-testid (str "rf-causa-diff-section-path-"
+                              (pr-str section-path))
+            :style       {:color (:accent-violet tokens)}}
+     "(root)"]
+    (into [:span {:data-testid (str "rf-causa-diff-section-path-"
+                                    (pr-str section-path))
+                  :style       {:color (:accent-violet tokens)
+                                :display "inline-flex"
+                                :flex-wrap "wrap"
+                                :gap "2px"}}]
+          (for [i (range (count section-path))]
+            (let [seg        (nth section-path i)
+                  prefix     (vec (take (inc i) section-path))
+                  on-click   (fn [^js e]
+                               (.preventDefault e)
+                               (rf/dispatch
+                                 [:rf.causa/copy-path-to-clipboard prefix]
+                                 {:frame :rf/causa}))]
+              ^{:key i}
+              [:span {:data-testid (str "rf-causa-diff-breadcrumb-segment-"
+                                        (pr-str section-path) "-" i)
+                      :on-click    on-click
+                      :title       (str "Copy path up to "
+                                        (pr-str prefix)
+                                        " (or Cmd-click)")
+                      :style       {:cursor      "pointer"
+                                    :color       (:accent-violet tokens)
+                                    :text-decoration "none"}}
+               (pr-str seg)])))))
+
 (defn breadcrumb
-  "Sticky path-header breadcrumb (per design §5.1). Clickable segments
-  emit copy-path events on click (Cmd-click defers to native browser
-  behaviour); the breadcrumb's surface-prefix is rendered as a faded
-  label so the user sees `app-db → [:cart] [:items]`.
+  "Sticky path-header breadcrumb (per design §5.1) carrying the section
+  path + the per-section affordance row (rf2-ykjl5):
+
+      [:cart :items]  ⟨Pin⟩ ⟨Show me when this changed⟩
+                      ⟨Copy path⟩ ⟨Copy value⟩
+                                            ◴ 3 changes
+
+  Path segments are individually clickable — a plain click copies the
+  absolute path up to and including that segment (the design's Cmd-
+  click integration in §5.1; we make plain click suffice and also keep
+  Cmd-click compatible since the click handler always fires).
 
   The container is `position: sticky; top: 0` so it stays pinned as
   the user scrolls through a long section body. Per the design's
   scroll-sticky-vs-click decision (§5.1 + §7.2 open question 5), v1
   uses scroll-sticky — the breadcrumb is the user's 'where am I'
-  anchor in a long diff tree."
-  [section-path child-summary]
-  (let [{:keys [added removed modified children]
-         :or   {added 0 removed 0 modified 0 children 0}} child-summary
-        total-changes (+ added removed modified children)]
-    [:header {:data-testid (str "rf-causa-diff-section-header-"
-                                (pr-str section-path))
-              :style {:position       "sticky"
-                      :top            0
-                      :z-index        1
-                      :display        "flex"
-                      :align-items    "center"
-                      :gap            "8px"
-                      :padding        "6px 12px"
-                      :background     (:bg-3 tokens)
-                      :border-bottom  (str "1px solid "
-                                           (:border-subtle tokens))
-                      :font-family    mono-stack
-                      :font-size      "12px"
-                      :color          (:text-primary tokens)
-                      :font-weight    600}}
-     [:span {:data-testid (str "rf-causa-diff-section-path-"
+  anchor in a long diff tree.
+
+  `subtree-value` is the unwrapped 'after' (or fallback) value at the
+  section's path, used as the payload for the Copy-value button. Older
+  callers that pass only `[path child-summary]` still work — the
+  Copy-value button copies `nil` in that case."
+  ([section-path child-summary]
+   (breadcrumb section-path child-summary nil))
+  ([section-path child-summary subtree-value]
+   (let [{:keys [added removed modified children]
+          :or   {added 0 removed 0 modified 0 children 0}} child-summary
+         total-changes (+ added removed modified children)
+         path-vec      (vec section-path)]
+     [:header {:data-testid (str "rf-causa-diff-section-header-"
+                                 (pr-str section-path))
+               :style {:position       "sticky"
+                       :top            0
+                       :z-index        1
+                       :display        "flex"
+                       :align-items    "center"
+                       :flex-wrap      "wrap"
+                       :gap            "8px"
+                       :padding        "6px 12px"
+                       :background     (:bg-3 tokens)
+                       :border-bottom  (str "1px solid "
+                                            (:border-subtle tokens))
+                       :font-family    mono-stack
+                       :font-size      "12px"
+                       :color          (:text-primary tokens)
+                       :font-weight    600}}
+      (breadcrumb-segments section-path)
+      ;; Affordance row — Pin / Show-me-when / Copy path / Copy value.
+      [:div {:data-testid (str "rf-causa-diff-section-affordances-"
                                (pr-str section-path))
-             :style {:color (:accent-violet tokens)}}
-      (if (empty? section-path)
-        "(root)"
-        (format-path section-path))]
-     (when (pos? total-changes)
-       [:span {:style {:font-family sans-stack
-                       :font-size "11px"
-                       :color (:text-tertiary tokens)
-                       :font-weight 400}}
-        (str "◴ "
-             total-changes
-             (if (= total-changes 1) " change" " changes"))])]))
+             :style       {:display     "inline-flex"
+                           :gap         "4px"
+                           :align-items "center"}}
+       (header-button
+         {:testid   (str "rf-causa-diff-section-pin-" (pr-str section-path))
+          :label    "Pin"
+          :colour   (:cyan tokens)
+          :on-click #(rf/dispatch [:rf.causa/pin-slice path-vec]
+                                  {:frame :rf/causa})})
+       (header-button
+         {:testid   (str "rf-causa-diff-section-show-when-"
+                         (pr-str section-path))
+          :label    "Show me when this changed"
+          :colour   (:magenta tokens)
+          :on-click #(rf/dispatch [:rf.causa/focus-slice-path path-vec]
+                                  {:frame :rf/causa})})
+       (header-button
+         {:testid   (str "rf-causa-diff-section-copy-path-"
+                         (pr-str section-path))
+          :label    "Copy path"
+          :on-click #(rf/dispatch [:rf.causa/copy-path-to-clipboard path-vec]
+                                  {:frame :rf/causa})})
+       (header-button
+         {:testid   (str "rf-causa-diff-section-copy-value-"
+                         (pr-str section-path))
+          :label    "Copy value"
+          :on-click #(rf/dispatch [:rf.causa/copy-value-to-clipboard
+                                   subtree-value]
+                                  {:frame :rf/causa})})]
+      (when (pos? total-changes)
+        [:span {:style {:font-family sans-stack
+                        :font-size "11px"
+                        :color (:text-tertiary tokens)
+                        :font-weight 400
+                        :margin-left "auto"}}
+         (str "◴ "
+              total-changes
+              (if (= total-changes 1) " change" " changes"))])])))
 
 ;; ---- annotated leaf renderers ------------------------------------------
 
@@ -392,11 +505,17 @@
 
 (defn section
   "Render a single `{:path :subtree}` section: sticky breadcrumb +
-  local annotated subtree."
+  local annotated subtree.
+
+  The breadcrumb carries the per-section affordances (Pin /
+  Show-me-when / Copy-path / Copy-value, rf2-ykjl5). The Copy-value
+  payload is the subtree's after-value (or fallback) extracted via
+  `subtree->after-value`."
   [{:keys [path subtree]} surface]
   (let [child-summary (if (= :children (at/op-of subtree))
                         (:child-summary subtree)
-                        nil)]
+                        nil)
+        after-value   (subtree->after-value subtree)]
     [:section {:data-testid (str "rf-causa-diff-section-"
                                  (pr-str path))
                :style {:margin         "8px 12px"
@@ -405,7 +524,7 @@
                                             (:border-subtle tokens))
                        :border-radius  "4px"
                        :overflow       "hidden"}}
-     (breadcrumb path child-summary)
+     (breadcrumb path child-summary after-value)
      [:div {:style {:padding "8px 12px"
                     :font-family mono-stack
                     :font-size "12px"

--- a/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
@@ -6,6 +6,7 @@
   each public renderer is invoked once and the load-bearing
   `data-testid` hooks asserted present in the produced hiccup."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.diff.annotated-tree :as at]
@@ -167,3 +168,244 @@
       (is (= :same (at/op-of tree)))
       ;; And via sections — empty.
       (is (= [] (sg/group-into-sections tree))))))
+
+;; ---- rf2-ykjl5: per-section-header affordances -------------------------
+;;
+;; The section header carries four buttons (Pin / Show-me-when /
+;; Copy-path / Copy-value) and the breadcrumb path renders as
+;; individually clickable segments — plain click copies the path-prefix
+;; up to and including that segment (the design's §5.1 Cmd-click
+;; integration; plain click suffices, Cmd-click is also compatible
+;; because the click handler always fires).
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (tree-seq (some-fn vector? seq?) seq tree)))
+
+(deftest section-header-renders-four-affordance-buttons
+  (testing "rf2-ykjl5 — each section header carries Pin, Show-me-when,
+            Copy-path, Copy-value buttons in the affordance row"
+    (let [tree     (at/diff-tree {:cart {:items []}}
+                                 {:cart {:items [{:id 7}]}})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          ;; The path lifts to either [:cart] or [:cart :items] depending
+          ;; on the grouper's singleton-promote rule. Find whichever.
+          {:keys [path]} (first sections)
+          suffix   (pr-str path)]
+      (is (some? (find-by-testid hiccup
+                                 (str "rf-causa-diff-section-affordances-"
+                                      suffix)))
+          "affordance row container present")
+      (is (some? (find-by-testid hiccup
+                                 (str "rf-causa-diff-section-pin-" suffix)))
+          "Pin button present")
+      (is (some? (find-by-testid hiccup
+                                 (str "rf-causa-diff-section-show-when-"
+                                      suffix)))
+          "Show-me-when button present")
+      (is (some? (find-by-testid hiccup
+                                 (str "rf-causa-diff-section-copy-path-"
+                                      suffix)))
+          "Copy-path button present")
+      (is (some? (find-by-testid hiccup
+                                 (str "rf-causa-diff-section-copy-value-"
+                                      suffix)))
+          "Copy-value button present"))))
+
+;; The on-click handlers fire `rf/dispatch` (async by design — the
+;; production click → enqueue path matches the slice-mini-panel's
+;; pre-rf2-gfxmk behaviour). To assert per-click without juggling the
+;; event-queue drain step, the tests intercept the macro-expansion
+;; target `rf/dispatch*` via `with-redefs` and capture the
+;; `[event opts]` tuple emitted by the click handler. (The `rf/dispatch`
+;; macro expands to `rf/dispatch*` with a `:rf.trace/call-site` stamped
+;; into the opts — we strip it before asserting so tests don't pin to
+;; source-line metadata.) The events themselves are tested independently
+;; in `panels.app_db_diff_events_cljs_test`.
+
+(defn- strip-call-site [opts]
+  (when (map? opts) (dissoc opts :rf.trace/call-site)))
+
+(defn- with-dispatch-capture*
+  [thunk]
+  (let [captured (atom [])
+        capture  (fn ([event] (swap! captured conj [event nil]) nil)
+                   ([event opts]
+                    (swap! captured conj [event (strip-call-site opts)])
+                    nil))]
+    (with-redefs [rf/dispatch* capture]
+      (thunk))
+    @captured))
+
+(defn- click-handler [hiccup testid]
+  (let [btn (find-by-testid hiccup testid)]
+    (:on-click (second btn))))
+
+(deftest section-header-pin-button-dispatches-pin-slice
+  (testing "rf2-ykjl5 — clicking the Pin button on a section header
+            dispatches :rf.causa/pin-slice with the section path,
+            targeted at the :rf/causa frame."
+    (let [tree     (at/diff-tree {:cart {:items []}}
+                                 {:cart {:items [{:id 7}]}})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          {:keys [path]} (first sections)
+          on-click (click-handler hiccup
+                                  (str "rf-causa-diff-section-pin-"
+                                       (pr-str path)))
+          captured (with-dispatch-capture*
+                     #(do (is (fn? on-click))
+                          (on-click #js {})))]
+      (is (= 1 (count captured)))
+      (is (= [:rf.causa/pin-slice path] (first (first captured))))
+      (is (= {:frame :rf/causa} (second (first captured)))
+          "dispatch targeted at the :rf/causa frame"))))
+
+(deftest section-header-show-when-button-dispatches-focus-slice-path
+  (testing "rf2-ykjl5 — Show-me-when button dispatches
+            :rf.causa/focus-slice-path with the section path"
+    (let [tree     (at/diff-tree {:cart {:items []}}
+                                 {:cart {:items [{:id 7}]}})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          {:keys [path]} (first sections)
+          on-click (click-handler hiccup
+                                  (str "rf-causa-diff-section-show-when-"
+                                       (pr-str path)))
+          captured (with-dispatch-capture*
+                     #(do (is (fn? on-click))
+                          (on-click #js {})))]
+      (is (= 1 (count captured)))
+      (is (= [:rf.causa/focus-slice-path path] (first (first captured))))
+      (is (= {:frame :rf/causa} (second (first captured)))))))
+
+(deftest section-header-copy-path-button-dispatches-copy-path
+  (testing "rf2-ykjl5 — Copy-path button dispatches
+            :rf.causa/copy-path-to-clipboard with the section path"
+    (let [tree     (at/diff-tree {:cart {:items []}}
+                                 {:cart {:items [{:id 7}]}})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          {:keys [path]} (first sections)
+          on-click (click-handler hiccup
+                                  (str "rf-causa-diff-section-copy-path-"
+                                       (pr-str path)))
+          captured (with-dispatch-capture*
+                     #(do (is (fn? on-click))
+                          (on-click #js {})))]
+      (is (= 1 (count captured)))
+      (is (= [:rf.causa/copy-path-to-clipboard path]
+             (first (first captured))))
+      (is (= {:frame :rf/causa} (second (first captured)))))))
+
+(deftest section-header-copy-value-button-payload-is-after-value
+  (testing "rf2-ykjl5 — Copy-value button dispatches
+            :rf.causa/copy-value-to-clipboard. The payload is the
+            section's after-value (the post-change value at the section
+            path) — for a :modified leaf at the section root, that's
+            :after."
+    (let [;; A pure leaf-modified section: {:status :pending} →
+          ;; {:status :submitting} ⇒ section subtree is a :modified
+          ;; leaf at path [:status].
+          tree     (at/diff-tree {:status :pending}
+                                 {:status :submitting})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          {:keys [path]} (first sections)
+          on-click (click-handler hiccup
+                                  (str "rf-causa-diff-section-copy-value-"
+                                       (pr-str path)))
+          captured (with-dispatch-capture*
+                     #(do (is (fn? on-click))
+                          (on-click #js {})))]
+      (is (= 1 (count captured)))
+      (is (= [:rf.causa/copy-value-to-clipboard :submitting]
+             (first (first captured)))
+          "Copy-value sends the :after scalar as the payload"))))
+
+(deftest section-header-copy-value-button-on-container-subtree
+  (testing "rf2-ykjl5 — when the section subtree is a `:children`
+            container (the common multi-key change case), Copy-value
+            sends the container's :value — the after-value at the
+            section path."
+    (let [;; Two keys change under [:user] → section lifts to [:user]
+          ;; and the subtree is a :children container.
+          tree     (at/diff-tree {:user {:name "ada" :age 30}}
+                                 {:user {:name "ada" :age 31}})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")
+          {:keys [path subtree]} (first sections)
+          on-click (click-handler hiccup
+                                  (str "rf-causa-diff-section-copy-value-"
+                                       (pr-str path)))
+          captured (with-dispatch-capture*
+                     #(do (is (fn? on-click))
+                          (on-click #js {})))]
+      (is (= 1 (count captured)))
+      (is (= [:rf.causa/copy-value-to-clipboard (:value subtree)]
+             (first (first captured)))
+          "Copy-value sends the subtree's :value (the after-container)"))))
+
+(deftest breadcrumb-segment-click-copies-prefix-path
+  (testing "rf2-ykjl5 — the breadcrumb renders one clickable segment per
+            path element; plain click copies the absolute path-prefix
+            up to AND INCLUDING that segment (design §5.1). Cmd-click
+            is also supported because the click handler always fires —
+            we just `preventDefault` so the browser's native Cmd-click
+            behaviour does not interfere."
+    ;; Drive `breadcrumb` directly with a known multi-segment path so
+    ;; the test is independent of the grouper's coalesce behaviour.
+    (let [section-path [:user :prefs :theme]
+          hdr          (render/breadcrumb section-path
+                                          {:added 0 :removed 0
+                                           :modified 1 :children 0}
+                                          :dark)
+          segment-clicks (atom [])
+          click-segment! (fn [i]
+                           (let [seg (find-by-testid
+                                       hdr
+                                       (str "rf-causa-diff-breadcrumb-segment-"
+                                            (pr-str section-path) "-" i))
+                                 handler (:on-click (second seg))]
+                             (is (fn? handler)
+                                 (str "segment " i " has on-click"))
+                             (swap! segment-clicks conj i)
+                             (handler #js {:preventDefault (fn [])})))
+          captured (with-dispatch-capture*
+                     #(doseq [i (range (count section-path))]
+                        (click-segment! i)))]
+      (is (= [0 1 2] @segment-clicks))
+      (is (= 3 (count captured))
+          "three clicks produce three dispatches")
+      (doseq [i (range (count section-path))]
+        (let [expected-prefix (vec (take (inc i) section-path))
+              [event opts]    (nth captured i)]
+          (is (= [:rf.causa/copy-path-to-clipboard expected-prefix]
+                 event)
+              (str "click on segment " i " dispatches copy-path with prefix "
+                   (pr-str expected-prefix)))
+          (is (= {:frame :rf/causa} opts)))))))
+
+(deftest breadcrumb-renders-root-when-section-path-empty
+  (testing "rf2-ykjl5 — empty section-path still renders the '(root)'
+            label with the legacy section-path testid hook"
+    (let [hdr (render/breadcrumb [] nil nil)]
+      (is (some? (find-by-testid hdr "rf-causa-diff-section-path-[]"))
+          "section-path span present even for the empty path")
+      (is (some? (find-by-testid hdr
+                                 "rf-causa-diff-section-affordances-[]"))
+          "affordance row still ships for the root section"))))
+
+(deftest breadcrumb-three-arity-back-compat-works
+  (testing "rf2-ykjl5 — the legacy `[path summary]` arity remains
+            callable; Copy-value just sends nil (no subtree-value
+            supplied)"
+    (let [hdr (render/breadcrumb [:a] {:added 1 :removed 0
+                                       :modified 0 :children 0})]
+      (is (vector? hdr))
+      (is (some? (find-by-testid hdr "rf-causa-diff-section-pin-[:a]"))))))


### PR DESCRIPTION
## Summary

Phase-1 follow-on of rf2-gfxmk (PR #1430). When the renderer switched to the sections-per-cluster model, the slice-mini-panel's four action buttons (Pin / Show-me-when / Copy-path / Copy-value) were dropped. This re-adds them on the section header (per the design's §5.1 sticky breadcrumb) so every section the renderer ships exposes the same affordances the old slice-mini-panel did.

Bead: rf2-ykjl5

## Per-button event mapping

| Button | Event | Payload |
|---|---|---|
| Pin | `:rf.causa/pin-slice` | `:path` (= section path) |
| Show me when this changed | `:rf.causa/focus-slice-path` | `:path` |
| Copy path | `:rf.causa/copy-path-to-clipboard` | `:path` |
| Copy value | `:rf.causa/copy-value-to-clipboard` | after-value at path |

All four event handlers already exist in `app-db-diff-events.cljs` (they were wired up for the slice-mini-panel) — this PR reuses them; no event re-implementation.

## Cmd-click on breadcrumb segment

Per design §5.1 the breadcrumb path renders as individually clickable spans. Plain click (or Cmd-click — the click handler always fires) on a segment dispatches `:rf.causa/copy-path-to-clipboard` with the absolute path-prefix up to AND INCLUDING the clicked segment.

## Where it ships

- `tools/causa/src/day8/re_frame2_causa/diff/render.cljs` — `breadcrumb` gains a 3-arity for the Copy-value payload (the 2-arity stays back-compatible); `section` extracts the subtree's after-value (handles all five `::op` cases) and threads it through.
- `tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs` — focused click-handler tests using `with-redefs` on `rf/dispatch*` to capture per-button dispatches without juggling the event-queue drain.

The shared `diff/render.cljs` covers BOTH the App-DB Diff panel and the Views sub-output drilldown (`panels/views_sub_diff.cljs`), which both call `diff-render/render-sections` — so the section-header affordances ship in both panels at once.

## Pin store semantics unchanged

The pin store remains keyed by `:path` — identical semantics to pre-rf2-gfxmk. The existing `pin-slice-event-still-wired` test in the panel test suite continues to pass.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 952 / 2759 assertions green
- [x] `cd implementation && npm run test:cljs` — 3273 / 9431 assertions green
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] All four buttons present per section-header
- [x] Each button dispatches the matching event with the correct path / value payload
- [x] Cmd/plain-click on each breadcrumb segment dispatches Copy-path with the prefix path
- [x] Pin store still keyed by `:path` (unchanged pin event)
- [x] Existing `breadcrumb` 2-arity callers still work