### PR TITLE
refactor(causa): DRY section-row primitive — managed_fx_template + event_lens (rf2-pie8q)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -64,6 +64,7 @@
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.theme.section :as section]
             [day8.re-frame2-causa.theme.perf-tier :as perf-tier]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]))
 
@@ -303,47 +304,11 @@
      :db-present? db-present?
      :present?    (or db-present? (seq fx))}))
 
-;; ---- section primitive --------------------------------------------------
-
-(defn- section-header
-  "Uppercased section label with optional count + collapse glyph.
-  Mirrors `managed_fx_template/section-header` for visual consistency."
-  [{:keys [label count* testid]}]
-  [:div {:data-testid testid
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "6px"
-                       :padding       "4px 0"
-                       :font-family   sans-stack
-                       :font-size     "11px"
-                       :font-weight   600
-                       :letter-spacing "0.6px"
-                       :text-transform "uppercase"
-                       :color         (:text-secondary tokens)}}
-   [:span {:style {:color (:text-tertiary tokens)
-                   :font-family mono-stack}}
-    "▼"]
-   label
-   (when count*
-     [:span {:style {:color (:text-tertiary tokens)
-                     :font-weight 400
-                     :font-family mono-stack}}
-      (str "(" count* ")")])])
-
-(defn- section
-  "One stacked section. `label` upper-cases; `body` is hiccup."
-  [{:keys [label count* testid]} body]
-  [:div {:data-testid testid
-         :style       {:padding "8px 12px"
-                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
-   (section-header {:label label :count* count*
-                    :testid (str testid "-header")})
-   [:div {:data-testid (str testid "-body")
-          :style       {:padding "6px 0 0 18px"
-                        :font-family mono-stack
-                        :font-size "12px"
-                        :color (:text-primary tokens)}}
-    body]])
+;; Section rhythm hoisted to `theme/section.cljc` per rf2-pie8q —
+;; identical visual contract is shared with
+;; `panels/managed_fx_template`. The Event lens panel uses the
+;; primitive's defaults: body always expanded (the lens does not
+;; collapse), `:container-padding` defaults to "8px 12px".
 
 ;; ---- tier-dot (reused from v1, survives) -------------------------------
 
@@ -427,11 +392,12 @@
 
 (defn- event-section
   [event-vec]
-  (section {:label "EVENT"
-            :testid "rf-causa-event-detail-section-event"}
-           [:div {:data-testid "rf-causa-event-detail-event-vector"
-                  :style {:font-weight 600}}
-            (inspector/inspect event-vec "event-detail/event")]))
+  (section/section-row
+    {:label "EVENT"
+     :testid "rf-causa-event-detail-section-event"}
+    [:div {:data-testid "rf-causa-event-detail-event-vector"
+           :style {:font-weight 600}}
+     (inspector/inspect event-vec "event-detail/event")]))
 
 ;; ---- §2 DISPATCH SITE --------------------------------------------------
 
@@ -464,30 +430,31 @@
   (let [coord            (dispatch-call-site cascade)
         [source origin]  (dispatch-source+origin cascade)
         display          (format-coord-display coord)]
-    (section {:label "DISPATCH SITE"
-              :testid "rf-causa-event-detail-section-dispatch"}
-             [:div
-              [:div {:style {:display "flex" :align-items "center"}}
-               (if display
-                 [:span {:data-testid "rf-causa-event-detail-dispatch-coord"
-                         :style {:color (:text-primary tokens)}}
-                  display]
-                 [:span {:data-testid "rf-causa-event-detail-dispatch-coord-absent"
-                         :style {:color (:text-tertiary tokens)
-                                 :font-style "italic"}}
-                  "source coord unavailable"])
-               (coord-chip coord "rf-causa-event-detail-dispatch-open-chip")]
-              (when (or source origin)
-                [:div {:data-testid "rf-causa-event-detail-dispatch-caption"
-                       :style {:color (:text-tertiary tokens)
-                               :font-family sans-stack
-                               :font-size "11px"
-                               :margin-top "4px"}}
-                 (cond-> "via "
-                   source (str source)
-                   (and source origin) (str " · origin ")
-                   (and (not source) origin) (str "origin ")
-                   origin (str origin))])])))
+    (section/section-row
+      {:label "DISPATCH SITE"
+       :testid "rf-causa-event-detail-section-dispatch"}
+      [:div
+       [:div {:style {:display "flex" :align-items "center"}}
+        (if display
+          [:span {:data-testid "rf-causa-event-detail-dispatch-coord"
+                  :style {:color (:text-primary tokens)}}
+           display]
+          [:span {:data-testid "rf-causa-event-detail-dispatch-coord-absent"
+                  :style {:color (:text-tertiary tokens)
+                          :font-style "italic"}}
+           "source coord unavailable"])
+        (coord-chip coord "rf-causa-event-detail-dispatch-open-chip")]
+       (when (or source origin)
+         [:div {:data-testid "rf-causa-event-detail-dispatch-caption"
+                :style {:color (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size "11px"
+                        :margin-top "4px"}}
+          (cond-> "via "
+            source (str source)
+            (and source origin) (str " · origin ")
+            (and (not source) origin) (str "origin ")
+            origin (str origin))])])))
 
 ;; ---- §3 INTERCEPTORS ---------------------------------------------------
 
