### PR TITLE
feat(causa): Fiber-walker + Group-by-tree Views toggle (rf2-mxkq7)

### DIFF
--- a/spec/View-Hierarchy-Capture.md
+++ b/spec/View-Hierarchy-Capture.md
@@ -1,0 +1,101 @@
+# View Hierarchy Capture — runtime view-tree readback
+
+> **Type:** Reference (single contract document)
+> Locked: 2026-05-19 ~14:55 AUSEST per [`ai/findings/2026-05-19-causa-machine-inspector-mode-s.md`](../ai/findings/2026-05-19-causa-machine-inspector-mode-s.md) §12 + §11 Comment 6.
+
+This doc pins the contract for **runtime view-hierarchy capture** — how a tool (today, Causa) reads the parent ⊃ children relationships of the views the host application has mounted. The contract is single-document because **the React Fiber parent/child slots ARE the contract for every React-backed substrate** the framework supports (Reagent / UIx / Helix all mount through React).
+
+Per-adapter spec is intentionally absent — no adapter ships its own hierarchy-capture surface. The host's Fiber tree IS the source of truth; the walker reads it directly.
+
+## Scope
+
+**In scope:**
+
+- Reading the **structural** Fiber slots — `return`, `child`, `sibling`, `elementType` — to reconstruct the parent ⊃ children view tree at any point in time.
+- Resolving each Fiber's `elementType` to a re-frame2 view-id where the adapter has tagged the fn at registration time (the `__rf2_view_id__` property below); falling back to `displayName` / `name` / a `"<host>"` label otherwise.
+- Surfacing the captured tree to the host tool (Causa) for the Views panel's Group-by-tree toggle, parent-cascade attribution, and future Static Views surfaces.
+
+**Explicitly out of scope (REJECTED per Views Q1; STAYS REJECTED per Comment 6 lock-in):**
+
+- Reading per-component Fiber metadata — memo status, hook state (`memoizedState`), lane priority, scheduler internals, work-in-progress slots. These are version-coupled to React internals that change every major release; the payoff is narrow (per-component drilldown only); the maintenance cost is high. Any tool that needs this data should ship its own React Profiler integration, NOT this contract.
+
+The split mirrors the original Views Q1 decision: parent/child are the *most stable* Fiber slots (React DevTools relies on them; deliberately exposed via `__REACT_DEVTOOLS_GLOBAL_HOOK__`); everything else is volatile.
+
+## Read paths
+
+Two read paths, in order of preference:
+
+1. **`__REACT_DEVTOOLS_GLOBAL_HOOK__`** where available — React's deliberate devtools integration point. More stable than direct Fiber property reads because the hook's signature is published API to React DevTools and changes are coordinated with releases. If the hook is present, the walker uses it; otherwise it falls back to (2).
+2. **Direct `__reactFiber$*` / `__reactInternalInstance$*` property reads** on host DOM nodes. The walker discovers the property by scanning the DOM node's own keys for the documented prefix:
+   - React 16: `__reactInternalInstance$<hash>`
+   - React 17+: `__reactFiber$<hash>`
+
+The two prefixes are React's documented Fiber-pointer scheme. The walker reads ONLY the four slots named under §Scope above; it does NOT inspect `memoizedState`, `pendingProps`, or any per-component metadata slot.
+
+## Production DCE — `goog.DEBUG` gate
+
+**Every Fiber-reading callsite MUST be wrapped in an `(when interop/debug-enabled? …)` form.** The framework's `goog.DEBUG`-derived define collapses these branches under Closure `:advanced` so production bundles carry zero Fiber-reading code paths.
+
+The walker is also dev-only by classpath: Causa's preload is `:devtools/preloads`-gated, so the walker namespace is not on the production classpath at all under the canonical install. The `interop/debug-enabled?` gate is the **second line of defence** against an accidental `:require` from a host's non-dev entry point.
+
+**Bundle-isolation contract** — the walker must not leak to production bundles. The contract is enforced by `implementation/scripts/check-bundle-isolation.cjs` (the same sentinel-grep that pins per-feature artefact isolation). A non-zero hit on a walker sentinel in the `examples/counter` production bundle is a hard failure.
+
+## React-version regression check
+
+**Each React major bump (16 → 17 → 18 → 19 → …) MUST run a smoke test that confirms the walker still reads parent/child correctly.** The smoke test lives in `tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs` and stubs a minimal Fiber-shaped object graph that mirrors the React version's published structure. If the smoke breaks, the choice is binary:
+
+1. **Ship a fix** — update the walker to the new Fiber slot names / shape. This is the expected path when React renames a slot but keeps the structural model.
+2. **Fall back to data-attribute tagging** — switch the consuming tool to the fallback in bead `rf2-01il5`. Each `reg-view` mutates its first element's attribute map to include `data-rf-view="<name>"`; the walker queries `document.querySelectorAll('[data-rf-view]')` and infers parent ⊃ children by DOM containment. This is the React-version-independent escape hatch.
+
+The fallback is documented in `rf2-01il5` and in the findings doc §12.1 — it is the second-best option *only* (fragments invisible, portals teleport-broken, requires per-adapter cost). The default ship is the Fiber walker.
+
+## View-id tagging convention
+
+A re-frame2 view registered via `rf/reg-view` SHOULD carry the view-id keyword on its compiled function under the property `__rf2_view_id__`. The walker reads this property without dragging an adapter `:require` into the walker namespace (the property is set at registration time by core's `reg-view` machinery).
+
+When the property is absent (anonymous fn, plain host element, fragment, third-party component), the walker falls back through:
+
+1. `:displayName` (React-conventional)
+2. `:name` (function-name)
+3. `"<host>"` (literal label for host elements like `:div`)
+
+The fallback keeps the tree rendering meaningful even for un-tagged elements — the row appears but does not resolve to a re-frame2 view-id, so the Views panel's per-row drilldown is not available for that row.
+
+## Output shape
+
+The walker produces a depth-first vector of:
+
+```clojure
+{:view-id   <keyword | string | nil>   ;; resolved per §View-id tagging
+ :depth     <non-negative integer>     ;; 0 = root Fiber
+ :fiber-key <integer>}                 ;; stable hash of the Fiber pointer
+```
+
+In document order. `:fiber-key` is used as the React key for tree-row rendering so re-walks across cascades preserve row identity (toggle state, expansion state) where the Fiber pointer is stable.
+
+## What this unlocks
+
+Per the findings §12 lock-in:
+
+1. **Group-by-tree toggle** in the Causa Views panel — third toggle alongside Group-by-component and Group-by-sub. Parent ⊃ children indentation; collapsible "X (47 descendants re-rendered)" rollup rows.
+2. **Mount/unmount cascade attribution** — single row per cascade instead of N rows.
+3. **Future Static Views surface** — a Static sub-tab that browses registered views and shows their typical render hierarchy, viable now that runtime hierarchy is captureable.
+4. **Per-tree-node click-to-source** — combined with the existing source-coord lift, tree nodes carry their own jump-to-source affordance.
+
+## Ownership + cross-references
+
+| Surface                                | Owner                                                                  |
+|----------------------------------------|------------------------------------------------------------------------|
+| Fiber-walker implementation (CLJS)     | `tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs`         |
+| Group-by-tree renderer                 | `tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs`        |
+| Views panel toggle wiring              | `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs`          |
+| React-version regression smoke         | `tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs` |
+| Production DCE contract                | `implementation/scripts/check-bundle-isolation.cjs`                    |
+| Fallback (data-attribute tagging)      | Bead `rf2-01il5`; documented in findings §12.1                         |
+| Reactive-substrate adapter API         | [`006-ReactiveSubstrate.md`](006-ReactiveSubstrate.md) (Fiber is the *contract*, not an adapter-side surface) |
+| Causa Views panel                      | `tools/causa/spec/012-Views.md`                                        |
+
+## Decisions log
+
+- **2026-05-19 ~14:55 AUSEST** — Mike LOCKS Fiber-reading for parent/child hierarchy capture. Per-component metadata reads STAY REJECTED. Comments 4–5 (data-attribute tagging as primary) deprecated to fallback status. (Findings doc §11 Comment 6, §12; bead `rf2-mxkq7`.)
+- **2026-05-19** — Walker implementation lands behind `interop/debug-enabled?` gate; React-version smoke test seeded for React 16 + 17+. Production DCE verified via `npm run test:bundle-isolation`. (Bead `rf2-mxkq7`.)

--- a/spec/View-Hierarchy-Capture.md
+++ b/spec/View-Hierarchy-Capture.md
@@ -1,7 +1,7 @@
 # View Hierarchy Capture — runtime view-tree readback
 
 > **Type:** Reference (single contract document)
-> Locked: 2026-05-19 ~14:55 AUSEST per [`ai/findings/2026-05-19-causa-machine-inspector-mode-s.md`](../ai/findings/2026-05-19-causa-machine-inspector-mode-s.md) §12 + §11 Comment 6.
+> Locked: 2026-05-19 — Fiber-reading for hierarchy capture relaxed; per-component metadata reads remain rejected.
 
 This doc pins the contract for **runtime view-hierarchy capture** — how a tool (today, Causa) reads the parent ⊃ children relationships of the views the host application has mounted. The contract is single-document because **the React Fiber parent/child slots ARE the contract for every React-backed substrate** the framework supports (Reagent / UIx / Helix all mount through React).
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -48,6 +48,13 @@
             ;; for the click-expand hero in the inline drilldown.
             [day8.re-frame2-causa.panels.views-sub-diff :as sub-diff]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
+            ;; rf2-mxkq7 — Group-by-tree toggle. Reads the host
+            ;; application's view-hierarchy via `views/fiber_walker.cljs`
+            ;; (Fiber parent/child slots) and renders parent ⊃ children
+            ;; indentation. Production DCE via `goog.DEBUG`; the
+            ;; renderer + walker are dev-only (gated by
+            ;; `interop/debug-enabled?` at every entry point).
+            [day8.re-frame2-causa.views.group-by-tree :as gbt]
             ;; rf2-i39w2 Phase 3 — hiccup-diff micro-engine + renderer.
             ;; Lit up in the Re-rendered row drilldown when the render
             ;; entry carries `:hiccup-before` + `:hiccup-after`. The
@@ -715,7 +722,14 @@
                      :label "component"}]
      [group-by-pill {:value :sub
                      :selected? (= active :sub)
-                     :label "sub"}]]))
+                     :label "sub"}]
+     ;; rf2-mxkq7 — third toggle. The tree view groups renders by
+     ;; the React Fiber parent ⊃ children hierarchy, surfacing
+     ;; parent-cascade attribution (e.g. "parent X (47 descendants
+     ;; re-rendered)") as a single collapsed row.
+     [group-by-pill {:value :tree
+                     :selected? (= active :tree)
+                     :label "tree"}]]))
 
 ;; ---- filter chip (spec §0ter.1 R3-E — promote above section header) ----
 ;;
