### PR TITLE
feat(flows): add :before slot to :rf.flow/computed payload (rf2-qlzh4)

### DIFF
--- a/implementation/flows/src/re_frame/flows.cljc
+++ b/implementation/flows/src/re_frame/flows.cljc
@@ -102,6 +102,22 @@
         [db false])
       (try
         (let [new-output (apply (:output flow) new-inputs)
+              ;; Per rf2-qlzh4: capture the pre-write value at the
+              ;; flow's `:path` BEFORE we assoc-in the new output.
+              ;; This becomes the `:before` slot on the
+              ;; `:rf.flow/computed` trace below — consumers (Causa
+              ;; Event Detail, re-frame-10x flow panel) no longer
+              ;; need to walk the epoch's `:db-before` snapshot to
+              ;; render "wrote [:cart :total] 47.50 -> 52.50". The
+              ;; read happens against `db` (the loop accumulator
+              ;; that includes prior flows' writes in this drain), so
+              ;; a downstream flow whose `:path` overlaps an upstream
+              ;; flow's `:path` sees the UPSTREAM's just-written
+              ;; value as its `:before` — the correct cascade-local
+              ;; semantics. Gated to dev-only so the read is DCE'd
+              ;; under `:advanced` + `goog.DEBUG=false`.
+              old-output (when interop/debug-enabled?
+                           (get-in db (:path flow)))
               new-db     (assoc-in db (:path flow) new-output)]
           (swap! last-inputs assoc-in [flow-id frame-id] new-inputs)
           ;; Per Spec 009 §:op-type vocabulary: `:rf.flow/computed`
@@ -109,24 +125,24 @@
           ;; `=`-equality so this only fires when inputs actually
           ;; changed.
           ;;
-          ;; Wire-bearing payloads (`:input-values`, `:result`) ride
-          ;; through `elision/elide-wire-value` per Spec 009 §Size
-          ;; elision in traces — the walker is the single normative
-          ;; emission site for `:rf.size/large-elided` (and the
-          ;; `:rf/redacted` privacy sentinel). Without this the flow
-          ;; trace bypassed the elision contract that every other
-          ;; wire-emitting surface honours; a flow reading or
-          ;; producing a large or sensitive value would surface raw
-          ;; on the trace bus. Off-box defaults match `event-emit` /
-          ;; `error-emit`.
+          ;; Wire-bearing payloads (`:input-values`, `:result`,
+          ;; `:before`) ride through `elision/elide-wire-value` per
+          ;; Spec 009 §Size elision in traces — the walker is the
+          ;; single normative emission site for `:rf.size/large-
+          ;; elided` (and the `:rf/redacted` privacy sentinel).
+          ;; Without this the flow trace bypassed the elision
+          ;; contract that every other wire-emitting surface honours;
+          ;; a flow reading or producing a large or sensitive value
+          ;; would surface raw on the trace bus. Off-box defaults
+          ;; match `event-emit` / `error-emit`.
           ;;
           ;; The `:path` opt on each walker call names where in the
-          ;; slice's root the wrapped value lives — `:result` IS the
-          ;; value at the flow's output path; each `:input-values`
-          ;; entry is the value at the matching input path. The
-          ;; walker reads `[:rf/elision :declarations <path>]` and
-          ;; emits the marker for schema-declared
-          ;; large slots.
+          ;; slice's root the wrapped value lives — `:result` and
+          ;; `:before` BOTH live at the flow's output path; each
+          ;; `:input-values` entry is the value at the matching input
+          ;; path. The walker reads `[:rf/elision :declarations
+          ;; <path>]` and emits the marker for schema-declared large
+          ;; slots.
           ;;
           ;; Outer `interop/debug-enabled?` gate keeps the elision
           ;; walker out of CLJS prod builds (rf2-drr4z) — Closure
@@ -141,6 +157,9 @@
                                                   {:frame frame-id :path input-path}))
                                               (:inputs flow)
                                               new-inputs)
