### PR TITLE
fix(causa): App-db panel renders cascade-history on first mount (rf2-boyc2)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -46,11 +46,13 @@
   toggles are no-ops on this axis."
   (:require [re-frame.core :as rf]
             [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.trace.projection :as projection]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- mount state ---------------------------------------------------------
@@ -294,25 +296,53 @@
     `:rf.causa/note-trace-event` into `:rf/causa` so the sub fires
     IMMEDIATELY on every push.
 
-  - `:epoch-history` — seeded from `(rf/epoch-history target)`
-    (rf2-1barg). Pre-mount epoch settles fire the
-    `:rf.causa/epoch-collector` cb but it short-circuits when
-    `:rf/causa` is not yet registered (host-side records would
-    otherwise route into a non-existent frame). The seed lifts the
-    accumulated history into Causa's reactive slot at first
-    Ctrl+Shift+C; later settles flow through the cb's dispatch path
-    on the standard reactive surface. Target frame defaults to
-    `:rf/default` per `defaults/default-target-frame` until a frame
-    picker lands."
+  - `:epoch-history` + `:target-frame` (rf2-1barg + rf2-boyc2) —
+    seeded together via `:rf.causa/set-target-frame` so the slot is
+    keyed on the frame the user will be observing on first paint.
+    Pre-rf2-boyc2 the seed was hardcoded to `:rf/default` — but
+    `compose-focus` derives the panel-observed frame from the head
+    focusable cascade in the trace buffer, so an app whose pre-mount
+    events ran on `:cart-frame` rendered the App-DB panel against
+    `:cart-frame` (the observed frame) while `:epoch-history` carried
+    the empty `:rf/default` ring. The composite's `:history-empty?`
+    resolved true → the panel rendered the boot empty-state
+    'app-db for :cart-frame is at the boot value. No diffs yet.'
+    EVEN WITH cascades from `:cart-frame` already in the buffer
+    (the Mike report). Frame-switch round-trip resolved it because
+    `set-frame-reducer` aligns the two axes; the first-mount path
+    had to do the same. The seed-frame is the head focusable
+    cascade's `:frame` (via `spine/focusable-head-frame-id` over the
+    same cascade projection panels read off), falling back to
+    `defaults/default-target-frame` when no focusable cascade exists
+    (cold start; only the `:ungrouped` bucket present). The
+    `:rf.causa/set-target-frame` event writes `:target-frame` and
+    re-seeds `:epoch-history` from `(rf/epoch-history seed-frame)`
+    in lockstep — symmetric with the picker path and the public
+    `core/set-target-frame!` API."
   []
   (rf/reg-frame :rf/causa {})
   ;; Seed the frame's app-db with whatever the trace-bus atom + the
   ;; framework's epoch ring buffer have accumulated so far. The host
   ;; may have driven dispatches before the user opened Causa.
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])
-    (rf/dispatch-sync [:rf.causa/sync-epoch-history
-                       (vec (rf/epoch-history defaults/default-target-frame))]))
+  (let [buffer     (trace-bus/buffer)
+        ;; Project the pre-mount trace buffer through the same pipeline
+        ;; the `:rf.causa/cascades` sub uses — projection + Causa-
+        ;; internal hard-filter — so the seed-frame matches what
+        ;; `compose-focus` will resolve on first paint. Without the
+        ;; internal filter a tool-frame cascade could be chosen as
+        ;; the head, which the user never sees in the L2 list.
+        cascades   (into [] (remove trace-bus/causa-internal-cascade?)
+                         (projection/group-cascades buffer))
+        seed-frame (or (spine/focusable-head-frame-id cascades)
+                       defaults/default-target-frame)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer])
+      ;; rf2-boyc2 — seed via `:rf.causa/set-target-frame` so
+      ;; `:target-frame` + `:epoch-history` move in lockstep keyed on
+      ;; the frame the user will be observing on first paint (the
+      ;; head focusable cascade's frame). Mirrors the picker-driven
+      ;; `set-frame-reducer` path and `core/set-target-frame!`.
+      (rf/dispatch-sync [:rf.causa/set-target-frame seed-frame])))
   ;; Hydrate the auto-filter pills (rf2-ak4ms). The preload-time
   ;; `filters/install!` call ran BEFORE the `:rf/causa` frame was
   ;; registered, so its hydrate attempt no-op'd; re-running here

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -98,6 +98,23 @@
   [cascades]
   (head-dispatch-id (focusable-cascades cascades)))
 
