### PR TITLE
feat(causa): Routing tab (7th tab) — lens on focused event (rf2-nrbs9)

### DIFF
--- a/tools/causa/spec/000-Vision.md
+++ b/tools/causa/spec/000-Vision.md
@@ -66,9 +66,9 @@ parent → child, request → response, nav-1 → nav-2). These are the cases
 where stack traces are insufficient because the wall clock IS the bug
 surface.
 
-Causa does NOT fragment the chrome with per-area tabs (no Routes tab, no
-SSR tab, no managed-effects tab). Instead, each existing tab grows
-**deep specialised renderings** for the cross-cutting work that lands in it:
+Causa does NOT fragment the chrome with per-area tabs (no SSR tab, no
+managed-effects tab). Instead, each existing tab grows **deep specialised
+renderings** for the cross-cutting work that lands in it:
 
 - The Event tab grows a per-fx **wire-boundary diff** for managed effects
   (request → wire → response → handler → app-db slice).
@@ -79,6 +79,13 @@ SSR tab, no managed-effects tab). Instead, each existing tab grows
 - The Issues tab grows **nav-token timelines** (swimlanes), **hydration
   mismatch bisectors**, **server error projection traces**.
 - The Causality popover grows **machine-edge types** (spawn, final, join).
+
+The one exception — **Machines and Routing are themselves cohesive sub-
+domains** with a registered topology (state-chart / route tree) and per-event
+transitions, so they each earn a dedicated lens tab rather than landing in
+App-db (per Mike's design call 2026-05-18, rf2-nrbs9). The posture: cohesive
+sub-domains with a register-time topology AND a per-event transition story
+earn their own lens tab; everything else extends an existing tab.
 
 The five idioms — **wall-clock timelines · boundary diffs · cascade trees ·
 schema explanations · lifecycle accounting** — repeat across all four areas
@@ -178,18 +185,24 @@ Each row is "new in re-frame2 → new tooling story Causa tells."
 | **`register-epoch-cb!`** | The per-cascade listener routes the Event tab + Issues tab + Causality popover. |
 | **Schemas (Malli)** (Spec 010) | Schema-violation rows in the Issues tab; **per-violation drill** with full Malli explanation + recovery-mode classification + source-coord. |
 | **SSR + hydration** (Spec 011) | **Hydration mismatch bisector** — canonical-EDN dfs to the first divergent node; server vs client side-by-side per `get-in` path; sub-attribution (which sub returned `nil` server / `:en-US` client + why). **Streaming SSR boundary timeline.** **Per-request response accumulator inspector.** **Head model inspector.** **Server error projection trace** (the security boundary visualised). |
-| **Routing** (Spec 012) | Route is a sub-tree of app-db — surfaced in App-db tab; **nav-token timeline** (swimlanes) makes stale-clobber races literally visible; **`:on-match` chain explicit in Event tab**; **match-rank explainer**; **pending-navigation card**; **route-chain visualiser**. |
+| **Routing** (Spec 012) | Dedicated **Routing tab** carrying the full route tree as the orientation surface; per-focused-event lens with `◆ HERE` / `◆ FROM` / `◆ TO` glyphs (rf2-nrbs9). **Nav-token timeline** (swimlanes) makes stale-clobber races literally visible; **`:on-match` chain explicit in Event tab**; **match-rank explainer**; **pending-navigation card**; **route-chain visualiser**. |
 | **`:origin` opt on dispatch** | Filter by actor via ribbon IN/OUT pills. |
 | **Data classification** (Spec 015) | Path-marked sensitive + large rendering: `[● REDACTED N]` magenta opaque + `[● ELIDED N]` yellow drillable. See [`018-Event-Spine.md`](018-Event-Spine.md) §12 for the per-surface rendering contract. |
 | **Managed effects** (`spec/Managed-Effects.md` eight-property contract) | **Wire-boundary diff** in the Event tab's "fx handlers that ran" block — per fx, show request payload (post-elision) → wire transit (status / headers / timing waterfall) → response → handler dispatched → app-db slice touched. One template; five surfaces (HTTP, WebSocket, machine `:invoke`, SSR `:rf.server/*`, flows). **Active managed-effects dashboard** — Erlang-Observer for what the runtime is currently busy doing. **Stale-suppression badges** uniform across all four cross-cutting areas. |
 | **Production-elision verifier** | Causa runs `npm run test:elision` and warns before deploy if a dev sentinel leaked. |
 
-## The 6-tab inventory
+## The 7-tab inventory
 
-The legacy 16-panel sidebar is dead. Causa ships a **6-tab detail panel**
+The legacy 16-panel sidebar is dead. Causa ships a **7-tab detail panel**
 (Layer 3 of the 4-layer chrome). Each tab is one projection of the focused
 event; selection in the L2 event list rebinds every tab. Cross-cutting
 concerns extend each tab; they do NOT add new tabs.
+
+Per Mike's design call (2026-05-18, rf2-nrbs9) **Routing earned its own tab**
+— promoted from "lives in App-db + Trace" because the App-db panel was
+getting busy and the routing slice (route tree + current match + nav
+transitions) is a cohesive sub-domain. The rule that surfaced from the call:
+cohesive sub-domains earn their own lens tab rather than overloading App-db.
 
 | # | Tab | Mnem | What it shows | Spec |
 |---|---|---|---|---|
@@ -198,7 +211,8 @@ concerns extend each tab; they do NOT add new tabs.
 | 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; **subs nested under each view row** showing return values; **per-sub invalidation-chain drill** (why did this sub re-run); replaces the legacy Subs panel. | [`012-Views.md`](012-Views.md) |
 | 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to the focused cascade; **wall-clock axis** for timer rings, retry waterfalls, deferred-dispatch arrivals; trace-type toggle row + IN/OUT pills + sensible defaults. | [`013-Trace-Bus.md`](013-Trace-Bus.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.3 |
 | 5 | **Machines** | `m` | UC1 (definition + sim) + UC2 (Mode A/B/C dynamic instances); supervision tree; **`:after`-timer countdown rings**; **cancellation cascade visualiser**; **`:invoke-all` join inspector**; **per-instance "why am I stuck" trace strip**; **hierarchical cascade animator**; **shift-click divergence highlighter**; **per-instance mini-scrubber**. MachineChart is Causa-internal. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
-| 6 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns + **flow cascade-halt alarms** + **open-redirect advisories** + **`:platforms` skip tallies** + **stale-suppression group**. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon + [`018-Event-Spine.md`](018-Event-Spine.md) §5.4 |
+| 6 | **Routing** | `r` | Always-on **route tree** (the orientation surface — every registered route). Per-focused-event lens: **`◆ HERE`** on the current matched route · **`◆ FROM` / `◆ TO`** when the focused cascade caused navigation · params + query for the active route. Silent when no routes registered. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab + [`018-Event-Spine.md`](018-Event-Spine.md) §5.6 |
+| 7 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns + **flow cascade-halt alarms** + **open-redirect advisories** + **`:platforms` skip tallies** + **stale-suppression group**. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon + [`018-Event-Spine.md`](018-Event-Spine.md) §5.4 |
 
 **Popovers** (transient overlays, invokable from any tab):
 

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -2,8 +2,8 @@
 
 The normative home for the per-tab content contracts beyond the hero
 4-layer chrome architecture in
-[`018-Event-Spine.md`](./018-Event-Spine.md). The 6-tab inventory in
-[`000-Vision.md`](./000-Vision.md) §The 6-tab inventory is the
+[`018-Event-Spine.md`](./018-Event-Spine.md). The 7-tab inventory in
+[`000-Vision.md`](./000-Vision.md) §The 7-tab inventory is the
 top-level navigation map; this doc gives the per-tab implementation
 contract a one-shot implementer needs — inputs (subs / events
 consumed), main interactions, observable outputs — without having to
@@ -15,7 +15,7 @@ The per-tab content this doc covers:
 |---|---|---|
 | Event tab content (fattened) | `event-detail` | Phase 2 (rf2-op3bz) + folds in former Effects panel content |
 | Issues tab content | `issues-ribbon` | Phase 5 (rf2-d1p4o); unified feed per [`018-Event-Spine.md`](./018-Event-Spine.md) §5.4 |
-| Routes (lives in App-db tab + Trace tab) | `routes` | Phase 5 (rf2-6blai); see §Routes content below |
+| Routing tab content (7th tab) | `routing` | rf2-nrbs9 — promoted from "lives in App-db + Trace" to its own L3 lens tab; see §Routing tab below |
 | Flows (lives in Views tab "Re-rendered" group) | `flows` | Phase 5 (rf2-83irn); see §Flows content below |
 
 ### Performance — dropped (cross-link to Chrome DevTools)
@@ -229,26 +229,102 @@ Per-cascade tier dots + duration ms stay inline in:
 
 That's the entire Causa-side perf surface post-rewrite.
 
-## Routes content — folded into App-db tab + Trace tab
+## Routing tab — 7th L3 tab (rf2-nrbs9)
 
-The pre-rewrite Routes panel is GONE. Route state is a sub-tree of
-app-db; the navigation timeline is trace data. Both surfaces are
-reachable in their respective tabs:
+Per Mike's design call (2026-05-18) Routing was promoted from "lives
+in App-db + Trace" to its own L3 lens tab. The App-db panel was
+getting busy and routing is a cohesive sub-domain (route tree +
+current match + nav transitions); cohesive sub-domains earn their own
+lens tab rather than overloading App-db. Parallel to the Machines tab
+in posture — always-on registered topology + per-focused-event lens.
 
-- **Active route + params** — the focused frame's `:rf/route` slice
-  appears in the **App-db tab** under the path `[:rf/route]` (or
-  whatever the frame stores it at). Diff is rendered like any other
-  app-db slice. Pin via right-click → "Pin watch".
-- **Navigation history** — `:rf.route.nav-token/*` + `:rf.route/url-changed`
-  trace events appear in the **Trace tab** when the `event` chip is
-  ON (default).
-- **Registered routes overview** — reachable via the Cmd-K palette
-  under the `:route` source: route-id, path-pattern, `:doc`. No
-  standalone tab.
+### Inputs
 
-The transition FSM state (`:idle` / `:loading` / `:error`) is part of
-the app-db slice and renders inline with the same colour-with-glyph
-treatment as before.
+- `:rf.causa/registered-routes` — flat `{<route-id> <meta>}` map
+  sourced from `(rf/registrations :route)` (the framework's
+  registrar). Falls back to a test-only override slot for fixtures
+  + JVM tests.
+- `:rf.causa/current-route-slice` — composite over `:rf.causa/target-
+  frame-db` reading the `:rf/route` slice. Switching the L1 frame
+  picker re-binds the lens to the new frame's route slice.
+- `:rf.causa/cascades` — the shared cascade projection. The composite
+  scans the focused cascade's trace events for the routing-emit.
+- `:rf.causa/focus` — the spine's focused dispatch-id + epoch.
+- `:rf.causa/routing-tab-data` — view-facing composite folding all of
+  the above into `{:silent? :routes :current :from-id :to-id
+  :navigated?}` per `routing_helpers/project-data`.
+
+### Lens model
+
+Always-shown structure: the **full route tree** — every registered
+route, sorted by path so siblings under a common prefix render
+contiguously and the rendering is deterministic. The tree is the
+orientation surface — a Causa user can flip to the Routing tab and
+immediately read the app's routing topology without digging through
+code.
+
+Per-focused-event highlighting:
+
+| Marker | Trigger | Visual |
+|---|---|---|
+| `◆ HERE` | Current matched route — always when no navigation happened | Violet chip (`accent-violet`); left-border accent |
+| `◆ FROM` | Cascade caused navigation — the prior route | Cyan chip; left-border accent |
+| `◆ TO` | Cascade caused navigation — the new route | Green chip; left-border accent; replaces `◆ HERE` (TO is the new HERE) |
+
+When the focused cascade has no routing impact, only `◆ HERE`
+surfaces — orientation glyph.
+
+### Detection contract — how the panel knows the cascade caused navigation
+
+The composite scans the focused cascade's trace events for a
+`:rf.route.nav-token/allocated` emit (per
+[`spec/012-Routing.md`](../../../spec/012-Routing.md) — the emit fires
+inside both `:rf.route/navigate` and `:rf/url-changed`). Detection:
+
+- The emit's `:tags :route-id` is the **TO** (the new route).
+- The current `:rf/route` slice's `:id` (when different from TO) is
+  the **FROM**.
+- Same-route re-navigations (different params/query, same route-id)
+  collapse FROM to nil — surfacing a FROM equal to TO is noise.
+
+### Active route slice — params + query + fragment
+
+Below the tree the panel renders a labelled grid for the active
+slice:
+
+    Params:    {:order-id "ord-1234"}
+    Query:     {:source "cart"}
+    Fragment:  "#step-3"
+
+Absent slots render as `—` so the lens always shows the same
+skeleton (predictable scanning).
+
+### Empty state
+
+When the host app registers no routes the panel renders only the
+header + a terse `No routes registered.` one-liner. No `(none)`
+placeholder, no marketing copy — silent-by-default per rf2-g3ghh.
+
+### Pre-rewrite app-db / trace overlap
+
+The transition FSM state (`:idle` / `:loading` / `:error`) is still
+part of the app-db slice (Spec 012) and still visible in the App-db
+tab's diff. The Routing tab is the dedicated lens; the App-db tab
+shows the raw slice diff like any other key. Navigation trace events
+(`:rf.route.nav-token/*` + `:rf.route/url-changed`) continue to
+appear in the Trace tab when the `event` chip is ON (default) —
+the Routing tab does not duplicate the firehose, it projects the
+single nav-event that pertains to the focused cascade.
+
+### Vision (future)
+
+- **Nav-token timeline (swimlanes)** popover trigger from the tab.
+- **`:on-match` chain explicit** in the Event tab's "fx handlers
+  that ran" block when the focused cascade is a routing cascade
+  (already noted under §Event tab — `:on-match` event chain (Routes)
+  later in this doc).
+- **Route-chain visualiser** — the `:parent`-chain walk for nested
+  layouts.
 
 ## MCP Server panel — dropped
 
@@ -517,6 +593,12 @@ the App-db tab under a `[reserved]` group banner, always-expanded,
 with each sub-key on its own line. See
 [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.2 R.11.
 
+Note that the Routing tab (§Routing tab above, rf2-nrbs9) is the
+primary lens for routing — including the route tree, current match,
+and FROM/TO nav transitions. The App-db slice pin is the raw-data
+echo for users who want to inspect the slice alongside other app-db
+state.
+
 ### Settings popup — full 6-section catalogue
 
 v1 ships the Settings popup with **4 sections** (Theme, Density,
@@ -571,5 +653,8 @@ tooltips; machine-edge types. See
   surfaces.
 - [`spec/013-Flows.md`](../../../spec/013-Flows.md) — what the Views
   tab surfaces (under "Re-rendered" group).
-- [`spec/012-Routing.md`](../../../spec/012-Routing.md) — route slice
-  appears in App-db tab; navigation timeline in Trace tab.
+- [`spec/012-Routing.md`](../../../spec/012-Routing.md) — the
+  framework substrate the Routing tab projects: the registrar
+  (`reg-route` + `(rf/registrations :route)`), the `:rf/route` slice,
+  and the `:rf.route.nav-token/allocated` emit the panel scans for
+  the FROM/TO marker derivation.

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -1,8 +1,8 @@
 # 018-Event-Spine
 
-The architectural core of Causa: the **4-layer chrome** + the **6-tab detail panel** + the **single-axis spine sub** (`:rf.causa/focus`) that binds every dependent surface to one user-controlled focal point.
+The architectural core of Causa: the **4-layer chrome** + the **7-tab detail panel** + the **single-axis spine sub** (`:rf.causa/focus`) that binds every dependent surface to one user-controlled focal point.
 
-This spec replaces the legacy 16-panel sidebar (now dead — see [`000-Vision.md`](000-Vision.md) §The 6-tab inventory and [`007-UX-IA.md`](007-UX-IA.md) §The 4-layer chrome) with a denser, keyboard-mnemonic, 10x-shaped layout. The event list is the load-bearing layer; every panel rebinds when selection moves.
+This spec replaces the legacy 16-panel sidebar (now dead — see [`000-Vision.md`](000-Vision.md) §The 7-tab inventory and [`007-UX-IA.md`](007-UX-IA.md) §The 4-layer chrome) with a denser, keyboard-mnemonic, 10x-shaped layout. The event list is the load-bearing layer; every panel rebinds when selection moves.
 
 ---
 
@@ -276,12 +276,12 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 
 ## §5 Tab bar + detail panel (Layers 3 + 4)
 
-### The 6 tabs
+### The 7 tabs
 
 ```
-┌──────────────────────────────────────────────────────────────────────────────────┐
-│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ⚠Issues 1                    │   L3
-└──────────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ○Routing  ⚠Issues 1                  │   L3
+└──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 | # | Tab | Mnem | What it shows for the focused event | Spec |
@@ -291,7 +291,8 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 | 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; each row lists subs used + sub return values; cluster-large-grids; isolation-scoped to selected frame | [`012-Views.md`](012-Views.md) |
 | 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to `:dispatch-id = <focus>`; trace-type toggle row at top + IN/OUT pills + sensible defaults | this doc §5.3 + [`013-Trace-Bus.md`](013-Trace-Bus.md) |
 | 5 | **Machines** | `m` | UC1 (definition + sim) + UC2 (Mode A/B/C dynamic instances); supervision tree | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
-| 6 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns | this doc §5.4 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon |
+| 6 | **Routing** | `r` | Always-on **route tree** (orientation surface); per-focused-event lens with `◆ HERE` on the current matched route + `◆ FROM` / `◆ TO` arrow when the cascade caused navigation; params + query for the active route. Silent when no routes registered. | this doc §5.6 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab |
+| 7 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns | this doc §5.4 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon |
 
 **Causality is a popover, not a tab** — invoked via `c` from any tab; see §10.
 
@@ -304,9 +305,9 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 ### Tab strip rendering
 
 ```
-┌──────────────────────────────────────────────────────────────────────────────────┐
-│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ⚠Issues 1                    │
-└──────────────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────────────────┐
+│ ◉Event  ○App-db  ○Views 8  ○Trace 47  ○Machines 1  ○Routing  ⚠Issues 1                  │
+└──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 - **Active:** `◉` gutter + 2px violet underline + `text-primary`.
@@ -316,7 +317,7 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 - **Dormant tab:** `text-disabled` + `○`; clickable → empty state.
 - **Count flash on LIVE update:** count flashes violet 200ms then settles. No continuous spinner.
 
-Single-row at all widths. Below 800px labels truncate to 3 chars (`Eve App Vie Tra Mac Iss`); counts always full. Below 560px the strip scrolls horizontally.
+Single-row at all widths. Below 800px labels truncate to 3 chars (`Eve App Vie Tra Mac Rou Iss`); counts always full. Below 560px the strip scrolls horizontally.
 
 ### Detail panel layout
 
@@ -518,6 +519,30 @@ Default scope = "All issues this session." Toggle to "Spine cascade only" to fil
 ### §5.5 Machines tab — see [`003-Machine-Inspector.md`](003-Machine-Inspector.md)
 
 Briefly: UC1 sim sub-mode (entry toggle; event picker; guards evaluated against mocked `:data`; failed-guard transitions listed greyed with Shift+Enter to fire-despite) + UC2 dynamic Mode A/B/C view modes (A=zero instances · B=1-3 instances on shared topology with per-instance hues · C=4+ instances with Erlang-Observer virtualised table + cluster-by-state count badges + shift-click divergence) + full XState parity for actor lifecycle (invoke auto-cleanup; spawn explicit; parent-stop cascades).
+
+### §5.6 Routing tab — parallel to Machines (rf2-nrbs9)
+
+The 7th tab — promoted from "lives in App-db + Trace" to its own lens tab per Mike's design call (2026-05-18). The full content contract lives in [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab; this section locks the L4 detail-panel switch entry + the lens model the Event-Spine asserts.
+
+**Always-shown structure:** the **full route tree** (every route registered via `re-frame.routing/reg-route`, sorted by path). This is the orientation surface — flipping to the Routing tab immediately reveals the app's routing topology without forcing the user to dig through code.
+
+**Per-focused-event highlighting** (parallel to the Machines tab's focused-event lens):
+
+| Marker | When | Visual |
+|---|---|---|
+| `◆ HERE` | The current matched route, always | Violet chip (`accent-violet`); left-border accent |
+| `◆ FROM` | Cascade caused navigation — the prior route | Cyan chip; left-border accent |
+| `◆ TO` | Cascade caused navigation — the new route | Green chip; left-border accent |
+
+When `◆ TO` is set, `◆ HERE` collapses into it — TO is the new HERE. When the focused cascade has no routing impact, only `◆ HERE` surfaces (orientation only).
+
+**Detection contract:** the panel scans the focused cascade's trace events for a `:rf.route.nav-token/allocated` emit (per [`spec/012-Routing.md`](../../../spec/012-Routing.md) — the emit fires inside both `:rf.route/navigate` and `:rf/url-changed`). The emit's `:tags :route-id` is the TO; the current `:rf/route` slice's `:id` (when different) is the FROM. Same-route re-navigations (different params/query, same route-id) collapse FROM — surfacing a FROM equal to TO is noise.
+
+**Below the tree:** params + query + fragment for the active route slice. Rendered as a labelled grid so the lens always shows the same skeleton (predictable scanning); absent slots render as `—`.
+
+**Silent state.** When the host app registers no routes the panel renders only the header + a terse `No routes registered.` one-liner. No `(none)` placeholder, no marketing copy (silent-by-default per rf2-g3ghh).
+
+**L4 case-switch entry.** The detail panel's case-switch (`shell.cljs` §L4 detail panel) routes `:routing → [routing/Panel]`. The panel reads `:rf.causa/routing-tab-data`, a composite over `:rf.causa/registered-routes` + `:rf.causa/current-route-slice` + `:rf.causa/cascades` + `:rf.causa/focus`.
 
 ---
 
@@ -982,7 +1007,7 @@ Complete map for the spine + chrome:
 |---|---|
 | **Ribbon nav cluster** | `j` back-one-event · `k` forward-one-event · `G` fast-forward-to-latest (= `⏭`, snap LIVE) |
 | **Event list (L2)** | `j` / `k` next/prev (alias of ribbon nav) · `J` / `K` cascade-root skip · `g g` / `G` top/bottom · `Enter` activate · `Space` pause auto-scroll · `[` / `]` (10x parity = `j`/`k`) · `*` pin · `r` rewind · `R` re-dispatch · `o` open source · `/` focus filter add-pill |
-| **Tab bar (L3)** | `1`–`6` jump to tab N · `Ctrl+→` / `Ctrl+←` next/prev tab · letter mnemonics: `e` Event · `a` App-db · `v` Views (incl. subs nested under each view) · `t` Trace · `m` Machines · `i` Issues |
+| **Tab bar (L3)** | `1`–`7` jump to tab N · `Ctrl+→` / `Ctrl+←` next/prev tab · letter mnemonics: `e` Event · `a` App-db · `v` Views (incl. subs nested under each view) · `t` Trace · `m` Machines · `r` Routing · `i` Issues |
 | **Detail panel (L4)** | `Tab` / `Shift+Tab` cycle focusables · `Esc` returns focus to event list |
 | **Mode + scrubbing** | `Space` pause/resume LIVE · `L` snap to LIVE (jump to head) · `←` / `→` step one cascade (= `j`/`k`) · `Shift+←` / `Shift+→` step cascade root · `Home` / `End` oldest/newest |
 | **Global** | `Ctrl+Shift+C` toggle Causa visibility · `Cmd-K` / `Ctrl+K` palette · `?` cheat-sheet · `,` or `s` settings popup (= `⚙`) · `o` popout (= `⛶`) · `c` Causality popover · `Esc` close modal / return to canvas |
@@ -994,7 +1019,7 @@ Complete map for the spine + chrome:
 - `c` (Causality tab) — Causality is now a popover (not a tab); `c` repurposed to open the popover from anywhere.
 - `p` (Performance) — Performance panel dropped; `p` unused (available for future tab if added).
 - `w` (Flows) — Flows folded into Views; `w` unused.
-- `r` (Routes panel) — Routes folded into App-db (route is a sub-tree of app-db); `r` returns to its event-action meaning (rewind).
+- ~~`r` (Routes panel) — Routes folded into App-db~~. **Restored** (rf2-nrbs9): Routing got promoted back to its own L3 tab (cohesive sub-domains earn their own lens tab). `r` is now the **Routing tab** mnemonic; the event-list `r` rewind binding stays on the L2 event list scope (the L2 list's key handler wins when focus is in the list; the tab-bar's letter mnemonic wins when focus is elsewhere).
 - `S` (Schemas) — schema violations live in Issues; `S` unused.
 - `h` (Hydration) — hydration mismatches live in Issues; `h` unused.
 

--- a/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
@@ -37,19 +37,25 @@
 ;; ---- canonical panel list ------------------------------------------------
 ;;
 ;; Single source of truth for the palette source aggregator. The ids
-;; mirror the 6 L3 tab ids in `shell.cljs` (per spec/018 §5); selecting
+;; mirror the 7 L3 tab ids in `shell.cljs` (per spec/018 §5); selecting
 ;; a row dispatches `:rf.causa/select-tab` so the visible tab flips.
 ;;
 ;; Causality removed (rf2-dqnuu) — it is now a popover, not a tab; per
 ;; spec/018 §10 + §11. The palette surfaces it via the dedicated
 ;; `:causality-popover-open` command (handled by the popover events
 ;; ns) rather than as a panel row.
+;;
+;; Routing added (rf2-nrbs9) — promoted from 'lives in App-db + Trace'
+;; to its own L3 lens tab. Per Mike's design call (2026-05-18):
+;; cohesive sub-domains earn their own tab rather than overloading
+;; App-db.
 (def palette-panels
   [{:id :event    :label "Event"}
    {:id :app-db   :label "App DB"}
    {:id :views    :label "Views"}
    {:id :trace    :label "Trace"}
    {:id :machines :label "Machines"}
+   {:id :routing  :label "Routing"}
    {:id :issues   :label "Issues"}])
 
 (defn- handler-entries

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -1,0 +1,365 @@
+(ns day8.re-frame2-causa.panels.routing
+  "Routing tab — the 7th L4 tab (rf2-nrbs9).
+
+  Per Mike's design call (2026-05-18 16:35): Routing earns its own
+  top-level tab in the Causa shell rather than piling into App-db
+  (`app-db panel gets busy`). Routing slices are a cohesive sub-domain
+  — the route tree + the current match + nav transitions — and the
+  bd memory `cohesive-subdomains-get-their-own-tab` codifies the
+  posture: cohesive sub-domains earn their own lens tab.
+
+  ## Lens model (parallel to Machines)
+
+  Always-shown structure: the full route tree (every registered
+  route, sorted by path). The tree is the orientation surface — a
+  Causa user can flip to the Routing tab and immediately see the
+  app's routing topology without having to dig through code.
+
+  Per-focused-event highlighting:
+
+  - `◆ HERE` on the current matched route (always — the orientation
+    glyph; even when the focused event has no routing impact).
+  - `◆ FROM` / `◆ TO` arrow when the focused cascade caused
+    navigation (the cascade carries a
+    `:rf.route.nav-token/allocated` trace event).
+  - Params + query for the active route surface below the tree.
+  - When the app has no routing registered: tab content silent
+    (no `(none)` placeholder per rf2-g3ghh silent-by-default).
+
+  ## ASCII sketch (focused event caused navigation)
+
+      ROUTING
+        /
+        ├ /cart            ◆ FROM ━━━━━━━━━━━━━━━━━━┓
+        ├ /checkout                                  ┃
+        │   ├ /payment              ━━━━━━━━━━━━━━━━┛
+        │   └ /confirm     ◆ TO    (matched)
+        ├ /admin
+        │   └ /audit
+        └ /404
+
+        Params: {:order-id \"ord-1234\"}
+        Query:  {:source \"cart\"}
+
+  ## Pure hiccup (rf2-tijr)
+
+  Same contract as every other Causa panel — the view is pure
+  hiccup, no Reagent / UIx / Helix references. Frame isolation
+  comes from the enclosing `[rf/frame-provider {:frame :rf/causa}]`
+  in `shell.cljs`. Every `subscribe` / `dispatch` here resolves to
+  `:rf/causa`.
+
+  ## Helpers
+
+  Pure-data projection (`project-route-tree`, `project-data`,
+  `from-to-from-cascade`, `assign-markers`) lives in
+  `routing_helpers.cljc` so the algebra runs under the JVM unit-test
+  target."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.routing-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+;; ---- visual primitives --------------------------------------------------
+
+(defn- marker-chip
+  "Render the `◆ HERE` / `◆ FROM` / `◆ TO` marker chip for a route row.
+  Returns nil when no marker — the row aligns naturally with its
+  siblings (the chip column is empty)."
+  [marker]
+  (when marker
+    (let [{:keys [label colour]}
+          (case marker
+            :here {:label "◆ HERE" :colour (:accent-violet tokens)}
+            :from {:label "◆ FROM" :colour (:cyan tokens)}
+            :to   {:label "◆ TO"   :colour (:green tokens)}
+            nil)]
+      (when label
+        [:span {:data-testid (str "rf-causa-routing-marker-" (name marker))
+                :style       {:color         colour
+                              :font-weight   600
+                              :font-family   sans-stack
+                              :font-size     "11px"
+                              :letter-spacing "0.3px"
+                              :margin-left   "12px"
+                              :white-space   "nowrap"}}
+         label]))))
+
+(defn- route-row
+  "One row in the route tree. Indentation is depth × 16px so nested
+  routes visually sit under their parents. Each row carries the
+  route's path + the route-id (mono-font) + a marker chip when
+  highlighted."
+  [{:keys [route-id path depth marker doc] :as _row}]
+  ;; testid uses the fully-qualified keyword (namespace + name) so two
+  ;; routes whose simple names collide (e.g. `:cart/edit` and
+  ;; `:admin/edit`) render with distinct testids. `pr-str` round-trips
+  ;; the keyword's whole reader form (`:route/cart`); strip the leading
+  ;; `:` so the resulting attribute reads as `rf-causa-routing-row-
+  ;; route/cart` — namespace-bearing but stripped of the colon prefix
+  ;; that confuses CSS selectors (a leading `:` would be parsed as a
+  ;; pseudo-class).
+  [:li {:data-testid (str "rf-causa-routing-row-" (subs (pr-str route-id) 1))
+        :data-marker (when marker (name marker))
+        :style       {:display        "flex"
+                      :align-items    "center"
+                      :gap            "8px"
+                      :padding        "3px 8px"
+                      :padding-left   (str (+ 8 (* (or depth 0) 16)) "px")
+                      :font-family    mono-stack
+                      :font-size      "12px"
+                      :color          (:text-primary tokens)
+                      :background     (case marker
+                                        :to   (:bg-active tokens)
+                                        :from (:bg-2 tokens)
+                                        :here (:bg-2 tokens)
+                                        "transparent")
+                      :border-left    (case marker
+                                        :to   (str "2px solid " (:green tokens))
+                                        :from (str "2px solid " (:cyan tokens))
+                                        :here (str "2px solid " (:accent-violet tokens))
+                                        "2px solid transparent")
+                      :border-radius  "2px"
+                      :line-height    "20px"
+                      :white-space    "nowrap"}}
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-size "11px"
+                   :min-width "16px"
+                   :text-align "right"}}
+    ;; A small `·` for non-root, blank for root — gives the tree a
+    ;; faint grid feel without ascii-art tree glyphs (those don't
+    ;; survive font-substitution well).
+    (if (pos? (or depth 0)) "·" "")]
+   [:span {:style {:color (:accent-violet tokens)
+                   :font-weight 500}}
+    path]
+   [:span {:style {:color (:text-tertiary tokens)
+                   :font-size "11px"}}
+    (str route-id)]
+   (when doc
+     [:span {:style {:color (:text-secondary tokens)
+                     :font-size "11px"
+                     :font-style "italic"
+                     :font-family sans-stack
+                     :overflow "hidden"
+                     :text-overflow "ellipsis"}}
+      doc])
+   (marker-chip marker)])
+
+(defn- header
+  "Tab header — title + a brief explainer of the lens model. Always
+  rendered (even when silent) so the user knows the tab exists; the
+  body switches between the tree and the silent state."
+  [{:keys [navigated? to-id]}]
+  [:div {:data-testid "rf-causa-routing-header"
+         :style       {:display       "flex"
+                       :align-items   "baseline"
+                       :justify-content "space-between"
+                       :padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:div
+    [:h2 {:style {:margin     "0"
+                  :font-size  "13px"
+                  :font-weight 600
+                  :text-transform "uppercase"
+                  :letter-spacing "0.5px"
+                  :color      (:text-primary tokens)}}
+     "Routing"]
+    [:p {:style {:margin "4px 0 0 0"
+                 :color  (:text-tertiary tokens)
+                 :font-size "11px"
+                 :line-height 1.4}}
+     "Lens on the focused event — the full route tree, with "
+     [:span {:style {:color (:accent-violet tokens) :font-weight 600}} "◆ HERE"]
+     " marking the active route"
+     (when navigated?
+       [:span " and "
+        [:span {:style {:color (:cyan tokens) :font-weight 600}} "◆ FROM"]
+        " / "
+        [:span {:style {:color (:green tokens) :font-weight 600}} "◆ TO"]
+        " marking the navigation transition"])
+     "."]]
+   (when (and navigated? to-id)
+     [:span {:data-testid "rf-causa-routing-nav-summary"
+             :style {:color (:green tokens)
+                     :font-size "11px"
+                     :font-family mono-stack}}
+      (str "→ " to-id)])])
+
+(defn- slice-detail
+  "Params / query / fragment breakdown for the current route slice.
+  Three labelled rows; absent slots render as `—` so the lens always
+  shows the same skeleton (predictable scanning)."
+  [{:keys [params query fragment] :as _current}]
+  [:div {:data-testid "rf-causa-routing-slice-detail"
+         :style       {:padding     "10px 16px"
+                       :border-top  (str "1px dotted " (:border-subtle tokens))
+                       :font-family mono-stack
+                       :font-size   "12px"
+                       :color       (:text-primary tokens)
+                       :display     "grid"
+                       :grid-template-columns "80px 1fr"
+                       :row-gap     "4px"
+                       :column-gap  "12px"}}
+   [:span {:style {:color (:text-tertiary tokens)}} "Params:"]
+   [:span (if (seq params) (pr-str params) "—")]
+   [:span {:style {:color (:text-tertiary tokens)}} "Query:"]
+   [:span (if (seq query) (pr-str query) "—")]
+   (when fragment
+     [:<>
+      [:span {:style {:color (:text-tertiary tokens)}} "Fragment:"]
+      [:span (pr-str fragment)]])])
+
+(defn- empty-state
+  "Silent state — rendered when the host app has no routes registered.
+  Per rf2-g3ghh silent-by-default the panel emits an empty section so
+  the chrome stays consistent across tabs (every tab carries the
+  header + an empty body when its data source is empty)."
+  []
+  [:div {:data-testid "rf-causa-routing-empty"
+         :style       {:padding "16px"
+                       :color   (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size "11px"
+                       :font-style "italic"}}
+   ;; Terse one-liner so the panel skeleton doesn't look broken (mirror
+   ;; of the Issues panel's :no-issues empty state). Honours silent-by-
+   ;; default — no `(none)` chip, no marketing copy.
+   "No routes registered."])
+
+;; ---- public view --------------------------------------------------------
+
+(rf/reg-view Panel
+  "The Routing tab's root view. Subscribes to
+  `:rf.causa/routing-tab-data` and renders the route tree + slice
+  detail or the silent state."
+  []
+  (let [{:keys [silent? routes current to-id navigated?]
+         :as _data}
+        @(rf/subscribe [:rf.causa/routing-tab-data])]
+    [:section {:data-testid "rf-causa-routing"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      "14px"}}
+     (header {:navigated? navigated? :to-id to-id})
+     [:div {:style {:flex 1 :overflow "auto"}}
+      (if silent?
+        (empty-state)
+        [:<>
+         (into [:ul {:data-testid "rf-causa-routing-tree"
+                     :style       {:list-style "none"
+                                   :margin     "8px 0 0 0"
+                                   :padding    "0 8px"
+                                   :display    "flex"
+                                   :flex-direction "column"
+                                   :gap        "1px"}}]
+               (for [row routes]
+                 ^{:key (str (:route-id row))}
+                 [route-row row]))
+         (when current
+           (slice-detail current))])]]))
+
+;; ---- registration entry --------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Routing panel's Causa-side registrations
+  (rf2-nrbs9). Registers:
+
+    - `:rf.causa/registered-routes` — flat `{<route-id> <meta>}` map
+      sourced from `(rf/registrations :route)` (the framework's
+      registrar). Falls back to a test-only override slot so JVM /
+      node-test fixtures can drive the projection without booting
+      a host that registers routes.
+    - `:rf.causa/current-route-slice` — composite over the spine's
+      target-frame app-db reading the `:rf/route` slice. Mirrors how
+      `app-db-diff` reaches the host's app-db.
+    - `:rf.causa/routing-tab-data` — view-facing composite folding
+      the registered-routes map + current route slice + focused
+      cascade into the shape the view consumes (see
+      `routing_helpers/project-data`).
+    - `:rf.causa/set-registered-routes-override-for-test` — test-only
+      override hook the gallery fixtures + JVM tests use to seed the
+      registered-routes slot without registering real routes.
+    - `:rf.causa/set-current-route-slice-override-for-test` — same
+      pattern for the current slice (drives the HERE marker)."
+  []
+
+  ;; Test-only override slot for the registered-routes registrar
+  ;; lookup. When set (non-nil), the `:rf.causa/registered-routes`
+  ;; sub returns this verbatim; when nil the sub falls through to
+  ;; `(rf/registrations :route)`. Mirrors the
+  ;; `:rf.causa/set-registered-machines-override-for-test` pattern
+  ;; (machine_inspector.cljs) so fixtures can seed without a live
+  ;; registrar.
+  (rf/reg-event-db :rf.causa/set-registered-routes-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :registered-routes-override)
+        (assoc db :registered-routes-override ov))))
+
+  (rf/reg-sub :rf.causa/registered-routes-override
+    (fn [db _query]
+      (get db :registered-routes-override)))
+
+  ;; The registrar lookup — production reads through `rf/registrations`
+  ;; (process-global atom outside re-frame's reactive graph; the sub
+  ;; re-fires whenever the trace-buffer writes, which is the same
+  ;; cadence the palette uses to recompute its handler index — see
+  ;; palette/subs.cljs §palette-index). For the panel this is over-
+  ;; eager (the route registrar rarely changes) but the cost is
+  ;; bounded by the number of registered routes (typically < 30) and
+  ;; the dependency chain keeps the override surface clean.
+  (rf/reg-sub :rf.causa/registered-routes
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/registered-routes-override]
+    (fn [[_buffer override] _query]
+      (or override (rf/registrations :route))))
+
+  ;; Test-only override slot for the current route slice. Same pattern
+  ;; as registered-routes above.
+  (rf/reg-event-db :rf.causa/set-current-route-slice-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :current-route-slice-override)
+        (assoc db :current-route-slice-override ov))))
+
+  (rf/reg-sub :rf.causa/current-route-slice-override
+    (fn [db _query]
+      (get db :current-route-slice-override)))
+
+  ;; The current route slice — production reads through the
+  ;; target-frame-db sub (registered by `app-db-diff/install!`); that
+  ;; sub composes `:rf.causa/target-frame` + `rf/get-frame-db` so
+  ;; switching the L1 frame picker re-binds the lens to the new
+  ;; frame's route slice. The override slot wins when set (test
+  ;; fixtures + JVM coverage).
+  (rf/reg-sub :rf.causa/current-route-slice
+    :<- [:rf.causa/target-frame-db]
+    :<- [:rf.causa/current-route-slice-override]
+    (fn [[target-db override] _query]
+      (cond
+        (some? override) override
+        (map? target-db) (:rf/route target-db)
+        :else            nil)))
+
+  ;; View-facing composite — folds registered-routes + current slice
+  ;; + focused cascade (via `:rf.causa/cascades` + `:rf.causa/focus`)
+  ;; into the shape `project-data` returns. The view subscribes to
+  ;; this single sub; every component prop the renderer needs is in
+  ;; the returned map.
+  (rf/reg-sub :rf.causa/routing-tab-data
+    :<- [:rf.causa/registered-routes]
+    :<- [:rf.causa/current-route-slice]
+    :<- [:rf.causa/cascades]
+    :<- [:rf.causa/focus]
+    (fn [[routes-map slice cascades focus] _query]
+      (let [focused-cascade (h/focused-cascade cascades
+                                               (:dispatch-id focus))]
+        (h/project-data routes-map slice focused-cascade))))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
@@ -1,0 +1,238 @@
+(ns day8.re-frame2-causa.panels.routing-helpers
+  "Pure projection helpers for the Causa Routing tab (rf2-nrbs9).
+
+  ## Why a separate `.cljc` ns
+
+  The panel view in `routing.cljs` paints the route-tree lens. The
+  *logic* — project the registered-routes registrar into a stable
+  tree structure, derive the current-vs-from-vs-to highlight from
+  the focused cascade's trace events + app-db slice — is pure data
+  → data. Splitting the algebra into `.cljc` so it runs under the
+  JVM unit-test target (`clojure -M:test`) is required by the
+  standing rule `feedback_jvm_interop_must_work.md`.
+
+  ## Lens model
+
+  Always-shown structure: the full route tree (every registered
+  route, sorted by path so the rendering is deterministic).
+
+  Per-focused-event highlighting:
+
+  - `◆ HERE` on the current matched route (always — orientation).
+  - `◆ FROM` / `◆ TO` arrow when the focused cascade caused
+    navigation; the `:rf.route.nav-token/allocated` trace event
+    plus the slice change identify the FROM (prior route) and TO
+    (newly matched route).
+  - Show params + query for the active route.
+  - No transition arrow when the focused event has no routing
+    impact (still shows `◆ HERE`).
+  - When the app has no routes registered: every projection helper
+    returns the silent shape (`{:routes [] :silent? true}`) and the
+    view honours silent-by-default per rf2-g3ghh.
+
+  ## Data shape contract
+
+  The composite the view consumes:
+
+      {:silent?    <bool>             ;; true when no routes registered
+       :routes     [<row> ...]        ;; the route tree, sorted by path
+       :current    <route-slice>      ;; the active :rf/route slice
+       :from-id    <route-id-or-nil>  ;; nav origin when the focused
+                                      ;; cascade caused navigation
+       :to-id      <route-id-or-nil>  ;; nav destination when the
+                                      ;; focused cascade caused navigation
+       :navigated? <bool>}            ;; true iff the focused cascade
+                                      ;; carries a :rf.route.nav-token/
+                                      ;; allocated trace event
+
+  Each `<row>` is:
+
+      {:route-id   <keyword>
+       :path       <string>
+       :depth      <int>              ;; tree depth (0 = root)
+       :doc        <string-or-nil>
+       :marker     <:here :from :to nil>}  ;; render glyph hint"
+  (:require [clojure.string :as str]))
+
+;; ---- route tree projection ----------------------------------------------
+
+(defn- path-segments
+  "Split a route path into its `/`-delimited segments. The root path
+  `/` collapses to `[]` so it slots in at depth 0; an empty / nil
+  path is treated as the root."
+  [path]
+  (let [p (or path "")]
+    (->> (str/split p #"/")
+         (remove str/blank?)
+         vec)))
+
+(defn- path-depth
+  "Tree depth for a route path. Root (`/` or empty) sits at depth 0;
+  every `/`-separated segment adds one level."
+  [path]
+  (count (path-segments path)))
+
+(defn project-route-tree
+  "Project the registered-routes map (`{<id> <meta>}`) into a vector
+  of `{:route-id :path :depth :doc}` rows sorted by path. The path
+  sort is lexicographic so siblings under a common prefix render
+  contiguously; depth comes for free from the path itself.
+
+  Returns `[]` when the registrar is empty — the silent-by-default
+  branch the view honours per rf2-g3ghh."
+  [routes-map]
+  (->> routes-map
+       (map (fn [[id meta]]
+              {:route-id id
+               :path     (or (:path meta) "")
+               :depth    (path-depth (:path meta))
+               :doc      (:doc meta)}))
+       (sort-by :path)
+       vec))
+
+;; ---- focused-cascade routing detection ----------------------------------
+
+(def ^:private nav-allocated-op
+  "Trace operation emitted by `:rf.route/navigate` and
+  `:rf.route/handle-url-change` when a navigation cascade allocates a
+  nav-token (per `implementation/routing/src/re_frame/routing.cljc`
+  §`trace/emit! :event :rf.route.nav-token/allocated`)."
+  :rf.route.nav-token/allocated)
+
+(defn focused-cascade
+  "Find the cascade in `cascades` whose `:dispatch-id` matches
+  `focused-id`. Returns nil when the id has aged out of the buffer
+  or the spine has no focus yet. Mirrors the focused-cascade lookup
+  used elsewhere (popover/causality_graph_helpers)."
+  [cascades focused-id]
+  (when focused-id
+    (some #(when (= focused-id (:dispatch-id %)) %) cascades)))
+
+(defn- cascade-trace-events
+  "Flatten every trace-event bucket on a cascade into one seq. Per
+  `re-frame.trace.projection/group-cascades` a cascade record carries
+  raw trace maps under `:handler`, `:fx`, `:effects`, `:subs`,
+  `:renders`, and `:other`; the `:event` slot is the bare event
+  vector (not a trace map) so it's excluded. The
+  `:rf.route.nav-token/allocated` emit lands in `:other` per the
+  projection's catch-all bucket."
+  [cascade]
+  (concat
+    (when-let [handler (:handler cascade)] [handler])
+    (when-let [fx (:fx cascade)] [fx])
+    (:effects cascade)
+    (:subs cascade)
+    (:renders cascade)
+    (:other cascade)))
+
+(defn nav-token-allocated-in-cascade
+  "Scan a cascade's trace-event buckets for a
+  `:rf.route.nav-token/allocated` event. Returns the trace event map
+  (with its `:tags` carrying `:route-id` + `:nav-token`) when present;
+  nil otherwise. The emit fires inside both `:rf.route/navigate` (a
+  programmatic dispatch) and `:rf/url-changed` (browser-driven URL
+  change), so this catches both navigation paths uniformly."
+  [cascade]
+  (when cascade
+    (some (fn [ev]
+            (when (and (map? ev)
+                       (= nav-allocated-op (:operation ev)))
+              ev))
+          (cascade-trace-events cascade))))
+
+(defn from-to-from-cascade
+  "Derive a `{:from-id :to-id :navigated?}` map from a focused cascade
+  + the current route slice.
+
+  - `:to-id` comes from the nav-token-allocated trace event (the new
+    route the cascade navigated to).
+  - `:from-id` is the current slice's `:id` IFF it differs from
+    `:to-id`. Two cases collapse to no FROM:
+      - first navigation in the session (no prior slice — `current`
+        is nil so `:from-id` resolves to nil).
+      - same-route re-navigation (different params/query but same
+        route-id — surfacing a FROM equal to TO is noise).
+
+  The slice's `:id` is the *post-navigation* value (the navigate
+  handler writes the slice before this projection runs); for the
+  prior route we would need to scan trace history, which is
+  out-of-scope for v1 — the same-id collapse keeps the lens honest.
+
+  Pre-navigation contract: when the cascade carries no nav-token
+  emit, returns `{:navigated? false :from-id nil :to-id nil}`."
+  [cascade current-slice]
+  (let [nav-ev (nav-token-allocated-in-cascade cascade)
+        to-id  (some-> nav-ev :tags :route-id)
+        current-id (:id current-slice)
+        from-id (when (and to-id current-id (not= to-id current-id))
+                  current-id)]
+    (cond
+      (nil? nav-ev)
+      {:navigated? false :from-id nil :to-id nil}
+
+      :else
+      {:navigated? true
+       :from-id    from-id
+       :to-id      to-id})))
+
+;; ---- row marker assignment ---------------------------------------------
+
+(defn assign-markers
+  "Decorate each row in `rows` with `:marker` ∈ #{:here :from :to nil}
+  per the lens contract.
+
+  Marker priority (per the spec):
+    1. `:to` wins (the navigation destination — the new HERE).
+    2. `:from` for the navigation origin.
+    3. `:here` for the current route when no navigation happened.
+
+  A route can hold `:to` AND `:here` simultaneously (TO is the new
+  current); we prefer the stronger `:to` glyph so the lens shows the
+  navigation outcome at a glance. The view can decide to render both
+  glyphs if it wants — the helper returns a single marker per row to
+  keep the contract crisp."
+  [rows {:keys [from-id to-id current-id navigated?]}]
+  (mapv (fn [row]
+          (let [id (:route-id row)
+                marker (cond
+                         (and to-id (= id to-id))          :to
+                         (and from-id (= id from-id))      :from
+                         ;; HERE shows whether or not we navigated —
+                         ;; it's the orientation glyph. When :to is
+                         ;; set the same row carries :to, so HERE
+                         ;; only surfaces independently when the
+                         ;; cascade didn't navigate.
+                         (and (not navigated?)
+                              current-id
+                              (= id current-id))
+                         :here
+                         :else nil)]
+            (assoc row :marker marker)))
+        rows))
+
+;; ---- composite projection ----------------------------------------------
+
+(defn project-data
+  "The view-facing composite. Folds the registered-routes map +
+  current route slice + focused cascade into the shape the panel
+  consumes (see ns doc §Data shape contract).
+
+  Inputs are all pre-projected by the registry sub layer; this fn is
+  pure data → data so it slots into the JVM unit-test target.
+
+  Silent-by-default per rf2-g3ghh: when no routes are registered the
+  fn returns `{:silent? true :routes [] ...}` and the view renders
+  the empty section (no `(none)` placeholder)."
+  [routes-map current-slice focused-cascade]
+  (let [rows         (project-route-tree routes-map)
+        silent?      (empty? rows)
+        nav          (from-to-from-cascade focused-cascade current-slice)
+        decorated    (assign-markers rows
+                                     (assoc nav
+                                       :current-id (:id current-slice)))]
+    {:silent?    silent?
+     :routes     decorated
+     :current    current-slice
+     :from-id    (:from-id nav)
+     :to-id      (:to-id nav)
+     :navigated? (:navigated? nav)}))

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -49,6 +49,7 @@
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-causa.panels.managed-fx-subs :as managed-fx-subs]
+            [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.views :as views]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.panels.trace-helpers :as trace-helpers]))
@@ -545,6 +546,13 @@
     ;; mounts inline in event_detail.cljs under the six-domino cascade,
     ;; so no L3 tab is added.
     (managed-fx-subs/install!)
