### PR TITLE
feat(core): Event lens substrate gaps — dispatch-site + effects-returned trace tags (rf2-twt7m)

### DIFF
--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -186,11 +186,19 @@
     (c) invoke the user handler with kind-appropriate inputs;
     (d) commit the return into the context.
 
-  See `kind-spec` for the per-kind :invoke / :commit pair."
+  See `kind-spec` for the per-kind :invoke / :commit pair.
+
+  Per rf2-twt7m Change 3: the produced interceptor carries
+  `:rf/default? true` so tools (Causa, Story, the Event lens
+  redesign rf2-zh2qc) can filter out the framework's auto-wrappers
+  without a hardcoded allowlist of `:rf/db-handler` /
+  `:rf/fx-handler` / `:rf/ctx-handler` interceptor ids. Self-
+  describing: the meta lives on the interceptor map itself."
   [kind handler-fn]
   (let [{:keys [interceptor-id invoke commit]} (get kind-spec kind)]
     (interceptor/->interceptor
-      :id interceptor-id
+      :id         interceptor-id
+      :rf/default? true
       :before
       (fn [ctx]
         (if (:rf/skip-handler? ctx)

--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -578,15 +578,41 @@
   603) and §Drain-loop pseudocode (lines 916, 961-963). Reserved-fx
   bodies for `:dispatch` and `:dispatch-later` read the envelope to
   propagate inheritable keys onto the child dispatch per §Cascade
-  propagation."
+  propagation.
+
+  The 7-arity additionally accepts the originating handler's full
+  effects map (the closed `{:db ... :fx ...}` shape, per Spec 002
+  §The binary fx-handler signature). It is used only to stamp shape
+  info onto the terminating `:event/do-fx` trace marker's `:tags`
+  (rf2-twt7m Change 2): `:fx` (the vector returned) and
+  `:db-present?` (boolean, true iff the handler returned a `:db`
+  slot). The map itself is NOT threaded into per-fx invocations —
+  fx handlers already receive the effects shape they need via per-
+  fx args. Callers without an effects map (e.g. machine-exit fx
+  walks) use a lower arity; the trace marker degrades gracefully
+  (no `:fx` / `:db-present?` slots on the emit)."
   ([frame-id fx-vec active-platform]
-   (do-fx frame-id fx-vec active-platform {} nil nil))
+   (do-fx frame-id fx-vec active-platform {} nil nil nil))
   ([frame-id fx-vec active-platform overrides]
-   (do-fx frame-id fx-vec active-platform overrides nil nil))
+   (do-fx frame-id fx-vec active-platform overrides nil nil nil))
   ([frame-id fx-vec active-platform overrides origin-event]
-   (do-fx frame-id fx-vec active-platform overrides origin-event nil))
+   (do-fx frame-id fx-vec active-platform overrides origin-event nil nil))
   ([frame-id fx-vec active-platform overrides origin-event parent-envelope]
+   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope nil))
+  ([frame-id fx-vec active-platform overrides origin-event parent-envelope effects]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
        (handle-one-fx frame-id pair active-platform overrides origin-event parent-envelope)))
-   (trace/emit! :event :event/do-fx {:frame frame-id})))
+   ;; Per rf2-twt7m Change 2: stamp `:fx` + `:db-present?` onto the
+   ;; `:event/do-fx` marker's `:tags` when the caller supplied the
+   ;; effects map. The full `:db` VALUE is NOT stamped — slice
+   ;; changes already ride the App-db diff trace
+   ;; (`:event/db-changed`), and the value can be huge. Presence +
+   ;; shape is what consumers (Event lens, Causa) need to align
+   ;; cascade rows with handler returns. The tag-map is the third
+   ;; arg to `trace/emit!`; `trace/emit!` itself is DCE-gated, so
+   ;; prod builds elide both the construction and the emit.
+   (trace/emit! :event :event/do-fx
+                (cond-> {:frame frame-id}
+                  (some? effects) (assoc :fx          (:fx effects)
+                                         :db-present? (contains? effects :db))))))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -549,13 +549,19 @@
   threaded into `do-fx` so reserved-fx defmethods (`:dispatch`,
   `:dispatch-later`) can copy inheritable keys (`:fx-overrides`,
   `:interceptor-overrides`, `:trace-id`, `:origin`, `:source`) onto
