### PR TITLE
fix(docs): default to light mode + add light/dark toggle (rf2-oqlxr)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,9 +31,18 @@ theme:
     repo: fontawesome/brands/git-alt
   language: en
   palette:
-    scheme: slate
-    primary: black
-    accent: indigo
+    - scheme: default
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   font:
     text: Inter
     code: JetBrains Mono


### PR DESCRIPTION
## Summary
- Default scheme flips from `slate` (dark) to `default` (light)
- Adds Material's standard light↔dark palette toggle (top-right header)
- Preserves Inter + JetBrains Mono typography and the Cursor-inspired CSS for users who pick dark

## Why
Mike feedback 2026-05-19: rf2-ftf4z (#1525) shipped dark-only. Users land on the docs site and see dark; he wants light as the entry point with dark as an opt-in.

## Mechanics
`docs/stylesheets/cursor-inspired.css` already scopes all colour overrides to `[data-md-color-scheme="slate"]` (line 44). In light mode those rules disengage; Material's stock light palette takes over. No CSS changes needed.

mkdocs.yml palette block becomes a list of two entries with toggle metadata — first entry (`default`) wins as the initial mode.

## Test plan
- [ ] `mkdocs serve` — page loads LIGHT
- [ ] Click sun icon (top-right) → switches to dark; click moon → back to light
- [ ] Both modes keep Inter + JetBrains Mono fonts
- [ ] Dark mode retains Cursor-inspired CSS overrides