### PR TITLE
feat(reagent-slim): Stage 4-G — counter-slim-and-fast Playwright smoke (rf2-6hyy)

### DIFF
--- a/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
+++ b/examples/reagent/counter_slim_and_fast/counter_slim_and_fast.spec.cjs
@@ -1,0 +1,72 @@
+/*
+ * counter-slim-and-fast — Playwright smoke (rf2-6hyy Stage 4-G).
+ *
+ * Drop-in parity with the canonical counter example
+ * (examples/reagent/counter/) — identical user-visible behaviour, just
+ * mounted on the day8/reagent-slim rewrite instead of the day8/re-frame2-
+ * reagent thin bridge. The substrate swap is observable only through
+ * the bundle-isolation grep
+ * (implementation/scripts/check-reagent-slim-bundle-isolation.cjs); the
+ * user-visible dataflow is identical.
+ *
+ * Assertions (mirrored from the canonical counter's spec shape):
+ *
+ *   1. Initial render lands the seeded value :count = 5.
+ *      (run fn dispatches [:counter/initialise]; the event handler
+ *      seeds {:count 5} per core.cljs.)
+ *   2. Clicking "+" once bumps the count to 6 (inc handler wired
+ *      through the slim adapter's render Reaction + queue-render!).
+ *   3. Clicking "-" twice brings the count back to 4 (dec handler
+ *      wired symmetrically; second click proves the Reaction's dep
+ *      tracking re-fires on each app-db change, not just the first).
+ *
+ * The boot also exercises reagent2.dom.server/render-to-static-markup
+ * (logged to the browser console for DCE-resistance). The Playwright
+ * spec doesn't assert on that log line — the binding contract for the
+ * pure-CLJS SSR claim is grep-based and lives in the bundle-isolation
+ * verifier — but a passing smoke confirms the SSR call doesn't throw
+ * at boot.
+ *
+ * Cross-references:
+ *   - examples/reagent/counter_slim_and_fast/core.cljs — the example source
+ *   - implementation/scripts/check-reagent-slim-bundle-isolation.cjs —
+ *     the binding S3-008 + S3-005 bundle-isolation contract
+ *   - implementation/adapters/reagent-slim/IMPL-SPEC.md §12 — the test
+ *     strategy this smoke participates in
+ */
+
+const { expectTextEquals, expectVisible } =
+  require('../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'counter-slim-and-fast smoke',
+  url:  '/counter-slim-and-fast/',
+  run:  async (page) => {
+    // The counter value sits inside [data-testid="counter-value"] —
+    // a <span> the view's reg-view'd component emits. Wait for the
+    // span to be visible before reading text (the boot path mounts
+    // via rdc/render which is async w.r.t. dispatch-sync, so the
+    // first paint may not be on the synchronous tick after navigation).
+    const value = page.locator('[data-testid="counter-value"]');
+    await expectVisible(value, 10000);
+
+    // 1. The :counter/initialise handler seeded :count = 5.
+    await expectTextEquals(value, '5', 10000);
+
+    // 2. "+" → :counter/inc → :count = 6. The button has no
+    //    test-id (the canonical counter doesn't carry one either),
+    //    so we resolve by accessible text. role=button name=text is
+    //    the most stable shape across re-renders.
+    await page.getByRole('button', { name: '+' }).click();
+    await expectTextEquals(value, '6');
+
+    // 3. "-" twice → :counter/dec → :count = 4. The second click
+    //    proves the slim's Reaction-around-render dependency tracking
+    //    survives an arbitrary number of app-db deltas (the first
+    //    click could pass via a one-shot effect; the second can't).
+    const minus = page.getByRole('button', { name: '-' });
+    await minus.click();
+    await minus.click();
+    await expectTextEquals(value, '4');
+  },
+};


### PR DESCRIPTION
## Summary

Final sub-stage (4-G) of the slim Reagent rewrite (rf2-6hyy). Adds the Playwright smoke that exercises the `counter-slim-and-fast` example end-to-end, completing the bead's "examples + MIGRATION polish" scope.

Stage 4 (rf2-6hyy) is now feature-complete. The slim rewrite (`day8/reagent-slim`) shipped across A→G:

