### PR TITLE
fix(causa): section-grouping count-rendered-nodes + apply tuned defaults (rf2-szzjh)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/diff/section_grouping.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/diff/section_grouping.cljc
@@ -20,11 +20,11 @@
   2. Each change point starts as a candidate section, headed by its
      full path with the change-point subtree as body.
   3. Coalesce siblings: if two candidate sections share an ancestor
-     within `max-coalesce-depth` (default 3) levels, merge into one
+     within `max-coalesce-depth` (default 2) levels, merge into one
      section headed by the shared ancestor; the new body is the
      annotated subtree rooted at the ancestor.
   4. Split overfilled: if a coalesced section would render more than
-     `max-unchanged-context` (default 50) paths of unchanged context,
+     `max-unchanged-context` (default 40) paths of unchanged context,
      split back into the constituent candidate sections.
   5. Whole-DB replacement: if every top-level key changed (count of
      changed top-level keys equals total top-level key count), emit
@@ -54,10 +54,20 @@
   (:require [day8.re-frame2-causa.diff.annotated-tree :as at]))
 
 (def default-opts
-  "Tunable knobs. Defaults per design §3.1.1; tune against a real corpus
-  (rf2-ogkh0)."
-  {:max-coalesce-depth    3
-   :max-unchanged-context 50})
+  "Tunable knobs. Defaults tuned by rf2-ogkh0's automated 53-pair corpus
+  sweep (`ai/findings/2026-05-19-causa-section-grouping-heuristics.md`)
+  — 1325 invocations across `depth ∈ {1..5}` × `context ∈ {20..100}`
+  on real `(before, after)` pairs from `examples/` + `testbeds/`:
+
+    - `:max-coalesce-depth 2` — minimum that maximises corpus-ideal
+      coalescence (52/53 entries land in [1,6] sections); higher
+      depths silently up-promote per-feature breadcrumbs to
+      generic container-level heads without changing section counts.
+    - `:max-unchanged-context 40` — minimum that handles the
+      vec-grow-paginate shape (`corner/vec-grow-deep`, 21-item feed)
+      cleanly without over-grouping any other corpus entry."
+  {:max-coalesce-depth    2
+   :max-unchanged-context 40})
 
 ;; ---- 1. walk to collect change points ----------------------------------
 
@@ -304,7 +314,7 @@
 
   Args:
     `root`  — root annotated node (from `annotated-tree/diff-tree`).
-    `opts`  — optional `{:max-coalesce-depth 3 :max-unchanged-context 50}`.
+    `opts`  — optional `{:max-coalesce-depth 2 :max-unchanged-context 40}`.
 
   Returns a sorted vector of `{:path [...] :subtree <annotated-node>}`.
 

--- a/tools/causa/src/day8/re_frame2_causa/diff/section_grouping.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/diff/section_grouping.cljc
@@ -188,21 +188,36 @@
   "Count how many nodes the renderer would visit for `subtree`. Used
   for the `max-unchanged-context` split rule (§3.1.1 step 3).
 
-  Counts every annotated node in the subtree — `:same`, `:added`,
-  `:removed`, `:modified`, `:children`. A `:children` container counts
-  as one + the sum of its children's counts.
+  ## Renderer-faithful accounting (rf2-szzjh)
 
-  The renderer collapses `:same` subtrees into single chips, so a
-  better proxy for 'paths the user actually sees' is the count of
-  non-`:same` nodes plus the count of `:same` direct children of
-  changed containers (which become chips). For v1 we use the simple
-  total-node count as a conservative upper bound — over-counting is
-  safe (more splits, smaller sections); under-counting would let
-  overfilled sections through."
+  The renderer (`diff/render.cljs`) collapses **all** `:same` direct
+  children of a `:children` container into a single
+  `(N entries unchanged)` chip — many siblings or few, the chip
+  occupies one row's worth of canvas. Earlier versions counted each
+  `:same` sibling verbatim, which inflated the cost of legitimately-
+  coalesced clusters with many unchanged siblings (e.g.
+  `pg/large-multi-tier`: 50 new catalog keys merged into a 200-key
+  unchanged catalog → counter reported 251, defeated every
+  `max-unchanged-context` ≤ 250 and shattered into 50 singletons).
+
+  This counter mirrors the renderer's collapse:
+
+  - `:children` container → `1` (header) + Σ counts for **non-`:same`**
+    children + `1` if **any** `:same` children exist (the chip)
+  - `:added` / `:removed` / `:modified` / `:same` leaf → `1`
+
+  Discovered by rf2-ogkh0's 53-pair corpus sweep; see
+  `ai/findings/2026-05-19-causa-section-grouping-heuristics.md` §5.1."
   [subtree]
   (let [op (at/op-of subtree)]
     (if (= op :children)
-      (+ 1 (reduce + 0 (map count-rendered-nodes (:children subtree))))
+      (let [children    (:children subtree)
+            same?       #(= :same (at/op-of %))
+            changed     (remove same? children)
+            any-same?   (boolean (some same? children))]
+        (+ 1
+           (reduce + 0 (map count-rendered-nodes changed))
+           (if any-same? 1 0)))
       1)))
 
 ;; ---- 5. whole-DB replacement detection --------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
