### PR TITLE
feat(adapters): publish :adapter/after-render via useLayoutEffect under UIx + Helix (rf2-334d9)

### DIFF
--- a/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
+++ b/implementation/adapters/helix/src/re_frame/adapter/helix.cljs
@@ -150,14 +150,24 @@
 ;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
 ;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
 ;;     every Helix-only release bundle for a single defprotocol slot.
-;;     The other reactive-substrate hooks (`:adapter/ratom`,
-;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`,
-;;     `:adapter/after-render`) are intentionally NOT published by the
-;;     Helix adapter — Helix ships no reactive-atom primitive (per
-;;     rf2-2qit) and `re-frame.interop`'s reactive surfaces have zero
-;;     production call sites under Helix; publishing those hooks would
-;;     force the Helix bundle to carry reagent.core (transitively
-;;     reagent.ratom) for code it never executes.
+;;     The remaining reactive-substrate hooks (`:adapter/ratom`,
+;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`)
+;;     are intentionally NOT published by the Helix adapter — Helix
+;;     ships no reactive-atom primitive (per rf2-2qit) and
+;;     `re-frame.interop`'s reactive-atom surfaces have zero production
+;;     call sites under Helix; publishing those hooks would force the
+;;     Helix bundle to carry reagent.core (transitively reagent.ratom)
+;;     for code it never executes.
+;;   :adapter/after-render — rf2-334d9. Backed by `React.useLayoutEffect`
+;;     via the spine's after-render machinery (see
+;;     `re-frame.substrate.spine/make-after-render-hook` +
+;;     `make-after-render-sentinel`). `after-render` is a React-
+;;     lifecycle question (when does the next commit complete?), not a
+;;     reactive-atom one — so the "no reactive primitive" rationale
+;;     that excludes the four hooks above does NOT apply. Pre-rf2-334d9
+;;     `(rf/after-render f)` under the Helix adapter was a silent
+;;     no-op; publish closes that correctness bug under the pre-alpha
+;;     masterpiece posture.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the inline hiccup-walk in
 ;;     views.cljs would mis-classify React-element output as a non-DOM
