### PR TITLE
chore(causa): sweep stale resize:horizontal CSS to match auto-inject (rf2-epnru)

### DIFF
--- a/docs/causa/01-installation.md
+++ b/docs/causa/01-installation.md
@@ -37,14 +37,17 @@ second — flex flow puts the aside to the right of the app column:
   box-sizing: border-box;            /* the 1px border lives inside the
                                         documented width */
   border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
-  resize: horizontal;                /* user-draggable width */
-  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
 
-Two complementary resize mechanisms — both browser-native, both
-JS-free — ship together:
+That's the whole consumer surface — no `resize: horizontal`, no
+`overflow: auto`. Causa auto-injects a polished drag handle on the
+panel's outer edge as soon as the shell mounts (per rf2-70u8q +
+`spec/007-UX-IA.md` §Resize affordance); the handle covers mouse,
+touch, and pen via pointer events and is keyboard-navigable.
+
+Two complementary resize mechanisms ship together:
 
 - **CSS variable** (host-owned, fixed-point sizing). Override
   `--rf-causa-inline-width` anywhere up the cascade to set the
@@ -52,11 +55,17 @@ JS-free — ship together:
   ```css
   :root { --rf-causa-inline-width: 560px; }
   ```
-- **Browser-native drag** (user-controlled). `resize: horizontal` +
-  `overflow: auto` give the host a drag-handle in the bottom corner;
-  the user drags to resize ad-hoc. The variable seeds the initial
-  size; a drag overrides it for the page lifetime; reload (or a
-  fresh cascade override) returns to the declared initial.
+- **Causa drag handle** (user-controlled, persisted; auto-injected).
+  Drag the panel's outer edge to resize. Width clamps to `[320px,
+  90vw]` and persists across reloads via `configure! :settings
+  :general :panel-width-px`. Double-click (or press Enter / Space
+  when focused) to reset to default. The variable seeds the initial
+  size; a drag overrides it; both write to the same `flex-basis`.
+
+Some teams prefer the browser-native handle (`resize: horizontal` +
+`overflow: auto` on the host). Causa detects that at render time via
+`getComputedStyle` and renders no handle of its own — the consumer
+wins, no double-handle.
 
 If Causa cannot find the host, it logs an actionable `console.error`
 and exposes the same diagnostic through

--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -10,10 +10,11 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
-       give the user a browser-native drag handle on the host (rf2-e07yk). */
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Causa (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
     :root { --rf-causa-accent: #7C5CFF; }
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/skills/causa/reference/launch-modes.md
+++ b/skills/causa/reference/launch-modes.md
@@ -89,8 +89,6 @@ body { margin: 0; }
   min-width: 320px;
   box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
-  resize: horizontal;
-  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
@@ -106,8 +104,7 @@ the host. Override the selector before Causa opens:
 ### Resizing the host
 
 The recommended CSS reads `--rf-causa-inline-width` for its
-`flex-basis`. Two cooperating resize mechanisms, both browser-native,
-both JS-free:
+`flex-basis`. Two cooperating resize mechanisms:
 
 1. **CSS variable** — host-owned, fixed-point sizing. Set the initial
    width or override per route/per build via the cascade. One
@@ -116,14 +113,19 @@ both JS-free:
    :root { --rf-causa-inline-width: 720px; }        /* global default */
    .debug-route { --rf-causa-inline-width: 960px; } /* per route */
    ```
-2. **Browser-native drag** — `resize: horizontal` + `overflow: auto`
-   gives the host a drag handle in its bottom-right corner. The user
-   drags, the host's used width updates, flex reflow shrinks `#app` to
-   fill the remainder. No CLJS, no listener, no Causa surface.
+2. **Causa drag handle** — auto-injected by Causa (rf2-70u8q; see
+   `tools/causa/spec/007-UX-IA.md` §Resize affordance) on the panel's
+   outer edge. Pointer-driven (mouse, touch, pen via pointer events),
+   keyboard-navigable, persisted across reloads via
+   `configure! :settings :general :panel-width-px`, clamped to
+   `[320px, 90vw]`, double-click to reset.
 
