### PR TITLE
feat(causa): event-row datetime as relative chip 'N{s|m|h|d} ago' (rf2-vbbq0)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -200,7 +200,7 @@ below remains the canonical shape; this callout records what the
 
 ### Row anatomy
 
-ONE row shape, decorated by gutter glyph + right-aligned icon badges + trailing redaction marker:
+ONE row shape, decorated by gutter glyph + right-aligned icon badges + trailing redaction marker + trailing relative-time chip:
 
 ```
 │ Col          │ Width        │ Content                              │
@@ -209,7 +209,22 @@ ONE row shape, decorated by gutter glyph + right-aligned icon badges + trailing 
 │ Event id     │ flex mono    │ :order/submit (long-keyword treated) │
 │ Badges       │ up to 3×16px │ ⚠ 🌐 🤖 (right-aligned)              │
 │ Red. marker  │ inline 80px  │ [● REDACTED N] / [● ELIDED N]        │
+│ Time chip    │ inline ≥30px │ now / 5s / 2m / 1h / 3d (right-aligned)│
 ```
+
+#### Relative-time chip (rf2-vbbq0)
+
+Each row carries a trailing right-aligned chip showing how long ago the cascade was dispatched. The chip's bucket strategy keeps old chips visually stable:
+
+| Diff               | Display |
+|---|---|
+| `< 1s`             | `now`   |
+| `< 60s`            | `Ns`    |
+| `< 60min`          | `Nm`    |
+| `< 24h`            | `Nh`    |
+| `≥ 24h`            | `Nd`    |
+
+A process-global 1s `setInterval` dispatches `:rf.causa/relative-time-tick` into the `:rf/causa` frame; the resulting trace event is filtered at ingest by `trace-bus/causa-internal-event?` so the tick never lands in the user-facing event list. The chip's `:title` attribute carries the absolute walltime (`HH:MM:SS · ISO · epoch-ms`) as the power-user reveal — hover the chip for the precise time without leaving L2. Replaces the v1 absolute datetime column dropped in Round-3 R3-C.
 
 #### Gutter glyphs
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -267,6 +267,29 @@
         (let [cascades (projection/group-cascades buffer)]
           (into [] (remove trace-bus/causa-internal-cascade?) cascades))))
 
+    ;; ---- L2 relative-time chip ticker (rf2-vbbq0) -----------------
+    ;;
+    ;; Every L2 row carries a small right-aligned chip showing how long
+    ;; ago the cascade was dispatched ("5s" / "2m" / "1h" / "3d"). A
+    ;; process-global `defonce` `setInterval` in `shell.cljs` dispatches
+    ;; `:rf.causa/relative-time-tick` once per second; the handler stamps
+    ;; the current wall clock into `:rf.causa/relative-time-now-ms` so
+    ;; the L2 view's subscribe re-fires every tick and the chip text
+    ;; recomputes against the latest now.
+    ;;
+    ;; `:rf.trace/no-emit? true` keeps the per-second tick out of the
+    ;; trace buffer (defence-in-depth — the ticker also targets
+    ;; `:rf/causa` so `trace-bus/causa-internal-event?` would drop the
+    ;; envelope at ingest anyway).
+    (rf/reg-sub :rf.causa/relative-time-now-ms
+      (fn [db _query]
+        (get db :rf.causa/relative-time-now-ms)))
+
+    (rf/reg-event-db :rf.causa/relative-time-tick
+      {:rf.trace/no-emit? true}
+      (fn [db [_ now-ms]]
+        (assoc db :rf.causa/relative-time-now-ms now-ms)))
+
     ;; ---- 4-layer chrome events (rf2-xy4yb / spec/018) -------------
 
     ;; L3 tab bar — flip the active tab. Six valid ids per spec/018 §5:

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -100,6 +100,7 @@
   `mount.cljs`. No per-substrate switches in view code."
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
@@ -297,6 +298,144 @@
       warn?    (conj "⚠")
       http?    (conj "🌐")
       machine? (conj "🤖"))))
