### PR TITLE
feat(docs): adopt Cursor-inspired color scheme + typography (rf2-ftf4z)

### DIFF
--- a/docs/stylesheets/cursor-inspired.css
+++ b/docs/stylesheets/cursor-inspired.css
@@ -1,0 +1,236 @@
+/* cursor-inspired.css
+ *
+ * Cursor-inspired colour scheme + typography for re-frame2's mkdocs-material
+ * docs site. Overrides the mkdocs-material CSS variables; no structural HTML
+ * changes, no marginalia/sidenote work. Reversible: delete this file and the
+ * matching `extra_css:` line in mkdocs.yml.
+ *
+ * Surface mirrored: cursor.com homepage — dark, refined, type-forward.
+ * Palette inspired by, not copied from, Cursor's identity. No logos or
+ * branded UI elements.
+ *
+ * Scope:
+ *   - Background / foreground / muted / accent / code surfaces
+ *   - Type stack (Inter for body, JetBrains Mono for code)
+ *   - Headline weights + spacing tuned for type-forward density
+ *
+ * Out of scope (separate beads):
+ *   - Sidenotes / marginalia / drop caps (Path B from rf2-nix3d findings)
+ *   - Klipse CodeMirror theming (rf2-zyetf compatibility)
+ */
+
+/* ----------------------------------------------------------------------- *
+ * Type stack — Inter for body, JetBrains Mono for code.
+ * Loaded via @import so we don't have to touch theme.font.text (which
+ * would couple to Material's font-loading machinery).
+ * ----------------------------------------------------------------------- */
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+/* ----------------------------------------------------------------------- *
+ * Slate (dark) palette overrides — Cursor-inspired.
+ *
+ * Concrete hex values:
+ *   bg          #0A0A0A   near-black, slight warmth
+ *   surface     #141414   slightly lifted (cards, code blocks)
+ *   border      #262626   hairline dividers
+ *   fg          #E5E5E5   off-white body type
+ *   fg-muted    #A3A3A3   secondary text
+ *   fg-dim      #737373   tertiary / captions
+ *   accent      #6366F1   indigo-violet (links, hover, focus)
+ *   accent-hot  #818CF8   accent on hover
+ *   code-fg     #E5E5E5   code text
+ *   code-bg     #161616   code block background
+ * ----------------------------------------------------------------------- */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:          #0A0A0A;
+  --md-default-bg-color--light:   #141414;
+  --md-default-bg-color--lighter: #1A1A1A;
+  --md-default-bg-color--lightest: #262626;
+
+  --md-default-fg-color:          #E5E5E5;
+  --md-default-fg-color--light:   #A3A3A3;
+  --md-default-fg-color--lighter: #737373;
+  --md-default-fg-color--lightest: #404040;
+
+  --md-typeset-color:             #E5E5E5;
+  --md-typeset-a-color:           #818CF8;
+
+  --md-primary-fg-color:          #0A0A0A;
+  --md-primary-fg-color--light:   #141414;
+  --md-primary-fg-color--dark:    #050505;
+  --md-primary-bg-color:          #E5E5E5;
+  --md-primary-bg-color--light:   #A3A3A3;
+
+  --md-accent-fg-color:           #818CF8;
+  --md-accent-fg-color--transparent: rgba(129, 140, 248, 0.1);
+  --md-accent-bg-color:           #FFFFFF;
+  --md-accent-bg-color--light:    #E5E5E5;
+
+  --md-code-fg-color:             #E5E5E5;
+  --md-code-bg-color:              #161616;
+  --md-code-hl-color:             rgba(129, 140, 248, 0.2);
+
+  /* Syntax highlighting tuned for the dark surface. */
+  --md-code-hl-number-color:      #F472B6;
+  --md-code-hl-special-color:     #F472B6;
+  --md-code-hl-function-color:    #A78BFA;
+  --md-code-hl-constant-color:    #A78BFA;
+  --md-code-hl-keyword-color:     #818CF8;
+  --md-code-hl-string-color:      #34D399;
+  --md-code-hl-name-color:        #E5E5E5;
+  --md-code-hl-operator-color:    #A3A3A3;
+  --md-code-hl-punctuation-color: #A3A3A3;
+  --md-code-hl-comment-color:     #737373;
+  --md-code-hl-generic-color:     #A3A3A3;
+  --md-code-hl-variable-color:    #E5E5E5;
+
+  --md-footer-bg-color:           #0A0A0A;
+  --md-footer-bg-color--dark:     #050505;
+  --md-footer-fg-color:           #E5E5E5;
+  --md-footer-fg-color--light:    #A3A3A3;
+  --md-footer-fg-color--lighter:  #737373;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Typography — type-forward, generous line-height.
+ * ----------------------------------------------------------------------- */
+:root {
+  --md-text-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --md-code-font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.md-typeset {
+  font-family: var(--md-text-font-family);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  letter-spacing: -0.005em;
+}
+
+/* Headings: tighter tracking, heavier weight — type-forward. */
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+  font-family: var(--md-text-font-family);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin-bottom: 1.5rem;
+}
+
+.md-typeset h2 {
+  margin-top: 2.5rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  padding-bottom: 0.4rem;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Code blocks — dense but breathable. Subtle border to lift them off the
+ * page (Cursor's product UI does this consistently).
+ * ----------------------------------------------------------------------- */
+.md-typeset code {
+  font-family: var(--md-code-font-family);
+  font-size: 0.78em;
+  border-radius: 4px;
+  padding: 0.15em 0.35em;
+}
+
+.md-typeset pre > code,
+.md-typeset .highlight pre {
+  font-size: 0.78em;
+  line-height: 1.65;
+  padding: 0.9rem 1.05rem;
+  border-radius: 6px;
+}
+
+.md-typeset .highlight {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px;
+  background: var(--md-code-bg-color);
+}
+
+.md-typeset .highlight pre {
+  background: transparent;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Links — refined accent, no underline by default, underline on hover.
+ * ----------------------------------------------------------------------- */
+.md-typeset a {
+  color: var(--md-typeset-a-color);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.md-typeset a:hover {
+  color: var(--md-accent-fg-color);
+  border-bottom-color: var(--md-accent-fg-color);
+}
+
+/* ----------------------------------------------------------------------- *
+ * Header / tabs — subtle, dark, type-forward.
+ * ----------------------------------------------------------------------- */
+.md-header {
+  background: var(--md-default-bg-color);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  box-shadow: none;
+}
+
+.md-tabs {
+  background: var(--md-default-bg-color);
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-tabs__link {
+  font-weight: 500;
+  opacity: 0.85;
+}
+
+.md-tabs__link:hover,
+.md-tabs__link--active {
+  opacity: 1;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Admonitions — quieter, in keeping with the refined aesthetic.
+ * ----------------------------------------------------------------------- */
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 6px;
+  border-width: 1px;
+  border-left-width: 3px;
+  font-size: 0.78rem;
+  box-shadow: none;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Tables — subtle borders, no heavy zebra stripes.
+ * ----------------------------------------------------------------------- */
+.md-typeset table:not([class]) {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px;
+  overflow: hidden;
+  font-size: 0.78rem;
+}
+
+.md-typeset table:not([class]) th {
+  background: var(--md-default-bg-color--light);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+/* ----------------------------------------------------------------------- *
+ * Klipse compatibility note:
+ *   Klipse renders CodeMirror with its own hard-coded white background +
+ *   black text (see docs/klipse/codemirror.css). Those cells will appear
+ *   as light cards on the dark surface — that's the cleanest non-invasive
+ *   outcome; reskinning CodeMirror is rf2-zyetf scope.
+ * ----------------------------------------------------------------------- */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,11 +31,12 @@ theme:
     repo: fontawesome/brands/git-alt
   language: en
   palette:
-    primary: blue
-    accent: blue
+    scheme: slate
+    primary: black
+    accent: indigo
   font:
-    text: IBM Plex Sans
-    code: Source Code Pro
+    text: Inter
+    code: JetBrains Mono
   features:
     - navigation.tabs
     - navigation.sections
@@ -50,6 +51,9 @@ theme:
 # in the list, otherwise search silently disappears.
 plugins:
   - search
+
+extra_css:
+  - stylesheets/cursor-inspired.css
 
 extra:
   social:


### PR DESCRIPTION
## Summary

Borrows Cursor.com's homepage aesthetic — dark, refined, type-forward — for the re-frame2 mkdocs-material docs site. Mike approved a "give it a go, we can always reverse the decision" trial. Scope is narrow:

- single CSS file: `docs/stylesheets/cursor-inspired.css`
- one `extra_css:` line in `mkdocs.yml`
- `theme.palette` flips to `scheme: slate` (dark)
- `theme.font` swaps to **Inter** (body) + **JetBrains Mono** (code)

## CSS variables overridden

| Token | Hex | Role |
| --- | --- | --- |
| `--md-default-bg-color` | `#0A0A0A` | page background (near-black, slight warmth) |
| `--md-typeset-color` | `#E5E5E5` | body type (off-white) |
| `--md-typeset-a-color` | `#818CF8` | links (indigo-violet) |
| `--md-accent-fg-color` | `#818CF8` | hover / focus accent |
| `--md-code-bg-color` | `#161616` | code-block surface |
| `--md-default-fg-color--light` | `#A3A3A3` | muted secondary text |
| `--md-default-fg-color--lighter` | `#737373` | tertiary / captions |
| `--md-default-fg-color--lightest` | `#404040` | hairline dividers |

Plus a tuned syntax-highlight palette (keywords `#818CF8`, strings `#34D399`, numbers `#F472B6`, comments `#737373`), footer/header surfaces, and admonition/table polish.

## Visual review

Built locally with `mkdocs serve`, screenshots taken at 1280x900:

- **`docs/guide/02-app-db.md`** — code blocks render clean against the dark surface; Clojure highlighting reads well; indigo links pop without being harsh.
- **`docs/causa/index.md`** — mixed prose + inline code reads cleanly; the muted indigo accent feels appropriate to a devtools docs surface.
- **`docs/cljs/index.md`** — klipse-heavy page; static (non-JS) code blocks render in the new dark theme. CodeMirror cells (when Klipse JS loads on the deployed site) will keep their hard-coded white background + black text; that's the cleanest non-invasive outcome — reskinning CodeMirror is `rf2-zyetf` scope.
- **Home** — type-forward Inter sans, refined accent, generous spacing, no shadows. Reads as a modern AI-tooling product.

Subjective verdict: **feels Cursor-y**. Deep near-black surface, refined indigo accent, type-forward Inter, generous line-height — translates the Cursor.com homepage aesthetic to a docs context without copying any branded identity.

## Out of scope (separate beads if pursued)

- Sidenotes / marginalia / drop caps (Path B from `rf2-nix3d` findings)
- CodeMirror dark theming for Klipse cells (`rf2-zyetf` compatibility track)
- Logo / branding lifts from Cursor

## Reversal path

Truly one PR:

1. delete `docs/stylesheets/cursor-inspired.css`
2. drop the `extra_css:` block in `mkdocs.yml`
3. revert `theme.palette` to `primary: blue / accent: blue` (and drop `scheme: slate`)
4. revert `theme.font` to `text: IBM Plex Sans / code: Source Code Pro`

## Gates

- `mkdocs build --strict` — **72 warnings (baseline; zero new)**
- `scripts/check_doc_slugs.py` — clean

## Test plan

- [ ] Pull the branch locally; `python -m mkdocs serve` from repo root
- [ ] Visit `/guide/02-app-db/`, `/causa/`, `/cljs/`, home — confirm dark theme + indigo accent applies
- [ ] Confirm code blocks readable; links visible; type feels Cursor-y
- [ ] Confirm `mkdocs build --strict` still 72 warnings