### PR TITLE
fix(causa): inline-resize variable propagation — P1 unblocks CI queue (rf2-6fqr5)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -180,30 +180,55 @@
   apply fn + tests reference one spelling."
   "--rf-causa-inline-width")
 
-(defn- layout-host-element
-  "Resolve the configured layout host element if Causa is mounted in
-  the right-rail. Falls back to nil under :overlay/:popout/test
-  runtimes — `apply-panel-width!` then writes to `:root` only, which
-  is harmless because the host element doesn't exist in those modes."
-  []
-  (when (and (exists? js/document) (.-querySelector js/document))
-    (try
-      (.querySelector js/document (config/get-layout-host-selector))
-      (catch :default _ nil))))
-
 (defn apply-panel-width!
-  "Write `px` as the value of `--rf-causa-inline-width` on both the
-  configured layout host (so the host's `flex-basis` re-evaluates
-  immediately) and the `<html>` root (so the cascade still resolves
-  for any consumer reading `var(--rf-causa-inline-width, 560px)`
-  further up the tree). No-op when neither element is present —
-  matches the apply-text-size! / apply-theme! pattern."
+  "Drive `--rf-causa-inline-width` on the `<html>` root from the user's
+  resize-handle setting.
+
+  - When `px` differs from `config/default-panel-width-px`, write the
+    value as an inline style on `<html>`. The recommended host CSS
+    reads `var(--rf-causa-inline-width, 560px)` for its `flex-basis`;
+    CSS custom properties inherit, so a declaration on `<html>`
+    resolves at every descendant — including the host — on the very
+    next paint.
+  - When `px` IS the default (or `nil`), REMOVE any existing inline
+    declaration rather than re-asserting it. This is the critical
+    move: keeping the property unset on `<html>` lets the consumer's
+    own override (e.g. `:root { --rf-causa-inline-width: 720px; }`
+    in the host stylesheet) resolve at the host via the documented
+    cascade. Asserting the default would otherwise shadow that
+    override — inline declarations on `<html>` beat any author-normal
+    selector-based rule, including `:root { ... }` in `<style>`
+    (rf2-6fqr5).
+
+  No-op when `<html>` is absent (test runtimes without a `document`
+  root). Matches the apply-text-size! / apply-theme! pattern, except
+  for the default-as-clear behaviour, which is unique to this
+  property because only this property is part of a documented
+  consumer-cascade contract.
+
+  ## Why we do NOT also write to the host element
+
+  An earlier draft (rf2-x8h9y) wrote the custom property on BOTH the
+  host element AND `<html>`. The host write trapped the cascade even
+  harder than the `<html>`-default trap above: inline style on the
+  host beats ALL selector-based declarations regardless of layer,
+  including the consumer's `:root` rule. Removed for the same
+  rf2-6fqr5 reason; the host's `var(...)` inherits from `<html>`
+  (or `:root`) on the next paint without any per-element write."
   [px]
-  (let [value (str (long (or px config/default-panel-width-px)) "px")]
-    (when-let [host (layout-host-element)]
-      (.setProperty (.-style host) panel-width-css-var value))
-    (when-let [html (html-root-element)]
-      (.setProperty (.-style html) panel-width-css-var value)))
+  (when-let [html (html-root-element)]
+    (let [px      (or px config/default-panel-width-px)
+          default config/default-panel-width-px]
+      (if (= (long px) (long default))
+        ;; Default value — clear any prior inline write so the
+        ;; consumer's cascade override (or the host CSS's `var(...)`
+        ;; fallback) wins.
+        (.removeProperty (.-style html) panel-width-css-var)
+        ;; Explicit user setting (drag handle / numeric input) —
+        ;; write inline on `<html>` so it overrides the consumer's
+        ;; baseline. The user's gesture is the strongest signal.
+        (.setProperty (.-style html) panel-width-css-var
+                      (str (long px) "px")))))
   nil)
 
 ;; ---- panel position -----------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
@@ -14,7 +14,9 @@
     5. Double-click handler dispatches `:rf.causa/reset-panel-width`
        which dispatches set-panel-width-px with the default value.
     6. `apply-panel-width!` writes the CSS custom property on the
-       host element.
+       `<html>` root so it cascades to the host via inheritance
+       (rf2-6fqr5 — writing it on the host's own inline style would
+       shadow consumer overrides on `:root`).
     7. `apply-all!` restores the persisted width on boot.
     8. Reload survival — `update-setting!` round-trips through
        localStorage (covered indirectly by config + effects)."
@@ -249,6 +251,57 @@
   ;; Even without a layout host present, the call should not throw.
   (is (nil? (settings-effects/apply-panel-width! 480))
       "no-op safe pre-mount"))