-  child dispatches. User fxs see it at `(:envelope m)`."
+  child dispatches. User fxs see it at `(:envelope m)`.
+
+  Per rf2-twt7m Change 2: the full effects map is also threaded to
+  `do-fx` (the 7-arity) so the terminating `:event/do-fx` trace
+  marker can stamp `:fx` (the returned vector) and `:db-present?`
+  (whether the handler returned a `:db` slot). The value of `:db`
+  is NOT stamped — App-db diff traces already carry slice changes."
   [effects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
     (let [active-platform (or (get-in frame-record [:config :platform])
                               interop/platform)
           event           (:event envelope)]
-      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope))))
+      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope effects))))
 
 ;; ---- process-event* phases ------------------------------------------------
 ;;

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1228,23 +1228,33 @@
   when set. Without this, a Causa-style bookkeeping handler would
   have its enqueue trace delivered to listeners (re-entering the
   consumer's trace-cb) before the handler-scope binding ever took
-  effect."
+  effect.
+
+  Per rf2-twt7m Change 1: hoist `:rf.trace/call-site` onto this
+  success-path emit too. The envelope's `:call-site` was stamped by
+  the surface `dispatch` / `dispatch-sync` macro (rf2-ts1a); we
+  publish it through `trace/with-call-site` so `build-event` hoists
+  it onto the trace event via the existing scope-driven hoist path
+  (same machinery the error path uses). Without this, the Event lens
+  redesign (rf2-zh2qc) and any consumer building click-to-source UX
+  on the enqueue trace would lose the dispatch-site coord."
   [envelope sync?]
   (let [event        (:event envelope)
         event-id     (when (vector? event) (first event))
         handler-meta (when event-id (registrar/lookup :event event-id))
         no-emit?     (trace/no-emit?-from-meta handler-meta)]
     (when-not no-emit?
-      (trace/emit! :event :event/dispatched
-                   (cond-> {:event    event
-                            :frame    (:frame envelope)
-                            :origin   (:origin envelope)
-                            :source   (:source envelope)
-                            :sync?    sync?}
-                     (:dispatch-id envelope)
-                     (assoc :dispatch-id (:dispatch-id envelope))
-                     (:parent-dispatch-id envelope)
-                     (assoc :parent-dispatch-id (:parent-dispatch-id envelope)))))))
+      (trace/with-call-site (:call-site envelope)
+        (trace/emit! :event :event/dispatched
+                     (cond-> {:event    event
+                              :frame    (:frame envelope)
+                              :origin   (:origin envelope)
+                              :source   (:source envelope)
+                              :sync?    sync?}
+                       (:dispatch-id envelope)
+                       (assoc :dispatch-id (:dispatch-id envelope))
+                       (:parent-dispatch-id envelope)
+                       (assoc :parent-dispatch-id (:parent-dispatch-id envelope))))))))
 
 (defn dispatch!
   "Append the event to the target frame's router queue. Per Spec 002:

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -213,7 +213,15 @@
   `*handler-scope*`). `op-type` discriminates the success vs error
   paths — see Spec 009 §Core fields and §Error event shape for the
   hoist contract (`:source` / `:recovery` / `:rf.trace/trigger-handler`
-  / `:rf.trace/call-site` / `:sensitive?`)."
+  / `:rf.trace/call-site` / `:sensitive?`).
+
+  Per rf2-twt7m Change 1: `:rf.trace/call-site` rides BOTH error and
+  success-path emits when the in-scope cascade was kicked off by a
+  call-site-capturing macro (`rf/dispatch` / `rf/dispatch-sync` /
+  `rf/subscribe` / `rf/inject-cofx`). Previously gated to errors
+  only; widened so consumers (Event lens, Causa, Story) can render
+  jump-to-source links from every event in a cascade, not just
+  errors."
   [op-type operation tags]
   (let [scope       *handler-scope*
         trigger     (some-> scope :trigger-handler)
@@ -224,7 +232,7 @@
         recovery    (if error?
                       (:recovery tags :no-recovery)
                       (:recovery tags))
-        call-site   (when error? (some-> scope :call-site))
+        call-site   (some-> scope :call-site)
         ;; Strip hoisted slots from `:tags` so they don't double-up at
         ;; the top level. Exception: the error path KEEPS `:source`
         ;; under `:tags` because boundary-interceptor / error-emit
@@ -246,7 +254,10 @@
       ;; error path always stamps (defaulting to :no-recovery above).
       (or error? recovery) (assoc :recovery recovery)
       trigger              (assoc :rf.trace/trigger-handler trigger)
-      ;; `:rf.trace/call-site` rides error traces only.
+      ;; `:rf.trace/call-site` rides BOTH error and success-path
+      ;; emits (rf2-twt7m Change 1). Hoisted from the in-scope
+      ;; cascade's call-site (envelope's macro-stamped coord or a
+      ;; `with-call-site` wrapper around a surface-macro body).
       call-site            (assoc :rf.trace/call-site call-site)
       ;; Top-level `:sensitive? true` stamp. Absent (not `false`)
       ;; when not sensitive — consumers treat absent as false.

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -406,3 +406,79 @@
           (rf/reg-event-db :test.fuudi/bad-middle
             "not-a-map-or-vector"
             (fn [db _] db))))))