@@ -533,18 +500,19 @@
   `user-interceptors` (test-level helper) before invoking this fn."
   [user-icpts]
   (when (seq user-icpts)
-    (section {:label "INTERCEPTORS"
-              :count* (count user-icpts)
-              :testid "rf-causa-event-detail-section-interceptors"}
-             (into [:div]
-                   ;; Per rf2-ppzid: `^{:key ...}` reader-meta on a fn
-                   ;; CALL FORM (a list) is lost — the fn returns a
-                   ;; fresh vector; `get-react-key` only reads :key
-                   ;; meta off the returned vector. `with-meta` on
-                   ;; the fn return preserves the key correctly.
-                   (for [icpt user-icpts]
-                     (with-meta (interceptor-row icpt)
-                                {:key (pr-str (:id icpt))}))))))
+    (section/section-row
+      {:label "INTERCEPTORS"
+       :count* (count user-icpts)
+       :testid "rf-causa-event-detail-section-interceptors"}
+      (into [:div]
+            ;; Per rf2-ppzid: `^{:key ...}` reader-meta on a fn
+            ;; CALL FORM (a list) is lost — the fn returns a
+            ;; fresh vector; `get-react-key` only reads :key
+            ;; meta off the returned vector. `with-meta` on
+            ;; the fn return preserves the key correctly.
+            (for [icpt user-icpts]
+              (with-meta (interceptor-row icpt)
+                         {:key (pr-str (:id icpt))}))))))
 
 ;; ---- §4 HANDLER --------------------------------------------------------
 
@@ -562,28 +530,29 @@
                   :fx  "reg-event-fx"
                   :ctx "reg-event-ctx"
                   (if kind (str "reg-event-" (name kind)) "reg-event-?"))]
-    (section {:label "HANDLER"
-              :testid "rf-causa-event-detail-section-handler"}
-             [:div {:style {:display "flex" :align-items "center"}}
-              [:span {:data-testid "rf-causa-event-detail-handler-flavour"
-                      :style {:color (:cyan tokens)
-                              :font-weight 600
-                              :margin-right "8px"}}
-               flavour]
-              [:span {:style {:color (:text-tertiary tokens)
-                              :margin-right "8px"}}
-               "·"]
-              (if display
-                [:span {:data-testid "rf-causa-event-detail-handler-coord"
-                        :style {:color (:text-primary tokens)}}
-                 display]
-                [:span {:data-testid "rf-causa-event-detail-handler-coord-absent"
-                        :style {:color (:text-tertiary tokens)
-                                :font-style "italic"}}
-                 (if event-id
-                   (str "no registration found for " (pr-str event-id))
-                   "no handler registered")])
-              (coord-chip coord "rf-causa-event-detail-handler-open-chip")])))
+    (section/section-row
+      {:label "HANDLER"
+       :testid "rf-causa-event-detail-section-handler"}
+      [:div {:style {:display "flex" :align-items "center"}}
+       [:span {:data-testid "rf-causa-event-detail-handler-flavour"
+               :style {:color (:cyan tokens)
+                       :font-weight 600
+                       :margin-right "8px"}}
+        flavour]
+       [:span {:style {:color (:text-tertiary tokens)
+                       :margin-right "8px"}}
+        "·"]
+       (if display
+         [:span {:data-testid "rf-causa-event-detail-handler-coord"
+                 :style {:color (:text-primary tokens)}}
+          display]
+         [:span {:data-testid "rf-causa-event-detail-handler-coord-absent"
+                 :style {:color (:text-tertiary tokens)
+                         :font-style "italic"}}
+          (if event-id
+            (str "no registration found for " (pr-str event-id))
+            "no handler registered")])
+       (coord-chip coord "rf-causa-event-detail-handler-open-chip")])))
 
 ;; ---- §5 EFFECTS RETURNED -----------------------------------------------
 
