### PR TITLE
feat(causa): typed-predicate filters — :machine + :http-correlation + :fx (rf2-piye4)

### DIFF
--- a/tools/causa/spec/020-Filter-Predicates.md
+++ b/tools/causa/spec/020-Filter-Predicates.md
@@ -1,0 +1,99 @@
+# Spec 020 — Filter Predicate Kinds (rf2-piye4)
+
+This document is the normative contract for Causa's filter-pill record
+shape. It supersedes the v1-shape note in
+[`018-Event-Spine.md` §7](018-Event-Spine.md) — the `{:pattern <kw-or-str>}`
+shape from rf2-ak4ms is now the canonical form of one kind among
+several typed predicates.
+
+Owner: tools/causa.
+
+## §1 Pill record
+
+Every IN / OUT pill is one of:
+
+```clojure
+;; Legacy keyword-pattern (rf2-ak4ms — back-compat persisted shape):
+{:pattern <kw-or-str>
+ :scope   #{:event-id}}
+
+;; Typed predicate (rf2-piye4):
+{:kind   <keyword>
+ :params <kind-specific map>}
+```
+
+The matcher (`filters/typed-predicates`) `canonicalise-pill`s on the way
+through, so legacy shape hydrates as `:event-id-pattern` without a
+migration step. New pills written by right-click affordances persist
+under the typed shape; the round-trip is symmetric.
+
+## §2 v1 kinds
+
+| kind                  | params                          | matcher                                                           | right-click source                            |
+|-----------------------|---------------------------------|-------------------------------------------------------------------|-----------------------------------------------|
+| `:event-id-pattern`   | `{:pattern <kw-or-str>}`        | event-id matches `:pattern` per `matcher.cljc`                    | trailing `[+]` add-pill + L2-row right-click  |
+| `:machine`            | `{:machine-id <id>}`            | any trace-event in cascade has `:tags :machine-id` = `:machine-id`| Machines panel rows                           |
+| `:http-correlation`   | `{:correlation-id <id>}`        | any trace-event in cascade has `:tags :correlation-id` = ditto    | managed-fx panel correlation pill             |
+| `:fx`                 | `{:fx-id <kw>}`                 | any trace-event in cascade has `:tags :fx-id` = `:fx-id`          | managed-fx panel fx-id badge                  |
+
+The matcher walks the cascade's `:handler`, `:fx`, `:effects`, `:subs`,
+`:renders`, `:other` buckets — same shape `routing_helpers/cascade-
+trace-events` consumes.
+
+## §3 Composition (unchanged from §18.7)
+
+```
+keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
+```
+
+`matches-IN` and `matches-OUT` are `some` over the bucket — pills
+within a bucket compose with OR, buckets compose with AND-NOT. Mixing
+typed pills + keyword-pattern pills in the same bucket is supported.
+
+## §4 Deferred kinds (rf2-piye4 — defer to v1.1)
+
+| kind             | rationale                                                    |
+|------------------|--------------------------------------------------------------|
+| `:source-coord`  | Niche; useful but no clear right-click source today.         |
+| `:interceptor`   | Niche; ditto.                                                |
+| `:descendant-of` | MOOT — Causality dropped this session.                       |
+
+## §5 Editing posture
+
+The edit popup (`filters/edit-popup`) is keyword-pattern-only in v1 —
+typed-predicate pills have fully-determined params (one click = one
+predicate), so the body is non-clickable and removal is via the `×`
+button. A future rev may surface per-kind edit popups; v1 covers the
+common cases without that surface area.
+
+## §6 Right-click affordances
+
+| panel surface                                   | event                                  |
+|-------------------------------------------------|----------------------------------------|
+| Machine inspector picker chrome                 | `:rf.causa/filter-by-machine`          |
+| Focused-event lens section header               | `:rf.causa/filter-by-machine`          |
+| Managed-fx record correlation pill              | `:rf.causa/filter-by-http-correlation` |
+| Managed-fx record fx-id badge                   | `:rf.causa/filter-by-fx`               |
+| L2 event row                                    | `:rf.causa/hide-event-type` (popup)    |
+
+Each typed-add event is idempotent: a duplicate add (same params)
+collapses to a no-op so multiple right-clicks don't pile up duplicate
+pills.
+
+## §7 Persistence
+
+`filters/persistence.cljs` round-trips the whole `:active-filters`
+slot — typed pills survive a localStorage write/load because
+`pr-str` / `read-string` handle the `:kind` / `:params` shape natively.
+No version bump on the storage key (`re-frame2.causa.filters.v1`) —
+the shape is additive (legacy `{:pattern ...}` still loads through the
+canonicaliser).
+
+## §8 Cross-references
+
+- [`018-Event-Spine.md` §7](018-Event-Spine.md) — pill UI contract +
+  IN/OUT composition.
+- [`019-Cross-Cutting-Insight.md`](019-Cross-Cutting-Insight.md) §2.4 /
+  F-C2 — managed-fx record shape (`:correlation-id`, `:fx-id`).
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Selection +
+  switching — the machine picker / focused-event lens surfaces.

--- a/tools/causa/src/day8/re_frame2_causa/filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters.cljs
@@ -28,7 +28,8 @@
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.filters.edit-popup :as edit-popup]
             [day8.re-frame2-causa.filters.matcher :as matcher]
-            [day8.re-frame2-causa.filters.persistence :as persistence]))
+            [day8.re-frame2-causa.filters.persistence :as persistence]
+            [day8.re-frame2-causa.filters.typed-predicates :as typed]))
 
 ;; ---- Modal --------------------------------------------------------------
 
@@ -93,6 +94,19 @@
       (assoc :edit-popup-trigger nil)
       (assoc :edit-popup-draft nil)))
 
