### PR TITLE
feat(causa): Settings popup expanded to 6 tabs — Keybindings + Buffer + content adds (rf2-ttnst)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -262,16 +262,39 @@ underneath. Closes on `Esc`, click outside, or click `✕`. Settings
 persist immediately on change (no Apply/Cancel — every toggle writes
 through to `(causa-config/configure! …)` on commit).
 
-Six sections (left-rail navigation, right-pane content):
+Six inner tabs (top tab strip, body below) — Mike 2026-05-19 §0ter.4
+walkthrough locks the list (rf2-ttnst):
 
-| Section | Content |
+| # | Tab | Mnemonic | Content |
+|---|---|---|---|
+| 1 | **General** | `g` | Text size · Panel width · Panel position · Auto-open-on-error · Density (Cosy / Compact — no Comfy) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) |
+| 2 | **Theme** | `t` | Dark / Light (accent stays fixed violet; per-tab default-expansion knob dropped) |
+| 3 | **Filters** | `f` | Active filter pills mirror · auto-filter-UI quick-open |
+| 4 | **Keybindings** | `k` | Read-only chord table (every binding the global listener captures) · master "Handle keys?" toggle. v1 is READ-ONLY; rebind UI is the v1.1 follow-on. |
+| 5 | **Buffer** | `b` | `:buffer/retained-epochs` · `:trace-buffer/keep` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" button with confirm modal |
+| 6 | **Diff** | `d` | Hiccup-diff opt-in `:highlight-fn-ref-changes?` toggle (sub-output diff layout fixed unified; section-grouping threshold fixed defaults — both dropped from the user surface) |
+
+**Inner-tab mnemonics** (g / t / f / k / b / d) — bare-letter
+keystrokes captured at the dialog level while the modal is open.
+The dialog's `on-key-down` stops propagation on every consumed key,
+and the global keydown listener gates spine bindings on a
+`target-inside-modal?` check (a `data-rf-causa-mode="settings"`
+closest-walk), so the inner mnemonics do not also drive the outer
+spine. Mnemonics are suppressed while the focused element is an
+`<input>` / `<textarea>` / `<select>` / contenteditable surface so
+typing into numeric knobs is not interrupted.
+
+**Dropped from earlier drafts** (per the same 2026-05-19 walkthrough):
+
+| Dropped | Rationale |
 |---|---|
-| **Filters** | Active filter pills mirror · Recommended-filters quick-add · auto-hide-error-overrides toggle |
-| **View** | Theme (Dark / Light / Dim) · Density (Cosy 28px / Compact 22px / Comfy 36px) · Long-keyword threshold · **Power user:** "Show tool frames in picker" toggle (off by default) |
-| **Keybindings** | Per-action chord editor table; reset-to-defaults |
-| **Buffer** | `:buffer/retained-epochs` · `:trace-buffer/keep` · `:app-db/inspector-collapse-threshold` · "Clear buffer now" |
-| **Popout** | `:popout/width` · `:popout/height` · `:popout/position` · "Open in popout now" |
-| **Actions** | `[factory-reset!]` BIG RED BUTTON · finer-grained resets |
+| Actions tab + factory-reset BIG RED BUTTON | Factory-reset stays code-only (`config/reset-settings!`) — a destructive UI button has no use case the confirm modal beneath "Clear buffer" does not already cover. |
+| Density Comfy tier | Two tiers cover the rhythm need; the third was a styling-pass aspiration with no observed demand. |
+| Per-tab default expansion (`:bookish` / `:dense`) | Each tab owns its expansion default; no global knob. |
+| Accent-violet user swap | Brand accent stays fixed; light/dark theme is the only colour axis. |
+| Sub-output diff layout (`:unified` / `:split` toggle) | Fixed unified. |
+| Section-grouping threshold | Fixed defaults; not user-tuneable. |
+| Popout as its own tab | Folds into General's Panel-position sub-section. |
 
 Full wireframe + per-field configure! mapping in
 [`018-Event-Spine.md`](./018-Event-Spine.md) §9. configure! API

--- a/tools/causa/spec/015-Configuration.md
+++ b/tools/causa/spec/015-Configuration.md
@@ -250,16 +250,56 @@ alone.
 
 ### `:settings`
 
-Bulk-replace the Settings popup state map (rf2-9poxq). Shape mirrors
-the `default-settings` block in `config.cljc`:
+Bulk-replace the Settings popup state map (rf2-9poxq; expanded by
+rf2-ttnst — Mike 2026-05-19 §0ter.4 walkthrough). Shape mirrors the
+`default-settings` block in `config.cljc`:
 
 ```clojure
-{:general   {:text-size           13          ; px; slider range 10–18
-             :panel-position      :right-rail ; :right-rail | :popout | :fullscreen
-             :panel-width-px      480         ; number; clamped [320, 0.9 × viewport-width-px]
-             :auto-open-on-error? false}
- :theme     :dark}                             ; :dark | :light
+{:general   {:text-size              13          ; px; slider range 10–18
+             :panel-position         :right-rail ; :right-rail | :popout | :fullscreen
+             :panel-width-px         480         ; number; clamped [320, 0.9 × viewport-width-px]
+             :auto-open-on-error?    false
+             :density                :cosy       ; #{:cosy :compact} — no :comfy in v1
+             :show-tool-frames?      false       ; reveal :rf/causa + :rf/pair2 in L1 picker
+             :long-keyword-threshold 24}         ; chars; long-keyword elision threshold
+ :theme     :dark                                ; :dark | :light
+ :diff      {:highlight-fn-ref-changes? false}   ; opt-in fn-ref classification
+ :buffer    {:retained-epochs                    200    ; epoch buffer depth
+             :trace-buffer/keep                  1000   ; raw trace-event ring depth
+             :app-db/inspector-collapse-threshold 50}}  ; inspector auto-collapse branching
 ```
+
+The `:general` slot carries three knobs introduced by rf2-ttnst:
+
+- `:density` — `:cosy` (default) or `:compact`. Drives the Views
+  detail rows + App-db diff rows vertical rhythm. The `:comfy` tier
+  catalogued earlier in spec/007-UX-IA.md §Density slider is dropped
+  in v1; persisted `:comfy` values from prior schemas are treated as
+  `:cosy` by the `:rf.causa/density` convenience sub.
+- `:show-tool-frames?` — boolean. When `true` the L1 frame-picker
+  dropdown reveals `:rf/causa` + `:rf/pair2`. Default `false` per
+  spec/007-UX-IA.md §Frame-observation isolation invariants §I1.
+- `:long-keyword-threshold` — integer (chars). Fully-qualified
+  keywords longer than the threshold elide in compact list cells.
+  Default `24`, was previously a fixed constant; now user-tuneable
+  per spec/007-UX-IA.md §Long-keyword treatment.
+
+The `:buffer` slot carries the buffer-depth tunables surfaced in the
+Buffer tab:
+
+- `:retained-epochs` — count of epochs Causa retains in its causal
+  ring. Default `200`.
+- `:trace-buffer/keep` — count of raw trace events kept. Mirrors
+  `trace-bus/default-buffer-depth` (`1000`).
+- `:app-db/inspector-collapse-threshold` — branch factor above which
+  the App-db inspector auto-collapses. Default `50`.
+
+The Buffer tab also exposes a destructive "Clear buffer now" action
+that fires `trace-bus/clear-buffer!` after a confirmation modal
+(`"Clear buffer? This deletes all retained epochs."` → Cancel /
+Clear). The action is dispatch-only and carries no `configure!`
+counterpart; hosts that need a programmatic clear call the trace-bus
+helper directly.
 
 The `:panel-width-px` slot (rf2-x8h9y) drives the
 `:right-rail` panel's horizontal width. The Causa drag handle (per

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -666,13 +666,49 @@
   identity-different references render as `:same` so idiomatic fresh-
   per-render closures don't drown the actual hiccup diff. Flip to
   `true` when diagnosing memoization issues — child re-renders because
