### PR TITLE
fix(story): preset propagates :project-root to Causa-as-RHS (rf2-r1uod)

### DIFF
--- a/tools/story/spec/005-SOTA-Features.md
+++ b/tools/story/spec/005-SOTA-Features.md
@@ -564,6 +564,32 @@ absolute coord isn't double-prefixed. The prefix lives in the shared
 `re-frame.source-coords.editor-uri/editor-uri` 3-arg form; Causa
 consumes the same helper and will plumb its own knob in a follow-up.
 
+##### Bridge to Causa-as-RHS (rf2-r1uod)
+
+When Causa is mounted as Story's RHS inspector (per [rf2-sgdd3](../README.md#stage-9-rf2-sgdd3-causa-as-rhs)),
+the Causa-side source-coord chips (Event lens Handler / Dispatch /
+Interceptors, Trace tab rows, Issues ribbon) read their on-disk root
+from Causa's `day8.re-frame2-causa.config/project-root` slot — NOT
+from Story's `re-frame.story.config/project-root`. To keep `:project-
+root` a single-source-of-truth setting the host only writes once,
+`(story/configure! {:project-root <path>})` is bridged into Causa's
+slot by `re-frame.story.causa-preset/propagate-project-root!`:
+
+- The propagator fires from two seams: (1) `story/configure!` after
+  `set-project-root!` lands (the common case — Causa's preload runs
+  before the testbed `run` fn), and (2) `causa-preset/ensure-causa-
+  mounted!` as defense-in-depth (lazy-load / hot-reload edge).
+- One-way (`story → causa`). Hosts that want Causa pointed at a
+  different on-disk root than Story call `causa-config/configure!`
+  directly AFTER `story/configure!` to override the bridge.
+- Feature-detect-safe: when Causa is not on the classpath the
+  propagator returns nil without touching the wire.
+
+Symmetric to shop's [rf2-6jyf6](https://github.com/day8/re-frame2/pull/1493) —
+Causa's standalone testbeds (shop) seed `:project-root` directly via
+`causa-config/configure!`; Story testbeds with Causa-as-RHS seed via
+`story/configure! :project-root` and let the bridge propagate.
+
 The shared URI builder lives at `re-frame.source-coords.editor-uri`
 under the core artefact and is CLJC-portable; Causa's mirror
 affordance (`day8.re-frame2-causa.open-in-editor`) consumes the same

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -126,7 +126,7 @@ into `:assertions` rather than throwing — see
 | Var / fn | Notes |
 |---|---|
 | `goog-define :rf.story/enabled?` | Compile-time DCE flag; `true` in dev, `false` in `:advanced`. See [`005-SOTA-Features.md`](005-SOTA-Features.md). |
-| `configure!` | `(configure! {:global-args {...}})` — set global args at boot. |
+| `configure!` | `(configure! {:global-args {...} :editor :vscode :project-root "..." :trace/show-sensitive? false})` — set global config at boot. `:project-root` is bridged into Causa's slot via `re-frame.story.causa-preset/propagate-project-root!` so Causa-as-RHS source-coord chips share the same on-disk root (rf2-r1uod; symmetric to shop's rf2-6jyf6). |
 
 ## Cross-references
 

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -76,6 +76,12 @@
             ;; Reagent / reagent.dom.client into their classpath.
             #?(:cljs [re-frame.story.ui.shell :as ui-shell])
             #?(:cljs [re-frame.story.ui.multi-substrate :as ui-multi-substrate])
+            ;; rf2-r1uod — Story → Causa `:project-root` bridge. `configure!`
+            ;; calls `causa-preset/propagate-project-root!` so Causa-as-RHS
+            ;; source-coord chips resolve coords against the same on-disk
+            ;; root Story uses. CLJS-only require because the propagator
+            ;; is CLJS-only (it feature-detects Causa via `find-ns-obj`).
+            #?(:cljs [re-frame.story.causa-preset :as causa-preset])
             #?(:clj [re-frame.story.macros :as macros]))
   ;; The seven reg-* macros are defined in the #?(:clj ...) blocks
   ;; below. Self-refer them via :require-macros so CLJS callers can
@@ -476,6 +482,14 @@
   (no prefix; source-coord file ships verbatim — useful when the
   classpath already resolves to absolute paths, and for tests).
 
+  Per rf2-r1uod the value is also bridged into Causa's `:project-root`
+  slot via `re-frame.story.causa-preset/propagate-project-root!` so
+  Causa-as-RHS source-coord chips (open-in-editor on the Handler /
+  Dispatch / Interceptor chips, Trace tab rows, Issues ribbon) resolve
+  against the same on-disk root. The bridge is one-way; hosts that want
+  Causa pointed at a different root call `causa-config/configure!`
+  directly AFTER `story/configure!`. Symmetric to shop's rf2-6jyf6.
+
   `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
   true` trace events per Spec 009 §Privacy (rf2-bclgj). Defaults to
   `false` — Story's per-variant trace-buffer listener (consumed by
@@ -493,7 +507,11 @@
   (when (some? editor)
     (config/set-editor! editor))
   (when (contains? opts :project-root)
-    (config/set-project-root! project-root))
+    (config/set-project-root! project-root)
+    ;; rf2-r1uod — bridge into Causa's `:project-root` slot so
+    ;; Causa-as-RHS source-coord chips share the same on-disk root.
+    ;; Feature-detect-safe (no-op when Causa is not on the classpath).
+    #?(:cljs (causa-preset/propagate-project-root!)))
   (when (contains? opts :trace/show-sensitive?)
     (config/set-show-sensitive! show-sensitive?))
   nil)

--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -110,6 +110,14 @@
      (some? (resolve-fn 'day8.re-frame2-causa.mount/open!))))
 
 #?(:cljs
+   (defn causa-config-available?
+     "True iff Causa's `configure!` surface is loaded — feature-detect
+     `day8.re-frame2-causa.config/configure!`. When false the
+     project-root propagator no-ops silently."
+     []
+     (some? (resolve-fn 'day8.re-frame2-causa.config/configure!))))
+
+#?(:cljs
    (defn filters-available?
      "True iff the Causa filters API (rf2-ak4ms, in flight) exposes a
      `configure!` fn. Feature-detect — when false the `:filters` step
@@ -141,6 +149,53 @@
      (when-let [open-fn (resolve-fn 'day8.re-frame2-causa.mount/open!)]
        (safe-call! "open!" open-fn))))
 
+;; ---- :project-root bridge (rf2-r1uod) ------------------------------------
+;;
+;; Symmetric to shop's rf2-6jyf6 (#1493): the source-coord chips in
+;; Causa-as-RHS need `causa-config/project-root` set, but Story testbeds
+;; configure only the Story side via `story/configure! {:project-root}`.
+;; Instead of asking every testbed to call BOTH configure surfaces, the
+;; preset (Story's Causa adapter) bridges the value one-way:
+;; `story/project-root → causa-config/project-root`.
+;;
+;; Single source of truth: the host sets `:project-root` once via
+;; `story/configure!`; the bridge propagates the value into Causa's slot
+;; so both Story's own 'Open' chips (rf2-zfy1e) and Causa-as-RHS's
+;; chips (rf2-5m5n2) resolve coords against the same on-disk root.
+;;
+;; Fires from two seams:
+;;   1. `story/configure!` after `set-project-root!` lands — the common
+;;      case (Causa's preload runs before the testbed `run` fn).
+;;   2. `ensure-causa-mounted!` — defense-in-depth for the (rare) case
+;;      where Causa's config ns loads AFTER `story/configure!` has
+;;      already fired (e.g. lazy loader / hot-reload edge).
+;;
+;; Idempotent: writing the same project-root twice is a no-op on
+;; Causa's `set-project-root!` (it's a plain reset!). Feature-detect-
+;; safe: when Causa is not on the classpath, the propagator returns
+;; nil without touching the wire.
+
+#?(:cljs
+   (defn propagate-project-root!
+     "Read Story's configured `:project-root` and propagate it into
+     Causa's config slot via `day8.re-frame2-causa.config/configure!`.
+     Returns the propagated value (or nil when there was nothing to do).
+
+     No-ops when:
+       - Causa's `configure!` is not on the classpath (preload absent).
+       - Story has no `:project-root` configured (the slot is nil).
+
+     The propagation is one-way Story → Causa; Causa-side edits do not
+     reflect back into Story's slot. Hosts that want to point Causa at
+     a different root from Story should call `causa-config/configure!`
+     directly AFTER `story/configure!` to override the bridge."
+     []
+     (when (and config/enabled? (causa-config-available?))
+       (when-let [root (config/get-project-root)]
+         (when-let [configure! (resolve-fn 'day8.re-frame2-causa.config/configure!)]
+           (safe-call! "config/configure!" configure! {:project-root root})
+           root)))))
+
 #?(:cljs
    (defn ensure-causa-mounted!
      "Always-on entry point used by the Story shell (rf2-sgdd3) to drive
@@ -152,9 +207,15 @@
      `mount/open!` finds the slot and mounts the Causa shell into it.
      Idempotent — Causa's own singleton state guarantees only one
      mount per process, subsequent calls flip visibility back to
-     visible if the user closed the shell."
+     visible if the user closed the shell.
+
+     rf2-r1uod: also propagates Story's configured `:project-root`
+     into Causa's config slot so the Causa-as-RHS source-coord chips
+     resolve absolute on-disk paths. The propagator is no-op-safe when
+     Story has no `:project-root` configured."
      []
      (when (and config/enabled? (causa-available?))
+       (propagate-project-root!)
        (apply-open!))))
 
 #?(:cljs

--- a/tools/story/test/re_frame/story/causa_preset_test.cljc
+++ b/tools/story/test/re_frame/story/causa_preset_test.cljc
@@ -124,3 +124,30 @@
        (story/reg-variant :story.nilpre/v
          {:doc "v"})
        (is (nil? (causa-preset/apply-preset! :story.nilpre/v))))))
+
+;; ---- CLJS-only: project-root propagator (rf2-r1uod) ----------------------
+
+#?(:cljs
+   (deftest cljs-propagate-project-root-no-causa-no-op
+     (testing "propagate-project-root! is a no-op when Causa config is not on the classpath"
+       ;; Seed Story's project-root via configure! — exercises the
+       ;; whole configure! → set-project-root! → propagator pipeline.
+       (story/configure! {:project-root "C:/Users/me/code/my-app"})
+       ;; The test build has no Causa namespace loaded, so
+       ;; causa-config-available? is false and propagate-project-root!
+       ;; returns nil without touching the wire.
+       (is (false? (causa-preset/causa-config-available?))
+           "this test assumes Causa is NOT on the classpath")
+       (is (nil? (causa-preset/propagate-project-root!))
+           "no propagation when Causa is absent")
+       ;; Reset so subsequent tests don't see the seeded value.
+       (story/configure! {:project-root nil}))))
+
+#?(:cljs
+   (deftest cljs-propagate-project-root-nil-when-unset
+     (testing "propagate-project-root! returns nil when Story has no project-root configured"
+       ;; Clear any prior seed (the fixture resets registrar but not
+       ;; the config atom).
+       (story/configure! {:project-root nil})
+       (is (nil? (causa-preset/propagate-project-root!))
+           "no propagation when Story's project-root is nil"))))

--- a/tools/story/testbeds/causa_rhs_smoke/core.cljs
+++ b/tools/story/testbeds/causa_rhs_smoke/core.cljs
@@ -21,6 +21,32 @@
             [day8.re-frame2-causa.config :as causa-config]
             [causa-rhs-smoke.stories]))
 
+;; rf2-r1uod — Causa-as-RHS open-in-editor project-root for the live
+;; testbed. Story testbeds register source-coords with classpath-
+;; relative `:file` slots; OS-side editor URI handlers reject relative
+;; paths. The Story testbeds source-path under shadow-cljs is
+;; `../tools/story/testbeds` so the on-disk root that prepends to a
+;; coord like `causa_rhs_smoke/stories.cljs:42` is the testbeds dir
+;; below. Plumbed via `story/configure! :project-root` and bridged
+;; into Causa's slot by `causa-preset/propagate-project-root!`.
+;; Symmetric to shop's rf2-6jyf6.
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/story/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent /
+  blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Story-API surface)."
+  [name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search
+                     (js/URLSearchParams.))
+          v      (.get params name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
 (defn ^:export run []
   ;; Disable Causa's standalone auto-open — the Story shell drives
   ;; `mount/open!` itself via `causa-preset/ensure-causa-mounted!`
@@ -29,5 +55,10 @@
   ;; to receive trace bus events).
   (causa-config/configure! {:launch/auto-open? false})
   (rf/init! reagent-adapter/adapter)
-  (story/configure! {:global-args {}})
+  ;; rf2-r1uod — `:project-root` plumbed through Story; the
+  ;; `causa-preset` bridge propagates it into Causa's slot so the
+  ;; Event lens / Trace rows / Issues ribbon open-in-editor chips
+  ;; resolve absolute on-disk paths.
+  (story/configure! {:global-args  {}
+                     :project-root (resolve-project-root)})
   (story/mount-shell! (js/document.getElementById "app")))

--- a/tools/story/testbeds/counter_with_stories/core.cljs
+++ b/tools/story/testbeds/counter_with_stories/core.cljs
@@ -46,6 +46,44 @@
    [views/counter-card {:label "Count"}]
    [elision/elision-card]])
 
+;; -- rf2-r1uod — Causa 'Open in editor' project-root for the live testbed.
+;;
+;; Story testbeds register source-coords with classpath-relative `:file`
+;; slots (e.g. `"counter_with_stories/core.cljs"`); OS-side editor URI
+;; handlers (`vscode://file/<path>...` etc.) resolve `<path>` against the
+;; filesystem and reject relative paths. Mike's live testbed runs from
+;; the mayor checkout `C:/Users/miket/code/re-frame2`; the Story
+;; testbeds source-path under shadow-cljs is `../tools/story/testbeds`
+;; so the absolute on-disk root that prepends to a coord like
+;; `counter_with_stories/core.cljs:42` is the testbeds dir below.
+;;
+;; The value is plumbed via `story/configure! :project-root` and bridged
+;; into Causa's slot by `re-frame.story.causa-preset/propagate-project-
+;; root!` so both Story's own 'Open' chips and Causa-as-RHS's chips (the
+;; Event lens Handler / Dispatch / Interceptors, Trace rows, Issues
+;; ribbon) resolve against the same root.
+;;
+;; Symmetric to shop's rf2-6jyf6; other hosts (CI, other devs) can
+;; override at runtime via the `?project-root=...` query string — no
+;; code change needed.
+
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/story/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent
+  / blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Story-API surface)."
+  [name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search
+                     (js/URLSearchParams.))
+          v      (.get params name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
 ;; -- Routing between app and story shell ----------------------------------
 ;;
 ;; The live app and the Story shell each own their own React root on
@@ -97,7 +135,17 @@
   ;; Configure the global args layer (Layer 1 of the args-precedence
   ;; chain; see IMPL-SPEC §5.2). The stories layer their own args on
   ;; top via reg-story / reg-variant.
-  (story/configure! {:global-args {:locale :en}})
+  ;;
+  ;; rf2-r1uod — `:project-root` seeds Story's own 'Open' chips AND
+  ;; (via the causa-preset bridge) Causa-as-RHS's open-in-editor
+  ;; chips so the Event lens / Trace rows / Issues ribbon resolve
+  ;; their classpath-relative source-coord `:file` slots to absolute
+  ;; on-disk URIs the OS-side editor handler can stat. Symmetric to
+  ;; shop's rf2-6jyf6. The `?project-root=...` query string lets
+  ;; other hosts override the mayor-checkout default without a code
+  ;; change.
+  (story/configure! {:global-args  {:locale :en}
+                     :project-root (resolve-project-root)})
   ;; Seed the live app's `:count` slot.
   (rf/dispatch-sync [:counter/initialise 5])
   ;; Install the always-on event-emit listener. The listener prints

--- a/tools/story/testbeds/counter_with_stories/story_static.cljs
+++ b/tools/story/testbeds/counter_with_stories/story_static.cljs
@@ -45,7 +45,17 @@
   ;; can ship with. Locale defaults to :en; the editor preference
   ;; doesn't matter because the open-in-editor affordance is dev-only
   ;; (file:// hrefs in a published site are not actionable).
-  (story/configure! {:global-args {:locale :en}})
+  ;;
+  ;; rf2-r1uod — `:project-root` is plumbed here for parity with
+  ;; the dev-flavoured `core.cljs` entry. In a published static build
+  ;; the open-in-editor chip is effectively dev-only (custom URI
+  ;; schemes don't resolve from a published HTML page), so the slot
+  ;; is harmless in this entry; mirroring the dev entry's wiring
+  ;; keeps the two `run` fns structurally identical and makes future
+  ;; "live-on-static" experiments (e.g. a published site that links
+  ;; back into the author's editor) trivial.
+  (story/configure! {:global-args  {:locale :en}
+                     :project-root "C:/Users/miket/code/re-frame2/tools/story/testbeds"})
   ;; Seed the live-app's :count slot so any embedded `counter-card`
   ;; view that renders under the variant canvas starts from a
   ;; deterministic value rather than `nil`.

--- a/tools/story/testbeds/login_form/core.cljs
+++ b/tools/story/testbeds/login_form/core.cljs
@@ -53,6 +53,35 @@
     " flip green."]])
 
 ;; ---------------------------------------------------------------------------
+;; rf2-r1uod — Causa-as-RHS open-in-editor project-root for the live
+;; testbed. Story testbeds register source-coords with classpath-
+;; relative `:file` slots; OS-side editor URI handlers reject relative
+;; paths. The Story testbeds source-path under shadow-cljs is
+;; `../tools/story/testbeds` so the on-disk root that prepends to a
+;; coord like `login_form/stories.cljs:42` is the testbeds dir below.
+;; Plumbed via `story/configure! :project-root` and bridged into
+;; Causa's slot by `causa-preset/propagate-project-root!`. Symmetric
+;; to shop's rf2-6jyf6.
+;; ---------------------------------------------------------------------------
+
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/story/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent /
+  blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Story-API surface)."
+  [name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search
+                     (js/URLSearchParams.))
+          v      (.get params name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
+;; ---------------------------------------------------------------------------
 ;; Hash-routing between the live app and the Story shell
 ;; ---------------------------------------------------------------------------
 
@@ -91,6 +120,10 @@
   (causa-config/configure! {:launch/auto-open? false})
   (rf/init! reagent-adapter/adapter)
   (story/install-canonical-vocabulary!)
+  ;; rf2-r1uod — `:project-root` plumbed through Story; the
+  ;; `causa-preset` bridge propagates it into Causa's slot so the
+  ;; Causa-as-RHS open-in-editor chips resolve absolute on-disk paths.
+  (story/configure! {:project-root (resolve-project-root)})
   ;; The live page wires `:rf.http/managed` to a demo override so
   ;; submit / retry have something to do. Story variants don't see
   ;; this — they allocate their own frames and the `force-fx-stub`


### PR DESCRIPTION
## Why

Symmetric to shop's #1493 (rf2-6jyf6): Story testbeds with Causa as RHS need `:project-root` on the Causa side too, so the open-in-editor chip works. Currently Story testbeds only configure Story.

Mike's live testbed observation (post-rf2-sgdd3 Causa-as-RHS landing): clicking 'open' on a Handler / Dispatch / Interceptors / Trace-row / Issues chip in the embedded Causa shell on any Story testbed (counter_with_stories, causa_rhs_smoke, login_form) silently no-op'd because the URI shipped a classpath-relative path (`vscode://file/counter_with_stories/core.cljs:42`) and VSCode's filesystem resolver rejected it.