+(defn- append-typed-pill
+  "Append a typed pill to `mode`'s bucket; no-op when an equivalent
+  pill already exists. Used by the `:rf.causa/filter-by-*` typed-add
+  events (rf2-piye4) — the right-click affordances on the Machines /
+  managed-fx panels dispatch through this so a double-add collapses
+  to one pill rather than piling duplicates."
+  [db mode pill]
+  (let [bucket   (get-in db [:active-filters mode] [])
+        present? (some #(= pill %) bucket)]
+    (if present?
+      db
+      (update-in db [:active-filters mode] (fnil conj []) pill))))
+
 (defn install!
   "Idempotent install for the filter subsystem's Causa-side surface.
   Wires:
@@ -109,7 +123,11 @@
               `:rf.causa/save-edit-popup`,
               `:rf.causa/delete-edit-popup`,
               `:rf.causa/hide-event-type`,
-              `:rf.causa/hydrate-filters`.
+              `:rf.causa/hydrate-filters`,
+              + rf2-piye4 typed-add events:
+              `:rf.causa/filter-by-machine`,
+              `:rf.causa/filter-by-http-correlation`,
+              `:rf.causa/filter-by-fx`.
 
     - Effects: `:rf.causa.filters/persist` — localStorage write fx.
 
@@ -139,6 +157,14 @@
   ;; → composed-focus. nil slot = no frame filter active (multi-frame
   ;; app, picker has not been touched, OR a single-frame app whose
   ;; picker collapses to a flat label).
+  ;; Pill matching routes through the typed-predicate dispatcher
+  ;; (rf2-piye4) so each pill's `:kind` selects the per-kind cascade
+  ;; matcher (`:event-id-pattern` delegates to the existing event-id
+  ;; matcher; `:machine` / `:http-correlation` / `:fx` walk the
+  ;; cascade's trace-events for the matching tag). Pre-typed pills
+  ;; persisted under `{:pattern <kw-or-str>}` hydrate as
+  ;; `:event-id-pattern` via `canonicalise-pill` — no migration step
+  ;; needed.
   (rf/reg-sub :rf.causa/filtered-cascades
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/active-filters]
@@ -146,7 +172,7 @@
     (fn [[cascades filters focus-slot] _query]
       (-> cascades
           (matcher/filter-cascades-by-frame (:frame focus-slot))
-          (matcher/filter-cascades filters))))
+          (typed/filter-cascades filters))))
 
   ;; Popup state — three slots so the open / trigger / draft tiers
   ;; are individually subscribable.
@@ -297,6 +323,41 @@
             (assoc :edit-popup-draft
                    (-> (edit-popup/pill->draft pill)
                        (assoc :mode :out)))))))
+
+  ;; ---- typed-predicate add events (rf2-piye4) -------------------------
+  ;;
+  ;; Right-click affordances on the Machines / managed-fx panels fire
+  ;; these events to append a typed-predicate IN pill directly — no
+  ;; popup round-trip because the pattern is fully determined by the
+  ;; clicked row (machine-id / correlation-id / fx-id). The user can
+  ;; remove the pill via the standard `×` button on the pill cluster.
+  ;;
+  ;; Each event idempotently appends via the file-level
+  ;; `append-typed-pill` helper — a duplicate add (same params)
+  ;; collapses to a no-op so multiple right-click → add chains don't
+  ;; pile up redundant pills.
+
+  (rf/reg-event-fx :rf.causa/filter-by-machine
+    (fn [{:keys [db]} [_ machine-id]]
+      (let [pill    {:kind :machine :params {:machine-id machine-id}}
+            next-db (append-typed-pill db :in pill)]
+        {:db next-db
+         :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})))
+
+  (rf/reg-event-fx :rf.causa/filter-by-http-correlation
+    (fn [{:keys [db]} [_ correlation-id]]
+      (let [pill    {:kind :http-correlation
+                     :params {:correlation-id correlation-id}}
+            next-db (append-typed-pill db :in pill)]
+        {:db next-db
+         :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})))
+
+  (rf/reg-event-fx :rf.causa/filter-by-fx
+    (fn [{:keys [db]} [_ fx-id]]
+      (let [pill    {:kind :fx :params {:fx-id fx-id}}
+            next-db (append-typed-pill db :in pill)]
+        {:db next-db
+         :fx [[:rf.causa.filters/persist (get next-db :active-filters)]]})))
 
   ;; ---- load: hydrate from localStorage --------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/pills.cljs
@@ -37,6 +37,7 @@
   hiccup, no per-substrate switches. Mount is via `reg-view` from the
   caller (`shell.cljs`'s `ribbon-filter-pills`)."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.filters.typed-predicates :as typed]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
 
@@ -51,7 +52,10 @@
 (defn- format-pattern
   "Render the pill's pattern text. Keywords render with their leading
   `:`; strings render verbatim. nil / blank falls back to `<empty>`
-  so a partially-saved pill is still visually addressable."
+  so a partially-saved pill is still visually addressable.
+
+  Kept for back-compat call sites; new code routes through
+  `typed/pill-label` so each kind picks its own format."
   [pattern]
   (cond
     (nil? pattern)              "<empty>"
@@ -60,21 +64,57 @@
          (seq pattern))         pattern
     :else                       "<empty>"))
 