-  the parent passes a new fn every time."
-  {:general   {:text-size           13              ; px — slider range 10–18
-               :panel-position      :right-rail     ; :right-rail | :popout | :fullscreen
-               :panel-width-px      default-panel-width-px ; rf2-x8h9y resize handle
-               :auto-open-on-error? false}
+  the parent passes a new fn every time.
+
+  ## :general additions (rf2-ttnst — Settings popup v1 expansion)
+
+  - `:density` (#{:cosy :compact}, default `:cosy`) — vertical-rhythm
+    knob applied to Views detail rows + App-db diff rows. Per Mike's
+    2026-05-19 walkthrough the Comfy tier is dropped; only two
+    densities ship in v1. Consumers read `:rf.causa/density` and
+    branch padding/line-height. Runtime plumbing into individual
+    panels lands incrementally.
+  - `:show-tool-frames?` (boolean, default `false`) — when true the
+    L1 frame picker dropdown reveals tool frames (`:rf/causa`,
+    `:rf/pair2`). OFF by default per spec/007-UX-IA.md §Frame-
+    observation isolation invariant I1.
+  - `:long-keyword-threshold` (integer, default 24) — character count
+    above which a fully-qualified keyword is elided in compact list
+    cells. Per spec/007-UX-IA.md §Long-keyword treatment; was
+    previously a fixed constant.
+
+  ## :buffer section (rf2-ttnst — Settings popup v1 expansion)
+
+  Buffer-depth tunables surfaced in the Buffer tab. All three are
+  numbers; runtime consumption lives in trace-bus + the diff/
+  inspector helpers and may be plumbed incrementally.
+
+  - `:retained-epochs` (default 200) — count of epochs to retain
+    in the causa epoch buffer.
+  - `:trace-buffer/keep` (default 1000) — count of raw trace events
+    to retain (mirrors `trace-bus/default-buffer-depth`).
+  - `:app-db/inspector-collapse-threshold` (default 50) — branch
+    factor above which the App-db inspector collapses by default."
+  {:general   {:text-size              13              ; px — slider range 10–18
+               :panel-position         :right-rail     ; :right-rail | :popout | :fullscreen
+               :panel-width-px         default-panel-width-px ; rf2-x8h9y resize handle
+               :auto-open-on-error?    false
+               :density                :cosy           ; #{:cosy :compact}
+               :show-tool-frames?      false
+               :long-keyword-threshold 24}
    :theme     :dark                                  ; :dark | :light
-   :diff      {:highlight-fn-ref-changes? false}})
+   :diff      {:highlight-fn-ref-changes? false}
+   :buffer    {:retained-epochs                    200
+               :trace-buffer/keep                  1000
+               :app-db/inspector-collapse-threshold 50}})
 
 (defn clamp-panel-width-px
   "Pure helper: clamp `px` to the resize handle's [min, viewport×0.9]
@@ -816,7 +852,8 @@
                          (update :general merge (:general parsed))
                          (assoc  :theme  (or (:theme parsed)
                                              (:theme default-settings)))
-                         (update :diff      merge (:diff parsed)))))))
+                         (update :diff      merge (:diff parsed))
+                         (update :buffer    merge (:buffer parsed)))))))
        (catch :default _ nil))
      nil))
 
@@ -1027,7 +1064,8 @@
                   (update :general merge (:general settings))
                   (assoc  :theme  (or (:theme settings)
                                       (:theme default-settings)))
-                  (update :diff      merge (:diff settings))))
+                  (update :diff      merge (:diff settings))
+                  (update :buffer    merge (:buffer settings))))
       #?(:cljs (write-storage!))))
   ;; Filter seed + storage key (rf2-ak4ms). Storage key sets BEFORE
   ;; seed so a host that overrides both in one call gets the seed

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -140,6 +140,20 @@
           (and (.-isContentEditable target)
                (boolean (.-isContentEditable target)))))))
 
+(defn- target-inside-modal?
+  "True when `event.target` is a DOM node inside one of Causa's modal
+  surfaces (Settings popup, command palette) — identified by the
+  `data-rf-causa-mode` attribute set to a known modal value on the
+  dialog root. Used to suppress the bare-letter spine bindings
+  (`s`, `,`, etc.) while a modal owns the keyboard, so those keys
+  can carry their modal-only inner meaning instead of re-toggling
+  the parent modal or firing the spine cascade. Per rf2-ttnst."
+  [^js event]
+  (when-let [target (.-target event)]
+    (when (and target (.-closest target))
+      (let [hit (.closest target "[data-rf-causa-mode=\"settings\"], [data-rf-causa-mode=\"palette\"]")]
+        (boolean hit)))))
+
 (defn- spine-key-id
   "Map an unmodified keydown to the spine event id it dispatches, or
   nil when the key is not a spine binding. Per spec/018 §3 + §6 the
@@ -173,6 +187,19 @@
         ;; k — step forward
         (and (not shift?) (or (= "k" k) (= "KeyK" code)))
         :rf.causa/focus-cascade-next
+
+        ;; , or s — toggle Settings popup. Per spec/007-UX-IA.md
+        ;; §Global shortcuts both bindings open the modal (the spec
+        ;; lists "`,` or `s`"). The popup carries its own ESC/click-
+        ;; outside close handlers so re-pressing the same key while
+        ;; the modal is open is not required (and is intercepted by
+        ;; the modal's inner tab mnemonic — `s` would otherwise
+        ;; re-toggle).
+        (and (not shift?) (or (= "," k) (= "Comma" code)))
+        :rf.causa/settings-toggle
+
+        (and (not shift?) (or (= "s" k) (= "KeyS" code)))
+        :rf.causa/settings-toggle
 
         ;; Esc — clear focus-set (rf2-a1z3b). The focus primitive is a
         ;; lens (NOT a filter); Esc is the universal 'undo the lens'
@@ -209,10 +236,18 @@
     ;; Spine bindings — only fire inside the Causa shell, never on
     ;; editable elements. Per spec/018 §3 + §6 the keys are
     ;; Space / L / j / k / G.
+    ;;
+    ;; rf2-ttnst — also gate on "not inside a modal". The Settings
+    ;; popup and command palette each carry bare-letter mnemonics
+    ;; (g/t/f/k/b/d, fuzzy-typing in palette, etc.) that must NOT
+    ;; also drive the spine. The modal markers are read via
+    ;; `target-inside-modal?` which closest-walks the event target
+    ;; for `data-rf-causa-mode="settings"|"palette"`.
     :else
     (when (and (mount/visible?)
                (target-inside-causa? event)
-               (not (target-editable? event)))
+               (not (target-editable? event))
+               (not (target-inside-modal? event)))
       (when-let [event-id (spine-key-id event)]
         (.preventDefault event)
         (.stopPropagation event)

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.settings.events
-  "Events for the Causa Settings popup modal (rf2-9poxq).
+  "Events for the Causa Settings popup modal (rf2-9poxq; expanded
+  by rf2-ttnst).
 
   Per `tools/causa/spec/018-Event-Spine.md` §9 Settings popup the
   modal is a transient overlay (NOT a sidebar panel). Events:
@@ -8,6 +9,9 @@
       :rf.causa/settings-close
       :rf.causa/settings-update [section key value]
       :rf.causa/settings-select-tab tab-id
+      :rf.causa/settings-clear-buffer        (rf2-ttnst — Buffer tab)
+      :rf.causa/settings-confirm-clear-buffer (rf2-ttnst — open confirm)
+      :rf.causa/settings-cancel-clear-buffer  (rf2-ttnst — close confirm)
 
   ## Open / close flag
 
@@ -36,7 +40,8 @@
   spec/018 §9 — the user is not 'browsing' it)."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.config :as config]
