### PR TITLE
fix(causa): expose detach! + Story calls it after disable-keybinding! (rf2-ycrt2)

### DIFF
--- a/tools/causa/spec/008-Embedding-Contract.md
+++ b/tools/causa/spec/008-Embedding-Contract.md
@@ -71,6 +71,26 @@ explicit `(mount/open!)` / `(mount/toggle!)` calls, the `:rf.causa/*`
 event surface — remain fully usable; only the window-level keystroke
 capture is suppressed.
 
+Hosts whose lifecycle places the `configure!` call BEFORE Causa's
+preload runs (boot-time configuration) need nothing further — the
+slot flip wins the read at attach time. Hosts whose mount lifecycle
+runs AFTER the preload (Story's `ensure-causa-mounted!` fires at
+variant-selection time) MUST additionally call
+`day8.re-frame2-causa.keybinding/detach!` AFTER the slot flip:
+
+```clojure
+(causa-config/configure! {:launch.keybinding/enabled? false})
+(causa-keybinding/detach!)
+```
+
+`detach!` is idempotent and safe to call when nothing is attached
+(no-op). Per rf2-ycrt2 (rf2-q7who.1 runtime follow-on) — the slot
+declares intent but is read only at attach time; without `detach!`
+the listener Causa's preload already installed under the default-true
+posture stays on `js/document` and continues consuming keypresses.
+The full API contract for `detach!` is documented in
+[`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!`.
+
 ## Scoping
 
 The `:scope` prop narrows the observation window:

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -198,7 +198,7 @@ down the propagation path don't double-fire.
 Hosts MUST set this BEFORE the Causa preload runs (the preload calls
 `keybinding/attach!` at adapter-ready time). Setting it afterwards is
 a no-op on the already-attached listener unless the host explicitly
-calls `keybinding/detach!`.
+calls `keybinding/detach!` (see below).
 
 The slot exists for embed hosts (per
 [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — Story
@@ -208,6 +208,45 @@ keybindings collide with Causa's. Story's command-palette
 capture-phase listener consumes the keypress before Story's handler
 fires. Per rf2-4eyik (rf2-q7who Thread A) — the embed-contract gap
 discovered via rf2-drprn.
+
+#### `keybinding/detach!` — public escape hatch (rf2-ycrt2)
+
+`day8.re-frame2-causa.keybinding/detach!` is the public companion to
+`attach!` for embed hosts whose mount lifecycle runs AFTER Causa's
+preload. The contract:
+
+```clojure
+(require '[day8.re-frame2-causa.keybinding :as causa-keybinding])
+
+(causa-keybinding/detach!)
+```
+
+- **No arguments**; returns `nil`.
+- **Idempotent**. Calling it when nothing is attached is a no-op (the
+  internal sentinel does not underflow); calling it twice in a row is
+  safe.
+- **Symmetric with `attach!`**. The pair `(attach!) → (detach!) →
+  (attach!)` flips between attached / not-attached cleanly without
+  leaking listeners.
+- **Safe in any host**. Guarded on `(exists? js/document)`.
+
+When to call: embed hosts that flip `:launch.keybinding/enabled?` to
+`false` from a **mount-time** hook (not boot-time) must follow the
+slot flip with `detach!`. The slot alone is read only at attach time;
+without `detach!` the listener Causa's preload installed under the
+default-true posture stays on `js/document` and continues consuming
+keypresses despite the intent declaration. Per rf2-ycrt2 (rf2-q7who.1
+runtime follow-on). Story's `ensure-causa-mounted!` is the canonical
+example: it calls `disable-keybinding!` (slot flip) then
+`detach-keybinding!` (runtime removal) on every variant-selection
+edge.
+
+Boot-time hosts (those that call `configure! {:launch.keybinding/enabled?
+false}` BEFORE Causa's preload runs) do NOT need to call `detach!` —
+their slot flip lands before `attach!` reads it, the short-circuit
+fires, and no listener is ever installed. `detach!` exists for the
+mount-time lifecycle the slot's attach-time-only read cannot cover
+alone.
 
 ### `:settings`
 

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -246,8 +246,19 @@
   nil)
 
 (defn detach!
-  "Remove the listener. Intended for tests; production sessions never
-  call this."
+  "Remove the global keydown listener if one is currently attached.
+  Idempotent — safe to call when nothing is attached (no-op), and safe
+  to call twice in a row (the second call is a no-op).
+
+  Public embed-host escape hatch (rf2-ycrt2 — rf2-q7who.1 follow-on).
+  The `:launch.keybinding/enabled?` config slot suppresses installation
+  only when read at attach time; embed hosts whose mount lifecycle
+  (e.g. Story's `ensure-causa-mounted!`) flips the slot AFTER Causa's
+  preload has already run must call `detach!` to remove the listener
+  that the preload installed under the default-true posture. Symmetric
+  with `attach!`; calling them in sequence (`attach! → detach! →
+  attach!`) flips between attached / not-attached cleanly without
+  leaking listeners or stale sentinel state."
   []
   (when (and (exists? js/document)
              (compare-and-set! attached-state true false))

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -352,6 +352,27 @@
         (is (zero? (count @listeners))
             "no listener was added or removed")))))
 
+(deftest detach-is-idempotent
+  (testing "rf2-ycrt2 — detach! is the public embed-host escape hatch
+            (Story calls it from ensure-causa-mounted! after flipping
+            :launch.keybinding/enabled? false); calling it twice in a
+            row must be safe — the second call removes nothing (the
+            sentinel is already false) and does not throw"
+    (with-stub-document
+      (fn [{:keys [listeners]}]
+        (keybinding/attach!)
+        (is (= 1 (count @listeners)))
+        (keybinding/detach!)
+        (is (false? (keybinding/attached?))
+            "first detach! flips the sentinel back to false")
+        (is (zero? (count @listeners))
+            "first detach! removed the listener")
+        (keybinding/detach!)
+        (is (false? (keybinding/attached?))
+            "second detach! keeps the sentinel at false (no underflow)")
+        (is (zero? (count @listeners))
+            "second detach! is a no-op on the listener set")))))
+
 (deftest attach-without-document-is-safe
   (testing "absence of js/document — node-test baseline — must not
             throw and must not flip the sentinel"

--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -242,11 +242,65 @@
      mounts never have Causa swallow the host's global keybindings
      (typically `Cmd/Ctrl+K` for Story's command palette). Per
      rf2-q7who.1 (rf2-4eyik sibling on the Causa side). Idempotent —
-     writing `false` over an existing `false` is a plain reset!."
+     writing `false` over an existing `false` is a plain reset!.
+
+     Sequencing: `disable-keybinding!` flips the slot (intent
+     declaration); rf2-ycrt2's `detach-keybinding!` removes the
+     listener Causa's preload already installed under the default-true
+     posture (runtime mechanism). Both fire from `ensure-causa-mounted!`
+     in that order."
      []
      (when (and config/enabled? (causa-config-available?))
        (when-let [configure! (resolve-fn 'day8.re-frame2-causa.config/configure!)]
          (safe-call! "config/configure!" configure! {:launch.keybinding/enabled? false})
+         true))))
+
+;; ---- keybinding/detach! bridge (rf2-ycrt2 — rf2-q7who.1 follow-on) -------
+;;
+;; `disable-keybinding!` above flips Causa's `:launch.keybinding/enabled?`
+;; slot to `false`, but that slot is only read at attach time (by
+;; `keybinding/attach!`). Causa's preload runs BEFORE Story's mount-time
+;; bridge fires — so by the time `disable-keybinding!` flips the slot,
+;; `attach!` has already installed the global keydown listener under the
+;; default-true posture. The listener stays on `js/document` and
+;; continues swallowing Story's `Cmd/Ctrl+K` despite the intent
+;; declaration.
+;;
+;; The fix (option (b) per rf2-ycrt2 operator decision): Causa exposes
+;; a public `detach!` fn (idempotent, safe to call without prior
+;; `attach!`). Story drives it after `disable-keybinding!` so the
+;; intent-declaration is matched by a runtime removal. Slot remains the
+;; baseline contract; `detach!` is the embed-host escape hatch.
+;;
+;; Option (a) — making the slot reactive (watcher on the atom that
+;; detaches on true → false transitions) — was considered but rejected:
+;; expands Causa's reactive surface for one case; option (b) is the
+;; smaller commitment and matches the existing symmetry with
+;; `attach!`.
+
+#?(:cljs
+   (defn detach-keybinding!
+     "Remove Causa's global keydown listener via
+     `day8.re-frame2-causa.keybinding/detach!`. Returns `true` when the
+     call landed, or `nil` when Causa's `keybinding` ns is not on the
+     classpath (preload absent).
+
+     Called by `ensure-causa-mounted!` AFTER `disable-keybinding!`
+     flipped the slot — the slot declares intent, `detach!` removes the
+     listener Causa's preload installed under the default-true posture.
+     The runtime gap rf2-q7who.1 declared but did not close — rf2-ycrt2
+     closes it.
+
+     Idempotent — `keybinding/detach!` is a no-op when nothing is
+     attached, so this bridge is safe on the rare edge where Causa's
+     preload was suppressed (e.g. host already set the slot to `false`
+     before Causa's preload ran). Feature-detect-safe — when Causa's
+     `keybinding` ns is absent the bridge returns nil without touching
+     the wire."
+     []
+     (when (and config/enabled? (causa-config-available?))
+       (when-let [detach! (resolve-fn 'day8.re-frame2-causa.keybinding/detach!)]
+         (safe-call! "keybinding/detach!" detach!)
          true))))
 
 #?(:cljs
@@ -270,11 +324,18 @@
      rf2-q7who.1: also disables Causa's global keybinding listener via
      `:launch.keybinding/enabled? false` so Story's own Cmd/Ctrl+K
      command palette is not swallowed by Causa's capture-phase
-     listener. The slot is idempotent on every variant edge."
+     listener. The slot is idempotent on every variant edge.
+
+     rf2-ycrt2: also calls `keybinding/detach!` AFTER the slot flip so
+     the listener Causa's preload installed (under the default-true
+     posture, before Story's mount-time bridge fires) is removed at
+     runtime — the slot alone is read only at attach time and would
+     leave the listener installed without this step."
      []
      (when (and config/enabled? (causa-available?))
        (propagate-project-root!)
        (disable-keybinding!)
+       (detach-keybinding!)
        (apply-open!))))
 
 #?(:cljs

--- a/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
@@ -20,11 +20,18 @@
     config-atom in the node-test build (Causa's source path is on the
     test classpath) and via a shimmed `configure!` fn that captures
     the call payload.
-  - `ensure-causa-mounted!` (rf2-q7who.1): calls `disable-keybinding!`
-    as part of the mount edge so Story's RHS-mounted Causa never
-    swallows the host's Cmd/Ctrl+K command palette."
+  - `detach-keybinding!` (rf2-ycrt2): drives Causa's
+    `keybinding/detach!` so the listener Causa's preload installed
+    under the default-true posture is removed at runtime (the slot
+    alone is read only at attach time).
+  - `ensure-causa-mounted!` (rf2-q7who.1 + rf2-ycrt2): calls
+    `disable-keybinding!` then `detach-keybinding!` as part of the
+    mount edge so Story's RHS-mounted Causa never swallows the host's
+    Cmd/Ctrl+K command palette — both the intent declaration (slot
+    flip) and the runtime mechanism (detach!) fire together."
   (:require [clojure.test :refer [deftest is testing]]
             [day8.re-frame2-causa.config :as causa-config]
+            [day8.re-frame2-causa.keybinding :as causa-keybinding]
             [re-frame.story.causa-preset :as causa-preset]))
 
 ;; ---- disable-keybinding! -------------------------------------------------
@@ -65,7 +72,38 @@
         (is (= {:launch.keybinding/enabled? false} @captured)
             "configure! is called with exactly the keybinding-disable slot")))))
 
