### PR TITLE
fix(causa): Event lens — swap DISPATCH/EVENT order + add COEFFECTS (rf2-jhhqt)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -557,6 +557,37 @@
                           :frame    frame-id
                           :recovery :no-recovery})))))))
 
+(def ^:private framework-coeffect-keys
+  "Coeffect keys populated by the runtime itself (not by user-registered
+  `reg-cofx` / `inject-cofx`). Filtered OUT of the `:coeffects` stamp on
+  `:event/do-fx` per rf2-jhhqt so the Event lens's COEFFECTS section
+  shows only user-injected coeffects (mirrors the INTERCEPTORS section's
+  filter-out-framework-defaults posture).
+
+  `:db` + `:event` are populated by `assemble-initial-ctx`; `:frame` ditto.
+  `:source` + `:trace-id` are envelope keys also surfaced on the cofx
+  map by `assemble-initial-ctx` for handler-body convenience."
+  #{:db :event :frame :source :trace-id})
+
+(defn- user-injected-coeffects
+  "Project the user-injected subset of a coeffects map. Pure data → data.
+
+  Filters out the framework-default keys per `framework-coeffect-keys`.
+  Returns nil when the projection is empty (so the caller can use
+  `(when ...)` to skip the trace stamp entirely — `:event/do-fx` consumers
+  treat ABSENT `:coeffects` as 'no user-injected coeffects', distinct
+  from an empty map which would itself be a 'stamped but empty' signal)."
+  [coeffects]
+  (when (map? coeffects)
+    (let [projected (reduce-kv (fn [acc k v]
+                                 (if (contains? framework-coeffect-keys k)
+                                   acc
+                                   (assoc acc k v)))
+                               {}
+                               coeffects)]
+      (when (seq projected)
+        projected))))
+
 (defn do-fx
   "Walk the :fx vector in source order. Per Spec 002 §`:fx` ordering rule 3:
   each entry's handler returns synchronously before the next begins.
@@ -590,16 +621,29 @@
   fx handlers already receive the effects shape they need via per-
   fx args. Callers without an effects map (e.g. machine-exit fx
   walks) use a lower arity; the trace marker degrades gracefully
-  (no `:fx` / `:db-present?` slots on the emit)."
+  (no `:fx` / `:db-present?` slots on the emit).
+
+  The 8-arity additionally accepts the handler's final coeffects map
+  (per rf2-jhhqt). The USER-INJECTED subset (everything outside
+  `framework-coeffect-keys`) is stamped onto the `:event/do-fx`
+  marker's `:tags` under `:coeffects` so the Causa Event lens's
+  COEFFECTS section can render values without a second emit. The
+  filter mirrors the INTERCEPTORS section's filter-out-framework-
+  defaults posture; the stamp is absent entirely (not an empty map)
+  when zero user coeffects were injected — `trace/emit!` itself is
+  DCE-gated so prod CLJS bundles elide both the projection and the
+  emit."
   ([frame-id fx-vec active-platform]
-   (do-fx frame-id fx-vec active-platform {} nil nil nil))
+   (do-fx frame-id fx-vec active-platform {} nil nil nil nil))
   ([frame-id fx-vec active-platform overrides]
-   (do-fx frame-id fx-vec active-platform overrides nil nil nil))
+   (do-fx frame-id fx-vec active-platform overrides nil nil nil nil))
   ([frame-id fx-vec active-platform overrides origin-event]
-   (do-fx frame-id fx-vec active-platform overrides origin-event nil nil))
+   (do-fx frame-id fx-vec active-platform overrides origin-event nil nil nil))
   ([frame-id fx-vec active-platform overrides origin-event parent-envelope]
-   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope nil))
+   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope nil nil))
   ([frame-id fx-vec active-platform overrides origin-event parent-envelope effects]
+   (do-fx frame-id fx-vec active-platform overrides origin-event parent-envelope effects nil))
+  ([frame-id fx-vec active-platform overrides origin-event parent-envelope effects coeffects]
    (doseq [pair fx-vec]
      (when (and (vector? pair) (seq pair))
        (handle-one-fx frame-id pair active-platform overrides origin-event parent-envelope)))
@@ -612,7 +656,15 @@
    ;; cascade rows with handler returns. The tag-map is the third
    ;; arg to `trace/emit!`; `trace/emit!` itself is DCE-gated, so
    ;; prod builds elide both the construction and the emit.
-   (trace/emit! :event :event/do-fx
-                (cond-> {:frame frame-id}
-                  (some? effects) (assoc :fx          (:fx effects)
-                                         :db-present? (contains? effects :db))))))
+   ;;
+   ;; Per rf2-jhhqt: additionally stamp `:coeffects` with the user-
+   ;; injected subset of the handler's coeffects map (filter out the
+   ;; framework defaults — `:db` `:event` `:frame` `:source` `:trace-id`).
+   ;; Stamp is absent entirely when zero user cofx — the Event lens
+   ;; treats absent as 'no COEFFECTS section'.
+   (let [user-cofx (user-injected-coeffects coeffects)]
+     (trace/emit! :event :event/do-fx
+                  (cond-> {:frame frame-id}
+                    (some? effects)  (assoc :fx          (:fx effects)
+                                            :db-present? (contains? effects :db))
+                    (some? user-cofx) (assoc :coeffects user-cofx))))))

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -555,13 +555,20 @@
   `do-fx` (the 7-arity) so the terminating `:event/do-fx` trace
   marker can stamp `:fx` (the returned vector) and `:db-present?`
   (whether the handler returned a `:db` slot). The value of `:db`
