### PR TITLE
feat(causa): Event lens 6-section redesign per Mike's verbatim design (rf2-zh2qc)

### DIFF
--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -97,10 +97,18 @@
 
 (def ^:private empty-cascade
   "Slot template for a cascade record. Per-cascade reduction starts here;
-  every key the consumer can rely on lives in the template."
+  every key the consumer can rely on lives in the template.
+
+  `:event` is the dispatched event VECTOR (the convenient
+  slim form most consumers need). `:dispatched` is the full
+  `:event/dispatched` trace EVENT — preserved so consumers (Causa's
+  Event lens) can read top-level hoisted slots like
+  `:rf.trace/call-site` (per rf2-twt7m Change 1) without reaching
+  back into the raw trace buffer."
   {:dispatch-id nil
    :frame       nil
    :event       nil
+   :dispatched  nil
    :handler     nil
    :fx          nil
    :effects     []
@@ -170,10 +178,16 @@
       [(cascade-frame frame-index ev) id])))
 
 (defn- absorb
-  "Fold one trace event into the per-cascade accumulator."
+  "Fold one trace event into the per-cascade accumulator.
+
+  The `:event` bucket lands the event VECTOR on `:event` (slim,
+  consumers' common case) AND the full trace event on `:dispatched`
+  (preserves top-level hoisted slots like `:rf.trace/call-site` per
+  rf2-twt7m Change 1)."
   [acc ev]
   (case (domino-bucket ev)
-    :event   (assoc acc :event (get-in ev [:tags :event]))
+    :event   (assoc acc :event      (get-in ev [:tags :event])
+                       :dispatched  ev)
     :handler (assoc acc :handler ev)
     :fx      (assoc acc :fx ev)
     :effect  (update acc :effects conj ev)
@@ -205,7 +219,12 @@
 
       {:dispatch-id <cascade-id-or-:ungrouped>
        :frame       <frame-id-or-nil>
-       :event       <event-vector or nil>     ;; from :event/dispatched
+       :event       <event-vector or nil>     ;; from :event/dispatched :tags
+       :dispatched  <trace-event or nil>      ;; the full :event/dispatched
+                                              ;;   trace event (top-level
+                                              ;;   :rf.trace/call-site,
+                                              ;;   :source, :origin per
+                                              ;;   rf2-twt7m Change 1)
        :handler     <trace-event or nil>      ;; the :run-end emit (last wins)
        :fx          <trace-event or nil>      ;; :event/do-fx
        :effects     [<trace-event> ...]       ;; :op-type :fx

--- a/implementation/core/test/re_frame/trace/projection_test.cljc
+++ b/implementation/core/test/re_frame/trace/projection_test.cljc
@@ -162,9 +162,29 @@
             collection-shaped defaults"
     (let [[c] (p/group-cascades [{:id 1 :op-type :event :operation :event/dispatched
                                   :tags {:dispatch-id 1 :event [:e]}}])]
-      (is (= #{:dispatch-id :frame :event :handler :fx :effects :subs :renders :other}
+      (is (= #{:dispatch-id :frame :event :dispatched :handler :fx :effects :subs :renders :other}
              (set (keys c))))
       (is (vector? (:effects c)))
       (is (vector? (:subs c)))
       (is (vector? (:renders c)))
       (is (vector? (:other c))))))
+
+(deftest group-cascades-dispatched-slot-carries-full-trace-event
+  (testing "the :dispatched slot preserves the full :event/dispatched
+            trace so consumers (Causa Event lens) can read top-level
+            hoisted slots like :rf.trace/call-site (rf2-twt7m Change 1)
+            without scanning the raw buffer"
+    (let [evs [{:id 1 :op-type :event :operation :event/dispatched
+                :tags {:dispatch-id 42 :event [:cart/add-item]}
+                :rf.trace/call-site {:file "src/views.cljs" :line 127}
+                :source :ui :origin :app}]
+          [c] (p/group-cascades evs)]
+      (is (some? (:dispatched c))
+          ":dispatched slot is populated with the trace event")
+      (is (= {:file "src/views.cljs" :line 127}
+             (:rf.trace/call-site (:dispatched c)))
+          "the call-site (rf2-twt7m Change 1) rides through the projection")
+      (is (= :ui (:source (:dispatched c)))
+          "the :source slot rides through the projection")
+      (is (= [:cart/add-item] (:event c))
+          ":event slot still holds the slim event vector"))))

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -328,44 +328,111 @@ L4 fills the remaining canvas (60% default; resizable via L2/L3 drag handle). Al
 
 The renderer does NOT depend on `binaryage/cljs-devtools` (that library targets the Chrome console; this is in-page hiccup). Pure hiccup, theme-token-driven, substrate-agnostic. See [`007-UX-IA.md`](007-UX-IA.md) §Detail panel renderer.
 
-### §5.1 Event tab content (the fattened Event tab)
+### §5.1 Event tab content — the 6-section Event lens
+
+Shipped layout per rf2-zh2qc (rewrite of the v1 'fattened Event tab').
+Top-of-panel: a single-line cascade-outcome summary; below: six stacked
+sections that read top-to-bottom as the developer scans.
 
 ```
-┌─ Event tab content (single scrollable column) ──────────────────────────────────────┐
-│ event       [:order/retry {:order-id 92 :attempt 2}]            ⏱ 11ms · tier ●     │
-│ source      src/cart/events.cljs:267  ↗ open in editor                              │
+┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
 │                                                                                      │
-│ handler     reg-event-fx :order/retry                                                │
-│   return    {:db <…> :fx [[:http/post …] [:dispatch [:notify "retrying"]]]}         │
+│ ▼ EVENT                                                                              │
+│   [:cart/add-item {:id 42 :qty 2}]                                                   │
 │                                                                                      │
-│ db writes (via :db key of return)                                                   │
-│   [:cart :order-status]  :idle   →  :retrying                                       │
-│   [:cart :attempt]       1       →  2                                               │
+│ ▼ DISPATCH SITE                                                                      │
+│   src/cart/views.cljs:127       [open ↗]                                             │
+│   via :ui · origin :app                                                              │
 │                                                                                      │
-│ fx (via :fx key of return)                                                          │
-│   [:http/post {:url "/orders/92/retry" :method :POST :body {…}}]                    │
-│   [:dispatch  [:notify "retrying"]]                                                 │
+│ ▼ INTERCEPTORS  (1)                                                                  │
+│   :auth/require-login          src/auth/interceptors.cljs:42   [open ↗]              │
 │                                                                                      │
-│ fx handlers that RAN  (= replacement for old Effects tab)                          │
-│   :http/post  ⏱ 87ms   → POST /orders/92/retry → 202 Accepted                       │
-│                          response { :queued-at "2026-05-17T16:42:16.602Z" }        │
-│   :dispatch   ⏱ <1ms   → queued [:notify "retrying"]  (ran as cascade #352)         │
+│ ▼ HANDLER                                                                            │
+│   reg-event-fx · src/cart/events.cljs:88                       [open ↗]              │
+│                                                                                      │
+│ ▼ EFFECTS RETURNED                                                                   │
+│   :db    <… changed; see App-db tab …>                                               │
+│   :fx    [[:http/post {…}] [:dispatch [:notify "added"]]]                            │
+│                                                                                      │
+│ ▼ EFFECTS HANDLERS RAN  (2)                                                          │
+│   :http/post   ⏱ 87ms  ✓ handled                                                     │
+│   ┌─ MANAGED FX [HTTP] · :http/post · 87ms ──────────────────────────────┐           │
+│   │ STATUS: ✓ 200 OK · correlation: c-abc12 · phase: completed           │           │
+│   │ ▼ REQUEST  ▼ WIRE TIMING  ▼ RESPONSE  ▼ HANDLER  ▼ APP-DB SLICE      │           │
+│   └────────────────────────────────────────────────────────────────────────┘         │
+│   :dispatch    ⏱ <1ms  ✓ handled  → queued [:notify "added"]                        │
 └──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
-Top-to-bottom content blocks:
+#### Cascade-outcome line (top-of-panel chrome)
 
-1. **Event vector + arg-map** — full event, expandable; perf tier dot + duration ms inline.
-2. **Source coords** — `src/path.cljs:N` chip; click → editor open via [`007-UX-IA.md`](007-UX-IA.md) §Editor protocol matrix (`o` key alias).
-3. **Handler registration** — `reg-event-db/fx/ctx` + handler name (disambiguates when multiple handlers compose).
-4. **Handler return value** — the raw `{:db … :fx [...]}` (or `:db` return for `-db`). Expandable.
-5. **db writes** — diff slice computed from `:db-before` vs return's `:db`. Path · before-value · after-value (via `inspect-diff`).
-6. **fx (declared)** — the `:fx` vector from the return.
-7. **fx handlers that RAN** — per-fx invocation row: handler-id · duration · result chip (HTTP → status+url; `:dispatch` → queued cascade-id) · expandable response/payload.
+`<event-id>   ✓/✗/⚠ <outcome> · <duration-ms> · cascade #<id> [· SSR✓]`
 
-All blocks use the §5 renderer. Long-keyword treatment (per [`007-UX-IA.md`](007-UX-IA.md)) applies to keyword leaves. Data-classification sentinels render per §12.
+- Glyph + colour: `✓ green` for success, `✗ red` for handler exception
+  / unhandled `:rf.error/*`, `⚠ amber` for partial outcomes
+  (`:rf.warning/depth-exceeded`, `:rf.warning/schema-violation-skipped`).
+- `SSR✓` orientation badge when the focused event is
+  `:rf.ssr/hydrated` / `:rf.ssr/hydration-complete`; omitted for
+  purely-client-side cascades.
 
-**Dropped from the Event tab:** subs ran (now in Views tab) · renders (now in Views tab). Both surfaces are reachable via tab switch (`v`).
+#### The 6 sections (Mike's verbatim order)
+
+1. **EVENT** — the dispatched event vector via `inspector/inspect`.
+   Always present.
+2. **DISPATCH SITE** — source-coord chip + `via :source · origin :origin`
+   caption. Reads `:rf.trace/call-site` off the `:event/dispatched`
+   trace (rf2-twt7m Change 1). Renders an absent-placeholder when no
+   call-site was captured.
+3. **INTERCEPTORS** — non-standard chain only, **silent when zero**
+   (the section is ABSENT entirely, NOT '(none)'). Reads
+   `(rf/handler-meta :event id) :interceptors` and filters out anything
+   carrying `:rf/default? true` (rf2-twt7m Change 3) plus the known
+   auto-wrapper ids (`:rf/db-handler` / `:rf/fx-handler` /
+   `:rf/ctx-handler`) as a belt-and-braces fallback.
+4. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [open ↗]`. Per
+   Q2: does NOT duplicate the event-id (already shown in §1). Reads
+   `(rf/handler-meta :event id)`.
+5. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`
+   was returned. Reads `:fx` + `:db-present?` off the `:event/do-fx`
+   trace's `:tags` (rf2-twt7m Change 2). `:db` is shown as
+   `<… changed; see App-db tab …>` — the diff itself lives in the
+   App-db tab. When the focused event is `:rf.ssr/hydrated`, an
+   additional `:rf.ssr/hydration-outcome` row renders with the
+   `{:duration-ms :subs-ran :mismatches}` payload + (when mismatches
+   > 0) a `→ jump to Issues bisector` affordance.
+6. **EFFECTS HANDLERS RAN** — silent-by-default when no fx ran. One
+   row per `:rf.fx/handled` (or override / skipped / exception) trace:
+   fx-id chip + perf-tier dot + status caption. For `:dispatch` the
+   queued child event renders inline as `→ queued [:foo …]`. For
+   managed-fx surfaces (`:rf.http/*`, `:rf.ws/*`, `:rf.machine/*`,
+   `:rf.server/*`, `:rf.flow/*`) the wire-boundary `record-panel`
+   mounts INLINE beneath the row per §8.3 of the findings doc — NOT
+   in a trailing block.
+
+#### Edge cases
+
+- **No call-site captured** — DISPATCH SITE shows
+  `"source coord unavailable"`; no open chip rendered.
+- **No user interceptors** — INTERCEPTORS section ABSENT entirely.
+- **No effects returned** — EFFECTS RETURNED section ABSENT.
+- **No fx handlers ran** — EFFECTS HANDLERS RAN section ABSENT.
+- **Handler threw** — §5 + §6 are both absent (handler never
+  returned / fx walk never started); a small footer caption renders:
+  `Handler threw — see Issues tab ⚠ for the exception detail.` This
+  is the ONE inline cross-reference to another tab.
+
+#### What's dropped from the Event tab
+
+- **subs ran** → Views tab.
+- **renders** → Views tab.
+- **`:other` errors / warnings / machine transitions** → Issues tab
+  (errors), Machines tab (transitions), Trace tab (firehose).
+- **db writes diff** → App-db tab. §5 carries only the `:db` presence
+  marker; the actual diff is the App-db tab's job.
+
+All sections use the §5 renderer. Long-keyword treatment (per
+[`007-UX-IA.md`](007-UX-IA.md)) applies to keyword leaves. Data-
+classification sentinels render per §12.
 
 ### §5.2 App-db tab content (changed-slices-first)
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -1,51 +1,63 @@
 (ns day8.re-frame2-causa.panels.event-detail
-  "Event-detail hero panel — §10 Lock 7 default view (Phase 2, rf2-op3bz).
+  "Event lens — the L4 default-tab panel rewritten per Mike's verbatim
+  6-section design (rf2-zh2qc, parent rf2-twt7m for substrate keys).
 
-  Per `tools/causa/spec/007-UX-IA.md` §The default landing view the
-  hero panel is Events / event-detail; per Phase 1 (rf2-n6x4q) the
-  foundation supplies a trace ring buffer + Causa frame isolation. This
-  ns adds the first live panel on top of that foundation.
+  This panel replaces the v1 'six-domino' renderer with a focused
+  Event lens shaped after Chrome DevTools: top-of-panel cascade-outcome
+  line + six stacked sections that read top-to-bottom as the developer
+  scans:
 
-  ## What this panel shows
+      ▼ EVENT                 the dispatched event vector
+      ▼ DISPATCH SITE         where the dispatch happened (source coord)
+      ▼ INTERCEPTORS          non-standard chain (silent when empty)
+      ▼ HANDLER               where the handler is defined (source coord)
+      ▼ EFFECTS RETURNED      the {:db ... :fx [...]} the handler returned
+      ▼ EFFECTS HANDLERS RAN  per-fx-handler rows + managed-fx inline
 
-  When a dispatch-id is selected (via the cascade list — for now, by
-  clicking any row), the panel renders the six-domino cascade for that
-  dispatch:
+  All other v1 dominos (subs, renders, other / errors) move to their
+  own tabs (Views / Issues). See `tools/causa/spec/018-Event-Spine.md`
+  §5.1 + `ai/findings/2026-05-18-event-lens-design.md` for design.
 
-    1. The event vector (the cascade root — from `:event/dispatched`).
-    2. The handler trace event (the `:run-end` emit — populated by
-       `re-frame.trace.projection/absorb`).
-    3. The `:event/do-fx` emit (the effects map about to be walked).
-    4. The list of `:rf.fx/handled` / override / skipped effects.
-    5. The list of `:sub/run` + `:sub/create` events.
-    6. The list of `:view/render` events.
+  ## Substrate-driven (rf2-twt7m)
 
-  Plus an `:other` bucket for traces that don't fit the six-domino
-  vocabulary (errors, warnings, machine transitions, etc.).
+  Three substrate changes in rf2-twt7m supply the data this lens
+  needs:
 
-  When no dispatch-id is selected the panel shows the cascade list —
-  one row per cascade, oldest first — so the user can click to drill
-  in. The cascade list is the placeholder until rf2-5yriz lands a
-  dedicated actions panel.
+    Change 1 — `:event/dispatched` traces carry `:rf.trace/call-site`
+               on success-path emits (previously error-only). DISPATCH
+               SITE section reads it.
+    Change 2 — `:event/do-fx` traces carry `:fx` (the returned vector)
+               and `:db-present?` (boolean) on their `:tags`. EFFECTS
+               RETURNED section reads them.
+    Change 3 — Framework-auto-wrapped interceptors carry
+               `:rf/default? true` so INTERCEPTORS can filter them out
+               without an allowlist.
 
-  ## Pure hiccup (rf2-tijr)
+  Handler-site coord reads via `(rf/handler-meta :event event-id)` —
+  no trace involvement; reads the registry at render time.
 
-  Per the substrate-agnostic contract the view is pure hiccup. The
-  substrate adapter installed via `rf/init!` handles the render — this
-  ns never references Reagent / UIx / Helix directly. Frame isolation
-  is provided by the enclosing `[rf/frame-provider {:frame :rf/causa}]`
-  in `shell.cljs`; every `subscribe` / `dispatch` here resolves to the
-  `:rf/causa` frame.
+  ## Pure hiccup, substrate-agnostic
 
-  ## Source-coord click-through
+  The panel emits hiccup; the substrate adapter installed via `rf/init!`
+  handles rendering. Per-section helpers mirror
+  `managed_fx_template/section` so the visual rhythm is uniform.
 
-  When a trace event carries `:rf.trace/trigger-handler` (per rf2-3nn8
-  / rf2-lf84g — handler scope rides on every emit), the source-coord
-  is shown as a small mono-font caption beneath the event. The click-
-  to-jump-to-editor hook (rf2-evgf5) is in flight; until it lands the
-  coord is non-interactive plain text per the bead's contract."
+  ## What replaced the v1 cascade-detail
+
+    - cascade-detail (six-domino renderer)  → event-lens (6 sections)
+    - event-row / handler-row / fx-row      → section/section-header
+    - subs-row / renders-row / other-row    → DELETED
+                                              (Views / Issues tabs)
+    - effects-row                           → §5 EFFECTS RETURNED
+                                              + §6 EFFECTS HANDLERS RAN
+    - 'Event detail' h1                     → cascade-outcome line
+
+  ## What survives
+
+    - install! (selection slot + composite sub + select/clear events)
+    - cascade-list (no-event-selected empty state)
+    - tier-dot (reused in cascade-outcome + per-fx duration)"
   (:require [re-frame.core :as rf]
-            [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
@@ -55,34 +67,12 @@
             [day8.re-frame2-causa.theme.perf-tier :as perf-tier]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]))
 
-;; ---- pure helpers --------------------------------------------------------
-
-(defn- format-edn
-  "Best-effort EDN-like format of an arbitrary value. Used to render
-  event vectors and trace `:tags` payloads in the mono column. Falls
-  back to `str` for unprintable values."
-  [v]
-  (try
-    (pr-str v)
-    (catch :default _
-      (str v))))
-
-(defn- trigger-handler-coord
-  "Pluck the source-coord (file + line) off an event's
-  `:rf.trace/trigger-handler` slot. nil when the slot is absent."
-  [ev]
-  (when-let [trigger (:rf.trace/trigger-handler ev)]
-    (let [{:keys [file line]} (:source-coord trigger)]
-      (when file
-        (cond-> file
-          line (str ":" line))))))
+;; ---- selection plumbing (survives from v1) -----------------------------
 
 (defn- selected-ref
   "Normalise the selection slot. Newer callers pass
-  `{:dispatch-id <id> :frame <frame-id>}` so non-default frames can be
-  distinguished even if a host implementation scopes dispatch ids per
-  frame. Older callers that still pass the raw id continue to resolve
-  by id only."
+  `{:dispatch-id <id> :frame <frame-id>}`; older callers continue to
+  resolve by raw id."
   [selection]
   (if (map? selection)
     selection
@@ -92,18 +82,14 @@
   "True iff `cascade` carries a real `:event` vector. The `:ungrouped`
   bucket produced by `re-frame.trace.projection/group-cascades` for
   registry-time emits / frame lifecycle outside a drain / REPL evals
-  carries no event vector. Per rf2-639lc head-cascade selection skips
-  this bucket so the L4 default-focus lands on the most recent ROUTED
-  cascade, not the projection's internal bucket."
+  carries no event vector — skip those for default-focus per rf2-639lc."
   [cascade]
   (vector? (:event cascade)))
 
 (defn- default-head-cascade
   "Pick the head (most recent) routed cascade from the cascade vector,
-  or nil when none exist. `:ungrouped` cascades are filtered out so a
-  registry-time emit can never become the default-focused row.
-  Cascades are oldest-first per group-cascades' contract; `last`
-  returns the head."
+  or nil when none exist. Cascades are oldest-first per group-cascades'
+  contract; `last` returns the head."
   [cascades]
   (last (filterv cascade-has-event? cascades)))
 
@@ -114,73 +100,256 @@
          (or (nil? selected-frame)
              (= selected-frame frame)))))
 
-;; ---- row renderers -------------------------------------------------------
+;; ---- pure projection helpers --------------------------------------------
 
-(defn- domino-row
-  "One labelled row inside the six-domino layout. `label` is the
-  short marker (e.g. \"event\", \"fx\", \"sub\"); `body` is hiccup
-  rendered to the right of the label. `tone` is one of the token
-  accent keys (`:accent-violet`, `:cyan`, etc.)."
-  [{:keys [label tone]} body]
-  [:div {:style {:display     "flex"
-                 :align-items "flex-start"
-                 :gap         "12px"
-                 :padding     "8px 12px"
-                 :border-bottom (str "1px solid " (:border-subtle tokens))}}
-   [:div {:style {:flex          "0 0 96px"
-                  :color         (tone tokens)
-                  :font-family   sans-stack
-                  :font-size     "11px"
-                  :font-weight   600
-                  :text-transform "uppercase"
-                  :letter-spacing "0.5px"
-                  :padding-top   "2px"}}
-    label]
-   [:div {:style {:flex          1
-                  :min-width     0
-                  :font-family   mono-stack
-                  :font-size     "13px"
-                  :color         (:text-primary tokens)
-                  :word-break    "break-word"}}
+(defn- format-coord-display
+  "Render a structured source-coord `{:file :line :column :ns}` as the
+  display string `\"file:line\"` (or just `\"file\"`). nil when the
+  coord lacks `:file`."
+  [{:keys [file line]}]
+  (when (and (string? file) (seq file))
+    (cond-> file
+      line (str ":" line))))
+
+(defn- dispatched-event-trace
+  "The `:event/dispatched` trace event for the cascade. Carries
+  `:rf.trace/call-site` per rf2-twt7m Change 1 + `:source` / `:origin`
+  hoisted by `trace.cljc/build-event`. The projection keeps it on
+  the `:dispatched` slot per `group-cascades`' contract."
+  [{:keys [dispatched]}]
+  dispatched)
+
+(defn- do-fx-trace
+  "The `:event/do-fx` trace event for the cascade — supplies
+  `:fx` + `:db-present?` per rf2-twt7m Change 2. Lives on the
+  cascade's `:fx` slot per `group-cascades`."
+  [{:keys [fx]}]
+  fx)
+
+(defn- handler-trace
+  "The `:run-end` handler trace — the cascade's `:handler` slot.
+  Carries `:duration-ms` on `:tags`."
+  [{:keys [handler]}]
+  handler)
+
+(defn- has-handler-exception?
+  "True iff the cascade's `:other` bucket carries a handler exception
+  trace. Used to swap the cascade-outcome glyph from ✓ to ✗ and to
+  suppress §5/§6 (the handler never returned)."
+  [{:keys [other]}]
+  (boolean
+    (some (fn [ev]
+            (let [op (:operation ev)]
+              (or (= :rf.error/handler-exception op)
+                  (= :rf.error/handler-threw op))))
+          (or other []))))
+
+(defn- has-warning?
+  "True iff the cascade carries a non-fatal warning that should pivot
+  the outcome glyph to ⚠ (amber). Per §5.1 the warning set is:
+  depth-exceeded, schema-violation-then-skipped. Pure predicate over
+  the cascade's `:other` bucket."
+  [{:keys [other]}]
+  (boolean
+    (some (fn [ev]
+            (let [op (:operation ev)]
+              (or (= :rf.warning/depth-exceeded op)
+                  (= :rf.warning/schema-violation-skipped op))))
+          (or other []))))
+
+(defn cascade-outcome
+  "Project a cascade record into a outcome-summary map for the top-of-
+  panel cascade-outcome line:
+
+      {:event-id    <kw>           ;; first element of :event vec
+       :glyph       \"✓\" | \"✗\" | \"⚠\"
+       :outcome     :ok | :error | :warning
+       :duration-ms <num-or-nil>
+       :dispatch-id <int>
+       :ssr?        <bool>}        ;; true when this was an SSR-hydration cascade
+
+  Pure data → data. JVM-portable."
+  [{:keys [event handler dispatch-id] :as cascade}]
+  (let [event-id    (when (vector? event) (first event))
+        duration-ms (get-in handler [:tags :duration-ms])
+        ssr?        (or (= :rf.ssr/hydrated event-id)
+                        (= :rf.ssr/hydration-complete event-id))
+        [outcome glyph] (cond
+                          (has-handler-exception? cascade) [:error   "✗"]
+                          (has-warning? cascade)           [:warning "⚠"]
+                          :else                            [:ok      "✓"])]
+    {:event-id    event-id
+     :glyph       glyph
+     :outcome     outcome
+     :duration-ms duration-ms
+     :dispatch-id dispatch-id
+     :ssr?        ssr?}))
+
+(defn- outcome-colour
+  [outcome]
+  (case outcome
+    :error   (:red tokens)
+    :warning (:yellow tokens)
+    :ok      (:green tokens)
+    (:text-secondary tokens)))
+
+(def ^:private default-interceptor-id?
+  "Per rf2-twt7m Change 3 the framework-auto-wrapped handler
+  interceptors carry `:rf/default? true` on the interceptor map.
+  Until older registrations migrate we also fallback-match the three
+  known ids so the panel never surfaces them."
+  #{:rf/db-handler :rf/fx-handler :rf/ctx-handler})
+
+(defn user-interceptors
+  "Filter `interceptors` (the chain on `(rf/handler-meta :event id)
+  :interceptors`) down to the user-visible ones — drop any flagged
+  `:rf/default? true`, plus the known auto-wrapper ids as a belt-and-
+  braces fallback. Pure fn; JVM-testable."
+  [interceptors]
+  (vec
+    (remove (fn [i]
+              (or (true? (:rf/default? i))
+                  (contains? default-interceptor-id? (:id i))))
+            (or interceptors []))))
+
+(defn effects-handlers-ran
+  "Build a vector of fx-handler rows for the §6 EFFECTS HANDLERS RAN
+  section. Each row carries `{:fx-id :operation :id :ev :duration-ms
+  :status}`. Read directly off the cascade's `:effects` slot. Pure fn."
+  [{:keys [effects]}]
+  (vec
+    (for [ev (or effects [])]
+      {:fx-id       (get-in ev [:tags :fx-id])
+       :fx-args     (get-in ev [:tags :fx-args])
+       :operation   (:operation ev)
+       :id          (:id ev)
+       :duration-ms (get-in ev [:tags :duration-ms])
+       :ev          ev})))
+
+(defn- fx-handled-status
+  "Map a fx-handled trace's `:operation` onto a compact status keyword
+  the row caption uses."
+  [operation]
+  (case operation
+    :rf.fx/handled                  :ok
+    :rf.fx/override-applied         :overridden
+    :rf.fx/skipped-on-platform      :skipped
+    :rf.error/fx-handler-exception  :error
+    :rf.error/no-such-fx            :error
+    :ok))
+
+(defn- fx-status-colour
+  [status]
+  (case status
+    :ok          (:green tokens)
+    :overridden  (:accent-violet tokens)
+    :skipped     (:text-tertiary tokens)
+    :error       (:red tokens)
+    (:text-secondary tokens)))
+
+(defn hydration-outcome-row
+  "Project the `:rf.ssr/hydration-outcome` row for §5 when the focused
+  event is a hydration-completion synthetic. Pure fn; returns nil when
+  the cascade isn't an SSR-hydration cascade or has no payload to
+  surface.
+
+  Reads the outcome data off the cascade's `:other` bucket — the
+  substrate emits `:rf.ssr/hydration-outcome` (or carries it on the
+  `:event/dispatched`'s tags); we look in both places to be tolerant."
+  [{:keys [event other] :as _cascade}]
+  (let [event-id (when (vector? event) (first event))]
+    (when (or (= :rf.ssr/hydrated event-id)
+              (= :rf.ssr/hydration-complete event-id))
+      (or
+        ;; Preferred: dedicated outcome trace on the cascade's :other
+        ;; bucket.
+        (some (fn [ev]
+                (when (= :rf.ssr/hydration-outcome (:operation ev))
+                  (:tags ev)))
+              (or other []))
+        ;; Fallback: payload rode in on the :event vector itself.
+        (when (and (vector? event) (>= (count event) 2))
+          (second event))))))
+
+(defn- dispatch-call-site
+  "Pluck the dispatch-site coord off the cascade's `:event/dispatched`
+  trace. Per rf2-twt7m Change 1 the coord rides as
+  `:rf.trace/call-site` on the success-path emit. Returns the
+  structured source-coord map (`{:file :line :column :ns}`) or nil."
+  [cascade]
+  (some-> (dispatched-event-trace cascade) :rf.trace/call-site))
+
+(defn- dispatch-source+origin
+  "Pluck `:source` (e.g. `:ui` `:timer` `:http`) and `:origin` from the
+  dispatched trace. Both are hoisted to the top level on success-path
+  emits via `trace.cljc/build-event`. Returns `[source origin]`."
+  [cascade]
+  (let [ev (dispatched-event-trace cascade)]
+    [(or (:source ev) (get-in ev [:tags :source]))
+     (or (:origin ev) (get-in ev [:tags :origin]))]))
+
+(defn- effects-returned
+  "Project the §5 EFFECTS RETURNED rows from the cascade's `:event/do-fx`
+  trace. Per rf2-twt7m Change 2 the trace carries `:fx` (the vector
+  returned) and `:db-present?` (boolean). Returns
+  `{:fx [...] :db-present? <bool> :present? <bool>}`. `:present?` is
+  true iff EITHER `:fx` or `:db-present?` is non-empty / true — used
+  to decide whether to render §5 at all (silent-by-default)."
+  [cascade]
+  (let [tags        (some-> (do-fx-trace cascade) :tags)
+        fx          (:fx tags)
+        db-present? (boolean (:db-present? tags))]
+    {:fx          fx
+     :db-present? db-present?
+     :present?    (or db-present? (seq fx))}))
+
+;; ---- section primitive --------------------------------------------------
+
+(defn- section-header
+  "Uppercased section label with optional count + collapse glyph.
+  Mirrors `managed_fx_template/section-header` for visual consistency."
+  [{:keys [label count* testid]}]
+  [:div {:data-testid testid
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "6px"
+                       :padding       "4px 0"
+                       :font-family   sans-stack
+                       :font-size     "11px"
+                       :font-weight   600
+                       :letter-spacing "0.6px"
+                       :text-transform "uppercase"
+                       :color         (:text-secondary tokens)}}
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-family mono-stack}}
+    "▼"]
+   label
+   (when count*
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-weight 400
+                     :font-family mono-stack}}
+      (str "(" count* ")")])])
+
+(defn- section
+  "One stacked section. `label` upper-cases; `body` is hiccup."
+  [{:keys [label count* testid]} body]
+  [:div {:data-testid testid
+         :style       {:padding "8px 12px"
+                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
+   (section-header {:label label :count* count*
+                    :testid (str testid "-header")})
+   [:div {:data-testid (str testid "-body")
+          :style       {:padding "6px 0 0 18px"
+                        :font-family mono-stack
+                        :font-size "12px"
+                        :color (:text-primary tokens)}}
     body]])
 
-(defn- coord-line
-  "Render the `:rf.trace/trigger-handler` coord underneath a row's
-  body. nil when no coord is present."
-  [ev]
-  (when-let [coord (trigger-handler-coord ev)]
-    [:div {:style {:font-family   mono-stack
-                   :font-size     "11px"
-                   :color         (:text-tertiary tokens)
-                   :margin-top    "4px"}}
-     "source • " coord]))
-
-(defn- event-row
-  "First domino: the dispatched event vector + (when available) the
-  trigger-handler source-coord lifted off the `:event/dispatched`
-  emit. `event-vec` is the event vector (e.g. `[:counter/inc]`)."
-  [event-vec handler-coord]
-  [domino-row {:label "event" :tone :accent-violet}
-   [:div
-    [:div {:style {:font-weight 600}}
-     (inspector/inspect event-vec "event-detail/event")]
-    (when handler-coord
-      [:div {:style {:font-family   mono-stack
-                     :font-size     "11px"
-                     :color         (:text-tertiary tokens)
-                     :margin-top    "4px"}}
-       "source • " handler-coord])]])
+;; ---- tier-dot (reused from v1, survives) -------------------------------
 
 (defn- tier-dot
-  "Render a perf-tier coloured dot + label for `duration-ms`. Per
-  `tools/causa/spec/007-UX-IA.md` §Colour system §Perf scale —
-  same ladder the Performance panel uses, hoisted into
-  `theme.perf-tier` per the rf2-6ja23 audit so every panel that
-  surfaces a per-node duration reads the same swatch / glyph / label.
-
-  Renders inline; the colour swatch carries the tier, the
-  `aria-label` carries the tier name + duration so the colour-blind
-  path doesn't need hue."
+  "Render a perf-tier coloured dot + label for `duration-ms`.
+  Reused in the cascade-outcome line + per-fx-handler rows."
   [duration-ms]
   (when (number? duration-ms)
     (let [tier   (perf-tier/classify-tier duration-ms)
@@ -193,7 +362,6 @@
               :style       {:display      "inline-flex"
                             :align-items  "center"
                             :gap          "6px"
-                            :margin-left  "8px"
                             :color        colour
                             :font-weight  600}}
        [:span {:style {:font-size "12px"}} glyph]
@@ -202,157 +370,423 @@
                        :color       (:text-secondary tokens)}}
         (str duration-ms "ms")]])))
 
-(defn- handler-row
-  "Second domino: the handler-ran emit. `ev` is the `:run-end` trace
-  event.
+;; ---- chrome: cascade-outcome line --------------------------------------
 
-  ## Tier dot (rf2-6ja23)
-
-  When `:duration-ms` is present on the emit's `:tags`, render the
-  perf-tier coloured dot + label alongside the raw `:phase` text.
-  Same ladder as the Performance panel (`theme.perf-tier`); the
-  raw `:duration-ms` number is kept in the EDN dump for power users."
-  [ev]
-  (let [duration-ms (get-in ev [:tags :duration-ms])]
-    [domino-row {:label "handler" :tone :cyan}
-     [:div
-      [:div {:style {:display     "flex"
-                     :align-items "center"
-                     :flex-wrap   "wrap"}}
-       [:span (inspector/inspect (select-keys (:tags ev) [:phase :duration-ms])
-                                 "event-detail/handler-tags")]
-       (tier-dot duration-ms)]
-      (coord-line ev)]]))
-
-(defn- fx-row
-  "Third domino: the `:event/do-fx` emit (the effects map about to be
-  walked)."
-  [ev]
-  [domino-row {:label "fx" :tone :cyan}
-   [:div
-    [:div (inspector/inspect (:tags ev) "event-detail/fx-tags")]
-    (coord-line ev)]])
-
-(defn- db-changed-events
-  "Pluck the `:event/db-changed` traces from a cascade's `:other`
-  bucket. Per Spec 002 §Drain-loop pseudocode every `:db` commit
-  emits one `:event/db-changed` trace; the projection routes those
-  to `:other` (they don't fit a domino slot per Spec 009
-  §`:op-type` vocabulary). For the EFFECTS row this is the only
-  cascade-side signal that the handler returned a `:db` effect — no
-  `:rf.fx/handled` is emitted for `:db` because the commit happens
-  in the interceptor chain, not in the fx walk."
-  [other]
-  (filter (fn [ev]
-            (and (= :event (:op-type ev))
-                 (= :event/db-changed (:operation ev))))
-          other))
-
-(defn effects-entries
-  "Build the EFFECTS row's display entries from a cascade. Combines:
-
-    1. `:event/db-changed` traces (if any) — surfaced as a virtual
-       `:db` entry per rf2-s0s5x Phase A so events that committed
-       only a `:db` effect (the common `reg-event-db` case) don't
-       lie with `EFFECTS (none)`.
-    2. `:op-type :fx` traces from the `:effects` slot — every fx
-       handler invocation (`:rf.fx/handled` /
-       `:rf.fx/override-applied` / `:rf.fx/skipped-on-platform`).
-
-  Returns a sequence of `{:fx-id <kw> :operation <kw> :id <int>}`
-  display rows in cascade order (`:db` first, then fx vector
-  entries). Empty when neither signal is present."
+(defn- cascade-outcome-line
+  "Top-of-panel single-line health summary. Replaces the v1
+  literal 'Event detail' h1."
   [cascade]
-  (let [db-rows (for [ev (db-changed-events (:other cascade))]
-                  {:fx-id     :db
-                   :operation (:operation ev)
-                   :id        (:id ev)
-                   :ev        ev})
-        fx-rows (for [ev (:effects cascade)]
-                  {:fx-id     (get-in ev [:tags :fx-id])
-                   :operation (:operation ev)
-                   :id        (:id ev)
-                   :ev        ev})]
-    (concat db-rows fx-rows)))
+  (let [{:keys [event-id glyph outcome duration-ms dispatch-id ssr?]}
+        (cascade-outcome cascade)]
+    [:header {:data-testid "rf-causa-event-detail-outcome"
+              :data-outcome (name outcome)
+              :style {:display       "flex"
+                      :align-items   "center"
+                      :gap           "10px"
+                      :padding       "12px 16px"
+                      :background    (:bg-3 tokens)
+                      :border-bottom (str "1px solid " (:border-subtle tokens))
+                      :font-family   sans-stack
+                      :font-size     "13px"}}
+     [:span {:data-testid "rf-causa-event-detail-outcome-event-id"
+             :style {:color (:accent-violet tokens)
+                     :font-family mono-stack
+                     :font-weight 600}}
+      (pr-str event-id)]
+     [:span {:style {:flex 1}}]
+     [:span {:data-testid (str "rf-causa-event-detail-outcome-glyph-" (name outcome))
+             :style {:color       (outcome-colour outcome)
+                     :font-weight 700
+                     :font-size   "14px"}}
+      glyph]
+     [:span {:style {:color (outcome-colour outcome)
+                     :font-family mono-stack
+                     :font-weight 600}}
+      (case outcome :ok "ok" :error "error" :warning "warning")]
+     [:span {:style {:color (:text-tertiary tokens)}} "·"]
+     (or (tier-dot duration-ms)
+         [:span {:style {:color (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size "11px"}}
+          "—"])
+     [:span {:style {:color (:text-tertiary tokens)}} "·"]
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-family mono-stack
+                     :font-size "11px"}}
+      (str "cascade #" dispatch-id)]
+     (when ssr?
+       [:span {:data-testid "rf-causa-event-detail-outcome-ssr-badge"
+               :style {:color (:cyan tokens)
+                       :font-family mono-stack
+                       :font-weight 700
+                       :font-size "11px"
+                       :margin-left "6px"}}
+        "SSR✓"])]))
 
-(defn- effects-row
-  "Fourth domino: the effects the cascade actually committed. Renders
-  a stacked list of fx-id + operation, with a virtual `:db` row when
-  the cascade emitted `:event/db-changed` (the cascade-side signal
-  for the `:db` effect — see `db-changed-events`).
+;; ---- §1 EVENT ----------------------------------------------------------
 
-  Per rf2-s0s5x Phase A: previously this row read only the
-  projection's `:effects` slot (built from `:op-type :fx` events),
-  which left pure `reg-event-db` handlers showing `(none)` even
-  though `:db` had been committed — the EFFECTS lie the bead calls
-  out. The composite `effects-entries` folds in `:event/db-changed`
-  from the `:other` bucket so the row reflects the cascade's actual
-  outcome."
+(defn- event-section
+  [event-vec]
+  (section {:label "EVENT"
+            :testid "rf-causa-event-detail-section-event"}
+           [:div {:data-testid "rf-causa-event-detail-event-vector"
+                  :style {:font-weight 600}}
+            (inspector/inspect event-vec "event-detail/event")]))
+
+;; ---- §2 DISPATCH SITE --------------------------------------------------
+
+(defn- coord-chip
+  "Reusable 'open in editor' chip. Renders nothing when `coord` has no
+  `:file`. Dispatches `:rf.causa/open-in-editor` with the structured
+  coord; the trace-bus thereby records the click + the editor handler
+  resolves the URI through the rf2-cm93v allowlist."
+  [coord testid]
+  (when (and (map? coord) (seq (:file coord)))
+    [:button {:data-testid testid
+              :on-click    (fn [e]
+                             (.stopPropagation e)
+                             (rf/dispatch [:rf.causa/open-in-editor
+                                           {:source-coord coord}]
+                                          {:frame :rf/causa}))
+              :style       {:background  "transparent"
+                            :color       (:cyan tokens)
+                            :border      (str "1px solid " (:border-default tokens))
+                            :padding     "1px 8px"
+                            :border-radius "3px"
+                            :margin-left "8px"
+                            :cursor      "pointer"
+                            :font-family mono-stack
+                            :font-size   "10px"}}
+     "open ↗"]))
+
+(defn- dispatch-site-section
   [cascade]
-  (let [entries (effects-entries cascade)]
-    [domino-row {:label "effects" :tone :green}
-     (if (empty? entries)
-       [:span {:data-testid "rf-causa-event-detail-effects-none"
-               :style {:color (:text-tertiary tokens)}}
-        "(none)"]
-       (into [:div {:data-testid "rf-causa-event-detail-effects"}]
-             (for [{:keys [fx-id operation id]} entries]
-               ^{:key id}
-               [:div {:data-testid (str "rf-causa-event-detail-effects-row-"
-                                        (name (or fx-id :unknown)))
-                      :style {:padding "2px 0"}}
-                [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
-                 (str fx-id)]
-                [:span {:style {:color (:text-secondary tokens)}}
-                 (str operation)]])))]))
+  (let [coord            (dispatch-call-site cascade)
+        [source origin]  (dispatch-source+origin cascade)
+        display          (format-coord-display coord)]
+    (section {:label "DISPATCH SITE"
+              :testid "rf-causa-event-detail-section-dispatch"}
+             [:div
+              [:div {:style {:display "flex" :align-items "center"}}
+               (if display
+                 [:span {:data-testid "rf-causa-event-detail-dispatch-coord"
+                         :style {:color (:text-primary tokens)}}
+                  display]
+                 [:span {:data-testid "rf-causa-event-detail-dispatch-coord-absent"
+                         :style {:color (:text-tertiary tokens)
+                                 :font-style "italic"}}
+                  "source coord unavailable"])
+               (coord-chip coord "rf-causa-event-detail-dispatch-open-chip")]
+              (when (or source origin)
+                [:div {:data-testid "rf-causa-event-detail-dispatch-caption"
+                       :style {:color (:text-tertiary tokens)
+                               :font-family sans-stack
+                               :font-size "11px"
+                               :margin-top "4px"}}
+                 (cond-> "via "
+                   source (str source)
+                   (and source origin) (str " · origin ")
+                   (and (not source) origin) (str "origin ")
+                   origin (str origin))])])))
 
-(defn- subs-row
-  "Fifth domino: subscription work (`:sub/run` + `:sub/create`)."
-  [subs]
-  [domino-row {:label "subs" :tone :cyan}
-   (if (empty? subs)
-     [:span {:style {:color (:text-tertiary tokens)}} "(none)"]
-     (into [:div]
-           (for [ev subs]
-             ^{:key (:id ev)}
-             [:div {:style {:padding "2px 0"}}
-              [:span {:style {:color (:accent-violet tokens) :margin-right "8px"}}
-               (str (get-in ev [:tags :sub-id]))]
+;; ---- §3 INTERCEPTORS ---------------------------------------------------
+
+(defn- interceptor-testid-suffix
+  "Render an interceptor id into a stable testid suffix. Qualified
+  keywords (`:auth/require-login`) render as `auth/require-login`;
+  bare keywords use their name; non-keyword ids fall through `str`.
+  Used so the test asserting on a per-interceptor row testid sees the
+  same id the registration declares."
+  [id]
+  (cond
+    (qualified-keyword? id) (str (namespace id) "/" (name id))
+    (keyword? id)           (name id)
+    (nil? id)               "unknown"
+    :else                   (str id)))
+
+(defn- interceptor-row
+  [{:keys [id file line] :as _interceptor}]
+  (let [coord   (when (string? file) {:file file :line line})
+        display (format-coord-display coord)
+        suffix  (interceptor-testid-suffix id)]
+    [:div {:data-testid (str "rf-causa-event-detail-interceptor-row-" suffix)
+           :style {:display "flex"
+                   :align-items "center"
+                   :padding "2px 0"}}
+     [:span {:style {:color (:accent-violet tokens)
+                     :margin-right "12px"
+                     :min-width "180px"}}
+      (pr-str id)]
+     (if display
+       [:span {:style {:color (:text-secondary tokens)}}
+        display]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :font-style "italic"
+                       :font-size "11px"}}
+        "rf2 std-interceptor"])
+     (coord-chip coord
+                 (str "rf-causa-event-detail-interceptor-open-chip-" suffix))]))
+
+(defn- interceptors-section
+  "Silent-by-default per §4.2 — the section is ABSENT entirely when
+  the user has no non-standard interceptors. Pre-computed via
+  `user-interceptors` (test-level helper) before invoking this fn."
+  [user-icpts]
+  (when (seq user-icpts)
+    (section {:label "INTERCEPTORS"
+              :count* (count user-icpts)
+              :testid "rf-causa-event-detail-section-interceptors"}
+             (into [:div]
+                   ;; Per rf2-ppzid: `^{:key ...}` reader-meta on a fn
+                   ;; CALL FORM (a list) is lost — the fn returns a
+                   ;; fresh vector; `get-react-key` only reads :key
+                   ;; meta off the returned vector. `with-meta` on
+                   ;; the fn return preserves the key correctly.
+                   (for [icpt user-icpts]
+                     (with-meta (interceptor-row icpt)
+                                {:key (pr-str (:id icpt))}))))))
+
+;; ---- §4 HANDLER --------------------------------------------------------
+
+(defn- handler-section
+  "Renders the handler-meta read off `(rf/handler-meta :event id)`.
+  Per Q2: shows `reg-event-<kind>` flavour + source coord; does NOT
+  duplicate the event-id (already shown in §1)."
+  [event-id meta]
+  (let [kind   (:event/kind meta)
+        coord  (when (string? (:file meta))
+                 {:file (:file meta) :line (:line meta)})
+        display (format-coord-display coord)
+        flavour (case kind
+                  :db  "reg-event-db"
+                  :fx  "reg-event-fx"
+                  :ctx "reg-event-ctx"
+                  (if kind (str "reg-event-" (name kind)) "reg-event-?"))]
+    (section {:label "HANDLER"
+              :testid "rf-causa-event-detail-section-handler"}
+             [:div {:style {:display "flex" :align-items "center"}}
+              [:span {:data-testid "rf-causa-event-detail-handler-flavour"
+                      :style {:color (:cyan tokens)
+                              :font-weight 600
+                              :margin-right "8px"}}
+               flavour]
               [:span {:style {:color (:text-tertiary tokens)
-                              :font-size "11px"}}
-               (str (:operation ev))]])))])
+                              :margin-right "8px"}}
+               "·"]
+              (if display
+                [:span {:data-testid "rf-causa-event-detail-handler-coord"
+                        :style {:color (:text-primary tokens)}}
+                 display]
+                [:span {:data-testid "rf-causa-event-detail-handler-coord-absent"
+                        :style {:color (:text-tertiary tokens)
+                                :font-style "italic"}}
+                 (if event-id
+                   (str "no registration found for " (pr-str event-id))
+                   "no handler registered")])
+              (coord-chip coord "rf-causa-event-detail-handler-open-chip")])))
 
-(defn- renders-row
-  "Sixth domino: view renders."
-  [renders]
-  [domino-row {:label "renders" :tone :magenta}
-   (if (empty? renders)
-     [:span {:style {:color (:text-tertiary tokens)}} "(none)"]
-     (into [:div]
-           (for [ev renders]
-             ^{:key (:id ev)}
-             [:div {:style {:padding "2px 0"
-                            :color   (:text-primary tokens)}}
-              (inspector/inspect (get-in ev [:tags :render-key])
-                                 (str "event-detail/render/" (:id ev)))])))])
+;; ---- §5 EFFECTS RETURNED -----------------------------------------------
 
-(defn- other-row
-  "Spec 009 §`:op-type` vocabulary calls out non-domino traces (errors,
-  warnings, machine transitions, etc.). Surfaced under a final row so
-  the cascade record is fully accountable to its input."
-  [other]
-  (when (seq other)
-    [domino-row {:label "other" :tone :yellow}
-     (into [:div]
-           (for [ev other]
-             ^{:key (:id ev)}
-             [:div {:style {:padding "2px 0"}}
-              [:span {:style {:color (:yellow tokens) :margin-right "8px"}}
-               (str (:op-type ev))]
-              [:span {:style {:color (:text-secondary tokens)}}
-               (str (:operation ev))]]))]))
+(defn- effects-returned-row
+  [label value testid value-style]
+  [:div {:data-testid testid
+         :style {:display "flex"
+                 :align-items "flex-start"
+                 :padding "2px 0"}}
+   [:span {:style {:color (:accent-violet tokens)
+                   :min-width "180px"
+                   :margin-right "12px"}}
+    label]
+   [:span {:style (merge {:color (:text-primary tokens)
+                          :min-width 0
+                          :flex 1
+                          :word-break "break-word"}
+                         (or value-style {}))}
+    value]])
 
-;; ---- cascade list (when no dispatch-id selected) ------------------------
+(defn- hydration-issues-jump-button
+  []
+  [:div {:data-testid "rf-causa-event-detail-hydration-issues-jump"
+         :style {:padding "4px 0 0 192px"}}
+   [:button {:on-click #(rf/dispatch [:rf.causa/select-tab :issues]
+                                     {:frame :rf/causa})
+             :style {:background  "transparent"
+                     :color       (:accent-violet tokens)
+                     :border      (str "1px solid " (:border-default tokens))
+                     :padding     "1px 8px"
+                     :border-radius "3px"
+                     :cursor      "pointer"
+                     :font-family mono-stack
+                     :font-size   "10px"}}
+    "→ jump to Issues bisector"]])
+
+(defn- effects-returned-section
+  "§5. Silent-by-default per §7.3 — the section is ABSENT when neither
+  `:db` nor `:fx` was returned. Optionally surfaces the hydration-
+  outcome row when the focused event is `:rf.ssr/hydrated`."
+  [cascade]
+  (let [{:keys [fx db-present? present?]} (effects-returned cascade)
+        hydration  (hydration-outcome-row cascade)
+        mismatches (or (:mismatches hydration)
+                       (:rf.ssr/mismatches hydration)
+                       0)
+        db-row     (when db-present?
+                     (effects-returned-row
+                       ":db"
+                       "<… changed; see App-db tab …>"
+                       "rf-causa-event-detail-effects-returned-row-db"
+                       {:color (:text-tertiary tokens)
+                        :font-style "italic"}))
+        fx-row     (when (seq fx)
+                     (effects-returned-row
+                       ":fx"
+                       (inspector/inspect (vec fx) "event-detail/effects-returned/fx")
+                       "rf-causa-event-detail-effects-returned-row-fx"
+                       nil))
+        hyd-row    (when hydration
+                     (effects-returned-row
+                       ":rf.ssr/hydration-outcome"
+                       (inspector/inspect hydration
+                                          "event-detail/effects-returned/hydration")
+                       "rf-causa-event-detail-effects-returned-row-hydration"
+                       nil))
+        jump-row   (when (and hydration (pos? mismatches))
+                     (hydration-issues-jump-button))
+        rows       (filterv some? [db-row fx-row hyd-row jump-row])]
+    (when (or present? hydration)
+      (section {:label "EFFECTS RETURNED"
+                :testid "rf-causa-event-detail-section-effects-returned"}
+               (into [:div] rows)))))
+
+;; ---- §6 EFFECTS HANDLERS RAN -------------------------------------------
+
+(defn- dispatch-fx-summary
+  "Render the `:dispatch` fx-handler row's caption — `→ queued event
+  [:foo …]` plus a click-to-focus affordance when the child cascade is
+  resolvable. For v1 we surface the dispatched event vector verbatim;
+  the focus pivot needs the child cascade-id which the fx-args don't
+  always carry — the row is best-effort."
+  [fx-args]
+  (let [child-event (first fx-args)]
+    [:span
+     [:span {:style {:color (:text-secondary tokens)}}
+      "→ queued "]
+     [:span {:style {:color (:text-primary tokens)}}
+      (pr-str child-event)]]))
+
+(defn- managed-fx-record-for-row
+  "Find the managed-fx record that corresponds to a given fx-handled
+  row, keyed by `:origin-event-id` (the row's trace-event `:id`).
+  Returns nil for non-managed fxs."
+  [records origin-event-id]
+  (some (fn [rec]
+          (when (= origin-event-id (:origin-event-id rec))
+            rec))
+        records))
+
+(defn- fx-handler-row
+  "One row inside §6. Renders fx-id chip + tier-dot + status caption,
+  followed (when applicable) by an inline managed-fx record-panel
+  per §8.3."
+  [{:keys [fx-id fx-args operation id duration-ms]} managed-fx-record]
+  (let [status (fx-handled-status operation)
+        colour (fx-status-colour status)
+        suffix (interceptor-testid-suffix fx-id)]
+    [:div {:data-testid (str "rf-causa-event-detail-effects-ran-row-" suffix)
+           :style {:padding "4px 0"}}
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :gap "10px"
+                    :flex-wrap "wrap"}}
+      [:span {:style {:color (:accent-violet tokens)
+                      :min-width "160px"}}
+       (pr-str fx-id)]
+      (when duration-ms (tier-dot duration-ms))
+      [:span {:style {:color colour :font-weight 600 :font-size "11px"}}
+       (case status
+         :ok          "✓ handled"
+         :overridden  "◑ overridden"
+         :skipped     "○ skipped on platform"
+         :error       "✗ errored"
+         "—")]
+      (when (= :dispatch fx-id)
+        (dispatch-fx-summary fx-args))]
+     (when managed-fx-record
+       [:div {:data-testid (str "rf-causa-event-detail-effects-ran-managed-fx-"
+                                 (or id "x"))
+              :style {:margin "6px 0 4px 16px"}}
+        (managed-fx/record-panel managed-fx-record)])]))
+
+(defn- effects-handlers-ran-section
+  "§6. Silent-by-default per §7.3 — the section is ABSENT when no fx
+  handlers ran (e.g. a no-op `reg-event-db` returning the same db).
+  Inline-mounts the managed-fx record beneath its causing fx-handler
+  row per §8.3 (colocation)."
+  [cascade]
+  (let [rows    (effects-handlers-ran cascade)
+        records (managed-fx-h/cascade->managed-fx-records cascade)]
+    (when (seq rows)
+      (section {:label "EFFECTS HANDLERS RAN"
+                :count* (count rows)
+                :testid "rf-causa-event-detail-section-effects-ran"}
+               (into [:div]
+                     ;; Per rf2-ppzid — `with-meta` on the fn return,
+                     ;; not `^{:key ...}` on the call form.
+                     (for [{:keys [id] :as row} rows]
+                       (with-meta
+                         (fx-handler-row row (managed-fx-record-for-row records id))
+                         {:key id})))))))
+
+;; ---- handler-threw footnote --------------------------------------------
+
+(defn- handler-threw-footer
+  "Per §7.5 — the ONE inline cross-reference to Issues tab when the
+  handler threw. §5/§6 are suppressed (the handler never returned);
+  the footer offers the explicit jump."
+  []
+  [:div {:data-testid "rf-causa-event-detail-handler-threw-footer"
+         :style {:padding "10px 16px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size "12px"
+                 :font-style "italic"}}
+   "Handler threw — see Issues tab "
+   [:span {:style {:color (:red tokens) :font-weight 600}} "⚠"]
+   " for the exception detail."])
+
+;; ---- the lens (replaces v1 cascade-detail) -----------------------------
+
+(defn- event-lens
+  "Render the 6-section Event lens for a cascade. Replaces the v1
+  `cascade-detail` six-domino renderer per rf2-zh2qc."
+  [{:keys [dispatch-id frame event] :as cascade}]
+  (let [event-id   (when (vector? event) (first event))
+        meta       (when event-id (rf/handler-meta :event event-id))
+        user-icpts (user-interceptors (:interceptors meta))
+        threw?     (has-handler-exception? cascade)]
+    [:div {:data-testid "rf-causa-event-detail-cascade"
+           :data-dispatch-id (str dispatch-id)
+           :data-frame (str frame)}
+     (cascade-outcome-line cascade)
+     (event-section event)
+     (dispatch-site-section cascade)
+     (interceptors-section user-icpts)
+     (handler-section event-id meta)
+     (when-not threw?
+       (effects-returned-section cascade))
+     (when-not threw?
+       (effects-handlers-ran-section cascade))
+     (when threw?
+       (handler-threw-footer))]))
+
+;; ---- cascade-list (empty-state, survives from v1) -----------------------
+
+(defn- format-edn
+  [v]
+  (try
+    (pr-str v)
+    (catch :default _
+      (str v))))
 
 (defn- cascade-list-row
   "One row in the cascade-list view. Clicking the row fires the
@@ -378,14 +812,9 @@
    (format-edn (or event :ungrouped))])
 
 (defn- cascade-list
-  "Empty-state list of cascades for the user to click into. Until the
-  actions panel lands (rf2-5yriz) this is the primary way to select a
-  dispatch-id.
-
-  Silent-by-default (rf2-b9f6z) — no prose; the panel reflects the L2
-  event-list focus like every other panel. When the buffer has
-  cascades, the list itself is the only affordance; when the buffer is
-  empty, the container renders empty."
+  "Empty-state list of cascades for the user to click into. Silent-by-
+  default (rf2-b9f6z) — no prose; the panel reflects the L2 event-list
+  focus like every other panel."
   [cascades]
   [:div {:data-testid "rf-causa-event-detail-empty"
          :style       {:padding "16px"}}
@@ -402,53 +831,13 @@
                            :background (:bg-3 tokens)}}
         :row-fn   cascade-list-row}))])
 
-;; ---- cascade detail (when a dispatch-id is selected) --------------------
-
-(defn- cascade-detail
-  "The six-domino cascade for the selected dispatch-id. `cascade` is a
-  single cascade record per `re-frame.trace.projection/group-cascades`.
-
-  When the cascade contains managed-fx invocations (per
-  `panels/managed-fx-helpers/cascade->managed-fx-records`), the
-  wire-boundary diff template (rf2-uyp86 / F-C2) mounts below the
-  six-domino window as an inline `<div>` per record. Cascades without
-  managed-fx invocations render unchanged."
-  [{:keys [dispatch-id frame event handler fx subs renders other] :as cascade}]
-  (let [managed-fx-records (managed-fx-h/cascade->managed-fx-records cascade)]
-    [:div {:data-testid "rf-causa-event-detail-cascade"
-           :data-dispatch-id (str dispatch-id)
-           :data-frame (str frame)
-           :data-managed-fx-count (str (count managed-fx-records))
-           :style       {:padding "8px 0"}}
-     [:div {:style {:padding "0 12px 8px 12px"
-                    :font-family sans-stack
-                    :font-size   "12px"
-                    :color       (:text-tertiary tokens)}}
-      [:span "Cascade"]]
-     [:div {:style {:border-top (str "1px solid " (:border-subtle tokens))}}
-      [event-row event (trigger-handler-coord (or handler fx))]
-      (when handler [handler-row handler])
-      (when fx [fx-row fx])
-      [effects-row cascade]
-      [subs-row subs]
-      [renders-row renders]
-      (other-row other)]
-     (when (seq managed-fx-records)
-       (managed-fx/records-list managed-fx-records))]))
-
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The hero panel's root view. Subscribes to
-  `:rf.causa/event-detail` and renders either the cascade-detail
-  layout (when a dispatch-id is selected) or the cascade-list empty
-  state (when not).
-
-  Note: this panel has no internal back-link affordance — under the
-  4-layer chrome (rf2-lv9bc) the L2 event list is always visible
-  alongside the L4 detail, so a 'back to events' affordance is
-  meaningless. Selection is cleared by clicking a different cascade
-  row, or programmatically via `:rf.causa/clear-selected-dispatch-id`."
+  "The Event lens panel's root view. Subscribes to
+  `:rf.causa/event-detail` and renders either the 6-section
+  `event-lens` (when a cascade is focused) or the cascade-list empty
+  state (when not)."
   []
   (let [{:keys [selected-dispatch-id selected-dispatch-frame selected-cascade cascades]}
         @(rf/subscribe [:rf.causa/event-detail])]
@@ -460,16 +849,10 @@
                              :color          (:text-primary tokens)
                              :font-family    sans-stack
                              :font-size      "14px"}}
-     [:header {:style {:padding "16px 16px 8px 16px"}}
-      [:h1 {:style {:font-size   "16px"
-                    :font-weight 600
-                    :margin      0
-                    :color       (:text-primary tokens)}}
-       "Event detail"]]
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond
         (and selected-dispatch-id selected-cascade)
-        (cascade-detail selected-cascade)
+        (event-lens selected-cascade)
 
         selected-dispatch-id
         [:div {:data-testid "rf-causa-event-detail-orphaned"
@@ -493,8 +876,8 @@
 
 (defn install!
   "Idempotent install for the Event Detail panel's Causa-side
-  registrations (Phase 2, rf2-op3bz). Owns the selection slot the
-  panel + its cross-panel `:rf.causa/cascades` consumers read off:
+  registrations. Owns the selection slot the panel + its cross-panel
+  `:rf.causa/cascades` consumers read off:
 
     - `:rf.causa/selected-dispatch-id` sub (cascade selection)
     - `:rf.causa/event-detail` composite sub
@@ -505,8 +888,6 @@
   `registry.cljs` — it is shared with the Causality Graph and
   Performance panels."
   []
-  ;; The dispatch-id the user has drilled into. nil = empty state
-  ;; (cascade list, per spec/007-UX-IA.md §The default landing view).
   (rf/reg-sub :rf.causa/selected-dispatch-id
     (fn [db _query]
       (:dispatch-id (selected-ref (or (get db :selected-dispatch)
@@ -518,62 +899,20 @@
                                 (get db :selected-dispatch-id))))))
 
   ;; Event-detail composite — produces everything the panel needs in
-  ;; one read so the view stays a thin renderer. Shape:
+  ;; one read so the view stays a thin renderer. Reads the EFFECTIVE
+  ;; focused dispatch-id off the spine sub (`:rf.causa/focus`); spine
+  ;; auto-advances to head in `:live` mode, so the panel never pins
+  ;; to a stale id that `focus-cascade-reducer` last wrote.
   ;;
-  ;;     {:cascades             [...]   ; all cascades, oldest first
-  ;;      :selected-dispatch-id <id>    ; nil when no selection
-  ;;      :selected-cascade     {...}}  ; nil when no selection
-  ;;                                    ; OR when the id is no
-  ;;                                    ; longer in the buffer
-  ;;
-  ;; The projection runs against the live buffer on every recompute.
-  ;; Per spec/007-UX-IA.md §Performance budget the panel renders at
-  ;; most ~200 cascades; the projection is O(n) over the buffer.
-  ;;
-  ;; ## Spine-driven focus (rf2-s0s5x Phase A)
-  ;;
-  ;; The composite reads the EFFECTIVE focused dispatch-id off the
-  ;; spine sub (`:rf.causa/focus`) rather than the legacy
-  ;; `:selected-dispatch-id` slot. The spine composer auto-advances
-  ;; the effective id to head in `:live` mode (rf2-s0s5x §Live
-  ;; auto-follow); reading the legacy slot would leave this panel
-  ;; pinned to a stale id that `focus-cascade-reducer` last wrote.
-  ;; The legacy slot remains as a shim for older direct readers (the
-  ;; orphaned-branch caption, MCP probes) but the focused-cascade
-  ;; computation here is canonically off the spine.
+  ;; Per rf2-639lc Bug 1: if the spine landed on `:ungrouped` (the
+  ;; projection's catch-all bucket for registry-time emits / frame
+  ;; lifecycle outside a drain), fall back to the most recent ROUTED
+  ;; cascade so the L4 default-focus never lands on the projection's
+  ;; internal bucket.
   (rf/reg-sub :rf.causa/event-detail
-    ;; Signal layer: depend on the shared `:rf.causa/cascades`
-    ;; projection + the spine focus so this composite recomputes
-    ;; when either changes. The `:<-` chain is the only sub-
-    ;; registration form in v2 (per Spec 002 §Subscriptions composing
-    ;; — reg-sub-raw is dropped; see `re-frame.subs/parse-reg-sub-args`).
-    ;;
-    ;; Per rf2-639lc Bug 2: when the user has not explicitly selected a
-    ;; cascade (legacy `:selected-dispatch-id` slot nil), default-focus
-    ;; the head cascade so the L4 Event tab renders cascade DETAIL on
-    ;; first mount rather than the cascade-LIST landing view (the L2
-    ;; event list is the list affordance under the 4-layer chrome;
-    ;; rf2-lv9bc folded the panel-internal list into a landing
-    ;; placeholder, but on first mount with a populated buffer the
-    ;; user expects the detail of the latest event). The head-fallback
-    ;; lives at the composite layer (not the view) so consumers of
-    ;; `:rf.causa/event-detail` (the panel + its tests) all see the
-    ;; same effective selection.
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/focus]
     (fn [[cascades focus] _query]
-      ;; Phase A spine wiring: read the EFFECTIVE focused id off the
-      ;; spine sub. The spine composer already snaps to head in :live
-      ;; mode (compose-focus, rf2-s0s5x), so this composite no longer
-      ;; needs the legacy head-fallback when the slot is nil.
-      ;;
-      ;; rf2-639lc Bug 1 preserved: if the spine landed on `:ungrouped`
-      ;; (the projection's catch-all bucket for registry-time emits /
-      ;; frame lifecycle outside a drain), fall back to the most recent
-      ;; ROUTED cascade so the L4 default-focus never lands on the
-      ;; projection's internal bucket. The spine's head-cascade picks
-      ;; the structural last entry; this panel-side filter keeps the
-      ;; user-visible default focused on a real cascade.
       (let [focus-id       (:dispatch-id focus)
             focus-frame    (:frame focus)
             ungrouped?     (= :ungrouped focus-id)
@@ -601,30 +940,17 @@
   ;; Spine shim (rf2-adve5) — `:rf.causa/select-dispatch-id` is the
   ;; legacy entry point used by causality / machine-inspector /
   ;; issues-ribbon / performance / routes / schema-violation-timeline
-  ;; / trace / mcp-server. It now writes through the spine via the
-  ;; same reducer the spec-018 `:rf.causa/focus-cascade` event uses,
-  ;; so a click in any of those existing panels updates the
-  ;; `:rf.causa/focus` sub the next-generation Layer-2 event list
-  ;; will read. The reducer also continues writing the
-  ;; `:selected-dispatch-id` + `:selected-dispatch` legacy slots so
-  ;; this panel's own sub graph (and every consumer of those subs)
-  ;; keeps reading what it always has — the shim is transparent.
+  ;; / trace / mcp-server. It writes through the spine via the same
+  ;; reducer the spec-018 `:rf.causa/focus-cascade` event uses.
   (rf/reg-event-db :rf.causa/select-dispatch-id
     (fn [db [_ dispatch-id frame-id]]
       (let [history  (get db :epoch-history [])
             epoch-id (spine/epoch-id-for-cascade history dispatch-id)
-            ;; rf2-xzzih: clicking the head cascade should stay LIVE
-            ;; (auto-follow new arrivals); only non-head clicks pin
-            ;; to RETRO. Compute head off the same focusable filter
-            ;; the L2 list uses so the spine's notion of 'head'
-            ;; agrees with what the user sees as the latest row.
             head-id  (spine/focusable-head-id (spine/db->cascades db))]
         (spine/focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
 
   ;; Programmatic clear of the focused cascade. Resets the spine focus
-  ;; back to LIVE (head-tracking) per the rf2-s0s5x Phase A semantics —
-  ;; clearing means "go back to following the live stream", same
-  ;; outcome the user gets by clicking the LIVE pill.
+  ;; back to LIVE (head-tracking) per the rf2-s0s5x Phase A semantics.
   (rf/reg-event-db :rf.causa/clear-selected-dispatch-id
     (fn [db _event]
       (-> db

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -1,33 +1,29 @@
 (ns day8.re-frame2-causa.panels.event-detail-cljs-test
-  "Tests for the Causa event-detail hero panel (Phase 2, rf2-op3bz).
+  "Tests for the Causa Event lens panel (rf2-zh2qc — rewrite of the
+  v1 six-domino renderer per Mike's verbatim 6-section design).
 
-  ## Three contracts under test
+  ## What this suite covers
 
-  1. **Default-focus head cascade on cold start.** With trace events
-     in the buffer but no explicit selection (rf2-639lc Bug 2), the
-     panel's `:rf.causa/event-detail` composite sub defaults
-     `:selected-dispatch-id` to the head (most recent routed)
-     cascade so the view renders cascade DETAIL on first mount.
-     The pre-rf2-639lc landing-list behaviour was redundant under the
-     4-layer chrome — the L2 event list is always visible alongside
-     L4 so the panel-internal list never carried weight (rf2-lv9bc).
-
-  2. **Cascade detail when something is selected.** With a selection
-     set via `:rf.causa/select-dispatch-id`, the composite sub returns
-     the matching cascade record and the view renders the six-domino
-     rows.
-
-  3. **Clear selection.** Dispatching `:rf.causa/clear-selected-
-     dispatch-id` empties the explicit selection; the panel
-     default-focuses the head cascade again per (1).
+    1. Default-focus / cascade selection / clear (carried over from v1
+       — the panel's spine plumbing didn't change).
+    2. Cascade-outcome line (top-of-panel) — glyph + colour + SSR badge
+       per §5.1 + the hydration-outcome addendum.
+    3. The 6 sections render in order: EVENT, DISPATCH SITE,
+       INTERCEPTORS, HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN.
+    4. Silent-by-default — sections ABSENT (not '(none)') when their
+       data is empty.
+    5. Handler threw → §5/§6 suppressed + Issues-tab footer renders.
+    6. Pure projection helpers (`user-interceptors`, `cascade-outcome`,
+       `effects-handlers-ran`, `hydration-outcome-row`).
+    7. The meta-on-vector pattern (rf2-ppzid) — :key reaches every
+       row inside :for blocks.
 
   ## Pure-data scope
 
   The view is pure hiccup; the tests assert against the hiccup tree
-  rather than booting a substrate adapter / mounting to the DOM. This
-  keeps the suite fast and host-portable per the same node-test
-  rationale as `preload_cljs_test.cljs`."
+  rather than booting a substrate adapter / mounting to the DOM."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -44,10 +40,6 @@
 (defn- causa-init! []
   (causa-test-support/reset-all!)
   (trace-bus/clear-buffer!)
-  ;; Reset the :sensitive? privacy gate to its default (suppress) so the
-  ;; redaction-state tests below start from a known baseline regardless
-  ;; of test ordering or prior toggles. Symmetric with
-  ;; sensitive_trace_cljs_test's own fixture.
   (config/set-show-sensitive! false)
   (config/reset-suppressed-count!))
 
@@ -56,46 +48,52 @@
     {:adapter plain-atom/adapter
      :init-fn causa-init!}))
 
-;; ---- fixture trace stream ------------------------------------------------
+;; ---- fixture stream builders -------------------------------------------
 
 (defn- cascade-evs
-  "Produce a representative one-cascade event stream — same shape as
-  re-frame.trace.projection's own tests. `dispatch-id` rides on every
-  event's `:tags :dispatch-id` per rf2-g6ih4."
+  "Build the canonical Event-lens cascade stream for a given dispatch-
+  id + event vector. Mirrors v1 `cascade-evs` but additionally:
+
+    - Hoists `:rf.trace/call-site` to the top level of the
+      `:event/dispatched` trace (rf2-twt7m Change 1) so the DISPATCH
+      SITE section has data.
+    - Stamps `:source` + `:origin` (also top-level — `build-event`'s
+      success-path hoist).
+    - Stamps `:fx` + `:db-present?` on the `:event/do-fx` trace's
+      `:tags` (rf2-twt7m Change 2) so EFFECTS RETURNED has data."
   ([dispatch-id event-vec id-base]
    (cascade-evs dispatch-id event-vec id-base nil))
-  ([dispatch-id event-vec id-base frame-id]
-   [{:id (+ id-base 1) :op-type :event    :operation :event/dispatched
-     :tags (cond-> {:dispatch-id dispatch-id :event event-vec}
-             frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 2) :op-type :event    :operation :event
+  ([dispatch-id event-vec id-base {:keys [frame-id call-site source origin fx db-present?]
+                                    :or   {fx          [[:db nil] [:dispatch [:bar]]]
+                                           db-present? true
+                                           source      :ui
+                                           origin      :app}}]
+   [(cond-> {:id (+ id-base 1) :op-type :event :operation :event/dispatched
+             :tags (cond-> {:dispatch-id dispatch-id :event event-vec}
+                     frame-id (assoc :frame frame-id))}
+      call-site (assoc :rf.trace/call-site call-site)
+      source    (assoc :source source)
+      origin    (assoc :origin origin))
+    {:id (+ id-base 2) :op-type :event :operation :event
      :tags (cond-> {:dispatch-id dispatch-id :phase :run-start}
              frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 3) :op-type :event    :operation :event
-     :tags (cond-> {:dispatch-id dispatch-id :phase :run-end}
+    {:id (+ id-base 3) :op-type :event :operation :event
+     :tags (cond-> {:dispatch-id dispatch-id :phase :run-end :duration-ms 11}
              frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 4) :op-type :event    :operation :event/do-fx
+    {:id (+ id-base 4) :op-type :event :operation :event/do-fx
      :tags (cond-> {:dispatch-id dispatch-id}
+             frame-id    (assoc :frame frame-id)
+             fx          (assoc :fx fx)
+             db-present? (assoc :db-present? true))}
+    {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+     :tags (cond-> {:dispatch-id dispatch-id :fx-id :db :duration-ms 1}
              frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 5) :op-type :fx       :operation :rf.fx/handled
-     :tags (cond-> {:dispatch-id dispatch-id :fx-id :db}
-             frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 6) :op-type :fx       :operation :rf.fx/handled
-     :tags (cond-> {:dispatch-id dispatch-id :fx-id :dispatch}
-             frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 7) :op-type :sub/run  :operation :sub/run
-     :tags (cond-> {:dispatch-id dispatch-id :sub-id :sub/foo}
-             frame-id (assoc :frame frame-id))}
-    {:id (+ id-base 8) :op-type :view     :operation :view/render
-     :tags (cond-> {:dispatch-id dispatch-id :render-key [:app/root nil]}
+    {:id (+ id-base 6) :op-type :fx :operation :rf.fx/handled
+     :tags (cond-> {:dispatch-id dispatch-id :fx-id :dispatch :fx-args [[:bar]]
+                    :duration-ms 0}
              frame-id (assoc :frame frame-id))}]))
 
 (defn- seed-buffer!
-  "Register Causa's handlers, allocate the :rf/causa frame, then push
-  the supplied events through Causa's trace-bus atom via
-  `collect-trace!` — the production path. Per rf2-e9s81
-  `:rf.causa/trace-buffer` thunks the atom, so a subsequent
-  subscribe returns the events directly."
   [evs]
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {})
@@ -103,10 +101,6 @@
     (trace-bus/collect-trace! ev)))
 
 (defn- expand-fn-component
-  "When `node` is a hiccup-style `[fn-component args...]` vector
-  (first element is a function rather than a keyword/string), invoke
-  the fn with the rest of the args so the test can recurse into the
-  rendered sub-tree. Otherwise return the node unchanged."
   [node]
   (if (and (vector? node) (fn? (first node)))
     (apply (first node) (rest node))
@@ -115,17 +109,7 @@
 (defn- hiccup-seq
   "Walk a hiccup tree and emit every node (vectors only). Vectors
   whose first element is a function are invoked first so the walker
-  descends into the sub-tree they would render to.
-
-  ## Recursive descent through fn-components (rf2-6ja23)
-
-  `[handler-row handler]` is a fn-component vector — the walker must
-  invoke `handler-row` to get the inner hiccup and then keep
-  descending. tree-seq alone only walks the structural children of
-  the original tree; without an `expand-fn-component` step in the
-  `children` lambda, deep testids inside fn-component vector bodies
-  (e.g. the `rf-causa-event-detail-tier-dot-*` span inside
-  `handler-row`) are unreachable."
+  descends into the rendered sub-tree."
   [tree]
   (let [children (fn [node]
                    (let [expanded (expand-fn-component node)]
@@ -145,43 +129,35 @@
             node))
         (hiccup-seq tree)))
 
-;; ---- (1) initial state: LIVE auto-focuses head (rf2-s0s5x Phase A) ------
-;;
-;; Pre-rf2-s0s5x the panel landed on a cascade-list 'empty state' until
-;; the user clicked a row. Phase A makes the panel spine-driven —
-;; `:rf.causa/event-detail` reads its `:selected-dispatch-id` off the
-;; spine `:rf.causa/focus` sub. With no stored focus, the spine
-;; composer returns LIVE + head; the panel renders the head cascade's
-;; detail. The cascade-list landing page only renders when the buffer
-;; is empty (no head to focus on).
-;;
-;; This subsumes the rf2-639lc Bug 2 default-focus contract — the
-;; spine's LIVE-tracks-head semantics is the canonical implementation
-;; of "head is the default selection"; the panel-side filter below
-;; preserves rf2-639lc Bug 1 (skip the :ungrouped bucket).
+(defn- find-all-by-testid
+  "Find every node in a hiccup tree whose attrs map has the given
+  `:data-testid`. Returns a (possibly empty) vector — useful for
+  asserting on counts."
+  [tree testid]
+  (vec
+    (filter (fn [node]
+              (and (vector? node)
+                   (map? (second node))
+                   (= testid (:data-testid (second node)))))
+            (hiccup-seq tree))))
+
+;; ---- (1) selection plumbing — survives from v1 -------------------------
 
 (deftest live-focus-renders-head-cascade-detail
   (testing "with cascades in the buffer + no explicit selection, the
             spine LIVE-tracks head and the panel renders the head
-            cascade's detail (rf2-s0s5x Phase A / rf2-639lc Bug 2)"
+            cascade's detail"
     (seed-buffer! (concat (cascade-evs 100 [:user/login {:id 42}] 0)
                           (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
-      ;; Composite sub: effective selection is the head's dispatch-id.
       (let [data @(rf/subscribe [:rf.causa/event-detail])]
         (is (= 200 (:selected-dispatch-id data))
             "head cascade (200, latest) is the default selection"))
-      ;; View: cascade-detail container renders for the head, not the
-      ;; landing list.
       (let [tree (event-detail/Panel)]
         (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
             "cascade-detail container renders for the head cascade")
         (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "no empty-state container when there's a head to focus on")
-        (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
-            "panel-internal cascade list NOT rendered on default-focus
-             — the L2 event list (rf-causa-event-list) is the list
-             affordance under the 4-layer chrome (rf2-lv9bc)")))))
+            "no empty-state container when there's a head to focus on")))))
 
 (deftest cold-start-with-no-cascades-renders-empty-container
   (testing "with an empty buffer + no selection the panel still
@@ -189,456 +165,418 @@
     (seed-buffer! [])
     (rf/with-frame :rf/causa
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container present even with an empty buffer")
-        (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
-            "no cascade list when there are zero cascades")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "no cascade-detail when there is nothing to default-focus")))))
-
-(deftest cold-start-default-focus-skips-ungrouped-bucket
-  (testing "per rf2-639lc Bug 1 the head-fallback ignores the
-            `:ungrouped` cascade (registry-time emits / frame
-            lifecycle outside a drain). Synthesise a trace with a
-            real cascade plus a stray registry-time emit (no
-            :dispatch-id tag — lands in the :ungrouped bucket); the
-            default focus must land on the real cascade's id."
-    (seed-buffer!
-      (concat (cascade-evs 100 [:user/login] 0)
-              ;; Stray emit with no :dispatch-id — group-cascades
-              ;; routes this to the :ungrouped bucket.
-              [{:id 50 :op-type :registry :operation :sub/registered
-                :tags {:sub-id :foo/bar}}]))
-    (rf/with-frame :rf/causa
-      (let [data @(rf/subscribe [:rf.causa/event-detail])]
-        (is (= 100 (:selected-dispatch-id data))
-            "default-focus picks the routed cascade (100), not the
-             :ungrouped bucket")))))
-
-;; ---- (2) cascade-detail when a dispatch-id is selected ------------------
-
-(deftest cascade-detail-renders-six-dominoes
-  (testing "after selecting a dispatch-id the panel switches to the
-            cascade-detail layout"
-    (seed-buffer! (cascade-evs 100 [:user/login {:id 42}] 0))
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
-      (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail container present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state container absent once a selection is set")
-        ;; Per rf2-lv9bc — the panel-internal '← Events' back-link was
-        ;; a pre-4-layer-chrome leftover. Under the 4-layer chrome the
-        ;; L2 event list is always visible alongside the L4 detail, so
-        ;; the affordance is meaningless. Assert positively that no
-        ;; back-link is rendered in either the header (cascade view)
-        ;; or the orphaned branch.
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-back"))
-            "no internal '← Events' back-link in the header — L2 event
-             list is always visible alongside L4 detail (rf2-lv9bc)")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-empty")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade")))))))
 
 (deftest selecting-non-existent-dispatch-id-shows-orphaned-state
   (testing "selecting a dispatch-id that's not in the buffer surfaces
             the orphaned-selection branch"
-    (seed-buffer! (cascade-evs 100 [:user/login {:id 42}] 0))
+    (seed-buffer! (cascade-evs 100 [:user/login] 0))
     (rf/with-frame :rf/causa
-      ;; 999 is not in the buffer — the composite sub returns
-      ;; :selected-cascade=nil; the view should surface the
-      ;; orphaned-state branch rather than the cascade rows.
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 999])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
-            "orphaned-selection container present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail absent when the id has no matching cascade")
-        ;; rf2-lv9bc — the orphaned branch's '← Events' button was the
-        ;; same pre-4-layer-chrome leftover; under the chrome the L2
-        ;; list is always visible so the user picks another cascade
-        ;; directly. The handler (`:rf.causa/clear-selected-dispatch-id`)
-        ;; is retained for programmatic clear.
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-orphaned-back"))
-            "no '← Events' button in the orphaned branch (rf2-lv9bc)")))))
-
-(deftest frame-qualified-selection-renders-the-matching-cascade
-  (testing "same dispatch-id in two frames resolves to the selected frame's cascade"
-    (seed-buffer! (concat (cascade-evs 100 [:counter/a-inc] 0 :counter/a)
-                          (cascade-evs 100 [:counter/b-inc] 100 :counter/b)))
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100 :counter/b])
-      (let [data @(rf/subscribe [:rf.causa/event-detail])]
-        (is (= :counter/b (:selected-dispatch-frame data)))
-        (is (= :counter/b (get-in data [:selected-cascade :frame])))
-        (is (= [:counter/b-inc] (get-in data [:selected-cascade :event])))))))
-
-;; ---- (3) the select / clear events -------------------------------------
-
-(deftest select-dispatch-id-event-writes-to-causa-frame
-  (testing ":rf.causa/select-dispatch-id sets :selected-dispatch-id on
-            the :rf/causa frame's db (not the host's :rf/default)"
-    (seed-buffer! [])
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 42]))
-    (let [causa-db   (frame/frame-app-db-value :rf/causa)
-          default-db (frame/frame-app-db-value :rf/default)]
-      (is (= 42 (:selected-dispatch-id causa-db))
-          "selection lands on the Causa frame")
-      (is (nil? (:selected-dispatch-id default-db))
-          "selection did NOT leak into :rf/default"))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade")))))))
 
 (deftest clear-selected-dispatch-id-snaps-to-live-head
-  (testing "after select + clear the panel snaps back to LIVE
-            head-tracking (rf2-s0s5x Phase A / rf2-639lc Bug 2).
-            Clearing the selection means 'resume following the live
-            stream' — the spine resets to :live and the panel renders
-            the head cascade's detail."
+  (testing "after select + clear the panel snaps back to LIVE head-tracking"
     (seed-buffer! (concat (cascade-evs 100 [:user/login] 0)
                           (cascade-evs 200 [:user/logout] 100)))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (rf/dispatch-sync [:rf.causa/clear-selected-dispatch-id])
-      (let [data @(rf/subscribe [:rf.causa/event-detail])
-            tree (event-detail/Panel)]
-        (is (= 200 (:selected-dispatch-id data))
-            "after clear the focus snaps back to the head (200) via the
-             spine's LIVE head-tracking")
-        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "head cascade's detail renders after clear (LIVE auto-tracks head)")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "no empty-state container — LIVE is focused on the head cascade")))))
+      (let [data @(rf/subscribe [:rf.causa/event-detail])]
+        (is (= 200 (:selected-dispatch-id data)))))))
 
-;; ---- (5) edge cases: empty buffer / missing id / sensitive redacted ----
-;;
-;; Per rf2-dkmq5: the existing tests cover the happy path; this section
-;; extends to the edge cases listed in the bead's findings doc
-;; (`ai/findings/causa-test-coverage-20260513-1706.md` recommendation #8).
-;;
-;;   - Empty buffer with a selection set — the panel must render the
-;;     orphaned-state branch rather than crashing on a nil cascade.
-;;   - No selection (initial state, empty buffer) — per spec/007-UX-IA.md
-;;     §The default landing view the panel renders the empty-state
-;;     container with the "no cascades yet" placeholder copy.
-;;   - Sensitive-redacted state — when the privacy gate has dropped the
-;;     selected dispatch-id's trace events the panel renders the
-;;     orphaned branch AND the shell-level `:rf.causa/suppressed-
-;;     sensitive-count` sub reports the suppression so the bottom-rail
-;;     `[● REDACTED N]` marker (rf2-a6buk / PR #705) renders.
-;;   - Sensitive opt-in pass-through — flipping `:trace/show-sensitive?`
-;;     true lets the same cascade reach the buffer; the panel then
-;;     renders the six-domino layout with no suppression count.
+;; ---- (2) the 6 sections render in order --------------------------------
 
-(deftest empty-buffer-with-selection-renders-orphaned-state
-  (testing "selecting a dispatch-id when the buffer is empty surfaces
-            the orphaned-selection branch rather than the cascade rows
-            or a nil-deref crash"
-    (seed-buffer! [])
+(deftest event-lens-renders-all-six-sections-when-fully-populated
+  (testing "a cascade with call-site + fx + interceptors yields the
+            full 6-section layout: EVENT, DISPATCH SITE, INTERCEPTORS,
+            HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN"
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :widget/poke
+        [(rf/->interceptor :id :auth/require-login)]
+        (fn [_ _] {})))
+    (seed-buffer!
+      (cascade-evs 100 [:widget/poke {:id 1}] 0
+                   {:call-site {:file "src/widget.cljs" :line 42}
+                    :source :ui :origin :app
+                    :fx [[:db nil] [:dispatch [:bar]]]
+                    :db-present? true}))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 42])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
-            "orphaned-selection container present when buffer is empty")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail absent — there is no cascade to render")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-empty"))
-            "empty-state cascade-list absent — a selection is set, so the
-             panel is in detail mode not list mode")))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-event"))
+            "§1 EVENT section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-dispatch"))
+            "§2 DISPATCH SITE section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-interceptors"))
+            "§3 INTERCEPTORS section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-handler"))
+            "§4 HANDLER section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-effects-returned"))
+            "§5 EFFECTS RETURNED section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-effects-ran"))
+            "§6 EFFECTS HANDLERS RAN section present")))))
 
-(deftest no-selection-empty-buffer-renders-default-landing-view
-  (testing "per spec/007-UX-IA.md §Default landing view, the panel's
-            initial state (no selection, no events) renders the empty-
-            state container silently — per rf2-b9f6z the panel reflects
-            the L2 event-list focus like every other panel, so the
-            empty container carries no prose"
-    (seed-buffer! [])
+(deftest cascade-outcome-line-replaces-literal-event-detail-h1
+  (testing "the literal 'Event detail' h1 is gone; the cascade-outcome
+            line carries the event-id + outcome glyph + duration"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/causa
-      (let [tree    (event-detail/Panel)
-            empty   (find-by-testid tree "rf-causa-event-detail-empty")
-            ;; Flatten every text node under the empty-state container
-            ;; so the silent-by-default assertion is agnostic to the
-            ;; container's exact hiccup nesting.
-            text    (->> (hiccup-seq empty)
-                         (filter string?)
-                         (apply str))]
-        (is (some? empty)
-            "empty-state container present in the initial state")
-        (is (nil? (find-by-testid tree "rf-causa-cascade-list"))
-            "no cascade list when there are zero cascades")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "no cascade-detail container in the initial state")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-orphaned"))
-            "no orphaned-state container in the initial state")
-        (is (= "" text)
-            "silent-by-default — empty-state container carries no prose
-             (rf2-b9f6z: drop pre-spine 'pick from cascade list' wording)")))))
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            outcome (find-by-testid tree "rf-causa-event-detail-outcome")
+            event-id (find-by-testid tree "rf-causa-event-detail-outcome-event-id")
+            ok-glyph (find-by-testid tree "rf-causa-event-detail-outcome-glyph-ok")
+            text     (->> (hiccup-seq tree) (filter string?) (apply str))]
+        (is (some? outcome) "outcome line present")
+        (is (some? event-id) "event-id shown in outcome line")
+        (is (some? ok-glyph) "✓ glyph rendered for happy path")
+        (is (not (re-find #"Event detail" text))
+            "literal 'Event detail' h1 has been removed")))))
 
-(deftest sensitive-redacted-cascade-renders-orphaned-and-bumps-count
-  (testing "when the privacy gate drops a :sensitive? cascade entirely,
-            the selected dispatch-id has no buffer match — the panel
-            renders the orphaned branch AND the shell-level redaction-
-            count sub reports the suppression so the bottom rail's
-            [● REDACTED N] marker (rf2-a6buk / PR #705) renders.
+;; ---- (3) cascade-outcome glyph + SSR badge -----------------------------
 
-            The bump is driven through the reactive production event
-            `:rf.causa/note-sensitive-suppressed` (rf2-0vxdn) — same
-            path `trace-bus/collect-trace!` uses when it drops a
-            `:sensitive? true` trace event in CLJS. Dispatch-sync so
-            the sub fires before the next render."
-    (registry/register-causa-handlers!)
-    (frame/reg-frame :rf/causa {})
-    ;; Privacy gate at its default (suppress sensitive). Verify a
-    ;; sensitive event going through trace-bus's collector is dropped
-    ;; before the buffer (per Spec 009 §Privacy + rf2-azls9) — the
-    ;; cascade's events never land, so the selected dispatch-id
-    ;; resolves to no cascade.
-    (trace-bus/collect-trace! {:id 1
-                               :op-type :event
-                               :operation :event/dispatched
-                               :sensitive? true
-                               :tags {:dispatch-id 777
-                                      :event [:user/secret]
-                                      :frame :rf/default}})
-    (is (empty? (trace-bus/buffer))
-        "the :sensitive? event was dropped before the buffer push")
-    ;; Drive the redaction-count bump through the reactive path
-    ;; explicitly. (The collect-trace! call above also dispatches
-    ;; `:rf.causa/note-sensitive-suppressed`, but only when
-    ;; `:rf/default` exists in the runtime; the test fixture leaves
-    ;; the chain-routing detail to the shell-side tests.)
+(deftest cascade-outcome-error-glyph-when-handler-threw
+  (testing "a handler exception flips the outcome to ✗ error (red)"
+    (seed-buffer!
+      (conj (cascade-evs 100 [:foo] 0)
+            {:id 99 :op-type :error :operation :rf.error/handler-exception
+             :tags {:dispatch-id 100 :event-id :foo}}))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/default])
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 777])
-      (let [tree   (event-detail/Panel)
-            count* @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-orphaned"))
-            "orphaned-selection container present — the redacted cascade
-             never reached the buffer")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail absent — the redacted cascade has no rows
-             to render")
-        (is (pos? count*)
-            "the suppressed-sensitive-count sub reports the drop so the
-             shell's bottom-rail [● REDACTED N] marker renders")))))
-
-(deftest sensitive-cascade-with-opt-in-renders-detail
-  (testing "with (causa-config/configure! {:trace/show-sensitive? true})
-            the same `:sensitive? true` event is NOT suppressed by
-            the privacy gate — the predicate inverts and the cascade
-            reaches the buffer. The panel then renders the cascade
-            via the standard happy-path branch.
-
-            We seed the reactive app-db buffer slot directly (same
-            pattern the other tests use) so the assertion stays
-            substrate-agnostic; the privacy-gate predicate is the
-            unit under test here, not collect-trace!'s atom-swap
-            (which `sensitive_trace_cljs_test` covers exhaustively)."
-    (config/set-show-sensitive! true)
-    ;; First — assert the privacy-gate predicate's opt-in path: with
-    ;; show-sensitive? true, a sensitive event does NOT get suppressed.
-    (is (false? (config/suppress-sensitive?
-                  {:sensitive? true
-                   :tags {:dispatch-id 888 :event [:user/secret]}}))
-        "with show-sensitive? true, the privacy gate is inert")
-    ;; Then — drive the reactive buffer to the same shape `collect-
-    ;; trace!` would produce with the gate open, and assert the panel
-    ;; renders the cascade-detail layout (no orphaned branch, no
-    ;; suppressed-count bump).
-    (seed-buffer! (->> (cascade-evs 888 [:user/secret] 200)
-                       (map #(assoc % :sensitive? true))))
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 888])
-      (let [tree   (event-detail/Panel)
-            count* @(rf/subscribe [:rf.causa/suppressed-sensitive-count])]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-cascade"))
-            "cascade-detail renders the six-domino layout under the
-             opt-in flag")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-orphaned"))
-            "no orphaned-state when the cascade is in the buffer")
-        (is (zero? count*)
-            "the suppressed-count is zero — nothing was dropped")))))
-
-;; ---- (6) handler-row perf-tier dot (rf2-6ja23) --------------------------
-;;
-;; The rf2-6ja23 audit hoists the perf-tier ladder into `theme/perf_tier.cljc`
-;; and wires the first cross-panel consumer: the handler row already
-;; surfaces `:duration-ms` (as raw EDN text); the audit adds a coloured
-;; dot + label so the eye picks up the tier the same way it does on the
-;; Performance panel.
-;;
-;; The tests below assert the dot renders for each tier's representative
-;; duration. The dot's testid carries the tier suffix
-;; (`rf-causa-event-detail-tier-dot-<tier>`) so the assertion is precise.
-
-(defn- cascade-evs-with-duration
-  "Variant of `cascade-evs` where the `:run-end` handler trace carries
-  a `:duration-ms` tag. The handler-row should render a perf-tier dot
-  matching `(classify-tier duration-ms)`."
-  [dispatch-id event-vec id-base duration-ms]
-  (mapv (fn [ev]
-          (if (= :run-end (get-in ev [:tags :phase]))
-            (assoc-in ev [:tags :duration-ms] duration-ms)
-            ev))
-        (cascade-evs dispatch-id event-vec id-base)))
-
-(deftest handler-row-renders-fast-tier-dot
-  (testing "handler :duration-ms 5ms classifies as :fast — green dot"
-    (seed-buffer! (cascade-evs-with-duration 300 [:counter/inc] 300 5))
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 300])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
-            "fast-tier dot present alongside the :duration-ms text")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-error")))
+        (is (nil?  (find-by-testid tree "rf-causa-event-detail-outcome-glyph-ok")))))))
 
-(deftest handler-row-renders-medium-tier-dot
-  (testing "handler :duration-ms 30ms classifies as :medium — yellow dot"
-    (seed-buffer! (cascade-evs-with-duration 301 [:counter/inc] 310 30))
+(deftest cascade-outcome-warning-glyph-when-depth-exceeded
+  (testing "a depth-exceeded warning flips the outcome to ⚠ warning"
+    (seed-buffer!
+      (conj (cascade-evs 100 [:foo] 0)
+            {:id 99 :op-type :warning :operation :rf.warning/depth-exceeded
+             :tags {:dispatch-id 100}}))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 301])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium"))
-            "medium-tier dot present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-glyph-warning")))))))
 
-(deftest handler-row-renders-slow-tier-dot
-  (testing "handler :duration-ms 75ms classifies as :slow — orange triangle"
-    (seed-buffer! (cascade-evs-with-duration 302 [:counter/inc] 320 75))
+(deftest cascade-outcome-ssr-badge-when-hydrated
+  (testing ":rf.ssr/hydrated event surfaces the SSR✓ badge on the
+            outcome line"
+    (seed-buffer! (cascade-evs 100 [:rf.ssr/hydrated {:duration-ms 87 :mismatches 0}] 0))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 302])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow"))
-            "slow-tier dot present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-outcome-ssr-badge")))))))
 
-(deftest handler-row-renders-blocking-tier-dot
-  (testing "handler :duration-ms 250ms classifies as :blocking — red triangle"
-    (seed-buffer! (cascade-evs-with-duration 303 [:counter/inc] 330 250))
+(deftest cascade-outcome-no-ssr-badge-for-ordinary-event
+  (testing "ordinary client-only cascades do NOT carry the SSR badge"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 303])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking"))
-            "blocking-tier dot present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))))))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-outcome-ssr-badge")))))))
 
-(deftest handler-row-omits-tier-dot-when-duration-ms-absent
-  (testing "without :duration-ms on the :run-end emit, no tier-dot
-            renders — the audit only wires the dot to nodes that
-            carry a measurable duration"
-    ;; The baseline `cascade-evs` builder leaves :duration-ms unset.
-    (seed-buffer! (cascade-evs 304 [:counter/inc] 340))
+;; ---- (4) DISPATCH SITE section -----------------------------------------
+
+(deftest dispatch-site-renders-call-site-coord-and-open-chip
+  (testing "the DISPATCH SITE section reads :rf.trace/call-site off the
+            :event/dispatched trace (rf2-twt7m Change 1) and renders
+            both the coord display + the open-in-editor chip"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0
+                                {:call-site {:file "src/views.cljs" :line 127}
+                                 :source :ui :origin :app}))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 304])
-      (let [tree (event-detail/Panel)]
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast"))
-            "no tier-dot when :duration-ms is absent")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            coord (find-by-testid tree "rf-causa-event-detail-dispatch-coord")
+            chip  (find-by-testid tree "rf-causa-event-detail-dispatch-open-chip")
+            caption (find-by-testid tree "rf-causa-event-detail-dispatch-caption")
+            text  (->> (hiccup-seq coord) (filter string?) (apply str))]
+        (is (some? coord) "dispatch coord rendered")
+        (is (some? chip)  "open-in-editor chip rendered alongside coord")
+        (is (re-find #"src/views\.cljs:127" text)
+            "coord display includes the file:line")
+        (is (some? caption) "via :source · origin :origin caption rendered")))))
 
-(deftest handler-row-omits-tier-dot-when-duration-ms-is-non-numeric
-  (testing "a malformed :duration-ms tag (e.g. nil or a string) does
-            NOT render a tier-dot — the dot is gated on (number?
-            duration-ms) so the panel never surfaces a misleading
-            green dot for un-measurable nodes"
-    (seed-buffer! (cascade-evs-with-duration 305 [:counter/inc] 350 "not-a-number"))
+(deftest dispatch-site-without-call-site-renders-placeholder
+  (testing "when no :rf.trace/call-site is captured the DISPATCH SITE
+            section renders the absent placeholder (not the open chip)"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0 {:call-site nil}))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 305])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-fast")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-medium")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-slow")))
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-tier-dot-blocking")))))))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-dispatch-coord-absent")))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-dispatch-open-chip")))))))
 
-;; ---- (7) EFFECTS row — non-lying empty state (rf2-s0s5x Phase A) -------
-;;
-;; Per the bead's Bug 1: the EFFECTS row previously showed `(none)` on
-;; cascades whose handler returned only `:db` — `:event/db-changed`
-;; lives in the projection's `:other` bucket (no `:op-type :fx` is
-;; emitted for the framework-driven `:db` commit), so the row's
-;; `(empty? effects)` branch fired even though the user clearly saw
-;; the state change. The fix folds `:event/db-changed` in as a virtual
-;; `:db` entry alongside the standard fx-handled traces; the row now
-;; shows `(none)` only when neither signal is present (true silence).
+;; ---- (5) INTERCEPTORS section — silent-by-default ----------------------
 
-(defn- cascade-evs-db-only
-  "Pure-db cascade — like `cascade-evs` but instead of the two
-  `:rf.fx/handled` rows it emits one `:event/db-changed` so the
-  projection bucketises `:effects` as empty AND surfaces the db
-  commit in `:other`. Mirrors what `reg-event-db` produces in
-  production (the shop testbed's `:cart/add-item` is the canonical
-  repro)."
-  [dispatch-id event-vec id-base]
-  [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
-    :tags {:dispatch-id dispatch-id :event event-vec}}
-   {:id (+ id-base 2) :op-type :event :operation :event
-    :tags {:dispatch-id dispatch-id :phase :run-end}}
-   {:id (+ id-base 3) :op-type :event :operation :event/db-changed
-    :tags {:dispatch-id dispatch-id :event-id (first event-vec)}}
-   {:id (+ id-base 4) :op-type :event :operation :event/do-fx
-    :tags {:dispatch-id dispatch-id}}])
-
-(deftest effects-row-renders-db-when-db-changed-emitted
-  (testing "rf2-s0s5x Phase A — a reg-event-db cascade emits
-            `:event/db-changed` but no `:rf.fx/handled`; the EFFECTS
-            row surfaces a virtual `:db` entry so the panel doesn't
-            lie with `(none)` when the cascade committed a `:db`
-            effect"
-    (seed-buffer! (cascade-evs-db-only 400 [:counter/inc] 400))
+(deftest interceptors-section-absent-when-zero-non-standard
+  (testing "per §4.2 + §7.2 — when the event has no non-standard
+            interceptors the INTERCEPTORS section is ABSENT entirely
+            (silent-by-default, NOT '(none)' placeholder)"
+    (rf/with-frame :rf/default
+      (rf/reg-event-db :counter/inc (fn [db _] db)))
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 400])
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects"))
-            "EFFECTS row renders the entries list, not the (none) span")
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-db"))
-            "db row carries a stable testid")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects-none"))
-            "no (none) caption when an effect was committed")))))
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-interceptors"))
+            "INTERCEPTORS section absent when zero user interceptors")))))
 
-(deftest effects-row-renders-fx-entries-when-handled
-  (testing "an fx-bearing cascade emits one `:rf.fx/handled` per fx
-            handler invocation; the EFFECTS row lists each by fx-id +
-            operation. Same fixture as `cascade-detail-renders-six-
-            dominoes` — two :rf.fx/handled entries (`:fx-id :db` and
-            `:fx-id :dispatch`)."
-    (seed-buffer! (cascade-evs 401 [:counter/inc] 400))
+(deftest interceptors-section-renders-user-interceptors
+  (testing "with a user interceptor on the chain INTERCEPTORS is
+            shown with one row per non-default interceptor"
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :auth/login
+        [(rf/->interceptor :id :auth/require-login)
+         (rf/->interceptor :id :auth/log-action)]
+        (fn [_ _] {})))
+    (seed-buffer! (cascade-evs 100 [:auth/login] 0))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 401])
-      (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects")))
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-db"))
-            "fx-id :db row present (from the cascade-evs fixture)")
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-row-dispatch"))
-            "fx-id :dispatch row present")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects-none")))))))
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            section (find-by-testid tree "rf-causa-event-detail-section-interceptors")]
+        (is (some? section) "section rendered")
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-interceptor-row-auth/require-login")))
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-interceptor-row-auth/log-action")))))))
 
-(deftest effects-row-shows-none-when-truly-empty
-  (testing "a cascade with no fx-handled traces AND no db-changed
-            trace renders `(none)` — the empty-state is only a lie
-            when there's actual cascade work; the silent path stays
-            silent."
-    (seed-buffer! [{:id 1 :op-type :event :operation :event/dispatched
-                    :tags {:dispatch-id 500 :event [:noop]}}
-                   {:id 2 :op-type :event :operation :event
-                    :tags {:dispatch-id 500 :phase :run-end}}
-                   {:id 3 :op-type :event :operation :event/do-fx
-                    :tags {:dispatch-id 500}}])
+;; ---- (6) HANDLER section -----------------------------------------------
+
+(deftest handler-section-shows-flavour-and-source-coord
+  (testing "HANDLER section shows reg-event-* flavour (per Q2 — does
+            NOT duplicate the event-id)"
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :cart/add-item (fn [_ _] {})))
+    (seed-buffer! (cascade-evs 100 [:cart/add-item {:id 1}] 0))
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/select-dispatch-id 500])
-      (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-none"))
-            "(none) caption renders for a truly empty cascade")
-        (is (nil? (find-by-testid tree "rf-causa-event-detail-effects")))))))
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            flav (find-by-testid tree "rf-causa-event-detail-handler-flavour")
+            flav-text (->> (hiccup-seq flav) (filter string?) (apply str))]
+        (is (some? flav) "flavour caption rendered")
+        (is (= "reg-event-fx" flav-text)
+            "shows reg-event-fx flavour for :fx-kind handler")))))
 
-(deftest effects-entries-orders-db-first
-  (testing "the entries fn surfaces db before fx-vector entries —
-            matches the runtime ordering (db commit precedes the fx
-            walk per Spec 002 §Drain-loop pseudocode)"
-    (let [cascade {:effects [{:id 5 :op-type :fx :operation :rf.fx/handled
-                              :tags {:fx-id :dispatch}}]
-                   :other   [{:id 3 :op-type :event :operation :event/db-changed
-                              :tags {}}]}
-          entries (event-detail/effects-entries cascade)]
-      (is (= [:db :dispatch] (mapv :fx-id entries))
-          "db row first (cascade order), then fx vector entries"))))
+(deftest handler-section-absent-coord-when-no-registration
+  (testing "an event with no registered handler renders the absent
+            placeholder (the lens never crashes on an unregistered id)"
+    (seed-buffer! (cascade-evs 100 [:never-registered/event] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-handler-coord-absent")))))))
+
+;; ---- (7) EFFECTS RETURNED — silent-by-default + hydration row ----------
+
+(deftest effects-returned-renders-db-marker-and-fx-vector
+  (testing "rf2-twt7m Change 2 stamps :fx + :db-present? on
+            :event/do-fx — EFFECTS RETURNED surfaces both rows"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0
+                                {:fx [[:dispatch [:bar]]]
+                                 :db-present? true}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-returned-row-db"))
+            ":db marker row present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-returned-row-fx"))
+            ":fx vector row present")))))
+
+(deftest effects-returned-section-absent-when-no-effects
+  (testing "per §7.3 — when neither :fx nor :db is present, §5 is ABSENT"
+    (seed-buffer! (cascade-evs 100 [:noop/event] 0
+                                {:fx nil :db-present? false}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-effects-returned")))))))
+
+(deftest hydration-outcome-row-renders-for-rf-ssr-hydrated
+  (testing "the hydration-outcome addendum surfaces a dedicated row
+            when the focused event is :rf.ssr/hydrated"
+    (seed-buffer!
+      (concat (cascade-evs 100
+                            [:rf.ssr/hydrated {:duration-ms 87 :subs-ran 142 :mismatches 0}]
+                            0
+                            {:fx nil :db-present? false})
+              [{:id 50 :op-type :event :operation :rf.ssr/hydration-outcome
+                :tags {:dispatch-id 100 :duration-ms 87 :subs-ran 142 :mismatches 0}}]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-returned-row-hydration"))
+            "hydration-outcome row renders inside §5")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-hydration-issues-jump"))
+            "no jump-to-Issues affordance when :mismatches is 0")))))
+
+(deftest hydration-outcome-row-jumps-to-issues-when-mismatches-pos
+  (testing "when :mismatches > 0 the hydration row carries the
+            jump-to-Issues affordance"
+    (seed-buffer!
+      (concat (cascade-evs 100 [:rf.ssr/hydrated {:mismatches 3}] 0
+                            {:fx nil :db-present? false})
+              [{:id 50 :op-type :event :operation :rf.ssr/hydration-outcome
+                :tags {:dispatch-id 100 :duration-ms 91 :mismatches 3}}]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-hydration-issues-jump"))
+            "jump-to-Issues affordance renders when mismatches > 0")))))
+
+;; ---- (8) EFFECTS HANDLERS RAN — silent-by-default + managed-fx inline -
+
+(deftest effects-handlers-ran-renders-one-row-per-fx
+  (testing "EFFECTS HANDLERS RAN renders one row per :rf.fx/handled
+            trace, keyed by trace :id"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-ran-row-db")))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-effects-ran-row-dispatch")))))))
+
+(deftest effects-handlers-ran-section-absent-when-no-fx-ran
+  (testing "per §7.3 — when no fx-handlers ran, §6 is ABSENT"
+    (let [evs (filterv #(not= :rf.fx/handled (:operation %))
+                       (cascade-evs 100 [:noop/event] 0))]
+      (seed-buffer! evs))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-effects-ran")))))))
+
+(deftest effects-handlers-ran-mounts-managed-fx-record-inline
+  (testing "per §8.3 — when an fx-handler is a managed-fx surface
+            (:rf.http/* etc.) the managed-fx record-panel mounts
+            INLINE beneath its causing row, not in a trailing block"
+    (seed-buffer!
+      [{:id 1 :op-type :event :operation :event/dispatched
+        :tags {:dispatch-id 100 :event [:cart/refresh]}}
+       {:id 2 :op-type :event :operation :event
+        :tags {:dispatch-id 100 :phase :run-end :duration-ms 3}}
+       {:id 3 :op-type :event :operation :event/do-fx
+        :tags {:dispatch-id 100}}
+       {:id 4 :op-type :fx :operation :rf.fx/handled
+        :tags {:dispatch-id 100 :fx-id :rf.http/get :duration-ms 87
+               :source :http :origin :app}}])
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            inline (find-by-testid tree "rf-causa-event-detail-effects-ran-managed-fx-4")]
+        (is (some? inline)
+            "managed-fx record-panel mounts inline beneath fx-handler row")))))
+
+;; ---- (9) handler-threw footer + suppression of §5/§6 -------------------
+
+(deftest handler-threw-suppresses-effects-sections-and-renders-footer
+  (testing "per §7.5 — when the handler threw, §5 + §6 are absent and
+            the footer caption pointing at Issues tab renders"
+    (seed-buffer!
+      (concat (cascade-evs 100 [:checkout/submit] 0
+                            {:fx nil :db-present? false})
+              [{:id 50 :op-type :error :operation :rf.error/handler-exception
+                :tags {:dispatch-id 100 :event-id :checkout/submit
+                       :exception-message "NullPointerException"}}]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-handler-threw-footer"))
+            "footer caption renders when handler threw")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-effects-returned"))
+            "§5 EFFECTS RETURNED absent — handler never returned")
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-effects-ran"))
+            "§6 EFFECTS HANDLERS RAN absent — fx walk never started")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-event"))
+            "§1 EVENT still present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-handler"))
+            "§4 HANDLER still present")))))
+
+;; ---- (10) pure projection helpers --------------------------------------
+
+(deftest user-interceptors-filters-rf-default-flagged-entries
+  (testing "user-interceptors removes anything carrying :rf/default? true
+            (rf2-twt7m Change 3) — no allowlist needed"
+    (let [chain [{:id :rf/db-handler :rf/default? true :before identity}
+                 {:id :auth/require-login :before identity}
+                 {:id :path :before identity}]
+          user  (event-detail/user-interceptors chain)]
+      (is (= 2 (count user))
+          "the auto-wrapper is filtered; the user interceptor + std :path remain")
+      (is (= #{:auth/require-login :path} (set (map :id user)))))))
+
+(deftest user-interceptors-falls-back-to-allowlist-when-flag-missing
+  (testing "for legacy registrations missing the :rf/default? flag, the
+            three known auto-wrapper ids are still filtered as a
+            belt-and-braces fallback"
+    (let [chain [{:id :rf/db-handler :before identity}
+                 {:id :rf/fx-handler :before identity}
+                 {:id :rf/ctx-handler :before identity}
+                 {:id :user-icpt :before identity}]
+          user  (event-detail/user-interceptors chain)]
+      (is (= [:user-icpt] (map :id user))))))
+
+(deftest cascade-outcome-projection-shape-is-stable
+  (testing "cascade-outcome returns the documented keys"
+    (let [out (event-detail/cascade-outcome
+                {:event [:foo] :handler {:tags {:duration-ms 5}}
+                 :dispatch-id 1 :other []})]
+      (is (= #{:event-id :glyph :outcome :duration-ms :dispatch-id :ssr?}
+             (set (keys out)))))))
+
+(deftest effects-handlers-ran-projects-rows-from-effects-bucket
+  (testing "effects-handlers-ran reads cascade :effects directly"
+    (let [rows (event-detail/effects-handlers-ran
+                 {:effects [{:id 5 :operation :rf.fx/handled
+                             :tags {:fx-id :db}}
+                            {:id 6 :operation :rf.fx/handled
+                             :tags {:fx-id :dispatch :fx-args [[:foo]]}}]})]
+      (is (= [:db :dispatch] (mapv :fx-id rows)))
+      (is (= [:rf.fx/handled :rf.fx/handled] (mapv :operation rows)))
+      (is (= [5 6] (mapv :id rows))))))
+
+(deftest hydration-outcome-row-nil-for-ordinary-events
+  (testing "hydration-outcome-row returns nil unless the event is
+            :rf.ssr/hydrated / :rf.ssr/hydration-complete"
+    (is (nil? (event-detail/hydration-outcome-row
+                {:event [:counter/inc] :other []})))
+    (is (some? (event-detail/hydration-outcome-row
+                 {:event [:rf.ssr/hydrated]
+                  :other [{:operation :rf.ssr/hydration-outcome
+                           :tags {:mismatches 0 :duration-ms 87}}]})))))
+
+;; ---- (11) meta-on-vector pattern (rf2-ppzid) ---------------------------
+
+(deftest fx-rows-carry-distinct-react-keys
+  (testing "rf2-ppzid — `with-meta` on the fn return preserves :key on
+            each row inside :for. Without the wrapper Reagent's
+            `get-react-key` reads from the source list and gets nil for
+            every row, causing reconciliation churn + a console warning"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            rows (find-all-by-testid tree "rf-causa-event-detail-effects-ran-row-db")]
+        (is (= 1 (count rows))
+            "exactly one :db row rendered (sanity)")
+        (let [section (find-by-testid tree "rf-causa-event-detail-section-effects-ran")
+              body    (some #(when (and (vector? %)
+                                        (map? (second %))
+                                        (= "rf-causa-event-detail-section-effects-ran-body"
+                                           (:data-testid (second %))))
+                               %)
+                            (hiccup-seq section))
+              row-elts (->> (hiccup-seq body)
+                            (filter (fn [n]
+                                      (and (vector? n)
+                                           (map? (second n))
+                                           (let [tid (str (or (:data-testid (second n)) ""))]
+                                             (str/starts-with?
+                                               tid
+                                               "rf-causa-event-detail-effects-ran-row-"))))))]
+          (is (every? #(some? (:key (meta %))) row-elts)
+              "every fx row vector carries a :key in its meta"))))))

--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -390,3 +390,136 @@
                       (cascade-evs dispatch-id ev (* (inc i) 50))))
        (mapcat identity)
        vec))
+
+;; ---- event-lens variants (rf2-zh2qc) -----------------------------------
+;;
+;; Builders that exercise the redesigned Event lens's 6-section layout
+;; under realistic combinations of substrate keys (rf2-twt7m): the
+;; dispatch-site coord on :event/dispatched, the :fx + :db-present?
+;; tags on :event/do-fx, and (in tests) the :rf/default? flag on
+;; framework-auto-wrapped interceptors.
+
+(defn event-lens-simple-buffer
+  "Happy-path Event lens fixture — call-site captured, :fx + :db
+  returned, two fx-handlers ran. Renders all 6 sections including
+  HANDLER (when the variant pre-registers the handler) and the
+  EFFECTS RETURNED summary."
+  []
+  (let [dispatch-id 100
+        id-base     50
+        tag         {:dispatch-id dispatch-id}]
+    [(assoc {:id (+ id-base 1) :op-type :event :operation :event/dispatched
+             :tags (assoc tag :event [:cart/add-item {:id 42 :qty 2}])
+             :source :ui :origin :app}
+            :rf.trace/call-site
+            {:file "src/cart/views.cljs" :line 127})
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 11)}
+     {:id (+ id-base 4) :op-type :event :operation :event/do-fx
+      :tags (assoc tag :fx [[:dispatch [:notify "added"]]]
+                       :db-present? true)}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :dispatch :fx-args [[:notify "added"]]
+                       :duration-ms 0)}]))
+
+(defn event-lens-with-interceptors-buffer
+  "Event lens fixture with a user interceptor on the chain. Note: the
+  INTERCEPTORS section reads handler-meta off the registry at render
+  time, so this fixture pairs with a variant `:events` slot that
+  registers a real handler with the desired interceptor chain."
+  []
+  (event-lens-simple-buffer))
+
+(defn event-lens-many-fx-buffer
+  "Event lens fixture — six fx handlers ran in the cascade, including
+  one managed-fx (HTTP). Exercises the inline managed-fx mount under
+  §6."
+  []
+  (let [dispatch-id 200
+        id-base     200
+        tag         {:dispatch-id dispatch-id}]
+    [(assoc {:id (+ id-base 1) :op-type :event :operation :event/dispatched
+             :tags (assoc tag :event [:dashboard/refresh-all])
+             :source :ui :origin :app}
+            :rf.trace/call-site
+            {:file "src/dashboard/views.cljs" :line 88})
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 47)}
+     {:id (+ id-base 3) :op-type :event :operation :event/do-fx
+      :tags (assoc tag :fx [[:db nil] [:rf.http/get {:url "/api/stats"}]
+                            [:dispatch [:refresh-done]]]
+                       :db-present? true)}
+     {:id (+ id-base 4) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :db :duration-ms 1)}
+     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :rf.http/get :duration-ms 87
+                       :source :http :origin :app
+                       :fx-args [{:url "/api/stats"}])}
+     {:id (+ id-base 6) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :metrics :duration-ms 2)}
+     {:id (+ id-base 7) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :persist :duration-ms 3)}
+     {:id (+ id-base 8) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :navigate :duration-ms 1)}
+     {:id (+ id-base 9) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :dispatch :fx-args [[:refresh-done]]
+                       :duration-ms 0)}]))
+
+(defn event-lens-handler-threw-buffer
+  "Event lens fixture — handler threw mid-run. §5 + §6 should be
+  ABSENT; the cascade-outcome glyph is ✗ red and the Issues-tab
+  footer is the only inline cross-reference."
+  []
+  (let [dispatch-id 300
+        id-base     300
+        tag         {:dispatch-id dispatch-id}]
+    [(assoc {:id (+ id-base 1) :op-type :event :operation :event/dispatched
+             :tags (assoc tag :event [:checkout/submit {:order-id 42}])
+             :source :ui :origin :app}
+            :rf.trace/call-site
+            {:file "src/checkout/views.cljs" :line 203})
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-start)}
+     {:id (+ id-base 3) :op-type :error :operation :rf.error/handler-exception
+      :tags (assoc tag :event-id :checkout/submit
+                       :exception-message "NullPointerException at checkout/submit-h:88"
+                       :severity :error)}]))
+
+(defn event-lens-hydration-completed-buffer
+  "Event lens fixture — a :rf.ssr/hydrated completion event. Renders
+  the SSR✓ outcome-line badge plus the hydration-outcome row inside
+  §5. With :mismatches 0 there's no jump-to-Issues affordance."
+  []
+  (let [dispatch-id 400
+        id-base     400
+        tag         {:dispatch-id dispatch-id}]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags (assoc tag :event [:rf.ssr/hydrated {:duration-ms 87
+                                                  :subs-ran 142
+                                                  :mismatches 0}])
+      :source :ssr :origin :app}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 87)}
+     {:id (+ id-base 3) :op-type :event :operation :event/do-fx
+      :tags tag}
+     {:id (+ id-base 4) :op-type :event :operation :rf.ssr/hydration-outcome
+      :tags (assoc tag :duration-ms 87 :subs-ran 142 :mismatches 0)}]))
+
+(defn event-lens-hydration-mismatch-buffer
+  "Event lens fixture — hydration completed WITH mismatches. The
+  hydration-outcome row carries the jump-to-Issues affordance."
+  []
+  (let [dispatch-id 401
+        id-base     410
+        tag         {:dispatch-id dispatch-id}]
+    [{:id (+ id-base 1) :op-type :event :operation :event/dispatched
+      :tags (assoc tag :event [:rf.ssr/hydrated {:duration-ms 91 :mismatches 3}])
+      :source :ssr :origin :app}
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 91)}
+     {:id (+ id-base 3) :op-type :event :operation :event/do-fx
+      :tags tag}
+     {:id (+ id-base 4) :op-type :event :operation :rf.ssr/hydration-outcome
+      :tags (assoc tag :duration-ms 91 :subs-ran 142 :mismatches 3)}]))

--- a/tools/causa/testbeds/panel_gallery/gallery_event.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_event.cljs
@@ -216,6 +216,62 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- 13. event-lens 6-section happy path (rf2-zh2qc) -------------
+  (story/reg-variant :story.causa.event/lens-simple
+    {:doc        "Event lens 6-section default: EVENT + DISPATCH SITE
+                 + HANDLER + EFFECTS RETURNED + EFFECTS HANDLERS RAN
+                 all populated. INTERCEPTORS absent (silent-by-default
+                 — no user interceptors on the chain). Exercises the
+                 rf2-twt7m substrate keys end-to-end."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-simple-buffer)]
+                  [:rf.causa/select-dispatch-id 100 nil]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 14. event-lens with many fx + inline managed-fx ---------------
+  (story/reg-variant :story.causa.event/lens-many-fx
+    {:doc        "Event lens with six fx-handlers in §6 EFFECTS
+                 HANDLERS RAN, one of them a managed HTTP fx that
+                 mounts its record-panel INLINE beneath the row per
+                 §8.3 of the findings doc."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-many-fx-buffer)]
+                  [:rf.causa/select-dispatch-id 200 nil]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- 15. event-lens handler-threw -----------------------------------
+  (story/reg-variant :story.causa.event/lens-handler-threw
+    {:doc        "Handler threw mid-run. §5 EFFECTS RETURNED + §6
+                 EFFECTS HANDLERS RAN are ABSENT; the cascade-outcome
+                 glyph is ✗ red and the Issues-tab footer is the ONE
+                 inline cross-reference per §7.5."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-handler-threw-buffer)]
+                  [:rf.causa/select-dispatch-id 300 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 16. event-lens hydration completed (no mismatches) ------------
+  (story/reg-variant :story.causa.event/lens-hydration-completed
+    {:doc        ":rf.ssr/hydrated event — outcome line carries the
+                 SSR✓ badge; §5 carries the dedicated hydration-
+                 outcome row with :duration-ms / :subs-ran /
+                 :mismatches 0 (no jump-to-Issues affordance)."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-hydration-completed-buffer)]
+                  [:rf.causa/select-dispatch-id 400 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 17. event-lens hydration with mismatches ----------------------
+  (story/reg-variant :story.causa.event/lens-hydration-mismatches
+    {:doc        ":rf.ssr/hydrated event with :mismatches 3 — §5
+                 hydration-outcome row carries the jump-to-Issues
+                 affordance so the developer can pivot to the
+                 bisector."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-hydration-mismatch-buffer)]
+                  [:rf.causa/select-dispatch-id 401 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- workspace --------------------------------------------------
 
   (story/reg-workspace :Workspace.causa.event/all


### PR DESCRIPTION
## Summary

Rewrites `tools/causa/src/.../panels/event_detail.cljs` per Mike's verbatim 6-section design — replaces the v1 six-domino renderer with the Event lens shaped for Chrome-DevTools-style scanning. Consumes the three substrate keys rf2-twt7m landed in PR #1476.

Cite: [`ai/findings/2026-05-18-event-lens-design.md`](../blob/main/ai/findings/2026-05-18-event-lens-design.md) (gitignored) + Mike's Q1–Q5 answers in the bead body.

## The 6 sections (Mike's verbatim order — Q1 confirmed)

```
┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
│ ▼ EVENT                  [:cart/add-item {:id 42 :qty 2}]                            │
│ ▼ DISPATCH SITE          src/cart/views.cljs:127 [open ↗]                            │
│                          via :ui · origin :app                                       │
│ ▼ INTERCEPTORS (1)       :auth/require-login   src/auth/icpt.cljs:42 [open ↗]        │
│ ▼ HANDLER                reg-event-fx · src/cart/events.cljs:88 [open ↗]             │
│ ▼ EFFECTS RETURNED       :db   <… changed; see App-db tab …>                         │
│                          :fx   [[:http/post {…}] [:dispatch [:notify "added"]]]      │
│ ▼ EFFECTS HANDLERS RAN (2)                                                           │
│                          :http/post  ⏱ 87ms  ✓ handled                              │
│                            ┌─ MANAGED FX [HTTP] · :http/post · 87ms ──┐              │
│                            │ … inline mount per §8.3 …                │              │
│                            └────────────────────────────────────────────┘            │
│                          :dispatch  ⏱ <1ms  ✓ handled  → queued [:notify "added"]   │
└──────────────────────────────────────────────────────────────────────────────────────┘
```

## Substrate keys consumed (rf2-twt7m PR #1476)

| rf2-twt7m change | Where it rides | Consumed by |
|---|---|---|
| **Change 1** — `:rf.trace/call-site` on `:event/dispatched` success-path emits | Top-level on the trace event | §2 DISPATCH SITE coord chip |
| **Change 2** — `:fx` + `:db-present?` on `:event/do-fx` `:tags` | Per `:event/do-fx` emit | §5 EFFECTS RETURNED `:db` marker + `:fx` vector |
| **Change 3** — `:rf/default? true` on framework-auto-wrapped interceptors | `:interceptors` chain on handler-meta | §3 INTERCEPTORS filter (`user-interceptors`) |

Additional projection change in this PR: `re-frame.trace.projection/group-cascades` now retains the full `:event/dispatched` trace on a new `:dispatched` slot of the per-cascade record (purely additive — the slim `:event` slot still holds the vector).

## Edge cases (per findings §7)

- **No call-site** — DISPATCH SITE shows "source coord unavailable"; no chip.
- **No user interceptors** — INTERCEPTORS section ABSENT entirely (silent, NOT `(none)`).
- **No effects returned** — §5 ABSENT.
- **No fx handlers ran** — §6 ABSENT.
- **Handler threw** — §5 + §6 absent; footer points at Issues tab (the ONE inline cross-tab affordance per §7.5).
- **`:rf.ssr/hydrated` event** — outcome line carries SSR✓ badge; §5 carries the dedicated `:rf.ssr/hydration-outcome` row; jump-to-Issues affordance when `:mismatches > 0`.

## Commits

1. `feat(trace): projection retains :event/dispatched trace on :dispatched slot` — substrate-adjacent.
2. `feat(causa): Event lens 6-section rewrite of cascade-detail` — panel + tests cohesively (the rewrite is one logical change).
3. `chore(causa): panel-gallery fixtures for Event lens variants` — 5 new fixtures + 5 new story variants.
4. `docs(causa-spec): 018 §5.1 reflects shipped Event lens layout`.

## Test plan

- [x] `implementation/core` — `clojure -M:test -d test -n re-frame.trace.projection-test` → 15 tests, 51 assertions, 0 failures.
- [x] `tools/causa` — `clojure -M:test` → 697 tests, 2051 assertions, 0 failures.
- [x] `implementation` — `npm run test:cljs` (node CLJS) → 2864 tests, 8215 assertions, 0 failures.
- [x] `implementation` — `npx shadow-cljs compile testbeds/panel-gallery` → Build completed (no errors; 4 pre-existing infer-warnings in `elk_layout.cljs`).
- [x] `scripts/test-fast-pr.sh` → PASS fast PR spine.
- [ ] `mkdocs build --strict` — local mkdocs not installed; spec edit is conventional markdown (added ASCII block + bulleted prose; no anchor changes).
- [ ] `npm run test:browser` — covers panel_gallery scenarios end-to-end; not run locally (gated by Playwright); CI will run.