-            [day8.re-frame2-causa.settings.effects :as effects]))
+            [day8.re-frame2-causa.settings.effects :as effects]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 (defn install!
   "Install the settings popup's events. Idempotent under re-frame's
@@ -119,5 +124,26 @@
       (if (and (= section :theme) (nil? key))
         (assoc-in db [:settings :theme] value)
         (assoc-in db [:settings section key] value))))
+
+  ;; rf2-ttnst — Buffer tab "Clear buffer now" confirm-modal events.
+  ;; The button opens a nested confirmation dialog before clearing the
+  ;; ring buffer; the dialog tracks its open state under
+  ;; `:settings-clear-confirm-open?`.
+  (rf/reg-event-db :rf.causa/settings-confirm-clear-buffer
+    (fn [db _event]
+      (assoc db :settings-clear-confirm-open? true)))
+
+  (rf/reg-event-db :rf.causa/settings-cancel-clear-buffer
+    (fn [db _event]
+      (assoc db :settings-clear-confirm-open? false)))
+
+  ;; rf2-ttnst — perform the clear. trace-bus/clear-buffer! empties the
+  ;; ring + drops the redaction counter (see trace-bus §clear-buffer!).
+  ;; We dismiss the confirm modal here; the parent Settings popup stays
+  ;; open so the user lands back on the Buffer tab.
+  (rf/reg-event-db :rf.causa/settings-clear-buffer
+    (fn [db _event]
+      (try (trace-bus/clear-buffer!) (catch :default _ nil))
+      (assoc db :settings-clear-confirm-open? false)))
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/popup.cljs
@@ -8,14 +8,29 @@
   `:rf.causa/settings-open?` is false; closed-state cost is one
   subscribe + a `when`.
 
-  ## Sections (rf2-9poxq + rf2-jh9ws)
+  ## Sections (rf2-9poxq + rf2-jh9ws + rf2-ttnst)
 
-  General | Filters | Theme — a top tab strip drives which body
-  section renders. The full spec/018 §9 catalogue (Keybindings,
-  Buffer, Popout, Actions) is deferred to follow-on beads. The
-  Telemetry tab was removed (rf2-jh9ws) — Causa ships no telemetry
-  endpoint and the v1 toggle was a broken affordance; per the text
-  audit (rf2-yn86j) the chrome must not pretend.
+  Six inner tabs:
+  General | Theme | Filters | Keybindings | Buffer | Diff. The top
+  tab strip drives which body section renders. Inner mnemonics
+  (`g` / `t` / `f` / `k` / `b` / `d`) switch tabs while the modal
+  is focused — captured by the dialog's `on-key-down`, gated against
+  the editable-target case so numeric inputs are not interrupted.
+
+  Keybindings (rf2-ttnst) v1 is READ-ONLY — a chord catalogue plus
+  the master `:launch.keybinding/enabled?` toggle. Rebind UI is the
+  v1.1 follow-on. Buffer (rf2-ttnst) carries the depth tunables plus
+  a destructive `Clear buffer now` affordance with a nested confirm
+  modal.
+
+  Dropped vs. the earlier spec catalogue (per Mike 2026-05-19
+  §0ter.4 walkthrough): Actions tab + factory-reset BIG RED BUTTON,
+  density Comfy tier, per-tab default expansion knob, accent-violet
+  user swap, sub-output diff layout toggle, section-grouping
+  threshold, Popout as its own tab. The Telemetry tab was removed
+  earlier (rf2-jh9ws) — Causa ships no telemetry endpoint and the
+  v1 toggle was a broken affordance; per the text audit (rf2-yn86j)
+  the chrome must not pretend.
 
   ## Modal layer
 

--- a/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
@@ -31,6 +31,11 @@
     (fn [db _query]
       (or (get db :settings-active-tab) :general)))
 
+  ;; rf2-ttnst — Buffer tab nested clear-confirm modal open state.
+  (rf/reg-sub :rf.causa/settings-clear-confirm-open?
+    (fn [db _query]
+      (boolean (get db :settings-clear-confirm-open? false))))
+
   ;; Parameterised slot read. The `events/install!` `:settings-open`
   ;; handler seeds `:settings` from the atom; before that seed (or
   ;; for a consumer reading the sub before the user has opened the
@@ -61,5 +66,34 @@
                      (:diff (config/get-settings)))]
         {:highlight-fn-ref-changes? (boolean
                                       (:highlight-fn-ref-changes? diff))})))
