### PR TITLE
fix(causa): Views panel React unique-key warning (rf2-gphsi)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -443,12 +443,20 @@
                :style {:display "flex" :flex-direction "column"}}
      [:header {:style group-section-style}
       (str (name group) " this cascade (" (count items) ")")]
+     ;; `^{:key rk}` reader meta on the `(case …)` form below would be
+     ;; attached to the source list and lost when `case` returns the
+     ;; branch's vector value — Reagent's `get-react-key` only reads
+     ;; `:key` meta from vectors (see reagent2.impl.template). Apply the
+     ;; key meta to the returned vector directly via `with-meta`.
+     ;; `single-row` and `cluster-row` always return a `[:div …]` vector,
+     ;; so `with-meta` is safe (never nil). (rf2-gphsi)
      (for [item items]
        (let [rk (row-key item)]
-         ^{:key rk}
-         (case (:kind item)
-           :single  (single-row item group (contains? expanded-rows rk))
-           :cluster (cluster-row item group (contains? expanded-clusters rk)))))]))
+         (with-meta
+           (case (:kind item)
+             :single  (single-row item group (contains? expanded-rows rk))
+             :cluster (cluster-row item group (contains? expanded-clusters rk)))
+           {:key rk})))]))
 
 ;; ---- chrome -------------------------------------------------------------
 
@@ -555,7 +563,15 @@
         :else
         [:div {:data-testid "rf-causa-views-groups"
                :style {:display "flex" :flex-direction "column"}}
-         (for [g h/group-order]
-           ^{:key g}
-           (group-section g (get groups g) expanded-rows expanded-clusters))])]
+         ;; `^{:key g}` reader meta on the `(group-section …)` call would
+         ;; be attached to the source list and lost — Reagent's
+         ;; `get-react-key` only reads `:key` meta from vectors. Apply
+         ;; the key directly to the returned `[:section …]` vector via
+         ;; `with-meta`, guarding for nil (empty groups → no section).
+         ;; (rf2-gphsi)
+         (for [g h/group-order
+               :let [section (group-section g (get groups g)
+                                            expanded-rows expanded-clusters)]
+               :when section]
+           (with-meta section {:key g}))])]
      (bottom-controls data)]))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
@@ -40,3 +40,76 @@
         "bottom-controls footer renders")
     (is (has-testid? tree "rf-causa-views-heatmap-toggle")
         "heatmap toggle is mounted (default: heatmap mode off)")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-gphsi — React unique-key warning regression guard
