### PR TITLE
feat(causa): focus-navigation primitive — gutter sets focus, [<][>] step within subset (rf2-a1z3b)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/focus_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/focus_helpers.cljc
@@ -1,0 +1,247 @@
+(ns day8.re-frame2-causa.focus-helpers
+  "Pure helpers for the focus-navigation primitive (rf2-a1z3b).
+
+  The focus primitive is NOT a filter — the full L2 event list keeps
+  rendering. In-focus rows show full opacity + open marker `⦿` in the
+  left gutter; out-of-focus rows render dimmed (~40% opacity); the
+  pivot (anchor row that established the focus) shows a filled marker.
+  Nav buttons + `j`/`k` keys skip past out-of-focus rows.
+
+  ## Dimension model
+
+  The 'focus set' is described by `{:dimension <kw> :value <v> :pivot-id <id>}`.
+  Four supported dimensions, picked implicitly from the clicked row's
+  properties (first applicable wins):
+
+  | Row property                          | Dimension              |
+  |---------------------------------------|------------------------|
+  | Triggered a machine transition        | `:machine-id`          |
+  | Triggered an HTTP fx                  | `:http-correlation-id` |
+  | Event-id (always available)           | `:event-id`            |
+  | Has source-coord (always available)   | `:source-coord`        |
+
+  `:event-id` is listed before `:source-coord` because almost every
+  event carries a source-coord — if `:source-coord` won the picker
+  every focus would degrade to 'all events from this code site',
+  which is rarely the user's intent. `:event-id` is the right default
+  for the average row. The `:source-coord` dimension exists so a
+  future right-click override (deferred) can opt into it.
+
+  ## Predicate model
+
+  Given `{:dimension :value}` the predicate accepts a cascade map
+  (from `re-frame.trace.projection/group-cascades`) and returns true
+  when that cascade matches the dimension. The predicate is pure and
+  JVM-runnable so the cljc spine module can call it inside both
+  reducers and subs.
+
+  ## Traversal
+
+  `next-in-focus-id` / `prev-in-focus-id` walk a cascade vector skipping
+  past out-of-focus rows. Bounds-clamped (stepping past the last
+  in-focus row returns nil, signalling 'at boundary')."
+  (:require [clojure.string :as str]))
+
+;; ---- cascade introspection ----------------------------------------------
+
+(defn event-id-of
+  "Best-effort pluck of the event-id from a cascade's `:event` vector.
+  The vector is `[event-id payload...]`; first element is the id.
+  Returns nil for the `:ungrouped` bucket / unrouted cascades."
+  [cascade]
+  (let [ev (:event cascade)]
+    (when (vector? ev)
+      (first ev))))
+
+(defn- str-contains?
+  "Cross-platform substring test — used in op-string heuristics below.
+  Wraps `clojure.string/includes?` so the call sites read like the
+  feature predicate they implement."
+  [s sub]
+  (str/includes? (str s) sub))
+
+(defn http-correlation-id-of
+  "If the cascade's events carry an HTTP correlation id (request-id),
+  return it — else nil. The HTTP fx tags `:request-id` on every event
+  in the request/response chain per Spec 009. Looks at every event in
+  the cascade's `:other` + `:effects` slots — the dispatched event
+  itself, the fx invocation, the success/failure dispatch all share
+  the same `:request-id` tag.
+
+  Falls back to `:correlation-id` for symmetry with the cancellation-
+  cascade tag vocabulary."
+  [cascade]
+  (let [all (concat (:other cascade) (:effects cascade)
+                    (when-let [f (:fx cascade)] [f])
+                    (when-let [h (:handler cascade)] [h]))]
+    (some (fn [ev]
+            (let [tags (:tags ev)]
+              (or (:request-id tags)
+                  (:correlation-id tags))))
+          all)))
+
+(defn machine-id-of
+  "If the cascade involves a state-machine — return the machine id.
+  Spec 005 machine traces carry `:machine-id` (or `:actor-id` for
+  spawned actors) on their tags. Looks first at the cascade's `:other`
+  bucket where machine traces land, then the `:event` tags (a
+  machine-routed dispatch tags `:machine-id` on the `:event/dispatched`
+  trace)."
+  [cascade]
+  (let [all (concat (:other cascade)
+                    (when-let [h (:handler cascade)] [h])
+                    (when-let [f (:fx cascade)] [f]))]
+    (some (fn [ev]
+            (let [tags (:tags ev)]
+              (or (:machine-id tags)
+                  (:actor-id tags))))
+          all)))
+
+(defn source-coord-of
+  "Pluck the cascade's source-coord — file:line of the dispatch site.
+  Looks at the `:rf.trace/trigger-handler` slot on the dispatched event
+  per Spec 009 §Source-coord. Returns a `file:line` string or nil."
+  [cascade]
+  (let [ev (or (:handler cascade) (:fx cascade)
+               (first (:other cascade)))]
+    (when-let [trigger (:rf.trace/trigger-handler ev)]
+      (let [{:keys [file line]} (:source-coord trigger)]
+        (when file
+          (cond-> file
+            line (str ":" line)))))))
+
+;; ---- dimension picker ---------------------------------------------------
+
+(def dimension-priority
+  "First-applicable wins. `:machine-id` and `:http-correlation-id`
+  beat `:event-id` because they answer the user's likely
+  'show me everything related to this thing' question more
+  specifically. `:source-coord` is last — almost every event carries
+  one, so it would otherwise dominate every gutter click."
+  [:machine-id :http-correlation-id :event-id :source-coord])
+
+(defn- dimension-value
+  "Pluck the value for `dimension` off `cascade`, or nil when the
+  cascade doesn't carry that dimension."
+  [cascade dimension]
+  (case dimension
+    :machine-id          (machine-id-of cascade)
+    :http-correlation-id (http-correlation-id-of cascade)
+    :event-id            (event-id-of cascade)
+    :source-coord        (source-coord-of cascade)
+    nil))
+
+(defn infer-dimension
+  "Pick the focus dimension for a gutter-clicked cascade. Returns
+  `{:dimension <kw> :value <v>}` or nil when no dimension applies
+  (cascade is `:ungrouped` / unrouted — no event-id, no machine,
+  no http, no source-coord).
+
+  Walks `dimension-priority` and returns the first dimension whose
+  value is non-nil. Pure data → data; JVM-runnable."
+  [cascade]
+  (some (fn [dimension]
+          (when-let [v (dimension-value cascade dimension)]
+            {:dimension dimension :value v}))
+        dimension-priority))
+
+;; ---- predicate builder --------------------------------------------------
+
+(defn build-focus-predicate
+  "Given a focus-set descriptor `{:dimension <kw> :value <v>}`, return
+  a `(fn [cascade] bool)` predicate that answers 'is this cascade
+  in-focus?'. Returns `(constantly true)` when focus-set is nil
+  (no focus active — every cascade is 'in focus'). Pure data →
+  function."
+  [focus-set]
+  (if-let [{:keys [dimension value]} focus-set]
+    (fn focus-pred [cascade]
+      (= value (dimension-value cascade dimension)))
+    (constantly true)))
+
+(defn in-focus?
+  "Convenience — true iff `cascade` matches `focus-set`. When
+  `focus-set` is nil every cascade is in-focus (the no-focus baseline).
+  Pure data."
+  [focus-set cascade]
+  ((build-focus-predicate focus-set) cascade))
+
+;; ---- labels for tooltip + ribbon chip ----------------------------------
+
+(defn dimension-label
+  "Human-readable label for the focus dimension. Used in the gutter
+  hover tooltip ('focus on …') and the ribbon chip ('🎯 <label> ✕').
+  Pure data; JVM-runnable."
+  [{:keys [dimension value]}]
+  (case dimension
+    :machine-id          (str "machine " value)
+    :http-correlation-id (str "HTTP " value)
+    :event-id            (str value)
+    :source-coord        (str "site " value)
+    (str value)))
+
+(defn pivot-label
+  "Short label for the ribbon chip — the pivot value alone, no
+  dimension prefix. Used inside the chip glyph slot where the
+  surrounding `🎯` + `✕` already telegraph the focus context."
+  [{:keys [value]}]
+  (str value))
+
+;; ---- traversal ----------------------------------------------------------
+
+(defn in-focus-ids
+  "Return a vector of `:dispatch-id`s from `cascades` that match
+  `focus-set`. Preserves cascade order. Pure data → vector."
+  [cascades focus-set]
+  (let [pred (build-focus-predicate focus-set)]
+    (into [] (comp (filter pred) (map :dispatch-id)) cascades)))
+
+(defn step-in-focus-id
+  "Compute the new `:dispatch-id` when stepping by `delta` (-1 prev,
+  +1 next) from `current-id` through `cascades`, skipping past
+  out-of-focus rows.
+
+  - Returns nil when `cascades` is empty OR no cascade matches
+    `focus-set` (every row is out-of-focus — no in-focus target exists).
+  - When `current-id` is itself out-of-focus or absent, behaves as if
+    stepping from the head (for +1) / tail (for -1) of the in-focus
+    subsequence.
+  - Bounds-clamped — at the first/last in-focus row, returns the
+    current id (no-op so the ribbon's `:disabled` state lights up).
+
+  Pure data → id-or-nil; JVM-runnable."
+  [cascades focus-set current-id delta]
+  (let [in-focus (in-focus-ids cascades focus-set)
+        n        (count in-focus)]
+    (when (pos? n)
+      (let [idx (some (fn [[i id]]
+                        (when (= current-id id) i))
+                      (map-indexed vector in-focus))
+            ;; When current-id isn't in the in-focus subset, treat it
+            ;; as if we're sitting just past the boundary — stepping
+            ;; forward lands on the first in-focus, stepping backward
+            ;; lands on the last. Mirrors the spine's "step from
+            ;; head when evicted" discipline.
+            base-idx (cond
+                       idx idx
+                       (neg? delta) n                ;; →  n-1  (last)
+                       :else        -1)              ;; →  0    (first)
+            new-idx  (-> (+ base-idx delta)
+                         (max 0)
+                         (min (dec n)))]
+        (nth in-focus new-idx)))))
+
+(defn at-focus-boundary?
+  "True when stepping by `delta` from `current-id` would not move
+  through the in-focus subset (already at the relevant edge). Drives
+  the ribbon's `[◀]` / `[▶]` `:disabled` state when focus is set.
+  Pure data → bool."
+  [cascades focus-set current-id delta]
+  (let [in-focus (in-focus-ids cascades focus-set)]
+    (cond
+      (empty? in-focus)               true
+      ;; current-id not in the subset → there IS room to step (we'll
+      ;; jump to the edge).
+      (not (some #(= current-id %) in-focus)) false
+      (neg? delta) (= current-id (first in-focus))
+      :else        (= current-id (last in-focus)))))

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -179,7 +179,19 @@
         ;; tab opens it, second `c` closes it. The toggle event lives
         ;; in popover/causality_events.cljs.
         (and (not shift?) (or (= "c" k) (= "KeyC" code)))
-        :rf.causa/causality-popover-toggle))))
+        :rf.causa/causality-popover-toggle
+
+        ;; Esc — clear focus-set (rf2-a1z3b). The focus primitive is a
+        ;; lens (NOT a filter); Esc is the universal 'undo the lens'
+        ;; gesture. Modals + popovers register their own Escape
+        ;; handlers on their input elements (the palette/causality/
+        ;; settings handlers preventDefault + stopPropagation before
+        ;; this listener fires), so Esc here only reaches the focus
+        ;; clear when no modal is open. When no focus-set is active
+        ;; the event handler is a no-op (`clear-focus-reducer` dissocs
+        ;; an absent slot).
+        (and (not shift?) (or (= "Escape" k) (= "Escape" code) (= "Esc" k)))
+        :rf.causa/clear-focus))))
 
 (defn- handle-keydown [^js event]
   (cond

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -93,6 +93,7 @@
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
+            [day8.re-frame2-causa.focus-helpers :as fh]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
@@ -484,6 +485,58 @@
                           :font-size   (:caption type-scale)}}
      (str "● REDACTED " redacted-count)]))
 
