### PR TITLE
feat(causa): :ungrouped events opt-in surface in Settings General (rf2-r9lyy)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -684,6 +684,15 @@
     above which a fully-qualified keyword is elided in compact list
     cells. Per spec/007-UX-IA.md §Long-keyword treatment; was
     previously a fixed constant.
+  - `:show-ungrouped?` (boolean, default `false`) — opt-in surface
+    for the `:ungrouped` pseudo-cascade bucket (per rf2-r9lyy / Mike
+    2026-05-19 closure of rf2-q60yf). OFF by default: the L2 event
+    list filters `:ungrouped` (registry-time emits, frame lifecycle
+    outside a drain, `:rf.ssr/hydration-mismatch`, REPL evals) per
+    rf2-639lc — silent-by-default. Flip ON to reveal those events
+    in L2 with a muted visual treatment; clicking the row focuses
+    the bucket so downstream panels populate. Useful when debugging
+    SSR / REPL / registry-time flows.
 
   ## :buffer section (rf2-ttnst — Settings popup v1 expansion)
 
@@ -703,6 +712,7 @@
                :auto-open-on-error?    false
                :density                :cosy           ; #{:cosy :compact}
                :show-tool-frames?      false
+               :show-ungrouped?        false           ; rf2-r9lyy opt-in pseudo-cascade surface
                :long-keyword-threshold 24}
    :theme     :dark                                  ; :dark | :light
    :diff      {:highlight-fn-ref-changes? false}

--- a/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/subs.cljs
@@ -87,6 +87,19 @@
       (boolean (or (get-in db [:settings :general :show-tool-frames?])
                    (config/get-setting :general :show-tool-frames?)))))
 
+  ;; rf2-r9lyy — convenience sub: should the L2 event list surface
+  ;; the `:ungrouped` pseudo-cascade bucket (registry-time emits /
+  ;; frame lifecycle / `:rf.ssr/hydration-mismatch` / REPL evals)?
+  ;; OFF by default — Causa is silent-by-default per Mike's 2026-05-19
+  ;; closure of rf2-q60yf. Flipping ON re-includes the bucket in L2
+  ;; with a muted row treatment; clicking the row focuses it so
+  ;; downstream panels (Event / App-db / Views / Trace) render against
+  ;; the bucket's events. Useful when debugging SSR / REPL flows.
+  (rf/reg-sub :rf.causa/show-ungrouped?
+    (fn [db _query]
+      (boolean (or (get-in db [:settings :general :show-ungrouped?])
+                   (config/get-setting :general :show-ungrouped?)))))
+
   ;; rf2-ttnst — convenience sub: long-keyword wrap threshold (chars).
   ;; Default 24 (was a fixed constant; now user-tuneable per spec/007-
   ;; UX-IA.md §Long-keyword treatment).

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -234,7 +234,8 @@
         auto-open?      @(rf/subscribe [:rf.causa/setting :general :auto-open-on-error?])
         density         @(rf/subscribe [:rf.causa/density])
         long-kw-thresh  @(rf/subscribe [:rf.causa/long-keyword-threshold])
-        show-tool?      @(rf/subscribe [:rf.causa/show-tool-frames?])]
+        show-tool?      @(rf/subscribe [:rf.causa/show-tool-frames?])
+        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])]
     [:div {:data-testid "rf-causa-settings-section-general"}
      [:h2 {:style (section-heading-style)} "General"]
 
@@ -440,7 +441,41 @@
               ":rf/pair2"]
        " in the L1 frame-picker dropdown. Default OFF — tool frames"
        " observing themselves is a known anti-pattern (see "
-       "spec/007-UX-IA.md §Frame-observation isolation invariants)."]]]))
+       "spec/007-UX-IA.md §Frame-observation isolation invariants)."]]
+
+     ;; ── Show :ungrouped pseudo-cascade events (rf2-r9lyy) ──────
+     ;;
+     ;; Opt-in surface for the `:ungrouped` bucket produced by
+     ;; `re-frame.trace.projection/group-cascades` (registry-time
+     ;; emits, frame lifecycle outside a drain, `:rf.ssr/hydration-
+     ;; mismatch`, REPL evals). Default OFF preserves Causa's
+     ;; silent-by-default posture (rf2-639lc filtered the bucket out
+     ;; of L2 entirely); flipping ON reveals the bucket as a muted
+     ;; L2 row so users debugging SSR / REPL flows can focus it and
+     ;; populate downstream panels. Per Mike 2026-05-19 closure of
+     ;; rf2-q60yf (Option B — opt-in chip/toggle).
+     [:div {:style (field-style)}
+      [:label {:style {:display "flex" :align-items "center" :gap "8px"
+                       :cursor "pointer"
+                       :font-size (:body type-scale)
+                       :color (:text-primary tokens)}}
+       [:input {:data-testid "rf-causa-settings-show-ungrouped"
+                :type        "checkbox"
+                :checked     (boolean show-ungrouped?)
+                :on-change   #(rf/dispatch
+                                [:rf.causa/settings-update
+                                 :general :show-ungrouped?
+                                 (boolean (.. % -target -checked))]
+                                {:frame :rf/causa})}]
+       "Show :ungrouped pseudo-cascade events in L2"]
+      [:p {:style (hint-style)}
+       "Reveals events outside any dispatch — "
+       [:code {:style {:font-family mono-stack
+                       :color (:text-tertiary tokens)}}
+        ":rf.ssr/*"]
+       ", registry-time emits, REPL evals, frame lifecycle. "
+       "Default OFF — Causa is silent-by-default. Useful when "
+       "debugging SSR / REPL flows."]]]))
 
 ;; ---- section: Filters ---------------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -266,6 +266,26 @@
   [cascade]
   (some? (event-id-of-cascade cascade)))
 
