### PR TITLE
fix(story): wire :launch.keybinding/enabled? false into Causa-RHS mount (rf2-q7who.1)

### DIFF
--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -196,6 +196,59 @@
            (safe-call! "config/configure!" configure! {:project-root root})
            root)))))
 
+;; ---- :launch.keybinding/enabled? bridge (rf2-q7who.1) -------------------
+;;
+;; Causa standalone attaches a window-level capture-phase `keydown`
+;; listener that handles `Ctrl+Shift+C` (shell toggle), `Cmd/Ctrl+K`
+;; (command palette), and the unmodified spine bindings. Story's own
+;; chrome registers its OWN `Cmd/Ctrl+K` command palette — with
+;; Causa's listener attached at the capture phase, Story's palette
+;; binding would never fire because Causa's handler calls
+;; `stopPropagation()` on every key it consumes.
+;;
+;; The fix: when Story drives Causa as RHS (the always-on RHS panel,
+;; rf2-sgdd3), set `:launch.keybinding/enabled? false` on Causa's
+;; config slot so Causa's `keybinding/attach!` short-circuits. Story's
+;; Cmd/Ctrl+K reaches its own command palette; Causa is still
+;; mountable / dispatchable / inspectable via every other surface
+;; (Story owns the open-Causa affordance for the RHS).
+;;
+;; Symmetric to `propagate-project-root!` above — the Story side
+;; bridges a value into Causa's config slot rather than asking every
+;; testbed to call `causa-config/configure!` directly. Standalone
+;; Causa (no Story) is unaffected — only Story-driven mounts disable
+;; the listener.
+;;
+;; Per rf2-4eyik (the sibling bead that shipped the config slot):
+;; "Hosts MUST set this BEFORE the Causa preload runs". Setting it
+;; from `ensure-causa-mounted!` means the slot lands at variant-
+;; selection time, after the preload's `keybinding/attach!` has
+;; already fired with the default `true`. The Causa-side bead is
+;; the slot owner; preload-time sequencing (e.g. a Story preload that
+;; sets the slot before Causa's preload runs) is the follow-on shape
+;; for live runtime collision removal. This wire-up is the in-source
+;; declaration of intent — every embed surface that drives Causa
+;; through `ensure-causa-mounted!` sets the slot, so downstream
+;; load-order fixes have a single canonical site to honour.
+
+#?(:cljs
+   (defn disable-keybinding!
+     "Set Causa's `:launch.keybinding/enabled?` config slot to `false`
+     via `day8.re-frame2-causa.config/configure!`. Returns `true` when
+     the call landed, or `nil` when Causa's `configure!` is not on the
+     classpath (preload absent).
+
+     Called by `ensure-causa-mounted!` so Story-driven Causa-as-RHS
+     mounts never have Causa swallow the host's global keybindings
+     (typically `Cmd/Ctrl+K` for Story's command palette). Per
+     rf2-q7who.1 (rf2-4eyik sibling on the Causa side). Idempotent —
+     writing `false` over an existing `false` is a plain reset!."
+     []
+     (when (and config/enabled? (causa-config-available?))
+       (when-let [configure! (resolve-fn 'day8.re-frame2-causa.config/configure!)]
+         (safe-call! "config/configure!" configure! {:launch.keybinding/enabled? false})
+         true))))
+
 #?(:cljs
    (defn ensure-causa-mounted!
      "Always-on entry point used by the Story shell (rf2-sgdd3) to drive
@@ -212,10 +265,16 @@
      rf2-r1uod: also propagates Story's configured `:project-root`
      into Causa's config slot so the Causa-as-RHS source-coord chips
      resolve absolute on-disk paths. The propagator is no-op-safe when
-     Story has no `:project-root` configured."
+     Story has no `:project-root` configured.
+
+     rf2-q7who.1: also disables Causa's global keybinding listener via
+     `:launch.keybinding/enabled? false` so Story's own Cmd/Ctrl+K
+     command palette is not swallowed by Causa's capture-phase
+     listener. The slot is idempotent on every variant edge."
      []
      (when (and config/enabled? (causa-available?))
        (propagate-project-root!)
+       (disable-keybinding!)
        (apply-open!))))
 
 #?(:cljs

--- a/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
@@ -1,0 +1,94 @@
+(ns re-frame.story.causa-preset-cljs-test
+  "CLJS-runtime tests for the per-story Causa preset, specifically the
+  Causa-as-RHS mount-time bridges that propagate Story-side configuration
+  into Causa's config slot.
+
+  ## Why a separate `_cljs_test.cljs` file
+
+  The pure data + JVM-runnable surface lives in
+  `re-frame.story.causa-preset-test` (.cljc). The `:node-test` build's
+  ns-regexp is `cljs-test$` — to land actual CLJS-runtime coverage the
+  test namespace name must match that pattern. Hence this companion
+  file. The `.cljc` sibling stays the home for the deep-merge / resolve
+  pure-data tests that round-trip through both JVM and CLJS.
+
+  ## Coverage
+
+  - `disable-keybinding!` (rf2-q7who.1): writes
+    `{:launch.keybinding/enabled? false}` into Causa's config slot via
+    its `configure!` surface. Verified directly against Causa's
+    config-atom in the node-test build (Causa's source path is on the
+    test classpath) and via a shimmed `configure!` fn that captures
+    the call payload.
+  - `ensure-causa-mounted!` (rf2-q7who.1): calls `disable-keybinding!`
+    as part of the mount edge so Story's RHS-mounted Causa never
+    swallows the host's Cmd/Ctrl+K command palette."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.config :as causa-config]
+            [re-frame.story.causa-preset :as causa-preset]))
+
+;; ---- disable-keybinding! -------------------------------------------------
+
+(deftest disable-keybinding-lands-on-causa-config-slot
+  (testing "disable-keybinding! writes false into Causa's :launch.keybinding/enabled? slot"
+    ;; The node-test build has tools/causa/src on the classpath, so
+    ;; `day8.re-frame2-causa.config` is loaded and `disable-keybinding!`
+    ;; can drive the real `configure!`. Seed the slot with the default
+    ;; (true) then verify the bridge flips it to false.
+    (causa-config/set-keybinding-enabled! true)
+    (is (true? (causa-config/keybinding-attach-enabled?))
+        "precondition: default keybinding-enabled? is true")
+    (is (true? (causa-preset/disable-keybinding!))
+        "disable-keybinding! returns true when the configure! call landed")
+    (is (false? (causa-config/keybinding-attach-enabled?))
+        "after disable-keybinding!, Causa's slot is false")
+    ;; Restore the default so subsequent tests in this suite see a
+    ;; clean slot.
+    (causa-config/set-keybinding-enabled! true)))
+
+(deftest disable-keybinding-shimmed-configure
+  (testing "disable-keybinding! calls Causa's configure! with the exact slot map"
+    ;; Belt-and-braces test: redef `causa-config-available?` (already
+    ;; true in this build) and the `resolve-fn` lookup so we capture
+    ;; the exact opts map the bridge sends to `configure!`. Guards the
+    ;; payload shape against accidental extras / typos.
+    (let [captured (atom nil)
+          shim-configure! (fn [opts] (reset! captured opts) nil)]
+      (with-redefs [causa-preset/causa-config-available?
+                    (fn [] true)
+                    causa-preset/resolve-fn
+                    (fn [sym]
+                      (when (= sym 'day8.re-frame2-causa.config/configure!)
+                        shim-configure!))]
+        (is (true? (causa-preset/disable-keybinding!))
+            "returns true when the configure! call landed")
+        (is (= {:launch.keybinding/enabled? false} @captured)
+            "configure! is called with exactly the keybinding-disable slot")))))
+
+;; ---- ensure-causa-mounted! drives the bridge -----------------------------
+
+(deftest ensure-causa-mounted-disables-keybinding
+  (testing "ensure-causa-mounted! drives disable-keybinding! on the mount edge"
+    ;; The shell calls ensure-causa-mounted! on every variant-selection
+    ;; edge. Verify the keybinding-disable bridge is invoked as part of
+    ;; that flow. We shim the Causa-availability gate AND
+    ;; `disable-keybinding!` itself so we can assert the wiring without
+    ;; depending on the underlying configure! plumbing (covered by the
+    ;; shimmed-configure test above). We also stub the `resolve-fn`
+    ;; lookup `apply-open!` uses so we don't actually try to mount a
+    ;; shell.
+    (let [disable-called? (atom false)
+          open-called?    (atom false)]
+      (with-redefs [causa-preset/causa-available?
+                    (fn [] true)
+                    causa-preset/disable-keybinding!
+                    (fn [] (reset! disable-called? true) true)
+                    causa-preset/resolve-fn
+                    (fn [sym]
+                      (when (= sym 'day8.re-frame2-causa.mount/open!)
+                        (fn [] (reset! open-called? true) nil)))]
+        (causa-preset/ensure-causa-mounted!)
+        (is (true? @disable-called?)
+            "disable-keybinding! is part of the mount edge")
+        (is (true? @open-called?)
+            "apply-open! still fires (keybinding wire-up does not break mount)")))))

--- a/tools/story/test/re_frame/story/causa_preset_test.cljc
+++ b/tools/story/test/re_frame/story/causa_preset_test.cljc
@@ -151,3 +151,8 @@
        (story/configure! {:project-root nil})
        (is (nil? (causa-preset/propagate-project-root!))
            "no propagation when Story's project-root is nil"))))