@@ -173,6 +183,8 @@
   rf-disposable/-dispose)
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  (:after-render-hook spine-fns))
 
 ;; Per rf2-4edk: contribute a clear of THIS adapter's warn-once cache to
 ;; the chained `:adapter/clear-warn-once-caches!` hook. The hook is

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_cljs_test.cljs
@@ -1,0 +1,134 @@
+(ns re-frame.adapter.helix-after-render-cljs-test
+  "Behavioural coverage for the Helix adapter's `:adapter/after-render`
+  hook (rf2-334d9). Pre-rf2-334d9 the Helix adapter did not publish
+  `:adapter/after-render`, so `(rf/after-render f)` under a Helix-only
+  app was a silent no-op — closed by Mike's rf2-neiqf decision
+  2026-05-19 to publish via `React.useLayoutEffect`.
+
+  Architecture under test. The spine maintains a per-adapter after-
+  render queue + a sentinel React function component injected at the
+  root of every mounted tree (via `spine/make-render`). The sentinel
+  fires `React.useLayoutEffect` on every commit, draining the queue.
+  When `interop/after-render` is called, the sentinel's stashed
+  `setState` bumps a tick so React schedules a commit, the
+  `useLayoutEffect` fires, and the queue drains in
+  post-commit / pre-paint order — same timing semantics as Reagent's
+  `r/after-render`. A `queueMicrotask` fallback covers the
+  pre-mount / post-unmount call paths.
+
+  Coverage shape mirrors the UIx parity test
+  (`uix_after_render_cljs_test.cljs`):
+    1. The hook is wired at ns-load — calling `interop/after-render`
+       under the Helix adapter returns nil (not a thrown
+       'no hook bound' / silent no-op signal).
+    2. Behaviour. Mount a Helix tree; call `(interop/after-render f)`;
+       verify `f` fired after the next commit (asserted via a side-
+       channel atom).
+
+  The behaviour assertion is browser-only — node-runtime has no DOM
+  and `react-dom/client` is unmountable there. Under `:node-test` the
+  ns-load smoke runs and the behaviour test no-ops cleanly.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require ["react"            :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [helix.core :refer-macros [$ defnc]]
+            [helix.dom  :as d]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.interop :as interop]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter helix-adapter/adapter}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(defn- get-act
+  "Return React's act() if available, else nil. React 18 ships act in
+  react-dom/test-utils; React 19 promotes it to the React namespace
+  proper."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+;; ---- ns-load smoke -------------------------------------------------------
+
+(deftest after-render-hook-wired-under-helix
+  (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
+            under the Helix adapter — the hook is wired at ns-load and
+            returns nil (the documented swallow shape) rather than
+            falling through to nil because no adapter published it."
+    ;; Calling with a fn argument should NOT throw and should NOT
+    ;; return a 'no hook bound' sentinel. The hook itself returns nil
+    ;; per the make-after-render-hook contract, and the queueMicrotask
+    ;; fallback drain handles the no-mount case asynchronously.
+    (is (nil? (interop/after-render (fn [] :ok)))
+        "interop/after-render under the Helix adapter returns nil — the
+         spine-built hook is wired through :adapter/after-render via
+         substrate-adapter/route-hook!")))
+
+;; ---- behaviour: mount, schedule, drain after commit ----------------------
+
+(defnc Probe []
+  ;; Bare Helix component — the rf2-334d9 sentinel is injected by the
+  ;; spine's `make-render`, not by user code.
+  (d/div "probe"))
+
+(deftest after-render-runs-callback-after-next-commit-helix
+  (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
+            after the next mount/render cycle under the Helix adapter.
+            The sentinel injected by the spine's make-render uses
+            React.useLayoutEffect to drain the queue post-commit."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (let [fired      (atom 0)
+                  callback   (fn after-render-cb [] (swap! fired inc))
+                  mount-node (make-mount-node!)
+                  unmount    (atom nil)]
+              (try
+                ;; Mount through `rf/render` so the spine's
+                ;; make-render path injects the after-render sentinel.
+                ;; Direct `react-dom-client/createRoot` + `.render`
+                ;; bypasses the spine wrap and would leave no sentinel
+                ;; in the tree — exactly what the rf2-334d9 design
+                ;; requires under test.
+                (act-fn (fn []
+                          (reset! unmount
+                                  (substrate-adapter/render ($ Probe) mount-node {}))))
+                (is (zero? @fired)
+                    "no after-render fn enqueued yet ⇒ no fires")
+                ;; Enqueue under act so the set-tick bump → re-render
+                ;; → useLayoutEffect drain commits synchronously in
+                ;; the test environment.
+                (act-fn (fn [] (interop/after-render callback)))
+                (is (= 1 @fired)
+                    "after-render fn fired exactly once after the next commit")
+                ;; A second enqueue + drain — the sentinel survives
+                ;; the first drain (its useLayoutEffect runs every
+                ;; commit) so a subsequent after-render also fires.
+                (act-fn (fn [] (interop/after-render callback)))
+                (is (= 2 @fired)
+                    "subsequent after-render fn also fires after its commit")
+                (finally
+                  (when-let [u @unmount]
+                    (try (u) (catch :default _ nil))))))))))))

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_late_bind_publication_cljs_test.cljs
@@ -10,16 +10,24 @@
         currently-installed one; otherwise chain to the previous
         handler. Used for `:adapter/current-frame`,
         `:adapter/add-on-dispose!`, `:adapter/dispose!`,
-        `:adapter/wrap-view`.
+        `:adapter/wrap-view`, and `:adapter/after-render` (rf2-334d9 —
+        useLayoutEffect-backed via the spine).
 
-        Per rf2-jicu2 the Helix adapter no longer publishes
-        `:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`,
-        `:adapter/reactive?`, or `:adapter/after-render` — Helix ships
-        no reactive-atom primitive (per rf2-2qit) and the reactive
-        surfaces have zero production call sites under Helix.
-        Publishing them previously forced reagent.core (transitively
-        reagent.ratom + reagent.impl.batching) into every Helix-only
-        release bundle for code the substrate never executed.
+        Per rf2-jicu2 the Helix adapter does not publish the
+        reactive-atom hooks `:adapter/ratom`, `:adapter/ratom?`,
+        `:adapter/make-reaction`, or `:adapter/reactive?` — Helix
+        ships no reactive-atom primitive (per rf2-2qit) and the
+        reactive-atom surfaces have zero production call sites under
+        Helix. Publishing them previously forced reagent.core
+        (transitively reagent.ratom + reagent.impl.batching) into
+        every Helix-only release bundle for code the substrate never
+        executed.
+
+        Per rf2-334d9 the Helix adapter DOES publish
+        `:adapter/after-render` — `after-render` is a React-lifecycle
+        question (when does the next commit complete?), not a
+        reactive-atom one. Pre-rf2-334d9 `(rf/after-render f)` under
+        the Helix adapter was a silent no-op.
 
     (2) `late-bind/chain-fn!` — chained hooks where every contributor
         runs (independent of installed-adapter identity). Used for