+    ;; Routing tab (rf2-nrbs9) — 7th L3 tab. Installs the registered-
+    ;; routes / current-route-slice / routing-tab-data subs +
+    ;; test-only overrides. Composes against `:rf.causa/target-frame-db`
+    ;; (registered by `app-db-diff/install!` above) so the install
+    ;; order is intentional, though re-frame's `:<-` resolution is
+    ;; lazy and the order is purely cosmetic.
+    (routing/install!)
     (views/install!)
     (trace/install!))
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -13,7 +13,7 @@
       ├───────────────────────────────────────────────────────┤
       │ L2  Event list (8 rows default; resizable; min 2)     │  the spine / timeline
       ├───────────────────────────────────────────────────────┤
-      │ L3  Tab bar (40px) — 6 tabs                           │  projection selector
+      │ L3  Tab bar (40px) — 7 tabs                           │  projection selector
       ├───────────────────────────────────────────────────────┤
       │ L4  Detail panel (fills remaining canvas)             │  per-tab content
       └───────────────────────────────────────────────────────┘
@@ -49,21 +49,23 @@
 
   ## Tab bar (L3)
 
-  Six tabs, mnemonic letters per spec/018 §11:
+  Seven tabs, mnemonic letters per spec/018 §11:
 
-      Event (e) · App-db (a) · Views (v) · Trace (t) · Machines (m) · Issues (i)
+      Event (e) · App-db (a) · Views (v) · Trace (t) · Machines (m) · Routing (r) · Issues (i)
 
   Selection lives on `:rf.causa/selected-tab` and drives the L4