+
+;; CLJS-only tests for the keybinding-disable bridge (rf2-q7who.1)
+;; live in `re-frame.story.causa-preset-cljs-test` — separate file so
+;; the `:node-test` build's `cljs-test$` ns-regexp picks them up (the
+;; .cljc file's namespace name does not).


### PR DESCRIPTION
## Why
Companion to PR #1497 (rf2-q7who A+B / rf2-4eyik) which added Causa's `:launch.keybinding/enabled?` config slot. Story now sets it to `false` when mounting Causa as RHS so Causa's capture-phase keydown listener does not swallow Story's own Cmd/Ctrl+K command palette.

## What
- New `disable-keybinding!` in `re-frame.story.causa-preset` — symmetric to `propagate-project-root!` (rf2-r1uod). Feature-detect-safe; no-op when Causa is absent.
- Wired into `ensure-causa-mounted!` so the slot lands on every variant-selection edge alongside the existing project-root bridge + `apply-open!`.
- Standalone Causa (no Story) is unaffected — only Story-driven mounts disable the listener.
- A new `causa_preset_cljs_test.cljs` (separate file because the node-test build's `cljs-test$` ns-regexp does not match the existing `.cljc` test ns name) covers:
  - the slot landing on Causa's config-atom directly,
  - the exact `configure!` payload via shimmed lookup,
  - `ensure-causa-mounted!` driving `disable-keybinding!` as part of the mount edge.

## Verification
- Story JVM tests: 750t / 2221a / 0F / 0E
- CLJS node tests: 2909t / 8335a / 0F / 0E (+3 tests, +7 assertions)
- Causa JVM tests (regression on rf2-4eyik's keybinding tests): 743t / 2186a / 0F / 0E — unchanged
- mkdocs --strict: N/A (no spec/docs changes)

Closes rf2-q7who.1.