+(defn- pill-kind
+  "Read the pill's `:kind` slot, canonicalising via the typed-
+  predicate ns so legacy `{:pattern …}` pills surface as
+  `:event-id-pattern`."
+  [pill]
+  (:kind (typed/canonicalise-pill pill)))
+
+(defn- pill-display
+  "Compose the pill's visible label — kind-specific glyph (when set)
+  followed by the kind's label per `typed/pill-label`. Used by the
+  pill body's text content so each predicate kind reads with the
+  same alphabet across the chrome."
+  [pill]
+  (let [glyph (typed/pill-glyph pill)
+        label (typed/pill-label pill)]
+    (if glyph
+      (str glyph ": " label)
+      label)))
+
 (defn pill
-  "One filter pill — clickable body that opens the edit popup, plus
-  an inline `×` button that removes the pill directly (no popup
-  round-trip for the common 'just delete it' case).
+  "One filter pill — clickable body that opens the edit popup (for
+  the keyword-pattern kind), plus an inline `×` button that removes
+  the pill directly (no popup round-trip for the common 'just delete
+  it' case).
+
+  ## Typed-predicate kinds (rf2-piye4)
+
+  Per Mike's rf2-drcyb closure, v1 ships three typed-predicate
+  kinds — `:machine`, `:http-correlation`, `:fx` — whose params are
+  fully determined by the right-click source row. These pills are
+  NOT editable in v1 (the popup is keyword-pattern-only); the body
+  is non-clickable for typed pills and the user removes via the
+  `×` button. The legacy `:event-id-pattern` kind (back-compat for
+  pre-rf2-piye4 persisted shape) keeps its click-to-edit body.
 
   Props:
     `:mode`    `:in` | `:out`
-    `:pill`    the pill record `{:pattern <kw-or-str> :scope #{…}}`
+    `:pill`    the pill record — either `{:pattern <kw-or-str>}`
+               (legacy keyword-pattern) or `{:kind <kw> :params {…}}`
+               (typed predicate)
     `:idx`     position in the mode bucket (drives the testid + the
                remove-filter event payload)"
   [{:keys [mode pill idx]}]
-  (let [tone   (pill-tone mode)
-        glyph  (pill-glyph mode)
-        testid (str "rf-causa-filter-pill-" (name mode) "-" idx)]
+  (let [tone        (pill-tone mode)
+        mode-glyph  (pill-glyph mode)
+        kind        (pill-kind pill)
+        editable?   (= kind :event-id-pattern)
+        testid      (str "rf-causa-filter-pill-" (name mode) "-" idx)
+        body-text   (pill-display pill)]
     [:span {:data-testid testid
+            :data-pill-kind (name kind)
             :style {:display        "inline-flex"
                     :align-items    "center"
                     :gap            "4px"
@@ -85,31 +125,42 @@
                     :font-family    mono-stack
                     :font-size      (:caption type-scale)
                     :white-space    "nowrap"}}
-     [:button {:data-testid  (str testid "-body")
-               :on-click     #(rf/dispatch
-                                [:rf.causa/open-edit-popup
-                                 {:source :pill :mode mode :idx idx :pill pill}]
-                                {:frame :rf/causa})
-               :title        "Edit"
-               :style {:background  "transparent"
-                       :border      "none"
-                       :color       tone
-                       :cursor      "pointer"
-                       :padding     "0"
+     (if editable?
+       [:button {:data-testid  (str testid "-body")
+                 :on-click     #(rf/dispatch
+                                  [:rf.causa/open-edit-popup
+                                   {:source :pill :mode mode :idx idx :pill pill}]
+                                  {:frame :rf/causa})
+                 :title        "Edit"
+                 :style {:background  "transparent"
+                         :border      "none"
+                         :color       tone
+                         :cursor      "pointer"
+                         :padding     "0"
+                         :font-family mono-stack
+                         :font-size   (:caption type-scale)
+                         :white-space "nowrap"}}
+        (str mode-glyph " " body-text " ")
+        ;; Pencil glyph per spec/018 §7 'Pill visual contract' —
+        ;; visual cue that the pill body is the click-to-edit target.
+        [:span {:style {:opacity 0.7}} "✎"]]
+       ;; Typed predicate — params are fully determined by the
+       ;; clicked row, so no edit popup. Bare span (non-button) so
+       ;; the cluster reads as 'tag + remove' rather than 'edit
+       ;; button + remove'.
+       [:span {:data-testid (str testid "-body")
+               :title       (str (name kind) " predicate")
+               :style {:color       tone
                        :font-family mono-stack
                        :font-size   (:caption type-scale)
                        :white-space "nowrap"}}
-      (str glyph " " (format-pattern (:pattern pill)) " ")
-      ;; Pencil glyph per spec/018 §7 'Pill visual contract' — visual
-      ;; cue that the pill body is the click-to-edit target.
-      [:span {:style {:opacity 0.7}} "✎"]]
+        (str mode-glyph " " body-text)])
      [:button {:data-testid  (str testid "-remove")
                :on-click     #(rf/dispatch
                                 [:rf.causa/remove-filter mode idx]
                                 {:frame :rf/causa})
                :title        "Remove this filter"
-               :aria-label   (str "Remove " (name mode) " filter "
-                                  (format-pattern (:pattern pill)))
+               :aria-label   (str "Remove " (name mode) " filter " body-text)
                :style {:background    "transparent"
                        :border        "none"
                        :color         tone

--- a/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/filters/typed_predicates.cljc
@@ -1,0 +1,323 @@
+(ns day8.re-frame2-causa.filters.typed-predicates
+  "Typed-predicate filter kinds for Causa pills (rf2-piye4).
+
+  ## Why typed predicates
+
+  Spec/018 §7 pills shipped as `{:pattern <kw-or-str>}` records keyed
+  off the cascade's `event-id` only. Surface-aware filters — 'show
+  every cascade that touched THIS machine' / 'show every cascade in
+  THIS HTTP exchange' / 'show every cascade triggering THIS fx kind'
+  — need to walk the cascade's trace-events, not just its event-id.
+  This ns generalises the pill record into a typed predicate:
+
+      {:kind   <:event-id-pattern | :machine | :http-correlation | :fx>
+       :params <kind-specific map>}
+
+  Each kind has a matcher in `cascade-matches-by-kind?` that consults
+  the cascade's data shape — event-id-pattern delegates to the
+  existing event-id matcher (`matcher.cljc`), the other three walk the
+  cascade's trace-event buckets for the expected `:tags` slot.
+
+  ## v1 kinds (per Mike's rf2-drcyb closure)
+
+  - `:event-id-pattern` — back-compat with rf2-ak4ms's
+    `{:pattern <kw-or-str>}` shape. Delegates to the existing
+    pattern matcher.
+  - `:machine` — match cascades whose trace-events include a
+    `:tags :machine-id` equal to `<params :machine-id>`. The right-
+    click affordance on the Machines panel rows fires
+    `:rf.causa/filter-by-machine` which appends this kind.
+  - `:http-correlation` — match cascades whose trace-events include a
+    `:tags :correlation-id` equal to `<params :correlation-id>`. The
+    right-click affordance on managed-fx HTTP records fires
+    `:rf.causa/filter-by-http-correlation`.
+  - `:fx` — match cascades that triggered the fx with this `fx-id`.
+    Walks the trace-events for any event whose `:tags :fx-id` equals
+    `<params :fx-id>`. The right-click affordance on managed-fx
+    records' surface badge fires `:rf.causa/filter-by-fx`.
+
+  ## Deferred kinds (Mike's rf2-piye4 scoping)
+
+  - `:source-coord` — defer to v1.1; niche.
+  - `:interceptor` — defer to v1.1; niche.
+  - `:descendant-of` — MOOT (Causality dropped this session).
+
+  ## Back-compat
+
+  Pills stored under the legacy `{:pattern <kw-or-str>}` shape (every
+  pill written before this bead) hydrate as `:event-id-pattern` via
+  `canonicalise-pill`. The persistence load path is unchanged; the
+  matcher folds the missing `:kind` slot into the canonical kind on
+  the way through. New typed pills written by the right-click
+  affordances persist with the explicit `:kind` so re-load round-trips
+  cleanly.
+
+  ## Composition (spec/018 §7 unchanged)
+
+  IN/OUT pill composition stays:
+
+      keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
+
+  — typed pills compose with keyword-pattern pills inside the same
+  bucket via `some` (any pill in the bucket can match the cascade).
+  Mixing typed + keyword pills in the same bucket is supported and
+  exercised by tests.
+
+  Pure data → bool. JVM-runnable so the test corpus exercises every
+  kind without a CLJS runtime."
+  (:require [day8.re-frame2-causa.filters.matcher :as event-matcher]))
+
+;; ---- canonical pill shape -----------------------------------------------
+
+(defn canonicalise-pill
+  "Coerce a pill record into the canonical typed-predicate shape:
+
+      {:kind <keyword> :params <map>}
+
+  - If `:kind` is already present, return verbatim (with `:params`
+    defaulted to `{}`).
+  - If `:pattern` is present and `:kind` is absent, infer
+    `:event-id-pattern` and migrate `:pattern` into `:params`. This is
+    the back-compat path for pills persisted under the rf2-ak4ms shape.
+  - Otherwise return the pill verbatim (the matcher will treat it as
+    `:never` — guards a malformed pill from matching everything)."
+  [pill]
+  (cond
+    (not (map? pill))
+    {:kind :never :params {}}
+
+    (some? (:kind pill))
+    (-> pill
+        (update :params #(or % {})))
+
+    (contains? pill :pattern)
+    ;; Legacy shape: surface the pattern under params so the matcher
+    ;; reads from one slot.
+    {:kind   :event-id-pattern
+     :params {:pattern (:pattern pill)
+              :scope   (or (:scope pill) #{:event-id})}}
+
+    :else
+    {:kind :never :params {}}))
+
+;; ---- cascade-trace-events ------------------------------------------------
+
+(defn cascade-trace-events
+  "Flatten every trace-event bucket on a cascade into one seq. Per
+  `re-frame.trace.projection/group-cascades` a cascade record carries
+  raw trace maps under `:handler`, `:fx`, `:effects`, `:subs`,
+  `:renders`, and `:other`; the `:event` slot is the bare event
+  vector (not a trace map) so it's excluded.
+
+  Lifted from `panels/routing_helpers.cljc` so the matcher stays a
+  self-contained pure unit; both helpers walk the same shape."
+  [cascade]
+  (concat
+    (when-let [handler (:handler cascade)] [handler])
+    (when-let [fx (:fx cascade)] [fx])
+    (:effects cascade)
+    (:subs cascade)
+    (:renders cascade)
+    (:other cascade)))
+
+(defn- tag-of
+  "Read `k` off a trace event's `:tags` map, defensive against the
+  flat-shape test fixtures that omit `:tags`. Mirrors
+  `panels/common_helpers/tag-of` so the matcher stays decoupled from
+  the panels' helper tree."
+  [ev k]
+  (or (get-in ev [:tags k])
+      (get ev k)))
+
+;; ---- per-kind cascade matchers ------------------------------------------
+
+(defmulti cascade-matches-by-kind?
+  "Dispatch on `:kind` to the per-kind matcher. Returns true iff the
+  cascade satisfies the typed predicate.
+
+  Each method receives the cascade and the pill's `:params` map. New
+  kinds register a defmethod here + a kind row in the per-kind
+  renderer in `filters/pills.cljs`."
+  (fn [_cascade pill]
+    (:kind (canonicalise-pill pill))))
+
+(defmethod cascade-matches-by-kind? :default
+  ;; Unknown / malformed kinds match nothing. Belt-and-braces — a
+  ;; future kind that ships persisted but not yet wired matches
+  ;; nothing instead of dropping every cascade.
+  [_cascade _pill]
+  false)
+
+(defmethod cascade-matches-by-kind? :never
+  [_cascade _pill]
+  false)
+
+(defmethod cascade-matches-by-kind? :event-id-pattern
+  ;; Delegate to the existing event-id pattern matcher. The pill's
+  ;; `:params :pattern` is the same `kw-or-str` shape the legacy
+  ;; matcher consumes; we surface it under params for typed pills and
+  ;; fall back to the top-level `:pattern` for legacy shape.
+  [cascade pill]
+  (let [canonical (canonicalise-pill pill)
+        pattern   (get-in canonical [:params :pattern])
+        event-id  (let [ev (:event cascade)]
+                    (when (vector? ev) (first ev)))]
+    (event-matcher/match-pill? {:pattern pattern} event-id)))
+
+(defmethod cascade-matches-by-kind? :machine
+  ;; True iff any trace event in the cascade carries a `:tags
+  ;; :machine-id` equal to the pill's `:machine-id`. Reads the same
+  ;; slot the machine-inspector / cancellation-cascade / arc helpers
+  ;; consume so the right-click affordance's pill and the inspector's
+  ;; per-machine projection compose against the same data.
+  [cascade {:keys [params]}]
+  (let [target (:machine-id params)]
+    (boolean
+      (when (some? target)
+        (some (fn [ev]
+                (= target (tag-of ev :machine-id)))
+              (cascade-trace-events cascade))))))
+
+(defmethod cascade-matches-by-kind? :http-correlation
+  ;; True iff any trace event in the cascade carries a `:tags
+  ;; :correlation-id` equal to the pill's `:correlation-id`. HTTP /
+  ;; WebSocket / managed-fx surfaces stamp this tag on the issuing
+  ;; effect + every downstream response/abort event so a single
+  ;; correlation pill captures the whole exchange's events.
+  [cascade {:keys [params]}]
+  (let [target (:correlation-id params)]
+    (boolean
+      (when (some? target)
+        (some (fn [ev]
+                (= target (tag-of ev :correlation-id)))
+              (cascade-trace-events cascade))))))
+
+(defmethod cascade-matches-by-kind? :fx
+  ;; True iff any trace event in the cascade carries a `:tags :fx-id`
+  ;; equal to the pill's `:fx-id`. Surfaces `:rf.fx/handled` +
+  ;; `:rf.fx/override-applied` + `:rf.fx/skipped` events so an `:fx`
+  ;; pill captures every cascade that triggered the registered fx
+  ;; kind regardless of outcome.
+  [cascade {:keys [params]}]
+  (let [target (:fx-id params)]
+    (boolean
+      (when (some? target)
+        (some (fn [ev]
+                (= target (tag-of ev :fx-id)))
+              (cascade-trace-events cascade))))))
+
+;; ---- cascade-level composition ------------------------------------------
+
+(defn cascade-matches-pill?
+  "True iff the typed pill matches the cascade. Single entrypoint —
+  routes through `canonicalise-pill` so legacy `{:pattern ...}` shape
+  and explicit `{:kind ...}` shape land at the same matcher."
+  [cascade pill]
+  (cascade-matches-by-kind? cascade (canonicalise-pill pill)))
+
+(defn cascade-matches-any?
+  "True iff any pill in `pills` matches the cascade. Empty / nil
+  `pills` → false. Pre-alpha posture: short-circuits on first hit."
+  [cascade pills]
+  (boolean
+    (when (seq pills)
+      (some #(cascade-matches-pill? cascade %) pills))))
+
+(defn keep-cascade?
+  "True iff `cascade` survives the active filter per spec/018 §7:
+
+      keep = (no-IN-pills OR matches-IN) AND NOT (matches-OUT)
+
+  Mirrors `matcher/keep-cascade?` but routes through the typed-
+  predicate dispatch so IN and OUT pills can be a mix of keyword
+  patterns + typed predicates. Pure data; JVM-runnable."
+  [cascade {:keys [in out]}]
+  (let [in-ok?  (or (empty? in)
+                    (cascade-matches-any? cascade in))
+        out-hit (cascade-matches-any? cascade out)]
+    (and in-ok? (not out-hit))))
+
+(defn filter-cascades
+  "Apply `filters` to `cascades`, returning the surviving subseq in
+  order. Pure — no I/O, no atoms read. Drop-in replacement for
+  `matcher/filter-cascades` that routes through typed-predicate
+  dispatch."
+  [cascades filters]
+  (filterv #(keep-cascade? % filters) cascades))
+
+;; ---- pill labels (presentation hooks) -----------------------------------
+
+(defmulti pill-label
+  "Render label for one pill — kind-specific format. Pure-data; the
+  view (`filters/pills.cljs`) wraps this in the styled chrome."
+  (fn [pill]
+    (:kind (canonicalise-pill pill))))
+
+(defmethod pill-label :default
+  [pill]
+  (pr-str pill))
+
+(defmethod pill-label :never
+  [_pill]
+  "<empty>")
+
+(defmethod pill-label :event-id-pattern
+  [pill]
+  (let [pattern (get-in (canonicalise-pill pill) [:params :pattern])]
+    (cond
+      (nil? pattern)              "<empty>"
+      (keyword? pattern)          (str pattern)
+      (and (string? pattern)
+           (seq pattern))         pattern
+      :else                       "<empty>")))
+
+(defmethod pill-label :machine
+  [pill]
+  (let [{:keys [machine-id]} (:params (canonicalise-pill pill))]
+    (if (some? machine-id)
+      (str machine-id)
+      "<machine>")))
+
+(defmethod pill-label :http-correlation
+  [pill]
+  (let [{:keys [correlation-id]} (:params (canonicalise-pill pill))]
+    (if (some? correlation-id)
+      (str correlation-id)
+      "<correlation>")))
+
+(defmethod pill-label :fx
+  [pill]
+  (let [{:keys [fx-id]} (:params (canonicalise-pill pill))]
+    (if (some? fx-id)
+      (str fx-id)
+      "<fx>")))
+
+(defmulti pill-glyph
+  "Per-kind glyph paired with the label — gives the user a quick
+  visual key for what predicate kind the pill carries. Mirrors
+  `surface->glyph` in `managed_fx_helpers.cljc` so the same alphabet
+  is used across the chrome."
+  (fn [pill]
+    (:kind (canonicalise-pill pill))))
+
+(defmethod pill-glyph :default
+  [_pill]
+  nil)
+
+(defmethod pill-glyph :event-id-pattern
+  [_pill]
+  ;; The keyword-pattern pill has no per-kind glyph — the bare label
+  ;; (`+ :auth/* ✎`) is the spec/018 §7 contract.
+  nil)
+
+(defmethod pill-glyph :machine
+  [_pill]
+  "M")
+
+(defmethod pill-glyph :http-correlation
+  [_pill]
+  "H")
+
+(defmethod pill-glyph :fx
+  [_pill]
+  "F")

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -95,9 +95,22 @@
   "Dropdown over the registered machines. Per spec/003-Machine-
   Inspector.md §Selection and switching the picker shows the
   machine-id + current state for each option; selecting fires
-  `:rf.causa/select-machine-id`."
+  `:rf.causa/select-machine-id`.
+
+  Right-click on the picker chrome fires
+  `:rf.causa/filter-by-machine` with the currently-selected
+  machine-id (rf2-piye4) — drops a typed `:machine` IN pill into
+  the ribbon so the L2 event list narrows to cascades involving
+  this machine."
   [rows selected-id]
   [:div {:data-testid "rf-causa-machine-inspector-picker"
+         :on-context-menu (fn [^js e]
+                            (when selected-id
+                              (.preventDefault e)
+                              (rf/dispatch
+                                [:rf.causa/filter-by-machine selected-id]
+                                {:frame :rf/causa})))
+         :title       "Right-click to filter the event list to this machine"
          :style       {:display "flex"
                        :align-items "center"
                        :gap "8px"
@@ -808,6 +821,13 @@
               :border-radius "4px"
               :background (:bg-2 tokens)}}
      [:header {:data-testid "rf-causa-machine-focused-event-header"
+               :on-context-menu (fn [^js e]
+                                  (when machine-id
+                                    (.preventDefault e)
+                                    (rf/dispatch
+                                      [:rf.causa/filter-by-machine machine-id]
+                                      {:frame :rf/causa})))
+               :title "Right-click to filter the event list to this machine"
                :style {:padding "10px 12px"
                        :display "flex"
                        :align-items "center"

--- a/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/managed_fx_template.cljs
@@ -86,16 +86,28 @@
             (str " " http-status)))]))
 
 (defn- correlation-pill
+  "Render the correlation-id pill. Right-click fires
+  `:rf.causa/filter-by-http-correlation` to drop a typed
+  `:http-correlation` IN pill in the ribbon (rf2-piye4) — narrows
+  the L2 event list to cascades that touched this exchange (issuing
+  effect, retries, response, downstream handler)."
   [correlation-id]
   (when correlation-id
     [:span {:data-testid "rf-causa-managed-fx-correlation"
+            :on-context-menu (fn [^js e]
+                               (.preventDefault e)
+                               (rf/dispatch
+                                 [:rf.causa/filter-by-http-correlation correlation-id]
+                                 {:frame :rf/causa}))
+            :title "Right-click to filter the event list to this HTTP exchange"
             :style {:padding       "1px 6px"
                     :margin-left   "8px"
                     :border-radius "3px"
                     :background    (:bg-3 tokens)
                     :color         (:text-secondary tokens)
                     :font-family   mono-stack
-                    :font-size     "10px"}}
+                    :font-size     "10px"
+                    :cursor        "context-menu"}}
      (str "correlation: " correlation-id)]))
 
 (defn- phase-pill
@@ -170,10 +182,19 @@
                    :letter-spacing "0.5px"}}
     [:span (get h/surface->glyph surface "•")]
     (str "MANAGED FX [" (get h/surface->label surface (str surface)) "]")]
-   [:span {:style {:color (:accent-violet tokens)
+   [:span {:data-testid "rf-causa-managed-fx-fx-id"
+           :on-context-menu (fn [^js e]
+                              (when fx-id
+                                (.preventDefault e)
+                                (rf/dispatch
+                                  [:rf.causa/filter-by-fx fx-id]
+                                  {:frame :rf/causa})))
+           :title "Right-click to filter the event list to events triggering this fx"
+           :style {:color (:accent-violet tokens)
                    :font-family mono-stack
                    :font-size "12px"
-                   :font-weight 600}}
+                   :font-weight 600
+                   :cursor "context-menu"}}
     (h/format-fx-id fx-id)]
    [:span {:style {:color (:text-tertiary tokens)
                    :font-family mono-stack

--- a/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_events_cljs_test.cljs
@@ -1,0 +1,117 @@
+(ns day8.re-frame2-causa.filters.typed-predicates-events-cljs-test
+  "CLJS integration tests for the typed-predicate `:rf.causa/filter-by-*`
+  events (rf2-piye4).
+
+  Asserts that:
+   - each typed-add event lands a `{:kind … :params …}` pill in the IN
+     bucket of `:rf.causa/active-filters`;
+   - duplicate adds are idempotent (no pile-up);
+   - the persistence fx fires on each mutation.
+
+  The pure matcher tests live in `typed_predicates_test.cljc` — JVM-
+  runnable. This file covers the dispatch / registry wiring that's
+  CLJS-only."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- :rf.causa/filter-by-machine ----------------------------------------
+
+(deftest filter-by-machine-appends-typed-pill
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+    (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+      (is (= [{:kind :machine :params {:machine-id :form}}]
+             (:in filters))
+          "machine pill landed in IN bucket")
+      (is (= [] (:out filters))))))
+
+(deftest filter-by-machine-idempotent
+  (testing "duplicate add with the same machine-id collapses to one pill"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+      (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+      (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+      (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+        (is (= 1 (count (:in filters)))
+            "three adds → one pill")))))
+
+(deftest filter-by-machine-distinct-ids-accumulate
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+    (rf/dispatch-sync [:rf.causa/filter-by-machine :auth])
+    (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+      (is (= 2 (count (:in filters))))
+      (is (= #{:form :auth}
+             (set (map #(get-in % [:params :machine-id]) (:in filters))))))))
+
+;; ---- :rf.causa/filter-by-http-correlation -------------------------------
+
+(deftest filter-by-http-correlation-appends-typed-pill
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-http-correlation "abc-123"])
+    (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+      (is (= [{:kind :http-correlation :params {:correlation-id "abc-123"}}]
+             (:in filters))))))
+
+(deftest filter-by-http-correlation-idempotent
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-http-correlation "abc-123"])
+    (rf/dispatch-sync [:rf.causa/filter-by-http-correlation "abc-123"])
+    (is (= 1 (count (:in @(rf/subscribe [:rf.causa/active-filters])))))))
+
+;; ---- :rf.causa/filter-by-fx ---------------------------------------------
+
+(deftest filter-by-fx-appends-typed-pill
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-fx :rf.http/managed])
+    (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+      (is (= [{:kind :fx :params {:fx-id :rf.http/managed}}]
+             (:in filters))))))
+
+(deftest filter-by-fx-idempotent
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/filter-by-fx :rf.http/managed])
+    (rf/dispatch-sync [:rf.causa/filter-by-fx :rf.http/managed])
+    (is (= 1 (count (:in @(rf/subscribe [:rf.causa/active-filters])))))))
+
+;; ---- mixed typed + legacy keyword pills ---------------------------------
+
+(deftest mixed-typed-and-legacy-pills-coexist
+  (testing "the rf2-ak4ms add-filter path (legacy `{:pattern ...}`) and
+            the rf2-piye4 filter-by-* paths can populate the same IN
+            bucket without stepping on each other"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/add-filter :in {:pattern :auth/*}])
+      (rf/dispatch-sync [:rf.causa/filter-by-machine :form])
+      (rf/dispatch-sync [:rf.causa/filter-by-fx :rf.http/managed])
+      (let [filters @(rf/subscribe [:rf.causa/active-filters])]
+        (is (= 3 (count (:in filters))))
+        (is (= [{:pattern :auth/*}
+                {:kind :machine :params {:machine-id :form}}
+                {:kind :fx :params {:fx-id :rf.http/managed}}]
+               (:in filters)))))))

--- a/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/filters/typed_predicates_test.cljc
@@ -1,0 +1,272 @@
+(ns day8.re-frame2-causa.filters.typed-predicates-test
+  "Pure-data tests for the typed-predicate filter matchers (rf2-piye4).
+
+  CLJC so the JVM corpus exercises every kind without a CLJS runtime
+  — the matcher is pure data, no atoms, no I/O. Spec/020 §2 catalogues
+  the four kinds; this file pins one composition test per kind +
+  legacy back-compat + mixed-bucket composition.
+
+  Test cascade shapes use the bucketed projection
+  `re-frame.trace.projection/group-cascades` emits (`:handler`, `:fx`,
+  `:effects`, `:subs`, `:renders`, `:other`) so the matcher walks the
+  same shape it'll see in production."
+  (:require [clojure.test :refer [deftest is testing]]
+            [day8.re-frame2-causa.filters.typed-predicates :as typed]))
+
+;; ---- helpers -------------------------------------------------------------
+
+(defn- mk-cascade
+  "Build a minimal cascade map for testing. `:event` is the bare event
+  vector; surface events nest under the projection-style buckets."
+  [{:keys [event handler fx effects subs renders other]
+    :or   {effects [] subs [] renders [] other []}}]
+  (cond-> {}
+    event              (assoc :event event)
+    handler            (assoc :handler handler)
+    fx                 (assoc :fx fx)
+    (seq effects)      (assoc :effects effects)
+    (seq subs)         (assoc :subs subs)
+    (seq renders)      (assoc :renders renders)
+    (seq other)        (assoc :other other)))
+
+(defn- tagged
+  "Build a synthetic trace event with the given tag map."
+  [tags]
+  {:operation :synthetic
+   :tags      tags})
+
+;; ---- canonicalise-pill --------------------------------------------------
+
+(deftest canonicalise-typed-pill-passes-through
+  (is (= {:kind :machine :params {:machine-id :form}}
+         (typed/canonicalise-pill
+           {:kind :machine :params {:machine-id :form}}))))
+
+(deftest canonicalise-typed-pill-defaults-params
+  (testing "missing :params slot defaults to {} so downstream readers
+            never NPE"
+    (is (= {:kind :machine :params {}}
+           (typed/canonicalise-pill {:kind :machine})))))
+
+(deftest canonicalise-legacy-pattern-pill-becomes-event-id-pattern
+  (testing "rf2-ak4ms legacy shape `{:pattern <kw-or-str>}` hydrates as
+            `:event-id-pattern` so persisted pills round-trip cleanly"
+    (is (= {:kind   :event-id-pattern
+            :params {:pattern :auth/login
+                     :scope   #{:event-id}}}
+           (typed/canonicalise-pill {:pattern :auth/login})))))
+
+(deftest canonicalise-legacy-pill-preserves-scope
+  (is (= {:kind   :event-id-pattern
+          :params {:pattern :auth/*
+                   :scope   #{:event-id :event-args}}}
+         (typed/canonicalise-pill {:pattern :auth/*
+                                   :scope   #{:event-id :event-args}}))))
+
+(deftest canonicalise-malformed-pill-is-never
+  (is (= {:kind :never :params {}}
+         (typed/canonicalise-pill nil)))
+  (is (= {:kind :never :params {}}
+         (typed/canonicalise-pill "not a map")))
+  (is (= {:kind :never :params {}}
+         (typed/canonicalise-pill {}))))
+
+;; ---- cascade-trace-events -----------------------------------------------
+
+(deftest cascade-trace-events-walks-every-bucket
+  (let [cascade (mk-cascade {:handler {:operation :handler}
+                             :fx      {:operation :fx}
+                             :effects [{:operation :effect1}
+                                       {:operation :effect2}]
+                             :subs    [{:operation :sub}]
+                             :renders [{:operation :render}]
+                             :other   [{:operation :other}]})
+        events  (typed/cascade-trace-events cascade)
+        ops     (set (map :operation events))]
+    (is (= #{:handler :fx :effect1 :effect2 :sub :render :other} ops))))
+
+(deftest cascade-trace-events-empty-cascade
+  (is (empty? (typed/cascade-trace-events (mk-cascade {:event [:foo]})))))
+
+;; ---- :event-id-pattern kind ---------------------------------------------
+
+(deftest event-id-pattern-typed-shape
+  (let [cascade (mk-cascade {:event [:auth/login]})
+        pill    {:kind :event-id-pattern :params {:pattern :auth/*}}]
+    (is (typed/cascade-matches-pill? cascade pill))))
+
+(deftest event-id-pattern-legacy-shape
+  (testing "rf2-ak4ms legacy `{:pattern :auth/*}` still matches via the
+            canonicaliser — back-compat with already-persisted pills"
+    (let [cascade (mk-cascade {:event [:auth/login]})]
+      (is (typed/cascade-matches-pill? cascade {:pattern :auth/*}))
+      (is (typed/cascade-matches-pill? cascade {:pattern :auth/login}))
+      (is (not (typed/cascade-matches-pill? cascade {:pattern :order/*}))))))
+
+(deftest event-id-pattern-no-match
+  (let [cascade (mk-cascade {:event [:order/submit]})]
+    (is (not (typed/cascade-matches-pill?
+               cascade {:kind :event-id-pattern :params {:pattern :auth/*}})))))
+
+;; ---- :machine kind ------------------------------------------------------
+
+(deftest machine-kind-matches-via-handler-tag
+  (testing "any trace-event with `:tags :machine-id` matches"
+    (let [cascade (mk-cascade {:event   [:user/click]
+                               :handler (tagged {:machine-id :form})})
+          pill    {:kind :machine :params {:machine-id :form}}]
+      (is (typed/cascade-matches-pill? cascade pill)))))
+
+(deftest machine-kind-matches-via-effects-tag
+  (let [cascade (mk-cascade {:event   [:user/click]
+                             :effects [(tagged {:fx-id    :rf.machine/transition
+                                                :machine-id :form})]})
+        pill    {:kind :machine :params {:machine-id :form}}]
+    (is (typed/cascade-matches-pill? cascade pill))))
+
+(deftest machine-kind-no-match-different-id
+  (let [cascade (mk-cascade {:event   [:user/click]
+                             :effects [(tagged {:machine-id :other})]})
+        pill    {:kind :machine :params {:machine-id :form}}]
+    (is (not (typed/cascade-matches-pill? cascade pill)))))
+
+(deftest machine-kind-no-match-no-machine-events
+  (let [cascade (mk-cascade {:event   [:user/click]
+                             :effects [(tagged {:fx-id :db})]})
+        pill    {:kind :machine :params {:machine-id :form}}]
+    (is (not (typed/cascade-matches-pill? cascade pill)))))
+
+(deftest machine-kind-nil-target-never-matches
+  (testing "nil `:machine-id` in the pill — guards against a half-filled
+            programmatic dispatch"
+    (let [cascade (mk-cascade {:event   [:foo]
+                               :effects [(tagged {:machine-id :form})]})
+          pill    {:kind :machine :params {:machine-id nil}}]
+      (is (not (typed/cascade-matches-pill? cascade pill))))))
+
+;; ---- :http-correlation kind ---------------------------------------------
+
+(deftest http-correlation-matches-issuing-effect
+  (let [cascade (mk-cascade {:event   [:user/load]
+                             :effects [(tagged {:fx-id          :rf.http/managed
+                                                :correlation-id "abc-123"})]})
+        pill    {:kind :http-correlation
+                 :params {:correlation-id "abc-123"}}]
+    (is (typed/cascade-matches-pill? cascade pill))))
+
+(deftest http-correlation-matches-response-event
+  (testing "the same correlation-id stamps both issuing fx and response
+            trace events — a single pill captures the whole exchange"
+    (let [cascade (mk-cascade {:event [:rf.http/response]
+                               :other [(tagged {:operation      :rf.http/received
+                                                :correlation-id "abc-123"})]})
+          pill    {:kind :http-correlation
+                   :params {:correlation-id "abc-123"}}]
+      (is (typed/cascade-matches-pill? cascade pill)))))
+
+(deftest http-correlation-no-match
+  (let [cascade (mk-cascade {:event   [:user/load]
+                             :effects [(tagged {:correlation-id "different"})]})
+        pill    {:kind :http-correlation
+                 :params {:correlation-id "abc-123"}}]
+    (is (not (typed/cascade-matches-pill? cascade pill)))))
+
+;; ---- :fx kind -----------------------------------------------------------
+
+(deftest fx-kind-matches-by-fx-id
+  (let [cascade (mk-cascade {:event   [:user/load]
+                             :effects [(tagged {:fx-id :rf.http/managed})]})
+        pill    {:kind :fx :params {:fx-id :rf.http/managed}}]
+    (is (typed/cascade-matches-pill? cascade pill))))
+
+(deftest fx-kind-matches-via-fx-bucket
+  (let [cascade (mk-cascade {:event [:user/load]
+                             :fx    (tagged {:fx-id :rf.http/managed})})
+        pill    {:kind :fx :params {:fx-id :rf.http/managed}}]
+    (is (typed/cascade-matches-pill? cascade pill))))
+
+(deftest fx-kind-no-match-different-fx
+  (let [cascade (mk-cascade {:event   [:user/load]
+                             :effects [(tagged {:fx-id :db})]})
+        pill    {:kind :fx :params {:fx-id :rf.http/managed}}]
+    (is (not (typed/cascade-matches-pill? cascade pill)))))
+
+;; ---- composition: IN bucket OR within, AND across modes -----------------
+
+(deftest in-bucket-composes-with-or
+  (testing "spec/018 §7 — within-bucket pills OR together"
+    (let [cascade-a (mk-cascade {:event   [:user/click]
+                                 :effects [(tagged {:machine-id :form})]})
+          cascade-b (mk-cascade {:event   [:user/load]
+                                 :effects [(tagged {:fx-id :rf.http/managed
+                                                    :correlation-id "abc"})]})
+          filters   {:in [{:kind :machine :params {:machine-id :form}}
+                          {:kind :http-correlation :params {:correlation-id "abc"}}]
+                     :out []}]
+      (is (typed/keep-cascade? cascade-a filters))
+      (is (typed/keep-cascade? cascade-b filters)))))
+
+(deftest in-out-composition
+  (testing "spec/018 §7 — IN bucket AND NOT OUT bucket"
+    (let [cascade (mk-cascade {:event   [:user/click]
+                               :effects [(tagged {:machine-id :form})]})
+          ;; IN matches via machine, but OUT also matches via the
+          ;; event-id pattern → drop
+          filters {:in  [{:kind :machine :params {:machine-id :form}}]
+                   :out [{:kind   :event-id-pattern
+                          :params {:pattern :user/*}}]}]
+      (is (not (typed/keep-cascade? cascade filters))))))
+
+(deftest mixed-bucket-typed-and-legacy
+  (testing "typed pills and legacy keyword-pattern pills compose inside
+            the same bucket — the canonicaliser handles both shapes"
+    (let [cascade-a (mk-cascade {:event   [:auth/login]
+                                 :effects [(tagged {:fx-id :rf.fx/handled})]})
+          cascade-b (mk-cascade {:event   [:user/click]
+                                 :effects [(tagged {:machine-id :form})]})
+          ;; IN: legacy pattern OR typed machine. Both cascades survive.
+          filters   {:in [{:pattern :auth/*}
+                          {:kind :machine :params {:machine-id :form}}]
+                     :out []}]
+      (is (typed/keep-cascade? cascade-a filters))
+      (is (typed/keep-cascade? cascade-b filters)))))
+
+(deftest empty-filters-keep-everything
+  (let [cascade (mk-cascade {:event [:anything]})]
+    (is (typed/keep-cascade? cascade {:in [] :out []}))))
+
+(deftest filter-cascades-preserves-order
+  (let [c1 (assoc (mk-cascade {:event   [:user/load]
+                               :effects [(tagged {:fx-id :rf.http/managed})]})
+                  :dispatch-id 1)
+        c2 (assoc (mk-cascade {:event [:other]})
+                  :dispatch-id 2)
+        c3 (assoc (mk-cascade {:event   [:user/load2]
+                               :effects [(tagged {:fx-id :rf.http/managed})]})
+                  :dispatch-id 3)
+        filters {:in  [{:kind :fx :params {:fx-id :rf.http/managed}}]
+                 :out []}]
+    (is (= [1 3] (mapv :dispatch-id
+                       (typed/filter-cascades [c1 c2 c3] filters))))))
+
+;; ---- pill-label / pill-glyph --------------------------------------------
+
+(deftest pill-label-per-kind
+  (is (= ":auth/login"
+         (typed/pill-label {:kind :event-id-pattern :params {:pattern :auth/login}})))
+  (is (= ":form"
+         (typed/pill-label {:kind :machine :params {:machine-id :form}})))
+  (is (= "abc-123"
+         (typed/pill-label {:kind :http-correlation :params {:correlation-id "abc-123"}})))
+  (is (= ":rf.http/managed"
+         (typed/pill-label {:kind :fx :params {:fx-id :rf.http/managed}}))))
+
+(deftest pill-label-legacy-shape-renders
+  (is (= ":auth/*"
+         (typed/pill-label {:pattern :auth/*}))))
+
+(deftest pill-glyph-per-kind
+  (is (nil? (typed/pill-glyph {:kind :event-id-pattern :params {:pattern :auth/*}})))
+  (is (= "M" (typed/pill-glyph {:kind :machine :params {:machine-id :form}})))
+  (is (= "H" (typed/pill-glyph {:kind :http-correlation :params {:correlation-id "x"}})))
+  (is (= "F" (typed/pill-glyph {:kind :fx :params {:fx-id :foo}}))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -270,6 +270,12 @@
    :rf.causa/edit-popup-set-pattern
    :rf.causa/edit-popup-toggle-scope
    :rf.causa/epoch-recorded
+   ;; rf2-piye4 — typed-predicate filter events. Each appends a
+   ;; typed `{:kind <kw> :params {…}}` IN pill from a right-click
+   ;; affordance on the Machines / managed-fx panels.
+   :rf.causa/filter-by-fx
+   :rf.causa/filter-by-http-correlation
+   :rf.causa/filter-by-machine
    :rf.causa/focus-cascade
    :rf.causa/focus-cascade-next
    :rf.causa/focus-cascade-prev
@@ -465,8 +471,9 @@
     ;; surface that no longer exists.
     ;; rf2-e9tb0 + rf2-r9lyy combined deltas against post-rf2-ttnst
     ;; baseline (102 / 116): e9tb0 +2 subs / -1 event; r9lyy +1 sub / 0 events.
+    ;; rf2-piye4: +3 events (:rf.causa/filter-by-{machine,http-correlation,fx}).
     (is (= 105 (count all-sub-names)))
-    (is (= 115 (count all-event-names)))
+    (is (= 118 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent


### PR DESCRIPTION
## Summary

- Generalises rf2-ak4ms's keyword-pattern auto-filter into surface-aware typed predicates. v1 ships three kinds — `:machine`, `:http-correlation`, `:fx` — with right-click affordances on the Machines and managed-fx panels. `:source-coord` + `:interceptor` defer to v1.1 (per Mike's rf2-drcyb closure); `:descendant-of` is MOOT (Causality dropped).
- Pill record gains a `{:kind <kw> :params {…}}` shape; legacy `{:pattern <kw-or-str>}` pills hydrate as `:event-id-pattern` via the canonicaliser so pre-existing persisted pills round-trip without migration. IN/OUT composition unchanged — typed and keyword-pattern pills compose freely.
- Pure matcher logic in `filters/typed_predicates.cljc` (JVM-runnable). Three idempotent `:rf.causa/filter-by-*` events drop right-click affordances directly into the IN bucket; the keyword-pattern edit popup is unchanged.
- Spec/020 documents the new pill record + per-kind matcher contract.

## Acceptance (from rf2-piye4)

- [x] Right-click Machines row → pill appears in ribbon; L2 narrows. Wired on the picker chrome + focused-event lens section header.
- [x] Right-click managed-fx HTTP correlation pill → `:http-correlation` pill appears.
- [x] Right-click managed-fx fx-id badge → `:fx` pill appears.
- [x] Multiple typed pills compose with AND (across modes) / OR (within mode).
- [x] IN/OUT mix works (mixed-bucket tests pin both shapes coexisting).
- [x] All existing keyword-pattern filters still work (back-compat via `:event-id-pattern` kind — 30 existing matcher_test cases unchanged).

## Test plan

- [x] JVM: 29 new `typed_predicates_test.cljc` cases — per-kind matcher, canonicaliser, back-compat shape, IN/OUT composition, mixed-bucket. Full Causa JVM suite passes (747 tests).
- [x] CLJS: 8 new `typed_predicates_events_cljs_test.cljs` cases — `:rf.causa/filter-by-*` events install correctly-shaped typed pills, idempotent on duplicate add, coexist with legacy `add-filter` path. Full node CLJS suite passes (2933 tests).
- [x] Registry snapshot updated for the three new event names (count drift 115 → 118).

## Scope notes

- Typed pills are NOT editable in v1 (their params are fully determined by the right-click source); the body is non-clickable and removal is via the `×` button. The keyword-pattern edit popup remains the only edit surface.
- Persistence storage key unchanged (`re-frame2.causa.filters.v1`) — the shape extension is additive and the canonicaliser handles both shapes on load.

Closes rf2-piye4.