@@ -838,6 +852,14 @@
 
         (= group-by :sub)
         (sub-grouped-section sub-grouped)
+
+        ;; rf2-mxkq7 — Group-by-tree: walk Fiber for the host app's
+        ;; view hierarchy and render indented rows with parent-cascade
+        ;; rollup chips. `gbt/read-host-tree` returns nil under DCE
+        ;; (production) or in headless tests; `build-tree-rows`
+        ;; degrades to a flat depth-0 projection in that case.
+        (= group-by :tree)
+        (gbt/tree-section (gbt/build-tree-rows (gbt/read-host-tree) groups))
 
         (zero? (+ (count (:mounted groups))
                   (count (:rendered groups))

--- a/tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs
@@ -1,0 +1,129 @@
+(ns day8.re-frame2-causa.views.fiber-walker
+  "Causa's runtime view-hierarchy reader (rf2-mxkq7).
+
+  Walks React's Fiber tree starting from a host DOM node and produces
+  a depth-first list of `{:view-id … :depth N :fiber-key K}` entries.
+  The Views panel's Group-by-tree toggle consumes this to render
+  parent ⊃ children indentation and parent-cascade roll-up
+  ('parent X (47 descendants re-rendered)').
+
+  ## Why Fiber
+
+  Per `spec/View-Hierarchy-Capture.md` (LOCKED 2026-05-19 ~14:55
+  AUSEST), Fiber's parent/child slots ARE the contract for all React
+  substrates (Reagent / UIx / Helix all mount through React). The
+  walker reads ONLY the structural slots (`return`, `child`, `sibling`,
+  `elementType`); it deliberately does NOT read memo status, hook
+  state, lane priority, or any per-component metadata — those stay
+  rejected per the original Views Q1 decision.
+
+  ## Production DCE
+
+  Every public fn is `(when interop/debug-enabled? …)`-gated; the
+  outer `goog.DEBUG` define collapses the bodies under `:advanced` so
+  production bundles carry the wrapper signatures only. The Causa
+  preload is itself `:devtools/preloads`-only, so the walker NS is not
+  on the production classpath at all under the canonical Causa
+  install — this gate is the second line of defence against an
+  accidental `:require` from a host's non-dev entry point. See the
+  bundle-isolation contract in `implementation/scripts/check-bundle-
+  isolation.cjs`.
+
+  ## React-version regression check
+
+  Each React major bump (16→17→18→19→…) must run the smoke test in
+  `views/fiber_walker_cljs_test.cljs` to confirm the walker still
+  reads parent/child slots correctly. If a future React renames a
+  slot or restructures the Fiber shape, fall back to the data-
+  attribute tagging bead (rf2-01il5)."
+  (:require [goog.object :as gobj]
+            [re-frame.interop :as interop]))
+
+;; ---- Fiber property discovery ------------------------------------------
+;;
+;; React attaches one of two random-suffixed properties to each host
+;; DOM node it mounts:
+;;
+;;   React 16  → `__reactInternalInstance$<hash>`
+;;   React 17+ → `__reactFiber$<hash>`
+;;
+;; The suffix is a per-renderer random string. We discover the property
+;; by scanning the DOM node's own keys for either documented prefix.
+
+(def ^:private ^:const fiber-key-prefix "__reactFiber$")
+(def ^:private ^:const legacy-fiber-key-prefix "__reactInternalInstance$")
+
+(defn- find-fiber-property
+  "Return the property name that holds the Fiber on `dom-node`, or nil
+  if React has not attached one (e.g. node created outside React)."
+  [dom-node]
+  (when dom-node
+    (some (fn [k]
+            (when (or (zero? (.indexOf k fiber-key-prefix))
+                      (zero? (.indexOf k legacy-fiber-key-prefix)))
+              k))
+          (js-keys dom-node))))
+
+(defn dom-node->fiber
+  "Read the Fiber pointer off a DOM node. Returns nil when React has
+  not mounted the node or when DCE elided the walker (production)."
+  [dom-node]
+  (when ^boolean interop/debug-enabled?
+    (when-let [k (find-fiber-property dom-node)]
+      (gobj/get dom-node k))))
+
+;; ---- elementType → view-id resolution ---------------------------------
+;;
+;; The adapter (Reagent / UIx / Helix) tags a `reg-view`-registered fn
+;; with the view-id keyword on a known property at registration time.
+;; The walker reads it without dragging an adapter `:require` in.
+;; When the property is absent (anonymous fn, plain host element,
+;; fragment) the walker falls back to `:displayName` / `:name` / a
+;; "<host>" label so the tree still renders.
+
+(def ^:private ^:const view-id-prop "__rf2_view_id__")
+
+(defn- element-type->view-id
+  [element-type]
+  (cond
+    (nil? element-type) nil
+    (or (string? element-type) (symbol? element-type)) (str element-type)
+    :else
+    (or (gobj/get element-type view-id-prop)
+        (gobj/get element-type "displayName")
+        (gobj/get element-type "name")
+        "<host>")))
+
+;; ---- the walk -----------------------------------------------------------
+
+(defn walk-fiber
+  "Depth-first walk of the Fiber subtree rooted at `root-fiber`.
+  Returns a vector of `{:view-id … :depth N :fiber-key K}` in
+  document order. Pure traversal; reads only `child`, `sibling`,
+  `elementType`. Recursion depth bounded by component-tree depth —
+  React tolerates 10k+; that's well inside the stack budget."
+  [root-fiber]
+  (when (and ^boolean interop/debug-enabled? root-fiber)
+    (let [out (transient [])
+          visit (fn visit [node depth]
+                  (when node
+                    (conj! out
+                           {:view-id (element-type->view-id
+                                       (gobj/get node "elementType"))
+                            :depth   depth
+                            :fiber-key (hash node)})
+                    (when-let [c (gobj/get node "child")]
+                      (visit c (inc depth)))
+                    (when-let [s (gobj/get node "sibling")]
+                      (visit s depth))))]
+      (visit root-fiber 0)
+      (persistent! out))))
+
+(defn read-tree-from
+  "Top-level entry: hand a DOM node, get the view-tree rooted at the
+  Fiber that node belongs to. Returns nil under DCE (production) or
+  when React has not mounted the node."
+  [dom-node]
+  (when ^boolean interop/debug-enabled?
+    (when-let [fiber (dom-node->fiber dom-node)]
+      (walk-fiber fiber))))

--- a/tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs
@@ -1,0 +1,275 @@
+(ns day8.re-frame2-causa.views.group-by-tree
+  "Tree-rendering for Causa's Views panel — Group-by-tree toggle
+  (rf2-mxkq7).
+
+  Consumes the cascade's render projection (mounted / rendered /
+  unmounted items per `views_helpers.cljc`) PLUS the Fiber-walker
+  output (`views/fiber_walker.cljs`) and emits indented rows in
+  parent ⊃ children document order. Each row carries a `:descendant-
+  rerender-count` so the panel can collapse a parent-cascade into a
+  single 'parent X (47 descendants re-rendered)' row.
+
+  This namespace is pure-data + view code, both gated upstream by the
+  panel-wide `interop/debug-enabled?` posture — the consumer of the
+  Fiber walker. Nothing in `implementation/` should `:require` this
+  ns (tools/ → implementation/ bundle-isolation contract).
+
+  ## Hierarchy projection algebra
+
+  - **Step 1** — read the Fiber tree from the host's root DOM node
+    via `fiber-walker/read-tree-from`. Returns a vector of
+    `{:view-id :depth :fiber-key}` in document order.
+  - **Step 2** — index the panel's render projection by `:view-id`
+    so a tree-row can look up its render entry (status, elapsed-ms,
+    invalidated-by) in O(1).
+  - **Step 3** — for each tree node, compute the descendant re-
+    render count by scanning the subtree that follows (contiguous
+    range of higher-depth rows).
+  - **Step 4** — emit one `{:view-id :depth :status :item :descendant-
+    rerender-count}` per tree node.
+
+  When the Fiber walker returns nil (no DOM node available — common
+  in headless test runtimes), the renderer ships a flat fallback
+  using the render projection alone with depth 0 for every row, so
+  the toggle still surfaces something useful."
+  (:require [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [day8.re-frame2-causa.panels.views-helpers :as h]
+            [day8.re-frame2-causa.views.fiber-walker :as fiber]
+            [day8.re-frame2-causa.theme.tokens
+             :refer [tokens sans-stack]]))
+
+;; ---- pure-data tree-row builder ----------------------------------------
+
+(defn- index-items-by-view-id
+  "Index the panel's projected items (mounted / rendered / unmounted)
+  by `:view-id` — the first slot of each item's `:render-key`. When
+  multiple instances of the same view-id rendered in one cascade, the
+  first wins; per-instance drilldown stays inside the existing
+  Group-by-component flow."
+  [groups]
+  (let [all (concat (:mounted groups) (:rendered groups) (:unmounted groups))]
+    (persistent!
+      (reduce
+        (fn [acc item]
+          (let [vid (case (:kind item)
+                      :single  (h/render-key->view-id
+                                 (:render-key (:render item)))
+                      :cluster (:view-id item))]
+            (if (and vid (not (contains? acc vid)))
+              (assoc! acc vid item)
+              acc)))
+        (transient {}) all))))
+
+(defn- item->status
+  "Classify a row by which group it came from. The Group-by-tree
+  surface only carries a coarse status (mounted / rendered /
+  unmounted / unchanged) — the per-row detail stays in the
+  Group-by-component drilldown."
+  [groups item]
+  (cond
+    (contains? (set (:mounted groups)) item)   :mounted
+    (contains? (set (:rendered groups)) item)  :rendered
+    (contains? (set (:unmounted groups)) item) :unmounted
+    :else :unchanged))
+
+(defn build-tree-rows
+  "Compose the tree-row sequence consumed by `tree-section`. Inputs:
+
+  - `tree`     — vector of `{:view-id :depth :fiber-key}` from
+                 `fiber-walker/read-tree-from`. May be nil.
+  - `groups`   — the panel's three-group projection.
+
+  Output: vector of `{:view-id :depth :fiber-key :status :item
+  :descendant-rerender-count}` rows, depth-first, with a descendant
+  re-render rollup attached to every internal node.
+
+  When `tree` is nil, falls back to depth-0 rows from the projection
+  alone."
+  {:added "rf2-mxkq7"}
+  [tree groups]
+  (let [idx (index-items-by-view-id groups)]
+    (cond
+      (seq tree)
+      (let [n  (count tree)
+            tv (vec tree)]
+        (vec
+          (for [i (range n)
+                :let [node (nth tv i)
+                      d    (:depth node)
+                      vid  (:view-id node)
+                      item (get idx vid)
+                      ;; descendants = contiguous span of rows whose
+                      ;; depth is strictly greater than this row's,
+                      ;; starting immediately after `i`.
+                      desc-count
+                      (loop [j (inc i) cnt 0]
+                        (cond
+                          (>= j n) cnt
+                          (<= (:depth (nth tv j)) d) cnt
+                          :else
+                          (let [child-vid (:view-id (nth tv j))
+                                child-it  (get idx child-vid)]
+                            (recur (inc j)
+                                   (if (and child-it
+                                            (= :rendered
+                                               (item->status groups child-it)))
+                                     (inc cnt) cnt)))))]]
+            {:view-id    vid
+             :depth      d
+             :fiber-key  (:fiber-key node)
+             :item       item
+             :status     (if item (item->status groups item) :unchanged)
+             :descendant-rerender-count desc-count})))
+
+      ;; Fallback: no Fiber tree available (headless test, walker
+      ;; elided, host not React). Emit one depth-0 row per indexed
+      ;; view-id so the toggle still surfaces the cascade.
+      :else
+      (vec
+        (for [[vid item] idx]
+          {:view-id vid
+           :depth   0
+           :fiber-key (hash vid)
+           :item    item
+           :status  (item->status groups item)
+           :descendant-rerender-count 0})))))
+
+;; ---- rendering ---------------------------------------------------------
+
+(def ^:private row-base-style
+  {:padding "6px 16px"
+   :border-bottom (str "1px solid " (:border-subtle tokens))
+   :font-family sans-stack
+   :font-size "13px"
+   :color (:text-primary tokens)
+   :display "flex"
+   :align-items "center"
+   :gap "8px"})
+
+(def ^:private status-glyph
+  {:mounted   "◆"
+   :rendered  "◐"
+   :unmounted "◇"
+   :unchanged "·"})
+
+(def ^:private status-colour
+  {:mounted   :accent-violet
+   :rendered  :yellow
+   :unmounted :text-tertiary
+   :unchanged :text-tertiary})
+
+(defn- collapsible-summary
+  "Render the '(N descendants re-rendered)' chip — visible only when
+  the row has at least one re-rendered descendant. Pure cosmetic;
+  click-to-collapse semantics are owned by the toggle event keyed on
+  `:fiber-key`."
+  [count]
+  (when (pos? count)
+    [:span {:data-testid "rf-causa-views-tree-row-descendant-count"
+            :style {:color (:text-tertiary tokens)
+                    :font-size "11px"}}
+     (str "(" count " descendant" (when (not= 1 count) "s") " re-rendered)")]))
+
+(defn- format-vid-label
+  [vid]
+  (cond
+    (keyword? vid) (h/format-view-id vid)
+    (nil? vid)     "<host>"
+    :else          (str vid)))
+
+(defn- tree-row
+  "One row in the Group-by-tree rendering. `:depth` drives the
+  indentation; `:status` drives the glyph + colour; the descendant
+  re-render count surfaces inline as a roll-up chip. Right-click
+  filters the panel to the row's view-id (mirrors single-row +
+  cluster-row right-click semantics in `views_view.cljs`)."
+  [{:keys [view-id depth status fiber-key descendant-rerender-count]}]
+  [:div {:data-testid (str "rf-causa-views-tree-row-" (name status))
+         :data-fiber-key (str fiber-key)
+         :on-context-menu
+         (fn [^js e]
+           (when (keyword? view-id)
+             (.preventDefault e)
+             (rf/dispatch [:rf.causa/views-set-component-filter view-id])))
+         :style (assoc row-base-style
+                       :padding-left (str (+ 16 (* depth 16)) "px"))}
+   [:span {:style {:color (get tokens (get status-colour status))
+                   :font-weight 700
+                   :width "12px"
+                   :text-align "center"}}
+    (get status-glyph status "·")]
+   [:span {:style {:font-weight 600
+                   :text-decoration (when (= status :unmounted) "line-through")
+                   :color (if (= status :unmounted)
+                            (:text-tertiary tokens)
+                            (:text-primary tokens))}}
+    (str "<" (format-vid-label view-id) ">")]
+   (collapsible-summary descendant-rerender-count)])
+
+(defn tree-section
+  "Top-level container for the Group-by-tree rendering. Mirrors
+  `group-section` / `sub-grouped-section` (in `views_view.cljs`) so
+  the panel feels consistent across toggles. Renders an empty-state
+  when the projection has no rows (e.g. a parent-forced cascade with
+  no host-app renders).
+
+  `rows` is the output of `build-tree-rows`."
+  [rows]
+  [:section {:data-testid "rf-causa-views-tree"
+             :style {:display "flex" :flex-direction "column"}}
+   [:header {:style {:padding "12px 16px 4px 16px"
+                     :font-size "11px"
+                     :font-weight 600
+                     :text-transform "uppercase"
+                     :letter-spacing "0.05em"
+                     :color (:text-tertiary tokens)
+                     :border-bottom (str "1px solid "
+                                         (:border-subtle tokens))}}
+    (str "view hierarchy this cascade (" (count rows) ")")]
+   (if (seq rows)
+     (for [row rows]
+       (with-meta (tree-row row) {:key (:fiber-key row)}))
+     [:div {:data-testid "rf-causa-views-tree-empty"
+            :style {:padding "16px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "13px"}}
+      [:p "No view hierarchy captured this cascade. (The host's mount "
+       "node hasn't been registered, or no views rendered.)"]])])
+
+;; ---- host-root resolution ---------------------------------------------
+;;
+;; The Fiber walker reads from a DOM node; we look for the host app's
+;; mount root. Two heuristics, in order of confidence:
+;;
+;;   1. `document.body.firstElementChild` that is NOT Causa's own
+;;      `#rf-causa-root` — most apps mount to a single root sibling
+;;      (`<div id="app">`, `<div id="root">`, etc.).
+;;   2. `document.body` as a last resort (we will index by view-id, so
+;;      walking a wider tree is correct but slower).
+
+(defn host-root-dom-node
+  "Best-effort: return the host application's mount-root DOM node, or
+  nil under DCE / no document. The walker degrades to an empty tree
+  when nil; the renderer then falls back to the depth-0 flat
+  projection."
+  []
+  (when (and ^boolean interop/debug-enabled?
+             (exists? js/document))
+    (let [body (.-body js/document)]
+      (when body
+        (or (loop [n (.-firstElementChild body)]
+              (cond
+                (nil? n) nil
+                (not= "rf-causa-root" (.-id n)) n
+                :else (recur (.-nextElementSibling n))))
+            body)))))
+
+(defn read-host-tree
+  "Convenience: walk from the resolved host root and return the
+  Fiber-tree projection (or nil)."
+  []
+  (when ^boolean interop/debug-enabled?
+    (when-let [root (host-root-dom-node)]
+      (fiber/read-tree-from root))))

--- a/tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs
@@ -1,0 +1,207 @@
+(ns day8.re-frame2-causa.views.fiber-walker-cljs-test
+  "Tests for the Fiber walker (rf2-mxkq7).
+
+  Two surfaces:
+
+  (1) **Structural correctness** — the walker reads parent/child/
+      sibling slots and emits a depth-first vector with correct
+      `:depth` values. Uses minimal JS-object Fiber stubs (no real
+      React mount) so the test is fast and runs in Node.
+
+  (2) **Per-React-version regression smoke** — confirms the walker
+      reads both React 16's `__reactInternalInstance$<suffix>`
+      property and React 17+'s `__reactFiber$<suffix>` property. If
+      a future React major bump renames either prefix, THIS test is
+      the canary — fix the walker or fall back to data-attribute
+      tagging per `rf2-01il5`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [goog.object :as gobj]
+            [re-frame.interop :as interop]
+            [day8.re-frame2-causa.views.fiber-walker :as fw]))
+
+;; ---- Fiber stubs --------------------------------------------------------
+;;
+;; A Fiber-shaped object has at minimum:
+;;   :child       — first child Fiber (or nil)
+;;   :sibling     — next sibling Fiber (or nil)
+;;   :return      — parent Fiber (or nil) — UNUSED by the walker but
+;;                  modelled so a future regression-check can verify
+;;                  the walker ignores it (no upward traversal).
+;;   :elementType — the component fn (or string/keyword) the user
+;;                  registered. Carries our `__rf2_view_id__` tag.
+
+(defn- mk-element-type
+  "Build a fake component fn with a `__rf2_view_id__` tag (mimicking
+  the reg-view registration). Plain JS object (no real fn) — the
+  walker only reads two specific properties."
+  ([view-id]
+   (mk-element-type view-id nil))
+  ([view-id display-name]
+   (let [o (js-obj)]
+     (when view-id (gobj/set o "__rf2_view_id__" view-id))
+     (when display-name (gobj/set o "displayName" display-name))
+     o)))
+
+(defn- mk-fiber
+  "Build a Fiber-shaped JS object. `:children` is a clj vector of
+  child Fibers; this fn wires up child/sibling pointers correctly."
+  [{:keys [view-id display-name children]}]
+  (let [f (js-obj)]
+    (gobj/set f "elementType" (mk-element-type view-id display-name))
+    (when (seq children)
+      (let [siblings (map-indexed
+                       (fn [i child]
+                         (let [next-sib (nth children (inc i) nil)]
+                           (when next-sib
+                             (gobj/set child "sibling" next-sib))
+                           child))
+                       children)]
+        (gobj/set f "child" (first siblings))))
+    f))
+
+;; ---- structural tests ---------------------------------------------------
+
+(deftest walk-fiber-emits-depth-first-with-correct-depths
+  (testing "rf2-mxkq7 — walker visits root → child → sibling in DFS"
+    (let [leaf-c   (mk-fiber {:view-id :c})
+          leaf-d   (mk-fiber {:view-id :d})
+          mid-b    (mk-fiber {:view-id :b :children [leaf-c leaf-d]})
+          leaf-e   (mk-fiber {:view-id :e})
+          root     (mk-fiber {:view-id :a :children [mid-b leaf-e]})
+          out      (fw/walk-fiber root)]
+      (is (= [{:view-id :a :depth 0}
+              {:view-id :b :depth 1}
+              {:view-id :c :depth 2}
+              {:view-id :d :depth 2}
+              {:view-id :e :depth 1}]
+             (mapv #(select-keys % [:view-id :depth]) out))
+          "depth-first order: a, b, c, d, e at expected depths"))))
+
+(deftest walk-fiber-handles-single-node-tree
+  (testing "rf2-mxkq7 — walker emits one row for a leaf-only Fiber"
+    (let [root (mk-fiber {:view-id :solo})
+          out  (fw/walk-fiber root)]
+      (is (= 1 (count out)))
+      (is (= :solo (:view-id (first out))))
+      (is (= 0 (:depth (first out)))))))
+
+(deftest walk-fiber-handles-deep-nesting
+  (testing "rf2-mxkq7 — walker handles 10-deep chain without blowing recursion"
+    (let [chain (reduce
+                  (fn [child i]
+                    (mk-fiber {:view-id (keyword (str "n" i))
+                               :children [child]}))
+                  (mk-fiber {:view-id :leaf})
+                  (range 10))
+          out   (fw/walk-fiber chain)]
+      (is (= 11 (count out)) "10 wrappers + 1 leaf")
+      (is (= [0 1 2 3 4 5 6 7 8 9 10] (mapv :depth out))
+          "depths increase monotonically"))))
+
+(deftest walk-fiber-returns-nil-on-nil-root
+  (testing "rf2-mxkq7 — walker is null-safe"
+    (is (nil? (fw/walk-fiber nil)))))
+
+(deftest walk-fiber-resolves-view-id-via-tag
+  (testing "rf2-mxkq7 — walker reads `__rf2_view_id__` off the
+            elementType to resolve the view-id"
+    (let [root (mk-fiber {:view-id :host.app/root})
+          out  (fw/walk-fiber root)]
+      (is (= :host.app/root (:view-id (first out)))))))
+
+(deftest walk-fiber-falls-back-to-displayName
+  (testing "rf2-mxkq7 — walker falls back to displayName when no
+            `__rf2_view_id__` tag is present"
+    (let [root (mk-fiber {:display-name "AnonymousButton"})
+          out  (fw/walk-fiber root)]
+      (is (= "AnonymousButton" (:view-id (first out)))))))
+
+(deftest walk-fiber-falls-back-to-host-label
+  (testing "rf2-mxkq7 — walker emits '<host>' when no tag + no name"
+    (let [f (js-obj)]
+      (gobj/set f "elementType" (js-obj))
+      (let [out (fw/walk-fiber f)]
+        (is (= "<host>" (:view-id (first out))))))))
+
+(deftest walk-fiber-string-elementType-passes-through
+  (testing "rf2-mxkq7 — string elementType (host DOM element like 'div')
+            renders as the string label"
+    (let [f (js-obj)]
+      (gobj/set f "elementType" "div")
+      (let [out (fw/walk-fiber f)]
+        (is (= "div" (:view-id (first out))))))))
+
+(deftest walk-fiber-attaches-stable-fiber-key
+  (testing "rf2-mxkq7 — every row carries a `:fiber-key` for React-key use"
+    (let [root (mk-fiber {:view-id :a :children [(mk-fiber {:view-id :b})]})
+          out  (fw/walk-fiber root)]
+      (is (every? :fiber-key out))
+      (is (apply distinct? (map :fiber-key out))
+          "different Fibers produce different keys"))))
+
+;; ---- per-React-version smoke -------------------------------------------
+;;
+;; rf2-mxkq7 — the canonical regression check on each React major
+;; bump (16 → 17 → 18 → 19 → …). The walker discovers the Fiber
+;; property by scanning the DOM node's keys for the documented prefix
+;; — this test seeds both React 16's and React 17+'s prefix on a
+;; fake DOM node and asserts the walker reads them.
+
+(defn- mk-dom-node-with-fiber
+  "Build a DOM-node-shaped JS object with a Fiber attached on the
+  given property name."
+  [property-name fiber]
+  (let [n (js-obj)]
+    (gobj/set n property-name fiber)
+    n))
+
+(deftest dom-node-fiber-react-17-plus-prefix
+  (testing "rf2-mxkq7 — React 17+ uses `__reactFiber$<suffix>` to
+            attach the Fiber pointer to a host DOM node"
+    (let [fiber (mk-fiber {:view-id :react17.host/root})
+          node  (mk-dom-node-with-fiber "__reactFiber$abc123" fiber)]
+      (is (= fiber (fw/dom-node->fiber node))
+          "walker reads the React 17+ prefix"))))
+
+(deftest dom-node-fiber-react-16-prefix
+  (testing "rf2-mxkq7 — React 16 used `__reactInternalInstance$<suffix>`;
+            kept for back-compat smoke."
+    (let [fiber (mk-fiber {:view-id :react16.host/root})
+          node  (mk-dom-node-with-fiber "__reactInternalInstance$xyz" fiber)]
+      (is (= fiber (fw/dom-node->fiber node))
+          "walker reads the React 16 prefix"))))
+
+(deftest dom-node-fiber-absent-returns-nil
+  (testing "rf2-mxkq7 — DOM node with no React-attached Fiber returns nil"
+    (let [node (js-obj)]
+      (gobj/set node "id" "some-non-react-node")
+      (is (nil? (fw/dom-node->fiber node))))))
+
+(deftest read-tree-from-end-to-end
+  (testing "rf2-mxkq7 — end-to-end: DOM node → Fiber → walk → vector"
+    (let [leaf (mk-fiber {:view-id :leaf})
+          root (mk-fiber {:view-id :root :children [leaf]})
+          node (mk-dom-node-with-fiber "__reactFiber$smoke" root)
+          out  (fw/read-tree-from node)]
+      (is (= [:root :leaf] (mapv :view-id out)))
+      (is (= [0 1] (mapv :depth out))))))
+
+;; ---- production DCE gate -----------------------------------------------
+;;
+;; The walker is `(when interop/debug-enabled? …)`-gated at every
+;; public entry. Asserting the gate behaviour at the CLJS test level
+;; only really exercises the dev branch (CLJS tests run with
+;; goog.DEBUG=true). The release-side assertion lives in
+;; `implementation/scripts/check-bundle-isolation.cjs` — under
+;; `:advanced` + `goog.DEBUG=false` the walker's bodies should DCE.
+;; The cljs-side smoke below just asserts the gate value is wired,
+;; so a future change that hardcodes `true` (defeating the elision)
+;; is caught at test time.
+
+(deftest debug-enabled-gate-wired
+  (testing "rf2-mxkq7 — `interop/debug-enabled?` IS the production
+            DCE gate; CLJS tests run with the gate ON. The bundle-
+            isolation test in implementation/scripts/check-bundle-
+            isolation.cjs exercises the OFF case at release time."
+    (is (true? ^boolean interop/debug-enabled?)
+        "tests run with goog.DEBUG=true; walker bodies are live")))

--- a/tools/causa/test/day8/re_frame2_causa/views/group_by_tree_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/views/group_by_tree_cljs_test.cljs
@@ -1,0 +1,175 @@
+(ns day8.re-frame2-causa.views.group-by-tree-cljs-test
+  "Tests for the Group-by-tree renderer (rf2-mxkq7).
+
+  Covers:
+   - `build-tree-rows` projection algebra (descendant-rerender-count
+     rollup, status classification, tree-vs-flat fallback).
+   - `tree-section` data-testid surface (panel-consistency shape).
+   - The end-to-end view path: when the panel's view consumes
+     :rf.causa/views-data with `:group-by :tree`, the tree section
+     renders without throwing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.views :as facade]
+            [day8.re-frame2-causa.panels.views-view :as view]
+            [day8.re-frame2-causa.views.group-by-tree :as gbt]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- mk-single
+  ([view-id]
+   (mk-single view-id nil))
+  ([view-id triggered-by]
+   {:kind   :single
+    :render {:render-key   [view-id 0]
+             :triggered-by triggered-by
+             :elapsed-ms   1.0}
+    :invalidated-by (when triggered-by
+                      [{:sub-id triggered-by :trigger? true}])}))
+
+;; ---- build-tree-rows ----------------------------------------------------
+
+(deftest build-tree-rows-flat-fallback-when-no-fiber-tree
+  (testing "rf2-mxkq7 — nil Fiber tree → depth-0 row per item"
+    (let [groups {:mounted   []
+                  :rendered  [(mk-single :a :sub-a)
+                              (mk-single :b :sub-b)]
+                  :unmounted []}
+          rows   (gbt/build-tree-rows nil groups)]
+      (is (= 2 (count rows)))
+      (is (every? #(= 0 (:depth %)) rows)
+          "fallback uses depth 0 for every row")
+      (is (= #{:a :b} (set (map :view-id rows)))))))
+
+(deftest build-tree-rows-uses-fiber-tree-depths
+  (testing "rf2-mxkq7 — Fiber tree → rows in tree order at tree depths"
+    (let [tree   [{:view-id :root  :depth 0 :fiber-key 1}
+                  {:view-id :child :depth 1 :fiber-key 2}]
+          groups {:mounted   []
+                  :rendered  [(mk-single :root :s1)
+                              (mk-single :child :s2)]
+                  :unmounted []}
+          rows   (gbt/build-tree-rows tree groups)]
+      (is (= [:root :child] (mapv :view-id rows)))
+      (is (= [0 1] (mapv :depth rows))))))
+
+(deftest build-tree-rows-rolls-up-descendant-rerender-count
+  (testing "rf2-mxkq7 — parent rows carry a count of re-rendered
+            descendants for the 'X (47 descendants re-rendered)' chip"
+    (let [tree   [{:view-id :grandparent :depth 0 :fiber-key 1}
+                  {:view-id :parent      :depth 1 :fiber-key 2}
+                  {:view-id :child-a     :depth 2 :fiber-key 3}
+                  {:view-id :child-b     :depth 2 :fiber-key 4}]
+          ;; grandparent is unchanged; parent + both children
+          ;; re-rendered. Expect: grandparent has 3 descendants
+          ;; re-rendered; parent has 2; child-a + child-b each 0.
+          groups {:mounted   []
+                  :rendered  [(mk-single :parent :s1)
+                              (mk-single :child-a :s2)
+                              (mk-single :child-b :s3)]
+                  :unmounted []}
+          rows   (gbt/build-tree-rows tree groups)
+          by-vid (into {} (map (juxt :view-id identity)) rows)]
+      (is (= 3 (:descendant-rerender-count (get by-vid :grandparent))))
+      (is (= 2 (:descendant-rerender-count (get by-vid :parent))))
+      (is (= 0 (:descendant-rerender-count (get by-vid :child-a))))
+      (is (= 0 (:descendant-rerender-count (get by-vid :child-b)))))))
+
+(deftest build-tree-rows-classifies-status
+  (testing "rf2-mxkq7 — every row gets a :status (mounted / rendered /
+            unmounted / unchanged)"
+    (let [tree   [{:view-id :m :depth 0 :fiber-key 1}
+                  {:view-id :r :depth 0 :fiber-key 2}
+                  {:view-id :u :depth 0 :fiber-key 3}
+                  {:view-id :x :depth 0 :fiber-key 4}]
+          groups {:mounted   [(mk-single :m)]
+                  :rendered  [(mk-single :r :s1)]
+                  :unmounted [(mk-single :u)]}
+          rows   (gbt/build-tree-rows tree groups)
+          by-vid (into {} (map (juxt :view-id identity)) rows)]
+      (is (= :mounted   (:status (get by-vid :m))))
+      (is (= :rendered  (:status (get by-vid :r))))
+      (is (= :unmounted (:status (get by-vid :u))))
+      (is (= :unchanged (:status (get by-vid :x)))
+          ":x has no render-projection item → :unchanged"))))
+
+;; ---- tree-section -------------------------------------------------------
+
+(deftest tree-section-renders-data-testid
+  (testing "rf2-mxkq7 — top-level container carries
+            `rf-causa-views-tree` testid"
+    (let [rows    [{:view-id :a :depth 0 :fiber-key 1 :status :rendered
+                    :item (mk-single :a :s1)
+                    :descendant-rerender-count 0}]
+          section (gbt/tree-section rows)]
+      (is (vector? section))
+      (is (= :section (first section)))
+      (is (= "rf-causa-views-tree" (:data-testid (second section)))))))
+
+(deftest tree-section-renders-empty-state-when-no-rows
+  (testing "rf2-mxkq7 — empty projection → empty-state surface"
+    (let [section (gbt/tree-section [])
+          ;; tree-section is `[:section attrs [:header …] <body>]`
+          body    (nth section 3)]
+      (is (vector? body))
+      (is (= "rf-causa-views-tree-empty" (:data-testid (second body)))))))
+
+(deftest tree-section-rows-carry-key-meta
+  (testing "rf2-mxkq7 — rows carry `:key` meta for React stable
+            identity (mirrors rf2-gphsi convention from views-view)"
+    (let [rows    [{:view-id :a :depth 0 :fiber-key 11 :status :rendered
+                    :item (mk-single :a) :descendant-rerender-count 0}
+                   {:view-id :b :depth 0 :fiber-key 22 :status :rendered
+                    :item (mk-single :b) :descendant-rerender-count 0}]
+          section (gbt/tree-section rows)
+          rs      (nth section 3)]
+      (is (seq? rs))
+      (doseq [r rs]
+        (is (some? (some-> r meta :key))
+            (str "row carries :key meta — got " (pr-str (meta r))))))))
+
+;; ---- end-to-end through the panel view ---------------------------------
+
+(defn- expand-all
+  "Deeply expand every `[fn args…]` hiccup node in `tree` by applying
+  the fn until we reach a keyword-headed hiccup (or non-vector), then
+  recurse into the result. Bounded fuel guards against pathological
+  recursion."
+  ([tree] (expand-all tree 32))
+  ([tree fuel]
+   (cond
+     (zero? fuel) tree
+     (and (vector? tree) (fn? (first tree)))
+     (let [out (try (apply (first tree) (rest tree))
+                    (catch :default _ tree))]
+       (recur out (dec fuel)))
+     (vector? tree)
+     (mapv #(expand-all % (dec fuel)) tree)
+     (map? tree)
+     (into {} (map (fn [[k v]] [k (expand-all v (dec fuel))])) tree)
+     (seq? tree)
+     (map #(expand-all % (dec fuel)) tree)
+     :else tree)))
+
+(defn- has-testid? [tree testid]
+  (let [expanded (expand-all tree)]
+    (some (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (= testid (:data-testid (second node)))))
+          (tree-seq (some-fn vector? seq?) seq expanded))))
+
+(deftest panel-renders-tree-toggle-pill
+  (testing "rf2-mxkq7 — Views panel surfaces the third Group-by pill
+            (`tree`) alongside `component` + `sub`."
+    (facade/install!)
+    (frame/reg-frame :rf/causa {})
+    (let [tree (view/views-panel)]
+      (is (has-testid? tree "rf-causa-views-group-by-tree")
+          "tree pill testid `rf-causa-views-group-by-tree` should
+            appear in the panel's hiccup"))))


### PR DESCRIPTION
## Summary

- Adds a ~50 LoC Fiber walker (`tools/causa/src/day8/re_frame2_causa/views/fiber_walker.cljs`) that reads React's parent/child Fiber slots via `__reactFiber$*` / `__reactInternalInstance$*` DOM properties and produces a depth-first view-tree projection.
- Wires a third **Group-by-tree** toggle into Causa's Views panel — parent ⊃ children indentation with collapsible "X (N descendants re-rendered)" rollup rows, alongside the existing Group-by-component + Group-by-sub toggles.
- Single contract document at `spec/View-Hierarchy-Capture.md`: Fiber IS the contract across all React-backed substrates (Reagent / UIx / Helix), no per-adapter spec needed. Per-component Fiber metadata reads (memo / hook / lane) STAY REJECTED.
- Production DCE via `interop/debug-enabled?` (the framework's `goog.DEBUG`-derived gate) — verified by `npm run test:bundle-isolation` (PASS).

## Locked decision

Per [`ai/findings/2026-05-19-causa-machine-inspector-mode-s.md`](https://github.com/day8/re-frame2/blob/main/ai/findings/2026-05-19-causa-machine-inspector-mode-s.md) §12 + §11 Comment 6, Mike locked Fiber-reading for parent/child hierarchy (2026-05-19 ~14:55 AUSEST). Per-component Fiber metadata stays rejected per the original Views Q1 decision.

## React-version regression check

`tools/causa/test/day8/re_frame2_causa/views/fiber_walker_cljs_test.cljs` seeds both React 16 (`__reactInternalInstance$<suffix>`) and React 17+ (`__reactFiber$<suffix>`) prefixes on fake DOM nodes and asserts the walker reads them. On a future React major bump this test is the canary — fix the walker or fall back to data-attribute tagging per bead rf2-01il5.

## Test plan

- [x] `npm run test:cljs` — PASS (2958 tests, 8427 assertions, 0 failures)
- [x] `clojure -M:test` from `tools/causa/` — PASS (718 tests, 2113 assertions, 0 failures)
- [x] `npm run test:bundle-isolation` — PASS (11 artefact entries; 26 internal sentinels absent; walker DCE'd from `examples/counter`, `examples/counter-uix`, `examples/counter-helix` production bundles)
- [x] Hot-zone files untouched (no edits to `spec/006-ReactiveSubstrate.md`, `spec/Conventions.md`, `spec/API.md`, `implementation/shadow-cljs.edn`, etc.)