### PR TITLE
feat+spec(story): :isolation slot + :modes semantics clarification (rf2-gqid4 + rf2-q5e36)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -94,18 +94,42 @@ and reject with `:rf.error/variant-shape` on miss.
 Body:
 
 ```clojure
-{:doc      "..."
- :layout   :grid | :prose | :variants-grid | :tabs | :custom
- :variants [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs
- :content  [{:type :prose :body "md..."} ...]    ; for :prose
- :render   <view-id>                              ; for :custom (a registered view)
- :modes    #{<mode-id> ...}}
+{:doc       "..."
+ :layout    :grid | :prose | :variants-grid | :tabs | :custom
+ :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs
+ :content   [{:type :prose :body "md..."} ...]    ; for :prose
+ :render    <view-id>                              ; for :custom (a registered view)
+ :modes     #{<mode-id> ...}
+ :isolation :isolated | :shared}                   ; rf2-gqid4 — :variants-grid only
 ```
 
 The `:variants-grid` layout (per Phase 2 SOTA refinement) renders
 every variant of a single parent story side-by-side; it differs from
 `:grid` (which renders an explicit `:variants` list) by enumerating
 variants from the registry.
+
+#### Workspace `:isolation` slot — `:variants-grid` mount strategy (rf2-gqid4)
+
+The optional `:isolation` slot tunes how `:variants-grid` mounts its
+cells. Two values:
+
+| Value       | Mount strategy                                         | When to use                                                                                                                                                                                                                                            |
+|-------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `:isolated` | **(default)** every cell mounts in parallel, each scoped to its variant-allocated frame via `frame-provider-ns-safe`. Baseline frame-isolation contract. | Most stories. The decorator + frame-provider pipeline keeps each cell's app-db / subscribes independent.                                                                                                                                              |
+| `:shared`   | cells mount ONE at a time with a prev/next navigator (◀ N/total ▶). Same serialised-mount strategy as `:tabs`. | Views whose `:component` internally hardcodes a frame-provider (e.g. `gallery_chrome.cljs` / rf2-sszlr). Parallel cells of such views share interior state because the last-seeded cell's app-db clobbers siblings — serialised mount restores per-variant state. |
+
+Only `:variants-grid` honours `:isolation`; other layouts ignore it.
+`:tabs` already serialises by construction.
+
+```clojure
+(story/reg-workspace :Workspace.gallery/all
+  {:layout    :variants-grid
+   :isolation :shared})    ; render cells serially with prev/next nav
+```
+
+Belt-and-braces to the Causa modal-positioning fix (rf2-om6fa);
+together they cover the full-viewport modal stack symptom *and* the
+remaining interior state-bleed.
 
 ### `(reg-decorator id metadata)`
 

--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -99,7 +99,7 @@ Body:
  :variants  [<variant-id> ...]                    ; for :grid / :variants-grid / :tabs
  :content   [{:type :prose :body "md..."} ...]    ; for :prose
  :render    <view-id>                              ; for :custom (a registered view)
