### PR TITLE
feat(causa): redacted-paths-modified hint chip on app-db diff (rf2-bz1cl)

### DIFF
--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -164,6 +164,55 @@ canvas:
 The full tree is rarely needed; the slice-centric view answers most
 questions.
 
+## Redacted-paths-modified hint chip
+
+Per [Spec 015 §Data Classification](../../../spec/015-Data-Classification.md)
+and [Security §Epoch privacy posture](../../../spec/Security.md#epoch-privacy-posture--raw-in-process-records-vs-projected-egress),
+an app-supplied epoch `:redact-fn` may substitute the `:rf/redacted`
+sentinel into `:db-before` / `:db-after` to keep sensitive material out
+of recorded records. When the underlying value at a redacted path
+actually changed across a cascade, the structural diff correctly sees
+`:rf/redacted` = `:rf/redacted` and emits no row — the elision
+contract is preserved (per [`diff/annotated_tree.cljc` §Sentinel
+handling](#)). The developer is left with an empty diff and no signal
+that anything happened in the redacted slot.
+
+Causa surfaces a **separate-from-diff** signal: a muted-grey chip
+at the top of the diff body when count > 0.
+
+```
+[· 3 redacted paths modified]
+```
+
+The chip uses the muted-`·` marker from the rf2-87lkf Views polish
+family (`·` = muted/informational; `✱` = amber/attention-cue). Hover
+to read the contract explanation; the chip is absent (no DOM) when
+count is 0.
+
+**Count semantics.** A path `P` counts when:
+
+1. `(= :rf/redacted (get-in db-before P))`, AND
+2. `(= :rf/redacted (get-in db-after  P))`, AND
+3. `P`'s parent subtree is NOT `identical?` across `db-before` /
+   `db-after` (something in the enclosing subtree changed).
+
+Distinct paths are counted independently. The reserved `:rf/elision`
+subtree at the root is skipped (the elision registry's own values may
+include `:rf/redacted` as documentation/sentinel form).
+
+**Heuristic upper bound.** Condition (3) is the structural-sharing
+tightener — without it every redacted slot in `app-db` would count for
+every cascade. With it the count is a tight upper bound: every counted
+path is provably in a mutated subtree AND opaque. It may over-state
+if a sibling slot changed and the redacted slot was incidentally
+untouched.
+
+Causa derives the count from raw epoch records using the heuristic
+above; the framework does not pre-compute it. A future enhancement
+(filed as a follow-on bead) could thread an accurate counter through
+the egress contract — until then the heuristic surface is the
+read-side answer.
+
 ## Read-only
 
 The app-db panel is **read-only forever** (lock #3 in

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -35,7 +35,8 @@
                 changed-reserved
                 pinned-slices
                 focused-path
-                focused-hits]}
+                focused-hits
+                redacted-modified-count]}
         @(rf/subscribe [:rf.causa/app-db-diff])]
     [:section {:data-testid "rf-causa-app-db-diff"
                :style       {:height         "100%"
@@ -64,6 +65,11 @@
 
         :else
         [:div
+         ;; rf2-bz1cl — redacted-paths-modified hint chip. nil when
+         ;; count is 0, so the chip surface is absent unless the
+         ;; cascade actually involved redacted slots in mutated
+         ;; subtrees.
+         (sections/redacted-modified-chip redacted-modified-count)
          (diff-render/render-sections changed-sections "app-db-diff")
          (sections/pinned-group pinned-slices)
          (sections/reserved-group changed-reserved)])]]))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -379,6 +379,180 @@
                  :after    (get-in db-after  path)}))
             history))))
 
