### PR TITLE
fix(causa): Story-RHS embed contract — keybinding toggle + tab-bar ARIA (rf2-q7who A+B)

### DIFF
--- a/tools/causa/spec/008-Embedding-Contract.md
+++ b/tools/causa/spec/008-Embedding-Contract.md
@@ -48,6 +48,29 @@ When embedded (`:compact? true`), the panel:
 
 The panel **knows it's embedded** via the `:compact?` flag.
 
+### Full-shell embed contract (Causa-as-Story-RHS)
+
+When a host mounts the **full Causa shell** (not a single panel) as
+its right-hand-side observability surface — Story does this per
+[`tools/story/spec/Tool-Pair.md`](../../story/spec/Tool-Pair.md) §RHS —
+the host MUST surrender Causa's global keybinding capture so its own
+shortcuts (typically `Cmd/Ctrl+K` for the host's command palette) are
+not swallowed by Causa's capture-phase listener:
+
+```clojure
+(causa-config/configure! {:launch.keybinding/enabled? false})
+```
+
+The slot is documented in [`015-Configuration.md`](./015-Configuration.md)
+§`:launch.keybinding/enabled?`. Per rf2-4eyik (rf2-q7who Thread A —
+embed-contract gap discovered via rf2-drprn). With the slot at `false`
+Causa's `keybinding/attach!` short-circuits and no global listener
+lands on `js/document`; the host's own bindings reach their handlers
+unimpeded. Causa's other surfaces — the in-shell ribbon buttons,
+explicit `(mount/open!)` / `(mount/toggle!)` calls, the `:rf.causa/*`
+event surface — remain fully usable; only the window-level keystroke
+capture is suppressed.
+
 ## Scoping
 
 The `:scope` prop narrows the observation window:

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -27,11 +27,12 @@ distinct from the persisted Settings shape per [`API.md`](./API.md)
 (require '[day8.re-frame2-causa.config :as causa-config])
 
 (causa-config/configure!
-  {:editor                :cursor
-   :project-root          "C:/Users/me/code/my-app"
-   :layout/host-selector  "[data-rf-causa-host]"
-   :launch/auto-open?     true
-   :trace/show-sensitive? false})
+  {:editor                       :cursor
+   :project-root                 "C:/Users/me/code/my-app"
+   :layout/host-selector         "[data-rf-causa-host]"
+   :launch/auto-open?            true
+   :launch.keybinding/enabled?   true
+   :trace/show-sensitive?        false})
 ```
 
 `configure!` MUST accept a map and MUST return `nil`. Keys not listed
@@ -172,6 +173,41 @@ Hosts that set this to `false` SHOULD do so before `rf/init!`, so the
 preload's adapter-ready probe sees the final launch posture before it
 would otherwise diagnose a missing host. The missing-host diagnostic is
 unchanged for the default path and for explicit opens.
+
+### `:launch.keybinding/enabled?`
+
+(The dot in the namespace portion nests the slot under the `:launch`
+family; Clojure keywords accept only one `/`, so nested namespaces
+spell as `launch.keybinding`. Read as `launch ▸ keybinding ▸
+enabled?`.)
+
+Controls whether `keybinding/attach!` installs Causa's global,
+capture-phase `keydown` listener. The listener handles Causa's
+spec-published shortcuts: `Ctrl+Shift+C` (shell toggle), `Cmd/Ctrl+K`
+(command palette), and the unmodified spine bindings
+(`Space` / `L` / `j` / `k` / `G` / `c` / `Esc`). It calls
+`stopPropagation()` for the keys it consumes so host bindings further
+down the propagation path don't double-fire.
+
+| Value | Meaning |
+|---|---|
+| `true` | Default. `keybinding/attach!` installs the listener; the standalone Causa shell behaves exactly as it did pre-rf2-4eyik. |
+| `false` | Suppress installation entirely. `keybinding/attach!` short-circuits to a no-op; the sentinel does not flip; no listener lands on `js/document`. |
+| `nil` | Reset to default (`true`). |
+
+Hosts MUST set this BEFORE the Causa preload runs (the preload calls
+`keybinding/attach!` at adapter-ready time). Setting it afterwards is
+a no-op on the already-attached listener unless the host explicitly
+calls `keybinding/detach!`.
+
+The slot exists for embed hosts (per
+[`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — Story
+mounts Causa as its right-hand-side panel) whose own global
+keybindings collide with Causa's. Story's command-palette
+(`Cmd/Ctrl+K`) is the canonical collision: without the toggle, Causa's
+capture-phase listener consumes the keypress before Story's handler
+fires. Per rf2-4eyik (rf2-q7who Thread A) — the embed-contract gap
+discovered via rf2-drprn.
 
 ### `:settings`
 