+(defn ungrouped-cascade?
+  "True iff `cascade` is the `:ungrouped` bucket produced by
+  `re-frame.trace.projection/group-cascades`. Used to give the
+  bucket a distinct muted treatment in L2 when the rf2-r9lyy
+  opt-in (`:settings/show-ungrouped?`) is on."
+  [cascade]
+  (= :ungrouped (:dispatch-id cascade)))
+
+(defn l2-cascade-visible?
+  "Pure helper. Should `cascade` render as a row in the L2 event
+  list? Always true for cascades carrying a real `:event` vector;
+  for the `:ungrouped` bucket, only true when the user has opted
+  in via Settings → General → Power user → 'Show :ungrouped pseudo-
+  cascade events in L2' (rf2-r9lyy). The ribbon nav (`◀ ▶ ⏭`) and
+  L2 walk both compose against this predicate so the visible row
+  set, the boundary detection, and the focus walk all agree."
+  [cascade show-ungrouped?]
+  (or (cascade-has-event? cascade)
+      (and show-ungrouped? (ungrouped-cascade? cascade))))
+
 (defn gutter-glyph
   "Pick the gutter glyph per spec/018 §4 Row anatomy. The selected row
   gets `◉`; an errored row gets `x`; a wholly-redacted row gets `▥`;
@@ -666,21 +686,26 @@
         cascades        @(rf/subscribe [:rf.causa/cascades])
         focus-set       @(rf/subscribe [:rf.causa/focus-set])
         show-tool?      false   ; Hardcoded — Power-user toggle UI not built yet
+        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
+        ;; bucket. Default OFF preserves silent-by-default; ON
+        ;; includes the bucket in L2 + the ribbon's boundary walk
+        ;; so the nav cluster's `[◀ ▶ ⏭]` agrees with what the user
+        ;; sees in L2.
+        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
         frames          (distinct-frames cascades show-tool?)
         redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
         filters         @(rf/subscribe [:rf.causa/active-filters])
         focused-id      (:dispatch-id focus)
         ;; Per rf2-fzbrw: the boundary predicates must align with the
         ;; user-visible event list. The L2 list filters `:ungrouped`
-        ;; (registry-time emits / lifecycle / REPL evals) via
-        ;; `cascade-has-event?`; if the ribbon walked the raw cascade
-        ;; vector instead, a buffer containing one real event PLUS the
-        ;; `:ungrouped` bucket would compute `at-tail?` against
-        ;; `:ungrouped` (= false) and leave `[<]` ENABLED on what the
-        ;; user sees as the first (only) event — clicking it would
-        ;; pin focus to the `:ungrouped` bucket and degrade the L4
-        ;; panels into an aggregate-across-all-events render.
-        event-cascades  (filterv cascade-has-event? cascades)
+        ;; (registry-time emits / lifecycle / REPL evals) by default;
+        ;; when the rf2-r9lyy opt-in is on the bucket appears in L2
+        ;; and the ribbon's walk MUST include it too, otherwise the
+        ;; user could click a visible bucket row in L2 that the
+        ;; `[<]` boundary refuses to step past. The `l2-cascade-
+        ;; visible?` predicate is the single source of truth — both
+        ;; surfaces compose against it.
+        event-cascades  (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
         ;; rf2-a1z3b — when a focus-set is active the nav buttons walk
         ;; ONLY the in-focus subset. Boundary predicates honour that
         ;; so `[◀]` greys at the first in-focus row and `[▶]` greys at
@@ -902,6 +927,13 @@
         pivot?      (and focus-set (= id (:pivot-id focus-set)))
         focus-active? (some? focus-set)
         out-of-focus? (and focus-active? (not in-focus?))
+        ;; rf2-r9lyy — the `:ungrouped` pseudo-cascade bucket renders
+        ;; with a distinct muted treatment when the opt-in is on (the
+        ;; bucket only reaches this row when the user has flipped the
+        ;; Settings → Power user → 'Show :ungrouped' toggle ON, per
+        ;; `l2-cascade-visible?`). Muted background + zero event vector
+        ;; signal "this is a pseudo-cascade outside any dispatch".
+        ungrouped?  (ungrouped-cascade? cascade)
         glyph       (gutter-glyph cascade focused-id)
         badges      (row-badges cascade)
         ev-id       (event-id-of-cascade cascade)
@@ -911,10 +943,20 @@
                       (= "x" glyph)                           (:red tokens)
                       (= "▥" glyph)                           (:magenta tokens)
                       :else                                   (:text-tertiary tokens))
-        bg          (if focused? (:bg-active tokens) "transparent")
-        border      (if focused?
-                      (str "1px solid " (:cyan tokens))
-                      "1px solid transparent")
+        bg          (cond
+                      focused?   (:bg-active tokens)
+                      ;; Muted background for the :ungrouped bucket so it
+                      ;; reads as visually distinct from the real-event
+                      ;; rows (rf2-r9lyy). Falls back to the same bg-2
+                      ;; the list uses if `:bg-2` is the only neutral
+                      ;; muted token available; the ribbon's own canvas
+                      ;; is bg-1 so this still reads as a recessed row.
+                      ungrouped? (:bg-2 tokens)
+                      :else      "transparent")
+        border      (cond
+                      focused?   (str "1px solid " (:cyan tokens))
+                      ungrouped? (str "1px dashed " (:border-subtle tokens))
+                      :else      "1px solid transparent")
         ;; rf2-ieg6d Bug 1 — only the focused row in the LIVE-at-head
         ;; auto-tracking branch carries a ref. RETRO and non-focused rows
         ;; get nil (no DOM-side scroll work, no per-render cost).
@@ -961,12 +1003,15 @@
                   ;; coord, handler duration) surface in this hover
                   ;; tooltip + the L4 Event tab on click. Default row
                   ;; body shows only `event-id + ⚠/🌐/🤖`.
