### PR TITLE
feat(causa): surface :ungrouped issues in Issues feed (rf2-2f40y)

### DIFF
--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -304,6 +304,7 @@ axis independent; empty / `nil` disables the axis.
 |---|---|
 | `:rf.causa/issues-filters` | `{:severities :prefixes :since-ms}` — single read for atomic re-render. |
 | `:rf.causa/issues-ribbon` | Composite — `{:issues :total :rendered :severity-counts :distinct-prefixes :filters :empty-kind}`. |
+| `:rf.causa.issues/ungrouped` | `{:issues [<row> ...] :total <int>}` — escape-hatch lane (rf2-2f40y) for issues whose `:dispatch-id` is the `:ungrouped` sentinel. The main feed is cascade-scoped (rf2-u6dhp) and `:ungrouped` cascades are structurally unfocusable (rf2-fzbrw); this sub feeds the dedicated lane the panel renders when current focus has no issues but `:ungrouped` does. Newest first. |
 
 ### Events
 

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -214,6 +214,44 @@ Two distinguished states:
 - **`:no-matches`** — issues exist but the active filters hide them
   all. Carries a `Clear filters` affordance.
 
+### `:ungrouped` escape-hatch lane (rf2-2f40y)
+
+The main feed is cascade-scoped (rf2-u6dhp) and `:ungrouped` cascades
+are structurally unfocusable (rf2-fzbrw — `compose-focus` snaps to the
+head of a real cascade). Together, the two invariants leave issues
+with `:dispatch-id :ungrouped` — issues emitted outside any dispatch
+context, e.g. `verify-hydration!` firing `:rf.ssr/hydration-mismatch`
+during SSR — un-navigable via L2/focus. Both invariants are
+individually correct; the gap was the missing surface.
+
+The Issues panel renders a dedicated **`:ungrouped` lane** below the
+cascade-scoped feed as the deliberate escape hatch. Per the rf2-2f40y
+operator decision (option (a), recorded in the bead notes) the lane
+preserves both invariants without relaxing `compose-focus` semantics.
+
+**Inputs:** `:rf.causa.issues/ungrouped` — a thin derivation off
+`:rf.causa/trace-buffer` returning `{:issues [<row> ...] :total <int>}`
+(newest first). No chip-filter histograms; the lane is a compact
+escape hatch, not a second filterable feed.
+
+**Visibility contract:** the lane is rendered iff
+- the cascade-scoped feed has no issues to surface (the panel's
+  `:empty-kind` is one of `:no-issues`, `:no-issues-for-event`, or
+  `:no-matches`), AND
+- at least one `:ungrouped` issue exists.
+
+While the focused cascade has its own issues the lane stays hidden
+so it doesn't compete with the user's current lens.
+
+**Visual treatment:** muted uppercase header `Issues outside any
+cascade` + a one-line clarifier (`Emitted outside any dispatch — no
+cascade to focus.`) above the per-issue rows. The rows reuse the same
+chrome as the cascade-scoped feed (`issue-row`); per-row click pivots
+are intentionally inert for `:ungrouped` (the existing `pivotable?`
+guard in `issue-row` checks `(not= :ungrouped dispatch-id)`), so the
+lane is a read-only surface — open-in-editor on the source-coord chip
+is the only outgoing affordance.
+
 ## Performance — dropped (see §Performance cross-link at top of file)
 
 The Performance panel is dropped from Causa. Use Chrome DevTools'

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon.cljs
@@ -324,6 +324,50 @@
                        :color       (:text-tertiary tokens)}}
    "No issues for this event."])
 