+(defn- ribbon-focus-chip
+  "Focus chip (rf2-a1z3b) — surfaces the active focus-set as
+  `🎯 <pivot-label> ✕`. Click `✕` clears focus; click the chip body
+  to scroll the pivot row into view (future). Renders nothing when
+  no focus-set is active.
+
+  Placement: directly after the nav cluster so the user's eye picks
+  it up next to `[◀][▶]` — those buttons step ONLY through the focus
+  subset while the chip is present, so the cluster reads naturally
+  as 'stepping inside this focus'."
+  [{:keys [focus-set]}]
+  (when focus-set
+    (let [label (fh/pivot-label focus-set)
+          tip   (str "Focus: " (fh/dimension-label focus-set)
+                     " (Esc to clear)")]
+      [:div {:data-testid "rf-causa-focus-chip"
+             :title       tip
+             :style       {:display        "inline-flex"
+                           :align-items    "center"
+                           :gap            "4px"
+                           :padding        "2px 6px 2px 8px"
+                           :background     (:bg-active tokens)
+                           :border         (str "1px solid " (:accent-violet tokens))
+                           :border-radius  "10px"
+                           :font-family    sans-stack
+                           :font-size      (:body type-scale)
+                           :color          (:text-primary tokens)
+                           :max-width      "240px"}}
+       [:span {:style {:color (:accent-violet tokens)
+                       :font-weight 600}}
+        "🎯"]                ;; 🎯 (UTF-16 surrogate pair for portability)
+       [:span {:data-testid "rf-causa-focus-chip-label"
+               :style {:overflow      "hidden"
+                       :text-overflow "ellipsis"
+                       :white-space   "nowrap"
+                       :max-width     "180px"
+                       :font-family   mono-stack
+                       :font-size     (:caption type-scale)}}
+        label]
+       [:button {:data-testid "rf-causa-focus-chip-clear"
+                 :on-click    #(rf/dispatch [:rf.causa/clear-focus] {:frame :rf/causa})
+                 :title       "Clear focus (Esc)"
+                 :aria-label  "Clear focus"
+                 :style       {:background    "transparent"
+                               :border        "none"
+                               :color         (:text-secondary tokens)
+                               :cursor        "pointer"
+                               :padding       "0 2px"
+                               :font-size     (:body type-scale)
+                               :line-height   "1"}}
+        "✕"]])))                  ;; ✕
+
 (defn- ribbon-right-icons
   "Right-icons cluster — `⚙` settings · `✕` close. Per spec/018 §3
   Right-icon behaviour the pop-out (`⛶`) slot is reserved for the
@@ -525,6 +578,7 @@
   [_props]
   (let [focus           @(rf/subscribe [:rf.causa/focus])
         cascades        @(rf/subscribe [:rf.causa/cascades])
+        focus-set       @(rf/subscribe [:rf.causa/focus-set])
         show-tool?      false   ; Hardcoded — Power-user toggle UI not built yet
         frames          (distinct-frames cascades show-tool?)
         redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
@@ -541,10 +595,17 @@
         ;; pin focus to the `:ungrouped` bucket and degrade the L4
         ;; panels into an aggregate-across-all-events render.
         event-cascades  (filterv cascade-has-event? cascades)
-        ids             (mapv :dispatch-id event-cascades)
+        ;; rf2-a1z3b — when a focus-set is active the nav buttons walk
+        ;; ONLY the in-focus subset. Boundary predicates honour that
+        ;; so `[◀]` greys at the first in-focus row and `[▶]` greys at
+        ;; the last. When no focus-set is active, fall through to the
+        ;; existing full-stream boundary semantics.
+        ids             (if focus-set
+                          (fh/in-focus-ids event-cascades focus-set)
+                          (mapv :dispatch-id event-cascades))
         at-head?        (or (empty? ids)
                             (= focused-id (last ids))
-                            (nil? focused-id))
+                            (and (nil? focused-id) (not focus-set)))
         at-tail?        (or (empty? ids)
                             (= focused-id (first ids)))]
     [:div {:data-testid "rf-causa-ribbon"
@@ -559,6 +620,7 @@
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail?}]
+     [ribbon-focus-chip {:focus-set focus-set}]
      [ribbon-frame-picker {:selected-frame (:frame focus)
                            :frames frames}]
      [ribbon-filter-pills {:filters filters}]
@@ -681,6 +743,28 @@
         (do (reset! last-scrolled-focus-id id)
             (scroll-focused-row-into-view! el))))))
 
