### PR TITLE
fix(causa): App-db diff + Views body — post-#1491 follow-up (rf2-ug1r6 + rf2-thodq)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -438,13 +438,53 @@
 (defn set-frame-reducer
   "Pure reducer for `:rf.causa/set-frame <frame-id>`. Writes `:frame`
   into the `:focus` slot and clears `:dispatch-id` so the spine snaps
-  to the new frame's head."
-  [db frame-id]
-  (-> db
-      (update :focus (fnil assoc {})
-              :frame frame-id
-              :dispatch-id nil
-              :mode :live)))
+  to the new frame's head.
+
+  ## rf2-ug1r6 + rf2-thodq — picker also drives `:target-frame` + reseeds
+  ## `:epoch-history`
+
+  The Causa app-db carries a single `:epoch-history` slot keyed by the
+  legacy `:target-frame`. Every per-frame composite (App-DB Diff's
+  selected-epoch-diff / sections / annotated-tree; Views' focused-
+  cascade-pair; the views-sub-diff records; the machine-inspector
+  scrubber) reads off that slot. Pre-fix the slot stayed on whatever
+  `:target-frame` was at boot (`:rf/default`) even when the user picked
+  a different frame in the ribbon picker — so:
+
+    - App-DB Diff's `:rf.causa/selected-epoch-diff` falls through to
+      `(peek history)` against the WRONG frame's history. If the boot
+      target had no epochs, `history-empty?` was true and the panel
+      rendered the 'app-db for :cart-frame is at the boot value. No
+      diffs yet.' empty-state EVEN WITH a focused cascade (rf2-ug1r6).
+    - Views' `:rf.causa/views-focused-cascade-pair` reads the same
+      wrong-frame history; `find-cascade-index` returns nil for the
+      focused `:epoch-id` (which was itself never resolved because
+      `epoch-id-for-cascade` walks the same wrong slot), the fallback
+      `(dec (count history))` returns nil for an empty boot-frame
+      history, `:has-cascade?` resolves to false, and the body renders
+      'No event focused.' EVEN WITH a focused cascade (rf2-thodq).
+
+  Both bugs share the same root: the picker writes only `[:focus :frame]`
+  but every per-frame composite reads off a slot keyed on a DIFFERENT
+  axis. The fix aligns the two axes — the picker IS the user's 'observe
+  this frame' gesture, identical in intent to `core/set-target-frame!`.
+
+  This reducer now also writes `:target-frame` and re-seeds the
+  `:epoch-history` slot from `epoch-history-for-frame` so every per-
+  frame sub re-fires off the standard app-db-write reactive path with
+  the correct frame's epochs. The pure 2-arg arity takes the resolved
+  history as a parameter (JVM-runnable); the event handler in
+  `install!` resolves it via `rf/epoch-history` at dispatch time."
+  ([db frame-id]
+   (set-frame-reducer db frame-id []))
+  ([db frame-id epoch-history-for-frame]
+   (-> db
+       (update :focus (fnil assoc {})
+               :frame frame-id
+               :dispatch-id nil
+               :mode :live)
+       (assoc :target-frame  frame-id
+              :epoch-history (vec epoch-history-for-frame)))))
 
 (defn preview-cascade-reducer
   "Pure reducer for `:rf.causa/preview-cascade <id>`. Sets `:previewing?
@@ -567,7 +607,12 @@
 
   (rf/reg-event-db :rf.causa/set-frame
     (fn [db [_ frame-id]]
-      (set-frame-reducer db frame-id)))
+      ;; rf2-ug1r6 + rf2-thodq — re-seed `:epoch-history` from the
+      ;; framework's per-frame ring at picker-change time so every
+      ;; per-frame composite (App-DB Diff, Views, machine-inspector)
+      ;; reads the picked frame's epochs immediately. See the reducer
+      ;; docstring for the shared root cause.
+      (set-frame-reducer db frame-id (rf/epoch-history frame-id))))
 
   (rf/reg-event-db :rf.causa/preview-cascade
     (fn [db [_ dispatch-id]]

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -669,3 +669,79 @@
           (is (not (str/includes? rendered-text ":rf/default"))
               "empty-state does NOT show the hardcoded default frame
                when the picker has selected a different frame"))))))
+
+;; ---- rf2-ug1r6 — picker change resets epoch-history slot ----------------
+;;
+;; rf2-fvplw wired `:rf.causa/observed-frame` + `:rf.causa/target-frame-
+;; db` to follow the picker, but the App-DB Diff panel's
+;; selected-epoch-* sub chain (the diff triples + annotated tree +
+;; sections) read off `:rf.causa/epoch-history` — a Causa-side slot
+;; keyed on the legacy `:target-frame` axis the picker did NOT touch.
+;; After a picker change the slot stayed on the previous (likely
+;; empty `:rf/default`) frame's history, so:
+;;
+;;   :rf.causa/selected-epoch-diff → (peek <empty>) → nil → composite's
+;;   :history-empty? → true → the panel rendered the boot empty-state
+;;   "app-db for :cart-frame is at the boot value. No diffs yet."
+;;   EVEN WITH a focused cascade in the picked frame (the Mike report).
+;;
+;; The fix in `spine/set-frame-reducer` aligns the two axes — picker
+;; now also writes `:target-frame` and re-seeds `:epoch-history` from
+;; the framework's per-frame ring. This regression guard asserts the
+;; alignment.
+
+(deftest set-frame-aligns-target-frame-and-resets-epoch-history
+  (testing "rf2-ug1r6 — picker writes `:target-frame` + clears the
+            `:epoch-history` slot so future `:rf.causa/epoch-recorded`
+            callbacks pump the picked frame's epochs into the right
+            slot. Pre-fix the slot stayed keyed to the legacy
+            target frame and the App-DB diff panel rendered empty-
+            state with a focused cascade present."
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :cart-frame {})
+    (rf/with-frame :rf/causa
+      ;; Seed the slot with stale `:rf/default` history; user picks
+      ;; `:cart-frame`; the slot MUST reset so the wrong-frame epochs
+      ;; do not bleed into the picked-frame panel.
+      (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                         [(mk-record :stale-e [:default/event] {} {})]])
+      (is (= 1 (count @(rf/subscribe [:rf.causa/epoch-history])))
+          "stale slot present pre-picker")
+      (rf/dispatch-sync [:rf.causa/set-frame :cart-frame])
+      (is (= :cart-frame @(rf/subscribe [:rf.causa/target-frame]))
+          ":target-frame follows picker so :rf.causa/epoch-recorded
+           delivers future cart-frame epochs into the slot")
+      (is (= [] @(rf/subscribe [:rf.causa/epoch-history]))
+          "stale `:rf/default` history MUST clear so the wrong-frame
+           records do not leak into the picked-frame panel"))))
+
+(deftest app-db-diff-renders-cart-frame-diff-after-picker-and-seed
+  (testing "rf2-ug1r6 — post-picker-change + post-history-reseed, the
+            App-DB Diff composite reports the cart-frame's diff (not
+            the boot empty-state). This is the structural inverse of
+            Mike's bug report: with the alignment in place, focused
+            cascades in the picked frame produce a real diff."
+    (registry/register-causa-handlers!)
+    (frame/reg-frame :rf/causa {})
+    (frame/reg-frame :rf/default {})
+    (frame/reg-frame :cart-frame {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-frame :cart-frame])
+      ;; Framework's `:rf.causa/epoch-recorded` cb re-pumps the
+      ;; cart-frame's ring into the slot; tests drive the wholesale
+      ;; overwrite directly.
+      (let [rec (-> (mk-record :cart-e [:cart/add]
+                               {:cart {:items []}}
+                               {:cart {:items [{:id 7}]}})
+                    (assoc :frame :cart-frame))]
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [rec]]))
+      (let [data @(rf/subscribe [:rf.causa/app-db-diff])]
+        (is (false? (:history-empty? data))
+            "history present for the picked frame → composite's
+             :history-empty? is false → panel renders the diff body
+             rather than the boot empty-state (rf2-ug1r6)")
+        (is (= :cart-frame (:target-frame data))
+            "composite's :target-frame surface reflects the picker
+             selection (rf2-fvplw — preserved post-rf2-ug1r6)")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_subs_cljs_test.cljs
@@ -147,3 +147,62 @@
               "no :epoch-id resolution for an evicted/unknown cascade")
           (is (= 31 (:epoch-id (:current pair)))
               "fallback to head when focus can't be resolved"))))))
+
+;; -------------------------------------------------------------------------
+;; rf2-thodq — picker change resets :epoch-history, re-seed via
+;; :rf.causa/sync-epoch-history surfaces the picked-frame cascade
+;; -------------------------------------------------------------------------
+;;
+;; Per `set-frame-reducer`'s docstring (rf2-ug1r6 + rf2-thodq) the
+;; picker now clears the `:epoch-history` slot and aligns
+;; `:target-frame` with `[:focus :frame]`. After the picker change, the
+;; framework's `epoch-recorded` callback re-pumps records into the slot
+;; per-frame — but in tests we drive that surface via
+;; `:rf.causa/sync-epoch-history`.
+;;
+;; This guard asserts that, post-picker-change + post-history-reseed,
+;; the Views composite's `:has-cascade?` resolves to true and the
+;; current cascade is the picked frame's head — the body MUST NOT show
+;; "No event focused." when an event in the picked frame IS focused
+;; (the rf2-thodq report).
+
+(deftest focused-cascade-pair-resolves-after-picker-change
+  (testing "Picker switches to :cart-frame; then the framework re-seeds
+            `:epoch-history` with that frame's records via
+            `:rf.causa/sync-epoch-history`. The composite MUST surface
+            the picked-frame cascade as `:current` so `:has-cascade?`
+            is true and the body renders the cascade — not the empty-
+            state. Pre-fix the picker left `:epoch-history` keyed to
+            the previous (likely empty) frame, the composite returned
+            `current = nil`, `:has-cascade? = false`, and the body
+            rendered 'No event focused.' even with an event focused."
+    (seed-causa!)
+    (let [cart-cascade (epoch {:epoch-id     50
+                               :dispatch-id  500
+                               :event-id     :cart/add
+                               :renders      [{:render-key [:cart/badge :tok-Z]
+                                               :elapsed-ms 4}]})]
+      (rf/with-frame :rf/causa
+        ;; User picks :cart-frame. Reducer also re-seeds
+        ;; :epoch-history (empty in the test fixture since the
+        ;; framework's epoch artefact isn't installed).
+        (rf/dispatch-sync [:rf.causa/set-frame :cart-frame])
+        (is (= [] @(rf/subscribe [:rf.causa/epoch-history]))
+            "post-picker-change the slot is reset to the picked
+             frame's history (empty here)")
+        (is (= :cart-frame @(rf/subscribe [:rf.causa/target-frame]))
+            ":target-frame follows the picker so :epoch-recorded
+             will deliver future records into the correct slot")
+        ;; Framework records a new epoch on :cart-frame — in
+        ;; production `:rf.causa/epoch-recorded` re-reads
+        ;; `(rf/epoch-history :cart-frame)` and writes the slot. The
+        ;; test seam dispatches the wholesale-overwrite event.
+        (rf/dispatch-sync [:rf.causa/sync-epoch-history [cart-cascade]])
+        (rf/dispatch-sync [:rf.causa/focus-cascade 500 :cart-frame])
+        (let [pair @(rf/subscribe [:rf.causa/views-focused-cascade-pair])]
+          (is (some? (:current pair))
+              "`:current` is non-nil → :has-cascade? true → body
+               renders the cascade, not the 'No event focused.'
+               empty-state (rf2-thodq)")
+          (is (= 50 (:epoch-id (:current pair)))
+              "the surfaced cascade is the picked frame's record"))))))

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -326,6 +326,55 @@
         "frame switch snaps to new frame's head")
     (is (= :live (get-in r [:focus :mode])))))
 
+;; -------------------------------------------------------------------------
+;; rf2-ug1r6 + rf2-thodq — picker also drives :target-frame +
+;; :epoch-history so every per-frame composite reads the picked frame's
+;; epochs. See `set-frame-reducer` docstring for the shared root cause.
+;; -------------------------------------------------------------------------
+
+(deftest set-frame-reducer-writes-target-frame
+  (testing "the picker IS the user's 'observe this frame' gesture —
+            align the legacy :target-frame slot with the new
+            [:focus :frame] axis so every per-frame composite reads
+            off one consistent frame identity."
+    (let [db {:focus {:dispatch-id :c1 :frame :rf/default :mode :live}
+              :target-frame :rf/default}
+          r  (spine/set-frame-reducer db :cart-frame)]
+      (is (= :cart-frame (:target-frame r))
+          ":target-frame follows the picker selection"))))
+
+(deftest set-frame-reducer-reseeds-epoch-history-with-resolved-vector
+  (testing "the 3-arg arity takes the resolved per-frame epoch history
+            and overwrites the slot — the App-DB Diff selected-epoch-*
+            chain + the Views focused-cascade-pair both pivot on this
+            slot, so a stale `:rf/default`-history slot is what caused
+            both panels to render empty-state after a picker change."
+    (let [cart-history [{:epoch-id 10 :dispatch-id 100
+                         :db-before {:k 1} :db-after {:k 2}}
+                        {:epoch-id 11 :dispatch-id 101
+                         :db-before {:k 2} :db-after {:k 3}}]
+          db           {:epoch-history [{:epoch-id 1}]   ; stale :rf/default head
+                        :target-frame  :rf/default}
+          r            (spine/set-frame-reducer db :cart-frame cart-history)]
+      (is (= cart-history (:epoch-history r))
+          ":epoch-history is the picked frame's ring contents")
+      (is (= :cart-frame (:target-frame r))
+          ":target-frame switches in lockstep")
+      (is (= :cart-frame (get-in r [:focus :frame]))
+          "[:focus :frame] still tracks the picker"))))
+
+(deftest set-frame-reducer-default-arity-clears-epoch-history
+  (testing "the 2-arg arity (back-compat for callers that don't have
+            the framework's per-frame ring handy) writes an empty
+            history — preserves the per-frame invariant rather than
+            leaving the slot stale across the switch."
+    (let [db {:epoch-history [{:epoch-id 1}]
+              :target-frame  :rf/default}
+          r  (spine/set-frame-reducer db :cart-frame)]
+      (is (= [] (:epoch-history r))
+          "no resolved history → slot cleared, never left stale")
+      (is (= :cart-frame (:target-frame r))))))
+
 (deftest preview-cascade-reducer-sets-previewing-true
   (let [db {}
         r  (spine/preview-cascade-reducer db :c2)]


### PR DESCRIPTION
## Summary

Post-rf2-fvplw / rf2-y8bik (#1491) Mike's live testbed surfaced two P2 follow-on bugs in the App-db + Views panels. Both share one root cause: the picker only wrote `[:focus :frame]` but every per-frame composite reads off the Causa-side `:epoch-history` slot, which is keyed on the legacy `:target-frame` axis the picker did NOT touch.

## Mike's verbatim observations

> Picks `:cart-frame` in picker, App-db panel correctly shows `:cart-frame` now (per rf2-fvplw fix), but says **"app-db for :cart-frame is at the boot value. No diffs yet."** even when he has an event focused in L2.
> (rf2-ug1r6)

> He has a focused event but Views body says **"No event focused."**
> (rf2-thodq)

## Shared root cause

The Causa app-db carries one `:epoch-history` slot keyed on the legacy `:target-frame` axis. Every per-frame composite reads off it (App-DB Diff's selected-epoch-diff / sections / annotated-tree; Views' focused-cascade-pair + views-sub-diff; the machine-inspector scrubber). Pre-fix the picker only wrote `[:focus :frame]` so the slot stayed pinned to whatever target was set at boot.

When the user picked `:cart-frame`:
- `selected-epoch-diff` fell through to `(peek <stale-history>)`. With an empty `:rf/default` boot history the composite's `:history-empty?` resolved true → App-db panel rendered the **boot empty-state** ("app-db for :cart-frame is at the boot value. No diffs yet.").
- `views-focused-cascade-pair` read the same wrong-frame history; `find-cascade-index` couldn't resolve the focused `:epoch-id` (also nil since `epoch-id-for-cascade` walks the same slot), the `(dec (count history))` head-fallback returned nil for empty history, `:has-cascade?` resolved false → body rendered **"No event focused."**

## Fix

`spine/set-frame-reducer` now aligns the two axes — the picker IS the user's "observe this frame" gesture, identical in intent to `core/set-target-frame!`. The reducer writes `:target-frame` in lockstep with `[:focus :frame]` and re-seeds `:epoch-history` from the framework's per-frame ring at picker-change time. Future `:rf.causa/epoch-recorded` callbacks now deliver picked-frame epochs into the correct slot via the existing target-frame gate. Pure 2-arg arity preserves JVM-runnability; the event handler's 3-arg call resolves `(rf/epoch-history frame-id)` at dispatch time.

## Test plan

- [x] `cd tools/causa && clojure -M:test` — 739 tests, 2179 assertions, 0 failures
- [x] `cd implementation && npm run test:cljs` — 2883 tests, 8229 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 2874 tests, 8187 assertions, 0 failures
- [x] `scripts/test-fast-pr.sh` — PASS

## New test coverage

- `spine_cljs_test`: 3 reducer-level tests pinning the `:target-frame` + `:epoch-history` writes (both arities).
- `views_subs_cljs_test`: rf2-thodq regression — picker + sync + focus produces `:current` non-nil → `:has-cascade?` true.
- `app_db_diff_cljs_test`: rf2-ug1r6 regression — picker resets the slot + the panel renders the diff body post-reseed.

Parent: #1491.