### PR TITLE
fix(causa): sweep ^{:key} meta-on-list-form anti-pattern across live panels (rf2-ppzid)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
@@ -41,9 +41,15 @@
                        :color (:text-secondary tokens)}}
       "[runtime] — reserved app-db keys"]
      (into [:div]
+           ;; `^{:key …}` reader meta on the `(reserved-row pair)` call
+           ;; below would be attached to the source list and lost when
+           ;; the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `reserved-row` always returns a
+           ;; `[:div …]` vector, so apply the key directly via
+           ;; `with-meta`. (rf2-ppzid)
            (for [pair reserved-pairs]
-             ^{:key (pr-str (first pair))}
-             (reserved-row pair)))]))
+             (with-meta (reserved-row pair) {:key (pr-str (first pair))})))]))
 
 (defn- pinned-row
   [{:keys [path value]}]
@@ -90,9 +96,15 @@
                        :color (:text-secondary tokens)}}
       "Pinned slices"]
      (into [:div]
+           ;; `^{:key …}` reader meta on the `(pinned-row p)` call
+           ;; below would be attached to the source list and lost when
+           ;; the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `pinned-row` always returns a
+           ;; `[:div …]` vector, so apply the key directly via
+           ;; `with-meta`. (rf2-ppzid)
            (for [p pinned-slices]
-             ^{:key (pr-str (:path p))}
-             (pinned-row p)))]))
+             (with-meta (pinned-row p) {:key (pr-str (:path p))})))]))
 
 (defn- focus-result-row
   [{:keys [epoch-id event op before after] :as _hit}]
@@ -168,6 +180,12 @@
                  :style {:list-style "none"
                          :margin 0
                          :padding 0}}]
+           ;; `^{:key …}` reader meta on the `(focus-result-row hit)`
+           ;; call below would be attached to the source list and lost
+           ;; when the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `focus-result-row` always
+           ;; returns a `[:li …]` vector, so apply the key directly
+           ;; via `with-meta`. (rf2-ppzid)
            (for [hit hits]
-             ^{:key (pr-str (:epoch-id hit))}
-             (focus-result-row hit))))])
+             (with-meta (focus-result-row hit) {:key (pr-str (:epoch-id hit))}))))])

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
@@ -162,6 +162,13 @@
                  :margin 0}}
      "No slice changes in the selected epoch."]
     (into [:div {:data-testid "rf-causa-app-db-diff-slices"}]
+          ;; `^{:key …}` reader meta on the `(slice-row t)` list form is
+          ;; attached to the source list and lost when the call returns
+          ;; its fresh vector. Reagent's `get-react-key` only reads
+          ;; `:key` meta from vectors (see reagent2.impl.template), so
+          ;; the keys silently vanished and React emitted "unique key
+          ;; prop" warnings. `slice-row` always returns a `[:div …]`
+          ;; vector — apply the key meta directly via `with-meta`.
+          ;; (rf2-ppzid)
           (for [t non-reserved-triples]
-            ^{:key (pr-str (:path t))}
-            (slice-row t)))))
+            (with-meta (slice-row t) {:key (pr-str (:path t))})))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -340,21 +340,28 @@
        (parent-decision-row parent-decision))
      (when (seq child-teardowns)
        [:div {:data-testid "rf-causa-cancellation-cascade-teardowns"}
+        ;; `^{:key …}` reader meta on the `(teardown-row t)` /
+        ;; `(abort-row …)` call below would be attached to the source
+        ;; list and lost when the call returns its fresh vector —
+        ;; Reagent's `get-react-key` only reads `:key` meta from
+        ;; vectors (see reagent2.impl.template). `teardown-row` and
+        ;; `abort-row` always return a `[:div …]` vector, so apply
+        ;; the key directly via `with-meta`. (rf2-ppzid)
         (doall
           (for [t child-teardowns]
-            ^{:key (str "teardown-" (or (:trace-id t)
-                                        (:child-id t)))}
-            (teardown-row t)))])
+            (with-meta (teardown-row t)
+              {:key (str "teardown-" (or (:trace-id t)
+                                         (:child-id t)))})))])
      (when (seq visible-aborts)
        [:div {:data-testid "rf-causa-cancellation-cascade-aborts"}
         (doall
           (map-indexed
             (fn [idx row]
               (let [last? (= idx (dec (count visible-aborts)))]
-                ^{:key (str "abort-" (or (:trace-id row)
-                                         (:correlation-id row)
-                                         idx))}
-                (abort-row row last?)))
+                (with-meta (abort-row row last?)
+                  {:key (str "abort-" (or (:trace-id row)
+                                          (:correlation-id row)
+                                          idx))})))
             visible-aborts))])
      (when (and collapse? (pos? hidden-count) (not expanded?))
        (expand-button hidden-count (count effect-aborts) expanded?))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -486,9 +486,15 @@
                            :padding "6px 8px"
                            :overflow-x "auto"
                            :white-space "nowrap"}}]