+(defn- focus-gesture-handler
+  "rf2-a1z3b — return the on-click handler for the L2 row's left
+  GUTTER. The gutter is the FOCUS surface (vs. the body, which is the
+  SELECTION surface). Click semantics:
+
+  - Out-of-focus row's gutter → set focus on the row's inferred
+    dimension (`fh/infer-dimension` picks first applicable from
+    machine / http / event-id / source-coord).
+  - Pivot row's gutter (same id, same dimension) → toggle focus OFF
+    (the `set-focus-reducer` recognises the duplicate and dissocs).
+  - In-focus non-pivot row's gutter → rebuild focus around this row
+    as the new pivot (dimension may stay the same or change).
+
+  Returns nil when no dimension can be inferred (`:ungrouped` /
+  unrouted cascade) — the gutter renders inert."
+  [cascade]
+  (when-let [{:keys [dimension value]} (fh/infer-dimension cascade)]
+    (fn [^js e]
+      (.stopPropagation e)
+      (rf/dispatch [:rf.causa/set-focus dimension value (:dispatch-id cascade)]
+                   {:frame :rf/causa}))))
+
 (defn- event-row
   "One row in the L2 event list. Single line per spec/018 §4 Row
   anatomy. Gutter glyph + event-id + right-anchored badge cluster +
@@ -694,40 +778,82 @@
   Pre-alpha the popup is the only context-menu surface (the rich
   multi-item menu lands behind a follow-on bead); preventing the
   browser context menu keeps the affordance discoverable on first
-  right-click."
-  [{:keys [cascade focused-id auto-track?]}]
-  (let [id        (:dispatch-id cascade)
-        focused?  (= id focused-id)
-        glyph     (gutter-glyph cascade focused-id)
-        badges    (row-badges cascade)
-        ev-id     (event-id-of-cascade cascade)
-        event-vec (:event cascade)
-        glyph-col (cond
-                    focused?                                (:cyan tokens)
-                    (= "x" glyph)                           (:red tokens)
-                    (= "▥" glyph)                           (:magenta tokens)
-                    :else                                   (:text-tertiary tokens))
-        bg        (if focused? (:bg-active tokens) "transparent")
-        border    (if focused?
-                    (str "1px solid " (:cyan tokens))
-                    "1px solid transparent")
+  right-click.
+
+  ## Focus gutter (rf2-a1z3b)
+
+  The leftmost ~14px is the FOCUS surface (gutter); the rest is the
+  SELECTION surface (body). Gutter click sets/toggles focus on the
+  row's inferred dimension; body click selects the cascade (and
+  CLEARS focus when the clicked row is out-of-focus). When a
+  focus-set is active, out-of-focus rows render at ~40% opacity and
+  the gutter renders an OPEN `⦿` marker; the pivot row renders a
+  FILLED `⦿` marker."
+  [{:keys [cascade focused-id auto-track? focus-set in-focus?]}]
+  (let [id          (:dispatch-id cascade)
+        focused?    (= id focused-id)
+        pivot?      (and focus-set (= id (:pivot-id focus-set)))
+        focus-active? (some? focus-set)
+        out-of-focus? (and focus-active? (not in-focus?))
+        glyph       (gutter-glyph cascade focused-id)
+        badges      (row-badges cascade)
+        ev-id       (event-id-of-cascade cascade)
+        event-vec   (:event cascade)
+        glyph-col   (cond
+                      focused?                                (:cyan tokens)
+                      (= "x" glyph)                           (:red tokens)
+                      (= "▥" glyph)                           (:magenta tokens)
+                      :else                                   (:text-tertiary tokens))
+        bg          (if focused? (:bg-active tokens) "transparent")
+        border      (if focused?
+                      (str "1px solid " (:cyan tokens))
+                      "1px solid transparent")
         ;; rf2-ieg6d Bug 1 — only the focused row in the LIVE-at-head
         ;; auto-tracking branch carries a ref. RETRO and non-focused rows
         ;; get nil (no DOM-side scroll work, no per-render cost).
-        ref-fn    (when focused? (focused-row-ref id auto-track?))]
+        ref-fn      (when focused? (focused-row-ref id auto-track?))
+        gutter-click (focus-gesture-handler cascade)
+        ;; rf2-a1z3b — clicking a row's body clears focus when the row
+        ;; is OUT-of-focus (the gesture model: body-click on dim row
+        ;; says 'I want to select this; abandon the focus lens'). When
+        ;; the row is IN-focus or no focus-set is active, body-click is
+        ;; pure selection per the existing contract.
+        body-click  (fn [_e]
+                      (when out-of-focus?
+                        (rf/dispatch [:rf.causa/clear-focus] {:frame :rf/causa}))
+                      (rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
+                                   {:frame :rf/causa}))
+        ;; Focus-aware gutter marker per rf2-a1z3b. The existing glyph
+        ;; (●/◉/x/▥) keeps semantics for the spine's selection +
+        ;; error/redacted state; an additional ⦿ marker rides ON TOP
+        ;; in the gutter when a focus-set is active to signal in-focus
+        ;; (open) vs pivot (filled). When no focus-set is active the
+        ;; gutter renders the legacy glyph only.
+        focus-marker (cond
+                       pivot?     "⦿"          ;; filled (pivot anchor)
+                       in-focus?  "◌"          ;; open marker for in-focus non-pivot rows
+                       :else      nil)
+        focus-marker-col (cond
+                           pivot?    (:accent-violet tokens)
+                           in-focus? (:accent-violet tokens)
+                           :else     (:text-tertiary tokens))]
     ;; Density (rf2-htik0 Bug 2): height 22px + padding "1px 6px" tightens
     ;; the row from the earlier 28px / "4px 8px" spec-baseline. Causa is
     ;; info-dense; keeps clickable hit-area while letting ~10 rows fit in
     ;; the same vertical budget the old 8 rows used.
     [:li (cond-> {:data-testid (str "rf-causa-event-row-" (str id))
-                  :on-click    #(rf/dispatch [:rf.causa/focus-cascade id (:frame cascade)]
-                                             {:frame :rf/causa})
+                  :on-click    body-click
                   :on-context-menu (fn [^js e]
                                      (when ev-id
                                        (.preventDefault e)
                                        (rf/dispatch
                                          [:rf.causa/hide-event-type ev-id]
                                          {:frame :rf/causa})))
+                  :data-rf-causa-in-focus (cond
+                                            (not focus-active?) "n/a"
+                                            in-focus?           "true"
+                                            :else               "false")
+                  :data-rf-causa-pivot    (if pivot? "true" "false")
                   :style {:display       "flex"
                           :align-items   "center"
                           :gap           "6px"
@@ -743,11 +869,47 @@
                           :color         (:text-primary tokens)
                           :white-space   "nowrap"
                           :overflow      "hidden"
-                          :text-overflow "ellipsis"}}
+                          :text-overflow "ellipsis"
+                          ;; rf2-a1z3b — out-of-focus rows dim to
+                          ;; `--rf-causa-row-dim-opacity` (default 0.4)
+                          ;; so the lens reads at a glance. Inline so
+                          ;; we don't need a stylesheet round-trip; the
+                          ;; CSS-var fallback keeps host overrides
+                          ;; possible.
+                          :opacity       (if out-of-focus?
+                                           "var(--rf-causa-row-dim-opacity, 0.4)"
+                                           1)}}
            ref-fn (assoc :ref ref-fn))