+
+;; ---- Relative-time chip (rf2-vbbq0) --------------------------------------
+;;
+;; Each L2 row carries a small right-aligned chip showing how long ago the
+;; cascade was dispatched ("5s", "2m", "1h", "3d"). Mike's design call
+;; (2026-05-19 Q10): bring datetime BACK to the default row, but as a
+;; dynamic relative chip — NOT an absolute timestamp, NOT the sequence
+;; number (dropped in R3-C), NOT the duration (not interesting).
+;;
+;; Bucketing keeps the chip silent-by-default — an old row that reads "5m"
+;; does not jitter second-by-second because the same minute-bucket maps
+;; back to "5m" regardless of the exact second inside the bucket. Buckets:
+;;
+;;   diff <   1s            → "now"
+;;   diff < 60s              → "Ns"
+;;   diff < 60min            → "Nm"
+;;   diff < 24h              → "Nh"
+;;   diff ≥ 24h              → "Nd"
+;;
+;; The view subscribes to a re-frame sub `:rf.causa/relative-time-now-ms`
+;; that is bumped by a `defonce` `setInterval` once per second. The tick
+;; event is namespaced under `:rf.causa/*` and dispatched against the
+;; `:rf/causa` frame, so per `trace-bus/causa-internal-event?` it is
+;; filtered out at ingest — the user's L2 list never sees it.
+
+(defn format-relative-time
+  "Pure helper. Given two epoch-ms values (current time + the cascade's
+  dispatched-time), returns the chip display string per the bucket
+  contract in the section comment above. Nil-safe on `then-ms` (returns
+  the empty string so the caller can decide whether to render anything).
+
+  Pure-data, JVM-runnable so callers can spec-test it without a CLJS
+  runtime."
+  [now-ms then-ms]
+  (if (or (nil? then-ms) (nil? now-ms))
+    ""
+    (let [diff-ms (max 0 (- now-ms then-ms))
+          s      (quot diff-ms 1000)]
+      (cond
+        (< diff-ms 1000)  "now"
+        (< s 60)          (str s "s")
+        (< s 3600)        (str (quot s 60) "m")
+        (< s 86400)       (str (quot s 3600) "h")
+        :else             (str (quot s 86400) "d")))))
+
+(defn format-absolute-time
+  "CLJS-side helper. Given an epoch-ms (the cascade's dispatched
+  `:time`), returns an absolute-time tooltip string for the chip's
+  `:title` attribute. Used as the power-user reveal that complements
+  the relative chip — clicking the row still opens the Event lens, but
+  a hover shows the precise walltime + epoch-ms.
+
+  Returns the empty string when `then-ms` is nil so the caller can
+  decide whether to attach the tooltip."
+  [then-ms]
+  (if (or (nil? then-ms) (not (exists? js/Date)))
+    ""
+    (let [d   (js/Date. then-ms)
+          iso (.toISOString d)
+          loc (.toLocaleTimeString d)]
+      (str loc " · " iso " (epoch-ms " then-ms ")"))))
+
+(defn cascade-dispatched-time-ms
+  "Pluck the cascade's dispatched-time from `:dispatched :time` (every
+  trace event carries `:time (interop/now-ms)` per `re-frame.trace.cljc
+  build-event`). Returns nil when the cascade has no `:dispatched`
+  slot or the slot's `:time` is not a number — defence-in-depth for
+  cascades synthesised by tests that omit the field."
+  [cascade]
+  (let [t (get-in cascade [:dispatched :time])]
+    (when (number? t) t)))
+
+(defn relative-time-chip
+  "Render the L2 row's right-aligned relative-time chip. `now-ms` is the
+  current wall clock supplied by the L2 view (sourced from the
+  `:rf.causa/relative-time-now-ms` sub so all rows tick coherently).
+  Renders nothing when the cascade carries no dispatched-time stamp."
+  [cascade now-ms]
+  (when-let [then-ms (cascade-dispatched-time-ms cascade)]
+    (let [now      (or now-ms (interop/now-ms))
+          label    (format-relative-time now then-ms)
+          tooltip  (format-absolute-time then-ms)]
+      [:span {:data-testid     "rf-causa-row-time-chip"
+              :data-then-ms    (str then-ms)
+              :title           tooltip
+              :style {:color         (:text-tertiary tokens)
+                      :flex-shrink   0
+                      :font-family   mono-stack
+                      :font-size     (:caption type-scale)
+                      :margin-left   "4px"
+                      :min-width     "30px"
+                      :text-align    "right"
+                      :white-space   "nowrap"}}
+       label])))
+
+;; ---- Relative-time ticker (rf2-vbbq0) ------------------------------------
+;;
+;; A single process-global ticker drives every L2 row's chip. A
+;; `setInterval` at 1s cadence dispatches `:rf.causa/relative-time-tick`
+;; into the `:rf/causa` frame; the event-db handler writes `(interop/
+;; now-ms)` into the `:rf.causa/relative-time-now-ms` slot, and the
+;; chip's parent (`event-list`) subscribes to that value. The ticker's
+;; trace events carry `:frame :rf/causa` so `trace-bus/causa-internal-
+;; event?` drops them at ingest (no buffer pressure, no L2 self-noise).
+;;
+;; `defonce` + idempotent start guard keeps shadow-cljs `:after-load`
+;; from spinning up a second timer. The interval handle is held on the
+;; defonce so a future teardown can clear it; today nothing calls clear.
+
+(defonce ^:private relative-time-ticker-state
+  ;; `{:handle <setInterval-id-or-nil>}` — defonce so the symbol is
+  ;; preserved across reloads; the inner map is mutated via reset!.
+  (atom {:handle nil}))
+
+(defn- relative-time-tick-cadence-ms
+  "Ticker cadence — 1s. Hoisted to a defn so tests can stub it."
+  []
+  1000)
+
+(defn- start-relative-time-ticker!
+  "Idempotent. Spins up a `setInterval` that dispatches
+  `:rf.causa/relative-time-tick` once per second so every L2 row's
+  chip recomputes against the latest wall clock. No-op when the timer
+  is already running, when `js/setInterval` is absent (some test
+  contexts), or when `js/document` is absent (node-test — no DOM, no
+  rendering, no need to tick). The chip's view falls back to
+  `(interop/now-ms)` at render time until the first tick lands."
+  []
+  (when (and (not (:handle @relative-time-ticker-state))
+             (exists? js/setInterval)
+             (exists? js/document))
+    (let [handle (js/setInterval
+                   (fn []
+                     (rf/dispatch [:rf.causa/relative-time-tick (interop/now-ms)]
+                                  {:frame :rf/causa}))
+                   (relative-time-tick-cadence-ms))]
+      (swap! relative-time-ticker-state assoc :handle handle)))
+  nil)
 
 ;; ---- L1 ribbon -----------------------------------------------------------
 