@@ -654,9 +623,10 @@
                      (hydration-issues-jump-button))
         rows       (filterv some? [db-row fx-row hyd-row jump-row])]
     (when (or present? hydration)
-      (section {:label "EFFECTS RETURNED"
-                :testid "rf-causa-event-detail-section-effects-returned"}
-               (into [:div] rows)))))
+      (section/section-row
+        {:label "EFFECTS RETURNED"
+         :testid "rf-causa-event-detail-section-effects-returned"}
+        (into [:div] rows)))))
 
 ;; ---- §6 EFFECTS HANDLERS RAN -------------------------------------------
 
@@ -726,16 +696,17 @@
   (let [rows    (effects-handlers-ran cascade)
         records (managed-fx-h/cascade->managed-fx-records cascade)]
     (when (seq rows)
-      (section {:label "EFFECTS HANDLERS RAN"
-                :count* (count rows)
-                :testid "rf-causa-event-detail-section-effects-ran"}
-               (into [:div]
-                     ;; Per rf2-ppzid — `with-meta` on the fn return,
-                     ;; not `^{:key ...}` on the call form.
-                     (for [{:keys [id] :as row} rows]
-                       (with-meta
-                         (fx-handler-row row (managed-fx-record-for-row records id))
-                         {:key id})))))))
+      (section/section-row
+        {:label "EFFECTS HANDLERS RAN"
+         :count* (count rows)
+         :testid "rf-causa-event-detail-section-effects-ran"}
+        (into [:div]
+              ;; Per rf2-ppzid — `with-meta` on the fn return,
+              ;; not `^{:key ...}` on the call form.
+              (for [{:keys [id] :as row} rows]
+                (with-meta
+                  (fx-handler-row row (managed-fx-record-for-row records id))
+                  {:key id})))))))
 
 ;; ---- handler-threw footnote --------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -46,46 +46,14 @@
             [day8.re-frame2-causa.chart.timing-waterfall :as waterfall]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]
+            [day8.re-frame2-causa.theme.section :as section]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]))
 
-;; ---- section header (collapsible) --------------------------------------
-
-(defn- section-header
-  "One row above a section's body — `▼ SECTION TITLE`. Pure visual;
-  collapse-toggle wires through the `:rf.causa.managed-fx/section-state`
-  sub when the panel adds per-record persistence (follow-on)."
-  [{:keys [label expanded? testid]}]
-  [:div {:data-testid testid
-         :style       {:display       "flex"
-                       :align-items   "center"
-                       :gap           "6px"
-                       :padding       "4px 0"
-                       :font-family   sans-stack
-                       :font-size     "11px"
-                       :font-weight   600
-                       :letter-spacing "0.6px"
-                       :text-transform "uppercase"
-                       :color         (:text-secondary tokens)}}
-   [:span {:style {:color (:text-tertiary tokens)
-                   :font-family mono-stack}}
-    (if expanded? "▼" "▶")]
-   label])
-
-(defn- section
-  [{:keys [label expanded? testid]} body]
-  [:div {:data-testid testid
-         :style       {:padding "8px 0"
-                       :border-bottom (str "1px dotted " (:border-subtle tokens))}}
-   (section-header {:label label
-                    :expanded? expanded?
-                    :testid (str testid "-header")})
-   (when expanded?
-     [:div {:data-testid (str testid "-body")
-            :style       {:padding "6px 0 0 18px"
-                          :font-family mono-stack
-                          :font-size "12px"
-                          :color (:text-primary tokens)}}
-      body])])
+;; Section rhythm hoisted to `theme/section.cljc` per rf2-pie8q —
+;; identical visual contract is shared with `panels/event_detail`.
+;; This panel passes `:container-padding "8px 0"` so the section sits
+;; flush against the record-panel's surrounding `padding "8px 12px"`
+;; outer wrapper (added below in `record-panel`).
 
 ;; ---- panel header ------------------------------------------------------
 