-  detail panel's case switch.
+  detail panel's case switch. Routing was promoted to its own tab
+  per rf2-nrbs9 (Mike's design call, 2026-05-18) — cohesive sub-
+  domains earn their own lens tab rather than overloading App-db.
 
   ## Detail panel (L4)
 
   Renders the active tab's projection of the focused event. Tabs
   reuse the existing per-panel views where possible (Event tab →
   `event-detail/Panel`, App-db → `app-db-diff/Panel`, Trace →
-  `trace/Panel`, Machines → `machine-inspector/Panel`, Issues →
-  `issues-ribbon/Panel`). The Views tab is a stub pending the §5.3
-  per-view content design.
+  `trace/Panel`, Machines → `machine-inspector/Panel`, Routing →
+  `routing/Panel`, Issues → `issues-ribbon/Panel`). The Views tab
+  is a stub pending the §5.3 per-view content design.
 
   ## Frame isolation (rf2-tijr Option C + rf2-in6l2)
 
@@ -96,6 +98,7 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.views :as views]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.palette :as palette]
@@ -116,9 +119,14 @@
   #{:rf/causa :rf/pair2})
 
 (def ^:private tabs
-  "The six L3 tabs per spec/018 §5 The 6 tabs. Order is the canonical
+  "The seven L3 tabs per spec/018 §5 The 7 tabs. Order is the canonical
   left-to-right ribbon order; the `:mnem` letter is the keyboard
   mnemonic (spec/018 §11).
+
+  Per rf2-nrbs9 Routing was promoted from 'lives in App-db + Trace' to
+  its own L3 tab — cohesive sub-domains earn their own lens tab rather
+  than overloading App-db. The tab sits between Machines and Issues
+  (alphabetical adjacency keeps the ribbon scannable).
 
   Labels use spaces (`App DB` not `App-db`) so the rendered text
   carries no `-` glyphs — Playwright's `getByRole('button', {name:
@@ -130,6 +138,7 @@
    {:id :views    :label "Views"    :mnem "v"}
    {:id :trace    :label "Trace"    :mnem "t"}
    {:id :machines :label "Machines" :mnem "m"}
+   {:id :routing  :label "Routing"  :mnem "r"}
    {:id :issues   :label "Issues"   :mnem "i"}])
 
 (def ^:private default-tab :event)