+;; ---- :ungrouped lane (rf2-2f40y) ---------------------------------------
+
+(defn- ungrouped-lane
+  "Dedicated surface for issues with `:dispatch-id :ungrouped` — issues
+  emitted outside any dispatch context (e.g. `verify-hydration!` firing
+  `:rf.ssr/hydration-mismatch`).
+
+  Per the rf2-2f40y operator decision (option (a)) this lane is the
+  escape hatch for the navigation hole that rf2-u6dhp (cascade-scoped
+  Issues feed) + rf2-fzbrw (`:ungrouped` cascades structurally
+  unfocusable) jointly opened. Both invariants are preserved; the lane
+  is a deliberate, scoped UI affordance for an explicit, scoped runtime
+  state.
+
+  Visibility contract (read by the public `Panel` view): rendered when
+  the focused cascade carries no issues AND `:ungrouped` issues exist.
+  When the focused cascade has its own issues the lane stays hidden so
+  it doesn't compete for attention with the user's current lens."
+  [ungrouped-issues]
+  [:section {:data-testid "rf-causa-issues-ungrouped-lane"
+             :style       {:border-top (str "1px solid " (:border-subtle tokens))
+                           :background (:bg-3 tokens)}}
+   [:header {:data-testid "rf-causa-issues-ungrouped-lane-header"
+             :style       {:padding     "8px 16px 4px 16px"
+                           :font-family sans-stack
+                           :font-size   "11px"
+                           :font-weight 600
+                           :letter-spacing "0.4px"
+                           :text-transform "uppercase"
+                           :color       (:text-tertiary tokens)}}
+    "Issues outside any cascade"]
+   [:p {:data-testid "rf-causa-issues-ungrouped-lane-help"
+        :style       {:margin      "0 16px 6px 16px"
+                      :font-family sans-stack
+                      :font-size   "11px"
+                      :color       (:text-tertiary tokens)
+                      :line-height 1.4}}
+    "Emitted outside any dispatch — no cascade to focus."]
+   (into [:ul {:data-testid "rf-causa-issues-ungrouped-lane-feed"
+               :style       {:list-style "none"
+                             :margin     0
+                             :padding    0}}]
+         (mapv issue-row ungrouped-issues))])
+
 (defn- empty-state-no-matches
   "Issues exist but the active filters hide them all. Carries a
   Clear filters affordance."
@@ -357,16 +401,33 @@
 
 (rf/reg-view Panel
   "The Issues ribbon panel's root view. Subscribes to
-  `:rf.causa/issues-ribbon` and renders the empty-state or the feed."
+  `:rf.causa/issues-ribbon` and renders the empty-state or the feed.
+
+  Per rf2-2f40y also subscribes to `:rf.causa.issues/ungrouped` and
+  renders the `:ungrouped` lane below the empty-state when the focused
+  cascade carries no issues but `:ungrouped` issues exist — the
+  navigation escape hatch for issues emitted outside any dispatch
+  context."
   []
   (let [{:keys [issues total rendered severity-counts distinct-prefixes
                 filters empty-kind]
          :as _data}
         @(rf/subscribe [:rf.causa/issues-ribbon])
+        {ungrouped-issues :issues
+         ungrouped-total  :total}
+        @(rf/subscribe [:rf.causa.issues/ungrouped])
         {:keys [severities prefixes since-ms]} filters
         any-filter? (boolean (or (seq severities)
                                  (seq prefixes)
-                                 (some? since-ms)))]
+                                 (some? since-ms)))
+        ;; The lane renders only when the focused cascade has no
+        ;; issues to show AND ungrouped issues exist — so it doesn't
+        ;; compete for attention with the user's current lens.
+        ;; `:empty-kind` discriminates the three "main feed is empty"
+        ;; branches; any of them qualifies as "focus has nothing to
+        ;; surface".
+        show-ungrouped-lane? (and (some? empty-kind)
+                                  (pos? ungrouped-total))]
     [:section {:data-testid "rf-causa-issues-ribbon"
                :style       {:height         "100%"
                              :display        "flex"
@@ -395,7 +456,9 @@
                                   :style       {:list-style "none"
                                                 :margin     0
                                                 :padding    0}}
-                       :row-fn   issue-row}))]]))
+                       :row-fn   issue-row}))
+      (when show-ungrouped-lane?
+        (ungrouped-lane ungrouped-issues))]]))
 
 ;; ---- registration entry --------------------------------------------------
 
@@ -461,6 +524,20 @@
       (h/project-feed buffer
                       (assoc filters :focus-dispatch-id (:dispatch-id focus))
                       (h/now-ms))))
+
+  ;; :ungrouped escape-hatch lane (rf2-2f40y). The main feed is
+  ;; cascade-scoped (rf2-u6dhp) and `:ungrouped` cascades are
+  ;; structurally unfocusable (rf2-fzbrw) — together those invariants
+  ;; left issues with `:dispatch-id :ungrouped` (e.g. `verify-hydration!`
+  ;; firing `:rf.ssr/hydration-mismatch`) un-navigable. This sub feeds
+  ;; the dedicated lane the panel renders below the cascade-scoped
+  ;; feed when current focus has no issues but `:ungrouped` does.
+  ;;
+  ;; Shape: `{:issues [<row> ...] :total <int>}`. Newest first.
+  (rf/reg-sub :rf.causa.issues/ungrouped
+    :<- [:rf.causa/trace-buffer]
+    (fn [buffer _query]
+      (h/project-ungrouped-feed buffer)))
 
   ;; ---- Issues ribbon events --------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/issues_ribbon_helpers.cljc