- :modes     #{<mode-id> ...}
+ :modes     #{<mode-id> ...}                       ; future-reserved — see below
  :isolation :isolated | :shared}                   ; rf2-gqid4 — :variants-grid only
 ```
 
@@ -107,6 +107,21 @@ The `:variants-grid` layout (per Phase 2 SOTA refinement) renders
 every variant of a single parent story side-by-side; it differs from
 `:grid` (which renders an explicit `:variants` list) by enumerating
 variants from the registry.
+
+#### Workspace `:modes` slot — future-reserved (v1) (rf2-q5e36)
+
+The workspace body's `:modes` slot is **declared but not honoured by
+the runtime in v1**. Workspaces inherit the chrome's `:active-modes`
+selection (the chrome-level toolbar, per
+[`010-Toolbar.md`](010-Toolbar.md)). Workspace-local mode scoping
+(override / union / cell fan-out matrix) is a v2 follow-up; the slot
+is reserved so existing bodies don't break when the runtime starts
+honouring it. **This paragraph is authoritative** for the workspace
+`:modes` slot semantics. The chrome-level toolbar is the only path
+that affects rendering today; see
+[`010-Toolbar.md`](010-Toolbar.md) §State location for the
+`:active-modes` slot every workspace render consumes via
+`re-frame.story.ui.state/shell-state-atom`.
 
 #### Workspace `:isolation` slot — `:variants-grid` mount strategy (rf2-gqid4)
 

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -59,6 +59,29 @@ variant of a single parent story side-by-side; it differs from `:grid`
 (which renders an explicit `:variants` list) by enumerating variants
 from the registry.
 
+### `:variants-grid :isolation` (rf2-gqid4)
+
+The workspace body's optional `:isolation` slot tunes the mount
+strategy for `:variants-grid`:
+
+- `:isolated` (default) — every cell mounts in parallel; each wraps
+  its rendered view in a per-variant frame-provider. Baseline
+  frame-isolation contract.
+- `:shared` — cells mount ONE at a time with a prev/next navigator
+  (◀ N/total ▶). Same serialised-mount strategy `:tabs` (rf2-ktnl8)
+  uses, scoped to the implicit `:variants-grid` enumeration.
+
+`:shared` is the affordance for views that internally hardcode a
+frame-provider (e.g. `gallery_chrome.cljs` / rf2-sszlr): parallel
+cells of such views share interior state because the last-seeded
+cell's app-db clobbers siblings. Serialised mount restores per-
+variant state without forcing the author to flip the workspace to
+`:tabs` (which loses the devcards `:variants-grid` semantic of
+enumerating variants from the registry).
+
+The normative slot definition lives in
+[`001-Authoring.md`](001-Authoring.md) §reg-workspace.
+
 ## Shell lifecycle
 
 ```clojure

--- a/tools/story/spec/010-Toolbar.md
+++ b/tools/story/spec/010-Toolbar.md
@@ -397,7 +397,17 @@ support 11px chip text.
   resize overlay).
 - **Workspace-local toolbar** — workspaces inherit the chrome's
   `:active-modes` for now; if workspaces want their own toolbar
-  scoping it lands as a v2 follow-up.
+  scoping it lands as a v2 follow-up. The workspace body's `:modes`
+  slot (declared in
+  [`001-Authoring.md`](001-Authoring.md) §reg-workspace) is
+  **future-reserved** in v1 — it is not honoured by the runtime
+  yet; the chrome's `:active-modes` is the only path that affects
+  rendering. See
+  [`001-Authoring.md`](001-Authoring.md) §Workspace `:modes` slot —
+  future-reserved (v1) for the authoritative wording (rf2-q5e36).
+  The v2 workspace-local toolbar will lock the workspace `:modes`
+  slot semantics (override vs union vs cell fan-out matrix) at that
+  point.
 - **Toolbar customisation API** — projects cannot register their own
   chip widgets in v1; the chip is uniform (`button` with mode id
   label). If the design-token panel (v1.1) needs richer chips, the

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -186,6 +186,10 @@
      Optional slots (per spec/001 §reg-workspace):
 
      - `:doc`       — string description.