@@ -68,13 +68,18 @@
    :status :submitting
    :flash  "Order saved"})
 
-(deftest render-cart-cascade-yields-four-section-blocks
-  (testing "cart cascade → 4 section blocks each with a testid"
+(deftest render-cart-cascade-yields-five-section-blocks
+  (testing "cart cascade at tuned default depth=2 (rf2-ogkh0) → 5
+            section blocks each with a testid. depth=2 keeps the
+            sub-cart change-points separated; the [:cart :gross]
+            singleton promotes to [:cart], the [:cart :items] cluster
+            keeps its full path."
     (let [tree     (at/diff-tree cart-before cart-after)
           sections (sg/group-into-sections tree)
           hiccup   (render/render-sections sections "app-db-diff")]
-      (is (= 4 (count sections)))
+      (is (= 5 (count sections)))
       (is (has-testid? hiccup "rf-causa-diff-section-[:cart]"))
+      (is (has-testid? hiccup "rf-causa-diff-section-[:cart :items]"))
       (is (has-testid? hiccup "rf-causa-diff-section-[:user :prefs]"))
       (is (has-testid? hiccup "rf-causa-diff-section-[:status]"))
       (is (has-testid? hiccup "rf-causa-diff-section-[:flash]")))))

--- a/tools/causa/test/day8/re_frame2_causa/diff/section_grouping_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/diff/section_grouping_cljs_test.cljc
@@ -216,3 +216,175 @@
 (deftest subtree-at-empty-path-returns-root
   (let [tree (at/diff-tree {:a 1} {:a 2})]
     (is (= tree (sg/subtree-at-path tree [])))))
+
+;; ---- (7) count-rendered-nodes — renderer-faithful chip accounting ------
+;;
+;; rf2-szzjh regression. The renderer collapses all `:same` direct
+;; children of a `:children` container into a single chip. The earlier
+;; counter charged each `:same` sibling as 1 (verbatim), inflating the
+;; cost of legitimately-coalesced clusters and shattering them under
+;; the `max-unchanged-context` split rule. See
+;; `ai/findings/2026-05-19-causa-section-grouping-heuristics.md` §5.1.
+
+(deftest count-rendered-nodes-charges-same-cluster-as-one-chip
+  (testing "rf2-szzjh: a :children container with many :same siblings
+            charges the WHOLE :same cluster as 1 (the renderer's
+            `(N entries unchanged)` chip), not 1 per sibling"
+    (let [;; 10 keys: 2 modified, 8 unchanged.
+          before   (into {} (for [i (range 10)] [(keyword (str "k" i)) i]))
+          after    (assoc before :k0 :changed :k1 :changed)
+          tree     (at/diff-tree before after)]
+      ;; Total nodes via the new counter:
+      ;;   container (1) + 2 :modified (2) + 1 :same-chip (1) = 4
+      ;; Old behaviour would have been: 1 + 2 + 8 = 11.
+      (is (= 4 (sg/count-rendered-nodes tree))
+          "container + 2 changed + 1 chip"))))
+
+(deftest count-rendered-nodes-no-same-children-no-chip
+  (testing "rf2-szzjh: when every child is changed, no chip is charged"
+    (let [before {:a 1 :b 2 :c 3}
+          after  {:a 9 :b 8 :c 7}
+          tree   (at/diff-tree before after)]
+      ;; All children changed → no :same children → no chip.
+      ;;   container (1) + 3 :modified (3) = 4
+      (is (= 4 (sg/count-rendered-nodes tree))))))
+
+(deftest count-rendered-nodes-leaf-ops-count-as-one
+  (testing "rf2-szzjh: each leaf op (:added :removed :modified :same)
+            counts as 1; only :children recurses"
+    (let [tree (at/diff-tree {:a 1} {:a 2})
+          leaf (sg/subtree-at-path tree [:a])]
+      (is (= 1 (sg/count-rendered-nodes leaf))))
+    (let [tree  (at/diff-tree {:a 1 :b 2} {:a 1 :b 2})]
+      ;; All same → root degrades to :same; counts as 1.
+      (is (= 1 (sg/count-rendered-nodes tree))))))
+
+(deftest count-rendered-nodes-recursion-skips-only-same-children
+  (testing "rf2-szzjh: non-:same children still recurse normally — a
+            nested `:children` subtree's cost still contributes verbatim"
+    (let [;; outer container has one :modified and one :children child
+          ;; (which itself has nested changes); :same siblings stay flat.
+          before {:outer {:inner-changed {:x 1 :y 2}
+                          :inner-same    "stable"}
+                  :touched 0
+                  :pad-a 1 :pad-b 2 :pad-c 3}
+          after  {:outer {:inner-changed {:x 9 :y 8}
+                          :inner-same    "stable"}
+                  :touched 1
+                  :pad-a 1 :pad-b 2 :pad-c 3}
+          tree   (at/diff-tree before after)]
+      ;; root :children — children: [:outer :children] [:touched :modified]
+      ;;                             + 3 :same (:pad-a/b/c)
+      ;; root count = 1
+      ;;            + count(:outer) + count(:touched)   ; non-same recurse
+      ;;            + 1                                  ; the :same chip
+      ;; :outer count = 1 (container)
+      ;;              + count(:inner-changed)            ; non-same
+      ;;              + 1                                ; :same chip for :inner-same
+      ;; :inner-changed count = 1 (container)
+      ;;                      + 2 :modified
+      ;;                      + 0 (no :same children)
+      ;;                      = 3
+      ;; :outer = 1 + 3 + 1 = 5
+      ;; :touched = 1
+      ;; root = 1 + 5 + 1 + 1 = 8
+      (is (= 8 (sg/count-rendered-nodes tree))))))
+
+;; ---- (8) pg/large-multi-tier regression --------------------------------
+;;
+;; rf2-szzjh + rf2-ogkh0. The corpus pathology: 50 new catalog SKUs
+;; merged into a 200-key catalog map. Pre-fix counter reported 251 for
+;; the [:catalog] subtree, defeated every (depth, context) ≤ 250, and
+;; shattered the cluster into 50 singleton sections. Post-fix the
+;; counter reports ≈52 (1 + 50 changed + 1 chip), well under the
+;; default budget; the cluster survives as one section.
+
+(defn- catalog-pad
+  "Build a 200-key catalog map of stable `:sku-NNN` entries."
+  []
+  (into {} (for [i (range 200)]
+             [(keyword (str "sku-" (format "%03d" i)))
+              {:price (* i 7) :stock (mod i 13)}])))
+
+(defn- catalog-with-new
+  "Catalog after merge: pad + 50 new `:sku-new-NNN` entries."
+  []
+  (merge (catalog-pad)
+         (into {} (for [i (range 50)]
+                    [(keyword (str "sku-new-" (format "%03d" i)))
+                     {:price (* i 11) :stock (mod i 9)}]))))
+
+(deftest large-multi-tier-counter-no-longer-walks-same-cluster
+  (testing "rf2-szzjh + rf2-ogkh0 pg/large-multi-tier: the counter cost
+            of the [:catalog] subtree (50 changed + 200 unchanged keys)
+            tracks the renderer's chip-collapse — small upper bound
+            (~52: container + 50 changes + 1 chip), NOT the 251-node
+            pre-fix verbatim walk that defeated every (depth, context)
+            ≤ 250 in the rf2-ogkh0 sweep."
+    (let [before    {:catalog (catalog-pad)}
+          after     {:catalog (catalog-with-new)}
+          tree      (at/diff-tree before after)
+          catalog   (sg/subtree-at-path tree [:catalog])
+          cost      (sg/count-rendered-nodes catalog)]
+      (is (= :children (at/op-of catalog))
+          ":catalog subtree is a :children container post-diff")
+      ;; Tight upper bound: 1 (container) + 50 (:added leaves) + 1 (chip) = 52.
+      ;; Pre-fix this would have been 1 + 50 + 200 = 251.
+      (is (= 52 cost)
+          (str "expected ~52 (chip-aware), got " cost
+               " — pre-fix the counter walked the :same cluster verbatim "
+               "and reported 251.")))))
+
+(deftest large-multi-tier-coalesces-at-fixed-budget
+  (testing "rf2-szzjh + rf2-ogkh0 pg/large-multi-tier: at a budget that
+            accommodates the 50 changes (context=60), the [:catalog]
+            cluster survives as ONE section. Pre-fix even context=250
+            shattered it into 50 singleton sections."
+    (let [before   {:catalog (catalog-pad)
+                    :auth    {:user {:name "alice"}}
+                    :cart    {:items [{:id 7 :qty 1}]}}
+          after    {:catalog (catalog-with-new)
+                    :auth    {:user {:name "alice" :last-seen 42}}
+                    :cart    {:items [{:id 7 :qty 1} {:id 22 :qty 1}]}}
+          tree     (at/diff-tree before after)
+          ;; context=60 chosen to clear the 52-node :catalog cost. The
+          ;; depth=2 budget lets [:auth :user :last-seen] coalesce up to
+          ;; [:auth :user], [:cart :items 1] up to [:cart :items].
+          sections (sg/group-into-sections tree
+                                           {:max-coalesce-depth    2
+                                            :max-unchanged-context 60})
+          paths    (set (map :path sections))]
+      ;; Expected: 3 sections — [:catalog], [:auth :user], [:cart :items].
+      ;; Pre-fix this shattered into 52 under ANY context ≤ 250.
+      (is (= 3 (count sections))
+          (str "expected 3 sections, got " (count sections)
+               ": " (mapv :path sections)))
+      (is (contains? paths [:catalog])
+          ":catalog stays coalesced (post-fix; pre-fix shattered into 50 shards)")
+      (is (or (contains? paths [:auth :user])
+              (contains? paths [:auth :user :last-seen]))
+          "auth section present")
+      (is (or (contains? paths [:cart :items])
+              (contains? paths [:cart]))
+          "cart section present"))))
+
+(deftest medium-multi-tier-coalesces-at-default-budget
+  (testing "rf2-szzjh: a smaller variant of the same shape — 10 new
+            catalog keys merged into a 40-key catalog — coalesces into
+            ONE [:catalog] section at the tuned default (depth=2,
+            context=40) post-fix. The chip-aware counter prevents the
+            200-sibling shatter; the smaller change-count fits the
+            default budget."
+    (let [pad      (into {} (for [i (range 40)]
+                              [(keyword (str "sku-" i)) {:price i}]))
+          extras   (into {} (for [i (range 10)]
+                              [(keyword (str "sku-new-" i)) {:price (+ 100 i)}]))
+          before   {:catalog pad}
+          after    {:catalog (merge pad extras)}
+          tree     (at/diff-tree before after)
+          ;; Tuned default — depth=2, context=40 (rf2-ogkh0).
+          sections (sg/group-into-sections tree)]
+      (is (= 1 (count sections))
+          (str "expected 1 section, got " (count sections)
+               ": " (mapv :path sections)))
+      (is (= [:catalog] (:path (first sections)))))))

--- a/tools/causa/test/day8/re_frame2_causa/diff/section_grouping_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/diff/section_grouping_cljs_test.cljc
@@ -42,18 +42,47 @@
 
 ;; ---- (1) cart-cascade worked example -----------------------------------
 
-(deftest cart-cascade-four-sections
-  (testing "design §3.1.1 worked example: cart cascade → 4 sections"
+(deftest cart-cascade-five-sections-at-tuned-defaults
+  (testing "cart cascade at tuned default depth=2 (rf2-ogkh0) → 5
+            sections. The [:cart :items 1 :qty] change point is 3
+            levels deep from [:cart]; depth=2 keeps it at [:cart
+            :items] rather than promoting up to [:cart], so the
+            sibling [:cart :gross] singleton stands as its own
+            section (promoted from [:cart :gross] up to [:cart] by
+            singleton-promote).
+
+            Sections: [:cart] (gross singleton promoted to parent),
+            [:cart :items] (items cluster), [:user :prefs] (theme
+            singleton), [:status], [:flash]. Pre-tune (depth=3) this
+            shape collapsed both cart change-points into a single
+            [:cart] section (4 sections total); depth=2 preserves
+            slice-identity per the findings doc §4.2 'per-feature
+            breadcrumbs'."
     (let [tree     (at/diff-tree cart-before cart-after)
           sections (sg/group-into-sections tree)]
-      ;; Sections: [:cart] (items + gross), [:user :prefs] (theme),
-      ;; [:status], [:flash]. Per design — the depth-3 coalescence
-      ;; swallows the inner [:cart :items] + [:cart :gross] changes
-      ;; into one [:cart] section.
-      (is (= 4 (count sections))
-          (str "expected 4 sections, got "
+      (is (= 5 (count sections))
+          (str "expected 5 sections, got "
                (count sections) ": "
                (mapv :path sections)))
+      (let [paths (set (map :path sections))]
+        (is (contains? paths [:cart])
+            "[:cart :gross] singleton promotes to [:cart]")
+        (is (contains? paths [:cart :items])
+            "[:cart :items] cluster (items 1 :qty + items 2)")
+        (is (contains? paths [:user :prefs])
+            "[:user :prefs] singleton promoted from [:user :prefs :theme]")
+        (is (contains? paths [:status]))
+        (is (contains? paths [:flash]))))))
+
+(deftest cart-cascade-four-sections-at-depth-3
+  (testing "with the legacy depth=3 budget the cart cascade collapses
+            [:cart :gross] + [:cart :items …] into a single [:cart]
+            section, yielding 4 sections. Documents the pre-tune
+            behaviour explicitly so the move to depth=2 is visible in
+            the test corpus."
+    (let [tree     (at/diff-tree cart-before cart-after)
+          sections (sg/group-into-sections tree {:max-coalesce-depth 3})]
+      (is (= 4 (count sections)))
       (let [paths (set (map :path sections))]
         (is (contains? paths [:cart]))
         (is (contains? paths [:user :prefs]))
@@ -148,14 +177,15 @@
       ;; depth 0 means even sibling pairs don't merge.
       (is (= 2 (count sections))))))
 
-(deftest heuristic-depth-3-coalesces-cart
-  (testing "max-coalesce-depth=3 (default): cart cascade collapses to
-            4 sections (verified in cart-cascade-four-sections)"
+(deftest heuristic-depth-2-coalesces-cart
+  (testing "max-coalesce-depth=2 (tuned default, rf2-ogkh0): cart
+            cascade lands at 5 sections (verified in
+            cart-cascade-five-sections-at-tuned-defaults)"
     ;; Already covered above; repeated for explicit sweep parity.
     (let [tree     (at/diff-tree cart-before cart-after)
           sections (sg/group-into-sections tree
-                                           {:max-coalesce-depth 3})]
-      (is (= 4 (count sections))))))
+                                           {:max-coalesce-depth 2})]
+      (is (= 5 (count sections))))))
 
 (deftest heuristic-depth-5-still-respects-root
   (testing "even with a wide depth-5 budget, root-level
@@ -300,10 +330,13 @@
 ;; default budget; the cluster survives as one section.
 
 (defn- catalog-pad
-  "Build a 200-key catalog map of stable `:sku-NNN` entries."
+  "Build a 200-key catalog map of stable `:sku-NNN` entries.
+  Uses `(str i)` rather than zero-padded ids — `format` isn't on the
+  CLJS reader's standard surface, and the leading zeros aren't load-
+  bearing for the test (only the cardinality is)."
   []
   (into {} (for [i (range 200)]
-             [(keyword (str "sku-" (format "%03d" i)))
+             [(keyword (str "sku-" i))
               {:price (* i 7) :stock (mod i 13)}])))
 
 (defn- catalog-with-new
@@ -311,7 +344,7 @@
   []
   (merge (catalog-pad)
          (into {} (for [i (range 50)]
-                    [(keyword (str "sku-new-" (format "%03d" i)))
+                    [(keyword (str "sku-new-" i))
                      {:price (* i 11) :stock (mod i 9)}]))))
 
 (deftest large-multi-tier-counter-no-longer-walks-same-cluster


### PR DESCRIPTION
## Summary

- **Fix:** `count-rendered-nodes` mirrors the renderer's `:same`-cluster chip collapse — a `:children` container's `:same` direct children now contribute **1** (the chip), not `count(siblings)`. Discovered by rf2-ogkh0's 53-pair corpus sweep: `pg/large-multi-tier` reported 251 nodes and defeated every (depth, context) ≤ 250.
- **Tune:** ship rf2-ogkh0's recommended section-grouping defaults — `:max-coalesce-depth 2` (was 3), `:max-unchanged-context 40` (was 50).

## Bug repro

`pg/large-multi-tier` shape: 50 new `:catalog/sku-new-*` keys merged into a 200-key map.

| | counter on `[:catalog]` subtree | `group-into-sections` outcome |
| --- | --- | --- |
| Pre-fix | 251 (1 + 50 + 200) | Shattered into 50 singleton `[:catalog :sku-new-*]` sections under any default (or any context ≤ 250) |
| Post-fix | 52 (1 + 50 + 1) | Coalesces as a single `[:catalog]` section at any context ≥ 52 |

The 50 changed leaves still count individually (the renderer shows them as 50 rows); only the 200-`:same` cluster collapses to its chip-representative 1.

## Tuned defaults

rf2-ogkh0's automated sweep — 1325 invocations across `depth ∈ {1..5}` × `context ∈ {20..100}` on 53 real `(before, after)` pairs from `examples/` + `testbeds/` — yielded:

- **depth=2** maximises corpus-ideal coalescence (52/53 entries land in [1,6] sections); higher depths silently up-promote per-feature breadcrumbs to generic container-level heads (`[:rf/machines]`, `[:catalog]`, ...) without changing section counts. Citation: `pg/five-key-changes`, `pg/mixed-ops`, `pf/title-refresh-success`, `tm/toggle-all-on`, `corner/cross-tier-edit`.
- **context=40** is the smallest that handles `corner/vec-grow-deep` (21-item paginate, 24-node `:items` subtree) cleanly. Larger values behave identically across the corpus.

Findings: `ai/findings/2026-05-19-causa-section-grouping-heuristics.md`.

## Test plan

- [x] `tools/causa/test/.../diff/section_grouping_cljs_test.cljc` — new regression tests:
  - `count-rendered-nodes-charges-same-cluster-as-one-chip` — pins the counter's chip-aware accounting on a 10-key (2 changed, 8 unchanged) shape
  - `count-rendered-nodes-no-same-children-no-chip` — no `:same` siblings → no chip charge
  - `count-rendered-nodes-leaf-ops-count-as-one` — each leaf op counts as 1
  - `count-rendered-nodes-recursion-skips-only-same-children` — non-`:same` children recurse normally
  - `large-multi-tier-counter-no-longer-walks-same-cluster` — the rf2-ogkh0 pathology: pre-fix 251, post-fix 52
  - `large-multi-tier-coalesces-at-fixed-budget` — at context=60 the catalog cluster survives as one section
  - `medium-multi-tier-coalesces-at-default-budget` — smaller variant (10/40) coalesces at the tuned (2, 40) defaults
- [x] Cart-cascade tests rebased onto depth=2 (5 sections, not 4; new `cart-cascade-four-sections-at-depth-3` test documents the legacy behaviour)
- [x] All existing test files still green (760 JVM, 2949 CLJS-node, 2940 browser)

## Gates

| gate | result |
| --- | --- |
| `scripts/test-fast-pr.sh` | PASS (2949 / 8432 assertions, 0 failures) |
| `cd implementation && npm run test:cljs` | PASS (rolled into fast-pr) |
| `cd implementation && npm run test:browser` | PASS (2940 / 8375 assertions, 0 failures) |
| `cd implementation && npm run story:build` | PASS (255 files, 200 compiled, 0 warnings) |
| `python -m mkdocs build --strict` | 72 warnings (matches `origin/main` baseline; **no new warnings**) |
| `python scripts/check_doc_slugs.py` | clean (exit 0) |
| `tools/causa` JVM test sweep | 760 tests, 2220 assertions, 0 failures |

Closes rf2-szzjh.