@@ -427,6 +427,37 @@
      :filters           filters
      :empty-kind        empty-kind}))
 
+;; ---- :ungrouped escape-hatch projection (rf2-2f40y) --------------------
+
+(defn project-ungrouped-feed
+  "Top-level projection for the `:ungrouped` lane — issues emitted
+  outside any dispatch context (canonical example: `verify-hydration!`
+  firing `:rf.ssr/hydration-mismatch` with `:dispatch-id :ungrouped`).
+
+  Per rf2-u6dhp the main Issues feed is cascade-scoped, and per
+  rf2-fzbrw `:ungrouped` cascades are structurally unfocusable
+  (`compose-focus` snaps to the head of a real cascade). The two
+  invariants are individually correct but together create a navigation
+  hole: `:ungrouped` issues cannot be reached via L2/focus. This
+  projection is the deliberate surface that closes the gap (per the
+  rf2-2f40y operator decision — option (a), dedicated lane).
+
+  Returns:
+
+      {:issues   [<row> ...]   ;; newest first
+       :total    <int>}        ;; count of :ungrouped issues
+
+  Cascade chip-filter histograms are intentionally omitted — the lane
+  is a compact escape hatch, not a second filterable feed. Pure data →
+  data; JVM-testable."
+  [events]
+  (let [all          (project-issues events)
+        ungrouped    (filterv #(= :ungrouped (:dispatch-id %)) all)
+        ;; Newest first for display parity with the main feed.
+        sorted       (vec (reverse ungrouped))]
+    {:issues sorted
+     :total  (count ungrouped)}))
+
 ;; ---- selection ----------------------------------------------------------
 
 (defn find-issue

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -434,6 +434,52 @@
       (is (= 2 (:total feed)))
       (is (= 2 (:rendered feed))))))
 