+     - `:modes`     — future-reserved (rf2-q5e36); workspaces inherit
+                      the chrome toolbar's `:active-modes` in v1 (see
+                      spec/001 §Workspace `:modes` slot for the
+                      authoritative wording + spec/010 §State location).
      - `:isolation` — `:variants-grid` mount strategy (rf2-gqid4):
                       `:isolated` (default — parallel cells with
                       per-variant frames) or `:shared` (serialised

--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -183,6 +183,15 @@
      - `:prose` → `:content` (vector of `{:type :prose|:variant ...}`)
      - `:custom` → `:render` (registered view id)
 
+     Optional slots (per spec/001 §reg-workspace):
+
+     - `:doc`       — string description.
+     - `:isolation` — `:variants-grid` mount strategy (rf2-gqid4):
+                      `:isolated` (default — parallel cells with
+                      per-variant frames) or `:shared` (serialised
+                      mount, one cell at a time with prev/next nav,
+                      for views that hardcode a frame-provider).
+
      Workspaces are 100% transit-shareable; the `:variants-grid` layout is
      the v1 devcards-style multi-variant pane (IMPL-SPEC §2.8.4)."
      [id metadata]

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -493,15 +493,27 @@
 
 (def Workspace
   "Schema for the body of `reg-workspace`. Per IMPL-SPEC §3.1.
-  Five layouts: `:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`."
+  Five layouts: `:grid`, `:prose`, `:variants-grid`, `:tabs`, `:custom`.
+
+  The optional `:isolation` slot (rf2-gqid4) tunes how `:variants-grid`
+  mounts its cells. `:isolated` (the default) mounts every variant
+  cell in parallel, each scoped to its own variant frame — the
+  baseline frame-isolation contract. `:shared` mounts ONE cell at a
+  time with a prev/next navigator, serialising the renderer. This is
+  the load-bearing affordance for views that internally hardcode a
+  frame-provider (the rf2-sszlr / `gallery_chrome.cljs` pattern):
+  parallel cells of such views share their interior state because the
+  last-seeded cell's app-db clobbers the others. Only honoured by
+  `:variants-grid`; ignored on other layouts."
   [:and
    [:map
-    [:doc      {:optional true} :string]
-    [:layout   [:enum :grid :prose :variants-grid :tabs :custom]]
-    [:variants {:optional true} [:vector :keyword]]
-    [:content  {:optional true} [:vector WorkspaceContentItem]]
-    [:render   {:optional true} :keyword]
-    [:modes    {:optional true} ModeRefSet]]
+    [:doc       {:optional true} :string]
+    [:layout    [:enum :grid :prose :variants-grid :tabs :custom]]
+    [:variants  {:optional true} [:vector :keyword]]
+    [:content   {:optional true} [:vector WorkspaceContentItem]]
+    [:render    {:optional true} :keyword]
+    [:modes     {:optional true} ModeRefSet]
+    [:isolation {:optional true} [:enum :isolated :shared]]]
    ;; Layout-specific requirements. :grid / :variants-grid / :tabs need
    ;; :variants; :prose needs :content; :custom needs :render.
    [:fn {:error/message

--- a/tools/story/src/re_frame/story/ui/workspace.cljc
+++ b/tools/story/src/re_frame/story/ui/workspace.cljc
@@ -27,6 +27,33 @@
   cells. A genuine one-at-a-time renderer serialises mounting so each
   visit re-seeds the active variant cleanly.
 
+  ## `:isolation :shared` for `:variants-grid` (rf2-gqid4)
+
+  The workspace body's optional `:isolation` slot tunes mount strategy
+  for `:variants-grid`. Two values:
+
+  - `:isolated` (default) — every variant cell mounts in parallel;
+    each cell wraps its rendered view in a per-variant frame-provider
+    so subscribes / dispatches route to the cell's allocated frame.
+    Baseline frame-isolation contract.
+  - `:shared` — variant cells mount ONE at a time with a prev/next
+    navigator. Equivalent strategy to `:tabs`, scoped to the implicit
+    `:variants-grid` enumeration. Use when a `:component` view
+    internally hardcodes a frame-provider (the
+    `gallery_chrome.cljs` / rf2-sszlr pattern): under `:isolated`
+    parallel-rendered cells share their interior state because the
+    last-seeded cell's app-db clobbers the rest, but a serialised
+    renderer re-seeds each cell on visit.
+
+  Belt-and-braces to `:tabs`. The Causa modal-positioning fix
+  (rf2-om6fa) covered the most visible failure mode (full-viewport
+  modal stack); `:isolation :shared` addresses the remaining interior
+  state-bleed without forcing the author to convert the workspace to
+  `:tabs` (which loses the devcards `:variants-grid` semantic of
+  enumerating from the registry).
+
+  Only honoured by `:variants-grid`; ignored on other layouts.
+
   Tab selection is held in a per-mount `r/atom` (local to the tabs
   component) — the workspace root already remounts on workspace swap
   (workspace-id-keyed `<section>`, per rf2-kgn0c) so the local atom's
@@ -473,6 +500,109 @@
                 "custom render: " (pr-str (:render active-cell))]
                nil))]]))))
 