+;; ---- redacted-paths-modified hint (rf2-bz1cl) ---------------------------
+;;
+;; The elision contract substitutes the `:rf/redacted` sentinel (per
+;; spec/015-Data-Classification.md §The classification model) at
+;; emission-time / build-time for sensitive paths. An app that installs
+;; an epoch `:redact-fn` (per docs/causa/03-time-travel.md §Privacy +
+;; redact-fn / Security.md §Epoch privacy posture) can substitute the
+;; sentinel into `:db-before` / `:db-after` directly. When that happens
+;; AND the underlying value at the redacted path actually changed
+;; across the epoch, the structural diff sees `:rf/redacted` on both
+;; sides and (correctly per the contract) emits no diff row — the
+;; renderer never tries to override the elision contract (per
+;; `diff/annotated_tree.cljc` §Sentinel handling).
+;;
+;; This leaves the developer with an empty diff and no signal that
+;; anything happened in the redacted slot. The hint surface
+;; (rf2-bz1cl) closes that gap: a separate chip on the diff panel
+;; says "N redacted paths modified" so the developer knows a real
+;; change happened at an opaque path even though no diff row is
+;; renderable.
+;;
+;; ## Count semantics — what counts as "redacted-modified"
+;;
+;; Causa runs in-process and reads RAW epoch records (not the
+;; egress-projected ones), so the only `:rf/redacted` sentinels in
+;; `:db-before` / `:db-after` come from an app-supplied `:redact-fn`
+;; (the `with-redacted` interceptor only redacts event-payload trace
+;; surfaces, not the recorded db). Wire-elision via
+;; `elide-wire-value` happens at the off-box egress boundary and never
+;; touches what Causa sees.
+;;
+;; The framework's egress projection (and the redact-fn that
+;; substitutes the sentinel) discards information about whether the
+;; underlying values actually changed — by design, that's what
+;; "redacted" means. Causa can't reconstruct what was lost; it can
+;; only emit a strong heuristic upper bound:
+;;
+;;   A path P is "redacted-modified" when:
+;;     1. `(= :rf/redacted (get-in db-before P))`
+;;     2. `(= :rf/redacted (get-in db-after  P))`
+;;     3. The path's PARENT subtree is NOT `identical?` across
+;;        `db-before` / `db-after` (something in this subtree changed).
+;;
+;; Condition (3) is the structural-sharing tightener. Without it,
+;; every redacted path in `app-db` would count toward every cascade's
+;; chip, swamping the signal. With it, only redacted paths inside a
+;; subtree that actually mutated count — a tight upper bound:
+;;
+;;   - **Sound for non-zero:** if the count is > 0, the corresponding
+;;     subtree provably mutated; the redacted slot is one possible
+;;     site of that mutation (along with any sibling slots that also
+;;     changed).
+;;   - **Unsound for direction:** the count can over-state if a
+;;     sibling slot changed and the redacted slot was incidentally
+;;     untouched. The chip's tooltip surfaces this approximation
+;;     ("N paths could have changed — the elision contract suppressed
+;;     the values").
+;;
+;; ## What this does NOT cover
+;;
+;; - Paths nominated as sensitive but with no live value (`nil` /
+;;   absent slot) — those don't carry the sentinel.
+;; - The egress-side `elide-wire-value` projection (Causa never sees
+;;   it; that's a property of off-box wire surfaces).
+;; - `:rf.size/large-elided` markers (orthogonal to privacy; tracked
+;;   independently).
+;; - Sub-tree pointer-equality false negatives from `assoc-in` rewrites
+;;   that produce a fresh subtree whose leaves are all equal. These
+;;   would mark a redacted leaf as "potentially modified" even though
+;;   nothing in the subtree changed. The structural-sharing diff has
+;;   the same property — it walks the changed subtree but emits no
+;;   rows when leaves match.
+;;
+;; ## Future enhancement (filed as follow-on)
+;;
+;; A wire-shape augmentation would let the framework annotate the
+;; epoch record with a precise "N redacted paths modified" counter
+;; computed BEFORE the redact-fn runs — eliminating the heuristic.
+;; That's a strictly larger change touching the egress contract; the
+;; chip ships with the heuristic in the meantime.
+
+(def redacted-sentinel
+  "The framework's privacy sentinel keyword. Mirrors
+  `re-frame.privacy/redacted-sentinel` so this artefact doesn't take a
+  hard dep on the privacy ns (Causa is bundle-isolated from
+  framework-internal helpers; the sentinel keyword is a public wire-
+  vocabulary constant per spec/015-Data-Classification.md)."
+  :rf/redacted)
+
+(defn- redacted-value?
+  "True when `v` is the framework's `:rf/redacted` sentinel.
+
+  Currently the sentinel is the bare keyword; the spec's composed form
+  (`:rf/redacted {:bytes N}` per spec/015 §Two parallel axes) is not
+  used as a leaf substitution shape today (the size marker is a
+  separate `:rf.size/large-elided` map and the privacy sentinel wins
+  the composition per the API.md §Composition rule). This predicate
+  matches the leaf-keyword form; if the framework ever introduces a
+  wrapped sensitive-leaf shape, extend here."
+  [v]
+  (= redacted-sentinel v))
+
+(defn count-redacted-modified-paths
+  "Walk `db-before` and `db-after` and return the count of distinct
+  paths where BOTH sides carry the `:rf/redacted` sentinel AND the
+  parent subtree differs in pointer-identity (i.e., something in the
+  enclosing subtree changed).
+
+  Pure data → int. JVM-runnable. Used by the App-DB Diff panel's
+  `redacted-paths-modified` chip (rf2-bz1cl) to surface 'N opaque
+  paths potentially changed; the elision contract suppressed the
+  values'.
+
+  ## Algorithm
+
+  Walk both maps in parallel, starting at the root. At each map level:
+
+    - If the parent maps are `identical?`, skip the entire subtree —
+      no descendant changed. (Structural-sharing short-circuit; same
+      as `diff-paths`.)
+    - Otherwise walk the union of keys:
+      - When the value at key k is `:rf/redacted` on BOTH sides,
+        increment the count (this counts the leaf path).
+      - When both values are maps and not `identical?`, recurse.
+      - Otherwise skip.
+
+  ## Skipped subtrees
+
+  Paths under reserved `:rf/elision` (the wire-elision declaration
+  registry — its own values can include the `:rf/redacted` sentinel
+  as a documentation example) are not counted. The exclusion matches
+  the spirit of `reserved-app-db-keys` — the runtime owns those slots
+  and their contents are not user data.
+
+  Per rf2-bz1cl."
+  ([db-before db-after]
+   (count-redacted-modified-paths db-before db-after []))
+  ([db-before db-after path]
+   (cond
+     ;; Both sides redacted at this slot → count this leaf and stop
+     ;; (don't recurse into a redacted scalar). MUST run BEFORE the
+     ;; pointer-equality short-circuit because the `:rf/redacted`
+     ;; keyword is interned — `(identical? :rf/redacted :rf/redacted)`
+     ;; is `true`, which would otherwise mask every redacted leaf as
+     ;; "subtree didn't change → skip".
+     (and (redacted-value? db-before) (redacted-value? db-after))
+     1
+
+     ;; Subtree-pointer short-circuit: nothing in this subtree
+     ;; changed, so no redacted-modified path can live below. Applies
+     ;; only AFTER the leaf-redacted check above, so we never use
+     ;; pointer equality to short-circuit a leaf comparison.
+     (identical? db-before db-after)
+     0
+
+     ;; Both maps, not identical → walk the union of keys. Skip the
+     ;; reserved `:rf/elision` subtree (the elision registry's own
+     ;; declarations carry the sentinel as an example/value form per
+     ;; spec/015 §Two parallel axes; counting them confuses the
+     ;; signal).
+     (and (map? db-before) (map? db-after))
+     (reduce
+       (fn [acc k]
+         (if (and (empty? path) (= :rf/elision k))
+           acc
+           (+ acc (count-redacted-modified-paths
+                    (get db-before k)
+                    (get db-after  k)
+                    (conj path k)))))
+       0
+       (distinct (concat (keys db-before) (keys db-after))))
+
+     :else 0)))
+
 ;; ---- diff caching --------------------------------------------------------
 
 (defn cache-key-of

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
@@ -9,6 +9,62 @@
 (def empty-state slices/empty-state)
 (def changed-slices-stack slices/changed-slices-stack)
 
+;; ---- rf2-bz1cl — redacted-paths-modified hint chip ----------------------
+;;
+;; A muted-grey `·`-marker chip at the top of the diff body. Surfaces
+;; "N redacted paths were modified at this cascade" when count > 0.
+;; The marker matches the family established by rf2-87lkf's Views polish
+;; (just merged in #1498) — `·` for muted / informational signal, `✱`
+;; for amber / attention-cue.
+;;
+;; Why a chip and not a diff row: the elision contract (per
+;; spec/015-Data-Classification.md + spec/Security.md §Epoch privacy
+;; posture) deliberately suppresses the underlying value at redacted
+;; paths. Synthesising a fake diff row that says "(redacted) → (redacted)"
+;; would either be useless (no signal) or misleading (suggesting the
+;; renderer broke the contract). The chip is a SEPARATE signal that
+;; complements the diff body without overriding it.
+;;
+;; Tooltip: the chip explains the elision contract so the developer
+;; understands both *what* the count means and *why* the values aren't
+;; in the diff body.
+
+(defn redacted-modified-chip
+  "Render a muted-grey informational chip above the diff body when
+  `count` > 0. Returns nil when count is 0/nil (no chip, no DOM).
+  Per rf2-bz1cl."
+  [count]
+  (when (and (number? count) (pos? count))
+    [:div {:data-testid "rf-causa-app-db-diff-redacted-modified-chip"
+           :title       (str count
+                             (if (= 1 count) " redacted path" " redacted paths")
+                             " in modified subtrees. The elision contract"
+                             " suppresses values where both sides are"
+                             " :rf/redacted, so no diff row is shown — but"
+                             " the enclosing subtree provably changed."
+                             " See spec/015-Data-Classification.md for the"
+                             " redaction contract.")
+           :style       {:display       "inline-flex"
+                         :align-items   "center"
+                         :gap           "6px"
+                         :margin        "8px 12px 0 12px"
+                         :padding       "3px 10px"
+                         :background    (:bg-3 tokens)
+                         :border        (str "1px solid " (:border-subtle tokens))
+                         :border-radius "10px"
+                         :color         (:text-tertiary tokens)
+                         :font-family   sans-stack
+                         :font-size     "11px"
+                         :line-height   "16px"
+                         :cursor        "help"
+                         :user-select   "none"}}
+     [:span {:style {:color (:text-tertiary tokens)
+                     :font-weight 600}} "·"]
+     [:span (str count
+                 (if (= 1 count)
+                   " redacted path modified"
+                   " redacted paths modified"))]]))
+
 (defn- reserved-row
   [[k v]]
   [:div {:data-testid (str "rf-causa-app-db-diff-reserved-" (pr-str k))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -49,6 +49,17 @@
   ;; as `diff-cache` above. Tests reset this atom between cases.
   (atom {}))
 
+(defonce redacted-modified-cache
+  ;; Per-`:epoch-id` cache for the redacted-paths-modified count
+  ;; computed by `:rf.causa/selected-epoch-redacted-modified-count`
+  ;; (rf2-bz1cl). Same caching contract as `diff-cache` above — the
+  ;; walk is bounded by `count-redacted-modified-paths`' structural-
+  ;; sharing short-circuit but cascades replay the same db-before /
+  ;; db-after pair across the inspector's life, so caching the
+  ;; final integer is still cheap insurance. Tests reset this atom
+  ;; between cases.
+  (atom {}))
+
 (defn install!
   "Install the App-DB Diff subscriptions."
   []
@@ -148,6 +159,49 @@
         (sg/group-into-sections annotated)
         [])))
 
+  ;; ---- rf2-bz1cl — redacted-paths-modified count ---------------------
+  ;;
+  ;; The structural diff (above) correctly emits NO rows when both
+  ;; sides of a path carry `:rf/redacted` — `:rf/redacted` = `:rf/redacted`
+  ;; structurally. When an app-supplied `:redact-fn` substitutes the
+  ;; sentinel into `:db-before` / `:db-after` AND the underlying values
+  ;; differ, the diff body is empty and the developer's "something
+  ;; changed" expectation is not met.
+  ;;
+  ;; This sub computes a separate-from-diff signal: the count of
+  ;; redacted leaves whose enclosing subtree mutated across the
+  ;; cascade. Heuristic upper bound — see
+  ;; `app-db-diff-helpers/count-redacted-modified-paths` for the
+  ;; semantics + approximation notes. The renderer surfaces the count
+  ;; as a muted chip above the diff body when count > 0.
+  ;;
+  ;; Selection fallback mirrors `:rf.causa/selected-epoch-diff` —
+  ;; the same selection-stale path that strands the diff panel
+  ;; strands the chip; same `(peek history)` fallback applies.
+  (rf/reg-sub :rf.causa/selected-epoch-redacted-modified-count
+    :<- [:rf.causa/epoch-history]
+    :<- [:rf.causa/selected-epoch-id]
+    (fn [[history selected-id] _query]
+      (let [record (or (when selected-id
+                         (find-epoch-in-history history selected-id))
+                       (peek history))]
+        (if record
+          (let [epoch-id (:epoch-id record)
+                cached   (get @redacted-modified-cache epoch-id ::miss)]
+            (if (not= ::miss cached)
+              cached
+              (let [n    (h/count-redacted-modified-paths
+                           (:db-before record)
+                           (:db-after  record))
+                    live (into #{} (map :epoch-id) history)]
+                (swap! redacted-modified-cache
+                       (fn [m]
+                         (-> m
+                             (select-keys live)
+                             (assoc epoch-id n))))
+                n)))
+          0))))
+
   (rf/reg-sub :rf.causa/pinned-slices-store
     (fn [db _query]
       (get db :pinned-slices-store {})))
@@ -185,15 +239,22 @@
     :<- [:rf.causa/focused-slice-path]
     :<- [:rf.causa/show-me-when-this-changed-result]
     :<- [:rf.causa/epoch-history]
-    (fn [[target db diff-triples sections pinned focused-path focused-hits history]
+    :<- [:rf.causa/selected-epoch-redacted-modified-count]
+    (fn [[target db diff-triples sections pinned focused-path focused-hits
+          history redacted-modified-count]
          _query]
       (let [{:keys [non-reserved]} (h/partition-reserved
                                      (or diff-triples []))]
-        {:target-frame          target
-         :history-empty?        (empty? history)
-         :changed-non-reserved  non-reserved
-         :changed-sections      sections
-         :changed-reserved      (h/reserved-summary db)
-         :pinned-slices         pinned
-         :focused-path          focused-path
-         :focused-hits          focused-hits}))))
+        {:target-frame              target
+         :history-empty?            (empty? history)
+         :changed-non-reserved      non-reserved
+         :changed-sections          sections
+         :changed-reserved          (h/reserved-summary db)
+         :pinned-slices             pinned
+         :focused-path              focused-path
+         :focused-hits              focused-hits
+         ;; rf2-bz1cl — redacted-paths-modified hint chip surface.
+         ;; Count > 0 when an app `:redact-fn` substituted the
+         ;; `:rf/redacted` sentinel into both `:db-before` /
+         ;; `:db-after` at the same path inside a mutated subtree.
+         :redacted-modified-count   redacted-modified-count}))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -55,7 +55,11 @@
   ;; `defonce` (lifted from let-local for rf2-o94sp testability).
   ;; Reset between tests so
   ;; cache-size assertions are reproducible across the corpus.
-  (reset! app-db-diff-subs/diff-cache {}))
+  (reset! app-db-diff-subs/diff-cache {})
+  ;; rf2-bz1cl — redacted-paths-modified cache mirrors the same
+  ;; per-`:epoch-id` caching contract; reset between tests for
+  ;; reproducibility.
+  (reset! app-db-diff-subs/redacted-modified-cache {}))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
@@ -184,7 +188,10 @@
         (is (true? (:history-empty? data)))
         (is (nil? (:focused-path data)))
         (is (= [] (:pinned-slices data)))
-        (is (= [] (:focused-hits data)))))))
+        (is (= [] (:focused-hits data)))
+        ;; rf2-bz1cl — chip count defaults to 0 (no history → no
+        ;; redacted-modified paths anywhere).
+        (is (= 0 (:redacted-modified-count data)))))))
 
 ;; ---- (3) selected-epoch-diff produces correct triples -------------------
 