+                          :before       (elision/elide-wire-value
+                                          old-output
+                                          {:frame frame-id :path (:path flow)})
                           :result       (elision/elide-wire-value
                                           new-output
                                           {:frame frame-id :path (:path flow)})

--- a/implementation/flows/test/re_frame/flows_trace_test.clj
+++ b/implementation/flows/test/re_frame/flows_trace_test.clj
@@ -150,7 +150,127 @@
           (is (= [3 4]         (:input-values tags))     ":input-values are the raw vec")
           (is (= 12            (:result tags))           ":result is the computed value")
           (is (= [:rect :area] (:path tags)))
-          (is (= :rf/default   (:frame tags))))))))
+          (is (= :rf/default   (:frame tags)))
+          ;; Per rf2-qlzh4: :before carries the value at :path
+          ;; immediately BEFORE this flow's write. On the first
+          ;; compute the slot has never been written, so :before is
+          ;; nil. The KEY must be present so consumers can rely on
+          ;; uniform shape (rather than discriminating between
+          ;; absent-key and explicit-nil).
+          (is (contains? tags :before)
+              ":before key present on every :rf.flow/computed trace")
+          (is (nil? (:before tags))
+              "first compute — :path has never been written; :before is nil"))))))
+
+;; ---------------------------------------------------------------------------
+;; 2b. :before slot tracks the pre-write value across drains (rf2-qlzh4)
+;;
+;; Per Spec 013 §Flow tracing: `:rf.flow/computed` carries `:before`
+;; — the value at the flow's `:path` immediately before this drain's
+;; write. Self-contained trace consumers (Causa Event Detail, 10x
+;; flow panel) render the "wrote [path] <before> -> <after>" line
+;; without walking the surrounding epoch's `:db-before` snapshot.
+;; These tests pin the contract across the edge cases the audit
+;; (ai/findings/2026-05-19-flow-trace-events-audit.md) flagged.
+;; ---------------------------------------------------------------------------
+
+(deftest computed-before-equals-prior-result-on-second-compute
+  (testing "second :rf.flow/computed's :before equals the first compute's :result"
+    (rf/reg-event-db :init      (fn [_ _] {:n 3}))
+    (rf/reg-event-db :replace-n (fn [db [_ v]] (assoc db :n v)))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (rf/dispatch-sync [:init])           ;; first compute: 3 -> 6
+    (rf/dispatch-sync [:replace-n 5])    ;; second compute: 5 -> 10
+    (let [computes (by-op :rf.flow/computed)]
+      (is (= 2 (count computes))
+          "one compute per real input change")
+      (let [[first-ev second-ev] computes]
+        (is (nil? (:before (:tags first-ev)))
+            "first compute :before is nil — :path slot was unwritten")
+        (is (= 6 (:before (:tags second-ev)))
+            ":before of the second compute equals the first compute's :result")
+        (is (= 10 (:result (:tags second-ev)))
+            ":result is the freshly-computed output value")))))
+
+(deftest computed-before-with-prior-value-already-at-path
+  (testing ":before carries the prior value when the path was written by a non-flow source first"
+    ;; Seed [:doubled] with a value the event handler put there before
+    ;; the flow ever fires. The first compute's :before MUST be that
+    ;; prior value — not nil — because the slot was non-empty.
+    (rf/reg-event-db :seed (fn [_ _] {:n 3 :doubled :preseeded}))
+    (rf/reg-flow {:id     :double
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:doubled]})
+    (rf/dispatch-sync [:seed])
+    (let [ev (last (by-op :rf.flow/computed))
+          tags (:tags ev)]
+      (is (= :preseeded (:before tags))
+          ":before reads the pre-existing value at :path, not nil")
+      (is (= 6 (:result tags))
+          ":result is the new flow output"))))
+
+(deftest computed-before-on-nested-path
+  (testing ":before reads the pre-write value at a deeply-nested :path"
+    (rf/reg-event-db :init  (fn [_ _] {:w 3 :h 4 :rect {:area :initial-area}}))
+    (rf/reg-event-db :grow  (fn [db _] (assoc db :w 5)))
+    (rf/reg-flow {:id     :area
+                  :inputs [[:w] [:h]]
+                  :output (fn [w h] (* w h))
+                  :path   [:rect :area]})
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:grow])
+    (let [[first-ev second-ev] (by-op :rf.flow/computed)]
+      (is (= :initial-area (:before (:tags first-ev)))
+          "first compute :before reads the pre-existing nested-path value")
+      (is (= 12 (:result (:tags first-ev)))
+          "first compute :result is the freshly-computed value (3 * 4)")
+      (is (= 12 (:before (:tags second-ev)))
+          "second compute :before equals the first compute's :result")
+      (is (= 20 (:result (:tags second-ev)))
+          "second compute :result reflects the input change (5 * 4)"))))
+
+(deftest computed-before-across-cascading-flows
+  (testing ":before is captured against the in-drain accumulator so chained-flow :before reads its own slot, not :path overlap"
+    ;; :A writes [:a-out]. :B reads [:a-out] and writes [:b-out]. The
+    ;; cascade fires A then B in the SAME drain — :B's :before must
+    ;; reflect the pre-drain value at [:b-out] (here nil on first
+    ;; compute), NOT some intermediate state from :A's write. Each
+    ;; flow's :before is independent — captured against its own :path.
+    (rf/reg-event-db :init (fn [_ _] {:n 3}))
+    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-flow {:id     :A
+                  :inputs [[:n]]
+                  :output (fn [n] (* 2 n))
+                  :path   [:a-out]})
+    (rf/reg-flow {:id     :B
+                  :inputs [[:a-out]]
+                  :output (fn [a] (str "B-saw-" a))
+                  :path   [:b-out]})
+    (rf/dispatch-sync [:init])
+    (let [first-pass (by-op :rf.flow/computed)
+          a-first    (first (filterv #(= :A (:flow-id (:tags %))) first-pass))
+          b-first    (first (filterv #(= :B (:flow-id (:tags %))) first-pass))]
+      (is (nil? (:before (:tags a-first)))
+          ":A's first :before is nil — [:a-out] was unwritten")
+      (is (= 6 (:result (:tags a-first))))
+      (is (nil? (:before (:tags b-first)))
+          ":B's first :before is nil — [:b-out] was unwritten — NOT 6 from :A's just-completed write at [:a-out]")
+      (is (= "B-saw-6" (:result (:tags b-first)))))
+    (reset! *captured* [])
+    (rf/dispatch-sync [:bump])
+    (let [second-pass (by-op :rf.flow/computed)
+          a-second    (first (filterv #(= :A (:flow-id (:tags %))) second-pass))
+          b-second    (first (filterv #(= :B (:flow-id (:tags %))) second-pass))]
+      (is (= 6 (:before (:tags a-second)))
+          ":A's :before on the second drain is its prior :result (6)")
+      (is (= 8 (:result (:tags a-second))))
+      (is (= "B-saw-6" (:before (:tags b-second)))
+          ":B's :before on the second drain is its prior :result (the string B-saw-6) — NOT :A's intermediate value")
+      (is (= "B-saw-8" (:result (:tags b-second)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3. :rf.flow/skip fires when value-equal input rewrite suppresses recompute
@@ -770,3 +890,33 @@
           ":input-values pass through unmodified")
       (is (= 12 (:result tags))
           ":result passes through unmodified"))))
+
+(deftest computed-trace-elides-large-before
+  (testing ":rf.flow/computed :before rides through elide-wire-value just like :result (rf2-qlzh4)"
+    ;; Seed [:derived :blob] with a non-nil value so :before is non-
+    ;; nil on the FIRST flow drain we observe. Then bump :n to drive
+    ;; a recompute whose :before reads the previous blob and is
+    ;; therefore schema-large. The walker must substitute the marker.
+    (rf/reg-event-db :init (fn [db _] (merge db {:n 1 :derived {:blob {:bytes "PRESEEDED"}}})))
+    (rf/reg-event-db :bump (fn [db _] (update db :n inc)))
+    (rf/reg-flow {:id     :payload
+                  :inputs [[:n]]
+                  :output (fn [n] {:bytes (str "blob-" n)})
+                  :path   [:derived :blob]})
+    (rf/reg-app-schema [:derived :blob] [:map {:large? true}])
+    (reset! *captured* [])
+    (rf/dispatch-sync [:init])
+    (rf/dispatch-sync [:bump])
+    (let [computes (by-op :rf.flow/computed)
+          last-ev  (last computes)
+          tags     (:tags last-ev)]
+      (is (some? last-ev) ":rf.flow/computed fired on the recompute")
+      (is (elision/marker? (:before tags))
+          ":before is replaced by the `:rf.size/large-elided` marker — the slot is schema-large")
+      (is (elision/marker? (:result tags))
+          ":result is similarly elided (sanity)")
+      (let [marker (:rf.size/large-elided (:before tags))]
+        (is (= [:derived :blob] (:path marker))
+            "before-marker carries the schema-declared path")
+        (is (= :schema (:reason marker))
+            "before-marker carries :reason :schema")))))

--- a/spec/013-Flows.md
+++ b/spec/013-Flows.md
@@ -222,7 +222,7 @@ Every flow lifecycle event emits a structured trace event under op-type `:flow`.
 | `:operation` | Fires when |
 |---|---|
 | `:rf.flow/registered` | `reg-flow` (or `:rf.fx/reg-flow`) successfully registers a flow against a frame, after cycle detection passes. |
-| `:rf.flow/computed` | A flow's `:output` fn ran and the result was written to `:path` (dirty-check observed input value-difference). |
+| `:rf.flow/computed` | A flow's `:output` fn ran and the result was written to `:path` (dirty-check observed input value-difference). Carries `:before` (the value at `:path` immediately before this drain's write — `nil` when the slot had never been written) alongside `:result`, so consumers render the wrote-line "wrote `[:path]` `<before>` → `<after>`" without walking the surrounding epoch's `:db-before` snapshot. Both ride through `elide-wire-value` against the flow's `:path` (rf2-qlzh4). |
 | `:rf.flow/skip` | The dirty-check found inputs `=`-equal to the previous run; the recompute was suppressed (§[Dirty-check semantics](#dirty-check-semantics) above; rf2-719e value-equal recompute suppression). |
 | `:rf.flow/cleared` | `clear-flow` (or `:rf.fx/clear-flow`) removed the flow from the per-frame registry and dissoc-in'd its output path. |
 | `:rf.flow/failed` | A flow's `:output` fn threw during recompute. The exception is re-thrown after the trace fires; see [§Failure semantics](#failure-semantics) for the four-rule contract (prior writes preserved, failing-flow's `last-inputs` not advanced, cascade halts, router emits `:rf.error/flow-eval-exception` per [009 §Error contract](009-Instrumentation.md#error-contract)). |

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -778,14 +778,17 @@
 ;;
 ;; Per spec/013-Flows.md + spec/009-Instrumentation.md:
 ;;   `:rf.flow/computed` (op-type `:flow`) carries `:flow-id`,
-;;   `:input-values`, `:result`, `:path`, `:frame` in `:tags`. Input
-;;   PATHS are not in the trace — they live on the flow registry entry
-;;   and are looked up via `(rf/handler-meta :flow id)` at render time.
+;;   `:input-values`, `:before`, `:result`, `:path`, `:frame` in
+;;   `:tags`. Input PATHS are not in the trace — they live on the
+;;   flow registry entry and are looked up via
+;;   `(rf/handler-meta :flow id)` at render time.
 ;;
-;; The before-value at the output path (the value the flow OVERWROTE)
-;; is not in the current trace; rf2-qlzh4 (open) adds a `:before` slot
-;; to `:rf.flow/computed` for full self-containment. Until then we
-;; render `(after-value)` only — better partial visibility than zero.
+;; Per rf2-qlzh4: `:before` carries the value at `:path` immediately
+;; before this flow's drain wrote — `nil` when the slot was unwritten
+;; — so the wrote-line renders self-contained without walking the
+;; surrounding epoch's `:db-before` snapshot. Rendering currently
+;; surfaces only `:result`; the `:before` slot is projected through
+;; for forthcoming "wrote [:path] <before> → <after>" diff rendering.
 
 (defn- flow-computed?
   [ev]
@@ -807,6 +810,9 @@
       {:flow-id      <keyword>      ;; the flow's :id
        :write-path   <vec>          ;; the flow's :path (where it wrote)
        :input-values <vec>          ;; raw values read from input paths
+       :before       <any>          ;; the value at :path BEFORE this
+                                    ;; drain wrote (rf2-qlzh4); nil when
+                                    ;; the slot had never been written
        :result       <any>          ;; the new output value at :path
        :frame        <kw-or-nil>    ;; the host frame
        :trace-id     <int>}         ;; trace event :id (stable row key)
@@ -821,6 +827,7 @@
         {:flow-id      (:flow-id tags)
          :write-path   (:path tags)
          :input-values (:input-values tags)
+         :before       (:before tags)
          :result       (:result tags)
          :frame        (:frame tags)
          :trace-id     (:id ev)}))))


### PR DESCRIPTION
## Summary

- `:rf.flow/computed` trace now carries `:before` — the value at the flow's `:path` immediately before this drain's write (nil when the slot had never been written). Closes the one soft gap rf2-oz0m7's audit flagged: the flow trace stream is now fully self-contained — Causa's Event Detail flows section and re-frame-10x's flow panel can render the wrote-line "wrote `[:path]` `<before>` -> `<after>`" without walking the surrounding epoch's `:db-before` snapshot.
- Captured against the loop accumulator (so chained flows each see their own pre-drain `:path` value, never an intermediate post-write value from an upstream sibling) inside the existing `interop/debug-enabled?` gate, so CLJS prod elision is unaffected.
- Wire-bearing — `:before` rides through `elision/elide-wire-value` against the flow's `:path` mirroring `:result`'s treatment, so a schema-large flow's pre-write value is replaced with the `:rf.size/large-elided` marker on emit.
- `spec/013-Flows.md` §Flow tracing summary documents the new slot.
- Causa Event Detail's `flows-fired` projection now passes `:before` through into the per-row map (no rendering change today; consumer-side rendering can move to it incrementally).

## Test plan

- [x] `clojure -M:test` from `implementation/flows/` — 83 tests, 374 assertions, 0/0 (includes new dedicated `:before`-slot tests covering: first-compute nil; second-compute equals prior `:result`; pre-existing non-flow value at the path; deeply-nested path; cascading flows where each captures against its own slot, not an upstream sibling's just-written value; elision walker substitutes the marker when the flow's `:path` is schema-large)
- [x] `npm run test:cljs` from `implementation/` — 2936 tests, 8386 assertions, 0/0 (including the Causa event-detail tests that exercise `flows-fired`)

## Notes

- No spec/009-Instrumentation.md update needed in this PR — 009 is hot-zone and its flow-trace-events row already names the wire-bearing payload as covered by the elision walker; the `:before` slot inherits that contract by being added at the same emit site. A small wording sweep across 009 to list `:before` in the column-payload column can ride on top via a follow-on bead if Mike wants it stamped explicitly there.
- Source: ai/findings/2026-05-19-flow-trace-events-audit.md.