+(defn focusable-head-frame-id
+  "The `:frame` of the head focusable cascade — i.e. the frame whose
+  most recent event is the latest L2-visible row. Returns nil when no
+  focusable cascade exists (cold start; buffer-cleared; only the
+  `:ungrouped` bucket present).
+
+  Used at first-mount seeding time (rf2-boyc2): `compose-focus` derives
+  the panel-observed frame from this same head cascade, so seeding the
+  Causa app-db's `:target-frame` + `:epoch-history` from the same axis
+  closes the initial-mount race where the App-DB panel renders the
+  boot empty-state for `:cart-frame` (the observed frame) because
+  `:epoch-history` was seeded from `:rf/default` (the legacy default).
+  Picker-driven `set-frame-reducer` already aligns the same two axes
+  on a frame change; this helper extends that alignment to mount."
+  [cascades]
+  (:frame (head-cascade (focusable-cascades cascades))))
+
 (defn cascade-by-id
   "Find a cascade in `cascades` by its `:dispatch-id`. Returns nil when
   no match (id refers to an evicted cascade, or a fresh session).

--- a/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/mount_cljs_test.cljs
@@ -826,6 +826,144 @@
                 (is (= [1 2] (mapv :id buf))
                     "seed preserves oldest-first ordering")))))))))
 