-;; ---- ensure-causa-mounted! drives the bridge -----------------------------
+;; ---- detach-keybinding! (rf2-ycrt2) --------------------------------------
+
+(deftest detach-keybinding-drives-causa-keybinding-detach
+  (testing "detach-keybinding! removes Causa's global keydown listener"
+    ;; Belt-and-braces test: redef `causa-config-available?` and the
+    ;; `resolve-fn` lookup so we capture that detach-keybinding! drives
+    ;; `keybinding/detach!` by symbol. The bridge is symbol-based
+    ;; (resolve-fn 'day8.re-frame2-causa.keybinding/detach!) so the
+    ;; assertion mirrors that lookup contract.
+    (let [called? (atom false)
+          shim-detach! (fn [] (reset! called? true) nil)]
+      (with-redefs [causa-preset/causa-config-available?
+                    (fn [] true)
+                    causa-preset/resolve-fn
+                    (fn [sym]
+                      (when (= sym 'day8.re-frame2-causa.keybinding/detach!)
+                        shim-detach!))]
+        (is (true? (causa-preset/detach-keybinding!))
+            "returns true when keybinding/detach! is reachable")
+        (is (true? @called?)
+            "keybinding/detach! was driven by the bridge")))))
+
+(deftest detach-keybinding-is-noop-without-causa
+  (testing "detach-keybinding! returns nil when Causa's keybinding ns is absent"
+    ;; Shim causa-config-available? false so the outer guard short-
+    ;; circuits — bridges must degrade silently when Causa is not on the
+    ;; classpath (the standalone-Story posture).
+    (with-redefs [causa-preset/causa-config-available? (fn [] false)]
+      (is (nil? (causa-preset/detach-keybinding!))
+          "no Causa → no work → nil"))))
+
+;; ---- ensure-causa-mounted! drives the bridges ----------------------------
 
 (deftest ensure-causa-mounted-disables-keybinding
   (testing "ensure-causa-mounted! drives disable-keybinding! on the mount edge"
@@ -74,15 +112,18 @@
     ;; that flow. We shim the Causa-availability gate AND
     ;; `disable-keybinding!` itself so we can assert the wiring without
     ;; depending on the underlying configure! plumbing (covered by the
-    ;; shimmed-configure test above). We also stub the `resolve-fn`
-    ;; lookup `apply-open!` uses so we don't actually try to mount a
-    ;; shell.
+    ;; shimmed-configure test above). We also stub `detach-keybinding!`
+    ;; and the `resolve-fn` lookup `apply-open!` uses so we don't
+    ;; actually try to mount a shell.
     (let [disable-called? (atom false)
+          detach-called?  (atom false)
           open-called?    (atom false)]
       (with-redefs [causa-preset/causa-available?
                     (fn [] true)
                     causa-preset/disable-keybinding!
                     (fn [] (reset! disable-called? true) true)
+                    causa-preset/detach-keybinding!
+                    (fn [] (reset! detach-called? true) true)
                     causa-preset/resolve-fn
                     (fn [sym]
                       (when (= sym 'day8.re-frame2-causa.mount/open!)
@@ -90,5 +131,79 @@
         (causa-preset/ensure-causa-mounted!)
         (is (true? @disable-called?)
             "disable-keybinding! is part of the mount edge")
+        (is (true? @detach-called?)
+            "detach-keybinding! is part of the mount edge")
         (is (true? @open-called?)
             "apply-open! still fires (keybinding wire-up does not break mount)")))))
+
+(deftest ensure-causa-mounted-sequences-slot-then-detach
+  (testing "rf2-ycrt2 — ensure-causa-mounted! flips the slot BEFORE
+            removing the listener; sequencing matters because a host
+            (or test runner) inspecting the slot mid-flow must always
+            see the declared intent. We capture the order via a shared
+            log and assert disable-keybinding! ran before
+            detach-keybinding!."
+    (let [calls (atom [])]
+      (with-redefs [causa-preset/causa-available?
+                    (fn [] true)
+                    causa-preset/disable-keybinding!
+                    (fn [] (swap! calls conj :disable) true)
+                    causa-preset/detach-keybinding!
+                    (fn [] (swap! calls conj :detach) true)
+                    causa-preset/resolve-fn
+                    (fn [sym]
+                      (when (= sym 'day8.re-frame2-causa.mount/open!)
+                        (fn [] (swap! calls conj :open) nil)))]
+        (causa-preset/ensure-causa-mounted!)
+        (is (= [:disable :detach :open] @calls)
+            "slot flip (intent) lands before detach! (runtime removal)
+             which lands before apply-open!")))))
+
+;; ---- runtime integration: slot + detach! together (rf2-ycrt2) ------------
+
+(deftest ensure-causa-mounted-clears-attached-listener
+  (testing "rf2-ycrt2 — simulate Causa's preload-time attach! under the
+            default-true posture, then drive ensure-causa-mounted!;
+            after the mount edge the keybinding sentinel must be false
+            (the listener was removed). This is the runtime contract
+            rf2-q7who.1 declared but did not close — the slot flip
+            alone wouldn't detach the listener; rf2-ycrt2 closes the
+            gap via detach-keybinding!."
+    ;; Restore baseline so attach! sees the default-true slot. Then
+    ;; simulate the preload: attach!. Without rf2-ycrt2 the listener
+    ;; would survive past ensure-causa-mounted!; with the fix the
+    ;; sentinel flips back to false.
+    (causa-config/set-keybinding-enabled! true)
+    (try
+      ;; Skip the inner attach when js/document is unstubbable (real
+      ;; browser-test) — the contract still proves on node-test where
+      ;; the keybinding suite's stub gates idempotency.
+      (when (exists? js/document)
+        (causa-keybinding/attach!)
+        (is (true? (causa-keybinding/attached?))
+            "precondition: preload-style attach! installed the listener"))
+      ;; Drive the mount edge. We shim Causa-availability + apply-open!
+      ;; so we don't try to mount a shell. `disable-keybinding!` and
+      ;; `detach-keybinding!` run for real (with-redefs unchanged) and
+      ;; their inner `resolve-fn` lookups resolve against Causa's live
+      ;; config/keybinding namespaces (both on the test classpath).
+      ;; Capture the original resolve-fn so the with-redefs delegate
+      ;; can fall through for the keybinding/detach! + configure!
+      ;; lookups without recursing on itself.
+      (let [orig-resolve-fn @#'causa-preset/resolve-fn]
+        (with-redefs [causa-preset/causa-available? (fn [] true)
+                      causa-preset/resolve-fn
+                      (fn [sym]
+                        (if (= sym 'day8.re-frame2-causa.mount/open!)
+                          (fn [] nil)
+                          (orig-resolve-fn sym)))]
+          (causa-preset/ensure-causa-mounted!)))
+      (is (false? (causa-config/keybinding-attach-enabled?))
+          "ensure-causa-mounted! flipped the slot to false")
+      (is (false? (causa-keybinding/attached?))
+          "ensure-causa-mounted! removed the listener (rf2-ycrt2 runtime gap closed)")
+      (finally
+        ;; Restore defaults so neighbouring tests see the baseline.
+        (causa-config/set-keybinding-enabled! true)
+        (when (exists? js/document)
+          (causa-keybinding/detach!))))))


### PR DESCRIPTION
## Why

PR #1497 added Causa's `:launch.keybinding/enabled?` config slot but `keybinding/attach!` reads it ONCE at preload time. PR #1500 declares Story sets the slot to `false` from `ensure-causa-mounted!` — but that fires AT MOUNT TIME, AFTER Causa's preload has already installed the global keydown listener under the default-true posture. Listener stays attached. Story's Cmd/Ctrl+K palette is still swallowed by Causa's capture-phase `stopPropagation()`.

## What

**Option (b)** per rf2-ycrt2 operator decision: Causa exposes a public `keybinding/detach!` fn; Story's `ensure-causa-mounted!` calls it after `disable-keybinding!`. Idempotent; symmetric with `attach!`.

The `detach!` implementation already existed for test isolation — this commit promotes its docstring to declare it a public embed-host escape hatch and adds the `detach-is-idempotent` double-detach test to lock the public contract.

Story side: new `detach-keybinding!` bridge (symmetric to `disable-keybinding!`) resolves Causa's `keybinding/detach!` via the existing symbol-lookup pattern. Wired into `ensure-causa-mounted!` after `disable-keybinding!`. Sequence: slot flip (intent declaration) → listener removal (runtime mechanism) → `mount/open!`.

Spec docs (Causa `015-Configuration.md` + `008-Embedding-Contract.md`) gain a `keybinding/detach!` subsection distinguishing the boot-time slot-flip path (no `detach!` needed — slot wins the attach-time read) from the mount-time path (slot flip + `detach!` mandatory — preload already attached the listener).

Option (a) — reactive slot via a watcher on the config atom — was considered. It would expand Causa's reactive surface for one case and quietly add a side effect to `set-keybinding-enabled!` not declared in its current docstring. Option (b) is the smaller commitment and matches the existing symmetry with `attach!`.

## Verification

- tools/causa JVM tests: 752t / 2201a / 0F (+1 deftest covering double-detach idempotency)
- tools/story JVM tests: 750t / 2221a / 0F (+3 deftests covering `detach-keybinding!` lookup, no-Causa no-op, mount-edge wiring, slot-then-detach sequencing, and the runtime-gap closure where `attach! → ensure-causa-mounted!` leaves `attached?` false)
- implementation cljs node tests: 2929t / 8377a / 0F
- mkdocs --strict: 72 pre-existing warnings on main (unrelated; `tools/causa/spec/` is outside the mkdocs surface)

Closes rf2-ycrt2.