### PR TITLE
fix(story-mcp): rename wire-key :include-sensitive? -> :include-sensitive (Anthropic schema 400) (rf2-y710n)

### DIFF
--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/slot_name_test.clj
@@ -20,7 +20,7 @@
 
   The three vocabularies compose. An agent learns once that:
 
-  - the input arg `:include-sensitive?` opts back in to sensitive
+  - the input arg `:include-sensitive` opts back in to sensitive
     events on any tool surfacing trace-like payloads,
   - the input arg `:max-tokens` overrides the 5,000-token cap on any
     tool,
@@ -41,10 +41,14 @@
 
   ## What this test guards
 
-  1. **Tool-arg slot-name parity** — `:include-sensitive?` /
+  1. **Tool-arg slot-name parity** — `:include-sensitive` /
      `:max-tokens` literals appear as INPUT-arg keys in every server's
      descriptor source and arg-parsing source. A rename on any server
-     trips this gate.
+     trips this gate. The wire-key drops the trailing `?` (per rf2-y710n)
+     because Anthropic's tool-input-schema regex
+     `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`; the predicate FUNCTION name
+     `include-sensitive?` keeps its `?` — the idiom belongs on the
+     predicate, not on a data key whose wire form disallows it.
   2. **No near-miss variants** — snake_case / pluralised / quoted
      forms (`:include_sensitive`, `:max_tokens`, `\"includeSensitive\"`)
      don't appear in any server's tool source.
@@ -107,12 +111,12 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private canonical-slots
-  [{:slot     :include-sensitive?
+  [{:slot     :include-sensitive
     :role     :opt-in-boolean
     :servers  #{:pair2-mcp :story-mcp}
     :sources  {:pair2-mcp ["tools/pair2-mcp/src/re_frame_pair2_mcp/tools/sensitive.cljs"
                            "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors.cljs"]
-               ;; story-mcp's `:include-sensitive?` parsing lives in
+               ;; story-mcp's `:include-sensitive` parsing lives in
                ;; `helpers.cljc` (rf2-73wuj — the cross-MCP `args/parse-
                ;; boolean` reader) and the slot schema lives in
                ;; `schemas.cljc` (`include-sensitive-schema` injector).
@@ -121,7 +125,13 @@
                :story-mcp ["tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc"
                            "tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc"]}
     :doc      "Opt-in boolean — pass `true` to disable the spec/009 §Privacy
-               default-drop on `:sensitive? true` items. Default false."}
+               default-drop on `:sensitive? true` items. Default false.
+               Wire-key has no trailing `?` (per rf2-y710n) because the
+               Anthropic tools/input_schema regex
+               `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`. The predicate FUNCTION
+               name `include-sensitive?` (e.g. `helpers/include-sensitive?`)
+               keeps the `?` — the idiom belongs on predicate fns, not on
+               a data key whose wire form disallows it."}
 
    {:slot     :max-tokens
     :role     :override-integer
@@ -169,12 +179,14 @@
   here breaks every server in lockstep — which is the right
   invariant. The slot keys in this set are the NAMESPACED framework
   forms (`:rf.size/include-large?` /
-  `:rf.size/include-sensitive?` — the walker opts) PLUS the
-  unqualified MCP-surface forms (`:include-sensitive?` —
-  inferred from the docstrings in vocab.cljc)."
+  `:rf.size/include-sensitive?` — the walker opts; these are internal
+  framework keys, NOT wire keys, so they retain the predicate `?`)
+  PLUS the unqualified MCP-surface form (`:include-sensitive` — no
+  `?` because the wire-key MUST omit `?` per Anthropic's tool input
+  schema regex `^[a-zA-Z0-9_.-]{1,64}$`; rf2-y710n)."
   #{":rf.size/include-large?"
     ":rf.size/include-sensitive?"
-    ":include-sensitive?"})
+    ":include-sensitive"})
 
 ;; ---------------------------------------------------------------------------
 ;; Argument-role schema gate. Each role pins a Malli shape — a
@@ -185,7 +197,7 @@
 
 (def ^:private OptInBoolean
   "A boolean-typed input arg payload."
-  [:map {:closed false} [:include-sensitive? :boolean]])
+  [:map {:closed false} [:include-sensitive :boolean]])
 
 (def ^:private OverrideInteger
   "An integer-typed input arg payload — non-negative because `0` is
@@ -202,8 +214,8 @@
   role's canonical schema. Drift in the role contract (e.g. a server
   silently accepting `:max-tokens \"5000\"` as a string) is caught
   upstream — these fixtures pin the AGENT-FACING canonical shape."