+;; -------------------------------------------------------------------------
+;; rf2-boyc2 — first-mount `:epoch-history` + `:target-frame` align with the
+;; observed frame (the head focusable cascade's frame).
+;; -------------------------------------------------------------------------
+;;
+;; Pre-fix the mount path hardcoded the seed frame to `:rf/default` via
+;; `(rf/epoch-history defaults/default-target-frame)` then dispatched
+;; `:rf.causa/sync-epoch-history`. But `compose-focus` derives the
+;; panel-observed frame from the head cascade in the trace buffer — so an
+;; app whose pre-mount events ran on `:cart-frame` rendered the App-DB
+;; panel against `:cart-frame` (observed) while `:epoch-history` was
+;; keyed on the empty `:rf/default` ring. `:history-empty?` resolved
+;; true; the panel rendered the boot empty-state for `:cart-frame` even
+;; with cascades from that frame in the buffer. Frame-switch round-trip
+;; resolved it (`set-frame-reducer` aligns the two axes); the first-
+;; mount path had to do the same. Fix: `ensure-causa-frame!` computes
+;; the seed frame via `spine/focusable-head-frame-id` over the same
+;; cascade projection panels read off and dispatches
+;; `:rf.causa/set-target-frame seed-frame` so `:target-frame` +
+;; `:epoch-history` move in lockstep.
+
+(defn- pre-mount-dispatch-event
+  "Build a trace event the projection groups into a cascade for the
+  given frame. Matches the shape produced by `event/dispatched` in the
+  framework's emit layer — enough for `projection/group-cascades` to
+  bucket the event into its dispatch-id-keyed cascade with `:frame`."
+  [id dispatch-id frame-id event-id]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :tags      {:dispatch-id dispatch-id
+               :frame       frame-id
+               :event       [event-id]}})
+
+(deftest first-open!-seeds-target-frame-from-head-focusable-cascade-frame
+  (testing "rf2-boyc2 — first open! reads the trace-bus buffer, projects
+            it through the same `group-cascades` + Causa-internal filter
+            the `:rf.causa/cascades` sub uses, and seeds `:target-frame`
+            from the head focusable cascade's `:frame`. This closes the
+            initial-mount race where the App-DB panel rendered the boot
+            empty-state for an observed frame whose `:epoch-history`
+            slot was still keyed on `:rf/default`."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)
+              cart-records [{:epoch-id     :e-1
+                             :frame        :cart-frame
+                             :db-before    {:cart {:items []}}
+                             :db-after     {:cart {:items [{:id 7}]}}
+                             :trigger-event [:cart/add-item]
+                             :event-id     :cart/add-item
+                             :trace-events []}]]
+          (with-redefs [substrate-adapter/render render-fn
+                        ;; Stub `rf/epoch-history` so the `:rf.causa/
+                        ;; set-target-frame` event handler's
+                        ;; `(rf/epoch-history target)` read returns the
+                        ;; pre-mount `:cart-frame` records the test wants
+                        ;; the panel to see. In production the framework's
+                        ;; epoch ring would already carry these.
+                        rf/epoch-history (fn [frame-id]
+                                           (case frame-id
+                                             :cart-frame cart-records
+                                             []))]
+            ;; Pre-mount: the host has dispatched events on :cart-frame
+            ;; while Causa was unmounted. The trace-bus atom accumulates
+            ;; the trace events; the framework's epoch ring (stubbed
+            ;; above) carries the corresponding :rf/epoch-record values.
+            (trace-bus/collect-trace!
+              (pre-mount-dispatch-event 1 100 :cart-frame :cart/add-item))
+            (trace-bus/collect-trace!
+              (pre-mount-dispatch-event 2 101 :cart-frame :cart/checkout))
+            (mount/open!)
+            (rf/with-frame :rf/causa
+              (is (= :cart-frame @(rf/subscribe [:rf.causa/target-frame]))
+                  "`:target-frame` seeds from the head focusable cascade's
+                   `:frame` — NOT the hardcoded `:rf/default`. Pre-fix
+                   the slot was `:rf/default` regardless of pre-mount
+                   cascades.")
+              (is (= cart-records @(rf/subscribe [:rf.causa/epoch-history]))
+                  "`:epoch-history` re-seeds from `(rf/epoch-history
+                   :cart-frame)` so the App-DB panel's
+                   `:rf.causa/selected-epoch-diff` returns the picked
+                   frame's diff body rather than `:history-empty? true`."))))))))
+
+(deftest first-open!-seeds-default-frame-when-no-pre-mount-cascades
+  (testing "rf2-boyc2 — cold start: no pre-mount cascades in the trace
+            buffer → `spine/focusable-head-frame-id` returns nil →
+            seed-frame falls back to `defaults/default-target-frame`
+            (`:rf/default`). Preserves the pre-fix cold-start behaviour
+            so the existing empty-history landing experience is
+            unchanged."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)]
+          (with-redefs [substrate-adapter/render render-fn
+                        rf/epoch-history (fn [_] [])]
+            (mount/open!)
+            (rf/with-frame :rf/causa
+              (is (= :rf/default @(rf/subscribe [:rf.causa/target-frame]))
+                  "cold start (no pre-mount cascades) → seed frame is
+                   the default `:rf/default`. Same surface as pre-fix."))))))))
+
+(deftest first-open!-ignores-causa-internal-cascades-when-picking-seed-frame
+  (testing "rf2-boyc2 — the seed-frame projection applies the same
+            Causa-internal hard-filter the `:rf.causa/cascades` sub
+            uses (per rf2-g1pt8). Without the filter a Causa-internal
+            tool-frame cascade could be chosen as the head, but those
+            are invisible in the L2 list — picking that frame as the
+            seed would be inconsistent with what the panel will
+            observe."
+    (with-stub-document
+      (fn [_doc]
+        (let [{:keys [render-fn]} (mk-render-stub)
+              cart-records [{:epoch-id :e-cart :frame :cart-frame
+                             :db-before {} :db-after {:k 1}
+                             :trigger-event [:cart/add] :event-id :cart/add
+                             :trace-events []}]]
+          (with-redefs [substrate-adapter/render render-fn
+                        rf/epoch-history (fn [frame-id]
+                                           (case frame-id
+                                             :cart-frame cart-records
+                                             []))]
+            ;; A real :cart-frame cascade (visible in L2) followed by a
+            ;; Causa-internal cascade (filtered from L2). Without the
+            ;; internal filter the latter would sort as head and the
+            ;; seed-frame would be wrong.
+            (trace-bus/collect-trace!
+              (pre-mount-dispatch-event 1 200 :cart-frame :cart/add))
+            (trace-bus/collect-trace!
+              (pre-mount-dispatch-event 2 201 :rf/causa
+                                        :rf.causa/select-tab))
+            (mount/open!)
+            (rf/with-frame :rf/causa
+              (is (= :cart-frame @(rf/subscribe [:rf.causa/target-frame]))
+                  "head L2-visible cascade is :cart-frame — the Causa-
+                   internal cascade is filtered out of the projection
+                   the way the `:rf.causa/cascades` sub filters it"))))))))
+
 (deftest open!-is-idempotent-on-causa-frame-registration
   (testing "subsequent open!s after the frame is registered surgical-
             update the frame's config (reg-frame contract per Spec 002

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -116,6 +116,44 @@
   (is (nil? (spine/step-dispatch-id [] :c1 +1)))
   (is (nil? (spine/step-dispatch-id [] nil -1))))
 
+;; ---- focusable-head-frame-id (rf2-boyc2) --------------------------------
+
+(deftest focusable-head-frame-id-returns-head-cascade-frame
+  (testing "rf2-boyc2 — the head focusable cascade's :frame is the seed
+            frame for first-mount `:target-frame` + `:epoch-history`. The
+            picker-driven `set-frame-reducer` aligns the same two axes
+            on a frame change; this helper extends the alignment to the
+            first-mount path so the App-DB panel doesn't render the boot
+            empty-state when pre-mount cascades exist on a non-default
+            frame."
+    (let [cascades [(cascade :c1 :cart-frame)
+                    (cascade :c2 :checkout-frame)
+                    (cascade :c3 :cart-frame)]]
+      (is (= :cart-frame (spine/focusable-head-frame-id cascades))
+          "head focusable cascade is :c3 — its :frame is :cart-frame"))))
+
+(deftest focusable-head-frame-id-skips-ungrouped
+  (testing "rf2-boyc2 — :ungrouped bucket is filtered out so the seed
+            frame is always a real, L2-visible cascade's frame. Without
+            the filter the bucket (no `:frame` slot) could be chosen as
+            the head, and `:target-frame nil` would resolve via
+            `set-target-frame`'s `(or frame-id default-target-frame)`
+            to `:rf/default` — wiping out a real pre-mount frame's
+            history."
+    (let [cascades [(cascade :c1 :cart-frame)
+                    (cascade :ungrouped nil)]]
+      (is (= :cart-frame (spine/focusable-head-frame-id cascades))
+          ":ungrouped is filtered; head focusable cascade is :c1"))))
+
+(deftest focusable-head-frame-id-empty-cascades-returns-nil
+  (testing "rf2-boyc2 — no focusable cascades → nil. Callers fall back
+            to `defaults/default-target-frame` so the cold-start path
+            behaves identically to pre-fix."
+    (is (nil? (spine/focusable-head-frame-id [])))
+    (is (nil? (spine/focusable-head-frame-id
+                [(cascade :ungrouped nil)]))
+        "only the :ungrouped bucket present → nil")))
+
 ;; -------------------------------------------------------------------------
 ;; (2) compose-focus — :head? + effective :dispatch-id derivation
 ;; -------------------------------------------------------------------------


### PR DESCRIPTION
## Why

On fresh open of any Causa-instrumented app whose pre-mount events ran on a non-default frame, the App-DB panel renders the placeholder `app-db for :<frame-id> is at the boot value. No diffs yet.` even when cascades for that frame are already in the buffer. Frame-switch round-trip resolves it — confirming the round-trip's unsub/resub fetches fresh state but the first-mount path skips the fetch.

Sibling race to the multi-frame panel-focus wave (rf2-fvplw + rf2-y8bik + rf2-ug1r6 + rf2-thodq, shipped via #1491 + #1492) but on the initial-mount seam rather than the picker-change seam — same architectural shape: the panel-observed frame (derived by `compose-focus` from the head cascade) drifts from the `:epoch-history` slot's frame.

## Diagnosis

`mount.cljs/ensure-causa-frame!` seeded `:epoch-history` from `(rf/epoch-history defaults/default-target-frame)` — always `:rf/default`. But `compose-focus` derives the observed frame from the head cascade in `(:rf.causa/cascades)` (which projects the trace buffer Causa just seeded). When pre-mount events ran on `:cart-frame`:

- `:rf.causa/observed-frame` resolved to `:cart-frame` (head cascade frame)
- `:epoch-history` was the empty `:rf/default` ring (wrong axis)
- `:rf.causa/selected-epoch-diff` fell through to `(peek <empty>)` → composite `:history-empty?` true → panel rendered the boot empty-state

## Fix

`ensure-causa-frame!` now projects the pre-mount trace buffer through the same pipeline `:rf.causa/cascades` uses (`group-cascades` + the Causa-internal hard-filter from rf2-g1pt8), picks the head focusable cascade's `:frame` via the new `spine/focusable-head-frame-id` helper, and dispatches `:rf.causa/set-target-frame seed-frame` so `:target-frame` + `:epoch-history` move in lockstep at mount time — symmetric with the picker-driven `set-frame-reducer` path and the public `core/set-target-frame!` API. Falls back to `defaults/default-target-frame` when no focusable cascade exists (cold start), preserving the pre-fix landing.

Picked fix-path #4 from the bead: re-use the seeding pattern from rf2-ug1r6 (`set-frame-reducer` re-seeds `:epoch-history`) for the initial-mount slice. Same architectural shape; closes the analogous gap on a different seam.

## Verification

- `spine_cljs_test`: 3 new tests pin `focusable-head-frame-id` — returns the head focusable cascade's frame; filters `:ungrouped`; nil on empty.
- `mount_cljs_test`: 3 new tests pin the seed path — `:target-frame` seeds from the head cascade's frame; falls back to `:rf/default` on cold start; filters Causa-internal cascades before picking the head.
- Pre-fix the regression tests fail with `:target-frame :rf/default` for pre-mount `:cart-frame` cascades. Post-fix they pass with `:target-frame :cart-frame` and `:epoch-history` carrying the picked-frame records.
- `npm run test:cljs`: 2912 tests, 8336 assertions, **0 failures, 0 errors**.
- `clojure -M:test` (Causa JVM): 743 tests, 2186 assertions, **0 failures, 0 errors**.
- `scripts/test-fast-pr.sh`: **PASS fast PR spine**.
- Existing panel-focus tests (rf2-fvplw / y8bik / ug1r6 / thodq) unchanged.

Closes rf2-boyc2.