### PR TITLE
feat(causa): clickable path segments in App-db diff -> popup inspector (rf2-e9tb0)

### DIFF
--- a/tools/causa/spec/004-App-DB-Diff.md
+++ b/tools/causa/spec/004-App-DB-Diff.md
@@ -20,9 +20,10 @@ that you weren't expecting (a reset, a clobber).
 
 A **slice-centric view** — the slices that changed in this epoch,
 each shown with `before` and `after` values, colour-coded by op
-(`:added` green, `:modified` yellow, `:removed` red). Plus **pinned
-watches** — slices the user explicitly marked, always visible across
-epochs. The full tree is one click away via the escape hatch.
+(`:added` green, `:modified` yellow, `:removed` red). Plus
+**clickable path segments** — every segment of every diff path opens
+a popup inspector at that path-prefix, so the user can inspect
+arbitrary sub-trees of `app-db` on demand.
 
 This is the **single most-used Causa surface** after the Event tab.
 The 400ms yellow → transparent diff-flash on touched slices is the
@@ -30,8 +31,10 @@ attention-cue that keeps the user oriented across cascades.
 
 ## Affordance
 
-App-db tab — slice-centric mini-panels above pinned-slices above the
-`Show full app-db tree ▸` escape hatch.
+App-db tab — slice-centric mini-panels. Each section's breadcrumb
+path renders as individually clickable segments; clicking any
+segment opens an inspector popup at the path-prefix up to and
+including that segment.
 
 ---
 
@@ -47,26 +50,25 @@ watching.
 A stack of focused slice mini-panels:
 
 ```
-┌─ Slice 1: [:cart :items]  (modified) ─────────────┐
+┌─ [:cart :items]   (modified) ─────────────────────┐
+│   ↑     ↑                                         │
+│   each segment is clickable; click opens the      │
+│   segment-inspector popup at that path-prefix     │
+│                                                   │
 │  before:  [{:id 7 :qty 1}]                        │
 │  after:   [{:id 7 :qty 1} {:id 22 :qty 1}]        │
 └────────────────────────────────────────────────────┘
 
-┌─ Slice 2: [:cart :totals :gross]  (added) ────────┐
+┌─ [:cart :totals :gross]   (added) ────────────────┐
 │  added:   $48.00                                  │
 └────────────────────────────────────────────────────┘
-
-┌─ Pinned slices ───────────────────────────────────┐
-│  [:user :auth :status]           :authenticated   │
-│  [:nav :route]                   :app/cart        │
-└────────────────────────────────────────────────────┘
-
-[Show full app-db tree ▸]
 ```
 
 The panel never renders the whole tree by default. Slice mini-panels
 are bounded by the size of the touched path. A 50MB `app-db` with
-two touched slices renders the same as a 100KB one.
+two touched slices renders the same as a 100KB one. Clicking the
+root segment of any breadcrumb opens the popup at `[]` — that's the
+escape hatch for 'show me app-db in its entirety'.
 
 ## Changed-paths derivation
 
@@ -97,18 +99,51 @@ The diff flash on epoch land is a 400ms tween (yellow → transparent)
 on each newly-touched slice. Respects `prefers-reduced-motion` — the
 tween becomes a static yellow border for 600ms.
 
-## Pinned slices
+## Clickable path segments (rf2-e9tb0)
 
-Right-click any value in the runtime → **Pin this slice**. The path
-persists to localStorage and renders in the Pinned-slices list across
-sessions.
+For each diff path like `[:cart :items 0 :price]`, each segment is
+independently clickable:
 