-Causa MUST NOT introduce a JS-driven draggable separator and MUST NOT
-set the variable from CLJS — the host's stylesheet is the single source
-of truth.
+Both mechanisms write the same `flex-basis` slot. Consumers that
+prefer the browser-native handle opt out by setting `resize:
+horizontal` on the host; Causa detects that via `getComputedStyle` at
+render time and yields (no double-handle). Causa MUST NOT set the
+variable from CLJS — the host's stylesheet is the single source of
+truth for the *initial* width.
 
 ### Suppress auto-open
 

--- a/skills/re-frame2-setup/reference/shadow-cljs.md
+++ b/skills/re-frame2-setup/reference/shadow-cljs.md
@@ -58,8 +58,6 @@ A re-frame2 app needs an HTML page that loads the compiled JS and has a mount po
       box-sizing: border-box;            /* the border lives inside the
                                             documented width */
       border-left: 1px solid #2a2a2a;   /* visual separator on the app side */
-      resize: horizontal;                /* user-draggable width */
-      overflow: auto;
     }
     #app { flex: 1; min-width: 0; }
     /* Resize from anywhere up the cascade: */
@@ -80,7 +78,7 @@ Four contractual bits:
 
 - **`<main id="app"></main>`** — the app mount point. Whatever id you use here, the entry ns must call `(js/document.getElementById "<same-id>")`. By convention it's `"app"`.
 - **`<aside data-rf-causa-host></aside>`** — Causa's default true-inline devtools host. Keep it as a right-side layout column beside `#app` when you enable `day8.re-frame2-causa.preload` (DOM order: `<main>` first, `<aside>` second — flex flow puts the aside on the right); otherwise Causa logs an actionable missing-host diagnostic and exposes the same status through `window.day8.re_frame2_causa.status()`.
-- **`.app-shell` flex CSS** — the host app owns sizing and layout. The minimal contract is a right column (`flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0; }`). Two complementary resize mechanisms ship together — both browser-native, both JS-free: (1) **CSS variable** — override `--rf-causa-inline-width` anywhere up the cascade (e.g. `:root { --rf-causa-inline-width: 720px; }`) to set the initial width (host-owned, per `rf2-um813`; default bumped 420 → 560 under `rf2-9ovfb`); (2) **Browser-native drag** — `resize: horizontal` + `overflow: auto` paint a drag-handle in the host's bottom corner so the user can resize ad-hoc. The variable seeds the initial size; a drag overrides it for the page lifetime. The snippet also publishes `--rf-causa-accent` (default `#7C5CFF`) on `:root` (rf2-9ovfb) so host stylesheets can colour their own dev chrome to match Causa.
+- **`.app-shell` flex CSS** — the host app owns sizing and layout. The minimal contract is a right column (`flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px`) and an app region that can shrink (`#app { flex: 1; min-width: 0; }`). Two complementary resize mechanisms ship together: (1) **CSS variable** — override `--rf-causa-inline-width` anywhere up the cascade (e.g. `:root { --rf-causa-inline-width: 720px; }`) to set the initial width (host-owned, per `rf2-um813`; default bumped 420 → 560 under `rf2-9ovfb`); (2) **Causa drag handle** — auto-injected by Causa (rf2-70u8q; see `spec/007-UX-IA.md` §Resize affordance) on the panel's outer edge, persisted across reloads via `configure! :settings :general :panel-width-px`, double-click to reset. No `resize: horizontal` / `overflow: auto` on the host — Causa owns the handle, the consumer's CSS surface stays minimal. A consumer that prefers the browser-native handle opts out by setting `resize: horizontal` on the host (yield-to-consumer detection). The snippet also publishes `--rf-causa-accent` (default `#7C5CFF`) on `:root` (rf2-9ovfb) so host stylesheets can colour their own dev chrome to match Causa.
 - **`<script src="/js/main.js">`** — `/js/` comes from `:asset-path "/js"`; `main.js` comes from the module name `:main`. If you rename either, this path follows.
 - **`/js/main.js` is an absolute path from site root.** That's correct for shadow-cljs's dev server.
 

