### PR TITLE
docs(causa): post-impl spec sweep — Machine Inspector Phase 5 + landings since #1414 (rf2-hrb4c)

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -199,6 +199,30 @@ structural template:
 
 Shift-click a third instance → tertiary focus (cyan); cap at 4 lanes.
 
+### Per-instance state-arc — v1 ships (rf2-nqw0v, Phase 5)
+
+The mini-scrubber's companion overlay. A thin SVG strip mounted ABOVE
+the chart that traces the focused instance's chronological
+state-trajectory:
+
+- **Origin** is the machine's initial state (`@idx 0`); each subsequent
+  point is one outer or microstep transition for the focused instance.
+- **Segments** fade between marker centres in the accent-violet palette
+  (matches the Causa brand violet; cyan / amber are reserved for
+  live-highlight / sim-mode respectively).
+- **Per-marker tooltip** is the browser-native SVG `<title>` element —
+  no Causa hover-tooltip machinery. Each title carries
+  `#<idx> <from> → <to> (<event>) @<ms>` so the developer reads the
+  trajectory by hovering markers in sequence.
+- **Trim semantics tied to scrubber position.** When the mini-scrubber
+  (below) is at `:present`, the arc renders the full trajectory; when
+  scrubbed to `idx N`, the arc trims to `[0..N]` so the strip mirrors
+  the chart's rewound state.
+
+Pure-data algebra (`machine_inspector_arc_helpers.cljc`) is
+JVM-runnable; the view module (`machine_inspector_arc.cljs`) is a
+thin CLJS renderer mounted via the chart primitive's overlay slot.
+
 ### Per-instance mini-scrubber
 
 When a machine instance is focused, an in-arc-strip mini-scrubber lets
@@ -215,6 +239,27 @@ This mini-scrubber is intra-tab content (inside the Machines tab); it
 is NOT related to the (now-dead) bottom rail / global scrubber. The
 global scrubber surface is the ribbon `[◀ ▶ ⏭]` cluster + the L2 event
 list per [`018-Event-Spine.md`](018-Event-Spine.md) §6.
+
+#### v1 ships — concrete widget shape (rf2-nqw0v, Phase 5)
+
+The shipped mini-scrubber is a horizontal `<input type="range">`
+beneath the chart (NOT the prose `◀ scrub ▶` widget — the spec text
+above is the user-facing mental model; the v1 mechanics use a native
+range input for keyboard-accessibility and OS-native drag semantics).
+
+- **Slider write surface.** Dragging dispatches
+  `:rf.causa/set-scrubber-position` into the per-slot reducer; the
+  chart's active-state highlight overrides to the scrubbed-to state;
+  the per-instance arc trims to `[0..idx]`.
+- **Domain.** `[0, max-idx]` where `max-idx` is the last transition
+  recorded for the focused instance.
+- **"⏭ present" button** sits next to the slider — snaps the position
+  back to head and re-engages live-tracking semantics. Equivalent to
+  setting position = `max-idx` AND re-arming the head-follow flag.
+- **Auto-flip to `:present` on max-idx drag.** Dragging the slider to
+  the right-edge max value auto-flips position state to `:present` so
+  head-tracking survives a future-tense scrub (vs. sticking at
+  numeric `max-idx` and silently lagging the next live transition).
 
 ## Spec 005 actor lifecycle — full XState parity
 
@@ -410,6 +455,49 @@ density makes the missing-orthogonal-router more visually jarring.
   a shared `chart/elk_loader.cljs`.
 
 ## Share affordance