@@ -757,7 +896,7 @@
   focus-set is active, out-of-focus rows render at ~40% opacity and
   the gutter renders an OPEN `⦿` marker; the pivot row renders a
   FILLED `⦿` marker."
-  [{:keys [cascade focused-id auto-track? focus-set in-focus?]}]
+  [{:keys [cascade focused-id auto-track? focus-set in-focus? now-ms]}]
   (let [id          (:dispatch-id cascade)
         focused?    (= id focused-id)
         pivot?      (and focus-set (= id (:pivot-id focus-set)))
@@ -901,7 +1040,14 @@
                        :color (:yellow tokens)
                        :font-size (:caption type-scale)}}
         (for [b badges]
-          ^{:key b} [:span b])])]))
+          ^{:key b} [:span b])])
+     ;; Relative-time chip (rf2-vbbq0). Right-aligned per Mike's design
+     ;; (2026-05-19 Q10) — "active-cascade-visibility" calls for the chip
+     ;; to ride on the row body rather than hide behind a hover tooltip.
+     ;; The chip itself carries an absolute-time `:title` tooltip as the
+     ;; power-user reveal. Rendered LAST so it sits flush right against
+     ;; the row's trailing edge.
+     (relative-time-chip cascade now-ms)]))
 
 (rf/reg-view event-list
   "L2 event list — per spec/018 §4 Event list. Single-line rows,
@@ -947,9 +1093,19 @@
   ;; mounted by the shell-view); defonce + DOM guards keep it a
   ;; no-op everywhere it matters.
   (inject-scrollbar-style!)