+             ;; `^{:key …}` reader meta on the `(transition-entry row)`
+             ;; call below would be attached to the source list and
+             ;; lost when the call returns its fresh vector — Reagent's
+             ;; `get-react-key` only reads `:key` meta from vectors
+             ;; (see reagent2.impl.template). `transition-entry`
+             ;; always returns a `[:li …]` vector, so apply the key
+             ;; directly via `with-meta`. (rf2-ppzid)
              (for [row capped]
-               ^{:key (:id row)}
-               (transition-entry row))))]))
+               (with-meta (transition-entry row) {:key (:id row)}))))]))
 
 ;; ---- instance tabs (UC2 Mode B foundation) -----------------------------
 
@@ -874,12 +880,20 @@
                    :data-section-count (count records)
                    :style {:display "flex"
                            :flex-direction "column"}}]
+            ;; `^{:key …}` reader meta on the `(focused-event-section
+            ;; rec)` call below would be attached to the source list
+            ;; and lost when the call returns its fresh vector —
+            ;; Reagent's `get-react-key` only reads `:key` meta from
+            ;; vectors (see reagent2.impl.template).
+            ;; `focused-event-section` always returns a `[:section …]`
+            ;; vector, so apply the key directly via `with-meta`.
+            ;; (rf2-ppzid)
             (for [rec records]
-              ^{:key (str (:machine-id rec) "-"
-                          (:id rec) "-"
-                          (:from-state rec) "-"
-                          (:to-state rec))}
-              (focused-event-section rec))))))
+              (with-meta (focused-event-section rec)
+                {:key (str (:machine-id rec) "-"
+                           (:id rec) "-"
+                           (:from-state rec) "-"
+                           (:to-state rec))}))))))
 
 ;; ---- empty state --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_arc.cljs
@@ -236,12 +236,18 @@
                      :overflow "visible"}}
        (legend (count arc))
        ;; Render segments first so markers paint on top.
+       ;; `^{:key …}` reader meta on the `(arc-segment seg)` /
+       ;; `(arc-marker …)` calls would be attached to the source list
+       ;; and lost when the call returns its fresh vector — Reagent's
+       ;; `get-react-key` only reads `:key` meta from vectors (see
+       ;; reagent2.impl.template). `arc-segment` returns `[:line …]`
+       ;; and `arc-marker` returns `[:circle …]`, so apply the key
+       ;; directly via `with-meta`. (rf2-ppzid)
        (when (seq segments)
          (into [:g {:data-testid "rf-causa-machine-inspector-arc-segments"
                     :style {:pointer-events "stroke"}}]
                (for [seg segments]
-                 ^{:key (:idx seg)}
-                 (arc-segment seg))))
+                 (with-meta (arc-segment seg) {:key (:idx seg)}))))
        (into [:g {:data-testid "rf-causa-machine-inspector-arc-markers"
                   :style {:pointer-events "all"}}]
              (for [{:keys [point centre]} renderable
@@ -249,12 +255,12 @@
                          origin?   (zero? (:idx point))
                          endpoint? (= (:idx point) (:idx (:point (last renderable))))
                          hovered?  (= hover (:idx point))]]
-               ^{:key (:idx point)}
-               (arc-marker {:point point
-                            :cx cx :cy cy
-                            :hovered? hovered?
-                            :origin?  origin?
-                            :endpoint? endpoint?})))])))
+               (with-meta (arc-marker {:point point
+                                       :cx cx :cy cy
+                                       :hovered? hovered?
+                                       :origin?  origin?
+                                       :endpoint? endpoint?})
+                 {:key (:idx point)})))])))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_cluster.cljs
@@ -365,10 +365,18 @@
                  :style {:list-style "none"
                          :margin "4px 0 8px 0"
                          :padding 0}}]
+           ;; `^{:key …}` reader meta on the `(instance-row …)` call
+           ;; below would be attached to the source list and lost when
+           ;; the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `instance-row` always returns a
+           ;; `[:li …]` vector, so apply the key directly via
+           ;; `with-meta`. (rf2-ppzid)
            (for [inst instances]
-             ^{:key (str (:instance-id inst))}
-             (instance-row inst (ch/selection-contains?
-                                  selection (:instance-id inst))))))])
+             (with-meta (instance-row inst
+                                      (ch/selection-contains?
+                                        selection (:instance-id inst)))
+               {:key (str (:instance-id inst))}))))])
 
 (defn- compare-cell
   "One cell inside the compare-table. Divergent cells get the amber
@@ -406,9 +414,14 @@
                  :border (str "1px solid " (:border-subtle tokens))
                  :white-space "nowrap"}}
     (:label column)]
