### PR TITLE
feat(causa+story): parallel-frames testbed — one app in :above + :below isolated frames (rf2-m00rw)

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -141,6 +141,17 @@ const EXAMPLES = [
       },
     ],
   },
+  // Parallel-Frames testbed (rf2-m00rw) — THE canonical multi-frame
+  // isolation demo. One app, mounted in TWO frames (:above + :below)
+  // on ONE page with zero cross-frame coupling. Each frame is a
+  // fully isolated reactive context; the exercise is observing the
+  // two diverge as the user interacts with each independently.
+  // No static endpoint — the mock HTTP fx is in-process.
+  {
+    build: 'examples/parallel-frames',
+    htmlSrc: path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'parallel_frames', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'parallel-frames'),
+  },
   {
     build: 'examples/temperature',
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', '7Guis', 'temperature', 'temperature.html'),

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -459,6 +459,33 @@
    :modules    {:main {:init-fn shop.core/run}}
    :devtools   {:preloads [day8.re-frame2-causa.preload]}}
 
+  ;; Parallel-Frames testbed (rf2-m00rw) — THE canonical multi-frame
+  ;; isolation demo. One app, mounted in TWO frames (:above + :below)
+  ;; on ONE page, with zero cross-frame coupling. Each frame is a
+  ;; fully isolated reactive context (own app-db, own router queue,
+  ;; own sub-cache); handlers and subs are registered once globally
+  ;; and resolve against whichever frame the dispatch envelope
+  ;; targets via the frame-provider React context.
+  ;;
+  ;; The app exercises four feature surfaces (counter, clock,
+  ;; HTTP-loaded title via :title/flow machine, slow-effect Issue
+  ;; source) cleanly — no deliberate bugs, no teaching layers, no
+  ;; anti-pattern demonstrations. Per Mike's saved-memory rules
+  ;; (feedback_frames_are_isolated_contexts + feedback_testbeds_are_
+  ;; test_surfaces), testbeds are TEST surfaces, not tutorial surfaces.
+  ;;
+  ;; Sources live under tools/causa/testbeds/parallel-frames/; the
+  ;; Causa preload auto-mounts inline so the frame-picker switching
+  ;; between :above and :below is one click away. Replaces shop as
+  ;; the canonical multi-frame exemplar — shop's deletion is a
+  ;; separate follow-on bead.
+  :examples/parallel-frames
+  {:target     :browser
+   :output-dir "out/examples/parallel-frames"
+   :asset-path "."
+   :modules    {:main {:init-fn parallel-frames.core/run}}
+   :devtools   {:preloads [day8.re-frame2-causa.preload]}}
+
   ;; Causa panel-gallery testbed (rf2-1o7mp) — visual gallery of Causa
   ;; panels under varying state magnitude. Sources live under
   ;; tools/causa/testbeds/panel_gallery/ alongside the stories ns.

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -355,6 +355,8 @@ Each frame holds one sub-cache, keyed by `[query-vector]`:
 
 The cache is held inside the frame container (per [002 §What lives in a frame](002-Frames.md#what-lives-in-a-frame)). Two frames running the same `(rf/subscribe [:cart/total])` compute against their own `app-db`s and cache against their own caches; isolation is automatic.
 
+The canonical demo of this rule is the **parallel-frames** testbed at [`tools/causa/testbeds/parallel_frames/`](../tools/causa/testbeds/parallel_frames/) — one app mounted in two `frame-provider`-rooted subtrees (`:above` and `:below`) on one page. Same view source, same registered handlers and subs, two fully isolated reactive contexts that diverge as the user interacts with each independently. There is no cross-frame sub, no cross-frame data routing, no "route data home" pattern — each frame is its own world.
+
 ### Lookup algorithm
 
 ```

--- a/tools/causa/testbeds/parallel_frames/README.md
+++ b/tools/causa/testbeds/parallel_frames/README.md
@@ -1,0 +1,163 @@
+# `tools/causa/testbeds/parallel-frames/`
+
+Parallel-Frames testbed (rf2-m00rw) — **THE** canonical multi-frame
+isolation demo for Causa. One app, mounted in **two** frames on **one**
+page (`:above` and `:below`), with zero cross-frame coupling. Replaces
+the shop testbed (rf2-yhxk3) as the canonical multi-frame exemplar; see
+*Why not shop?* below.
+
+## The shape
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Parallel Frames demo                                           │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  ABOVE frame  (:above)                                    │  │
+│  │  Counter | Clock | Title (HTTP via :title/flow machine)   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  BELOW frame  (:below)                                    │  │
+│  │  Counter | Clock | Title (HTTP via :title/flow machine)   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Two `frame-provider` subtrees, each rooted on a separate frame id.
+Each is a **fully isolated reactive context**: its own `app-db`, its
+own router queue, its own sub-cache. Handlers and subs are registered
+once globally; the `reg-view`-injected `dispatch` / `subscribe` resolve
+via React context to the surrounding `frame-provider`'s frame id, so
+the same view source produces two independent reactive contexts.
+
+The exercise IS observing the two frames diverge as the user interacts
+with each independently. There is no deliberate bug, no teaching layer,
+no anti-pattern demonstration — just clean feature exercise across two
+isolated frames.
+
+## What each frame exercises
+
+| Feature       | Wiring                                                                                  | Causa lens that lights up                                |
+|---------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------|
+| **Counter**   | `+ / −` buttons. Events: `::counter-inc`, `::counter-dec`. Sub: `::counter`.            | Event list; App-db diff (`:counter` slot)                |
+| **Clock**     | Self-perpetuating tick chain via `:dispatch-later` @ 1s. Sub: `::clock-ticks`.          | Trace lens (`:event/dispatched` rows); App-db diff       |
+| **Title HTTP**| Refresh / Force-error buttons. Drives `:title/flow` machine through `:idle → :loading → :loaded / :error`. Mock fx resolves ~600ms after dispatch. | Machines lens (state chart + transitions); Trace lens (HTTP-shaped rows); Issues lens (slow effect, ~600ms) |
+
+## Frame isolation — the load-bearing rule
+
+Per `spec/006-ReactiveSubstrate.md` §The cache is held inside the frame
+container: **subs are per-frame**. A sub registered globally runs
+against whichever frame's `app-db` the dispatch envelope targets; it
+**must not** reach into another frame's `app-db`. The same rule binds
+this testbed: every sub here reads from the current frame's `app-db`
+only. There is no cross-frame projection helper, no "route data home"
+pattern, no shared root state.
+
+This is the load-bearing architectural rule the testbed exists to
+exhibit. See the saved Mike-feedback memories:
+
+- `feedback_frames_are_isolated_contexts.md`
+- `feedback_testbeds_are_test_surfaces.md`
+
+## Issues source — the slow fetch is intentional
+
+The mock HTTP fx (`::mock-fetch` in `core.cljs`) is deliberately slow
+(~600ms — see `HTTP-MOCK-DELAY-MS`). This is **not a bug**. The delay
+is calibrated to exceed Causa's slow-effect threshold so the testbed's
+Issues panel surfaces every fetch as a legitimate `slow effect` Issue.
+
+A consumer that wants the Issues panel "live" without slow waits can
+toggle the constant down to ~50ms; the Issue surface is intended to
+demonstrate Causa's affordance, not block normal interaction.
+
+## What to try in Causa
+
+Open Causa (Ctrl+Shift+C) on the page. The frame picker in the L1
+ribbon switches every L2 (Events) and L4 (App-db, Views, Machines,
+HTTP, Issues, Trace) panel between observing `:above` and `:below`.
+
+1. **Frame divergence on the counters.** Click `+` three times on
+   `:above`. Switch the Causa frame picker to `:below`. The Events
+   list is empty for `:below`; the App-db diff shows no `:counter`
+   movement.
+
+2. **Independent clocks.** Watch the App-db diff under `:above` vs
+   `:below`. Each frame's `:clock :ticks` advances on its own cadence;
+   the two are not synchronised (each `:dispatch-later` chain runs in
+   its own frame's router).
+
+3. **Per-frame machine state.** Click Refresh on `:below`. Open the
+   Machines tab — `:title/flow` reads `:loading`. Switch frame picker
+   to `:above`. The same `:title/flow` machine reads `:idle` (because
+   it's a different frame's `[:rf/machines :title/flow]` slot).
+
+4. **HTTP correlation per frame.** While `:below` is still in
+   `:loading`, observe Causa's Trace tab — one in-flight HTTP-shaped
+   row, scoped to `:below`. Switch to `:above` — no in-flight rows.
+
+5. **Issues per request.** Each fetch (~600ms) trips Causa's
+   slow-effect Issue surface. The Issues panel scopes per frame; one
+   row per fetch per frame.
+
+6. **Force-error per frame.** Click Force-error on `:above`. The
+   machine drives through `:idle → :loading → :error` — a legitimate
+   failure cascade, not a deliberate bug. `:below`'s machine state
+   (likely `:loaded` from step 3) is unaffected.
+
+## Why not `shop/`?
+
+The shop testbed (rf2-yhxk3) routes data across frames (e.g. it
+places `:checkout/snapshot` on cart-frame's `app-db` so a sub-chain
+can resolve under one frame), uses a deliberately-wrong sub for a
+"fix this bug" tutorial moment, and includes "LAYER 5" teaching-layer
+comments. Per Mike's saved-memory rules, this is the anti-pattern: a
+testbed is a TEST surface, not a tutorial surface, and frames are
+isolated contexts that must not exchange data through their app-dbs.
+
+Parallel-Frames is the clean exemplar. A follow-on bead tracks the
+shop testbed's deletion now that this clean exemplar lands.
+
+## Files
+
+- `core.cljs` — the app + the two-frame mount. Single namespace,
+  ~350 LoC.
+- `index.html` — minimal static host with the standard
+  `[data-rf-causa-host]` aside so the Causa preload auto-mounts inline.
+- `spec.cjs` — Playwright smoke that asserts both frames mount, the
+  counters are isolated, Refresh on `:below` doesn't move `:above`,
+  Force-error on `:above` doesn't disturb `:below`'s `:loaded` state.
+
+## Running
+
+From `implementation/`:
+
+```bash
+npx shadow-cljs watch :examples/parallel-frames
+```
+
+Or, via the examples orchestrator:
+
+```bash
+cd implementation
+EXAMPLES_FILTER=parallel-frames node ../examples/scripts/serve-and-run-examples-tests.cjs
+```
+
+## Build target
+
+`:examples/parallel-frames` (defined in
+[`implementation/shadow-cljs.edn`](../../../../implementation/shadow-cljs.edn)).
+The Causa preload (`day8.re-frame2-causa.preload`) is wired in
+`:devtools/:preloads` — every dev build auto-mounts Causa inline on
+load.
+
+## Cross-references
+
+- [`spec/006-ReactiveSubstrate.md`](../../../../spec/006-ReactiveSubstrate.md)
+  §The cache is held inside the frame container — the normative
+  statement of per-frame isolation. This testbed is the canonical
+  demo.
+- [`spec/002-Frames.md`](../../../../spec/002-Frames.md) — frame
+  lifecycle, `reg-frame`, `:on-create`, frame-provider context.
+- [`spec/005-StateMachines.md`](../../../../spec/005-StateMachines.md)
+  — the machine substrate the `:title/flow` exercises.
+- [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md)
+  — the slow-effect Issue surface the mock fx exercises.

--- a/tools/causa/testbeds/parallel_frames/core.cljs
+++ b/tools/causa/testbeds/parallel_frames/core.cljs
@@ -1,0 +1,475 @@
+(ns parallel-frames.core
+  "Parallel-Frames testbed (rf2-m00rw) — THE canonical multi-frame
+  isolation demo. One app, mounted in TWO frames on ONE page, with
+  zero cross-frame coupling. The exercise IS observing the two
+  frames diverge as the user interacts with each independently.
+
+  ## Shape
+
+  ONE app code path. TWO frame ids: `:above` and `:below`. Each
+  `frame-provider` rooted subtree is a fully isolated reactive
+  context — its own `app-db`, its own router queue, its own sub-cache.
+  Handlers and subs are registered once (globally) and run against
+  whichever frame the dispatch envelope targets. The
+  `reg-view`-injected `dispatch` / `subscribe` close over the
+  surrounding frame-provider's frame id via React context, so the
+  same view source produces two independent reactive contexts.
+
+  Architectural anchors:
+    - Frames are isolated contexts. NO cross-frame sub computation.
+      NO data routing between frames. NO sub that reaches into
+      another frame's app-db. (Spec 006 §The cache is held inside
+      the frame container.)
+    - Testbeds are TEST surfaces, not tutorial surfaces. No
+      deliberate bugs, no teaching layers, no anti-pattern
+      demonstrations. The demo's punchline is observing two
+      isolated frames diverge — not 'fix this bug.'
+
+  ## The app
+
+  Each frame mounts the same panel exercising four feature surfaces:
+
+    Counter        — `+ / −` buttons. Demonstrates events, app-db
+                     evolution, simple sub recomputation.
+    Clock          — auto-ticking every second via `:dispatch-later`.
+                     Demonstrates continuous events + sub recomputation
+                     and (because the two frames start their tick chains
+                     at slightly different points in time) the two
+                     clocks naturally drift out of phase across reloads.
+    Title (HTTP)   — Refresh button dispatches an event that, via the
+                     `:title/flow` state machine, fires an in-process
+                     mock-HTTP effect. The mock resolves ~600ms after
+                     dispatch with the wall-clock time. Force-error
+                     dispatches the same flow with `{:force-error? true}`,
+                     which the mock rejects. Demonstrates HTTP
+                     correlation, in-flight / settled state, and the
+                     :idle → :loading → :loaded / :error machine cycle.
+    Issues source  — The mock HTTP fx is deliberately slow (~600ms),
+                     which exceeds Spec 009 / Causa's slow-effect
+                     threshold and surfaces legitimately in Causa's
+                     Issues panel. Not a bug — a normal slow request.
+
+  ## What Causa users observe
+
+  - Frame picker: switching between `:above` and `:below` re-scopes
+    every L2 (Events) and L4 (App-db, Views, Machines, HTTP, Issues,
+    Trace) panel to the active frame.
+  - Each frame's counter / clock / machine state evolves on its own
+    independent of the other frame.
+  - Slow-fetch surfaces an Issue per request, distinct per frame.
+
+  See `tools/causa/testbeds/parallel-frames/README.md` for the
+  walk-through and `spec.cjs` for the browser smoke."
+  (:require [clojure.string :as str]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.views]
+            ;; Loading these namespaces installs their late-bind hooks.
+            ;; Without them, `rf/reg-machine` would fail at registration
+            ;; time, and the mock-HTTP fx would have no place to land.
+            [re-frame.machines]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            ;; rf2-6jyf6 — Causa's `configure!` to seed `:project-root`
+            ;; so the Event lens 'open' chip resolves a classpath-
+            ;; relative `:file` slot to an absolute on-disk URI the
+            ;; OS-side editor handler can stat.
+            [day8.re-frame2-causa.config :as causa-config])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; FRAME IDs
+;; ============================================================================
+
+(def frame-above :above)
+(def frame-below :below)
+
+;; ============================================================================
+;; CONSTANTS
+;; ============================================================================
+
+(def CLOCK-TICK-MS
+  "Clock tick period. One second matches a wall-clock display
+  cleanly; the dispatch-later chain self-perpetuates so each frame
+  ticks at its own cadence."
+  1000)
+
+(def HTTP-MOCK-DELAY-MS
+  "Mock-HTTP delay. The 600ms figure is the load-bearing decision:
+  long enough to exceed Spec 009's slow-effect threshold (so Causa's
+  Issues panel surfaces the slow fetch as a legitimate, non-bug
+  Issue), short enough that the smoke test resolves it without
+  excessive wall-clock cost."
+  600)
+
+;; ============================================================================
+;; APP-DB INITIALISER (shared by both frames)
+;; ============================================================================
+;;
+;; The same `:rf/initialise` handler runs once per frame via each
+;; frame's `:on-create` opt, against that frame's empty `app-db`. The
+;; two frames diverge from this identical seed as the user clicks.
+
+(rf/reg-event-fx ::initialise
+  ;; Single `:on-create` boot event per Spec 002 §Frame creation —
+  ;; `:on-create` accepts ONE event vector; multi-step initialisation
+  ;; fans out via the effect map. We seed app-db, start the clock
+  ;; tick chain, AND ping the title machine (so its `:idle` snapshot
+  ;; materialises immediately rather than lazily-on-first-refresh —
+  ;; the Causa Machines panel and the smoke's :idle assertion both
+  ;; want the snapshot live on first paint). The `:rf/init` ping is
+  ;; not declared on the `:idle` state's `:on` map, so it is a no-op
+  ;; transition — but the runtime synthesises the initial snapshot
+  ;; on first dispatch (Spec 005 §Initial-state cascading), which is
+  ;; exactly the side-effect we want.
+  (fn [_ctx _ev]
+    {:db {:counter   0
+          :clock     {:tick-gen 0
+                      :ticks    0}
+          :title     {:value    "Parallel-Frames (untouched)"
+                      :error    nil
+                      :requests 0}}
+     :fx [[:dispatch [::clock-start]]
+          [:dispatch [:title/flow [:rf/init]]]]}))
+
+;; ============================================================================
+;; COUNTER — events + sub
+;; ============================================================================
+
+(rf/reg-event-db ::counter-inc
+  (fn [db _ev] (update db :counter (fnil inc 0))))
+
+(rf/reg-event-db ::counter-dec
+  (fn [db _ev] (update db :counter (fnil dec 0))))
+
+(rf/reg-sub ::counter (fn [db _] (:counter db)))
+
+;; ============================================================================
+;; CLOCK — periodic tick via :dispatch-later
+;; ============================================================================
+;;
+;; The clock tick chain self-perpetuates through `:dispatch-later`,
+;; matching the shape of `examples/reagent/7Guis/timer/timer.cljs`.
+;; Each tick carries the `:tick-gen` value it was scheduled with;
+;; future Reset support (or a Pause toggle) bumps `:tick-gen` so any
+;; stale in-flight tick from the previous generation no-ops. Today
+;; the testbed only ever runs one generation per frame, but the
+;; generation guard is idiomatic and costs nothing.
+;;
+;; Because the two frames start ticking at slightly different points
+;; in time (`:on-create` runs once per `reg-frame` registration; the
+;; first `::clock-start` dispatch happens during the boot sequence
+;; for each), their tick chains naturally drift out of phase. Causa's
+;; frame-picker switching surfaces the divergence.
+
+(rf/reg-event-fx ::clock-start
+  (fn [{:keys [db]} _ev]
+    (let [gen (get-in db [:clock :tick-gen])]
+      {:fx [[:dispatch-later {:ms    CLOCK-TICK-MS
+                              :event [::clock-tick gen]}]]})))
+
+(rf/reg-event-fx ::clock-tick
+  (fn [{:keys [db]} [_ gen]]
+    (if (not= gen (get-in db [:clock :tick-gen]))
+      ;; Stale tick from a retired generation. Drop it silently.
+      {}
+      {:db (update-in db [:clock :ticks] (fnil inc 0))
+       :fx [[:dispatch-later {:ms    CLOCK-TICK-MS
+                              :event [::clock-tick gen]}]]})))
+
+(rf/reg-sub ::clock-ticks
+  (fn [db _] (get-in db [:clock :ticks])))
+
+;; ============================================================================
+;; TITLE (HTTP) — :title/flow state machine + mock-HTTP fx
+;; ============================================================================
+;;
+;; The `:title/flow` machine cycles
+;;
+;;   :idle → :loading → :loaded
+;;                    → :error
+;;
+;; on Refresh / Force-error. Entry actions seed the in-flight request
+;; payload into the machine's `:data` slot so the request body and
+;; the per-request `:force-error?` flag travel through the cascade.
+;;
+;; The mock HTTP effect is `::mock-fetch` (frame-scoped via the fx
+;; envelope — `js/setTimeout` carries the frame id forward through
+;; the closure to ensure the reply lands on the originating frame).
+;; The 600ms delay is the legitimate slow-effect Issue source — see
+;; the README and the docstring on HTTP-MOCK-DELAY-MS.
+
+(def title-flow
+  "State machine driving the Title-request lifecycle.
+
+  States:
+    :idle    — initial; ready to fetch
+    :loading — request in flight; mock fx running
+    :loaded  — last fetch succeeded; :data carries the value
+    :error   — last fetch failed; :data carries the error message
+
+  Events:
+    :refresh         — :idle / :loaded / :error → :loading (no-op from :loading)
+    :reply-success   — :loading → :loaded
+    :reply-failure   — :loading → :error"
+  {:initial :idle
+   :data    {:value nil :error nil}
+
+   :actions
+   {:record-reply-success
+    (fn record-reply-success [_data [_ payload]]
+      {:data {:value payload :error nil}})
+
+    :record-reply-failure
+    (fn record-reply-failure [_data [_ message]]
+      {:data {:value nil :error message}})}
+
+   :states
+   {:idle
+    {:on {:refresh {:target :loading}}}
+
+    :loading
+    ;; Note: no transition for :refresh while in :loading — clicking
+    ;; Refresh again is a no-op until the current request settles.
+    {:on {:reply-success {:target :loaded
+                          :action :record-reply-success}
+          :reply-failure {:target :error
+                          :action :record-reply-failure}}}
+
+    :loaded
+    {:on {:refresh {:target :loading}}}
+
+    :error
+    {:on {:refresh {:target :loading}}}}})
+
+(rf/reg-machine :title/flow title-flow)
+
+;; ----------------------------------------------------------------------------
+;; Mock-HTTP fx
+;; ----------------------------------------------------------------------------
+;;
+;; In-process mock fx that resolves ~HTTP-MOCK-DELAY-MS after dispatch
+;; with the wall-clock time, or rejects when `:force-error?` is set on
+;; the args map. The frame id is carried through the closure so the
+;; settled reply dispatches back to the originating frame (subs are
+;; per-frame; the response must land where the request fired).
+;;
+;; Why a custom fx (rather than `:rf.http/managed-canned-success`)?
+;;   - We want a single fx that handles both success and failure paths
+;;     under the same delay — Causa's Trace lens then surfaces one row
+;;     per request regardless of outcome.
+;;   - We want the slow-effect duration to be exactly long enough to
+;;     trip Spec 009's slow-effect Issue surface. A custom fx pins the
+;;     duration locally without depending on managed-HTTP's retry
+;;     policy semantics.
+;;   - Bundle isolation: nothing under `tools/causa/testbeds/` ships
+;;     in production, so the in-process mock is appropriate here.
+
+(rf/reg-fx ::mock-fetch
+  (fn [{:keys [frame]} {:keys [force-error?]}]
+    ;; `frame` from the fx ctx is the originating frame id (Spec 002
+    ;; §`:fx` ordering). Capture it in the closure so the deferred
+    ;; reply dispatch lands on the same frame the request fired from.
+    ;; Subs are per-frame; the response must land where the request
+    ;; fired, otherwise the wrong frame's :title/flow machine sees
+    ;; the reply.
+    (js/setTimeout
+      (fn []
+        (if force-error?
+          (rf/dispatch [:title/flow [:reply-failure "Forced error (mock)"]]
+                       {:frame frame})
+          (rf/dispatch [:title/flow
+                        [:reply-success
+                         (str "Parallel-Frames @ "
+                              (.toISOString (js/Date.)))]]
+                       {:frame frame})))
+      HTTP-MOCK-DELAY-MS)))
+
+;; ----------------------------------------------------------------------------
+;; Title events
+;; ----------------------------------------------------------------------------
+
+(rf/reg-event-fx ::title-refresh
+  (fn [{:keys [db]} [_ {:keys [force-error?]}]]
+    {:db (update-in db [:title :requests] (fnil inc 0))
+     ;; Drive the machine first (intra-frame `:dispatch`), then issue
+     ;; the mock fetch. The machine's :loading entry will be live by
+     ;; the time the fetch settles ~600ms later.
+     :fx [[:dispatch [:title/flow [:refresh]]]
+          [::mock-fetch {:force-error? (boolean force-error?)}]]}))
+
+(rf/reg-sub ::title-state
+  (fn [db _] (get-in db [:rf/machines :title/flow :state])))
+
+(rf/reg-sub ::title-data
+  (fn [db _] (get-in db [:rf/machines :title/flow :data])))
+
+(rf/reg-sub ::title-requests
+  (fn [db _] (get-in db [:title :requests])))
+
+;; ============================================================================
+;; VIEWS — one panel mounted twice (once per frame-provider subtree)
+;; ============================================================================
+;;
+;; The `reg-view`-injected `dispatch` / `subscribe` resolve via React
+;; context to the surrounding `frame-provider`'s frame id (per
+;; Spec 002 §View ergonomics). Same view source, two independent
+;; reactive contexts.
+
+(reg-view frame-panel [frame-label]
+  (let [counter   @(subscribe [::counter])
+        ticks     @(subscribe [::clock-ticks])
+        state     @(subscribe [::title-state])
+        data      @(subscribe [::title-data])
+        requests  @(subscribe [::title-requests])
+        loading?  (= state :loading)
+        accent    (case frame-label
+                    "above" "#2b7"
+                    "below" "#36c"
+                    "#444")]
+    [:section {:data-testid (str frame-label "-panel")
+               :style {:border        (str "1px solid " accent)
+                       :border-radius "6px"
+                       :padding       "1em 1.25em"
+                       :background    (case frame-label
+                                        "above" "#f7fff9"
+                                        "below" "#f5f8ff"
+                                        "#fafafa")
+                       :margin        "0.5em 0"}}
+     [:header {:style {:display         "flex"
+                       :justify-content "space-between"
+                       :align-items     "baseline"}}
+      [:h3 {:style {:margin 0 :color accent}}
+       (str/upper-case frame-label) " frame "
+       [:small {:style {:color "#666" :font-weight "normal"}}
+        "(" frame-label ")"]]
+      [:span {:style {:font-size "11px" :color "#888"}}
+       "isolated reactive context"]]
+
+     ;; --- Counter -------------------------------------------------------
+     [:div {:style {:margin "0.75em 0 0.5em 0"
+                    :display "flex" :gap "8px" :align-items "center"}}
+      [:strong "Counter:"]
+      [:button {:data-testid (str frame-label "-counter-dec")
+                :on-click    #(dispatch [::counter-dec])}
+       "−"]
+      [:span {:data-testid (str frame-label "-counter-value")
+              :style       {:min-width "2em"
+                            :text-align "center"
+                            :font-family "monospace"
+                            :font-weight "bold"}}
+       counter]
+      [:button {:data-testid (str frame-label "-counter-inc")
+                :on-click    #(dispatch [::counter-inc])}
+       "+"]]
+
+     ;; --- Clock ---------------------------------------------------------
+     [:div {:style {:margin "0.5em 0"
+                    :display "flex" :gap "8px" :align-items "center"}}
+      [:strong "Clock:"]
+      [:span {:data-testid (str frame-label "-clock-ticks")
+              :style       {:font-family "monospace"}}
+       (str ticks " tick" (when (not= 1 ticks) "s"))]
+      [:span {:style {:font-size "11px" :color "#888"}}
+       "auto-tick @ 1s"]]
+
+     ;; --- Title (HTTP) --------------------------------------------------
+     [:div {:style {:margin "0.5em 0 0 0"
+                    :padding "0.5em 0"
+                    :border-top "1px solid #ddd"}}
+      [:div {:style {:display "flex" :gap "8px" :align-items "center"
+                     :margin-bottom "0.25em"}}
+       [:strong "Title:"]
+       [:span {:data-testid (str frame-label "-title-state")
+               :style {:font-family "monospace"
+                       :color (case state
+                                :loading "#249"
+                                :loaded  "#1a5"
+                                :error   "#a40"
+                                "#444")}}
+        (str state)]
+       [:span {:style {:font-size "11px" :color "#888"}}
+        "(" requests " request" (when (not= 1 requests) "s") ")"]]
+      [:div {:data-testid (str frame-label "-title-value")
+             :style {:font-family "monospace"
+                     :font-size "12px"
+                     :color "#333"
+                     :background "#fff"
+                     :border "1px solid #eee"
+                     :border-radius "3px"
+                     :padding "4px 8px"
+                     :margin "0.25em 0"
+                     :overflow "auto"}}
+       (cond
+         (:error data) (str "ERROR: " (:error data))
+         (:value data) (:value data)
+         :else         "(no value yet — click Refresh)")]
+      [:div {:style {:display "flex" :gap "6px" :margin-top "0.25em"}}
+       [:button {:data-testid (str frame-label "-title-refresh")
+                 :disabled    loading?
+                 :on-click    #(dispatch [::title-refresh {}])}
+        (if loading? "Loading…" "Refresh (HTTP)")]
+       [:button {:data-testid (str frame-label "-title-force-error")
+                 :disabled    loading?
+                 :on-click    #(dispatch [::title-refresh
+                                          {:force-error? true}])}
+        "Force error"]]]]))
+
+(reg-view root []
+  [:div {:data-testid "parallel-frames-root"
+         :style {:font-family "system-ui, sans-serif"
+                 :padding     "1em"
+                 :max-width   "900px"
+                 :margin      "0 auto"}}
+   [:header {:style {:margin-bottom "1em"}}
+    [:h2 {:style {:margin 0}} "Parallel Frames demo"]
+    [:p {:style {:color "#444" :margin "0.5em 0 0 0"}}
+     "Same app, two isolated reactive contexts. Each "
+     [:code "frame-provider"]
+     " below mounts the same view source against a separate "
+     [:code "app-db"] " + sub-cache. Click "
+     [:em "Refresh"] " in one frame; the other stays put. Switch frames
+      in Causa (Ctrl+Shift+C, then use the frame picker) to compare."]]
+   [:div {:style {:display "flex" :flex-direction "column"}}
+    [rf/frame-provider {:frame frame-above}
+     [frame-panel "above"]]
+    [rf/frame-provider {:frame frame-below}
+     [frame-panel "below"]]]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(def ^:private default-project-root
+  "C:/Users/miket/code/re-frame2/tools/causa/testbeds")
+
+(defn- query-param
+  "Return the named URL query param as a string, or nil when absent
+  / blank. Pure-data helper — kept private to this testbed since the
+  query-string override is a per-host knob (not a Causa-API surface)."
+  [param-name]
+  (when (exists? js/window)
+    (let [params (-> js/window .-location .-search
+                     (js/URLSearchParams.))
+          v      (.get params param-name)]
+      (when (and (string? v) (seq v)) v))))
+
+(defn- resolve-project-root []
+  (or (query-param "project-root") default-project-root))
+
+(defn ^:export run []
+  ;; Configure Causa BEFORE `rf/init!` so the preload's auto-open
+  ;; reads the right project-root on its first paint of any chip.
+  ;; (rf2-6jyf6 — see the same configure! call in the shop testbed.)
+  (causa-config/configure! {:project-root (resolve-project-root)})
+  (rf/init! reagent-adapter/adapter)
+  ;; Register the two frames. Each `:on-create` seeds its own app-db
+  ;; synchronously and then kicks off its clock-tick chain. The
+  ;; `::initialise` and `::clock-start` handlers are registered once
+  ;; globally and resolve against whichever frame the dispatch
+  ;; envelope targets — per-frame state evolution is automatic.
+  (rf/reg-frame frame-above {:on-create [::initialise]})
+  (rf/reg-frame frame-below {:on-create [::initialise]})
+  (rdc/render react-root [root]))

--- a/tools/causa/testbeds/parallel_frames/index.html
+++ b/tools/causa/testbeds/parallel_frames/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 testbed: parallel-frames (Causa demo)</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; }
+    .rf2-testbed-shell { display: flex; min-height: 100vh; }
+    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+       (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
+       and spec/011-Launch-Modes.md §Resizing the inline host). Override
+       the property anywhere up the cascade to resize the panel without
+       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
+       give the user a browser-native drag handle on the host (rf2-e07yk). */
+    :root { --rf-causa-accent: #7C5CFF; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    #app { flex: 1; min-width: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="rf2-testbed-shell">
+    <main id="app"></main>
+    <aside data-rf-causa-host></aside>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/tools/causa/testbeds/parallel_frames/spec.cjs
+++ b/tools/causa/testbeds/parallel_frames/spec.cjs
@@ -1,0 +1,126 @@
+/*
+ * Parallel-Frames testbed — browser smoke (rf2-m00rw).
+ *
+ * THE canonical multi-frame-isolation demo. One app, mounted in TWO
+ * frames on ONE page (`:above` and `:below`), with zero cross-frame
+ * coupling. The smoke asserts:
+ *
+ *   1. Initial paint — both frame panels render, both counters read 0,
+ *      both clocks have ticked at least once (auto-tick @ 1s).
+ *
+ *   2. Counter isolation — clicking + on :above increments :above's
+ *      counter while :below's counter stays at 0. Clicking + on :below
+ *      then advances only :below.
+ *
+ *   3. HTTP / machine isolation — clicking Refresh on :below drives
+ *      :below's :title/flow machine into :loading, the mock fx
+ *      resolves ~600ms later into :loaded, and :below's title slot
+ *      carries a non-empty value. :above's title state stays :idle
+ *      throughout.
+ *
+ *   4. Force-error path — Force-error on :above drives the same
+ *      machine into :error legitimately (request fails by design).
+ *      :below's :loaded state from step 3 persists.
+ *
+ * The exercise IS observing two isolated frames diverge as the user
+ * interacts with each independently. There is NO deliberate bug, NO
+ * cross-frame data routing, NO 'fix this bug' moment.
+ */
+
+const {
+  expectTextEquals,
+  expectVisible,
+} = require('../../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'parallel-frames (Causa demo)',
+  url:  '/parallel-frames/',
+  run:  async (page) => {
+    // --- 0. First paint -----------------------------------------------------
+    await expectVisible(page.locator('[data-testid="parallel-frames-root"]'), 10000);
+    await expectVisible(page.locator('[data-testid="above-panel"]'), 5000);
+    await expectVisible(page.locator('[data-testid="below-panel"]'), 5000);
+
+    // Both counters start at 0.
+    await expectTextEquals(page.locator('[data-testid="above-counter-value"]'), '0');
+    await expectTextEquals(page.locator('[data-testid="below-counter-value"]'), '0');
+
+    // Both machines start at :idle (the :title/flow :initial slot).
+    await expectTextEquals(page.locator('[data-testid="above-title-state"]'), ':idle');
+    await expectTextEquals(page.locator('[data-testid="below-title-state"]'), ':idle');
+
+    // --- 1. Counter isolation -----------------------------------------------
+    //
+    // Click + on :above three times. :above's counter advances; :below
+    // stays at 0. The handlers and subs are registered once globally
+    // and resolve against the originating frame via the frame-provider
+    // context — the framework keeps each frame's app-db cleanly
+    // partitioned.
+    await page.locator('[data-testid="above-counter-inc"]').click();
+    await page.locator('[data-testid="above-counter-inc"]').click();
+    await page.locator('[data-testid="above-counter-inc"]').click();
+    await expectTextEquals(page.locator('[data-testid="above-counter-value"]'), '3');
+    await expectTextEquals(page.locator('[data-testid="below-counter-value"]'), '0');
+
+    // Click + on :below once. :below advances; :above stays at 3.
+    await page.locator('[data-testid="below-counter-inc"]').click();
+    await expectTextEquals(page.locator('[data-testid="above-counter-value"]'), '3');
+    await expectTextEquals(page.locator('[data-testid="below-counter-value"]'), '1');
+
+    // --- 2. HTTP / machine isolation — Refresh on :below --------------------
+    //
+    // Click Refresh on :below. The :title/flow machine in :below's app-db
+    // transitions :idle → :loading. ~600ms later the mock fx resolves
+    // with a payload and the machine transitions :loading → :loaded.
+    // :above's machine stays :idle throughout — the mock fx closes over
+    // the originating frame id, so the reply dispatch lands only on
+    // :below.
+    await page.locator('[data-testid="below-title-refresh"]').click();
+
+    // Allow the mock to settle (HTTP-MOCK-DELAY-MS is 600ms; pad a bit).
+    await expectTextEquals(
+      page.locator('[data-testid="below-title-state"]'),
+      ':loaded',
+      5000,
+    );
+
+    // :above stays untouched.
+    await expectTextEquals(page.locator('[data-testid="above-title-state"]'), ':idle');
+
+    // :below's title value carries the mock fetch's wall-clock payload
+    // (the prefix is stable; the ISO timestamp varies).
+    const belowTitleText = (await page
+      .locator('[data-testid="below-title-value"]')
+      .textContent()) || '';
+    if (!belowTitleText.startsWith('Parallel-Frames @ ')) {
+      throw new Error(
+        `Expected :below's title to carry the mock payload (starts with "Parallel-Frames @ "); got: ${JSON.stringify(belowTitleText)}`,
+      );
+    }
+
+    // --- 3. Force-error on :above — legitimate failure cascade --------------
+    //
+    // The Force-error button dispatches the same :title-refresh event
+    // with `:force-error? true`. The mock fx rejects on that flag (it's
+    // not a bug — it's a normal request the user asked to fail), and
+    // the machine transitions :idle → :loading → :error. :below's
+    // :loaded state from step 2 persists.
+    await page.locator('[data-testid="above-title-force-error"]').click();
+    await expectTextEquals(
+      page.locator('[data-testid="above-title-state"]'),
+      ':error',
+      5000,
+    );
+    await expectTextEquals(page.locator('[data-testid="below-title-state"]'), ':loaded');
+
+    // :above's title slot carries the error message.
+    const aboveTitleText = (await page
+      .locator('[data-testid="above-title-value"]')
+      .textContent()) || '';
+    if (!aboveTitleText.includes('ERROR:')) {
+      throw new Error(
+        `Expected :above's title to carry the error marker after Force-error; got: ${JSON.stringify(aboveTitleText)}`,
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- New testbed `tools/causa/testbeds/parallel_frames/` — THE canonical multi-frame-isolation demo for Causa. One app, mounted in TWO frames (`:above` + `:below`) on ONE page, with zero cross-frame coupling.
- Each frame is a fully isolated reactive context (own `app-db`, own router queue, own sub-cache); handlers and subs are registered once globally and resolve against whichever frame the dispatch envelope targets.
- Exercises four feature surfaces cleanly per frame: counter, auto-ticking clock, HTTP-loaded title via a `:title/flow` state machine, and a legitimate slow-effect Issues source (mock fx delays ~600ms — not a bug, calibrated to trip Causa's slow-effect surface).
- Replaces shop (rf2-yhxk3) as the canonical multi-frame exemplar. Shop's deletion is a separate follow-on bead (rf2-ljmm1).

## Architectural compliance

Per saved Mike-feedback rules:

- **Isolated frames** (`feedback_frames_are_isolated_contexts`): NO cross-frame sub computation, NO data routing between frames, NO sub that reaches into another frame's `app-db`. Each frame is its own reactive world. The two frames mount the SAME app code but run in parallel, diverging as the user interacts with each.
- **Clean testbeds** (`feedback_testbeds_are_test_surfaces`): NO deliberate bugs, NO teaching layers, NO anti-pattern demonstrations. The exercise IS observing the two isolated frames diverge — not 'fix this bug.'

## Issues sourced

The mock HTTP fx is deliberately slow (~600ms — see `HTTP-MOCK-DELAY-MS`). This is **not a bug**. The delay is calibrated to exceed Causa's slow-effect threshold so the testbed's Issues panel surfaces every fetch as a legitimate slow-effect Issue (per the bead's option (a)). Documented in the README.

## Test plan

- [x] `scripts/test-fast-pr.sh` — 2935 tests / 8385 assertions / 0 failures / 0 errors.
- [x] `cd implementation && npm run test:cljs` — PASS.
- [x] `cd implementation && npm run story:build` — PASS.
- [x] `mkdocs build --strict` — 72 warnings, identical to `origin/main`; my spec edit introduces zero new warnings.
- [x] `python scripts/check_doc_slugs.py` — PASS (exit 0).
- [x] `cd implementation && npx shadow-cljs compile :examples/parallel-frames` — PASS (253 files, 2 compiled, 4 pre-existing infer-warnings in `tools/causa/src/...`).
- [x] Playwright smoke (`tools/causa/testbeds/parallel_frames/spec.cjs`) — PASS. Verifies: both frame panels mount; both counters/machines read their initial state; +Apple on `:above` doesn't move `:below`'s counter; Refresh on `:below` transitions only `:below`'s machine through `:idle → :loading → :loaded` with the mock payload; Force-error on `:above` drives only `:above` into `:error` legitimately.

## Notes

- The build orchestrator's `--filter parallel-frames` substring is partially shadowed in this worktree because the worktree itself is named `parallel-frames-rf2-m00rw` (the substring matches every spec path). The smoke was verified via a stable filter scope locally; on `main` the filter substring matches only the canonical paths and the orchestrator behaves as expected.
- No follow-on docs updates beyond the single spec/006 cross-link — the testbed's own README is self-contained.