+
+;; ---- rf2-twt7m Change 3 — :rf/default? tag on auto-wrappers ---------------
+;;
+;; The framework auto-wraps the user handler into a kind-appropriate
+;; interceptor (:rf/db-handler / :rf/fx-handler / :rf/ctx-handler).
+;; Pre-rf2-twt7m a tool wanting to distinguish "framework default" from
+;; "user supplied" had to maintain a hardcoded allowlist of these three
+;; ids. Per rf2-twt7m Change 3 the auto-wrapper carries `:rf/default?
+;; true` on the interceptor map itself; self-describing.
+;;
+;; Causa, Story, and the Event lens redesign (rf2-zh2qc) read
+;; `(rf/handler-meta :event id) :interceptors` and filter
+;; `(remove :rf/default?)` to surface only the user's interceptor chain.
+
+(deftest auto-wrapper-carries-rf-default-tag
+  (testing "reg-event-db auto-wrapper has :rf/default? true"
+    (rf/reg-event-db :test.twt7m/db-handler (fn [db _] db))
+    (let [interceptors (-> (rf/handler-meta :event :test.twt7m/db-handler)
+                           :interceptors)
+          auto-wrapper (last interceptors)]
+      (is (= :rf/db-handler (:id auto-wrapper))
+          "the auto-wrapper sits at the tail of the interceptor chain")
+      (is (= true (:rf/default? auto-wrapper))
+          "the auto-wrapper carries :rf/default? true")))
+
+  (testing "reg-event-fx auto-wrapper has :rf/default? true"
+    (rf/reg-event-fx :test.twt7m/fx-handler (fn [_ _] {}))
+    (let [interceptors (-> (rf/handler-meta :event :test.twt7m/fx-handler)
+                           :interceptors)
+          auto-wrapper (last interceptors)]
+      (is (= :rf/fx-handler (:id auto-wrapper)))
+      (is (= true (:rf/default? auto-wrapper)))))
+
+  (testing "reg-event-ctx auto-wrapper has :rf/default? true"
+    (rf/reg-event-ctx :test.twt7m/ctx-handler (fn [ctx] ctx))
+    (let [interceptors (-> (rf/handler-meta :event :test.twt7m/ctx-handler)
+                           :interceptors)
+          auto-wrapper (last interceptors)]
+      (is (= :rf/ctx-handler (:id auto-wrapper)))
+      (is (= true (:rf/default? auto-wrapper))))))
+
+(deftest user-supplied-interceptors-do-not-carry-rf-default-tag
+  (testing "user-supplied interceptors do NOT carry :rf/default? true —
+   only the framework-auto-wrapper at the chain tail does"
+    (let [user-icpt {:id :test.twt7m/user :before identity :after identity}]
+      (rf/reg-event-db :test.twt7m/with-user-icpt
+        [user-icpt]
+        (fn [db _] db))
+      (let [interceptors (-> (rf/handler-meta :event :test.twt7m/with-user-icpt)
+                             :interceptors)
+            user-slot    (first interceptors)
+            auto-wrapper (last interceptors)]
+        (is (= 2 (count interceptors))
+            "user interceptor + auto-wrapper = 2 entries")
+        (is (= :test.twt7m/user (:id user-slot)))
+        (is (not (contains? user-slot :rf/default?))
+            "user-supplied interceptor carries no :rf/default? slot")
+        (is (= true (:rf/default? auto-wrapper))
+            "only the auto-wrapper carries :rf/default? true")))))
+
+(deftest tooling-can-filter-defaults-via-rf-default-tag
+  (testing "the self-describing tag lets tools filter without an id
+   allowlist — `(remove :rf/default?)` surfaces user-supplied
+   interceptors only"
+    (let [a {:id :test.twt7m/a :before identity}
+          b {:id :test.twt7m/b :after identity}]
+      (rf/reg-event-db :test.twt7m/filtering
+        [a b]
+        (fn [db _] db))
+      (let [interceptors (-> (rf/handler-meta :event :test.twt7m/filtering)
+                             :interceptors)
+            user-only    (vec (remove :rf/default? interceptors))]
+        (is (= 3 (count interceptors)) "two user + one framework auto-wrapper")
+        (is (= 2 (count user-only))
+            "filtering by :rf/default? leaves the two user interceptors")
+        (is (= [:test.twt7m/a :test.twt7m/b] (mapv :id user-only)))))))

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -582,3 +582,81 @@
       (is (= [:fx-test/issue-with-event :payload-1]
              (:event @captured-ctx))
           "ctx :event is the originating event vector"))))