+;;
+;; The Views panel renders two `for` loops over sibling Reagent elements:
+;; (1) `group-section` iterates `items` and emits one row per item;
+;; (2) `views-panel` iterates `h/group-order` and emits one `group-section`
+;; per group. Both previously attached `^{:key …}` reader meta to a
+;; function-call list form (a `(case …)` form and a `(group-section …)`
+;; call respectively). That meta is dropped at evaluation — Reagent's
+;; `get-react-key` only reads `:key` from vector meta — producing React
+;; "unique key prop" warnings in panel_gallery fixtures (dense-subs,
+;; three-group, filter-applied, heatmap). Fix moves the key meta onto
+;; the returned `[:div …]` / `[:section …]` vector via `with-meta`.
+;; This test asserts every child vector carries `:key` meta so the
+;; regression cannot recur silently. (rf2-gphsi)
+;; ---------------------------------------------------------------------------
+
+(defn- mk-single-item [view-id triggered-by]
+  {:kind          :single
+   :render        {:render-key      [view-id 0]
+                   :triggered-by    triggered-by
+                   :elapsed-ms      1.5
+                   :props-before    nil
+                   :props-after     nil}
+   :invalidated-by [{:sub-id triggered-by :trigger? true}]})
+
+(deftest group-section-children-carry-key-meta
+  (facade/install!)
+  (frame/reg-frame :rf/causa {})
+  (let [items   [(mk-single-item ::comp-a ::sub-a)
+                 (mk-single-item ::comp-b ::sub-b)
+                 (mk-single-item ::comp-c ::sub-c)]
+        section (#'view/group-section :rendered items #{} #{})
+        ;; `section` is `[:section attrs [:header …] <for-lazy-seq>]`
+        ;; — the `for` over rows ships as a single seq in the tail
+        ;; vector slot; Reagent walks the seq and applies React keys
+        ;; per child via `get-react-key`. Pull that seq and assert
+        ;; each row carries `:key` meta.
+        rows    (nth section 3)]
+    (is (seq? rows) "rows ship as a seq inside the section vector")
+    (is (= 3 (count rows)) "one row per item")
+    (doseq [row rows]
+      (is (vector? row)
+          (str "row is a hiccup vector — got " (pr-str (type row))))
+      (is (some? (some-> (meta row) :key))
+          (str "row carries :key meta — got " (pr-str (meta row)))))
+    (is (= ["[:day8.re-frame2-causa.panels.views-view-cljs-test/comp-a 0]"
+            "[:day8.re-frame2-causa.panels.views-view-cljs-test/comp-b 0]"
+            "[:day8.re-frame2-causa.panels.views-view-cljs-test/comp-c 0]"]
+           (mapv #(-> % meta :key) rows))
+        "each row's :key is the per-item row-key (pr-str of :render-key)")))
+
+(deftest views-panel-group-loop-keys-each-section
+  ;; Exercises the top-level (for [g h/group-order] …) loop. The panel's
+  ;; sub returns nil under the empty fixture, so we stub the resolution
+  ;; path by reaching into the inner builders directly via the private
+  ;; group-section var and confirming the same with-meta wrapping the
+  ;; panel applies. The panel-level loop guards nil with `:when section`
+  ;; and wraps non-nil sections via `(with-meta section {:key g})`.
+  (facade/install!)
+  (frame/reg-frame :rf/causa {})
+  (let [items [(mk-single-item ::comp-a ::sub-a)]
+        ;; emulate the panel-loop expression for two groups
+        sections (for [g [:mounted :rendered]
+                       :let [s (#'view/group-section g items #{} #{})]
+                       :when s]
+                   (with-meta s {:key g}))]
+    (is (= 2 (count sections)))
+    (doseq [s sections]
+      (is (some? (some-> (meta s) :key))
+          (str "panel-loop section carries :key meta — got "
+               (pr-str (meta s)))))))


### PR DESCRIPTION
Closes-ref: rf2-gphsi (do not auto-close — bead stays open)

## Symptom

Per `bd show rf2-gphsi`: the Views panel emitted React warnings —
`Each child in a list should have a unique "key" prop. Check the
render method of reagent? It was passed a child from reagent?` —
under the panel_gallery fixtures exposed by **rf2-sszlr**:
`dense-subs`, `three-group`, `filter-applied`, `heatmap`. Two
warnings per panel render. Non-fatal — variants rendered correctly
and the rf2-kgn0c workspace-switch smoke passed after filtering
FATAL_ERROR_RE patterns, but every panel mount under the gallery
sprayed dev-console noise.

## Root cause

Two `for` loops in `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs`
attached `^{:key …}` reader meta to a **function-call list form** instead
of to the returned hiccup vector:

1. **`group-section`** (per-item row loop, line 446) wrapped a `(case …)`
   form returning the result of `single-row` or `cluster-row`.
2. **`views-panel`** (per-group section loop, line 558) wrapped a
   `(group-section …)` call.

Reader meta on a list form is metadata on the source list — once the
form evaluates, the returned value (a fresh vector) does not inherit
the meta. Reagent's `get-react-key` (see
`implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs`
§407) only reads `:key` meta from vectors:

```clojure
(defn- get-react-key [v]
  (let [k (when (vector? v) (some-> (meta v) :key))]
    (or k …)))
```

— so both sites silently lost their keys.

Sites elsewhere in the panel (`heatmap-bar` segments,
`invalidated-by-list` rows, cluster-instances) attach `^{:key x}` to
**vector literals**, which the reader preserves. They are correct.

## Fix

Move the key onto the returned vector via `with-meta`. For the
top-level group loop, guard `group-section`'s nil return (empty
groups render nothing) via a `:when` clause so `with-meta` only ever
sees a `[:section …]` vector. `single-row` and `cluster-row` always
return a `[:div …]` vector so the inner site needs no nil guard.

Per-key choice rationale:

- **Per-row key** = `row-key item` — the existing private helper
  returning `(pr-str (:render-key item))` for `:single` rows and
  `(str "cluster:" (pr-str [view-id triggered-by]))` for `:cluster`
  rows. Already designed for stable React keying; we just had to
  actually deliver it to Reagent.
- **Per-group key** = the group keyword (`:mounted` / `:rendered` /
  `:unmounted`) — three fixed siblings, the keyword is locally unique.

## Test

`tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs`
gains two regressions guards:

1. `group-section-children-carry-key-meta` — synthesises three
   `:single` items, calls `#'view/group-section` directly, walks
   into the section's `for` lazy-seq slot, and asserts every child
   is a vector with `:key` meta whose value matches the
   per-`row-key` keying.
2. `views-panel-group-loop-keys-each-section` — emulates the
   panel-level `(for [g h/group-order] :when …)` loop with two
   groups and asserts each `with-meta`-wrapped section carries
   `:key` meta.

## Gates

- `cd tools/causa && clojure -M:test` — 952 tests / 2759 assertions, 0 failures
- `cd implementation && npm run test:cljs` — 3266 tests / 9401 assertions, 0 failures
- `scripts/test-fast-pr.sh` — PASS

## Bead

- rf2-gphsi · P3 BUG — discovered from rf2-sszlr
- Per task brief: bead stays OPEN; not closed by this PR