--- a/skills/re-frame2/reference/tooling/causa.md
+++ b/skills/re-frame2/reference/tooling/causa.md
@@ -35,8 +35,6 @@ Do **not** load this leaf to learn what Causa is — load `tools/causa/README.md
   min-width: 320px;
   box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
-  resize: horizontal;
-  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
@@ -76,7 +74,7 @@ Sizing units are unrestricted (`px`, `rem`, `vw`, `min(...)`, `clamp(...)`, …)
 
 The variable is published as `day8.re-frame2-causa.config/default-layout-host-css-var` and the 560px default as `default-layout-host-width` (bumped 420 → 560 under `rf2-9ovfb`) so tooling can refer to them without forking the string. **Causa MUST NOT introduce a CLJS setter for this property** — the host's stylesheet is the single source of truth.
 
-The recommended host snippet also enables a browser-native drag handle (`resize: horizontal` + `overflow: auto`). The variable seeds the initial width; a user drag overrides it for the page lifetime. Both mechanisms write the same `flex-basis` slot — no parallel sizing channel.
+Causa also auto-injects a drag handle on the panel's outer edge (rf2-70u8q; see `tools/causa/spec/007-UX-IA.md` §Resize affordance). The variable seeds the initial width; a user drag overrides it (persisted across reloads via `configure! :settings :general :panel-width-px`, clamped to `[320px, 90vw]`, double-click to reset). Both mechanisms write the same `flex-basis` slot — no parallel sizing channel. Consumers that prefer the browser-native handle opt out by setting `resize: horizontal` on the host; Causa detects that via `getComputedStyle` and yields (no double-handle).
 
 ## Brand-accent CSS variable (`--rf-causa-accent`)
 

--- a/testbeds/deep_machine/index.html
+++ b/testbeds/deep_machine/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/deliberate_throw/index.html
+++ b/testbeds/deliberate_throw/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/drain_depth_trigger/index.html
+++ b/testbeds/drain_depth_trigger/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/http_toggle/index.html
+++ b/testbeds/http_toggle/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/large_dispatcher/index.html
+++ b/testbeds/large_dispatcher/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/long_flow_w_failure/index.html
+++ b/testbeds/long_flow_w_failure/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/multi_frame/index.html
+++ b/testbeds/multi_frame/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/non_trivial_app_db/index.html
+++ b/testbeds/non_trivial_app_db/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/schema_violation/index.html
+++ b/testbeds/schema_violation/index.html
@@ -6,7 +6,7 @@
   <style>
     body { margin: 0; font-family: sans-serif; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>

--- a/testbeds/ssr_hydration_mismatch/index.html
+++ b/testbeds/ssr_hydration_mismatch/index.html
@@ -6,7 +6,7 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1 { margin-top: 0; }
   </style>

--- a/testbeds/ssr_multi_frame/index.html
+++ b/testbeds/ssr_multi_frame/index.html
@@ -6,7 +6,7 @@
   <style>
     body { font-family: sans-serif; margin: 0; }
     .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 420px; min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
     h1, h3 { margin: 0.25em 0; }
     p { margin: 0.25em 0; }

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -61,11 +61,14 @@ body { margin: 0; }
                                           it, the host renders 1px wider
                                           than the var(...) value */
   border-left: 1px solid #2a2a2a;     /* visual separator on the app side */
-  resize: horizontal;                  /* user-draggable width (see below) */
-  overflow: auto;
 }
 #app { flex: 1; min-width: 0; }
 ```
