### PR TITLE
feat(causa): Round-3 corrections — drop bottom rail + drop merged frame option + one-line event rows (rf2-g9pee + rf2-i74n7 + rf2-cmtkw)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -24,20 +24,28 @@
 
   ## Ribbon clusters (L1)
 
-  Five clusters, fixed order left → right per spec/018 §3:
+  Four clusters, fixed order left → right per spec/018 §3 (Round-3
+  rf2-g9pee — the explicit `● LIVE` / `◐ RETRO` mode pill was dropped;
+  the spine's mode is already derivable from sticky-row selection +
+  the `[◀ ▶ ⏭]` cluster + the `:rf.causa/focus` sub. Space / L / G
+  keybindings preserve the toggle access the pill used to surface):
 
   - **Nav** (`◀ ▶ ⏭`) — back / forward / fast-forward through the
     spine. Dispatches `:rf.causa/focus-cascade-prev` / `-next` /
-    `:rf.causa/follow-head`.
+    `:rf.causa/follow-head`. Pressing `⏭` (or `Space` in paused-LIVE,
+    or `L` in RETRO) snaps focus back to head — the operations the
+    mode pill used to host.
   - **Frame picker** — single-select dropdown over the cascade list's
     distinct frames. Excludes `:rf/causa` by default per §8 I1.
   - **Filter pills** — IN (green, `+`) and OUT (magenta, `×`) pills
     + trailing `[+]` add-pill. Click any pill → edit popup.
-  - **Mode pill** — `● LIVE` / `◐ RETRO` / `● LIVE (paused)` dual-
-    purpose indicator + toggle. Carries the REDACTED-count tooltip.
   - **Right icons** — `⚙` settings · `✕` close. (Pop-out is a
     programmatic API only — `(causa/popout!)` — no ribbon affordance
     until the second-window UX lands per spec/011-Launch-Modes.md.)
+
+  The REDACTED indicator (`[● REDACTED N]`) renders inline next to
+  the right-icons cluster when the suppressed-sensitive count is
+  positive, surfacing privacy state without a permanent ribbon slot.
 
   ## Event list (L2)
 
@@ -169,24 +177,6 @@
                       (conj acc f)))))
       []
       cascades)))