-- **Each pin shows the path and current value** (live-updating on
-  every epoch).
-- **Right-click a pin** → Unpin · Edit path · Open source (jumps to the
-  most-recent `reg-event-*` registration that touched this path).
-- **Pin order** is user-controlled (drag to reorder); persisted.
-- **Pins are per-frame.** Switching frames switches the pin set.
+- Click `:cart` → popup shows app-db at `[:cart]`
+- Click `:items` → popup shows app-db at `[:cart :items]`
+- Click `0` → popup shows app-db at `[:cart :items 0]`
+- Click `:price` → popup shows app-db at `[:cart :items 0 :price]`
+  (the leaf)
+
+The popup renders the value at the inspected path via Causa's
+existing data-inspector primitive — the same cljs-devtools-shaped
+expandable tree every L4 detail panel uses.
+
+Discoverability: segments carry a dotted underline + pointer cursor
+on hover, and a `Inspect app-db at <prefix>` tooltip on hover. The
+underlying path colour stays accent-violet so the inline path still
+scans as a single phrase when the user isn't pointing at it.
+
+Three close affordances:
+
+  1. `Esc` while the popup is focused.
+  2. Click outside (backdrop) — the backdrop swallows clicks and
+     dispatches close; the dialog stops propagation so click-throughs
+     on its body don't close.
+  3. `✕` button in the header.
+
+The popup is a transient overlay (modal-light, not a full-window
+modal). The escape-hatch use case ('let me see app-db in its
+entirety') is served by clicking the leftmost segment of any
+breadcrumb — that path-prefix is `[<first-seg>]`, so to inspect the
+whole root the user clicks the root segment of the synthesised
+`(root)` breadcrumb on a `:children` section rooted at `[]`. The
+popup body then renders the entire `app-db` as an expandable tree.
+
+## What this replaces (rf2-e9tb0)
+
+The pinned-watches strip was DROPPED when clickable path segments
+landed (Mike 2026-05-19 Q13). The diff already identifies changes
+surgically; the pin-this-up-front flow was redundant when any prefix
+of any diff path can be inspected with one click on its breadcrumb
+segment. The `:rf.causa/pin-slice` / `:rf.causa/unpin-slice` /
+`:rf.causa/reorder-pinned-slices` events and the corresponding
+`:pinned-slices-store` slot are no longer registered.
 
 ## Reserved-keys group
 
@@ -149,17 +184,10 @@ for `:rf/machines`.")
 
 ## Full-tree escape hatch
 
-The `Show full app-db tree ▸` row at the bottom expands to fill the
-canvas:
-
-- Virtualised lazy-expand collapsible tree.
-- Only first 100 keys at each level eager-render; deeper levels load
-  on click.
-- Search input at the top filters by path or value substring.
-- Persistent breadcrumb at the top of the tree shows the currently
-  focused path.
-- Path-click → copies the path to clipboard (for pasting into a sub
-  or for a pin).
+Per rf2-e9tb0 the explicit `Show full app-db tree ▸` row was dropped
+in favour of segment-inspector reuse — clicking the root segment of
+any breadcrumb opens the popup at the inspected path; chaining up
+from any diff section to the root is a one-click affordance.
 
 The full tree is rarely needed; the slice-centric view answers most
 questions.
@@ -236,11 +264,10 @@ truth; pokes from the debugger are out of scope.
 
 The user can:
 
-- Right-click → Copy value
-- Right-click → Copy path
-- Right-click → Pin this slice
-- Right-click → Show me when this changed *(pivots the canvas to a
-  list of epochs that touched the path; see below)*
+- Click a breadcrumb segment → opens the segment-inspector popup
+  (rf2-e9tb0)
+- Click the Copy value / Copy path / Show me when this changed
+  affordance buttons in the section header
 
 Not present:
 
@@ -283,10 +310,11 @@ faster than re-reading the source.
 - **Slice virtualisation** for slices whose `after` value is large
   (e.g., a 10k-entry vector). The slice mini-panel renders the head
   and tail, with a `… 9970 entries …` ellipsis; click expands.
-- **Pinned-slice deref** is bounded to one path per pin per epoch;
-  pinned slices add O(pins) per epoch, not O(db-size).
-- **Full-tree** virtualises rows past the viewport; never DOM-mounts
-  more than ~80 rows.
+- **Segment-inspector popup** resolves the inspected value via
+  `get-in` (O(path-depth)) against the live target-frame db; no
+  separate watch graph. Per-node expand-state is shared with the
+  data-inspector slot in `:rf/causa` app-db so a value the user
+  drilled into in the inspector stays drilled when reopened.
 
 ## Empty state
 
@@ -297,8 +325,6 @@ Before any dispatches:
    No diffs yet — every dispatch will land here with the slices
    it touched.
 ```
-
-The pinned-slices area is empty until the user pins something.
 
 ## Vision
 

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -175,23 +175,29 @@ Slice-centric `app-db` inspector. Reads the host frame's `app-db` via
 | Sub | Returns |
 |---|---|
 | `:rf.causa/selected-epoch-diff` | Diff triples for the selected (or newest) epoch. Composite over history + selection. |
-| `:rf.causa/pinned-slices-store` | `{frame-id [path ...]}` — separate from time-travel's `:pin-store` (whole-epoch pins); this is per-frame slice-path pinning. |
-| `:rf.causa/pinned-slices` | Live-derefed pinned slices for the current target-frame: `[{:path <vec> :value <current>} ...]`. |
 | `:rf.causa/focused-slice-path` | The "Show me when this changed" focused path, or `nil`. |
 | `:rf.causa/show-me-when-this-changed-result` | Vector of epoch hit-maps for epochs touching the focused path. `[]` when no focus. |
-| `:rf.causa/app-db-diff` | Composite — `{:target-frame :history-empty? :changed-non-reserved :changed-reserved :pinned-slices :focused-path :focused-hits}`. The `[runtime]` group always renders current `:rf/*` slot contents per spec §Reserved-keys group. |
+| `:rf.causa/app-db-diff` | Composite — `{:target-frame :history-empty? :changed-non-reserved :changed-reserved :focused-path :focused-hits :redacted-modified-count}`. The `[runtime]` group always renders current `:rf/*` slot contents per spec §Reserved-keys group. |
+| `:rf.causa/segment-inspector-open?` | rf2-e9tb0 — true iff the segment-inspector popup is open. |
+| `:rf.causa/segment-inspector-path` | rf2-e9tb0 — the inspected path (vector), or `nil` when closed. |
+| `:rf.causa/segment-inspector-value` | rf2-e9tb0 — the current value at the inspected path against the target-frame db. |
 
 ### Events
 
 | Event | Vector shape | Behaviour |
 |---|---|---|
-| `:rf.causa/pin-slice` | `[_ path]` | Pins a slice path. Duplicates are dropped at the helper layer. |
-| `:rf.causa/unpin-slice` | `[_ path]` | Unpins. |
-| `:rf.causa/reorder-pinned-slices` | `[_ new-order]` | Replaces pin order; the caller computes the permutation. |
 | `:rf.causa/focus-slice-path` | `[_ path]` | Sets the "Show me when this changed" focused path. |
 | `:rf.causa/clear-slice-focus` | `[_]` | Drops the focus. |
 | `:rf.causa/copy-value-to-clipboard` | `[_ value]` | `event-fx` — emits `{:fx [[:rf.causa.fx/copy-to-clipboard {:text (pr-str value)}]]}`. |
 | `:rf.causa/copy-path-to-clipboard` | `[_ path]` | `event-fx` — same shape, `pr-str path`. |
+| `:rf.causa/open-segment-inspector` | `[_ path]` | rf2-e9tb0 — opens the segment-inspector popup at `path` (vector). |
+| `:rf.causa/close-segment-inspector` | `[_]` | rf2-e9tb0 — closes the popup. |
+
+> **rf2-e9tb0 — pinned-slices removed.** The `:rf.causa/pin-slice`,
+> `:rf.causa/unpin-slice`, `:rf.causa/reorder-pinned-slices` events
+> and the `:rf.causa/pinned-slices-store` + `:rf.causa/pinned-slices`
+> subs were dropped when the pinned-watches strip was superseded by
+> the segment-inspector popup. Catalogued here for the audit trail.
 
 ### Effects
 

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -356,15 +356,12 @@ Corruption (schema fails) → Causa wipes the slot and writes the
 default shape, surfacing a one-time toast: "Settings were corrupted
 and have been reset to defaults."
 
-Per-frame-app-db pinned slices live under a separate key:
-`day8.re-frame2-causa/pinned-slices/<frame-id>/v1`.
-
-```clojure
-{:pinned-slices [{:path [:user :auth :status]
-                  :label "auth status"
-                  :pinned-at 1715518800000}
-                 ...]}
-```
+> **rf2-e9tb0 — pinned-slices localStorage slot deprecated.** The
+> per-frame-app-db pinned-slices key (`day8.re-frame2-causa/pinned-
+> slices/<frame-id>/v1`) is no longer written; the pinned-watches
+> strip was superseded by the App-DB Diff segment-inspector popup
+> (per `004-App-DB-Diff.md` §Clickable path segments). Legacy slots
+> are ignored on read — Causa never resurrects them.
 
 ## Trace-event tags Causa emits
 

--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -136,11 +136,17 @@
    label])
 
 (defn- breadcrumb-segments
-  "Render the section path as individual clickable segments. Plain click
-  copies the absolute path up to and including the clicked segment;
-  Cmd-click (or Ctrl-click on non-Mac) is the explicit modifier the
-  design (§5.1) calls out — both gestures dispatch
-  `:rf.causa/copy-path-to-clipboard` with the prefix path."
+  "Render the section path as individual clickable segments (rf2-e9tb0).
+  Each segment is independently clickable; a click opens the App-DB
+  segment-inspector popup at the path-prefix up to and INCLUDING that
+  segment. So clicking `:cart` in `[:cart :items 0 :price]` opens the
+  popup at `[:cart]`; clicking `:price` opens it at the full leaf path.
+
+  Hover styling — a dotted underline + pointer cursor — makes the
+  segments discoverable as click targets without screaming through the
+  diff body. The colour stays the same accent-violet that all path
+  text uses, so the inline path still scans as a single phrase when
+  the user isn't pointing at it."
   [section-path]
   (if (empty? section-path)
     [:span {:data-testid (str "rf-causa-diff-section-path-"
@@ -158,33 +164,40 @@
                   prefix     (vec (take (inc i) section-path))
                   on-click   (fn [^js e]
                                (.preventDefault e)
+                               (.stopPropagation e)
                                (rf/dispatch
-                                 [:rf.causa/copy-path-to-clipboard prefix]
+                                 [:rf.causa/open-segment-inspector prefix]
                                  {:frame :rf/causa}))]
               ^{:key i}
               [:span {:data-testid (str "rf-causa-diff-breadcrumb-segment-"
                                         (pr-str section-path) "-" i)
                       :on-click    on-click
-                      :title       (str "Copy path up to "
-                                        (pr-str prefix)
-                                        " (or Cmd-click)")
-                      :style       {:cursor      "pointer"
-                                    :color       (:accent-violet tokens)
-                                    :text-decoration "none"}}
+                      :title       (str "Inspect app-db at "
+                                        (pr-str prefix))
+                      :style       {:cursor          "pointer"
+                                    :color           (:accent-violet tokens)
+                                    :text-decoration "underline"
+                                    :text-decoration-style "dotted"
+                                    :text-underline-offset "2px"
+                                    :text-decoration-color (:border-default tokens)}}
                (pr-str seg)])))))
 
 (defn breadcrumb
   "Sticky path-header breadcrumb (per design §5.1) carrying the section
   path + the per-section affordance row (rf2-ykjl5):
 
-      [:cart :items]  ⟨Pin⟩ ⟨Show me when this changed⟩
+      [:cart :items]  ⟨Show me when this changed⟩
                       ⟨Copy path⟩ ⟨Copy value⟩
                                             ◴ 3 changes
 
-  Path segments are individually clickable — a plain click copies the
-  absolute path up to and including that segment (the design's Cmd-
-  click integration in §5.1; we make plain click suffice and also keep
-  Cmd-click compatible since the click handler always fires).
+  Path segments are individually clickable (rf2-e9tb0) — clicking any
+  segment opens the App-DB segment-inspector popup at the path-prefix
+  up to and including that segment. Discoverable via a dotted
+  underline + pointer cursor on hover.
+
+  The Pin affordance is dropped (rf2-e9tb0 — pinned-watches replaced
+  by on-demand segment inspection); the diff already identifies
+  changes surgically, so pinning paths up-front is redundant.
 
   The container is `position: sticky; top: 0` so it stays pinned as
   the user scrolls through a long section body. Per the design's
@@ -221,18 +234,14 @@
                        :color          (:text-primary tokens)
                        :font-weight    600}}
       (breadcrumb-segments section-path)
-      ;; Affordance row — Pin / Show-me-when / Copy path / Copy value.
+      ;; Affordance row — Show-me-when / Copy path / Copy value.
+      ;; Pin was dropped under rf2-e9tb0 when pinned-watches was
+      ;; superseded by the clickable-segment inspector popup.
       [:div {:data-testid (str "rf-causa-diff-section-affordances-"
                                (pr-str section-path))
              :style       {:display     "inline-flex"
                            :gap         "4px"
                            :align-items "center"}}
-       (header-button
-         {:testid   (str "rf-causa-diff-section-pin-" (pr-str section-path))
-          :label    "Pin"
-          :colour   (:cyan tokens)
-          :on-click #(rf/dispatch [:rf.causa/pin-slice path-vec]
-                                  {:frame :rf/causa})})
        (header-button
          {:testid   (str "rf-causa-diff-section-show-when-"
                          (pr-str section-path))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -16,7 +16,17 @@
   Canonical exemplar of the panel facade pattern documented in
   `tools/causa/spec/Conventions.md` — facade owns the public
   `reg-view`, leaves expose plain fns + `install!`, the facade's
-  `install!` chains leaf installs and returns `nil`."
+  `install!` chains leaf installs and returns `nil`.
+
+  ## rf2-e9tb0 — pinned-watches dropped
+
+  The pinned-slices strip was removed when path-segment click-to-
+  inspect landed (Mike 2026-05-19 Q13). The diff already identifies
+  changes surgically; pinning paths up-front is redundant when any
+  prefix of any diff path can be opened in the segment inspector via
+  one click on its breadcrumb segment. The escape-hatch use case
+  ('let me see app-db in its entirety') is now served by clicking the
+  root segment of any breadcrumb."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.diff.render :as diff-render]
             [day8.re-frame2-causa.panels.app-db-diff-events :as events]
@@ -33,7 +43,6 @@
                 history-empty?
                 changed-sections
                 changed-reserved
-                pinned-slices
                 focused-path
                 focused-hits
                 redacted-modified-count]}
@@ -60,7 +69,6 @@
         history-empty?
         [:div
          (sections/empty-state target-frame)
-         (sections/pinned-group pinned-slices)
          (sections/reserved-group changed-reserved)]
 
         :else
@@ -71,7 +79,6 @@
          ;; subtrees.
          (sections/redacted-modified-chip redacted-modified-count)
          (diff-render/render-sections changed-sections "app-db-diff")
-         (sections/pinned-group pinned-slices)
          (sections/reserved-group changed-reserved)])]]))
 
 (defn install!

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_events.cljs
@@ -1,30 +1,18 @@
 (ns day8.re-frame2-causa.panels.app-db-diff-events
-  "Events and effects for the App-DB Diff panel."
-  (:require [re-frame.core :as rf]
-            [day8.re-frame2-causa.defaults :as defaults]
-            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]))
+  "Events and effects for the App-DB Diff panel.
+
+  ## rf2-e9tb0 — pinned-slices events dropped
+
+  The `:rf.causa/pin-slice`, `:rf.causa/unpin-slice`, and
+  `:rf.causa/reorder-pinned-slices` events were removed when the
+  pinned-watches strip was superseded by the path-segment inspector
+  popup (Mike 2026-05-19 Q13). The matching `pin-path` / `unpin-path`
+  / `reorder-paths` helpers were pulled in lockstep."
+  (:require [re-frame.core :as rf]))
 
 (defn install!
   "Install the App-DB Diff events and effects."
   []
-  (rf/reg-event-db :rf.causa/pin-slice
-    (fn [db [_ path]]
-      (let [target (get db :target-frame defaults/default-target-frame)]
-        (update db :pinned-slices-store
-                h/pin-path target path))))
-
-  (rf/reg-event-db :rf.causa/unpin-slice
-    (fn [db [_ path]]
-      (let [target (get db :target-frame defaults/default-target-frame)]
-        (update db :pinned-slices-store
-                h/unpin-path target path))))
-
-  (rf/reg-event-db :rf.causa/reorder-pinned-slices
-    (fn [db [_ new-order]]
-      (let [target (get db :target-frame defaults/default-target-frame)]
-        (update db :pinned-slices-store
-                h/reorder-paths target new-order))))
-
   (rf/reg-event-db :rf.causa/focus-slice-path
     (fn [db [_ path]]
       (assoc db :focused-slice-path path)))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -37,12 +37,14 @@
   those keys render in a separate `[runtime]` group; the rest render
   as slice mini-panels.
 
-  ## Pin store — `pin-path` / `unpin-path` / `reorder-paths`
+  ## rf2-e9tb0 — pin-store helpers dropped
 
-  The pin store is per-frame: `{frame-id [path-1 path-2 ...]}`. Order
-  preserved by vector. Pins are paths (vectors of keys), not values —
-  the live value derefs against the current target-frame on each
-  recompute (per spec §Performance — O(pins) per epoch, not O(db)).
+  `pin-path` / `unpin-path` / `reorder-paths` / `slice-pins-for-frame`
+  / `live-pinned-slices` and their `pinned-slices-store` slot were
+  removed when path-segment click-to-inspect replaced the pinned-
+  watches strip (Mike 2026-05-19 Q13). The matching subs / events
+  were pulled in lockstep from `app_db_diff_subs.cljs` and
+  `app_db_diff_events.cljs`.
 
   ## 'Show me when this changed' — `epochs-touching-path`
 
@@ -235,61 +237,6 @@
     (for [k (sort reserved-app-db-keys)
           :when (contains? db k)]
       [k (get db k)])))
-
-;; ---- pin store -----------------------------------------------------------
-
-(defn slice-pins-for-frame
-  "Return the slice-path pin vector for `frame-id` in `store`, or `[]`
-  when none. The slice-pin store is `{frame-id [path-1 path-2 ...]}`;
-  vector order is the user's drag-reorder order. Sibling helper
-  `time-travel-helpers/epoch-pins-for-frame` returns the per-frame
-  epoch-pin vector for the Time-Travel scrubber; both helpers
-  destructure a different `store` shape so they aren't
-  interchangeable."
-  [store frame-id]
-  (vec (get store frame-id [])))
-
-(defn pin-path
-  "Add `path` to the pin vector for `frame-id` in `store`. Duplicates
-  are dropped (re-pinning an existing path is a no-op). Pure data →
-  updated store.
-
-  Refusing duplicates is the spec's implied contract — the pin list
-  is a vector of paths, and the user's mental model is 'pin this once'
-  not 'pin this every time I click'."
-  [store frame-id path]
-  (let [existing (vec (get store frame-id []))]
-    (if (some #(= path %) existing)
-      store
-      (assoc store frame-id (conj existing path)))))
-
-(defn unpin-path
-  "Remove `path` from the pin vector for `frame-id`. Pure data →
-  updated store. No-op when `path` is absent."
-  [store frame-id path]
-  (update store frame-id
-          (fn [pins]
-            (vec (remove #(= path %) (or pins []))))))
-
-(defn reorder-paths
-  "Replace the pin vector for `frame-id` with `new-order`. The caller
-  is responsible for supplying a vector that's a permutation of the
-  current pin vector — this fn is the thin write-through; the drag-
-  reorder UI computes the permutation.
-
-  Pure data → updated store."
-  [store frame-id new-order]
-  (assoc store frame-id (vec new-order)))
-
-(defn live-pinned-slices
-  "Project the pin vector for `frame-id` into a vector of
-  `{:path :value}` maps where `:value` is the current value of the
-  path in `db`. Used by the panel's Pinned-slices group.
-
-  Pure data → data. JVM-runnable."
-  [store frame-id db]
-  (mapv (fn [path] {:path path :value (get-in db path)})
-        (slice-pins-for-frame store frame-id)))
 
 ;; ---- 'Show me when this changed' walker ---------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_sections.cljs
@@ -107,60 +107,16 @@
            (for [pair reserved-pairs]
              (with-meta (reserved-row pair) {:key (pr-str (first pair))})))]))
 
-(defn- pinned-row
-  [{:keys [path value]}]
-  [:div {:data-testid (str "rf-causa-app-db-diff-pinned-" (pr-str path))
-         :style       {:display "flex"
-                       :justify-content "space-between"
-                       :gap "12px"
-                       :padding "4px 12px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family mono-stack
-                       :font-size "12px"}}
-   [:span {:style {:color (:text-primary tokens)}}
-    (f/truncate (f/format-edn path) 36)]
-   [:span {:style {:display "flex" :gap "8px" :align-items "center"}}
-    [:span {:style {:color (:text-tertiary tokens)}}
-     (f/truncate (f/format-edn value) 36)]
-    [:button {:data-testid (str "rf-causa-app-db-diff-unpin-" (pr-str path))
-              :on-click    #(rf/dispatch [:rf.causa/unpin-slice path]
-                                         {:frame :rf/causa})
-              :style       {:background "transparent"
-                            :border     "none"
-                            :color      (:text-tertiary tokens)
-                            :cursor     "pointer"
-                            :font-family mono-stack
-                            :font-size  "11px"}
-              :title       "Unpin"}
-     "✕"]]])
-
-(defn pinned-group
-  [pinned-slices]
-  (when (seq pinned-slices)
-    [:section {:data-testid "rf-causa-app-db-diff-pinned-group"
-               :style       {:margin "12px 12px"
-                             :background (:bg-3 tokens)
-                             :border (str "1px solid " (:border-subtle tokens))
-                             :border-radius "4px"}}
-     [:header {:style {:padding "6px 12px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family sans-stack
-                       :font-size "11px"
-                       :font-weight 600
-                       :text-transform "uppercase"
-                       :letter-spacing "0.5px"
-                       :color (:text-secondary tokens)}}
-      "Pinned slices"]
-     (into [:div]
-           ;; `^{:key …}` reader meta on the `(pinned-row p)` call
-           ;; below would be attached to the source list and lost when
-           ;; the call returns its fresh vector — Reagent's
-           ;; `get-react-key` only reads `:key` meta from vectors (see
-           ;; reagent2.impl.template). `pinned-row` always returns a
-           ;; `[:div …]` vector, so apply the key directly via
-           ;; `with-meta`. (rf2-ppzid)
-           (for [p pinned-slices]
-             (with-meta (pinned-row p) {:key (pr-str (:path p))})))]))
+;; ---- rf2-e9tb0 — pinned-slices dropped --------------------------------
+;;
+;; The pinned-watches strip and its `pinned-row` / `pinned-group`
+;; renderers were removed when path-segment click-to-inspect landed
+;; (Mike 2026-05-19 Q13). The App-DB Diff body no longer carries a
+;; pinned-slices section; the matching subs / events / helpers were
+;; pulled from `app_db_diff_subs.cljs`, `app_db_diff_events.cljs`, and
+;; `app_db_diff_helpers.cljc` in the same commit. The user inspects
+;; arbitrary app-db paths on demand via the segment-inspector popup
+;; that opens when any path-segment in a diff breadcrumb is clicked.
 
 (defn- focus-result-row
   [{:keys [epoch-id event op before after] :as _hit}]

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_slices.cljs
@@ -87,21 +87,14 @@
                       :text-transform "uppercase"
                       :letter-spacing "0.5px"}}
        (f/op->label op)]]
+     ;; rf2-e9tb0 — Pin button dropped here too. The legacy slice-row /
+     ;; changed-slices-stack pair is the pre-rf2-gfxmk fallback that
+     ;; the live panel no longer renders (sections-per-cluster replaced
+     ;; it); the cleanup keeps the fallback consistent with the active
+     ;; surface.
      [:div {:style {:display "flex"
                     :gap "6px"
                     :margin-bottom "6px"}}
-      [:button {:data-testid (str "rf-causa-app-db-diff-pin-" (pr-str path))
-                :on-click    #(rf/dispatch [:rf.causa/pin-slice path]
-                                           {:frame :rf/causa})
-                :style       {:background  "transparent"
-                              :color       (:cyan tokens)
-                              :border      (str "1px solid " (:border-default tokens))
-                              :padding     "1px 6px"
-                              :border-radius "4px"
-                              :cursor      "pointer"
-                              :font-family sans-stack
-                              :font-size   "10px"}}
-       "Pin"]
       [:button {:data-testid (str "rf-causa-app-db-diff-show-when-"
                                   (pr-str path))
                 :on-click    #(rf/dispatch [:rf.causa/focus-slice-path path]

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -229,17 +229,6 @@
                 n)))
           0))))
 
-  (rf/reg-sub :rf.causa/pinned-slices-store
-    (fn [db _query]
-      (get db :pinned-slices-store {})))
-
-  (rf/reg-sub :rf.causa/pinned-slices
-    :<- [:rf.causa/pinned-slices-store]
-    :<- [:rf.causa/target-frame]
-    :<- [:rf.causa/target-frame-db]
-    (fn [[store target db] _query]
-      (h/live-pinned-slices store target db)))
-
   (rf/reg-sub :rf.causa/focused-slice-path
     (fn [db _query]
       (get db :focused-slice-path)))
@@ -262,12 +251,11 @@
     :<- [:rf.causa/target-frame-db]
     :<- [:rf.causa/selected-epoch-diff]
     :<- [:rf.causa/selected-epoch-sections]
-    :<- [:rf.causa/pinned-slices]
     :<- [:rf.causa/focused-slice-path]
     :<- [:rf.causa/show-me-when-this-changed-result]
     :<- [:rf.causa/epoch-history]
     :<- [:rf.causa/selected-epoch-redacted-modified-count]
-    (fn [[target db diff-triples sections pinned focused-path focused-hits
+    (fn [[target db diff-triples sections focused-path focused-hits
           history redacted-modified-count]
          _query]
       (let [{:keys [non-reserved]} (h/partition-reserved
@@ -277,7 +265,6 @@
          :changed-non-reserved      non-reserved
          :changed-sections          sections
          :changed-reserved          (h/reserved-summary db)
-         :pinned-slices             pinned
          :focused-path              focused-path
          :focused-hits              focused-hits
          ;; rf2-bz1cl — redacted-paths-modified hint chip surface.

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
@@ -1,0 +1,255 @@
+(ns day8.re-frame2-causa.panels.app-db-segment-inspector
+  "App-DB segment inspector popup (rf2-e9tb0).
+
+  Per `tools/causa/spec/004-App-DB-Diff.md` §Clickable path segments,
+  each segment in an App-DB Diff section breadcrumb is independently
+  clickable. A click opens this transient overlay showing the app-db
+  value at the clicked path-prefix — `:cart` shows app-db at `[:cart]`,
+  `:items` shows app-db at `[:cart :items]`, and so on.
+
+  Replaces the dropped pinned-watches strip (Mike 2026-05-19 Q13). The
+  diff already identifies changes surgically; on-demand inspection at
+  any prefix removes the need to pin paths up-front.
+
+  ## Modal-light overlay
+
+  Mounted at the shell-view root alongside the other modals so its
+  subscribes resolve through the shell's `frame-provider` to
+  `:rf/causa` (the same mount discipline as `settings.popup`,
+  `palette`, and `popover.causality` — see those files' docstrings for
+  the rationale). Closed-state cost is one subscribe + a `when` — the
+  body short-circuits to nil when `:rf.causa/segment-inspector-open?`
+  is false.
+
+  Visually the popup is lighter than the Settings modal — a smaller
+  centred dialog with a 15% dim backdrop, mirroring the causality
+  popover's chrome (transient overlay, not a full-window modal). The
+  body renders the value at the inspected path via
+  `theme/data-inspector/inspect` — the same primitive every L4 detail
+  panel uses, so the renderer is uniform with the diff body.
+
+  ## Three close affordances
+
+  Per the bead's scope:
+
+    1. `Esc` — handled by the popup's keydown listener.
+    2. Click outside (backdrop) — backdrop's `:on-click` dispatches
+       close; the dialog stops propagation so click-throughs on its
+       body don't close.
+    3. ✕ button in the header.
+
+  ## Why every dispatch carries `{:frame :rf/causa}`
+
+  Sister fix to rf2-smvvz (Settings popup) + rf2-w8lxg (Causality
+  popover). Subscribes resolve through the React-context tier at
+  render time; dispatches from `:on-click` / `:on-key-down` fire AFTER
+  React pops the context, so the dispatch would otherwise land on
+  `:rf/default` and the close handler would silently no-op. Carrying
+  the `{:frame :rf/causa}` opt at call time pins the envelope to
+  Causa's frame regardless of click-time React context."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+;; ---- subs ----------------------------------------------------------------
+
+(defn install-subs! []
+  ;; The slot shape: nil = closed; `{:path <vec>}` = open at that path.
+  ;; Storing the path in app-db lets the popup survive shadow-cljs
+  ;; `:after-load` re-renders without losing the user's context.
+  (rf/reg-sub :rf.causa/segment-inspector-slot
+    (fn [db _]
+      (get db :segment-inspector)))
+
+  (rf/reg-sub :rf.causa/segment-inspector-open?
+    :<- [:rf.causa/segment-inspector-slot]
+    (fn [slot _]
+      (some? slot)))
+
+  (rf/reg-sub :rf.causa/segment-inspector-path
+    :<- [:rf.causa/segment-inspector-slot]
+    (fn [slot _]
+      (:path slot)))
+
+  ;; Resolve the value at the inspected path against the host frame's
+  ;; current db. `:rf.causa/target-frame-db` (installed by app-db-diff-
+  ;; subs) is the live deref against the picker-selected frame; we read
+  ;; through the same seam so the popup follows the picker without any
+  ;; bespoke wiring. Empty path returns the whole db (the inspector
+  ;; renders the root map).
+  (rf/reg-sub :rf.causa/segment-inspector-value
+    :<- [:rf.causa/segment-inspector-path]
+    :<- [:rf.causa/target-frame-db]
+    (fn [[path db] _]
+      (if (seq path)
+        (get-in db path)
+        db))))
+
+;; ---- events --------------------------------------------------------------
+
+(defn install-events! []
+  (rf/reg-event-db :rf.causa/open-segment-inspector
+    (fn [db [_ path]]
+      (assoc db :segment-inspector {:path (vec path)})))
+
+  (rf/reg-event-db :rf.causa/close-segment-inspector
+    (fn [db _]
+      (dissoc db :segment-inspector))))
+
+;; ---- styles --------------------------------------------------------------
+;;
+;; Backdrop honours `:rf.causa/modal-positioning` (rf2-om6fa) so
+;; Story testbeds get an in-cell overlay rather than a viewport-spanning
+;; one. Same shape as the causality popover.
+
+(defn- backdrop-style [positioning]
+  (let [absolute? (= positioning :absolute)]
+    {:position         (if absolute? "absolute" "fixed")
+     :top              0
+     :left             0
+     :right            0
+     :bottom           0
+     :background       "rgba(0,0,0,0.20)"
+     :display          "flex"
+     :align-items      "flex-start"
+     :justify-content  "center"
+     :padding-top      (if absolute? "6%" "10vh")
+     :z-index          (if absolute? 101 2147483645)}))
+
+(defn- dialog-style []
+  {:width            "560px"
+   :max-width        "92vw"
+   :max-height       "72vh"
+   :display          "flex"
+   :flex-direction   "column"
+   :background       (:bg-1 tokens)
+   :border           (str "1px solid " (:border-default tokens))
+   :border-radius    "8px"
+   :box-shadow       "rgba(0,0,0,0.6) 0 20px 56px"
+   :overflow         "hidden"
+   :font-family      sans-stack
+   :color            (:text-primary tokens)})
+
+(defn- header-style []
+  {:display          "flex"
+   :align-items      "center"
+   :justify-content  "space-between"
+   :padding          "10px 14px"
+   :background       (:bg-2 tokens)
+   :border-bottom    (str "1px solid " (:border-subtle tokens))})
+
+(defn- body-style []
+  {:flex             1
+   :overflow         "auto"
+   :padding          "12px 14px"
+   :background       (:bg-2 tokens)
+   :font-family      mono-stack
+   :font-size        (:body type-scale)
+   :color            (:text-primary tokens)})
+
+(defn- close-button-style []
+  {:background       "transparent"
+   :border           "none"
+   :color            (:text-secondary tokens)
+   :font-size        "16px"
+   :line-height      1
+   :cursor           "pointer"
+   :padding          "2px 8px"
+   :border-radius    "3px"})
+
+;; ---- key handling --------------------------------------------------------
+
+(defn- handle-keydown
+  "Esc closes the popup. Other keys bubble — the global keybindings
+  (palette, causality) still resolve when the popup is open."
+  [^js e]
+  (when (= "Escape" (.-key e))
+    (.preventDefault e)
+    (.stopPropagation e)
+    (rf/dispatch [:rf.causa/close-segment-inspector]
+                 {:frame :rf/causa})))
+
+;; ---- view ----------------------------------------------------------------
+
+(defn- header-title
+  "Render the dialog header: a label + the inspected path. Empty path
+  inspects the root db; the title says 'app-db (root)' so the user
+  isn't left wondering what they're looking at."
+  [path]
+  [:span {:data-testid "rf-causa-segment-inspector-title"
+          :style {:color       (:text-primary tokens)
+                  :font-weight 600
+                  :font-size   (:body type-scale)
+                  :font-family sans-stack
+                  :display     "inline-flex"
+                  :align-items "baseline"
+                  :gap         "8px"}}
+   [:span {:style {:color (:text-secondary tokens)}} "app-db at"]
+   [:code {:style {:color       (:accent-violet tokens)
+                   :font-family mono-stack
+                   :font-size   "12px"}}
+    (if (seq path)
+      (f/format-edn (vec path))
+      "(root)")]])
+
+(defn- popup-view
+  "Hiccup for the open popup. Caller (`Popup` reg-view) has gated on
+  `:rf.causa/segment-inspector-open?` already."
+  []
+  (let [path        @(rf/subscribe [:rf.causa/segment-inspector-path])
+        value       @(rf/subscribe [:rf.causa/segment-inspector-value])
+        positioning @(rf/subscribe [:rf.causa/modal-positioning])]
+    [:div {:data-testid "rf-causa-segment-inspector-backdrop"
+           :data-rf-causa-modal-positioning (name (or positioning :fixed))
+           :on-click    #(rf/dispatch [:rf.causa/close-segment-inspector]
+                                      {:frame :rf/causa})
+           :on-key-down handle-keydown
+           :tab-index   -1
+           :style       (backdrop-style positioning)}
+     [:div {:data-testid "rf-causa-segment-inspector-dialog"
+            :data-rf-causa-mode "segment-inspector"
+            :on-click    #(.stopPropagation %)
+            :on-key-down handle-keydown
+            :tab-index   0
+            :style       (dialog-style)}
+      ;; Header
+      [:div {:style (header-style)}
+       (header-title path)
+       [:button {:data-testid "rf-causa-segment-inspector-close"
+                 :title       "Close (Esc)"
+                 :on-click    (fn [^js e]
+                                (.stopPropagation e)
+                                (rf/dispatch [:rf.causa/close-segment-inspector]
+                                             {:frame :rf/causa}))
+                 :style       (close-button-style)}
+        "✕"]]
+      ;; Body — the cljs-devtools-shaped expandable tree at the path.
+      ;; A unique `node-key` per (open) keeps the inspector's per-node
+      ;; expand-state from colliding with the App-db Diff panel's
+      ;; renders of the same value. The path's pr-str is stable across
+      ;; renders so toggle state survives shadow-cljs reloads.
+      [:div {:data-testid "rf-causa-segment-inspector-body"
+             :style       (body-style)}
+       (inspector/inspect (f/display-value value)
+                          (str "segment-inspector/" (pr-str (vec path))))]]]))
+
+(rf/reg-view Popup
+  "The App-DB segment inspector popup. Renders only when
+  `:rf.causa/segment-inspector-open?` is true; closed-state is a
+  single subscribe + a `when` — cheap.
+
+  Per rf2-in6l2 `reg-view`-registered so the body's subscribes route
+  through the React-context tier to `:rf/causa`."
+  []
+  (when @(rf/subscribe [:rf.causa/segment-inspector-open?])
+    (popup-view)))
+
+(defn install!
+  "Idempotent install for the segment-inspector's Causa-side
+  registrations. Returns nil per the facade convention."
+  []
+  (install-subs!)
+  (install-events!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -43,6 +43,8 @@
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector
+             :as app-db-segment-inspector]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
@@ -543,6 +545,14 @@
     ;; and the slot's reducer helpers live in spine.cljs.
     (spine/install!)
     (app-db-diff/install!)
+    ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any
+    ;; path-segment in the App-DB Diff breadcrumb is clicked. Installs
+    ;; after `app-db-diff` so the segment-inspector's
+    ;; `:rf.causa/segment-inspector-value` sub can chain off
+    ;; `:rf.causa/target-frame-db` (registered by app-db-diff's subs).
+    ;; Registration order is cosmetic — re-frame resolves `:<-` lazily;
+    ;; the top-down dependency reading is the rationale.
+    (app-db-segment-inspector/install!)
     ;; Cancellation-cascade visualiser (rf2-59e7k) — installs the
     ;; subs + events for the Machines tab side-panel + the trace-row
     ;; popover. The view-side `reg-view`s are picked up at ns-load.

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -105,6 +105,8 @@
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector
+             :as app-db-segment-inspector]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
@@ -1420,4 +1422,11 @@
     ;; modals: shell-root mount so subscribes resolve through the
     ;; `:rf/causa` frame-provider; closed-state cost is one subscribe
     ;; + a when-gate.
-    [share-modal/Modal]]])
+    [share-modal/Modal]
+    ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any
+    ;; path-segment in the App-DB Diff breadcrumb is clicked. Same
+    ;; mount discipline as the other modals: shell-root mount so the
+    ;; popup's subscribes resolve through the shell's `:rf/causa`
+    ;; frame-provider; closed-state cost is one subscribe + a when-
+    ;; gate.
+    [app-db-segment-inspector/Popup]]])

--- a/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
@@ -191,9 +191,11 @@
             node))
         (tree-seq (some-fn vector? seq?) seq tree)))
 
-(deftest section-header-renders-four-affordance-buttons
-  (testing "rf2-ykjl5 — each section header carries Pin, Show-me-when,
-            Copy-path, Copy-value buttons in the affordance row"
+(deftest section-header-renders-three-affordance-buttons
+  (testing "rf2-ykjl5 — section header carries Show-me-when, Copy-path,
+            Copy-value buttons in the affordance row. rf2-e9tb0 — the
+            Pin button was dropped when pinned-watches was replaced by
+            the segment-inspector popup."
     (let [tree     (at/diff-tree {:cart {:items []}}
                                  {:cart {:items [{:id 7}]}})
           sections (sg/group-into-sections tree)
@@ -206,9 +208,9 @@
                                  (str "rf-causa-diff-section-affordances-"
                                       suffix)))
           "affordance row container present")
-      (is (some? (find-by-testid hiccup
-                                 (str "rf-causa-diff-section-pin-" suffix)))
-          "Pin button present")
+      (is (nil? (find-by-testid hiccup
+                                (str "rf-causa-diff-section-pin-" suffix)))
+          "Pin button is gone — pinned-watches feature dropped (rf2-e9tb0)")
       (is (some? (find-by-testid hiccup
                                  (str "rf-causa-diff-section-show-when-"
                                       suffix)))
@@ -250,26 +252,6 @@
 (defn- click-handler [hiccup testid]
   (let [btn (find-by-testid hiccup testid)]
     (:on-click (second btn))))
-
-(deftest section-header-pin-button-dispatches-pin-slice
-  (testing "rf2-ykjl5 — clicking the Pin button on a section header
-            dispatches :rf.causa/pin-slice with the section path,
-            targeted at the :rf/causa frame."
-    (let [tree     (at/diff-tree {:cart {:items []}}
-                                 {:cart {:items [{:id 7}]}})
-          sections (sg/group-into-sections tree)
-          hiccup   (render/render-sections sections "app-db-diff")
-          {:keys [path]} (first sections)
-          on-click (click-handler hiccup
-                                  (str "rf-causa-diff-section-pin-"
-                                       (pr-str path)))
-          captured (with-dispatch-capture*
-                     #(do (is (fn? on-click))
-                          (on-click #js {})))]
-      (is (= 1 (count captured)))
-      (is (= [:rf.causa/pin-slice path] (first (first captured))))
-      (is (= {:frame :rf/causa} (second (first captured)))
-          "dispatch targeted at the :rf/causa frame"))))
 
 (deftest section-header-show-when-button-dispatches-focus-slice-path
   (testing "rf2-ykjl5 — Show-me-when button dispatches
@@ -356,13 +338,13 @@
              (first (first captured)))
           "Copy-value sends the subtree's :value (the after-container)"))))
 
-(deftest breadcrumb-segment-click-copies-prefix-path
-  (testing "rf2-ykjl5 — the breadcrumb renders one clickable segment per
-            path element; plain click copies the absolute path-prefix
-            up to AND INCLUDING that segment (design §5.1). Cmd-click
-            is also supported because the click handler always fires —
-            we just `preventDefault` so the browser's native Cmd-click
-            behaviour does not interfere."
+(deftest breadcrumb-segment-click-opens-segment-inspector
+  (testing "rf2-e9tb0 — the breadcrumb renders one clickable segment
+            per path element; a plain click opens the App-DB segment-
+            inspector popup at the absolute path-prefix up to AND
+            INCLUDING that segment. So clicking `:cart` in
+            `[:cart :items 0 :price]` opens the popup at `[:cart]`;
+            clicking `:price` opens it at the full leaf path."
     ;; Drive `breadcrumb` directly with a known multi-segment path so
     ;; the test is independent of the grouper's coalesce behaviour.
     (let [section-path [:user :prefs :theme]
@@ -380,7 +362,8 @@
                              (is (fn? handler)
                                  (str "segment " i " has on-click"))
                              (swap! segment-clicks conj i)
-                             (handler #js {:preventDefault (fn [])})))
+                             (handler #js {:preventDefault  (fn [])
+                                            :stopPropagation (fn [])})))
           captured (with-dispatch-capture*
                      #(doseq [i (range (count section-path))]
                         (click-segment! i)))]
@@ -390,11 +373,61 @@
       (doseq [i (range (count section-path))]
         (let [expected-prefix (vec (take (inc i) section-path))
               [event opts]    (nth captured i)]
-          (is (= [:rf.causa/copy-path-to-clipboard expected-prefix]
+          (is (= [:rf.causa/open-segment-inspector expected-prefix]
                  event)
-              (str "click on segment " i " dispatches copy-path with prefix "
+              (str "click on segment " i " opens the inspector at prefix "
                    (pr-str expected-prefix)))
           (is (= {:frame :rf/causa} opts)))))))
+
+(deftest breadcrumb-segments-have-hover-styling
+  (testing "rf2-e9tb0 — clickable segments carry discoverable hover
+            styling (dotted underline + pointer cursor + a tooltip) so
+            the user knows they're interactive without screaming
+            through the diff body"
+    (let [section-path [:cart :items]
+          hdr          (render/breadcrumb section-path
+                                          {:added 0 :removed 0
+                                           :modified 1 :children 0}
+                                          nil)
+          seg          (find-by-testid
+                         hdr
+                         (str "rf-causa-diff-breadcrumb-segment-"
+                              (pr-str section-path) "-0"))
+          props        (second seg)
+          style        (:style props)]
+      (is (= "pointer" (:cursor style))
+          "pointer cursor advertises click affordance")
+      (is (= "underline" (:text-decoration style))
+          "underline marks the segment as clickable text")
+      (is (= "dotted" (:text-decoration-style style))
+          "dotted underline keeps the chrome quiet")
+      (is (string? (:title props))
+          "tooltip text explains what clicking does"))))
+
+(deftest breadcrumb-segments-have-no-pin-affordance
+  (testing "rf2-e9tb0 — clicking a segment opens the inspector; it
+            does NOT pin the path. Pinned-watches was the dropped
+            alternative — this regression guard catches any future
+            attempt to reintroduce pin-on-segment-click."
+    (let [section-path [:cart]
+          hdr          (render/breadcrumb section-path
+                                          {:added 0 :removed 0
+                                           :modified 1 :children 0}
+                                          nil)
+          seg          (find-by-testid
+                         hdr
+                         (str "rf-causa-diff-breadcrumb-segment-"
+                              (pr-str section-path) "-0"))
+          handler      (:on-click (second seg))
+          captured     (with-dispatch-capture*
+                         #(handler #js {:preventDefault  (fn [])
+                                        :stopPropagation (fn [])}))]
+      (is (= 1 (count captured)))
+      (is (not= :rf.causa/pin-slice (first (first (first captured))))
+          "click MUST NOT dispatch :rf.causa/pin-slice")
+      (is (= :rf.causa/open-segment-inspector
+             (first (first (first captured))))
+          "click opens the segment inspector"))))
 
 (deftest breadcrumb-renders-root-when-section-path-empty
   (testing "rf2-ykjl5 — empty section-path still renders the '(root)'
@@ -406,11 +439,12 @@
                                  "rf-causa-diff-section-affordances-[]"))
           "affordance row still ships for the root section"))))
 
-(deftest breadcrumb-three-arity-back-compat-works
+(deftest breadcrumb-two-arity-back-compat-works
   (testing "rf2-ykjl5 — the legacy `[path summary]` arity remains
             callable; Copy-value just sends nil (no subtree-value
-            supplied)"
+            supplied). rf2-e9tb0 — pin testid was dropped; assert on
+            the copy-path button instead."
     (let [hdr (render/breadcrumb [:a] {:added 1 :removed 0
                                        :modified 0 :children 0})]
       (is (vector? hdr))
-      (is (some? (find-by-testid hdr "rf-causa-diff-section-pin-[:a]"))))))
+      (is (some? (find-by-testid hdr "rf-causa-diff-section-copy-path-[:a]"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -10,10 +10,12 @@
      returns the panel's render data; the pin / unpin / focus events
      write into `:rf/causa`'s app-db.
 
-  2. **Pin / unpin / reorder / focus events update Causa's frame.**
-     Per spec §Pinned slices + §'Show me when this changed' — the
-     view fires `:rf.causa/pin-slice` etc. and the state lives in
-     the Causa frame.
+  2. **Focus events update Causa's frame.**
+     Per spec §'Show me when this changed' — the view fires
+     `:rf.causa/focus-slice-path` and the state lives in the Causa
+     frame. (Pin / unpin / reorder events were dropped under rf2-e9tb0
+     when path-segment click-to-inspect superseded the pinned-watches
+     strip.)
 
   3. **Reserved-keys segregation at the panel level.** The view
      renders the `[runtime]` group separately from the slice mini-
@@ -147,27 +149,41 @@
 ;; ---- (1) registry wires the subs / events -------------------------------
 
 (deftest registry-installs-app-db-diff-subs
-  (testing "register-causa-handlers! installs the Phase 5 subs"
+  (testing "register-causa-handlers! installs the Phase 5 subs.
+            Pinned-slices subs were removed under rf2-e9tb0 (clickable
+            path segments replaced the pinned-watches strip)."
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/target-frame-db)))
     (is (some? (registrar/handler :sub :rf.causa/selected-epoch-record)))
     (is (some? (registrar/handler :sub :rf.causa/selected-epoch-diff)))
-    (is (some? (registrar/handler :sub :rf.causa/pinned-slices-store)))
-    (is (some? (registrar/handler :sub :rf.causa/pinned-slices)))
     (is (some? (registrar/handler :sub :rf.causa/focused-slice-path)))
     (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
-    (is (some? (registrar/handler :sub :rf.causa/app-db-diff)))))
+    (is (some? (registrar/handler :sub :rf.causa/app-db-diff)))
+    ;; rf2-e9tb0 — segment-inspector subs registered alongside.
+    (is (some? (registrar/handler :sub :rf.causa/segment-inspector-open?)))
+    (is (some? (registrar/handler :sub :rf.causa/segment-inspector-path)))
+    (is (some? (registrar/handler :sub :rf.causa/segment-inspector-value)))
+    ;; Pinned-slices subs are gone.
+    (is (nil? (registrar/handler :sub :rf.causa/pinned-slices-store)))
+    (is (nil? (registrar/handler :sub :rf.causa/pinned-slices)))))
 
 (deftest registry-installs-app-db-diff-events
-  (testing "register-causa-handlers! installs the Phase 5 events"
+  (testing "register-causa-handlers! installs the Phase 5 events.
+            Pin / unpin / reorder events were removed under rf2-e9tb0;
+            the segment-inspector open / close events landed in their
+            place."
     (registry/register-causa-handlers!)
-    (is (some? (registrar/handler :event :rf.causa/pin-slice)))
-    (is (some? (registrar/handler :event :rf.causa/unpin-slice)))
-    (is (some? (registrar/handler :event :rf.causa/reorder-pinned-slices)))
     (is (some? (registrar/handler :event :rf.causa/focus-slice-path)))
     (is (some? (registrar/handler :event :rf.causa/clear-slice-focus)))
     (is (some? (registrar/handler :event :rf.causa/copy-value-to-clipboard)))
-    (is (some? (registrar/handler :event :rf.causa/copy-path-to-clipboard)))))
+    (is (some? (registrar/handler :event :rf.causa/copy-path-to-clipboard)))
+    ;; rf2-e9tb0 — segment-inspector events registered.
+    (is (some? (registrar/handler :event :rf.causa/open-segment-inspector)))
+    (is (some? (registrar/handler :event :rf.causa/close-segment-inspector)))
+    ;; Pin events are gone.
+    (is (nil? (registrar/handler :event :rf.causa/pin-slice)))
+    (is (nil? (registrar/handler :event :rf.causa/unpin-slice)))
+    (is (nil? (registrar/handler :event :rf.causa/reorder-pinned-slices)))))
 
 (deftest registry-installs-clipboard-fx
   (testing "register-causa-handlers! installs the :rf.causa.fx/copy-to-
@@ -178,7 +194,10 @@
 ;; ---- (2) composite sub returns sane defaults ----------------------------
 
 (deftest app-db-diff-sub-defaults
-  (testing ":rf.causa/app-db-diff returns sane defaults on a fresh frame"
+  (testing ":rf.causa/app-db-diff returns sane defaults on a fresh frame.
+            rf2-e9tb0 — `:pinned-slices` was dropped from the composite
+            when the pinned-watches strip was replaced by the segment-
+            inspector popup."
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
     (frame/reg-frame :rf/default {})
@@ -187,8 +206,9 @@
         (is (= :rf/default (:target-frame data)))
         (is (true? (:history-empty? data)))
         (is (nil? (:focused-path data)))
-        (is (= [] (:pinned-slices data)))
         (is (= [] (:focused-hits data)))
+        (is (not (contains? data :pinned-slices))
+            "the composite no longer carries :pinned-slices")
         ;; rf2-bz1cl — chip count defaults to 0 (no history → no
         ;; redacted-modified paths anywhere).
         (is (= 0 (:redacted-modified-count data)))))))
@@ -374,63 +394,68 @@
         (is (contains? reserved-keys-shown :rf/route))
         (is (contains? reserved-keys-shown :rf/machines))))))
 
-;; ---- (5) pin / unpin events write to Causa frame ------------------------
+;; ---- (5) rf2-e9tb0 — segment-inspector events + state ------------------
 
-(deftest pin-slice-event-writes-to-causa-frame
-  (testing ":rf.causa/pin-slice lands the path on :rf/causa's
-            :pinned-slices-store, NOT on the host's app-db"
+(deftest open-segment-inspector-writes-path-to-causa-frame
+  (testing "rf2-e9tb0 — :rf.causa/open-segment-inspector writes the
+            requested path into Causa's frame at :segment-inspector.
+            The path is normalised to a vector so callers can pass
+            seqs / lists / vectors interchangeably."
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
     (frame/reg-frame :rf/default {})
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]]))
-    (is (= {:rf/default [[:user :auth :status]]}
-           (:pinned-slices-store (frame/frame-app-db-value :rf/causa))))
-    (is (nil? (:pinned-slices-store (frame/frame-app-db-value :rf/default))))))
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector
+                         (list :cart :items 0 :price)])
+      (is (= {:path [:cart :items 0 :price]}
+             (:segment-inspector (frame/frame-app-db-value :rf/causa)))))))
 
-(deftest pin-and-unpin-roundtrip
-  (testing ":rf.causa/pin-slice then :rf.causa/unpin-slice → empty pin vector"
+(deftest close-segment-inspector-drops-slot
+  (testing "rf2-e9tb0 — :rf.causa/close-segment-inspector dissocs the
+            slot so the popup reg-view's `when`-gate short-circuits"
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
-    (frame/reg-frame :rf/default {})
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:a]])
-      (rf/dispatch-sync [:rf.causa/pin-slice [:b]])
-      (let [s1 (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
-        (is (= [[:a] [:b]] (get s1 :rf/default))))
-      (rf/dispatch-sync [:rf.causa/unpin-slice [:a]])
-      (let [s2 (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
-        (is (= [[:b]] (get s2 :rf/default)))))))
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart]])
+      (is (some? (:segment-inspector (frame/frame-app-db-value :rf/causa))))
+      (rf/dispatch-sync [:rf.causa/close-segment-inspector])
+      (is (nil? (:segment-inspector (frame/frame-app-db-value :rf/causa)))))))
 
-(deftest reorder-pinned-slices-replaces-pin-order
-  (testing ":rf.causa/reorder-pinned-slices replaces the per-frame pin
-            vector with the supplied permutation"
+(deftest segment-inspector-open?-tracks-slot-presence
+  (testing "rf2-e9tb0 — :rf.causa/segment-inspector-open? is true iff
+            the :segment-inspector slot is non-nil"
     (registry/register-causa-handlers!)
     (frame/reg-frame :rf/causa {})
-    (frame/reg-frame :rf/default {})
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:a]])
-      (rf/dispatch-sync [:rf.causa/pin-slice [:b]])
-      (rf/dispatch-sync [:rf.causa/pin-slice [:c]])
-      (rf/dispatch-sync [:rf.causa/reorder-pinned-slices [[:c] [:a] [:b]]])
-      (let [s (:pinned-slices-store (frame/frame-app-db-value :rf/causa))]
-        (is (= [[:c] [:a] [:b]] (get s :rf/default)))))))
+      (is (false? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart :items]])
+      (is (true? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
+      (rf/dispatch-sync [:rf.causa/close-segment-inspector])
+      (is (false? @(rf/subscribe [:rf.causa/segment-inspector-open?]))))))
 
-(deftest pinned-slices-sub-derefs-live-values
-  (testing ":rf.causa/pinned-slices returns live values from the host
-            frame's current app-db"
-    (seed-causa! {:user {:auth {:status :authenticated}}
-                  :cart {:items [{:id 7}]}}
+(deftest segment-inspector-value-resolves-against-target-frame-db
+  (testing "rf2-e9tb0 — :rf.causa/segment-inspector-value reads through
+            :rf.causa/target-frame-db with `get-in` so the popup always
+            shows the picker-selected frame's current value at the
+            inspected path. Empty path yields the whole db (root
+            inspection)."
+    (seed-causa! {:cart {:items [{:id 7 :qty 1}]
+                         :gross 42}
+                  :user "ada"}
                  [])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]])
-      (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]])
-      (let [slices @(rf/subscribe [:rf.causa/pinned-slices])]
-        (is (= 2 (count slices)))
-        (is (= {:path [:user :auth :status] :value :authenticated}
-               (first slices)))
-        (is (= {:path [:cart :items] :value [{:id 7}]}
-               (second slices)))))))
+      ;; Leaf at [:cart :gross]
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart :gross]])
+      (is (= 42 @(rf/subscribe [:rf.causa/segment-inspector-value])))
+      ;; Sub-map at [:cart]
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:cart]])
+      (is (= {:items [{:id 7 :qty 1}] :gross 42}
+             @(rf/subscribe [:rf.causa/segment-inspector-value])))
+      ;; Root: empty path → whole db.
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector []])
+      (is (= {:cart {:items [{:id 7 :qty 1}] :gross 42}
+              :user "ada"}
+             @(rf/subscribe [:rf.causa/segment-inspector-value]))))))
 
 ;; ---- (6) focus event + 'Show me when this changed' result ---------------
 
@@ -579,36 +604,18 @@
         (is (some? (find-by-testid tree
                                    "rf-causa-app-db-diff-focus-hit-:e-1")))))))
 
-(deftest pinned-group-renders-when-pins-present
-  (testing "the Pinned-slices section renders when pins exist for the
-            current target-frame"
+(deftest pinned-group-absent-after-rf2-e9tb0
+  (testing "rf2-e9tb0 — the Pinned-slices section was removed from the
+            App-DB Diff panel when the pinned-watches strip was
+            superseded by the segment-inspector popup. The panel
+            never renders the pinned-group testid hook anymore."
     (seed-causa! {:user {:auth {:status :authenticated}}}
                  [])
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:user :auth :status]])
       (let [tree (app-db-diff/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-app-db-diff-pinned-group"))
-            "pinned group container present")
-        (is (some? (find-by-testid tree
-                                   "rf-causa-app-db-diff-pinned-[:user :auth :status]"))
-            "pinned row for the pinned path is present")))))
-
-(deftest pin-slice-event-still-wired
-  (testing "the :rf.causa/pin-slice event remains registered and lands
-            the pin in the Causa frame. The Pin button UI moved off the
-            slice mini-panel under rf2-gfxmk Phase 1 (slices are now
-            rendered as sections-per-cluster); pin / show-me-when
-            affordances on the section header are a follow-on."
-    (seed-causa! {:cart {:items [{:id 7}]}}
-                 [(mk-record :e-1 [:cart/add]
-                             {:cart {:items []}}
-                             {:cart {:items [{:id 7}]}})])
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]])
-      (let [causa-db (frame/frame-app-db-value :rf/causa)]
-        (is (= [[:cart :items]]
-               (get-in causa-db [:pinned-slices-store :rf/default]))
-            "pin landed in :rf/causa's :pinned-slices-store")))))
+        (is (nil? (find-by-testid tree "rf-causa-app-db-diff-pinned-group"))
+            "pinned-group is gone — the panel surface no longer carries
+             the pinned-watches strip")))))
 
 (deftest focus-slice-path-event-still-wired
   (testing "the :rf.causa/focus-slice-path event remains registered. UI

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_events_cljs_test.cljs
@@ -4,7 +4,13 @@
   Calls the leaf's `install!` directly (NOT the umbrella
   `register-causa-handlers!`) so the leaf is pinned as an
   independently usable install unit. Dispatches one happy-path
-  event and asserts the resulting :rf/causa app-db transition."
+  event and asserts the resulting :rf/causa app-db transition.
+
+  rf2-e9tb0 — the pin / unpin / reorder events were removed when the
+  pinned-watches strip was superseded by the segment-inspector
+  popup. Only focus-slice-path + the clipboard fx remain on this
+  leaf; segment-inspector events live on the
+  `app-db-segment-inspector` leaf."
   (:require [cljs.test :refer-macros [deftest is use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -18,17 +24,18 @@
 
 (deftest leaf-install-registers-events-and-fxs
   (events/install!)
-  (is (some? (registrar/handler :event :rf.causa/pin-slice)))
-  (is (some? (registrar/handler :event :rf.causa/unpin-slice)))
   (is (some? (registrar/handler :event :rf.causa/focus-slice-path)))
   (is (some? (registrar/handler :event :rf.causa/clear-slice-focus)))
-  (is (some? (registrar/handler :fx :rf.causa.fx/copy-to-clipboard))))
+  (is (some? (registrar/handler :fx :rf.causa.fx/copy-to-clipboard)))
+  ;; rf2-e9tb0 — pin events were dropped at this leaf.
+  (is (nil? (registrar/handler :event :rf.causa/pin-slice)))
+  (is (nil? (registrar/handler :event :rf.causa/unpin-slice)))
+  (is (nil? (registrar/handler :event :rf.causa/reorder-pinned-slices))))
 
-(deftest pin-slice-dispatch-writes-pin-store
+(deftest focus-slice-path-dispatch-writes-causa-frame
   (events/install!)
   (frame/reg-frame :rf/causa {})
   (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/pin-slice [:cart :items]]))
-  (is (= [[:cart :items]]
-         (get-in (frame/frame-app-db-value :rf/causa)
-                 [:pinned-slices-store :rf/default]))))
+    (rf/dispatch-sync [:rf.causa/focus-slice-path [:cart :items]]))
+  (is (= [:cart :items]
+         (:focused-slice-path (frame/frame-app-db-value :rf/causa)))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -33,12 +33,16 @@
        triples whose path roots in `:rf/machines` / `:rf/route` /
        etc. into a separate group.
 
-    4. **Pin-store transitions.** Pin / unpin / reorder transitions
-       are pure-data → updated-store, and `live-pinned-slices`
-       derefs the current value against `app-db`.
+    4. **`epochs-touching-path` walks the history.** Returns only
+       epochs that touched the focused path, classified by op.
 
-    5. **`epochs-touching-path` walks the history.** Returns only
-       epochs that touched the focused path, classified by op."
+  ## rf2-e9tb0 — pin-store helpers dropped
+
+  Pin-store tests (`pin-path`, `unpin-path`, `reorder-paths`,
+  `slice-pins-for-frame`, `live-pinned-slices`) were removed when the
+  pinned-watches strip was superseded by the segment-inspector popup.
+  The helpers themselves are gone — the matching test deftests have
+  been pulled in lockstep."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]))
@@ -227,62 +231,7 @@
               [:rf/route {:id :app/home}]]
              summary)))))
 
-;; ---- (4) pin-store transitions ------------------------------------------
-
-(deftest pin-path-appends-to-empty-store
-  (let [out (h/pin-path {} :rf/default [:user :auth :status])]
-    (is (= {:rf/default [[:user :auth :status]]} out))))
-
-(deftest pin-path-rejects-duplicates
-  (testing "re-pinning an existing path is a no-op"
-    (let [s0 (h/pin-path {} :rf/default [:a])
-          s1 (h/pin-path s0 :rf/default [:a])]
-      (is (= s0 s1)))))
-
-(deftest pin-path-per-frame-isolation
-  (testing "pins on one frame don't leak into another"
-    (let [s (-> {}
-                (h/pin-path :rf/default [:a])
-                (h/pin-path :rf/other [:b]))]
-      (is (= [[:a]] (get s :rf/default)))
-      (is (= [[:b]] (get s :rf/other))))))
-
-(deftest unpin-path-drops-the-path
-  (let [s0 (-> {} (h/pin-path :rf/default [:a]) (h/pin-path :rf/default [:b]))
-        s1 (h/unpin-path s0 :rf/default [:a])]
-    (is (= [[:b]] (get s1 :rf/default)))))
-
-(deftest unpin-path-noop-on-miss
-  (let [s {:rf/default [[:a]]}]
-    (is (= s (h/unpin-path s :rf/default [:nope]))
-        "removing a missing path returns the store unchanged")))
-
-(deftest reorder-paths-replaces-pin-order
-  (let [s0 (-> {} (h/pin-path :rf/default [:a])
-               (h/pin-path :rf/default [:b])
-               (h/pin-path :rf/default [:c]))
-        s1 (h/reorder-paths s0 :rf/default [[:c] [:a] [:b]])]
-    (is (= [[:c] [:a] [:b]] (get s1 :rf/default))
-        "user-supplied permutation overwrites the previous order")))
-
-(deftest slice-pins-for-frame-defaults-to-empty
-  (is (= [] (h/slice-pins-for-frame {} :rf/default))))
-
-(deftest live-pinned-slices-derefs-against-current-db
-  (testing "live-pinned-slices projects per-pin :path + current :value"
-    (let [store {:rf/default [[:cart :items]
-                              [:user :auth :status]
-                              [:missing :path]]}
-          db    {:cart {:items [{:id 7}]}
-                 :user {:auth {:status :authenticated}}}
-          out   (h/live-pinned-slices store :rf/default db)]
-      (is (= 3 (count out)))
-      (is (= [{:path [:cart :items]         :value [{:id 7}]}
-              {:path [:user :auth :status]  :value :authenticated}
-              {:path [:missing :path]       :value nil}]
-             out)))))
-
-;; ---- (5) 'Show me when this changed' walker -----------------------------
+;; ---- (4) 'Show me when this changed' walker -----------------------------
 
 (defn- mk-record
   "Build a minimal `:rf/epoch-record` for diff-walker tests. The

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_sections_cljs_test.cljs
@@ -24,11 +24,9 @@
 (deftest reserved-group-collapses-when-empty
   (is (nil? (sections/reserved-group []))))
 
-(deftest pinned-group-renders-when-slices-present
-  (let [tree (sections/pinned-group
-               [{:path [:cart :items] :value [{:id 7}]}])]
-    (is (has-testid? tree "rf-causa-app-db-diff-pinned-group"))
-    (is (has-testid? tree "rf-causa-app-db-diff-pinned-[:cart :items]"))))
+;; rf2-e9tb0 — `pinned-group` and `pinned-row` were dropped when path-
+;; segment click-to-inspect replaced the pinned-watches strip; the
+;; matching render tests went with them.
 
 (deftest focus-result-panel-renders-no-hits-message
   (let [tree (sections/focus-result-panel [:cart :items] [])]
@@ -76,14 +74,6 @@
         rows (find-vectors-with-key-meta tree)]
     (is (>= (count rows) 2) "at least one row per pair carries :key meta")
     (is (every? vector? rows) "every keyed row is a vector")))
-
-(deftest pinned-group-rows-carry-key-meta
-  (let [tree (sections/pinned-group
-               [{:path [:cart :items] :value [{:id 7}]}
-                {:path [:user :id]    :value 99}])
-        rows (find-vectors-with-key-meta tree)]
-    (is (>= (count rows) 2))
-    (is (every? vector? rows))))
 
 (deftest focus-result-panel-hits-carry-key-meta
   (let [tree (sections/focus-result-panel

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_slices_cljs_test.cljs
@@ -4,7 +4,7 @@
   Renders each public slice fn (`empty-state`, `slice-row`,
   `changed-slices-stack`) once and asserts the load-bearing
   `data-testid` hook is present in the produced hiccup."
-  (:require [cljs.test :refer-macros [deftest is]]
+  (:require [cljs.test :refer-macros [deftest is testing]]
             [day8.re-frame2-causa.panels.app-db-diff-slices :as slices]))
 
 (defn- has-testid? [tree testid]
@@ -20,11 +20,20 @@
     (is (has-testid? tree "rf-causa-app-db-diff-empty"))))
 
 (deftest slice-row-renders-with-action-buttons
-  (let [tree (slices/slice-row {:op :modified :path [:cart :items]
-                                :before [] :after [{:id 7}]})]
-    (is (has-testid? tree "rf-causa-app-db-diff-slice-[:cart :items]"))
-    (is (has-testid? tree "rf-causa-app-db-diff-pin-[:cart :items]"))
-    (is (has-testid? tree "rf-causa-app-db-diff-show-when-[:cart :items]"))))
+  (testing "rf2-e9tb0 — Pin button dropped from slice-row in lockstep
+            with the pinned-watches strip removal. Show-me-when stays
+            (independent affordance)."
+    (let [tree (slices/slice-row {:op :modified :path [:cart :items]
+                                  :before [] :after [{:id 7}]})]
+      (is (has-testid? tree "rf-causa-app-db-diff-slice-[:cart :items]"))
+      (is (nil? (some (fn [node]
+                        (and (vector? node)
+                             (map? (second node))
+                             (= "rf-causa-app-db-diff-pin-[:cart :items]"
+                                (:data-testid (second node)))))
+                      (tree-seq (some-fn vector? seq?) seq tree)))
+          "Pin button is gone — pinned-watches feature dropped (rf2-e9tb0)")
+      (is (has-testid? tree "rf-causa-app-db-diff-show-when-[:cart :items]")))))
 
 (deftest changed-slices-stack-renders-no-changes-state-on-empty
   (is (has-testid? (slices/changed-slices-stack [])

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
@@ -20,7 +20,7 @@
                 (reset! subs/annotated-tree-cache {})
                 (reset! subs/redacted-modified-cache {}))}))
 
-(deftest leaf-install-registers-the-twelve-subs
+(deftest leaf-install-registers-the-active-subs
   (subs/install!)
   ;; rf2-fvplw — `:rf.causa/observed-frame` is the picker/focus-aware
   ;; seam that replaces the legacy `:rf.causa/target-frame` read inside
@@ -31,13 +31,14 @@
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-diff)))
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-annotated-tree)))
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-sections)))
-  (is (some? (registrar/handler :sub :rf.causa/pinned-slices-store)))
-  (is (some? (registrar/handler :sub :rf.causa/pinned-slices)))
   (is (some? (registrar/handler :sub :rf.causa/focused-slice-path)))
   (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
   ;; rf2-bz1cl — redacted-paths-modified hint sub.
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-redacted-modified-count)))
-  (is (some? (registrar/handler :sub :rf.causa/app-db-diff))))
+  (is (some? (registrar/handler :sub :rf.causa/app-db-diff)))
+  ;; rf2-e9tb0 — pinned-slices subs are gone.
+  (is (nil? (registrar/handler :sub :rf.causa/pinned-slices-store)))
+  (is (nil? (registrar/handler :sub :rf.causa/pinned-slices))))
 
 (deftest diff-caches-are-leaf-level-atoms
   (is (some? subs/diff-cache))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -151,8 +151,11 @@
    :rf.causa/mode-c-selection
    ;; rf2-7hwwe — `:after` ring tick driver wall-clock surface + hover slot.
    :rf.causa/now-ms
-   :rf.causa/pinned-slices
-   :rf.causa/pinned-slices-store
+   ;; rf2-e9tb0 — App-DB segment-inspector popup subs.
+   :rf.causa/segment-inspector-open?
+   :rf.causa/segment-inspector-path
+   :rf.causa/segment-inspector-slot
+   :rf.causa/segment-inspector-value
    :rf.causa/palette-active-item
    :rf.causa/palette-cursor
    :rf.causa/palette-index
@@ -252,6 +255,8 @@
    :rf.causa/clear-selected-dispatch-id
    :rf.causa/clear-slice-focus
    :rf.causa/clear-trace-buffer
+   ;; rf2-e9tb0 — App-DB segment-inspector popup close event.
+   :rf.causa/close-segment-inspector
    :rf.causa/clear-trace-filters
    :rf.causa/close-edit-popup
    :rf.causa/close-shell
@@ -283,6 +288,8 @@
    :rf.causa/note-trace-event
    :rf.causa/open-edit-popup
    :rf.causa/open-in-editor
+   ;; rf2-e9tb0 — App-DB segment-inspector popup open event.
+   :rf.causa/open-segment-inspector
    :rf.causa/open-settings
    :rf.causa/open-share-url-in-new-tab
    :rf.causa/palette-close
@@ -293,13 +300,11 @@
    :rf.causa/palette-open
    :rf.causa/palette-set-query
    :rf.causa/palette-toggle
-   :rf.causa/pin-slice
    :rf.causa/preview-cascade
    ;; rf2-vbbq0 — L2 row relative-time chip ticker (writes `:rf.causa/
    ;; relative-time-now-ms` once per second so chips recompute coherently).
    :rf.causa/relative-time-tick
    :rf.causa/remove-filter
-   :rf.causa/reorder-pinned-slices
    ;; rf2-x8h9y — resize-handle double-click reset.
    :rf.causa/reset-panel-width
    :rf.causa/reset-suppressed-counters
@@ -368,7 +373,6 @@
    :rf.causa/toggle-live-pause
    :rf.causa/toggle-mode-c-cluster-expanded
    :rf.causa/toggle-mode-c-selection
-   :rf.causa/unpin-slice
    ;; Views panel events (rf2-21ob3) — replaces the legacy Subscriptions
    ;; panel events. See `tools/causa/spec/012-Views.md`.
    :rf.causa/views-collapse-all-rows
@@ -457,8 +461,12 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    (is (= 102 (count all-sub-names)))
-    (is (= 116 (count all-event-names)))
+    ;; rf2-e9tb0 — net +2 subs (–2 pinned-slices, +4 segment-inspector)
+    ;; and –1 events (–3 pin/unpin/reorder, +2 open/close segment-
+    ;; inspector). Against the post-rf2-ttnst Settings expansion
+    ;; baseline (102 subs / 116 events) → 104 subs / 115 events.
+    (is (= 104 (count all-sub-names)))
+    (is (= 115 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent
@@ -792,11 +800,17 @@
     (rf/with-frame :rf/causa
       (is (= [] @(rf/subscribe [:rf.causa/epoch-history]))))))
 
-(deftest sub-pinned-slices-store-defaults-empty
-  (testing ":rf.causa/pinned-slices-store defaults to {}"
+;; rf2-e9tb0 — :rf.causa/pinned-slices-store sub was dropped when the
+;; pinned-watches strip was superseded by the segment-inspector popup.
+
+(deftest sub-segment-inspector-defaults-closed
+  (testing "rf2-e9tb0 — :rf.causa/segment-inspector-open? defaults to
+            false on a fresh frame; :rf.causa/segment-inspector-path
+            defaults to nil"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (is (= {} @(rf/subscribe [:rf.causa/pinned-slices-store]))))))
+      (is (false? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
+      (is (nil? @(rf/subscribe [:rf.causa/segment-inspector-path]))))))
 
 (deftest sub-issues-filters-default-disabled
   (testing ":rf.causa/issues-filters has empty axes on a fresh frame"
@@ -835,7 +849,9 @@
         (is (nil? (:selected-cascade data)))))))
 
 (deftest sub-app-db-diff-shape-on-empty-history
-  (testing ":rf.causa/app-db-diff returns history-empty? true with no epochs"
+  (testing ":rf.causa/app-db-diff returns history-empty? true with no epochs.
+            rf2-e9tb0 — :pinned-slices was dropped from the composite
+            (pinned-watches strip removed)."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (let [data @(rf/subscribe [:rf.causa/app-db-diff])]
@@ -843,7 +859,7 @@
         (is (= :rf/default (:target-frame data)))
         (is (contains? data :changed-non-reserved))
         (is (contains? data :changed-reserved))
-        (is (= [] (:pinned-slices data)))
+        (is (not (contains? data :pinned-slices)))
         (is (nil? (:focused-path data)))
         (is (= [] (:focused-hits data)))))))
 
@@ -996,16 +1012,19 @@
       (rf/dispatch-sync [:rf.causa/views-set-component-filter nil])
       (is (nil? @(rf/subscribe [:rf.causa/views-component-filter]))))))
 
-(deftest event-pin-slice-and-unpin-slice
-  (testing ":rf.causa/pin-slice + unpin-slice update :pinned-slices-store"
+(deftest event-segment-inspector-open-and-close
+  (testing "rf2-e9tb0 — :rf.causa/open-segment-inspector writes the
+            requested path into Causa's frame; close drops it. The
+            popup is then visible / invisible via the open? sub."
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/pin-slice [:users :count]])
-      (let [store @(rf/subscribe [:rf.causa/pinned-slices-store])]
-        (is (= [[:users :count]] (get store :rf/default))))
-      (rf/dispatch-sync [:rf.causa/unpin-slice [:users :count]])
-      (let [store @(rf/subscribe [:rf.causa/pinned-slices-store])]
-        (is (= [] (get store :rf/default [])))))))
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector [:users :count]])
+      (is (true? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
+      (is (= [:users :count]
+             @(rf/subscribe [:rf.causa/segment-inspector-path])))
+      (rf/dispatch-sync [:rf.causa/close-segment-inspector])
+      (is (false? @(rf/subscribe [:rf.causa/segment-inspector-open?])))
+      (is (nil? @(rf/subscribe [:rf.causa/segment-inspector-path]))))))
 
 (deftest event-focus-slice-path-and-clear
   (testing ":rf.causa/focus-slice-path + clear-slice-focus round-trip"

--- a/tools/causa/testbeds/panel_gallery/fixtures_app_db.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_app_db.cljs
@@ -2,18 +2,20 @@
   "Pure fixture builders for the Causa App-db tab gallery
   (rf2-sszlr — rebuild for new 6-tab Causa shape).
 
-  The app-db-diff panel reads four slots from the Causa frame:
+  The app-db-diff panel reads three slots from the Causa frame:
 
     - `:epoch-history`         — vector of `:rf/epoch-record` maps
     - `:selected-epoch-id`     — optional, drives 'diff this epoch'
-    - `:pinned-slices-store`   — `{frame-id [path ...]}`
     - `:focused-slice-path`    — optional, drives 'Show me when this
                                  changed' result
 
   The composite `:rf.causa/app-db-diff` projects these into the map the
-  facade view destructures (`:changed-non-reserved`, `:pinned-slices`,
-  `:changed-reserved`, `:focused-path`, `:focused-hits`,
-  `:history-empty?`, `:target-frame`).
+  facade view destructures (`:changed-non-reserved`, `:changed-reserved`,
+  `:focused-path`, `:focused-hits`, `:history-empty?`, `:target-frame`).
+
+  rf2-e9tb0 — `:pinned-slices-store` and `:pinned-slices` were
+  dropped when the pinned-watches strip was superseded by the
+  segment-inspector popup.
 
   ## Why seed via `:rf.causa/sync-epoch-history`
 
@@ -63,7 +65,8 @@
 
 (defn empty-buffer
   "No epochs — panel renders the `[empty]` state with the
-  pinned/reserved scaffolding only."
+  reserved-keys scaffolding only (rf2-e9tb0 dropped the pinned-watches
+  strip)."
   []
   [])
 

--- a/tools/causa/testbeds/panel_gallery/gallery_app_db.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_app_db.cljs
@@ -3,9 +3,13 @@
   (rf2-sszlr — gallery rebuild for spec/018-Event-Spine).
 
   The App-db tab body is the `app-db-diff/Panel` view: the changed-
-  slices + pinned-slices + reserved-keys group + 'Show me when this
-  changed' walker. Each variant seeds its frame's `:epoch-history`
-  via REAL Causa init events fired into the variant frame.
+  slices + reserved-keys group + 'Show me when this changed' walker.
+  Each variant seeds its frame's `:epoch-history` via REAL Causa init
+  events fired into the variant frame.
+
+  rf2-e9tb0 — the pinned-watches strip was dropped in favour of the
+  segment-inspector popup; the gallery's variants no longer touch
+  `:pinned-slices-store`.
 
   ## Frame isolation
 
@@ -13,9 +17,8 @@
   variant-id}]`. Subscriptions inside the rendered tree resolve to
   the variant frame; `:rf.causa/app-db-diff` reads the seeded
   `:epoch-history` (and any `:selected-epoch-id` /
-  `:pinned-slices-store` / `:focused-slice-path`). Each variant
-  therefore observes its own bespoke history in isolation; no two
-  variants share state."
+  `:focused-slice-path`). Each variant therefore observes its own
+  bespoke history in isolation; no two variants share state."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures-app-db :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
@@ -33,9 +36,10 @@
 
   (story/reg-tag :feature/causa-app-db
     {:axis :feature
-     :doc  "Causa App-db tab — changed slices, pinned slices,
-            reserved-keys group, and the 'Show me when this changed'
-            walker (per spec/018-Event-Spine §5.2)."})
+     :doc  "Causa App-db tab — changed slices, reserved-keys group,
+            and the 'Show me when this changed' walker (per spec/018-
+            Event-Spine §5.2). Pinned-watches strip dropped under
+            rf2-e9tb0."})
 
   (story/reg-story :story.causa.app-db
     {:doc        "Visual gallery of the Causa App-db tab under varying
@@ -58,7 +62,8 @@
   ;; ----- 2. empty (no epochs) -----------------------------------------
   (story/reg-variant :story.causa.app-db/empty
     {:doc        "No epochs in history. Panel renders the empty-state
-                 + pinned + reserved scaffolding only."
+                 + reserved scaffolding only (rf2-e9tb0 dropped the
+                 pinned-watches strip)."
      :events     [[:rf.causa/sync-epoch-history (fixtures/empty-buffer)]]
      :tags       #{:dev :state/empty}
      :substrates #{:reagent}})


### PR DESCRIPTION
## Summary

Replace the pinned-watches strip with a popup inspector opened by clicking any path segment in an App-DB Diff breadcrumb. For each diff path like `[:cart :items 0 :price]`, each segment is independently clickable: clicking `:cart` opens the popup at `[:cart]`; clicking `:items` at `[:cart :items]`; and so on. The popup renders the value at the inspected path via the existing `theme/data-inspector/inspect` primitive (cljs-devtools-shaped expandable tree).

## Why (Mike's Q13)

> "Because app-db updates are identified so surgically, we probably don't need to see pinned. Somewhere we need to allow them to look at app-db in its entirety. Perhaps the path for the identified change has clickable segment, and if clicked, popups up an app-db inspector for that segment."

The diff already identifies changes surgically, so pinning paths up-front is redundant when any prefix of any diff path can be inspected with one click. The escape-hatch use case ("show me app-db in its entirety") is now served by clicking the root segment of any breadcrumb.

## UI behaviour

- **Hover**: path segments carry a dotted underline + pointer cursor + a `Inspect app-db at <prefix>` tooltip so the affordance is discoverable without screaming through the diff body.
- **Click**: opens the segment-inspector popup at the path-prefix up to AND INCLUDING the clicked segment. The popup is a modal-light overlay (15% dim backdrop, smaller centred dialog mirroring the causality popover's chrome).
- **Close**: three affordances — `Esc` keydown, click outside (backdrop dispatches close; dialog stops propagation), and the `X` button in the header.
- **Body**: the inspected value rendered via the existing data-inspector primitive — same expandable tree every L4 detail panel uses, so the renderer is uniform with the diff body. Per-node expand state shares the data-inspector slot in `:rf/causa` app-db.

## What this replaces

Pinned-slices feature dropped wholesale. Removed:

- Events: `:rf.causa/pin-slice`, `:rf.causa/unpin-slice`, `:rf.causa/reorder-pinned-slices`
- Subs: `:rf.causa/pinned-slices-store`, `:rf.causa/pinned-slices`
- Helpers: `pin-path`, `unpin-path`, `reorder-paths`, `slice-pins-for-frame`, `live-pinned-slices`
- Renderers: `pinned-row`, `pinned-group`; the Pin button on `slice-row` and on the section breadcrumb header

Added:

- New `app-db-segment-inspector` facade with subs / events / view inline; mounted at the shell root alongside the other modals via `[app-db-segment-inspector/Popup]`.
- Events: `:rf.causa/open-segment-inspector`, `:rf.causa/close-segment-inspector`
- Subs: `:rf.causa/segment-inspector-open?`, `:rf.causa/segment-inspector-path`, `:rf.causa/segment-inspector-slot`, `:rf.causa/segment-inspector-value`

Specs updated: `004-App-DB-Diff.md` (replace pinned-watches paragraph with clickable-segments + popup spec); `014-Registry-Catalogue.md` (sub/event tables); `API.md` (deprecate the pinned-slices localStorage slot).

## Test plan

- [x] `scripts/test-fast-pr.sh` — pass
- [x] `cd implementation && npm run test:cljs` — pass (2939 tests / 8432 assertions)
- [x] `cd implementation && npm run test:browser` — pass (2930 tests / 8375 assertions)
- [x] `cd implementation && npm run story:build` — pass
- [x] `python -m mkdocs build --strict` — 72 baseline warnings, no new
- [x] `python scripts/check_doc_slugs.py` — clean
- [x] New unit tests: open / close roundtrip, open? sub tracks slot presence, segment-inspector-value resolves through `target-frame-db` with `get-in`, root-path inspection yields whole db, breadcrumb segments now dispatch open-segment-inspector (regression guard: never `pin-slice`), hover styling present
- [x] Registry test pinned to `103` subs / `119` events / `5` fxs (net +2 subs, -1 event)