### PR TITLE
fix(examples): EXAMPLES_FILTER narrows spec runner + build (rf2-mpa3x)

### DIFF
--- a/examples/scripts/run-examples-tests.cjs
+++ b/examples/scripts/run-examples-tests.cjs
@@ -59,6 +59,31 @@ const BASE_URL = process.env.EXAMPLES_BASE_URL || 'http://127.0.0.1:8030';
 // `examples/reagent/realworld/realworld.spec.cjs` cleanly. Unset (or
 // empty) = the full sweep.
 const FILTER = (process.env.EXAMPLES_FILTER || '').trim();
+// rf2-mpa3x — normalize before substring-matching. Two cosmetic
+// conventions diverge between build ids and spec paths:
+//
+//   1. Build ids use kebab-case (`examples/causa-rhs-smoke`); on-disk
+//      dirs use snake_case (`tools/story/testbeds/causa_rhs_smoke/`).
+//      A user naturally supplies the build-id form to EXAMPLES_FILTER,
+//      so the literal substring `causa-rhs-smoke` failed to match the
+//      underscore-bearing spec path. Map `_` → `-` on both sides.
+//   2. Path separators differ across platforms (`\` on Windows, `/`
+//      elsewhere). The saved-memory substring trap recommends the
+//      path-separator-aware form (`testbeds/shop` or `testbeds\shop`)
+//      so a bare `shop` isn't shadowed by a worktree-name substring.
+//      Normalize `\` → `/` on both sides so `testbeds/shop` works on
+//      every platform (Git Bash on Windows, Linux, macOS) without the
+//      user remembering which slash to type.
+//
+// The substring-trap protection is preserved verbatim — the only
+// change is collapsing two cosmetic variants before `.includes()`.
+function normalizeForFilter(s) {
+  return s.replace(/_/g, '-').replace(/\\/g, '/');
+}
+function matchesFilter(filePath) {
+  if (FILTER === '') return true;
+  return normalizeForFilter(filePath).includes(normalizeForFilter(FILTER));
+}
 // __dirname is <repo>/examples/scripts; the example tree sits at
 // <repo>/examples (one level up). rf2-p8f2s broadened discovery to
 // include tool-owned testbeds under <repo>/tools/<tool>/testbeds/ and
@@ -132,11 +157,11 @@ function withTimeout(promise, ms, label) {
 
 (async () => {
   const allSpecFiles = listSpecFiles(SPEC_ROOTS);
-  // rf2-h9ut9 — apply EXAMPLES_FILTER substring match against the
-  // absolute spec path so narrow runs only execute matching specs.
-  const specFiles = FILTER
-    ? allSpecFiles.filter((f) => f.includes(FILTER))
-    : allSpecFiles;
+  // rf2-h9ut9 + rf2-mpa3x — apply EXAMPLES_FILTER substring match
+  // against the absolute spec path so narrow runs only execute matching
+  // specs. The normalisation in `matchesFilter` bridges the kebab/snake
+  // and `\`/`/` cosmetic gaps without weakening the substring trap.
+  const specFiles = allSpecFiles.filter(matchesFilter);
   if (specFiles.length === 0) {
     if (FILTER) {
       console.error(

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -428,8 +428,20 @@ const EXAMPLES = [
 // filter = pass-through. The same predicate gates compile, stage, and
 // the JVM live-SSR bring-up below so a narrow run never spins up
 // resources for excluded surfaces.
+//
+// rf2-mpa3x — `normalizeForFilter` collapses kebab/snake and `\`/`/`
+// cosmetic variants on both sides before substring-matching. Build ids
+// already use kebab-case so this is a no-op for typical filters; the
+// gain is symmetry with `run-examples-tests.cjs` (which sees
+// snake_case-bearing spec paths). Keep the predicate in lockstep so a
+// single EXAMPLES_FILTER value gates compile, stage, and spec runner
+// identically. See the runner for the substring-trap rationale.
+function normalizeForFilter(s) {
+  return s.replace(/_/g, '-').replace(/\\/g, '/');
+}
 function selectedExample(ex) {
-  return FILTER === '' || ex.build.includes(FILTER);
+  if (FILTER === '') return true;
+  return normalizeForFilter(ex.build).includes(normalizeForFilter(FILTER));
 }
 
 function selectedExamples() {


### PR DESCRIPTION
## Bug

`EXAMPLES_FILTER=causa-rhs-smoke npm run test:examples` (or any narrow filter from a build id) compiled only the matching shadow-cljs build but the spec runner failed to apply the same filter. Two cosmetic conventions diverge:

1. **Kebab vs snake** — build ids use kebab-case (`examples/causa-rhs-smoke`), but on-disk directories use snake_case (`tools/story/testbeds/causa_rhs_smoke/`). The literal substring `causa-rhs-smoke` is not contained in the snake_case spec path, so the runner matched zero specs.
2. **Platform separator** — `\` on Windows, `/` elsewhere. The saved-memory substring trap recommends the path-separator-aware form (`testbeds/shop` / `testbeds\shop`); only one of these literally worked per platform.

Pre-fix symptom: `EXAMPLES_FILTER=causa-rhs-smoke` compiled one build, then the spec runner exited with `matched zero specs (scanned 17 candidates)` and exit 1.

Reported by the rf2-dbiut PR #1514 worker as 18+ "404 / build artifact missing" spec failures; the modern surface produces the cleaner "matched zero specs" error after PR #1474 broadened spec discovery, but the underlying mismatch is the same.

## Fix

Apply normalisation (`_` -> `-`, `\` -> `/`) on both the filter and the comparison string in **both** the spec runner (`run-examples-tests.cjs`) and the build orchestrator (`serve-and-run-examples-tests.cjs`). Same `normalizeForFilter` definition in each script for symmetry. The substring-trap protection (saved memory `orchestrator-filter-substring-trap-2026-05-18`) is preserved verbatim: the worktree directory name is still a substring of every spec path, so users must still pass the path-separator-aware form (`testbeds/shop`) to disambiguate.

## Test plan

- [x] Manual filter on the original repro: `EXAMPLES_FILTER=causa-rhs-smoke node ../examples/scripts/serve-and-run-examples-tests.cjs` -> `Ran 1 example specs. 0 failures, 0 skipped.`
- [x] Manual filter (bead instruction): `EXAMPLES_FILTER=parallel_frames node ../examples/scripts/serve-and-run-examples-tests.cjs` -> `Ran 1 example specs. 0 failures, 0 skipped.`
- [x] Path-aware substring trap still applies: filtering on the worktree directory name still matches every spec (user-disambiguation contract unchanged).
- [x] `scripts/test-fast-pr.sh` — PASS (2944 tests / 8417 assertions, 0/0)
- [x] `cd implementation && npm run test:cljs` — PASS (2944/8417, 0/0)
- [x] `cd implementation && npm run test:browser` — PASS (2935/8360, 0/0)
- [x] `mkdocs build --strict` — 72 warnings (unchanged pre-existing baseline; this PR touches no docs)
- [x] Cross-platform — normalisation is a pure JS string op; works identically on Windows (PowerShell + Git Bash) and Unix.

## Saved memory preservation note

`orchestrator-filter-substring-trap-2026-05-18`: filter is still path-substring-matched. The normalisation step collapses two cosmetic variants but does not weaken the substring guarantee. A worker testing this change in its own worktree (whose directory name contains a substring of the bead id) still needs the path-separator-aware form (`testbeds/<name>` / `examples/<name>`) to avoid matching every spec — that contract is unchanged.