+
+### v1 ships — share-URL (rf2-nqw0v, Phase 5)
+
+The v1 Share button is a `⤴ Share` chip in the panel header that
+opens a modal carrying a copyable URL encoding the current Machines-
+tab inspection posture. NOT the PNG / SVG / Mermaid copy-as
+sub-menu — that is the broader vision (preserved below as v1.1
+deferred work).
+
+Encoded slots, as a flat URL query-string:
+
+| Param | Source slot | Meaning |
+|---|---|---|
+| `causa-share=1` | sentinel | "this URL carries a Causa share." Without it the loader skips share-restore on mount. |
+| `machine=<id>` | `:focused-machine-id` | The machine the inspector is bound to. |
+| `pos=<int>` | `:scrubber-position` | The mini-scrubber's `[0, max-idx]` position (omitted when `:present`). |
+| `mode=<mode-x>` | `:view-mode` | UC2 dynamic mode pin (`mode-a`/`mode-b`/`mode-c`). |
+| `tab=<id>` | active L3 tab id | The L3 tab the recipient lands on (defaults to `machines`). |
+
+Encoded form is human-legible and trivially diff-friendly — `?causa-
+share=1&machine=auth/login&pos=3&mode=mode-b&tab=machines` — so the
+URL can be pasted into a PR comment, a code-review note, or a chat
+without explanation overhead.
+
+On load, `maybe-restore-from-location!` parses the query-string and
+dispatches `:rf.causa/restore-from-share-url` into the per-slot
+reducers. The dispatch is one-shot per page-load: subsequent
+in-session navigation does not re-read the URL.
+
+Lock #4 (no session export) is preserved by scope: the URL encodes
+only the **visible inspection posture** (which machine, which
+scrubber index, which view mode, which tab). It does NOT serialise
+the trace stream, the epoch buffer, or the app-db — the recipient
+sees the same inspector view against THEIR runtime state, not the
+sender's.
+
+The share modal itself mounts at the shell-view root (parallel to the
+palette / settings popup pattern); `share.cljs` + `share_modal.cljs`
+hold the URL parsing + the modal renderer; both are
+production-elided per [`Principles.md`](Principles.md) §Production
+elision is non-negotiable.
+
+### v1.1 deferred — Copy machine as PNG / SVG / Mermaid
 
 Right-click on the machine chart (or use the panel header's `⋯`
 overflow menu) surfaces a **Copy machine as…** sub-menu:

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -159,6 +159,45 @@ The orienting layer. Single-line rows; latest-on-bottom; virtualised; eight visi
 | Resizable | Drag handle on L2/L3 boundary | Min 2 rows ≈ 56px; max bounded by canvas |
 | Virtualisation | Viewport + 20-row overscan | Uses existing `panels/overflow_indicator.cljs` |
 