- 4-A (PR #227) — `reagent2.ratom`: RAtom + Reaction + flush! + reaction macro (~390 LoC + 25 deftests)
- 4-B (PR #234) — `reagent2.impl.batching` + `reagent2.dom.client/flush-views!` (microtask scheduler, ~380 LoC + 23 deftests)
- 4-C (PR #241) — `reagent2.impl.component`: Form-1/2/3 runtime detection, 7-key cap, error-boundary, lifecycle plumbing, reg-view compile-time fold (~440 LoC + 38 deftests)
- 4-D (PR #246) — `reagent2.impl.template`: full hiccup→React pipeline, parse-tag, narrowed `convert-prop-value`, deref-capture inside the render method, `re-frame.adapter.reagent-slim` substrate Var, `counter_slim_and_fast` example source (~870 LoC + 71 deftests)
- 4-E (PR #250) — `reagent2.dom.server`: pure-CLJS render-to-static-markup + parity test against react-dom/server (~410 LoC + 37 deftests)
- 4-F (PR #252) — five throw-on-call shims for React-19-removed surfaces, MIGRATION M-42 (~75 LoC + 6 deftests)
- 4-G (this PR) — Playwright smoke for the counter example (72 LoC, 1 spec)

## Stage 4-A → 4-G continuity

Single Maven artefact: `day8/reagent-slim`. All seven sub-stages landed against `implementation/adapters/reagent-slim/`. The substrate-shape adapter Var (`re-frame.adapter.reagent-slim/adapter`) is drop-in via `(rf/init! reagent-slim-adapter/adapter)` per rf2-wbnl (late-bind `current-component` hook, PR #249).

## Test coverage delta

This PR: +1 Playwright spec (no CLJS deftest delta). Cumulative across Stage 4-A → 4-G: ~200 CLJS deftests / ~600 assertions added across `implementation/adapters/reagent-slim/test/`.

## Bundle isolation verification

`cd implementation && npm run test:reagent-slim:bundle-isolation`

```
PASS reagent-slim-bundle-isolation: 3 contracts passed; 19 sentinel checks;
slim=…/out/examples/counter-slim-and-fast (426507 chars);
stock=…/out/examples/counter (429378 chars)
```

Contract 1 (methodology): stock-Reagent sentinels REACHABLE from the stock-Reagent counter bundle — 5/5 sentinels PRESENT.
Contract 2 (S3-008): stock-Reagent impl ABSENT from the slim bundle — 5/5 sentinels ABSENT.
Contract 3 (S3-005): react-dom/server ABSENT from the slim bundle — 5/5 sentinels ABSENT.

## Example app

`examples/reagent/counter_slim_and_fast/` was created in Stage 4-D (PR #246). This PR adds the missing Playwright smoke. End-to-end boot via `npm run test:examples` against the EXAMPLES_FILTER:

```
[:examples/counter-slim-and-fast] Build completed. (124 files, 123 compiled, 0 warnings, 11.86s)
Ran 1 example specs. 0 failures, 0 skipped.
```

Assertions: initial render seeds 5, "+" → 6, "-" twice → 4. The boot also exercises `reagent2.dom.server/render-to-static-markup` (the pure-CLJS SSR seam), which lets Contract 3 above bind to a non-vacuous claim — the SSR path IS in the bundle, yet no `react-dom/server` symbols appear.

## MIGRATION addition

M-42 already shipped in PR #252 (Stage 4-F). It documents the five throw-on-call shims (`reagent2.dom/render` etc.) with replacement recipes, anchored `#legacy-mount-path` and `#dom-node-removal` links, the `ex-info` shape, and the Type-B classification for the migration agent. No further MIGRATION edits required in Stage 4-G — the doc is feature-complete for the slim rewrite.

## Decision-bead status

rf2-4g71 (the `coerce-context-value` deletion question) is CLOSED. Option B selected: keep `coerce-context-value` as defensive coverage shared between both adapters; the function is load-bearing for the classic-Reagent bridge path. IMPL-SPEC §11.1 reflects the retraction; M-41 in `migration/from-re-frame-v1/README.md` documents the user-side behaviour.

## Gate results

- `bash scripts/test-fast-pr.sh` — PASS
- `cd implementation && npm run test:cljs` — PASS (2925 / 8358 / 0)
- `cd implementation && npm run test:bundle-isolation` — PASS (11 artefacts, 26 sentinels)
- `cd implementation && npm run test:reagent-slim:bundle-isolation` — PASS (3 contracts, 19 sentinels)
- `cd implementation && npm run story:build` — PASS
- `EXAMPLES_FILTER=counter-slim-and-fast node …/serve-and-run-examples-tests.cjs` — PASS (1/1)
- `python -m mkdocs build --strict` — 72 warnings (baseline; zero new)
- `python scripts/check_doc_slugs.py` — clean
- `bash .github/scripts/verify-version-lockstep.sh` — PASS (16 artefacts pinned to 0.0.1.alpha)