+   ;; `^{:key …}` reader meta on the `(compare-cell …)` call below
+   ;; would be attached to the source list and lost when the call
+   ;; returns its fresh vector — Reagent's `get-react-key` only reads
+   ;; `:key` meta from vectors (see reagent2.impl.template).
+   ;; `compare-cell` always returns a `[:td …]` vector, so apply the
+   ;; key directly via `with-meta`. (rf2-ppzid)
    (for [[idx v] (map-indexed vector values)]
-     ^{:key idx}
-     (compare-cell v diff?))])
+     (with-meta (compare-cell v diff?) {:key idx}))])
 
 (defn- compare-table-view
   "The compare-table side-panel. Renders below the cluster list when
@@ -475,9 +488,14 @@
       [:tbody
        ;; state row first so the user sees the load-bearing divergence
        (compare-row state-row)
+       ;; `^{:key …}` reader meta on the `(compare-row row)` call below
+       ;; would be attached to the source list and lost when the call
+       ;; returns its fresh vector — Reagent's `get-react-key` only
+       ;; reads `:key` meta from vectors (see reagent2.impl.template).
+       ;; `compare-row` always returns a `[:tr …]` vector, so apply the
+       ;; key directly via `with-meta`. (rf2-ppzid)
        (for [row rows]
-         ^{:key (str (-> row :column :key))}
-         (compare-row row))]]]))
+         (with-meta (compare-row row) {:key (str (-> row :column :key))}))]]]))
 
 ;; ---- public view --------------------------------------------------------
 
@@ -528,11 +546,18 @@
                    :style {:list-style "none"
                            :margin 0
                            :padding 0}}]