+;; ---- :ungrouped escape-hatch lane (rf2-2f40y) ---------------------------
+
+(deftest project-ungrouped-feed-empty-stream
+  (testing "an empty stream produces an empty :ungrouped projection"
+    (let [feed (h/project-ungrouped-feed [])]
+      (is (= [] (:issues feed)))
+      (is (= 0  (:total feed))))))
+
+(deftest project-ungrouped-feed-keeps-only-ungrouped
+  (testing ":ungrouped lane surfaces only issues whose :dispatch-id is
+            the :ungrouped sentinel — issues attached to a real cascade
+            stay in the main cascade-scoped feed"
+    (let [stream [(error-ev   1 :rf.ssr/hydration-mismatch
+                              {:time 100})                 ;; no :dispatch-id → :ungrouped
+                  (error-ev   2 :rf.error/handler-exception
+                              {:time 200 :tags {:dispatch-id 7}})
+                  (warning-ev 3 :rf.warning/missing-doc
+                              {:time 300})]                ;; no :dispatch-id → :ungrouped
+          feed   (h/project-ungrouped-feed stream)]
+      (is (= 2 (:total feed)))
+      (is (= #{1 3} (set (map :id (:issues feed))))))))
+
+(deftest project-ungrouped-feed-newest-first
+  (testing ":ungrouped lane reverses the buffer so the newest-pushed
+            issue lands first — display parity with the main feed,
+            which also surfaces newest first."
+    ;; Stream is chronological (oldest first; mirrors the trace bus's
+    ;; collect order).
+    (let [stream [(error-ev   1 :rf.ssr/hydration-mismatch  {:time 100})
+                  (error-ev   2 :rf.error/handler-exception {:time 200})
+                  (warning-ev 3 :rf.warning/missing-doc     {:time 300})]
+          feed   (h/project-ungrouped-feed stream)]
+      (is (= [3 2 1] (mapv :id (:issues feed)))))))
+
+(deftest project-ungrouped-feed-ignores-success-traces
+  (testing "non-issue trace events never reach the :ungrouped lane —
+            success-path traces have their own panels"
+    (let [stream [{:id 1 :op-type :event :operation :event/dispatched
+                   :time 100 :tags {}}
+                  {:id 2 :op-type :fx :operation :rf.fx/handled
+                   :time 200 :tags {}}
+                  (error-ev 3 :rf.ssr/hydration-mismatch {:time 300})]
+          feed   (h/project-ungrouped-feed stream)]
+      (is (= 1 (:total feed)))
+      (is (= [3] (mapv :id (:issues feed)))))))
+
 ;; ---- (10) source-coord ------------------------------------------------
 
 (deftest source-coord-projection

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -551,6 +551,123 @@
         (is (nil? (find-by-testid tree "rf-causa-issues-feed"))
             "no feed list rendered when the focused cascade has no issues")))))
 
+;; ---- :ungrouped escape-hatch lane (rf2-2f40y) --------------------------
+
+(deftest registry-installs-ungrouped-sub
+  (testing "register-causa-handlers! installs the :ungrouped escape-
+            hatch sub (rf2-2f40y)"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa.issues/ungrouped))
+        ":rf.causa.issues/ungrouped sub registered")))
+
+(deftest ungrouped-sub-filters-to-ungrouped-only
+  (testing ":rf.causa.issues/ungrouped surfaces only issues whose
+            :dispatch-id is the :ungrouped sentinel"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.ssr/hydration-mismatch}))
+      (push-trace! (mk-issue {:id 2 :op-type :error
+                              :operation :rf.error/handler-threw
+                              :dispatch-id 7}))
+      (push-trace! (mk-issue {:id 3 :op-type :warning
+                              :operation :rf.warning/recoverable}))
+      (let [data @(rf/subscribe [:rf.causa.issues/ungrouped])]
+        (is (= 2 (:total data))
+            "two issues lack :dispatch-id → :ungrouped sentinel")
+        (is (= #{1 3} (set (map :id (:issues data))))
+            "cascade-attached issue id 2 stays out of the lane")))))
+
+(deftest ungrouped-lane-renders-when-focus-has-no-issues-but-ungrouped-exists
+  (testing "the :ungrouped lane surfaces when the focused cascade has
+            no issues but :ungrouped issues exist — the navigation
+            escape hatch for issues emitted outside any dispatch.
+
+            Seed a real focusable cascade (so cascade scope engages)
+            with no issues, plus an :ungrouped issue — the production
+            scenario the bead describes (e.g. `verify-hydration!` firing
+            `:rf.ssr/hydration-mismatch` outside any dispatch while the
+            user is focused on a real cascade)."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Real focusable cascade with no issues — so the user lands on
+      ;; the `:no-issues-for-event` branch.
+      (push-trace! {:id 99 :time 1000 :op-type :event
+                    :operation :event/dispatched
+                    :tags {:dispatch-id 99 :event [:noop]}})
+      (rf/dispatch-sync [:rf.causa/focus-cascade 99])
+      ;; :ungrouped issue — the escape-hatch case.
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.ssr/hydration-mismatch}))
+      (let [tree (issues-ribbon/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-issues-ungrouped-lane"))
+            ":ungrouped lane container rendered")
+        (is (some? (find-by-testid tree "rf-causa-issues-ungrouped-lane-header"))
+            ":ungrouped lane header rendered")
+        (is (some? (find-by-testid tree "rf-causa-issues-ungrouped-lane-feed"))
+            ":ungrouped lane feed rendered")
+        ;; The issue row uses the same per-row chrome as the main feed.
+        (is (some? (find-by-testid tree "rf-causa-issues-row-1"))
+            "the :ungrouped issue renders with the shared row chrome")))))
+
+(deftest ungrouped-lane-hidden-when-focused-cascade-has-issues
+  (testing "when the focused cascade carries issues the :ungrouped lane
+            stays hidden — it doesn't compete with the user's current
+            lens. The focused-cascade feed is the user's surface; the
+            lane is only the escape-hatch fallback."
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; One in-cascade issue + one :ungrouped issue.
+      (push-trace! (mk-issue {:id 1 :op-type :error
+                              :operation :rf.error/handler-threw
+                              :dispatch-id 7}))
+      (push-trace! (mk-issue {:id 2 :op-type :error
+                              :operation :rf.ssr/hydration-mismatch}))
+      (rf/dispatch-sync [:rf.causa/focus-cascade 7])
+      (let [tree (issues-ribbon/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-issues-feed"))
+            "the cascade-scoped feed renders with focused-cascade issues")
+        (is (nil? (find-by-testid tree "rf-causa-issues-ungrouped-lane"))
+            ":ungrouped lane hidden while the focused cascade has issues")))))
+
+(deftest ungrouped-lane-hidden-when-no-ungrouped-issues
+  (testing "the :ungrouped lane stays hidden when no :ungrouped issues
+            exist — even when the focused cascade has no issues (the
+            'All clear' / 'No issues for this event' state)"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; No :ungrouped issues; buffer is fully empty → :no-issues.
+      (let [tree (issues-ribbon/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-issues-empty-no-issues"))
+            "All-clear empty state present")
+        (is (nil? (find-by-testid tree "rf-causa-issues-ungrouped-lane"))
+            ":ungrouped lane hidden when no :ungrouped issues exist")))))
+
+(deftest ungrouped-lane-surfaces-on-no-matches-state
+  (testing "the lane also surfaces when chip filters hide every
+            cascade-scoped issue (:no-matches) — :no-matches is one of
+            the 'focus has nothing to show' branches the visibility
+            contract honours, distinct from :no-issues-for-event"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Focused cascade with one warning + an :ungrouped error.
+      (push-trace! (mk-issue {:id 1 :op-type :warning
+                              :operation :rf.warning/recoverable
+                              :dispatch-id 7}))
+      (push-trace! (mk-issue {:id 2 :op-type :error
+                              :operation :rf.ssr/hydration-mismatch}))
+      (rf/dispatch-sync [:rf.causa/focus-cascade 7])
+      ;; Toggle a severity the focused cascade's only issue doesn't carry —
+      ;; the cascade-scoped feed lands on :no-matches.
+      (rf/dispatch-sync [:rf.causa.issues/toggle-severity :advisory])
+      (let [data @(rf/subscribe [:rf.causa/issues-ribbon])
+            tree (issues-ribbon/Panel)]
+        (is (= :no-matches (:empty-kind data)))
+        (is (some? (find-by-testid tree "rf-causa-issues-ungrouped-lane"))
+            ":ungrouped lane surfaces alongside the :no-matches empty
+             state — the user can still navigate to :ungrouped issues
+             while filters hide everything else")))))
+
 ;; ---- (10) frame isolation ----------------------------------------------
 
 (deftest issues-filter-state-does-not-leak-into-default-frame


### PR DESCRIPTION
## Why
rf2-u6dhp + rf2-fzbrw together created a navigation hole: issues with `:dispatch-id :ungrouped` (e.g. `verify-hydration!` firing `:rf.ssr/hydration-mismatch`) couldn't be navigated to because the Issues feed is cascade-scoped and `:ungrouped` cascades are structurally unfocusable. Both invariants are correct individually; the gap was the missing surface.

## What
Option (a) per the rf2-2f40y operator decision (recorded in bead notes): dedicated `:ungrouped` lane in the Issues panel chrome, shown when the cascade-scoped feed has no issues to surface but `:ungrouped` issues exist. Preserves both invariants.

- New helper `project-ungrouped-feed` in `issues_ribbon_helpers.cljc` (pure-data, JVM-testable)
- New sub `:rf.causa.issues/ungrouped` — thin derivation off `:rf.causa/trace-buffer`
- Lane render below the cascade-scoped feed with muted uppercase header `Issues outside any cascade` + one-line clarifier; rows reuse the existing `issue-row` chrome (whose `pivotable?` guard already keeps `:ungrouped` rows read-only — open-in-editor is the only outgoing affordance)
- Visibility contract: visible iff `:empty-kind ∈ #{:no-issues :no-issues-for-event :no-matches}` AND `(pos? ungrouped-total)`
- Spec updates: `tools/causa/spec/016-Auxiliary-Panels.md` (new §`:ungrouped` escape-hatch lane subsection cross-linking rf2-u6dhp + rf2-fzbrw) and `tools/causa/spec/014-Registry-Catalogue.md` (catalogue row for the new sub)

## Verification
- Causa JVM tests: 743 tests / 2186 assertions / 0F / 0E
- CLJS node tests: 2893 tests / 8249 assertions / 0F / 0E
- 4 new helper unit tests covering: empty stream, `:ungrouped`-only filter, newest-first ordering, success-trace exclusion
- 5 new view tests covering: sub registration, sub filter behaviour, lane visible under `:no-issues-for-event` with `:ungrouped` issue, lane hidden when focused cascade has issues, lane hidden when no `:ungrouped` issues exist, lane visible alongside `:no-matches`
- mkdocs `--strict`: my edits introduce zero new warnings (baseline has 72 pre-existing warnings in unrelated docs)

Closes rf2-2f40y.