+
+;; ---- rf2-twt7m Change 2 — :event/do-fx carries :fx + :db-present? ---------
+;;
+;; The handler's return shape is otherwise invisible at the trace level —
+;; the :db value already rides through :event/db-changed diffs (not
+;; stamped on the do-fx marker because it can be huge), and the :fx
+;; vector lives in the interceptor context's :effects slot for the
+;; duration of the cascade but never makes it onto a trace. Per
+;; rf2-twt7m Change 2 we now stamp :fx (the vector) and :db-present?
+;; (boolean) onto the :event/do-fx marker that terminates the do-fx
+;; walk. Stamps the SHAPE, not deep values; Event lens (rf2-zh2qc)
+;; consumers can align cascade rows with handler returns.
+
+(deftest event-do-fx-stamps-fx-and-db-present
+  (testing "reg-event-fx returning {:db ... :fx [...]} fires :event/do-fx
+   with :fx (the vector) and :db-present? true under :tags (same slot
+   placement as :frame — payload-shaped tags ride under :tags)"
+    (rf/reg-fx :fx-test/do-fx-shape (fn [_ _] :ok))
+    (rf/reg-event-fx :fx-test/returns-db-and-fx
+      (fn [_ _]
+        {:db {:seeded? true}
+         :fx [[:fx-test/do-fx-shape {:k 1}]]}))
+    (let [acc (collect-traces! ::do-fx-shape)]
+      (try
+        (rf/dispatch-sync [:fx-test/returns-db-and-fx])
+        (let [[dof] (filterv #(= :event/do-fx (:operation %)) @acc)
+              tags  (:tags dof)]
+          (is (some? dof) ":event/do-fx fired")
+          (is (= true (:db-present? tags))
+              ":db-present? true because the handler returned a :db slot")
+          (is (= [[:fx-test/do-fx-shape {:k 1}]] (:fx tags))
+              ":fx vector matches what the handler returned"))
+        (finally
+          (rf/remove-trace-cb! ::do-fx-shape))))))
+
+(deftest event-do-fx-stamps-when-only-fx-returned
+  (testing "reg-event-fx returning {:fx [...]} only (no :db slot) stamps
+   :db-present? false and :fx with the vector"
+    (rf/reg-fx :fx-test/no-db-fx (fn [_ _] :ok))
+    (rf/reg-event-fx :fx-test/fx-only
+      (fn [_ _]
+        {:fx [[:fx-test/no-db-fx {}]]}))
+    (let [acc (collect-traces! ::no-db)]
+      (try
+        (rf/dispatch-sync [:fx-test/fx-only])
+        (let [[dof] (filterv #(= :event/do-fx (:operation %)) @acc)
+              tags  (:tags dof)]
+          (is (some? dof) ":event/do-fx fired")
+          (is (= false (:db-present? tags))
+              ":db-present? false because the handler returned no :db slot")
+          (is (= [[:fx-test/no-db-fx {}]] (:fx tags))
+              ":fx vector matches what the handler returned"))
+        (finally
+          (rf/remove-trace-cb! ::no-db))))))
+
+(deftest event-do-fx-stamp-rides-under-tags
+  (testing ":fx and :db-present? are payload-shaped slots — they ride
+   under :tags alongside :frame (consistent with how every payload
+   slot on a trace event is placed; top-level is reserved for
+   substrate-hoisted slots like :rf.trace/call-site,
+   :rf.trace/trigger-handler, :source, :recovery, :sensitive?)"
+    (rf/reg-event-fx :fx-test/top-level-shape
+      (fn [_ _] {:db {:x 1} :fx []}))
+    (let [acc (collect-traces! ::top-level)]
+      (try
+        (rf/dispatch-sync [:fx-test/top-level-shape])
+        (let [[dof] (filterv #(= :event/do-fx (:operation %)) @acc)
+              tags  (:tags dof)]
+          (is (some? dof) ":event/do-fx fired")
+          (is (contains? tags :fx)          ":fx lives under :tags")
+          (is (contains? tags :db-present?) ":db-present? lives under :tags")
+          (is (contains? tags :frame)       ":frame is alongside (pre-existing)")
+          (is (not (contains? dof :fx))
+              ":fx is NOT at top level")
+          (is (not (contains? dof :db-present?))
+              ":db-present? is NOT at top level"))
+        (finally
+          (rf/remove-trace-cb! ::top-level))))))

--- a/implementation/core/test/re_frame/success_path_call_site_test.clj
+++ b/implementation/core/test/re_frame/success_path_call_site_test.clj
@@ -1,0 +1,136 @@
+(ns re-frame.success-path-call-site-test
+  "Per rf2-twt7m Change 1 — `:rf.trace/call-site` rides success-path trace
+  events.
+
+  Mirror to `success_path_trigger_handler_test` (rf2-lf84g) for the
+  call-site slot. Where trigger-handler names the registration site of
+  the in-scope handler, call-site names the **invocation line** of the
+  surface macro (`rf/dispatch`, `rf/dispatch-sync`, `rf/subscribe`,
+  `rf/inject-cofx`).
+
+  Originally introduced (rf2-ts1a) for error events only; widened by
+  rf2-twt7m so success-path traces — starting with `:event/dispatched`
+  itself — also carry the dispatch-site coord. The Event lens redesign
+  (rf2-zh2qc) and any consumer building click-to-source UX on the
+  enqueue trace would otherwise lose the slot.
+
+  Locked shape (per rf2-ts1a):
+
+    {:ns <sym> :file <string> :line <int> :column <int>}
+
+  Slot placement: top-level on the trace event, NOT under `:tags` —
+  mirrors the error / trigger-handler shape exactly. Production
+  elision: rides the same `interop/debug-enabled?` gate the rest of
+  the trace surface uses; no separate elision contract.
+
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.flows :as flows]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+;; ---- fixtures -------------------------------------------------------------
+
+(defn reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (reset! flows/flows {})
+  (reset! schemas/schemas-by-frame {})
+  (trace/clear-trace-cbs!)
+  (rf/init! plain-atom/adapter)
+  (require 're-frame.routing :reload)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- record-traces
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- events-of [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+;; ---- Change 1 — `:event/dispatched` carries `:rf.trace/call-site` ---------
+
+(deftest event-dispatched-success-carries-call-site
+  (testing ":event/dispatched (success path) carries :rf.trace/call-site
+   when the dispatch came in via the macro form"
+    (rf/reg-event-db :rf2-twt7m/noop (fn [db _] db))
+    (let [evs       (record-traces
+                      (fn []
+                        (rf/dispatch-sync [:rf2-twt7m/noop])))
+          [enqueue] (events-of evs :event/dispatched)]
+      (is (some? enqueue) ":event/dispatched fired")
+      (is (contains? enqueue :rf.trace/call-site)
+          ":rf.trace/call-site hoisted onto the success-path emit")
+      (let [cs (:rf.trace/call-site enqueue)]
+        (is (symbol? (:ns cs))   ":ns is a symbol")
+        (is (string? (:file cs)) ":file is a string")
+        (is (integer? (:line cs)) ":line is an integer")
+        (is (re-find #"success_path_call_site_test" (:file cs))
+            (str ":file should point at this test file — got " (:file cs)))))))
+
+(deftest event-dispatched-call-site-rides-at-top-level
+  (testing ":rf.trace/call-site is a top-level field on success traces,
+   NOT nested under :tags — mirrors the error / trigger-handler shape"
+    (rf/reg-event-db :rf2-twt7m/top-level (fn [db _] db))
+    (let [evs       (record-traces
+                      (fn []
+                        (rf/dispatch-sync [:rf2-twt7m/top-level])))
+          [enqueue] (events-of evs :event/dispatched)]
+      (is (contains? enqueue :rf.trace/call-site)
+          ":rf.trace/call-site lives at top level")
+      (is (not (contains? (:tags enqueue) :rf.trace/call-site))
+          ":rf.trace/call-site does NOT live under :tags"))))
+
+(deftest event-dispatched-fn-form-omits-call-site
+  (testing "the fn-form `dispatch-sync*` does NOT stamp a call-site,
+   so :event/dispatched carries no slot — better no-data than
+   poison-data (mirrors the error-path contract)"
+    (rf/reg-event-db :rf2-twt7m/fn-form (fn [db _] db))
+    (let [evs       (record-traces
+                      (fn []
+                        (rf/dispatch-sync* [:rf2-twt7m/fn-form])))
+          [enqueue] (events-of evs :event/dispatched)]
+      (is (some? enqueue) ":event/dispatched fired")
+      (is (not (contains? enqueue :rf.trace/call-site))
+          ":rf.trace/call-site omitted on the fn-form path"))))
+
+;; ---- inner cascade emits carry the same call-site -------------------------
+
+(deftest cascade-success-traces-carry-call-site
+  (testing "every success-path trace emitted INSIDE the cascade (e.g.
+   :event/db-changed, :event/do-fx, :rf.fx/handled) carries the
+   dispatch's call-site — rf2-twt7m Change 1 widens the hoist to
+   match the trigger-handler treatment (rf2-lf84g)"
+    (rf/reg-fx :rf2-twt7m/my-fx (fn [_ _] :ok))
+    (rf/reg-event-fx :rf2-twt7m/cascade
+                     (fn [_ _] {:db {:n 1} :fx [[:rf2-twt7m/my-fx {}]]}))
+    (let [evs       (record-traces
+                      (fn []
+                        (rf/dispatch-sync [:rf2-twt7m/cascade])))
+          [dbc]     (events-of evs :event/db-changed)
+          [dof]     (events-of evs :event/do-fx)
+          [handled] (events-of evs :rf.fx/handled)]
+      (is (some? dbc) ":event/db-changed fired")
+      (is (some? dof) ":event/do-fx fired")
+      (is (some? handled) ":rf.fx/handled fired")
+      ;; The macro stamps a call-site onto the envelope;
+      ;; `process-event!` binds it via `with-dispatch-id+call-site`;
+      ;; every emit inside the cascade hoists it (rf2-twt7m).
+      (is (contains? dbc :rf.trace/call-site)
+          ":event/db-changed carries the dispatch's call-site")
+      (is (contains? dof :rf.trace/call-site)
+          ":event/do-fx carries the dispatch's call-site")
+      (is (contains? handled :rf.trace/call-site)
+          ":rf.fx/handled carries the dispatch's call-site"))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -382,7 +382,7 @@ The framework emits trace events from these call sites:
 
 - `events.cljc` — `:warning :rf.warning/interceptors-in-metadata-map`; `:rf.error/effect-map-shape`; `:rf.error/effect-handler-bad-return` (per rf2-k3bj).
 - `subs.cljc` — `:sub/create`, `:sub/run`; `:rf.error/no-such-sub` and `:rf.error/sub-exception` for failure paths.
-- `fx.cljc` — `:event/do-fx` per drain step, `:rf.fx/handled` per dispatched fx, `:fx/override-applied`, `:warning :rf.fx/skipped-on-platform`, `:rf.error/fx-handler-exception`, `:rf.error/no-such-fx`, plus `:rf.machine/spawned` and `:rf.machine/destroyed`.
+- `fx.cljc` — `:event/do-fx` per drain step (per rf2-twt7m the emit's `:tags` additionally carries `:fx` (the vector the handler returned) and `:db-present?` (boolean — was the handler's return-map's `:db` slot supplied?) so consumers can align cascade rows with handler returns without re-reading the interceptor context; the `:db` VALUE is intentionally NOT stamped — slice changes already ride `:event/db-changed`. Both slots sit under `:tags` alongside `:frame`, consistent with the payload-shaped tag convention), `:rf.fx/handled` per dispatched fx, `:fx/override-applied`, `:warning :rf.fx/skipped-on-platform`, `:rf.error/fx-handler-exception`, `:rf.error/no-such-fx`, plus `:rf.machine/spawned` and `:rf.machine/destroyed`.
 - `cofx.cljc` — `:rf.error/no-such-cofx` (emitted by `inject-cofx` when the cofx-id has no registered handler), `:warning :rf.cofx/skipped-on-platform` (emitted when a registered cofx's `:platforms` excludes the active platform; mirrors `:rf.fx/skipped-on-platform` per [011 §Effect handling on the server](011-SSR.md#effect-handling-on-the-server)).
 - `router.cljc` — `:event :event` (`:run-start` and `:run-end` phases), `:event :event/dispatched`, `:event :event/db-changed`, `:rf.error/handler-exception`, `:rf.error/drain-depth-exceeded`, `:rf.error/no-such-handler`, `:warning :rf.warning/dispatch-from-async-callback-fell-through-to-default` (emitted alongside `:rf.error/no-such-handler` when a dispatch landed on `:rf/default` purely because the resolution chain fell through and the handler is missing; per rf2-o8m0), `:rf.error/dispatch-sync-in-handler`, `:rf.error/frame-destroyed`, `:rf.error/flow-eval-exception`, `:rf.frame/drain-interrupted` (lifecycle event emitted when the drain loop detects a destroyed frame mid-cycle; per [002 §Edge cases worth pinning](002-Frames.md#edge-cases-worth-pinning)).
 - `frame.cljc` — `:frame/created`, `:frame/re-registered`, `:frame/destroyed`, `:rf.machine.lifecycle/destroyed`.
@@ -791,7 +791,7 @@ Every handler-execution boundary the runtime crosses (the router's `process-even
 | Slot | Carries | Per |
 |---|---|---|
 | `:trigger-handler` | Registration coord of the in-scope handler — `{:kind :id :source-coord {...}}` or nil when no source-coord is stamped. Hoisted as the top-level `:rf.trace/trigger-handler` field on every emit. | rf2-3nn8 (error path) / rf2-lf84g (success path) |
-| `:call-site` | Compile-time invocation coord of the surface reached through its macro form (`dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`) — `{:ns :file :line :column}` or nil for fn-form callers. Hoisted as `:rf.trace/call-site` on error emits only. | rf2-ts1a |
+| `:call-site` | Compile-time invocation coord of the surface reached through its macro form (`dispatch`, `dispatch-sync`, `subscribe`, `inject-cofx`) — `{:ns :file :line :column}` or nil for fn-form callers. Hoisted as `:rf.trace/call-site` on every emit (success and error). | rf2-ts1a (error-path landing) / rf2-twt7m (widened to success path) |
 | `:dispatch-id` | Cascade-wide correlation id — allocated once on entry to the drain (`router.cljc`'s `process-event!`) and merged into `:tags :dispatch-id` of every event emitted inside the cascade. | rf2-g6ih4 |
 | `:sensitive?` | Boolean. True when the router computed a schema-derived sensitive-path overlap for the in-scope handler (the handler-meta annotation has been removed — rf2-hjs2d). Emitted events get a top-level `:sensitive? true` stamp; absent reads as false (per [§Privacy / sensitive data in traces](#privacy--sensitive-data-in-traces)). | rf2-isdwf |
 | `:no-emit?` | Boolean. True when the in-scope handler's registration meta carries `:rf.trace/no-emit? true`. `emit!` / `emit-error!` short-circuit (no envelope allocation, no listener fan-out) when bound true. | rf2-qsjda |
@@ -827,7 +827,7 @@ Slot values are nil when unbound. Consumers reading a slot off an event MUST tre
 | Slot | Hoisted as | When | Notes |
 |---|---|---|---|
 | `:trigger-handler` | top-level `:rf.trace/trigger-handler` | every emit (success and error) when bound | Omitted entirely when unbound (no placeholder data). Per [§`:rf.trace/trigger-handler`](#rftracetrigger-handler--naming-the-in-scope-handler). |
-| `:call-site` | top-level `:rf.trace/call-site` | **error emits only** when bound | Success-path emits drop the slot — call-site rides error traces only, where jump-to-source matters. Per [§`:rf.trace/call-site`](#rftracecall-site--naming-the-invocation-line-rf2-ts1a). |
+| `:call-site` | top-level `:rf.trace/call-site` | every emit (success and error) when bound | Per rf2-twt7m the hoist widened from error-only to all emits — the Event lens and any consumer rendering jump-to-source on success-path events (`:event/dispatched`, `:event/do-fx`, `:rf.fx/handled`) needs the dispatch-site coord on the cascade entry, not just on errors. Omitted entirely when unbound. Per [§`:rf.trace/call-site`](#rftracecall-site--naming-the-invocation-line-rf2-ts1a). |
 | `:dispatch-id` | `:tags :dispatch-id` | every emit when bound and `:tags` does not already supply one | Caller-supplied `:tags :dispatch-id` wins. Per [§Dispatch correlation](#dispatch-correlation-dispatch-id--parent-dispatch-id). |
 | `:sensitive?` | top-level `:sensitive? true` | every emit when scope is sensitive and `:tags :sensitive?` does not supply its own reading | Caller-supplied `:tags :sensitive?` wins (queue-time `:event/dispatched` computes its own reading before scope is bound). Absent reads as false. Per [§Privacy / sensitive data in traces](#privacy--sensitive-data-in-traces). |
 | `:no-emit?` | **not hoisted** | — | Acts as a short-circuit signal: `emit!` / `emit-error!` skip envelope construction and listener fan-out entirely when bound true. The slot never appears on any emitted event. Per [§Trace-emission opt-out](#trace-emission-opt-out-rftraceno-emit-event-meta). |
@@ -949,7 +949,30 @@ Coverage:
 
 Production elision (Q3=B): **dev-only**. Each macro expands to `(if interop/debug-enabled? <stamping-branch> <no-stamping-branch>)`; under `:advanced` + `goog.DEBUG=false` the closure compiler constant-folds the gate to false and the entire stamping branch DCE's — the literal `{:rf.trace/call-site {...}}` map vanishes from the bundle. Apps using `goog.DEBUG=true` builds (or any JVM build) get the field; the default `:advanced` + `goog.DEBUG=false` production build does not — the elision-probe (per [§Production builds](#production-builds-zero-overhead-zero-code)) asserts the `"rf.trace/call-site"` string fragment is absent from the production bundle. The trace surface itself is still gated; this is an additional compile-time gate that strips the call-site machinery even when the trace surface is kept live.
 
-The mechanism is "compile-time map + handler-scope bind + emit-error read." The macro produces a literal map at compile time; the runtime publishes it on the `:call-site` slot of `re-frame.trace/*handler-scope*` around the underlying `*`-fn call (or threads the value through the dispatch envelope so `process-event!` binds it for the handler chain, per [§Handler-scope](#handler-scope-the-in-scope-reading-at-emit-time)); `emit-error!` reads the slot and hoists it onto the emitted event when bound. No new namespace or registry; consumer access is `(:rf.trace/call-site event)`.
+The mechanism is "compile-time map + handler-scope bind + emit read." The macro produces a literal map at compile time; the runtime publishes it on the `:call-site` slot of `re-frame.trace/*handler-scope*` around the underlying `*`-fn call (or threads the value through the dispatch envelope so `process-event!` binds it for the handler chain, per [§Handler-scope](#handler-scope-the-in-scope-reading-at-emit-time)); `build-event` reads the slot and hoists it onto every emitted event (success and error) when bound. The queue-time `:event/dispatched` emit additionally wraps its `trace/emit!` in a `with-call-site` binding sourced from the envelope's `:call-site` slot, so the enqueue trace carries the dispatch-site coord even though `process-event!`'s cascade-wide binding hasn't fired yet. No new namespace or registry; consumer access is `(:rf.trace/call-site event)`.
+
+Per rf2-twt7m the hoist widened from error-only to every emit (success and error). The Event lens redesign (rf2-zh2qc) and any consumer rendering jump-to-source on success-path events (`:event/dispatched`, `:event/do-fx`, `:rf.fx/handled`, `:event/db-changed`, `:sub/run`, `:rf.machine/transition`) needs the dispatch-site coord on the cascade entry, not just on errors. The semantics match the trigger-handler widening (rf2-lf84g): better one consistent rule than two paths to remember.
+
+#### `:rf/default?` — framework-auto-wrapped interceptor flag (rf2-twt7m)
+
+`reg-event-db` / `reg-event-fx` / `reg-event-ctx` each wrap the user's handler into a kind-appropriate interceptor (`:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler`) before appending it to the user-supplied `:interceptors` chain. The wrapper appears in `(rf/handler-meta :event id) :interceptors` alongside the user's own interceptors; consumer tools (Causa, the Event lens, IDE inspectors) frequently want to surface ONLY the user's chain — the framework auto-wrapper is implementation detail, not user-authored configuration worth showing.
+
+Per rf2-twt7m the auto-wrapper carries `:rf/default? true` on its interceptor map. Self-describing — tools filter without a hardcoded id allowlist:
+
+```clojure
+(->> (rf/handler-meta :event :my/event)
+     :interceptors
+     (remove :rf/default?))                ;; → only the user's interceptors
+```
+
+Shape and reservation:
+
+- The flag is a top-level boolean on the interceptor map (the same map the chain stores).
+- `:rf/default?` is owned by the framework under the `:rf/*` reserved namespace (per [Conventions §Reserved namespaces](Conventions.md#reserved-namespaces-framework-owned)).
+- User-supplied interceptors MUST NOT set `:rf/default?` true — the slot identifies framework-injected entries only.
+- Absent (or `false`) means "user-authored." Tools that branch on the flag treat absent and `false` identically (nil-safe access).
+
+Production elision: the flag rides on a registry-meta surface (`handler-meta`) — not on a trace event — so the trace-surface DCE gate does not apply. The flag is one keyword + one boolean per registered event, lives in process memory only, and is consumed by dev tooling that itself does not ship to production (the framework's own dispatch path does not branch on it).
 
 ### Error namespace convention — five prefix shapes
 


### PR DESCRIPTION
## Summary

Three small DCE-gated substrate edits that unblock the Event lens redesign (rf2-zh2qc). Each commit is one logical change; the changes are sized so each lands cleanly in isolation. Per `ai/findings/2026-05-18-event-lens-design.md` §10 + §2.2 + §3.1 + §4.1.

### Change 1 — `:rf.trace/call-site` on `:event/dispatched` (success path)

Per rf2-ts1a the dispatch-site coord was captured by the `rf/dispatch` / `rf/dispatch-sync` macro and rode through the envelope, but `build-event` only hoisted it onto error events. Success-path emits — starting with `:event/dispatched` itself — dropped the slot.

- `implementation/core/src/re_frame/trace.cljc` — `build-event` hoist gate widened from `(when error? ...)` to unconditional.
- `implementation/core/src/re_frame/router.cljc` — `emit-dispatched-trace!` wraps its emit in `trace/with-call-site` sourced from the envelope's `:call-site` (the queue-time emit fires before `process-event!`'s cascade-wide binding).
- `implementation/core/test/re_frame/success_path_call_site_test.clj` — new file, 4 tests / 16 assertions.

LoC delta: +171 / −14 (most of that is the new test file + docstring).

### Change 2 — `:fx` + `:db-present?` on `:event/do-fx`

`:event/do-fx` pre-change carried `{:frame frame-id}` only. The handler's return shape lived in the interceptor context's `:effects` slot for the cascade but never made it onto a trace.

Stamps onto the `:event/do-fx` trace's `:tags` (alongside `:frame`):
- `:fx` — the vector the handler returned (or nil).
- `:db-present?` — boolean, true iff the handler returned a `:db` slot. The `:db` VALUE is intentionally NOT stamped — slice changes already ride the `:event/db-changed` diff trace.

- `implementation/core/src/re_frame/fx.cljc` — new 7-arity of `do-fx` accepts the originating effects map; lower arities (machine-exit walks, nav-token wrappers) degrade gracefully.
- `implementation/core/src/re_frame/router.cljc` — `run-fx-effects!` threads `effects` to the new arity.
- `implementation/core/test/re_frame/fx_test.clj` — 3 new tests / 17 assertions.

LoC delta: +117 / −7.

### Change 3 — `:rf/default? true` on framework-auto-wrapped interceptors

The framework wraps user handlers into `:rf/db-handler` / `:rf/fx-handler` / `:rf/ctx-handler` interceptors and appends them to the chain. Tools wanting to surface only user-authored interceptors had to maintain a hardcoded id allowlist. Self-describing tag now lives on the wrapper map itself:

    (->> (rf/handler-meta :event :my/event)
         :interceptors
         (remove :rf/default?))

- `implementation/core/src/re_frame/events.cljc` — `wrap-event-handler` adds `:rf/default? true` to the auto-wrapper.
- `implementation/core/test/re_frame/events_test.clj` — 3 new tests / 14 assertions.

LoC delta: +86 / −2.

### Docs

`spec/009-Instrumentation.md` updated: §Canonical slot set + §Emit-side hoist contract reflect the widened `:call-site` hoist (Change 1); fx.cljc bullet documents the new `:event/do-fx` payload (Change 2); new §`:rf/default?` framework-auto-wrapped interceptor flag subsection (Change 3).

### DCE posture

All three changes preserve the existing `interop/debug-enabled?` gate posture — trace emission sits inside that gate, the new payload construction sits inside the emit, and the `:rf/default?` flag is a one-keyword stamp on a registry-meta map (no trace involvement at all).

### Unblocks

rf2-zh2qc (Event lens redesign) which depends on `:call-site` + `:fx` + `:db-present?` being available on the cascade entry's success traces.

## Test plan

- [x] `cd implementation/core && clojure -M:test` — 582 tests / 2963 assertions / 0 failures.
- [x] All adjacent JVM artefacts: machines (206/731), epoch (174/645), routing (98/450), schemas (157/18110), flows (78/349), http (193/588), ssr (171/569). All green.
- [x] `cd implementation && npm run test:cljs` — 3287 tests / 9472 assertions / 0 failures.
- [x] `scripts/test-fast-pr.sh` — green.
- [ ] CI test:browser + test:elision + test:bundle-isolation (run in GH Actions).