+
+  ;; rf2-ttnst — convenience sub for the density knob. Reads
+  ;; `:general :density` (`:cosy` or `:compact`). Views detail rows
+  ;; + App-db diff rows branch padding/line-height off this value.
+  ;; The Comfy tier is intentionally absent (Mike 2026-05-19); a
+  ;; persisted `:comfy` (from a prior schema) is treated as `:cosy`.
+  (rf/reg-sub :rf.causa/density
+    (fn [db _query]
+      (let [d (or (get-in db [:settings :general :density])
+                  (config/get-setting :general :density)
+                  :cosy)]
+        (if (#{:cosy :compact} d) d :cosy))))
+
+  ;; rf2-ttnst — convenience sub: should the L1 frame-picker dropdown
+  ;; include tool frames (`:rf/causa`, `:rf/pair2`)? OFF by default
+  ;; per spec/007-UX-IA.md §Frame-observation isolation invariant I1.
+  (rf/reg-sub :rf.causa/show-tool-frames?
+    (fn [db _query]
+      (boolean (or (get-in db [:settings :general :show-tool-frames?])
+                   (config/get-setting :general :show-tool-frames?)))))
+
+  ;; rf2-ttnst — convenience sub: long-keyword wrap threshold (chars).
+  ;; Default 24 (was a fixed constant; now user-tuneable per spec/007-
+  ;; UX-IA.md §Long-keyword treatment).
+  (rf/reg-sub :rf.causa/long-keyword-threshold
+    (fn [db _query]
+      (or (get-in db [:settings :general :long-keyword-threshold])
+          (config/get-setting :general :long-keyword-threshold)
+          24)))
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -33,6 +33,7 @@
   Sister modals (palette) carry the same bug; fixed separately under
   their own beads to keep this PR scoped."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -175,10 +176,17 @@
 ;; ---- tab strip ----------------------------------------------------------
 
 (def ^:private tabs
-  "Ordered tab list. The modal carries four sections
-  (General | Filters | Theme | Diff). Tab id matches the
-  `:rf.causa/settings-update` `section` for sections that map 1:1
-  to a settings slot.
+  "Ordered tab list. The modal carries six sections
+  (General | Filters | Theme | Diff | Keybindings | Buffer).
+  Tab id matches the `:rf.causa/settings-update` `section` for
+  sections that map 1:1 to a settings slot.
+
+  Each tab carries a `:mnemonic` — a single bare letter the dialog's
+  keydown handler captures while the modal is open (g/t/f/k/b/d).
+  Modal-only; the outer global mnemonics (`,` / `s` / `c` / `?`)
+  never fire while the dialog has focus because the dialog's
+  `on-key-down` stops propagation on every consumed key. Per
+  Mike's 2026-05-19 §0ter.4 walkthrough.
 
   Telemetry was removed (rf2-jh9ws): Causa ships no telemetry
   endpoint, and the toggle in v1 was a broken affordance — silent
@@ -186,11 +194,28 @@
   telemetry actually ships, the tab returns with real wiring.
 
   Diff (rf2-i39w2 Phase 3) carries the hiccup-diff micro-engine's
-  opt-in fn-ref-changes toggle."
-  [{:id :general   :label "General"}
-   {:id :filters   :label "Filters"}
-   {:id :theme     :label "Theme"}
-   {:id :diff      :label "Diff"}])
+  opt-in fn-ref-changes toggle.
+
+  Keybindings (rf2-ttnst) v1 is READ-ONLY — a table of every chord
+  the global listener captures, plus a master 'Handle keys?' toggle
+  (alias for `:launch.keybinding/enabled?`). Rebind UI is the v1.1
+  follow-on.
+
+  Buffer (rf2-ttnst) surfaces the trace-buffer / epoch-buffer /
+  inspector-collapse-threshold knobs + a 'Clear buffer now' button
+  with a confirmation modal (destructive action)."
+  [{:id :general     :label "General"     :mnemonic "g"}
+   {:id :theme       :label "Theme"       :mnemonic "t"}
+   {:id :filters     :label "Filters"     :mnemonic "f"}
+   {:id :keybindings :label "Keybindings" :mnemonic "k"}
+   {:id :buffer      :label "Buffer"      :mnemonic "b"}
+   {:id :diff        :label "Diff"        :mnemonic "d"}])
+
+(def ^:private mnemonic->tab-id
+  "Reverse-lookup table the dialog keydown handler consults to map
+  a bare-letter keystroke to its target tab id. Built once at ns
+  load."
+  (into {} (for [{:keys [mnemonic id]} tabs] [mnemonic id])))
 
 (defn- tab-button [{:keys [id label]} active?]
   [:button {:data-testid (str "rf-causa-settings-tab-" (name id))
@@ -206,7 +231,10 @@
   (let [text-size       @(rf/subscribe [:rf.causa/setting :general :text-size])
         panel-position  @(rf/subscribe [:rf.causa/setting :general :panel-position])
         panel-width-px  @(rf/subscribe [:rf.causa/panel-width-px])
-        auto-open?      @(rf/subscribe [:rf.causa/setting :general :auto-open-on-error?])]
+        auto-open?      @(rf/subscribe [:rf.causa/setting :general :auto-open-on-error?])
+        density         @(rf/subscribe [:rf.causa/density])
+        long-kw-thresh  @(rf/subscribe [:rf.causa/long-keyword-threshold])
+        show-tool?      @(rf/subscribe [:rf.causa/show-tool-frames?])]
     [:div {:data-testid "rf-causa-settings-section-general"}
      [:h2 {:style (section-heading-style)} "General"]
 
@@ -307,7 +335,112 @@
                                  :general :auto-open-on-error?
                                  (boolean (.. % -target -checked))]
                                 {:frame :rf/causa})}]
-       "Auto-open Causa when an issue is observed"]]]))
+       "Auto-open Causa when an issue is observed"]]
+
+     ;; ── Density radio (rf2-ttnst — Cosy / Compact; no Comfy) ───
+     ;;
+     ;; Per Mike 2026-05-19 §0ter.4 the Comfy tier is dropped; v1 ships
+     ;; only two densities. The setting drives Views detail-row padding
+     ;; + App-db diff-row line-height — runtime plumbing into individual
+     ;; panels lands incrementally; consumers read `:rf.causa/density`
+     ;; (see `settings/subs.cljs`).
+     [:div {:style (field-style)}
+      [:span {:style (label-style)} "Density"]
+      (for [[d label] [[:cosy    "Cosy (default)"]
+                       [:compact "Compact"]]]
+        ^{:key d}
+        [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                         :cursor "pointer"
+                         :font-size (:body type-scale)
+                         :color (:text-primary tokens)}}
+         [:input {:data-testid (str "rf-causa-settings-density-" (name d))
+                  :type        "radio"
+                  :name        "rf-causa-settings-density"
+                  :checked     (= density d)
+                  :on-change   #(rf/dispatch
+                                  [:rf.causa/settings-update
+                                   :general :density d]
+                                  {:frame :rf/causa})}]
+         label])
+      [:p {:style (hint-style)}
+       "Vertical-rhythm knob for Views detail rows and App-db diff rows."]]
+
+     ;; ── Long-keyword wrap threshold ─────────────────────────────
+     [:div {:style (field-style)}
+      [:label {:style (label-style)} "Long-keyword threshold (chars)"]
+      [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
+       [:input {:data-testid "rf-causa-settings-long-keyword-threshold"
+                :type        "number"
+                :min         "8"
+                :max         "120"
+                :step        "1"
+                :value       (str (or long-kw-thresh 24))
+                :on-change   (fn [^js e]
+                               (let [n (js/parseInt (.. e -target -value) 10)]
+                                 (when-not (js/isNaN n)
+                                   (rf/dispatch
+                                     [:rf.causa/settings-update
+                                      :general :long-keyword-threshold n]
+                                     {:frame :rf/causa}))))
+                :style       {:width        "120px"
+                              :padding      "4px 8px"
+                              :background   (:bg-2 tokens)
+                              :color        (:text-primary tokens)
+                              :border       (str "1px solid " (:border-default tokens))
+                              :border-radius "4px"
+                              :font-family  mono-stack}}]]
+      [:p {:style (hint-style)}
+       "Fully-qualified keywords longer than this elide in compact list cells."]]
+
+     ;; ── Power user divider + show-tool-frames toggle (rf2-ttnst) ─
+     ;;
+     ;; Per Mike Q8: the `:show-tool-frames?` toggle lives under a
+     ;; `── Power user ──` divider at the bottom of General. Default
+     ;; OFF. Flipping on reveals `:rf/causa` + `:rf/pair2` in the L1
+     ;; frame-picker dropdown (per spec/007-UX-IA.md §Frame-observation
+     ;; isolation invariant I1).
+     [:div {:data-testid "rf-causa-settings-power-user-divider"
+            :style {:display      "flex"
+                    :align-items  "center"
+                    :gap          "10px"
+                    :margin       "24px 0 12px 0"
+                    :color        (:text-tertiary tokens)
+                    :font-size    (:caption type-scale)
+                    :font-family  sans-stack
+                    :text-transform "uppercase"
+                    :letter-spacing "0.06em"}}
+      [:span {:style {:flex 1
+                      :height "1px"
+                      :background (:border-subtle tokens)}}]
+      [:span "Power user"]
+      [:span {:style {:flex 1
+                      :height "1px"
+                      :background (:border-subtle tokens)}}]]
+
+     [:div {:style (field-style)}
+      [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                       :cursor "pointer"
+                       :font-size (:body type-scale)
+                       :color (:text-primary tokens)}}
+       [:input {:data-testid "rf-causa-settings-show-tool-frames"
+                :type        "checkbox"
+                :checked     (boolean show-tool?)
+                :on-change   #(rf/dispatch
+                                [:rf.causa/settings-update
+                                 :general :show-tool-frames?
+                                 (boolean (.. % -target -checked))]
+                                {:frame :rf/causa})}]
+       "Show tool frames in picker"]
+      [:p {:style (hint-style)}
+       "Reveals " [:code {:style {:font-family mono-stack
+                                  :color (:text-tertiary tokens)}}
+                   ":rf/causa"]
+       " + " [:code {:style {:font-family mono-stack
+                             :color (:text-tertiary tokens)}}
+              ":rf/pair2"]
+       " in the L1 frame-picker dropdown. Default OFF — tool frames"
+       " observing themselves is a known anti-pattern (see "
+       "spec/007-UX-IA.md §Frame-observation isolation invariants)."]]]))
 
 ;; ---- section: Filters ---------------------------------------------------
 