+
+(deftest apply-panel-width-does-not-pin-host-inline-style
+  ;; Regression for rf2-6fqr5: an earlier draft wrote the CSS custom
+  ;; property as an INLINE style on the layout host as well as on
+  ;; `<html>`. Inline declarations beat any selector-based rule in
+  ;; the cascade, so a consumer's `:root { --rf-causa-inline-width:
+  ;; 720px; }` was silently shadowed by Causa's host write. The
+  ;; documented inline-host contract (spec/011-Launch-Modes.md
+  ;; §Resizing the inline host) requires that an override anywhere
+  ;; up the cascade takes effect — which means Causa MUST NOT write
+  ;; the property to the host element itself; the host inherits the
+  ;; value from `<html>` via the `var(...)` lookup on the next paint.
+  (when (and (exists? js/document) (.-createElement js/document))
+    (let [host (.createElement js/document "aside")]
+      (.setAttribute host "data-rf-causa-host" "")
+      (when (.-body js/document)
+        (.appendChild (.-body js/document) host))
+      (try
+        (settings-effects/apply-panel-width! 480)
+        (is (= "" (.getPropertyValue (.-style host)
+                                     "--rf-causa-inline-width"))
+            "host element MUST NOT carry the CSS var as an inline style")
+        (finally
+          (when (.-parentNode host)
+            (.removeChild (.-parentNode host) host)))))))
+
+(deftest apply-panel-width-clears-html-inline-when-default
+  ;; Regression for rf2-6fqr5: an earlier draft asserted the default
+  ;; value as an inline style on `<html>` at boot. Inline `<html>`
+  ;; declarations beat author-normal `:root { ... }` rules (the cascade
+  ;; treats inline as the highest origin), so a consumer's documented
+  ;; `:root { --rf-causa-inline-width: 720px; }` was silently shadowed
+  ;; by Causa's default-assertion. When the user has NOT explicitly
+  ;; resized — i.e. the value still equals `default-panel-width-px` —
+  ;; `apply-panel-width!` MUST clear any prior inline declaration so
+  ;; the consumer's `:root` override (or the host CSS's `var(...)`
+  ;; fallback) wins.
+  (when-let [html (and (exists? js/document)
+                       (.-documentElement js/document))]
+    ;; Prime an inline declaration first to prove the clear path runs.
+    (.setProperty (.-style html) "--rf-causa-inline-width" "999px")
+    (settings-effects/apply-panel-width! config/default-panel-width-px)
+    (is (= "" (.getPropertyValue (.-style html)
+                                 "--rf-causa-inline-width"))
+        "default value MUST clear the inline `<html>` declaration")
+    ;; nil arg also routes to the default and must clear.
+    (.setProperty (.-style html) "--rf-causa-inline-width" "888px")
+    (settings-effects/apply-panel-width! nil)
+    (is (= "" (.getPropertyValue (.-style html)
+                                 "--rf-causa-inline-width"))
+        "nil arg defaults to the published width and clears the inline")))
 
 ;; ---- panel-width-px sub --------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes the P1 `causa-inline-resize` Playwright failure that's been forcing every PR through `--admin` merges since #1448 landed.

Bead: rf2-6fqr5.

## Failure (verbatim)

```
FAIL causa-inline-resize: Override --rf-causa-inline-width: 720px did not
propagate to the host element. Last reading:
{"host":{"left":720,"right":1280,"width":560},
 "app":{"left":0,"right":720,"width":720},
 "flexBasisVar":"560px"}.
Did the host CSS stop reading the variable?
```

## Root cause

`settings.effects/apply-panel-width!` (added under rf2-x8h9y, PR #1448) wrote `--rf-causa-inline-width` as an INLINE style on BOTH the layout host element AND `<html>` — even at boot, because `apply-all!` calls it once with the default 560px.

In the CSS cascade, inline-style declarations beat author-normal selector-based ones (`:root { ... }` in a `<style>` tag is selector-based; `element.style.setProperty(...)` is inline). So the consumer's documented `:root { --rf-causa-inline-width: 720px; }` override was silently shadowed by Causa's inline write. The `flexBasisVar: "560px"` reading in the failure message was exactly the smoking gun — it's `getComputedStyle(host).getPropertyValue(...)` returning Causa's pinned default.

This is hypothesis (3) from the bead — cascade override — but applied to BOTH the host (host inline wins over everything) and `<html>` (html inline wins over `:root { ... }` selectors).

## Fix

1. **Drop the host-element inline write entirely.** The host's `var(--rf-causa-inline-width, 560px)` inherits from `<html>` on the next paint; the per-element write was redundant and broke the cascade contract.
2. **Default-as-clear on `<html>`.** When `apply-panel-width!` is called with the default value (or `nil`), REMOVE the `<html>` inline declaration rather than re-asserting it. Asserting the default would shadow consumer `:root` overrides for the same specificity reason. Explicit user resize gestures (non-default px) still write inline on `<html>` — the user's gesture wins over the consumer baseline.

## Regression tests

- `apply-panel-width-does-not-pin-host-inline-style` — host element never carries the property as inline style.
- `apply-panel-width-clears-html-inline-when-default` — default value (and nil) clears any prior inline declaration on `<html>`.

## Test plan

- [x] `npm run test:examples` (was the failing gate) — 41 specs, 0 failures
- [x] `scripts/test-fast-pr.sh` — 3266 cljs tests, 0 failures
- [x] `npm run test:browser` — 3257 tests, 0 failures
- [x] Cascade-override regression test added in CLJS suite