-  {:opt-in-boolean   [{:include-sensitive? true}
-                      {:include-sensitive? false}]
+  {:opt-in-boolean   [{:include-sensitive true}
+                      {:include-sensitive false}]
    :override-integer [{:max-tokens 5000}
                       {:max-tokens 0}                       ; cap disabled
                       {:max-tokens 1}                       ; tight cap
@@ -216,12 +228,12 @@
 ;; Each variant is matched with a regex that compiles a trailing
 ;; negative-lookahead so we only match the variant when it's NOT
 ;; immediately followed by a keyword-extender character. Plain
-;; `str/includes?` on a substring would false-positive: the variant
-;; `:include-sensitive` is technically a substring of the canonical
-;; `:include-sensitive?`, so a naive check would always trip even in
-;; a clean codebase. The regex form pins the variant as a full
-;; keyword token — followed by whitespace, paren, brace, colon, comma,
-;; etc — anything that isn't a keyword-extender.
+;; `str/includes?` on a substring would false-positive: e.g. the
+;; variant `:max-tokens` is technically a substring of `:max-tokens-arg`
+;; or `:max-tokens?`, so a naive check would trip even in a clean
+;; codebase. The regex form pins the variant as a full keyword token —
+;; followed by whitespace, paren, brace, colon, comma, etc — anything
+;; that isn't a keyword-extender.
 ;; ---------------------------------------------------------------------------
 
 ;; `variant-regex` lives in `re-frame.mcp-conformance.fixtures`
@@ -312,7 +324,7 @@
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/descriptors_knobs.cljs"
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/cap.cljs"
                      "tools/pair2-mcp/src/re_frame_pair2_mcp/tools/elision.cljs"]
-         ;; story-mcp's `:include-sensitive?` parsing / schema lives in
+         ;; story-mcp's `:include-sensitive` parsing / schema lives in
          ;; `helpers.cljc` + `schemas.cljc` (no `sensitive.cljc` —
          ;; that's pair2-mcp's shape). The other entries below are the
          ;; full tools/ surface, covered for near-miss-variant defence.

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -46,12 +46,20 @@ returns the post-pipeline state plus a sharable URL.
 Wire-egress posture: `:app-db` is routed through
 `re-frame.core/elide-wire-value` against the variant frame's
 `[:rf/elision]` registry; declared-sensitive paths land
-`:rf/redacted` by default. Pass `:include-sensitive? true` to opt
+`:rf/redacted` by default. Pass `:include-sensitive true` to opt
 out — BUT the opt-in is honoured only when the server was started
 with `--allow-sensitive-reads` (rf2-g9fje); when that gate is
-closed (the default), the `:include-sensitive?` slot is omitted
+closed (the default), the `:include-sensitive` slot is omitted
 from the `tools/list` schema entirely and any caller-supplied
 value is silently ignored at egress.
+
+The wire-key shape (`:include-sensitive`, no `?`) satisfies the
+Anthropic Messages API regex on tool input-schema property keys:
+`^[a-zA-Z0-9_.-]{1,64}$` — the predicate-style trailing `?` is
+rejected at the host. The predicate FUNCTION
+`helpers/include-sensitive?` keeps its `?` (the Clojure idiom
+belongs on the predicate, not on the data key whose wire form
+disallows it).
 
 ```clojure
 {:lifecycle      :ok | :failed-loaders | :failed-events | ...
@@ -259,7 +267,7 @@ accumulator (no re-run). Useful for agents that want to inspect the
 last-run state without paying the cost of a fresh `run-variant`.
 
 Assertion records carrying `:sensitive? true` are dropped at egress
-by default; `:include-sensitive? true` opts back in subject to the
+by default; `:include-sensitive true` opts back in subject to the
 same `--allow-sensitive-reads` boot gate as `preview-variant` /
 `run-variant`.
 
@@ -267,11 +275,19 @@ same `--allow-sensitive-reads` boot gate as `preview-variant` /
 
 The three tools that surface live frame state (`preview-variant`,
 `run-variant`, `read-failures`) all accept a per-call
-`:include-sensitive?` boolean to opt out of the default redaction
+`:include-sensitive` boolean to opt out of the default redaction
 posture (see [`tools/Tool-Pair.md`](../../../spec/Tool-Pair.md)
 §Direct-read privacy posture). Per the rf2-uaymx (b) decision that
 opt-in is itself gated by a server-side boot flag, mirroring the
 `--allow-eval` posture pair2-mcp uses for `eval-cljs` (rf2-zyoj2):
+
+The wire-key shape (`:include-sensitive`, no `?`) is the form the
+host accepts: the Anthropic Messages API enforces
+`^[a-zA-Z0-9_.-]{1,64}$` on tool input-schema property keys, which
+rejects the trailing `?` of the Clojure predicate-style boolean
+convention. The predicate function `helpers/include-sensitive?`
+retains the `?` — the idiom belongs on the predicate, not on the
+data key.
 
 | Path | Mechanism |
 |---|---|
@@ -281,17 +297,17 @@ opt-in is itself gated by a server-side boot flag, mirroring the
 
 Closed by default. When closed:
 
-- `tools/list` omits the `:include-sensitive?` slot from the input
+- `tools/list` omits the `:include-sensitive` slot from the input
   schemas of the three affected tools — agents never see an opt-in
   they couldn't exercise.
 - The wire-egress scrubbers silently ignore any caller-supplied
-  `:include-sensitive? true` — declared-sensitive `:app-db` paths
+  `:include-sensitive true` — declared-sensitive `:app-db` paths
   remain `:rf/redacted`; assertion records stamped `:sensitive?
   true` remain dropped.
 - The server logs one line at boot:
   `Sensitive reads: gated (default; pass --allow-sensitive-reads to opt in)`.
 
-When open, the per-call `:include-sensitive? true` is honoured as
+When open, the per-call `:include-sensitive true` is honoured as
 documented — raw values cross the wire, the operator has signed
 off on the egress posture by passing the flag.
 

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -24,18 +24,26 @@ agent-onboarding text.
 **Input.**
 
 ```clojure
-{:variant-id         keyword (required)
- :substrate          keyword (optional)
- :active-modes       [keyword] (optional)
- :cell-overrides     {keyword any} (optional)
- :base-url           string (optional)
- :include-sensitive? boolean (optional, gated — see below)}
+{:variant-id        keyword (required)
+ :substrate         keyword (optional)
+ :active-modes      [keyword] (optional)
+ :cell-overrides    {keyword any} (optional)
+ :base-url          string (optional)
+ :include-sensitive boolean (optional, gated — see below)}
 ```
 
-`:include-sensitive?` is honoured ONLY when the server was started
+`:include-sensitive` is honoured ONLY when the server was started
 with `--allow-sensitive-reads` (rf2-g9fje); when that boot gate is
 closed (the default) the slot is omitted from `tools/list` and any
 caller-supplied value is silently ignored at egress.
+
+The wire-key shape (`:include-sensitive`, no `?`) satisfies the
+Anthropic Messages API regex on tool input-schema property keys:
+`^[a-zA-Z0-9_.-]{1,64}$`. The trailing `?` Clojure-idiomatic for
+booleans is rejected at the host, so the wire form drops it. The
+predicate FUNCTION `helpers/include-sensitive?` retains its `?` —
+the idiom belongs on the predicate, not on the data key whose wire
+form disallows it.
 
 **Output.**
 
@@ -139,16 +147,16 @@ projection — byte stability matters for round-tripping).
 **Input.**
 
 ```clojure
-{:variant-id         keyword (required)
- :substrate          keyword (optional)
- :active-modes       [keyword] (optional)
- :cell-overrides     {keyword any} (optional)
- :timeout-ms         number  (optional, capped at 30000)
- :include-sensitive? boolean (optional, gated — see `preview-variant`)}
+{:variant-id        keyword (required)
+ :substrate         keyword (optional)
+ :active-modes      [keyword] (optional)
+ :cell-overrides    {keyword any} (optional)
+ :timeout-ms        number  (optional, capped at 30000)
+ :include-sensitive boolean (optional, gated — see `preview-variant`)}
 ```
 
 `:timeout-ms` is clamped to 30 s (matches `:rf.http/timeout-ms`
-baseline per rf2-it1cd; rf2-g9fje). `:include-sensitive?` follows
+baseline per rf2-it1cd; rf2-g9fje). `:include-sensitive` follows
 the same `--allow-sensitive-reads` gate as `preview-variant`.
 
 **Output.**
@@ -200,13 +208,13 @@ hosts return `{:violations [] :hint "axe-core requires the in-browser panel."}`.
 **Input.**
 
 ```clojure
-{:variant-id         keyword (required)
- :include-sensitive? boolean (optional, gated — see `preview-variant`)}
+{:variant-id        keyword (required)
+ :include-sensitive boolean (optional, gated — see `preview-variant`)}
 ```
 
 **Output.** `{:assertions [map] :passing? boolean}`. No re-run.
 
-`:include-sensitive?` follows the same `--allow-sensitive-reads`
+`:include-sensitive` follows the same `--allow-sensitive-reads`
 boot gate as `preview-variant` / `run-variant`. Assertion records
 stamped `:sensitive? true` are dropped at egress by default.
 

--- a/tools/story-mcp/src/re_frame/story_mcp/config.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/config.cljc
@@ -19,7 +19,7 @@
     or programmatically (tests).
   - `allow-sensitive-reads?` — atom holding the sensitive-read gate. Read
     by the wire-egress scrubbers (`helpers/include-sensitive?`); a `false`
-    value forces redaction regardless of any per-call `:include-sensitive?`
+    value forces redaction regardless of any per-call `:include-sensitive`
     arg. Symmetric with `--allow-eval` in pair2-mcp (rf2-zyoj2): arbitrary
     code execution + raw sensitive-state reads are operator-only opt-ins,
     not caller-controlled toggles.
@@ -124,7 +124,7 @@
 ;; Per the rf2-uaymx (b) decision and rf2-zyoj2's `--allow-eval` precedent,
 ;; raw sensitive-state reads are an operator-only opt-in. The wire-egress
 ;; helpers (`helpers/include-sensitive?`) defer to this atom — when it is
-;; `false` the per-call `:include-sensitive?` arg is silently treated as
+;; `false` the per-call `:include-sensitive` arg is silently treated as
 ;; `false`, so a hostile or careless caller cannot exfiltrate declared-
 ;; sensitive `:app-db` slots / assertion records by flipping a JSON
 ;; boolean. Closed-by-default; opened by `--allow-sensitive-reads` CLI
@@ -133,7 +133,7 @@
 
 (defonce
   ^{:doc "Atom holding the sensitive-read gate. Defaults to `false`. Per
-         the rf2-uaymx (b) decision the per-call `:include-sensitive?`
+         the rf2-uaymx (b) decision the per-call `:include-sensitive`
          arg is honoured ONLY when this atom is also `true`. Symmetric
          with `allow-eval?` in pair2-mcp."}
   allow-sensitive-reads?
@@ -149,7 +149,7 @@
 
 (defn sensitive-reads-allowed?
   "True iff raw sensitive-read egress is currently enabled. The wire-
-  egress helpers AND each per-call `:include-sensitive?` arg must both
+  egress helpers AND each per-call `:include-sensitive` arg must both
   be `true` for raw values to cross the wire."
   []
   (boolean @allow-sensitive-reads?))

--- a/tools/story-mcp/src/re_frame/story_mcp/server.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/server.cljc
@@ -219,7 +219,7 @@
     (rf2-g9fje). Symmetric with `--allow-writes` and with pair2-mcp's
     `--allow-eval`: operator-only opt-in, no `=value` variant. Default
     off; when off, the wire-egress scrubbers silently ignore any
-    `:include-sensitive? true` per-call arg and `tools/list` omits the
+    `:include-sensitive true` per-call arg and `tools/list` omits the
     slot from advertised input schemas.
 
   Unknown flags are logged and ignored — the MCP spec doesn't define

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/dev.cljc
@@ -74,7 +74,7 @@
   Wire-egress posture (rf2-73wuj): the `:app-db` slot is routed
   through `re-frame.core/elide-wire-value`; the `:assertions` vec is
   filtered through `strip-sensitive`. Off-box defaults apply unless
-  the caller passes `:include-sensitive? true`."
+  the caller passes `:include-sensitive true`."
   [args]
   (h/with-variant args
     (fn [vk _body]
@@ -145,7 +145,7 @@
 
    {:name           "preview-variant"
     :category       :dev
-    :description    "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive? true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
+    :description    "Given a variant id, return the canvas state (app-db, assertions, rendered-hiccup, elapsed) + a sharable URL. The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
     :typicalTokens  2000
     :inputSchema {:type "object"
                   :properties (s/with-max-tokens

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/helpers.cljc
@@ -29,7 +29,7 @@
   privacy-posture rules to every live `:app-db` slice and assertion
   accumulator before egress. Off-box defaults (schema-declared
   sensitive paths return `:rf/redacted`; assertion records stamped
-  `:sensitive? true` are dropped). The shared `:include-sensitive?`
+  `:sensitive? true` are dropped). The shared `:include-sensitive`
   arg is the documented opt-in escape hatch."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
@@ -97,24 +97,30 @@
 (defn include-sensitive?
   "True iff the caller opted in to forwarding `:sensitive? true` records
   / app-db slots AND the operator has opened the server-side gate.
-  Default off. Reads the `:include-sensitive?` arg via the cross-MCP
+  Default off. Reads the `:include-sensitive` arg via the cross-MCP
   `args/parse-boolean` parser (so string-form booleans `\"true\"` /
   `\"yes\"` / `\"1\"` are accepted alongside the JSON `true`).
+
+  Predicate FUNCTION name retains the `?` per the Clojure idiom; the
+  wire/data KEY is `:include-sensitive` (no `?`) because Anthropic's
+  Messages API rejects `?` in tool input-schema property keys
+  (`^[a-zA-Z0-9_.-]{1,64}$`). The `?` belongs on the predicate, not on
+  the data key.
 
   ## Boot-time gate (rf2-g9fje)
 
   The operator-only gate `config/sensitive-reads-allowed?` (set by
   `--allow-sensitive-reads`, mirroring pair2-mcp's `--allow-eval`) is
   the outer check: when it is `false`, this fn always returns `false`,
-  the per-call `:include-sensitive?` arg is silently ignored, and
+  the per-call `:include-sensitive` arg is silently ignored, and
   declared-sensitive `:app-db` slots / assertion records remain
   redacted regardless of what the caller asked for. The MCP caller
-  surface (`tools/list`) likewise omits `:include-sensitive?` from
+  surface (`tools/list`) likewise omits `:include-sensitive` from
   the descriptor schemas when the gate is closed (see `schemas/
   with-include-sensitive`)."
   [arguments]
   (and (config/sensitive-reads-allowed?)
-       (args/parse-boolean (get arguments :include-sensitive?) false)))
+       (args/parse-boolean (get arguments :include-sensitive) false)))
 
 (defn required-arg
   "Read a required argument. Returns `[value nil]` on success, or

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -47,7 +47,7 @@
         "tool-registry: every entry must carry positive-integer :typicalTokens")
 
 (defn- strip-include-sensitive
-  "Remove the `:include-sensitive?` slot from a tool's `:inputSchema`
+  "Remove the `:include-sensitive` slot from a tool's `:inputSchema`
   properties. The slot is baked into the descriptor at load time by
   `schemas/with-include-sensitive`; this fn runs at `tools/list` time
   and removes it when the operator-only gate is closed (rf2-g9fje) so
@@ -55,8 +55,8 @@
   to ignore. Idempotent: tools whose schema never carried the slot are
   returned unchanged."
   [schema]
-  (if (contains? (:properties schema) :include-sensitive?)
-    (update schema :properties dissoc :include-sensitive?)
+  (if (contains? (:properties schema) :include-sensitive)
+    (update schema :properties dissoc :include-sensitive)
     schema))
 
 (defn tool-descriptors
@@ -77,11 +77,11 @@
 
   ## Sensitive-read gate (rf2-g9fje)
 
-  The `:include-sensitive?` slot is stripped from every tool's input
+  The `:include-sensitive` slot is stripped from every tool's input
   schema when the operator-only gate (`config/sensitive-reads-allowed?`)
   is closed — agents shouldn't see an opt-in they can't exercise. The
   three affected tools (`preview-variant`, `run-variant`, `read-failures`)
-  silently ignore caller-supplied `:include-sensitive? true` at the
+  silently ignore caller-supplied `:include-sensitive true` at the
   helper layer regardless, so the descriptor strip is purely a UX
   improvement and a defence-in-depth signal."
   []

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/schemas.cljc
@@ -21,7 +21,7 @@
 (def include-sensitive-schema
   "Recurring fragment — every tool that surfaces a live `:app-db`
   slice or assertion accumulator accepts the cross-MCP
-  `:include-sensitive?` opt-in (rf2-73wuj). Default false:
+  `:include-sensitive` opt-in (rf2-73wuj). Default false:
   declared-sensitive paths land `:rf/redacted` via `elide-wire-value`,
   and assertion records stamped `:sensitive? true` are dropped via
   `strip-sensitive`. Pass true to forward the raw values; per the
@@ -31,7 +31,15 @@
   `--allow-sensitive-reads` (rf2-g9fje). When that operator-only gate
   is closed, the slot is omitted from `tools/list` advertisements (so
   agents don't even see it) and any caller-supplied value is silently
-  ignored at egress."
+  ignored at egress.
+
+  Wire-key shape: the property key is `:include-sensitive` (no `?`).
+  The Anthropic Messages API constrains tool input-schema property
+  keys to `^[a-zA-Z0-9_.-]{1,64}$` — the trailing `?` Clojure-idiomatic
+  for booleans is rejected at the host, so the wire form drops it. The
+  predicate FUNCTION `helpers/include-sensitive?` retains the `?` (the
+  Clojure idiom belongs on the predicate, not on the data key whose
+  wire form disallows it)."
   {:type "boolean"
    :description (str "Opt in to forwarding sensitive `:app-db` slots and "
                      "assertion records. Default false (declared-sensitive paths "
@@ -47,7 +55,7 @@
   (assoc props :max-tokens max-tokens-schema))
 
 (defn with-include-sensitive
-  "Inject the `:include-sensitive?` slot into a tool's `:properties`
+  "Inject the `:include-sensitive` slot into a tool's `:properties`
   map. Used by tools that surface a live `:app-db` slice or assertion
   accumulator (`preview-variant`, `run-variant`, `read-failures`).
 
@@ -55,6 +63,10 @@
   stripped at `tools/list` time by `registry/tool-descriptors` when the
   server's `--allow-sensitive-reads` gate is closed (rf2-g9fje) — so a
   closed gate hides the opt-in from agents entirely, and an open gate
-  surfaces it verbatim."
+  surfaces it verbatim.
+
+  Wire-key shape: the property key is `:include-sensitive` (no `?`)
+  to satisfy Anthropic's `^[a-zA-Z0-9_.-]{1,64}$` constraint on tool
+  input-schema property keys; see `include-sensitive-schema`."
   [props]
-  (assoc props :include-sensitive? include-sensitive-schema))
+  (assoc props :include-sensitive include-sensitive-schema))

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/testing.cljc
@@ -48,8 +48,8 @@
                                clamped to `max-timeout-ms` (30000) per
                                rf2-g9fje so one slow request can't park
                                the single-threaded stdio loop.
-    :include-sensitive? optional — opt out of wire-egress redaction
-                                   (default false; rf2-73wuj)"
+    :include-sensitive optional — opt out of wire-egress redaction
+                                  (default false; rf2-73wuj)"
   [args]
   (h/with-variant args
     (fn [vk _body]
@@ -137,7 +137,7 @@
   scrubbed vec so the agent's view of green/red is consistent with
   the records it actually sees — a dropped sensitive failure doesn't
   quietly flip `:passing?` to true. Default off; opt out with
-  `:include-sensitive? true`."
+  `:include-sensitive true`."
   [args]
   (h/with-variant-id args
     (fn [vk]
@@ -159,7 +159,7 @@
   "Testing-category descriptors, in IMPL-SPEC §7.2 order."
   [{:name           "run-variant"
     :category       :testing
-    :description    "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`). The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive? true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
+    :description    "Execute a variant's four-phase lifecycle (loaders → events → render → play); return the result map (`:frame :app-db :assertions :rendered-hiccup :elapsed-ms :passing?`). The `:app-db` slot is routed through `re-frame.core/elide-wire-value` against the variant frame's `[:rf/elision]` registry — declared-sensitive paths return `:rf/redacted` and oversize slots return the `:rf.size/large-elided` marker by default. Pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
     :typicalTokens  2000
     :inputSchema {:type "object"
                   :properties (s/with-max-tokens
@@ -204,7 +204,7 @@
 
    {:name           "read-failures"
     :category       :testing
-    :description    "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`. Assertion records carrying `:sensitive? true` are dropped at egress by default; pass `:include-sensitive? true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
+    :description    "Accumulated assertion failures for a variant frame (since the most recent `run-variant`). Returns `{:total :failures :passing?}`. Assertion records carrying `:sensitive? true` are dropped at egress by default; pass `:include-sensitive true` to opt out (per spec/Tool-Pair.md §Direct-read privacy posture)."
     :typicalTokens  500
     :inputSchema {:type "object"
                   :properties (s/with-max-tokens

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -1155,13 +1155,13 @@
 ;; value through `re-frame.core/elide-wire-value` before egress, with
 ;; off-box defaults (`:rf.size/include-sensitive?` and
 ;; `:rf.size/include-large?` both default false). The cross-MCP
-;; `:include-sensitive?` arg (rf2-vw4sq) is the documented escape hatch.
+;; `:include-sensitive` arg (rf2-vw4sq) is the documented escape hatch.
 ;;
 ;; These tests pin the contract at the story-mcp surface: a sensitive
 ;; slot declared through app-schema metadata on the variant's frame must
 ;; surface as `:rf/redacted` in the tool's response `:app-db` slot by
 ;; default, and as the raw value when the caller opts in via
-;; `:include-sensitive? true`. Assertion records carrying the top-level
+;; `:include-sensitive true`. Assertion records carrying the top-level
 ;; `:sensitive? true` stamp must be dropped by default and included
 ;; when opted in.
 ;;
@@ -1250,13 +1250,13 @@
             "non-sensitive slots survive the walk")))))
 
 (deftest preview-variant-app-db-includes-sensitive-when-opted-in
-  (testing ":include-sensitive? true forwards the raw value through the walker"
+  (testing ":include-sensitive true forwards the raw value through the walker"
     (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
       (let [r (invoke "preview-variant" {:variant-id "story.button/primary"
-                                         :include-sensitive? true})
+                                         :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= "TOPSECRET" (get-in s [:app-db :secret]))
@@ -1277,13 +1277,13 @@
             "the :secret slot is redacted at egress")))))
 
 (deftest run-variant-app-db-includes-sensitive-when-opted-in
-  (testing "run-variant's :include-sensitive? true forwards the raw value"
+  (testing "run-variant's :include-sensitive true forwards the raw value"
     (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
       (let [r (invoke "run-variant" {:variant-id "story.button/primary"
-                                     :include-sensitive? true})
+                                     :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= "TOPSECRET" (get-in s [:app-db :secret])))))))
@@ -1361,7 +1361,7 @@
             ":passing? runs against the scrubbed vec — agent's view is consistent")))))
 
 (deftest read-failures-includes-sensitive-when-opted-in
-  (testing ":include-sensitive? true preserves sensitive records"
+  (testing ":include-sensitive true preserves sensitive records"
     (config/set-allow-sensitive-reads! true)
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid
@@ -1373,7 +1373,7 @@
                        :sensitive? true
                        :reason     "expected TOPSECRET got something-else"}]})
       (let [r (invoke "read-failures" {:variant-id "story.button/primary"
-                                       :include-sensitive? true})
+                                       :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= 2 (:total s)) "both records survive the egress")
@@ -1381,26 +1381,26 @@
         (is (false? (:passing? s)) "the visible failure flips :passing?")))))
 
 (deftest egress-tools-input-schema-carries-include-sensitive
-  (testing "every tool surfacing :app-db or assertions accepts :include-sensitive?"
+  (testing "every tool surfacing :app-db or assertions accepts :include-sensitive"
     (doseq [tname ["preview-variant" "run-variant" "read-failures"]]
       (let [t     (some #(when (= tname (:name %)) %) registry/tool-registry)
             props (-> t :inputSchema :properties)]
-        (is (contains? props :include-sensitive?)
-            (str tname " missing :include-sensitive? slot"))
-        (is (= "boolean" (-> props :include-sensitive? :type))
-            (str tname " :include-sensitive? slot is not boolean-typed"))))))
+        (is (contains? props :include-sensitive)
+            (str tname " missing :include-sensitive slot"))
+        (is (= "boolean" (-> props :include-sensitive :type))
+            (str tname " :include-sensitive slot is not boolean-typed"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Sensitive-read boot gate (rf2-g9fje)
 ;;
-;; Per the rf2-uaymx (b) decision: the per-call `:include-sensitive?` arg
+;; Per the rf2-uaymx (b) decision: the per-call `:include-sensitive` arg
 ;; is honoured ONLY when the operator opened the server-side gate at boot
 ;; (`--allow-sensitive-reads`). When the gate is closed:
 ;;
-;;   1. `tools/list` omits `:include-sensitive?` from the input schemas of
+;;   1. `tools/list` omits `:include-sensitive` from the input schemas of
 ;;      preview-variant / run-variant / read-failures (caller UX — no
 ;;      ghost knob).
-;;   2. `:include-sensitive? true` on a tool call is silently ignored at
+;;   2. `:include-sensitive true` on a tool call is silently ignored at
 ;;      the egress helpers (defence-in-depth — even a caller who learned
 ;;      about the slot some other way can't exfiltrate raw values).
 ;; ---------------------------------------------------------------------------
@@ -1419,54 +1419,54 @@
           "absent flag leaves the slot unset so merge respects sysprop/env defaults"))))
 
 (deftest tools-list-strips-include-sensitive-when-gate-closed
-  (testing "tools/list omits :include-sensitive? from the schema when the gate is closed"
+  (testing "tools/list omits :include-sensitive from the schema when the gate is closed"
     (is (false? (config/sensitive-reads-allowed?)))
     (let [descriptors (registry/tool-descriptors)]
       (doseq [tname ["preview-variant" "run-variant" "read-failures"]]
         (let [t     (some #(when (= tname (:name %)) %) descriptors)
               props (-> t :inputSchema :properties)]
-          (is (not (contains? props :include-sensitive?))
-              (str "gate closed: " tname " must not advertise :include-sensitive?")))))))
+          (is (not (contains? props :include-sensitive))
+              (str "gate closed: " tname " must not advertise :include-sensitive")))))))
 
 (deftest tools-list-surfaces-include-sensitive-when-gate-open
-  (testing "tools/list advertises :include-sensitive? when the gate is open"
+  (testing "tools/list advertises :include-sensitive when the gate is open"
     (config/set-allow-sensitive-reads! true)
     (let [descriptors (registry/tool-descriptors)]
       (doseq [tname ["preview-variant" "run-variant" "read-failures"]]
         (let [t     (some #(when (= tname (:name %)) %) descriptors)
               props (-> t :inputSchema :properties)]
-          (is (contains? props :include-sensitive?)
-              (str "gate open: " tname " must advertise :include-sensitive?"))
-          (is (= "boolean" (-> props :include-sensitive? :type))))))))
+          (is (contains? props :include-sensitive)
+              (str "gate open: " tname " must advertise :include-sensitive"))
+          (is (= "boolean" (-> props :include-sensitive :type))))))))
 
 (deftest preview-variant-gate-closed-ignores-per-call-flag
-  (testing "with gate closed, :include-sensitive? true is silently ignored at egress"
+  (testing "with gate closed, :include-sensitive true is silently ignored at egress"
     (is (false? (config/sensitive-reads-allowed?)))
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
       (let [r (invoke "preview-variant" {:variant-id "story.button/primary"
-                                         :include-sensitive? true})
+                                         :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= :rf/redacted (get-in s [:app-db :secret]))
             "gate closed: per-call opt-in is dropped; redaction stands")))))
 
 (deftest run-variant-gate-closed-ignores-per-call-flag
-  (testing "with gate closed, :include-sensitive? true is silently ignored at egress"
+  (testing "with gate closed, :include-sensitive true is silently ignored at egress"
     (is (false? (config/sensitive-reads-allowed?)))
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid {:public "ok" :secret "TOPSECRET"})
       (declare-sensitive! vid [:secret])
       (let [r (invoke "run-variant" {:variant-id "story.button/primary"
-                                     :include-sensitive? true})
+                                     :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= :rf/redacted (get-in s [:app-db :secret]))
             "gate closed: per-call opt-in is dropped; redaction stands")))))
 
 (deftest read-failures-gate-closed-ignores-per-call-flag
-  (testing "with gate closed, :include-sensitive? true does not surface sensitive records"
+  (testing "with gate closed, :include-sensitive true does not surface sensitive records"
     (is (false? (config/sensitive-reads-allowed?)))
     (with-clean-frame [vid :story.button/primary]
       (seed-app-db! vid
@@ -1477,7 +1477,7 @@
                        :sensitive? true
                        :reason     "leak"}]})
       (let [r (invoke "read-failures" {:variant-id "story.button/primary"
-                                       :include-sensitive? true})
+                                       :include-sensitive true})
             s (:structuredContent r)]
         (is (success? r))
         (is (= 1 (:total s))


### PR DESCRIPTION
## Why
The wire property key `:include-sensitive?` violates Anthropic's tool input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` — any Claude Code session loading story-mcp returns HTTP 400 on every tool call.

## What
Option 1 from rf2-y710n (operator decision recorded in bead notes): drop `?` from the wire/data key everywhere. Predicate function name `include-sensitive?` retains its `?` (the idiom belongs on the predicate, not on the data key whose wire form disallows it).

## Scope
- Schema helper + arg reader + ~5 call sites in `tools/story-mcp/src/`
- ~10 test references in `tools/story-mcp/test/`
- ~9 doc references in `tools/story-mcp/spec/` (API.md + 002-Tool-Registry.md), with new prose explaining the Anthropic regex constraint and the wire-key/predicate-fn split
- Internal walker option `:rf.size/include-sensitive?` is a different keyword and intentionally retains its `?`

## Verification
- `clojure -M:test` in `tools/story-mcp/`: 124 tests, 596 assertions, 0 failures
- `npm run test:cljs` in `implementation/`: 2883 tests, 8229 assertions, 0 failures
- Post-rename grep confirms every remaining `include-sensitive?` is either the predicate FUNCTION (`(defn include-sensitive?`, `h/include-sensitive?`, prose mentioning the fn name) or the namespaced walker option `:rf.size/include-sensitive?` — no wire-key `?` residue.

Closes rf2-y710n.