-                  :title (row-tooltip-text cascade)
+                  :title (if ungrouped?
+                           ":ungrouped — events outside any dispatch (:rf.ssr/*, registry-time emits, REPL evals, frame lifecycle). Click to focus the bucket."
+                           (row-tooltip-text cascade))
                   :data-rf-causa-in-focus (cond
                                             (not focus-active?) "n/a"
                                             in-focus?           "true"
                                             :else               "false")
                   :data-rf-causa-pivot    (if pivot? "true" "false")
+                  :data-rf-causa-ungrouped (if ungrouped? "true" "false")
                   :style {:display       "flex"
                           :align-items   "center"
                           :gap           "6px"
@@ -979,7 +1024,10 @@
                           :border-radius "2px"
                           :font-family   mono-stack
                           :font-size     (:mono-body type-scale)
-                          :color         (:text-primary tokens)
+                          :color         (if ungrouped?
+                                           (:text-secondary tokens)
+                                           (:text-primary tokens))
+                          :font-style    (if ungrouped? "italic" "normal")
                           :white-space   "nowrap"
                           :overflow      "hidden"
                           :text-overflow "ellipsis"
@@ -989,9 +1037,16 @@
                           ;; we don't need a stylesheet round-trip; the
                           ;; CSS-var fallback keeps host overrides
                           ;; possible.
-                          :opacity       (if out-of-focus?
+                          ;; rf2-r9lyy — :ungrouped rows render at 0.7
+                          ;; opacity even when in-focus so the bucket
+                          ;; reads as visually recessed against the real
+                          ;; cascade rows. Out-of-focus still wins (the
+                          ;; 0.4 dim is more aggressive).
+                          :opacity       (cond
+                                           out-of-focus?
                                            "var(--rf-causa-row-dim-opacity, 0.4)"
-                                           1)}}
+                                           ungrouped? 0.7
+                                           :else      1)}}
            ref-fn (assoc :ref ref-fn))
      ;; Gutter — FOCUS surface (rf2-a1z3b). Click sets/toggles focus
      ;; on the row's inferred dimension. The hit-area is the 14px
@@ -1033,7 +1088,16 @@
              :style {:flex "1 1 auto" :overflow "hidden"
                      :text-overflow "ellipsis"
                      :min-width "0"}}