-  is NOT stamped — App-db diff traces already carry slice changes."
-  [effects frame frame-record fx-overrides envelope]
+  is NOT stamped — App-db diff traces already carry slice changes.
+
+  Per rf2-jhhqt: the handler's final coeffects map is also threaded
+  to `do-fx` (the 8-arity) so the terminating `:event/do-fx` trace
+  marker can stamp `:coeffects` with the user-injected subset (the
+  framework defaults `:db` `:event` `:frame` `:source` `:trace-id`
+  are filtered out inside `do-fx`). Powers the Event lens's COEFFECTS
+  section without a second emit."
+  [effects coeffects frame frame-record fx-overrides envelope]
   (when-let [fx-vec (:fx effects)]
     (let [active-platform (or (get-in frame-record [:config :platform])
                               interop/platform)
           event           (:event envelope)]
-      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope effects))))
+      (fx/do-fx frame fx-vec active-platform fx-overrides event envelope effects coeffects))))
 
 ;; ---- process-event* phases ------------------------------------------------
 ;;
@@ -703,6 +710,7 @@
   inheritable keys onto child dispatches."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
   (let [effects   (:effects final-ctx)
+        coeffects (:coeffects final-ctx)
         error     (:rf/interceptor-error final-ctx)
         db-before (get-in final-ctx [:coeffects :db])]
     (when error
@@ -717,7 +725,7 @@
       ;; child dispatch on stale derived state — side effects (HTTP /
       ;; navigation / analytics) would escape.
       (when (run-flows! frame event event-id start-ms)
-        (run-fx-effects! effects frame frame-record fx-overrides envelope)))
+        (run-fx-effects! effects coeffects frame frame-record fx-overrides envelope)))
     error))
 
 (defn- emit-cascade-trailers!

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -660,3 +660,63 @@
               ":db-present? is NOT at top level"))
         (finally
           (rf/remove-trace-cb! ::top-level))))))