+;; ---- :variants-grid :isolation :shared renderer (rf2-gqid4) ------------
+;;
+;; When a `:variants-grid` workspace body declares `:isolation :shared`,
+;; cells mount ONE at a time with a prev/next navigator. Same serialised-
+;; mount strategy as `:tabs` (rf2-ktnl8), but presented as a navigator
+;; (◀ N/total ▶) rather than a tab strip so the devcards "all states"
+;; reading remains the dominant UX — the navigator is the
+;; state-isolation lever, not a tab vocabulary.
+
+#?(:cljs
+   (def ^:private shared-styles
+     {:shared-wrap {:display "flex" :flex-direction "column" :gap "8px"}
+      :nav-strip   {:display         "flex"
+                    :flex-direction  "row"
+                    :align-items     "center"
+                    :gap             "8px"
+                    :border-bottom   "1px solid #3c3c3c"
+                    :padding-bottom  "4px"}
+      :nav-button  {:background    "#2d2d2d"
+                    :border        "1px solid #3c3c3c"
+                    :border-radius "3px"
+                    :color         "#cccccc"
+                    :font-family   "monospace"
+                    :font-size     "11px"
+                    :padding       "4px 10px"
+                    :cursor        "pointer"}
+      :nav-button-disabled {:background  "#252526"
+                            :color       "#666666"
+                            :cursor      "not-allowed"}
+      :nav-label   {:color       "#9cdcfe"
+                    :font-family "monospace"
+                    :font-size   "11px"
+                    :font-weight "bold"}
+      :nav-body    {:display "block"}}))
+
+#?(:cljs
+   (defn- shared-grid-renderer
+     "Reagent component for `:variants-grid` with `:isolation :shared`.
+
+     Renders ONE cell at a time and exposes prev/next buttons. Identical
+     mount-serialisation guarantee as `:tabs` — only one cell is
+     simultaneously mounted, so a view that hardcodes a frame-provider
+     does not collide with the variant-allocated frames of sibling
+     cells.
+
+     Selection is held in a per-mount `r/atom`; the workspace root
+     remounts on workspace swap (workspace-id-keyed `<section>`) so the
+     atom's lifetime matches one workspace selection. Clamps the index
+     on hot-reload-driven cell-vector shrinkage, mirroring
+     `tabs-renderer`."
+     [cells]
+     (r/with-let [selected (r/atom 0)]
+       (let [n            (count cells)
+             idx          (max 0 (min @selected (dec n)))
+             active-cell  (nth cells idx nil)
+             prev-enabled (pos? idx)
+             next-enabled (< idx (dec n))
+             label        (case (:type active-cell)
+                            :variant (pr-str (:variant-id active-cell))
+                            :prose   (str "prose " (inc idx))
+                            :custom  (str "custom " (inc idx))
+                            (str "cell " (inc idx)))]
+         [:div {:style (:shared-wrap shared-styles)}
+          [:div {:style      (:nav-strip shared-styles)
+                 :role       "group"
+                 :aria-label "Workspace cell navigator"}
+           [:button {:style    (merge (:nav-button shared-styles)
+                                      (when-not prev-enabled
+                                        (:nav-button-disabled shared-styles)))
+                     :type     "button"
+                     :disabled (not prev-enabled)
+                     :data-test-shared-prev "true"
+                     :on-click #(when prev-enabled
+                                  (swap! selected dec))}
+            "◀"]                       ; ◀
+           [:span {:style (:nav-label shared-styles)
+                   :data-test-shared-position (str (inc idx) "/" n)}
+            (str (inc idx) " / " n " — " label)]
+           [:button {:style    (merge (:nav-button shared-styles)
+                                      (when-not next-enabled
+                                        (:nav-button-disabled shared-styles)))
+                     :type     "button"
+                     :disabled (not next-enabled)
+                     :data-test-shared-next "true"
+                     :on-click #(when next-enabled
+                                  (swap! selected inc))}
+            "▶"]]                      ; ▶
+          [:div {:style              (:nav-body shared-styles)
+                 :data-test-shared-body (str idx)}
+           (when active-cell
+             (case (:type active-cell)
+               :variant
+               ^{:key (cell-key idx active-cell)}
+               [variant-cell (:variant-id active-cell)]
+               :prose
+               ^{:key (cell-key idx active-cell)}
+               [prose-block (:body active-cell)]
+               :custom
+               ^{:key (cell-key idx active-cell)}
+               [:div {:style (:cell styles)}
+                "custom render: " (pr-str (:render active-cell))]
+               nil))]]))))
+
 #?(:cljs
    (defn workspace-view
      "Render a workspace. Resolves the cells and dispatches per layout.
@@ -521,6 +651,17 @@
               ;; `gallery_chrome.cljs`).
               (= :tabs (:layout body))
               [tabs-renderer cells]
