### PR TITLE
feat(causa): Views polish — Group-by + right-click filter chip + sub-status decoration (rf2-r2s2l)

### DIFF
--- a/tools/causa/spec/012-Views.md
+++ b/tools/causa/spec/012-Views.md
@@ -315,6 +315,45 @@ reasoning "which sub triggered all this rendering?" rather than "which
 views ran?" The two views are mathematically symmetric; the toggle
 lets the user pick their entry point.
 
+The toggle ships as a pill row in the bottom-controls footer:
+
+```
+Group by [◉ component] [○ sub]
+```
+
+State lives in `:rf/causa`'s app-db at `:views/group-by` (default
+`:component`); written by `:rf.causa/set-views-group-by`; read by
+`:rf.causa/views-group-by`. Switching mode is panel-scoped — no
+spine pivot, no cross-tab effect.
+
+The `:sub` mode renders only over the **Re-rendered** group's per-
+render sub attribution (Mounted has no prior to compare; Unmounted
+has no current). When a cascade is parent-forced (no sub
+invalidations), the panel renders an empty-state explaining the
+case rather than a blank section.
+
+## Component filter chip
+
+Right-clicking any Views row dispatches
+`:rf.causa/views-set-component-filter` with the row's `view-id`. A
+chip appears ABOVE the three-group section header:
+
+```
+┌─ Filtered to: <cart/list> × ────────────────────────────────┐
+│  (panel scopes every group to renders of cart/list only)    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Per `findings/2026-05-17-causa-consolidated-design.md` §0ter.1
+R3-E the chip is **panel-scoped** (NOT ribbon-scoped — the ribbon
+carries event-list filters). The bottom-controls footer keeps a
+secondary clear button for the scrolled-past case.
+
+The right-click pattern mirrors `shell.cljs`'s event-row context-
+menu: direct dispatch, no separate context-menu UI surface. v1
+ships one action ("filter to this component"); a multi-item menu
+lands behind a follow-on bead if/when more actions accumulate.
+
 ## Sub-status legibility
 
 Subs nested under each view row carry sub-cache-state information
@@ -329,6 +368,24 @@ on the sub-id when the cache state is interesting:
 | `:invalidated` | yellow `◌` | Inputs changed; no watcher to drive recompute |
 | `:cached-no-watcher` | tertiary `○` | Cached but zero watchers; value may be stale |
 | `:error` | red `▲ !` | Most recent compute threw |
+
+### Re-rendered-row sub-status decoration
+
+Inside the Re-rendered group's right-column "Rerendered because" list,
+each consumed sub carries one of three statuses (per
+`findings/2026-05-17-causa-consolidated-design.md` §0ter.1 R3):
+
+| Status | Glyph + colour | Meaning |
+|---|---|---|
+| `:cache-miss-trigger` | amber `✱` (bold) | Sub recomputed; new value DIFFERS from prior. Likely cause of the re-render. |
+| `:cache-miss-equal`   | muted `≈`        | Sub recomputed; new value structurally EQUALS prior. React skipped re-render of any view reading only this sub. |
+| `:cache-hit`          | muted `·`        | Sub did NOT recompute this cascade; the view read the cached value. |
+
+The classifier lives in `views_helpers.cljc` as
+`sub-status`; the renderer's per-status chrome (glyph + tooltip +
+aria-label + `data-marker` attribute) is encapsulated in
+`views_view.cljs` `sub-status-chrome`. Tests assert all three
+statuses render their respective glyphs.
 
 Compared to the legacy Subs panel, this is a leaner surface — the sub
 no longer gets its own row; it's a decorator on the view's "subs used"

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_helpers.cljc
@@ -250,6 +250,33 @@
 
 ;; ---- re-rendered group: invalidating-sub layout -----------------------
 
+(defn sub-status
+  "Classify one `:invalidated-by` row into one of three statuses for the
+  glyph decoration in the Re-rendered group's right-column list (per
+  spec §Sub-status legibility + §0ter.1 R3 — the cache-miss-equal
+  gap):
+
+    `:cache-miss-trigger` — sub's recomputed value changed and is
+      the trigger for this re-render. Rendered as `✱` (amber).
+    `:cache-miss-equal`   — sub recomputed this cascade but the new
+      value structurally equalled the prior; React skipped re-render
+      of any view reading only this sub. Rendered as `≈` (muted).
+    `:cache-hit`          — sub was consumed but did NOT recompute
+      (cache hit). Rendered as `·` (muted).
+
+  Inputs:
+    - `row` — one entry from `re-render-invalidated-by`'s output
+      vector. Carries `:trigger?` (true → trigger) and
+      `:recomputed?` (true → recomputed this cascade).
+
+  The three statuses are mutually exclusive; the classifier returns
+  a single keyword."
+  [row]
+  (cond
+    (:trigger? row)     :cache-miss-trigger
+    (:recomputed? row)  :cache-miss-equal
+    :else               :cache-hit))
+
 (defn re-render-invalidated-by
   "Per spec §Per-row content (Re-rendered) — derive the 'Invalidated
   by' list for one re-render row. Returns a vector
@@ -264,7 +291,8 @@
     means parent re-rendered → forced child re-render (the row
     surfaces a synthetic `:sub-id ::parent-forced` entry).
   - The remaining `:sub-runs` entries this cascade are also-
-    consumed subs (`:trigger? false`, marked `·` in the view).
+    consumed subs (`:trigger? false`, marked `·` for cache-hit or
+    `≈` for cache-miss-equal in the view per `sub-status`).
     The view filters these to subs the component actually consumed
     once per-render sub-attribution lands.
 
@@ -283,6 +311,95 @@
                         :recomputed? (boolean (:recomputed? sr))
                         :trigger?    false})]
     (vec (concat (filter some? [trigger parent-forced]) sub-rows))))
+
+;; ---- group-by sub: inverted hierarchy ----------------------------------
+;;
+;; Per spec §Group-by toggle the alternate hierarchy is `:sub` —
+;; top-level rows are subs that ran this cascade; under each sub-row,
+;; the components that consumed it. Answers the symmetric question:
+;; "which sub caused all this rendering?"
+;;
+;; The data is mathematically symmetric with the `:component`
+;; grouping: each Re-rendered single-row's `:invalidated-by` list
+;; carries `{:sub-id ... :trigger? ...}` rows, which we invert here
+;; into `sub-id → [view-id ...]`. We restrict to the Re-rendered
+;; group only — Mounted / Unmounted sub-attribution isn't surfaced
+;; per-render (Mounted has no prior to compare; Unmounted has no
+;; current).
+
+(defn build-sub-grouped
+  "Invert the `:rendered` group's component → subs mapping into a
+  sub → components mapping. Returns a vector of sub-rows, each:
+
+    `{:sub-id       <sub-id>
+      :trigger?     <bool>        ; true when this sub triggered
+                                   ; at least one re-render this cascade
+      :recomputed?  <bool>        ; true when this sub recomputed
+      :views        [{:view-id <kw>
+                      :render-key <[view-id token]>
+                      :trigger? <bool>
+                      :elapsed-ms <ms>} ...]
+      :view-count   <N>}`
+
+  `rendered-items` is the clustered+annotated `:rendered` group
+  (each item from `cluster-renders` with `:invalidated-by`).
+  Cluster items contribute their cluster's `:triggered-by` sub-id
+  with `:view-count` = cluster's `:count`. Single items contribute
+  each `:invalidated-by` row's `:sub-id`.
+
+  Stable ordering: sub-rows sort by first-occurrence index in the
+  source list so the inverted view keeps a deterministic order
+  matching the source cascade."
+  [rendered-items]
+  (let [contributions
+        (for [[idx item] (map-indexed vector rendered-items)
+              :let [r (:render item)
+                    view-id (render-key->view-id (:render-key r))
+                    invalidated-by (or (:invalidated-by item) [])]
+              row    invalidated-by]
+          {:idx          idx
+           :sub-id       (:sub-id row)
+           :trigger?     (boolean (:trigger? row))
+           :recomputed?  (boolean (:recomputed? row))
+           :clustered?   (= :cluster (:kind item))
+           :clustered-n  (when (= :cluster (:kind item)) (:count item))
+           :view-id      (or view-id (:view-id item))
+           :render-key   (:render-key r)
+           :elapsed-ms   (:elapsed-ms r)})
+        by-sub (group-by :sub-id contributions)
+        first-idx (reduce (fn [acc {:keys [sub-id idx]}]
+                            (if (contains? acc sub-id)
+                              acc
+                              (assoc acc sub-id idx)))
+                          {}
+                          contributions)
+        sub-rows
+        (for [[sub-id rows] by-sub
+              :let [any-trigger?    (some :trigger? rows)
+                    any-recomputed? (some :recomputed? rows)
+                    views (vec (for [r rows]
+                                 (cond-> {:view-id      (:view-id r)
+                                          :render-key   (:render-key r)
+                                          :trigger?     (:trigger? r)
+                                          :elapsed-ms   (:elapsed-ms r)}
+                                   (:clustered? r)
+                                   (assoc :clustered?  true
+                                          :clustered-n (:clustered-n r)))))
+                    view-count (reduce + 0
+                                       (map (fn [r]
+                                              (if (:clustered? r)
+                                                (or (:clustered-n r) 1)
+                                                1))
+                                            rows))]]
+          {:sub-id       sub-id
+           :trigger?     (boolean any-trigger?)
+           :recomputed?  (boolean any-recomputed?)
+           :views        views
+           :view-count   view-count
+           ::order       (get first-idx sub-id 0)})]
+    (->> sub-rows
+         (sort-by ::order)
+         (mapv #(dissoc % ::order)))))
 
 ;; ---- assembled views-data ---------------------------------------------
 
@@ -346,8 +463,14 @@
                                      :trigger?    true
                                      :clustered?  true}])))
                         items)))
-        cascade-ms (reduce + 0 (keep :elapsed-ms current-renders))]
+        cascade-ms (reduce + 0 (keep :elapsed-ms current-renders))
+        ;; Per spec §Group-by toggle — the inverted hierarchy
+        ;; (sub-rows at top, components consumed underneath) reuses
+        ;; the :rendered group's annotated items. The view-layer's
+        ;; group-by `:sub` renderer reads `:sub-grouped`.
+        sub-grouped (build-sub-grouped (:rendered clustered-with-invalidated))]
     {:groups         clustered-with-invalidated
+     :sub-grouped    sub-grouped
      :totals         {:mounted    (count (:mounted groups))
                       :rendered   (count (:rendered groups))
                       :unmounted  (count (:unmounted groups))

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -88,22 +88,43 @@
    :font-size "12px"
    :color (:text-secondary tokens)})
 
-;; ---- ✱ / · marker chrome (rf2-87lkf — Delta 2 polish) ------------------
+;; ---- ✱ / ≈ / · marker chrome (rf2-87lkf — Delta 2 polish ·
+;;                               rf2-r2s2l — cache-miss-equal) -------------
 ;;
-;; The two markers in the Re-rendered group's "Rerendered because" column
+;; The three markers in the Re-rendered group's "Rerendered because" column
 ;; answer the developer's first question — "for each sub the view
-;; consumed, did its value change since last cascade?" The visual
-;; hierarchy puts `✱` (value changed → likely cause) ahead of `·` (sub
-;; recomputed, value unchanged → React skipped re-render). Amber for `✱`
-;; carries the "this is the interesting case" weight; muted-grey `·`
-;; recedes. Inline-block + fixed width keeps the marker column
-;; scannable when dense.
+;; consumed, what happened to it this cascade?" The visual hierarchy:
+;;
+;;   `✱` `:cache-miss-trigger` — value changed → likely cause of the
+;;        re-render (amber, bold).
+;;   `≈` `:cache-miss-equal`   — sub recomputed but new value structurally
+;;        equals previous (React skipped re-render). Muted grey.
+;;   `·` `:cache-hit`          — sub was consumed but did NOT recompute
+;;        (cache hit). Muted grey.
+;;
+;; The `≈` shape distinguishes recomputed-but-equal from cache-hit at a
+;; glance without colliding with the spec's reserved `○` (cached-no-
+;; watcher) / `◐` (re-running) glyph vocabulary. Inline-block + fixed
+;; width keeps the marker column scannable when dense.
 
 (def ^:private trigger-glyph-style
   {:color         (:yellow tokens)       ; amber → "this changed; look here"
    :font-weight   700
    :font-size     "14px"                 ; slightly larger than 12px body so the glyph reads
    :line-height   1                      ; tight so vertical rhythm matches `·`
+   :display       "inline-block"
+   :width         "12px"
+   :text-align    "center"
+   :margin-right  "6px"})
+
+(def ^:private equal-glyph-style
+  ;; Same visual weight as the cache-hit `·` (muted) — both are
+  ;; informational, neither is the cause of the re-render. The
+  ;; shape distinction is what carries the signal.
+  {:color         (:text-tertiary tokens)
+   :font-weight   400
+   :font-size     "14px"
+   :line-height   1
    :display       "inline-block"
    :width         "12px"
    :text-align    "center"
@@ -125,11 +146,42 @@
   facing framing matches the section header \"Rerendered because\")."
   "Value changed since last cascade — this sub's recompute returned a value that differs from the previous one. (Likely cause of the re-render.)")
 
-(def ^:private non-trigger-glyph-tooltip
-  "Hover text for `·` — explains the marker means \"sub recomputed but
+(def ^:private equal-glyph-tooltip
+  "Hover text for `≈` — explains the marker means \"sub recomputed but
   value unchanged\". React skipped the re-render of any view subscribed
-  only to this sub, so the `·` is informational — not a cause."
+  only to this sub, so the `≈` is informational — not a cause. Per
+  spec §0ter.1 R3 — cache-miss-equal completes the three-status
+  taxonomy alongside `✱` and `·`."
   "Sub recomputed, value unchanged — the substrate re-ran this sub during the cascade but the new value structurally equals the previous one. (React skipped re-render of any view reading only this sub.)")
+
+(def ^:private non-trigger-glyph-tooltip
+  "Hover text for `·` — explains the marker means \"sub did NOT
+  recompute this cascade\" (cache hit). The view read the cached
+  value; no work."
+  "Cache hit — the sub did not recompute this cascade; the view read the cached value. (Not a cause of the re-render.)")
+
+(defn- sub-status-chrome
+  "Per spec §0ter.1 R3 — three-status decoration. Returns the glyph
+  string + style map + tooltip + data-marker attribute value for a
+  row's classified status. Encapsulated so the test ns can verify
+  every status renders its respective chrome (`rf2-r2s2l`)."
+  [status]
+  (case status
+    :cache-miss-trigger
+    {:glyph "✱" :style trigger-glyph-style
+     :tooltip trigger-glyph-tooltip
+     :data-marker "trigger"
+     :aria-label "value changed"}
+    :cache-miss-equal
+    {:glyph "≈" :style equal-glyph-style
+     :tooltip equal-glyph-tooltip
+     :data-marker "cache-miss-equal"
+     :aria-label "value unchanged"}
+    :cache-hit
+    {:glyph "·" :style non-trigger-glyph-style
+     :tooltip non-trigger-glyph-tooltip
+     :data-marker "cache-hit"
+     :aria-label "cache hit"}))
 
 ;; ---- small helpers ------------------------------------------------------
 
@@ -166,14 +218,21 @@
 
 ;; ---- 'Rerendered because' list (Re-rendered) ---------------------------
 ;;
-;; Per spec §Per-row content (Re-rendered) the right-column lists every
-;; sub the component consumed this cascade with a marker per sub:
+;; Per spec §Per-row content (Re-rendered) + spec §Sub-status legibility
+;; the right-column lists every sub the component consumed this cascade
+;; with a per-sub status marker (rf2-r2s2l three-status taxonomy):
 ;;
-;;   `✱` (amber, bold) — the sub's recomputed value DIFFERS from the
-;;        previous cascade's value (likely cause of the re-render).
-;;   `·` (muted grey)  — the sub recomputed but the new value structurally
-;;        equals the previous (React skipped re-render of any view reading
-;;        only this sub).
+;;   `✱` (amber, bold) — `:cache-miss-trigger`. Sub's recomputed value
+;;        DIFFERS from the previous cascade's value (likely cause of
+;;        the re-render).
+;;   `≈` (muted grey)  — `:cache-miss-equal`. Sub recomputed but the
+;;        new value structurally equals the previous (React skipped
+;;        re-render of any view reading only this sub).
+;;   `·` (muted grey)  — `:cache-hit`. Sub was consumed but did NOT
+;;        recompute this cascade; the view read the cached value.
+;;
+;; Classifier lives in `views_helpers.cljc` (`sub-status`); per-status
+;; chrome lives in `sub-status-chrome` (above).
 ;;
 ;; The kw `:invalidated-by` and the testid `rf-causa-views-invalidated-by`
 ;; are stable internal-data + test-contract surfaces (rf2-87lkf bead
@@ -188,24 +247,21 @@
          :style {:display "flex"
                  :flex-direction "column"
                  :gap "2px"}}
-   (for [[i row] (map-indexed vector invalidated-by)]
+   (for [[i row] (map-indexed vector invalidated-by)
+         :let [status (h/sub-status row)
+               chrome (sub-status-chrome status)]]
      ^{:key i}
      [:div {:role "listitem"
             :style mono-style}
-      [:span {:style       (if (:trigger? row)
-                             trigger-glyph-style
-                             non-trigger-glyph-style)
-              ;; Hover tooltip per rf2-87lkf — Delta 2. `title` ships
-              ;; the explanation on every browser without a dispatch
-              ;; round-trip; ARIA labels mirror it for screen readers.
-              :title       (if (:trigger? row)
-                             trigger-glyph-tooltip
-                             non-trigger-glyph-tooltip)
-              :aria-label  (if (:trigger? row)
-                             "value changed"
-                             "value unchanged")
-              :data-marker (if (:trigger? row) "trigger" "non-trigger")}
-       (if (:trigger? row) "✱" "·")]
+      [:span {:style       (:style chrome)
+              ;; Hover tooltip per rf2-87lkf — Delta 2 + rf2-r2s2l
+              ;; cache-miss-equal. `title` ships the explanation on
+              ;; every browser without a dispatch round-trip; ARIA
+              ;; labels mirror it for screen readers.
+              :title       (:tooltip chrome)
+              :aria-label  (:aria-label chrome)
+              :data-marker (:data-marker chrome)}
+       (:glyph chrome)]
       [:span (format-sub-id (:sub-id row))]
       (when (:clustered? row)
         [:span {:style {:margin-left "6px"
@@ -332,6 +388,22 @@
        (str "elapsed " (format-ms (:elapsed-ms r))
             " · (mount/commit phase data ships when React Profiler available)")]]]))
 
+(defn- right-click-filter-handler
+  "Per spec §0ter.1 R3-E + bead rf2-r2s2l — right-click any Views row
+  applies the panel-local `:rf.causa/views-set-component-filter` to
+  the row's view-id. Mirrors `shell.cljs`'s event-row pattern (direct
+  dispatch on context-menu; no separate context-menu UI surface).
+  `preventDefault` suppresses the browser's native menu so the
+  developer's right-click lands on Causa's affordance, not the host
+  page's menu. The dispatch resolves to `:rf/causa` via React-context
+  (the panel mounts inside Causa's frame-provider — the same way
+  every other in-panel `rf/dispatch` here resolves)."
+  [view-id]
+  (fn [^js e]
+    (when view-id
+      (.preventDefault e)
+      (rf/dispatch [:rf.causa/views-set-component-filter view-id]))))
+
 (defn- single-row
   "One render row in either Mounted, Re-rendered, or Unmounted. The
   two-column layout for Re-rendered (spec §Per-row content (Re-
@@ -344,6 +416,10 @@
     [:div {:data-testid (str "rf-causa-views-row-" (name group))
            :on-click    #(rf/dispatch [:rf.causa/views-toggle-row
                                        (pr-str (:render-key r))])
+           :on-context-menu (right-click-filter-handler view-id)
+           :title       (when view-id
+                          (str "Right-click → filter Views panel to "
+                               "<" (h/format-view-id view-id) ">"))
            :style       (cond-> row-clickable-style
                           struck? (assoc :text-decoration "line-through"
                                          :color (:text-tertiary tokens)))}
@@ -384,6 +460,10 @@
   (let [{:keys [view-id triggered-by count total-ms avg-ms p95-ms]} item
         ckey   (str "cluster:" (pr-str [view-id triggered-by]))]
     [:div {:data-testid (str "rf-causa-views-cluster-" (name group))
+           :on-context-menu (right-click-filter-handler view-id)
+           :title (when view-id
+                    (str "Right-click → filter Views panel to "
+                         "<" (h/format-view-id view-id) ">"))
            :style row-style}
      [:div {:style {:display "flex" :gap "12px" :align-items "flex-start"}}
       [:span {:style {:color (:yellow tokens) :font-weight 700}}
@@ -468,6 +548,95 @@
              :cluster (cluster-row item group (contains? expanded-clusters rk)))
            {:key rk})))]))
 
+;; ---- sub-grouped renderer (spec §Group-by toggle / rf2-r2s2l) ----------
+;;
+;; Inverted hierarchy: top-level rows are subs that ran this cascade;
+;; under each sub-row, the components that consumed it. Answers
+;; "which sub caused all this rendering?" The data is shaped by
+;; `views_helpers.cljc` `build-sub-grouped` over the Re-rendered
+;; group's annotated items (the only group with per-render sub
+;; attribution under v1 instrumentation).
+
+(defn- sub-row
+  "One row in the sub-grouped layout. The sub-id is the top-level
+  identifier; the consumed view-ids list under it. The trigger glyph
+  follows the same chrome the component-mode uses so the marker
+  vocabulary is consistent across both modes."
+  [{:keys [sub-id trigger? recomputed? views view-count]}]
+  (let [status (cond
+                 trigger?    :cache-miss-trigger
+                 recomputed? :cache-miss-equal
+                 :else       :cache-hit)
+        chrome (sub-status-chrome status)]
+    [:div {:data-testid "rf-causa-views-sub-row"
+           :data-sub-id (pr-str sub-id)
+           :style row-style}
+     [:div {:style {:display "flex"
+                    :align-items "center"
+                    :gap "8px"
+                    :flex-wrap "wrap"}}
+      [:span {:style (:style chrome)
+              :title (:tooltip chrome)
+              :aria-label (:aria-label chrome)
+              :data-marker (:data-marker chrome)}
+       (:glyph chrome)]
+      [:span {:style {:font-weight 600 :font-family mono-stack}}
+       (format-sub-id sub-id)]
+      [:span {:style {:color (:text-tertiary tokens) :font-size "11px"}}
+       (str "→ " view-count " view" (when (not= 1 view-count) "s"))]]
+     [:div {:style {:padding-left "24px"
+                    :margin-top "4px"
+                    :display "flex"
+                    :flex-direction "column"
+                    :gap "2px"}}
+      (for [v views]
+        ^{:key (pr-str (:render-key v))}
+        [:div {:data-testid "rf-causa-views-sub-row-consumer"
+               :on-context-menu (right-click-filter-handler (:view-id v))
+               :title (when (:view-id v)
+                        (str "Right-click → filter Views panel to "
+                             "<" (h/format-view-id (:view-id v)) ">"))
+               :style (assoc mono-style :cursor "default")}
+         [:span {:style {:display "inline-block" :width "12px"
+                         :text-align "center" :margin-right "6px"
+                         :color (if (:trigger? v)
+                                  (:yellow tokens)
+                                  (:text-tertiary tokens))}}
+          (if (:trigger? v) "✱" "·")]
+         [:span (str "<" (h/format-view-id (:view-id v)) ">")]
+         (when (:clustered? v)
+           [:span {:style {:margin-left "6px"
+                           :color (:text-tertiary tokens)
+                           :font-size "11px"}}
+            (str "× " (or (:clustered-n v) 1) " (clustered)")])
+         [:span {:style {:margin-left "8px"
+                         :color (:text-tertiary tokens)
+                         :font-size "11px"}}
+          (format-ms (:elapsed-ms v))]])]]))
+
+(defn- sub-grouped-section
+  "Top-level container for the sub-grouped renderer. Mirrors
+  `group-section`'s header + listing shape so the panel feels
+  consistent across toggles. Renders an empty-state when there are
+  no subs with consumers (e.g. a parent-forced cascade with no
+  sub invalidations)."
+  [sub-rows]
+  [:section {:data-testid "rf-causa-views-sub-grouped"
+             :style {:display "flex" :flex-direction "column"}}
+   [:header {:style group-section-style}
+    (str "subs that ran this cascade (" (count sub-rows) ")")]
+   (if (seq sub-rows)
+     (for [s sub-rows]
+       (with-meta (sub-row s) {:key (pr-str (:sub-id s))}))
+     [:div {:data-testid "rf-causa-views-sub-grouped-empty"
+            :style {:padding "16px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "13px"}}
+      [:p "No sub invalidations this cascade. (Re-renders were "
+       "parent-forced, or no subs were consumed by the views that "
+       "ran.)"]])])
+
 ;; ---- chrome -------------------------------------------------------------
 
 (defn- header-block
@@ -494,9 +663,109 @@
              (str " · cascade " (pr-str did)))
            " · cascade ms: " (format-ms (:cascade-ms (:totals data))))])])
 
+;; ---- group-by toggle (spec §Group-by toggle / rf2-r2s2l) ---------------
+;;
+;; Bottom-controls pill `[◉ component] [○ sub]`. Switches the Views
+;; hierarchy between the default three-group (Mounted / Re-rendered
+;; / Unmounted) layout and the inverted sub-rows-first layout (a
+;; sub → views-consumed map). The two views are mathematically
+;; symmetric per spec; the toggle lets the user pick their entry
+;; point ("which views ran?" vs "which sub caused all this
+;; rendering?").
+
+(def ^:private group-by-pill-base-style
+  {:padding       "2px 8px"
+   :font-size     "11px"
+   :cursor        "pointer"
+   :background    "transparent"
+   :border        (str "1px solid " (:border-default tokens))
+   :color         (:text-secondary tokens)
+   :font-family   sans-stack})
+
+(defn- group-by-pill
+  "One pill in the bottom-controls group-by toggle. `selected?` drives
+  the filled `◉` vs hollow `○` glyph + foreground colour so the active
+  pill reads at a glance."
+  [{:keys [value selected? label]}]
+  [:button {:data-testid (str "rf-causa-views-group-by-" (name value))
+            :on-click #(rf/dispatch [:rf.causa/views-set-group-by value])
+            :aria-pressed (if selected? "true" "false")
+            :style (cond-> group-by-pill-base-style
+                     selected?
+                     (assoc :color       (:text-primary tokens)
+                            :font-weight 600
+                            :border      (str "1px solid "
+                                              (:accent-violet tokens))))}
+   (str (if selected? "◉" "○") " " label)])
+
+(defn- group-by-toggle
+  [group-by]
+  (let [active (or group-by :component)]
+    [:div {:data-testid "rf-causa-views-group-by-toggle"
+           :role "radiogroup"
+           :aria-label "Group by"
+           :style {:display "flex"
+                   :gap "6px"
+                   :align-items "center"}}
+     [:span {:style {:color (:text-tertiary tokens) :font-size "11px"
+                     :margin-right "4px"}}
+      "Group by"]
+     [group-by-pill {:value :component
+                     :selected? (= active :component)
+                     :label "component"}]
+     [group-by-pill {:value :sub
+                     :selected? (= active :sub)
+                     :label "sub"}]]))
+
+;; ---- filter chip (spec §0ter.1 R3-E — promote above section header) ----
+;;
+;; The component-filter chip appears ABOVE the three-group section
+;; header (per §0ter.1 R3-E refinement) — the chip is panel-scoped
+;; (NOT ribbon-scoped — ribbon carries event-list filters). The
+;; `bottom-controls` clear button at the foot of the panel is the
+;; secondary affordance; the chip is the primary surface so the user
+;; sees the filter applied from anywhere in the panel.
+
+(defn- filter-chip
+  [view-id]
+  (when view-id
+    [:div {:data-testid "rf-causa-views-filter-chip"
+           :style {:padding "8px 16px"
+                   :display "flex"
+                   :align-items "center"
+                   :gap "6px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))
+                   :background (:bg-1 tokens)}}
+     [:span {:style {:color (:text-tertiary tokens) :font-size "11px"}}
+      "Filtered to:"]
+     [:button {:data-testid "rf-causa-views-filter-chip-clear"
+               :on-click #(rf/dispatch
+                            [:rf.causa/views-set-component-filter nil])
+               :aria-label (str "Clear filter on "
+                                (h/format-view-id view-id))
+               :title "Clear filter"
+               :style {:display "inline-flex"
+                       :align-items "center"
+                       :gap "6px"
+                       :padding "2px 8px"
+                       :background "transparent"
+                       :border (str "1px solid " (:accent-violet tokens))
+                       :color (:text-primary tokens)
+                       :border-radius "10px"
+                       :font-family mono-stack
+                       :font-size "12px"
+                       :cursor "pointer"}}
+      [:span {:style {:font-weight 600}}
+       (str "<" (h/format-view-id view-id) ">")]
+      [:span {:style {:opacity 0.7
+                      :border-left (str "1px solid " (:accent-violet tokens))
+                      :padding-left "6px"}}
+       "×"]]]))
+
 (defn- bottom-controls
   [data]
-  (let [cf (:component-filter data)]
+  (let [cf      (:component-filter data)
+        groupby (:group-by data)]
     [:footer {:data-testid "rf-causa-views-controls"
               :style {:padding "8px 16px"
                       :border-top (str "1px solid " (:border-subtle tokens))
@@ -505,6 +774,7 @@
                       :align-items "center"
                       :font-size "11px"
                       :color (:text-secondary tokens)}}
+     [group-by-toggle groupby]
      (when cf
        [:button {:data-testid "rf-causa-views-clear-filter"
                  :on-click #(rf/dispatch
@@ -542,6 +812,9 @@
   []
   (let [data @(rf/subscribe [:rf.causa/views-data])
         groups (:groups data)
+        sub-grouped (:sub-grouped data)
+        group-by (or (:group-by data) :component)
+        component-filter (:component-filter data)
         expanded-rows (or (:expanded-rows data) #{})
         expanded-clusters (or (:expanded-clusters data) #{})]
     [:section {:data-testid "rf-causa-views"
@@ -553,10 +826,18 @@
                        :font-family sans-stack
                        :font-size "14px"}}
      (header-block data)
+     ;; rf2-r2s2l — Filter chip lives ABOVE the body content (per
+     ;; §0ter.1 R3-E refinement). Panel-scoped affordance; the
+     ;; secondary clear button lives in `bottom-controls` for the
+     ;; user who scrolled past the chip.
+     (filter-chip component-filter)
      [:div {:style {:flex 1 :overflow "auto"}}
       (cond
         (not (:has-cascade? data))
         (empty-state data)
+
+        (= group-by :sub)
+        (sub-grouped-section sub-grouped)
 
         (zero? (+ (count (:mounted groups))
                   (count (:rendered groups))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_helpers_cljs_test.cljc
@@ -216,3 +216,121 @@
   (doseq [g h/group-order]
     (is (some? (get h/group-glyph g))
         (str "glyph for " g))))
+
+;; ---- (6) sub-status classifier (rf2-r2s2l) ------------------------------
+;;
+;; Per spec §0ter.1 R3 — three statuses per sub in the Re-rendered
+;; group's Rerendered-because list:
+;;   :cache-miss-trigger — recomputed + value changed (`✱`)
+;;   :cache-miss-equal   — recomputed + value equal   (`≈`)
+;;   :cache-hit          — did not recompute          (`·`)
+
+(deftest sub-status-trigger-classifies-as-cache-miss-trigger
+  (testing "any row marked :trigger? true is :cache-miss-trigger
+            regardless of :recomputed?"
+    (is (= :cache-miss-trigger
+           (h/sub-status {:sub-id :s :trigger? true :recomputed? true})))
+    (is (= :cache-miss-trigger
+           (h/sub-status {:sub-id :s :trigger? true :recomputed? false})))))
+
+(deftest sub-status-recomputed-non-trigger-classifies-as-cache-miss-equal
+  (testing "a non-trigger row whose sub recomputed this cascade is
+            :cache-miss-equal — the recompute returned a value
+            structurally equal to the prior, so React skipped the
+            re-render of any view reading only this sub"
+    (is (= :cache-miss-equal
+           (h/sub-status {:sub-id :s :trigger? false :recomputed? true})))))
+
+(deftest sub-status-non-recomputed-classifies-as-cache-hit
+  (testing "a row that didn't recompute is :cache-hit — the view
+            read the cached value; no work"
+    (is (= :cache-hit
+           (h/sub-status {:sub-id :s :trigger? false :recomputed? false})))))
+
+;; ---- (7) build-sub-grouped (rf2-r2s2l) ---------------------------------
+;;
+;; Per spec §Group-by toggle — invert the component → subs mapping
+;; into sub → components.
+
+(deftest build-sub-grouped-empty
+  (testing "no rendered items → empty sub-grouped list"
+    (is (= [] (h/build-sub-grouped [])))))
+
+(deftest build-sub-grouped-single-trigger
+  (testing "one single-row item with one trigger sub → one sub-row
+            with the consuming view listed underneath"
+    (let [items [{:kind :single
+                  :render {:render-key [:cart/list :tok-1]
+                           :triggered-by :cart/items
+                           :elapsed-ms 1.0}
+                  :invalidated-by [{:sub-id :cart/items :trigger? true
+                                    :recomputed? true}]}]
+          out (h/build-sub-grouped items)]
+      (is (= 1 (count out)))
+      (let [sub-row (first out)]
+        (is (= :cart/items (:sub-id sub-row)))
+        (is (true? (:trigger? sub-row)))
+        (is (= 1 (:view-count sub-row)))
+        (is (= 1 (count (:views sub-row))))
+        (is (= :cart/list (:view-id (first (:views sub-row)))))
+        (is (true? (:trigger? (first (:views sub-row)))))))))
+
+(deftest build-sub-grouped-many-views-per-sub
+  (testing "two components consume the same sub → one sub-row whose
+            :views list carries both"
+    (let [items [{:kind :single
+                  :render {:render-key [:cart/list :tok-1]
+                           :triggered-by :auth/user
+                           :elapsed-ms 1.0}
+                  :invalidated-by [{:sub-id :auth/user :trigger? true
+                                    :recomputed? true}]}
+                 {:kind :single
+                  :render {:render-key [:cart/footer :tok-2]
+                           :triggered-by :auth/user
+                           :elapsed-ms 0.5}
+                  :invalidated-by [{:sub-id :auth/user :trigger? true
+                                    :recomputed? true}]}]
+          out (h/build-sub-grouped items)]
+      (is (= 1 (count out)))
+      (is (= :auth/user (:sub-id (first out))))
+      (is (= 2 (:view-count (first out))))
+      (is (= #{:cart/list :cart/footer}
+             (set (map :view-id (:views (first out)))))))))
+
+(deftest build-sub-grouped-cluster-row-contributes-cluster-count
+  (testing "a :cluster item contributes its :count to :view-count
+            (per spec §Per-row content (Re-rendered) — clustered
+            renders share one trigger sub)"
+    (let [items [{:kind         :cluster
+                  :view-id      :grid/cell
+                  :triggered-by :grid/data
+                  :count        80
+                  :total-ms     8.0
+                  :avg-ms       0.1
+                  :p95-ms       0.2
+                  :renders      []
+                  :invalidated-by [{:sub-id :grid/data :trigger? true
+                                    :recomputed? true :clustered? true}]}]
+          out (h/build-sub-grouped items)]
+      (is (= 1 (count out)))
+      (is (= 80 (:view-count (first out))))
+      (is (= 1 (count (:views (first out)))))
+      (is (true? (:clustered? (first (:views (first out)))))))))
+
+(deftest build-sub-grouped-preserves-source-order
+  (testing "sub-rows sort by first-occurrence index in the source
+            items so the inverted view's row order is stable across
+            renders of the same projection"
+    (let [items [{:kind :single
+                  :render {:render-key [:b :tok-1] :triggered-by :sub-b
+                           :elapsed-ms 1.0}
+                  :invalidated-by [{:sub-id :sub-b :trigger? true
+                                    :recomputed? true}]}
+                 {:kind :single
+                  :render {:render-key [:a :tok-2] :triggered-by :sub-a
+                           :elapsed-ms 1.0}
+                  :invalidated-by [{:sub-id :sub-a :trigger? true
+                                    :recomputed? true}]}]
+          out (h/build-sub-grouped items)]
+      (is (= [:sub-b :sub-a] (mapv :sub-id out))
+          "sub-b appeared in the first source item → ordered first"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
@@ -220,24 +220,31 @@
 
 (deftest rerendered-because-list-marker-tooltips
   (testing "Delta 2 — every marker in the list has a `title` hover
-            tooltip + `aria-label`. The trigger glyph carries the
-            'value changed' tooltip; non-trigger carries 'value
-            unchanged'."
-    (let [invalidated-by [{:sub-id ::sub-a :trigger? true}
-                          {:sub-id ::sub-b :trigger? false}
-                          {:sub-id ::sub-c :trigger? false}]
+            tooltip + `aria-label`. Trigger glyph carries 'value
+            changed' tooltip; recomputed-but-equal carries 'value
+            unchanged'; cache-hit carries 'cache hit'. Per rf2-r2s2l
+            the three-status taxonomy supersedes the prior
+            trigger/non-trigger binary."
+    (let [invalidated-by [{:sub-id ::sub-a :trigger? true  :recomputed? true}
+                          {:sub-id ::sub-b :trigger? false :recomputed? true}
+                          {:sub-id ::sub-c :trigger? false :recomputed? false}]
           list-node (#'view/rerendered-because-list invalidated-by)
           markers   (collect-by-pred
                       list-node
                       #(contains? % :data-marker))
           trigger   (filter #(= "trigger" (:data-marker (second %)))
                             markers)
-          non-trig  (filter #(= "non-trigger" (:data-marker (second %)))
+          equal     (filter #(= "cache-miss-equal"
+                                (:data-marker (second %)))
+                            markers)
+          hits      (filter #(= "cache-hit" (:data-marker (second %)))
                             markers)]
       (is (= 1 (count trigger))
           (str "one trigger marker — got " (count trigger)))
-      (is (= 2 (count non-trig))
-          (str "two non-trigger markers — got " (count non-trig)))
+      (is (= 1 (count equal))
+          (str "one cache-miss-equal marker — got " (count equal)))
+      (is (= 1 (count hits))
+          (str "one cache-hit marker — got " (count hits)))
       (doseq [m markers]
         (is (string? (:title (second m)))
             (str "marker has a hover :title — got " (pr-str (second m))))
@@ -247,20 +254,26 @@
                    (:title (second (first trigger))))
           "trigger tooltip mentions 'changed since last cascade'")
       (is (re-find #"value unchanged"
-                   (:title (second (first non-trig))))
-          "non-trigger tooltip mentions 'value unchanged'"))))
+                   (:title (second (first equal))))
+          "cache-miss-equal tooltip mentions 'value unchanged'")
+      (is (re-find #"(?i)cache hit"
+                   (:title (second (first hits))))
+          "cache-hit tooltip mentions 'cache hit'"))))
 
 (deftest rerendered-because-list-marker-glyphs
-  (testing "Delta 2 — trigger glyph is `✱` (amber-weighted); non-trigger
-            glyph is `·` (muted)."
+  (testing "Delta 2 + rf2-r2s2l — three glyphs cover the three-status
+            taxonomy: `✱` for cache-miss-trigger, `≈` for
+            cache-miss-equal, `·` for cache-hit"
     (let [list-node (#'view/rerendered-because-list
-                      [{:sub-id ::sub-a :trigger? true}
-                       {:sub-id ::sub-b :trigger? false}])
+                      [{:sub-id ::sub-a :trigger? true  :recomputed? true}
+                       {:sub-id ::sub-b :trigger? false :recomputed? true}
+                       {:sub-id ::sub-c :trigger? false :recomputed? false}])
           glyphs    (->> (tree-seq (some-fn vector? seq?) seq
                                    (expand-fn list-node))
                          (filter string?))]
-      (is (some #(= "✱" %) glyphs) "the `✱` glyph renders for triggers")
-      (is (some #(= "·" %) glyphs) "the `·` glyph renders for non-triggers"))))
+      (is (some #(= "✱" %) glyphs) "the `✱` glyph renders for cache-miss-trigger")
+      (is (some #(= "≈" %) glyphs) "the `≈` glyph renders for cache-miss-equal")
+      (is (some #(= "·" %) glyphs) "the `·` glyph renders for cache-hit"))))
 
 (deftest cluster-row-trigger-marker-has-tooltip
   (testing "Delta 2 — the cluster row's single ✱ trigger marker also
@@ -280,6 +293,226 @@
           "exactly one trigger marker on a cluster row")
       (is (string? (:title (second (first markers))))
           "cluster trigger marker has a :title hover tooltip"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-r2s2l — Views polish (Group-by toggle + filter chip + cache-miss-
+;; equal sub-status decoration) regression guards
+;; ---------------------------------------------------------------------------
+
+(deftest rerendered-because-list-renders-all-three-statuses
+  (testing "rf2-r2s2l — every sub-status (cache-miss-trigger /
+            cache-miss-equal / cache-hit) renders its glyph alongside
+            a distinct `:data-marker` attribute. Asserts the three-
+            status taxonomy covers the prior `:trigger? true/false`
+            binary."
+    (let [invalidated-by [{:sub-id :sub-a :trigger? true  :recomputed? true}
+                          {:sub-id :sub-b :trigger? false :recomputed? true}
+                          {:sub-id :sub-c :trigger? false :recomputed? false}]
+          list-node (#'view/rerendered-because-list invalidated-by)
+          markers   (collect-by-pred list-node #(contains? % :data-marker))
+          by-marker (into {} (for [m markers]
+                               [(:data-marker (second m)) m]))]
+      (is (= #{"trigger" "cache-miss-equal" "cache-hit"}
+             (set (keys by-marker)))
+          "all three markers ship in the rendered list")
+      (let [glyphs (->> (tree-seq (some-fn vector? seq?) seq
+                                  (expand-fn list-node))
+                        (filter string?)
+                        set)]
+        (is (contains? glyphs "✱") "✱ glyph renders for cache-miss-trigger")
+        (is (contains? glyphs "≈") "≈ glyph renders for cache-miss-equal")
+        (is (contains? glyphs "·") "·  glyph renders for cache-hit"))
+      (is (re-find #"value unchanged"
+                   (:title (second (get by-marker "cache-miss-equal"))))
+          "cache-miss-equal tooltip mentions 'value unchanged'")
+      (is (re-find #"(?i)cache hit"
+                   (:title (second (get by-marker "cache-hit"))))
+          "cache-hit tooltip mentions 'cache hit'"))))
+
+(deftest right-click-on-row-dispatches-component-filter
+  (testing "rf2-r2s2l — `:on-context-menu` on a single-row is a
+            function that, when invoked with a synthetic event,
+            calls preventDefault + dispatches
+            `:rf.causa/views-set-component-filter` with the row's
+            view-id"
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (let [item {:kind :single
+                :render {:render-key [::comp 0]
+                         :triggered-by ::sub
+                         :elapsed-ms 1.0}
+                :invalidated-by [{:sub-id ::sub :trigger? true}]}
+          row (#'view/single-row item :rendered false)
+          attrs (second row)
+          handler (:on-context-menu attrs)
+          prevented? (atom false)
+          dispatched (atom [])
+          fake-event #js {:preventDefault #(reset! prevented? true)}]
+      (is (fn? handler) "single-row carries an :on-context-menu handler")
+      (with-redefs [re-frame.core/dispatch*
+                    (fn
+                      ([ev]      (swap! dispatched conj ev) nil)
+                      ([ev _opts] (swap! dispatched conj ev) nil))]
+        (handler fake-event))
+      (is (true? @prevented?)
+          ".preventDefault was called so the host page's native menu is suppressed")
+      (is (= [[:rf.causa/views-set-component-filter ::comp]]
+             @dispatched)
+          "dispatch payload is the panel-local filter event with the row's view-id"))))
+
+(deftest right-click-on-cluster-row-dispatches-component-filter
+  (testing "rf2-r2s2l — cluster rows also wire up the right-click
+            filter so a clustered grid (1000 cells in one row) is
+            still filter-targetable"
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (let [item {:kind         :cluster
+                :view-id      ::cell
+                :triggered-by ::grid-data
+                :count        80
+                :total-ms     8.0
+                :avg-ms       0.1
+                :p95-ms       0.2
+                :renders      []
+                :invalidated-by [{:sub-id ::grid-data :trigger? true
+                                  :clustered? true}]}
+          row (#'view/cluster-row item :rendered false)
+          attrs (second row)
+          handler (:on-context-menu attrs)
+          dispatched (atom [])
+          fake-event #js {:preventDefault (fn [])}]
+      (is (fn? handler) "cluster-row carries an :on-context-menu handler")
+      (with-redefs [re-frame.core/dispatch*
+                    (fn
+                      ([ev]      (swap! dispatched conj ev) nil)
+                      ([ev _opts] (swap! dispatched conj ev) nil))]
+        (handler fake-event))
+      (is (= [[:rf.causa/views-set-component-filter ::cell]]
+             @dispatched)))))
+
+(deftest filter-chip-renders-with-clear-button
+  (testing "rf2-r2s2l — `filter-chip` returns hiccup for a chip carrying
+            the filtered component name + an inline `×` clear button.
+            Per §0ter.1 R3-E the chip lives above the section headers,
+            promoting the affordance out of the bottom-controls
+            footer"
+    (let [chip (#'view/filter-chip :cart/list)]
+      (is (some? chip) "non-nil view-id → chip renders")
+      (is (some #(= (:data-testid (second %))
+                    "rf-causa-views-filter-chip")
+                (filter vector?
+                        (tree-seq (some-fn vector? seq?) seq chip)))
+          "filter-chip carries the rf-causa-views-filter-chip data-testid")
+      (let [texts (->> (tree-seq (some-fn vector? seq?) seq chip)
+                       (filter string?))]
+        (is (some #(re-find #"Filtered to" %) texts)
+            "chip ships the 'Filtered to:' label")
+        (is (some #(re-find #"cart/list" %) texts)
+            "chip ships the filtered view-id label")
+        (is (some #(= "×" %) texts)
+            "chip ships the × clear glyph")))))
+
+(deftest filter-chip-returns-nil-when-no-filter
+  (testing "rf2-r2s2l — chip renders nothing when no component filter
+            is active so the panel chrome stays silent-by-default"
+    (is (nil? (#'view/filter-chip nil)))))
+
+(defn- expand-pills [tree]
+  "Walk the hiccup tree expanding any inline pill fns (the
+  group-by-toggle uses Reagent component-vectors `[group-by-pill {…}]`
+  rather than direct hiccup). Returns a flat seq of every expanded
+  vector + atom string."
+  (->> (tree-seq (some-fn vector? seq?) seq tree)
+       (mapcat (fn [node]
+                 (if (and (vector? node) (fn? (first node)))
+                   (let [expanded (try (apply (first node) (rest node))
+                                       (catch :default _ node))]
+                     (tree-seq (some-fn vector? seq?) seq expanded))
+                   [node])))))
+
+(deftest group-by-toggle-renders-both-pills-with-selection-state
+  (testing "rf2-r2s2l — bottom-controls group-by-toggle ships both
+            pills (component + sub); the selected pill carries
+            `aria-pressed=\"true\"` so screen readers + tests can
+            assert the active mode"
+    (let [toggle (#'view/group-by-toggle :component)
+          flat   (expand-pills toggle)
+          buttons (->> flat
+                       (keep (fn [node]
+                               (when (and (vector? node)
+                                          (map? (second node))
+                                          (:data-testid (second node)))
+                                 node))))
+          by-testid (into {} (for [b buttons]
+                               [(:data-testid (second b)) b]))]
+      (is (contains? by-testid "rf-causa-views-group-by-component"))
+      (is (contains? by-testid "rf-causa-views-group-by-sub"))
+      (is (= "true"
+             (:aria-pressed (second (get by-testid
+                                         "rf-causa-views-group-by-component")))))
+      (is (= "false"
+             (:aria-pressed (second (get by-testid
+                                         "rf-causa-views-group-by-sub")))))
+      (let [glyphs (->> flat (filter string?) (apply str))]
+        (is (re-find #"◉" glyphs)
+            "the active mode renders the filled ◉ pill glyph")
+        (is (re-find #"○" glyphs)
+            "the inactive mode renders the hollow ○ pill glyph")))))
+
+(deftest group-by-toggle-flips-on-sub
+  (testing "rf2-r2s2l — flipping the active mode flips the selection
+            state of both pills (component → sub means component
+            pill loses ◉ and sub pill gains it)"
+    (let [toggle (#'view/group-by-toggle :sub)
+          flat   (expand-pills toggle)
+          buttons (->> flat
+                       (keep (fn [node]
+                               (when (and (vector? node)
+                                          (map? (second node))
+                                          (:data-testid (second node)))
+                                 node))))
+          by-testid (into {} (for [b buttons]
+                               [(:data-testid (second b)) b]))]
+      (is (= "false"
+             (:aria-pressed (second (get by-testid
+                                         "rf-causa-views-group-by-component")))))
+      (is (= "true"
+             (:aria-pressed (second (get by-testid
+                                         "rf-causa-views-group-by-sub"))))))))
+
+(deftest sub-grouped-section-renders-rows
+  (testing "rf2-r2s2l — sub-grouped-section renders one row per sub
+            with view-count + each consuming view listed"
+    (let [sub-rows [{:sub-id :cart/items
+                     :trigger? true :recomputed? true
+                     :views [{:view-id :cart/list
+                              :render-key [:cart/list :tok-1]
+                              :trigger? true :elapsed-ms 1.0}]
+                     :view-count 1}
+                    {:sub-id :auth/user
+                     :trigger? false :recomputed? false
+                     :views [{:view-id :cart/header
+                              :render-key [:cart/header :tok-2]
+                              :trigger? false :elapsed-ms 0.5}]
+                     :view-count 1}]
+          section (#'view/sub-grouped-section sub-rows)
+          testids (->> (tree-seq (some-fn vector? seq?) seq section)
+                       (keep #(when (and (vector? %)
+                                         (map? (second %)))
+                                (:data-testid (second %))))
+                       set)]
+      (is (contains? testids "rf-causa-views-sub-grouped"))
+      (is (contains? testids "rf-causa-views-sub-row"))
+      (is (contains? testids "rf-causa-views-sub-row-consumer")))))
+
+(deftest sub-grouped-section-empty-state
+  (testing "rf2-r2s2l — empty sub-grouped list renders the empty-state
+            teaching message so the user understands the parent-
+            forced cascade case"
+    (let [section (#'view/sub-grouped-section [])
+          texts (->> (tree-seq (some-fn vector? seq?) seq section)
+                     (filter string?))]
+      (is (some #(re-find #"No sub invalidations" %) texts)))))
 
 (deftest no-invalidated-by-ui-text-in-row-rendering
   (testing "Delta 1 — the rendered row tree has zero 'Invalidated by'

--- a/tools/causa/testbeds/panel_gallery/gallery_views.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_views.cljs
@@ -93,9 +93,24 @@
   (story/reg-variant :story.causa.views/filter-applied
     {:doc        "Two epochs with renders across multiple view-ids;
                  variant seeds the panel's component-filter to
-                 `:cart/list` so only those rows surface."
+                 `:cart/list` so only those rows surface. The
+                 panel-scoped filter chip renders above the section
+                 headers (per §0ter.1 R3-E)."
      :events     [[:rf.causa/sync-epoch-history (fixtures/filter-applied-buffer)]
                   [:rf.causa/views-set-component-filter :cart/list]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
+  ;; ----- 7. group-by sub (inverted hierarchy, rf2-r2s2l) ------------
+  (story/reg-variant :story.causa.views/group-by-sub
+    {:doc        "Same dense-subs cascade as variant 3, but with the
+                 group-by toggle flipped to :sub — the inverted
+                 hierarchy shows sub-rows at the top with the
+                 components they invalidated nested underneath.
+                 Pins the §Group-by toggle's :sub branch + the
+                 sub-grouped-section renderer."
+     :events     [[:rf.causa/sync-epoch-history (fixtures/dense-subs-buffer)]
+                  [:rf.causa/views-set-group-by :sub]]
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 


### PR DESCRIPTION
## Summary

- **Group-by toggle** — bottom-controls pill `[◉ component] [○ sub]` flips the Views hierarchy between the default three-group (Mounted/Re-rendered/Unmounted) layout and an inverted sub-grouped layout that answers "which sub caused all this rendering?"
- **Right-click → filter chip** — right-click any Views row dispatches `:rf.causa/views-set-component-filter` (no separate context-menu UI; mirrors `shell.cljs`'s event-row pattern); the chip renders above the section headers per §0ter.1 R3-E.
- **`cache-miss-equal` sub-status decoration** — three-status taxonomy (`✱` / `≈` / `·`) completes the Re-rendered-row gap that the prior `✱`/`·` binary missed.

## Group-by behaviour

Default `:component` renders the existing three-group layout unchanged. `:sub` mode renders a sub→components hierarchy over the Re-rendered group's per-render sub attribution (Mounted has no prior to compare; Unmounted has no current — per v1 instrumentation). State lives in `:views/group-by` on `:rf/causa`'s app-db; panel-scoped (no spine pivot). Parent-forced cascades with no sub invalidations render an empty-state explaining the case.

The toggle reuses the existing `:rf.causa/views-set-group-by` event + `:rf.causa/views-group-by` sub (no new registrations).

## Filter chip ux

- **Right-click any Views row** → `preventDefault` (suppresses host page's native menu) + `rf/dispatch [:rf.causa/views-set-component-filter view-id]`. Applies to both single rows and cluster rows.
- **Chip placement** — above the section header (per §0ter.1 R3-E refinement), so the filter affordance is visible from anywhere in the panel. The existing bottom-controls clear button remains as a secondary affordance for users scrolled past the chip.
- **Chip clear** — × button on the chip dispatches `:rf.causa/views-set-component-filter nil`.

## Sub-status table

| Status | Glyph | Colour | Meaning |
|---|---|---|---|
| `:cache-miss-trigger` | `✱` | amber (bold) | Sub recomputed; value DIFFERS from prior. Likely cause. |
| `:cache-miss-equal` | `≈` | muted | Sub recomputed; value EQUALS prior. React skipped re-render. **NEW.** |
| `:cache-hit` | `·` | muted | Sub did NOT recompute. View read cached value. |

Glyph choice: `≈` (almost-equal) is semantically apt for "recomputed-but-equal" and doesn't collide with the spec's reserved `○` (cached-no-watcher) or `◐` (re-running) glyphs in the broader sub-cache-state taxonomy. The classifier lives in `views_helpers.cljc` (`sub-status`); per-status chrome (glyph + tooltip + aria-label + `data-marker`) is encapsulated in `views_view.cljs` `sub-status-chrome`.

## Test plan

- [x] `scripts/test-fast-pr.sh` — green
- [x] `npm run test:cljs` — 2975 tests / 8509 assertions / 0 failures
- [x] `npm run test:browser` — 2952 tests / 8413 assertions / 0 failures
- [x] `npm run story:build` — green
- [x] `npm run test:bundle-isolation` — green
- [x] `npm run test:causa-feature-gate` — 14/14 matrix rows
- [x] `mkdocs build --strict` — 72 warnings (baseline; no new)
- [x] `python scripts/check_doc_slugs.py` — clean
- [x] New tests: 3 classifier statuses + sub-grouped algebra (5 cases) + right-click handlers (single + cluster) + filter chip (rendered + nil) + group-by toggle (active mode rendering + state flip) + sub-grouped renderer (rendered + empty state)
- [x] Updated tests: marker-tooltips + marker-glyphs assert all three statuses (was 2 of 3)

## Rebased against main

Branch is fresh-cut from `origin/main` post-#1515 land; rebased once after #1516 (rf2-vbbq0 datetime chip) landed. Registry snapshot counts (subs=101 / events=118 / fxs=5) accepted from the rebase — this PR adds zero new registrations (the `:rf.causa/views-set-group-by` event + `:rf.causa/views-group-by` sub were already registered).