### PR TITLE
feat(causa): panel-gallery UC1 sim pending-input variant (rf2-cujgr)

### DIFF
--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -115,7 +115,7 @@ function waitForReady(url, timeoutMs) {
         id:          'machines',
         workspaceRe: /Workspace\.causa\.machines\/all/,
         cardTestid:  'panel-gallery-machines-card',
-        expectedAtLeast: 6,
+        expectedAtLeast: 7,
       },
       {
         id:          'issues',

--- a/tools/causa/testbeds/panel_gallery/gallery_machines.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_machines.cljs
@@ -29,7 +29,11 @@
   rail surfaces an event picker + Step / Reset buttons. The Sim
   state slot is `:sim/by-machine {<id> <sim-state>}` — the
   `:rf.causa/sim-start` event seeds it. The 'sim mid-step' variant
-  fires sim-start then sim-step to land mid-execution."
+  fires sim-start then sim-step to land mid-execution. The
+  'sim pending-input' variant fires sim-start then seeds the
+  controlled-input slots (`:pending-event` / `:pending-data`) via
+  `:rf.causa/sim-set-pending-event` + `-pending-data` so the side
+  rail's compose box is populated mid-type but not yet stepped."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures-machines :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
@@ -145,11 +149,6 @@
   ;; definition into Causa's app-db), then sim-step with the
   ;; `:start` event so the cloned snapshot advances :idle → :loading
   ;; mid-execution. The variant renders the side rail + amber tint.
-  ;;
-  ;; TODO(rf2-sszlr follow-on): a deterministic 'mid-step with
-  ;; pending input populated' variant requires the sim's
-  ;; pending-event input to be controlled-input driven; the variant
-  ;; currently exercises one full step + leaves the trail visible.
   (story/reg-variant :story.causa.machines/uc1-sim-mid-step
     {:doc        "Single :loader machine + UC1 Sim active mid-step:
                  sim-start clones the definition, sim-step fires
@@ -172,12 +171,52 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- 7. UC1 Sim pending-input ------------------------------------
+  ;;
+  ;; Same UC1 Sim sub-mode as variant 6, but instead of stepping the
+  ;; cloned snapshot we seed the controlled-input slots
+  ;; (`:pending-event` + `:pending-data`) via the existing sim API
+  ;; (`:rf.causa/sim-set-pending-event` +
+  ;; `:rf.causa/sim-set-pending-data`). The snapshot stays at
+  ;; `:idle`; the side-rail event-input shows `[:start]` already
+  ;; typed and the payload input shows a sample EDN map, so the
+  ;; Step button is primed but not yet pressed.
+  ;;
+  ;; Approach (b) per rf2-cujgr — uses the existing sim API instead of
+  ;; bypass-writing app-db. Deterministic because the variant `:events`
+  ;; vector is dispatched in order at boot, the same order the existing
+  ;; `uc1-sim-mid-step` variant already relies on.
+  (story/reg-variant :story.causa.machines/uc1-sim-pending-input
+    {:doc        "Single :loader machine + UC1 Sim active with the
+                 side-rail controlled inputs populated mid-compose:
+                 `:pending-event` is `[:start]` and `:pending-data` is
+                 a sample EDN map. The snapshot stays at `:idle` — the
+                 user has typed but not yet pressed Step. Renders the
+                 side rail + amber tint with the inputs primed."
+     :events     [[:rf.causa/set-registered-machines-override-for-test [:loader]]
+                  [:rf.causa/set-machine-snapshots-override-for-test
+                   {:loader (fixtures/snapshot :idle
+                              {:result nil :attempts 0 :error nil})}]
+                  [:rf.causa/set-machine-definitions-override-for-test
+                   {:loader fixtures/loader-definition}]
+                  [:rf.causa/sync-trace-buffer (fixtures/no-transitions-buffer)]
+                  [:rf.causa/select-machine-id :loader]
+                  [:rf.causa/sim-start {:machine-id :loader
+                                        :definition fixtures/loader-definition}]
+                  [:rf.causa/sim-set-pending-event
+                   {:machine-id :loader :text "[:start]"}]
+                  [:rf.causa/sim-set-pending-data
+                   {:machine-id :loader :text "{:result :data}"}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- workspace ---------------------------------------------------
   (story/reg-workspace :Workspace.causa.machines/all
-    {:doc      "All six Machines tab variants in one auto-grid.
+    {:doc      "All seven Machines tab variants in one auto-grid.
                 Scroll to see the panel's response across no-machines
                 / single Mode A / single Mode B / multi-machine /
-                many-transitions / UC1 Sim mid-step."
+                many-transitions / UC1 Sim mid-step / UC1 Sim
+                pending-input."
      :layout   :variants-grid
      :story    :story.causa.machines
      :columns  2


### PR DESCRIPTION
## Summary

Adds a 7th variant `:story.causa.machines/uc1-sim-pending-input` to
the panel-gallery Machines tab story. It demonstrates the Machine
Inspector side rail with the controlled-input slots primed mid-
compose: the `:loader` snapshot stays at `:idle`, `:pending-event` is
`[:start]`, `:pending-data` is a sample EDN map — Step button primed
but not yet pressed.

Parent: rf2-sszlr (panel-gallery rebuild for spec/018-Event-Spine).

## Approach (a) vs (b)

The bead offered two paths:

- **(a)** Extend the testbed seed event to write `:sim/by-machine/:pending-event` directly to app-db.
- **(b)** Wire `:rf.causa/sim-set-pending-event` into the variant `:events`.

**Picked (b).** It uses the existing sim API (`sim-set-pending-event` + `sim-set-pending-data`), needs no new fixture or seed-event extension, and matches the determinism pattern the existing `uc1-sim-mid-step` variant already relies on (variant `:events` dispatch in order at boot). Approach (a) would have required a bespoke seed event or app-db bypass slot that pollutes the rest of the testbed for no determinism win.

## Changes

- `tools/causa/testbeds/panel_gallery/gallery_machines.cljs` — new variant + workspace docstring update.
- `tools/causa/testbeds/panel_gallery/_smoke.cjs` — `expectedAtLeast` for machines bumped 6 → 7.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 733 tests / 2168 assertions / 0 failures
- [x] `cd implementation && npm run test:cljs` — 2857 tests / 8168 assertions / 0 failures
- [x] `cd implementation && npm run test:browser` — 2848 tests / 8126 assertions / 0 failures
- [x] `npx shadow-cljs compile :testbeds/panel-gallery` — clean build (only pre-existing infer-warnings in `elk_layout.cljs`)
- [x] `scripts/test-fast-pr.sh` — PASS