### PR TITLE
spec(machines-viz): amend Vision — quality bar + XState-decision-trace requirement (rf2-omsnb)

### DIFF
--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -1,0 +1,630 @@
+# 000-Vision: Machines-Viz — the re-frame2 state-chart component
+
+## Quality bar
+
+The v1.0 `MachineChart` is held to an explicit, named standard:
+
+> **Good interactive, integrated visualisation, robust to
+> complexity, beautiful, highly ergonomic.**
+
+The comparator is **Stately Studio**. Machines-Viz v1.0 MUST match
+Stately Studio's level on **interactivity** (clickable nodes /
+edges / guards / actions with live response), **layout robustness**
+(nested compound states, parallel regions, multi-source edges, no
+edge-crossing collapse at machine sizes seen in real apps), and
+**visual ergonomics** (legibility at glance, motion that aids
+comprehension rather than ornament, density that fits a Causa
+panel without scroll-thrash).
+
+Stately Studio is the floor, not the ceiling:
+
+- **Floor:** if we ship something weaker than Stately Studio on
+  any of the three axes above, the chart is not done.
+- **Ceiling-not-imposed-by-prior-art:** where divergence from
+  Stately Studio is principled (aesthetic coherence with Causa,
+  full visual control, native re-frame2 plumbing), Machines-Viz
+  **does** diverge — by intent, with rationale captured in the
+  decision-trace below. Stately Studio's choices are inputs, not
+  defaults.
+
+This bar is load-bearing for the rest of this doc. Every design
+decision in §Rendering stack and every entry in §Decision trace
+below is calibrated against it.
+
+## Decision-trace requirement (XState / Stately prior art)
+
+Every design decision in this spec MUST trace to Stately / XState
+prior art using the four-row template:
+
+```
+**Decision:** <name>
+**Stately / XState's choice:** <what they do + why>
+**re-frame2's choice:** <same or different>
+**Rationale if diverge:** <explicit reason — Lock #1, no-paid-
+product, native-plumbing, aesthetic coherence, …>
+```
+
+The rule is not "copy Stately." The rule is **make every choice
+traceable to the closest prior-art comparator**. The spec is then
+auditable against the prior art rather than reading as an opinion
+piece. Where re-frame2 diverges, the divergence is named and the
+reason is on the page; where re-frame2 aligns, the agreement is
+named and the input is acknowledged.
+
+This template applies to:
+
+- Rendering stack choices (layout engine, renderer, static export
+  format) — see §Decision trace below.
+- Data-model choices (machine-definition format, share-URL
+  encoding, snapshot transport).
+- Runtime-integration choices (active-state highlighting
+  transport, instance-attach mechanism).
+- UX choices that have a clear Stately analogue (zoom / pan,
+  minimap, source-jump, sim playground).
+
+New design decisions added to this spec follow the same template.
+Where no clear Stately / XState analogue exists, the decision row
+says so explicitly (`re-frame2-native; no Stately analogue`).
+
+## Why it exists
+
+re-frame2 ships state machines (Spec 005) as a first-class registry.
+A registered machine's transition table is data; its runtime
+snapshot lives at `[:rf/machines <id>]`; its lifecycle, transitions,
+microsteps, `:after` timers, and `:invoke-all` joins all emit
+structured trace events (Spec 009). Visualising a machine is a
+direct projection of those substrates — no new runtime surface
+required.
+
+`tools/machines-viz/` ships the projection as **one component**
+(`MachineChart`) plus a **read-only viewer page** that renders a
+chart from a URL fragment. Causa's Machine Inspector panel
+([`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md))
+embeds it as content; Story's per-variant machine panel embeds it
+the same way. The component is the single source of charting truth;
+the hosts add transition-history ribbons, source-coord jumps, and
+panel chrome around it.
+
+The read-only viewer is the receiving end of the "Copy machine as →
+Share URL" affordance — a chart pasted into a PR description, a
+design doc, a Slack thread, or a whiteboard.
+
+## What it is
+
+A standalone CLJS jar — `day8/re-frame2-machines-viz` — that
+exports:
+
+1. **The `MachineChart` component.** A React-flavoured CLJS
+   component (substrate-agnostic via the v2 `:view` registration
+   surface; substrates' adapters re-export) that renders a
+   directional state-chart for one registered machine. It reads
+   `[:rf/machines <id>]` for live-highlight and subscribes to the
+   Spec 009 trace stream for transition / microstep / timer /
+   invoke-all granularity.
+2. **The read-only viewer page.** A statically hostable single-file
+   page (`tools/machines-viz/public/viewer.html`) that decodes a
+   `#machine=<base64-edn>` URL fragment and renders the encoded
+   chart in a no-runtime `MachineChart` (the same component with
+   click handlers no-op'd and live-trace subscription disabled).
+3. **The share-URL encoding rules.** EDN → transit-write →
+   base64url, with a `:rf.machines-viz.share/v1` envelope keying the
+   encoding version. Roundtrips: `(encode-share-url chart-state)`
+   and `(decode-share-url url)`.
+4. **PNG and SVG exporters.** Client-side rasterisers that emit a
+   chart image at 2x DPR (PNG) or as `image/svg+xml` (SVG) with
+   embedded fonts. Both include `<title>` / `<desc>` (SVG) or alt-
+   text sidecar (PNG) summarising the machine id, current state,
+   and node / transition counts.
+5. **Mermaid `stateDiagram-v2` exporter.** A pure-data emitter
+   (`day8.re-frame2-machines-viz.mermaid/emit`) that takes a
+   registered machine definition and returns a fenced markdown
+   code block suitable for paste into a GitHub README / PR
+   description / Notion. The emitter is lossy by design — `:after`
+   target edges render but countdown rings are omitted, parallel
+   regions render as independent region trees without broadcast
+   macrostep semantics, and `:invoke-all` rows are omitted (Mermaid
+   stateDiagram-v2 doesn't model those runtime semantics). The loss
+   is flagged in a `%% comment` at the top of the output. Per
+   [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #4.
+
+## What it isn't
+
+- **Not** a visualiser-as-product. The Stately Visualizer +
+  Stately Studio occupy that lane — paste-and-render editors,
+  saved-machine registries, multiplayer canvases, commercial
+  SaaS shells. Per [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/),
+  Stately's own Visualizer is officially deprecated within their
+  docs (replaced by the commercial Stately Editor); investing in
+  the visualiser-as-product lane chases a sunsetted product.
+  Machines-Viz is the **component the framework's own tools
+  embed**, plus a read-only viewer for shared URLs. See
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #1.
+- **Not** a session recorder. The share-URL serialises **only**
+  machine topology + a single current-state snapshot. No trace
+  stream, no epoch buffer, no app-db slices, no conversation
+  buffer. Per Causa Lock #4 (session export forbidden), lifted
+  into Machines-Viz as load-bearing.
+- **Not** an *interactive* Markdown-embed. Machines-Viz **does**
+  ship a Mermaid `stateDiagram-v2` exporter at v1.0 (per rf2-deo2i;
+  see [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #4); it
+  emits a fenced markdown code block for paste into a GitHub README
+  / PR description / Notion. The emitter is **lossy by design**:
+  `:after` target edges render but rings are omitted, parallel
+  region broadcast macrosteps are flattened to independent region
+  trees, and `:invoke-all` rows are omitted. The loss is flagged in
+  a `%% comment` at the top of the output. The share-URL viewer is
+  the interactive complement that renders the full topology; the
+  Mermaid emitter is the static-paste affordance.
+- **Not** an editor. Machines are authored in code via
+  `reg-machine`; Machines-Viz visualises what's already
+  registered. There is no canvas-driven authoring affordance, no
+  edit-the-machine-and-export-EDN flow. Post-v1 candidates
+  exist (a "paste a machine definition" web playground) but
+  v1.0 ships read-only.
+- **Not** a registrar, dispatch, effect, or component layer.
+  Machines-Viz is a downstream consumer of the framework's
+  instrumentation surface. If a chart needs data the framework
+  doesn't emit, the answer is to file a `bd` bead against
+  `spec/009-Instrumentation.md` — not to bolt a parallel
+  surface onto Machines-Viz. Same posture Causa takes (per
+  [Causa Principles §Observation only](../../causa/spec/Principles.md)).
+- **Not** part of any production bundle. The bundle-isolation
+  contract in [`tools/README.md`](../../README.md) holds: nothing
+  under `implementation/` may `:require` from `machines-viz`.
+
+## What re-frame2 unlocks for Machines-Viz
+
+Each row is "new in re-frame2 → new charting story Machines-Viz
+must tell."
+
+| re-frame2 capability | Machines-Viz surface |
+|---|---|
+| **`[:rf/machines <id>]` snapshot location** (Spec 005) | Live-highlight reads the snapshot directly; deref drives node-pulse on the active state. |
+| **`:rf.machine/transition` trace events** (Spec 009) | Edges glow on the matching event; the chart animates the from→to transition. |
+| **`:rf.machine.microstep/transition`** | Microstep-granular replay within an `:always`-driven cascade; intermediate states render with a "microstep" badge. |
+| **`:rf.machine.timer/*` events** | `:after`-bearing states render a countdown ring; the ring fills at 60Hz when the panel is visible. |
+| **`:rf.machine.invoke-all/*` events** | Parallel-child rows render with per-child state plus the join-condition label (`:all` / `:any` / `{:n N}` / `{:fn ...}`). |
+| **`:rf.machine/spawned` + `-destroyed`** | Dynamic actors appear / disappear in the parent chart's "spawned" tray; gensym'd ids surface with `:system-id` aliases parenthesised. |
+| **State-tags** (Spec 005 §State tags) | Tag-membership coloured rings on state nodes; tags listed in the node tooltip. |
+| **Source-coord stamping** (Spec 001) | Every state, transition, guard, and action carries a source-coord chip — click jumps to the registration. |
+| **`reg-machine` definition as data** | The whole chart layout is a function of the transition table; no reflection, no instrumented build. |
+| **Compound states + parallel regions** | Nested compound states render with recursive active-child highlighting; parallel regions render as side-by-side panes. |
+| **Final states with `:on-done`** | `:final?` nodes render with a doubled border; entering one fires the `:on-done` edge highlight before the auto-destroy. |
+
+## Where it lives in the stack
+
+```
+              ┌────────────────────────────────┐
+              │  Causa (Machine Inspector)     │   ─  embeds  ─┐
+              │   • transition-history ribbon  │               │
+              │   • source-coord chips         │               │
+              │   • frame picker               │               │
+              └────────────────────────────────┘               │
+                                                               ▼
+              ┌────────────────────────────────┐
+              │  Story (per-variant machine    │   ─  embeds  ─┐
+              │  panel)                        │               │
+              │   • per-variant scope          │               │
+              │   • compact chrome             │               │
+              └────────────────────────────────┘               │
+                                                               ▼
+                              ┌─────────────────────────────────────┐
+                              │  tools/machines-viz/                │
+                              │   • MachineChart component          │
+                              │   • read-only viewer page           │
+                              │   • share-URL encoder / decoder     │
+                              │   • PNG / SVG export                │
+                              └─────────────────────────────────────┘
+                                                               │
+                                                               ▼
+                              ┌─────────────────────────────────────┐
+                              │  implementation/machines + core     │
+                              │   • reg-machine + transition tables │
+                              │   • [:rf/machines <id>] snapshots   │
+                              │   • Spec 009 trace bus events       │
+                              └─────────────────────────────────────┘
+```
+
+`tools/causa/` and `tools/story/` both depend on
+`tools/machines-viz/`. The arrow does not invert. Machines-Viz
+does not know about Causa's chrome or Story's variant runtime —
+it only knows it has a `:machine-id`, a `:frame-id`, and two
+callbacks the host wired.
+
+## Surface set
+
+v1.0 `MachineChart` is one component rendered across **three
+interactive surfaces** plus the existing **Mermaid static
+emitter**:
+
+1. **Causa panel — the canonical observability surface.** The
+   Machines tab of Causa's 7-tab detail panel embeds
+   `MachineChart` as its content view (per
+   [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)).
+   This is the front door for live machine observability — the
+   panel wires the transition-history ribbon, source-coord jumps,
+   frame picker, UC1 sim playground, and UC2 instance browser
+   around the chart. Causa is the primary consumer; the chart's
+   ergonomics are tuned for this surface first.
+
+2. **User-app drop-in — production observability of running
+   machines.** The component ships as a substrate-agnostic
+   `:view` registration that consumer apps can mount into their
+   own UI to surface a registered machine to end-users or
+   internal operators. **v1.0 in scope** — not speculative; the
+   bundle-isolation contract holds (the component is a tool jar,
+   so consumers opting in pay the bundle cost deliberately).
+   Typical uses: internal admin dashboards visualising the order-
+   fulfilment machine, support tools showing the state of a
+   stuck workflow, an operator console for a long-running pipeline.
+
+3. **Docs cells — interactive embedding in mkdocs pages.** The
+   chart renders inside narrative docs (the re-frame2 guide,
+   per-tool spec pages) so a reader can scrub through a state
+   machine's transitions inline with the prose. v1.0 covers
+   embedding a registered machine from a docs-time `reg-machine`
+   form. **Klipse-style paste-and-render (an arbitrary EDN
+   pasted into a page that renders without registration) is
+   deferred to v1.1** per
+   [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #1 (no
+   visualiser-as-product); the v1.0 docs-cell surface uses the
+   chart against a registered machine, not pasted text.
+
+The **fourth surface** is the existing Mermaid
+`stateDiagram-v2` emitter
+(`re-frame.machines.mermaid` per rf2-deo2i / rf2-yamkm — pure
+text-to-SVG via the Mermaid DSL):
+
+4. **Mermaid static surface — docs prose, README, AI-pair chat
+   replies.** Same emitter, different consumption — a fenced
+   markdown code block pasted into a GitHub README, a PR
+   description, a Notion doc, or a re-frame2-pair chat reply
+   when the user isn't in a running-app session. Lossy by design
+   (`:after` rings, `:invoke-all` rows, parallel-region macrostep
+   semantics absent). Per
+   [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #4.
+
+**One model, four surfaces.** All four consume the same
+`reg-machine` body (EDN). The interactive three share the
+`MachineChart` component + the ELK + hand-rolled-SVG renderer; the
+fourth shares the model but emits Mermaid DSL instead of SVG. The
+shared model is the lever — features that arrive on the
+interactive surfaces (state tags, `:invoke-all` join condition
+labels, source-coord chips) cascade automatically; nothing is
+re-derived per surface.
+
+## Rendering stack
+
+The v1.0 `MachineChart` is built on:
+
+- **Layout engine: ELK.js** (Eclipse Layout Kernel, JS port).
+  Hierarchical / compound-graph layout, handles nested states,
+  parallel regions, multi-source edges with bundling. Same engine
+  Stately Studio runs on; VS Code's `mermaid-state-machine`
+  preview also uses it. Bundle ~600 KB. License: **EPL-2.0**.
+  Compatibility check against re-frame2's MIT posture is OWED
+  (5-minute legal sign-off; EPL-2.0 is compatible with MIT use
+  but the sign-off is deliberate — see decision-trace row below).
+- **Interactive renderer: hand-rolled SVG.** No React Flow, no
+  Cytoscape, no general-purpose graph library. Direct SVG output
+  driven by ELK's layout result. Cost: ~weeks of polish to reach
+  React Flow's out-of-the-box ergonomics on hover / pan / zoom /
+  edge-routing. Pay-off: full visual control, aesthetic coherence
+  with Causa, no opinionated default look.
+- **Static renderer: Mermaid** (already shipped, per the rf2-yamkm
+  relocation to `implementation/machines/src/re_frame/machines/mermaid.cljc`).
+  Stays in its lane: text-to-SVG via the `stateDiagram-v2` DSL for
+  Markdown-embed cases; not extended into interactive territory.
+
+**Three renderers, one shared model.** All three consume the same
+`reg-machine` body. The interactive surfaces (Causa panel,
+user-app drop-in, docs cells) share the ELK + SVG renderer; the
+static surface (Mermaid) is a parallel emitter against the same
+model.
+
+| Renderer | Layout | Output | Surface | Status |
+|---|---|---|---|---|
+| Mermaid | Mermaid-internal (Dagre-derived) | static SVG via DSL | docs prose, README, AI-pair chat replies | shipped (`re-frame.machines.mermaid`) |
+| ELK + SVG (`MachineChart`) | ELK.js | interactive SVG | Causa panel + user-app drop-in + docs cells | v1.0 commitment |
+
+### Alternatives rejected (with reasons)
+
+- **Graphviz-WASM (hpcc-js-wasm).** Excellent quality but
+  ~1.5 MB. The Causa panel must feel responsive; the bundle cost
+  is not worth it.
+- **Dagre / dagre-d3.** Smaller (~100 KB) but weak on nested
+  compound states; maintenance stalled. Stately migrated AWAY
+  from Dagre to ELK; re-frame2 will not migrate towards a
+  sunsetted engine.
+- **Cytoscape.js.** Full graph library; canvas-first; ~350 KB;
+  more opinion than the bar requires.
+- **D3-hierarchy + custom edge routing.** End up reinventing ELK
+  badly.
+- **React Flow alone.** Opinionated default aesthetic
+  (rounded-corner nodes, default edge style) collides with the
+  "beautiful + integrated" bar without significant override work.
+- **JointJS / GoJS.** Commercial; wrong fit for re-frame2's
+  open-source posture.
+
+## Decision trace
+
+The locked rendering-stack decisions (rf2-04gvh closure, locked
+2026-05-19), expressed in the §Decision-trace template above.
+
+### Layout engine
+
+**Decision:** Layout engine for the interactive `MachineChart`.
+
+**Stately / XState's choice:** **ELK.js** (Stately Studio's
+production stack). Stately's legacy Visualizer used Dagre; Stately
+migrated to ELK as machine sizes outgrew Dagre's nesting / parallel-
+region handling.
+
+**re-frame2's choice:** **ELK.js. Same choice.**
+
+**Rationale if diverge:** No divergence. Stately got this right;
+the migration story (Dagre → ELK) is the evidence. Adopting ELK
+sets the same layout-robustness floor without re-walking the
+exploration.
+
+### Interactive renderer
+
+**Decision:** Library for the interactive chart surface (where
+ELK's layout result becomes interactive DOM).
+
+**Stately / XState's choice:** **React Flow** (Stately Studio's
+current stack). Stately's legacy Visualizer used custom SVG; the
+Studio rebuild moved to React Flow for time-to-MVP and built-in
+pan / zoom / minimap affordances.
+
+**re-frame2's choice:** **Hand-rolled SVG. Diverge.**
+
+**Rationale if diverge:** Three reasons compound.
+
+- **Aesthetic coherence with Causa.** React Flow has a
+  recognisable default look (rounded corners, particular edge
+  style); the Causa devtool aesthetic is distinct (re-com
+  typography, dense layout, source-coord chips everywhere). A
+  React Flow chart embedded in a Causa panel reads as a foreign
+  body unless heavily overridden — and heavy override defeats
+  the "out-of-the-box ergonomics" reason to pick React Flow.
+- **Full visual control.** Active-state highlighting is a CSS-
+  class swap on a rendered SVG node; transition glow is a stroke
+  animation on an SVG path. The hand-rolled surface lets every
+  pixel be intentional. React Flow's component model gates this
+  freedom.
+- **Distinctive look as a feature, not a bug.** Stately's choice
+  optimises for days-to-MVP. re-frame2's choice optimises for
+  weeks-of-polish-to-distinctive-aesthetic. The trade is
+  deliberate; both poles are defensible; re-frame2 picks the
+  latter pole.
+
+The cost is named: ~weeks of polish to reach React Flow's pan /
+zoom / hover / edge-routing baseline. The pay-off is named:
+aesthetic coherence and visual distinctiveness against the
+Stately-clone risk.
+
+### Static renderer
+
+**Decision:** Renderer for the static / Markdown-embed surface
+(README, AI-pair chat replies, prose docs).
+
+**Stately / XState's choice:** **None.** Stately Studio replaces
+static export with the live-editor canvas (the product offering).
+The legacy Visualizer offered a "Copy as PlantUML" affordance but
+no Mermaid `stateDiagram-v2` output.
+
+**re-frame2's choice:** **Mermaid `stateDiagram-v2`. Diverge
+(re-frame2 ships a static surface; Stately doesn't).**
+
+**Rationale if diverge:** Mermaid is the markdown-paste workhorse
+for GitHub READMEs, PR descriptions, Notion, Slack code blocks.
+Stately's commercial model doesn't optimise for that surface
+because their utility lever is the editor, not the embed. re-frame2
+already shipped the Mermaid emitter (per rf2-deo2i and the rf2-yamkm
+relocation); the static surface is essentially free value over the
+shared model. Lossy by design (`:after` rings + `:invoke-all` rows
+absent — flagged inline in the output's `%% comment`); the
+interactive surfaces carry the lossless cases.
+
+### Model format
+
+**Decision:** Format the chart consumes as input.
+
+**Stately / XState's choice:** **TypeScript object literals**
+(XState v5: `createMachine({ ... })` over a TS-typed config
+object). Stately Studio's editor produces and ingests the same
+shape (plus JSON for the share / export pipeline).
+
+**re-frame2's choice:** **EDN** — the `reg-machine` body, with
+keywords, sets, nested maps, and namespaced keys preserved
+verbatim. **Diverge.**
+
+**Rationale if diverge:** re-frame2's authoring surface is EDN
+(per [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md)); the
+chart consumes the registered shape directly. Converting to JSON
+would lose keyword types, set-vs-vector distinctions, and the
+namespaced-keys idiom — all of which the chart wants to render
+(state tags, fully-qualified guard / action names, the
+`:rf.machine.invoke-all/...` namespace conventions). Same EDN-first
+posture re-frame2 takes across the wire (transit on the share-URL,
+EDN on every registry surface).
+
+### License chain
+
+**Decision:** License-compatibility posture for the rendering
+stack.
+
+**Stately / XState's choice:** Stately Studio is **closed
+proprietary** on top of MIT / BSD libraries (React, React Flow,
+ELK). The product's value-add lives behind a SaaS / commercial
+licence; the OSS pieces sit underneath.
+
+**re-frame2's choice:** **MIT throughout, with a deliberate
+EPL-2.0 sign-off for ELK.** Same OSS posture as the rest of
+re-frame2; no closed components; no SaaS layer.
+
+**Rationale if diverge:** This is divergence on **business
+model**, not on the OSS pieces. The 5-minute sign-off owed:
+EPL-2.0 (ELK's license) is compatible with MIT use — EPL-2.0
+copyleft applies to modifications of the EPL-2.0 code itself, not
+to consumers that link against it — but the sign-off is on the
+checklist before the MachineChart implementation bead is
+dispatched. (Owner: Mike. Tracked as a follow-on of rf2-04gvh.)
+
+### Active-state highlighting transport
+
+**Decision:** How the chart learns which state(s) are currently
+active, and how live transitions trigger edge highlights.
+
+**Stately / XState's choice:** **`@xstate/inspect` WebSocket
+bridge.** XState's runtime inspect protocol opens a WebSocket to
+a separate inspector window (or browser extension); the running
+machine sends transition events over the wire; the inspector
+renders the chart and highlights.
+
+**re-frame2's choice:** **Spec 009 trace bus, in-process.** The
+chart subscribes to the existing trace bus
+([`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md))
+for `:rf.machine/transition`, `:rf.machine.microstep/transition`,
+`:rf.machine.timer/*`, and `:rf.machine.invoke-all/*` events; live
+highlighting is a `swap!` on a local atom triggered by trace
+callbacks. **Diverge.**
+
+**Rationale if diverge:** re-frame2 already has a structured
+trace bus carrying every event the chart needs, in-process, at
+near-zero cost. Inventing a WebSocket bridge would duplicate
+existing instrumentation and impose a separate-window UX where
+the in-app Causa panel does not need one. The Stately choice is
+optimised for "attach my external inspector to a running
+production app from another window"; that use case is served by
+`tools/re-frame2-pair-mcp/` over raw nREPL (the AI-pair surface),
+not by `MachineChart`'s rendering plane.
+
+## Scope and roadmap
+
+### v1.0 (the foundation)
+
+The component + the read-only viewer + the encoding rules — the
+surface Causa and Story require to ship their panels.
+
+- `MachineChart` component (per [`API.md`](./API.md) §MachineChart).
+- Read-only viewer page (per [`API.md`](./API.md) §Read-only viewer).
+- Share-URL encoding (per [`API.md`](./API.md) §Share-URL encoding).
+- PNG + SVG exporters.
+- Mermaid `stateDiagram-v2` exporter (per
+  [`API.md`](./API.md) §Mermaid `stateDiagram-v2`) — the
+  Markdown-paste affordance. Lossy by design (`:after` rings +
+  `:invoke-all` rows omitted; flagged inline). Per
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #4.
+- Compound / parallel / `:after` / `:invoke-all` / `:final?`
+  rendering as specified in
+  [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+  §What the panel shows + §`:invoke-all` viz + §Performance.
+- Source-coord chips on every clickable element (the host wires
+  the editor URL handler via `:on-state-click` /
+  `:on-transition-click`).
+- Accessibility: SVG `<title>` / `<desc>` + machine summary text
+  alternative. **Full chart alt-view defers to v1.1** (same
+  posture Causa 003 §Accessibility takes — the transition-history
+  ribbon + machine picker on the host side carry the accessible
+  surface in v1.0).
+
+### What v1.0 does NOT do
+
+The non-goals are as load-bearing as the goals. v1.0 explicitly
+does **not** include:
+
+- **No standalone Visualizer product.** The Machines-Viz jar is a
+  component the framework's own tools embed plus a read-only
+  viewer for shared URLs — not a Day8-hosted SaaS, not a
+  paste-and-render editor product, not a multi-user canvas. Per
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #1
+  (component-not-product). Stately Studio's lane is deliberately
+  not contested.
+- **No paste-and-render at v1.0.** Pasting arbitrary EDN into a
+  page that renders without registration (Klipse-style live
+  evaluation) is **deferred to v1.1**. The v1.0 docs-cell surface
+  renders against a registered machine; the v1.0 viewer page
+  renders against a share-URL payload (also a registered shape,
+  just encoded for transit). The Klipse-style affordance is a
+  candidate, not a commitment.
+- **No editor surface.** `MachineChart` is a read-only renderer.
+  Machines are authored in code via `reg-machine`; the EDN in
+  source files is the source of truth. There is no canvas-driven
+  authoring affordance, no edit-the-machine-and-export-EDN flow,
+  no round-trip between a visual canvas and source.
+- **No closed-source dependencies.** Every library in the
+  rendering stack is open-source-compatible with re-frame2's MIT
+  posture (ELK is EPL-2.0, deliberately signed-off as MIT-
+  compatible for consumers). No commercial layout engines
+  (JointJS / GoJS); no SaaS-only rendering services; no
+  Day8-hosted infrastructure in the dependency graph.
+
+### v1.1 candidates (not committed)
+
+- Chart alt-view for screen readers (the v1 commitment deferred
+  from accessibility).
+- "Paste a machine definition" web playground hosted under the
+  viewer page (Stately-Visualizer-style onboarding flow).
+- D2 / `xstate-json` emitters alongside Mermaid (the topology fn
+  generalises; D2 + xstate-json are different output grammars over
+  the same input). Per [Spec 005 §Future §Diagram export](../../../spec/005-StateMachines.md#diagram-export-from-transition-tables).
+
+### Out of scope (any version)
+
+- A canvas-driven machine editor.
+- A multi-user / multiplayer canvas.
+- A saved-machine registry (the share-URL is the only persistence
+  affordance; long-term storage is the user's problem).
+- Statechart-from-non-machine-code visualisation (Stately Studio
+  2026 visualises Redux without XState; not Machines-Viz's lane).
+- SCXML import / export.
+- A Day8-hosted SaaS shell.
+
+## Peer-product comparison (where the v1 ship-list lands)
+
+Beyond the Quality bar (§Quality bar, above — Stately Studio as
+the named comparator), the v1 ship-list is calibrated against
+three peer products:
+
+- **Stately Visualizer** — the gorilla. Pastable EDN-equivalent
+  rendering, animation, zoom/pan. Officially deprecated within
+  Stately's docs; their commercial Editor is the recommended
+  replacement.
+- **XState Inspector (`@xstate/inspect`)** — runtime attach;
+  live highlights; transition log; send-event surface.
+- **Mermaid statechart** (`stateDiagram-v2`) — static rendering
+  from text-as-code; the Markdown-embed workhorse.
+
+Where Machines-Viz **wins** against the peer set (per
+`ai/findings/sweep-tools-vs-sota-2026-05-13.md` §machines-viz):
+
+- `:after` countdown rings + microstep replay (no peer has both).
+- `:invoke-all` join visualisation with the join-condition label
+  (`:all` / `:any` / `{:n N}` / `{:fn ...}`).
+- Live trace integration tied to the Spec 009 bus.
+- Source-coord per node — every state, transition, guard, action
+  jumps to source.
+- Bundle isolation by classpath, not by tree-shaking discipline.
+- Mermaid `stateDiagram-v2` export as a peer to the SVG / PNG /
+  share-URL trio — paste into a GitHub README and it renders.
+  Stately Studio has no Markdown-paste posture; the XState
+  Inspector has no exporter at all. Per
+  [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #4.
+
+Where Machines-Viz **defers** to peers:
+
+- Paste-and-render onboarding — v1.1 candidate; the v1 share-URL
+  viewer is the closest thing.
+- Statechart-from-non-machine code — Stately Studio's lane.
+
+## See also
+
+- [`Principles.md`](./Principles.md) — the load-bearing principles.
+- [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) — the locks; questions, options, picks (Lock #1 = component-not-product).
+- [`API.md`](./API.md) — the consolidated public surface (`MachineChart` contract, viewer page URL, share-URL encoding).
+- [`tools/causa/spec/000-Vision.md`](../../causa/spec/000-Vision.md) — Causa's Vision; the sibling observability surface that embeds `MachineChart` as the Machines tab.
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — Causa's embedding-side spec; the source of truth for transition-history ribbon, source-coord integration, `:invoke-all` viz, share-affordance UX.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the registry + authoring surface Machines-Viz visualises.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) — the trace bus the live-highlight + active-state transport consumes.

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1,0 +1,638 @@
+# API
+
+The consolidated user-facing surface. Implementer-readable: every
+symbol a consumer of Machines-Viz might reach for.
+
+This doc is a **reference**. The normative descriptions for the
+embedding-host side of these surfaces live in
+[`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md);
+where the two drift, this doc owns the **component contract** and
+the **share-URL encoding**, and Causa 003 owns the **panel chrome**.
+
+## Installation
+
+```clojure
+;; consumer deps.edn — typically transitive through Causa or Story
+{:deps {day8/re-frame2-machines-viz {:mvn/version "..."}}}
+```
+
+For Causa users: pulled transitively via `day8/re-frame2-causa`.
+For Story users with a machine panel: pulled transitively via
+`day8/re-frame2-story`. Direct dependents (a custom dev shell that
+wants a chart without the rest of Causa) declare it themselves.
+
+## `MachineChart` component
+
+The single chart-rendering surface. Substrate-agnostic — exported
+by every substrate adapter Machines-Viz ships against (Reagent /
+UIx / Helix).
+
+### Namespace
+
+```clojure
+(:require [day8.re-frame2-machines-viz.chart :as viz])
+```
+
+### Signature
+
+```clojure
+[viz/MachineChart props]
+```
+
+`props` is a map; the schema below is closed (the chart rejects
+unrecognised keys at registration time).
+
+### Props
+
+| Prop | Required | Default | Meaning |
+|---|---|---|---|
+| `:machine-id` | yes | n/a | The id of the registered machine to render. The chart resolves the definition via `(rf/machine-meta machine-id)` and the snapshot via `[:rf/machines machine-id]`. |
+| `:frame-id` | yes | n/a | The frame within which to resolve the registration and the snapshot. Hosts that observe only one frame can hard-code it; multi-frame hosts (Causa, Story) pass the user-selected frame here. |
+| `:on-state-click` | no | `nil` | `(fn [state-id state-meta] ...)`. Fires when the user clicks a state node. Hosts wire this to their click semantics (Causa: jump to source; Story: highlight in chrome; viewer: no-op). |
+| `:on-transition-click` | no | `nil` | `(fn [from-state event-id to-state transition-meta] ...)`. Fires on a transition edge click. |
+| `:on-guard-click` | no | `nil` | `(fn [guard-name source-meta] ...)`. Fires when the user clicks a guard label inside a transition's tooltip. |
+| `:on-action-click` | no | `nil` | `(fn [action-name source-meta] ...)`. Fires when the user clicks an action label inside a state's entry/exit tooltip. |
+| `:read-only?` | no | `false` | If `true`, all `:on-*` callbacks are no-op'd regardless of what the host passes. The viewer page sets this. |
+| `:show-microsteps?` | no | `true` | Whether intermediate `:always` microstep nodes are rendered. |
+| `:show-after-rings?` | no | `true` | Whether `:after` countdown rings render on the source states. |
+| `:show-invoke-all?` | no | `true` | Whether `:invoke-all` children render as a row of mini-machines (vs. a collapsed single icon). |
+| `:show-spawned?` | no | `true` | Whether dynamically `:rf.machine/spawn`-ed children appear in the parent's spawn-tray. |
+| `:height` | no | `nil` (flex) | Fixed height in pixels. Useful for uniform-ribbon layouts. |
+| `:width` | no | `nil` (flex) | Fixed width in pixels. |
+| `:initial-zoom` | no | `1.0` | Starting zoom factor. The user can zoom/pan after mount; the prop only sets the initial value. |
+| `:auto-pan?` | no | `false` | Whether the chart auto-pans on every transition to keep the active state visible. Causa's panel sets this from its localStorage toggle; the viewer page leaves it off. |
+| `:current-state-override` | no | `nil` | A `{:state ... :data ...}` map that overrides the live snapshot. Used by the read-only viewer page to render the shared snapshot — when sourced from a share URL, `:data` is always absent (the share schema carries `:state` only; per [§Share-URL payload schema](#share-url-payload-schema)). Out-of-scope for live charts. |
+
+The four `:on-*` callback shapes are mirrored from
+[Causa 003 §Source-coord integration](../../causa/spec/003-Machine-Inspector.md#source-coord-integration);
+the `*-meta` argument carries the registered source-coord map for the
+clicked element.
+
+### What renders
+
+For the selected machine, the chart shows:
+
+- **A directional state-chart.** Nodes are states (compound states
+  nested visually). Edges are transitions, labelled with their
+  triggering event id.
+- **The current state pulses.** Compound states' active child is
+  highlighted recursively. The pulse is the only continuous
+  animation; backgrounded charts pause it.
+- **Tooltips.** Hover a state for its tags + entry/exit actions;
+  hover an edge for its guard + action functions.
+- **`:invoke` / `:invoke-all` spawned children.** Per
+  `:show-invoke-all?`, render as a horizontal row of mini-machines
+  with the join-condition label below. Per
+  [Causa 003 §`:invoke-all` viz](../../causa/spec/003-Machine-Inspector.md#invoke-all-viz).
+- **`:after` countdown rings.** A filling arc on the source state
+  while a timer is scheduled; updates at 60Hz when the chart is
+  visible (per [DESIGN-RATIONALE Lock #8](./DESIGN-RATIONALE.md)).
+- **`:final?` states.** Rendered with a doubled border + checkmark
+  glyph.
+- **State-tag badges.** Each state node carries a coloured ring
+  per active tag union member (per Spec 005 §State tags).
+- **Microstep flashes.** Per `:show-microsteps?`, intermediate
+  states in an `:always` cascade flash briefly before the cascade
+  resolves.
+
+What does **not** render (the chart fires the callback and the
+host decides):
+
+- Transition history ribbon (Causa's chrome; lives in
+  `tools/causa/`).
+- Source-coord chips with editor-URL handler wiring (the chart
+  fires `:on-*-click`; the host opens the file).
+- A machine picker dropdown (the host owns frame + machine
+  selection).
+
+### Data sources
+
+The chart reads from the framework's public surfaces; it does not
+introduce new registries.
+
+| Surface | Used for |
+|---|---|
+| `(rf/machine-meta machine-id)` | Resolves the registered definition (states, transitions, guards, actions, source coords). |
+| `[:rf/machines <id>]` slot in frame `app-db` | Live current-state + data snapshot; deref drives the pulse. |
+| `:rf.machine/transition` trace events | Edge glow on the matching transition. |
+| `:rf.machine.microstep/transition` events | Microstep flashes. |
+| `:rf.machine.timer/scheduled` / `-fired` / `-stale-after` | `:after` countdown ring scheduling. |
+| `:rf.machine.invoke-all/started` / `-all-completed` / `-some-completed` / `-any-failed` | `:invoke-all` row updates. |
+| `:rf.machine/spawned` / `-destroyed` | Spawn-tray contents on the parent. |
+| `:rf.machine/done` | `:final?` entry highlight before auto-destroy. |
+| `:rf.machine/system-id-bound` / `-released` | Aliased addressing in the spawn-tray (gensym shows `:gensym-42 (:auth/main)`). |
+
+Source: lifted from
+[Causa 003 §Data sources](../../causa/spec/003-Machine-Inspector.md#data-sources).
+
+## Performance invariants
+
+This section is **load-bearing and conformance-level**, not guidance.
+The chart's runtime hot path is the single largest regression
+surface for Machines-Viz (per
+[`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
+findings 1+2; audit-bead rf2-j3iwt). Once an implementation couples
+live snapshot / trace ticks to graph recompute, the coupling is hard
+to remove without rewriting the rendering pipeline. The MUSTs below
+exist so that coupling never lands.
+
+### Topology state and runtime-highlight state MUST be strictly separate
+
+`MachineChart` maintains **two disjoint state planes**:
+
+- **Topology / layout plane.** The node positions, edge routes,
+  compound-state nesting, and the chart's measured viewbox. Derived
+  from `(rf/machine-meta machine-id)` plus the user's expand/collapse
+  state. This plane is **structural**: changing it requires re-laying
+  out the graph.
+- **Runtime-highlight plane.** The active-state pulse, transition
+  edge glow, microstep flash, `:after` countdown ring progress,
+  `:invoke-all` row state, spawn-tray contents, timer state, and
+  every other per-trace decoration. Derived from `[:rf/machines <id>]`
+  plus the `:rf.machine/*` trace bus. This plane is **decorative**:
+  changing it MUST NOT touch the topology plane.
+
+Implementations MUST hold these planes in disjoint reactive
+subscriptions. The runtime-highlight plane MUST NOT participate in
+any computation whose output reaches the layout plane. The two
+planes share no caches.
+
+### Transition / microstep / timer updates MUST change attrs/classes only
+
+Live updates triggered by `[:rf/machines <id>]` snapshot changes or
+by any `:rf.machine/*` trace event MUST mutate **only**:
+
+- DOM attributes (`class`, `style.opacity`, `style.transform` on
+  decoration layers, SVG `stroke-dasharray` / `stroke-dashoffset`,
+  ARIA labels).
+- CSS-driven animations (the heartbeat pulse, the transition glow,
+  the microstep flash, the `prefers-reduced-motion` step animation).
+
+Live updates MUST NOT:
+
+- Re-run layout (no `dagre`/`elk`/custom layout call).
+- Re-measure nodes (no `getBBox`, no `getBoundingClientRect` in any
+  code path reached by a trace tick or a snapshot deref).
+- Insert or remove topology DOM nodes (state nodes, edge paths,
+  compound containers). Decoration overlays (rings, glows, badges)
+  MAY mount and unmount; topology MUST NOT.
+- Mutate any reactive value that the topology plane subscribes to.
+
+A trace event that arrives at 60Hz MUST cost less than one paint
+frame end-to-end on the chart's hot path.
+
+### Layout-invalidation boundary is load-bearing
+
+The **only** triggers permitted to invalidate the topology / layout
+plane are:
+
+1. **Machine (re-)registration.** `reg-machine` (or its hot-reload
+   re-invocation) for the bound `:machine-id` within the bound
+   `:frame-id`. Detected via the framework's registry-change signal
+   (per Spec 001) — not via `:rf.machine/*` trace events.
+2. **User-driven compound-state expand / collapse.** The chart's
+   own UI event, scoped to the chart instance.
+3. **A `:show-*` prop transition** that adds or removes topology
+   (e.g. `:show-invoke-all?` flipping false → true reveals the
+   row of mini-machines; that row is topology, not decoration).
+   Transitions of `:show-after-rings?` are decoration-only and MUST
+   NOT trigger layout.
+4. **Container resize** of the chart's bounding box (only when the
+   layout algorithm depends on available width / height).
+
+No other code path may invalidate layout. In particular:
+
+- `:rf.machine/transition`, `:rf.machine.microstep/transition`,
+  `:rf.machine.timer/scheduled` / `-fired` / `-stale-after`,
+  `:rf.machine.invoke-all/*`, `:rf.machine/spawned` / `-destroyed`,
+  `:rf.machine/done`, `:rf.machine/system-id-bound` / `-released`
+  trace events MUST NOT reach the layout pipeline.
+- A `[:rf/machines <id>]` snapshot deref MUST NOT reach the layout
+  pipeline.
+- `:auto-pan?` MUST be implemented as a viewport translate (a CSS
+  transform on the chart's outer group), never as a re-layout. The
+  auto-pan code path MUST NOT call `getBBox` on topology nodes
+  inside a trace-event handler; the active-node bbox MUST be cached
+  during the last layout pass.
+
+Implementations MUST place an explicit comment marking the
+layout-invalidation boundary as load-bearing in the code that owns
+it (the function or watcher that decides "should layout re-run?").
+The comment MUST cite this section and DESIGN-RATIONALE Lock #9 and
+Lock #11.
+
+### One chart-level, visibility-gated animation clock
+
+`:after` countdown rings, the active-state heartbeat pulse, and any
+other continuous animation in the chart MUST be driven by a
+**single, per-chart-instance animation clock**.
+
+- The clock is **one** `requestAnimationFrame` loop (or equivalent)
+  per `MachineChart` instance. It MUST NOT be one loop per ring,
+  per node, per state, or per timer.
+- The clock is **visibility-gated**. It MUST start when the chart
+  becomes visible (per `IntersectionObserver` and/or
+  `document.visibilityState`) and MUST stop when the chart leaves
+  the viewport or the document is hidden.
+- The clock drives ring fills and pulse phase by reading the
+  framework's authoritative timer state on each tick; it does not
+  own the timer. The framework's clock keeps running regardless of
+  the chart's visibility (per Lock #8); the chart's clock is purely
+  presentational.
+- A chart with no scheduled `:after` timers and no active state to
+  pulse MUST stop its clock entirely until the next snapshot or
+  trace tick wakes it.
+
+Implementations MUST NOT create `setInterval`, `setTimeout`, or
+`requestAnimationFrame` registrations per-node, per-ring, or
+per-timer. A 50-chart Story grid with 5 rings each MUST run at most
+50 animation loops total — not 250.
+
+Per [DESIGN-RATIONALE Lock #8](./DESIGN-RATIONALE.md) (visibility
+gating) and [Lock #11](./DESIGN-RATIONALE.md) (the layout/runtime
+separation this section codifies).
+
+## Read-only viewer
+
+A static page at the canonical hosted URL (or self-hosted by the
+consumer) that renders a chart decoded from a URL fragment.
+
+### URL shape
+
+```
+https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=<base64-edn>
+```
+
+Or, when self-hosted:
+
+```
+https://acme.example.com/path/to/viewer.html#machine=<base64-edn>
+```
+
+### Behaviour
+
+- On page load, the viewer reads `location.hash`, strips the
+  leading `#machine=`, base64url-decodes, transit-reads, and
+  validates the envelope (per [§Share-URL payload schema](#share-url-payload-schema)
+  below).
+- Validation failure → a banner: "This share-URL is malformed or
+  was produced by a newer Machines-Viz." No chart renders.
+- Validation success → the viewer mounts `MachineChart` with:
+  - `:machine-id` and `:frame-id` from the payload's
+    `:chart-state` (per [§Share-URL payload schema](#share-url-payload-schema)).
+  - `:read-only?` set to `true`.
+  - `:current-state-override` from the payload's snapshot.
+  - All `:show-*` flags default to `true`.
+  - `:auto-pan?` off.
+- A single banner at the top of the page reads: **"This is a
+  static machine chart, not a Causa session — interactions are
+  disabled."**
+- A "show idle" toggle below the banner clears
+  `:current-state-override` so the chart renders the machine at
+  rest. Per [DESIGN-RATIONALE Lock #5](./DESIGN-RATIONALE.md).
+- The page is statically hostable. Per
+  [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md), the
+  canonical hosted instance at `day8.github.io` is a convenience,
+  not a contract; consumers can self-host.
+
+### What the viewer never does
+
+- It never transmits the URL fragment to a server. The fragment is
+  read client-side via `location.hash`; nothing sends it.
+- It never loads transit events, app-db slices, or any data
+  outside the validated payload schema.
+- It never receives runtime `:data` — the share payload's
+  `:snapshot` carries `:state` only (per
+  [§Share-URL payload schema](#share-url-payload-schema)). The
+  viewer cannot display data values because there are none to
+  display.
+- It never receives local-filesystem `:source-coords` — they are
+  not part of the share schema. The viewer has no editor handler
+  wired, so source coords would be inert anyway; excluding them
+  prevents accidental disclosure of workstation paths.
+- It never enables `:on-*` callbacks. Hosts requesting a "click in
+  the viewer goes to my docs site" would have to fork the page;
+  the canonical viewer is read-only end-to-end.
+
+Source: lifted from
+[Causa 003 §Share affordance](../../causa/spec/003-Machine-Inspector.md#share-affordance).
+
+## Share-URL encoding
+
+### Encoder
+
+```clojure
+(:require [day8.re-frame2-machines-viz.share :as share])
+
+(share/encode-share-url chart-state)
+;; => "https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=..."
+
+(share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html"})
+;; => "https://acme.example.com/viewer.html#machine=..."
+```
+
+`chart-state` is a map with the schema in
+[§Share-URL payload schema](#share-url-payload-schema) below. The
+encoder:
+
+1. Validates `chart-state` against the schema. Anything outside the
+   allowlist is silently dropped — including runtime `:data` on
+   `:snapshot` and any `:source-coords` the caller passes (per
+   [Principles §No session data in shares](./Principles.md)).
+2. Strips metadata off `:definition` (registered definitions carry
+   source-coord meta per Spec 001; that meta must not propagate
+   into the share payload).
+3. Canonicalises map / set ordering (per
+   [Principles §Reproducible from the registry alone](./Principles.md)).
+4. Wraps in the versioned envelope.
+5. EDN-prints → transit-writes → base64url-encodes.
+6. Wraps the fragment into the `:host` URL.
+
+### Decoder
+
+```clojure
+(share/decode-share-url url)
+;; => {:rf.machines-viz.share/v "1"
+;;     :rf.machines-viz.share/chart {:machine-id :auth/login-flow ...}
+;;     :rf.machines-viz.share/created 1736000000000}
+;; or throws :rf.machines-viz.share/decode-failed with :reason
+```
+
+Failure modes:
+
+| `:reason` | Meaning |
+|---|---|
+| `:malformed-fragment` | The `#machine=` fragment isn't valid base64url. |
+| `:malformed-payload` | Decoded bytes aren't valid transit. |
+| `:missing-envelope` | The payload is missing `:rf.machines-viz.share/v` or `:rf.machines-viz.share/chart`. |
+| `:unknown-version` | `:rf.machines-viz.share/v` is newer than the decoder knows. |
+| `:invalid-chart-state` | `:rf.machines-viz.share/chart` doesn't validate. |
+
+### Pipeline
+
+```
+chart-state  →  validate + canonicalise  →  envelope wrap
+             →  EDN-print  →  transit-write  →  base64url  →  URL fragment
+```
+
+Per [DESIGN-RATIONALE Lock #3](./DESIGN-RATIONALE.md).
+
+### Share-URL payload schema
+
+Share URLs are **viewer-side artefacts** — they exist solely to let
+a remote recipient render the chart. The schema is deliberately
+narrow: it carries the machine topology and the active-state
+**name** for visual continuity, and nothing else. Two classes of
+data are structurally excluded:
+
+- **Runtime `:data`** — the machine's per-snapshot data value is
+  not part of the share payload. A well-intentioned operator
+  clicking "Copy as Share URL" must not be able to exfiltrate
+  tokens, form contents, request payloads, or any other sensitive
+  value the running machine has accumulated. Per
+  [Principles §No session data in shares](./Principles.md).
+- **Local-filesystem `:source-coords`** — source coordinates carry
+  absolute file paths (per [`spec/Spec-Schemas.md` §`:rf/source-coord-meta`](../../../spec/Spec-Schemas.md#rfsource-coord-meta))
+  which reveal usernames, workstation layout, and internal repo
+  structure. Source-coord chips are an editor-side affordance for
+  the operator running Causa; the viewer page has **no editor
+  handler wired** and cannot use them. They are dropped at encode
+  time.
+
+```clojure
+(def ShareEnvelope
+  [:map
+   [:rf.machines-viz.share/v      :string]   ;; encoding version, "1" at v1.0
+   [:rf.machines-viz.share/chart  ChartState]
+   [:rf.machines-viz.share/created :int]])   ;; wall-clock ms at encode time
+
+(def ChartState
+  [:map
+   [:machine-id  keyword?]              ;; the registered machine's id
+   [:frame-id    keyword?]              ;; the registered machine's frame
+   [:definition  MachineDefinition]     ;; the topology (states, transitions, guards, actions, :invoke, :invoke-all, :after)
+   [:snapshot   {:optional true}        ;; the current-state name at share time — name ONLY, no :data
+    [:map {:closed true}
+     [:state    keyword?]]]])           ;; the registered state-id; nothing else permitted in :snapshot
+```
+
+The `:snapshot` map is `{:closed true}` and carries `:state` only.
+Runtime `:data` is structurally absent from the share payload; the
+encoder neither reads nor serialises it. The decoder rejects any
+`:snapshot` carrying additional keys with `:invalid-chart-state`.
+The viewer page mounts `MachineChart` with `:current-state-override`
+set to `{:state <state-name>}` (and `:data` therefore `nil`); the
+chart pulses the state node without any data-driven affordance.
+
+`:source-coords` is **not a top-level key** of `ChartState`. Source
+coords live only in the operator-side `(rf/machine-meta machine-id)`
+return value and never traverse the share pipeline. The viewer page
+renders with `:on-state-click` / `:on-transition-click` etc.
+no-op'd (per [§Read-only viewer](#read-only-viewer)), so the
+absence of source coords is observationally invisible.
+
+The `MachineDefinition` shape matches the `reg-machine` registered
+definition (per Spec 005 §Snapshot shape + §Transition table grammar)
+with **only** the topology slots included — `:guards` and `:actions`
+maps are encoded as **names only** (their fn bodies are not
+serialised; consumers re-resolve against their own registry if they
+want to run the machine). The encoder **strips metadata** off the
+definition before serialisation (registered definitions carry
+source-coord meta per Spec 001; that meta does not propagate). The
+viewer page never resolves guards or actions; it only renders.
+
+Anything not in the schema is silently dropped by the encoder. New
+top-level keys (and any future expansion of `:snapshot`) require
+an explicit `:rf.machines-viz.share/allow?` opt-in plus an
+operator-controlled redaction hook (per
+[Principles §No session data in shares](./Principles.md)); CI
+enforces.
+
+### URL length
+
+For typical machines (~20 states, ~30 transitions) the encoded URL
+is under 4KB. Common URL limits sit around 8KB; we have headroom
+for moderately-sized charts.
+
+Charts large enough to exceed 8KB surface a fallback affordance
+(in the host that called `encode-share-url` — typically Causa's
+share menu): **"Copy as EDN fragment instead"** which puts the
+EDN on the clipboard instead of the URL. Per
+[Causa 003 §Share affordance §Performance](../../causa/spec/003-Machine-Inspector.md#performance_1).
+
+## Exporters
+
+### PNG
+
+```clojure
+(:require [day8.re-frame2-machines-viz.export :as export])
+
+(export/chart-as-png! chart-element)
+;; => Promise resolving to a Blob (image/png at 2x DPR)
+
+(export/copy-png-to-clipboard! chart-element)
+;; => Promise; clipboard contains the PNG + a text/plain alt-text sidecar
+```
+
+The PNG is rasterised at 2x DPR on a transparent background; the
+current-state highlight is included. An alt-text sidecar (a
+`text/plain` clipboard payload) summarises the machine: id, current
+state, node count, transition count.
+
+### SVG
+
+```clojure
+(export/chart-as-svg chart-element)
+;; => String — image/svg+xml with embedded fonts
+
+(export/copy-svg-to-clipboard! chart-element)
+;; => Promise; clipboard contains the SVG as image/svg+xml
+```
+
+The SVG includes `<title>` and `<desc>` elements summarising the
+machine (same content as the PNG sidecar). Fonts are embedded so the
+SVG renders identically when pasted into a doc or a Figma frame.
+
+### Share URL
+
+```clojure
+(export/share-url chart-element)
+;; => URL string
+
+(export/copy-share-url-to-clipboard! chart-element)
+;; => Promise; clipboard contains the URL as text/plain
+```
+
+`chart-element` is the in-DOM element rendered by `MachineChart`
+(or a hiccup-equivalent reference). The export functions derive the
+payload from the element's bound props + the live snapshot.
+
+### Mermaid `stateDiagram-v2`
+
+```clojure
+(:require [day8.re-frame2-machines-viz.mermaid :as mermaid]
+          [day8.re-frame2-machines-viz.export  :as export])
+
+(mermaid/emit definition)
+;; => String — a fenced ```mermaid block containing a
+;;    `stateDiagram-v2` rendering of the machine's static topology
+
+(mermaid/emit definition {:fenced? false :header-comment? false})
+;; => String — just the diagram body, no markdown fence, no caveat
+
+(export/chart-as-mermaid chart-element)
+;; => String — convenience wrapper that pulls `definition` off the
+;;    bound chart-element and calls `mermaid/emit`
+
+(export/copy-mermaid-to-clipboard! chart-element)
+;; => Promise; clipboard contains the fenced markdown block as
+;;    text/plain — paste into a GitHub README / PR description /
+;;    Notion / any Mermaid-aware renderer and it renders inline.
+```
+
+`mermaid/emit` is the load-bearing pure function; it takes the same
+normalised machine definition `(rf/machine-meta machine-id)` returns
+(per [Spec 005 §Transition table grammar](../../../spec/005-StateMachines.md#transition-table-grammar))
+and emits a string suitable for paste. It is substrate-independent
+and DOM-independent — callable from JVM tests, from the JS bundle,
+and from the read-only viewer.
+
+The emitter is **static-topology only**:
+
+- States render as Mermaid nodes; compound `:states` render as
+  `state X { ... }` blocks with their own `[*] --> initial`.
+- Event transitions render as `from --> to : event` edges. `:*`
+  wildcard edges render with `*` as the label. Multiple-candidate
+  vectors render every target-bearing guarded branch.
+- `:after` transitions render as plain edges labelled
+  `after(<delay>)`; the countdown-ring semantics are lossy.
+- `:always` transitions render as plain edges labelled `always`;
+  microstep timing remains lossy.
+- Top-level fallback `:on` renders from a synthetic `root fallback`
+  node because Mermaid has no exact deepest-wins fallback primitive.
+- `:type :parallel` machines render as independent region state
+  trees inside a synthetic parallel root. Broadcast macrostep
+  semantics are lossy.
+- `:final?` states render a `state --> [*]` terminal edge.
+- `:initial` becomes `[*] --> <initial>`.
+
+The following data does **not** survive the round-trip:
+
+- `:after` timer rings — Mermaid `stateDiagram-v2` has no
+  countdown-ring vocabulary. The timer's `:target` edge still
+  renders (as a plain event-less edge), but the countdown semantics
+  are lost.
+- `:invoke-all` rows of mini-machines — Mermaid has no
+  spawn-and-join row grammar that maps cleanly; the row is omitted
+  entirely.
+- Parallel-region broadcast macrosteps — regions render, but Mermaid
+  cannot express that one event is broadcast through every active
+  region before the snapshot commits.
+- Microstep flashes, transition glow, `:tags`, guard evaluation,
+  actions — none of these are static topology and none round-trip.
+  Guard ids may appear on edge labels, but their runtime truth
+  semantics do not.
+
+The omission is flagged in a `%% comment` at the top of the emitted
+block, so a reader who pastes the output into a doc sees the
+lossy-round-trip caveat without consulting the spec. The full
+topology renders correctly in the SVG / share-URL viewer; Mermaid
+is the Markdown-paste lane only.
+
+Source: per [DESIGN-RATIONALE Lock #4](./DESIGN-RATIONALE.md) (the
+"Mermaid covers the static-paste lane" lift, revised 2026-05-15 per
+rf2-deo2i — Mermaid emit promoted from v1.1 to v1.0 as a thin
+static-topology exporter), and
+[Spec 005 §Future §Diagram export](../../../spec/005-StateMachines.md#diagram-export-from-transition-tables)
+(the framework-level forward-pointer the tool-side exporter
+realises).
+
+### Accessibility
+
+Per [Causa 003 §Accessibility](../../causa/spec/003-Machine-Inspector.md#accessibility)
+(the share-affordance subsection; not the panel-level one — that's
+the second `#accessibility_1`) and
+[Lock #10 above](./DESIGN-RATIONALE.md):
+
+- **SVG**: `<title>` + `<desc>` summarise the machine textually.
+- **PNG**: a `text/plain` alt-text payload rides on the clipboard
+  alongside the image, with the same summary.
+- **Both**: a screen reader pasting the artefact into a document
+  has the same overview the sighted user has.
+
+The chart's in-place alt-view (for screen-reader navigation of the
+live chart itself, not the export) is a **v1.1 commitment**, per
+[`000-Vision.md` §v1.1 candidates](./000-Vision.md#v11-candidates-not-committed)
+and Causa 003 §Accessibility. v1.0 ships without it; the embedding
+host's transition-history ribbon + machine picker carry the
+accessible surface in the meantime.
+
+## Public CLJS API surface — summary
+
+```clojure
+day8.re-frame2-machines-viz.chart/MachineChart    ; component
+day8.re-frame2-machines-viz.share/encode-share-url
+day8.re-frame2-machines-viz.share/decode-share-url
+day8.re-frame2-machines-viz.mermaid/emit          ; pure fn — definition → string
+day8.re-frame2-machines-viz.export/chart-as-png!
+day8.re-frame2-machines-viz.export/chart-as-svg
+day8.re-frame2-machines-viz.export/chart-as-mermaid
+day8.re-frame2-machines-viz.export/share-url
+day8.re-frame2-machines-viz.export/copy-png-to-clipboard!
+day8.re-frame2-machines-viz.export/copy-svg-to-clipboard!
+day8.re-frame2-machines-viz.export/copy-mermaid-to-clipboard!
+day8.re-frame2-machines-viz.export/copy-share-url-to-clipboard!
+```
+
+No global state, no init function. The component is referentially
+transparent over its props; the share / export functions are pure
+(modulo the clipboard).
+
+## See also
+
+- [`000-Vision.md`](./000-Vision.md) — scope + non-goals + roadmap.
+- [`Principles.md`](./Principles.md) — load-bearing principles.
+- [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) — locks; cites Causa 003 lift-points. Lock #8, Lock #9, and Lock #11 are the rationales behind [§Performance invariants](#performance-invariants).
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — embedding-host contract; the source spec these surfaces lifted from.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) — the registry the chart visualises.
+- [`spec/009-Instrumentation.md`](../../../spec/009-Instrumentation.md) — the trace bus the live-highlight consumes.

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -1,0 +1,769 @@
+# DESIGN-RATIONALE
+
+The direction-setting decisions that shape Machines-Viz. Each entry
+captures:
+
+- **The question** that was being decided.
+- **Options considered** that were walked through.
+- **The pick** that was locked.
+- **The why** — the reasoning trail.
+- **Date locked** + the locker.
+
+This doc is the load-bearing artefact of the per-tool spec
+convention. It exists so that a future contributor (human or AI) can
+read it and not re-ask the same questions. Where the spec text reads
+"per lock #N in DESIGN-RATIONALE.md", this is where to come.
+
+A subset of these locks are **lifted from
+[`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)**.
+Causa Spec 003 specified `MachineChart`'s prop surface, share-URL
+encoding, transition-history ribbon, and `:invoke-all` viz before
+this tool had its own spec folder. The scaffold (rf2-x50eu)
+migrates those decisions into Machines-Viz's home; Causa's 003
+remains the authoritative source for the **embedding-side**
+contract (transition history ribbon UX, source-coord jumps,
+Causa's panel chrome). Where the two could drift, this doc cites
+back to 003.
+
+---
+
+## Lock #1 — Scope: component-not-product
+
+**Locked 2026-05-13 (Mike).** **Ship as one embeddable component
+plus a read-only viewer page.** No paste-and-render editor, no
+saved-chart registry, no multiplayer canvas.
+
+### Question
+
+What surface does Machines-Viz ship at v1.0?
+
+### Options considered
+
+- **A Stately-Visualizer equivalent.** A web app where the user
+  pastes a `reg-machine` body and watches it render. Rejected as
+  product-shaped.
+- **A registry SaaS shell.** Save charts, share via URL or iframe,
+  Day8-hosted. Rejected as product-shaped and on the privacy axis.
+- **A multi-user canvas.** Multiplayer editing à la Stately Studio.
+  Rejected — out of lane.
+- **One embeddable component + a static read-only viewer page.**
+  Causa and Story embed the component; the viewer page renders a
+  shared URL. The framework owns the registry (via `reg-machine`);
+  Machines-Viz owns the rendering.
+
+### Pick
+
+**One embeddable component + a static read-only viewer page.**
+
+### Why
+
+- **Stately's own Visualizer is officially deprecated** within
+  their docs (per
+  [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/)).
+  The commercial Stately Editor is the recommended replacement.
+  Investing in the deprecated-product lane is chasing a sunset.
+- **Restraint principle** — a chart component the framework's own
+  tools embed has clear scope. A visualiser product accretes
+  features (registry, sharing UX, collaboration, billing, auth).
+  Each feature is "easy to add, hard to remove."
+- **Privacy by surface** — a Day8-hosted registry means Day8 sees
+  customers' machines. A static viewer + a client-side share-URL
+  means we see nothing. The privacy bet beats the utility bet.
+- **Bundle isolation holds trivially** — the component is the
+  only artefact; the viewer is a separate page. No conditional
+  compilation, no per-host build tricks.
+- **Mermaid covers the static-paste lane** — Spec 005's post-v1
+  `(machine->mermaid)` exporter handles Markdown-embed cases; the
+  share-URL viewer handles interactive cases. Both lanes are
+  served without growing this jar.
+
+---
+
+## Lock #2 — `MachineChart` prop contract
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).**
+**Props: `:machine-id`, `:frame-id`, `:on-state-click`,
+`:on-transition-click` (plus read-only flags).**
+
+### Question
+
+What does the host pass to `MachineChart` to render a chart?
+
+### Options considered
+
+- **Pass the machine definition directly.** The host pulls the
+  registration via `(rf/machine-meta id)` and passes the
+  transition table to the chart. Rejected — couples hosts to the
+  framework's internal definition shape and makes hot-reload
+  fragile (the chart wouldn't re-pick-up edits without explicit
+  host plumbing).
+- **Pass the snapshot directly.** The host derefs
+  `[:rf/machines <id>]` and passes the snapshot to the chart.
+  Rejected — the chart loses access to history (transition
+  events, microstep replay, `:after` rings); it would have to
+  re-derive snapshot transitions from frame deltas.
+- **Pass an id + a frame.** The chart resolves the registration
+  via `(rf/machine-meta machine-id)` and subscribes to
+  `[:rf/machines machine-id]` within `frame-id`. The host stays
+  thin; the chart owns its data plane.
+
+### Pick
+
+**Pass an id + a frame, plus two callbacks.**
+
+```clojure
+[viz/MachineChart {:machine-id          :auth/login-flow
+                   :frame-id            :app/main
+                   :on-state-click      (fn [state-id state-meta] ...)
+                   :on-transition-click (fn [from event-id to] ...)
+                   :read-only?          false      ;; viewer page sets true
+                   :show-microsteps?    true       ;; per-chart preference
+                   :show-after-rings?   true
+                   :show-invoke-all?    true}]
+```
+
+### Why
+
+- **Thin host interface** — the host doesn't need to thread the
+  definition or the snapshot. Causa's panel is a one-liner;
+  Story's per-variant panel is the same.
+- **Hot-reload safe** — the chart re-reads `(rf/machine-meta id)`
+  on every mount and on registry-change traces; the host doesn't
+  have to plumb hot-reload through.
+- **Callback shape locks the host's freedom** — Causa wires
+  `:on-state-click` to "jump to source"; Story wires it to
+  "highlight in the per-variant chrome"; the viewer page no-ops
+  both. Each host chooses, the component stays neutral.
+- **Per-chart visibility toggles ride on props** — `:show-microsteps?`
+  etc. let the host (or the chart's own settings menu) toggle
+  granularity without re-mounting. Defaults are conservative;
+  hosts opt in.
+- **Read-only flag opts out of clicks** — the viewer page sets
+  `:read-only? true` so neither callback fires regardless of
+  what the host passes.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Embedding posture. The prop names matched there are reproduced
+here verbatim.
+
+---
+
+## Lock #3 — Share-URL encoding: EDN → transit → base64url
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **Pipeline
+is `chart-state → EDN-print → transit-write → base64url → URL
+fragment`. Versioned envelope; topology + current-state snapshot
+only.**
+
+### Question
+
+How does Machines-Viz encode a chart for sharing?
+
+### Options considered
+
+- **JSON.** Lossy for keywords, sets, namespaced keys. Rejected
+  on the EDN-first principle.
+- **EDN raw + URL-encode.** Verbose; large machines blow past the
+  URL length limit fast.
+- **Transit-write + base64url, unversioned.** Compact; URL-safe.
+  Rejected on the format-evolution axis — without a version
+  envelope, future encoding changes are breaking.
+- **EDN → transit-write → base64url + versioned envelope.** The
+  envelope keys (`:rf.machines-viz.share/v`,
+  `:rf.machines-viz.share/chart`,
+  `:rf.machines-viz.share/created`) ride at the outermost level;
+  decoders dispatch on `:rf.machines-viz.share/v`.
+
+### Pick
+
+**EDN → transit-write → base64url + versioned envelope.**
+
+### Why
+
+- **EDN preserves the registered shape** — keywords, sets, nested
+  maps, namespaced keys all round-trip. JSON would force re-
+  coercion.
+- **Transit is compact** — typical machines (~20 states, ~30
+  transitions) encode to a sub-4KB URL after base64url. Common
+  URL limits sit around 8KB; we have headroom for moderate-sized
+  charts.
+- **Base64url is URL-safe** — no `+` or `/` in the alphabet; no
+  percent-encoding contention.
+- **Fragment, not query** — URL fragments are never sent in HTTP
+  requests; the share-URL is invisible to servers and to
+  browsers' navigation logs. The chart never traverses a server
+  by accident.
+- **Versioned envelope is the cheapest evolution insurance** —
+  any future change to the payload schema bumps `:rf.machines-viz.share/v`;
+  old decoders refuse old payloads with a clear message rather
+  than rendering garbage.
+- **Charts exceeding URL limits** — the `Copy as edn fragment
+  instead` fallback puts the EDN on the clipboard for paste-into-
+  a-doc. Per Causa 003 §Share affordance §Performance.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share affordance §Share URL + §Performance.
+
+---
+
+## Lock #4 — Markdown-embed: Mermaid emit ships at v1.0
+
+**Locked 2026-05-13 (Mike); revised 2026-05-15 (Mike, per
+rf2-deo2i — Mermaid emit promoted from v1.1 to v1.0 as a thin
+static-topology exporter).** **Machines-Viz ships a Mermaid
+`stateDiagram-v2` exporter at v1.0 alongside the PNG / SVG /
+share-URL trio. The emitter is pure-data, JVM-side, and lossy by
+design: `:after` target edges render while rings are omitted,
+parallel regions render as independent region trees without broadcast
+macrostep semantics, `:invoke-all` rows are omitted, and the loss is
+flagged in the emitted output.**
+
+### Question
+
+Should Machines-Viz emit Mermaid `stateDiagram-v2` as one of its
+export formats?
+
+### Options considered
+
+- **Ship Mermaid emit at v1.0** (this pick, revised 2026-05-15).
+  Differentiator vs Stately Visualizer (which has no Markdown-embed
+  posture). The static topology round-trips cleanly; `:after` rings
+  and `:invoke-all` rows are flagged as omitted in a leading
+  `%% comment`, while `:after` target edges and parallel-region
+  trees still render as lossy static topology. Users who want the
+  full topology fall back to the share-URL viewer / SVG export.
+- **Defer to v1.1.** The static topology fits Mermaid; `:after`
+  rings, microstep replay, `:invoke-all` joins do not. The output
+  is a partial chart; users may not realise. *Original 2026-05-13
+  pick; revised away from 2026-05-15.*
+- **Don't ship at all in Machines-Viz; defer to the framework's
+  `(rf/machine->mermaid)`.** Spec 005's post-v1
+  `(rf/machine->mermaid definition)` is already enumerated as a
+  framework deliverable; Machines-Viz duplicates it.
+
+### Pick
+
+**Ship Mermaid emit at v1.0 — as
+`day8.re-frame2-machines-viz.mermaid/emit` (the pure data fn) plus
+`export/chart-as-mermaid` + `export/copy-mermaid-to-clipboard!` (the
+DOM-side wrappers).**
+
+### Why
+
+- **The static-paste lane is wide.** "Paste this into a GitHub
+  README and it renders" is Mermaid's killer feature; every peer
+  state-chart tool (Stately Studio, XState Inspector, plain
+  text-based stateCharts) hits the lane. A v1 surface that ships
+  PNG / SVG / share-URL but omits Mermaid leaves the cheapest
+  paste-into-Markdown affordance on the floor.
+- **The emitter is small.** Pure-data, JVM-callable, no
+  substrate coupling. ~150 lines of CLJC; the spec footprint is
+  larger than the code footprint. The "duplication with the
+  framework-level `(rf/machine->mermaid)`" worry from the original
+  2026-05-13 pick is misplaced — Machines-Viz consumes a
+  `definition` map (from `(rf/machine-meta id)`), the framework
+  consumes the same `definition` map; the two are the same
+  function on the same input, and either one being absent leaves
+  a gap. Per [Principles §Observation only](./Principles.md),
+  Machines-Viz can host the canonical implementation since the
+  function is observation-only (pure-data, no runtime surface);
+  the framework-level forward-pointer in
+  [Spec 005 §Future §Diagram export](../../../spec/005-StateMachines.md#diagram-export-from-transition-tables)
+  remains as a re-export surface for consumers who pull
+  `re-frame2` without the tools jar.
+- **Lossy-output semantics is documented inline.** The emitter
+  prepends a `%% Generated by re-frame2-machines-viz · :after
+  rings + :invoke-all rows omitted` comment to every output, plus
+  the parallel-region broadcast-semantics caveat.
+  Readers who paste the output into a doc see the caveat without
+  consulting the spec; readers who suppress the comment via
+  `{:header-comment? false}` are taking responsibility explicitly.
+- **The Mermaid lane and the share-URL lane are complementary,
+  not competitive.** The share-URL viewer renders the full
+  topology including rings and joins; Mermaid doesn't. Users
+  reach for whichever surface fits their channel: PR description →
+  Mermaid; live-debugging chat → share-URL viewer.
+- **Test cost is low.** Pure-data emitter + JVM `clojure -M:test`
+  exercising the canonical idle → loading → success/error fixture
+  plus compound-state, namespaced-id, and wildcard-edge cases.
+  No browser test, no shadow-cljs build dependency.
+
+### Why the 2026-05-13 → 2026-05-15 revision
+
+The original 2026-05-13 lock argued the framework-level
+`(rf/machine->mermaid)` covered the lane and Machines-Viz would
+duplicate. Re-reviewing post-rf2-deo2i: (a) the framework-level
+exporter is post-v1 (per Spec 005 §Future) with no concrete
+landing-bead; (b) consumers reach for Mermaid via Machines-Viz's
+clipboard / share affordances (the same UI that hosts PNG / SVG /
+share-URL), not via a framework-level fn call; (c) the function is
+data-only and substrate-independent, so it can live in
+Machines-Viz without violating the bundle-isolation contract; and
+(d) the "we'll add it in v1.1 as a thin wrapper around the
+framework's exporter" plan in the original lock is strictly more
+work than landing the emitter in Machines-Viz directly.
+
+Source: lifted to v1.0 per rf2-deo2i; the framework-level
+`(rf/machine->mermaid)` forward-pointer in Spec 005 §Future
+remains as a re-export surface (a thin shim that calls
+`day8.re-frame2-machines-viz.mermaid/emit`), to be wired when the
+framework ships its `re-frame.machines` public API.
+
+---
+
+## Lock #5 — Current-state in share-URL: state name only, no `:data`
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003; tightened
+2026-05-14 per rf2-li3o4).** **The share-URL payload carries the
+topology + the current state's name (`:state` keyword only). No
+runtime `:data`; no transition history; no event vector; no
+app-db slices; no source-coords.**
+
+### Question
+
+What state-information does the share-URL carry?
+
+### Options considered
+
+- **Topology only.** The chart renders with no active state; the
+  recipient sees the machine "at rest." Rejected — the sharer's
+  intent is usually "look at the state I was in"; a topology-only
+  share loses that context.
+- **Topology + a transition history.** The chart can replay the
+  last N transitions on load. Rejected — encodes session data,
+  violates the no-session-export principle (Causa Lock #4 lifted),
+  inflates the URL beyond practical limits.
+- **Topology + full snapshot (state + `:data`).** The original
+  lift from Causa 003. Rejected (rf2-li3o4) — `:data` is operator-
+  side runtime accumulation; a well-intentioned "Copy as Share
+  URL" click would exfiltrate tokens, form contents, and request
+  payloads. The accident-class beats the visual-continuity
+  marginal benefit.
+- **Topology + the state name only.** The chart highlights the
+  active state node; `:data` is unavailable to the viewer (which
+  has no per-data affordance anyway — the chart's data display
+  is operator-side, in Causa's inspector chrome). The recipient
+  has a "show idle" toggle to clear the highlight.
+
+### Pick
+
+**Topology + the state name only (`:snapshot` is `{:closed true}`
+with `:state` only).**
+
+### Why
+
+- **Visual continuity holds** — the recipient sees which state the
+  sharer was in; the pulse / highlight needs the state name only.
+  The chart's data display is operator-side chrome (Causa's
+  inspector panel), not a `MachineChart` affordance.
+- **Privacy is structural, not prose** — the encoder cannot emit
+  `:data` because the schema is `{:closed true}` on `:snapshot`.
+  Operators cannot accidentally share runtime values; an
+  operator who wants to share a data value pastes it explicitly
+  via a different channel.
+- **Reproducible-from-registry-alone** holds for the topology;
+  the state name is the only non-reproducible bit and is purely
+  a visual hint.
+- **"Show idle" toggle** — the viewer page offers a one-click
+  "clear active state" if the recipient wants to discuss the
+  machine in the abstract. Causa 003 §Share-URL §Read-only viewer
+  specifies this affordance.
+- **No source-coords either** — source coords carry absolute file
+  paths; the viewer has no editor handler wired; they are
+  structurally absent from the share schema. Definition metadata
+  is stripped before serialisation so macro-captured coords cannot
+  leak through `:definition` either.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share-URL §NOT a session export + §Privacy posture, then
+tightened per the rf2-li3o4 security audit (the lift carried a
+broader `:data :any` than this jar's Principles permitted; the
+schema now matches the Principles).
+
+---
+
+## Lock #6 — Read-only viewer: same component, click handlers no-op'd
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **The
+viewer page mounts the same `MachineChart` component with
+`:read-only? true`. No transition-history ribbon (there's no
+history); a single banner labels it as a static snapshot.**
+
+### Question
+
+What renders inside the read-only viewer page?
+
+### Options considered
+
+- **A reduced-feature `StaticMachineChart` component.** Separate
+  artefact, narrower surface. Rejected on duplication grounds.
+- **The same `MachineChart` with click handlers no-op'd.** The
+  `:read-only? true` flag suppresses callback firing; the
+  component renders normally.
+
+### Pick
+
+**Same component, `:read-only? true`.**
+
+### Why
+
+- **One renderer, one set of bugs.** The static viewer and the
+  embedded inspector go down identical render paths; any
+  rendering bug surfaces in both.
+- **The component already encapsulates the rendering.** Hiding
+  the transition-history ribbon is the host's responsibility —
+  the viewer page's host renders no ribbon, Causa's host renders
+  one.
+- **The banner labels the surface** — "This is a static machine
+  chart, not a Causa session — interactions are disabled." Per
+  Causa 003 §Read-only viewer.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Share-URL §Read-only viewer.
+
+---
+
+## Lock #7 — Hosting posture: statically hostable, client-side rendering
+
+**Locked 2026-05-13 (Mike).** **The viewer page is a single
+static HTML file + the Machines-Viz CLJS bundle; no server logic;
+no Day8-hosted infrastructure.**
+
+### Question
+
+How does the read-only viewer page get to a user?
+
+### Options considered
+
+- **Day8-hosted SaaS shell** with a backing database for saved
+  charts. Rejected on Lock #1 (component-not-product) plus
+  privacy (no Day8 sees customer machines).
+- **Day8-hosted static page** with no backend; client-side
+  decoding. Cleanest of the hosted options.
+- **Statically hostable; consumer hosts the page themselves**
+  alongside their app. No Day8 dependency.
+
+### Pick
+
+**Statically hostable; the canonical hosted instance lives at
+`day8.github.io/re-frame2-machines-viz/` (or equivalent docs URL)
+but is **not load-bearing** — every consumer can self-host.**
+
+### Why
+
+- **No Day8-side service to operate.** The page is a static
+  asset; if `day8.github.io` goes down, every self-hoster keeps
+  working.
+- **Privacy holds maximally.** Even the canonical hosted page
+  decodes client-side; the URL fragment is never transmitted.
+- **Embed in docs without iframe gymnastics.** The viewer page
+  can be loaded by a `<script>` tag in the consumer's own docs
+  site; the consumer chooses where it lives.
+- **The canonical instance is a convenience, not a contract.**
+  Users sharing a URL with the canonical viewer get one-click
+  rendering; users who don't trust day8.github.io can self-host
+  the page and point share-URLs at their own instance.
+
+---
+
+## Lock #8 — `:after` countdown rings: 60Hz when visible, paused when not
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003).** **`:after`
+countdown rings render at 60Hz while the chart is on-screen;
+backgrounded charts pause the ring render but the underlying
+timer keeps running.**
+
+### Question
+
+How do `:after` countdown rings update?
+
+### Options considered
+
+- **Continuous 60Hz.** Smooth; uses more CPU than necessary when
+  the chart isn't visible.
+- **Event-driven via trace stream.** The ring updates only on
+  `:rf.machine.timer/scheduled` / `-fired` events. Choppy.
+- **60Hz when visible, paused when backgrounded.** The
+  `IntersectionObserver` / `document.visibilityState` gates the
+  render loop; the framework's clock (per Spec 005) keeps
+  running, so the timer fires correctly whether or not the ring
+  is rendering.
+
+### Pick
+
+**60Hz when visible, paused when backgrounded — driven by a single
+per-chart animation clock, never per-node / per-ring timers.**
+
+### Why
+
+- **The timer is the source of truth, not the ring.** The ring
+  is a visualisation of the timer; pausing the ring does not pause
+  the timer.
+- **Backgrounded panels burn no CPU.** A Story page with 50
+  variants, each with a chart, each with a ring, would consume
+  significant CPU if every ring rendered at 60Hz. Visibility-
+  gating reduces it to "only the visible charts pay the cost."
+- **One clock per chart, not per ring.** Per-node /
+  per-ring `requestAnimationFrame` loops scale O(rings × charts);
+  a single per-chart clock scales O(charts). A 50-chart × 5-ring
+  Story grid means 50 loops, not 250. This is enforced as a MUST
+  in [API.md §Performance invariants](./API.md#performance-invariants)
+  and is part of the load-bearing layout/runtime separation in
+  Lock #11 below.
+- **`prefers-reduced-motion` clamps the ring to a step
+  animation** — not a smooth fill. The user controls.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Performance + §Animation (the broader UX baseline lives in
+[Causa 007-UX-IA](../../causa/spec/007-UX-IA.md)). The
+single-animation-clock clarification was added 2026-05-14 per the
+perf-audit findings (rf2-j3iwt) and rf2-t1yvw.
+
+---
+
+## Lock #9 — Layout: recompute on registry change, not on transition
+
+**Locked 2026-05-13 (Mike, lifted from Causa 003); tightened
+2026-05-14 (Mike, per rf2-t1yvw + perf-audit rf2-j3iwt).** **Chart
+layout MUST run only on machine (re-)registration, user-driven
+compound-state expand/collapse, a `:show-*` prop transition that
+adds or removes topology, or chart container resize. Live
+transitions, microsteps, timer updates, and snapshot derefs MUST
+update node attributes/classes only — never re-lay-out.**
+
+### Question
+
+When does Machines-Viz recompute chart layout?
+
+### Options considered
+
+- **On every transition.** Smooth animation; flickers on large
+  charts as the layout shifts.
+- **Never** — fixed layout from first registration. Compound-
+  state expand/collapse is broken.
+- **On registry change + on compound expand/collapse only.**
+  The layout is stable across transitions; the highlight moves
+  through a stable graph.
+
+### Pick
+
+**On machine (re-)registration + on user-driven compound
+expand/collapse + on a `:show-*` topology-affecting prop transition
++ on container resize. No other trigger.**
+
+The exhaustive enumeration of permitted layout-invalidation triggers
+— and the explicit denylist of trace events and snapshot derefs —
+lives in
+[API.md §Performance invariants §Layout-invalidation boundary is
+load-bearing](./API.md#performance-invariants). Implementations MUST
+place an explicit comment marking the layout-invalidation boundary
+as load-bearing, citing that section and this lock.
+
+### Why
+
+- **Stable graphs are easier to read.** A chart that re-layouts
+  on every transition makes the user re-orient on every event;
+  cognitive cost wins over visual flourish.
+- **Performance** — re-layout is O(nodes × edges) at minimum;
+  60Hz re-layout on a 50-state chart is expensive. The highest-
+  risk regression in this jar is a future impl coupling
+  trace-tick or snapshot deref to layout; once that coupling
+  lands it is hard to remove without rewriting the rendering
+  pipeline (per
+  [`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
+  finding 1; audit-bead rf2-j3iwt). The MUST in
+  [API.md §Performance invariants](./API.md#performance-invariants)
+  exists so that coupling cannot accidentally land.
+- **Hot-reload** triggers a registry-change event, which triggers
+  a layout pass — so editing a machine and saving causes the
+  chart to redraw correctly without manual intervention.
+
+Source: lifted from Causa
+[`003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md)
+§Performance; tightened to MUST 2026-05-14 per rf2-t1yvw + audit-bead
+rf2-j3iwt.
+
+---
+
+## Lock #10 — Source migration from Causa 003
+
+**Locked 2026-05-13 (Mike).** **The following content migrates
+from Causa 003 to this jar's spec when implementation work
+begins. Until then, Causa 003 remains the read-the-spec source of
+truth.**
+
+### Migrating content
+
+| Topic | Causa 003 section | Lands in Machines-Viz spec at |
+|---|---|---|
+| `MachineChart` prop contract | §Embedding posture | [`API.md`](./API.md) §MachineChart (already lifted) |
+| Share-URL encoding pipeline | §Share affordance §Share URL + §Performance | [`API.md`](./API.md) §Share-URL encoding (already lifted) |
+| Read-only viewer behaviour | §Share-URL §Read-only viewer | [`API.md`](./API.md) §Read-only viewer (already lifted) |
+| `:after` countdown rings — render rules | §Performance | [`API.md`](./API.md) §Performance invariants + Lock #8 above |
+| Layout-recompute rules | §Performance | [`API.md`](./API.md) §Performance invariants + Lock #9 above |
+| Topology / runtime-highlight separation (load-bearing) | (originated here 2026-05-14 per rf2-t1yvw) | [`API.md`](./API.md) §Performance invariants + Lock #11 below |
+| `:invoke-all` viz — row of mini-machines | §`:invoke-all` viz | future 001-Rendering.md (post-scaffold; not in this PR) |
+| PNG / SVG export — accessibility | §Accessibility | [`API.md`](./API.md) §Exporters |
+| Privacy posture for share-URL | §Privacy posture | [Principles §No session data in shares](./Principles.md) (already lifted) |
+| Auto-pan on transition | §Auto-pan | future 001-Rendering.md |
+
+### What stays in Causa 003 (the embedding-host side)
+
+- **Transition-history ribbon UX** — Causa's chrome around the
+  chart; not part of `MachineChart` itself.
+- **Source-coord jumps via Causa's editor-URL handler** — the
+  framework registry exposes coords; Causa wires the URL handler;
+  Machines-Viz fires `:on-state-click` and stops there.
+- **Causa's machine picker dropdown.**
+- **Causa's panel header + auto-pan toggle persistence.**
+
+### Why
+
+The split is **chart-component-concerns vs embedding-host-
+concerns**. Everything that's about rendering / encoding /
+export lives here; everything that's about Causa's panel chrome
+or Story's per-variant ribbon lives in those tools' spec.
+
+The migration is staged: this scaffold PR (rf2-x50eu) covers
+[`API.md`](./API.md) + this rationale + Principles + Vision. The
+detailed rendering / layout / export specs (a future
+`001-Rendering.md`, possibly more) land as separate beads once
+implementation work picks up.
+
+Until those land, **Causa 003 is the source of truth for
+unmigrated content**, and this DESIGN-RATIONALE cites back to it.
+
+---
+
+## Lock #11 — Topology / layout state and runtime-highlight state are strictly separate
+
+**Locked 2026-05-14 (Mike, per rf2-t1yvw + perf-audit rf2-j3iwt).**
+**`MachineChart` maintains two disjoint state planes — a topology /
+layout plane and a runtime-highlight plane. The two share no
+caches, no subscriptions, no derived values. Runtime-highlight
+updates MUST mutate attrs / classes only; they MUST NOT reach the
+layout plane.**
+
+### Question
+
+How does `MachineChart` keep the live-trace and snapshot hot path
+from regressing into a full graph recompute?
+
+### Options considered
+
+- **One unified reactive graph.** Every reactive value flows into a
+  single `MachineChart` render function; the renderer figures out
+  what changed. Rejected — when the framework's reactive substrate
+  is too lenient about granularity (or the renderer's diffing
+  misses), trace ticks bleed into layout work. The audit
+  (rf2-j3iwt) flagged this as the highest-risk future regression.
+- **Disjoint planes by convention.** Document the separation in
+  prose; trust the implementer to maintain it. Rejected — the perf-
+  audit explicitly recommended raising this above guidance because
+  "once the coupling lands, it is hard to remove without rewriting
+  the rendering pipeline."
+- **Disjoint planes as a load-bearing invariant.** A MUST in the
+  spec, an explicit comment at the layout-invalidation boundary in
+  the implementation, and a forbidden-paths list (trace events,
+  snapshot derefs) that fence layout off from the hot path.
+
+### Pick
+
+**Disjoint planes as a load-bearing invariant.** Two state planes:
+
+- **Topology / layout plane** — node positions, edge routes, compound
+  nesting, the chart's measured viewbox. Owned by
+  `(rf/machine-meta machine-id)` + the user's expand/collapse state +
+  the `:show-*` props that affect topology presence.
+- **Runtime-highlight plane** — pulse, edge glow, microstep flash,
+  `:after` ring progress, `:invoke-all` row state, spawn-tray
+  contents, timer state. Owned by `[:rf/machines <id>]` + the
+  `:rf.machine/*` trace bus.
+
+The runtime-highlight plane MUST NOT participate in any computation
+whose output reaches the topology plane. The two planes share no
+caches.
+
+The exhaustive normative rules live in
+[API.md §Performance invariants](./API.md#performance-invariants):
+
+- Topology vs runtime-highlight separation (MUST).
+- Trace/snapshot updates change attrs/classes only (MUST).
+- Layout-invalidation boundary enumeration + load-bearing comment
+  requirement.
+- Single chart-level visibility-gated animation clock for `:after`
+  rings (MUST; never per-node timers).
+
+### Why
+
+- **Highest-risk future regression.** The perf-audit (rf2-j3iwt)
+  identified this as the single largest regression surface for
+  Machines-Viz. Once coupling between trace ticks and layout lands
+  in an implementation, removing it requires rewriting the pipeline.
+  Pinning the invariant before implementation lands is cheap;
+  unpinning a coupled implementation later is expensive.
+- **Two state planes match the data sources.** The topology comes
+  from a registry that changes on edit; the runtime highlight
+  comes from a snapshot + trace bus that change at runtime
+  frequency. The implementation should reflect the same split.
+- **Trace events arrive at 60Hz; layout is O(nodes × edges).**
+  Coupling the two means every event pays the layout cost;
+  decoupling means events pay only the attr-mutation cost. A 50-
+  state chart with a 60Hz trace stream is the worst case the spec
+  must protect against.
+- **Spec is the artefact, code is downstream.** Per the project
+  posture (CLAUDE.md), the spec is the load-bearing description.
+  Pinning the invariant in the spec ensures every future
+  implementer (human or AI) reaches the same answer without re-
+  litigating it.
+- **Visibility-gated single animation clock falls out of the same
+  separation.** A per-ring `requestAnimationFrame` would cross the
+  plane boundary (each ring would own its own subscription to the
+  timer); a single chart-level clock that reads the framework
+  timer respects it. Lock #8 codifies the visibility gating; this
+  lock codifies the single-clock posture.
+
+Per
+[`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
+findings 1+2; audit-bead rf2-j3iwt.
+
+---
+
+## Open questions
+
+The locks above cover the v1.0 surface. Open questions deferred
+to implementation:
+
+- **Layout algorithm** — Dagre? ELK? Custom? (Causa 003 doesn't
+  pick; defer until first cut.)
+- **SVG primitive vs Canvas vs HTML/CSS** — Causa 003 hints
+  "SVG primitive" (per §Share affordance §Performance) but
+  doesn't lock; defer to a `001-Rendering.md` bead.
+- **Component substrate** — `MachineChart` is registered via
+  `reg-view` (Spec 004) so it works across Reagent / UIx /
+  Helix; the registration spec lives in a future capability doc.
+- **Test corpus shape** — a snapshot-tested fixture per
+  rendering case (compound, parallel, `:after`, `:invoke-all`,
+  `:final?`); shape mirrors the framework's conformance corpus.
+  Defer to implementation.
+- **Edge labels on dense graphs** — Causa 003 doesn't address
+  label collision; defer.
+
+Each of these will land as a Locked entry above when picked, or
+as a bead against this jar.
+
+---
+
+## See also
+
+- [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — the source spec these locks migrated from; embedding-host contract.
+- [`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md) — Causa's locks; #4 (no session export) is lifted into Lock #5 above.
+- [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/) — visualizer-as-product deprecation rationale.
+- [`ai/findings/sweep-tools-vs-sota-2026-05-13.md`](../../../ai/findings/) §machines-viz — peer-comparison + gap analysis.
+- [`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/) — perf audit findings 1+2 underpinning Lock #11 + the API.md §Performance invariants MUSTs; audit-bead rf2-j3iwt.
+- [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) §Future — `(machine->mermaid)` exporter forward-pointer.

--- a/tools/machines-viz/spec/Principles.md
+++ b/tools/machines-viz/spec/Principles.md
@@ -1,0 +1,298 @@
+# Principles
+
+The load-bearing principles. When a design call has two reasonable
+options, these are the tie-breakers. Implementers and contributors
+should be able to read this doc and reach the same answers
+Machines-Viz already reached.
+
+These are downstream of the framework's
+[Principles](../../../spec/Principles.md) and Causa's
+[Principles](../../causa/spec/Principles.md); they are
+*Machines-Viz-specific*. Where they overlap, this doc cites instead
+of repeating.
+
+## Observation only — no new runtime surfaces
+
+Machines-Viz is a **downstream consumer** of re-frame2's
+instrumentation surface. It must not add:
+
+- New registries.
+- New dispatch types.
+- New effect substrates.
+- New component substrates.
+
+If a chart needs data the framework doesn't emit, the answer is to
+**add to the framework's instrumentation** (via a spec amendment in
+`spec/009-Instrumentation.md` or `spec/005-StateMachines.md`) — not
+to bolt a parallel surface onto Machines-Viz.
+
+This is the same posture Causa takes
+([Causa Principles §Observation only](../../causa/spec/Principles.md)).
+The rule applies twice in this jar: once because the framework
+should not grow tooling-only surfaces, once because every host that
+embeds `MachineChart` must be able to count on identical behaviour.
+
+## Embedding-host-agnostic — one component, many hosts
+
+`MachineChart` does not know its host. Causa wraps it in the
+Machine Inspector panel; Story wraps it in a per-variant ribbon;
+the read-only viewer page wraps it in plain HTML. The component's
+contract is the same in every case:
+
+- Inputs: `:machine-id`, `:frame-id`, `:on-state-click`,
+  `:on-transition-click`, plus the read-only/no-op flags the
+  viewer uses.
+- Outputs: rendered SVG + the four callback events fired on user
+  interaction.
+- No assumptions: the component does **not** assume the host
+  surfaces a frame picker, a transition-history ribbon, an editor
+  URL handler, or any other Causa-shaped affordance. Hosts add
+  those.
+
+When two hosts disagree on a behaviour, the resolution lives in
+this jar — not in either host. Hosts that need different behaviour
+pass it via props or via the (small) configuration surface in
+[`API.md`](./API.md).
+
+## Bundle isolation by classpath
+
+Per [`tools/README.md`](../../README.md), tools are kept off
+consumer apps' production classpaths **structurally**. Machines-Viz
+inherits the contract: nothing in `implementation/` may `:require`
+from this jar. Causa requires this jar; Story requires this jar;
+the framework runtime does not.
+
+This is non-negotiable. A consumer who deploys a re-frame2 app to
+production must not ship a single byte of charting code. The
+mechanism is the same as the substrate-adapter split: the wrong
+artefact is absent from the classpath.
+
+## EDN-first on the wire
+
+Share-URLs encode the chart payload as EDN, not JSON. EDN preserves
+the keywords, sets, vectors, and nested maps that
+`reg-machine` definitions carry; JSON would lose the type
+information and force a re-coercion layer.
+
+The encoding pipeline:
+
+```
+chart-state  →  EDN-print  →  transit-write  →  base64url  →  URL fragment
+```
+
+Transit handles the binary-compactness; base64url is URL-safe; the
+fragment is invisible to servers and browsers' navigation logs (the
+hash component is never sent in the HTTP request). The decoding
+pipeline runs the inverse. Same EDN-first posture the MCP triplet
+takes (per `ai/findings/sweep-tools-vs-sota-2026-05-13.md` §EDN-
+first wire vocabulary).
+
+A versioned envelope keys the encoding so future format evolution
+is non-breaking:
+
+```clojure
+{:rf.machines-viz.share/v "1"           ;; encoding version
+ :rf.machines-viz.share/chart   { ... } ;; the payload
+ :rf.machines-viz.share/created <ms>}   ;; encode-time wall-clock
+```
+
+A decoder that reads a newer-than-known version refuses to render
+and surfaces "this chart was shared from a newer Machines-Viz; try
+upgrading."
+
+## No session data in shares
+
+A share URL is a **viewer-side artefact**: its only job is to let
+a remote recipient render the chart. Anything that exists for the
+operator's local convenience (runtime data values, editor jumps,
+filesystem paths) must not propagate. The share-URL serialises
+**only** machine topology + the current state's **name** for
+visual continuity.
+
+Forbidden in a share payload:
+
+- **Runtime `:data` from the machine snapshot.** A machine's `:data`
+  value may carry tokens, form contents, request payloads, or any
+  other runtime accumulation. The share schema's `:snapshot` map
+  is `{:closed true}` and carries `:state` only; `:data` is
+  structurally absent. This is the highest-priority class of
+  exclusion — the accident the schema protects against is a well-
+  intentioned operator clicking "Copy as Share URL" without
+  realising the snapshot is included.
+- **Local-filesystem `:source-coords`.** Source coords carry
+  absolute file paths (per
+  [`spec/Spec-Schemas.md` §`:rf/source-coord-meta`](../../../spec/Spec-Schemas.md#rfsource-coord-meta))
+  revealing usernames, workstation layout, and internal repo
+  structure. They have no use to the remote viewer (the viewer
+  page has no editor handler wired) and are dropped at encode
+  time. Definition metadata is stripped before serialisation so
+  that macro-captured coords on the topology cannot leak either.
+- Trace events (no event vectors; no dispatch ids; no causal walk).
+- Epoch history (no app-db slices outside `[:rf/machines <id>]`).
+- User-input data (no form values, no inputs the user typed).
+- Conversation buffers (no AI-co-pilot history).
+- Cross-machine state unless the sharer's chart explicitly includes
+  it via `:invoke-all`.
+- Any data from any panel other than the machine chart.
+
+The principle exists because the framework's runtime carries
+sensitive data by default (per
+[Spec 009 §Privacy](../../../spec/009-Instrumentation.md)). A share-
+URL that exfiltrates trace events is a privacy hole; one that
+exfiltrates `:data` is the same hole through a different door; one
+that leaks `:file` paths is a smaller hole but the same accident-
+class. We close all three structurally. Per Causa Lock #4 — Session
+export, lifted here.
+
+The encoder is the gatekeeper: it accepts a `chart-state` value and
+silently drops anything outside the allowlist before serialising —
+including runtime `:data` on `:snapshot` and any `:source-coords`
+the caller passes. The allowlist lives in [`API.md`](./API.md)
+§Share-URL payload schema; CI tests enforce that any new top-level
+key requires an explicit `:rf.machines-viz.share/allow?` opt-in
+plus an operator-controlled redaction hook.
+
+## Reproducible from the registry alone
+
+A shared chart's topology must be reproducible byte-for-byte from
+the same `reg-machine` call. Two consumers with the same re-frame2
+build and the same machine definition should encode to the same
+EDN regardless of when they encoded.
+
+This means:
+
+- **Map keys sort deterministically** (alphabetical by name, then
+  namespace) before EDN serialisation.
+- **Set members sort the same way.**
+- **Source coords** are encoded only when present in the
+  definition's metadata — never synthesised at encode time.
+- **No timestamps** other than the explicit `:rf.machines-viz.share/created`
+  envelope key; the payload itself is timeless.
+
+Reproducibility lets two consumers diff their charts when they
+disagree about a machine's behaviour. The diff is meaningful only
+if the encoding is canonical.
+
+The only non-reproducible bit is the **current-state snapshot** —
+which is purely a visual-highlight hint. The viewer has a "show
+idle" toggle that clears it.
+
+## Read-only is the default
+
+The default `MachineChart` is a viewer. Interactions are limited
+to:
+
+- Click a state node → fire `:on-state-click` (host decides what to
+  do: Causa jumps to source; the viewer page no-ops).
+- Click an edge → fire `:on-transition-click` (host decides).
+- Hover an edge / state → reveal a tooltip (this is the
+  component's own affordance; no host wiring).
+
+Machines-Viz **never** dispatches into the framework runtime. It
+**never** calls `restore-epoch`. It **never** writes to `app-db`.
+Same posture Causa takes
+([Causa Principles §Read-only by default](../../causa/spec/Principles.md))
+— the difference is that Causa's posture has a "mutate by
+confirmation" escape (re-dispatch via right-click etc.); Machines-
+Viz has no escape. The component is observation, full stop.
+
+If a host needs to drive the runtime from a chart click (Causa's
+"jump to source", say), the host wires that through its own
+machinery — Machines-Viz fires the callback and stops there.
+
+## Charts pulse only the active state
+
+The only continuous animation in a chart is the active state's
+1.2s heartbeat pulse (lifted from Causa 007-UX-IA §Animation —
+only the active machine's node pulses). Everything else is
+event-driven:
+
+- Transition: one ~250ms edge-glow on the matching event.
+- Microstep: one 150ms intermediate node flash.
+- `:after` countdown: a fill ring that updates at 60Hz **only**
+  when the chart is visible; backgrounded charts pause the fill.
+- `:invoke-all` join completes: one ~400ms row-collapse animation.
+
+No looping animations except the heartbeat. No "look at me I'm
+running" continuous strobes. Every animation respects
+`prefers-reduced-motion`; reduced motion clamps durations to 0
+except a 1-frame opacity tween where layout needs to settle.
+
+This is the framework's animation-communicates-not-decorates
+principle, applied to charts.
+
+## Colour is never alone
+
+Every coloured marker pairs with a shape, icon, or text:
+
+- Active state: green fill + a filled-glyph badge + the state-name
+  label.
+- `:after` countdown ring: amber arc + the countdown-clock icon +
+  the remaining-ms text.
+- `:final?` state: doubled border + a "✓" glyph.
+- `:invoke-all` failed child: red fill + an "!" badge + "failed"
+  label.
+- Stale microstep node: grey + dashed border + "(microstep)" text.
+
+The colour-blind path is reachable without hue. Same posture
+Causa takes
+([Causa 007-UX-IA §Colour is never alone](../../causa/spec/007-UX-IA.md)).
+
+## Restraint over completeness
+
+The temptation to grow a chart component into a full editor is
+real. The component is striking; the editor is striking-er;
+visualisation-as-product is a peer-set norm.
+
+We resist:
+
+- No drag-to-reposition (the layout is computed; the user does not
+  edit it).
+- No state-rename inside the chart (the user edits source; the
+  chart re-layouts).
+- No transition-add gesture (the user edits source).
+- No saved-chart registry (the share-URL is the only persistence
+  affordance; bookmark it, drop it in a doc).
+- No multi-user / multiplayer canvas.
+
+If a chart feature is in the v1 ship list (per
+[`000-Vision.md`](./000-Vision.md) §Scope and roadmap), it lands.
+Otherwise: defer to v1.1, or let Stately Studio own the lane. The
+machine inspector's job is to **show the cascade**, not to
+**author the machine**.
+
+## Production elision is non-negotiable
+
+The chart depends on the framework's trace bus + the
+`[:rf/machines <id>]` snapshot, both of which are gated on
+`re-frame.interop/debug-enabled?` in production (per
+[Spec 009 §Production builds](../../../spec/009-Instrumentation.md#production-builds-zero-overhead-zero-code)).
+Machines-Viz contributes its own sentinels to the elision verifier
+(`npm run test:elision`); CI blocks any leak.
+
+Production builds (`:advanced` + `goog.DEBUG=false`) elide every
+surface this jar consumes. The chart is invisible in production —
+not "renders with a warning," not "degrades gracefully," **absent
+from the classpath**.
+
+## Backed by the framework's principles
+
+When in doubt, defer to the framework's
+[Principles](../../../spec/Principles.md):
+
+- **Regularity over cleverness** — one obvious way to render a
+  state, an edge, a microstep.
+- **Named things over anonymous things** — every state has a
+  stable id; every transition has a stable selector; every callback
+  prop has a stable name.
+- **Public query surfaces** — Machines-Viz reads only what the
+  framework's public registrar / trace bus / `[:rf/machines]`
+  surface exposes.
+- **Deterministic execution** — Machines-Viz's rendering is a
+  function of `(reg-machine def, snapshot, trace-history)`; no
+  hidden side-effects.
+
+Machines-Viz is a downstream artefact of the framework's
+AI-first discipline. The principles above are what *Machines-Viz
+adds* over the framework's baseline; everything below is
+inherited.

--- a/tools/machines-viz/spec/README.md
+++ b/tools/machines-viz/spec/README.md
@@ -1,0 +1,59 @@
+# Machines-Viz (`day8/re-frame2-machines-viz`) — Spec
+
+## Files
+
+- **[000-Vision.md](000-Vision.md)** — What `MachineChart` is, what the read-only viewer guarantees, the share-URL encoding format; relationship to Stately Visualizer (visualizer-as-product is out of scope).
+- **[Principles.md](Principles.md)** — Bundle isolation, EDN-first wire, observation-only, embedding-host-agnostic, no session data in shares, read-only by default.
+- **[API.md](API.md)** — Consolidated public surface: `MachineChart` component contract, read-only viewer URL, share-URL encoding pipeline + payload schema, PNG / SVG exporters.
+- **[DESIGN-RATIONALE.md](DESIGN-RATIONALE.md)** — The locks. Question, options, pick, why, locker. Several locks lift content from [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md); cross-references retained.
+
+## How to use
+
+This folder is scaffolded for the v1.0 surface. Read
+[`000-Vision.md`](000-Vision.md) first to anchor scope (one
+embeddable component + a read-only viewer page; no
+visualizer-as-product), then [`Principles.md`](Principles.md) for
+the tie-breakers, then [`API.md`](API.md) for the consolidated
+contract. [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) records the
+locks; it cites [Causa 003](../../causa/spec/003-Machine-Inspector.md)
+where decisions were originally specced on the embedding side.
+
+Numbered capability docs (`001-Rendering.md`, etc.) land as
+implementation work picks up; this scaffold is intentionally
+**API + locks first, capability detail later**. Until the
+capability docs land, [Causa 003](../../causa/spec/003-Machine-Inspector.md)
+is the source of truth for unmigrated content (transition-history
+ribbon UX, source-coord wiring, `:invoke-all` row layout details).
+
+## Status
+
+Scaffolded by [rf2-x50eu](../../../.beads/) — 2026-05-13. The spec
+covers the v1.0 contract the implementation will satisfy; the first
+shipped surface is the Mermaid `stateDiagram-v2` exporter.
+
+### Shipped
+
+- **Mermaid `stateDiagram-v2` exporter** — per
+  [rf2-deo2i](../../../.beads/) and
+  [`API.md`](API.md) §Mermaid `stateDiagram-v2`. Implemented at
+  `src/day8/re_frame2_machines_viz/mermaid.cljc` (~500 LoC). Covers
+  the read-only diagram surface enumerated in
+  [`000-Vision.md`](000-Vision.md) §item 5 (single-state machines,
+  composite states, parallel regions, transition labels, entry/exit
+  actions, action/`do` labels, `invoke-all` row layout). JVM + CLJS
+  test corpora cover the projection and the markdown-fence wrapping.
+
+### Pending implementation
+
+- `MachineChart` Reagent component — the live in-page renderer.
+- Read-only viewer page — the standalone hosted surface that accepts
+  a share URL and renders without an embedding host.
+- Share-URL encoding pipeline — payload schema + compression +
+  versioning per [`API.md`](API.md) §Share URL.
+- PNG / SVG exporters — file-emitting surfaces alongside the
+  Mermaid markdown export.
+- Capability docs (`001-Rendering.md`, etc.) — author alongside
+  each surface as it lands. The Mermaid exporter's contract
+  currently lives in [`API.md`](API.md) only; a dedicated
+  capability doc may land when sibling capabilities arrive and a
+  shared surface emerges.


### PR DESCRIPTION
## Summary

- Adds an explicit **Quality bar** to `tools/machines-viz/spec/000-Vision.md` — "good interactive, integrated visualisation, robust to complexity, beautiful, highly ergonomic", with Stately Studio as the named comparator (floor: never ship weaker than; ceiling-not-imposed-by-prior-art: principled divergence on aesthetic).
- Adds an **XState/Stately decision-trace requirement** — every design decision in this spec MUST trace to prior art using a four-row template (Decision / Stately-XState's choice / re-frame2's choice / Rationale if diverge). Applied to the locked rendering stack: ELK.js layout, hand-rolled SVG renderer, Mermaid static export, EDN model, MIT+EPL-2.0 license chain, Spec 009 trace bus for active-state highlighting.
- Adds an explicit **Surface set** (Causa panel + user-app drop-in + docs cells + Mermaid statics) and **What v1.0 does NOT do** (no standalone Visualizer product per Lock #1, no paste-and-render at v1.0, no editor surface, no closed-source deps).

## Decisions locked

- **rf2-bnlo4** (closed 2026-05-19): machines-viz **survives as a separate artefact**. Causa is the front door for observability; machines-viz is the focused visualisation artefact behind it. Definitions are EDN (already Spec 005 idiom). Quality bar = 'as good as Stately Studio.'
- **rf2-04gvh** (closed 2026-05-19): rendering stack locked — **ELK.js** layout engine (matches Stately Studio; EPL-2.0 compatibility sign-off owed before impl), **hand-rolled SVG** interactive renderer (deliberately diverges from Stately Studio's React Flow; rationale: aesthetic coherence with Causa + full visual control + weeks-of-polish accepted), **Mermaid** for the static surface (already shipped per rf2-deo2i, relocated to `implementation/machines` per rf2-yamkm; stays in its lane).

## Scope note — scaffold restoration

`tools/machines-viz/` was collapsed by **rf2-yamkm** on 2026-05-18 (PR #1409). Mike's 2026-05-19 decision on rf2-bnlo4 **reverses** that collapse posture — machines-viz survives as a separate artefact. This PR therefore **restores** the pre-collapse `tools/machines-viz/spec/` scaffold (000-Vision.md, API.md, DESIGN-RATIONALE.md, Principles.md, README.md, all verbatim from `89809be2^`) and then amends only **000-Vision.md** per rf2-omsnb's scope.

NOT restored in this PR (out of scope; impl follow-on):

- `tools/machines-viz/deps.edn`
- `tools/machines-viz/README.md` (tool root)
- `tools/machines-viz/src/` (the Mermaid emitter relocation to `implementation/machines/src/re_frame/machines/mermaid.cljc` per rf2-yamkm stays — that emitter still ships from `implementation/machines`)
- `tools/machines-viz/test/`

## Test plan

- [x] `mkdocs --strict` warning count: **72** (identical to `origin/main` baseline). Verified with the machines-viz directory moved aside and the diff showing zero net new warnings.
- [x] `python scripts/check_doc_slugs.py` — clean exit (no broken targets or anchors).
- [x] `scripts/test-fast-pr.sh` — runs cleanly through the deterministic gates (lockstep version, skill/MCP drift, core JVM tests, JS harness helpers). CLJS node integration step hits a worktree-local `shadow-cljs not recognized` infra issue unrelated to this spec-only change.

## Notes

- **This PR is spec-only.** No implementation code, no `tools/machines-viz/src/` files. The eventual MachineChart implementation is a follow-on bead Mike will file once the spec lands.
- The five-minute **EPL-2.0 compatibility sign-off** for ELK.js is owed before the impl bead is dispatched (tracked on rf2-04gvh).
- The Causa Vision (`tools/causa/spec/000-Vision.md`) currently says "MachineChart is Causa-internal" + "Causa → `implementation/machines/` (directly; no `tools/machines-viz/` hop)" — text that predates Mike's 2026-05-19 reversal. **Not edited here** per the brief's "read-only" instruction on Causa specs. Reconciling Causa's Vision with the restored machines-viz boundary is a separate follow-on.
- No AI attribution per repo conventions.