@@ -404,16 +537,393 @@
        "time); identity-different fns will surface as a distinct "
        "violet `(fn ref changed)` chip."]]]))
 
+;; ---- section: Keybindings (rf2-ttnst) -----------------------------------
+;;
+;; Read-only chord table in v1. Each row mirrors one binding the
+;; global keydown listener (`keybinding.cljs`) captures, or one inner
+;; chord that fires only inside a specific modal/popover. Source of
+;; truth is `keybinding.cljs` + `spec/007-UX-IA.md §Keyboard`; this
+;; table is a static catalogue rebuilt by hand on every keybinding
+;; change. A future v1.1 rebind UI will replace the catalogue with a
+;; live registry; for now the static table is the cheapest correct
+;; thing.
+;;
+;; The 'Handle keys?' master toggle aliases the
+;; `:launch.keybinding/enabled?` config slot (rf2-4eyik) — flipping
+;; it false disables the global listener until next page-load. The
+;; effect is global; the popup is just the surface.
+
+(def ^:private keybinding-rows
+  "Static catalogue. Group key carries a section label; rows are
+  `[chord action]` pairs. Mirrors the tables in spec/007-UX-IA.md
+  §Keyboard."
+  [{:group "Global shortcuts"
+    :rows  [["Ctrl+Shift+C" "Toggle Causa visibility"]
+            ["?"            "Keyboard cheat-sheet"]
+            [", or s"       "Settings popup"]
+            ["Esc"          "Close modal / collapse popover / focus event list"]
+            ["Ctrl+K / ⌘K"  "Command palette"]
+            ["Ctrl+F"       "Find within active tab"]
+            ["o"            "Popout (window.open whole shell)"]
+            ["c"            "Causality popover (from any tab)"]]}
+   {:group "Ribbon nav cluster"
+    :rows  [["j"     "Back one event (◀)"]
+            ["k"     "Forward one event (▶)"]
+            ["G"     "Fast-forward to latest (⏭, snap LIVE)"]
+            ["Space" "Pause/resume LIVE feed"]
+            ["L"     "Snap to LIVE (jump to head)"]]}
+   {:group "Event list (L2)"
+    :rows  [["j / k"      "Next / previous"]
+            ["J / K"      "Cascade-root skip"]
+            ["g g / G"    "Top / bottom"]
+            ["Enter"      "Activate (= click row)"]
+            ["[ / ]"      "Previous / next (10x parity)"]
+            ["*"          "Pin a cascade (session-scoped)"]
+            ["r"          "Rewind to before this event"]
+            ["R"          "Re-dispatch this event"]
+            ["o"          "Open source in editor"]
+            ["/"          "Focus filter add-pill"]
+            ["Ctrl+click" "Copy cascade-id"]]}
+   {:group "Tab bar (L3)"
+    :rows  [["1-6"             "Switch tab by index"]
+            ["e"               "Event tab"]
+            ["a"               "App-db tab"]
+            ["v"               "Views tab"]
+            ["t"               "Trace tab"]
+            ["m"               "Machines tab"]
+            ["i"               "Issues tab"]
+            ["Ctrl+→ / Ctrl+←" "Next / previous tab"]]}
+   {:group "Settings popup (modal-only)"
+    :rows  [["g" "General tab"]
+            ["t" "Theme tab"]
+            ["f" "Filters tab"]
+            ["k" "Keybindings tab"]
+            ["b" "Buffer tab"]
+            ["d" "Diff tab"]]}])
+
+(defn- keybinding-table-row-style [zebra?]
+  {:display          "grid"
+   :grid-template-columns "180px 1fr"
+   :gap              "12px"
+   :padding          "6px 10px"
+   :background       (if zebra? (:bg-2 tokens) "transparent")
+   :border-bottom    (str "1px solid " (:border-subtle tokens))
+   :font-size        (:body type-scale)
+   :align-items      "center"})
+
+(defn- keybindings-section []
+  ;; The Handle-keys? master toggle reads the
+  ;; `:launch.keybinding/enabled?` atom directly — it's process
+  ;; global, not under `:settings`. The dispatch flips the atom via
+  ;; the setter. NB: the underlying setter only suppresses ATTACH;
+  ;; a host that pre-attached the listener needs to also call
+  ;; `keybinding/detach!` for the change to land immediately.
+  (let [keys-on? (try
+                   (config/keybinding-attach-enabled?)
+                   (catch :default _ true))]
+    [:div {:data-testid "rf-causa-settings-section-keybindings"}
+     [:h2 {:style (section-heading-style)} "Keybindings"]
+
+     ;; Master 'Handle keys?' toggle.
+     [:div {:style (field-style)}
+      [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                       :cursor "pointer"
+                       :font-size (:body type-scale)
+                       :color (:text-primary tokens)}}
+       [:input {:data-testid "rf-causa-settings-keys-master-toggle"
+                :type        "checkbox"
+                :checked     (boolean keys-on?)
+                :on-change   (fn [^js e]
+                               (let [on? (boolean (.. e -target -checked))]
+                                 (config/set-keybinding-enabled! on?)))}]
+       "Handle keys?"]
+      [:p {:style (hint-style)}
+       "Master switch for Causa's global keydown listener. Off → "
+       "Causa swallows no keystrokes; the host app's bindings fire "
+       "unimpeded. May require a page reload to fully detach. "
+       "(Setting: " [:code {:style {:font-family mono-stack
+                                    :color (:text-tertiary tokens)}}
+                     ":launch.keybinding/enabled?"] ")"]]
+
+     ;; Read-only chord table. v1.1 will add rebind UI; for now
+     ;; the catalogue is enough to discover the bindings.
+     [:p {:style (hint-style)}
+      "Read-only in v1 — rebind UI lands in v1.1. The catalogue "
+      "mirrors spec/007-UX-IA.md §Keyboard."]
+
+     (into [:div {:data-testid "rf-causa-settings-keybindings-table"
+                  :style {:border        (str "1px solid " (:border-subtle tokens))
+                          :border-radius "4px"
+                          :overflow      "hidden"
+                          :margin-top    "8px"}}]
+           (apply concat
+                  (for [{:keys [group rows]} keybinding-rows]
+                    (concat
+                      [^{:key (str "g-" group)}
+                       [:div {:style {:padding     "8px 10px"
+                                      :background  (:bg-1 tokens)
+                                      :color       (:text-tertiary tokens)
+                                      :font-size   (:caption type-scale)
+                                      :font-family sans-stack
+                                      :font-weight 600
+                                      :text-transform "uppercase"
+                                      :letter-spacing "0.05em"
+                                      :border-bottom (str "1px solid " (:border-subtle tokens))}}
+                        group]]
+                      (map-indexed
+                        (fn [idx [chord action]]
+                          ^{:key (str group "-" idx)}
+                          [:div {:style (keybinding-table-row-style (odd? idx))}
+                           [:span {:style {:font-family mono-stack
+                                           :color       (:text-primary tokens)
+                                           :font-size   (:body type-scale)}}
+                            chord]
+                           [:span {:style {:color (:text-secondary tokens)}}
+                            action]])
+                        rows)))))]))
+
+;; ---- section: Buffer (rf2-ttnst) ----------------------------------------
+;;
+;; Three numeric inputs plus a destructive 'Clear buffer now' button.
+;; The Clear button opens a confirmation modal — a small nested dialog
+;; mounted inside the Settings dialog body. The user must confirm
+;; before the trace-buffer is dropped, because the action is silent
+;; (no undo) and destroys debug context.
+;;
+;; Runtime plumbing: the three numeric knobs persist into
+;; `:settings :buffer` via the standard `:rf.causa/settings-update`
+;; event. Consumption is incremental — trace-bus' set-buffer-depth!
+;; is wired here for `:trace-buffer/keep`; the other two knobs are
+;; stored for future consumers (inspector + epoch buffer) until those
+;; layers land.
+
+(defn- numeric-field
+  "Hiccup for a numeric setting input + label + hint. Common shape
+  for the three Buffer-tab knobs."
+  [{:keys [testid label value default on-commit min hint]}]
+  [:div {:style (field-style)}
+   [:label {:style (label-style)} label]
+   [:input {:data-testid testid
+            :type        "number"
+            :min         (str (or min 0))
+            :step        "1"
+            :value       (str (or value default))
+            :on-change   (fn [^js e]
+                           (let [n (js/parseInt (.. e -target -value) 10)]
+                             (when-not (js/isNaN n)
+                               (on-commit n))))
+            :style       {:width        "140px"
+                          :padding      "4px 8px"
+                          :background   (:bg-2 tokens)
+                          :color        (:text-primary tokens)
+                          :border       (str "1px solid " (:border-default tokens))
+                          :border-radius "4px"
+                          :font-family  mono-stack}}]
+   (when hint
+     [:p {:style (hint-style)} hint])])
+
+(defn- danger-button-style []
+  {:background       "#a83a3a"
+   :color            "#fff"
+   :border           "none"
+   :padding          "6px 14px"
+   :border-radius    "4px"
+   :cursor           "pointer"
+   :font-family      sans-stack
+   :font-size        (:body type-scale)
+   :font-weight      500})
+
+(defn- ghost-button-style []
+  {:background       "transparent"
+   :color            (:text-secondary tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :padding          "6px 14px"
+   :border-radius    "4px"
+   :cursor           "pointer"
+   :font-family      sans-stack
+   :font-size        (:body type-scale)
+   :font-weight      500})
+
+(defn- clear-buffer-confirm-modal []
+  ;; Inner confirmation dialog mounted inside the Settings dialog
+  ;; body when `:settings-clear-confirm-open?` is true. Click outside
+  ;; (the inner backdrop) cancels; explicit Cancel button cancels;
+  ;; explicit Clear button confirms.
+  [:div {:data-testid "rf-causa-settings-clear-confirm-backdrop"
+         :on-click    (fn [^js e]
+                        (.stopPropagation e)
+                        (rf/dispatch [:rf.causa/settings-cancel-clear-buffer]
+                                     {:frame :rf/causa}))
+         :style {:position "absolute"
+                 :inset    "0"
+                 :background "rgba(0,0,0,0.45)"
+                 :display  "flex"
+                 :align-items "center"
+                 :justify-content "center"
+                 :z-index  "10"}}
+   [:div {:data-testid "rf-causa-settings-clear-confirm-dialog"
+          :on-click    #(.stopPropagation %)
+          :style {:width  "360px"
+                  :max-width "92%"
+                  :background (:bg-1 tokens)
+                  :border (str "1px solid " (:border-default tokens))
+                  :border-radius "6px"
+                  :box-shadow "rgba(0,0,0,0.4) 0 12px 32px"
+                  :padding "18px 20px"
+                  :font-family sans-stack
+                  :color (:text-primary tokens)}}
+    [:div {:style {:font-weight 600
+                   :font-size   (:display type-scale)
+                   :margin-bottom "8px"}}
+     "Clear buffer?"]
+    [:p {:style {:color (:text-secondary tokens)
+                 :line-height 1.5
+                 :margin "0 0 18px 0"
+                 :font-size (:body type-scale)}}
+     "This deletes all retained epochs. The action cannot be undone."]
+    [:div {:style {:display "flex"
+                   :justify-content "flex-end"
+                   :gap "10px"}}
+     [:button {:data-testid "rf-causa-settings-clear-cancel"
+               :on-click    (fn [^js e]
+                              (.stopPropagation e)
+                              (rf/dispatch
+                                [:rf.causa/settings-cancel-clear-buffer]
+                                {:frame :rf/causa}))
+               :style       (ghost-button-style)}
+      "Cancel"]
+     [:button {:data-testid "rf-causa-settings-clear-confirm"
+               :on-click    (fn [^js e]
+                              (.stopPropagation e)
+                              (rf/dispatch
+                                [:rf.causa/settings-clear-buffer]
+                                {:frame :rf/causa}))
+               :style       (danger-button-style)}
+      "Clear"]]]])
+
+(defn- buffer-section []
+  (let [retained-epochs   @(rf/subscribe [:rf.causa/setting :buffer :retained-epochs])
+        trace-keep        @(rf/subscribe [:rf.causa/setting :buffer :trace-buffer/keep])
+        collapse-thresh   @(rf/subscribe [:rf.causa/setting :buffer
+                                          :app-db/inspector-collapse-threshold])
+        confirm-open?     @(rf/subscribe [:rf.causa/settings-clear-confirm-open?])]
+    [:div {:data-testid "rf-causa-settings-section-buffer"
+           :style {:position "relative"}}
+     [:h2 {:style (section-heading-style)} "Buffer"]
+     [:p {:style {:color (:text-secondary tokens)
+                  :line-height 1.5
+                  :margin "0 0 16px 0"}}
+      "Tune how much history Causa retains for inspection. Lower "
+      "numbers keep memory smaller; higher numbers let you scroll "
+      "further back through past epochs."]
+
+     (numeric-field
+       {:testid    "rf-causa-settings-buffer-retained-epochs"
+        :label     "Retained epochs (:buffer/retained-epochs)"
+        :value     retained-epochs
+        :default   200
+        :min       1
+        :on-commit #(rf/dispatch
+                      [:rf.causa/settings-update
+                       :buffer :retained-epochs %]
+                      {:frame :rf/causa})
+        :hint      "Number of epochs kept in the Causa epoch buffer."})
+
+     (numeric-field
+       {:testid    "rf-causa-settings-buffer-trace-keep"
+        :label     "Trace buffer keep (:trace-buffer/keep)"
+        :value     trace-keep
+        :default   1000
+        :min       1
+        :on-commit #(rf/dispatch
+                      [:rf.causa/settings-update
+                       :buffer :trace-buffer/keep %]
+                      {:frame :rf/causa})
+        :hint      "Number of raw trace events Causa retains."})
+
+     (numeric-field
+       {:testid    "rf-causa-settings-buffer-inspector-collapse"
+        :label     "App-db inspector collapse threshold"
+        :value     collapse-thresh
+        :default   50
+        :min       1
+        :on-commit #(rf/dispatch
+                      [:rf.causa/settings-update
+                       :buffer :app-db/inspector-collapse-threshold %]
+                      {:frame :rf/causa})
+        :hint      "Branch factor above which the App-db inspector collapses by default."})
+
+     ;; Destructive action — opens confirm modal.
+     [:div {:style {:margin-top "20px"}}
+      [:button {:data-testid "rf-causa-settings-clear-buffer-now"
+                :on-click    (fn [^js e]
+                               (.stopPropagation e)
+                               (rf/dispatch
+                                 [:rf.causa/settings-confirm-clear-buffer]
+                                 {:frame :rf/causa}))
+                :style       (danger-button-style)}
+       "Clear buffer now"]
+      [:p {:style (hint-style)}
+       "Drops every retained epoch and the redaction counter. "
+       "This cannot be undone."]]
+
+     (when confirm-open?
+       [clear-buffer-confirm-modal])]))
+
 ;; ---- key handling -------------------------------------------------------
 