-      (render-event-id-only event-vec)]
+      (if ungrouped?
+        ;; rf2-r9lyy — the :ungrouped pseudo-cascade has no event
+        ;; vector by construction. Render a clear muted label instead
+        ;; of the defence-in-depth `<no event>` fallback so the user
+        ;; understands they're looking at the bucket of events outside
+        ;; any dispatch.
+        [:span {:style {:color      (:text-tertiary tokens)
+                        :font-style "italic"}}
+         ":ungrouped (pseudo-cascade)"]
+        (render-event-id-only event-vec))]
      (when (seq badges)
        [:span {:data-testid "rf-causa-row-badges"
                :style {:display "flex" :gap "4px" :flex-shrink 0
@@ -1100,6 +1164,11 @@
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
         focus          @(rf/subscribe [:rf.causa/focus])
         focus-set      @(rf/subscribe [:rf.causa/focus-set])
+        ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
+        ;; bucket. Default OFF preserves silent-by-default; ON
+        ;; surfaces the bucket as a muted L2 row that focuses the
+        ;; bucket on click so downstream panels populate.
+        show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
         ;; rf2-vbbq0 — one subscribe per render drives every chip's
         ;; relative-time text. Falls back to `(interop/now-ms)` before
         ;; the first tick lands so the chips render correctly on the
@@ -1114,7 +1183,7 @@
         auto-track?    (and (= :live (:mode focus))
                             (:head? focus)
                             (not (:paused? focus)))
-        event-cascades (filterv cascade-has-event? cascades)
+        event-cascades (filterv #(l2-cascade-visible? % show-ungrouped?) cascades)
         ;; rf2-a1z3b — precompute the focus predicate ONCE per render
         ;; so the per-row work is a single fn call rather than a
         ;; predicate rebuild per row.

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -1,6 +1,20 @@
 (ns day8.re-frame2-causa.spine
   "The single-axis spine substrate (rf2-adve5).
 
+  ## rf2-r9lyy — `:ungrouped` opt-in surface
+
+  By default the spine strips the `:ungrouped` pseudo-cascade bucket
+  from every walk (`focusable-cascades`) so the bucket is never a
+  focus target — pinning to it degrades the L4 panels into an
+  aggregate look (rf2-fzbrw). Mike's 2026-05-19 closure of rf2-q60yf
+  flipped this from a hard contract to an opt-in: the new
+  `:settings/show-ungrouped?` knob (defaults `false`) reveals the
+  bucket in L2 and lets the user click it to focus. When the flag
+  is `true`, the spine's helpers/reducers include `:ungrouped` in
+  their walks; when `false`, the existing strict behaviour is
+  preserved. Every public arity that previously walked
+  `focusable-cascades` gains an additive arity that takes the flag.
+
   Per `tools/causa/spec/018-Event-Spine.md` §6 Spine binding the spine
   sub `:rf.causa/focus` is the one axis every dependent surface reads
   from. When a user clicks a row, EVERY dependent surface (count
@@ -44,6 +58,7 @@
   updates the legacy slots."
   (:require [re-frame.core :as rf]
             [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.focus-helpers :as fh]
             [day8.re-frame2-causa.panels.common-helpers :as common]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
@@ -55,9 +70,9 @@
   time'. The `:ungrouped` bucket produced by `projection/group-cascades`
   for registry-time emits / frame lifecycle outside a drain / REPL
   evals carries no event vector and is therefore NOT a valid focus
-  target: pinning to it leaves every event-detail / app-db / views
-  panel with no cascade to render, which degrades into the unwanted
-  'all subs / all handlers' aggregate look.
+  target BY DEFAULT: pinning to it leaves every event-detail / app-db
+  / views panel with no cascade to render, which degrades into the
+  unwanted 'all subs / all handlers' aggregate look.
 
   Strip the bucket before any spine walk so:
     - the head/tail boundary predicates align with what the user sees
@@ -67,10 +82,23 @@
     - `compose-focus` cannot resolve an effective dispatch-id to
       `:ungrouped` for a stored slot that was already pointing there.
 
+  ## rf2-r9lyy — opt-in inclusion
+
+  Mike 2026-05-19 closure of rf2-q60yf: pass `show-ungrouped? true`
+  (the 2-arity) to KEEP the bucket. Users debugging SSR / REPL /
+  registry-time flows opt in via Settings → General → Power user
+  → 'Show :ungrouped pseudo-cascade events in L2'. When the flag
+  is on, the bucket appears as a focusable target so clicking it
+  populates the downstream panels with its trace events.
+
   Pure data; JVM-runnable; idempotent (re-filtering a cleaned vector
   is a no-op)."
-  [cascades]
-  (filterv #(not= :ungrouped (:dispatch-id %)) cascades))
+  ([cascades]
+   (focusable-cascades cascades false))
+  ([cascades show-ungrouped?]
+   (if show-ungrouped?
+     (vec cascades)
+     (filterv #(not= :ungrouped (:dispatch-id %)) cascades))))
 
 (defn head-cascade
   "The latest cascade in the projected list — the cascade whose
@@ -94,9 +122,15 @@
   Used for click-on-head detection (rf2-xzzih): clicking the visible
   head event should stay LIVE; the raw `head-dispatch-id` would treat
   an `:ungrouped` bucket as the head if it sorted last, which the
-  user never sees as a focusable row."
-  [cascades]
-  (head-dispatch-id (focusable-cascades cascades)))
+  user never sees as a focusable row.
+
+  rf2-r9lyy — the 2-arity threads `show-ungrouped?` through
+  `focusable-cascades` so the head-detection also lights up the
+  bucket when the user has opted in."
+  ([cascades]
+   (focusable-head-id cascades false))
+  ([cascades show-ungrouped?]
+   (head-dispatch-id (focusable-cascades cascades show-ungrouped?))))
 
 (defn focusable-head-frame-id
   "The `:frame` of the head focusable cascade — i.e. the frame whose
@@ -111,7 +145,12 @@
   boot empty-state for `:cart-frame` (the observed frame) because
   `:epoch-history` was seeded from `:rf/default` (the legacy default).
   Picker-driven `set-frame-reducer` already aligns the same two axes
-  on a frame change; this helper extends that alignment to mount."
+  on a frame change; this helper extends that alignment to mount.
+
+  Mount-seed callers stay on the 1-arity (which always strips
+  `:ungrouped`) because the bucket carries `:frame nil` — seeding
+  `:target-frame nil` is never useful regardless of the
+  `:show-ungrouped?` knob."
   [cascades]
   (:frame (head-cascade (focusable-cascades cascades))))
 
@@ -234,9 +273,20 @@
   Without this scoping the composer would pick the global head
   (whatever frame fired the latest event), which under multi-frame
   apps drifts focus off the picker's frame on every cross-frame
-  dispatch."
-  [focus cascades]
-  (let [focusable* (focusable-cascades cascades)
+  dispatch.
+
+  ## rf2-r9lyy — `:show-ungrouped?` opt-in
+
+  Pass `show-ungrouped? true` via the 3-arity to include the
+  `:ungrouped` bucket as a valid focus target. When on:
+    - the head walk considers `:ungrouped` as a possible head;
+    - a stored `:dispatch-id :ungrouped` is pinnable (does not snap
+      to head).
+  When off (default 2-arity), the existing strict behaviour applies."
+  ([focus cascades]
+   (compose-focus focus cascades false))
+  ([focus cascades show-ungrouped?]
+  (let [focusable* (focusable-cascades cascades show-ungrouped?)
         slot-frame (:frame focus)
         focusable  (if slot-frame
                      (filterv #(= slot-frame (:frame %)) focusable*)
@@ -245,11 +295,15 @@
         slot-id    (:dispatch-id focus)
         paused?    (boolean (:paused? focus))
         ;; rf2-fzbrw — a slot pointing at nil OR the :ungrouped bucket
-        ;; is NOT a valid focus pin. (Evicted ids are still a valid
-        ;; pin: the event-detail panel surfaces its orphaned-state
-        ;; copy off them, so we don't conflate "evicted" with "never
-        ;; valid".)
-        slot-pinnable? (and slot-id (not= :ungrouped slot-id))
+        ;; is NOT a valid focus pin BY DEFAULT. (Evicted ids are still
+        ;; a valid pin: the event-detail panel surfaces its orphaned-
+        ;; state copy off them, so we don't conflate "evicted" with
+        ;; "never valid".) rf2-r9lyy — when `show-ungrouped?` is on,
+        ;; `:ungrouped` IS pinnable so the user's click on the bucket
+        ;; row sticks.
+        slot-pinnable? (and slot-id
+                            (or show-ungrouped?
+                                (not= :ungrouped slot-id)))
         mode       (or (:mode focus)
                        (if (or (nil? slot-id) (= slot-id head-id))
                          :live
@@ -292,7 +346,7 @@
      :head?       (or (nil? eff-id)
                       (= eff-id head-id))
      :previewing? (boolean (:previewing? focus))
-     :paused?     paused?}))
+     :paused?     paused?})))
 
 ;; ---- pure reducers exposed for direct unit testing ----------------------
 
@@ -369,12 +423,16 @@
   The 3-arg arity (back-compat for callers that don't have the epoch
   buffer handy) treats `epoch-history` as empty so `:epoch-id`
   resolves to nil. Production callers in `install!` go through the
-  4-arg arity."
+  4-arg arity. rf2-r9lyy — the 5-arg arity threads
+  `show-ungrouped?` so the step walk includes the `:ungrouped`
+  bucket when the user has opted in."
   ([db cascades delta]
-   (focus-step-reducer db cascades [] delta))
+   (focus-step-reducer db cascades [] delta false))
   ([db cascades epoch-history delta]
+   (focus-step-reducer db cascades epoch-history delta false))
+  ([db cascades epoch-history delta show-ungrouped?]
    (let [slot-frame (get-in db [:focus :frame])
-         focusable* (focusable-cascades cascades)
+         focusable* (focusable-cascades cascades show-ungrouped?)
          ;; rf2-oziyr — when the frame-picker has restricted the
          ;; inspectable surface, the step walk MUST honour that
          ;; restriction so [◀ ▶ ⏭] / j / k step through the picker's
@@ -385,8 +443,9 @@
          ;; rf2-s0s5x Phase A: resolve current-id through the same
          ;; composer the spine sub uses, so in LIVE mode `j` steps
          ;; back from the CURRENT head rather than from a stale
-         ;; stored id.
-         current-id (:dispatch-id (compose-focus (get db :focus) cascades))
+         ;; stored id. rf2-r9lyy — pass show-ungrouped? so the
+         ;; composer's pinnability check honours the opt-in.
+         current-id (:dispatch-id (compose-focus (get db :focus) cascades show-ungrouped?))
          ;; rf2-a1z3b — when a focus-set is active, step skips past
          ;; out-of-focus cascades to the next/prev in-focus row. When
          ;; no focus-set is active, fall through to the plain
@@ -573,6 +632,18 @@
   [db]
   (get db :epoch-history []))
 
+(defn- db->show-ungrouped?
+  "Read the live `:show-ungrouped?` opt-in flag (rf2-r9lyy) off the
+  Causa app-db's seeded settings slot, falling back to the config
+  atom for callers that fire before the settings popup has been
+  opened (the popup's `:settings-open` handler seeds the slot from
+  the atom on first open). Mirrors the read shape used by the
+  `:rf.causa/show-ungrouped?` sub in `settings/subs.cljs`."
+  [db]
+  (boolean
+    (or (get-in db [:settings :general :show-ungrouped?])
+        (config/get-setting :general :show-ungrouped?))))
+
 (defn install!
   "Idempotent install — register the `:rf.causa/focus` sub + its
   driving events. Called from `registry.cljs`'s
@@ -593,25 +664,36 @@
   (rf/reg-sub :rf.causa/focus
     :<- [:rf.causa/focus-slot]
     :<- [:rf.causa/cascades]
-    (fn [[focus cascades] _query]
-      (compose-focus focus cascades)))
+    :<- [:rf.causa/show-ungrouped?]
+    (fn [[focus cascades show-ungrouped?] _query]
+      (compose-focus focus cascades show-ungrouped?)))
 
   ;; ---- events ----------------------------------------------------------
+  ;;
+  ;; rf2-r9lyy — the focus-cascade / focus-cascade-prev / next handlers
+  ;; read the live `:show-ungrouped?` setting off the db so the step /
+  ;; head detection walks include the `:ungrouped` bucket when the user
+  ;; has opted in. The settings popup writes through the same slot;
+  ;; pre-popup-seed reads fall back to the config atom via the helper
+  ;; below (mirrors the `:rf.causa/show-ungrouped?` sub).
 
   (rf/reg-event-db :rf.causa/focus-cascade
     (fn [db [_ dispatch-id frame-id]]
-      (let [cascades (db->cascades db)
-            head-id  (focusable-head-id cascades)
-            epoch-id (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
+      (let [cascades       (db->cascades db)
+            show-ungrouped? (db->show-ungrouped? db)
+            head-id        (focusable-head-id cascades show-ungrouped?)
+            epoch-id       (epoch-id-for-cascade (db->epoch-history db) dispatch-id)]
         (focus-cascade-reducer db dispatch-id frame-id epoch-id head-id))))
 
   (rf/reg-event-db :rf.causa/focus-cascade-prev
     (fn [db _event]
-      (focus-step-reducer db (db->cascades db) (db->epoch-history db) -1)))
+      (focus-step-reducer db (db->cascades db) (db->epoch-history db) -1
+                          (db->show-ungrouped? db))))
 
   (rf/reg-event-db :rf.causa/focus-cascade-next
     (fn [db _event]
-      (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1)))
+      (focus-step-reducer db (db->cascades db) (db->epoch-history db) +1
+                          (db->show-ungrouped? db))))
 
   (rf/reg-event-db :rf.causa/follow-head
     (fn [db _event]

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -195,6 +195,8 @@
    :rf.causa/settings-open?
    :rf.causa/show-me-when-this-changed-result
    :rf.causa/show-tool-frames?
+   ;; rf2-r9lyy — opt-in surface for the :ungrouped pseudo-cascade bucket.
+   :rf.causa/show-ungrouped?
    ;; rf2-v869p Phase 2 — UC1 Sim sub-mode subs.
    :rf.causa/sim-active?
    :rf.causa/sim-available-transitions
@@ -461,11 +463,9 @@
     ;; that lived here through rf2-qy0nu (the 8-dead-panel sweep) was
     ;; deleted with the panels themselves — every line referenced a
     ;; surface that no longer exists.
-    ;; rf2-e9tb0 — net +2 subs (–2 pinned-slices, +4 segment-inspector)
-    ;; and –1 events (–3 pin/unpin/reorder, +2 open/close segment-
-    ;; inspector). Against the post-rf2-ttnst Settings expansion
-    ;; baseline (102 subs / 116 events) → 104 subs / 115 events.
-    (is (= 104 (count all-sub-names)))
+    ;; rf2-e9tb0 + rf2-r9lyy combined deltas against post-rf2-ttnst
+    ;; baseline (102 / 116): e9tb0 +2 subs / -1 event; r9lyy +1 sub / 0 events.
+    (is (= 105 (count all-sub-names)))
     (is (= 115 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -471,6 +471,90 @@
         (is (empty? (find-all-by-testid-prefix tree "rf-causa-event-row-"))
             "no event rows render — the :ungrouped bucket is filtered out")))))
 
+;; -------------------------------------------------------------------------
+;; rf2-r9lyy — :ungrouped opt-in surface (Option B)
+;;
+;; The `:settings/show-ungrouped?` knob (Settings → General → Power user)
+;; flips the bucket from "always filtered" to "revealed as a muted L2
+;; row". Default OFF preserves silent-by-default. The opt-in:
+;;   - reveals the :ungrouped bucket as an L2 row carrying
+;;     `data-rf-causa-ungrouped="true"`;
+;;   - the row's body-click dispatches `:rf.causa/focus-cascade
+;;     :ungrouped` so the spine pins to the bucket;
+;;   - the spine reducer + composer accept the pin under the opt-in
+;;     (covered directly by spine_cljs_test.cljs).
+;; -------------------------------------------------------------------------
+
+(deftest event-list-reveals-ungrouped-bucket-when-opt-in
+  (testing "rf2-r9lyy — `:show-ungrouped? true` reveals the :ungrouped
+            row in L2 with a distinct muted treatment"
+    (causa-setup!)
+    (config/update-setting! :general :show-ungrouped? true)
+    (try
+      (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+      (trace-bus/collect-trace! {:id 50 :op-type :registry
+                                 :operation :sub/registered
+                                 :tags {:sub-id :foo/bar}})
+      (rf/with-frame :rf/causa
+        (let [tree (shell/shell-view)
+              rows (find-all-by-testid-prefix tree "rf-causa-event-row-")
+              ungrouped-row (find-by-testid tree "rf-causa-event-row-:ungrouped")]
+          (is (= 2 (count rows))
+              "both the real event AND the :ungrouped bucket render under opt-in")
+          (is (some? ungrouped-row)
+              ":ungrouped bucket row is present")
+          (is (= "true"
+                 (:data-rf-causa-ungrouped (second ungrouped-row)))
+              ":ungrouped row carries the data attribute for visual treatment")))
+      (finally
+        (config/update-setting! :general :show-ungrouped? false)))))
+
+(deftest event-list-hides-ungrouped-bucket-by-default
+  (testing "rf2-r9lyy — silent-by-default. The opt-in defaults OFF; the
+            :ungrouped bucket is not rendered in L2."
+    (causa-setup!)
+    ;; Belt-and-braces: assert the default; do not flip the knob.
+    (is (false? (config/get-setting :general :show-ungrouped?))
+        ":show-ungrouped? defaults OFF (silent-by-default)")
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! {:id 50 :op-type :registry
+                               :operation :sub/registered
+                               :tags {:sub-id :foo/bar}})
+    (rf/with-frame :rf/causa
+      (let [tree (shell/shell-view)
+            rows (find-all-by-testid-prefix tree "rf-causa-event-row-")]
+        (is (= 1 (count rows))
+            "only the real event renders — :ungrouped is filtered out")
+        (is (nil? (find-by-testid tree "rf-causa-event-row-:ungrouped"))
+            ":ungrouped row is absent by default")))))
+
+(deftest event-list-ungrouped-row-click-dispatches-focus-cascade
+  (testing "rf2-r9lyy — clicking the revealed :ungrouped row dispatches
+            `:rf.causa/focus-cascade :ungrouped` so the spine pins the
+            bucket and downstream panels populate"
+    (causa-setup!)
+    (config/update-setting! :general :show-ungrouped? true)
+    (try
+      (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+      (trace-bus/collect-trace! {:id 50 :op-type :registry
+                                 :operation :sub/registered
+                                 :tags {:sub-id :foo/bar}})
+      (let [dispatches (atom [])]
+        (with-redefs [rf/dispatch* (fn
+                                     ([ev]       (swap! dispatches conj ev) nil)
+                                     ([ev _opts] (swap! dispatches conj ev) nil))]
+          (rf/with-frame :rf/causa
+            (let [tree (shell/shell-view)
+                  row  (find-by-testid tree "rf-causa-event-row-:ungrouped")
+                  handler (:on-click (second row))]
+              (is (some? row) ":ungrouped row is present")
+              (when handler (handler nil)))))
+        (is (some #(and (= :rf.causa/focus-cascade (first %))
+                        (= :ungrouped (second %))) @dispatches)
+            ":rf.causa/focus-cascade fired with `:ungrouped` as the id"))
+      (finally
+        (config/update-setting! :general :show-ungrouped? false)))))
+
 (deftest event-row-click-dispatches-focus-cascade
   (testing "spec/018 §6 — row click dispatches :rf.causa/focus-cascade,
             spine flips to :retro, every dependent surface rebinds"

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -813,6 +813,91 @@
            (spine/focusable-cascades fixture-cascades))
         "no :ungrouped → no-op")))
 
+;; -------------------------------------------------------------------------
+;; rf2-r9lyy — :ungrouped opt-in surface (Option B)
+;;
+;; Mike 2026-05-19 closure of rf2-q60yf: the `:settings/show-ungrouped?`
+;; knob flips the bucket from "always stripped" to "user-revealed". The
+;; spine respects the opt-in: when on, the bucket is a valid focusable
+;; target so clicking the L2 row pins it; when off (default), the
+;; existing strict behaviour applies and pinning to :ungrouped snaps to
+;; head.
+;; -------------------------------------------------------------------------
+
+(deftest focusable-cascades-include-ungrouped-when-opt-in
+  (testing "rf2-r9lyy — `show-ungrouped? true` keeps the bucket so the
+            user can focus it"
+    (is (= 3 (count (spine/focusable-cascades
+                      fixture-cascades-with-ungrouped true))))
+    (is (some #(= :ungrouped (:dispatch-id %))
+              (spine/focusable-cascades
+                fixture-cascades-with-ungrouped true)))
+    (is (= 2 (count (spine/focusable-cascades
+                      fixture-cascades-with-ungrouped false)))
+        "show-ungrouped? false preserves the strict default")))
+
+(deftest focusable-head-id-includes-ungrouped-when-opt-in
+  (testing "rf2-r9lyy — when `show-ungrouped?` is on the head walk
+            considers :ungrouped as a possible head (the bucket sorts
+            last per the first-id sentinel)"
+    (is (= :ungrouped
+           (spine/focusable-head-id
+             fixture-cascades-with-ungrouped true)))
+    (is (= :c2
+           (spine/focusable-head-id
+             fixture-cascades-with-ungrouped false))
+        "show-ungrouped? false preserves the strict default")))
+
+(deftest compose-focus-pins-ungrouped-when-opt-in
+  (testing "rf2-r9lyy — `show-ungrouped? true` lets a stored
+            `:dispatch-id :ungrouped` stick (effective id is
+            :ungrouped, not the head)"
+    (let [r (spine/compose-focus {:dispatch-id :ungrouped :mode :retro}
+                                 fixture-cascades-with-ungrouped
+                                 true)]
+      (is (= :ungrouped (:dispatch-id r))
+          "stored :ungrouped is pinnable under opt-in"))))
+
+(deftest compose-focus-defaults-to-strict-when-opt-in-off
+  (testing "rf2-r9lyy — `show-ungrouped? false` (default) preserves
+            the rf2-fzbrw contract: a stored :ungrouped snaps to head"
+    (let [r (spine/compose-focus {:dispatch-id :ungrouped :mode :retro}
+                                 fixture-cascades-with-ungrouped
+                                 false)]
+      (is (= :c2 (:dispatch-id r))
+          "show-ungrouped? off → snap to head"))
+    (let [r (spine/compose-focus {:dispatch-id :ungrouped :mode :retro}
+                                 fixture-cascades-with-ungrouped)]
+      (is (= :c2 (:dispatch-id r))
+          "2-arity (legacy) preserves the strict default"))))
+
+(deftest focus-step-reducer-walks-into-ungrouped-when-opt-in
+  (testing "rf2-r9lyy — when `show-ungrouped?` is on, stepping forward
+            from the last real cascade lands on :ungrouped (the bucket
+            sorts at the head per the first-id sentinel)"
+    (let [db {:focus {:dispatch-id :c2 :mode :retro}
+              :selected-dispatch-id :c2}
+          r  (spine/focus-step-reducer db
+                                       fixture-cascades-with-ungrouped
+                                       []
+                                       +1
+                                       true)]
+      (is (= :ungrouped (get-in r [:focus :dispatch-id]))
+          "show-ungrouped? on → step forward into the bucket"))))
+
+(deftest focus-step-reducer-skips-ungrouped-when-opt-in-off
+  (testing "rf2-r9lyy — when `show-ungrouped?` is off (default), the
+            step walk never lands on :ungrouped (rf2-fzbrw default)"
+    (let [db {:focus {:dispatch-id :c2 :mode :retro}
+              :selected-dispatch-id :c2}
+          r  (spine/focus-step-reducer db
+                                       fixture-cascades-with-ungrouped
+                                       []
+                                       +1
+                                       false)]
+      (is (= db r)
+          "show-ungrouped? off → boundary no-op at the last real cascade"))))
+
 (deftest focus-step-reducer-prev-on-first-event-is-no-op
   (testing "rf2-fzbrw — [<] on the first (oldest) real event returns db
             unchanged. The boundary is a true no-op so focus cannot


### PR DESCRIPTION
## Summary

Implements **rf2-r9lyy** — opt-in surface for the `:ungrouped` pseudo-cascade bucket (registry-time emits, frame lifecycle outside a drain, `:rf.ssr/hydration-mismatch`, REPL evals) per Mike's 2026-05-19 closure of rf2-q60yf (Option B: opt-in chip / toggle).

The bucket was previously filtered out of L2 unconditionally (rf2-639lc) and unreachable for focus (rf2-fzbrw) — silent-by-default but invisible to users debugging SSR / REPL workflows. The new `:settings/show-ungrouped?` knob reveals the bucket on demand.

- `config.cljc` — `:show-ungrouped?` boolean default `false` in `:general` section.
- `settings/subs.cljs` — `:rf.causa/show-ungrouped?` convenience sub.
- `settings/view.cljs` — toggle under existing Power-user divider, alongside Show-tool-frames.
- `spine.cljs` — additive arities thread `show-ungrouped?` through `focusable-cascades` / `focusable-head-id` / `compose-focus` / `focus-step-reducer`. The `:rf.causa/focus` sub composes against `:rf.causa/show-ungrouped?` so it rebinds when the user flips the knob.
- `shell.cljs` — new `l2-cascade-visible?` helper is the single source of truth for L2 row visibility AND ribbon boundary detection. Bucket renders with distinct muted treatment: dashed border, italic `:ungrouped (pseudo-cascade)` label, secondary text colour, 0.7 opacity, `data-rf-causa-ungrouped` attribute. Body-click dispatches `:rf.causa/focus-cascade :ungrouped` so downstream panels populate; gutter is inert (no inferable focus dimension).
- **Toggle-only in v1** — no ribbon chip per the bead's "lean toggle-only" advisory. Lower-noise default; chip can land later if the toggle alone proves insufficient.

## Default OFF

`:show-ungrouped?` defaults `false` and the new tests assert the silent-by-default contract: a buffer carrying real cascades plus the `:ungrouped` bucket renders only the real cascades; clicking nav at the only real event remains a boundary no-op.

## Visual treatment when ON

The revealed L2 row reads as visually recessed against real cascade rows:

- Muted bg (`bg-2`) + dashed border (`border-subtle`) instead of transparent / solid.
- Italic `:ungrouped (pseudo-cascade)` label in secondary text colour instead of the violet event-id.
- Body-text colour drops to `text-secondary`; the row dims to 0.7 opacity even when in-focus.
- `:title` tooltip: `:ungrouped — events outside any dispatch (:rf.ssr/*, registry-time emits, REPL evals, frame lifecycle). Click to focus the bucket.`
- `data-rf-causa-ungrouped="true"` on the row for downstream tooling / e2e tests.

## Test plan

- [x] `npm run test:cljs` — 2921 tests, 8346 assertions, 0 failures (was 2912 before; 9 new deftests).
- [x] `npm run test:browser` — 2912 tests, 0 failures.
- [x] `scripts/test-fast-pr.sh` — PASS.
- [x] `python scripts/check_doc_slugs.py` — exit 0.
- [x] `mkdocs build --strict` — no new warnings (warnings present on `origin/main` are unrelated; CI stages `spec/` + `migration/` into `docs/` before build).
- [x] Unit coverage:
  - `spine_cljs_test.cljs` — 6 new deftests around `focusable-cascades` / `focusable-head-id` / `compose-focus` / `focus-step-reducer` with the flag on / off.
  - `shell_cljs_test.cljs` — 3 new deftests: reveal under opt-in, silent-by-default, click → `:rf.causa/focus-cascade :ungrouped`.
  - `registry_cljs_test.cljs` — catalogue + count bumped for the new sub.