+
+;; ---- rf2-jhhqt: :coeffects stamp on :event/do-fx -------------------------
+;;
+;; Per rf2-jhhqt the user-injected subset of the handler's final
+;; coeffects map rides under `:tags :coeffects` on :event/do-fx.
+;; Mirrors the rf2-twt7m Change 2 stamping: substrate-side filter keeps
+;; the framework defaults (:db :event :frame :source :trace-id) out so
+;; the Event lens's COEFFECTS section reads a pre-filtered map.
+
+(deftest event-do-fx-stamps-user-injected-coeffects
+  (testing "a handler whose chain injects user coeffects (:now etc.)
+   sees them stamped under :tags :coeffects on :event/do-fx; the
+   framework defaults (:db :event :frame) are filtered out at the
+   substrate"
+    (rf/reg-fx :fx-test/cofx-sink (fn [_ _] :ok))
+    (rf/reg-cofx :fx-test/now
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :fx-test/now] "2026-05-18T19:00:00Z")))
+    (rf/reg-cofx :fx-test/locale
+      (fn [ctx]
+        (assoc-in ctx [:coeffects :fx-test/locale] :en-AU)))
+    (rf/reg-event-fx :fx-test/uses-user-cofx
+      [(rf/inject-cofx :fx-test/now)
+       (rf/inject-cofx :fx-test/locale)]
+      (fn [_ _] {:db {:k 1}
+                 :fx [[:fx-test/cofx-sink :go]]}))
+    (let [acc (collect-traces! ::user-cofx)]
+      (try
+        (rf/dispatch-sync [:fx-test/uses-user-cofx])
+        (let [[dof] (filterv #(= :event/do-fx (:operation %)) @acc)
+              cofx  (get-in dof [:tags :coeffects])]
+          (is (some? dof) ":event/do-fx fired")
+          (is (= {:fx-test/now    "2026-05-18T19:00:00Z"
+                  :fx-test/locale :en-AU}
+                 cofx)
+              "only the user-injected coeffects ride under :tags :coeffects")
+          (is (not (contains? cofx :db))    "framework :db NOT stamped")
+          (is (not (contains? cofx :event)) "framework :event NOT stamped")
+          (is (not (contains? cofx :frame)) "framework :frame NOT stamped"))
+        (finally
+          (rf/remove-trace-cb! ::user-cofx))))))
+
+(deftest event-do-fx-coeffects-stamp-absent-when-no-user-cofx
+  (testing "a handler with no inject-cofx has its :event/do-fx fire
+   WITHOUT a :coeffects stamp (silent-by-default — distinct from a
+   stamped empty map)"
+    (rf/reg-fx :fx-test/plain-sink (fn [_ _] :ok))
+    (rf/reg-event-fx :fx-test/no-user-cofx
+      (fn [_ _] {:db {:k 1}
+                 :fx [[:fx-test/plain-sink :go]]}))
+    (let [acc (collect-traces! ::no-cofx)]
+      (try
+        (rf/dispatch-sync [:fx-test/no-user-cofx])
+        (let [[dof] (filterv #(= :event/do-fx (:operation %)) @acc)
+              tags  (:tags dof)]
+          (is (some? dof) ":event/do-fx fired")
+          (is (not (contains? tags :coeffects))
+              ":coeffects key ABSENT on :tags when no user cofx injected"))
+        (finally
+          (rf/remove-trace-cb! ::no-cofx))))))

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -329,21 +329,26 @@ L4 fills the remaining canvas (60% default; resizable via L2/L3 drag handle). Al
 
 The renderer does NOT depend on `binaryage/cljs-devtools` (that library targets the Chrome console; this is in-page hiccup). Pure hiccup, theme-token-driven, substrate-agnostic. See [`007-UX-IA.md`](007-UX-IA.md) §Detail panel renderer.
 
-### §5.1 Event tab content — the 6-section Event lens
+### §5.1 Event tab content — the 7-section Event lens
 
-Shipped layout per rf2-zh2qc (rewrite of the v1 'fattened Event tab').
-Top-of-panel: a single-line cascade-outcome summary; below: six stacked
+Shipped layout per rf2-zh2qc + rf2-jhhqt (the latter swaps DISPATCH SITE
+before EVENT per Mike's Q1 verbatim, and adds the COEFFECTS section).
+Top-of-panel: a single-line cascade-outcome summary; below: seven stacked
 sections that read top-to-bottom as the developer scans.
 
 ```
 ┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
 │                                                                                      │
-│ ▼ EVENT                                                                              │
-│   [:cart/add-item {:id 42 :qty 2}]                                                   │
-│                                                                                      │
 │ ▼ DISPATCH SITE                                                                      │
 │   src/cart/views.cljs:127       [open ↗]                                             │
 │   via :ui · origin :app                                                              │
+│                                                                                      │
+│ ▼ EVENT                                                                              │
+│   [:cart/add-item {:id 42 :qty 2}]                                                   │
+│                                                                                      │
+│ ▼ COEFFECTS  (2)                                                                     │
+│   :now            #inst "2026-05-18T19:00:00Z"                                       │
+│   :local-storage  {:user/last-cart-id "cart-42"}                                     │
 │                                                                                      │
 │ ▼ INTERCEPTORS  (1)                                                                  │
 │   :auth/require-login          src/auth/interceptors.cljs:42   [open ↗]              │
@@ -376,24 +381,33 @@ sections that read top-to-bottom as the developer scans.
   `:rf.ssr/hydrated` / `:rf.ssr/hydration-complete`; omitted for
   purely-client-side cascades.
 
-#### The 6 sections (Mike's verbatim order)
+#### The 7 sections (Mike's verbatim order, rf2-jhhqt)
 
-1. **EVENT** — the dispatched event vector via `inspector/inspect`.
-   Always present.
-2. **DISPATCH SITE** — source-coord chip + `via :source · origin :origin`
+1. **DISPATCH SITE** — source-coord chip + `via :source · origin :origin`
    caption. Reads `:rf.trace/call-site` off the `:event/dispatched`
    trace (rf2-twt7m Change 1). Renders an absent-placeholder when no
-   call-site was captured.
-3. **INTERCEPTORS** — non-standard chain only, **silent when zero**
+   call-site was captured. **Comes FIRST** per Mike's Q1 — the
+   developer's first instinct ("who fired this?") gets the most
+   prominent slot.
+2. **EVENT** — the dispatched event vector via `inspector/inspect`.
+   Always present.
+3. **COEFFECTS** — user-injected coeffects only, **silent when zero**
+   (the section is ABSENT entirely, NOT '(none)'). Reads `:coeffects`
+   off the `:event/do-fx` trace's `:tags` (rf2-jhhqt — the runtime
+   stamps the user-injected subset; the framework defaults `:db`
+   `:event` `:frame` `:source` `:trace-id` are filtered at the
+   substrate). Mirrors the INTERCEPTORS section's filter-out-framework-
+   defaults posture. Each row: `<:cofx-id>  <inspected-value>`.
+4. **INTERCEPTORS** — non-standard chain only, **silent when zero**
    (the section is ABSENT entirely, NOT '(none)'). Reads
    `(rf/handler-meta :event id) :interceptors` and filters out anything
    carrying `:rf/default? true` (rf2-twt7m Change 3) plus the known
    auto-wrapper ids (`:rf/db-handler` / `:rf/fx-handler` /
    `:rf/ctx-handler`) as a belt-and-braces fallback.
-4. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [open ↗]`. Per
-   Q2: does NOT duplicate the event-id (already shown in §1). Reads
+5. **HANDLER** — `reg-event-<kind> · src/file.cljs:N [open ↗]`. Per
+   Q2: does NOT duplicate the event-id (already shown in §2). Reads
    `(rf/handler-meta :event id)`.
-5. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`
+6. **EFFECTS RETURNED** — silent-by-default when neither `:db` nor `:fx`
    was returned. Reads `:fx` + `:db-present?` off the `:event/do-fx`
    trace's `:tags` (rf2-twt7m Change 2). `:db` is shown as
    `<… changed; see App-db tab …>` — the diff itself lives in the
@@ -401,7 +415,7 @@ sections that read top-to-bottom as the developer scans.
    additional `:rf.ssr/hydration-outcome` row renders with the
    `{:duration-ms :subs-ran :mismatches}` payload + (when mismatches
    > 0) a `→ jump to Issues bisector` affordance.
-6. **EFFECTS HANDLERS RAN** — silent-by-default when no fx ran. One
+7. **EFFECTS HANDLERS RAN** — silent-by-default when no fx ran. One
    row per `:rf.fx/handled` (or override / skipped / exception) trace:
    fx-id chip + perf-tier dot + status caption. For `:dispatch` the
    queued child event renders inline as `→ queued [:foo …]`. For
@@ -414,10 +428,11 @@ sections that read top-to-bottom as the developer scans.
 
 - **No call-site captured** — DISPATCH SITE shows
   `"source coord unavailable"`; no open chip rendered.
+- **No user coeffects** — COEFFECTS section ABSENT entirely.
 - **No user interceptors** — INTERCEPTORS section ABSENT entirely.
 - **No effects returned** — EFFECTS RETURNED section ABSENT.
 - **No fx handlers ran** — EFFECTS HANDLERS RAN section ABSENT.
-- **Handler threw** — §5 + §6 are both absent (handler never
+- **Handler threw** — §6 + §7 are both absent (handler never
   returned / fx walk never started); a small footer caption renders:
   `Handler threw — see Issues tab ⚠ for the exception detail.` This
   is the ONE inline cross-reference to another tab.

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -4,11 +4,12 @@
 
   This panel replaces the v1 'six-domino' renderer with a focused
   Event lens shaped after Chrome DevTools: top-of-panel cascade-outcome
-  line + six stacked sections that read top-to-bottom as the developer
+  line + seven stacked sections that read top-to-bottom as the developer
   scans:
 
-      ▼ EVENT                 the dispatched event vector
       ▼ DISPATCH SITE         where the dispatch happened (source coord)
+      ▼ EVENT                 the dispatched event vector
+      ▼ COEFFECTS             user-injected coeffects (silent when zero)
       ▼ INTERCEPTORS          non-standard chain (silent when empty)
       ▼ HANDLER               where the handler is defined (source coord)
       ▼ EFFECTS RETURNED      the {:db ... :fx [...]} the handler returned
@@ -18,10 +19,9 @@
   own tabs (Views / Issues). See `tools/causa/spec/018-Event-Spine.md`
   §5.1 + `ai/findings/2026-05-18-event-lens-design.md` for design.
 
-  ## Substrate-driven (rf2-twt7m)
+  ## Substrate-driven (rf2-twt7m + rf2-jhhqt)
 
-  Three substrate changes in rf2-twt7m supply the data this lens
-  needs:
+  Four substrate changes supply the data this lens needs:
 
     Change 1 — `:event/dispatched` traces carry `:rf.trace/call-site`
                on success-path emits (previously error-only). DISPATCH
@@ -32,6 +32,11 @@
     Change 3 — Framework-auto-wrapped interceptors carry
                `:rf/default? true` so INTERCEPTORS can filter them out
                without an allowlist.
+    Change 4 — (rf2-jhhqt) `:event/do-fx` traces additionally carry
+               `:coeffects` on their `:tags` — the USER-INJECTED subset
+               of the handler's final coeffects map (framework defaults
+               filtered out at the substrate). COEFFECTS section reads
+               it.
 
   Handler-site coord reads via `(rf/handler-meta :event event-id)` —
   no trace involvement; reads the registry at render time.
@@ -44,12 +49,12 @@
 
   ## What replaced the v1 cascade-detail
 
-    - cascade-detail (six-domino renderer)  → event-lens (6 sections)
+    - cascade-detail (six-domino renderer)  → event-lens (7 sections)
     - event-row / handler-row / fx-row      → section/section-header
     - subs-row / renders-row / other-row    → DELETED
                                               (Views / Issues tabs)
-    - effects-row                           → §5 EFFECTS RETURNED
-                                              + §6 EFFECTS HANDLERS RAN
+    - effects-row                           → §6 EFFECTS RETURNED
+                                              + §7 EFFECTS HANDLERS RAN
     - 'Event detail' h1                     → cascade-outcome line
 
   ## What survives
@@ -388,7 +393,7 @@
                        :margin-left "6px"}}
         "SSR✓"])]))
 
-;; ---- §1 EVENT ----------------------------------------------------------
+;; ---- §2 EVENT ----------------------------------------------------------
 
 (defn- event-section
   [event-vec]
@@ -399,7 +404,7 @@
            :style {:font-weight 600}}
      (inspector/inspect event-vec "event-detail/event")]))
 
-;; ---- §2 DISPATCH SITE --------------------------------------------------
+;; ---- §1 DISPATCH SITE --------------------------------------------------
 
 (defn- coord-chip
   "Reusable 'open in editor' chip. Renders nothing when `coord` has no
@@ -456,20 +461,73 @@
             (and (not source) origin) (str "origin ")
             origin (str origin))])])))
 
-;; ---- §3 INTERCEPTORS ---------------------------------------------------
+;; ---- shared id → testid-suffix renderer --------------------------------
 
 (defn- interceptor-testid-suffix
-  "Render an interceptor id into a stable testid suffix. Qualified
-  keywords (`:auth/require-login`) render as `auth/require-login`;
-  bare keywords use their name; non-keyword ids fall through `str`.
-  Used so the test asserting on a per-interceptor row testid sees the
-  same id the registration declares."
+  "Render an interceptor / cofx / fx id into a stable testid suffix.
+  Qualified keywords (`:auth/require-login`) render as
+  `auth/require-login`; bare keywords use their name; non-keyword ids
+  fall through `str`. Shared across §3 COEFFECTS, §4 INTERCEPTORS, and
+  §7 EFFECTS HANDLERS RAN so a test asserting on a per-row testid sees
+  the same id the registration declares."
   [id]
   (cond
     (qualified-keyword? id) (str (namespace id) "/" (name id))
     (keyword? id)           (name id)
     (nil? id)               "unknown"
     :else                   (str id)))
+
+;; ---- §3 COEFFECTS ------------------------------------------------------
+
+(defn user-coeffects
+  "Project the user-injected coeffects map off the cascade's
+  `:event/do-fx` trace (rf2-jhhqt — substrate Change 4 stamps the
+  user-injected subset on `:tags :coeffects`). Pure fn; JVM-testable.
+
+  Returns the map (preserving id → value pairs) or nil when the
+  cascade carries no coeffects stamp / the stamp is empty. The
+  substrate filters the framework defaults (`:db` `:event` `:frame`
+  `:source` `:trace-id`) at emit-time so this fn is a thin reader —
+  it does NOT re-filter."
+  [cascade]
+  (let [m (some-> (do-fx-trace cascade) :tags :coeffects)]
+    (when (and (map? m) (seq m))
+      m)))
+
+(defn- coeffect-row
+  [id value]
+  (let [suffix (interceptor-testid-suffix id)]
+    [:div {:data-testid (str "rf-causa-event-detail-coeffect-row-" suffix)
+           :style {:display "flex"
+                   :align-items "flex-start"
+                   :padding "2px 0"}}
+     [:span {:style {:color (:accent-violet tokens)
+                     :min-width "180px"
+                     :margin-right "12px"}}
+      (pr-str id)]
+     [:span {:style {:color (:text-primary tokens)
+                     :min-width 0
+                     :flex 1
+                     :word-break "break-word"}}
+      (inspector/inspect value (str "event-detail/coeffect/" suffix))]]))
+
+(defn- coeffects-section
+  "§3. Silent-by-default — section is ABSENT entirely when zero user
+  coeffects were injected (mirrors INTERCEPTORS' posture)."
+  [cascade]
+  (let [user-cofx (user-coeffects cascade)]
+    (when (seq user-cofx)
+      (section/section-row
+        {:label "COEFFECTS"
+         :count* (count user-cofx)
+         :testid "rf-causa-event-detail-section-coeffects"}
+        (into [:div]
+              ;; Per rf2-ppzid — `with-meta` on fn return preserves :key.
+              (for [[id v] user-cofx]
+                (with-meta (coeffect-row id v)
+                           {:key (pr-str id)})))))))
+
+;; ---- §4 INTERCEPTORS ---------------------------------------------------
 
 (defn- interceptor-row
   [{:keys [id file line] :as _interceptor}]
@@ -514,7 +572,7 @@
               (with-meta (interceptor-row icpt)
                          {:key (pr-str (:id icpt))}))))))
 
-;; ---- §4 HANDLER --------------------------------------------------------
+;; ---- §5 HANDLER --------------------------------------------------------
 
 (defn- handler-section
   "Renders the handler-meta read off `(rf/handler-meta :event id)`.
@@ -554,7 +612,7 @@
             "no handler registered")])
        (coord-chip coord "rf-causa-event-detail-handler-open-chip")])))
 
-;; ---- §5 EFFECTS RETURNED -----------------------------------------------
+;; ---- §6 EFFECTS RETURNED -----------------------------------------------
 
 (defn- effects-returned-row
   [label value testid value-style]
@@ -628,7 +686,7 @@
          :testid "rf-causa-event-detail-section-effects-returned"}
         (into [:div] rows)))))
 
-;; ---- §6 EFFECTS HANDLERS RAN -------------------------------------------
+;; ---- §7 EFFECTS HANDLERS RAN -------------------------------------------
 
 (defn- dispatch-fx-summary
   "Render the `:dispatch` fx-handler row's caption — `→ queued event
@@ -728,8 +786,19 @@
 ;; ---- the lens (replaces v1 cascade-detail) -----------------------------
 
 (defn- event-lens
-  "Render the 6-section Event lens for a cascade. Replaces the v1
-  `cascade-detail` six-domino renderer per rf2-zh2qc."
+  "Render the 7-section Event lens for a cascade. Replaces the v1
+  `cascade-detail` six-domino renderer per rf2-zh2qc; COEFFECTS slot
+  added in rf2-jhhqt + section order corrected to honour Mike's Q1
+  answer (DISPATCH SITE first, then EVENT).
+
+  Order (top → bottom):
+    §1 DISPATCH SITE         where the dispatch happened (source coord)
+    §2 EVENT                 the dispatched event vector
+    §3 COEFFECTS             user-injected coeffects (silent when zero)
+    §4 INTERCEPTORS          non-standard chain (silent when zero)
+    §5 HANDLER               where the handler is defined (source coord)
+    §6 EFFECTS RETURNED      {:db ... :fx [...]} the handler returned
+    §7 EFFECTS HANDLERS RAN  per-fx-handler rows + managed-fx inline"
   [{:keys [dispatch-id frame event] :as cascade}]
   (let [event-id   (when (vector? event) (first event))
         meta       (when event-id (rf/handler-meta :event event-id))
@@ -739,8 +808,9 @@
            :data-dispatch-id (str dispatch-id)
            :data-frame (str frame)}
      (cascade-outcome-line cascade)
-     (event-section event)
      (dispatch-site-section cascade)
+     (event-section event)
+     (coeffects-section cascade)
      (interceptors-section user-icpts)
      (handler-section event-id meta)
      (when-not threw?

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -8,13 +8,14 @@
        — the panel's spine plumbing didn't change).
     2. Cascade-outcome line (top-of-panel) — glyph + colour + SSR badge
        per §5.1 + the hydration-outcome addendum.
-    3. The 6 sections render in order: EVENT, DISPATCH SITE,
-       INTERCEPTORS, HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN.
+    3. The 7 sections render in order (Mike's Q1 verbatim per
+       rf2-jhhqt): DISPATCH SITE, EVENT, COEFFECTS, INTERCEPTORS,
+       HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN.
     4. Silent-by-default — sections ABSENT (not '(none)') when their
        data is empty.
-    5. Handler threw → §5/§6 suppressed + Issues-tab footer renders.
-    6. Pure projection helpers (`user-interceptors`, `cascade-outcome`,
-       `effects-handlers-ran`, `hydration-outcome-row`).
+    5. Handler threw → §6/§7 suppressed + Issues-tab footer renders.
+    6. Pure projection helpers (`user-interceptors`, `user-coeffects`,
+       `cascade-outcome`, `effects-handlers-ran`, `hydration-outcome-row`).
     7. The meta-on-vector pattern (rf2-ppzid) — :key reaches every
        row inside :for blocks.
 
@@ -63,7 +64,7 @@
       `:tags` (rf2-twt7m Change 2) so EFFECTS RETURNED has data."
   ([dispatch-id event-vec id-base]
    (cascade-evs dispatch-id event-vec id-base nil))
-  ([dispatch-id event-vec id-base {:keys [frame-id call-site source origin fx db-present?]
+  ([dispatch-id event-vec id-base {:keys [frame-id call-site source origin fx db-present? coeffects]
                                     :or   {fx          [[:db nil] [:dispatch [:bar]]]
                                            db-present? true
                                            source      :ui
@@ -84,7 +85,8 @@
      :tags (cond-> {:dispatch-id dispatch-id}
              frame-id    (assoc :frame frame-id)
              fx          (assoc :fx fx)
-             db-present? (assoc :db-present? true))}
+             db-present? (assoc :db-present? true)
+             (seq coeffects) (assoc :coeffects coeffects))}
     {:id (+ id-base 5) :op-type :fx :operation :rf.fx/handled
      :tags (cond-> {:dispatch-id dispatch-id :fx-id :db :duration-ms 1}
              frame-id (assoc :frame frame-id))}
@@ -188,12 +190,41 @@
       (let [data @(rf/subscribe [:rf.causa/event-detail])]
         (is (= 200 (:selected-dispatch-id data)))))))
 
-;; ---- (2) the 6 sections render in order --------------------------------
+;; ---- (2) the 7 sections render in order --------------------------------
 
-(deftest event-lens-renders-all-six-sections-when-fully-populated
-  (testing "a cascade with call-site + fx + interceptors yields the
-            full 6-section layout: EVENT, DISPATCH SITE, INTERCEPTORS,
-            HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS RAN"
+(def ^:private ^:const section-root-testids
+  "The seven section root testids (post-rf2-jhhqt) in the order they
+  SHOULD appear top-to-bottom in the rendered Event lens. Used by
+  `section-testids-in-order` to filter out section-header / section-
+  body children testids the `section/section-row` primitive emits."
+  #{"rf-causa-event-detail-section-dispatch"
+    "rf-causa-event-detail-section-event"
+    "rf-causa-event-detail-section-coeffects"
+    "rf-causa-event-detail-section-interceptors"
+    "rf-causa-event-detail-section-handler"
+    "rf-causa-event-detail-section-effects-returned"
+    "rf-causa-event-detail-section-effects-ran"})
+
+(defn- section-testids-in-order
+  "Walk the rendered hiccup tree and return the data-testids of every
+  section ROOT in document order. Filters out the per-section
+  `*-header` / `*-body` children testids `section/section-row` emits."
+  [tree]
+  (->> (hiccup-seq tree)
+       (keep (fn [node]
+               (when (and (vector? node) (map? (second node)))
+                 (let [tid (str (or (:data-testid (second node)) ""))]
+                   (when (contains? section-root-testids tid)
+                     tid)))))
+       (distinct)
+       (vec)))
+
+(deftest event-lens-renders-all-seven-sections-when-fully-populated
+  (testing "a cascade with call-site + fx + interceptors + user
+            coeffects yields the full 7-section layout in the
+            rf2-jhhqt-shipped order: DISPATCH SITE, EVENT, COEFFECTS,
+            INTERCEPTORS, HANDLER, EFFECTS RETURNED, EFFECTS HANDLERS
+            RAN"
     (rf/with-frame :rf/default
       (rf/reg-event-fx :widget/poke
         [(rf/->interceptor :id :auth/require-login)]
@@ -203,22 +234,55 @@
                    {:call-site {:file "src/widget.cljs" :line 42}
                     :source :ui :origin :app
                     :fx [[:db nil] [:dispatch [:bar]]]
-                    :db-present? true}))
+                    :db-present? true
+                    :coeffects {:now "2026-05-18T19:00:00Z"
+                                :local-storage {:user/last-cart-id "cart-42"}}}))
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
       (let [tree (event-detail/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-event-detail-section-event"))
-            "§1 EVENT section present")
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-dispatch"))
-            "§2 DISPATCH SITE section present")
+            "§1 DISPATCH SITE section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-event"))
+            "§2 EVENT section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-coeffects"))
+            "§3 COEFFECTS section present")
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-interceptors"))
-            "§3 INTERCEPTORS section present")
+            "§4 INTERCEPTORS section present")
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-handler"))
-            "§4 HANDLER section present")
+            "§5 HANDLER section present")
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-effects-returned"))
-            "§5 EFFECTS RETURNED section present")
+            "§6 EFFECTS RETURNED section present")
         (is (some? (find-by-testid tree "rf-causa-event-detail-section-effects-ran"))
-            "§6 EFFECTS HANDLERS RAN section present")))))
+            "§7 EFFECTS HANDLERS RAN section present")))))
+
+(deftest event-lens-section-order-matches-mike-q1-verbatim
+  (testing "rf2-jhhqt — sections render top-to-bottom in the verbatim
+            Mike-approved order: DISPATCH SITE → EVENT → COEFFECTS →
+            INTERCEPTORS → HANDLER → EFFECTS RETURNED → EFFECTS
+            HANDLERS RAN"
+    (rf/with-frame :rf/default
+      (rf/reg-event-fx :widget/poke
+        [(rf/->interceptor :id :auth/require-login)]
+        (fn [_ _] {})))
+    (seed-buffer!
+      (cascade-evs 100 [:widget/poke {:id 1}] 0
+                   {:call-site {:file "src/widget.cljs" :line 42}
+                    :coeffects {:now "2026-05-18T19:00:00Z"}
+                    :fx [[:db nil] [:dispatch [:bar]]]
+                    :db-present? true}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree  (event-detail/Panel)
+            order (section-testids-in-order tree)]
+        (is (= ["rf-causa-event-detail-section-dispatch"
+                "rf-causa-event-detail-section-event"
+                "rf-causa-event-detail-section-coeffects"
+                "rf-causa-event-detail-section-interceptors"
+                "rf-causa-event-detail-section-handler"
+                "rf-causa-event-detail-section-effects-returned"
+                "rf-causa-event-detail-section-effects-ran"]
+               order)
+            "section testids appear in the rf2-jhhqt-shipped order")))))
 
 (deftest cascade-outcome-line-replaces-literal-event-detail-h1
   (testing "the literal 'Event detail' h1 is gone; the cascade-outcome
@@ -470,6 +534,63 @@
             inline (find-by-testid tree "rf-causa-event-detail-effects-ran-managed-fx-4")]
         (is (some? inline)
             "managed-fx record-panel mounts inline beneath fx-handler row")))))
