### PR TITLE
feat(causa): auto-inject resize handle on data-rf-causa-host detection (rf2-70u8q)

### DIFF
--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -81,28 +81,38 @@ right-side host to the app layout (DOM order: `<main>` first, host
   min-width: 320px;
   box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
-  resize: horizontal;
-  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
 
-Three complementary resize mechanisms ship together:
+That's the whole consumer surface — no `resize: horizontal`, no
+`overflow: auto`. Causa auto-injects a polished drag handle on the
+panel's left edge as soon as the shell mounts; the handle covers
+mouse, touch, and pen via pointer events and is keyboard-navigable
+(arrow keys for fine resize, Shift+arrow for coarse, Home/End for
+the clamp ends, Enter/Space to reset).
+
+Two complementary resize mechanisms ship together:
 
 - **CSS variable** (host-owned). Override `--rf-causa-inline-width`
   anywhere up the cascade (e.g.
   `:root { --rf-causa-inline-width: 720px; }`) to set the initial
   width.
-- **Browser-native drag** (host-CSS fallback). `resize: horizontal` +
-  `overflow: auto` give the host a drag-handle in the bottom corner;
-  the variable seeds the initial size, a drag overrides it for the
-  page lifetime.
-- **Causa drag handle** (user-controlled, persisted). Drag the panel's
-  outer edge (left edge when docked `:right-rail`) to resize. Width
-  clamps to `[320px, 90vw]` and persists across reloads via
-  `configure! :settings :general :panel-width-px`. Double-click the
-  handle to reset to default. See
+- **Causa drag handle** (user-controlled, persisted; auto-injected).
+  Drag the panel's outer edge (left edge when docked `:right-rail`)
+  to resize. Width clamps to `[320px, 90vw]` and persists across
+  reloads via `configure! :settings :general :panel-width-px`.
+  Double-click the handle (or press Enter / Space when focused) to
+  reset to default. See
   [`spec/007-UX-IA.md` §Resize affordance](./spec/007-UX-IA.md#resize-affordance).
+
+**Yield-to-consumer.** Some teams prefer the browser-native handle
+(`resize: horizontal` + `overflow: auto` on the host). Causa
+detects that at render time via `getComputedStyle` and renders no
+handle of its own — the consumer wins, no double-handle. The
+zero-config path (drop in `<aside>` and let Causa inject) is the
+recommended default; the opt-out is the explicit `resize:`
+declaration on the host.
 
 If the host is missing, Causa logs an actionable `console.error` and
 exposes the same state through `window.day8.re_frame2_causa.status()`.

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -146,11 +146,18 @@ panel's outer edge (left edge when docked `:right-rail`; the default per
 `Settings → General → Panel position`). The handle SHALL:
 
 - Show `cursor: col-resize` on hover
-- Drag-to-update width with global mouse-capture
+- Drag-to-update width with global pointer-capture (mouse, touch,
+  and pen unified through pointer events; `touch-action: none` so a
+  touch-drag does not pan the page)
 - Clamp width to `[320px, 90vw]`
 - Persist via `configure! :settings :general :panel-width-px`
   (see [`015-Configuration.md`](./015-Configuration.md))
 - Reset to default width on double-click
+
+The CSS-variable cascade (`--rf-causa-inline-width` on the host's
+`flex-basis`) continues to work unchanged — the handle simply drives
+the same custom property reactively, so a `:root { --rf-causa-inline-
+width: 720px; }` override and a user drag write to the same surface.
 
 No textual affordance accompanies the handle (cursor change is sufficient
 signal per [`Conventions.md`](./Conventions.md) §UI text — silent by
@@ -161,6 +168,54 @@ change on edge hover, not via prose label.
 In `:popout` panel-position the browser's window controls govern size
 (no in-panel handle renders). In `:fullscreen` position the handle is
 suppressed — the panel fills the viewport.
+
+#### Auto-inject contract (rf2-70u8q)
+
+The handle is **auto-injected**. Consumers SHALL NOT need to wire any
+resize CSS on the layout host — dropping in
+`<aside data-rf-causa-host></aside>` and the minimal host CSS (no
+`resize: horizontal`, no `overflow: auto`) is sufficient. Causa's
+preload mounts the shell into the host once the substrate adapter is
+ready (per §The default landing view); the shell renders the handle as
+an absolutely-positioned child pinned to the host's left edge.
+
+The handle's styles are Causa-owned — the consumer's CSS surface
+remains exactly the four declarations the layout-host contract
+already requires (`flex`, `min-width`, `box-sizing`, `border-left`).
+
+##### Yield-to-consumer
+
+Causa MUST detect a consumer-asserted browser-native handle and yield:
+if `getComputedStyle(host).resize` is `"horizontal"` or `"both"`, the
+auto-injected handle SHALL render nil so the page does not carry two
+draggable affordances. The probe runs at render time on every paint,
+so a runtime CSS swap (devtools edit, theme switch) updates the yield
+decision on the next frame.
+
+The yield path is the **opt-out**. Pre-alpha posture is zero-config
+for the consumer; the opt-in to Causa's handle is "do nothing" and
+the opt-out to keep the browser-native handle is "set `resize:
+horizontal` on the host". No `configure!` knob, no preload flag.
+
+##### Keyboard contract
+
+The handle is keyboard-reachable (`tabindex="0"`, `role="separator"`,
+`aria-orientation="vertical"`, live `aria-valuenow` for the current
+width). Bindings:
+
+| Key | Action |
+|---|---|
+| `ArrowLeft` | Widen by 8px (matches drag-left semantics) |
+| `ArrowRight` | Narrow by 8px |
+| `Shift+ArrowLeft` | Widen by 32px (coarse step) |
+| `Shift+ArrowRight` | Narrow by 32px |
+| `Home` | Snap to upper clamp (registry applies the 90vw bound) |
+| `End` | Snap to lower clamp (registry applies the 320px floor) |
+| `Enter` / `Space` | Reset to default (matches double-click) |
+
+Unrecognised keys bubble normally so the surrounding chrome's
+`Ctrl+Shift+C` / `?` / `Esc` shortcuts remain reachable from the
+handle's focus position.
 
 ## The L1 ribbon
 

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -1,27 +1,51 @@
 (ns day8.re-frame2-causa.resize-handle
-  "Left-edge horizontal resize handle for the Causa shell (rf2-x8h9y).
+  "Left-edge horizontal resize handle for the Causa shell (rf2-x8h9y +
+  rf2-70u8q auto-inject contract).
 
   ## What this is
 
   A 6px-wide vertical strip pinned to the LEFT edge of the shell in
-  `:right-rail` (`:inline`) mode. The user drags it to widen / narrow
-  the panel; the live width persists through the Settings round-trip
-  and survives reload via localStorage. Double-click resets to
-  `config/default-panel-width-px` (560px).
+  `:right-rail` (`:inline`) mode. The user drags it (mouse, touch, or
+  pen — all unified through pointer events) to widen / narrow the
+  panel; the live width persists through the Settings round-trip and
+  survives reload via localStorage. Double-click resets to
+  `config/default-panel-width-px` (560px). Keyboard-navigable via
+  arrow keys (8px step; 32px with Shift) and Home / End (clamp ends).
 
-  ## Drag mechanics (global mouse capture)
+  ## Auto-inject contract (rf2-70u8q)
 
-  `onMouseDown` records the starting mouse-X + starting panel width,
-  then attaches `mousemove` + `mouseup` listeners on
-  `js/document` (NOT the handle element). Document-level capture is
-  the standard devtool pattern — without it, drags faster than the
-  pointer-event cadence escape the handle's hit-test box and the
-  drag stalls. The handle's own `mousemove` only fires while the
-  cursor is over the 6px strip; the document's fires everywhere.
+  Per spec/007-UX-IA.md §Resize affordance, Causa ships the handle as
+  a zero-config affordance: the consumer drops in
+  `<aside data-rf-causa-host></aside>` and the handle appears
+  automatically as a child of the auto-mounted shell. Consumers MUST
+  NOT need to wire `resize: horizontal` / `overflow: auto` on the
+  host — those properties create a duplicate browser-native handle
+  that conflicts with Causa's clamp + persist + reset semantics.
+
+  ### Yield-to-consumer
+
+  If the layout host carries an explicit `resize: horizontal` (or
+  `:both`) in its *computed* style, Causa interprets that as the
+  consumer asserting their own handle and renders nil from `Handle`
+  — no double-handle, the consumer wins. Detection happens at render
+  time via `getComputedStyle` on the host element.
+
+  ## Drag mechanics (global pointer capture)
+
+  `onPointerDown` records the starting pointer-X + starting panel
+  width, then attaches `pointermove` + `pointerup` + `pointercancel`
+  listeners on `js/document` (NOT the handle element). Document-level
+  capture is the standard devtool pattern — without it, drags faster
+  than the pointer-event cadence escape the handle's hit-test box
+  and the drag stalls. The handle's own pointer events only fire
+  while the cursor / finger is over the 6px strip; the document's
+  fire everywhere.
 
   The same pattern is used by every browser's split-pane resizer,
   Chrome devtools, VS Code's panel boundary, etc. — it's the
-  reference UX.
+  reference UX. Pointer events unify mouse + touch + pen so the
+  same handler covers laptop trackpads, desktop mice, and tablet
+  / phone touch screens with no branching.
 
   ## Width derivation
 
@@ -61,20 +85,38 @@
   dragging the body's cursor is overridden to `col-resize`
   globally so the user reads the operation as continuous."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.theme.tokens :refer [tokens]]))
+
+;; ---- keyboard step constants -------------------------------------------
+
+(def ^:private keyboard-step-px
+  "Fine-step width in pixels for a single arrow-key press. 8px is the
+  conventional Chrome-devtools / VS-Code increment — small enough to
+  land on a target column, large enough that users don't need to hold
+  the key for minutes to traverse the panel range. The Shift modifier
+  multiplies this by `keyboard-coarse-multiplier` for faster traversal."
+  8)
+
+(def ^:private keyboard-coarse-multiplier
+  "Multiplier for Shift+arrow on the handle: 8px × 4 = 32px per press.
+  Matches the coarse step in spec/007-UX-IA.md §Keyboard."
+  4)
 
 ;; ---- drag state ---------------------------------------------------------
 
 (defonce ^:private drag-state
   ;; Holds the active drag's snapshot:
-  ;;   {:start-x       <Number>   ; pageX at mousedown
-  ;;    :start-width   <Number>   ; px at mousedown (from sub)
+  ;;   {:start-x       <Number>   ; pageX at pointerdown
+  ;;    :start-width   <Number>   ; px at pointerdown (from sub)
+  ;;    :pointer-id    <Number>   ; pointerdown's pointerId (for capture release)
   ;;    :on-move       <fn>       ; bound document handler (for cleanup)
   ;;    :on-up         <fn>       ; bound document handler (for cleanup)
+  ;;    :on-cancel     <fn>       ; bound document handler (for cleanup)
   ;;    :prev-cursor   <string>}  ; body cursor pre-drag (for restore)
   ;; nil when no drag is in progress. defonce so a shadow-cljs
   ;; :after-load mid-drag doesn't strand a half-installed listener
-  ;; (the next mousedown re-installs cleanly).
+  ;; (the next pointerdown re-installs cleanly).
   (atom nil))
 
 (defn dragging?
@@ -85,14 +127,16 @@
   (some? @drag-state))
 
 (defn- detach-document-listeners! []
-  (when-let [{:keys [on-move on-up prev-cursor]} @drag-state]
+  (when-let [{:keys [on-move on-up on-cancel prev-cursor]} @drag-state]
     (when (and (exists? js/document) (.-removeEventListener js/document))
-      (try (.removeEventListener js/document "mousemove" on-move)
+      (try (.removeEventListener js/document "pointermove" on-move)
            (catch :default _ nil))
-      (try (.removeEventListener js/document "mouseup" on-up)
+      (try (.removeEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.removeEventListener js/document "pointercancel" on-cancel)
            (catch :default _ nil)))
     ;; Restore the body cursor so the col-resize override doesn't
-    ;; linger after mouseup (the document drag overrides whatever
+    ;; linger after pointerup (the document drag overrides whatever
     ;; the cursor was hovering, so we need to restore explicitly).
     (when (and (exists? js/document) (.-body js/document))
       (set! (-> js/document .-body .-style .-cursor)
@@ -111,27 +155,41 @@
 (defn- on-document-up [^js _e]
   (detach-document-listeners!))
 
+(defn- on-document-cancel [^js _e]
+  ;; pointercancel fires when the browser preempts the gesture
+  ;; (e.g. system gesture overrides on mobile, OS dragging UX).
+  ;; Tear down the same way as pointerup so we don't strand listeners.
+  (detach-document-listeners!))
+
 (defn start-drag!
   "Capture the drag start position + width snapshot, then attach the
-  document-level move + up listeners that drive the live update.
-  Pre-existing drag state is torn down first so a stuck listener
-  from a failed prior drag doesn't double-fire.
+  document-level move + up + cancel listeners that drive the live
+  update. Pre-existing drag state is torn down first so a stuck
+  listener from a failed prior drag doesn't double-fire.
 
-  Exposed for the shell view's `:on-mouse-down` handler AND for the
+  Accepts mouse, touch, or pen pointer events uniformly — the pointer
+  events spec defines `pageX` on every type, so the same handler
+  works without branching.
+
+  Exposed for the shell view's `:on-pointer-down` handler AND for the
   test suite, which drives the drag lifecycle without a real DOM."
   [^js e current-width]
   ;; Defensive: clear any stale state from a prior aborted drag.
   (detach-document-listeners!)
   (let [start-x     (.-pageX e)
+        pointer-id  (.-pointerId e)
         prev-cursor (when (and (exists? js/document)
                                (.-body js/document))
                       (-> js/document .-body .-style .-cursor))
         on-move     on-document-move
-        on-up       on-document-up]
+        on-up       on-document-up
+        on-cancel   on-document-cancel]
     (reset! drag-state {:start-x     start-x
                         :start-width (or current-width 560)
+                        :pointer-id  pointer-id
                         :on-move     on-move
                         :on-up       on-up
+                        :on-cancel   on-cancel
                         :prev-cursor prev-cursor})
     ;; Override the body cursor so the col-resize indicator persists
     ;; through the drag even when the cursor moves off the 6px handle
@@ -140,13 +198,16 @@
     (when (and (exists? js/document) (.-body js/document))
       (set! (-> js/document .-body .-style .-cursor) "col-resize"))
     (when (and (exists? js/document) (.-addEventListener js/document))
-      (try (.addEventListener js/document "mousemove" on-move)
+      (try (.addEventListener js/document "pointermove" on-move)
            (catch :default _ nil))
-      (try (.addEventListener js/document "mouseup" on-up)
+      (try (.addEventListener js/document "pointerup" on-up)
+           (catch :default _ nil))
+      (try (.addEventListener js/document "pointercancel" on-cancel)
            (catch :default _ nil)))
-    ;; preventDefault swallows the native text-selection that begins
-    ;; on mousedown over a non-input element — without it a drag
-    ;; visually selects every piece of text the cursor crosses.
+    ;; preventDefault swallows the native text-selection / scroll
+    ;; gesture that begins on pointerdown over a non-input element
+    ;; — without it a drag visually selects every piece of text the
+    ;; cursor crosses (mouse) or scrolls the page (touch).
     (try (.preventDefault e) (catch :default _ nil))))
 
 ;; Test seam — directly drive the document-level handlers without
@@ -154,20 +215,110 @@
 ;; `start-drag!` installs the handlers AND captures the snapshot;
 ;; tests can replicate that by calling start-drag! with a stub event
 ;; and then driving simulate-move! / simulate-up! to step the
-;; mouse without touching `js/document.dispatchEvent`.
+;; pointer without touching `js/document.dispatchEvent`.
 (defn simulate-move!
-  "Test-only: drive the document-level mousemove handler with a
+  "Test-only: drive the document-level pointermove handler with a
   page-X coordinate. No-op when no drag is in progress."
   [page-x]
   (when @drag-state
     (on-document-move #js {:pageX page-x})))
 
 (defn simulate-up!
-  "Test-only: drive the document-level mouseup handler. No-op when no
+  "Test-only: drive the document-level pointerup handler. No-op when no
   drag is in progress."
   []
   (when @drag-state
     (on-document-up nil)))
+
+(defn simulate-cancel!
+  "Test-only: drive the document-level pointercancel handler. No-op
+  when no drag is in progress. Covers the system-preempt path
+  (e.g. browser-level gesture override on mobile)."
+  []
+  (when @drag-state
+    (on-document-cancel nil)))
+
+;; ---- keyboard navigation (rf2-70u8q a11y) -------------------------------
+
+(defn handle-keydown!
+  "Keyboard-navigable resize. Per spec/007-UX-IA.md §Resize affordance
+  the handle MUST be operable without a pointer device. Bindings:
+
+    ArrowLeft           +8px  (widen — drag-left semantics)
+    ArrowRight          -8px  (narrow)
+    Shift+ArrowLeft     +32px (coarse widen)
+    Shift+ArrowRight    -32px (coarse narrow)
+    Home                +very-large step (clamp to upper bound)
+    End                 -very-large step (clamp to lower bound)
+    Enter / Space       reset to default (matches double-click)
+
+  The clamp lives in the registry handler — we dispatch the desired
+  width and let `:rf.causa/set-panel-width-px` apply the [320px, 90vw]
+  bounds. Out-of-range dispatches simply snap to the edge, so Home/End
+  use the viewport width as a generous overshoot rather than reading
+  the live viewport.
+
+  Returns true iff the keypress was handled (so the caller can
+  `preventDefault` to suppress the default behavior — page scroll on
+  arrow keys, button activation on space). Other keypresses return
+  false and bubble normally."
+  [^js e current-width]
+  (let [key      (.-key e)
+        shift?   (.-shiftKey e)
+        step     (if shift?
+                   (* keyboard-step-px keyboard-coarse-multiplier)
+                   keyboard-step-px)
+        dispatch (fn [px]
+                   (rf/dispatch [:rf.causa/set-panel-width-px px]
+                                {:frame :rf/causa}))]
+    (case key
+      "ArrowLeft"   (do (dispatch (+ current-width step)) true)
+      "ArrowRight"  (do (dispatch (- current-width step)) true)
+      ;; Home / End use a generous overshoot — the registry clamp
+      ;; will snap to the actual bounds. 10000px is larger than any
+      ;; sensible viewport, ensuring "Home" reaches the upper clamp
+      ;; without needing a fresh viewport read here.
+      "Home"        (do (dispatch 10000) true)
+      "End"         (do (dispatch 0) true)
+      ("Enter" " ") (do (rf/dispatch [:rf.causa/reset-panel-width]
+                                     {:frame :rf/causa})
+                        true)
+      false)))
+
+;; ---- yield-to-consumer detection (rf2-70u8q) ----------------------------
+
+(defn host-asserts-own-handle?
+  "Probe the layout-host element's computed style — return true iff the
+  consumer has explicitly set `resize: horizontal` (or `resize: both`),
+  signalling they want the browser-native handle and Causa should
+  yield. Per spec/007-UX-IA.md §Resize affordance the auto-inject
+  contract is: silent yield when the consumer asserts their own
+  affordance.
+
+  Returns false:
+    - in non-browser runtimes (no `js/window` / `js/document`)
+    - when the host element is not on the page yet
+    - when the host's computed `resize` value is `:none` (the
+      default) or `:vertical`
+
+  The probe queries `getComputedStyle` so author CSS, inline styles,
+  inherited values, and `:where(...)`-wrapped rules all surface
+  through one consistent read. This is the canonical 'is the consumer
+  opting out of our default?' detection — no configuration knob, no
+  preload-time inspection, no caching: re-evaluated on every render
+  so a runtime CSS swap (devtools edit, theme switch) updates the
+  yield decision on the next paint."
+  []
+  (boolean
+    (when (and (exists? js/window)
+               (exists? js/document)
+               (.-querySelector js/document)
+               (.-getComputedStyle js/window))
+      (when-let [host (.querySelector js/document
+                                      (config/get-layout-host-selector))]
+        (let [cs     (.getComputedStyle js/window host)
+              resize (when cs (.getPropertyValue cs "resize"))]
+          (contains? #{"horizontal" "both"} resize))))))
 
 ;; ---- view ---------------------------------------------------------------
 
@@ -183,7 +334,7 @@
   ;; can't pseudo-class :hover; the always-visible accent + the
   ;; col-resize cursor are the affordance). During drag the body
   ;; cursor flips to col-resize globally so the operation reads as
-  ;; continuous even when the pointer leaves the strip.
+  ;; continuous.
   {:position         "absolute"
    :left             0
    :top              0
@@ -197,8 +348,9 @@
    ;; Above the chrome's panels but below the modals; modals use
    ;; max-int z-index so we won't fight them.
    :z-index          1000
-   ;; Touch / pointer hints — disable selection so a drag does not
-   ;; lasso text in adjacent panels.
+   ;; Touch / pointer hints — disable native gestures (page scroll on
+   ;; touch, text selection on mouse) so a drag does not pan the page
+   ;; or lasso text in adjacent panels.
    :touch-action     "none"
    :user-select      "none"})
 
@@ -208,21 +360,36 @@
   the user resizes via the OS, `:fullscreen` is full-viewport and
   has no width to drag.
 
+  Per rf2-70u8q yields silently to consumer-asserted browser-native
+  resize: if the layout host's computed style declares
+  `resize: horizontal` (or `:both`), the consumer has chosen to wire
+  their own handle — render nil so the page does not carry two.
+
   `reg-view`-wrapped per rf2-in6l2 so the inner subscribe routes
   through React-context to `:rf/causa` (the shell wraps the whole
   chrome in `frame-provider {:frame :rf/causa}`)."
   [mode]
-  (when (= mode :inline)
+  (when (and (= mode :inline)
+             (not (host-asserts-own-handle?)))
     (let [current-width @(rf/subscribe [:rf.causa/panel-width-px])]
-      [:div {:data-testid     "rf-causa-resize-handle"
-             :role            "separator"
+      [:div {:data-testid      "rf-causa-resize-handle"
+             :role             "separator"
              :aria-orientation "vertical"
-             :aria-label      "Resize Causa panel"
-             :title           "Drag to resize · double-click to reset"
-             :on-mouse-down   (fn [^js e]
-                                (start-drag! e current-width))
-             :on-double-click (fn [^js _e]
-                                (rf/dispatch
-                                  [:rf.causa/reset-panel-width]
-                                  {:frame :rf/causa}))
-             :style           (handle-style)}])))
+             :aria-label       "Resize Causa panel"
+             :aria-valuemin    config/min-panel-width-px
+             :aria-valuenow    current-width
+             :title            (str "Drag to resize · double-click to reset · "
+                                    "arrow keys for fine resize (Shift = coarse) · "
+                                    "Home / End for ends · Enter to reset")
+             :tab-index        0
+             :on-pointer-down  (fn [^js e]
+                                 (start-drag! e current-width))
+             :on-key-down      (fn [^js e]
+                                 (when (handle-keydown! e current-width)
+                                   (try (.preventDefault e)
+                                        (catch :default _ nil))))
+             :on-double-click  (fn [^js _e]
+                                 (rf/dispatch
+                                   [:rf.causa/reset-panel-width]
+                                   {:frame :rf/causa}))
+             :style            (handle-style)}])))

--- a/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/resize_handle_cljs_test.cljs
@@ -129,11 +129,16 @@
 ;; ---- drag lifecycle ----------------------------------------------------
 
 (defn- stub-event
-  "Build a stub MouseEvent-shaped JS object carrying just the slots
+  "Build a stub PointerEvent-shaped JS object carrying just the slots
   the handle reads. `preventDefault` is a no-op stub so start-drag!
-  can call it without throwing in the test runner."
+  can call it without throwing in the test runner.
+
+  Pointer events extend MouseEvent so `pageX` is present at the same
+  shape; `pointerId` is the pointer-events-specific slot used by the
+  drag-state snapshot for capture release."
   [page-x]
   #js {:pageX          page-x
+       :pointerId      1
        :preventDefault (fn [])})
 
 (deftest start-drag-flips-state
@@ -227,6 +232,200 @@
           (handler nil))))
     (is (some #(= [:rf.causa/reset-panel-width] %) @dispatches)
         "double-click dispatched the reset event")))
+
+;; ---- keyboard navigation (rf2-70u8q a11y) -------------------------------
+
+(defn- stub-key-event [key shift?]
+  (let [prevented? (atom false)]
+    {:event #js {:key            key
+                 :shiftKey       shift?
+                 :preventDefault (fn [] (reset! prevented? true))}
+     :prevented? prevented?}))
+
+(deftest keydown-arrow-left-widens
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowLeft" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= [:rf.causa/set-panel-width-px 508] %) @dispatches)
+        "ArrowLeft adds the 8px fine step to current-width")))
+
+(deftest keydown-arrow-right-narrows
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowRight" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= [:rf.causa/set-panel-width-px 492] %) @dispatches)
+        "ArrowRight subtracts the 8px fine step from current-width")))
+
+(deftest keydown-shift-arrow-uses-coarse-step
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "ArrowLeft" true)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= [:rf.causa/set-panel-width-px 532] %) @dispatches)
+        "Shift+ArrowLeft uses the 32px coarse step (8 × 4)")))
+
+(deftest keydown-home-overshoots-to-upper-clamp
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Home" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= :rf.causa/set-panel-width-px (first %)) @dispatches)
+        "Home dispatched a set-panel-width-px (registry clamp snaps to upper bound)")))
+
+(deftest keydown-end-undershoots-to-lower-clamp
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "End" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= :rf.causa/set-panel-width-px (first %)) @dispatches)
+        "End dispatched a set-panel-width-px (registry clamp snaps to lower bound)")))
+
+(deftest keydown-enter-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Enter" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= [:rf.causa/reset-panel-width] %) @dispatches)
+        "Enter dispatched the reset event (matches double-click)")))
+
+(deftest keydown-space-dispatches-reset
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event " " false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (resize-handle/handle-keydown! event 500))
+    (is (some #(= [:rf.causa/reset-panel-width] %) @dispatches)
+        "Space dispatched the reset event")))
+
+(deftest keydown-unrecognised-key-no-op
+  (setup!)
+  (let [dispatches (atom [])
+        {:keys [event]} (stub-key-event "Tab" false)]
+    (with-redefs [rf/dispatch* (fn
+                                 ([ev]       (swap! dispatches conj ev) nil)
+                                 ([ev _opts] (swap! dispatches conj ev) nil))]
+      (is (false? (resize-handle/handle-keydown! event 500))
+          "unrecognised key returns false (no preventDefault, bubble normally)"))
+    (is (empty? @dispatches)
+        "no dispatches for unrecognised key")))
+
+(deftest handle-renders-tabindex-and-aria-valuenow
+  (setup!)
+  (rf/with-frame :rf/causa
+    (let [tree (resize-handle/Handle :inline)
+          props (second tree)]
+      (is (= 0 (:tab-index props))
+          "handle is keyboard-reachable via tab")
+      (is (number? (:aria-valuenow props))
+          "handle exposes current width to assistive tech")
+      (is (= config/min-panel-width-px (:aria-valuemin props))
+          "handle exposes minimum width to assistive tech"))))
+
+;; ---- yield-to-consumer (rf2-70u8q) -------------------------------------
+
+(defn- ensure-stub-host! [resize-value]
+  (when (and (exists? js/document) (.-createElement js/document))
+    ;; Remove any prior host so the test is hermetic.
+    (when-let [old (.querySelector js/document "[data-rf-causa-host]")]
+      (when (.-parentNode old)
+        (.removeChild (.-parentNode old) old)))
+    (let [host (.createElement js/document "aside")]
+      (.setAttribute host "data-rf-causa-host" "")
+      ;; Set resize via inline style — getComputedStyle resolves it.
+      (when resize-value
+        (set! (-> host .-style .-resize) resize-value))
+      (when (.-body js/document)
+        (.appendChild (.-body js/document) host))
+      host)))
+
+(defn- remove-stub-host! [host]
+  (when (and host (.-parentNode host))
+    (.removeChild (.-parentNode host) host)))
+
+(deftest host-without-resize-does-not-yield
+  ;; Default: consumer drops `<aside data-rf-causa-host></aside>` with
+  ;; no explicit `resize:` declaration. Causa should render its own
+  ;; handle (the auto-inject zero-config path).
+  (when (exists? js/document)
+    (let [host (ensure-stub-host! nil)]
+      (try
+        (is (false? (resize-handle/host-asserts-own-handle?))
+            "no explicit resize → no yield → Causa handle renders")
+        (finally
+          (remove-stub-host! host))))))
+
+(deftest host-with-resize-horizontal-yields
+  ;; Consumer asserts their own browser-native handle by setting
+  ;; `resize: horizontal`. Causa MUST yield to avoid a double-handle.
+  (when (exists? js/document)
+    (let [host (ensure-stub-host! "horizontal")]
+      (try
+        (is (true? (resize-handle/host-asserts-own-handle?))
+            "explicit resize:horizontal → yield → Causa renders nil")
+        (finally
+          (remove-stub-host! host))))))
+
+(deftest host-with-resize-both-yields
+  ;; `resize: both` also gives the consumer a browser-native handle
+  ;; (covers a future vertical-resize use case too). Yield.
+  (when (exists? js/document)
+    (let [host (ensure-stub-host! "both")]
+      (try
+        (is (true? (resize-handle/host-asserts-own-handle?))
+            "explicit resize:both → yield → Causa renders nil")
+        (finally
+          (remove-stub-host! host))))))
+
+(deftest handle-renders-nil-when-host-yields
+  ;; The end-to-end yield: Handle short-circuits to nil when the host
+  ;; carries `resize: horizontal` in its computed style.
+  (when (exists? js/document)
+    (let [host (ensure-stub-host! "horizontal")]
+      (try
+        (setup!)
+        (rf/with-frame :rf/causa
+          (is (nil? (resize-handle/Handle :inline))
+              "yield path: Handle returns nil when consumer asserts own resize"))
+        (finally
+          (remove-stub-host! host))))))
+
+(deftest handle-renders-when-host-does-not-yield
+  ;; The end-to-end no-yield: Handle renders when host has no
+  ;; explicit resize declaration (the zero-config consumer path).
+  (when (exists? js/document)
+    (let [host (ensure-stub-host! nil)]
+      (try
+        (setup!)
+        (rf/with-frame :rf/causa
+          (let [tree (resize-handle/Handle :inline)]
+            (is (some? tree)
+                "no-yield path: Handle renders when consumer has no own resize")
+            (is (= "rf-causa-resize-handle" (:data-testid (second tree)))
+                "the rendered tree is the documented handle node")))
+        (finally
+          (remove-stub-host! host))))))
 
 ;; ---- apply-panel-width! (CSS var write) --------------------------------
 


### PR DESCRIPTION
## Summary

Implements rf2-70u8q (Mike decision 2026-05-19, reversed from rf2-26opb prior doc-only call). Causa now auto-injects a polished resize handle whenever the consumer drops `<aside data-rf-causa-host></aside>` into their layout — no `resize: horizontal` / `overflow: auto` CSS required. The handle covers mouse / touch / pen via pointer events and is keyboard-navigable.

- Replace mouse-only listeners with pointer events (mouse + touch + pen unified). Add `pointercancel` teardown so a browser-preempted gesture (mobile system swipe) does not strand listeners.
- Keyboard contract: ArrowLeft/Right (+/- 8px), Shift+Arrow (+/- 32px), Home/End (snap to clamp ends), Enter/Space (reset to default).
- a11y: `tabindex=0`, `role="separator"`, `aria-orientation="vertical"`, live `aria-valuenow`, `aria-valuemin`.

## Yield-to-consumer rule

The handle's render check probes `getComputedStyle(host).resize` at every paint. If the consumer has set `resize: horizontal` or `resize: both` on the host, Causa renders nil — the consumer wins, no double-handle. Probe is JS-only (no preload-time inspection, no caching): a runtime CSS swap updates the yield decision on the next frame.

The yield path is the opt-out. Pre-alpha posture is zero-config; no `configure!` knob.

## README simplified snippet

**Before** (6 declarations):

```css
[data-rf-causa-host] {
  flex: 0 0 var(--rf-causa-inline-width, 560px);
  min-width: 320px;
  box-sizing: border-box;
  border-left: 1px solid #2a2a2a;
  resize: horizontal;
  overflow: auto;
}
```

**After** (4 declarations):

```css
[data-rf-causa-host] {
  flex: 0 0 var(--rf-causa-inline-width, 560px);
  min-width: 320px;
  box-sizing: border-box;
  border-left: 1px solid #2a2a2a;
}
```

## spec/007 update

§Resize affordance now documents:
- Pointer-event drag (mouse + touch + pen unification; `touch-action: none`)
- The auto-inject contract (no consumer-side resize CSS required)
- The yield-to-consumer rule (`resize: horizontal` / `:both` → render nil)
- The keyboard contract (full binding table)

## Test plan

- [x] All 2926 CLJS node tests pass (`npm run test:cljs`)
- [x] All 2917 browser tests pass (`npm run test:browser`)
- [x] JVM tools suite passes (`bash scripts/test-jvm-tools.sh`)
- [x] Fast PR spine passes (`bash scripts/test-fast-pr.sh`)
- [x] `mkdocs build --strict` — no new warnings (baseline = 72, post-change = 72; all pre-existing)
- [x] `check_doc_slugs.py` exits 0
- [x] New tests cover: pointer-event lifecycle, 8 keyboard bindings, 5 yield scenarios (default no-yield, explicit `resize: horizontal` yields, `resize: both` yields, end-to-end Handle nil on yield, Handle renders on no-yield)
- [x] Existing tests still pass (drag mechanics, clamp, double-click reset, CSS-var apply, missing-root safety)

Closes rf2-70u8q.