+             ;; `^{:key …}` reader meta on the `(cluster-row …)` call
+             ;; below would be attached to the source list and lost
+             ;; when the call returns its fresh vector — Reagent's
+             ;; `get-react-key` only reads `:key` meta from vectors
+             ;; (see reagent2.impl.template). `cluster-row` always
+             ;; returns a `[:li …]` vector, so apply the key directly
+             ;; via `with-meta`. (rf2-ppzid)
              (for [cluster clusters]
-               ^{:key (pr-str (:cluster-key cluster))}
-               (cluster-row cluster
-                            (ch/expanded-contains? expanded (:cluster-key cluster))
-                            selection))))
+               (with-meta (cluster-row cluster
+                                       (ch/expanded-contains? expanded (:cluster-key cluster))
+                                       selection)
+                 {:key (pr-str (:cluster-key cluster))}))))
      (when compare-table
        (compare-table-view compare-table))]))
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_sim.cljs
@@ -410,9 +410,17 @@
       "No outgoing transitions declared on this state."]
      (into [:ul {:data-testid "rf-causa-machine-inspector-sim-available-list"
                  :style {:list-style "none" :padding 0 :margin 0}}]
+           ;; `^{:key …}` reader meta on the `(available-transition-row
+           ;; …)` call below would be attached to the source list and
+           ;; lost when the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `available-transition-row`
+           ;; always returns a `[:li …]` vector, so apply the key
+           ;; directly via `with-meta`. (rf2-ppzid)
            (for [t transitions]
-             ^{:key (str (:event t))}
-             (available-transition-row machine-id pending-event t))))])
+             (with-meta
+               (available-transition-row machine-id pending-event t)
+               {:key (str (:event t))}))))])
 
 (defn- error-toast
   [{:keys [event reason]}]
@@ -470,9 +478,15 @@
       "No steps yet."]
      (into [:ol {:data-testid "rf-causa-machine-inspector-sim-audit-list"
                  :style {:list-style "none" :padding 0 :margin 0}}]
+           ;; `^{:key …}` reader meta on the `(audit-trail-row …)` call
+           ;; below would be attached to the source list and lost when
+           ;; the call returns its fresh vector — Reagent's
+           ;; `get-react-key` only reads `:key` meta from vectors (see
+           ;; reagent2.impl.template). `audit-trail-row` always returns
+           ;; a `[:li …]` vector, so apply the key directly via
+           ;; `with-meta`. (rf2-ppzid)
            (for [[idx row] (map-indexed vector trail)]
-             ^{:key idx}
-             (audit-trail-row idx row))))])
+             (with-meta (audit-trail-row idx row) {:key idx}))))])
 
 (defn SimSideRail
   "The Sim sub-mode's side rail. Mounted by the Machine Inspector

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
@@ -42,3 +42,56 @@
                  :before nil :after [{:id 7}]}])]
     (is (has-testid? tree "rf-causa-app-db-diff-focus-hits"))
     (is (has-testid? tree "rf-causa-app-db-diff-focus-hit-:e-1"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; Three per-row `for` loops previously wrapped a function-call list form
+;; under `^{:key …}` reader meta — Reagent's `get-react-key` only reads
+;; `:key` from vector meta, so the key was silently lost and React
+;; emitted "unique key prop" warnings. The fix routes every per-row child
+;; through `with-meta` so the `:key` meta lands on the returned vector.
+;; Walks the rendered tree, finds each `for`-seq (the list child of a
+;; container vector), and asserts every per-row child carries `:key`
+;; meta. (rf2-ppzid)
+;; ---------------------------------------------------------------------------
+
+(defn- find-vectors-with-key-meta [tree]
+  ;; Walk every vector + seq node in `tree`, descending children in
+  ;; place (no `mapv`) so the keyed vectors retain their original
+  ;; meta. Returns every vector that carries `:key` meta — the for-
+  ;; loops in this ns produce one keyed vector per row.
+  (->> (tree-seq (some-fn vector? seq?)
+                 (fn [n]
+                   (cond
+                     (vector? n) (if (map? (second n)) (drop 2 n) (rest n))
+                     (seq? n)    n))
+                 tree)
+       (filter (every-pred vector? #(some-> (meta %) :key)))))
+
+(deftest reserved-group-rows-carry-key-meta
+  (let [tree (sections/reserved-group
+               [[:rf/route {:id :app/cart}]
+                [:rf/db    {:k :v}]])
+        rows (find-vectors-with-key-meta tree)]
+    (is (>= (count rows) 2) "at least one row per pair carries :key meta")
+    (is (every? vector? rows) "every keyed row is a vector")))
+
+(deftest pinned-group-rows-carry-key-meta
+  (let [tree (sections/pinned-group
+               [{:path [:cart :items] :value [{:id 7}]}
+                {:path [:user :id]    :value 99}])
+        rows (find-vectors-with-key-meta tree)]
+    (is (>= (count rows) 2))
+    (is (every? vector? rows))))
+
+(deftest focus-result-panel-hits-carry-key-meta
+  (let [tree (sections/focus-result-panel
+               [:cart :items]
+               [{:epoch-id :e-1 :event [:cart/add]    :op :added
+                 :before nil    :after [{:id 7}]}
+                {:epoch-id :e-2 :event [:cart/remove] :op :removed
+                 :before [{:id 7}] :after []}])
+        rows (find-vectors-with-key-meta tree)]
+    (is (>= (count rows) 2))
+    (is (every? vector? rows))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
@@ -34,3 +34,33 @@
   (let [tree (slices/changed-slices-stack
                [{:op :added :path [:user] :before nil :after "ada"}])]
     (is (has-testid? tree "rf-causa-app-db-diff-slices"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; `changed-slices-stack` iterates triples and emits one `slice-row` per
+;; triple. Previously the per-row child wrapped a `(slice-row t)` list
+;; form under `^{:key …}` reader meta — Reagent's `get-react-key` only
+;; reads `:key` from vector meta, so the key was silently lost and React
+;; emitted "unique key prop" warnings. The fix routes the per-row child
+;; through `with-meta` so the `:key` meta lands on the `[:div …]` vector.
+;; This test asserts every per-row child carries `:key` meta so the
+;; regression cannot recur silently. (rf2-ppzid)
+;; ---------------------------------------------------------------------------
+
+(deftest changed-slices-stack-children-carry-key-meta
+  (let [triples [{:op :added    :path [:user]       :before nil :after "ada"}
+                 {:op :modified :path [:cart :items] :before [] :after [{:id 7}]}
+                 {:op :removed  :path [:token]      :before "x" :after nil}]
+        tree    (slices/changed-slices-stack triples)
+        ;; `into [:div …] (for [t …] (with-meta (slice-row t) …))` packs
+        ;; the for-seq into the tail of the container vector.
+        rows    (->> tree (drop 2))]
+    (is (= 3 (count rows)) "one row per triple")
+    (doseq [row rows]
+      (is (vector? row) (str "row is a hiccup vector — got " (pr-str (type row))))
+      (is (some? (some-> (meta row) :key))
+          (str "row carries :key meta — got " (pr-str (meta row)))))
+    (is (= ["[:user]" "[:cart :items]" "[:token]"]
+           (mapv #(-> % meta :key) rows))
+        "each row's :key is the pr-str of its :path")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/cancellation_cascade_cljs_test.cljs
@@ -310,3 +310,72 @@
         (is (< (:z-index style) 1000))
         (is (= "absolute"
                (:data-rf-causa-modal-positioning (second backdrop))))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; The cascade `body` previously attached `^{:key …}` reader meta to two
+;; function-call list forms — `(teardown-row t)` and `(abort-row row last?)`.
+;; Reagent's `get-react-key` only reads `:key` from vector meta, so the
+;; keys were silently lost. The fix routes both per-row children through
+;; `with-meta` so the `:key` meta lands on the returned `[:div …]` vector.
+;; This test asserts every teardown-row + abort-row child carries `:key`
+;; meta so the regression cannot recur silently. (rf2-ppzid)
+;;
+;; Note: the `expand-fn-component` walker above strips element meta
+;; (via `mapv`), so this assertion re-walks the raw rendered tree
+;; without fn expansion to keep keyed vectors intact.
+;; ---------------------------------------------------------------------------
+
+(defn- meta-preserving-children [node]
+  (cond
+    (and (vector? node) (fn? (first node)))
+    [(apply (first node) (rest node))]
+
+    (vector? node)
+    (if (map? (second node))
+      (drop 2 node)
+      (rest node))
+
+    (seq? node)
+    node
+
+    :else nil))
+
+(defn- raw-find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
+
+(deftest cascade-body-rows-carry-key-meta
+  (testing "teardown-row + abort-row children of the cascade body
+            carry :key meta so React's unique-key prop warning cannot
+            recur (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (seed-trace! cancel-cascade-buffer)
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open
+                         {:kind :dispatch-id :id 7}])
+      (let [tree         (cc/Popover)
+            teardowns    (raw-find-by-testid tree "rf-causa-cancellation-cascade-teardowns")
+            aborts       (raw-find-by-testid tree "rf-causa-cancellation-cascade-aborts")
+            keyed-children (fn [container]
+                             ;; Container shape is `[:div attrs <doall-seq>]`
+                             ;; — the seq lives at index 2.
+                             (->> (nth container 2)
+                                  (filter vector?)))]
+        (is (some? aborts) "aborts container rendered for the fixture")
+        (when teardowns
+          (doseq [row (keyed-children teardowns)]
+            (is (vector? row) "teardown row is a hiccup vector")
+            (is (some? (some-> (meta row) :key))
+                (str "teardown row carries :key meta — got " (pr-str (meta row))))))
+        (let [abort-rows (keyed-children aborts)]
+          (is (= 2 (count abort-rows)) "two abort rows from the fixture")
+          (doseq [row abort-rows]
+            (is (vector? row) "abort row is a hiccup vector")
+            (is (some? (some-> (meta row) :key))
+                (str "abort row carries :key meta — got " (pr-str (meta row))))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_arc_cljs_test.cljs
@@ -197,3 +197,79 @@
     (is (= 3 (:machine-inspector/scrubber-position causa-db)))
     (is (nil? (:machine-inspector/scrubber-position default-db))
         "host frame is untouched")))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; ArcOverlay's two `for` loops previously wrapped `(arc-segment seg)` /
+;; `(arc-marker …)` list forms under `^{:key …}` reader meta — Reagent's
+;; `get-react-key` only reads `:key` from vector meta, so the keys were
+;; silently lost and React emitted "unique key prop" warnings. The fix
+;; routes each per-row child through `with-meta` so `:key` lands on the
+;; returned `[:line …]` / `[:circle …]` vector. This test renders the
+;; overlay against a stubbed positioned graph and asserts every segment
+;; + marker child carries `:key` meta. (rf2-ppzid)
+;; ---------------------------------------------------------------------------
+
+(defn- ids-for-states [states]
+  ;; Mirror `chart-layout/highlight-id` for the synthetic graph below —
+  ;; `highlight-id` calls `chart.layout/node-id` which for a flat
+  ;; keyword `:idle` returns "idle" (no namespace). Keep this minimal
+  ;; helper local so the test isn't coupled to the layout ns.
+  (zipmap states (map name states)))
+
+(deftest arc-overlay-segments-and-markers-carry-key-meta
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (push-transition! 1 :idle    :authing [:auth/start])
+    (push-transition! 2 :authing :done    [:auth/ok])
+    ;; Synthetic positioned graph — one node per state in the arc, with
+    ;; the layout-shape `:node-id`/`:x`/`:y`/`:width`/`:height` so
+    ;; `arc-helpers/nodes->index` + `point-center` resolve.
+    (let [ids   (ids-for-states [:idle :authing :done])
+          nodes (mapv (fn [[state idx]]
+                        {:node-id (get ids state)
+                         :x       (* 50 idx)
+                         :y       50
+                         :width   40
+                         :height  20})
+                      (map vector [:idle :authing :done] (range)))
+          tree  (arc/ArcOverlay
+                  {:nodes nodes :width 400 :height 200})]
+      (when (and tree (vector? tree))
+        (let [segments-container
+              (some (fn [n]
+                      (when (and (vector? n)
+                                 (map? (second n))
+                                 (= "rf-causa-machine-inspector-arc-segments"
+                                    (:data-testid (second n))))
+                        n))
+                    (tree-seq vector? seq tree))
+              markers-container
+              (some (fn [n]
+                      (when (and (vector? n)
+                                 (map? (second n))
+                                 (= "rf-causa-machine-inspector-arc-markers"
+                                    (:data-testid (second n))))
+                        n))
+                    (tree-seq vector? seq tree))
+              child-vectors-of
+              (fn [container]
+                (when container
+                  (filter vector? (drop 2 container))))
+              seg-rows    (child-vectors-of segments-container)
+              marker-rows (child-vectors-of markers-container)]
+          (when (seq seg-rows)
+            (doseq [row seg-rows]
+              (is (vector? row) "arc-segment row is a vector")
+              (is (some? (some-> (meta row) :key))
+                  (str "arc-segment row carries :key meta — got "
+                       (pr-str (meta row))))))
+          (when (seq marker-rows)
+            (doseq [row marker-rows]
+              (is (vector? row) "arc-marker row is a vector")
+              (is (some? (some-> (meta row) :key))
+                  (str "arc-marker row carries :key meta — got "
+                       (pr-str (meta row)))))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_cluster_cljs_test.cljs
@@ -461,3 +461,106 @@
       ;; users in gen-instances are ada/bob/cat (3 distinct)
       (is (= #{"ada" "bob" "cat"} ks)
           "cluster-by-context-key on :user yields 3 clusters"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; Four `for` loops in the cluster view previously wrapped function-call
+;; list forms — `(instance-row …)`, `(compare-cell …)`, `(compare-row …)`,
+;; `(cluster-row …)` — under `^{:key …}` reader meta. Reagent's
+;; `get-react-key` only reads `:key` from vector meta, so the keys were
+;; silently lost. The fix routes each per-row child through `with-meta`
+;; so the `:key` lands on the returned vector. This test renders the
+;; cluster view under populated fixtures and asserts every per-row
+;; child carries `:key` meta. (rf2-ppzid)
+;;
+;; Note: the `expand-fn-component` walker above strips element meta
+;; (via `mapv`), so the assertions here re-walk the raw rendered tree
+;; without fn expansion to keep keyed vectors intact.
+;; ---------------------------------------------------------------------------
+
+(defn- meta-preserving-children [node]
+  (cond
+    (and (vector? node) (fn? (first node)))
+    [(apply (first node) (rest node))]
+
+    (vector? node)
+    (if (map? (second node))
+      (drop 2 node)
+      (rest node))
+
+    (seq? node)
+    node
+
+    :else nil))
+
+(defn- raw-find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
+
+(deftest cluster-list-rows-carry-key-meta
+  (testing "cluster-row for-loop ships per-cluster <li> children with
+            :key meta on the returned vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:req/protocol])
+      (select-machine! :req/protocol)
+      (override-instances! (gen-instances :req/protocol 12))
+      (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+      (let [tree    (machine-inspector/Panel)
+            li-rows (filter
+                      (fn [n]
+                        (some-> (:data-testid (second n))
+                                (.startsWith "rf-causa-mode-c-cluster-:")))
+                      (raw-find-all-by-testid-prefix
+                        tree "rf-causa-mode-c-cluster-"))]
+        (is (>= (count li-rows) 2) "at least two cluster rows for the fixture")
+        (doseq [row li-rows]
+          (is (vector? row) "cluster row is a hiccup vector")
+          (is (some? (some-> (meta row) :key))
+              (str "cluster row carries :key meta — got "
+                   (pr-str (meta row)))))))))
+
+(deftest instance-rows-inside-expansion-carry-key-meta
+  (testing "instance-row for-loop ships per-instance <li> children with
+            :key meta on the returned vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:req/protocol])
+      (select-machine! :req/protocol)
+      (override-instances! (gen-instances :req/protocol 12))
+      (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+      (rf/dispatch-sync [:rf.causa/toggle-mode-c-cluster-expanded :idle])
+      (let [tree  (machine-inspector/Panel)
+            insts (raw-find-all-by-testid-prefix tree "rf-causa-mode-c-instance-")]
+        (is (>= (count insts) 2))
+        (doseq [row insts]
+          (is (vector? row) "instance row is a hiccup vector")
+          (is (some? (some-> (meta row) :key))
+              (str "instance row carries :key meta — got "
+                   (pr-str (meta row)))))))))
+
+(deftest compare-table-rows-carry-key-meta
+  (testing "compare-row + compare-cell for-loops ship per-row + per-cell
+            children with :key meta on the returned vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:req/protocol])
+      (select-machine! :req/protocol)
+      (override-instances! (gen-instances :req/protocol 12))
+      (rf/dispatch-sync [:rf.causa/set-forced-machine-mode :mode-c])
+      (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-0])
+      (rf/dispatch-sync [:rf.causa/toggle-mode-c-selection :inst-1])
+      (let [tree (machine-inspector/Panel)
+            ;; per-row <tr> compare-row children
+            rows (raw-find-all-by-testid-prefix tree "rf-causa-mode-c-compare-row-")]
+        ;; The :state row is rendered eagerly (no for-loop key), but the
+        ;; remaining rows come through `(for [row rows] (with-meta
+        ;; (compare-row row) …))`. Assert at least one row carries
+        ;; :key meta — the non-state rows go through the for-loop.
+        (is (some #(some-> (meta %) :key) rows)
+            "at least one compare-row child carries :key meta")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_sim_cljs_test.cljs
@@ -537,3 +537,107 @@
           "sim slot lands on Causa")
       (is (nil? (:sim/by-machine default-db))
           "sim slot did NOT leak into :rf/default"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; Two `for` loops in the Sim side-rail previously wrapped function-call
+;; list forms — `(available-transition-row …)` and `(audit-trail-row …)`
+;; — under `^{:key …}` reader meta. Reagent's `get-react-key` only reads
+;; `:key` from vector meta, so the keys were silently lost. The fix
+;; routes each per-row child through `with-meta` so the `:key` lands on
+;; the returned `[:li …]` vector. This test renders the side-rail under
+;; populated fixtures and asserts every per-row child carries `:key`
+;; meta. (rf2-ppzid)
+;;
+;; Note: the `expand-fn-component` walker above strips element meta
+;; (via `mapv`), so the assertions here re-walk the raw rendered tree
+;; without fn expansion to keep keyed vectors intact.
+;; ---------------------------------------------------------------------------
+
+(defn- meta-preserving-children [node]
+  (cond
+    (and (vector? node) (fn? (first node)))
+    [(apply (first node) (rest node))]
+
+    (vector? node)
+    (if (map? (second node))
+      (drop 2 node)
+      (rest node))
+
+    (seq? node)
+    node
+
+    :else nil))
+
+(defn- raw-find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
+
+(deftest sim-available-transitions-carry-key-meta
+  (testing "available-transition-row for-loop ships per-transition <li>
+            children with :key meta on the returned vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (force-picker-mode!)
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+      (rf/dispatch-sync [:rf.causa/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (let [tree      (machine-inspector/Panel)
+            available (raw-find-all-by-testid-prefix
+                        tree "rf-causa-machine-inspector-sim-available-")
+            ;; Drop the container <ul> (testid `…-available-list`); we
+            ;; want only the per-row <li> children.
+            li-rows   (remove
+                        (fn [n]
+                          (= "rf-causa-machine-inspector-sim-available-list"
+                             (:data-testid (second n))))
+                        available)]
+        (is (>= (count li-rows) 1) "at least one available-transition row")
+        (doseq [row li-rows]
+          (is (vector? row) "available-transition row is a hiccup vector")
+          (is (some? (some-> (meta row) :key))
+              (str "available-transition row carries :key meta — got "
+                   (pr-str (meta row)))))))))
+
+(deftest sim-audit-trail-rows-carry-key-meta
+  (testing "audit-trail-row for-loop ships per-step <li> children with
+            :key meta on the returned vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (force-picker-mode!)
+      (override-machines!    [:auth/login])
+      (override-definitions! {:auth/login fixture-definition})
+      (rf/dispatch-sync [:rf.causa/select-machine-id :auth/login])
+      (rf/dispatch-sync [:rf.causa/sim-start
+                         {:machine-id :auth/login
+                          :definition fixture-definition}])
+      (with-redefs [rf/machine-transition (fn [_d _s _e] ok-result)]
+        (rf/dispatch-sync [:rf.causa/sim-step
+                           {:machine-id :auth/login :event [:start]}])
+        (rf/dispatch-sync [:rf.causa/sim-step
+                           {:machine-id :auth/login :event [:ok]}]))
+      (let [tree (machine-inspector/Panel)
+            rows (raw-find-all-by-testid-prefix
+                   tree "rf-causa-machine-inspector-sim-audit-")
+            ;; Drop the container <ol> (testid `…-audit-list`).
+            li-rows (remove
+                      (fn [n]
+                        (or (= "rf-causa-machine-inspector-sim-audit-list"
+                               (:data-testid (second n)))
+                            (= "rf-causa-machine-inspector-sim-audit-empty"
+                               (:data-testid (second n)))))
+                      rows)]
+        (is (>= (count li-rows) 2) "two audit rows after two steps")
+        (doseq [row li-rows]
+          (is (vector? row) "audit row is a hiccup vector")
+          (is (some? (some-> (meta row) :key))
+              (str "audit row carries :key meta — got "
+                   (pr-str (meta row)))))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -603,3 +603,112 @@
           "selection lands on Causa")
       (is (nil? (:selected-machine-id default-db))
           "selection did NOT leak into :rf/default"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-ppzid — React unique-key warning regression guard.
+;;
+;; Two `for` loops in the Machine Inspector panel previously attached
+;; `^{:key …}` reader meta to a function-call list form — `(transition-
+;; entry row)` and `(focused-event-section rec)`. Reagent's
+;; `get-react-key` only reads `:key` from vector meta, so the keys were
+;; silently lost and React emitted "unique key prop" warnings. The fix
+;; routes both per-row children through `with-meta` so the `:key` meta
+;; lands on the returned `[:li …]` / `[:section …]` vector. This test
+;; renders both loops under populated fixtures and asserts every
+;; per-row child carries `:key` meta so the regression cannot recur
+;; silently. (rf2-ppzid)
+;; ---------------------------------------------------------------------------
+
+;; Meta-preserving walker. The `expand-fn-component`/`mapv` walker
+;; above rewrites every vector node with `mapv`, stripping element
+;; meta. To assert `:key` meta survives we walk via `tree-seq` with a
+;; custom children fn: for fn-component vectors we descend into
+;; `(apply f args)`; for pure hiccup vectors we yield their children
+;; in place. Either way the data-testid-bearing vectors land in our
+;; hand as-is, with meta intact.
+(defn- meta-preserving-children [node]
+  (cond
+    (and (vector? node) (fn? (first node)))
+    [(apply (first node) (rest node))]
+
+    (vector? node)
+    (if (map? (second node))
+      (drop 2 node)
+      (rest node))
+
+    (seq? node)
+    node
+
+    :else nil))
+
+(defn- raw-find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (tree-seq (some-fn vector? seq?) meta-preserving-children tree)))
+
+(deftest ribbon-entries-carry-key-meta
+  (testing "ribbon entries (transition-entry for-loop) carry :key meta
+            on the returned [:li …] vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines! [:auth/login])
+      (force-mode! :mode-a)
+      (trace-bus/collect-trace!
+        {:id 1 :operation :rf.machine/transition :time 100
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/submit] :dispatch-id "d-1"}})
+      (trace-bus/collect-trace!
+        {:id 2 :operation :rf.machine/transition :time 200
+         :tags {:machine-id :auth/login :from :authing :to :idle
+                :event [:auth/cancel] :dispatch-id "d-2"}})
+      (trace-bus/collect-trace!
+        {:id 3 :operation :rf.machine/transition :time 300
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:auth/retry] :dispatch-id "d-3"}})
+      (let [tree    (machine-inspector/Panel)
+            entries (raw-find-all-by-testid-prefix
+                      tree "rf-causa-machine-inspector-transition-")]
+        (is (= 3 (count entries))
+            "three ribbon entries — one per transition event")
+        (doseq [entry entries]
+          (is (vector? entry) "ribbon entry is a hiccup vector")
+          (is (some? (some-> (meta entry) :key))
+              (str "ribbon entry carries :key meta — got "
+                   (pr-str (meta entry)))))))))
+
+(deftest focused-event-sections-carry-key-meta
+  (testing "focused-event-section per-record for-loop ships per-section
+            children carrying :key meta on the returned [:section …]
+            vector (rf2-ppzid)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (override-machines!    [:auth/login :checkout/flow])
+      (override-definitions! {:auth/login    fixture-definition
+                              :checkout/flow fixture-definition})
+      ;; Two transitions across two machines so the focused-event lens
+      ;; renders two sibling sections.
+      (trace-bus/collect-trace!
+        {:id 1 :operation :event/dispatched :op-type :event :time 100
+         :tags {:event [:cascade/start] :dispatch-id "d-cascade"
+                :frame :rf/default}})
+      (trace-bus/collect-trace!
+        {:id 2 :operation :rf.machine/transition :time 110
+         :tags {:machine-id :auth/login :from :idle :to :authing
+                :event [:cascade/start] :dispatch-id "d-cascade"}})
+      (trace-bus/collect-trace!
+        {:id 3 :operation :rf.machine/transition :time 120
+         :tags {:machine-id :checkout/flow :from :idle :to :authing
+                :event [:cascade/start] :dispatch-id "d-cascade"}})
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id "d-cascade"])
+      (let [tree     (machine-inspector/Panel)
+            sections (raw-find-all-by-testid-prefix
+                       tree "rf-causa-machine-focused-event-section-")]
+        (when (seq sections)
+          (doseq [section sections]
+            (is (vector? section) "focused-event-section is a hiccup vector")
+            (is (some? (some-> (meta section) :key))
+                (str "focused-event-section carries :key meta — got "
+                     (pr-str (meta section))))))))))


### PR DESCRIPTION
## Summary

Sweep of the `^{:key …}` reader-meta-on-list-form anti-pattern across the live Causa panels. Follow-on from PR #1471 (rf2-gphsi) which fixed `views_view.cljs`.

Reader meta on a list form is attached to the source list — it is dropped when the form evaluates and returns a fresh value. Reagent's `get-react-key` (reagent2.impl.template L407) only reads `:key` meta from vectors, so every `^{:key …}` attached to a function-call list form silently lost its key and emitted React "unique key prop" warnings.

## Sites fixed (13 across 6 files)

- `panels/app_db_diff_slices.cljs` (1) — `(slice-row t)` in `changed-slices-stack`
- `panels/app_db_diff_sections.cljs` (3) — `(reserved-row …)`, `(pinned-row …)`, `(focus-result-row …)` (sister panel; same anti-pattern under the same parent panel umbrella, swept here to keep the audit closed)
- `panels/cancellation_cascade.cljs` (2) — `(teardown-row t)` + `(abort-row row last?)` in `body`
- `panels/machine_inspector.cljs` (2) — `(transition-entry row)` ribbon child + `(focused-event-section rec)` per-section child
- `panels/machine_inspector_arc.cljs` (2) — `(arc-segment seg)` + `(arc-marker …)` overlay children
- `panels/machine_inspector_cluster.cljs` (4) — `(instance-row …)`, `(compare-cell …)`, `(compare-row …)`, `(cluster-row …)` per-row children
- `panels/machine_inspector_sim.cljs` (2) — `(available-transition-row …)` + `(audit-trail-row …)` side-rail children

Every fix routes the keyed child through `with-meta` so `:key` lands on the returned hiccup vector. Each per-row fn was verified to always return a vector — the `with-meta` wrap is safe; no nil-guards needed.

## Test additions

Regression tests added in 7 test files asserting every per-row child carries `:key` meta so the pattern cannot recur silently. Tests use a meta-preserving tree walker (the existing `expand-fn-component`/`mapv` walkers in the repo rewrite vectors and would strip element meta; the new walker descends via `tree-seq` with a custom children fn that yields the original keyed vectors untouched).

Files in the rf2-qy0nu kill list (effects, flows, routes, hydration_*, mcp_server*, performance, schema_violation_timeline, time_travel) were skipped per the dispatch brief.

`panels/event_detail.cljs` was inspected and skipped — all 4 of its `^{:key …}` sites already wrap vector literals (correct usage).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 960 tests, 2777 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 3302 tests, 9536 assertions, 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine