### PR TITLE
fix(causa): open-in-editor uses absolute paths (rf2-6jyf6)

### DIFF
--- a/tools/causa/testbeds/shop/core.cljs
+++ b/tools/causa/testbeds/shop/core.cljs
@@ -118,7 +118,12 @@
             ;; correct here (mirrors testbeds/http_toggle and the
             ;; cart_total testbed this one supersedes).
             [re-frame.http-test-support]
-            [re-frame.adapter.reagent :as reagent-adapter])
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; rf2-6jyf6 — Causa's `configure!` to seed `:project-root`
+            ;; so the Event lens 'open' chip resolves a classpath-
+            ;; relative `:file` slot to an absolute on-disk URI the
+            ;; OS-side editor handler (VS Code et al.) can stat.
+            [day8.re-frame2-causa.config :as causa-config])
   (:require-macros [re-frame.core :refer [reg-view]]))
 
 ;; ============================================================================
@@ -836,7 +841,42 @@
 (defonce react-root
   (rdc/create-root (js/document.getElementById "app")))
 
+;; rf2-6jyf6 — Causa 'Open in editor' project-root for the live testbed.
+;;
+;; Source-coords are stamped at registration time with a classpath-
+;; relative `:file` (e.g. `"shop/core.cljs"`), but OS-side editor URI
+;; handlers (`vscode://file/<path>...` etc.) resolve `<path>` against
+;; the filesystem and reject relative paths. Mike's live testbed runs
+;; from the mayor checkout `C:/Users/miket/code/re-frame2`; shop's
+;; source-path under shadow-cljs is `../tools/causa/testbeds` so the
+;; absolute on-disk root that prepends to a coord like
+;; `shop/core.cljs:88` is the testbeds dir below.
+;;
+;; Hosts that run the same testbed from a different worktree (CI, other
+;; devs) can override at runtime via the `?project-root=...` query
+;; string — no code change needed. An empty / absent override falls
+;; back to the mayor-checkout default below.
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent
+  / blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Causa-API surface)."
+  [name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search
+                     (js/URLSearchParams.))
+          v      (.get params name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
 (defn ^:export run []
+  ;; Configure Causa BEFORE `rf/init!` so the preload's auto-open
+  ;; reads the right project-root on its first paint of any chip.
+  (causa-config/configure! {:project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
   ;; Register the three frames; :on-create seeds each frame's
   ;; app-db synchronously per Spec 002 §Frame creation.


### PR DESCRIPTION
## Summary

Per Mike's live-testbed observation (shop @ :8767, post-#1490 Event lens ordering):

> Clicking 'open' on the Handler chip (and all other source-coord chips — Dispatch / Interceptors / Trace rows) in Causa fails to open the file in VSCode because the file path is RELATIVE (e.g. `src/cart/events.cljs:88`), not absolute. VSCode's open-in-editor URI scheme requires absolute paths. Relative paths silently fail.

The Causa-side machinery for prepending a configured project-root already exists end-to-end (rf2-5m5n2 wired `:project-root` through `causa-config/configure!` -> `set-project-root!` -> `resolve-uri` -> `editor-uri/editor-uri` 3-arg form -> `compose-path`); the matrix tests in `open_in_editor_cljs_test.cljs` already pin the URI composition.

The gap was that no testbed actually called `configure!` with a `:project-root`, so the live shop session at :8767 was the relative-path path. This PR closes that gap.

### Before / After

```
Before: vscode://file/shop/core.cljs:88            -> silently no-ops
After:  vscode://file/C:/Users/miket/code/re-frame2/tools/causa/testbeds/shop/core.cljs:88
```

### Affects every source-coord chip

The single `resolve-uri` seam in `tools/causa/src/.../open_in_editor.cljs` is shared by the render-time chip and the `:rf.editor/open` reg-fx, so this one configure! call lights up:
- Event lens Dispatch chip
- Event lens Handler chip
- Event lens Interceptors chips
- Trace tab row source chips
- Issues ribbon source chips
- Hydration debugger chip

### Per-host override

The default root targets Mike's mayor checkout (`C:/Users/miket/code/re-frame2/tools/causa/testbeds`). Other hosts (CI, other devs, alternate worktrees) can override at runtime via `?project-root=...` on the page URL without a code change:

```
http://localhost:8767/?project-root=/Users/alice/code/re-frame2/tools/causa/testbeds
```

## Test plan

- [x] `cd tools/causa && clojure -M:test` -> 739 tests, 2179 assertions, 0/0
- [x] `cd implementation && npm run test:cljs` -> 2877 tests, 8214 assertions, 0/0
- [x] `scripts/test-fast-pr.sh` -> PASS fast PR spine
- [x] `cd implementation && npm run test:browser -- --filter shop` -> 2868 tests, 0/0
- [x] `cd implementation && npm run test:examples -- --filter shop` -> 1 example, 0 failures
- [ ] **Mike's live-testbed verification**: click 'open' on a Handler chip in the shop testbed at :8767, file opens in VS Code at the right line.

Note: bead `rf2-6jyf6` stays OPEN per Mike's instruction until live-testbed verification confirms VS Code launches.