@@ -318,9 +354,10 @@ Theme tab or `(configure! {:settings {:theme :light}})`.
 
 ## Vision — full configure! key inventory (30+ keys)
 
-v1 ships ~5 host-supplied keys (`:editor` / `:project-root` /
-`:layout/host-selector` / `:launch/auto-open?` / `:trace/show-sensitive?`)
-plus the `:filters` seed slot. The full destination per
+v1 ships ~6 host-supplied keys (`:editor` / `:project-root` /
+`:layout/host-selector` / `:launch/auto-open?` /
+`:launch.keybinding/enabled?` / `:trace/show-sensitive?`) plus the
+`:filters` seed slot. The full destination per
 [`ai/findings/2026-05-17-10x-config-options-for-causa.md`](#findings)
 absorbs every re-frame-10x configuration option that translates plus
 several Causa-native additions. The full list, grouped by phase

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -319,6 +319,23 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 
 Single-row at all widths. Below 800px labels truncate to 3 chars (`Eve App Vie Tra Mac Rou Iss`); counts always full. Below 560px the strip scrolls horizontally.
 
+### Tab strip ARIA
+
+The L3 tab strip uses the proper ARIA tab pattern (per rf2-lvf8t —
+rf2-q7who Thread B):
+
+- The wrapping element is a generic container (`<div>`) with
+  `role='tablist'` and a descriptive `aria-label`. It MUST NOT be a
+  `<nav>` element: tabs are not site navigation, and a `<nav>`
+  landmark collides with host-app `<nav>` landmarks under role-based
+  queries (`getByRole('navigation')` becomes ambiguous when Causa is
+  embedded — e.g. as Story's right-hand-side panel).
+- Each tab button carries `role='tab'` and `aria-selected="true"` /
+  `"false"` reflecting the active tab.
+
+The `data-testid="rf-causa-tab-bar"` selector remains the canonical
+test addressing surface; ARIA is the user-facing assistive contract.
+
 ### Detail panel layout
 
 L4 fills the remaining canvas (60% default; resizable via L2/L3 drag handle). All value displays in the detail panel use the cljs-devtools-shaped renderer (`theme/data_inspector.cljc`):

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -224,6 +224,63 @@
   []
   @auto-open?)
 
+;; ---- *keybinding-enabled?* (rf2-4eyik — embed-host opt-out for the
+;; global keydown listener) ------------------------------------------------
+;;
+;; Causa attaches a window-level capture-phase `keydown` listener
+;; (`keybinding/attach!`) that handles `Ctrl+Shift+C` (shell toggle),
+;; `Cmd/Ctrl+K` (command palette), and the unmodified spine bindings
+;; (`Space` / `L` / `j` / `k` / `G` / `c` / `Esc`). The handler calls
+;; `stopPropagation()` for keys it consumes so host bindings further down
+;; the event path don't double-fire.
+;;
+;; Embed hosts (Story mounts Causa as its right-hand-side panel)
+;; routinely register their own `Cmd/Ctrl+K` palette + their own
+;; bindings. With Causa's listener attached at the capture phase the
+;; host's own bindings never fire — the embed silently swallows
+;; keystrokes that belong to the host (rf2-q7who Thread A, observed
+;; via rf2-drprn).
+;;
+;; The flag is the host's surrender switch: set it to `false` BEFORE
+;; the Causa preload runs (typically inside the host's boot sequence
+;; via `(causa-config/configure! {:launch.keybinding/enabled? false})`)
+;; and `keybinding/attach!` short-circuits to a no-op. The shell is
+;; still mountable / dispatchable / inspectable via Causa's other
+;; surfaces (the host owns its own open-Causa affordance); only the
+;; global listener is suppressed.
+;;
+;; Standalone Causa (the default) keeps the listener attached — the
+;; default is `true` so existing hosts that never set the flag observe
+;; no behaviour change.
+
+(defonce
+  ^{:doc "Atom controlling whether `keybinding/attach!` installs the
+         global window-level keydown listener. Default `true` (the
+         standalone Causa shell needs its Ctrl+Shift+C / Cmd-K / spine
+         bindings). Set to `false` by embed hosts (Story RHS, third-
+         party tool surfaces) whose own keybindings collide with
+         Causa's — `attach!` short-circuits to a no-op. Per rf2-4eyik
+         (rf2-q7who Thread A)."}
+  keybinding-enabled?
+  (atom true))
+
+(defn set-keybinding-enabled!
+  "Replace the `:launch.keybinding/enabled?` flag. `nil` resets to the
+  default (`true`). Hosts MUST set this BEFORE the Causa preload runs
+  (the preload calls `keybinding/attach!` at adapter-ready time);
+  setting it afterwards is a no-op on the already-attached listener
+  unless the host explicitly calls `keybinding/detach!`."
+  [v]
+  (reset! keybinding-enabled? (if (nil? v) true (boolean v)))
+  nil)
+
+(defn keybinding-attach-enabled?
+  "Return true when `keybinding/attach!` should install the global
+  keydown listener. Read by `keybinding/attach!` at attach time. Per
+  rf2-4eyik (rf2-q7who Thread A)."
+  []
+  @keybinding-enabled?)
+
 (defonce
   ^{:doc "Atom holding Causa's 'Open in editor' preference. Default
          `:vscode`. Accepts the keywords `:vscode` / `:cursor` /
@@ -895,6 +952,15 @@
        `true`. Story/tool pages that deliberately run without an app
        layout host may set this to `false` before `rf/init!`; explicit
        open!/toggle! still diagnose a missing host.
+    `{:launch.keybinding/enabled? <bool>}` — whether `keybinding/attach!`
+       installs Causa's global window-level keydown listener
+       (Ctrl+Shift+C / Cmd/Ctrl+K / spine bindings). Defaults to
+       `true` — standalone Causa needs the listener. Embed hosts
+       (Story mounts Causa as RHS) set `false` so their own global
+       keybindings — typically `Cmd/Ctrl+K` for the host's command
+       palette — are not swallowed by Causa's capture-phase listener.
+       Per rf2-4eyik (rf2-q7who Thread A). MUST be set BEFORE the
+       Causa preload runs.
     `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
        true` trace events per Spec 009 §Privacy (rf2-azls9). Defaults
        to `false` — Causa's trace collector drops sensitive events
@@ -932,6 +998,7 @@
   [{:keys [editor project-root settings]
     host-selector-opt :layout/host-selector
     auto-open-opt :launch/auto-open?
+    keybinding-opt :launch.keybinding/enabled?
     show-sensitive-opt :trace/show-sensitive?
     filters-opt :filters
     filters-key-opt :filters/storage-key
@@ -944,6 +1011,8 @@
     (set-layout-host-selector! host-selector-opt))
   (when (contains? opts :launch/auto-open?)
     (set-auto-open! auto-open-opt))
+  (when (contains? opts :launch.keybinding/enabled?)
+    (set-keybinding-enabled! keybinding-opt))
   (when (contains? opts :trace/show-sensitive?)
     (set-show-sensitive! show-sensitive-opt))
   ;; NB: `settings` here is the destructured bulk-config map; the

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -55,6 +55,7 @@
   editable-element guard means even a future Causa-side input field
   (e.g. the filter-pill edit popup) doesn't fight the user typing."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.mount :as mount]))
 
 (defonce ^:private attached-state
@@ -228,9 +229,18 @@
 
 (defn attach!
   "Install the global Ctrl+Shift+C listener once. No-op on second +
-  subsequent calls (the `attached-state` sentinel survives reloads)."
+  subsequent calls (the `attached-state` sentinel survives reloads).
+
+  Honours the `:launch.keybinding/enabled?` config slot (rf2-4eyik —
+  rf2-q7who Thread A). When the slot is `false` the listener is NOT
+  installed: embed hosts (Story RHS, third-party tool surfaces) flip
+  the slot before the preload runs so their own global keybindings
+  (typically `Cmd/Ctrl+K` for the host's command palette) are not
+  swallowed by Causa's capture-phase listener. Standalone Causa
+  (default, slot = `true`) attaches as before."
   []
   (when (and (exists? js/document)
+             (config/keybinding-attach-enabled?)
              (compare-and-set! attached-state false true))
     (.addEventListener js/document "keydown" handle-keydown true))
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -1029,14 +1029,22 @@
   `aria-label` doubles the visible label as `<tab-label> tab` so the
   button's accessible name never collides with host-app role queries
   (Playwright's `getByRole('button', {name: '-'})` matched our
-  `App-db` tab when only `title` was set)."
+  `App-db` tab when only `title` was set).
+
+  Per rf2-lvf8t (rf2-q7who Thread B) each button carries `role='tab'`
+  and `aria-selected={active?}` so the tab strip exposes the proper
+  ARIA tab pattern. Assistive tech announces the buttons as tabs
+  rather than generic buttons and reads the selected state correctly;
+  `getByRole('tab')` lookups in host integration tests resolve here."
   [{:keys [id label mnem active?]}]
   (let [glyph (if active? "◉" "○")
         color (if active? (:text-primary tokens) (:text-secondary tokens))]
-    [:button {:data-testid (str "rf-causa-tab-" (name id))
-              :on-click    #(rf/dispatch [:rf.causa/select-tab id] {:frame :rf/causa})
-              :title       (str label " (" mnem ")")
-              :aria-label  (str "Causa " label " tab")
+    [:button {:data-testid   (str "rf-causa-tab-" (name id))
+              :role          "tab"
+              :aria-selected (if active? "true" "false")
+              :on-click      #(rf/dispatch [:rf.causa/select-tab id] {:frame :rf/causa})
+              :title         (str label " (" mnem ")")
+              :aria-label    (str "Causa " label " tab")
               :style {:background    "transparent"
                       :border        "none"
                       :border-bottom (if active?
@@ -1062,10 +1070,23 @@
   App-db).
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
-  `:rf/causa`."
+  `:rf/causa`.
+
+  Per rf2-lvf8t (rf2-q7who Thread B) the wrapping element is a
+  generic `<div>` carrying `role='tablist'` — the proper ARIA pattern
+  for a tab strip. The earlier `<nav>` was both semantically wrong
+  (tabs aren't site navigation) and a strict-mode hazard for host
+  apps that also expose a `<nav>` landmark: Playwright's
+  `getByRole('navigation')` lookup became ambiguous when Causa was
+  mounted alongside a host nav, every Story integration test using
+  the role failed (rf2-q7who Thread B — discovered via rf2-drprn).
+  Per-tab buttons carry `role='tab'` + `aria-selected` (see
+  `tab-button`). `data-testid='rf-causa-tab-bar'` is unchanged."
   []
   (let [selected @(rf/subscribe [:rf.causa/selected-tab])]
-    [:nav {:data-testid "rf-causa-tab-bar"
+    [:div {:data-testid "rf-causa-tab-bar"
+           :role        "tablist"
+           :aria-label  "Causa panel tabs"
            :style {:display       "flex"
                    :align-items   "center"
                    :gap           "4px"

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -32,6 +32,7 @@
   level keydown-dispatch story lives in the Playwright lane (rf2-s2bhn)
   on a real document."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.keybinding :as keybinding]))
 
 ;; ---- helpers -------------------------------------------------------------
@@ -443,3 +444,65 @@
     (is (nil? (spine-key-id (mk-event {:key "Enter"}))))
     (is (nil? (spine-key-id (mk-event {})))
         "empty event → nil")))
+
+;; ---- (6) :launch.keybinding/enabled? toggle (rf2-4eyik — rf2-q7who.A) ----
+;;
+;; Per Spec 015-Configuration §`:launch.keybinding/enabled?` the slot
+;; controls whether `attach!` installs the window-level capture-phase
+;; listener. Default `true` (existing hosts unaffected); embed hosts —
+;; Story mounts Causa as its RHS panel — flip it to `false` so their own
+;; global keybindings (typically `Cmd/Ctrl+K`) aren't swallowed by the
+;; capture-phase `stopPropagation()`.
+;;
+;; Each test sets the slot, exercises attach!, and ALWAYS resets it in
+;; a `finally` so the default (`true`) survives into neighbouring
+;; tests in the same suite run.
+
+(deftest attach-disabled-by-config-is-noop
+  (testing "rf2-4eyik (rf2-q7who.A) — with :launch.keybinding/enabled?
+            false, attach! does NOT register the global listener and
+            does NOT flip the sentinel; the embed-host contract"
+    (with-stub-document
+      (fn [{:keys [listeners]}]
+        (try
+          (config/set-keybinding-enabled! false)
+          (is (false? (config/keybinding-attach-enabled?))
+              "config flag flipped false")
+          (is (false? (keybinding/attached?))
+              "baseline — sentinel starts at false")
+          (keybinding/attach!)
+          (is (false? (keybinding/attached?))
+              "attach! short-circuited; sentinel stayed false")
+          (is (zero? (count @listeners))
+              "no listener registered on the stub document")
+          (finally
+            ;; Restore the default so neighbouring tests
+            ;; (attach-is-idempotent, detach-round-trips) see the
+            ;; baseline they were written against.
+            (config/set-keybinding-enabled! true)))))))
+
+(deftest attach-default-is-enabled
+  (testing "rf2-4eyik (rf2-q7who.A) — default config is true; attach!
+            registers as it did pre-rf2-4eyik. Defends against an
+            accidental flip of the default."
+    (with-stub-document
+      (fn [{:keys [listeners]}]
+        (is (true? (config/keybinding-attach-enabled?))
+            "default state — slot is true")
+        (keybinding/attach!)
+        (is (true? (keybinding/attached?))
+            "sentinel flipped true under default config")
+        (is (= 1 (count @listeners))
+            "one keydown listener registered as before")))))
+
+(deftest config-set-keybinding-enabled-nil-resets-to-true
+  (testing "rf2-4eyik — `nil` arg restores the default `true` per the
+            convention shared with set-auto-open! / set-editor!"
+    (try
+      (config/set-keybinding-enabled! false)
+      (is (false? (config/keybinding-attach-enabled?)))
+      (config/set-keybinding-enabled! nil)
+      (is (true? (config/keybinding-attach-enabled?))
+          "nil restores the default")
+      (finally
+        (config/set-keybinding-enabled! true)))))

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -269,6 +269,54 @@
           (is (some? (find-by-testid tree (str "rf-causa-tab-" (name tab-id))))
               (str "tab button for " tab-id)))))))
 
+(deftest tab-bar-uses-tablist-aria-pattern
+  (testing "rf2-lvf8t (rf2-q7who Thread B) — the L3 tab strip uses the
+            proper ARIA tab pattern: a generic container with
+            role='tablist', per-tab buttons with role='tab' and
+            aria-selected matching the active tab. The previous
+            wrapping <nav> element was wrong (tabs aren't site
+            navigation) AND collided with host-app `<nav>` landmarks
+            under Playwright's `getByRole('navigation')` strict-mode
+            lookups when Causa was embedded in Story."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            tab-bar (find-by-testid tree "rf-causa-tab-bar")
+            head    (first tab-bar)
+            attrs   (second tab-bar)]
+        (is (some? tab-bar) "tab-bar still found by data-testid")
+        (is (= :div head)
+            "wrapping element is a generic <div>, NOT <nav>")
+        (is (= "tablist" (:role attrs))
+            "role='tablist' set on the wrapping element")
+        (is (string? (:aria-label attrs))
+            "aria-label present so the tablist has an accessible name"))
+      ;; Per-tab ARIA: role='tab' on every button, aria-selected matching
+      ;; the active state. The active tab is the default :event.
+      (let [tree (shell/shell-view)]
+        (doseq [tab-id expected-tab-ids]
+          (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
+                attrs (second btn)]
+            (is (some? btn) (str "tab button for " tab-id " present"))
+            (is (= "tab" (:role attrs))
+                (str "tab " tab-id " carries role='tab'"))
+            (is (contains? attrs :aria-selected)
+                (str "tab " tab-id " carries aria-selected"))
+            (is (= (if (= tab-id :event) "true" "false")
+                   (:aria-selected attrs))
+                (str "tab " tab-id " aria-selected matches the active tab"))))))
+    ;; After switching tabs the aria-selected flips with the active tab.
+    (select-tab! :machines)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)]
+        (doseq [tab-id expected-tab-ids]
+          (let [btn   (find-by-testid tree (str "rf-causa-tab-" (name tab-id)))
+                attrs (second btn)]
+            (is (= (if (= tab-id :machines) "true" "false")
+                   (:aria-selected attrs))
+                (str "after select-tab :machines, tab " tab-id
+                     " aria-selected reflects the new active tab"))))))))
+
 (deftest tab-click-dispatches-select-tab
   (testing "spec/018 §5 — clicking a tab fires :rf.causa/select-tab"
     (causa-setup!)


### PR DESCRIPTION
## Why

`rf2-q7who` identified three embedding-contract gaps surfaced when Causa is
mounted as Story's right-hand-side observability panel (discovered via
rf2-drprn). This PR ships threads **A** + **B**; thread C (rf2-7cqak) is
deferred per the parent bead body — C is "purely a Story-side test-quality
issue if A + B are fixed" and auto-resolves once A+B fix the structural
causes.

## What

### Commit 1 — rf2-4eyik (Thread A): `:launch.keybinding/enabled?` toggle

- Adds `:launch.keybinding/enabled?` slot to `day8.re-frame2-causa.config`.
  Default `true` (standalone Causa unaffected).
- `keybinding/attach!` reads the slot at attach time and short-circuits to
  a no-op when `false` — no listener lands on `js/document`, sentinel does
  not flip.
- Embed hosts (Story RHS) flip the slot via
  `(causa-config/configure! {:launch.keybinding/enabled? false})` BEFORE
  the Causa preload runs so their global `Cmd/Ctrl+K` and other bindings
  reach their handlers instead of being swallowed by Causa's capture-phase
  `stopPropagation()`.
- Causa's other surfaces (in-shell ribbon, explicit `mount/open!` /
  `mount/toggle!`, the `:rf.causa/*` event surface) remain fully usable
  when the slot is `false`; only the window-level keystroke capture is
  suppressed.

The slot uses dot-separation (`launch.keybinding/enabled?`) because Clojure
keywords accept only one `/`; reads as `launch ▸ keybinding ▸ enabled?`.

Spec: `015-Configuration.md` documents the slot alongside
`:launch/auto-open?`. `008-Embedding-Contract.md` gains a "Full-shell embed
contract" section pointing the host at the surrender switch.

### Commit 2 — rf2-lvf8t (Thread B): tab-bar `<nav>` → `role='tablist'`

- Wrapping element flips from `<:nav>` to `<:div>` with `role='tablist'`
  and `aria-label="Causa panel tabs"`.
- Per-tab buttons gain `role='tab'` + `aria-selected="true"`/`"false"`
  matching the active tab.
- Spec: `018-Event-Spine.md` §5 ("Tab strip ARIA") documents the new
  contract and calls out the embed-host hazard the old `<nav>` created.

The `data-testid="rf-causa-tab-bar"` selector is unchanged — every
existing testid-addressed test continues to pass.

## Verification

- `npm run test:cljs` (from `implementation/`): **2887 tests / 8277
  assertions / 0 failures / 0 errors** (+1 deftest over baseline:
  `tab-bar-uses-tablist-aria-pattern`; +3 deftests from the keybinding
  test file: `attach-disabled-by-config-is-noop`,
  `attach-default-is-enabled`, `config-set-keybinding-enabled-nil-resets-to-true`).
- `clojure -M:test` (from `tools/causa/`): **739 tests / 2179 assertions /
  0 failures / 0 errors**.
- `mkdocs build --strict`: 72 pre-existing warnings (unrelated — all
  `guide/` and `skills/` paths that link to `spec/` paths missing from
  the mkdocs nav; verified identical warning count without my spec
  edits stashed). None of my doc changes introduce new warnings.

## Follow-on: Story preset wire-up

Story's Causa preset lives at `tools/story/src/re_frame/story/causa_preset.cljc`
(NOT `preset/causa.cljs` as the parent task spec suggested). Concurrent
agent rf2-r1uod is in flight on that surface, so this PR deliberately
**does NOT** touch the preset. Once this PR merges, a follow-on bead
should add `(causa-config/configure! {:launch.keybinding/enabled? false})`
into Story's full-shell Causa mount path so Story's command palette
becomes the canonical owner of `Cmd/Ctrl+K` when Causa is embedded.
Filing as a separate bead under rf2-q7who keeps the surfaces independent
and avoids preset/causa.cljs contention.

Closes rf2-4eyik, rf2-lvf8t.

Parent rf2-q7who → mayor closes as decision-resolved with cross-refs.