### PR TITLE
fix(docs): repair link rot blocking mkdocs --strict (rf2-qw5mh)

### DIFF
--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -46,10 +46,55 @@
 #        - spec/SPEC-AUTHORING.md links to conformance/ (sibling directory
 #          of spec/, staged into docs/spec/conformance/) — rewrite the bare
 #          directory link to conformance/README.md.
+#
+# Pre-build staging (rf2-qw5mh).
+#
+# The published site needs spec/ and migration/ to live inside docs_dir so
+# MkDocs can see them. CI did this via a shell step (.github/workflows/docs.yml:
+# "Stage spec/ + migration/ into docs/"). Locally, a contributor running
+# `mkdocs build --strict` without that step would see dozens of WARNINGs
+# about missing spec/*.md and migration/*.md targets — link-rot that's not
+# actually rot, just a missing staging step.
+#
+# We promote the staging into this hook (on_pre_build), so that ANY local
+# or CI invocation of mkdocs (build, serve, --strict) auto-stages the two
+# trees. CI keeps its explicit step as a redundant belt-and-braces; both
+# are idempotent (rm -rf + copy). The staged dirs are .gitignored.
 
 import re
+import shutil
+from pathlib import Path
 
 GH_BLOB_BASE = "https://github.com/day8/re-frame2/blob/main"
+
+# Trees that live at the repo root but need to render inside the site.
+# Source dir (repo root) -> staged dir (under docs_dir).
+_STAGE = (
+    ("spec", "spec"),
+    ("migration", "migration"),
+)
+
+
+def on_pre_build(config):
+    """Mirror spec/ and migration/ into docs_dir before MkDocs scans files.
+
+    Idempotent: removes the existing staged copy first. The staged paths
+    are gitignored (see .gitignore: /docs/spec/, /docs/migration/) so this
+    never dirties the worktree. CI runs the equivalent shell step in
+    .github/workflows/docs.yml; both are safe to coexist.
+    """
+    docs_dir = Path(config["docs_dir"])
+    repo_root = docs_dir.parent
+    for src_name, dest_name in _STAGE:
+        src = repo_root / src_name
+        if not src.is_dir():
+            # Source tree absent — skip silently. A clean checkout always
+            # has both; the guard keeps the hook safe in unusual layouts.
+            continue
+        dest = docs_dir / dest_name
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.copytree(src, dest)
 
 # Case 1a: guide/* and skills/* pages link to spec via ../../spec/ — collapse
 # one level. Both trees live at docs/<tree>/X.md (depth 2 below repo root),


### PR DESCRIPTION
## Summary

- `mkdocs_hooks.py` gains an `on_pre_build` hook that mirrors the repo-root `spec/` and `migration/` trees into `docs_dir` before MkDocs scans files. The narrative guide + skills already cross-link to these trees via paths the existing rewriter expects to find at `docs/spec/` and `docs/migration/`; without staging, those rewrites resolve to missing files and `mkdocs build --strict` aborts with dozens of false-positive WARNINGs.
- Previously the staging happened only in CI (`.github/workflows/docs.yml` "Stage spec/ + migration/ into docs/"), so any contributor running `mkdocs build --strict` locally hit the link rot. The hook is idempotent (rm-rf + copytree); CI's explicit step stays as belt-and-braces.

## Why root cause, not symptom

The bead originally suggested excluding `skills/` from the build (Category A) and patching one missing anchor in `spec/Security.md` (Category B). Investigation:

- The `skills/re-frame2-implementor.md` warnings only fire when `spec/` isn't staged — the hook's existing `_GUIDE_TO_SPEC` rule rewrites `../../spec/ -> ../spec/` correctly for `skills/` (depth-2 source). With `spec/` staged the link resolves.
- The `Security.md#epoch-privacy-posture-...` anchor exists (line 96 of `spec/Security.md`); the warning was only that `spec/Security.md` itself wasn't in the staged tree.
- The mayor checkout's "6 warnings" all come from `migration/` not being staged (mayor had a stale `docs/spec/` from a prior local mirror but no `docs/migration/`).

So neither Category A's exclusion nor Category B's anchor restore would actually fix the gate. Auto-staging fixes all of it.

## Before / after

- Before (clean worktree, no pre-staging): `Aborted with 72 warnings in strict mode!`
- After (clean worktree, hook runs `on_pre_build`): 0 WARNINGs, build clean
- `python scripts/check_doc_slugs.py` still clean (PR #1536 fixed the orthogonal `tools/causa/spec/018-Event-Spine.md` path bug earlier today)

## Test plan

- [x] `python -m mkdocs build --strict` from clean checkout (no `docs/spec/` or `docs/migration/`): exits 0
- [x] `python scripts/check_doc_slugs.py --verbose`: `no broken links`
- [x] `python scripts/check_doc_slugs.py --self-test --verbose`: all 9 self-tests pass
- [x] CI's existing "Stage spec/ + migration/ into docs/" step in `docs.yml` continues to work (idempotent — both rm-rf + recopy)
- [ ] (CI will confirm) the docs deploy still publishes nav-discoverable content unchanged