+  ;; rf2-vbbq0 — kick the relative-time ticker on first paint. The
+  ;; `defonce` + handle guard keeps it a single timer regardless of
+  ;; mount cycles / shadow-cljs `:after-load` reloads.
+  (start-relative-time-ticker!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
         focus          @(rf/subscribe [:rf.causa/focus])
         focus-set      @(rf/subscribe [:rf.causa/focus-set])
+        ;; rf2-vbbq0 — one subscribe per render drives every chip's
+        ;; relative-time text. Falls back to `(interop/now-ms)` before
+        ;; the first tick lands so the chips render correctly on the
+        ;; first paint (which beats the 1s tick cadence).
+        now-ms         (or @(rf/subscribe [:rf.causa/relative-time-now-ms])
+                           (interop/now-ms))
         focused-id     (:dispatch-id focus)
         ;; LIVE+head+not-paused = the auto-tracking branch from
         ;; spine/compose-focus. Only here do we want scroll-into-view
@@ -994,7 +1150,8 @@
                            :focused-id  focused-id
                            :auto-track? auto-track?
                            :focus-set   focus-set
-                           :in-focus?   (focus-pred cascade)}])))]))
+                           :in-focus?   (focus-pred cascade)
+                           :now-ms      now-ms}])))]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -185,6 +185,8 @@
    :rf.causa/modal-positioning
    ;; rf2-x8h9y — horizontal resize handle width.
    :rf.causa/panel-width-px
+   ;; rf2-vbbq0 — L2 row relative-time chip clock (1s ticker writes here).
+   :rf.causa/relative-time-now-ms
    :rf.causa/selected-tab
    ;; rf2-9poxq — Settings popup subs.
    :rf.causa/setting
@@ -302,6 +304,9 @@
    :rf.causa/palette-toggle
    :rf.causa/pin-slice
    :rf.causa/preview-cascade
+   ;; rf2-vbbq0 — L2 row relative-time chip ticker (writes `:rf.causa/
+   ;; relative-time-now-ms` once per second so chips recompute coherently).
+   :rf.causa/relative-time-tick
    :rf.causa/remove-filter
    :rf.causa/reorder-pinned-slices
    ;; rf2-x8h9y — resize-handle double-click reset.
@@ -456,8 +461,8 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    (is (= 100 (count all-sub-names)))
-    (is (= 117 (count all-event-names)))
+    (is (= 101 (count all-sub-names)))
+    (is (= 118 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -1213,3 +1213,190 @@
     (rf/with-frame :rf/causa
       (is (= :fixed @(rf/subscribe [:rf.causa/modal-positioning]))
           "no-opt render re-defaults the slot to :fixed"))))