+
+              ;; rf2-gqid4: `:variants-grid` + `:isolation :shared`
+              ;; mounts cells one-at-a-time via a prev/next navigator.
+              ;; Same serialised-mount strategy as `:tabs`, applied to
+              ;; the implicit `:variants-grid` enumeration. Belt-and-
+              ;; braces for hardcoded-frame-provider views without
+              ;; forcing the author to flip the workspace to `:tabs`
+              ;; (which loses registry-enumerating semantics).
+              (and (= :variants-grid (:layout body))
+                   (= :shared        (:isolation body)))
+              [shared-grid-renderer cells]
 
               (= :prose (:layout body))
               [:div {:style (:prose-flow styles)}

--- a/tools/story/test/re_frame/story_authoring_validation_test.clj
+++ b/tools/story/test/re_frame/story_authoring_validation_test.clj
@@ -73,6 +73,24 @@
         (is (= :rf.error/workspace-shape (:rf.error (ex-data e))))
         (is (re-find #"workspace schema" (.getMessage e)))))))
 
+(deftest reg-workspace-isolation-slot-accepts-both-values
+  ;; rf2-gqid4 — the optional `:isolation` slot accepts `:isolated`
+  ;; (default) and `:shared`. Other values reject with
+  ;; :rf.error/workspace-shape.
+  (testing ":isolation :isolated registers cleanly"
+    (is (some? (story/reg-workspace :Workspace.iso-ok/isolated
+                 {:layout :variants-grid :isolation :isolated}))))
+  (testing ":isolation :shared registers cleanly"
+    (is (some? (story/reg-workspace :Workspace.iso-ok/shared
+                 {:layout :variants-grid :isolation :shared}))))
+  (testing "an unknown :isolation value rejects with :rf.error/workspace-shape"
+    (try
+      (story/reg-workspace :Workspace.iso-bad/sandboxed
+        {:layout :variants-grid :isolation :sandboxed})
+      (is false "expected an exception")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :rf.error/workspace-shape (:rf.error (ex-data e))))))))
+
 (deftest reg-decorator-bad-shape-carries-error-key
   (testing "an invalid decorator body raises with :rf.error in ex-data"
     (try

--- a/tools/story/test/re_frame/story_ui_test.clj
+++ b/tools/story/test/re_frame/story_ui_test.clj
@@ -596,6 +596,36 @@
   (testing "unknown layouts degrade gracefully"
     (is (= [] (workspace/resolve-layout :Workspace.x/y {:layout :weird})))))
 
+;; ---- rf2-gqid4 :isolation slot ------------------------------------------
+
+(deftest variants-grid-isolation-default-is-isolated
+  (testing "absent :isolation slot resolves cells identically to baseline (data-shape)"
+    (story/reg-variant :story.iso-a/a {:events []})
+    (story/reg-variant :story.iso-a/b {:events []})
+    (let [baseline (workspace/resolve-layout
+                     :Workspace.iso-a/all
+                     {:layout :variants-grid})
+          explicit (workspace/resolve-layout
+                     :Workspace.iso-a/all
+                     {:layout :variants-grid :isolation :isolated})]
+      ;; :isolation is a mount-strategy slot; cell-resolution is identical.
+      (is (= baseline explicit))
+      (is (= 2 (count baseline))))))
+
+(deftest variants-grid-isolation-shared-preserves-cell-resolution
+  (testing ":isolation :shared resolves the same cell vector as :isolated"
+    (story/reg-variant :story.iso-b/x {:events []})
+    (story/reg-variant :story.iso-b/y {:events []})
+    (let [isolated (workspace/resolve-layout
+                     :Workspace.iso-b/all
+                     {:layout :variants-grid :isolation :isolated})
+          shared   (workspace/resolve-layout
+                     :Workspace.iso-b/all
+                     {:layout :variants-grid :isolation :shared})]
+      ;; The slot tunes mount strategy, not enumeration.
+      (is (= isolated shared))
+      (is (= 2 (count shared))))))
+
 ;; ---- docs mode (rf2-rodx) -----------------------------------------------
 
 (deftest docs-parent-story-id


### PR DESCRIPTION
## Why

Two small audit follow-ons from rf2-9tnsc workspace-mode investigation. Both P3.

## What

**Commit 1 (rf2-gqid4)**: `:isolation` config slot on the workspace body. Only honoured by `:variants-grid`; values `:isolated` (default — parallel cells, baseline frame-isolation contract) and `:shared` (serialised mount, one cell at a time with a prev/next navigator). The `:shared` affordance restores per-variant interior state for views whose `:component` internally hardcodes a frame-provider (`gallery_chrome.cljs` / rf2-sszlr pattern) without forcing the author to flip the workspace to `:tabs`. Belt-and-braces to the Causa modal-positioning fix (rf2-om6fa). Surface: `Workspace` schema (new optional `[:enum :isolated :shared]`), `workspace.cljc` `shared-grid-renderer` + dispatch branch in `workspace-view`, spec/001 + spec/003 + `reg-workspace` docstring, JVM resolver tests + schema-validation tests.

**Commit 2 (rf2-q5e36)**: spec clarification — the workspace body's `:modes` slot is declared in spec/001 but spec/010 §Out-of-scope defers workspace-local toolbar to v2. A spec read of `workspace.cljc` confirms the slot is **declared-but-not-honoured** in v1: the chrome's `:active-modes` is the only path that affects rendering. spec/001 gets the authoritative paragraph; spec/010 cross-links to it. No runtime change.

## Verification

- story JVM tests: 753t / 2228a / 0F / 0E (re-run after both commits)
- cljs node tests: 2935t / 8385a / 0F / 0E
- `mkdocs build --strict`: 72 pre-existing warnings, **zero new** (verified against clean tree)
- `check_doc_slugs.py --verbose`: 0 broken links

## Surprises

- `:isolation` was genuinely new — no prior shape on the workspace body. The Workspace schema gains one optional enum, no other surfaces affected.
- spec/001 vs spec/010 on `:modes`: neither was authoritative — the slot was declared in spec/001 with no semantics and listed as v2-out-of-scope in spec/010. The renderer ignores it. spec/001 is now the authoritative home with spec/010 cross-linking.

Closes rf2-gqid4, rf2-q5e36.