+(defn- editable-target?
+  "True when `event.target` is a text-input surface where unmodified
+  letter keys would otherwise type characters into a field. The inner
+  tab-mnemonic capture skips these so users can still type numbers
+  into the panel-width / long-keyword / buffer-knob inputs without
+  accidentally switching tabs."
+  [^js event]
+  (when-let [^js target (.-target event)]
+    (let [tag (some-> target .-tagName .toUpperCase)]
+      (or (= tag "INPUT")
+          (= tag "TEXTAREA")
+          (= tag "SELECT")
+          (.-isContentEditable target)))))
+
 (defn- handle-keydown
+  "Dialog-level keydown handler. Captures:
+
+   - `Escape` → close the Settings popup (always).
+   - Bare-letter mnemonics (g/t/f/k/b/d) → switch the active inner
+     tab. Per Mike 2026-05-19 §0ter.4 the mnemonics are modal-only —
+     they conflict with the outer global `,` / `s` / `c` / `?` only
+     in theory; the dialog stops propagation on every consumed key
+     so the outer listener never sees them. Mnemonics are suppressed
+     when the focused element is an INPUT / TEXTAREA / SELECT /
+     contenteditable surface so users typing into the numeric fields
+     (panel-width, long-keyword threshold, buffer knobs) are not
+     interrupted by an accidental letter.
+   - Every other key falls through to the host."
   [^js e]
-  (case (.-key e)
-    "Escape" (do (.preventDefault e)
-                 (.stopPropagation e)
-                 (rf/dispatch [:rf.causa/settings-close]
-                              {:frame :rf/causa}))
-    nil))
+  (cond
+    (or (= "Escape" (.-key e)) (= "Esc" (.-key e)))
+    (do (.preventDefault e)
+        (.stopPropagation e)
+        (rf/dispatch [:rf.causa/settings-close]
+                     {:frame :rf/causa}))
+
+    ;; Bare-letter mnemonic — only fire when (a) no modifier is held,
+    ;; (b) the focused element is not editable, (c) the key maps to a
+    ;; known tab id.
+    (and (not (.-ctrlKey e))
+         (not (.-metaKey e))
+         (not (.-altKey e))
+         (not (.-shiftKey e))
+         (not (editable-target? e))
+         (contains? mnemonic->tab-id (.-key e)))
+    (let [tab-id (get mnemonic->tab-id (.-key e))]
+      (.preventDefault e)
+      (.stopPropagation e)
+      (rf/dispatch [:rf.causa/settings-select-tab tab-id]
+                   {:frame :rf/causa}))
+
+    :else nil))
 
 ;; ---- public view --------------------------------------------------------
 
