### PR TITLE
fix(causa): App-db + Views panels follow focus correctly (rf2-fvplw + rf2-y8bik)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -52,8 +52,23 @@
 (defn install!
   "Install the App-DB Diff subscriptions."
   []
-  (rf/reg-sub :rf.causa/target-frame-db
+  ;; rf2-fvplw — panel-observed frame follows the spine `:rf.causa/focus`.
+  ;; The frame-picker writes `[:focus :frame]` via `:rf.causa/set-frame`,
+  ;; and `compose-focus` also derives `:frame` from the focused cascade.
+  ;; Without this seam the App-db panel previously read only the legacy
+  ;; `:target-frame` slot (which `:rf.causa/set-frame` does NOT touch),
+  ;; so it stayed hardcoded to `:rf/default` no matter what the user
+  ;; picked. The legacy slot survives as the fallback when no focus has
+  ;; resolved a frame yet (cold start, no focusable cascades) — keeps
+  ;; the boot-time empty-state useful.
+  (rf/reg-sub :rf.causa/observed-frame
+    :<- [:rf.causa/focus]
     :<- [:rf.causa/target-frame]
+    (fn [[focus target] _query]
+      (or (:frame focus) target)))
+
+  (rf/reg-sub :rf.causa/target-frame-db
+    :<- [:rf.causa/observed-frame]
     :<- [:rf.causa/epoch-history]
     (fn [[target _epoch-history] _query]
       (rf/get-frame-db target)))
@@ -156,8 +171,13 @@
         (h/epochs-touching-path history focused-path)
         [])))
 