+
+The user-draggable resize handle is auto-injected by Causa
+(rf2-70u8q; see [`007-UX-IA.md` §Resize affordance](./007-UX-IA.md#resize-affordance)).
+Consumers do not wire `resize: horizontal` / `overflow: auto`; the
+handle's styles and behaviour are Causa-owned.
 
 The host owns sizing and layout. Causa owns the shell rendered inside
 the host. For the framework-side Tool-Pair surfaces Causa consumes
@@ -96,8 +99,6 @@ that matches Causa's recommended default (560px per rf2-9ovfb):
   min-width: 320px;
   box-sizing: border-box;
   border-left: 1px solid #2a2a2a;
-  resize: horizontal;
-  overflow: auto;
 }
 ```
 
@@ -140,8 +141,7 @@ sizing; introducing a CLJS setter would split that source.
 ### User-draggable resize
 
 The recommended host snippet ships two complementary resize
-mechanisms — both browser-native, both JS-free, both writing the
-same `flex-basis` slot:
+mechanisms, both writing the same `flex-basis` slot:
 
 1. **CSS variable** (host-owned, fixed-point sizing) — the
    `--rf-causa-inline-width` property described above. The host's
@@ -149,31 +149,33 @@ same `flex-basis` slot:
    overrides (per-route, per-user, per-build). One declaration, no
    pointer events, no runtime cost. This is the path for "the team
    agreed Causa should default to 720px on the debug route."
-2. **Browser-native drag** (user-controlled, ad-hoc sizing) — the
-   `resize: horizontal` + `overflow: auto` pair on
-   `[data-rf-causa-host]`. The browser paints a drag-handle in the
-   bottom corner of the host (per
-   [CSS UI L3 §`resize`](https://drafts.csswg.org/css-ui-3/#resize)),
-   the user drags it, the host's *used* width updates, and flex
-   reflow shrinks `#app` to fill the remainder. No CLJS, no listener,
-   no Causa surface — the browser owns the interaction. This is the
-   path for "I want a bit more room for the event-detail panel right
-   now."
+2. **Causa drag handle** (user-controlled, auto-injected, persisted) —
+   per rf2-70u8q + [`007-UX-IA.md` §Resize affordance](./007-UX-IA.md#resize-affordance),
+   Causa mounts a polished handle on the panel's outer edge as soon
+   as the shell renders. Pointer-driven (mouse, touch, pen unified
+   via pointer events; `touch-action: none`), keyboard-navigable
+   (arrow keys for fine resize, Shift for coarse, Home/End for
+   clamps, Enter/Space to reset), width clamps to `[320px, 90vw]`,
+   persists across reloads via
+   `configure! :settings :general :panel-width-px`, double-click to
+   reset. This is the path for "I want a bit more room for the
+   event-detail panel right now."
 
 The two cooperate cleanly. The variable establishes the initial
-size; a drag overrides it for the page lifetime; reload (or a fresh
-`--rf-causa-inline-width` override up the cascade) returns to the
-declared initial. The drag handle is the bottom-right corner of the
-host element (in LTR layouts) and is keyboard-accessible per the
-browser's standard `resize` semantics; no ARIA wiring is required.
+size; a drag overrides it (and persists); reload restores the
+persisted width unless a fresh `--rf-causa-inline-width` override up
+the cascade has shifted the default.
 
-Causa MUST NOT introduce a JS-driven draggable separator — the
-`resize: horizontal` contract covers the user-drag requirement at
-zero runtime surface, zero new failure modes, and zero ARIA
-semantics for Causa to maintain. If a future use case demands
-pointer-capture beyond what the browser primitive provides, it MUST
-write to `--rf-causa-inline-width` (preserving cascade semantics);
-it MUST NOT introduce a parallel sizing channel.
+##### Yield-to-consumer
+
+Some teams prefer the browser-native handle (`resize: horizontal` +
+`overflow: auto` on the host). Causa MUST detect that at render time
+via `getComputedStyle(host).resize` and render no handle of its own
+when the value is `"horizontal"` or `"both"` — the consumer wins, no
+double-handle. The zero-config path (drop in `<aside>` and let Causa
+inject) is the recommended default; the opt-out is the explicit
+`resize:` declaration on the host. No `configure!` knob, no preload
+flag.
 
 ### Inline-style cascade contract
 

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -147,8 +147,13 @@
   ;;   - default geometry (560px flex-basis per rf2-9ovfb, 320px floor)
   ;;   - a single one-line override path:
   ;;       :root { --rf-causa-inline-width: 720px; }
-  ;;   - a user-draggable resize handle via the browser-native
-  ;;     `resize: horizontal` + `overflow: auto` on the host
+  ;;   - a user-draggable resize handle auto-injected by Causa
+  ;;     (per rf2-70u8q + spec/007-UX-IA.md §Resize affordance) — the
+  ;;     consumer no longer wires `resize: horizontal` / `overflow:
+  ;;     auto`; Causa mounts its own handle as soon as the shell
+  ;;     renders. Consumers that prefer the browser-native handle
+  ;;     opt out by setting `resize: horizontal` on the host (yield-
+  ;;     to-consumer detection per spec/007 §Yield-to-consumer).
   ;;   - app content to the left stays in normal flex flow
   ;;     (no overlay, no body padding).
   ;;   - `--rf-causa-accent` published on `:root` (rf2-9ovfb) so
@@ -176,8 +181,6 @@
     min-width: 320px;
     box-sizing: border-box;
     border-left: 1px solid #2a2a2a;
-    resize: horizontal;
-    overflow: auto;
   }
   #app { flex: 1; min-width: 0; }
 </style>")

--- a/tools/causa/testbeds/parallel_frames/index.html
+++ b/tools/causa/testbeds/parallel_frames/index.html
@@ -10,10 +10,11 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
-       give the user a browser-native drag handle on the host (rf2-e07yk). */
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Causa (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
     :root { --rf-causa-accent: #7C5CFF; }
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 0; }
   </style>
 </head>

--- a/tools/causa/testbeds/perf_counter/index.html
+++ b/tools/causa/testbeds/perf_counter/index.html
@@ -10,10 +10,11 @@
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
-       JS or a fork of this rule. `resize: horizontal` + `overflow: auto`
-       give the user a browser-native drag handle on the host (rf2-e07yk). */
+       JS or a fork of this rule. The user-draggable resize handle is
+       auto-injected by Causa (rf2-70u8q; spec/007-UX-IA.md §Resize
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
     :root { --rf-causa-accent: #7C5CFF; }
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; resize: horizontal; overflow: auto; }
+    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
     #app { flex: 1; min-width: 0; padding: 2em; }
   </style>
 </head>


### PR DESCRIPTION
## Summary

Sweeps stale `resize: horizontal` + `overflow: auto` references from consumer-side host CSS now that PR #1522 (rf2-70u8q) ships Causa's auto-injected resize handle. Tree is now consistent with the new auto-inject contract.

### Files updated

| File | Change |
|---|---|
| `tools/causa/src/day8/re_frame2_causa/config.cljc` | `default-layout-host-snippet` diagnostic dropped stale CSS, comments refer to auto-inject + yield-to-consumer |
| `tools/causa/spec/011-Launch-Modes.md` | Layout host contract + User-draggable resize sections rewritten for auto-inject + yield-to-consumer |
| `tools/causa/testbeds/parallel_frames/index.html` | Inline CSS + comment dropped stale rules |
| `tools/causa/testbeds/perf_counter/index.html` | Same |
| `testbeds/{deep_machine,deliberate_throw,drain_depth_trigger,http_toggle,large_dispatcher,long_flow_w_failure,multi_frame,non_trivial_app_db,schema_violation,ssr_hydration_mismatch,ssr_multi_frame}/index.html` | 11 testbeds — dropped stale CSS |
| `examples/reagent/counter/index.html` | Same |
| `docs/causa/01-installation.md` | Tutorial CSS + prose updated to describe auto-inject + yield-to-consumer |
| `skills/causa/reference/launch-modes.md` | Skill reference matches new contract |
| `skills/re-frame2-setup/reference/shadow-cljs.md` | Same |
| `skills/re-frame2/reference/tooling/causa.md` | Same |

LoC delta: +95 / -80 across 20 files.

## What stays unchanged

- `tools/causa/src/day8/re_frame2_causa/resize_handle.cljs` + `resize_handle_cljs_test.cljs` — these reference `resize: horizontal` only to document the yield-to-consumer detection contract; that text is correct as-is.
- `tools/causa/spec/007-UX-IA.md` + `tools/causa/README.md` — already updated by PR #1522.
- `docs/klipse/codemirror.css` — unrelated `overflow: auto` on CodeMirror styling.
- Per-template CSS (`tools/template/.../app.css`) — already had only the minimal rules.

## Verification

```
$ grep -rn '\[data-rf-causa-host\]' tools/ docs/ skills/ examples/ testbeds/ spec/ -A 6 \
    | grep -E '(resize: horizontal|overflow: auto)'
(no output)
```

Zero hits on the host CSS block with stale CSS.

## Test plan

- [x] `scripts/test-fast-pr.sh` — passes (585 + 2925 tests, 0 failures)
- [x] `cd implementation && npm run test:cljs` — passes (2925 tests, 0 failures); the diagnostic console.error now emits the new minimal snippet
- [x] `cd implementation && npm run test:browser` — passes (2916 tests, 0 failures)
- [x] `mkdocs build --strict` — same 72 pre-existing warnings before and after; zero new warnings introduced
- [x] `python scripts/check_doc_slugs.py` — clean