### PR TITLE
fix(causa): frame-picker + :frame attribution in multi-frame shop demo (rf2-oziyr)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -663,10 +663,11 @@ The single-axis selection that every layer reads from.
         │
         ▼
 :rf.causa/active-filters           ← IN/OUT pill state (Causa app-db slot)
+:rf.causa/focus-slot               ← spine slot incl. picker's :frame (per rf2-oziyr)
         │
         ▼
 :rf.causa/filtered-cascades        ← single switch point: list + scrubber + counters
-        │
+        │                            (composes IN/OUT pills + picker frame)
         ▼
 :rf.causa/focus                    ← spine: {:dispatch-id :epoch-id :frame :mode :head? :previewing?}
         │
@@ -676,9 +677,10 @@ The single-axis selection that every layer reads from.
         └──── L4 detail panel (per-tab content)
 ```
 
-The filtering happens at the data layer (`:rf.causa/filtered-cascades`), not at render. Two reasons:
+The filtering happens at the data layer (`:rf.causa/filtered-cascades`), not at render. Three reasons:
 1. Virtualisation cares about row count — render-time filtering means the virtualiser budgets unfiltered rows.
 2. Scrubbing must respect filters — `[◀ ▶ ⏭]` walks `:rf.causa/filtered-cascades`, not all cascades.
+3. The frame picker is a filter too — per rf2-oziyr the picker's `:frame` selection (stored on `:focus :frame` via `:rf.causa/set-frame`) is composed into `:rf.causa/filtered-cascades` alongside the IN/OUT pills so the L2 list, scrubber, and nav `[◀ ▶ ⏭]` walk the picker-scoped cascade list as one. Spine's LIVE auto-tracking ALSO respects the picker frame so `:head?` and the head walk are scoped per-frame.
 
 ### LIVE / RETRO transitions
 

--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -130,11 +130,23 @@
   ;; cascade list (event-list, scrubber, palette, Issues counter)
   ;; reads `:rf.causa/filtered-cascades`; raw `:rf.causa/cascades`
   ;; stays available for unfiltered totals.
+  ;;
+  ;; Per spec/018 §3 Frame dropdown + rf2-oziyr: the frame picker is
+  ;; ALSO a data-layer filter. The picker's selection lives on the
+  ;; spine's `:focus :frame` slot (written by `:rf.causa/set-frame`);
+  ;; we read the raw slot here (not the composed `:rf.causa/focus` sub)
+  ;; to avoid the cycle composed-focus → cascades → filtered-cascades
+  ;; → composed-focus. nil slot = no frame filter active (multi-frame
+  ;; app, picker has not been touched, OR a single-frame app whose
+  ;; picker collapses to a flat label).
   (rf/reg-sub :rf.causa/filtered-cascades
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/active-filters]
-    (fn [[cascades filters] _query]
-      (matcher/filter-cascades cascades filters)))
+    :<- [:rf.causa/focus-slot]
+    (fn [[cascades filters focus-slot] _query]
+      (-> cascades
+          (matcher/filter-cascades-by-frame (:frame focus-slot))
+          (matcher/filter-cascades filters))))
 
   ;; Popup state — three slots so the open / trigger / draft tiers
   ;; are individually subscribable.

--- a/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc
@@ -171,3 +171,31 @@
   order. Pure — no I/O, no atoms read."
   [cascades filters]
   (filterv #(keep-cascade? % filters) cascades))
+
+;; ---- frame-picker filter (rf2-oziyr) -------------------------------------
+
+(defn keep-cascade-for-frame?
+  "True iff `cascade`'s `:frame` matches the picker-selected
+  `picker-frame`. nil / absent `picker-frame` means 'no frame filter
+  active' — every cascade survives. Cascades whose `:frame` slot is
+  nil (the `:ungrouped` bucket from registry-time emits / lifecycle
+  outside a drain) drop out when a frame filter is active.
+
+  Per spec/018 §3 Frame dropdown: the picker is single-select and the
+  L2 list MUST show only the picked frame's cascades. Filtering at
+  the data layer keeps the virtualisation budget honest and the
+  ribbon nav (`◀ ▶ ⏭`) walking the same surface every consumer reads.
+
+  Pure data; JVM-runnable."
+  [cascade picker-frame]
+  (or (nil? picker-frame)
+      (= picker-frame (:frame cascade))))
+
+(defn filter-cascades-by-frame
+  "Restrict `cascades` to those whose `:frame` matches `picker-frame`.
+  nil `picker-frame` returns `cascades` unchanged. Pure — no I/O, no
+  atoms read. Per spec/018 §3 Frame dropdown + rf2-oziyr."
+  [cascades picker-frame]
+  (if (nil? picker-frame)
+    cascades
+    (filterv #(keep-cascade-for-frame? % picker-frame) cascades)))

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -206,12 +206,26 @@
   points at `:ungrouped` OR points at an evicted cascade. Combined
   with the LIVE auto-follow above this makes 'buffer non-empty +
   effective :dispatch-id nil' structurally unreachable — the L4
-  panels never have to handle the 'no cascade' degraded render."
+  panels never have to handle the 'no cascade' degraded render.
+
+  ## Frame-picker scoping (rf2-oziyr)
+
+  When `slot-frame` is non-nil (the frame-picker has restricted the
+  inspectable surface to one frame), the head walk runs over
+  cascades restricted to that frame so `:live` mode auto-tracks the
+  picked frame's head and `[◀ ▶ ⏭]` boundaries respect the picker.
+  Without this scoping the composer would pick the global head
+  (whatever frame fired the latest event), which under multi-frame
+  apps drifts focus off the picker's frame on every cross-frame
+  dispatch."
   [focus cascades]
-  (let [focusable  (focusable-cascades cascades)
+  (let [focusable* (focusable-cascades cascades)
+        slot-frame (:frame focus)
+        focusable  (if slot-frame
+                     (filterv #(= slot-frame (:frame %)) focusable*)
+                     focusable*)
         head-id    (head-dispatch-id focusable)
         slot-id    (:dispatch-id focus)
-        slot-frame (:frame focus)
         paused?    (boolean (:paused? focus))
         ;; rf2-fzbrw — a slot pointing at nil OR the :ungrouped bucket
         ;; is NOT a valid focus pin. (Evicted ids are still a valid
@@ -343,7 +357,15 @@
   ([db cascades delta]
    (focus-step-reducer db cascades [] delta))
   ([db cascades epoch-history delta]
-   (let [focusable  (focusable-cascades cascades)
+   (let [slot-frame (get-in db [:focus :frame])
+         focusable* (focusable-cascades cascades)
+         ;; rf2-oziyr — when the frame-picker has restricted the
+         ;; inspectable surface, the step walk MUST honour that
+         ;; restriction so [◀ ▶ ⏭] / j / k step through the picker's
+         ;; cascades only, matching what the user sees in L2.
+         focusable  (if slot-frame
+                      (filterv #(= slot-frame (:frame %)) focusable*)
+                      focusable*)
          ;; rf2-s0s5x Phase A: resolve current-id through the same
          ;; composer the spine sub uses, so in LIVE mode `j` steps
          ;; back from the CURRENT head rather than from a stale

--- a/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/matcher_test.cljc
@@ -172,3 +172,47 @@
                     {:event [:anim-frame]}]]
       (is (= cascades
              (matcher/filter-cascades cascades {:in [] :out []}))))))
+
+;; ---- frame-picker filter (rf2-oziyr) ------------------------------------
+
+(deftest keep-cascade-for-frame-nil-picker-keeps-everything
+  (testing "nil picker-frame means 'no frame filter' — every cascade survives"
+    (is (matcher/keep-cascade-for-frame? {:frame :cart-frame} nil))
+    (is (matcher/keep-cascade-for-frame? {:frame :checkout-frame} nil))
+    (is (matcher/keep-cascade-for-frame? {:frame nil} nil))))
+
+(deftest keep-cascade-for-frame-matching-frame-keeps
+  (is (matcher/keep-cascade-for-frame? {:frame :cart-frame} :cart-frame))
+  (is (matcher/keep-cascade-for-frame? {:frame :rf/default} :rf/default)))
+
+(deftest keep-cascade-for-frame-non-matching-frame-drops
+  (is (not (matcher/keep-cascade-for-frame? {:frame :cart-frame} :checkout-frame)))
+  (is (not (matcher/keep-cascade-for-frame? {:frame nil} :cart-frame))
+      "ungrouped/frame-less cascade drops when a frame filter is active"))
+
+(deftest filter-cascades-by-frame-nil-is-identity
+  (let [cascades [{:dispatch-id 1 :frame :cart-frame}
+                  {:dispatch-id 2 :frame :checkout-frame}
+                  {:dispatch-id 3 :frame nil}]]
+    (is (= cascades (matcher/filter-cascades-by-frame cascades nil)))))
+
+(deftest filter-cascades-by-frame-restricts-and-preserves-order
+  (testing "rf2-oziyr — picker filter at data layer keeps only matching
+            cascades; order preserved so [◀ ▶ ⏭] walks the same surface"
+    (let [cascades [{:dispatch-id 1 :frame :cart-frame}
+                    {:dispatch-id 2 :frame :checkout-frame}
+                    {:dispatch-id 3 :frame :cart-frame}
+                    {:dispatch-id 4 :frame :checkout-frame}]]
+      (is (= [1 3] (mapv :dispatch-id
+                         (matcher/filter-cascades-by-frame cascades :cart-frame))))
+      (is (= [2 4] (mapv :dispatch-id
+                         (matcher/filter-cascades-by-frame cascades :checkout-frame)))))))
+
+(deftest filter-cascades-by-frame-drops-frameless
+  (testing "ungrouped / frame-less cascades drop when a frame filter is
+            active — keeps the L2 list aligned with the picker label"
+    (let [cascades [{:dispatch-id 1 :frame :cart-frame}
+                    {:dispatch-id :ungrouped :frame nil}
+                    {:dispatch-id 2 :frame :cart-frame}]]
+      (is (= [1 2] (mapv :dispatch-id
+                         (matcher/filter-cascades-by-frame cascades :cart-frame)))))))

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -150,14 +150,26 @@
       (is (true? (:head? r))))))
 
 (deftest compose-focus-derives-frame-from-cascade
-  (testing ":frame derives from the focused cascade — overrides any
-            stored slot frame so retro selections track the cascade
-            they pin to"
+  (testing ":frame derives from the focused cascade when the picker
+            and cascade frames agree (the common case post-click —
+            focus-cascade-reducer writes the cascade's frame onto the
+            slot so they're consistent)"
     (let [r (spine/compose-focus {:dispatch-id :c2 :mode :retro
-                                  :frame :stale-frame}
+                                  :frame :rf/default}
                                  fixture-cascades)]
       (is (= :rf/default (:frame r))
-          "frame comes from the cascade record, not the stored slot"))))
+          "frame comes from the cascade record"))))
+
+(deftest compose-focus-stale-slot-frame-falls-through
+  (testing "rf2-oziyr — when the slot's :frame restricts the focusable
+            walk to an empty subset (e.g. mid-transition between
+            picker selections), :frame falls back to the slot value so
+            the picker label and the panel stay consistent"
+    (let [r (spine/compose-focus {:dispatch-id :c2 :mode :retro
+                                  :frame :unknown-frame}
+                                 fixture-cascades)]
+      (is (= :unknown-frame (:frame r))
+          "no cascade in :unknown-frame → slot's :frame wins as fallback"))))
 
 (deftest compose-focus-paused-flag-rides-through
   (let [r (spine/compose-focus {:dispatch-id nil :mode :live :paused? true}
@@ -171,6 +183,41 @@
                                 :previewing? true}
                                fixture-cascades)]
     (is (true? (:previewing? r)))))
+
+;; ---- frame-picker scoping (rf2-oziyr) -----------------------------------
+
+(def ^:private multi-frame-fixture
+  "Mixed-frame fixture — :cart-frame and :checkout-frame interleaved.
+  Latest overall is the checkout cascade :c4; latest in :cart-frame is
+  :c3. Used to verify compose-focus's picker-aware head selection."
+  [(cascade :c1 :cart-frame)
+   (cascade :c2 :checkout-frame)
+   (cascade :c3 :cart-frame)
+   (cascade :c4 :checkout-frame)])
+
+(deftest compose-focus-picker-frame-scopes-head-walk
+  (testing "rf2-oziyr — when the picker (slot :frame) restricts to one
+            frame, LIVE head tracking auto-snaps to that frame's head,
+            not the global head"
+    (let [r (spine/compose-focus {:frame :cart-frame :mode :live}
+                                 multi-frame-fixture)]
+      (is (= :c3 (:dispatch-id r))
+          "head of :cart-frame is :c3, NOT :c4 (the global head)")
+      (is (= :cart-frame (:frame r)))
+      (is (true? (:head? r))))
+    (let [r (spine/compose-focus {:frame :checkout-frame :mode :live}
+                                 multi-frame-fixture)]
+      (is (= :c4 (:dispatch-id r))
+          "head of :checkout-frame is :c4")
+      (is (= :checkout-frame (:frame r))))))
+
+(deftest compose-focus-nil-picker-frame-keeps-global-head
+  (testing "rf2-oziyr — no picker restriction (slot :frame nil) keeps
+            the pre-existing behaviour: LIVE tracks global head"
+    (let [r (spine/compose-focus {:frame nil :mode :live}
+                                 multi-frame-fixture)]
+      (is (= :c4 (:dispatch-id r))
+          "global head wins when picker is unset"))))
 
 ;; -------------------------------------------------------------------------
 ;; (3) focus-cascade-reducer — writes :focus + legacy shim
@@ -721,6 +768,23 @@
           db       {}
           r        (spine/focus-step-reducer db cascades -1)]
       (is (= db r)))))
+
+(deftest focus-step-reducer-respects-picker-frame
+  (testing "rf2-oziyr — when the picker has scoped to one frame, [◀]
+            and [▶] walk only that frame's cascades. Cross-frame
+            cascades are invisible to the nav so the user can't
+            accidentally step into a frame they're not inspecting."
+    (let [cascades [(cascade :c1 :cart-frame)
+                    (cascade :c2 :checkout-frame)
+                    (cascade :c3 :cart-frame)
+                    (cascade :c4 :checkout-frame)]
+          db       {:focus {:frame :cart-frame
+                            :dispatch-id :c3
+                            :mode :live}}
+          r        (spine/focus-step-reducer db cascades -1)]
+      (is (= :c1 (get-in r [:focus :dispatch-id]))
+          "prev from :c3 (cart head) skips :c2 (checkout) and lands on :c1
+           (the only other cart cascade)"))))
 
 (deftest compose-focus-snaps-to-head-when-slot-id-is-ungrouped
   (testing "rf2-fzbrw — even in :retro, a stored slot pointing at


### PR DESCRIPTION
## Summary

P1 bug in the live shop testbed (post rf2-yhxk3 #1479).

**Mike's symptoms (verbatim):**
1. **Frame-picker filter wrong** — selecting `:checkout-frame` in Causa's frame-picker at the top of the shell does NOT filter L2 event list to that frame's events. Cart-frame events still show.
2. **Events attributed to `:rf/default`** — clicking an event in L2 list shows its `:frame` as `:rf/default` rather than the actual frame the event was dispatched into.

## Root cause

(c) Causa wiring. The substrate emits `:frame` on `:event/dispatched` correctly (router.cljc/emit-dispatched-trace! line 1256) and the trace projection groups cascades by `[frame dispatch-id]` correctly (projection.cljc). But Causa was not consuming the picker selection:

- `:rf.causa/filtered-cascades` composed only `:rf.causa/active-filters` (IN/OUT pills); the picker's `:focus :frame` (written by `:rf.causa/set-frame`) was never consumed by any downstream sub.
- `compose-focus` walked the unrestricted cascade vector to pick LIVE head, so `:head?` and `:rf.causa/focus :dispatch-id` drifted off the picker on every cross-frame dispatch.
- `focus-step-reducer` (`[◀ ▶ ⏭]` / `j` / `k`) walked the same unrestricted vector and could step into a frame the user wasn't inspecting.

## What changed

- **`tools/causa/src/day8/re_frame2_causa/filters/matcher.cljc`**: new `keep-cascade-for-frame?` + `filter-cascades-by-frame` helpers (pure data, JVM-runnable).
- **`tools/causa/src/day8/re_frame2_causa/filters.cljs`**: `:rf.causa/filtered-cascades` now also reads `:rf.causa/focus-slot` and composes the picker frame alongside the pills. No-cycle: focus-slot is the raw db slot, not the composed sub.
- **`tools/causa/src/day8/re_frame2_causa/spine.cljs`**: `compose-focus` restricts focusable cascades to `slot-frame` before head/by-id resolution; `focus-step-reducer` applies the same restriction so step nav respects the picker. Stale-slot-frame falls back to the slot value so the panel and picker label stay consistent during transitions.
- **`tools/causa/spec/018-Event-Spine.md`**: sub-graph + filter rationale updated to capture the picker-as-filter contract (rf2-oziyr).
- **Tests**: 5 new matcher tests + 3 new spine tests cover the picker contract. Existing `compose-focus-derives-frame-from-cascade` adjusted to match the new model (cascade-frame wins when picker matches; slot-frame falls through when no cascade exists in that frame), and a new test captures the fallthrough.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 739 tests, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2861 tests, 0 failures
- [x] `cd implementation/core && clojure -M:test` — 583 tests, 0 failures
- [x] `bash scripts/test-fast-pr.sh` — PASS
- [x] `npx shadow-cljs compile examples/shop` — build OK
- [ ] Manual smoke at http://localhost:8767/ — pick `:checkout-frame`, see only checkout-frame events; click one, see `:frame :checkout-frame`. (Defer to Mike — local shop testbed not booted in worker session.)

## Acceptance criteria

- [x] L2 event list filters correctly when frame-picker changes (data-layer filter via `:rf.causa/filtered-cascades`).
- [x] Clicked events show their actual frame (`:checkout-frame`, not `:rf/default`) — both intra-frame and cross-frame dispatches. Spine's `:frame` derives from the cascade record (which already carries the correct frame from the substrate's `:event/dispatched` trace).
- [x] Regression tests in matcher + spine cover the new behaviour.