+
+;; ---- (8.5) COEFFECTS section — silent-by-default + rendering -----------
+
+(deftest coeffects-section-absent-when-zero-user-coeffects
+  (testing "rf2-jhhqt — when the cascade carries no user-injected
+            coeffects stamp the COEFFECTS section is ABSENT entirely
+            (silent-by-default, NOT '(none)' placeholder)"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-coeffects"))
+            "COEFFECTS section absent when zero user coeffects stamped")))))
+
+(deftest coeffects-section-renders-one-row-per-user-injected-cofx
+  (testing "with `:now` + `:local-storage` stamped on :event/do-fx, the
+            COEFFECTS section renders one row per id with the value
+            surfaced via the data-inspector"
+    (seed-buffer!
+      (cascade-evs 100 [:cart/restore] 0
+                   {:coeffects {:now "2026-05-18T19:00:00Z"
+                                :local-storage {:user/last-cart-id "cart-42"}}}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            section (find-by-testid tree "rf-causa-event-detail-section-coeffects")]
+        (is (some? section) "COEFFECTS section rendered")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-coeffect-row-now"))
+            ":now row rendered")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-coeffect-row-local-storage"))
+            ":local-storage row rendered")))))
+
+(deftest coeffects-section-renders-qualified-keyword-ids
+  (testing "qualified-keyword cofx ids (e.g. :auth/token, :env/build)
+            render via the same testid-suffix scheme used by INTERCEPTORS"
+    (seed-buffer!
+      (cascade-evs 100 [:checkout/submit] 0
+                   {:coeffects {:auth/token "tok-abc"
+                                :env/build :prod}}))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-coeffect-row-auth/token")))
+        (is (some? (find-by-testid tree "rf-causa-event-detail-coeffect-row-env/build")))))))
+
+(deftest user-coeffects-helper-projects-stamp-from-do-fx
+  (testing "user-coeffects reads :tags :coeffects off the cascade's :fx
+            (do-fx) trace; returns nil when the stamp is absent / empty"
+    (is (= {:now "2026-05-18"}
+           (event-detail/user-coeffects
+             {:fx {:tags {:coeffects {:now "2026-05-18"}}}})))
+    (is (nil? (event-detail/user-coeffects {:fx {:tags {}}}))
+        "absent stamp → nil")
+    (is (nil? (event-detail/user-coeffects {:fx {:tags {:coeffects {}}}}))
+        "empty stamp → nil (silent-by-default)")
+    (is (nil? (event-detail/user-coeffects {:fx nil}))
+        "no do-fx trace → nil")))
 
 ;; ---- (9) handler-threw footer + suppression of §5/§6 -------------------
 

