### PR TITLE
feat(causa): surface Flows in Event Detail — peer section (rf2-lo37i)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -398,12 +398,14 @@ L4 fills the remaining canvas (60% default; resizable via L2/L3 drag handle). Al
 
 The renderer does NOT depend on `binaryage/cljs-devtools` (that library targets the Chrome console; this is in-page hiccup). Pure hiccup, theme-token-driven, substrate-agnostic. See [`007-UX-IA.md`](007-UX-IA.md) §Detail panel renderer.
 
-### §5.1 Event tab content — the 7-section Event lens
+### §5.1 Event tab content — the 8-section Event lens
 
-Shipped layout per rf2-zh2qc + rf2-jhhqt (the latter swaps DISPATCH SITE
-before EVENT per Mike's Q1 verbatim, and adds the COEFFECTS section).
-Top-of-panel: a single-line cascade-outcome summary; below: seven stacked
-sections that read top-to-bottom as the developer scans.
+Shipped layout per rf2-zh2qc + rf2-jhhqt + rf2-lo37i (rf2-jhhqt swaps
+DISPATCH SITE before EVENT per Mike's Q1 verbatim and adds the COEFFECTS
+section; rf2-lo37i adds the FLOWS section as a peer surface to make the
+cascade's flow step first-class). Top-of-panel: a single-line cascade-
+outcome summary; below: eight stacked sections that read top-to-bottom
+as the developer scans.
 
 ```
 ┌─ Event lens · :cart/add-item                              ✓ ok · 11ms · #347 · SSR✓ ┐
@@ -436,6 +438,16 @@ sections that read top-to-bottom as the developer scans.
 │   │ ▼ REQUEST  ▼ WIRE TIMING  ▼ RESPONSE  ▼ HANDLER  ▼ APP-DB SLICE      │           │
 │   └────────────────────────────────────────────────────────────────────────┘         │
 │   :dispatch    ⏱ <1ms  ✓ handled  → queued [:notify "added"]                        │
+│                                                                                      │
+│ ▼ FLOWS  (3)                                                                         │
+│   ▸ :cart-total                wrote [:cart :total]   52.50                         │
+│                                  read  [:cart :items]                                │
+│     ↳ :tax-due       via :cart-total                                                 │
+│                                wrote [:tax :due]      5.25                          │
+│                                  read  [:cart :total]                                │
+│     ↳ :grand-total-display     via :cart-total, :tax-due                            │
+│                                wrote [:checkout :grand-total]  57.75                │
+│                                  read  [:cart :total] [:tax :due]                    │
 └──────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -450,7 +462,7 @@ sections that read top-to-bottom as the developer scans.
   `:rf.ssr/hydrated` / `:rf.ssr/hydration-complete`; omitted for
   purely-client-side cascades.
 
-#### The 7 sections (Mike's verbatim order, rf2-jhhqt)
+#### The 8 sections (Mike's verbatim order, rf2-jhhqt + rf2-lo37i)
 
 1. **DISPATCH SITE** — source-coord chip + `via :source · origin :origin`
    caption. Reads `:rf.trace/call-site` off the `:event/dispatched`
@@ -492,6 +504,30 @@ sections that read top-to-bottom as the developer scans.
    `:rf.server/*`, `:rf.flow/*`) the wire-boundary `record-panel`
    mounts INLINE beneath the row per §8.3 of the findings doc — NOT
    in a trailing block.
+8. **FLOWS** — silent-by-default when no flows fired (rf2-lo37i —
+   peer section between the handler-driven effects and any conceptual
+   `RETURNED VALUE` slot). Reads `:rf.flow/computed` traces (op-type
+   `:flow`) from the cascade's `:other` bucket per
+   [spec/013-Flows.md §Flow tracing](../../spec/013-Flows.md#flow-tracing)
+   and [spec/009-Instrumentation.md §Flow trace events](../../spec/009-Instrumentation.md#flow-trace-events).
+   One row per firing in cascade order (the framework's topo-sorted
+   walk):
+   - `▸ :flow-id` (or `↳ :flow-id  via :upstream-flow` when the row's
+     read path overlaps a preceding row's write path — subtle indent +
+     `↳` glyph linking back to the upstream flow id)
+   - `wrote <write-path>` + after-value (via `inspector/inspect`)
+   - `read <input-path-1> <input-path-2> …` — input paths recovered
+     from the registry via `(rf/handler-meta :flow flow-id)` (the
+     per-firing trace does not carry input PATHS; rf2-qlzh4 polish
+     bead tracks adding `:before` to the trace payload for full self-
+     containment). When the flow has been cleared mid-session the
+     read line renders `input paths unavailable (flow may have been
+     cleared)` instead of paths.
+
+   `:rf.flow/skip` traces (value-equal dirty-check suppression per
+   [spec/013-Flows.md §Dirty-check semantics](../../spec/013-Flows.md#dirty-check-semantics))
+   are NOT rendered as rows — a flow that didn't recompute did not
+   touch app-db, so it stays out of the cascade-detail by default.
 
 #### Edge cases
 
@@ -501,10 +537,16 @@ sections that read top-to-bottom as the developer scans.
 - **No user interceptors** — INTERCEPTORS section ABSENT entirely.
 - **No effects returned** — EFFECTS RETURNED section ABSENT.
 - **No fx handlers ran** — EFFECTS HANDLERS RAN section ABSENT.
-- **Handler threw** — §6 + §7 are both absent (handler never
-  returned / fx walk never started); a small footer caption renders:
-  `Handler threw — see Issues tab ⚠ for the exception detail.` This
-  is the ONE inline cross-reference to another tab.
+- **No flows fired** — FLOWS section ABSENT entirely (silent-by-
+  default; no '(none)' placeholder).
+- **Flow cleared mid-session** — FLOWS section still renders the row
+  (the firing happened); the read-paths line renders the absent
+  placeholder since `(rf/handler-meta :flow id)` returns nil.
+- **Handler threw** — §6 + §7 + §8 are all absent (handler never
+  returned / fx walk never started / flow walk never reached); a
+  small footer caption renders: `Handler threw — see Issues tab ⚠
+  for the exception detail.` This is the ONE inline cross-reference
+  to another tab.
 
 #### What's dropped from the Event tab
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -4,7 +4,7 @@
 
   This panel replaces the v1 'six-domino' renderer with a focused
   Event lens shaped after Chrome DevTools: top-of-panel cascade-outcome
-  line + seven stacked sections that read top-to-bottom as the developer
+  line + eight stacked sections that read top-to-bottom as the developer
   scans:
 
       ▼ DISPATCH SITE         where the dispatch happened (source coord)
@@ -14,6 +14,7 @@
       ▼ HANDLER               where the handler is defined (source coord)
       ▼ EFFECTS RETURNED      the {:db ... :fx [...]} the handler returned
       ▼ EFFECTS HANDLERS RAN  per-fx-handler rows + managed-fx inline
+      ▼ FLOWS                 auto-fired flow recomputes (silent when none)
 
   All other v1 dominos (subs, renders, other / errors) move to their
   own tabs (Views / Issues). See `tools/causa/spec/018-Event-Spine.md`
@@ -62,7 +63,8 @@
     - install! (selection slot + composite sub + select/clear events)
     - cascade-list (no-event-selected empty state)
     - tier-dot (reused in cascade-outcome + per-fx duration)"
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as string]
+            [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
@@ -766,6 +768,240 @@
                   (fx-handler-row row (managed-fx-record-for-row records id))
                   {:key id})))))))
 
+;; ---- §8 FLOWS ----------------------------------------------------------
+;; rf2-lo37i — Flows fire automatically AFTER fx handlers run. Each flow's
+;; `:output` fn reads from `:inputs` paths and writes to a `:path`. Without
+;; first-class visibility here a developer cannot attribute an app-db
+;; change to the flow that caused it. Surfaced as a peer section sitting
+;; after §7 EFFECTS HANDLERS RAN — the cascade-order placement: flows are
+;; the framework's automatic step after the handler-effects complete.
+;;
+;; Per spec/013-Flows.md + spec/009-Instrumentation.md:
+;;   `:rf.flow/computed` (op-type `:flow`) carries `:flow-id`,
+;;   `:input-values`, `:result`, `:path`, `:frame` in `:tags`. Input
+;;   PATHS are not in the trace — they live on the flow registry entry
+;;   and are looked up via `(rf/handler-meta :flow id)` at render time.
+;;
+;; The before-value at the output path (the value the flow OVERWROTE)
+;; is not in the current trace; rf2-qlzh4 (open) adds a `:before` slot
+;; to `:rf.flow/computed` for full self-containment. Until then we
+;; render `(after-value)` only — better partial visibility than zero.
+
+(defn- flow-computed?
+  [ev]
+  (= :rf.flow/computed (:operation ev)))
+
+(defn- flow-skip?
+  [ev]
+  (= :rf.flow/skip (:operation ev)))
+
+(defn flows-fired
+  "Project the ordered seq of flow firings from a cascade's `:other`
+  bucket. Each row is the projection of one `:rf.flow/computed` trace
+  in cascade firing order (which is the framework's topo order — a
+  flow downstream of another flow's output ALWAYS fires after the
+  upstream flow).
+
+  Per-row shape:
+
+      {:flow-id      <keyword>      ;; the flow's :id
+       :write-path   <vec>          ;; the flow's :path (where it wrote)
+       :input-values <vec>          ;; raw values read from input paths
+       :result       <any>          ;; the new output value at :path
+       :frame        <kw-or-nil>    ;; the host frame
+       :trace-id     <int>}         ;; trace event :id (stable row key)
+
+  Pure data → data. Returns an empty vector when the cascade carries
+  no `:rf.flow/computed` events (silent-by-default — the section is
+  OMITTED entirely for the empty state)."
+  [{:keys [other]}]
+  (vec
+    (for [ev (filterv flow-computed? (or other []))]
+      (let [tags (:tags ev)]
+        {:flow-id      (:flow-id tags)
+         :write-path   (:path tags)
+         :input-values (:input-values tags)
+         :result       (:result tags)
+         :frame        (:frame tags)
+         :trace-id     (:id ev)}))))
+
+(defn flows-skipped
+  "Project the ordered seq of `:rf.flow/skip` firings (value-equal
+  dirty-check suppression per Spec 013 §Dirty-check semantics).
+
+  Skips are NOT rendered as flow rows — a flow that didn't recompute
+  didn't write app-db, so it's noise inside the cascade-detail. The
+  helper exists for tests + future surfaces (a future toggle could
+  expose them; for the silent-by-default rendering policy they stay
+  hidden)."
+  [{:keys [other]}]
+  (vec
+    (for [ev (filterv flow-skip? (or other []))]
+      (let [tags (:tags ev)]
+        {:flow-id  (:flow-id tags)
+         :reason   (:reason tags)
+         :frame    (:frame tags)
+         :trace-id (:id ev)}))))
+
+(defn flow-read-paths
+  "Look up the registered `:inputs` paths for a flow id. Reads
+  `(rf/handler-meta :flow flow-id)` so the read paths render even
+  though the per-firing `:rf.flow/computed` trace doesn't carry them.
+
+  Returns the input-paths vector (e.g. `[[:cart :items] [:tax :rate]]`)
+  or `nil` when the flow is no longer registered (e.g. cleared
+  mid-session via `:rf.fx/clear-flow`)."
+  [flow-id]
+  (when flow-id
+    (some-> (rf/handler-meta :flow flow-id) :inputs)))
+
+(defn flows-with-chain-marks
+  "Tag each flow row with `:via?` — true when ANY of its read paths
+  matches a preceding flow row's write path. Subtle indicator for
+  the chained-flow case (Mike's §13 design — '↳ via :upstream-flow').
+
+  Pure data → data. Walks rows left-to-right; the `:via?` decision
+  depends on every preceding row's `:write-path`, so the result is
+  order-sensitive — call AFTER `flows-fired` (which preserves
+  cascade order).
+
+  Returns a vector matching the input order, each row enriched with:
+
+    `:read-paths`  — input-paths vec (looked up from registry; nil
+                      when the flow is no longer registered)
+    `:via?`        — true iff at least one read-path overlaps with a
+                      preceding row's write-path
+    `:via-flow-ids` — vec of upstream flow-ids the chain rides on
+                      (empty when `:via?` is false). Stable order:
+                      first-write-wins per upstream path."
+  [rows]
+  (vec
+    (reduce
+      (fn [acc {:keys [flow-id] :as row}]
+        (let [read-paths   (flow-read-paths flow-id)
+              path->writer (into {} (map (juxt :write-path :flow-id) acc))
+              via-flows    (vec (distinct
+                                  (keep path->writer (or read-paths []))))]
+          (conj acc
+                (assoc row
+                       :read-paths   (vec read-paths)
+                       :via?         (boolean (seq via-flows))
+                       :via-flow-ids via-flows))))
+      []
+      (or rows []))))
+
+(defn- flow-row
+  "One row inside the §8 FLOWS section. Shape per design:
+
+      ▸ :flow-id              wrote [:write :path]   <result>
+                              read  [:in1] [:in2]
+      ↳ :chained-flow         wrote [:other :path]   <result>
+                              read  [:in :read :the-upstream :wrote]"
+  [{:keys [flow-id write-path result read-paths via? via-flow-ids trace-id]}]
+  (let [suffix (interceptor-testid-suffix flow-id)]
+    [:div {:data-testid (str "rf-causa-event-detail-flow-row-" suffix)
+           :data-via    (str via?)
+           :style {:padding     "4px 0"
+                   :padding-left (if via? "20px" "0")}}
+     ;; Header line: glyph + flow-id + via attribution
+     [:div {:style {:display     "flex"
+                    :align-items "center"
+                    :gap         "8px"
+                    :flex-wrap   "wrap"}}
+      [:span {:data-testid (str "rf-causa-event-detail-flow-row-glyph-" suffix)
+              :style {:color       (if via?
+                                     (:text-secondary tokens)
+                                     (:text-tertiary tokens))
+                      :font-weight 600
+                      :font-size   "12px"}}
+       (if via? "↳" "▸")]
+      [:span {:data-testid (str "rf-causa-event-detail-flow-row-id-" suffix)
+              :style {:color       (:accent-violet tokens)
+                      :font-weight 600
+                      :min-width   "160px"}}
+       (pr-str flow-id)]
+      (when via?
+        [:span {:data-testid (str "rf-causa-event-detail-flow-row-via-" suffix)
+                :style {:color       (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-style  "italic"
+                        :font-size   "11px"}}
+         (str "via "
+              (string/join
+                ", "
+                (map pr-str via-flow-ids)))])]
+     ;; wrote line
+     [:div {:data-testid (str "rf-causa-event-detail-flow-row-wrote-" suffix)
+            :style {:display      "flex"
+                    :align-items  "flex-start"
+                    :padding      "2px 0 2px 24px"}}
+      [:span {:style {:color       (:text-tertiary tokens)
+                      :margin-right "10px"
+                      :min-width   "48px"
+                      :font-family sans-stack
+                      :font-size   "11px"}}
+       "wrote"]
+      [:span {:data-testid (str "rf-causa-event-detail-flow-row-write-path-" suffix)
+              :style {:color       (:cyan tokens)
+                      :margin-right "12px"}}
+       (pr-str write-path)]
+      [:span {:style {:color    (:text-primary tokens)
+                      :min-width 0
+                      :flex     1}}
+       (inspector/inspect result
+                          (str "event-detail/flow/"
+                               (or trace-id "x")
+                               "/result"))]]
+     ;; read line — placeholder when registry lookup failed (flow cleared)
+     [:div {:data-testid (str "rf-causa-event-detail-flow-row-read-" suffix)
+            :style {:display     "flex"
+                    :align-items "flex-start"
+                    :padding     "2px 0 2px 24px"}}
+      [:span {:style {:color       (:text-tertiary tokens)
+                      :margin-right "10px"
+                      :min-width   "48px"
+                      :font-family sans-stack
+                      :font-size   "11px"}}
+       "read"]
+      (if (seq read-paths)
+        (into [:span {:style {:color (:text-secondary tokens)
+                              :flex 1
+                              :word-break "break-word"}}]
+              (for [p read-paths]
+                [:span {:style {:color (:cyan tokens)
+                                :margin-right "8px"}}
+                 (pr-str p)]))
+        [:span {:data-testid (str "rf-causa-event-detail-flow-row-read-absent-" suffix)
+                :style {:color       (:text-tertiary tokens)
+                        :font-style  "italic"
+                        :font-size   "11px"}}
+         "input paths unavailable (flow may have been cleared)"])]]))
+
+(defn- flows-section
+  "§8 FLOWS — peer section between §7 EFFECTS HANDLERS RAN and any
+  future RETURNED-VALUE / handler-return section. Renders one row per
+  `:rf.flow/computed` trace in cascade firing order. Chained flows
+  (a downstream flow that reads from an upstream flow's write path)
+  carry the `↳ via :upstream` indicator.
+
+  Silent-by-default per Mike's policy (rf2-yn86j wave + bead): when
+  the cascade carries NO flow firings the section is ABSENT entirely.
+  A no-op cascade should not produce a 'FLOWS — none fired' row."
+  [cascade]
+  (let [rows (flows-with-chain-marks (flows-fired cascade))]
+    (when (seq rows)
+      (section/section-row
+        {:label "FLOWS"
+         :count* (count rows)
+         :testid "rf-causa-event-detail-section-flows"}
+        (into [:div]
+              (for [{:keys [trace-id flow-id] :as row} rows]
+                (with-meta
+                  (flow-row row)
+                  ;; Trace-id is the stable per-firing key. Fall back to
+                  ;; flow-id when the trace lacks an :id (older fixtures).
+                  {:key (or trace-id flow-id)})))))))
+
 ;; ---- handler-threw footnote --------------------------------------------
 
 (defn- handler-threw-footer
@@ -786,10 +1022,13 @@
 ;; ---- the lens (replaces v1 cascade-detail) -----------------------------
 
 (defn- event-lens
-  "Render the 7-section Event lens for a cascade. Replaces the v1
+  "Render the 8-section Event lens for a cascade. Replaces the v1
   `cascade-detail` six-domino renderer per rf2-zh2qc; COEFFECTS slot
   added in rf2-jhhqt + section order corrected to honour Mike's Q1
-  answer (DISPATCH SITE first, then EVENT).
+  answer (DISPATCH SITE first, then EVENT); FLOWS slot added in
+  rf2-lo37i — peer section after EFFECTS HANDLERS RAN that surfaces
+  the framework's automatic-after-fx flow firings (Spec 013 cascade
+  step 4 — previously invisible to Causa).
 
   Order (top → bottom):
     §1 DISPATCH SITE         where the dispatch happened (source coord)
@@ -798,7 +1037,8 @@
     §4 INTERCEPTORS          non-standard chain (silent when zero)
     §5 HANDLER               where the handler is defined (source coord)
     §6 EFFECTS RETURNED      {:db ... :fx [...]} the handler returned
-    §7 EFFECTS HANDLERS RAN  per-fx-handler rows + managed-fx inline"
+    §7 EFFECTS HANDLERS RAN  per-fx-handler rows + managed-fx inline
+    §8 FLOWS                 auto-fired flow recomputes in cascade order"
   [{:keys [dispatch-id frame event] :as cascade}]
   (let [event-id   (when (vector? event) (first event))
         meta       (when event-id (rf/handler-meta :event event-id))
@@ -817,6 +1057,8 @@
        (effects-returned-section cascade))
      (when-not threw?
        (effects-handlers-ran-section cascade))
+     (when-not threw?
+       (flows-section cascade))
      (when threw?
        (handler-threw-footer))]))
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event_detail_cljs_test.cljs
@@ -535,6 +535,306 @@
         (is (some? inline)
             "managed-fx record-panel mounts inline beneath fx-handler row")))))
 
+;; ---- (8.4) FLOWS section — rf2-lo37i ----------------------------------
+
+(defn- flow-computed-ev
+  "Build one `:rf.flow/computed` trace event ready to seed into the
+  cascade's `:other` bucket. Matches the per-firing trace shape
+  Spec 009 §Flow trace events documents (and the JVM
+  flows_trace_test.clj canon)."
+  [dispatch-id id-base flow-id {:keys [write-path input-values result frame]
+                                 :or   {frame :rf/default}}]
+  {:id        id-base
+   :op-type   :flow
+   :operation :rf.flow/computed
+   :tags      {:dispatch-id  dispatch-id
+               :flow-id      flow-id
+               :path         write-path
+               :input-values input-values
+               :result       result
+               :frame        frame}})
+
+(deftest flows-section-absent-when-no-flows-fired
+  (testing "rf2-lo37i — silent-by-default: a cascade with zero
+            `:rf.flow/computed` traces in `:other` renders NO FLOWS
+            section (the section is OMITTED entirely, not '(none)')"
+    (seed-buffer! (cascade-evs 100 [:counter/inc] 0))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-flows"))
+            "FLOWS section absent when no flows fired")))))
+
+(deftest flows-section-renders-one-row-per-rf-flow-computed
+  (testing "rf2-lo37i — each `:rf.flow/computed` trace in `:other`
+            renders as one flow row with the id + write-path + after-
+            value (result)"
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :cart-total
+                    :inputs [[:cart :items]]
+                    :output (fn [_] 0)
+                    :path   [:cart :total]}))
+    (seed-buffer!
+      (concat (cascade-evs 100 [:cart/add-item] 0)
+              [(flow-computed-ev 100 50 :cart-total
+                                  {:write-path  [:cart :total]
+                                   :input-values [[:apple :banana]]
+                                   :result      52.5})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-event-detail-section-flows"))
+            "FLOWS section present")
+        (is (some? (find-by-testid tree "rf-causa-event-detail-flow-row-cart-total"))
+            "per-flow row renders for :cart-total")
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-flow-row-id-cart-total"))
+            "flow-id chip present in row")
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-flow-row-write-path-cart-total"))
+            "write-path renders")
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-flow-row-wrote-cart-total"))
+            "'wrote' line renders")
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-flow-row-read-cart-total"))
+            "'read' line renders")))))
+
+(deftest flows-section-renders-input-paths-from-registry
+  (testing "rf2-lo37i — `:rf.flow/computed` does not carry input PATHS
+            (only :input-values). The render-time lookup via
+            `(rf/handler-meta :flow id)` recovers the paths from the
+            registered flow"
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :tax-due
+                    :inputs [[:cart :total] [:tax :rate]]
+                    :output (fn [t r] (* t r))
+                    :path   [:tax :due]}))
+    (seed-buffer!
+      (concat (cascade-evs 100 [:cart/add-item] 0)
+              [(flow-computed-ev 100 50 :tax-due
+                                  {:write-path  [:tax :due]
+                                   :input-values [50.0 0.105]
+                                   :result      5.25})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            read-row (find-by-testid tree
+                                      "rf-causa-event-detail-flow-row-read-tax-due")
+            text (->> (hiccup-seq read-row) (filter string?) (apply str))]
+        (is (some? read-row) "'read' line renders")
+        (is (re-find #":cart :total" text)
+            "first input path rendered")
+        (is (re-find #":tax :rate" text)
+            "second input path rendered")
+        (is (nil? (find-by-testid tree
+                                   "rf-causa-event-detail-flow-row-read-absent-tax-due"))
+            "no 'absent' placeholder when registry resolves the paths")))))
+
+(deftest flows-section-read-line-shows-placeholder-when-flow-cleared
+  (testing "rf2-lo37i — when a flow id appears in trace but the
+            registry no longer carries it (cleared mid-session) the
+            'read' line renders the absent-placeholder"
+    (seed-buffer!
+      (concat (cascade-evs 100 [:cart/add-item] 0)
+              [(flow-computed-ev 100 50 :gone-flow
+                                  {:write-path  [:cart :total]
+                                   :input-values [1 2]
+                                   :result      3})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (some? (find-by-testid tree
+                                    "rf-causa-event-detail-flow-row-read-absent-gone-flow"))
+            "absent placeholder renders when registry lookup fails")))))
+
+(deftest flows-section-renders-chained-via-marker-when-downstream-of-prior-flow
+  (testing "rf2-lo37i — when a flow reads a path that an EARLIER flow
+            in the same cascade wrote, the downstream row carries the
+            `↳ via :upstream` marker"
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :cart-total
+                    :inputs [[:cart :items]]
+                    :output (fn [_] 0)
+                    :path   [:cart :total]})
+      (rf/reg-flow {:id     :tax-due
+                    :inputs [[:cart :total]]
+                    :output (fn [t] t)
+                    :path   [:tax :due]}))
+    (seed-buffer!
+      (concat (cascade-evs 100 [:cart/add-item] 0)
+              [(flow-computed-ev 100 50 :cart-total
+                                  {:write-path  [:cart :total]
+                                   :input-values [[:apple]]
+                                   :result      52.5})
+               (flow-computed-ev 100 51 :tax-due
+                                  {:write-path  [:tax :due]
+                                   :input-values [52.5]
+                                   :result      5.25})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            up    (find-by-testid tree "rf-causa-event-detail-flow-row-cart-total")
+            down  (find-by-testid tree "rf-causa-event-detail-flow-row-tax-due")
+            via   (find-by-testid tree
+                                   "rf-causa-event-detail-flow-row-via-tax-due")]
+        (is (some? up)   "upstream :cart-total row present")
+        (is (some? down) "downstream :tax-due row present")
+        (is (some? via)  "↳ via marker renders on downstream row")
+        (is (nil? (find-by-testid tree
+                                   "rf-causa-event-detail-flow-row-via-cart-total"))
+            "upstream row does NOT carry a via marker (no preceding writer)")))))
+
+(deftest flows-section-rows-preserve-cascade-firing-order
+  (testing "rf2-lo37i — rows render in cascade firing order (topo-sorted
+            by the framework). Asserting on the document-order of
+            row testids is the contract."
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :a-flow
+                    :inputs [[:in]]
+                    :output identity :path [:a]})
+      (rf/reg-flow {:id     :b-flow
+                    :inputs [[:a]]
+                    :output identity :path [:b]})
+      (rf/reg-flow {:id     :c-flow
+                    :inputs [[:b]]
+                    :output identity :path [:c]}))
+    (seed-buffer!
+      (concat (cascade-evs 100 [:trigger] 0)
+              [(flow-computed-ev 100 50 :a-flow
+                                  {:write-path [:a] :input-values [1] :result 1})
+               (flow-computed-ev 100 51 :b-flow
+                                  {:write-path [:b] :input-values [1] :result 1})
+               (flow-computed-ev 100 52 :c-flow
+                                  {:write-path [:c] :input-values [1] :result 1})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)
+            row-tids (->> (hiccup-seq tree)
+                          (keep (fn [n]
+                                  (when (and (vector? n) (map? (second n)))
+                                    (let [tid (str (or (:data-testid (second n)) ""))]
+                                      (when (and (str/starts-with?
+                                                   tid "rf-causa-event-detail-flow-row-")
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-id-"))
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-wrote-"))
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-read-"))
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-write-path-"))
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-glyph-"))
+                                                  (not (str/starts-with?
+                                                         tid "rf-causa-event-detail-flow-row-via-")))
+                                        tid)))))
+                          (distinct)
+                          (vec))]
+        (is (= ["rf-causa-event-detail-flow-row-a-flow"
+                "rf-causa-event-detail-flow-row-b-flow"
+                "rf-causa-event-detail-flow-row-c-flow"]
+               row-tids)
+            "flow rows appear in cascade firing order")))))
+
+(deftest flows-section-sits-between-effects-handlers-ran-and-handler-threw-footer
+  (testing "rf2-lo37i — FLOWS is a peer section that sits AFTER §7
+            EFFECTS HANDLERS RAN. Asserts section order via the
+            section-root testids walker"
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :a-flow
+                    :inputs [[:in]] :output identity :path [:a]}))
+    (seed-buffer!
+      (concat (cascade-evs 100 [:trigger] 0)
+              [(flow-computed-ev 100 50 :a-flow
+                                  {:write-path [:a] :input-values [1] :result 1})]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree   (event-detail/Panel)
+            tids   (->> (hiccup-seq tree)
+                        (keep (fn [n]
+                                (when (and (vector? n) (map? (second n)))
+                                  (let [tid (str (or (:data-testid (second n)) ""))]
+                                    (when (#{"rf-causa-event-detail-section-effects-ran"
+                                             "rf-causa-event-detail-section-flows"}
+                                            tid)
+                                      tid)))))
+                        (distinct)
+                        (vec))]
+        (is (= ["rf-causa-event-detail-section-effects-ran"
+                "rf-causa-event-detail-section-flows"]
+               tids)
+            "FLOWS appears AFTER EFFECTS HANDLERS RAN in document order")))))
+
+(deftest flows-section-absent-when-handler-threw
+  (testing "rf2-lo37i — when the handler threw, the effects walk never
+            ran, so flows never fired. The FLOWS section should be
+            absent (mirrors §6 + §7 suppression)"
+    (seed-buffer!
+      (concat (cascade-evs 100 [:checkout/submit] 0
+                            {:fx nil :db-present? false})
+              [{:id 50 :op-type :error :operation :rf.error/handler-exception
+                :tags {:dispatch-id 100 :event-id :checkout/submit
+                       :exception-message "NullPointerException"}}]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 100])
+      (let [tree (event-detail/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-event-detail-section-flows"))
+            "FLOWS section absent when handler threw")))))
+
+(deftest flows-fired-helper-projects-rows-from-other-bucket
+  (testing "rf2-lo37i — `flows-fired` reads `:rf.flow/computed` traces
+            off the cascade's `:other` bucket and returns one row per
+            firing, preserving event-list order"
+    (let [cascade {:other [{:id 1 :op-type :flow :operation :rf.flow/computed
+                            :tags {:flow-id :a :path [:a] :input-values [1]
+                                   :result 1 :frame :rf/default}}
+                           {:id 2 :op-type :flow :operation :rf.flow/skip
+                            :tags {:flow-id :b :reason :inputs-value-equal}}
+                           {:id 3 :op-type :flow :operation :rf.flow/computed
+                            :tags {:flow-id :c :path [:c] :input-values [2]
+                                   :result 4 :frame :rf/default}}
+                           ;; Unrelated noise the projection must ignore:
+                           {:id 4 :op-type :error :operation :rf.error/handler-exception
+                            :tags {}}]}
+          rows    (event-detail/flows-fired cascade)]
+      (is (= 2 (count rows)) "skip traces are NOT projected as rows")
+      (is (= [:a :c] (mapv :flow-id rows)) "order preserved")
+      (is (= [[:a] [:c]] (mapv :write-path rows)))
+      (is (= [1 4] (mapv :result rows))))))
+
+(deftest flows-skipped-helper-projects-skips-from-other-bucket
+  (testing "rf2-lo37i — `flows-skipped` reads `:rf.flow/skip` traces;
+            useful for tests + future surfaces"
+    (let [cascade {:other [{:id 1 :op-type :flow :operation :rf.flow/skip
+                            :tags {:flow-id :b :reason :inputs-value-equal}}
+                           {:id 2 :op-type :flow :operation :rf.flow/computed
+                            :tags {:flow-id :a :path [:a] :input-values [1]
+                                   :result 1}}]}
+          rows    (event-detail/flows-skipped cascade)]
+      (is (= [:b] (mapv :flow-id rows)) "only skip rows projected")
+      (is (= [:inputs-value-equal] (mapv :reason rows))))))
+
+(deftest flows-with-chain-marks-flags-via-when-input-overlaps-prior-write
+  (testing "rf2-lo37i — `flows-with-chain-marks` is pure data → data.
+            Flows whose input paths intersect a PRECEDING row's write
+            path get :via? true + :via-flow-ids populated"
+    (rf/with-frame :rf/default
+      (rf/reg-flow {:id     :upstream
+                    :inputs [[:in]] :output identity :path [:upstream-out]})
+      (rf/reg-flow {:id     :downstream
+                    :inputs [[:upstream-out]] :output identity :path [:final]}))
+    (let [rows [{:flow-id :upstream   :write-path [:upstream-out]}
+                {:flow-id :downstream :write-path [:final]}]
+          enriched (event-detail/flows-with-chain-marks rows)]
+      (is (false? (:via? (first enriched)))
+          "first row never marked :via? (no preceding rows)")
+      (is (true? (:via? (second enriched)))
+          "second row marked :via? — its [:upstream-out] read matches
+           the first row's write-path")
+      (is (= [:upstream] (:via-flow-ids (second enriched)))
+          ":via-flow-ids names the upstream flow"))))
+
 ;; ---- (8.5) COEFFECTS section — silent-by-default + rendering -----------
 
 (deftest coeffects-section-absent-when-zero-user-coeffects


### PR DESCRIPTION
## Summary

- Adds the 8th section (`FLOWS`) to the Event lens as a peer surface AFTER `EFFECTS HANDLERS RAN`. Surfaces auto-fired flow recomputes so a user can attribute an app-db write to the flow that caused it (cascade step 4 — previously invisible to Causa).
- Per-flow row payload: flow-id chip + glyph (▸ standalone / ↳ chained), `wrote <path> <after-value>`, `read <input-paths>` (with absent-placeholder when the flow was cleared mid-session), and a `via :upstream` marker when the row's read paths overlap a preceding row's write path.
- Silent-by-default — section is OMITTED entirely when zero flows fired. `:rf.flow/skip` traces (value-equal dirty-check suppressions) are not rendered as rows. Suppressed alongside §6/§7 when the handler threw.

## Trace data source

Reads each `:rf.flow/computed` trace (op-type `:flow`) off the cascade's `:other` bucket per `re-frame.trace.projection`. The trace carries `:flow-id` / `:input-values` / `:result` / `:path` / `:frame` in `:tags`. Input PATHS are recovered at render time via `(rf/handler-meta :flow flow-id)` — the per-firing trace omits them but the registry carries them.

Audit context: `ai/findings/2026-05-19-flow-trace-events-audit.md` (rf2-oz0m7) verdict was PARTIAL but GOOD — four of five fields available; `:before` slot recoverable from epoch `:db-before`. Currently the row renders the after-value only; the optional `:before` framework polish is tracked separately.

## Consumer interface for sibling beads

The cascade-trace projection is implemented as pure functions on `panels.event_detail` — `flows-fired`, `flows-skipped`, `flows-with-chain-marks`. Sibling bead **rf2-s8r6c** (App-db diff path origins) consumes the same projection: filter to `:rf.flow/computed`, index by `:write-path`, tag matching diff slice rows with `:flow-id`. Same shape feeds **rf2-tv8t1** (Views sub-status 3-link 'sub → flow' attribution). No framework change required; the registry + trace stream are sufficient.

## Spec

`tools/causa/spec/018-Event-Spine.md` §5.1 — section heading bumped to '8-section Event lens'; visual mock extended with FLOWS rows; per-section description + edge cases updated.

## Test plan

- [x] `npm run test:cljs` from `implementation/` (2936 tests / 8386 assertions / 0 failures)
- [x] `clojure -M:test` from `tools/causa/` (718 tests / 2113 assertions / 0 failures)
- [x] New panel coverage: silent-by-default empty-state, one-row-per-computed, registry input-path lookup, absent-placeholder on cleared flow, chained-via marker, cascade firing order, section order, handler-threw suppression, pure projection helpers