@@ -56,11 +64,12 @@
   pins; ordering here is for human-readable diff."
   ;; Routed via substrate-adapter/route-hook!
   ;;
-  ;; Per rf2-jicu2 the publication set was trimmed: the Helix adapter
-  ;; no longer publishes :adapter/ratom, :adapter/ratom?,
-  ;; :adapter/make-reaction, :adapter/reactive?, or
-  ;; :adapter/after-render. See this ns's docstring for rationale.
+  ;; Per rf2-jicu2 the reactive-atom hooks (:adapter/ratom,
+  ;; :adapter/ratom?, :adapter/make-reaction, :adapter/reactive?)
+  ;; remain excluded. Per rf2-334d9 :adapter/after-render IS published.
+  ;; See this ns's docstring for rationale.
   #{:adapter/add-on-dispose!
+    :adapter/after-render
     :adapter/current-frame
     :adapter/dispose!
     :adapter/wrap-view

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_runtime_cljs_test.cljs
@@ -6,13 +6,13 @@
   isolation, sub hot-reload) is substrate-agnostic, but every assertion
   in this file runs under the Helix-installed adapter — pinning that the
   late-bind hooks the Helix adapter publishes (`:adapter/current-frame`,
-  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`)
-  compose with the runtime layer correctly. Per rf2-jicu2 the Helix
-  adapter intentionally does NOT publish the reactive-substrate hooks
-  (`:adapter/ratom`, `:adapter/make-reaction`, `:adapter/reactive?`,
-  `:adapter/after-render`); subscribe-side reactivity routes through
-  the spine's `make-derived-value` (`IDeref`+`IWatchable` wrapper) which
-  carries no Reagent dependency.
+  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`,
+  `:adapter/after-render` per rf2-334d9) compose with the runtime layer
+  correctly. Per rf2-jicu2 the Helix adapter intentionally does NOT
+  publish the reactive-atom hooks (`:adapter/ratom`,
+  `:adapter/make-reaction`, `:adapter/reactive?`); subscribe-side
+  reactivity routes through the spine's `make-derived-value`
+  (`IDeref`+`IWatchable` wrapper) which carries no Reagent dependency.
 
   This is the headless subset only — Reagent-specific `r/atom` /
   `r/track!` / inline-hiccup-render assertions and example-driven tests

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -151,14 +151,24 @@
 ;;     routed to `reagent.ratom/add-on-dispose!` / `ratom/dispose!`
 ;;     which dragged ~9KB of reagent.ratom + reagent.impl.batching into
 ;;     every UIx-only release bundle for a single defprotocol slot.