+#### v1 ships — Compact density baseline (rf2-htik0)
+
+The spec table's row-height baseline is `28px` ("cosy"; the named
+default in the View settings table); v1 ships at `22px` ("compact"
+per [`007-UX-IA.md` §Density slider](007-UX-IA.md#density-slider))
+without exposing a user-facing density picker for the L2 surface
+yet. Container height drops from 224px to 200px (8 × 22px + gaps +
+outer padding); min-height drops 56px → 48px so the L2/L3 drag
+handle can still squeeze the list to ~2 rows. The named tiers
+remain in the spec (compact/cosy/comfy) so a future density picker
+re-flips the rhythm without a re-design pass.
+
+#### v1 ships — Nav-button semantics (rf2-htik0)
+
+The ribbon's `[◀ ▶]` nav cluster: `◀` (prev / step backward in time)
+is disabled at the **oldest** event (no older to step to); `▶` (next
+/ step forward) is disabled at the **most recent** event (no newer
+to step to). The earlier shell prototype shipped these inverted —
+the v1 fix swapped the `at-head?` / `at-tail?` predicates and the
+docstring now reads as the actual semantics. Recorded here so the
+spec's nav-button semantics line up with the runtime contract for
+test rigs that pin enable / disable state across the buffer
+boundaries.
+
+#### v1 ships — Full event vector inline (rf2-htik0)
+
+The Row anatomy table below documents the `Event id` column as
+`:order/submit` (the event-id alone). v1 ships the **full dispatched
+event vector** inline (`[:cart/add-item {:item-id "apple" :qty 2}]`)
+truncated at the 80-char inline cap (`<head>…]` suffix preserves the
+closing bracket so the row still reads as a vector). The event-id
+gets the accent-violet keyword colour so it pops out of the payload;
+the payload renders in the row's default text colour. Empty payloads
+collapse to `[:counter/inc]` (no `{}` placeholder). The 80-char cap
+is a single-row legibility constraint — clicking the row opens the
+L4 Event tab with the full untruncated vector. The Row anatomy table
+below remains the canonical shape; this callout records what the
+`Event id` column actually packs at v1.
+
 ### Row anatomy
 
 ONE row shape, decorated by gutter glyph + right-aligned icon badges + trailing redaction marker:

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -709,7 +709,7 @@ The single-axis selection that every layer reads from.
 | `:rf.causa/focus-cascade-next` | `▶` button · `k` / `→` key | Steps `:dispatch-id` forward one in `:rf.causa/filtered-cascades`; flips `:mode → :retro` if not already at head |
 | `:rf.causa/follow-head` | `⏭` button · `L` key · click mode pill when RETRO | Sets `:mode :live`, clears pinned id, snaps `:dispatch-id` to head |
 | `:rf.causa/toggle-live-pause` | `Space` key · click mode pill when LIVE | Pauses/resumes LIVE buffer-to-list flow; buffer continues collecting; mode stays LIVE (paused) |
-| `:rf.causa/set-frame <frame-id>` | Frame picker selection | Writes `:frame` slot; clears `:dispatch-id` to head of new frame |
+| `:rf.causa/set-frame <frame-id>` | Frame picker selection | Writes `:frame` slot; clears `:dispatch-id` to head of new frame. Per the multi-frame panel-focus fix wave (rf2-fvplw / rf2-y8bik / rf2-ug1r6 / rf2-thodq) the same write ALSO re-seeds `:rf.causa/target-frame` (the per-frame projection axis the App-db diff + Views composites read) AND `:rf.causa/epoch-history` (the cached snapshot of `(rf/epoch-history target)`) so every per-frame panel follows the picker as one atomic move — see [§Multi-frame panel-focus invariant (P) — v1 ships](#multi-frame-panel-focus-invariant-p--v1-ships) below. |
 | `:rf.causa/preview-cascade <id>` | Row hover (before click commits) | Sets `:previewing? true`, `:dispatch-id <id>` transiently; reverts on hover-out without click |
 
 ### Per-layer rebind table
@@ -953,6 +953,41 @@ The browser feature gate that asserts I1 + I3 + I4 together is the canonical iso
 **Gate name:** `tools/causa/test/day8/re_frame2_causa/isolation_test.cljs` (new file). Runs under `npm run test:browser`. **Failure blocks merge.**
 
 **Lint I2:** unit test asserting the dev-time lint predicate throws on a deliberately-misconfigured Causa-namespaced sub feeding a host-data render path; passes on the actual Causa registry. Lives in `tools/causa/test/day8/re_frame2_causa/sub_graph_lint_test.cljs` (new file). Runs under `npm run test:cljs`.
+
+### Multi-frame panel-focus invariant (P) — v1 ships
+
+The four invariants above (I1–I4) keep Causa-internal renders OUT of
+inspected-host-frame panels. The complementary invariant — panels
+follow the picker INTO whichever inspected frame the user picks —
+landed as the multi-frame panel-focus fix wave (rf2-fvplw + rf2-y8bik
++ rf2-ug1r6 + rf2-thodq):
+
+| Slot | Owner | What `:rf.causa/set-frame` does |
+|---|---|---|
+| `:focus :frame` | spine | Set to picked frame-id; clears `:dispatch-id` to head of new frame. |
+| `:rf.causa/target-frame` | per-frame projection axis | Re-seeded to picked frame-id. This is the legacy axis the App-db diff + Views composites compose against; pre-fix the picker only wrote the spine's `:focus :frame` and the composites stayed bound to whichever frame was last targeted (commonly `:rf/default`). |
+| `:rf.causa/epoch-history` | cached snapshot | Re-seeded from `(rf/epoch-history <picked-frame>)` so the App-db diff's `:selected-epoch-diff` / `:sections` / `:annotated-tree` and Views' `:focused-cascade-pair` / `:views-sub-diff` composites refresh against the new frame's epoch ring in the same dispatch. |
+
+**Invariant P (Panel follows focus):** every per-frame panel
+composite (App-db diff, Views, Machines, Issues, Trace) MUST refresh
+its data axis on every `:rf.causa/set-frame` write within the same
+dispatch. No panel may persist a frame-binding that survives a picker
+selection. The picker is the single seam that re-routes every
+per-frame surface.
+
+The composite seam `:rf.causa/observed-frame` reads
+`(:frame focus)` first (the spine slot the picker writes; also
+derived by `compose-focus` from the focused cascade) and falls back
+to `:rf.causa/target-frame` so click-on-row picker-less navigation
+also rebinds. Both writes happen in the same `:rf.causa/set-frame`
+reducer so the App-db diff renders the diff body for the picked frame
+on the next render-frame, and the Views panel's `:has-cascade?`
+guard does not flip to `false` between picks.
+
+Test gates: `spine_cljs_test.cljs` pins the `:target-frame` +
+`:epoch-history` writes on both arities of the reducer; the
+`app_db_diff_cljs_test.cljs` + `views_subs_cljs_test.cljs` regression
+suites pin the panel render bodies post-reseed.
 
 ---
 


### PR DESCRIPTION
## Summary

Augment-only spec sweep covering landings since rf2-c8myv (#1414, the parent sweep). Mirrors that PR's method: no paragraphs deleted; 'v1 ships' callouts where impl diverged from spec language. Two spec files touched.

- **`tools/causa/spec/003-Machine-Inspector.md`** (+88 LoC) — Phase 5 backfill for rf2-nqw0v (#1415): per-instance state-arc section (SVG overlay, native `<title>` tooltips, trim-tied-to-scrubber); mini-scrubber 'v1 ships' callout (the shipped widget is `<input type="range">` + ⏭ present, not the prose '◀ scrub ▶'); Share-affordance split into 'v1 ships — share-URL' (the actual `?causa-share=1&machine=...&pos=...&mode=...&tab=...` feature) and 'v1.1 deferred — PNG / SVG / Mermaid' (the existing prose preserved verbatim under the deferred sub-heading).

- **`tools/causa/spec/018-Event-Spine.md`** (+76 LoC) — L2 event-list 'v1 ships' callouts for rf2-htik0 (#1451): Compact density baseline (22px vs spec's 28px cosy); nav-button semantics (`◀` disabled at oldest, `▶` disabled at most recent — the earlier prototype shipped these inverted); full event vector inline (rows render `[event-id payload]` truncated at 80 chars, not just the event-id). Plus a new §8 sub-section 'Multi-frame panel-focus invariant (P) — v1 ships' documenting the picker's atomic re-seed of `:rf.causa/target-frame` + `:rf.causa/epoch-history` (rf2-fvplw + rf2-y8bik + rf2-ug1r6 + rf2-thodq fix wave, #1491 + #1492), and the §6 spine-events table now records the same re-seed on `:rf.causa/set-frame`.

## Sources

Per the bead's inventory of landings since #1414, mapped to spec impact:

| PR / bead | Spec target | This sweep |
|---|---|---|
| rf2-nqw0v Phase 5 (#1415) | tools/causa/spec/003 | augmented (commit 1) |
| rf2-htik0 L2 density (#1451) | tools/causa/spec/018 | augmented (commit 2) |
| rf2-fvplw + rf2-y8bik (#1491), rf2-ug1r6 + rf2-thodq (#1492) | tools/causa/spec/018 | augmented (commit 3) |
| rf2-87lkf Views polish (#1498) | tools/causa/spec/012 | already documented |
| rf2-sgdd3 + rf2-q9kv5 + rf2-r1uod + rf2-q7who A+B | tools/causa/spec/008 + tools/story/spec/005 + API | already documented |
| rf2-yhxk3 → rf2-m00rw parallel-frames | spec/006 cross-link | already done |
| rf2-x8h9y panel resize | tools/causa/spec/007 + 015 | already documented |
| rf2-bz1cl + rf2-dl3gx redacted-modified chip | tools/causa/spec/004 + spec/Spec-Schemas | already documented |
| rf2-2f40y :ungrouped lane | tools/causa/spec/016 + 014 | already documented |
| rf2-jhhqt Event lens DISPATCH/EVENT + COEFFECTS | tools/causa/spec/018 | already documented |
| rf2-oziyr frame-picker L2 filter | tools/causa/spec/018 | already documented |
| rf2-y710n + rf2-ihq4d MCP wire-key rename | tools/{story-mcp,re-frame2-pair-mcp}/spec | already documented |
| rf2-r1uod + rf2-6jyf6 :project-root | tools/causa/spec/015 + tools/story/spec/005 + API | already documented |
| rf2-e2ufx + rf2-hy9sm rename | cross-references | already consistent post-rename |
| rf2-q5e36 + rf2-gqid4 :isolation | tools/story/spec | shipped as feat+spec already |
| rf2-6jyf6 shop testbed :project-root | shop testbed deleted (#1508) | no spec impact |

No-augment-needed (UI / CSS / Causa-internal fixes with no spec divergence):

- rf2-ppzid Reagent `^{:key}` meta sweep (#1475) — Causa-internal CLJS fix; no spec impact.
- rf2-pwfl4 Machine Inspector text audit (#1445) — UI text only; no spec impact.
- rf2-gz7vi Machines chart font polish (#1454) — CSS only; no spec impact.
- rf2-ak3ty Spine epoch-id (#1453) — spec already pinned `:epoch-id` as a first-class focus slot; close was 'no spec change'.
- rf2-w15el Views focus one-liner (#1455) — bug fix; the invariant was already spec'd.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exits clean (0).
- [x] `python -m mkdocs build` — 6 warnings, all pre-existing on origin/main (migration/from-re-frame-v1 nav refs); zero new warnings introduced by this sweep.
- [x] `scripts/test-fast-pr.sh` — path-policy, changed-surfaces, story-feature-load-port, browser-test-report, gate-report, local-browser-harness all pass. The CLJS node integration step requires `npm install` in `implementation/` (not run in this docs-only worktree) and is expected to be exercised by CI.

## Method

Parent sweep: rf2-c8myv (#1414, closed). This is the follow-on for items rf2-c8myv explicitly skipped because their source hadn't merged yet, plus the landings between #1414 and this PR. Same posture:

- **Augment-only.** No paragraphs deleted; existing prose preserved verbatim.
- **'v1 ships' callouts** where the impl diverged from the spec's earlier wording (mini-scrubber widget shape, share affordance scope, L2 row density, L2 nav-button semantics, L2 row content).
- **Cross-link discipline.** New anchors verified by `check_doc_slugs.py`; em-dash-aware slug spelling.
- **No new beads filed.** Every landed PR in the bead's inventory either had spec impact (augmented here or pre-existing) or had none (no-spec-impact list above).