-     [:span {:style {:width "14px" :color glyph-col :flex-shrink 0
-                     :text-align "center"}}
-      glyph]
+     ;; Gutter — FOCUS surface (rf2-a1z3b). Click sets/toggles focus
+     ;; on the row's inferred dimension. The hit-area is the 14px
+     ;; gutter cell; stopPropagation prevents the body-click handler
+     ;; from also firing.
+     [:span (cond-> {:data-testid (str "rf-causa-row-gutter-" (str id))
+                     :style       {:width        "14px"
+                                   :flex-shrink  0
+                                   :display      "inline-flex"
+                                   :align-items  "center"
+                                   :justify-content "center"
+                                   :align-self   "stretch"
+                                   :cursor       (if gutter-click "pointer" "default")
+                                   :color        focus-marker-col
+                                   :font-size    "11px"}
+                     :title       (cond
+                                    pivot?
+                                    (str "Clear focus on " (fh/dimension-label focus-set))
+
+                                    (and focus-active? in-focus?)
+                                    (str "Re-anchor focus on this row ("
+                                         (fh/dimension-label focus-set) ")")
+
+                                    gutter-click
+                                    (str "Focus on " (fh/dimension-label (fh/infer-dimension cascade)))
+
+                                    :else
+                                    "")}
+              gutter-click (assoc :on-click gutter-click))
+      (or focus-marker
+          [:span {:style {:color glyph-col}} glyph])]
      ;; Bug 3 (rf2-htik0): render the real event vector inline —
      ;; `[:cart/add-item {:item-id "apple"}]`, NOT just `:cart/add-item`.
      ;; Truncates at ~80 chars with `…]` suffix to keep the row single-line.
@@ -810,6 +972,7 @@
   (inject-scrollbar-style!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
         focus          @(rf/subscribe [:rf.causa/focus])
+        focus-set      @(rf/subscribe [:rf.causa/focus-set])
         focused-id     (:dispatch-id focus)
         ;; LIVE+head+not-paused = the auto-tracking branch from
         ;; spine/compose-focus. Only here do we want scroll-into-view
@@ -818,7 +981,11 @@
         auto-track?    (and (= :live (:mode focus))
                             (:head? focus)
                             (not (:paused? focus)))
-        event-cascades (filterv cascade-has-event? cascades)]
+        event-cascades (filterv cascade-has-event? cascades)
+        ;; rf2-a1z3b — precompute the focus predicate ONCE per render
+        ;; so the per-row work is a single fn call rather than a
+        ;; predicate rebuild per row.
+        focus-pred     (fh/build-focus-predicate focus-set)]
     [:div {:data-testid "rf-causa-event-list"
            :style {:height        "200px"   ; 8 rows × 22px + gaps + padding (rf2-htik0)
                    :min-height    "48px"    ; 2 rows minimum
@@ -848,7 +1015,9 @@
                ^{:key (str (:dispatch-id cascade))}
                [event-row {:cascade     cascade
                            :focused-id  focused-id
-                           :auto-track? auto-track?}])))]))
+                           :auto-track? auto-track?
+                           :focus-set   focus-set
+                           :in-focus?   (focus-pred cascade)}])))]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -44,6 +44,7 @@
   future spine-aware list updates the legacy slots."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.focus-helpers :as fh]
             [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
@@ -348,7 +349,15 @@
          ;; back from the CURRENT head rather than from a stale
          ;; stored id.
          current-id (:dispatch-id (compose-focus (get db :focus) cascades))
-         new-id     (step-dispatch-id focusable current-id delta)
+         ;; rf2-a1z3b — when a focus-set is active, step skips past
+         ;; out-of-focus cascades to the next/prev in-focus row. When
+         ;; no focus-set is active, fall through to the plain
+         ;; step-dispatch-id walk so the existing nav semantics are
+         ;; preserved exactly.
+         focus-set  (get db :focus-set)
+         new-id     (if focus-set
+                      (fh/step-in-focus-id focusable focus-set current-id delta)
+                      (step-dispatch-id focusable current-id delta))
          head-id    (head-dispatch-id focusable)]
      (if (or (nil? new-id)
              ;; rf2-fzbrw — boundary no-op. Stepping past either edge
@@ -425,6 +434,41 @@
     (-> db
         (assoc-in [:focus :previewing?] true)
         (assoc-in [:focus :dispatch-id] dispatch-id))))