@@ -745,3 +752,102 @@
         (is (= :cart-frame (:target-frame data))
             "composite's :target-frame surface reflects the picker
              selection (rf2-fvplw — preserved post-rf2-ug1r6)")))))
+
+;; ---- rf2-bz1cl — redacted-paths-modified hint chip ----------------------
+;;
+;; Per spec/015-Data-Classification.md the elision contract substitutes
+;; the `:rf/redacted` sentinel at sensitive paths. An app-supplied
+;; epoch `:redact-fn` (per spec/Security.md §Epoch privacy posture) can
+;; substitute the sentinel into `:db-before` / `:db-after` directly.
+;; When that happens the structural diff sees `:rf/redacted` on both
+;; sides → no row → empty diff body → developer can't tell anything
+;; changed.
+;;
+;; The chip closes that gap. These tests pin the surface end-to-end:
+;; composite count slot + view render.
+
+(deftest redacted-modified-count-zero-when-no-redacted-history
+  (testing "the composite's `:redacted-modified-count` is 0 when no
+            cascade involved a redacted leaf"
+    (seed-causa! {:counter 1}
+                 [(mk-record :e-1 [:counter/inc] {:counter 0} {:counter 1})])
+    (rf/with-frame :rf/causa
+      (let [data @(rf/subscribe [:rf.causa/app-db-diff])]
+        (is (= 0 (:redacted-modified-count data)))))))
+
+(deftest redacted-modified-count-non-zero-when-redact-fn-substituted
+  (testing "when a `:redact-fn` substituted `:rf/redacted` into both
+            `:db-before` and `:db-after` at the same path inside a
+            mutated subtree, the count is non-zero — the chip will
+            surface on the view"
+    (let [before {:auth {:token :rf/redacted :method :jwt}}
+          after  {:auth {:token :rf/redacted :method :session}}]
+      (seed-causa! after [(mk-record :e-1 [:auth/rotate] before after)])
+      (rf/with-frame :rf/causa
+        (let [data @(rf/subscribe [:rf.causa/app-db-diff])]
+          (is (= 1 (:redacted-modified-count data))
+              "the :auth :token leaf is redacted both sides; the parent
+               subtree mutated (sibling :method changed); chip count = 1"))))))
+
+(deftest redacted-modified-count-cache-hits-on-repeat-deref
+  (testing "the count is cached per `:epoch-id`; second deref returns
+            the same integer (the cache short-circuit pattern mirrors
+            `:selected-epoch-diff`)"
+    (let [before {:auth {:token :rf/redacted}}
+          after  {:auth {:token :rf/redacted :method :session}}]
+      (seed-causa! after [(mk-record :e-1 [:auth/rotate] before after)])
+      (rf/with-frame :rf/causa
+        (let [first-call  @(rf/subscribe
+                             [:rf.causa/selected-epoch-redacted-modified-count])
+              second-call @(rf/subscribe
+                             [:rf.causa/selected-epoch-redacted-modified-count])]
+          (is (= 1 first-call))
+          (is (= first-call second-call))
+          (is (= 1 (count @app-db-diff-subs/redacted-modified-cache))
+              "cache holds exactly one entry for the one live epoch"))))))
+
+(deftest redacted-modified-chip-renders-when-count-positive
+  (testing "the chip is in the rendered hiccup tree when the count is
+            > 0; the tooltip text mentions the redaction contract so
+            the developer understands what the chip means"
+    (let [before {:auth {:token :rf/redacted :method :jwt}}
+          after  {:auth {:token :rf/redacted :method :session}}]
+      (seed-causa! after [(mk-record :e-1 [:auth/rotate] before after)])
+      (rf/with-frame :rf/causa
+        (let [tree (app-db-diff/Panel)
+              chip (find-by-testid
+                     tree "rf-causa-app-db-diff-redacted-modified-chip")]
+          (is (some? chip) "chip is present when count > 0")
+          (let [chip-text (pr-str chip)]
+            (is (str/includes? chip-text "1 redacted path modified")
+                "singular phrasing for count = 1")
+            (is (str/includes? (or (:title (second chip)) "")
+                               "elision contract")
+                "tooltip mentions the contract that explains the chip")))))))
+
+(deftest redacted-modified-chip-absent-when-count-zero
+  (testing "the chip is NOT in the rendered hiccup tree when no
+            redacted-modified paths exist — no DOM clutter for the
+            common (no privacy declarations) case"
+    (seed-causa! {:counter 1}
+                 [(mk-record :e-1 [:counter/inc] {:counter 0} {:counter 1})])
+    (rf/with-frame :rf/causa
+      (let [tree (app-db-diff/Panel)]
+        (is (nil? (find-by-testid
+                    tree "rf-causa-app-db-diff-redacted-modified-chip"))
+            "chip absent when count = 0")))))
+
+(deftest redacted-modified-chip-uses-plural-phrasing-for-many
+  (testing "more than one redacted path → plural form"
+    (let [before {:auth   {:token   :rf/redacted}
+                  :secret {:api-key :rf/redacted}}
+          after  {:auth   {:token   :rf/redacted :method :session}
+                  :secret {:api-key :rf/redacted :rotated-at 99}}]
+      (seed-causa! after [(mk-record :e-1 [:auth/rotate] before after)])
+      (rf/with-frame :rf/causa
+        (let [tree (app-db-diff/Panel)
+              chip (find-by-testid
+                     tree "rf-causa-app-db-diff-redacted-modified-chip")]
+          (is (some? chip))
+          (is (str/includes? (pr-str chip) "2 redacted paths modified")
+              "plural phrasing for count > 1"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -350,3 +350,102 @@
   (testing "when no epoch touched the path, returns an empty vector"
     (let [history [(mk-record :e-1 [:a] {} {:other 1})]]
       (is (= [] (h/epochs-touching-path history [:never :touched]))))))
+
+;; ---- (6) count-redacted-modified-paths (rf2-bz1cl) ----------------------
+;;
+;; Contract per `count-redacted-modified-paths`:
+;;
+;;   - Walks both dbs in parallel.
+;;   - Counts paths where BOTH sides carry `:rf/redacted` AND the
+;;     parent subtree differs in pointer-identity.
+;;   - Skips the reserved `:rf/elision` subtree.
+;;   - Returns 0 for identical dbs, nil-safe.
+
+(deftest redacted-modified-count-zero-when-no-redacted
+  (testing "no redacted leaves anywhere → count is 0"
+    (is (= 0 (h/count-redacted-modified-paths {:a 1}      {:a 2})))
+    (is (= 0 (h/count-redacted-modified-paths {}          {})))
+    (is (= 0 (h/count-redacted-modified-paths {:a {:b 1}} {:a {:b 2}})))))
+
+(deftest redacted-modified-count-zero-when-only-one-side-redacted
+  (testing "the chip is for `:rf/redacted` on BOTH sides — when only
+            one side carries the sentinel, the diff algorithm already
+            emits a normal :modified row and the count is 0."
+    (is (= 0 (h/count-redacted-modified-paths
+               {:auth {:token "secret"}}
+               {:auth {:token :rf/redacted}}))
+        "after-only sentinel → 0 (normal :modified diff row)")
+    (is (= 0 (h/count-redacted-modified-paths
+               {:auth {:token :rf/redacted}}
+               {:auth {:token "fresh-secret"}}))
+        "before-only sentinel → 0 (normal :modified diff row)")))
+
+(deftest redacted-modified-count-counts-redacted-both-sides
+  (testing "the canonical case: both sides redacted at the same path,
+            in a parent subtree that mutated (a sibling slot's value
+            changed). The diff algorithm sees :rf/redacted = :rf/redacted
+            → no row; this counter is the separate signal."
+    (let [before {:auth {:token :rf/redacted :method :jwt}}
+          after  {:auth {:token :rf/redacted :method :session}}]
+      (is (= 1 (h/count-redacted-modified-paths before after))))))
+
+(deftest redacted-modified-count-zero-when-subtree-pointer-equal
+  (testing "if the parent subtree is identical? across before/after,
+            nothing inside it changed — skip it entirely, even if it
+            contains a redacted slot. Mirrors the structural-sharing
+            short-circuit in `diff-paths`."
+    (let [inner  {:token :rf/redacted :method :jwt}
+          before {:auth inner :user "ada"}
+          after  (assoc before :user "bob")]
+      (is (identical? (:auth before) (:auth after))
+          "sanity: :auth subtree is pointer-equal across before/after")
+      (is (= 0 (h/count-redacted-modified-paths before after))
+          ":auth subtree didn't mutate → redacted slot isn't counted"))))
+
+(deftest redacted-modified-count-multiple-paths-distinct
+  (testing "distinct redacted leaves in mutated subtrees count
+            independently. Two redacted leaves at two different paths
+            → count is 2."
+    (let [before {:auth   {:token   :rf/redacted}
+                  :secret {:api-key :rf/redacted}
+                  :public {:n 1}}
+          after  {:auth   {:token   :rf/redacted :method :session}
+                  :secret {:api-key :rf/redacted :rotated-at 99}
+                  :public {:n 1}}]
+      (is (= 2 (h/count-redacted-modified-paths before after))))))
+
+(deftest redacted-modified-count-nested-redacted
+  (testing "a redacted leaf deep in a nested tree counts when the
+            enclosing subtree mutated."
+    (let [before {:users {"u-1" {:profile {:ssn :rf/redacted :age 30}}}}
+          after  {:users {"u-1" {:profile {:ssn :rf/redacted :age 31}}}}]
+      (is (= 1 (h/count-redacted-modified-paths before after))))))
+
+(deftest redacted-modified-count-skips-rf-elision-subtree
+  (testing "the reserved `:rf/elision` subtree carries the elision
+            registry; its own values may include `:rf/redacted` as
+            example/documentation form. Counting them would confuse
+            the signal — skip the entire subtree at the root."
+    (let [before {:rf/elision {:sensitive-declarations
+                               {[:foo] {:sensitive? true
+                                        :sentinel :rf/redacted}}}
+                  :auth {:token :rf/redacted}}
+          after  (-> before
+                     (assoc-in [:rf/elision :sensitive-declarations [:bar]]
+                               {:sensitive? true :sentinel :rf/redacted})
+                     (assoc-in [:auth :method] :session))]
+      (is (= 1 (h/count-redacted-modified-paths before after))
+          "only the :auth :token path counts; the :rf/elision tree is skipped"))))
+
+(deftest redacted-modified-count-handles-nil-db
+  (testing "nil-tolerant — a halted-destroy record may carry nil
+            :db-before or :db-after per rf2-v0jwt. The counter must
+            not throw."
+    (is (= 0 (h/count-redacted-modified-paths nil nil)))
+    (is (= 0 (h/count-redacted-modified-paths nil {:a 1})))
+    (is (= 0 (h/count-redacted-modified-paths {:a 1} nil)))))
+
+(deftest redacted-modified-count-pointer-equal-dbs
+  (testing "identical? whole dbs → 0 immediately (no walk)."
+    (let [db {:auth {:token :rf/redacted}}]
+      (is (= 0 (h/count-redacted-modified-paths db db))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
@@ -17,9 +17,10 @@
     {:adapter plain-atom/adapter
      :init-fn (fn []
                 (reset! subs/diff-cache {})
-                (reset! subs/annotated-tree-cache {}))}))
+                (reset! subs/annotated-tree-cache {})
+                (reset! subs/redacted-modified-cache {}))}))
 
-(deftest leaf-install-registers-the-eleven-subs
+(deftest leaf-install-registers-the-twelve-subs
   (subs/install!)
   ;; rf2-fvplw — `:rf.causa/observed-frame` is the picker/focus-aware
   ;; seam that replaces the legacy `:rf.causa/target-frame` read inside
@@ -34,10 +35,16 @@
   (is (some? (registrar/handler :sub :rf.causa/pinned-slices)))
   (is (some? (registrar/handler :sub :rf.causa/focused-slice-path)))
   (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
+  ;; rf2-bz1cl — redacted-paths-modified hint sub.
+  (is (some? (registrar/handler :sub :rf.causa/selected-epoch-redacted-modified-count)))
   (is (some? (registrar/handler :sub :rf.causa/app-db-diff))))
 
 (deftest diff-caches-are-leaf-level-atoms
   (is (some? subs/diff-cache))
   (is (map? @subs/diff-cache))
   (is (some? subs/annotated-tree-cache))
-  (is (map? @subs/annotated-tree-cache)))
+  (is (map? @subs/annotated-tree-cache))
+  ;; rf2-bz1cl — redacted-modified count cache mirrors the existing
+  ;; per-`:epoch-id` caching contract.
+  (is (some? subs/redacted-modified-cache))
+  (is (map? @subs/redacted-modified-cache)))


### PR DESCRIPTION
## Why

The elision contract (per [spec/015-Data-Classification.md](../blob/main/spec/015-Data-Classification.md) + [docs/causa/03-time-travel.md §Privacy + redact-fn](../blob/main/docs/causa/03-time-travel.md)) suppresses the diff body when both sides of a path carry `:rf/redacted` even when the underlying values differ. An app that installs an epoch `:redact-fn` to keep secrets out of recorded `:db-before` / `:db-after` ends up with empty diff bodies on cascades that touched only redacted slots — the developer's "something changed" expectation is not met.

## What

Surface a **separate-from-diff** hint chip at the top of the App-db diff body:

```
[· 3 redacted paths modified]
```

- **Surface choice:** App-db diff panel — the canonical "what changed" home (option A1 from the dispatch scope). Reads naturally next to the diff body the chip explains.
- **Count semantics:** Causa-derived heuristic upper bound. A path counts when both `db-before` and `db-after` carry `:rf/redacted` AND the parent subtree's pointer differs (structural-sharing tightener — only redacted slots inside mutated subtrees count). Skips the reserved `:rf/elision` subtree.
- **Approximation:** the count can over-state if a sibling slot in a mutated subtree changed while the redacted slot incidentally didn't. The chip's tooltip surfaces the contract so the developer understands "N paths could have changed — the elision contract suppressed the values." A wire-shape enhancement that would let the framework compute an exact figure (computed BEFORE `:redact-fn` runs, parallel to the `:rf.epoch/sensitive?` rollup) is filed as follow-on **rf2-dl3gx**.
- **Visual:** muted `·` marker chip matching the rf2-87lkf Views polish family (just merged in #1498). Hover for the elision-contract explanation. Absent (no DOM) when count = 0 — no clutter for the common case.

## Why a chip and not a diff row

A synthetic `(redacted) → (redacted)` diff row would either carry no signal (useless) or suggest the renderer broke the contract (misleading). The chip is a SEPARATE signal that complements the diff body without overriding it — the renderer never touches the elision contract.

## Files

- `tools/causa/src/.../panels/app_db_diff_helpers.cljc` — new `count-redacted-modified-paths` pure-data helper + `:rf/redacted` sentinel constant
- `tools/causa/src/.../panels/app_db_diff_subs.cljs` — new `:rf.causa/selected-epoch-redacted-modified-count` sub + per-`:epoch-id` cache mirroring `diff-cache` / `annotated-tree-cache`; new `:redacted-modified-count` slot on composite read-model
- `tools/causa/src/.../panels/app_db_diff_sections.cljs` — `redacted-modified-chip` renderer
- `tools/causa/src/.../panels/app_db_diff.cljs` — wires the chip above the diff body
- `tools/causa/spec/004-App-DB-Diff.md` — new normative section "Redacted-paths-modified hint chip" describing the count semantics + heuristic approximation
- Tests: 14 new cases across helpers (pure-data), subs (registration + cache), and view (chip render + tooltip + plural phrasing)

## Verification

- `tools/causa` JVM tests: 752 tests / 2201 assertions / 0F / 0E
- `implementation/` CLJS node tests (`npm run test:cljs`): 2921 tests / 8358 assertions / 0F / 0E
- `mkdocs build --strict`: 72 warnings, all pre-existing on `main` (none introduced by this PR — counted identical pre/post)

Follow-on bead: rf2-dl3gx — wire-shape enhancement to thread an exact counter through the egress contract.

Closes rf2-bz1cl.