+  ;; rf2-fvplw — `:target-frame` in the composite output is the
+  ;; *observed* frame (picker-selected / focused-cascade frame), not
+  ;; the legacy `:target-frame` slot. The empty-state body uses this
+  ;; value, so the user always sees the frame their focus is on rather
+  ;; than the hardcoded `:rf/default`.
   (rf/reg-sub :rf.causa/app-db-diff
-    :<- [:rf.causa/target-frame]
+    :<- [:rf.causa/observed-frame]
     :<- [:rf.causa/target-frame-db]
     :<- [:rf.causa/selected-epoch-diff]
     :<- [:rf.causa/selected-epoch-sections]

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -461,15 +461,25 @@
 ;; ---- chrome -------------------------------------------------------------
 
 (defn- header-block
+  "rf2-y8bik — the cascade-metadata `:p` (`Frame: … · cascade … ·
+  cascade ms: …`) ONLY renders when a cascade is actually focused.
+  Pre-fix the line surfaced whenever `(:frame data)` was truthy, but
+  `:frame` is populated from `:rf.causa/focus` (the spine's frame
+  slot) independent of focus state — so a frame-picker selection with
+  no focused cascade left the header advertising `:cart-frame ·
+  cascade 35 · cascade ms: 0µs` while the body read `No event
+  focused.` Silent-by-default: empty body → empty chrome header,
+  except the panel title which is part of the L4 tab affordance."
   [data]
   [:header {:style {:padding "16px 16px 8px 16px"}}
    [:h1 {:style {:font-size "16px" :font-weight 600 :margin 0
                  :color (:text-primary tokens)}}
     "Views"]
-   (when-let [frame (:frame data)]
-     [:p {:style {:font-size "11px" :color (:text-tertiary tokens)
+   (when (and (:has-cascade? data) (:frame data))
+     [:p {:data-testid "rf-causa-views-header-meta"
+          :style {:font-size "11px" :color (:text-tertiary tokens)
                   :margin "2px 0 0 0"}}
-      (str "Frame: " frame
+      (str "Frame: " (:frame data)
            (when-let [did (:dispatch-id data)]
              (str " · cascade " (pr-str did)))
            " · cascade ms: " (format-ms (:cascade-ms (:totals data))))])])

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -32,6 +32,7 @@
   mounting to a DOM. Keeps the suite fast + host-portable on node-
   test."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -615,3 +616,56 @@
       (let [causa-db (frame/frame-app-db-value :rf/causa)]
         (is (= [:cart :items]
                (:focused-slice-path causa-db)))))))
+
+;; ---- rf2-fvplw — App-db panel follows picker / focused frame -----------
+
+(deftest observed-frame-follows-rf-causa-set-frame
+  (testing "rf2-fvplw — the frame-picker dispatches `:rf.causa/set-frame`
+            which writes `[:focus :frame]`. The App-db panel's
+            `:rf.causa/observed-frame` sub picks the focused frame up,
+            and the composite's `:target-frame` surface reflects it.
+            Pre-fix the panel read the legacy `:rf.causa/target-frame`
+            slot (which `:rf.causa/set-frame` does NOT touch) and stayed
+            stuck on `:rf/default` regardless of picker selection."
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :checkout-frame {})
+    (rf/with-frame :rf/causa
+      ;; Cold-start sanity — observed frame is the default before any
+      ;; picker selection lands.
+      (is (= :rf/default @(rf/subscribe [:rf.causa/observed-frame])))
+      (is (= :rf/default (:target-frame @(rf/subscribe [:rf.causa/app-db-diff]))))
+      ;; User picks :checkout-frame in the ribbon dropdown.
+      (rf/dispatch-sync [:rf.causa/set-frame :checkout-frame])
+      (is (= :checkout-frame @(rf/subscribe [:rf.causa/observed-frame])))
+      (is (= :checkout-frame
+             (:target-frame @(rf/subscribe [:rf.causa/app-db-diff])))
+          "composite's :target-frame surface follows the picker"))))
+
+(deftest empty-state-renders-picker-selected-frame
+  (testing "rf2-fvplw — when history is empty for the picked frame, the
+            empty-state body shows the picked frame's name (NOT the
+            hardcoded `:rf/default`). Pre-fix the body always read
+            'app-db for :rf/default is at the boot value.' regardless
+            of picker selection — the contradiction Mike's testbed
+            surfaced when picking `:checkout-frame` displayed
+            `:rf/default` boot copy."
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :checkout-frame {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-frame :checkout-frame])
+      (let [tree (app-db-diff/Panel)
+            empty (find-by-testid tree "rf-causa-app-db-diff-empty")]
+        (is (some? empty) "empty state present (history is empty)")
+        ;; Walk the empty-state node and find the `:code` node carrying
+        ;; the frame id. The frame id renders inside a `[:code …]` child
+        ;; of the first `:p`; assert the text reflects the picker.
+        (let [rendered-text (pr-str empty)]
+          (is (str/includes? rendered-text ":checkout-frame")
+              "empty-state mentions the picker-selected frame")
+          (is (not (str/includes? rendered-text ":rf/default"))
+              "empty-state does NOT show the hardcoded default frame
+               when the picker has selected a different frame"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
@@ -19,8 +19,12 @@
                 (reset! subs/diff-cache {})
                 (reset! subs/annotated-tree-cache {}))}))
 
-(deftest leaf-install-registers-the-ten-subs
+(deftest leaf-install-registers-the-eleven-subs
   (subs/install!)
+  ;; rf2-fvplw — `:rf.causa/observed-frame` is the picker/focus-aware
+  ;; seam that replaces the legacy `:rf.causa/target-frame` read inside
+  ;; `:rf.causa/target-frame-db` + the composite.
+  (is (some? (registrar/handler :sub :rf.causa/observed-frame)))
   (is (some? (registrar/handler :sub :rf.causa/target-frame-db)))
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-record)))
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-diff)))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
@@ -6,7 +6,7 @@
   and asserts the structural data-testid hooks ship: the panel root,
   the controls footer, the heatmap toggle, and the three-group
   container."
-  (:require [cljs.test :refer-macros [deftest is use-fixtures]]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -113,3 +113,62 @@
       (is (some? (some-> (meta s) :key))
           (str "panel-loop section carries :key meta — got "
                (pr-str (meta s)))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-y8bik — header-block silent-by-default regression guard
+;;
+;; The Views composite's `:frame` slot is populated from
+;; `:rf.causa/focus` (which carries the spine's `:frame` slot —
+;; written by the frame-picker via `:rf.causa/set-frame` and by
+;; `compose-focus` from the focused cascade) INDEPENDENT of whether a
+;; cascade is actually focused. Pre-fix the `header-block` rendered the
+;; cascade-metadata `:p` (`Frame: :cart-frame · cascade 35 · cascade
+;; ms: 0µs`) whenever `(:frame data)` was truthy. Mike's live testbed
+;; surfaced the contradictory shape — header advertised cascade
+;; metadata while the body read `No event focused.`
+;;
+;; Fix: the metadata `:p` ONLY renders when `:has-cascade?` is true —
+;; the panel title stays (it is part of the L4 tab affordance) but
+;; the cascade-metadata line stays silent when there is no focused
+;; cascade to describe.
+;; ---------------------------------------------------------------------------
+
+(defn- find-by-testid-in [tree testid]
+  (some (fn [node]
+          (and (vector? node)
+               (map? (second node))
+               (= testid (:data-testid (second node)))
+               node))
+        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
+             (map expand-fn))))
+
+(deftest header-block-suppresses-cascade-meta-when-no-cascade-focused
+  (testing "no focused cascade → cascade-metadata `:p` is absent even
+            when `:frame` is set (frame-picker scoped, no event focused)."
+    (let [data   {:frame        :cart-frame
+                  :dispatch-id  35
+                  :totals       {:cascade-ms 0.0}
+                  :has-cascade? false}
+          header (#'view/header-block data)]
+      (is (nil? (find-by-testid-in header "rf-causa-views-header-meta"))
+          "cascade-metadata `:p` MUST NOT render when no cascade focused"))))
+
+(deftest header-block-renders-cascade-meta-when-cascade-focused
+  (testing "focused cascade present → cascade-metadata `:p` renders so
+            the user still sees frame / cascade-id / cascade-ms when
+            there IS something to describe."
+    (let [data   {:frame        :cart-frame
+                  :dispatch-id  35
+                  :totals       {:cascade-ms 1.2}
+                  :has-cascade? true}
+          header (#'view/header-block data)]
+      (is (some? (find-by-testid-in header "rf-causa-views-header-meta"))
+          "cascade-metadata `:p` renders when there's a cascade")))
+
+  (testing "no `:frame` at all (cold start) → metadata stays silent
+            even with `:has-cascade?` true, since there's nothing to
+            print."
+    (let [data   {:has-cascade? true}
+          header (#'view/header-block data)]
+      (is (nil? (find-by-testid-in header "rf-causa-views-header-meta"))
+          "metadata stays silent when there's no frame to print"))))


### PR DESCRIPTION
## Summary

Two related panel-focus-following bugs Mike hit in the shop multi-frame testbed (post-#1489 rf2-oziyr P1 frame-picker fix). Both are about how Causa panels should follow the focused cascade / frame-picker selection.

### rf2-fvplw (P2) — App-db panel shows `:rf/default` regardless of picker selection

Mike's live-testbed report after picking `:checkout-frame` in the frame-picker:

> app-db for :rf/default is at the boot value.
> No diffs yet.

**Root cause.** The App-db panel read the legacy `:rf.causa/target-frame` slot (which `:rf.causa/set-target-frame` writes). The frame-picker dispatches `:rf.causa/set-frame` — which writes to `[:focus :frame]` (the spine slot consumed by `:rf.causa/focus`), NOT `:target-frame`. Two parallel slots; the App-db panel was reading the wrong one.

**Fix.** New `:rf.causa/observed-frame` seam — picker/focus-aware. Reads `(:frame focus)` first (the spine slot the picker writes to, also derived from the focused cascade by `compose-focus`), falls back to `:rf.causa/target-frame` only when nothing has resolved a frame yet (cold start). `:rf.causa/target-frame-db` + the `:rf.causa/app-db-diff` composite both read this new seam, so the empty-state body, the deref'd app-db value, and the pinned-slices store keying all follow the picker.

### rf2-y8bik (P3) — Views panel header inconsistent with empty body

Mike's report:

> Header: `Frame: :cart-frame · cascade 35 · cascade ms: 0µs`
> Body:   `No event focused.`

Contradictory — header advertised cascade metadata while body said no cascade was focused.

**Root cause.** The Views composite's `:frame` slot is populated from `:rf.causa/focus` independent of focus state. The `header-block` rendered the cascade-metadata `:p` whenever `(:frame data)` was truthy, but `:frame` survives even when no cascade is focused (the picker writes it; `compose-focus` propagates it).

**Fix.** Gate the cascade-metadata `:p` on `(:has-cascade? data)`. The panel title stays (it is part of the L4 tab affordance); the cascade-metadata line stays silent when no cascade is focused. Per silent-by-default — empty body = empty chrome metadata.

## Per-file LoC

- `tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs` — +24/-2 (new `:rf.causa/observed-frame` sub + composite rewire)
- `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs` — +12/-4 (header-block guard)
- Tests: `app_db_diff_cljs_test.cljs` (+55), `app_db_diff_subs_cljs_test.cljs` (+5), `views_view_cljs_test.cljs` (+60)

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 739 tests / 2179 assertions / 0 fail
- [x] `cd implementation && npm run test:cljs` — 2872 tests / 8202 assertions / 0 fail
- [x] `cd implementation && npm run test:browser` — 2863 tests / 8160 assertions / 0 fail
- [x] `scripts/test-fast-pr.sh` — PASS fast PR spine
- [x] `npm run test:bundle-isolation` — PASS
- [x] `npm run test:reagent-slim:bundle-isolation` — PASS
- [ ] Manual smoke at `:8767` — deferred (no live shop testbed boot in worker worktree; live-testbed reviewer is reading the output)

## Regression coverage

- App-db: `observed-frame-follows-rf-causa-set-frame` pins the seam tracks the picker; `empty-state-renders-picker-selected-frame` pins the empty-state body reflects the picker-selected frame (not hardcoded `:rf/default`).
- Views: `header-block-suppresses-cascade-meta-when-no-cascade-focused` pins the suppression; `header-block-renders-cascade-meta-when-cascade-focused` pins the positive path stays intact.

## In-flight collision-avoidance

Disjoint from #1490 (rf2-jhhqt Event lens polish — touches `panels/event_detail.cljs` + spec/018). This PR touches `panels/app_db_diff*.cljs` + `panels/views_view.cljs` + matching tests only.