+
+;; ---- focus-set reducers (rf2-a1z3b) -------------------------------------
+
+(defn set-focus-reducer
+  "Pure reducer for `:rf.causa/set-focus`. Writes a focus-set descriptor
+  `{:dimension <kw> :value <v> :pivot-id <dispatch-id>}` into the
+  `:focus-set` slot. The pivot id is the dispatch-id of the cascade
+  whose gutter was clicked — the L2 row uses it to render the filled
+  `⦿` pivot marker (vs the open `⦿` for other in-focus rows).
+
+  When the same pivot+dimension combo is set twice (gutter click on
+  the existing pivot), returns db with the slot CLEARED — the toggle-
+  off contract per the gesture model. Comparing dimension+value
+  (not pivot-id alone) means clicking a DIFFERENT in-focus row's
+  gutter rebuilds focus around that new pivot rather than toggling
+  off; only clicking the SAME pivot toggles.
+
+  Pure data; JVM-runnable."
+  [db dimension value pivot-id]
+  (let [current (get db :focus-set)]
+    (if (and current
+             (= dimension (:dimension current))
+             (= value (:value current))
+             (= pivot-id (:pivot-id current)))
+      (dissoc db :focus-set)
+      (assoc db :focus-set {:dimension dimension
+                            :value     value
+                            :pivot-id  pivot-id}))))
+
+(defn clear-focus-reducer
+  "Pure reducer for `:rf.causa/clear-focus`. Drops the `:focus-set` slot
+  unconditionally. Wired from the Esc keybind, the ribbon chip's `✕`,
+  and a body-click on an out-of-focus row."
+  [db]
+  (dissoc db :focus-set))
 
 ;; ---- registration --------------------------------------------------------
 
@@ -506,5 +550,27 @@
   (rf/reg-event-db :rf.causa/preview-cascade
     (fn [db [_ dispatch-id]]
       (preview-cascade-reducer db dispatch-id)))
+
+  ;; ---- focus-set (rf2-a1z3b) -----------------------------------------
+  ;;
+  ;; The focus-set is a lens NOT a filter — the L2 list keeps rendering
+  ;; every cascade, but rows that don't match the focus-set descriptor
+  ;; dim to ~40% opacity and the `[◀]` / `[▶]` nav buttons skip past
+  ;; them to the next/prev in-focus row. The focus-set rides centrally
+  ;; in the spine slot so cross-panel triggers (Machines panel click →
+  ;; focus-set on a machine; managed-fx row click → focus-set on the
+  ;; HTTP correlation id) all flow through the same write surface.
+
+  (rf/reg-sub :rf.causa/focus-set
+    (fn [db _query]
+      (get db :focus-set)))
+
+  (rf/reg-event-db :rf.causa/set-focus
+    (fn [db [_ dimension value pivot-id]]
+      (set-focus-reducer db dimension value pivot-id)))
+
+  (rf/reg-event-db :rf.causa/clear-focus
+    (fn [db _event]
+      (clear-focus-reducer db)))
 
   nil)