@@ -359,21 +327,31 @@
                            :background    (:bg-2 tokens)}}
    (panel-header record)
    [:div {:style {:padding "8px 12px"}}
-    (section {:label "REQUEST" :expanded? false
-              :testid (str "rf-causa-managed-fx-section-request")}
-             (request-section record))
-    (section {:label "WIRE TIMING" :expanded? true
-              :testid (str "rf-causa-managed-fx-section-wire")}
-             (wire-section record))
-    (section {:label "RESPONSE" :expanded? false
-              :testid (str "rf-causa-managed-fx-section-response")}
-             (response-section record))
-    (section {:label "HANDLER DISPATCHED" :expanded? false
-              :testid (str "rf-causa-managed-fx-section-handler")}
-             (handler-section record))
-    (section {:label "APP-DB SLICE TOUCHED" :expanded? true
-              :testid (str "rf-causa-managed-fx-section-app-db")}
-             (app-db-slice-section record))]])
+    (section/section-row
+      {:label "REQUEST" :expanded? false
+       :testid "rf-causa-managed-fx-section-request"
+       :container-padding "8px 0"}
+      (request-section record))
+    (section/section-row
+      {:label "WIRE TIMING" :expanded? true
+       :testid "rf-causa-managed-fx-section-wire"
+       :container-padding "8px 0"}
+      (wire-section record))
+    (section/section-row
+      {:label "RESPONSE" :expanded? false
+       :testid "rf-causa-managed-fx-section-response"
+       :container-padding "8px 0"}
+      (response-section record))
+    (section/section-row
+      {:label "HANDLER DISPATCHED" :expanded? false
+       :testid "rf-causa-managed-fx-section-handler"
+       :container-padding "8px 0"}
+      (handler-section record))
+    (section/section-row
+      {:label "APP-DB SLICE TOUCHED" :expanded? true
+       :testid "rf-causa-managed-fx-section-app-db"
+       :container-padding "8px 0"}
+      (app-db-slice-section record))]])
 
 ;; ---- list panel --------------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/theme/section.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/section.cljc
