### PR TITLE
fix(story): drop dead rf-causa-mode-pill assertion from causa-rhs-smoke (rf2-dbiut)

### DIFF
--- a/tools/story/testbeds/causa_rhs_smoke/spec.cjs
+++ b/tools/story/testbeds/causa_rhs_smoke/spec.cjs
@@ -17,8 +17,13 @@
  *                                       dispatch-id)
  *   story-trace-cascade-row          →  clicking an L2 event row renders
  *                                       Event-tab cascade detail
- *   story-trace-scrub-note           →  Causa mode pill toggles LIVE ↔
- *                                       RETRO on nav-prev / follow-head
+ *   story-trace-scrub-note           →  (no replacement — the L1 mode
+ *                                       pill that previously carried
+ *                                       LIVE / RETRO was dropped in
+ *                                       PR #1509 / rf2-g9pee; mode is
+ *                                       derivable from spine focus +
+ *                                       `[◀ ▶ ⏭]` cluster, not from a
+ *                                       dedicated DOM surface)
  *
  * Each scenario is a thin regression smoke — one assertion per
  * contract, not an exhaustive walk. Causa's own deep coverage lives in
@@ -207,29 +212,14 @@ module.exports = {
       5000,
     );
 
-    // ----- Scenario 4: mode pill reflects LIVE ↔ RETRO -------------------
+    // ----- (Retired Scenario 4: mode pill reflected LIVE ↔ RETRO) --------
     //
-    // Replacement for retired `story-trace-scrub-note`. The Story-side
-    // hint banner displayed the scrub state; the Causa-side equivalent
-    // is the L1 mode pill (`rf-causa-mode-pill`). After the prev-step
-    // above, the spine is in RETRO + non-head, so per shell.cljs
-    // `mode-pill-text` the pill reads "◐ RETRO". Snapping to head via
-    // nav-head returns the pill to "● LIVE".
-
-    const pill = page.locator('[data-testid="rf-causa-mode-pill"]');
-    await pill.waitFor({ state: 'visible', timeout: 5000 });
-
-    await waitForValue(
-      () => pill.textContent(),
-      (text) => /◐\s*RETRO/.test(text || ''),
-      { timeoutMs: 5000, description: 'mode pill reads RETRO after nav-prev step' },
-    );
-
-    await page.locator('[data-testid="rf-causa-nav-head"]').click();
-    await waitForValue(
-      () => pill.textContent(),
-      (text) => /●\s*LIVE/.test(text || ''),
-      { timeoutMs: 5000, description: 'mode pill returns to LIVE after nav-head snap' },
-    );
+    // The Story-side `story-trace-scrub-note` originally mapped to the
+    // L1 `rf-causa-mode-pill` chip. PR #1509 / rf2-g9pee dropped the
+    // mode-pill entirely: LIVE / RETRO state is derivable from spine
+    // focus (`:focus :mode :head? :paused?`) + the existing
+    // `[◀ ▶ ⏭]` cluster, and Space / L / G keybindings cover the
+    // toggle. No replacement DOM surface exists, so the assertion is
+    // intentionally absent here.
   },
 };


### PR DESCRIPTION
## Summary

- Drop Scenario 4's `[data-testid="rf-causa-mode-pill"]` assertion from `tools/story/testbeds/causa_rhs_smoke/spec.cjs` — the element was removed in PR #1509 (rf2-g9pee) and the smoke has been broken on `origin/main` since.
- Update the retired-scenario mapping comment so `story-trace-scrub-note` records that no Causa-side replacement surface exists.

## Why

PR #1509 / rf2-g9pee dropped the Causa L1 mode-pill entirely as part of the Round-3 bottom-rail removal. The Story-side smoke's Scenario 4 still expected the pill to be present and to toggle LIVE / RETRO, so `causa-rhs-smoke` failed end-to-end on every fresh checkout. Discovered by the rf2-qd5r6 worker while wrapping PR #1512.

## Decision

Option (a): drop the assertion, do not replace it.

Per rf2-g9pee's settled posture: LIVE / RETRO state is derivable from spine focus (`:focus :mode :head? :paused?`) plus the existing `[◀ ▶ ⏭]` ribbon cluster, and Space / L / G keybindings preserve the toggle. No dedicated DOM surface carries the mode anymore, so there is nothing to re-bind the assertion to. Restoring the test-id in Causa source was explicitly rejected upstream (pre-alpha masterpiece — no back-compat shims).

The Causa cljs regression guard (`tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs` — asserting the mode-pill is absent) is intentionally untouched: it is the load-bearing test that proves rf2-g9pee's removal stuck.

## Test plan

- [x] `causa-rhs-smoke` now passes (was failing on `origin/main`)
- [x] `scripts/test-fast-pr.sh` — PASS
- [x] `cd implementation && npm run test:cljs` — 2941 tests / 8412 assertions, 0 failures
- [x] `cd implementation && npm run test:browser` — 2932 tests / 8355 assertions, 0 failures
- [x] `cd implementation && npm run story:build` — PASS
- [x] `mkdocs build --strict` — 72 warnings unchanged (pre-existing baseline; this PR touches no doc files)
- [x] `python scripts/check_doc_slugs.py` — clean