--- a/tools/causa/test/day8/re_frame2_causa/focus_helpers_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/focus_helpers_test.cljc
@@ -1,0 +1,203 @@
+(ns day8.re-frame2-causa.focus-helpers-test
+  "Pure-data tests for the focus-navigation helpers (rf2-a1z3b).
+
+  Coverage:
+
+  - Dimension picker — all four default dimensions (event-id,
+    machine-id, http-correlation-id, source-coord) + the picker's
+    first-applicable priority + the nil-cascade fallback.
+  - Predicate builder — focused predicate per dimension; nil focus-set
+    is identity-true.
+  - Traversal — `in-focus-ids`, `step-in-focus-id` skip out-of-focus
+    rows; `at-focus-boundary?` greys nav at the edges.
+
+  JVM-only test (`.cljc`) — the helpers are pure data; running them
+  under cljs.test would only add CLJS round-trip latency for no
+  additional coverage. The spine-integration tests (CLJS) exercise
+  the helpers through the wired reducer surface."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.focus-helpers :as fh]))
+
+;; ---- cascade fixtures ---------------------------------------------------
+
+(defn- cascade
+  "Build a synthetic cascade. `opts` controls which dimensions the
+  cascade carries — every test can compose one with exactly the
+  shape the test needs.
+
+  Recognised keys: :id (dispatch-id), :event-id, :machine-id,
+  :request-id, :source-coord-file, :source-coord-line."
+  [{:keys [id event-id machine-id request-id source-coord-file source-coord-line]
+    :or   {id 1}}]
+  (cond-> {:dispatch-id id
+           :frame       :rf/default
+           :event       (when event-id [event-id {}])
+           :handler     (cond-> {}
+                          source-coord-file
+                          (assoc :rf.trace/trigger-handler
+                                 {:source-coord (cond-> {:file source-coord-file}
+                                                  source-coord-line
+                                                  (assoc :line source-coord-line))}))
+           :fx          nil
+           :effects     []
+           :subs        []
+           :renders     []
+           :other       []}
+    machine-id (update :other conj {:tags {:machine-id machine-id}
+                                    :operation :rf.machine/transition})
+    request-id (update :other conj {:tags {:request-id request-id}
+                                    :operation :rf.http/dispatched})))
+
+;; ---- (1) infer-dimension — all four dimensions --------------------------
+
+(deftest infer-dimension-event-id
+  (testing "Plain event row → :event-id dimension"
+    (is (= {:dimension :event-id :value :cart/add-item}
+           (fh/infer-dimension (cascade {:id 1 :event-id :cart/add-item}))))))
+
+(deftest infer-dimension-machine-id
+  (testing "Machine transition wins over event-id (more specific)"
+    (is (= {:dimension :machine-id :value :checkout-flow/main}
+           (fh/infer-dimension
+             (cascade {:id         1
+                       :event-id   :cart/add-item
+                       :machine-id :checkout-flow/main}))))))
+
+(deftest infer-dimension-http-correlation
+  (testing "HTTP request-id wins when no machine present"
+    (is (= {:dimension :http-correlation-id :value "req-42"}
+           (fh/infer-dimension
+             (cascade {:id         1
+                       :event-id   :api/load-cart
+                       :request-id "req-42"}))))))
+
+(deftest infer-dimension-source-coord
+  (testing "Source-coord is the LAST dimension — only used when nothing else applies"
+    (is (= {:dimension :event-id :value :counter/inc}
+           (fh/infer-dimension
+             (cascade {:id                1
+                       :event-id          :counter/inc
+                       :source-coord-file "src/foo.cljs"
+                       :source-coord-line 42})))
+        "event-id still wins when both present"))
+
+  (testing "Cascade with only source-coord (no event-id) → :source-coord wins"
+    (is (= {:dimension :source-coord :value "src/foo.cljs:42"}
+           (fh/infer-dimension
+             (cascade {:id                1
+                       :source-coord-file "src/foo.cljs"
+                       :source-coord-line 42}))))))
+
+(deftest infer-dimension-machine-beats-http
+  (testing "Priority — machine > http > event-id > source-coord"
+    (is (= :machine-id
+           (:dimension
+             (fh/infer-dimension
+               (cascade {:id 1 :event-id :foo :machine-id :m :request-id "req"})))))))
+
+(deftest infer-dimension-nil-for-empty-cascade
+  (testing "Cascade with no event-id / machine / http / source-coord → nil"
+    (is (nil? (fh/infer-dimension (cascade {:id :ungrouped}))))))
+
+;; ---- (2) build-focus-predicate ------------------------------------------
+
+(deftest build-focus-predicate-event-id
+  (let [pred (fh/build-focus-predicate {:dimension :event-id :value :cart/add-item})]
+    (is (true? (pred (cascade {:id 1 :event-id :cart/add-item}))))
+    (is (false? (pred (cascade {:id 2 :event-id :cart/remove-item}))))))
+
+(deftest build-focus-predicate-machine
+  (let [pred (fh/build-focus-predicate {:dimension :machine-id :value :m/one})]
+    (is (true? (pred (cascade {:id 1 :event-id :x :machine-id :m/one}))))
+    (is (false? (pred (cascade {:id 2 :event-id :x :machine-id :m/two}))))
+    (is (false? (pred (cascade {:id 3 :event-id :x}))))))
+
+(deftest build-focus-predicate-http
+  (let [pred (fh/build-focus-predicate {:dimension :http-correlation-id :value "req-7"})]
+    (is (true? (pred (cascade {:id 1 :event-id :load :request-id "req-7"}))))
+    (is (false? (pred (cascade {:id 2 :event-id :load :request-id "req-8"}))))))
+
+(deftest build-focus-predicate-source-coord
+  (let [pred (fh/build-focus-predicate {:dimension :source-coord :value "src/foo.cljs:42"})]
+    (is (true? (pred (cascade {:id 1 :source-coord-file "src/foo.cljs" :source-coord-line 42}))))
+    (is (false? (pred (cascade {:id 2 :source-coord-file "src/bar.cljs" :source-coord-line 42}))))))
+
+(deftest build-focus-predicate-nil-focus-set-is-identity
+  (let [pred (fh/build-focus-predicate nil)]
+    (is (true? (pred (cascade {:id 1 :event-id :anything})))
+        "nil focus-set = no focus active = every cascade is in-focus")))
+
+;; ---- (3) traversal ------------------------------------------------------
+
+(def ^:private cs
+  [(cascade {:id :c1 :event-id :foo})
+   (cascade {:id :c2 :event-id :bar})
+   (cascade {:id :c3 :event-id :foo})
+   (cascade {:id :c4 :event-id :baz})
+   (cascade {:id :c5 :event-id :foo})])
+
+(deftest in-focus-ids-returns-only-matching
+  (is (= [:c1 :c3 :c5]
+         (fh/in-focus-ids cs {:dimension :event-id :value :foo})))
+  (is (= [:c2]
+         (fh/in-focus-ids cs {:dimension :event-id :value :bar})))
+  (is (= []
+         (fh/in-focus-ids cs {:dimension :event-id :value :nope}))))
+
+(deftest in-focus-ids-nil-focus-set-returns-every-id
+  (is (= [:c1 :c2 :c3 :c4 :c5] (fh/in-focus-ids cs nil))))
+
+(deftest step-in-focus-id-skips-out-of-focus
+  (let [fset {:dimension :event-id :value :foo}]
+    (testing "Forward from :c1 skips :c2 to land on :c3"
+      (is (= :c3 (fh/step-in-focus-id cs fset :c1 +1))))
+    (testing "Forward from :c3 skips :c4 to land on :c5"
+      (is (= :c5 (fh/step-in-focus-id cs fset :c3 +1))))
+    (testing "Backward from :c5 skips :c4 to land on :c3"
+      (is (= :c3 (fh/step-in-focus-id cs fset :c5 -1))))
+    (testing "Backward from :c3 skips :c2 to land on :c1"
+      (is (= :c1 (fh/step-in-focus-id cs fset :c3 -1))))))
+
+(deftest step-in-focus-id-bounded-at-edges
+  (let [fset {:dimension :event-id :value :foo}]
+    (testing "Backward from first in-focus (:c1) stays at :c1 (boundary)"
+      (is (= :c1 (fh/step-in-focus-id cs fset :c1 -1))))
+    (testing "Forward from last in-focus (:c5) stays at :c5 (boundary)"
+      (is (= :c5 (fh/step-in-focus-id cs fset :c5 +1))))))
+
+(deftest step-in-focus-id-from-out-of-focus
+  (let [fset {:dimension :event-id :value :foo}]
+    (testing "Forward from out-of-focus :c2 lands on first in-focus :c1"
+      (is (= :c1 (fh/step-in-focus-id cs fset :c2 +1)))
+      "out-of-focus current treated as just-before-start; +1 → first")
+    (testing "Backward from out-of-focus :c4 lands on last in-focus :c5"
+      (is (= :c5 (fh/step-in-focus-id cs fset :c4 -1)))
+      "out-of-focus current treated as just-past-end; -1 → last")))
+
+(deftest step-in-focus-id-empty-result
+  (let [fset {:dimension :event-id :value :nope}]
+    (is (nil? (fh/step-in-focus-id cs fset :c1 +1))
+        "no in-focus rows → nil (caller treats as 'cannot step')")))
+
+(deftest at-focus-boundary
+  (let [fset {:dimension :event-id :value :foo}]
+    (is (true? (fh/at-focus-boundary? cs fset :c1 -1))   "prev at first in-focus")
+    (is (true? (fh/at-focus-boundary? cs fset :c5 +1))   "next at last in-focus")
+    (is (false? (fh/at-focus-boundary? cs fset :c3 -1)))
+    (is (false? (fh/at-focus-boundary? cs fset :c3 +1)))
+    (is (false? (fh/at-focus-boundary? cs fset :c2 +1))
+        "currently OUT-of-focus → not at boundary; step lands on edge")
+    (is (true? (fh/at-focus-boundary? cs {:dimension :event-id :value :nope} :c1 +1))
+        "no in-focus rows → boundary always (nothing to step to)")))
+
+;; ---- (4) dimension-label ------------------------------------------------
+
+(deftest dimension-label-formats
+  (is (= ":cart/add-item" (fh/dimension-label {:dimension :event-id :value :cart/add-item})))
+  (is (= "machine :checkout-flow/main"
+         (fh/dimension-label {:dimension :machine-id :value :checkout-flow/main})))
+  (is (= "HTTP req-42"
+         (fh/dimension-label {:dimension :http-correlation-id :value "req-42"})))
+  (is (= "site src/foo.cljs:42"
+         (fh/dimension-label {:dimension :source-coord :value "src/foo.cljs:42"}))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -128,6 +128,8 @@
    :rf.causa/event-detail
    :rf.causa/filtered-cascades
    :rf.causa/focus
+   ;; rf2-a1z3b — focus-navigation primitive slot sub.
+   :rf.causa/focus-set
    :rf.causa/focus-slot
    :rf.causa/focused-slice-path
    :rf.causa/issues-filters
@@ -250,6 +252,10 @@
    :rf.causa/causality-popover-toggle
    :rf.causa/causality-popover-toggle-layout
    :rf.causa/clear-machine-selection
+   ;; rf2-a1z3b — focus-navigation primitive (gutter click on L2 row sets a
+   ;; focus-set; `[◀][▶]` step within the in-focus subset).
+   :rf.causa/clear-focus
+   :rf.causa/clear-machine-selection
    :rf.causa/clear-mode-c-selection
    :rf.causa/clear-selected-dispatch-id
    :rf.causa/clear-slice-focus
@@ -308,6 +314,8 @@
    :rf.causa/select-epoch
    :rf.causa/select-machine-id
    :rf.causa/select-tab
+   ;; rf2-a1z3b — focus-navigation primitive write event.
+   :rf.causa/set-focus
    :rf.causa/set-forced-machine-mode
    :rf.causa/set-frame
    :rf.causa/set-machine-definitions-override-for-test
@@ -452,8 +460,8 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    (is (= 100 (count all-sub-names)))
-    (is (= 117 (count all-event-names)))
+    (is (= 101 (count all-sub-names)))
+    (is (= 120 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent

--- a/tools/causa/test/day8/re_frame2_causa/spine_focus_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_focus_cljs_test.cljs
@@ -1,0 +1,152 @@
+(ns day8.re-frame2-causa.spine-focus-cljs-test
+  "CLJS coverage for the focus-set wiring on the spine (rf2-a1z3b).
+
+  The pure helpers (`fh/infer-dimension`, `fh/build-focus-predicate`,
+  `fh/step-in-focus-id`) are covered by the JVM `focus_helpers_test.cljc`
+  suite; this file exercises the spine-side reducers + the sub
+  registration so the wired surface is asserted end-to-end:
+
+  1. `set-focus-reducer` — slot write + toggle-off contract.
+  2. `clear-focus-reducer` — drops slot.
+  3. `focus-step-reducer` — skips out-of-focus cascades when a
+     focus-set is active.
+  4. The registered sub `:rf.causa/focus-set` returns the slot.
+
+  Same fixture discipline as `spine_cljs_test.cljs` so any future
+  spine-side wiring follows a single test pattern."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- cascade fixture ----------------------------------------------------
+
+(defn- cascade
+  [{:keys [id event-id machine-id]
+    :or   {id 1}}]
+  (cond-> {:dispatch-id id
+           :frame       :rf/default
+           :event       (when event-id [event-id {}])
+           :handler     nil :fx nil :effects [] :subs [] :renders []
+           :other       []}
+    machine-id (update :other conj {:tags {:machine-id machine-id}
+                                    :operation :rf.machine/transition})))
+
+(def ^:private cs
+  [(cascade {:id :c1 :event-id :foo})
+   (cascade {:id :c2 :event-id :bar})
+   (cascade {:id :c3 :event-id :foo})
+   (cascade {:id :c4 :event-id :bar})
+   (cascade {:id :c5 :event-id :foo})])
+
+;; ---- (1) set-focus-reducer ----------------------------------------------
+
+(deftest set-focus-writes-slot
+  (let [db' (spine/set-focus-reducer {} :event-id :foo :c1)]
+    (is (= {:dimension :event-id :value :foo :pivot-id :c1}
+           (:focus-set db')))))
+
+(deftest set-focus-rebuilds-around-new-pivot
+  (let [db  {:focus-set {:dimension :event-id :value :foo :pivot-id :c1}}
+        db' (spine/set-focus-reducer db :event-id :foo :c3)]
+    (is (= {:dimension :event-id :value :foo :pivot-id :c3}
+           (:focus-set db'))
+        "same value, different pivot → re-pivot, NOT toggle off")))
+
+(deftest set-focus-on-same-pivot-toggles-off
+  (let [db  {:focus-set {:dimension :event-id :value :foo :pivot-id :c1}}
+        db' (spine/set-focus-reducer db :event-id :foo :c1)]
+    (is (nil? (:focus-set db'))
+        "identical descriptor → clear the slot (toggle-off contract)")))
+
+(deftest set-focus-changing-dimension-replaces
+  (let [db  {:focus-set {:dimension :event-id :value :foo :pivot-id :c1}}
+        db' (spine/set-focus-reducer db :machine-id :checkout :c1)]
+    (is (= {:dimension :machine-id :value :checkout :pivot-id :c1}
+           (:focus-set db'))
+        "different dimension → replace, even if pivot id is identical")))
+
+;; ---- (2) clear-focus-reducer --------------------------------------------
+
+(deftest clear-focus-drops-slot
+  (let [db  {:focus-set {:dimension :event-id :value :foo :pivot-id :c1}}]
+    (is (nil? (:focus-set (spine/clear-focus-reducer db)))))
+  (testing "no-op when slot is already absent"
+    (is (nil? (:focus-set (spine/clear-focus-reducer {}))))))
+
+;; ---- (3) focus-step-reducer with focus-set ------------------------------
+
+(deftest step-skips-out-of-focus-rows
+  (let [db {:focus     {:dispatch-id :c1 :mode :retro}
+            :focus-set {:dimension :event-id :value :foo :pivot-id :c1}}
+        db' (spine/focus-step-reducer db cs [] +1)]
+    (is (= :c3 (get-in db' [:focus :dispatch-id]))
+        ":c1 +1 (focus-set on :foo) → skip :c2 (bar), land on :c3")))
+
+(deftest step-prev-skips-out-of-focus-rows
+  (let [db {:focus     {:dispatch-id :c5 :mode :retro}
+            :focus-set {:dimension :event-id :value :foo :pivot-id :c1}}
+        db' (spine/focus-step-reducer db cs [] -1)]
+    (is (= :c3 (get-in db' [:focus :dispatch-id]))
+        ":c5 -1 (focus-set on :foo) → skip :c4 (bar), land on :c3")))
+
+(deftest step-boundary-no-op-with-focus-set
+  (let [db {:focus     {:dispatch-id :c5 :mode :retro}
+            :focus-set {:dimension :event-id :value :foo :pivot-id :c5}}
+        db' (spine/focus-step-reducer db cs [] +1)]
+    (is (= db db')
+        "boundary: stepping past last in-focus is a no-op (db unchanged)")))
+
+(deftest step-without-focus-set-walks-every-cascade
+  (let [db {:focus {:dispatch-id :c1 :mode :retro}}
+        db' (spine/focus-step-reducer db cs [] +1)]
+    (is (= :c2 (get-in db' [:focus :dispatch-id]))
+        "no focus-set → standard step-dispatch-id walks every cascade incl :c2")))
+
+(deftest step-with-machine-dimension
+  (let [cs-m [(cascade {:id :c1 :event-id :foo :machine-id :checkout})
+              (cascade {:id :c2 :event-id :bar})
+              (cascade {:id :c3 :event-id :foo :machine-id :checkout})
+              (cascade {:id :c4 :event-id :bar})
+              (cascade {:id :c5 :event-id :foo :machine-id :checkout})]
+        db   {:focus     {:dispatch-id :c1 :mode :retro}
+              :focus-set {:dimension :machine-id :value :checkout :pivot-id :c1}}
+        db'  (spine/focus-step-reducer db cs-m [] +1)]
+    (is (= :c3 (get-in db' [:focus :dispatch-id]))
+        ":machine-id focus skips non-machine cascades")))
+
+;; ---- (4) registered sub -------------------------------------------------
+
+(deftest focus-set-sub-returns-slot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (testing "Initially nil"
+      (is (nil? @(rf/subscribe [:rf.causa/focus-set]))))
+    (testing "After :rf.causa/set-focus dispatch"
+      (rf/dispatch-sync [:rf.causa/set-focus :event-id :foo :c1])
+      (is (= {:dimension :event-id :value :foo :pivot-id :c1}
+             @(rf/subscribe [:rf.causa/focus-set]))))
+    (testing "After :rf.causa/clear-focus dispatch"
+      (rf/dispatch-sync [:rf.causa/clear-focus])
+      (is (nil? @(rf/subscribe [:rf.causa/focus-set]))))))


### PR DESCRIPTION
## Summary

Foundational focus-navigation primitive for the Causa L2 event list. NOT a filter — the full L2 list keeps rendering; in-focus rows render full opacity with marker glyphs in the gutter, out-of-focus rows render dimmed (~40% opacity), and the ribbon nav buttons skip past out-of-focus rows to the next/prev in-focus cascade. Cross-panel triggers (Machines panel, managed-fx panel) will plug into the same spine slot incrementally.

## Lens model

| Row state    | Visual                                                  |
|--------------|---------------------------------------------------------|
| Out of focus | Dimmed via `var(--rf-causa-row-dim-opacity, 0.4)`       |
| In focus     | Full opacity + open marker (`◌`) in left gutter         |
| Pivot        | Full opacity + filled marker (`⦿`) in left gutter       |

ASCII sketch of the L2 list with focus active on `:cart/add-item`:

```
┌─────────────────────────────────────────────────────────┐
│ ⦿  [:cart/add-item {:item-id "apple" :qty 2}]           │  ← pivot
│ ●  [:user/save-pref {:k :theme :v :dark}]   (dim 40%)   │
│ ◌  [:cart/add-item {:item-id "milk" :qty 1}]            │  ← in-focus
│ ●  [:nav/route-changed]                     (dim 40%)   │
│ ◌  [:cart/add-item {:item-id "egg" :qty 6}]             │  ← in-focus
└─────────────────────────────────────────────────────────┘
```

The `[◀]` `[▶]` buttons in the ribbon (and `j`/`k` keys) now step ONLY through the three in-focus rows. The ribbon also shows the chip `🎯 :cart/add-item ✕` next to the nav cluster.

## Gesture model — gutter vs body distinction is load-bearing

The left ~14px of every L2 row is the **FOCUS** surface (gutter). The rest of the row body is the **SELECTION** surface. Distinct semantics:

| Gesture                                  | Effect                                                  |
|------------------------------------------|---------------------------------------------------------|
| Click out-of-focus row's **GUTTER**      | Becomes new pivot; focus rebuilds around its dimension  |
| Click out-of-focus row's **BODY**        | Selects; focus CLEARED                                  |
| Click pivot's **GUTTER** again           | Toggles focus OFF                                       |
| Click in-focus row's **GUTTER** (non-pivot) | Re-anchors focus around the clicked row              |
| Click in-focus row's **BODY**            | Selects within subset; focus stays                      |
| **Esc** key                              | Clears focus                                            |
| Ribbon chip **✕**                        | Clears focus                                            |

## Default dimensions (implicit-from-context)

| Clicked-row property                         | Focus dimension          |
|----------------------------------------------|--------------------------|
| Triggered a machine transition               | `:machine-id`            |
| Triggered an HTTP fx                         | `:http-correlation-id`   |
| Event-id (always present on routed cascades) | `:event-id`              |
| Has source-coord (no event-id case)          | `:source-coord`          |

`:event-id` is listed BEFORE `:source-coord` because almost every cascade carries a source-coord — letting it win would degrade most focus clicks to 'all events from this code site'. `:event-id` is the right default for the average row; a future right-click override (deferred) lets the user opt into source-coord.

## Surface touched

| File                                                   | Change |
|--------------------------------------------------------|--------|
| `tools/causa/src/day8/re_frame2_causa/focus_helpers.cljc` | NEW — pure-data dimension picker + predicate builder + traversal helpers (~218 LoC) |
| `tools/causa/src/day8/re_frame2_causa/spine.cljs`         | `:focus-set` slot + 2 reducers + 2 events + 1 sub; `focus-step-reducer` now focus-aware (~65 LoC) |
| `tools/causa/src/day8/re_frame2_causa/shell.cljs`         | L2 row gutter strip + dim CSS + markers; ribbon focus chip; focus-aware boundary signals (~210 LoC) |
| `tools/causa/src/day8/re_frame2_causa/keybinding.cljs`    | Esc → `:rf.causa/clear-focus` (~12 LoC) |
| `tools/causa/test/day8/re_frame2_causa/focus_helpers_test.cljc` | NEW — covers all 4 dimensions + priority + traversal (~190 LoC) |
| `tools/causa/test/day8/re_frame2_causa/spine_focus_cljs_test.cljs` | NEW — reducer + toggle-off + step-skip + boundary + registered-sub round-trip (~150 LoC) |
| `tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs`   | Catalogue + count bumps for the new events + sub |

## Tests covered

- All 4 default dimensions inferred correctly (`infer-dimension-event-id`, `-machine-id`, `-http-correlation`, `-source-coord`).
- Dimension priority — `:machine-id` > `:http-correlation-id` > `:event-id` > `:source-coord`.
- Each unfocus path: gutter-toggle on pivot (`set-focus-on-same-pivot-toggles-off`), Esc / chip ✕ (`clear-focus-drops-slot`), body-click on out-of-focus (in shell test).
- Re-pivot behaviour — same value, different pivot id REPLACES (does not toggle).
- Navigation skip-behaviour — `step-skips-out-of-focus-rows` (forward + back), `step-with-machine-dimension`, `step-boundary-no-op-with-focus-set`, `step-without-focus-set-walks-every-cascade`.
- Registered sub round-trip — `focus-set-sub-returns-slot`.

## Gates

- `cd tools/causa && clojure -M:test` — 724 tests / 2149 assertions, 0 failures.
- `cd implementation && npm run test:cljs` — 2840 tests / 8154 assertions, 0 failures.
- `scripts/test-fast-pr.sh` — PASS.

## Worth Mike's eye

- The focus-set is a small, self-contained slot at the spine layer — cross-panel triggers (Machines panel click → `:rf.causa/set-focus :machine-id <id> <pivot-id>`; managed-fx click → `:http-correlation-id`) will dispatch the same event going forward, no new wire needed.
- I picked `◌` for the in-focus non-pivot marker and `⦿` for the pivot rather than the bead's open/filled `⦿` pair because the latter renders identically at most font sizes; `◌` provides clear visual differentiation. Trivial to swap if you prefer the original.
- The CSS variable `--rf-causa-row-dim-opacity` defaults to 0.4 inline; a host stylesheet can override it for accessibility tuning without a code change.

## Test plan

- [ ] Open Causa shell (`Ctrl+Shift+C`); confirm L2 rows render with gutter strip; no visual regression on existing selection / error / redacted glyphs.
- [ ] Click an L2 row's gutter — focus chip appears; out-of-focus rows dim.
- [ ] Click `[◀]` `[▶]` — focus walks only in-focus rows; greys at boundaries.
- [ ] Press `j` `k` — same behaviour as ribbon buttons.
- [ ] Press `Esc` — focus clears.
- [ ] Click chip `✕` — focus clears.
- [ ] Click out-of-focus row's body — selects + clears focus.
- [ ] Click pivot's gutter again — focus toggles off.