@@ -1,0 +1,111 @@
+(ns day8.re-frame2-causa.theme.section
+  "Shared stacked-section primitive (rf2-pie8q).
+
+  Causa panels use a uniform rhythm of stacked sections — small upper-
+  cased header (`▼ SECTION TITLE`) followed by a body, separated from
+  the next section by a 1px dotted horizontal rule. The visual contract
+  is documented in `tools/causa/spec/007-UX-IA.md` and was reinvented
+  twice — once in `panels/managed_fx_template/section` (rf2-uyp86) and
+  again in `panels/event_detail/section` (rf2-zh2qc PR #1480). Both
+  invented identical typography (sans-stack, 11px, weight 600, letter-
+  spacing 0.6px, uppercase, `:text-secondary`) and identical body
+  styling (mono-stack, 12px, `:text-primary`, 6px/0/0/18px padding).
+
+  Hoisting the shape here gives the two consumers a single source of
+  truth so a future rhythm tweak (a tighter letter-spacing, say, or a
+  swap of the dotted rule for a solid one) lands in one place.
+
+  ## Shape
+
+      (section-row
+        {:label   \"REQUEST\"
+         :testid  \"rf-causa-managed-fx-section-request\"
+         :expanded? false}
+        body-hiccup)
+
+  Options:
+
+    `:label`             — required; the uppercase title text.
+    `:testid`            — required; base data-testid. The header div
+                           gets `<testid>-header`; the body div gets
+                           `<testid>-body`. The outer container carries
+                           the plain `:testid`.
+    `:expanded?`         — default `true`. When `false` the glyph is
+                           `▶` and the body div is NOT rendered (matches
+                           managed_fx_template's collapsed semantics).
+                           When `true` the glyph is `▼` and the body
+                           always renders.
+    `:count*`            — optional; non-nil renders as ` (N)` after
+                           the label in `:text-tertiary` (mono-stack).
+                           Matches event_detail's INTERCEPTORS / EFFECTS
+                           HANDLERS RAN sections.
+    `:container-padding` — optional CSS string; default `\"8px 12px\"`
+                           (event_detail's choice). Callers that want
+                           the managed_fx_template rhythm pass `\"8px 0\"`
+                           — the only divergent token between the two
+                           consumers.
+
+  Pure hiccup. `.cljc` so JVM consumers (the spec linter, future
+  story snapshots) can require it without a CLJS runtime.
+
+  ## What is intentionally NOT here
+
+    - No interactivity. Click-to-toggle wiring is the caller's
+      responsibility — the primitive only renders the visual state the
+      caller passes via `:expanded?`. (Per the bead: 'sans tone-key,
+      with collapse glyph'.)
+    - No body-shape opinions. The body argument is opaque hiccup.
+    - No section-stacking helper. Callers compose by listing sections
+      inline; the dotted bottom border draws the rhythm."
+  (:require [day8.re-frame2-causa.theme.tokens
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- header
+  "Internal header row. See `section-row` for the public contract."
+  [{:keys [label expanded? count* testid]}]
+  [:div {:data-testid testid
+         :style       {:display        "flex"
+                       :align-items    "center"
+                       :gap            "6px"
+                       :padding        "4px 0"
+                       :font-family    sans-stack
+                       :font-size      "11px"
+                       :font-weight    600
+                       :letter-spacing "0.6px"
+                       :text-transform "uppercase"
+                       :color          (:text-secondary tokens)}}
+   [:span {:style {:color       (:text-tertiary tokens)
+                   :font-family mono-stack}}
+    (if expanded? "▼" "▶")]
+   label
+   (when count*
+     [:span {:style {:color       (:text-tertiary tokens)
+                     :font-weight 400
+                     :font-family mono-stack}}
+      (str "(" count* ")")])])
+
+(defn section-row
+  "Render one stacked section.
+
+  See ns docstring for the option map. `body` is appended as the second
+  positional argument so call sites read top-to-bottom (`label …` then
+  body)."
+  [{:keys [label expanded? count* testid container-padding]
+    :or   {expanded?         true
+           container-padding "8px 12px"}}
+   body]
+  [:div {:data-testid testid
+         :style       {:padding       container-padding
+                       :border-bottom (str "1px dotted "
+                                           (:border-subtle tokens))}}
+   (header {:label     label
+            :expanded? expanded?
+            :count*    count*
+            :testid    (str testid "-header")})
+   (when expanded?
+     [:div {:data-testid (str testid "-body")
+            :style       {:padding     "6px 0 0 18px"
+                          :font-family mono-stack
+                          :font-size   "12px"
+                          :color       (:text-primary tokens)}}
+      body])])

--- a/tools/causa/test/day8/re_frame2_causa/theme/section_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/section_cljs_test.cljc
@@ -1,0 +1,158 @@
+(ns day8.re-frame2-causa.theme.section-cljs-test
+  "Pure-data tests for the shared section-row primitive (rf2-pie8q).
+
+  ## Why the `.cljc` + `_cljs_test` naming
+
+  Same dual-target pattern as `perf_tier_cljs_test.cljc`:
+
+    - Cognitect's test-runner (CLJ) picks it up via the default
+      `.*-test$` regex on the ns name.
+    - Shadow's `:node-test` build picks it up via the `cljs-test$`
+      regex on the ns name.
+
+  ## What's under test
+
+  1. **Structural identity** — outer container + header + body all
+     carry the expected testids; header glyph reflects `:expanded?`.
+  2. **Collapsed semantics** — when `:expanded? false`, body div is
+     omitted entirely (matches managed_fx_template's contract).
+  3. **`:count*` option** — silent when nil, renders ` (N)` when set
+     (event_detail's INTERCEPTORS / EFFECTS HANDLERS RAN contract).
+  4. **`:container-padding` option** — defaults to event_detail's
+     `\"8px 12px\"` and is overridable to `\"8px 0\"` for
+     managed_fx_template's rhythm."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.theme.section :as section]))
+
+;; ---- hiccup walker -----------------------------------------------------
+
+(defn- walk-hiccup
+  "Depth-first seq of every hiccup vector inside `tree`."
+  [tree]
+  (let [acc (volatile! [])]
+    (letfn [(visit [node]
+              (when (vector? node)
+                (vswap! acc conj node)
+                (doseq [child node] (visit child))))]
+      (visit tree)
+      @acc)))
+
+(defn- find-by-testid
+  [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (walk-hiccup tree)))
+
+(defn- testids
+  [tree]
+  (->> (walk-hiccup tree)
+       (keep (fn [n] (when (map? (second n))
+                       (:data-testid (second n)))))
+       set))
+
+(defn- all-strings
+  "Depth-first collection of every string descendant in `tree`."
+  [tree]
+  (let [acc (volatile! [])]
+    (letfn [(visit [node]
+              (cond
+                (string? node)     (vswap! acc conj node)
+                (sequential? node) (doseq [c node] (visit c))
+                (map? node)        nil
+                :else              nil))]
+      (visit tree)
+      @acc)))
+
+;; ---- (1) structural identity --------------------------------------------
+
+(deftest renders-outer-header-body-testids
+  (let [out (section/section-row {:label "REQUEST"
+                                  :testid "rf-causa-managed-fx-section-request"}
+                                 [:span "payload"])
+        ids (testids out)]
+    (is (contains? ids "rf-causa-managed-fx-section-request")
+        "outer container carries the base testid")
+    (is (contains? ids "rf-causa-managed-fx-section-request-header")
+        "header carries -header suffix")
+    (is (contains? ids "rf-causa-managed-fx-section-request-body")
+        "body carries -body suffix when expanded (the default)")))
+
+(deftest header-glyph-reflects-expanded
+  (testing "expanded? true → ▼ glyph"
+    (let [out (section/section-row {:label "X" :testid "t" :expanded? true} "b")]
+      (is (some #(= "▼" %) (flatten out)))
+      (is (not-any? #(= "▶" %) (flatten out)))))
+  (testing "expanded? false → ▶ glyph"
+    (let [out (section/section-row {:label "X" :testid "t" :expanded? false} "b")]
+      (is (some #(= "▶" %) (flatten out)))
+      (is (not-any? #(= "▼" %) (flatten out))))))
+
+(deftest expanded-default-is-true
+  (let [out (section/section-row {:label "X" :testid "t"} "b")]
+    (is (some #(= "▼" %) (flatten out))
+        "no :expanded? key → defaults to true → ▼ glyph + body rendered")
+    (is (contains? (testids out) "t-body"))))
+
+;; ---- (2) collapsed semantics --------------------------------------------
+
+(deftest collapsed-omits-body-div
+  (let [out (section/section-row {:label "REQUEST" :testid "t"
+                                  :expanded? false}
+                                 [:span {:data-testid "payload-marker"} "p"])
+        ids (testids out)]
+    (is (contains? ids "t")           "outer container still renders")
+    (is (contains? ids "t-header")    "header still renders")
+    (is (not (contains? ids "t-body")) "body div is omitted when collapsed")
+    (is (not (contains? ids "payload-marker"))
+        "body hiccup is NOT mounted when collapsed (matches
+         managed_fx_template's pre-refactor behaviour)")))
+
+;; ---- (3) :count* option -------------------------------------------------
+
+(deftest count-silent-when-nil
+  (let [out  (section/section-row {:label "INTERCEPTORS" :testid "t"} "b")
+        text (apply str (all-strings out))]
+    (is (not (re-find #"\(" text))
+        "no count-in-parens when :count* is nil")))
+
+(deftest count-renders-in-parens
+  (let [out  (section/section-row {:label "INTERCEPTORS" :testid "t"
+                                   :count* 3}
+                                  "b")
+        text (apply str (all-strings out))]
+    (is (re-find #"\(3\)" text)
+        "count renders as (N) after the label")))
+
+;; ---- (4) :container-padding option --------------------------------------
+
+(deftest container-padding-default-matches-event-detail
+  (let [out      (section/section-row {:label "X" :testid "t"} "b")
+        outer    (find-by-testid out "t")
+        padding  (get-in outer [1 :style :padding])]
+    (is (= "8px 12px" padding)
+        "default padding matches event_detail's pre-refactor rhythm")))
+
+(deftest container-padding-overridable
+  (let [out      (section/section-row {:label "X" :testid "t"
+                                       :container-padding "8px 0"} "b")
+        outer    (find-by-testid out "t")
+        padding  (get-in outer [1 :style :padding])]
+    (is (= "8px 0" padding)
+        "managed_fx_template can opt into its tighter no-horizontal-pad
+         rhythm by passing :container-padding explicitly")))
+
+;; ---- (5) ladder-style consistency check ---------------------------------
+
+(deftest dotted-border-bottom-always-rendered
+  (testing "border-bottom is the dotted-rule rhythm that draws the
+            stacked-section separator"
+    (let [out   (section/section-row {:label "X" :testid "t"} "b")
+          outer (find-by-testid out "t")
+          bb    (get-in outer [1 :style :border-bottom])]
+      (is (string? bb))
+      (is (re-find #"dotted" bb)
+          "the separator rule is dotted, not solid"))))


### PR DESCRIPTION
## Summary

Extract the stacked-section visual contract — uppercased header (`▼ SECTION TITLE`), dotted horizontal-rule separator, mono-stack body — out of the two consumers (`panels/managed_fx_template`, `panels/event_detail`) that had each invented identical typography. Per [`ai/findings/2026-05-18-event-lens-design.md` §11.6](../tree/main/ai/findings) (deferred from rf2-zh2qc PR #1480 to keep that rewrite focused), both reinvented the same border / padding / typography. The new `theme/section.cljc` primitive accepts:

- `:label`, `:testid` — required
- `:expanded?` — default `true`; toggles glyph (`▼` / `▶`) + whether body div renders (collapsed = body omitted, matches managed_fx_template's pre-refactor semantics)
- `:count*` — optional `(N)` suffix in `:text-tertiary` after the label
- `:container-padding` — default `"8px 12px"` (event_detail's rhythm); managed_fx_template passes `"8px 0"` (its tighter rhythm) explicitly

Pure hiccup. `.cljc` so JVM consumers can require without a CLJS runtime.

## Per-file LoC delta

| file | before | after | net |
| --- | ---: | ---: | ---: |
| `tools/causa/src/day8/re_frame2_causa/theme/section.cljc` (NEW) | — | 109 | +109 |
| `tools/causa/test/day8/re_frame2_causa/theme/section_cljs_test.cljc` (NEW) | — | 160 | +160 |
| `tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs` | 400 | 378 | −22 |
| `tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs` | 963 | 934 | −29 |

(Sums above approximate; see `git diff --stat`.)

## Visual identity

No visual regression. The primitive's pre-refactor styling is preserved verbatim:

- managed_fx_template — gets `:container-padding "8px 0"` at every call site → identical to pre-refactor
- event_detail — uses default `"8px 12px"` → identical to pre-refactor
- All testids (`<base>` / `<base>-header` / `<base>-body`) preserved verbatim
- Collapsed-body semantics preserved (managed_fx_template's `:expanded? false` sections still omit the body div)

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 733 tests / 2168 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 2857 tests / 8168 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 2848 tests / 8126 assertions / 0 failures
- [x] `scripts/test-fast-pr.sh` — green
- [x] `npx shadow-cljs compile :testbeds/panel-gallery` — clean build
- [x] New `theme/section_cljs_test.cljc` — 9 tests / 19 assertions cover structural identity, collapsed semantics, `:count*` rendering, `:container-padding` default + override