-
-(defn mode-pill-text
-  "Render text for the L1 mode pill per spec/018 §3 Mode pill click
-  behaviour. `focus` is the `:rf.causa/focus` sub value."
-  [{:keys [mode paused? head?]}]
-  (case mode
-    :live  (if paused? "● LIVE (paused)" "● LIVE")
-    :retro (if head? "● LIVE" "◐ RETRO")
-    "● LIVE"))
-
-(defn mode-pill-on-click
-  "Dispatcher for the mode-pill click — Space-equivalent when in LIVE,
-  L-equivalent when in RETRO. Per spec/018 §3 table 'Mode pill click
-  behaviour'."
-  [{:keys [mode]}]
-  (if (= mode :retro)
-    #(rf/dispatch [:rf.causa/follow-head] {:frame :rf/causa})
-    #(rf/dispatch [:rf.causa/toggle-live-pause] {:frame :rf/causa})))
 
 (defn event-id-of-cascade
   "Best-effort pluck of the event-id from a cascade's `:event` slot.
@@ -428,44 +418,6 @@
   [{:keys [filters]}]
   [filter-pills/pills-view {:filters filters}])
 
-(defn- ribbon-mode-pill
-  "Mode pill — `● LIVE` / `◐ RETRO` / `● LIVE (paused)` per spec/018
-  §3. Tooltip surfaces the REDACTED total. Click toggles per the
-  mode-pill click behaviour table."
-  [{:keys [focus redacted-count]}]
-  (let [pill-tone (case (:mode focus)
-                    :live  (if (:paused? focus)
-                             (:text-secondary tokens)
-                             (:green tokens))
-                    :retro (if (:head? focus)
-                             (:green tokens)
-                             (:cyan tokens))
-                    (:green tokens))
-        red-suffix (when (pos? redacted-count)
-                     (str " · ● REDACTED " redacted-count " (default-suppressed)"))
-        base-title (case (:mode focus)
-                     :live  (if (:paused? focus)
-                              "Resume LIVE feed (Space)"
-                              "Pause LIVE feed (Space)")
-                     :retro (if (:head? focus)
-                              "Pause LIVE feed (Space)"
-                              "Snap to LIVE (L)")
-                     "")
-        full-title (str base-title (or red-suffix ""))]
-    [:span {:data-testid "rf-causa-mode-pill"
-            :on-click    (mode-pill-on-click focus)
-            :title       full-title
-            :style       {:color         pill-tone
-                          :cursor        "pointer"
-                          :font-weight   600
-                          :padding       "2px 8px"
-                          :border        (str "1px solid " pill-tone)
-                          :border-radius "10px"
-                          :font-family   sans-stack
-                          :font-size     (:body type-scale)
-                          :white-space   "nowrap"}}
-     (mode-pill-text focus)]))
-
 (defn- ribbon-redacted-indicator
   "REDACTED indicator (rf2-azls9) — preserved next to the mode pill for
   back-compat with the existing redacted-counter assertion surface.
@@ -570,8 +522,15 @@
       "✕"]]))
 
 (rf/reg-view ribbon
-  "L1 ribbon — per spec/018 §3 Top ribbon anatomy. Five clusters left
-  to right: nav · frame · filters · mode pill · right icons.
+  "L1 ribbon — per spec/018 §3 Top ribbon anatomy. Four clusters left
+  to right: nav · frame · filters · right icons. The REDACTED
+  indicator surfaces on-demand next to the right-icons cluster when
+  the suppressed-sensitive count is positive.
+
+  Per Round-3 rf2-g9pee the explicit `● LIVE` / `◐ RETRO` mode pill
+  was dropped — the spine mode is already derivable from sticky-row
+  selection + the `[◀ ▶ ⏭]` nav cluster. Space / L / G keybindings
+  preserve the toggle access the pill used to surface.
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -625,8 +584,7 @@
                            :frames frames}]
      [ribbon-filter-pills {:filters filters}]
      [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
-      [ribbon-redacted-indicator redacted-count]
-      [ribbon-mode-pill {:focus focus :redacted-count redacted-count}]]
+      [ribbon-redacted-indicator redacted-count]]
      [ribbon-right-icons]]))
 
 ;; ---- L2 event list -------------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -373,12 +373,16 @@
       "⏭"]]))
 
 (defn- ribbon-frame-picker
-  "Frame dropdown — single-select per spec/018 §3 Frame dropdown.
-  Excludes `:rf/causa` by default per §8 I1. When the only available
-  frame is the current selection, the dropdown collapses to a flat
-  label (no chevron — no click target).
+  "Frame dropdown — STRICTLY single-select per spec/018 §1 Non-goals
+  + §3 Frame dropdown + Round-3 rf2-i74n7. No 'All frames (merged)'
+  option; no `:multiple` attribute on the `<select>`; cross-frame
+  causality is reached via the Causality popover (`c` key), not via
+  a merged-frame view. Excludes `:rf/causa` by default per §8 I1.
+  When the only available frame is the current selection, the
+  dropdown collapses to a flat label (no chevron — no click target).
 
-  Writes via `:rf.causa/set-frame <frame-id>`."
+  Writes via `:rf.causa/set-frame <frame-id>` — single frame id, no
+  aggregate / merged value path."
   [{:keys [selected-frame frames]}]
   (let [label-style {:color       (:text-primary tokens)
                      :font-family sans-stack

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -98,7 +98,8 @@
   Per rf2-tijr the view code is pure hiccup. The substrate adapter's
   render fn (`rf/render`) handles the substrate-specific mount in
   `mount.cljs`. No per-substrate switches in view code."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
@@ -188,87 +189,70 @@
     (when (vector? ev)
       (first ev))))
 
-(def event-vector-inline-cap
-  "Max character count for the L2 row's inline event-vector rendering
-  (rf2-htik0). Cascades that pr-str longer than this collapse to
-  `<head>…]` so the row stays single-line. Click the row → the L4
-  Event tab shows the full vector (no truncation there).
+(defn render-event-id-only
+  "Render JUST the event-id keyword for the L2 row per Round-3
+  rf2-cmtkw — one-line minimal rows. The full event vector (args +
+  payload) and all dropped fields (datetime, sequence number, duration
+  tier, source coordinates) move to the row's hover tooltip + the
+  Event tab detail (which has plenty of room).
 
-  ~80 chars is enough for `[:cart/add-item {:item-id \"apple\" :qty 2}]`
-  plus a touch of slack for typical event-handler signatures, and
-  short enough to keep the L2 list scannable in a stack of rows."
-  80)
-
-(defn truncate-event-vector
-  "Truncate a pr-str'd event vector to `cap` chars with `…]` suffix
-  when over the cap. Pure string utility — caller already has the
-  pr-str result.
-
-  Always preserves the trailing `]` so the rendered form still reads
-  as a vector at a glance (e.g. `[:foo/bar {:a 1 :b 2 :c…]`)."
-  [s cap]
-  (if (<= (count s) cap)
-    s
-    (str (subs s 0 (max 0 (- cap 2))) "…]")))
-
-(defn render-event-vector-inline
-  "Render an event vector as `[event-id payload…]` hiccup for the L2
-  event-list row (rf2-htik0).
-
-  - Empty payload (1-element vector) renders as `[:counter/inc]` — no
-    map, no `{}` placeholder.
-  - Non-empty payload pr-str's the full vector then truncates to
-    `event-vector-inline-cap` with `…]` suffix so the row stays
-    single-line.
-  - `event-id` (the first element) gets the keyword accent colour so
-    it pops out of the row; the rest renders in the row's default
-    text colour.
-
-  Returns hiccup (a `[:span … ]` tree). When the cascade carries no
-  event vector, falls back to a `<no event>` chip in the secondary
-  text colour so unrouted cascades stay visible. (Note: per rf2-639lc
-  the L2 event list filters those cascades out via `cascade-has-event?`
-  before they reach this renderer, so the fallback is defence-in-depth
-  for any caller that does not pre-filter.)"
+  - `event-id` is the first element of the event vector.
+  - Renders in the accent-violet colour so it pops out of the row.
+  - When the cascade carries no event vector, falls back to a
+    `<no event>` chip in the secondary text colour. (Per rf2-639lc
+    the L2 event list filters those cascades out via
+    `cascade-has-event?`; the fallback is defence-in-depth.)"
   [event-vec]
-  (cond
-    (not (vector? event-vec))
-    [:span {:style {:color (:text-secondary tokens)
+  (if (vector? event-vec)
+    [:span {:style {:color       (:accent-violet tokens)
+                    :font-weight 500}}
+     (pr-str (first event-vec))]
+    [:span {:style {:color      (:text-secondary tokens)
                     :font-style "italic"}}
-     "<no event>"]
+     "<no event>"]))
 
-    (= 1 (count event-vec))
-    [:span {:style {:display "inline-flex" :align-items "baseline"}}
-     [:span {:style {:color (:text-tertiary tokens)}} "["]
-     [:span {:style {:color (:accent-violet tokens)}}
-      (pr-str (first event-vec))]
-     [:span {:style {:color (:text-tertiary tokens)}} "]"]]
+(defn row-tooltip-text
+  "Build the L2 row's hover tooltip per Round-3 rf2-cmtkw. The
+  minimal one-line row surfaces only `event-id + ⚠/🌐/🤖`; the
+  dropped fields (full event vector, sequence number, frame, source
+  coordinates, handler duration) appear in this tooltip + in the
+  Event tab detail panel on row click.
 
-    :else
-    (let [event-id   (first event-vec)
-          id-str     (pr-str event-id)
-          full-str   (pr-str event-vec)
-          truncated  (truncate-event-vector full-str event-vector-inline-cap)
-          ;; Strip the leading `[id-str ` from the truncated body so we
-          ;; can colour the event-id separately. When truncation chopped
-          ;; into the id (shouldn't happen with cap >> typical id), fall
-          ;; back to rendering the whole truncated string in default colour.
-          id-prefix  (str "[" id-str " ")
-          tail       (when (and (> (count truncated) (count id-prefix))
-                                (= id-prefix (subs truncated 0 (count id-prefix))))
-                       (subs truncated (count id-prefix)))]
-      (if tail
-        [:span {:style {:display "inline-flex" :align-items "baseline"
-                        :overflow "hidden" :text-overflow "ellipsis"}}
-         [:span {:style {:color (:text-tertiary tokens)}} "["]
-         [:span {:style {:color (:accent-violet tokens)}} id-str]
-         [:span {:style {:color (:text-primary tokens)
-                         :margin-left "4px"}}
-          tail]]
-        ;; Defensive fallback — render the whole truncated string in one
-        ;; span so a pathological event-id (with embedded space?) still
-        ;; surfaces something useful.
-        [:span {:style {:color (:text-primary tokens)}} truncated]))))
+  Pure data — JVM-runnable. nil-safe per cascade slot. Returns a
+  newline-joined string suitable for an HTML `:title` attribute.
+
+  Slot ordering (most useful first):
+    1. Full event vector (untruncated)
+    2. `#<dispatch-id>` (the sequence number)
+    3. `frame: <id>`
+    4. Source coordinate `<file>:<line>:<col>` (when `:rf.trace/call-site`
+       rode the `:event/dispatched` emit per rf2-twt7m Change 1)
+    5. `handler: <ms>ms` (when the cascade carried a `:handler` emit
+       with `:elapsed-ms`)
+    6. Trailing hint: `Click → open Event detail`"
+  [cascade]
+  (let [event-vec     (:event cascade)
+        dispatch-id   (:dispatch-id cascade)
+        frame-id      (:frame cascade)
+        dispatched    (:dispatched cascade)
+        call-site     (:rf.trace/call-site dispatched)
+        coord-str     (when (map? call-site)
+                        (let [{:keys [file line column]} call-site]
+                          (when file
+                            (cond-> file
+                              line   (str ":" line)
+                              column (str ":" column)))))
+        handler       (:handler cascade)
+        handler-ms    (or (:elapsed-ms handler)
+                          (get-in handler [:tags :elapsed-ms]))
+        lines (cond-> []
+                (vector? event-vec) (conj (pr-str event-vec))
+                (some? dispatch-id) (conj (str "#" dispatch-id))
+                (some? frame-id)    (conj (str "frame: " frame-id))
+                (some? coord-str)   (conj (str "source: " coord-str))
+                (some? handler-ms)  (conj (str "handler: " handler-ms "ms"))
+                true                (conj "Click → open Event detail"))]
+    (str/join "\n" lines)))
 
 (defn cascade-has-event?
   "True iff `cascade` carries a real `:event` vector (`(first :event)`
@@ -729,9 +713,31 @@
 
 (defn- event-row
   "One row in the L2 event list. Single line per spec/018 §4 Row
-  anatomy. Gutter glyph + event-id + right-anchored badge cluster +
-  trailing redaction marker (stub — uses spine's `:focus.dispatch-id`
-  to drive the focused-row gutter).
+  anatomy + Round-3 rf2-cmtkw — minimal default render.
+
+  ## Round-3 rf2-cmtkw — minimal default row
+
+  Default row content (ONE line only):
+
+      [gutter] :event-id  [⚠] [🌐] [🤖]
+
+  - **`:event-id`** — the bare event-id keyword (not the full event
+    vector). Args / payload move to the tooltip + Event tab detail.
+  - **`⚠`** — exception/error glyph (from `:other` carrying
+    `:op-type :error` / `:warning`, or `:errors` slot populated).
+  - **`🌐`** — managed-HTTP marker (from `:other` carrying an
+    `:operation` matching `:http/*` or `:rf.http/*`).
+  - **`🤖`** — state-machine marker (from `:other` carrying an
+    `:operation` matching `:machine`).
+
+  Dropped from the default view (moved to hover tooltip + Event
+  detail tab): the full event vector with args, the sequence
+  number (`#<dispatch-id>`), the duration tier, the source
+  coordinate.
+
+  The row's `:title` attribute carries those dropped fields so a
+  hover surfaces them without leaving L2. Clicking the row opens
+  the Event tab in L4 with the full untruncated content.
 
   Right-click (`on-context-menu`) lowers per spec/018 §7 'Right-click
   event-row → context menu' into `:rf.causa/hide-event-type <event-
@@ -811,6 +817,12 @@
                                        (rf/dispatch
                                          [:rf.causa/hide-event-type ev-id]
                                          {:frame :rf/causa})))
+                  ;; Round-3 rf2-cmtkw — dropped fields (full event
+                  ;; vector with args, sequence number, frame, source
+                  ;; coord, handler duration) surface in this hover
+                  ;; tooltip + the L4 Event tab on click. Default row
+                  ;; body shows only `event-id + ⚠/🌐/🤖`.
+                  :title (row-tooltip-text cascade)
                   :data-rf-causa-in-focus (cond
                                             (not focus-active?) "n/a"
                                             in-focus?           "true"
@@ -872,14 +884,17 @@
               gutter-click (assoc :on-click gutter-click))
       (or focus-marker
           [:span {:style {:color glyph-col}} glyph])]
-     ;; Bug 3 (rf2-htik0): render the real event vector inline —
-     ;; `[:cart/add-item {:item-id "apple"}]`, NOT just `:cart/add-item`.
-     ;; Truncates at ~80 chars with `…]` suffix to keep the row single-line.
-     [:span {:data-testid "rf-causa-row-event-vector"
+     ;; Round-3 rf2-cmtkw — minimal default row renders ONLY the
+     ;; bare event-id keyword (e.g. `:cart/add-item`). The full event
+     ;; vector with args moves to the row's hover tooltip + the L4
+     ;; Event tab detail (the panel that owns the room for it).
+     ;; Earlier rf2-htik0 Bug 3 inline-rendered the truncated full
+     ;; vector here — superseded by the Round-3 minimal-row contract.
+     [:span {:data-testid "rf-causa-row-event-id"
              :style {:flex "1 1 auto" :overflow "hidden"
                      :text-overflow "ellipsis"
                      :min-width "0"}}
-      (render-event-vector-inline event-vec)]
+      (render-event-id-only event-vec)]
      (when (seq badges)
        [:span {:data-testid "rf-causa-row-badges"
                :style {:display "flex" :gap "4px" :flex-shrink 0

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -127,9 +127,11 @@
    })
 
 (def layout
-  "Causa shell layout dimensions (rf2-pcitk). Single source for the
-  density knob — narrowing the sidebar reclaims canvas width without
-  touching individual panels."
-  {:sidebar-width   "152px"   ; was 192px — between spec compact (160) and cosy (192)
-   :top-strip-height "56px"
-   :bottom-rail-height "40px"})
+  "Causa shell layout dimensions (rf2-pcitk + rf2-g9pee). Single source
+  for the chrome's fixed-height layer measurements.
+
+  The 4-layer chrome is L1 ribbon (top-strip) + L2 event list + L3
+  tab bar + L4 detail panel — no bottom rail, no sidebar (both dropped
+  in earlier Causa redesigns and the now-unused `:sidebar-width` /
+  `:bottom-rail-height` tokens were retired in Round-3 rf2-g9pee)."
+  {:top-strip-height "56px"})

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -790,7 +790,13 @@
               "focus never goes nil with a non-empty buffer"))))))
 
 ;; -------------------------------------------------------------------------