The Causa-side machinery for prepending a configured project-root already exists end-to-end (rf2-5m5n2 wired `:project-root` through `causa-config/configure!` -> `set-project-root!` -> `resolve-uri` -> `editor-uri/editor-uri` 3-arg form -> `compose-path`; PR #1493 wired the shop testbed's call). The gap was that no Story testbed called `causa-config/configure!` with a root — and asking each testbed to call BOTH `story/configure!` AND `causa-config/configure!` would have been explicit-but-not-DRY.

## What

Option (2)+(A) per rf2-r1uod operator decision (recorded in bead notes):

### Propagator (single source of truth in Story)

`re-frame.story.causa-preset` (rf2-q9kv5) gains a one-way bridge `propagate-project-root!` that reads Story's `:project-root` slot and feeds it into Causa's `causa-config/configure!` surface. Fires from two seams:

1. `story/configure!` after `set-project-root!` lands (the common path).
2. `causa-preset/ensure-causa-mounted!` (defense-in-depth for lazy-load / hot-reload edge).

Feature-detect-safe (`causa-config-available?` via `find-ns-obj`), idempotent on identical roots, one-way Story -> Causa.

### Testbeds (4 entries seeded with `:project-root`)

- `counter_with_stories/core.cljs` -- extended existing `configure!` call with `:project-root`; added `?project-root=...` query-string override matching shop's #1493 pattern.
- `counter_with_stories/story_static.cljs` -- static-export entry; mirrored configure! shape for parity.
- `causa_rhs_smoke/core.cljs` -- added `:project-root` to existing `configure!` call; added `?project-root` override.
- `login_form/core.cljs` -- added a new `story/configure!` call (the only one of the four that didn't have one); added `?project-root` override.

Each defaults to `C:/Users/miket/code/re-frame2/tools/story/testbeds` (the mayor-checkout-relative on-disk root for the shadow-cljs `../tools/story/testbeds` source-path).

### Docs

- `tools/story/spec/005-SOTA-Features.md` §Project-root prefix gains a sub-section on the rf2-r1uod bridge contract.
- `tools/story/spec/API.md` `configure!` row updated with the full opts surface and a rf2-r1uod cross-reference.

### Vestige check

Grep confirms no Story testbed still calls `causa-config/configure! :project-root` directly. Remaining `causa-config/configure!` calls in the testbeds only set `:launch/auto-open? false` (a Causa-side knob unrelated to the project root).

## Test plan

- [x] `cd implementation && npm run test:cljs` -> 2883 tests, 8229 assertions, 0 failures / 0 errors (+2 propagator unit tests).
- [x] `cd tools/story && clojure -M:test` -> 750 tests, 2221 assertions, 0 failures / 0 errors.
- [x] Vestige grep: no Story testbed calls `causa-config/configure! :project-root` -- the bridge is the single source.
- [x] `mkdocs --strict` not run -- the two edited spec docs (`tools/story/spec/005-SOTA-Features.md`, `tools/story/spec/API.md`) are NOT in the root `mkdocs.yml` (only the root `spec/` tree is published).
- [ ] **Mike's live-testbed verification**: from any Story-with-Causa testbed (`#/stories` in counter_with_stories / login_form, or the causa_rhs_smoke entry), click 'open' on a Causa Event lens Handler / Dispatch / Interceptor chip, file opens in VS Code at the right line.

## Notes

The preset namespace turned out to be exactly the right place for the bridge -- it was already Story's Causa-adapter, already feature-detected Causa via `find-ns-obj`, and already had a `safe-call!` shim for "throw doesn't take down the variant render". The propagator slotted in alongside `apply-open!` / `apply-tab!` / `apply-filters!` / `apply-focus!` with the same lifecycle discipline.

The `ensure-causa-mounted!` defense-in-depth hook turned out to matter less than I'd expected -- in practice Causa's preload runs before the testbed `run` fn so `story/configure!` is always called AFTER Causa's config ns is loaded. But the second seam is essentially free (the propagator is no-op-fast when there's nothing to do) and guards against future host wiring orders.

Closes rf2-r1uod.