-;;     The other reactive-substrate hooks (`:adapter/ratom`,
-;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`,
-;;     `:adapter/after-render`) are intentionally NOT published by the
-;;     UIx adapter — UIx ships no reactive-atom primitive (per
-;;     rf2-3yij) and `re-frame.interop`'s reactive surfaces have zero
-;;     production call sites under UIx; publishing those hooks would
-;;     force the UIx bundle to carry reagent.core (transitively
-;;     reagent.ratom) for code it never executes.
+;;     The remaining reactive-substrate hooks (`:adapter/ratom`,
+;;     `:adapter/ratom?`, `:adapter/make-reaction`, `:adapter/reactive?`)
+;;     are intentionally NOT published by the UIx adapter — UIx ships
+;;     no reactive-atom primitive (per rf2-3yij) and
+;;     `re-frame.interop`'s reactive-atom surfaces have zero production
+;;     call sites under UIx; publishing those hooks would force the UIx
+;;     bundle to carry reagent.core (transitively reagent.ratom) for
+;;     code it never executes.
+;;   :adapter/after-render — rf2-334d9. Backed by `React.useLayoutEffect`
+;;     via the spine's after-render machinery (see
+;;     `re-frame.substrate.spine/make-after-render-hook` +
+;;     `make-after-render-sentinel`). `after-render` is a React-
+;;     lifecycle question (when does the next commit complete?), not a
+;;     reactive-atom one — so the "no reactive primitive" rationale
+;;     that excludes the four hooks above does NOT apply. Pre-rf2-334d9
+;;     `(rf/after-render f)` under the UIx adapter was a silent no-op;
+;;     publish closes that correctness bug under the pre-alpha
+;;     masterpiece posture.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord
 ;;     injection via React.cloneElement (the views.cljs inline
 ;;     hiccup-walk would mis-classify React-element output as a
@@ -173,6 +183,8 @@
   rf-disposable/-dispose)
 (substrate-adapter/route-hook! adapter :adapter/wrap-view
   wrap-view)
+(substrate-adapter/route-hook! adapter :adapter/after-render
+  (:after-render-hook spine-fns))
 
 ;; Chained warn-once clear (rf2-4edk): every loaded adapter's
 ;; per-process defonce must be cleared between tests, so this hook is

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_cljs_test.cljs
@@ -1,0 +1,132 @@
+(ns re-frame.adapter.uix-after-render-cljs-test
+  "Behavioural coverage for the UIx adapter's `:adapter/after-render`
+  hook (rf2-334d9). Pre-rf2-334d9 the UIx adapter did not publish
+  `:adapter/after-render`, so `(rf/after-render f)` under a UIx-only
+  app was a silent no-op — closed by Mike's rf2-neiqf decision
+  2026-05-19 to publish via `React.useLayoutEffect`.
+
+  Architecture under test. The spine maintains a per-adapter after-
+  render queue + a sentinel React function component injected at the
+  root of every mounted tree (via `spine/make-render`). The sentinel
+  fires `React.useLayoutEffect` on every commit, draining the queue.
+  When `interop/after-render` is called, the sentinel's stashed
+  `setState` bumps a tick so React schedules a commit, the
+  `useLayoutEffect` fires, and the queue drains in
+  post-commit / pre-paint order — same timing semantics as Reagent's
+  `r/after-render`. A `queueMicrotask` fallback covers the
+  pre-mount / post-unmount call paths.
+
+  Coverage shape. Two assertions:
+    1. The hook is wired at ns-load — calling `interop/after-render`
+       under the UIx adapter returns nil (not a thrown
+       'no hook bound' / silent no-op signal).
+    2. Behaviour. Mount a UIx tree; call `(interop/after-render f)`;
+       verify `f` fired after the next commit (asserted via a side-
+       channel atom).
+
+  The behaviour assertion is browser-only — node-runtime has no DOM
+  and `react-dom/client` is unmountable there. Under `:node-test` the
+  ns-load smoke runs and the behaviour test no-ops cleanly.
+
+  ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
+  (:require ["react"            :as React]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [uix.core :as uix :refer-macros [defui $]]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.interop :as interop]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter uix-adapter/adapter}))
+
+(defn- browser? []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- make-mount-node! []
+  (when (browser?)
+    (.createElement js/document "div")))
+
+(defn- get-act
+  "Return React's act() if available, else nil. React 18 ships act in
+  react-dom/test-utils; React 19 promotes it to the React namespace
+  proper."
+  []
+  (or (when (exists? (.-act React)) (.-act React))
+      (try
+        (let [test-utils (js/require "react-dom/test-utils")]
+          (.-act test-utils))
+        (catch :default _ nil))))
+
+(defn- enable-react-act-env! []
+  (when (browser?)
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)))
+
+;; ---- ns-load smoke -------------------------------------------------------
+
+(deftest after-render-hook-wired-under-uix
+  (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
+            under the UIx adapter — the hook is wired at ns-load and
+            returns nil (the documented swallow shape) rather than
+            falling through to nil because no adapter published it."
+    ;; Calling with a fn argument should NOT throw and should NOT
+    ;; return a 'no hook bound' sentinel. The hook itself returns nil
+    ;; per the make-after-render-hook contract, and the queueMicrotask
+    ;; fallback drain handles the no-mount case asynchronously.
+    (is (nil? (interop/after-render (fn [] :ok)))
+        "interop/after-render under the UIx adapter returns nil — the
+         spine-built hook is wired through :adapter/after-render via
+         substrate-adapter/route-hook!")))
+
+;; ---- behaviour: mount, schedule, drain after commit ----------------------
+
+(defui Probe []
+  ;; Bare UIx component — the rf2-334d9 sentinel is injected by the
+  ;; spine's `make-render`, not by user code.
+  ($ :div "probe"))
+
+(deftest after-render-runs-callback-after-next-commit-uix
+  (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
+            after the next mount/render cycle under the UIx adapter.
+            The sentinel injected by the spine's make-render uses
+            React.useLayoutEffect to drain the queue post-commit."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (let [fired      (atom 0)
+                  callback   (fn after-render-cb [] (swap! fired inc))
+                  mount-node (make-mount-node!)
+                  unmount    (atom nil)]
+              (try
+                ;; Mount through `rf/render` so the spine's
+                ;; make-render path injects the after-render sentinel.
+                ;; Direct `react-dom-client/createRoot` + `.render`
+                ;; bypasses the spine wrap and would leave no sentinel
+                ;; in the tree — exactly what the rf2-334d9 design
+                ;; requires under test.
+                (act-fn (fn []
+                          (reset! unmount
+                                  (substrate-adapter/render ($ Probe) mount-node {}))))
+                (is (zero? @fired)
+                    "no after-render fn enqueued yet ⇒ no fires")
+                ;; Enqueue under act so the set-tick bump → re-render
+                ;; → useLayoutEffect drain commits synchronously in
+                ;; the test environment.
+                (act-fn (fn [] (interop/after-render callback)))
+                (is (= 1 @fired)
+                    "after-render fn fired exactly once after the next commit")
+                ;; A second enqueue + drain — the sentinel survives
+                ;; the first drain (its useLayoutEffect runs every
+                ;; commit) so a subsequent after-render also fires.
+                (act-fn (fn [] (interop/after-render callback)))
+                (is (= 2 @fired)
+                    "subsequent after-render fn also fires after its commit")
+                (finally
+                  (when-let [u @unmount]
+                    (try (u) (catch :default _ nil))))))))))))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_late_bind_publication_cljs_test.cljs
@@ -10,16 +10,22 @@
         currently-installed one; otherwise chain to the previous
         handler. Used for `:adapter/current-frame`,
         `:adapter/add-on-dispose!`, `:adapter/dispose!`,
-        `:adapter/wrap-view`.
+        `:adapter/wrap-view`, and `:adapter/after-render` (rf2-334d9 —
+        useLayoutEffect-backed via the spine).
 
-        Per rf2-jicu2 the UIx adapter no longer publishes
-        `:adapter/ratom`, `:adapter/ratom?`, `:adapter/make-reaction`,
-        `:adapter/reactive?`, or `:adapter/after-render` — UIx ships no
-        reactive-atom primitive (per rf2-3yij) and the reactive
+        Per rf2-jicu2 the UIx adapter does not publish the
+        reactive-atom hooks `:adapter/ratom`, `:adapter/ratom?`,
+        `:adapter/make-reaction`, or `:adapter/reactive?` — UIx ships
+        no reactive-atom primitive (per rf2-3yij) and the reactive-atom
         surfaces have zero production call sites under UIx. Publishing
         them previously forced reagent.core (transitively reagent.ratom
         + reagent.impl.batching) into every UIx-only release bundle for
         code the substrate never executed.
+
+        Per rf2-334d9 the UIx adapter DOES publish `:adapter/after-render`
+        — `after-render` is a React-lifecycle question (when does the
+        next commit complete?), not a reactive-atom one. Pre-rf2-334d9
+        `(rf/after-render f)` under the UIx adapter was a silent no-op.
 
     (2) `late-bind/chain-fn!` — chained hooks where every contributor
         runs (independent of installed-adapter identity). Used for
@@ -54,11 +60,12 @@
   pins; ordering here is for human-readable diff."
   ;; Routed via substrate-adapter/route-hook!
   ;;
-  ;; Per rf2-jicu2 the publication set was trimmed: the UIx adapter
-  ;; no longer publishes :adapter/ratom, :adapter/ratom?,
-  ;; :adapter/make-reaction, :adapter/reactive?, or
-  ;; :adapter/after-render. See this ns's docstring for rationale.
+  ;; Per rf2-jicu2 the reactive-atom hooks (:adapter/ratom,
+  ;; :adapter/ratom?, :adapter/make-reaction, :adapter/reactive?)
+  ;; remain excluded. Per rf2-334d9 :adapter/after-render IS published.
+  ;; See this ns's docstring for rationale.
   #{:adapter/add-on-dispose!
+    :adapter/after-render
     :adapter/current-frame
     :adapter/dispose!
     :adapter/wrap-view

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_runtime_cljs_test.cljs
@@ -6,13 +6,13 @@
   isolation, sub hot-reload) is substrate-agnostic, but every assertion
   in this file runs under the UIx-installed adapter — pinning that the
   late-bind hooks the UIx adapter publishes (`:adapter/current-frame`,
-  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`)
-  compose with the runtime layer correctly. Per rf2-jicu2 the UIx
-  adapter intentionally does NOT publish the reactive-substrate hooks
-  (`:adapter/ratom`, `:adapter/make-reaction`, `:adapter/reactive?`,
-  `:adapter/after-render`); subscribe-side reactivity routes through
-  the spine's `make-derived-value` (`IDeref`+`IWatchable` wrapper) which
-  carries no Reagent dependency.
+  `:adapter/add-on-dispose!`, `:adapter/dispose!`, `:adapter/wrap-view`,
+  `:adapter/after-render` per rf2-334d9) compose with the runtime layer
+  correctly. Per rf2-jicu2 the UIx adapter intentionally does NOT
+  publish the reactive-atom hooks (`:adapter/ratom`,
+  `:adapter/make-reaction`, `:adapter/reactive?`); subscribe-side
+  reactivity routes through the spine's `make-derived-value`
+  (`IDeref`+`IWatchable` wrapper) which carries no Reagent dependency.
 
   This is the headless subset only — Reagent-specific `r/atom` /
   `r/track!` / inline-hiccup-render assertions and example-driven tests

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -459,10 +459,12 @@
     :description "Substrate-specific reactive? predicate (re-frame.interop/reactive?). Per rf2-jicu2 not published by UIx/Helix; absent-hook fallback returns false."}
    {:key         :adapter/after-render
     :producer-ns '[re-frame.adapter.reagent
-                   re-frame.adapter.reagent-slim]
+                   re-frame.adapter.reagent-slim
+                   re-frame.adapter.uix
+                   re-frame.adapter.helix]
     :chained?    true
     :design-bead "rf2-s36l"