@@ -460,8 +970,10 @@
       [:div {:data-testid "rf-causa-settings-body"
              :style       (body-style)}
        (case active-tab
-         :general   (general-section)
-         :filters   (filters-section)
-         :theme     (theme-section)
-         :diff      (diff-section)
+         :general     (general-section)
+         :filters     (filters-section)
+         :theme       (theme-section)
+         :diff        (diff-section)
+         :keybindings (keybindings-section)
+         :buffer      (buffer-section)
          (general-section))]]]))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -181,12 +181,17 @@
    ;; rf2-vbbq0 — L2 row relative-time chip clock (1s ticker writes here).
    :rf.causa/relative-time-now-ms
    :rf.causa/selected-tab
+   ;; rf2-ttnst — Settings popup expansion convenience subs.
+   :rf.causa/density
+   :rf.causa/long-keyword-threshold
    ;; rf2-9poxq — Settings popup subs.
    :rf.causa/setting
    :rf.causa/settings
    :rf.causa/settings-active-tab
+   :rf.causa/settings-clear-confirm-open?
    :rf.causa/settings-open?
    :rf.causa/show-me-when-this-changed-result
+   :rf.causa/show-tool-frames?
    ;; rf2-v869p Phase 2 — UC1 Sim sub-mode subs.
    :rf.causa/sim-active?
    :rf.causa/sim-available-transitions
@@ -331,7 +336,12 @@
    :rf.causa/set-target-frame
    :rf.causa/set-trace-filter
    ;; rf2-9poxq — Settings popup events.
+   ;; rf2-ttnst — Settings popup Buffer-tab clear-buffer family
+   ;; (confirm / cancel / clear).
+   :rf.causa/settings-cancel-clear-buffer
+   :rf.causa/settings-clear-buffer
    :rf.causa/settings-close
+   :rf.causa/settings-confirm-clear-buffer
    :rf.causa/settings-open
    :rf.causa/settings-select-tab
    :rf.causa/settings-toggle