--- a/tools/causa/testbeds/panel_gallery/fixtures.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures.cljs
@@ -432,6 +432,32 @@
   []
   (event-lens-simple-buffer))
 
+(defn event-lens-with-coeffects-buffer
+  "Event lens fixture exercising the COEFFECTS section (rf2-jhhqt).
+  Stamps two user-injected coeffects (`:now` + `:local-storage`) onto
+  the `:event/do-fx` trace's `:tags :coeffects` slot — the substrate
+  filter has already excluded the framework defaults (`:db` `:event`
+  `:frame` `:source` `:trace-id`)."
+  []
+  (let [dispatch-id 110
+        id-base     60
+        tag         {:dispatch-id dispatch-id}]
+    [(assoc {:id (+ id-base 1) :op-type :event :operation :event/dispatched
+             :tags (assoc tag :event [:cart/restore])
+             :source :ui :origin :app}
+            :rf.trace/call-site
+            {:file "src/cart/events.cljs" :line 211})
+     {:id (+ id-base 2) :op-type :event :operation :event
+      :tags (assoc tag :phase :run-end :duration-ms 7)}
+     {:id (+ id-base 3) :op-type :event :operation :event/do-fx
+      :tags (assoc tag :fx [[:db nil]]
+                       :db-present? true
+                       :coeffects {:now "2026-05-18T19:00:00Z"
+                                   :local-storage {:user/last-cart-id "cart-42"
+                                                   :user/wishlist-ids #{"sku-9"}}})}
+     {:id (+ id-base 4) :op-type :fx :operation :rf.fx/handled
+      :tags (assoc tag :fx-id :db :duration-ms 1)}]))
+
 (defn event-lens-many-fx-buffer
   "Event lens fixture — six fx handlers ran in the cascade, including
   one managed-fx (HTTP). Exercises the inline managed-fx mount under

--- a/tools/causa/testbeds/panel_gallery/gallery_event.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_event.cljs
@@ -272,6 +272,19 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- 18. event-lens user-injected COEFFECTS (rf2-jhhqt) ------------
+  (story/reg-variant :story.causa.event/lens-with-coeffects
+    {:doc        "Event lens with the §3 COEFFECTS section populated by
+                 two user-injected coeffects (`:now` + `:local-storage`)
+                 stamped on `:event/do-fx :tags :coeffects`. The
+                 substrate has already filtered the framework defaults
+                 (`:db` `:event` `:frame` `:source` `:trace-id`) so the
+                 panel just renders what arrived."
+     :events     [[:rf.causa/sync-trace-buffer (fixtures/event-lens-with-coeffects-buffer)]
+                  [:rf.causa/select-dispatch-id 110 nil]]
+     :tags       #{:dev :state/small}
+     :substrates #{:reagent}})
+
   ;; ----- workspace --------------------------------------------------
 
   (story/reg-workspace :Workspace.causa.event/all


### PR DESCRIPTION
## Summary

Two-part polish on the just-shipped Event lens (PR #1480 rf2-zh2qc), in response to Mike's live-testbed feedback:

**(1) Bug fix — section order corrected to Mike's Q1 verbatim**

PR #1480 implemented EVENT-first / DISPATCH-second. Mike's Q1 answer from the morning design pass was the opposite:

> 1. DISPATCH SITE — source-coord chip
> 2. EVENT — the full event vector

The developer's first instinct is "who fired this?" — DISPATCH SITE now claims the prominent top slot.

**(2) Feature — new COEFFECTS section (§3)**

Renders the USER-INJECTED coeffects between EVENT and INTERCEPTORS. Mirrors the INTERCEPTORS section's filter-out-framework-defaults posture: the substrate (`re-frame.fx/do-fx`) now stamps the user-injected subset of the handler's final coeffects map onto `:event/do-fx :tags :coeffects`, filtering out the framework defaults (`:db` `:event` `:frame` `:source` `:trace-id`) at emit-time. Silent-by-default — section ABSENT entirely when zero user cofx.

**Final 7-section order (post-fix)**

1. DISPATCH SITE
2. EVENT
3. COEFFECTS (NEW)
4. INTERCEPTORS
5. HANDLER (no change — Mike confirmed keep-current)
6. EFFECTS RETURNED
7. EFFECTS HANDLERS RAN

## COEFFECTS data source — option (b) chosen

Investigated (a) Causa-side registry inspection vs (b) substrate stamp. Picked **(b)**: the cascade carries `:fx` (the do-fx trace) but no coeffects today; option (a) gives us cofx IDs from the chain (via `:cofx-<id>` interceptor names) but not their values — and the VALUE is what the developer wants to see. Option (b) adds a single payload-shaped stamp under `:tags :coeffects` (same pattern as rf2-twt7m Change 2's `:fx` + `:db-present?`), DCE-gated through `trace/emit!`, with the user-injected filter applied substrate-side so consumers read a pre-projected map. Scope-minimal: just the user-injected subset, not the full coeffects map.

## Per-commit LoC

| Commit | File | LoC |
| --- | --- | --- |
| feat(re-frame) | `core/src/re_frame/fx.cljc` | +57 / -13 |
| feat(re-frame) | `core/src/re_frame/router.cljc` | +12 / -4 |
| feat(re-frame) | `core/test/re_frame/fx_test.clj` | +60 / 0 |
| fix(causa) | `tools/causa/src/.../panels/event_detail.cljs` | +84 / -33 |
| fix(causa) | `tools/causa/test/.../event_detail_cljs_test.cljs` | +146 / -10 |
| fix(causa) | `tools/causa/testbeds/panel_gallery/fixtures.cljs` | +26 / 0 |
| fix(causa) | `tools/causa/testbeds/panel_gallery/gallery_event.cljs` | +13 / 0 |
| docs(causa-spec) | `tools/causa/spec/018-Event-Spine.md` | +32 / -17 |

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 739 tests / 2179 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2873 tests / 8203 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 2864 tests / 8161 assertions, 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] `cd implementation/core && clojure -M:test` (core JVM) — 585 tests / 2974 assertions, 0 failures
- [x] New tests: order assertion + 4 COEFFECTS regression tests + 2 substrate-side fx tests
- [x] panel_gallery: `lens-with-coeffects` variant added (axis `state/small`)
- [ ] Manual :8767 smoke — deferred (no live testbed boot from background worker)

## Collision avoidance

Touches `tools/causa/src/.../panels/event_detail.cljs` + spec + tests + fixtures + substrate `fx.cljc` / `router.cljc`. Disjoint from PR #1489 (rf2-oziyr — `filters.cljs` + `spine.cljs`). No other active worker.