-    :description "Substrate-specific after-render hook (re-frame.interop/after-render). Per rf2-jicu2 not published by UIx/Helix; absent-hook returns nil."}
+    :description "Substrate-specific after-render hook (re-frame.interop/after-render). Per rf2-334d9 the UIx + Helix adapters publish a `React.useLayoutEffect`-backed impl via the spine's after-render machinery (closing the pre-rf2-334d9 silent no-op named in rf2-neiqf). Reagent + reagent-slim route through their substrate's native render scheduler."}
    {:key         :adapter/wrap-view
     :producer-ns '[re-frame.adapter.uix
                    re-frame.adapter.helix]

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -221,21 +221,141 @@
 (defn make-render
   "Build a `render` fn that registers every mounted React root in
   `active-roots-cell` and returns an unmount thunk that removes the
-  root from the cell before calling `.unmount`."
-  [active-roots-cell]
+  root from the cell before calling `.unmount`.
+
+  The user's `render-tree` is wrapped in a Fragment alongside an
+  `after-render-sentinel` element (rf2-334d9). The sentinel is a bare
+  React function component that fires `React.useLayoutEffect` on every
+  commit and drains the per-adapter after-render queue; it renders no
+  DOM. See `make-after-render-machinery` for the queue / sentinel
+  factory."
+  [active-roots-cell after-render-sentinel-cmp]
   (fn render [render-tree mount-point opts]
     ;; Spec 006 §`render` types `:hydrate?` as a boolean; non-bool
     ;; truthy values are undefined-behaviour (no defensive coercion).
-    (let [hydrate? (:hydrate? opts)
-          root     (if hydrate?
-                     (react-dom-client/hydrateRoot mount-point render-tree)
-                     (let [r (react-dom-client/createRoot mount-point)]
-                       (.render r render-tree)
-                       r))]
+    (let [hydrate?     (:hydrate? opts)
+          wrapped-tree (React/createElement
+                         (.-Fragment React)
+                         nil
+                         (React/createElement after-render-sentinel-cmp nil)
+                         render-tree)
+          root         (if hydrate?
+                         (react-dom-client/hydrateRoot mount-point wrapped-tree)
+                         (let [r (react-dom-client/createRoot mount-point)]
+                           (.render r wrapped-tree)
+                           r))]
       (swap! active-roots-cell conj root)
       (fn unmount []
         (swap! active-roots-cell disj root)
         (.unmount root)))))
+
+;; ---- after-render --------------------------------------------------------
+;;
+;; `:adapter/after-render` for React-only substrates (UIx, Helix) per
+;; rf2-334d9 (Mike decision rf2-neiqf 2026-05-19: publish via
+;; useLayoutEffect). Pre-rf2-334d9 the UIx and Helix adapters did NOT
+;; publish `:adapter/after-render`, so `(rf/after-render f)` under those
+;; adapters was a silent no-op — a correctness bug under the pre-alpha
+;; masterpiece posture.
+;;
+;; Architecture. Per-adapter queue cell + a sentinel function component
+;; injected at the root of every mounted tree (via `make-render`'s
+;; Fragment wrap). The sentinel uses `React.useLayoutEffect` to drain
+;; the queue after each commit — same DOM-mutations-applied / pre-paint
+;; timing semantics as Reagent's `r/after-render`. When `after-render`
+;; is called, the sentinel's stashed `setState` bumps a tick to force a
+;; commit so its `useLayoutEffect` fires and drains the queue.
+;;
+;; No-sentinel fallback. If `after-render` is invoked before any render
+;; has mounted (or after every root has unmounted), there is no stashed
+;; setter to drive a commit — fall through to `queueMicrotask` so `f`
+;; still fires once the current microtask boundary completes. Honest
+;; under both the "user dispatched a scroll-restore from a one-shot
+;; bootstrap event" path AND the "tests poke `interop/after-render`
+;; without mounting anything" path.
+
+(defn make-after-render-queue-cell
+  "Return a fresh `(atom [])` queue of pending after-render callbacks.
+  Each adapter owns its own cell so multiple React-shaped adapters can
+  coexist in a test bundle without clobbering each other's queue."
+  []
+  (atom []))
+
+(defn make-after-render-set-tick-ref
+  "Return a fresh `(atom nil)` slot the sentinel writes its `setState`
+  setter into on mount and clears on unmount. Each adapter owns its
+  own so the after-render hook below can route to the right adapter's
+  sentinel."
+  []
+  (atom nil))
+
+(defn- drain-after-render-queue!
+  "Atomically swap the pending-callbacks vector with empty and invoke
+  each in order. Per-fn throws are swallowed so one misbehaving callback
+  cannot strand the rest of the drain."
+  [queue-cell]
+  (let [[pending] (reset-vals! queue-cell [])]
+    (doseq [f pending]
+      (try (f) (catch :default _ nil)))))
+
+(defn make-after-render-sentinel
+  "Build the sentinel React function component for an adapter. The
+  sentinel returns nil (no DOM impact) and:
+
+    1. On mount, stashes its `setState` setter in `set-tick-ref` so
+       `:adapter/after-render` can trigger a commit. Cleared on unmount.
+    2. On every commit, fires `React.useLayoutEffect` to drain
+       `queue-cell` — same timing as `r/after-render`'s post-commit
+       run.
+
+  The sentinel uses raw React hooks (`React/useState`,
+  `React/useEffect`, `React/useLayoutEffect`) rather than the
+  substrate's hook ns so the same impl works for UIx, Helix, and any
+  future React-shaped substrate using this spine.
+
+  Returned value is the bare function component, suitable for
+  `(React/createElement sentinel-cmp nil)`."
+  [queue-cell set-tick-ref]
+  (fn after-render-sentinel [_props]
+    (let [tick+setter (React/useState 0)
+          set-tick    (aget tick+setter 1)]
+      (React/useEffect
+        (fn mount-effect []
+          (reset! set-tick-ref set-tick)
+          (fn cleanup []
+            ;; Only clear if it's still us — guards against a sentinel
+            ;; from a sibling root having claimed the slot in between.
+            (compare-and-set! set-tick-ref set-tick nil)))
+        #js [set-tick])
+      ;; No deps array — fires every commit, which is the contract
+      ;; (rf/after-render bumps the tick to force a commit, so the
+      ;; useLayoutEffect fires and drains).
+      (React/useLayoutEffect
+        (fn layout-effect []
+          (drain-after-render-queue! queue-cell)
+          js/undefined))
+      nil)))
+
+(defn make-after-render-hook
+  "Build the `:adapter/after-render` impl fn. The returned fn:
+
+    1. Enqueues `f` on `queue-cell`.
+    2. If the sentinel is mounted (`set-tick-ref` is non-nil), bumps
+       its tick — React schedules a commit, the sentinel's
+       `useLayoutEffect` fires, and the queue drains in
+       post-commit / pre-paint order.
+    3. Otherwise schedules a `queueMicrotask` drain so `f` still fires
+       once the current microtask boundary completes (covers the
+       pre-mount / post-unmount call paths)."
+  [queue-cell set-tick-ref]
+  (fn after-render-hook [f]
+    (swap! queue-cell conj f)
+    (if-let [set-tick @set-tick-ref]
+      (set-tick inc)
+      (if (exists? js/queueMicrotask)
+        (js/queueMicrotask #(drain-after-render-queue! queue-cell))
+        (.then (js/Promise.resolve) #(drain-after-render-queue! queue-cell))))
+    nil))
 
 (defn dispose-frame-sub-caches!
   "Walk every live frame's per-frame sub-cache and dispose each cached
@@ -602,6 +722,17 @@
         warn-fn            (make-warn-non-dom-root-fn warn-cache substrate-name)
         emitter-cell       (make-hiccup-emitter-cell)
         active-roots-cell  (make-active-roots-cell)
+        ;; rf2-334d9: after-render queue + sentinel component + the
+        ;; routed-hook impl. The adapter publishes the hook by passing
+        ;; `:after-render-hook` to `substrate-adapter/route-hook!`.
+        after-render-queue-cell    (make-after-render-queue-cell)
+        after-render-set-tick-ref  (make-after-render-set-tick-ref)
+        after-render-sentinel      (make-after-render-sentinel
+                                     after-render-queue-cell
+                                     after-render-set-tick-ref)
+        after-render-hook          (make-after-render-hook
+                                     after-render-queue-cell
+                                     after-render-set-tick-ref)
         subscribe-cont     (make-subscribe-container gensym-prefix-sub)
         make-derived       (make-derived-value-fn gensym-prefix-derived)
         ;; Precompute the `use-subscribe` watch-key keyword namespace
@@ -618,7 +749,7 @@
                                (subs s 0 (dec n))
                                s))
         wrap-view-fn       (make-wrap-view warn-fn)
-        render-fn          (make-render active-roots-cell)
+        render-fn          (make-render active-roots-cell after-render-sentinel)
         dispose-fn         (make-dispose-adapter!
                              {:active-roots-cell active-roots-cell
                               :warn-cache        warn-cache
@@ -749,4 +880,7 @@
      :frame-provider              frame-provider
      :flush-views!                flush-views!
      :wrap-view                   wrap-view-fn
-     :clear-warned-non-dom-roots! clear-warned}))
+     :clear-warned-non-dom-roots! clear-warned
+     ;; rf2-334d9 — :adapter/after-render impl. Each adapter publishes
+     ;; this via substrate-adapter/route-hook!.
+     :after-render-hook           after-render-hook}))


### PR DESCRIPTION
## Summary

- Closes rf2-334d9 (parent rf2-neiqf decision 2026-05-19 — publish via `React.useLayoutEffect`).
- `(rf/after-render f)` under the UIx and Helix adapters was a silent no-op; this PR publishes `:adapter/after-render` from both via shared spine machinery.
- `after-render` is a React-lifecycle question, not a reactive-atom one, so the `:adapter/ratom`-class exclusions remain in place for UIx/Helix; only the after-render exclusion is lifted.

## Architecture

The spine (`re-frame.substrate.spine`) owns the shared after-render plumbing:

- A per-adapter queue cell + a sentinel React function component (`make-after-render-sentinel`) injected at the root of every mounted tree via `make-render`'s Fragment wrap. The sentinel uses `React.useLayoutEffect` to drain the queue after each commit — same DOM-mutations-applied / pre-paint timing as Reagent's `r/after-render`.
- The `:adapter/after-render` hook impl (`make-after-render-hook`) enqueues `f`, then bumps the sentinel's stashed `setState` tick to force a commit. A `queueMicrotask` fallback covers the pre-mount / post-unmount call paths.
- Both adapter files (`uix.cljs`, `helix.cljs`) publish via `substrate-adapter/route-hook!` using `(:after-render-hook spine-fns)`. Adapter docstrings updated: the `:adapter/after-render` exclusion is removed; the four reactive-atom hook exclusions remain.

## Test plan

- [x] `npm run test:cljs` — 2948 tests, 0 failures, 0 errors (includes new `uix_after_render_cljs_test` + `helix_after_render_cljs_test`).
- [x] `npm run test:browser` — green.
- [x] `npm run test:bundle-isolation` — `counter-uix` 411503 chars, `counter-helix` 441047 chars, no reagent.* leaked. The sentinel uses raw React (createElement, useState, useEffect, useLayoutEffect) so no reagent dependency is dragged in.
- [x] Late-bind directory updated to list UIx + Helix as producers of `:adapter/after-render`; per-adapter publication tests updated to pin the new key; runtime-cljs-test docstrings updated.

## Notes

- Spec/006 has no mention of after-render, so no spec edit is needed.
- The behaviour tests mount through `substrate-adapter/render` (not raw `react-dom-client/createRoot`) so the sentinel is actually in the tree under test.