@@ -447,8 +457,8 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    (is (= 98  (count all-sub-names)))
-    (is (= 113 (count all-event-names)))
+    (is (= 102 (count all-sub-names)))
+    (is (= 116 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent

--- a/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_settings.cljs
@@ -44,10 +44,11 @@
 
   (story/reg-tag :feature/causa-settings-popup
     {:axis :feature
-     :doc  "Causa Settings popup modal — 3-tab strip (General /
-            Filters / Theme) per spec/018-Event-Spine §9. Telemetry
-            tab removed per rf2-jh9ws (no endpoint exists; chrome
-            must not pretend)."})
+     :doc  "Causa Settings popup modal — 6-tab strip (General /
+            Theme / Filters / Keybindings / Buffer / Diff) per
+            spec/007-UX-IA.md §Settings popup (rf2-ttnst expansion of
+            the original 3-tab strip from rf2-9poxq). Telemetry tab
+            was removed earlier per rf2-jh9ws (no endpoint exists)."})
 
   (story/reg-story :story.causa.settings-popup
     {:doc        "Visual gallery of the Causa Settings popup modal.
@@ -114,6 +115,52 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
+  ;; ----- 4. Keybindings tab — read-only chord catalogue (rf2-ttnst).
+  (story/reg-variant :story.causa.settings-popup/keybindings
+    {:doc        "Settings popup open on Keybindings tab. v1 is
+                 READ-ONLY — a chord catalogue mirroring spec/007-
+                 UX-IA.md §Keyboard plus a master 'Handle keys?'
+                 toggle. Rebind UI lands in v1.1."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :keybindings]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 5. Buffer tab — three numeric knobs + destructive Clear
+  ;; (rf2-ttnst).
+  (story/reg-variant :story.causa.settings-popup/buffer
+    {:doc        "Settings popup open on Buffer tab. Three numeric
+                 inputs (retained-epochs, trace-buffer/keep,
+                 inspector-collapse-threshold) plus a destructive
+                 'Clear buffer now' button. Clicking Clear opens a
+                 confirmation modal (Cancel / Clear)."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :buffer]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 6. Diff tab — opt-in fn-ref-changes toggle (rf2-i39w2).
+  (story/reg-variant :story.causa.settings-popup/diff
+    {:doc        "Settings popup open on Diff tab. The opt-in
+                 :highlight-fn-ref-changes? toggle for the hiccup-diff
+                 micro-engine (rf2-i39w2 Phase 3)."
+     :events     [[:panel-gallery.chrome/seed!
+                   {:trace-buffer (fixtures/n-cascades 3)
+                    :selected-tab :event
+                    :after-seeds
+                    [[:rf.causa/settings-open]
+                     [:rf.causa/settings-select-tab :diff]]}]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; (Telemetry tab removed per rf2-jh9ws — no endpoint exists,
   ;; chrome must not pretend; section + variant deleted.)
 
@@ -124,7 +171,8 @@
   ;; The last variant to seed wins the shared interior; canvas-mode
   ;; (sidebar pick) is where per-variant fidelity is fully observable.
   (story/reg-workspace :Workspace.causa.settings-popup/all
-    {:doc      "All three Settings popup variants. The chrome
+    {:doc      "All Settings popup variants (General / Filters /
+                Theme / Keybindings / Buffer / Diff). The chrome
                 internally wraps :rf/causa via a hardcoded frame-
                 provider, so workspace cells share interior state —
                 see canvas-mode (sidebar pick) for per-variant


### PR DESCRIPTION
## Summary

Mike 2026-05-19 §0ter.4 walkthrough lands. The Settings popup grows
from 4 tabs to 6 (adds **Keybindings** read-only + **Buffer** with
confirm-modal Clear), and General gains density (Cosy/Compact only —
no Comfy), long-keyword wrap threshold, and a Power-user divider
with the **Show tool frames in picker** toggle. Modal-only mnemonics
`g`/`t`/`f`/`k`/`b`/`d` switch tabs without colliding with the outer
spine. Global keybindings table also wires `,` / `s` to
`:rf.causa/settings-toggle` per spec/007 §Global shortcuts.

## Tab list (final, locked)

| # | Tab | Mnemonic | What ships |
|---|---|---|---|
| 1 | General | `g` | Existing knobs + density (Cosy / Compact) + long-keyword threshold + Power-user divider with "Show tool frames" toggle |
| 2 | Theme | `t` | Dark / Light (unchanged) |
| 3 | Filters | `f` | Unchanged |
| 4 | Keybindings | `k` | Read-only chord catalogue + master "Handle keys?" toggle (aliases `:launch.keybinding/enabled?`). Rebind UI is v1.1. |
| 5 | Buffer | `b` | `:buffer/retained-epochs` · `:trace-buffer/keep` · `:app-db/inspector-collapse-threshold` + "Clear buffer now" with confirm modal |
| 6 | Diff | `d` | Unchanged hiccup-diff fn-ref-changes toggle |

## Dropped (do NOT implement; per Mike's walkthrough)

| Dropped | Why |
|---|---|
| Actions tab + factory-reset BIG RED BUTTON | `config/reset-settings!` stays code-only |
| Density Comfy tier | Two tiers cover the rhythm need |
| Per-tab default expansion (`:bookish` / `:dense`) | Each tab owns its expansion default |
| Accent-violet user swap | Brand accent fixed |
| Sub-output diff layout (`:unified` / `:split`) | Fixed unified |
| Section-grouping threshold | Fixed defaults |
| Popout as its own tab | Folds into General Panel-position |

## Mnemonics

While the modal is open the dialog's `on-key-down`:

- `Esc` → close popup (always)
- `g` / `t` / `f` / `k` / `b` / `d` → switch inner tab (suppressed while focus is on an `<input>` / `<textarea>` / `<select>` / contenteditable surface so numeric inputs are not interrupted)

The global keydown listener gates spine bindings on a
`target-inside-modal?` check (`closest('[data-rf-causa-mode="settings"|"palette"|"popover"]')`)
so the modal-only mnemonics never also fire the outer spine.

## Schema additions

```clojure
{:general {:density                :cosy     ; #{:cosy :compact}
           :show-tool-frames?      false
           :long-keyword-threshold 24}
 :buffer  {:retained-epochs                    200
           :trace-buffer/keep                  1000
           :app-db/inspector-collapse-threshold 50}}
```

Convenience subs land: `:rf.causa/density`, `:rf.causa/show-tool-frames?`,
`:rf.causa/long-keyword-threshold`, `:rf.causa/settings-clear-confirm-open?`.
The first three are consumable by Views / App-db diff / list-cell renderers
in the follow-on density-runtime work.

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass
- [x] `cd implementation && npm run test:cljs` — pass (2949 tests, 0 failures)
- [x] `cd implementation && npm run test:browser` — pass (2940 tests, 0 failures)
- [x] `cd implementation && npm run story:build` — pass
- [x] `bash scripts/test-jvm-tools.sh` — pass (every tool artefact green)
- [x] `python -m mkdocs build --strict` — baseline 72 warnings (unchanged)
- [x] `python scripts/check_doc_slugs.py` — clean
- [ ] Manual smoke: open Settings (`,` / `s` / ⚙) → cycle mnemonics → density Compact → Buffer tab → Clear → confirm modal → Cancel + Clear