+
+;; -------------------------------------------------------------------------
+;; (N) L2 row — relative-time chip (rf2-vbbq0)
+;; -------------------------------------------------------------------------
+;;
+;; Mike's design call (2026-05-19 Q10): bring datetime BACK to the
+;; default L2 row, but as a dynamic relative chip ("5s" / "2m" / "1h" /
+;; "3d") — NOT an absolute timestamp, NOT seq#, NOT duration. Placement
+;; is INLINE on the row, right-aligned, so active cascades stay visible
+;; without forcing a hover.
+;;
+;; Bucket contract:
+;;
+;;   diff < 1s   → "now"
+;;   diff < 60s  → "Ns"     (1s-resolution; jitters per tick while young)
+;;   diff < 60m  → "Nm"     (minute-bucket; old chips stay stable)
+;;   diff < 24h  → "Nh"
+;;   diff ≥ 24h  → "Nd"
+
+(deftest format-relative-time-now-bucket
+  (testing "rf2-vbbq0 — diff < 1s collapses to the 'now' silent-by-
+            default bucket so jitter at the millisecond boundary never
+            renders to the user."
+    (is (= "now" (shell/format-relative-time 1000 1000)))
+    (is (= "now" (shell/format-relative-time 1500 1000)))
+    (is (= "now" (shell/format-relative-time 1999 1000)))))
+
+(deftest format-relative-time-seconds-bucket
+  (testing "rf2-vbbq0 — diff in [1s, 60s) renders as 'Ns'."
+    (is (= "1s"  (shell/format-relative-time 2000   1000)))
+    (is (= "5s"  (shell/format-relative-time 6000   1000)))
+    (is (= "59s" (shell/format-relative-time 60000  1000)))))
+
+(deftest format-relative-time-minutes-bucket
+  (testing "rf2-vbbq0 — diff in [60s, 60m) renders as 'Nm' — the minute
+            bucket so an old row's chip does not jitter per tick."
+    (is (= "1m" (shell/format-relative-time 61000     1000)))
+    (is (= "1m" (shell/format-relative-time 90000     1000)))
+    (is (= "2m" (shell/format-relative-time 121000    1000)))
+    (is (= "5m" (shell/format-relative-time 301000    1000)))
+    (is (= "59m" (shell/format-relative-time 3541000  1000)))))
+
+(deftest format-relative-time-hours-bucket
+  (testing "rf2-vbbq0 — diff in [60m, 24h) renders as 'Nh'."
+    (is (= "1h" (shell/format-relative-time 3601000      1000)))
+    (is (= "1h" (shell/format-relative-time 3700000      1000)))
+    (is (= "2h" (shell/format-relative-time 7300000      1000)))
+    (is (= "23h" (shell/format-relative-time (+ 1000 (* 23 3600 1000)) 1000)))))
+
+(deftest format-relative-time-days-bucket
+  (testing "rf2-vbbq0 — diff ≥ 24h renders as 'Nd'."
+    (is (= "1d" (shell/format-relative-time (+ 1000 (* 24 3600 1000)) 1000)))
+    (is (= "3d" (shell/format-relative-time (+ 1000 (* 72 3600 1000)) 1000)))))
+
+(deftest format-relative-time-clamps-negative-diff
+  (testing "rf2-vbbq0 — a then-ms larger than now-ms (clock skew /
+            test stub ordering) clamps to 0 → 'now' rather than rendering
+            a negative chip."
+    (is (= "now" (shell/format-relative-time 1000 5000)))))
+
+(deftest format-relative-time-nil-safe
+  (testing "rf2-vbbq0 — nil inputs short-circuit so the caller can decide
+            whether to render anything."
+    (is (= "" (shell/format-relative-time nil  1000)))
+    (is (= "" (shell/format-relative-time 1000 nil)))
+    (is (= "" (shell/format-relative-time nil  nil)))))
+
+(deftest cascade-dispatched-time-ms-reads-dispatched-slot
+  (testing "rf2-vbbq0 — the chip's source-of-truth for the cascade's
+            walltime is `:dispatched :time`. Each trace event carries
+            `:time (interop/now-ms)` per `re-frame.trace.cljc build-event`."
+    (is (= 1234567 (shell/cascade-dispatched-time-ms
+                     {:dispatch-id 1
+                      :dispatched  {:time 1234567}})))
+    (is (nil? (shell/cascade-dispatched-time-ms {:dispatch-id 1}))
+        "no :dispatched slot → nil")
+    (is (nil? (shell/cascade-dispatched-time-ms
+                {:dispatch-id 1 :dispatched {}}))
+        "dispatched slot without :time → nil")
+    (is (nil? (shell/cascade-dispatched-time-ms
+                {:dispatch-id 1 :dispatched {:time "not-a-number"}}))
+        "non-numeric :time is treated as absent — defence-in-depth")))
+
+(defn- dispatch-trace-ev-with-time
+  "Variant of `dispatch-trace-ev` that stamps the trace event's `:time`
+  so the cascade's `:dispatched :time` carries the chip's reference."
+  [id event-vec time-ms]
+  (assoc (dispatch-trace-ev id event-vec) :time time-ms))
+
+(deftest event-row-renders-relative-time-chip
+  (testing "rf2-vbbq0 — every L2 row carries a right-aligned relative-
+            time chip. The chip's text reflects the bucket; the chip's
+            `:title` carries the absolute walltime for the power-user
+            reveal."
+    (causa-setup!)
+    (let [now-ms     1000000
+          then-ms    (- now-ms 5000)]  ;; 5 seconds ago
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      (rf/with-frame :rf/causa
+        ;; Seed the now-ms so the chip's display is deterministic.
+        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              chip (find-by-testid tree "rf-causa-row-time-chip")
+              attrs (second chip)
+              label (text-nodes chip)]
+          (is (some? chip) "chip renders per row")
+          (is (= "5s" label) "chip text reflects the seconds-bucket")
+          (is (string? (:title attrs))
+              "chip carries a :title tooltip for the power-user reveal")
+          (is (re-find #"epoch-ms" (:title attrs))
+              "tooltip carries the epoch-ms")
+          (is (= (str then-ms) (:data-then-ms attrs))
+              "chip stamps the source then-ms so tests can pin the value"))))))
+
+(deftest event-row-chip-now-bucket
+  (testing "rf2-vbbq0 — a row at t=0 (chip seeded with same now) renders
+            the 'now' bucket."
+    (causa-setup!)
+    (let [now-ms 1000000]
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] now-ms))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              chip (find-by-testid tree "rf-causa-row-time-chip")]
+          (is (= "now" (text-nodes chip))
+              "diff = 0 → 'now' bucket"))))))
+
+(deftest event-row-chip-minute-bucket
+  (testing "rf2-vbbq0 — at t+90s the chip rolls into the minute bucket
+            and reads '1m' (not '90s')."
+    (causa-setup!)
+    (let [now-ms  1000000
+          then-ms (- now-ms 90000)]
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              chip (find-by-testid tree "rf-causa-row-time-chip")]
+          (is (= "1m" (text-nodes chip))
+              "90s ago → '1m' (minute bucket; jitter dampened)"))))))
+
+(deftest event-row-chip-hour-bucket
+  (testing "rf2-vbbq0 — at t+3700s the chip rolls into the hour bucket
+            and reads '1h'."
+    (causa-setup!)
+    (let [now-ms  10000000
+          then-ms (- now-ms 3700000)] ;; 3700s ≈ 1h2m
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              chip (find-by-testid tree "rf-causa-row-time-chip")]
+          (is (= "1h" (text-nodes chip))
+              "3700s ago → '1h'"))))))
+
+(deftest event-row-chip-absent-when-no-dispatched-time
+  (testing "rf2-vbbq0 — defence-in-depth: a synthesised cascade carrying
+            no `:dispatched :time` (registry-time emits, stripped-down
+            fixtures) renders no chip rather than a misleading 'now'."
+    (causa-setup!)
+    ;; dispatch-trace-ev (without time stamp) — :dispatched slot will
+    ;; lack `:time`, so the chip MUST NOT render.
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            chip (find-by-testid tree "rf-causa-row-time-chip")]
+        (is (nil? chip)
+            "chip is absent when the cascade has no dispatched :time")))))
+
+(deftest relative-time-now-ms-sub-reads-app-db-slot
+  (testing "rf2-vbbq0 — the `:rf.causa/relative-time-now-ms` sub returns
+            whatever the tick event stamped into the slot. Nil before
+            the first tick lands; the L2 view falls back to `(interop/
+            now-ms)` so chips still render on the first paint."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (is (nil? @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "no value before the first tick lands"))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/relative-time-tick 42]))
+    (rf/with-frame :rf/causa
+      (is (= 42 @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "sub returns whatever the tick handler wrote"))))


### PR DESCRIPTION
## Summary

L2 event-list rows now carry a small right-aligned relative-time chip
("now" / "5s" / "2m" / "1h" / "3d") showing how long ago each cascade
was dispatched. Mike's design call (2026-05-19 Q10): bring datetime
BACK to the default row — but as a dynamic relative chip, NOT an
absolute timestamp, NOT seq#, NOT duration. Replaces the v1 datetime
column that Round-3 R3-C dropped.

## Behaviour

### Placement (option a — inline)

Chip renders on the row body, right-aligned, after the badge cluster:

```
◉ :app/click          🌐 🤖   5s
● :order/submit                2m
● :auth/login                  1h
```

Lean (a) over hover-only (b) for active-cascade visibility: the
freshness signal is the point — hiding it behind hover loses the
"is this row current?" read at a glance. The chip itself carries an
absolute-walltime `:title` tooltip (`HH:MM:SS · ISO · epoch-ms`) as
the power-user reveal — hover the chip to see the precise time
without leaving L2.

### Bucket strategy

Bucketing keeps old chips visually stable — an "Nm" row does not
jitter per tick because the same minute-bucket maps back to the
same display regardless of the exact second inside it:

| Diff | Display |
|---|---|
| `< 1s` | `now` |
| `< 60s` | `Ns` |
| `< 60min` | `Nm` |
| `< 24h` | `Nh` |
| `≥ 24h` | `Nd` |

### Ticker throttling

A process-global 1s `setInterval` (defonce + idempotent start guard)
dispatches `:rf.causa/relative-time-tick` against the `:rf/causa`
frame; `trace-bus/causa-internal-event?` drops the resulting trace at
ingest so the tick never lands in the user-facing event list. The L2
view subscribes to `:rf.causa/relative-time-now-ms` so all rows tick
coherently; falls back to `(interop/now-ms)` before the first tick
lands so chips render correctly on first paint.

The `:rf.causa/relative-time-tick` event handler is annotated
`:rf.trace/no-emit? true` as defence-in-depth — the per-second
heartbeat is structurally invisible to Causa's own trace surface.

Per-second render cost: 8 visible rows × cheap hiccup chip work,
shared `now-ms` value sub. Bucket-based display ensures the
*displayed text* of older rows is stable across seconds even though
the parent view re-renders.

### Density

Chip fits both Cosy and Compact density: ≥30px min-width with
right-aligned mono-stack caption font; sits flush in the existing
22px tightened row height (rf2-htik0 Bug 2). No row height overflow.

## Test plan

- [x] `format-relative-time` bucket unit tests (now / s / m / h / d)
- [x] Clock-skew clamp (`then > now` → "now", not negative)
- [x] Nil-safety (nil now-ms or nil then-ms → empty string)
- [x] `cascade-dispatched-time-ms` reads `:dispatched :time`; nil-safe
- [x] Row at t=0 shows "now"
- [x] Row at t+5s shows "5s"
- [x] Row at t+90s shows "1m" (minute bucket; jitter dampened)
- [x] Row at t+3700s shows "1h"
- [x] Chip absent when cascade has no dispatched `:time`
- [x] `:rf.causa/relative-time-now-ms` sub returns app-db slot value
- [x] Registry catalogue snapshot (event-name + sub-name + counts)
- [x] `scripts/test-fast-pr.sh` — passes
- [x] `npm run test:cljs` — 2963 tests, 0 failures
- [x] `npm run test:browser` — 2954 tests, 0 failures
- [x] `npm run story:build` — clean
- [x] `mkdocs build --strict` — 72 warnings (baseline; no new)
- [x] `python scripts/check_doc_slugs.py` — clean

Closes rf2-vbbq0.