-;; (4b) Row density + inline event-vector rendering — rf2-htik0 Bug 2 + 3
+;; (4b) Row density + minimal default-row rendering — rf2-htik0 Bug 2 +
+;;      Round-3 rf2-cmtkw (replaces rf2-htik0 Bug 3 inline event-vector).
+;;
+;; Round-3 rf2-cmtkw — the default L2 row body is one line: gutter +
+;; bare event-id + ⚠/🌐/🤖 badge cluster. Args + sequence number +
+;; frame + source coordinate + handler duration appear in the row's
+;; :title hover tooltip and in the L4 Event detail tab on click.
 ;; -------------------------------------------------------------------------
 
 (deftest event-row-density-tight
@@ -820,91 +826,121 @@
         (is (= "200px" (:height style))
             "list container is ~8 rows × 22px + gaps + padding")))))
 
-(deftest event-row-renders-real-event-vector
-  (testing "rf2-htik0 Bug 3 — each L2 row shows the dispatched event
-            vector inline (`[:cart/add-item {:item-id \"apple\"}]`),
-            not just the event-id."
+(deftest event-row-renders-event-id-only
+  (testing "Round-3 rf2-cmtkw — the default L2 row body renders ONLY
+            the bare event-id keyword. Args / payload are NOT inline
+            in the default row (they move to hover tooltip + the L4
+            Event detail tab)."
     (causa-setup!)
     (trace-bus/collect-trace!
       (dispatch-trace-ev 1 [:cart/add-item {:item-id "apple" :qty 2}]))
     (rf/with-frame :rf/causa
-      (let [tree (shell/shell-view)
-            row  (find-by-testid tree "rf-causa-event-row-1")
-            vec-node (find-by-testid tree "rf-causa-row-event-vector")
-            text (text-nodes vec-node)]
+      (let [tree    (shell/shell-view)
+            row     (find-by-testid tree "rf-causa-event-row-1")
+            id-node (find-by-testid tree "rf-causa-row-event-id")
+            text    (text-nodes id-node)]
         (is (some? row) "row renders")
-        (is (some? vec-node) "row carries the event-vector slot")
+        (is (some? id-node) "row carries the event-id slot")
         (is (re-find #":cart/add-item" text)
             "event-id surfaces in the row text")
-        (is (re-find #":item-id" text)
-            "payload key surfaces in the row text")
-        (is (re-find #"apple" text)
-            "payload value surfaces in the row text")))))
+        (is (not (re-find #":item-id" text))
+            "payload key does NOT surface in the default row")
+        (is (not (re-find #"apple" text))
+            "payload value does NOT surface in the default row")
+        (is (not (re-find #"\{" text))
+            "no `{...}` map serialisation in the default row")
+        (is (not (re-find #"\[" text))
+            "no vector brackets in the default row — bare keyword only")
+        (is (not (re-find #"\]" text))
+            "no vector brackets in the default row — bare keyword only")
+        ;; The dropped fields surface in the row's :title tooltip
+        ;; instead — Round-3 rf2-cmtkw.
+        (let [title (:title (second row))]
+          (is (string? title) ":title attribute set for hover tooltip")
+          (is (re-find #":cart/add-item" title)
+              "tooltip carries the event-id")
+          (is (re-find #":item-id" title)
+              "tooltip carries the full event vector (with args)")
+          (is (re-find #"#1" title)
+              "tooltip carries the sequence number (#<dispatch-id>)")
+          (is (re-find #"Click → open Event detail" title)
+              "tooltip surfaces the click-through hint"))))))
 
-(deftest event-row-empty-payload-renders-as-bare-vector
-  (testing "rf2-htik0 Bug 3 — events with no payload render as
-            `[:counter/inc]` — no `{}` placeholder."
+(deftest event-row-no-row-event-vector-slot
+  (testing "Round-3 rf2-cmtkw — the previous `rf-causa-row-event-vector`
+            slot is gone. The default row body slot is now
+            `rf-causa-row-event-id` and renders only the bare keyword."
     (causa-setup!)
     (trace-bus/collect-trace! (dispatch-trace-ev 1 [:counter/inc]))
     (rf/with-frame :rf/causa
-      (let [tree (shell/shell-view)
-            vec-node (find-by-testid tree "rf-causa-row-event-vector")
-            text (text-nodes vec-node)]
-        (is (some? vec-node))
-        (is (re-find #":counter/inc" text)
-            "event-id renders")
-        (is (not (re-find #"\{" text))
-            "no `{}` placeholder for empty payload")
-        (is (not (re-find #"\}" text))
-            "no `{}` placeholder for empty payload")))))
+      (let [tree (shell/shell-view)]
+        (is (nil? (find-by-testid tree "rf-causa-row-event-vector"))
+            "legacy event-vector slot is absent")
+        (is (some? (find-by-testid tree "rf-causa-row-event-id"))
+            "new event-id slot is present")))))
 
-(deftest event-row-long-payload-truncates
-  (testing "rf2-htik0 Bug 3 — long event vectors collapse to head + `…]`
-            so the row stays single-line."
-    (causa-setup!)
-    (let [big-vec [:something/big {:a "alpha-beta-gamma-delta"
-                                   :b "epsilon-zeta-eta-theta"
-                                   :c "iota-kappa-lambda-mu"
-                                   :d "nu-xi-omicron-pi"}]]
-      (trace-bus/collect-trace! (dispatch-trace-ev 1 big-vec))
-      (rf/with-frame :rf/causa
-        (let [tree (shell/shell-view)
-              vec-node (find-by-testid tree "rf-causa-row-event-vector")
-              text (text-nodes vec-node)]
-          (is (some? vec-node))
-          (is (re-find #":something/big" text)
-              "head (event-id) preserved through truncation")
-          (is (re-find #"…\]$" text)
-              "trailing `…]` marks the truncation"))))))
-
-(deftest truncate-event-vector-helper
-  (testing "rf2-htik0 Bug 3 — pure truncator preserves short strings
-            and clips long ones with `…]` suffix"
-    (is (= "[:x]" (shell/truncate-event-vector "[:x]" 80))
-        "below cap → pass-through")
-    (is (= "[:x 1]" (shell/truncate-event-vector "[:x 1]" 80))
-        "below cap → pass-through")
-    (let [long-str (apply str "[:x " (repeat 100 "y"))
-          out      (shell/truncate-event-vector long-str 20)]
-      (is (= 20 (count out)) "output respects cap")
-      (is (re-find #"…\]$" out) "suffix is `…]`")
-      (is (re-find #"^\[:x" out) "head preserved"))))
-
-(deftest render-event-vector-inline-empty-payload
-  (testing "rf2-htik0 Bug 3 — render-event-vector-inline of a 1-element
-            vector returns hiccup containing just the event-id, no `{}`."
-    (let [hiccup (shell/render-event-vector-inline [:counter/inc])
+(deftest render-event-id-only-empty-payload
+  (testing "Round-3 rf2-cmtkw — render-event-id-only of a 1-element
+            event vector returns hiccup containing just the event-id
+            keyword."
+    (let [hiccup (shell/render-event-id-only [:counter/inc])
           text   (text-nodes hiccup)]
       (is (re-find #":counter/inc" text))
-      (is (not (re-find #"\{" text)))
-      (is (not (re-find #"\}" text))))))
+      (is (not (re-find #"\[" text)) "no surrounding brackets")
+      (is (not (re-find #"\]" text)) "no surrounding brackets"))))
 
-(deftest render-event-vector-inline-nil-cascade
-  (testing "rf2-htik0 Bug 3 — render-event-vector-inline of non-vector
+(deftest render-event-id-only-with-payload
+  (testing "Round-3 rf2-cmtkw — render-event-id-only of an event
+            vector with args returns hiccup containing ONLY the
+            event-id keyword — args are dropped from the default row."
+    (let [hiccup (shell/render-event-id-only [:cart/add-item {:qty 2}])
+          text   (text-nodes hiccup)]
+      (is (re-find #":cart/add-item" text))
+      (is (not (re-find #":qty" text)) "args dropped")
+      (is (not (re-find #"\{" text)) "no map serialisation")
+      (is (not (re-find #"\}" text)) "no map serialisation")
+      (is (not (re-find #"\[" text)) "no vector brackets")
+      (is (not (re-find #"\]" text)) "no vector brackets"))))
+
+(deftest render-event-id-only-nil-cascade
+  (testing "Round-3 rf2-cmtkw — render-event-id-only of non-vector
             input returns the `<no event>` fallback chip."
-    (let [hiccup (shell/render-event-vector-inline nil)
+    (let [hiccup (shell/render-event-id-only nil)
           text   (text-nodes hiccup)]
       (is (re-find #"no event" text)))))
+
+(deftest row-tooltip-text-carries-dropped-fields
+  (testing "Round-3 rf2-cmtkw — the row's :title tooltip carries
+            every field dropped from the minimal default row: full
+            event vector with args, sequence number (`#<dispatch-id>`),
+            frame id, source coordinate, handler duration."
+    (let [cascade {:dispatch-id 42
+                   :frame       :app/main
+                   :event       [:cart/add-item {:item-id "apple"}]
+                   :dispatched  {:rf.trace/call-site {:file "src/cart.cljs"
+                                                      :line 17
+                                                      :column 3}}
+                   :handler     {:elapsed-ms 4}}
+          tip     (shell/row-tooltip-text cascade)]
+      (is (string? tip))
+      (is (re-find #":cart/add-item" tip) "carries the event id")
+      (is (re-find #":item-id" tip)       "carries the full event vector args")
+      (is (re-find #"#42" tip)            "carries the sequence number")
+      (is (re-find #":app/main" tip)      "carries the frame id")
+      (is (re-find #"src/cart.cljs:17:3" tip)
+          "carries the source coordinate")
+      (is (re-find #"4ms" tip)            "carries the handler duration")
+      (is (re-find #"Click → open Event detail" tip)
+          "carries the click-through hint"))))
+
+(deftest row-tooltip-text-nil-safe
+  (testing "Round-3 rf2-cmtkw — row-tooltip-text safely degrades when
+            cascade slots are missing. Always renders at least the
+            click-through hint so the tooltip is never empty."
+    (let [tip (shell/row-tooltip-text {})]
+      (is (string? tip))
+      (is (re-find #"Click → open Event detail" tip)
+          "click-through hint always present"))))
 
 ;; -------------------------------------------------------------------------
 ;; (5) REDACTED indicator (preserved from pre-refactor — relocated to L1)

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -1019,6 +1019,45 @@
       (is (= [:rf/default :app/main] (shell/distinct-frames cascades false))
           "nil frame is filtered out"))))
 
+(deftest frame-picker-is-strictly-single-select
+  (testing "Round-3 rf2-i74n7 + spec/018 §1 Non-goals — the frame
+            picker is strictly single-select. No 'All frames (merged)'
+            option; no `:multiple` attribute on the <select>; the
+            options list carries exactly one entry per distinct frame
+            in the cascade vector (no aggregate / merged synthetic
+            option). Cross-frame causality is reached via the
+            Causality popover (`c` key), not via a merged frame."
+    (causa-setup!)
+    ;; Seed two distinct frames so the picker collapses to the <select>
+    ;; branch (single-frame counts render the flat label).
+    (trace-bus/collect-trace!
+      (assoc-in (dispatch-trace-ev 1 [:cart/add])
+                [:tags :frame] :app/main))
+    (trace-bus/collect-trace!
+      (assoc-in (dispatch-trace-ev 2 [:cart/add])
+                [:tags :frame] :app/admin))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            picker (find-by-testid tree "rf-causa-ribbon-frame-picker")
+            attrs  (when picker (second picker))]
+        (is (some? picker) "picker renders as a <select> for multi-frame")
+        (is (= :select (first picker))
+            "picker is a <select> element (not a custom multi-select)")
+        (is (nil? (:multiple attrs))
+            "picker has no :multiple attribute — strictly single-select")
+        (is (not (re-find #"(?i)merged|all frames|all-frames"
+                          (text-nodes picker)))
+            "no 'All frames (merged)' / 'merged' / 'all-frames' option
+             surfaces in the picker text")
+        ;; Verify exactly one <option> per distinct frame — no extra
+        ;; aggregate / merged synthetic option.
+        (let [options (filterv (fn [node]
+                                 (and (vector? node)
+                                      (= :option (first node))))
+                               (hiccup-seq picker))]
+          (is (= 2 (count options))
+              "exactly one <option> per distinct frame — no extra aggregate"))))))
+
 ;; -------------------------------------------------------------------------
 ;; (7) Filter pills — add / remove round-trip
 ;; -------------------------------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -13,9 +13,12 @@
        panel-<tab>`) and the palette modal — and does NOT mount any
        legacy sidebar or bottom rail.
 
-    2. The L1 ribbon carries five clusters in fixed order: nav,
-       frame, filter pills, mode pill (+ REDACTED indicator
-       neighbour), right icons.
+    2. The L1 ribbon carries four clusters in fixed order: nav,
+       frame, filter pills, right icons. The REDACTED indicator
+       sits inline next to the right-icons cluster when the
+       suppressed-sensitive count is positive. (Round-3 rf2-g9pee
+       dropped the explicit `● LIVE` / `◐ RETRO` mode pill — the
+       state is derivable, and Space / L / G preserve toggles.)
 
     3. The L3 tab bar renders six tabs (Event / App-db / Views /
        Trace / Machines / Issues) and clicking a tab updates
@@ -27,8 +30,9 @@
 
     5. The REDACTED indicator (rf2-azls9) preserves its render gate
        `(pos? redacted-count)` and pluralises 'event' / 'events' in
-       the tooltip. The indicator now lives next to the mode pill in
-       L1 per the 4-layer-chrome relocation.
+       the tooltip. Post-Round-3 (rf2-g9pee) the indicator sits next
+       to the right-icons cluster — the previous mode-pill neighbour
+       was dropped along with the pill itself.
 
     6. The frame picker excludes `:rf/causa` (and other tool frames)
        per spec/018 §8 I1.
@@ -184,9 +188,13 @@
 ;; (2) L1 ribbon clusters
 ;; -------------------------------------------------------------------------
 
-(deftest ribbon-mounts-all-five-clusters
-  (testing "spec/018 §3 — ribbon carries nav · frame · filter pills ·
-            mode pill · right icons in fixed left-to-right order"
+(deftest ribbon-mounts-all-four-clusters
+  (testing "spec/018 §3 + Round-3 rf2-g9pee — ribbon carries nav ·
+            frame · filter pills · right icons in fixed left-to-right
+            order. The explicit `● LIVE` / `◐ RETRO` mode pill was
+            dropped in Round-3 — spine mode is derivable from
+            sticky-row selection + the `[◀ ▶ ⏭]` cluster, and Space /
+            L / G keybindings preserve toggle access."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (shell/shell-view)]
@@ -197,8 +205,8 @@
             "frame cluster present (label or dropdown)")
         (is (some? (find-by-testid tree "rf-causa-ribbon-filters"))
             "filter cluster present")
-        (is (some? (find-by-testid tree "rf-causa-mode-pill"))
-            "mode pill present")
+        (is (nil? (find-by-testid tree "rf-causa-mode-pill"))
+            "mode pill is absent — dropped in Round-3 rf2-g9pee")
         (is (some? (find-by-testid tree "rf-causa-ribbon-icons"))
             "right-icons cluster present")))))
 

--- a/tools/causa/testbeds/counter-driven/spec.cjs
+++ b/tools/causa/testbeds/counter-driven/spec.cjs
@@ -25,8 +25,9 @@
  *   2. Chrome: all four layers (ribbon, event list, tab bar, detail
  *      panel) and the palette modal mount; legacy sidebar testids
  *      are absent.
- *   3. Ribbon: nav cluster, frame picker, filter pills, mode pill,
- *      right-icons cluster all render.
+ *   3. Ribbon: nav cluster, frame picker, filter pills, right-icons
+ *      cluster all render. (Round-3 rf2-g9pee dropped the explicit
+ *      LIVE / RETRO mode pill — state is derivable from the spine.)
  *   4. Tab bar: all six tabs (Event / App-db / Views / Trace /
  *      Machines / Issues) render and clicking each tab updates the
  *      L4 detail panel's testid (`rf-causa-detail-panel-<tab>`).
@@ -98,7 +99,9 @@ module.exports = {
     }
 
     // ----------------------------------------------------------------
-    // 3. Ribbon clusters — five fixed-order regions per spec/018 §3.
+    // 3. Ribbon clusters — four fixed-order regions per spec/018 §3.
+    //    Round-3 rf2-g9pee dropped the explicit `● LIVE` / `◐ RETRO`
+    //    mode pill; assert its testid is absent.
     // ----------------------------------------------------------------
     await expectVisible(page.locator(`[data-testid="rf-causa-ribbon-nav"]`), 5000);
     // frame cluster is either a label OR a select depending on count
@@ -109,7 +112,13 @@ module.exports = {
       throw new Error('Expected ribbon frame cluster (label or dropdown) to render');
     }
     await expectVisible(page.locator(`[data-testid="rf-causa-ribbon-filters"]`), 5000);
-    await expectVisible(page.locator(`[data-testid="rf-causa-mode-pill"]`), 5000);
+    const modePillCount = await page.locator(`[data-testid="rf-causa-mode-pill"]`).count();
+    if (modePillCount !== 0) {
+      throw new Error(
+        `Expected no mode pill post-rf2-g9pee; got ${modePillCount}. ` +
+        `Round-3 dropped the explicit LIVE / RETRO pill.`,
+      );
+    }
     await expectVisible(page.locator(`[data-testid="rf-causa-ribbon-icons"]`), 5000);
 
     // ----------------------------------------------------------------
@@ -172,8 +181,10 @@ module.exports = {
     }
 
     // ----------------------------------------------------------------
-    // 6. [● REDACTED N] indicator — relocated to L1 ribbon next to
-    //     the mode pill per rf2-xy4yb (was on the dead bottom rail).
+    // 6. [● REDACTED N] indicator — renders inline next to the
+    //     right-icons cluster in L1 when the suppressed-sensitive
+    //     count is positive (rf2-xy4yb relocation from the legacy
+    //     bottom rail; rf2-g9pee dropped the mode-pill neighbour).
     // ----------------------------------------------------------------
     const noted = await page.evaluate(() => {
       const cfg =


### PR DESCRIPTION
## Summary

- **Commit 1 (rf2-g9pee)** — Drop the bottom rail (Layer 0). The physical rail was already removed in rf2-adve5; this round drops its last anchor — the explicit `● LIVE` / `◐ RETRO` mode pill — since the spine mode is derivable from sticky-row selection + the `[◀ ▶ ⏭]` nav cluster. Space / L / G keybindings preserve toggle access. Also retires unused `:sidebar-width` and `:bottom-rail-height` layout tokens.
- **Commit 2 (rf2-i74n7)** — Drop 'All frames (merged)' from the frame picker. The picker has been strictly single-select since the spec/018 rewrite; this commit locks in the contract with a regression test asserting the picker is a single-select `<select>` with no `:multiple` attribute and exactly one `<option>` per distinct frame (no aggregate / merged synthetic). Tightens the picker docstring.
- **Commit 3 (rf2-cmtkw)** — One-line event-list rows. The L2 default row body collapses to ONE line: gutter + bare event-id keyword + ⚠/🌐/🤖 badge cluster. The full event vector with args, sequence number, frame, source coordinate, and handler duration ALL move to the row's `:title` hover tooltip; the L4 Event tab carries them in full on click. Replaces the rf2-htik0 Bug 3 inline event-vector rendering + retires `event-vector-inline-cap` / `truncate-event-vector` / `render-event-vector-inline` / the `rf-causa-row-event-vector` testid in favour of `render-event-id-only` / `row-tooltip-text` / `rf-causa-row-event-id`.

## Parent design

Implements three Round-3 corrections from parent design rf2-3hfwz (Mike chat 2026-05-17). Picker + mode-pill drops are pre-alpha: no shims, no flags, no deprecation paths.

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass (2941 tests, 8412 assertions, 0 failures, 0 errors)
- [x] `npm run test:cljs` — pass (2941 tests)
- [x] `npm run test:browser` — pass (2932 tests, 8355 assertions, 0 failures, 0 errors)
- [x] `npm run story:build` — pass
- [x] `mkdocs build --strict` — pass (after staging spec/+migration/ into docs/; no new warnings)
- [x] `python scripts/check_doc_slugs.py` — pass

## Breaking changes

Yes — testid + helper-fn surfaces shifted in three places. All consumers within this repo are updated in the same PR:

- `rf-causa-mode-pill` testid is gone (browser testbed asserts its absence).
- `rf-causa-row-event-vector` testid is replaced with `rf-causa-row-event-id`.
- `shell/render-event-vector-inline` + `shell/truncate-event-vector` + `shell/event-vector-inline-cap` are gone; replaced with `shell/render-event-id-only` + `shell/row-tooltip-text`.
- `theme/tokens.cljc` `layout` map drops `:sidebar-width` and `:bottom-rail-height`; only `:top-strip-height` remains.

The Space / L / G keybindings (and the `[◀ ▶ ⏭]` nav cluster) preserve every operation the mode-pill used to surface, so end-user functionality is unchanged.