@@ -879,7 +888,9 @@
      label]))
 
 (rf/reg-view tab-bar
-  "L3 tab bar — six tabs per spec/018 §5 The 6 tabs.
+  "L3 tab bar — seven tabs per spec/018 §5 The 7 tabs (Routing
+  promoted to its own tab per rf2-nrbs9; was previously folded into
+  App-db).
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -911,7 +922,7 @@
 (rf/reg-view detail-panel
   "L4 detail panel — case-switch on `:rf.causa/selected-tab`. Reuses
   existing Panel views for Event / App-db / Trace / Machines /
-  Issues; Views is a stub pending follow-on impl.
+  Routing / Issues; Views is a stub pending follow-on impl.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`. The wrapping `<div>` paints `bg-2` as a contrast
@@ -936,6 +947,12 @@
        :views    [views/Panel]
        :trace    [trace/Panel]
        :machines [machine-inspector/Panel]
+       ;; Routing tab (rf2-nrbs9) — 7th L3 tab; lens on the focused
+       ;; event over the registered-routes tree per spec/016 §Routing
+       ;; tab content. Mike's design call (2026-05-18): cohesive sub-
+       ;; domains earn their own lens tab rather than overloading
+       ;; App-db.
+       :routing  [routing/Panel]
        :issues   [issues-ribbon/Panel]
        [unknown-tab-stub selected])]))
 

--- a/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
@@ -14,7 +14,7 @@
 ;; ---- fixture inputs -----------------------------------------------------
 
 (def sample-panels
-  ;; rf2-qy0nu — palette-panels now mirrors the 6 L3 tab ids. We use
+  ;; rf2-qy0nu / rf2-nrbs9 — palette-panels now mirrors the 7 L3 tab ids. We use
   ;; `:event` first (so the panel-items-shape test pins the first row's
   ;; action) and include `:trace` for the cross-source collision tests.
   ;; A third entry rounds out the panel-items-shape `(count items) = 3`

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -1,0 +1,228 @@
+(ns day8.re-frame2-causa.panels.routing-cljs-test
+  "CLJS-side wiring + view tests for Causa's Routing tab (rf2-nrbs9).
+
+  ## What's under test (in addition to the pure-data tests in
+  `routing_helpers_cljs_test.cljc`)
+
+    1. **Registry wires the subs** — every sub the panel reads gets
+       installed by `register-causa-handlers!`, and the `:routing`
+       tab id is in the L3 tabs vector + the palette panel list.
+
+    2. **Render contract** — root container + header + tree (or
+       empty state) match the production view tree.
+
+    3. **Silent state** — when no routes are registered the panel
+       renders the empty body (`No routes registered.`), no tree.
+
+    4. **Orientation HERE marker** — when routes are registered and
+       a current route slice exists, the current row carries the
+       `:here` marker.
+
+    5. **FROM / TO markers** — when the focused cascade carries a
+       `:rf.route.nav-token/allocated` trace event the corresponding
+       rows carry `:from` / `:to` markers.
+
+    6. **Frame isolation** — every read targets `:rf/causa`'s frame;
+       the panel never reads the host frame's app-db directly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.palette.subs :as palette-subs]
+            [day8.re-frame2-causa.panels.routing :as routing]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers (mirror issues_ribbon_view_cljs_test) ---------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(def cart-routes
+  {:route/cart      {:path "/cart"      :doc "cart"}
+   :route/checkout  {:path "/checkout"  :doc "checkout"}
+   :route/payment   {:path "/checkout/payment"}
+   :route/confirm   {:path "/checkout/confirm"}})
+
+(defn- nav-allocated [route-id]
+  {:id        99
+   :op-type   :event
+   :operation :rf.route.nav-token/allocated
+   :tags      {:route-id route-id :nav-token "nav-1"}})
+
+;; ---- (1) registry wiring + tab inventory --------------------------------
+
+(deftest registry-installs-routing-subs
+  (testing "register-causa-handlers! installs every Routing-tab sub"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa/registered-routes))
+        ":rf.causa/registered-routes sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/registered-routes-override))
+        "test-only override sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/current-route-slice))
+        ":rf.causa/current-route-slice sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/current-route-slice-override))
+        "test-only override sub registered")
+    (is (some? (registrar/handler :sub :rf.causa/routing-tab-data))
+        "view-facing composite sub registered")
+    (is (some? (registrar/handler :event :rf.causa/set-registered-routes-override-for-test))
+        "test-only override event registered")
+    (is (some? (registrar/handler :event :rf.causa/set-current-route-slice-override-for-test))
+        "test-only override event registered")))
+
+(deftest palette-includes-routing
+  (testing "the palette's canonical panel list carries the :routing entry"
+    (let [ids (set (map :id palette-subs/palette-panels))]
+      (is (contains? ids :routing) ":routing in palette-panels")
+      (is (= 7 (count palette-subs/palette-panels))
+          "exactly 7 entries — Event / App DB / Views / Trace / Machines / Routing / Issues"))))
+
+;; ---- (2) silent state ---------------------------------------------------
+
+(deftest panel-renders-silent-state-when-no-routes
+  (testing "no routes registered → empty-state body, no tree"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Seed both overrides to nil so the panel falls through.
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing"))
+            "panel root present")
+        (is (some? (find-by-testid tree "rf-causa-routing-header"))
+            "header always renders")
+        (is (some? (find-by-testid tree "rf-causa-routing-empty"))
+            "silent state body present")
+        (is (nil? (find-by-testid tree "rf-causa-routing-tree"))
+            "tree NOT rendered")))))
+
+;; ---- (3) orientation HERE marker ----------------------------------------
+
+(deftest panel-renders-here-marker-without-navigation
+  (testing "current slice present + no nav cascade → HERE on the active row"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)
+            cart-row (find-by-testid tree "rf-causa-routing-row-route/cart")]
+        (is (some? (find-by-testid tree "rf-causa-routing-tree"))
+            "tree renders when routes exist")
+        (is (some? cart-row) "current route row renders")
+        (is (= "here" (:data-marker (second cart-row)))
+            "current route row carries the HERE marker")
+        (is (some? (find-by-testid tree "rf-causa-routing-marker-here"))
+            "HERE chip text rendered")))))
+
+;; ---- (4) FROM / TO markers ---------------------------------------------
+
+(deftest panel-renders-from-to-when-cascade-navigated
+  (testing "focused cascade with nav-token emit → FROM + TO markers"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Current slice still on the FROM route — simulates reading
+      ;; the panel while the cascade is mid-flight (or against a stale
+      ;; snapshot); the helpers expose both markers.
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
+                        {:frame :rf/causa})
+      ;; Seed the trace-buffer with a nav-allocated cascade + focus on it.
+      ;; The cascade projector buckets the nav-allocated emit under :other.
+      (let [nav-event (nav-allocated :route/confirm)
+            ;; A minimal trace-buffer that the projection's group-cascades
+            ;; will bucket into one cascade with id=99.
+            buffer [{:id 99 :op-type :event :operation :event/dispatched
+                     :tags {:dispatch-id 99
+                            :event [:rf.route/navigate :route/confirm]}}
+                    (assoc nav-event :tags
+                           (assoc (:tags nav-event) :dispatch-id 99))]]
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer]
+                          {:frame :rf/causa})
+        (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
+
+      (let [tree (routing/Panel)
+            cart-row    (find-by-testid tree "rf-causa-routing-row-route/cart")
+            confirm-row (find-by-testid tree "rf-causa-routing-row-route/confirm")]
+        (is (some? cart-row)    "cart row present")
+        (is (some? confirm-row) "confirm row present")
+        (is (= "from" (:data-marker (second cart-row)))
+            "cart row carries the FROM marker")
+        (is (= "to" (:data-marker (second confirm-row)))
+            "confirm row carries the TO marker")
+        (is (some? (find-by-testid tree "rf-causa-routing-marker-from"))
+            "FROM chip text rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-marker-to"))
+            "TO chip text rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
+            "header nav summary surfaces the TO id")))))
+
+;; ---- (5) slice detail rendering ----------------------------------------
+
+(deftest panel-renders-slice-detail
+  (testing "params + query + fragment grid rendered when current slice present"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id     :route/confirm
+                          :params {:order-id "ord-1234"}
+                          :query  {:source "cart"}}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
+            "slice detail grid present")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
@@ -1,0 +1,262 @@
+(ns day8.re-frame2-causa.panels.routing-helpers-cljs-test
+  "Pure-data tests for Causa's Routing tab helpers (rf2-nrbs9).
+
+  Dual-target naming (`.cljc` + `_cljs_test`):
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+    1. **project-route-tree** — registrar map → row vector, sorted
+       by path; correct depth derivation; empty registrar → `[]`.
+    2. **focused-cascade** — lookup by dispatch-id.
+    3. **nav-token-allocated-in-cascade** — scans `:other` bucket
+       for the `:rf.route.nav-token/allocated` emit; nil when
+       absent.
+    4. **from-to-from-cascade** — derives `{:from-id :to-id
+       :navigated?}` per the lens contract.
+    5. **assign-markers** — TO wins over FROM wins over HERE; HERE
+       only surfaces when no navigation happened.
+    6. **project-data** — top-level composite; silent state when no
+       routes; correct decoration when focused event causes
+       navigation."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.routing-helpers :as h]))
+
+;; ---- fixture builders ---------------------------------------------------
+
+(defn- route
+  "Build a registrar-shaped route metadata map."
+  ([path] (route path nil))
+  ([path doc] (cond-> {:path path}
+                doc (assoc :doc doc))))
+
+(def cart-routes
+  "Realistic registrar shape — a small e-commerce route set."
+  {:route/root      (route "/")
+   :route/cart      (route "/cart"      "shopping cart")
+   :route/checkout  (route "/checkout"  "checkout overview")
+   :route/payment   (route "/checkout/payment")
+   :route/confirm   (route "/checkout/confirm")
+   :route/admin     (route "/admin")
+   :route/audit     (route "/admin/audit")
+   :route/not-found (route "/404")})
+
+(defn- nav-allocated-trace
+  "Build a `:rf.route.nav-token/allocated` trace event map mirroring
+  the shape `(trace/emit! :event :rf.route.nav-token/allocated ...)`
+  produces in `re-frame.routing`."
+  [route-id nav-token & [dispatch-id]]
+  {:id        1
+   :op-type   :event
+   :operation :rf.route.nav-token/allocated
+   :tags      (cond-> {:route-id route-id :nav-token nav-token}
+                dispatch-id (assoc :dispatch-id dispatch-id))})
+
+(defn- cascade
+  "Build a minimal cascade record per `re-frame.trace.projection`
+  shape — only the slots the helpers actually read."
+  [dispatch-id event-vec & {:keys [other effects fx handler]
+                            :or {other [] effects [] fx nil handler nil}}]
+  {:dispatch-id dispatch-id
+   :event       event-vec
+   :handler     handler
+   :fx          fx
+   :effects     effects
+   :subs        []
+   :renders     []
+   :other       other})
+
+;; ---- project-route-tree -------------------------------------------------
+
+(deftest project-route-tree-test
+  (testing "empty registrar yields []"
+    (is (= [] (h/project-route-tree {}))))
+
+  (testing "single route yields one row at depth 0 for root"
+    (let [rows (h/project-route-tree {:route/root (route "/")})]
+      (is (= 1 (count rows)))
+      (is (= :route/root (-> rows first :route-id)))
+      (is (= "/" (-> rows first :path)))
+      (is (= 0 (-> rows first :depth)))))
+
+  (testing "multi-segment paths derive depth from segment count"
+    (let [rows (h/project-route-tree cart-routes)
+          by-id (into {} (map (juxt :route-id identity)) rows)]
+      (is (= 0 (get-in by-id [:route/root :depth])))
+      (is (= 1 (get-in by-id [:route/cart :depth])))
+      (is (= 1 (get-in by-id [:route/checkout :depth])))
+      (is (= 2 (get-in by-id [:route/payment :depth])))
+      (is (= 2 (get-in by-id [:route/audit :depth])))))
+
+  (testing "rows are sorted by path lexicographically"
+    (let [paths (mapv :path (h/project-route-tree cart-routes))]
+      (is (= paths (sort paths)))))
+
+  (testing "doc is carried through when present, nil otherwise"
+    (let [by-id (into {} (map (juxt :route-id identity))
+                      (h/project-route-tree cart-routes))]
+      (is (= "shopping cart" (get-in by-id [:route/cart :doc])))
+      (is (nil? (get-in by-id [:route/payment :doc]))))))
+
+;; ---- focused-cascade ----------------------------------------------------
+
+(deftest focused-cascade-test
+  (testing "nil focused-id → nil"
+    (is (nil? (h/focused-cascade [(cascade 1 [:a])] nil))))
+
+  (testing "no match → nil"
+    (is (nil? (h/focused-cascade [(cascade 1 [:a])] 99))))
+
+  (testing "match returns the cascade record"
+    (let [c (cascade 7 [:foo])]
+      (is (= c (h/focused-cascade [(cascade 1 [:a]) c (cascade 9 [:b])] 7))))))
+
+;; ---- nav-token-allocated-in-cascade -------------------------------------
+
+(deftest nav-token-allocated-in-cascade-test
+  (testing "nil cascade → nil"
+    (is (nil? (h/nav-token-allocated-in-cascade nil))))
+
+  (testing "cascade with no nav emit → nil"
+    (is (nil? (h/nav-token-allocated-in-cascade (cascade 1 [:foo])))))
+
+  (testing "nav emit in :other bucket is found"
+    (let [c (cascade 1 [:rf.route/navigate :route/cart]
+              :other [(nav-allocated-trace :route/cart "nav-1")])
+          ev (h/nav-token-allocated-in-cascade c)]
+      (is (some? ev))
+      (is (= :route/cart (-> ev :tags :route-id)))
+      (is (= "nav-1" (-> ev :tags :nav-token)))))
+
+  (testing "nav emit in :effects bucket is also found"
+    (let [c (cascade 1 [:foo]
+              :effects [(nav-allocated-trace :route/x "nav-2")])]
+      (is (some? (h/nav-token-allocated-in-cascade c))))))
+
+;; ---- from-to-from-cascade -----------------------------------------------
+
+(deftest from-to-from-cascade-test
+  (testing "no nav emit → not navigated"
+    (let [c (cascade 1 [:foo])
+          {:keys [navigated? from-id to-id]}
+          (h/from-to-from-cascade c {:id :route/cart})]
+      (is (false? navigated?))
+      (is (nil? from-id))
+      (is (nil? to-id))))
+
+  (testing "nav from cart to confirm yields both ids"
+    (let [c (cascade 1 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-7")])
+          {:keys [navigated? from-id to-id]}
+          (h/from-to-from-cascade c {:id :route/cart})]
+      (is (true? navigated?))
+      (is (= :route/cart from-id))
+      (is (= :route/confirm to-id))))
+
+  (testing "first navigation (no prior slice) yields nil FROM"
+    (let [c (cascade 1 [:rf.route/navigate :route/cart]
+              :other [(nav-allocated-trace :route/cart "nav-1")])
+          {:keys [navigated? from-id to-id]}
+          (h/from-to-from-cascade c nil)]
+      (is (true? navigated?))
+      (is (nil? from-id))
+      (is (= :route/cart to-id))))
+
+  (testing "same-route re-navigation collapses FROM to nil"
+    (let [c (cascade 1 [:rf.route/navigate :route/cart {:filter :all}]
+              :other [(nav-allocated-trace :route/cart "nav-3")])
+          {:keys [navigated? from-id to-id]}
+          (h/from-to-from-cascade c {:id :route/cart :params {:filter :open}})]
+      (is (true? navigated?))
+      (is (nil? from-id) "from collapses when TO == current")
+      (is (= :route/cart to-id)))))
+
+;; ---- assign-markers -----------------------------------------------------
+
+(deftest assign-markers-test
+  (let [rows (h/project-route-tree cart-routes)]
+    (testing "no navigation: HERE on the current route only"
+      (let [decorated (h/assign-markers rows
+                                        {:current-id :route/cart
+                                         :from-id    nil
+                                         :to-id      nil
+                                         :navigated? false})
+            by-id (into {} (map (juxt :route-id :marker)) decorated)]
+        (is (= :here (get by-id :route/cart)))
+        (is (nil? (get by-id :route/checkout)))
+        (is (nil? (get by-id :route/audit)))))
+
+    (testing "navigation: FROM + TO win; HERE suppressed (TO is the new HERE)"
+      (let [decorated (h/assign-markers rows
+                                        {:current-id :route/confirm
+                                         :from-id    :route/cart
+                                         :to-id      :route/confirm
+                                         :navigated? true})
+            by-id (into {} (map (juxt :route-id :marker)) decorated)]
+        (is (= :from (get by-id :route/cart)))
+        (is (= :to   (get by-id :route/confirm)))
+        ;; Current-id == TO; HERE is suppressed in favour of TO.
+        (is (not= :here (get by-id :route/confirm)))))
+
+    (testing "navigation with same-route collapse: only TO surfaces"
+      (let [decorated (h/assign-markers rows
+                                        {:current-id :route/cart
+                                         :from-id    nil
+                                         :to-id      :route/cart
+                                         :navigated? true})
+            by-id (into {} (map (juxt :route-id :marker)) decorated)]
+        (is (= :to (get by-id :route/cart)))
+        (is (nil? (get by-id :route/checkout)))))))
+
+;; ---- project-data composite --------------------------------------------
+
+(deftest project-data-silent-test
+  (testing "silent state — no routes registered"
+    (let [data (h/project-data {} {:id :route/anything} nil)]
+      (is (true? (:silent? data)))
+      (is (= [] (:routes data)))
+      (is (false? (:navigated? data))))))
+
+(deftest project-data-orientation-test
+  (testing "no focused cascade but routes present — orientation HERE only"
+    (let [data (h/project-data cart-routes {:id :route/cart} nil)
+          by-id (into {} (map (juxt :route-id :marker)) (:routes data))]
+      (is (false? (:silent? data)))
+      (is (false? (:navigated? data)))
+      (is (= :here (get by-id :route/cart)))
+      (is (= :route/cart (get-in data [:current :id]))))))
+
+(deftest project-data-navigation-test
+  (testing "focused cascade caused navigation — FROM + TO render"
+    (let [c (cascade 42 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-9" 42)])
+          data (h/project-data cart-routes {:id :route/confirm} c)
+          by-id (into {} (map (juxt :route-id :marker)) (:routes data))]
+      (is (true? (:navigated? data)))
+      (is (= :route/confirm (:to-id data)))
+      ;; Note: current-slice's :id is the POST-nav value (the slice
+      ;; reflects TO), so the FROM is derived from the nav-token emit
+      ;; ∧ the slice difference. Since current.id == to-id, FROM
+      ;; collapses to nil per from-to-from-cascade contract.
+      (is (nil? (:from-id data)))
+      (is (= :to (get by-id :route/confirm)))))
+
+  (testing "nav cascade with distinct current slice — FROM ≠ TO"
+    ;; This simulates the case where the panel is reading mid-cascade:
+    ;; the nav-token emit identifies TO; the current slice (perhaps
+    ;; from a stale snapshot, or a different frame) carries the prior
+    ;; route-id; helper produces both markers.
+    (let [c (cascade 1 [:rf.route/navigate :route/confirm]
+              :other [(nav-allocated-trace :route/confirm "nav-3")])
+          data (h/project-data cart-routes {:id :route/cart} c)
+          by-id (into {} (map (juxt :route-id :marker)) (:routes data))]
+      (is (true? (:navigated? data)))
+      (is (= :route/cart (:from-id data)))
+      (is (= :route/confirm (:to-id data)))
+      (is (= :from (get by-id :route/cart)))
+      (is (= :to   (get by-id :route/confirm))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -165,6 +165,12 @@
    :rf.causa/palette-query
    :rf.causa/palette-results
    :rf.causa/registered-machines
+   ;; rf2-nrbs9 — Routing tab (7th L3 tab) sub family.
+   :rf.causa/registered-routes
+   :rf.causa/registered-routes-override
+   :rf.causa/current-route-slice
+   :rf.causa/current-route-slice-override
+   :rf.causa/routing-tab-data
    :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
@@ -307,6 +313,9 @@
    :rf.causa/set-machine-definitions-override-for-test
    :rf.causa/set-machine-instances-override-for-test
    :rf.causa/set-machine-snapshots-override-for-test
+   ;; rf2-nrbs9 — Routing tab test-only override events.
+   :rf.causa/set-current-route-slice-override-for-test
+   :rf.causa/set-registered-routes-override-for-test
    :rf.causa/set-mode-c-cluster-by
    :rf.causa/set-mode-c-context-key
    ;; rf2-om6fa — Story-aware modal positioning opt.
@@ -443,8 +452,8 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    (is (= 95  (count all-sub-names)))
-    (is (= 115 (count all-event-names)))
+    (is (= 100 (count all-sub-names)))
+    (is (= 117 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -52,6 +52,7 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.views :as views]
             [day8.re-frame2-causa.panels.trace :as trace]))
 
@@ -241,27 +242,29 @@
           ":rf.causa/follow-head dispatched on ⏭ click"))))
 
 ;; -------------------------------------------------------------------------
-;; (3) L3 tab bar — six tabs, mnemonics, selection
+;; (3) L3 tab bar — seven tabs, mnemonics, selection
 ;; -------------------------------------------------------------------------
 
 (def ^:private expected-tab-ids
-  "Authoritative tab inventory per spec/018 §5 The 6 tabs."
-  [:event :app-db :views :trace :machines :issues])
+  "Authoritative tab inventory per spec/018 §5 The 7 tabs (Routing
+  promoted to its own L3 tab per rf2-nrbs9; was previously folded
+  into App-db)."
+  [:event :app-db :views :trace :machines :routing :issues])
 
-(deftest tab-bar-renders-six-tabs
-  (testing "spec/018 §5 — six tabs (Event / App-db / Views / Trace /
-            Machines / Issues)"
+(deftest tab-bar-renders-seven-tabs
+  (testing "spec/018 §5 — seven tabs (Event / App-db / Views / Trace /
+            Machines / Routing / Issues)"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)
             tabs (find-all-by-testid-prefix tree "rf-causa-tab-")]
         ;; Need to filter out the L4 detail panel and tab-bar root.
-        (is (= 6 (count (filter (fn [n]
+        (is (= 7 (count (filter (fn [n]
                                   (let [t (:data-testid (second n))]
                                     (some #(= t (str "rf-causa-tab-" (name %)))
                                           expected-tab-ids)))
                                 tabs)))
-            "6 tab buttons render")
+            "7 tab buttons render")
         (doseq [tab-id expected-tab-ids]
           (is (some? (find-by-testid tree (str "rf-causa-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))
@@ -310,12 +313,15 @@
 (def ^:private expected-detail-fn
   "Authoritative tab-id → Panel-fn mapping. Mirrors the case-switch in
   `shell/detail-panel`. The Views tab routes to the full Views panel
-  per spec/012-Views.md (rf2-21ob3) — Subs panel is retired."
+  per spec/012-Views.md (rf2-21ob3) — Subs panel is retired. The
+  Routing tab routes to the new lens panel per rf2-nrbs9 — promoted
+  from 'lives in App-db + Trace'."
   {:event    event-detail/Panel
    :app-db   app-db-diff/Panel
    :views    views/Panel
    :trace    trace/Panel
    :machines machine-inspector/Panel
+   :routing  routing/Panel
    :issues   issues-ribbon/Panel})
 
 (deftest detail-panel-routes-each-tab-to-its-view-fn

--- a/tools/causa/testbeds/panel_gallery/core.cljs
+++ b/tools/causa/testbeds/panel_gallery/core.cljs
@@ -1,10 +1,10 @@
 (ns panel-gallery.core
   "Boot for the Causa panel gallery testbed (rf2-sszlr — rebuilt for
-  the new 6-tab Causa shape).
+  the new 7-tab Causa shape).
 
   ## What this testbed is
 
-  A visual gallery of the six L4 tab panels (Event / App-db / Views
+  A visual gallery of the seven L4 tab panels (Event / App-db / Views
   / Trace / Machines / Issues) plus the full 4-layer Causa chrome,
   framed exactly like Storybook frames UI components. Scroll the
   workspace; see what each panel looks like under varying state
@@ -14,7 +14,7 @@
 
   Per `tools/causa/spec/018-Event-Spine.md` the new chrome is four
   stacked layers — top ribbon + event list + tab bar + detail panel
-  — with six L4 tabs replacing the legacy sidebar's 16+ panels.
+  — with seven L4 tabs replacing the legacy sidebar's 16+ panels.
   Causality is a `c`-key popover (not a tab); Time Travel is folded
   into the spine.
 
@@ -68,6 +68,7 @@
             [panel-gallery.gallery-views]
             [panel-gallery.gallery-trace]
             [panel-gallery.gallery-machines]
+            [panel-gallery.gallery-routing]
             [panel-gallery.gallery-issues]
             [panel-gallery.gallery-chrome]
             ;; Chrome follow-on galleries — rf2-mpn8m settings popup,
@@ -84,9 +85,9 @@
 (defn- landing-view []
   [:div {:class "gallery-landing"}
    [:h1 "Causa panel gallery"]
-   [:p "A visual gallery of the new 6-tab Causa chrome (per "
+   [:p "A visual gallery of the new 7-tab Causa chrome (per "
     [:code "tools/causa/spec/018-Event-Spine.md"]
-    ") and each of the six L4 tab panels."]
+    ") and each of the seven L4 tab panels."]
    [:p "Open the gallery at "
     [:a {:href "#/stories"} [:code "#/stories"]]
     " to scroll the workspaces."]

--- a/tools/causa/testbeds/panel_gallery/fixtures_routing.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_routing.cljs
@@ -1,0 +1,104 @@
+(ns panel-gallery.fixtures-routing
+  "Pure fixture builders for the Causa Routing tab gallery (rf2-nrbs9).
+
+  The Routing panel reads:
+
+    - `:rf.causa/registered-routes` — defaults to `(rf/registrations
+      :route)`; test override slot exists at
+      `:rf.causa/set-registered-routes-override-for-test`.
+    - `:rf.causa/current-route-slice` — defaults to the target-frame
+      app-db's `:rf/route` slot; test override slot at
+      `:rf.causa/set-current-route-slice-override-for-test`.
+    - `:rf.causa/cascades` — drives the FROM/TO detection. Seed via
+      `:rf.causa/sync-trace-buffer` + `:rf.causa/focus-cascade` so
+      the spine's focused cascade carries the
+      `:rf.route.nav-token/allocated` emit.
+
+  Variants:
+
+    1. no-routes-registered (silent)
+    2. current-route-only (◆ HERE)
+    3. from-to-transition (◆ FROM / ◆ TO)
+    4. nested-route-tree (depth 3+)")
+
+;; ---- route registrar fixtures -------------------------------------------
+
+(def cart-routes
+  "Shallow e-commerce route set — exercises depth 0 / 1 / 2 paths and
+  the current/from/to lens."
+  {:route/root      {:path "/"                  :doc "home"}
+   :route/cart      {:path "/cart"              :doc "shopping cart"}
+   :route/checkout  {:path "/checkout"          :doc "checkout overview"}
+   :route/payment   {:path "/checkout/payment"  :doc "payment step"}
+   :route/confirm   {:path "/checkout/confirm"  :doc "confirmation"}
+   :route/admin     {:path "/admin"             :doc "admin landing"}
+   :route/audit     {:path "/admin/audit"       :doc "admin audit log"}
+   :route/not-found {:path "/404"               :doc "fallback"}})
+
+(def deep-routes
+  "Deeper nesting exercises the indentation behaviour at depth 3+."
+  {:route/root          {:path "/"}
+   :route/docs          {:path "/docs"                              :doc "docs landing"}
+   :route/docs.guide    {:path "/docs/guide"                        :doc "guide section"}
+   :route/docs.api      {:path "/docs/api"                          :doc "API reference"}
+   :route/docs.api.subs {:path "/docs/api/subs"                     :doc "subs API"}
+   :route/docs.api.evts {:path "/docs/api/events"                   :doc "events API"}
+   :route/docs.api.evts.detail {:path "/docs/api/events/detail"     :doc "single event detail"}
+   :route/docs.guide.routing   {:path "/docs/guide/routing"         :doc "routing chapter"}
+   :route/blog          {:path "/blog"                              :doc "blog index"}
+   :route/blog.post     {:path "/blog/post"                         :doc "single post"}})
+
+;; ---- route-slice fixtures ----------------------------------------------
+
+(def cart-slice
+  {:id     :route/cart
+   :params {}
+   :query  {}})
+
+(def confirm-slice
+  {:id       :route/confirm
+   :params   {:order-id "ord-1234"}
+   :query    {:source "cart"}
+   :fragment "step-3"})
+
+(def docs-api-detail-slice
+  {:id     :route/docs.api.evts.detail
+   :params {:event-id "user/login"}
+   :query  {:tab :timeline}})
+
+;; ---- trace-buffer fixtures (drive FROM/TO detection) -------------------
+
+(defn- nav-allocated-trace
+  "Build a `:rf.route.nav-token/allocated` trace event mirroring the
+  shape `(trace/emit! :event :rf.route.nav-token/allocated ...)`
+  produces in `re-frame.routing`."
+  [id dispatch-id route-id nav-token]
+  {:id        id
+   :op-type   :event
+   :operation :rf.route.nav-token/allocated
+   :tags      {:dispatch-id dispatch-id
+               :route-id    route-id
+               :nav-token   nav-token}})
+
+(defn- event-dispatched-trace
+  "Build an `:event/dispatched` trace event — the cascade root."
+  [id dispatch-id event-vec]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :tags      {:dispatch-id dispatch-id
+               :event       event-vec}})
+
+(defn nav-buffer
+  "Trace buffer carrying one cascade that navigates to `to-route`.
+  Returns a vector shaped exactly as `re-frame.trace.projection/
+  group-cascades` consumes."
+  [dispatch-id to-route nav-token]
+  [(event-dispatched-trace 1 dispatch-id [:rf.route/navigate to-route])
+   (nav-allocated-trace 2 dispatch-id to-route nav-token)])
+
+(defn no-nav-buffer
+  "Trace buffer carrying one cascade that does NOT navigate. Used by
+  the orientation variants where only `◆ HERE` should render."
+  [dispatch-id event-vec]
+  [(event-dispatched-trace 1 dispatch-id event-vec)])

--- a/tools/causa/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_routing.cljs
@@ -1,0 +1,127 @@
+(ns panel-gallery.gallery-routing
+  "Story coverage for the **Routing tab** of the 7-tab Causa chrome
+  (rf2-nrbs9 — the new 7th L3 tab promoted from 'lives in App-db +
+  Trace').
+
+  The Routing tab body is the `routing/Panel` view. The panel reads:
+
+    - `:rf.causa/registered-routes`     — default `(rf/registrations
+                                          :route)`; test override slot
+                                          exists.
+    - `:rf.causa/current-route-slice`   — default target-frame's
+                                          `:rf/route`; test override
+                                          slot exists.
+    - `:rf.causa/cascades`              — drives FROM/TO detection.
+    - `:rf.causa/focus`                 — the spine's focused
+                                          dispatch-id.
+
+  Each variant seeds the override slots via the test-only events
+  (`:rf.causa/set-registered-routes-override-for-test`,
+  `:rf.causa/set-current-route-slice-override-for-test`) and the
+  trace-buffer via `:rf.causa/sync-trace-buffer` +
+  `:rf.causa/focus-cascade` (for the FROM/TO variant)."
+  (:require [re-frame.story :as story]
+            [panel-gallery.fixtures-routing :as fixtures]
+            [panel-gallery.panel-views :as panel-views]))
+
+(defn register-gallery-view! []
+  (panel-views/register!))
+
+(defn register-all!
+  "Register the Routing tab Story surface. Idempotent under
+  `install-canonical-vocabulary!` resets so the namespace is
+  reloadable."
+  []
+  (story/install-canonical-vocabulary!)
+  (register-gallery-view!)
+
+  (story/reg-tag :feature/causa-routing
+    {:axis :feature
+     :doc  "Causa Routing tab — lens over the registered-routes tree
+            with HERE/FROM/TO markers driven by the focused cascade
+            per spec/016 §Routing tab + spec/018 §5.6."})
+
+  (story/reg-story :story.causa.routing
+    {:doc        "Visual gallery of the Causa Routing tab under varying
+                 registrar shapes + nav cascades. Each variant seeds
+                 the registered-routes + current-slice override slots
+                 via test-only events and the trace-buffer via
+                 :rf.causa/sync-trace-buffer."
+     :component  :panel-gallery.routing/Panel
+     :tags       #{:dev :feature/causa-routing}
+     :substrates #{:reagent}})
+
+  ;; ----- 1. no routes registered (silent) ----------------------------
+  (story/reg-variant :story.causa.routing/no-routes
+    {:doc        "Host app has no routes registered. Panel renders
+                 the silent empty-state — terse one-liner, no tree.
+                 Honours silent-by-default per rf2-g3ghh."
+     :events     [[:rf.causa/set-registered-routes-override-for-test {}]
+                  [:rf.causa/set-current-route-slice-override-for-test nil]]
+     :tags       #{:dev :state/empty}
+     :substrates #{:reagent}})
+
+  ;; ----- 2. current route only (◆ HERE) ------------------------------
+  (story/reg-variant :story.causa.routing/current-route-only
+    {:doc        "Routes registered + a current slice; focused
+                 cascade did NOT navigate. The current row carries
+                 the ◆ HERE marker — orientation only."
+     :events     [[:rf.causa/set-registered-routes-override-for-test
+                   fixtures/cart-routes]
+                  [:rf.causa/set-current-route-slice-override-for-test
+                   fixtures/cart-slice]
+                  [:rf.causa/sync-trace-buffer
+                   (fixtures/no-nav-buffer 1 [:cart/refresh])]
+                  [:rf.causa/focus-cascade 1 nil]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
+  ;; ----- 3. FROM → TO transition (◆ FROM / ◆ TO) ---------------------
+  (story/reg-variant :story.causa.routing/from-to-transition
+    {:doc        "Focused cascade carried a nav-token allocation —
+                 the panel renders ◆ FROM on the prior route and
+                 ◆ TO on the destination. Params/query for the
+                 destination surface below the tree."
+     :events     [[:rf.causa/set-registered-routes-override-for-test
+                   fixtures/cart-routes]
+                  ;; Slice still on the FROM route so the helper can
+                  ;; derive FROM ≠ TO. (Production: the slice writes
+                  ;; the TO value during the cascade, but the panel
+                  ;; can read it mid-flight — the lens shows both
+                  ;; markers when the snapshot is split.)
+                  [:rf.causa/set-current-route-slice-override-for-test
+                   fixtures/cart-slice]
+                  [:rf.causa/sync-trace-buffer
+                   (fixtures/nav-buffer 1 :route/confirm "nav-1")]
+                  [:rf.causa/focus-cascade 1 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 4. nested route tree (depth 3+) -----------------------------
+  (story/reg-variant :story.causa.routing/nested-route-tree
+    {:doc        "Deeper nesting exercises the indentation behaviour
+                 at depth 3+ (`/docs/api/events/detail` lands at
+                 depth 4). HERE marks the active deeply-nested
+                 route; params + query surface below the tree."
+     :events     [[:rf.causa/set-registered-routes-override-for-test
+                   fixtures/deep-routes]
+                  [:rf.causa/set-current-route-slice-override-for-test
+                   fixtures/docs-api-detail-slice]
+                  [:rf.causa/sync-trace-buffer
+                   (fixtures/no-nav-buffer 1 [:docs/refresh])]
+                  [:rf.causa/focus-cascade 1 nil]]
+     :tags       #{:dev :state/medium}
+     :substrates #{:reagent}})
+
+  ;; ----- variants-grid workspace ------------------------------------
+  (story/reg-workspace :workspace.causa.routing/all
+    {:doc      "All four Routing tab variants in one auto-grid.
+                Scroll to see the panel's response across no-routes /
+                current-route-only / from-to-transition /
+                nested-route-tree."
+     :layout   :variants-grid
+     :story    :story.causa.routing
+     :columns  2
+     :tags     #{:dev}}))
+
+(register-all!)

--- a/tools/causa/testbeds/panel_gallery/panel_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/panel_views.cljs
@@ -1,7 +1,7 @@
 (ns panel-gallery.panel-views
   "Registered re-frame views referenced by Story variant `:component`
   slots in the Causa panel gallery (rf2-sszlr — rebuilt for the new
-  6-tab Causa shape).
+  7-tab Causa shape).
 
   Story canvas resolves `:component` to a registered re-frame view
   via `(rf/view <id>)` (per
@@ -16,9 +16,9 @@
   a card that sets a fixed-ish height so the variants-grid layout
   stays visually uniform.
 
-  ## The 6 L4 tabs
+  ## The 7 L4 tabs
 
-  Per spec/018-Event-Spine.md §5 the chrome surfaces six tabs whose
+  Per spec/018-Event-Spine.md §5 the chrome surfaces seven tabs whose
   bodies are existing per-panel Panel views:
 
     - **Event**    → `event-detail/Panel`
@@ -26,6 +26,7 @@
     - **Views**    → `views/Panel`
     - **Trace**    → `trace/Panel`
     - **Machines** → `machine-inspector/Panel`
+    - **Routing**  → `routing/Panel` (rf2-nrbs9 — 7th tab)
     - **Issues**   → `issues-ribbon/Panel`
 
   (Causality is NOT a tab — it's a `c`-key popover; gallery variants
@@ -57,6 +58,7 @@
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.routing :as routing]
             [day8.re-frame2-causa.panels.trace :as trace]
             [day8.re-frame2-causa.panels.views :as views]
             [day8.re-frame2-causa.shell :as shell]
@@ -128,6 +130,14 @@
          :data-testid "panel-gallery-machines-card"}
    [machine-inspector/Panel]])
 
+(defn- routing-tab-panel
+  "Embedded mount of the Routing tab body — the routing panel
+  (rf2-nrbs9; spec/016 §Routing tab + spec/018 §5.6)."
+  [_args]
+  [:div {:style       card-style
+         :data-testid "panel-gallery-routing-card"}
+   [routing/Panel]])
+
 (defn- issues-tab-panel
   "Embedded mount of the Issues tab body — the issues-ribbon panel."
   [_args]
@@ -179,6 +189,7 @@
   (rf/reg-view* :panel-gallery.views/Panel    views-tab-panel)
   (rf/reg-view* :panel-gallery.trace/Panel    trace-tab-panel)
   (rf/reg-view* :panel-gallery.machines/Panel machines-tab-panel)
+  (rf/reg-view* :panel-gallery.routing/Panel  routing-tab-panel)
   (rf/reg-view* :panel-gallery.issues/Panel   issues-tab-panel)
   (rf/reg-view* :panel-gallery.chrome/Shell   chrome-shell)
   nil)


### PR DESCRIPTION
## Summary

Per Mike's design call (2026-05-18 16:35): Routing earns its own L3 tab in the Causa shell, parallel to Machines. Causa moves from 6 tabs to 7. Promoted from "lives in App-db + Trace" because the App-db panel was getting busy — routing slices are a cohesive sub-domain (route tree + current match + nav transitions), and the rule that surfaced from the call: **cohesive sub-domains earn their own lens tab rather than overloading App-db** (bd memory `cohesive-subdomains-get-their-own-tab`).

Dependency: rf2-qy0nu (which deleted the old dead `routes.cljs`) landed via #1477. This bead builds the new panel fresh per the lens design — no compat with the deleted file.

## Lens model (parallel to Machines)

Always-shown structure: the **full route tree** (every route registered via `re-frame.routing/reg-route`, sorted by path) — the orientation surface.

Per-focused-event highlighting:

- `◆ HERE` on the current matched route (always — orientation glyph)
- `◆ FROM` / `◆ TO` arrow when the focused cascade caused navigation
- Params + query for the active route surface below the tree
- Silent state when no routes registered (per rf2-g3ghh silent-by-default)

**Detection contract**: the composite scans the focused cascade's trace events for a `:rf.route.nav-token/allocated` emit (fires inside both `:rf.route/navigate` and `:rf/url-changed`). The emit's `:route-id` is the TO; the current slice's `:id` (when different) is the FROM. Same-route re-navigations collapse FROM (TO == current is noise).

## ASCII sketches

**Focused event caused navigation:**

```
ROUTING
  /
  ├ /cart            ◆ FROM ━━━━━━━━━━━━━━━━━━┓
  ├ /checkout                                  ┃
  │   ├ /payment              ━━━━━━━━━━━━━━━━┛
  │   └ /confirm     ◆ TO    (matched)
  ├ /admin
  │   └ /audit
  └ /404

  Params: {:order-id "ord-1234"}
  Query:  {:source "cart"}
```

**Focused event didn't navigate** (orientation only):

```
ROUTING
  /
  ├ /cart            ◆ HERE  (matched)
  ├ /checkout
  ...
```

**App has no routing registered**: tab content silent.

## What changed

**NEW**: `panels/routing.cljs` (~340 LoC), `panels/routing_helpers.cljc` (~220 LoC), matching tests (~440 LoC combined), `testbeds/panel_gallery/{fixtures,gallery}_routing.cljs` for 4 variants.

**EDITED**: `shell.cljs` (+:routing tab + L4 case-switch), `registry.cljs` (wire install!), `palette/subs.cljs` (7-entry panel list), `testbeds/panel_gallery/{core,panel_views}.cljs` (gallery wiring + Panel view), `registry_cljs_test.cljs` + `shell_cljs_test.cljs` (catalogue + count snapshots).

**SPEC**: `000-Vision.md` (6-tab → 7-tab inventory + new Routing row + posture distillation), `016-Auxiliary-Panels.md` (replaced §Routes content with normative §Routing tab), `018-Event-Spine.md` (new §5.6 + 7-tabs heading + `r` mnemonic in keyboard map).

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 705 tests, 2109 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2870 tests, 8318 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 2861 tests, 8276 assertions, 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] No mkdocs nav reference to `tools/causa/spec` — no docs gate needed

Bead `rf2-nrbs9` remains OPEN (Mike will close).