### PR TITLE
feat(causa): reshape Routes lens — flat list + search + Simulate-URL (rf2-lq0ef)

### DIFF
--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -53,6 +53,20 @@
          ;; apps that don't install Causa don't get epoch unless they ask.
          day8/re-frame2-epoch {:local/root "../../implementation/epoch"}
 
+         ;; Per rf2-lq0ef — `day8/re-frame2-routing` is a hard dep of
+         ;; Causa. The Routes lens uses `re-frame.routing.match` directly
+         ;; for the Simulate-URL surface: paste a URL, the lens runs
+         ;; `match-against` on every registered route's compiled pattern
+         ;; and ranks the matching candidates by `:rf.route/rank`. The
+         ;; helper ns (`day8.re-frame2-causa.panels.routing-helpers`)
+         ;; `:require`s `re-frame.routing.match` at load time so a host
+         ;; without the routing artefact on its classpath would crash
+         ;; Causa's preload. Most real hosts already pull routing, but
+         ;; the Routes lens must work even for hosts that haven't
+         ;; registered any routes yet — same posture as the
+         ;; re-frame2-epoch dep above.
+         day8/re-frame2-routing {:local/root "../../implementation/routing"}
+
          ;; Per rf2-wl5pa — Causa targets day8/reagent-slim (the rewrite)
          ;; rather than stock Reagent. Causa has zero direct `reagent.*`
          ;; requires under tools/causa/src/ (the dep is purely the

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -413,30 +413,36 @@ side-effect it performs).
 
 ## Routes panel
 
-Spec: [`spec/012-Routing.md`](../../../spec/012-Routing.md). Surfaces
-registered routes, the active `:rf/route` slice, and recent navigation
-history (the `:rf.route.nav-token/*` + `:rf.route/url-changed` trace
-stream).
+Spec: [`spec/012-Routing.md`](../../../spec/012-Routing.md) (framework
+substrate) + [`016-Auxiliary-Panels.md`](./016-Auxiliary-Panels.md)
+§Routes tab (Causa-side lens). Surfaces registered routes as a flat
+catalogue, the active `:rf/route` slice, and per-focused-event
+FROM/TO markers. Search + Simulate-URL drive the interactive
+surface; the previous URL-path-segmentation tree was dropped per
+rf2-lq0ef (audit verdict B).
 
 ### Subscriptions
 
 | Sub | Returns |
 |---|---|
-| `:rf.causa/registered-routes` | `(rf/registrations :route)`. Wrapped in `try` for older builds without the `:route` kind. Test override via `:registered-routes-override`. |
-| `:rf.causa/active-route-slice` | The `:rf/route` slot off the target-frame's `app-db`. |
-| `:rf.causa/active-route-slice-override` | Test override for the slice — wired separately from the live slice sub so integration tests can override the slice without disturbing the target-frame-db chain. |
-| `:rf.causa/route-history-events` | Trace-buffer's route-history slice — filtered to the three operations Spec 012 §Trace events enumerates. |
-| `:rf.causa/selected-route-id` | Route-id or `nil`. |
-| `:rf.causa/routes-data` | Composite — `{:rows :total :active-route :selected-route-id :history :empty-kind}`. |
+| `:rf.causa/registered-routes` | `(rf/registrations :route)`. Test override via `:registered-routes-override`. |
+| `:rf.causa/registered-routes-override` | Test override slot. |
+| `:rf.causa/current-route-slice` | The `:rf/route` slot off the target-frame's `app-db`. |
+| `:rf.causa/current-route-slice-override` | Test override slot. |
+| `:rf.causa/routing-tab-data` | View-facing composite per `routing_helpers/project-data` — `{:silent? :routes :total-routes :filtered? :current :from-id :to-id :navigated? :query :sim-url :sim-result}`. |
+| `:rf.causa.routing/query` | Substring search input value. |
+| `:rf.causa.routing/sim-url` | Simulate-URL input value. |
+| `:rf.causa.routing/expanded` | Set of route-ids whose meta-expander is open. |
 
 ### Events
 
 | Event | Vector shape | Behaviour |
 |---|---|---|
-| `:rf.causa/select-route` | `[_ route-id]` | Sets selection. |
-| `:rf.causa/clear-route-selection` | `[_]` | Clears selection. |
+| `:rf.causa.routing/set-query` | `[_ s]` | Sets the substring search filter; blank clears. |
+| `:rf.causa.routing/set-sim-url` | `[_ s]` | Sets the Simulate-URL input; blank clears. |
+| `:rf.causa.routing/toggle-row` | `[_ route-id]` | Toggles the meta-expander for a row. |
 | `:rf.causa/set-registered-routes-override-for-test` | `[_ ov]` | Test-only override hook. |
-| `:rf.causa/set-active-route-slice-override-for-test` | `[_ ov]` | Test-only slice override. |
+| `:rf.causa/set-current-route-slice-override-for-test` | `[_ ov]` | Test-only slice override. |
 
 ## Machine inspector
 

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -266,14 +266,46 @@ Per-cascade tier dots + duration ms stay inline in:
 
 That's the entire Causa-side perf surface post-rewrite.
 
-## Routing tab — 7th L3 tab (rf2-nrbs9)
+## Routes tab — 7th L3 tab (rf2-nrbs9, reshaped per rf2-lq0ef)
 
 Per Mike's design call (2026-05-18) Routing was promoted from "lives
 in App-db + Trace" to its own L3 lens tab. The App-db panel was
-getting busy and routing is a cohesive sub-domain (route tree +
+getting busy and routing is a cohesive sub-domain (route catalogue +
 current match + nav transitions); cohesive sub-domains earn their own
 lens tab rather than overloading App-db. Parallel to the Machines tab
 in posture — always-on registered topology + per-focused-event lens.
+
+### Shape: flat catalogue (rf2-lq0ef)
+
+The lens is a **flat catalogue sorted by `:path`** — never a tree.
+The previous URL-path-segmentation indentation (`project-route-tree`)
+was decorative: the audit
+([`ai/findings/2026-05-19-routing-inheritance-audit.md`](../../../ai/findings/2026-05-19-routing-inheritance-audit.md))
+found that routes are flat in the spec + impl, `:parent` plays no
+role in matching, and the match-resolver is structural (6-rule rank
+on URL pattern). Indenting routes by URL-segment count conflated
+URL-prefix similarity with semantic hierarchy — those are independent
+(a child route can live anywhere in the URL space).
+
+The lens shape now mirrors the actual contract:
+
+- **Flat list sorted by `:path`** (lexicographic). No indentation, no
+  depth.
+- **Per-row chips**: route-id + path + doc, with letter badges
+  (`M` / `L` / `T` / `P`) for routes carrying `:on-match` /
+  `:can-leave` / `:tags` / `:parent`. Click the row chevron to
+  expand the full registrar meta inline.
+- **Substring search** across route-id + path + doc.
+- **Simulate-URL** — paste a URL into Try URL, the panel ranks every
+  matching route by its 6-rule `:rf.route/rank` tuple and highlights
+  the winner. This is the load-bearing interactive surface — it
+  exposes the structural match contract per
+  [`spec/012-Routing.md`](../../../spec/012-Routing.md) §Route
+  ranking algorithm.
+- **`:parent` annotation** — when a row carries `:parent`, render a
+  compact `↑ :route/parent` inline pointer; expanding the row
+  surfaces the full registrar meta (including the `:rf.route/chain`
+  surface the impl exposes).
 
 ### Inputs
 
@@ -287,20 +319,18 @@ in posture — always-on registered topology + per-focused-event lens.
 - `:rf.causa/cascades` — the shared cascade projection. The composite
   scans the focused cascade's trace events for the routing-emit.
 - `:rf.causa/focus` — the spine's focused dispatch-id + epoch.
+- `:rf.causa.routing/query` — substring filter input (driven by
+  `:rf.causa.routing/set-query`).
+- `:rf.causa.routing/sim-url` — Simulate-URL input (driven by
+  `:rf.causa.routing/set-sim-url`).
+- `:rf.causa.routing/expanded` — set of expanded route-ids (driven by
+  `:rf.causa.routing/toggle-row`).
 - `:rf.causa/routing-tab-data` — view-facing composite folding all of
-  the above into `{:silent? :routes :current :from-id :to-id
-  :navigated?}` per `routing_helpers/project-data`.
+  the above into `{:silent? :routes :total-routes :filtered?
+  :current :from-id :to-id :navigated? :query :sim-url :sim-result}`
+  per `routing_helpers/project-data`.
 
-### Lens model
-
-Always-shown structure: the **full route tree** — every registered
-route, sorted by path so siblings under a common prefix render
-contiguously and the rendering is deterministic. The tree is the
-orientation surface — a Causa user can flip to the Routing tab and
-immediately read the app's routing topology without digging through
-code.
-
-Per-focused-event highlighting:
+### Per-focused-event highlighting
 
 | Marker | Trigger | Visual |
 |---|---|---|
@@ -324,9 +354,31 @@ inside both `:rf.route/navigate` and `:rf/url-changed`). Detection:
 - Same-route re-navigations (different params/query, same route-id)
   collapse FROM to nil — surfacing a FROM equal to TO is noise.
 
+### Simulate-URL contract
+
+The simulator walks the registered-routes map, calls
+`re-frame.routing.match/match-against` on each route's compiled
+pattern (or compiles it on the fly for test-only fixtures), and
+ranks the matching candidates by `:rf.route/rank` descending — the
+same order `match-url` walks the registry table. The first candidate
+is the winner.
+
+The result block surfaces:
+
+- The normalised path (query and fragment stripped).
+- Every matching candidate, with its `:rf.route/rank` tuple and the
+  parsed `:params` map.
+- The winner highlighted (green border + `WINNER` glyph).
+- An empty result block when no route matches (i.e. `match-url` would
+  return nil for this URL).
+
+Query coercion and `:params` / `:query` schema validation are out of
+scope for the simulator — the lens is about exposing the rank
+cascade, not full match semantics.
+
 ### Active route slice — params + query + fragment
 
-Below the tree the panel renders a labelled grid for the active
+Below the catalogue the panel renders a labelled grid for the active
 slice:
 
     Params:    {:order-id "ord-1234"}
@@ -341,16 +393,17 @@ skeleton (predictable scanning).
 When the host app registers no routes the panel renders only the
 header + a terse `No routes registered.` one-liner. No `(none)`
 placeholder, no marketing copy — silent-by-default per rf2-g3ghh.
+Search + Simulate-URL are hidden when the catalogue is empty.
 
 ### Pre-rewrite app-db / trace overlap
 
 The transition FSM state (`:idle` / `:loading` / `:error`) is still
 part of the app-db slice (Spec 012) and still visible in the App-db
-tab's diff. The Routing tab is the dedicated lens; the App-db tab
+tab's diff. The Routes tab is the dedicated lens; the App-db tab
 shows the raw slice diff like any other key. Navigation trace events
 (`:rf.route.nav-token/*` + `:rf.route/url-changed`) continue to
 appear in the Trace tab when the `event` chip is ON (default) —
-the Routing tab does not duplicate the firehose, it projects the
+the Routes tab does not duplicate the firehose, it projects the
 single nav-event that pertains to the focused cascade.
 
 ### Vision (future)
@@ -361,7 +414,8 @@ single nav-event that pertains to the focused cascade.
   (already noted under §Event tab — `:on-match` event chain (Routes)
   later in this doc).
 - **Route-chain visualiser** — the `:parent`-chain walk for nested
-  layouts.
+  layouts (i.e. expand the inline `:parent` annotation into the full
+  `:rf.route/chain` graph).
 
 ## MCP Server panel — dropped
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -1,45 +1,44 @@
 (ns day8.re-frame2-causa.panels.routing
-  "Routing tab — the 7th L4 tab (rf2-nrbs9).
+  "Routes tab — the 7th L4 tab (rf2-nrbs9, reshaped per rf2-lq0ef).
 
-  Per Mike's design call (2026-05-18 16:35): Routing earns its own
+  Per Mike's design call (2026-05-18 16:35): Routes earns its own
   top-level tab in the Causa shell rather than piling into App-db
   (`app-db panel gets busy`). Routing slices are a cohesive sub-domain
-  — the route tree + the current match + nav transitions — and the
-  bd memory `cohesive-subdomains-get-their-own-tab` codifies the
+  — the route catalogue + the current match + nav transitions — and
+  the bd memory `cohesive-subdomains-get-their-own-tab` codifies the
   posture: cohesive sub-domains earn their own lens tab.
 
-  ## Lens model (parallel to Machines)
+  ## Lens model (post-rf2-lq0ef reshape)
 
-  Always-shown structure: the full route tree (every registered
-  route, sorted by path). The tree is the orientation surface — a
-  Causa user can flip to the Routing tab and immediately see the
-  app's routing topology without having to dig through code.
+  Routes are FLAT in the spec + impl. The previous tree projection
+  indented rows by URL-path-segment depth — purely decorative, no
+  semantic load (audit verdict B,
+  `ai/findings/2026-05-19-routing-inheritance-audit.md`). The new
+  lens mirrors the actual contract:
 
-  Per-focused-event highlighting:
+  - **Flat catalogue** sorted by `:path` (lexicographic). No
+    indentation, no depth derivation.
+  - **Per-row chips**: route-id + path + doc, with small letter
+    badges (`M` / `L` / `T` / `P`) for routes carrying `:on-match` /
+    `:can-leave` / `:tags` / `:parent`. Click the row to expand the
+    full registrar meta inline.
+  - **Substring search** across route-id + path + doc.
+  - **Simulate-URL** — paste a URL, see every route that matches
+    plus its 6-rule `:rf.route/rank` tuple; the winner is the
+    first row by rank-descending (mirrors `match-url`).
+  - **`:parent` annotation** — when a row carries `:parent`, render
+    a compact `↑ → :route/account` inline pointer; expanding the row
+    surfaces the full `:rf.route/chain`.
 
-  - `◆ HERE` on the current matched route (always — the orientation
-    glyph; even when the focused event has no routing impact).
+  Per-focused-event highlighting (unchanged from rf2-nrbs9):
+
+  - `◆ HERE` on the current matched route (always — orientation).
   - `◆ FROM` / `◆ TO` arrow when the focused cascade caused
     navigation (the cascade carries a
     `:rf.route.nav-token/allocated` trace event).
-  - Params + query for the active route surface below the tree.
+  - Params + query for the active route surface below the catalogue.
   - When the app has no routing registered: tab content silent
     (no `(none)` placeholder per rf2-g3ghh silent-by-default).
-
-  ## ASCII sketch (focused event caused navigation)
-
-      ROUTING
-        /
-        ├ /cart            ◆ FROM ━━━━━━━━━━━━━━━━━━┓
-        ├ /checkout                                  ┃
-        │   ├ /payment              ━━━━━━━━━━━━━━━━┛
-        │   └ /confirm     ◆ TO    (matched)
-        ├ /admin
-        │   └ /audit
-        └ /404
-
-        Params: {:order-id \"ord-1234\"}
-        Query:  {:source \"cart\"}
 
   ## Pure hiccup (rf2-tijr)
 
@@ -51,10 +50,10 @@
 
   ## Helpers
 
-  Pure-data projection (`project-route-tree`, `project-data`,
-  `from-to-from-cascade`, `assign-markers`) lives in
-  `routing_helpers.cljc` so the algebra runs under the JVM unit-test
-  target."
+  Pure-data projection (`project-routes`, `project-data`,
+  `from-to-from-cascade`, `assign-markers`, `filter-rows`,
+  `simulate-url`) lives in `routing_helpers.cljc` so the algebra runs
+  under the JVM unit-test target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
@@ -81,31 +80,97 @@
                               :font-family   sans-stack
                               :font-size     "11px"
                               :letter-spacing "0.3px"
-                              :margin-left   "12px"
+                              :margin-left   "8px"
                               :white-space   "nowrap"}}
          label]))))
 
+(defn- meta-badge
+  "Single-letter badge surfacing presence of a metadata key. Letters
+  are deliberate one-glyph hints — `M` = `:on-match`, `L` =
+  `:can-leave`, `T` = `:tags`, `P` = `:parent`. The colour scheme
+  maps to the semantic palette: `:can-leave` is yellow (guard),
+  `:on-match` is cyan (event), `:tags` is magenta (user labels),
+  `:parent` is violet (hierarchy hint)."
+  [kind]
+  (let [{:keys [letter colour title]}
+        (case kind
+          :on-match  {:letter "M" :colour (:cyan tokens)         :title ":on-match"}
+          :can-leave {:letter "L" :colour (:yellow tokens)       :title ":can-leave"}
+          :tags      {:letter "T" :colour (:magenta tokens)      :title ":tags"}
+          :parent    {:letter "P" :colour (:accent-violet tokens) :title ":parent"}
+          nil)]
+    (when letter
+      [:span {:data-testid (str "rf-causa-routing-badge-" (name kind))
+              :title       title
+              :style       {:display         "inline-block"
+                            :min-width       "14px"
+                            :height          "14px"
+                            :line-height     "14px"
+                            :padding         "0 3px"
+                            :margin-right    "4px"
+                            :background      (:bg-3 tokens)
+                            :color           colour
+                            :border          (str "1px solid " colour)
+                            :border-radius   "3px"
+                            :font-family     mono-stack
+                            :font-size       "9px"
+                            :font-weight     700
+                            :text-align      "center"}}
+       letter])))
+
+(defn- parent-annotation
+  "Compact inline `↑ :route/account` pointer rendered next to a row
+  with `:parent`. The audit found this is the ONLY semantically
+  load-bearing `:parent` axis (`:rf.route/chain` for view-shell
+  composition); the lens surfaces it as a per-row hint rather than
+  a tree-defining structure."
+  [parent-id]
+  (when parent-id
+    [:span {:data-testid "rf-causa-routing-parent-ptr"
+            :style       {:color       (:text-tertiary tokens)
+                          :font-family mono-stack
+                          :font-size   "11px"
+                          :margin-left "8px"
+                          :white-space "nowrap"}}
+     (str "↑ " parent-id)]))
+
+(defn- meta-expander
+  "Click-to-expand registrar meta map. Renders the full meta as
+  `pr-str` text, indented under the row. Used when the user has
+  clicked the row's chevron to drill in."
+  [row]
+  [:pre {:data-testid (str "rf-causa-routing-meta-"
+                           (subs (pr-str (:route-id row)) 1))
+         :style       {:margin "4px 0 8px 24px"
+                       :padding "8px 12px"
+                       :background (:bg-1 tokens)
+                       :border-left (str "2px solid " (:border-default tokens))
+                       :color (:text-secondary tokens)
+                       :font-family mono-stack
+                       :font-size "11px"
+                       :white-space "pre-wrap"
+                       :overflow-x "auto"
+                       :max-height "200px"
+                       :overflow-y "auto"}}
+   (with-out-str
+     (println "; route" (:route-id row))
+     (println (pr-str (:meta row))))])
+
 (defn- route-row
-  "One row in the route tree. Indentation is depth × 16px so nested
-  routes visually sit under their parents. Each row carries the
-  route's path + the route-id (mono-font) + a marker chip when
-  highlighted."
-  [{:keys [route-id path depth marker doc] :as _row}]
+  "One row in the catalogue. No indentation — routes are flat.
+  Each row carries: chevron (expand toggle), marker chip column,
+  badges, route-id (mono), path (highlighted), doc (italic), and
+  the parent pointer when present."
+  [{:keys [route-id path marker doc parent has-on-match? has-can-leave? tags]
+    :as row}
+   {:keys [expanded? on-toggle]}]
   ;; testid uses the fully-qualified keyword (namespace + name) so two
   ;; routes whose simple names collide (e.g. `:cart/edit` and
-  ;; `:admin/edit`) render with distinct testids. `pr-str` round-trips
-  ;; the keyword's whole reader form (`:route/cart`); strip the leading
-  ;; `:` so the resulting attribute reads as `rf-causa-routing-row-
-  ;; route/cart` — namespace-bearing but stripped of the colon prefix
-  ;; that confuses CSS selectors (a leading `:` would be parsed as a
-  ;; pseudo-class).
+  ;; `:admin/edit`) render with distinct testids.
   [:li {:data-testid (str "rf-causa-routing-row-" (subs (pr-str route-id) 1))
         :data-marker (when marker (name marker))
-        :style       {:display        "flex"
-                      :align-items    "center"
-                      :gap            "8px"
-                      :padding        "3px 8px"
-                      :padding-left   (str (+ 8 (* (or depth 0) 16)) "px")
+        :style       {:display        "block"
+                      :padding        "0"
                       :font-family    mono-stack
                       :font-size      "12px"
                       :color          (:text-primary tokens)
@@ -120,36 +185,234 @@
                                         :here (str "2px solid " (:accent-violet tokens))
                                         "2px solid transparent")
                       :border-radius  "2px"
-                      :line-height    "20px"
-                      :white-space    "nowrap"}}
-   [:span {:style {:color (:text-tertiary tokens)
+                      :line-height    "20px"}}
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :padding "3px 8px"
+                  :cursor "pointer"
+                  :white-space "nowrap"
+                  :overflow "hidden"}
+          :on-click on-toggle}
+    [:span {:data-testid (str "rf-causa-routing-chevron-"
+                              (subs (pr-str route-id) 1))
+            :style {:color (:text-tertiary tokens)
+                    :font-size "10px"
+                    :min-width "12px"
+                    :user-select "none"}}
+     (if expanded? "▾" "▸")]
+    [:span {:style {:color (:accent-violet tokens)
+                    :font-weight 500
+                    :min-width "120px"}}
+     path]
+    [:span {:style {:color (:text-tertiary tokens)
+                    :font-size "11px"
+                    :min-width "140px"}}
+     (str route-id)]
+    [:span {:style {:display "inline-flex"
+                    :align-items "center"
+                    :margin-left "4px"}}
+     (when has-on-match?  (meta-badge :on-match))
+     (when has-can-leave? (meta-badge :can-leave))
+     (when (seq tags)     (meta-badge :tags))
+     (when parent         (meta-badge :parent))]
+    (when doc
+      [:span {:style {:color (:text-secondary tokens)
+                      :font-size "11px"
+                      :font-style "italic"
+                      :font-family sans-stack
+                      :overflow "hidden"
+                      :text-overflow "ellipsis"
+                      :flex 1}}
+       doc])
+    (parent-annotation parent)
+    (marker-chip marker)]
+   (when expanded?
+     (meta-expander row))])
+
+;; ---- search box ---------------------------------------------------------
+
+(defn- search-box
+  "Substring filter input. Matches against route-id + path + doc per
+  `routing_helpers/filter-rows`."
+  [query total-routes filtered?]
+  [:div {:data-testid "rf-causa-routing-search"
+         :style       {:display "flex"
+                       :align-items "center"
+                       :gap "8px"
+                       :padding "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family sans-stack}}
+   [:label {:style {:color (:text-tertiary tokens)
+                    :font-size "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-routing-search-input"
+            :placeholder "route-id, path, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.routing/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex 1
+                          :background (:bg-3 tokens)
+                          :color (:text-primary tokens)
+                          :border (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding "4px 8px"
+                          :font-family mono-stack
+                          :font-size "12px"}}]
+   [:span {:data-testid "rf-causa-routing-search-count"
+           :style {:color (:text-tertiary tokens)
+                   :font-family mono-stack
                    :font-size "11px"
-                   :min-width "16px"
+                   :min-width "60px"
                    :text-align "right"}}
-    ;; A small `·` for non-root, blank for root — gives the tree a
-    ;; faint grid feel without ascii-art tree glyphs (those don't
-    ;; survive font-substitution well).
-    (if (pos? (or depth 0)) "·" "")]
+    (cond
+      filtered?              (str "match")
+      (= 1 total-routes)     "1 route"
+      :else                  (str total-routes " routes"))]])
+
+;; ---- Simulate-URL -------------------------------------------------------
+
+(defn- rank-cell
+  "Render a single rank tuple as compact mono text. The 6-tuple is
+  `[static total -splat catch-all? -optional -reg-index]` per
+  `parse-pattern`; we surface it verbatim — the lens is about exposing
+  the cascade, not interpreting it."
+  [rank]
+  [:span {:style {:font-family mono-stack
+                  :font-size "11px"
+                  :color (:text-secondary tokens)}}
+   (pr-str rank)])
+
+(defn- sim-candidate-row
+  "One row in the Simulate-URL result table — winner highlighted."
+  [{:keys [route-id rank params winner? path]}]
+  [:li {:data-testid (str "rf-causa-routing-sim-candidate-"
+                          (subs (pr-str route-id) 1))
+        :data-winner (when winner? "true")
+        :style       {:display "flex"
+                      :align-items "center"
+                      :gap "8px"
+                      :padding "3px 8px"
+                      :background (if winner? (:bg-active tokens) "transparent")
+                      :border-left (if winner?
+                                     (str "2px solid " (:green tokens))
+                                     "2px solid transparent")
+                      :border-radius "2px"
+                      :font-family mono-stack
+                      :font-size "12px"
+                      :white-space "nowrap"}}
+   [:span {:style {:color (if winner? (:green tokens) (:text-tertiary tokens))
+                   :font-weight 600
+                   :font-size "10px"
+                   :min-width "50px"}}
+    (if winner? "WINNER" "")]
    [:span {:style {:color (:accent-violet tokens)
-                   :font-weight 500}}
+                   :min-width "140px"}}
     path]
    [:span {:style {:color (:text-tertiary tokens)
-                   :font-size "11px"}}
+                   :font-size "11px"
+                   :min-width "160px"}}
     (str route-id)]
-   (when doc
+   (rank-cell rank)
+   (when (seq params)
      [:span {:style {:color (:text-secondary tokens)
                      :font-size "11px"
-                     :font-style "italic"
-                     :font-family sans-stack
-                     :overflow "hidden"
-                     :text-overflow "ellipsis"}}
-      doc])
-   (marker-chip marker)])
+                     :margin-left "8px"}}
+      (pr-str params)])])
+
+(defn- simulate-url-section
+  "URL simulator surface — paste a URL, see every matching route and
+  its rank tuple, winner highlighted."
+  [sim-url sim-result]
+  [:div {:data-testid "rf-causa-routing-sim"
+         :style       {:padding "10px 16px"
+                       :border-top (str "1px solid " (:border-subtle tokens))
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :background (:bg-1 tokens)}}
+   [:div {:style {:display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :font-family sans-stack}}
+    [:label {:style {:color (:text-tertiary tokens)
+                     :font-size "10px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"
+                     :min-width "60px"}}
+     "Try URL"]
+    [:input {:type        "text"
+             :data-testid "rf-causa-routing-sim-input"
+             :placeholder "/cart  or  /checkout/payment?step=2"
+             :value       (or sim-url "")
+             :on-change   (fn [e]
+                            (rf/dispatch [:rf.causa.routing/set-sim-url
+                                          (-> e .-target .-value)]
+                                         {:frame :rf/causa}))
+             :style       {:flex 1
+                           :background (:bg-3 tokens)
+                           :color (:text-primary tokens)
+                           :border (str "1px solid " (:border-default tokens))
+                           :border-radius "3px"
+                           :padding "4px 8px"
+                           :font-family mono-stack
+                           :font-size "12px"}}]
+    (when (and sim-url (not= "" sim-url))
+      [:button {:data-testid "rf-causa-routing-sim-clear"
+                :on-click (fn [_]
+                            (rf/dispatch [:rf.causa.routing/set-sim-url ""]
+                                         {:frame :rf/causa}))
+                :style {:background "transparent"
+                        :border (str "1px solid " (:border-default tokens))
+                        :border-radius "3px"
+                        :color (:text-tertiary tokens)
+                        :padding "3px 8px"
+                        :font-family sans-stack
+                        :font-size "11px"
+                        :cursor "pointer"}}
+       "clear"])]
+   (when sim-result
+     (let [{:keys [path candidates winner]} sim-result]
+       [:div {:data-testid "rf-causa-routing-sim-result"
+              :style {:margin-top "8px"}}
+        [:div {:style {:font-family mono-stack
+                       :font-size "11px"
+                       :color (:text-tertiary tokens)
+                       :padding "0 8px 4px 8px"}}
+         (str "matched against path " (pr-str path) " — "
+              (cond
+                (empty? candidates) "no route matches (match-url → nil)"
+                :else (str (count candidates)
+                           (if (= 1 (count candidates)) " candidate" " candidates")
+                           "; winner = " winner)))]
+        (when (seq candidates)
+          [:div {:style {:display "grid"
+                         :grid-template-columns "50px 140px 160px 1fr"
+                         :column-gap "8px"
+                         :padding "0 8px 2px 8px"
+                         :font-family sans-stack
+                         :font-size "10px"
+                         :color (:text-tertiary tokens)
+                         :text-transform "uppercase"
+                         :letter-spacing "0.4px"}}
+           [:span ""] [:span "path"] [:span "route-id"] [:span "rank · params"]])
+        (into [:ul {:style {:list-style "none"
+                            :margin "0"
+                            :padding "0"
+                            :display "flex"
+                            :flex-direction "column"
+                            :gap "1px"}}]
+              (for [c candidates]
+                ^{:key (str (:route-id c))}
+                [sim-candidate-row c]))]))])
+
+;; ---- header / slice-detail / empty-state --------------------------------
 
 (defn- header
-  "Tab header — title + a brief explainer of the lens model. Always
-  rendered (even when silent) so the user knows the tab exists; the
-  body switches between the tree and the silent state."
   [{:keys [navigated? to-id]}]
   [:div {:data-testid "rf-causa-routing-header"
          :style       {:display       "flex"
@@ -165,20 +428,21 @@
                   :text-transform "uppercase"
                   :letter-spacing "0.5px"
                   :color      (:text-primary tokens)}}
-     "Routing"]
+     "Routes"]
     [:p {:style {:margin "4px 0 0 0"
                  :color  (:text-tertiary tokens)
                  :font-size "11px"
                  :line-height 1.4}}
-     "Lens on the focused event — the full route tree, with "
+     "Flat catalogue of registered routes — search above, paste a URL "
+     "into Try URL to see the 6-rule rank cascade. "
      [:span {:style {:color (:accent-violet tokens) :font-weight 600}} "◆ HERE"]
-     " marking the active route"
+     " marks the active route"
      (when navigated?
-       [:span " and "
+       [:span "; "
         [:span {:style {:color (:cyan tokens) :font-weight 600}} "◆ FROM"]
         " / "
         [:span {:style {:color (:green tokens) :font-weight 600}} "◆ TO"]
-        " marking the navigation transition"])
+        " mark the navigation transition"])
      "."]]
    (when (and navigated? to-id)
      [:span {:data-testid "rf-causa-routing-nav-summary"
@@ -188,9 +452,7 @@
       (str "→ " to-id)])])
 
 (defn- slice-detail
-  "Params / query / fragment breakdown for the current route slice.
-  Three labelled rows; absent slots render as `—` so the lens always
-  shows the same skeleton (predictable scanning)."
+  "Params / query / fragment breakdown for the current route slice."
   [{:keys [params query fragment] :as _current}]
   [:div {:data-testid "rf-causa-routing-slice-detail"
          :style       {:padding     "10px 16px"
@@ -212,10 +474,6 @@
       [:span (pr-str fragment)]])])
 
 (defn- empty-state
-  "Silent state — rendered when the host app has no routes registered.
-  Per rf2-g3ghh silent-by-default the panel emits an empty section so
-  the chrome stays consistent across tabs (every tab carries the
-  header + an empty body when its data source is empty)."
   []
   [:div {:data-testid "rf-causa-routing-empty"
          :style       {:padding "16px"
@@ -223,21 +481,21 @@
                        :font-family sans-stack
                        :font-size "11px"
                        :font-style "italic"}}
-   ;; Terse one-liner so the panel skeleton doesn't look broken (mirror
-   ;; of the Issues panel's :no-issues empty state). Honours silent-by-
-   ;; default — no `(none)` chip, no marketing copy.
    "No routes registered."])
 
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Routing tab's root view. Subscribes to
-  `:rf.causa/routing-tab-data` and renders the route tree + slice
-  detail or the silent state."
+  "The Routes tab's root view. Subscribes to
+  `:rf.causa/routing-tab-data` and renders the flat catalogue +
+  Simulate-URL + slice detail (or the silent state when no routes
+  are registered)."
   []
-  (let [{:keys [silent? routes current to-id navigated?]
+  (let [{:keys [silent? routes total-routes filtered? current to-id navigated?
+                query sim-url sim-result]
          :as _data}
-        @(rf/subscribe [:rf.causa/routing-tab-data])]
+        @(rf/subscribe [:rf.causa/routing-tab-data])
+        expanded @(rf/subscribe [:rf.causa.routing/expanded])]
     [:section {:data-testid "rf-causa-routing"
                :style       {:height         "100%"
                              :display        "flex"
@@ -247,11 +505,13 @@
                              :font-family    sans-stack
                              :font-size      "14px"}}
      (header {:navigated? navigated? :to-id to-id})
-     [:div {:style {:flex 1 :overflow "auto"}}
-      (if silent?
-        (empty-state)
-        [:<>
-         (into [:ul {:data-testid "rf-causa-routing-tree"
+     (if silent?
+       (empty-state)
+       [:<>
+        (search-box query total-routes filtered?)
+        (simulate-url-section sim-url sim-result)
+        [:div {:style {:flex 1 :overflow "auto"}}
+         (into [:ul {:data-testid "rf-causa-routing-list"
                      :style       {:list-style "none"
                                    :margin     "8px 0 0 0"
                                    :padding    "0 8px"
@@ -260,42 +520,46 @@
                                    :gap        "1px"}}]
                (for [row routes]
                  ^{:key (str (:route-id row))}
-                 [route-row row]))
+                 [route-row row
+                  {:expanded? (contains? expanded (:route-id row))
+                   :on-toggle (fn [_]
+                                (rf/dispatch [:rf.causa.routing/toggle-row
+                                              (:route-id row)]
+                                             {:frame :rf/causa}))}]))
          (when current
-           (slice-detail current))])]]))
+           (slice-detail current))]])]))
 
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
-  "Idempotent install for the Routing panel's Causa-side registrations
-  (rf2-nrbs9). Registers:
+  "Idempotent install for the Routes panel's Causa-side registrations
+  (rf2-nrbs9, reshaped per rf2-lq0ef). Registers:
 
     - `:rf.causa/registered-routes` — flat `{<route-id> <meta>}` map
-      sourced from `(rf/registrations :route)` (the framework's
-      registrar). Falls back to a test-only override slot so JVM /
-      node-test fixtures can drive the projection without booting
-      a host that registers routes.
+      sourced from `(rf/registrations :route)`. Falls back to a
+      test-only override slot so JVM / node-test fixtures can drive
+      the projection without booting a host that registers routes.
     - `:rf.causa/current-route-slice` — composite over the spine's
-      target-frame app-db reading the `:rf/route` slice. Mirrors how
-      `app-db-diff` reaches the host's app-db.
+      target-frame app-db reading the `:rf/route` slice.
     - `:rf.causa/routing-tab-data` — view-facing composite folding
-      the registered-routes map + current route slice + focused
-      cascade into the shape the view consumes (see
+      registered-routes + current slice + focused cascade + search
+      query + Simulate-URL into the shape the view consumes (see
       `routing_helpers/project-data`).
+    - `:rf.causa.routing/query` + `:rf.causa.routing/sim-url` +
+      `:rf.causa.routing/expanded` — UI state slots (search input,
+      Simulate-URL input, expanded-row set).
+    - `:rf.causa.routing/set-query`,
+      `:rf.causa.routing/set-sim-url`,
+      `:rf.causa.routing/toggle-row` — dispatch hooks the view fires.
     - `:rf.causa/set-registered-routes-override-for-test` — test-only
       override hook the gallery fixtures + JVM tests use to seed the
       registered-routes slot without registering real routes.
     - `:rf.causa/set-current-route-slice-override-for-test` — same
-      pattern for the current slice (drives the HERE marker)."
+      pattern for the current slice."
   []
 
-  ;; Test-only override slot for the registered-routes registrar
-  ;; lookup. When set (non-nil), the `:rf.causa/registered-routes`
-  ;; sub returns this verbatim; when nil the sub falls through to
-  ;; `(rf/registrations :route)`. Mirrors the
-  ;; `:rf.causa/set-registered-machines-override-for-test` pattern
-  ;; (machine_inspector.cljs) so fixtures can seed without a live
-  ;; registrar.
+  ;; Test-only override slots --------------------------------------------
+
   (rf/reg-event-db :rf.causa/set-registered-routes-override-for-test
     (fn [db [_ ov]]
       (if (nil? ov)
@@ -306,22 +570,6 @@
     (fn [db _query]
       (get db :registered-routes-override)))
 
-  ;; The registrar lookup — production reads through `rf/registrations`
-  ;; (process-global atom outside re-frame's reactive graph; the sub
-  ;; re-fires whenever the trace-buffer writes, which is the same
-  ;; cadence the palette uses to recompute its handler index — see
-  ;; palette/subs.cljs §palette-index). For the panel this is over-
-  ;; eager (the route registrar rarely changes) but the cost is
-  ;; bounded by the number of registered routes (typically < 30) and
-  ;; the dependency chain keeps the override surface clean.
-  (rf/reg-sub :rf.causa/registered-routes
-    :<- [:rf.causa/trace-buffer]
-    :<- [:rf.causa/registered-routes-override]
-    (fn [[_buffer override] _query]
-      (or override (rf/registrations :route))))
-
-  ;; Test-only override slot for the current route slice. Same pattern
-  ;; as registered-routes above.
   (rf/reg-event-db :rf.causa/set-current-route-slice-override-for-test
     (fn [db [_ ov]]
       (if (nil? ov)
@@ -332,12 +580,48 @@
     (fn [db _query]
       (get db :current-route-slice-override)))
 
-  ;; The current route slice — production reads through the
-  ;; target-frame-db sub (registered by `app-db-diff/install!`); that
-  ;; sub composes `:rf.causa/target-frame` + `rf/get-frame-db` so
-  ;; switching the L1 frame picker re-binds the lens to the new
-  ;; frame's route slice. The override slot wins when set (test
-  ;; fixtures + JVM coverage).
+  ;; UI state (search query, simulate-URL input, expanded rows) ----------
+
+  (rf/reg-event-db :rf.causa.routing/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.routing/query)
+        (assoc db :rf.causa.routing/query q))))
+
+  (rf/reg-sub :rf.causa.routing/query
+    (fn [db _]
+      (get db :rf.causa.routing/query)))
+
+  (rf/reg-event-db :rf.causa.routing/set-sim-url
+    (fn [db [_ url]]
+      (if (or (nil? url) (= "" url))
+        (dissoc db :rf.causa.routing/sim-url)
+        (assoc db :rf.causa.routing/sim-url url))))
+
+  (rf/reg-sub :rf.causa.routing/sim-url
+    (fn [db _]
+      (get db :rf.causa.routing/sim-url)))
+
+  (rf/reg-event-db :rf.causa.routing/toggle-row
+    (fn [db [_ route-id]]
+      (let [expanded (or (:rf.causa.routing/expanded db) #{})]
+        (assoc db :rf.causa.routing/expanded
+               (if (contains? expanded route-id)
+                 (disj expanded route-id)
+                 (conj expanded route-id))))))
+
+  (rf/reg-sub :rf.causa.routing/expanded
+    (fn [db _]
+      (or (:rf.causa.routing/expanded db) #{})))
+
+  ;; Production data subs -------------------------------------------------
+
+  (rf/reg-sub :rf.causa/registered-routes
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa/registered-routes-override]
+    (fn [[_buffer override] _query]
+      (or override (rf/registrations :route))))
+
   (rf/reg-sub :rf.causa/current-route-slice
     :<- [:rf.causa/target-frame-db]
     :<- [:rf.causa/current-route-slice-override]
@@ -347,19 +631,18 @@
         (map? target-db) (:rf/route target-db)
         :else            nil)))
 
-  ;; View-facing composite — folds registered-routes + current slice
-  ;; + focused cascade (via `:rf.causa/cascades` + `:rf.causa/focus`)
-  ;; into the shape `project-data` returns. The view subscribes to
-  ;; this single sub; every component prop the renderer needs is in
-  ;; the returned map.
+  ;; View-facing composite -----------------------------------------------
+
   (rf/reg-sub :rf.causa/routing-tab-data
     :<- [:rf.causa/registered-routes]
     :<- [:rf.causa/current-route-slice]
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/focus]
-    (fn [[routes-map slice cascades focus] _query]
+    :<- [:rf.causa.routing/query]
+    :<- [:rf.causa.routing/sim-url]
+    (fn [[routes-map slice cascades focus query sim-url] _query]
       (let [focused-cascade (h/focused-cascade cascades
                                                (:dispatch-id focus))]
-        (h/project-data routes-map slice focused-cascade))))
+        (h/project-data routes-map slice focused-cascade query sim-url))))
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
@@ -1,31 +1,40 @@
 (ns day8.re-frame2-causa.panels.routing-helpers
-  "Pure projection helpers for the Causa Routing tab (rf2-nrbs9).
+  "Pure projection helpers for the Causa Routing tab (rf2-nrbs9, rf2-lq0ef).
 
   ## Why a separate `.cljc` ns
 
-  The panel view in `routing.cljs` paints the route-tree lens. The
-  *logic* — project the registered-routes registrar into a stable
-  tree structure, derive the current-vs-from-vs-to highlight from
-  the focused cascade's trace events + app-db slice — is pure data
-  → data. Splitting the algebra into `.cljc` so it runs under the
-  JVM unit-test target (`clojure -M:test`) is required by the
-  standing rule `feedback_jvm_interop_must_work.md`.
+  The panel view in `routing.cljs` paints the routes lens. The
+  *logic* — project the registered-routes registrar into a flat
+  catalogue, derive the current-vs-from-vs-to highlight from the
+  focused cascade, filter by a substring query, and simulate a URL
+  against the registered patterns — is pure data → data. Splitting
+  the algebra into `.cljc` so it runs under the JVM unit-test target
+  (`clojure -M:test`) is required by the standing rule
+  `feedback_jvm_interop_must_work.md`.
 
-  ## Lens model
+  ## Lens model (post-rf2-lq0ef reshape)
 
-  Always-shown structure: the full route tree (every registered
-  route, sorted by path so the rendering is deterministic).
+  The lens is a **flat catalogue sorted by `:path`** — never a tree.
+  The audit (`ai/findings/2026-05-19-routing-inheritance-audit.md`
+  verdict B) found that the previous URL-path-segmentation indentation
+  was decorative: routes are flat in the spec + impl, `:parent` plays
+  no role in matching, and the match-resolver is structural
+  (6-rule rank on URL pattern). The previous tree conflated URL-prefix
+  similarity with semantic hierarchy.
 
-  Per-focused-event highlighting:
+  The flat-list shape mirrors the contract. The load-bearing
+  interactive surface is **Simulate-URL** — paste a URL and see the
+  6-rule rank tuple per candidate plus the winner; that exposes the
+  match contract Causa users actually need to reason about.
+
+  Per-focused-event highlighting (unchanged from rf2-nrbs9):
 
   - `◆ HERE` on the current matched route (always — orientation).
   - `◆ FROM` / `◆ TO` arrow when the focused cascade caused
-    navigation; the `:rf.route.nav-token/allocated` trace event
-    plus the slice change identify the FROM (prior route) and TO
-    (newly matched route).
-  - Show params + query for the active route.
-  - No transition arrow when the focused event has no routing
-    impact (still shows `◆ HERE`).
+    navigation; the `:rf.route.nav-token/allocated` trace event plus
+    the slice change identify the FROM (prior route) and TO (newly
+    matched route).
+  - Show params + query + fragment for the active route.
   - When the app has no routes registered: every projection helper
     returns the silent shape (`{:routes [] :silent? true}`) and the
     view honours silent-by-default per rf2-g3ghh.
@@ -35,60 +44,184 @@
   The composite the view consumes:
 
       {:silent?    <bool>             ;; true when no routes registered
-       :routes     [<row> ...]        ;; the route tree, sorted by path
+       :routes     [<row> ...]        ;; flat, sorted by :path
        :current    <route-slice>      ;; the active :rf/route slice
        :from-id    <route-id-or-nil>  ;; nav origin when the focused
                                       ;; cascade caused navigation
        :to-id      <route-id-or-nil>  ;; nav destination when the
                                       ;; focused cascade caused navigation
-       :navigated? <bool>}            ;; true iff the focused cascade
+       :navigated? <bool>             ;; true iff the focused cascade
                                       ;; carries a :rf.route.nav-token/
                                       ;; allocated trace event
+       :query      <string-or-nil>    ;; substring filter applied to rows
+       :sim-url    <string-or-nil>    ;; URL pasted into the simulator
+       :sim-result <map-or-nil>}      ;; result of simulate-url for sim-url
 
   Each `<row>` is:
 
       {:route-id   <keyword>
        :path       <string>
-       :depth      <int>              ;; tree depth (0 = root)
        :doc        <string-or-nil>
-       :marker     <:here :from :to nil>}  ;; render glyph hint"
-  (:require [clojure.string :as str]))
+       :parent     <route-id-or-nil>   ;; from registrar meta
+       :tags       <set-or-nil>        ;; from registrar meta
+       :has-on-match? <bool>
+       :has-can-leave? <bool>
+       :rank       <vector-or-nil>     ;; the 6-tuple :rf.route/rank
+       :meta       <map>               ;; full registrar meta (for click-to-expand)
+       :marker     <:here :from :to nil>}"
+  (:require [clojure.string :as str]
+            [re-frame.routing.match :as match]))
 
-;; ---- route tree projection ----------------------------------------------
+;; ---- route catalogue projection -----------------------------------------
 
-(defn- path-segments
-  "Split a route path into its `/`-delimited segments. The root path
-  `/` collapses to `[]` so it slots in at depth 0; an empty / nil
-  path is treated as the root."
-  [path]
-  (let [p (or path "")]
-    (->> (str/split p #"/")
-         (remove str/blank?)
-         vec)))
-
-(defn- path-depth
-  "Tree depth for a route path. Root (`/` or empty) sits at depth 0;
-  every `/`-separated segment adds one level."
-  [path]
-  (count (path-segments path)))
-
-(defn project-route-tree
+(defn project-routes
   "Project the registered-routes map (`{<id> <meta>}`) into a vector
-  of `{:route-id :path :depth :doc}` rows sorted by path. The path
-  sort is lexicographic so siblings under a common prefix render
-  contiguously; depth comes for free from the path itself.
+  of catalogue rows sorted lexicographically by `:path`. Each row
+  carries the route-id, path, doc, parent, tags, the rank tuple, and
+  the full meta map (so the view's click-to-expand surface can render
+  the registrar entry verbatim).
+
+  Per the audit (verdict B): no `:depth` field, no indentation hint.
+  Routes are flat in the spec + impl; the catalogue mirrors that.
 
   Returns `[]` when the registrar is empty — the silent-by-default
   branch the view honours per rf2-g3ghh."
   [routes-map]
   (->> routes-map
        (map (fn [[id meta]]
-              {:route-id id
-               :path     (or (:path meta) "")
-               :depth    (path-depth (:path meta))
-               :doc      (:doc meta)}))
+              {:route-id        id
+               :path            (or (:path meta) "")
+               :doc             (:doc meta)
+               :parent          (:parent meta)
+               :tags            (:tags meta)
+               :has-on-match?   (some? (:on-match meta))
+               :has-can-leave?  (some? (:can-leave meta))
+               :rank            (:rf.route/rank meta)
+               :meta            meta}))
        (sort-by :path)
        vec))
+
+;; ---- substring filter ---------------------------------------------------
+
+(defn- row-haystack
+  "Compose the searchable haystack for a single row — route-id, path,
+  and doc, joined with spaces. Lower-cased once at projection time so
+  the filter can do case-insensitive `clojure.string/includes?` without
+  re-lowering."
+  [row]
+  (str/lower-case
+    (str (some-> (:route-id row) str) " "
+         (:path row) " "
+         (or (:doc row) ""))))
+
+(defn filter-rows
+  "Substring filter. Empty / blank query returns rows verbatim;
+  otherwise keep rows whose route-id, path, or doc contains the
+  lower-cased query as a substring. Case-insensitive — the user's
+  query is lower-cased once and matched against pre-lowered haystacks."
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv (fn [row] (str/includes? (row-haystack row) needle))
+                 rows)))))
+
+;; ---- Simulate-URL -------------------------------------------------------
+;;
+;; Per Spec 012 §Bidirectional URL ↔ params §match-url, ranking is the
+;; pre-sorted route table walked in :rf.route/rank descending order;
+;; the first pattern that matches the path is the winner. For the
+;; simulator we want to surface ALL matching candidates with their
+;; rank tuples, not just the winner — that's the load-bearing
+;; interactive surface that exposes the 6-rule cascade.
+
+(defn- split-url
+  "Strip fragment + query off a URL string, returning just the path
+  segment. Mirrors the splitting `match-url` performs before invoking
+  `match-against`. Fragments are dropped (do not participate in
+  matching per Spec 012 §Fragments); query strings are dropped
+  (route patterns match against the path only)."
+  [url]
+  (when (string? url)
+    (let [[no-frag] (str/split url #"#" 2)
+          [path]    (str/split no-frag #"\?" 2)]
+      (cond
+        (str/blank? path) "/"
+        :else             path))))
+
+(defn- normalize-path
+  "Strip a trailing slash from a multi-segment path so `/cart/` and
+  `/cart` both match the same pattern. Single `/` is preserved.
+  Mirrors `normalize-match-path` in re-frame.routing — the simulator
+  must use the same normalization so its results match what
+  match-url would actually return."
+  [path]
+  (cond
+    (or (nil? path) (= "/" path)) (or path "/")
+    (and (str/ends-with? path "/") (< 1 (count path))) (subs path 0 (dec (count path)))
+    :else path))
+
+(defn- compile-pattern-on-demand
+  "If a registrar entry was seeded without `:rf.route/compiled` (e.g.
+  test fixtures pass bare `{:path ...}` maps), compile the pattern on
+  the fly. The 6-tuple ranks at the test-only override slot will not
+  have the `(- reg-index)` trailing element, but the structural 5-tuple
+  is enough to demonstrate the simulator's contract; the production
+  path always has the full 6-tuple."
+  [meta]
+  (or (:rf.route/compiled meta)
+      (when-let [path (:path meta)]
+        (try
+          (match/parse-pattern path)
+          (catch #?(:clj Exception :cljs :default) _ nil)))))
+
+(defn simulate-url
+  "Run `url` against every registered route's pattern. Returns
+  {:url <input>
+   :path <stripped path>
+   :candidates [{:route-id :rank :params :winner? :path} ...]
+   :winner <route-id-or-nil>}
+
+  Candidates are sorted by `:rf.route/rank` descending — the same
+  order `match-url` walks the registry table. The first candidate is
+  the winner (the route `match-url` would resolve to). Non-matching
+  routes are excluded; an empty `:candidates` vector means
+  `match-url` would return nil for this URL.
+
+  This is purely structural — query coercion and `:params` / `:query`
+  schema validation are out of scope for the simulator. The lens is
+  about the rank cascade, not full match semantics."
+  [routes-map url]
+  (let [trimmed (some-> url str/trim)]
+    (cond
+      (or (nil? trimmed) (= "" trimmed))
+      {:url        nil
+       :path       nil
+       :candidates []
+       :winner     nil}
+
+      :else
+      (let [path (normalize-path (split-url trimmed))
+            candidates
+            (->> routes-map
+                 (keep (fn [[id meta]]
+                         (when-let [compiled (compile-pattern-on-demand meta)]
+                           (when-let [params (match/match-against compiled path)]
+                             {:route-id id
+                              :path     (:path meta)
+                              :rank     (or (:rf.route/rank meta)
+                                            (:rank compiled))
+                              :params   params}))))
+                 (sort-by :rank #(compare %2 %1))
+                 vec)
+            winner-id (some-> candidates first :route-id)
+            decorated (mapv #(assoc % :winner? (= (:route-id %) winner-id))
+                            candidates)]
+        {:url        trimmed
+         :path       path
+         :candidates decorated
+         :winner     winner-id}))))
 
 ;; ---- focused-cascade routing detection ----------------------------------
 
@@ -196,11 +329,6 @@
                 marker (cond
                          (and to-id (= id to-id))          :to
                          (and from-id (= id from-id))      :from
-                         ;; HERE shows whether or not we navigated —
-                         ;; it's the orientation glyph. When :to is
-                         ;; set the same row carries :to, so HERE
-                         ;; only surfaces independently when the
-                         ;; cascade didn't navigate.
                          (and (not navigated?)
                               current-id
                               (= id current-id))
@@ -213,8 +341,9 @@
 
 (defn project-data
   "The view-facing composite. Folds the registered-routes map +
-  current route slice + focused cascade into the shape the panel
-  consumes (see ns doc §Data shape contract).
+  current route slice + focused cascade + UI controls (search query +
+  Simulate-URL) into the shape the panel consumes (see ns doc §Data
+  shape contract).
 
   Inputs are all pre-projected by the registry sub layer; this fn is
   pure data → data so it slots into the JVM unit-test target.
@@ -222,16 +351,26 @@
   Silent-by-default per rf2-g3ghh: when no routes are registered the
   fn returns `{:silent? true :routes [] ...}` and the view renders
   the empty section (no `(none)` placeholder)."
-  [routes-map current-slice focused-cascade]
-  (let [rows         (project-route-tree routes-map)
-        silent?      (empty? rows)
-        nav          (from-to-from-cascade focused-cascade current-slice)
-        decorated    (assign-markers rows
-                                     (assoc nav
-                                       :current-id (:id current-slice)))]
-    {:silent?    silent?
-     :routes     decorated
-     :current    current-slice
-     :from-id    (:from-id nav)
-     :to-id      (:to-id nav)
-     :navigated? (:navigated? nav)}))
+  ([routes-map current-slice focused-cascade]
+   (project-data routes-map current-slice focused-cascade nil nil))
+  ([routes-map current-slice focused-cascade query sim-url]
+   (let [rows         (project-routes routes-map)
+         silent?      (empty? rows)
+         nav          (from-to-from-cascade focused-cascade current-slice)
+         decorated    (assign-markers rows
+                                      (assoc nav
+                                        :current-id (:id current-slice)))
+         filtered     (filter-rows decorated query)
+         sim-result   (when (and sim-url (not (str/blank? sim-url)))
+                        (simulate-url routes-map sim-url))]
+     {:silent?       silent?
+      :routes        filtered
+      :total-routes  (count rows)
+      :filtered?     (not= (count rows) (count filtered))
+      :current       current-slice
+      :from-id       (:from-id nav)
+      :to-id         (:to-id nav)
+      :navigated?    (:navigated? nav)
+      :query         query
+      :sim-url       sim-url
+      :sim-result    sim-result})))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -1,18 +1,23 @@
 (ns day8.re-frame2-causa.panels.routing-cljs-test
-  "CLJS-side wiring + view tests for Causa's Routing tab (rf2-nrbs9).
+  "CLJS-side wiring + view tests for Causa's Routes tab (rf2-nrbs9,
+  reshaped per rf2-lq0ef).
 
   ## What's under test (in addition to the pure-data tests in
   `routing_helpers_cljs_test.cljc`)
 
     1. **Registry wires the subs** — every sub the panel reads gets
-       installed by `register-causa-handlers!`, and the `:routing`
-       tab id is in the L3 tabs vector + the palette panel list.
+       installed by `register-causa-handlers!`, plus the new UI-state
+       subs/events (`:rf.causa.routing/query`,
+       `:rf.causa.routing/sim-url`, `:rf.causa.routing/expanded`,
+       `:rf.causa.routing/toggle-row`, etc.) — and the `:routing` tab
+       id is in the L3 tabs vector + the palette panel list.
 
-    2. **Render contract** — root container + header + tree (or
-       empty state) match the production view tree.
+    2. **Render contract** — root container + header + search box +
+       Simulate-URL section + flat list (or empty state).
 
     3. **Silent state** — when no routes are registered the panel
-       renders the empty body (`No routes registered.`), no tree.
+       renders the empty body (`No routes registered.`), no list, no
+       search.
 
     4. **Orientation HERE marker** — when routes are registered and
        a current route slice exists, the current row carries the
@@ -91,7 +96,9 @@
   {:route/cart      {:path "/cart"      :doc "cart"}
    :route/checkout  {:path "/checkout"  :doc "checkout"}
    :route/payment   {:path "/checkout/payment"}
-   :route/confirm   {:path "/checkout/confirm"}})
+   :route/confirm   {:path "/checkout/confirm"
+                     :parent :route/checkout
+                     :on-match [:confirm/load]}})
 
 (defn- nav-allocated [route-id]
   {:id        99
@@ -102,7 +109,7 @@
 ;; ---- (1) registry wiring + tab inventory --------------------------------
 
 (deftest registry-installs-routing-subs
-  (testing "register-causa-handlers! installs every Routing-tab sub"
+  (testing "register-causa-handlers! installs every Routes-tab sub"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/registered-routes))
         ":rf.causa/registered-routes sub registered")
@@ -114,6 +121,18 @@
         "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.causa/routing-tab-data))
         "view-facing composite sub registered")
+    (is (some? (registrar/handler :sub :rf.causa.routing/query))
+        ":rf.causa.routing/query sub registered (search input)")
+    (is (some? (registrar/handler :sub :rf.causa.routing/sim-url))
+        ":rf.causa.routing/sim-url sub registered (Simulate-URL input)")
+    (is (some? (registrar/handler :sub :rf.causa.routing/expanded))
+        ":rf.causa.routing/expanded sub registered (row expansion)")
+    (is (some? (registrar/handler :event :rf.causa.routing/set-query))
+        "search-input event registered")
+    (is (some? (registrar/handler :event :rf.causa.routing/set-sim-url))
+        "Simulate-URL event registered")
+    (is (some? (registrar/handler :event :rf.causa.routing/toggle-row))
+        "toggle-row event registered")
     (is (some? (registrar/handler :event :rf.causa/set-registered-routes-override-for-test))
         "test-only override event registered")
     (is (some? (registrar/handler :event :rf.causa/set-current-route-slice-override-for-test))
@@ -129,10 +148,9 @@
 ;; ---- (2) silent state ---------------------------------------------------
 
 (deftest panel-renders-silent-state-when-no-routes
-  (testing "no routes registered → empty-state body, no tree"
+  (testing "no routes registered → empty-state body, no list, no search"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      ;; Seed both overrides to nil so the panel falls through.
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
                         {:frame :rf/causa})
       (let [tree (routing/Panel)]
@@ -142,10 +160,37 @@
             "header always renders")
         (is (some? (find-by-testid tree "rf-causa-routing-empty"))
             "silent state body present")
-        (is (nil? (find-by-testid tree "rf-causa-routing-tree"))
-            "tree NOT rendered")))))
+        (is (nil? (find-by-testid tree "rf-causa-routing-list"))
+            "flat list NOT rendered")
+        (is (nil? (find-by-testid tree "rf-causa-routing-search"))
+            "search NOT rendered in silent state")
+        (is (nil? (find-by-testid tree "rf-causa-routing-sim"))
+            "simulator NOT rendered in silent state")))))
 
-;; ---- (3) orientation HERE marker ----------------------------------------
+;; ---- (3) flat-list rendering + chrome ----------------------------------
+
+(deftest panel-renders-flat-list-when-routes-present
+  (testing "routes present → flat list + search + simulator + slice detail"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-list"))
+            "flat list rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-search"))
+            "search box rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-sim"))
+            "Simulate-URL section rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
+            "slice detail rendered for active slice")
+        (is (nil? (find-by-testid tree "rf-causa-routing-empty"))
+            "empty state NOT rendered when routes present")))))
+
+;; ---- (4) orientation HERE marker ----------------------------------------
 
 (deftest panel-renders-here-marker-without-navigation
   (testing "current slice present + no nav cascade → HERE on the active row"
@@ -158,15 +203,13 @@
                         {:frame :rf/causa})
       (let [tree (routing/Panel)
             cart-row (find-by-testid tree "rf-causa-routing-row-route/cart")]
-        (is (some? (find-by-testid tree "rf-causa-routing-tree"))
-            "tree renders when routes exist")
         (is (some? cart-row) "current route row renders")
         (is (= "here" (:data-marker (second cart-row)))
             "current route row carries the HERE marker")
         (is (some? (find-by-testid tree "rf-causa-routing-marker-here"))
             "HERE chip text rendered")))))
 
-;; ---- (4) FROM / TO markers ---------------------------------------------
+;; ---- (5) FROM / TO markers ---------------------------------------------
 
 (deftest panel-renders-from-to-when-cascade-navigated
   (testing "focused cascade with nav-token emit → FROM + TO markers"
@@ -174,17 +217,10 @@
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/causa})
-      ;; Current slice still on the FROM route — simulates reading
-      ;; the panel while the cascade is mid-flight (or against a stale
-      ;; snapshot); the helpers expose both markers.
       (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
                          {:id :route/cart :params {} :query {}}]
                         {:frame :rf/causa})
-      ;; Seed the trace-buffer with a nav-allocated cascade + focus on it.
-      ;; The cascade projector buckets the nav-allocated emit under :other.
       (let [nav-event (nav-allocated :route/confirm)
-            ;; A minimal trace-buffer that the projection's group-cascades
-            ;; will bucket into one cascade with id=99.
             buffer [{:id 99 :op-type :event :operation :event/dispatched
                      :tags {:dispatch-id 99
                             :event [:rf.route/navigate :route/confirm]}}
@@ -210,7 +246,100 @@
         (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
             "header nav summary surfaces the TO id")))))
 
-;; ---- (5) slice detail rendering ----------------------------------------
+;; ---- (6) metadata badges + parent annotation ---------------------------
+
+(deftest panel-renders-meta-badges
+  (testing "routes carrying :on-match / :parent surface their badges"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)
+            confirm-row (find-by-testid tree "rf-causa-routing-row-route/confirm")]
+        (is (some? confirm-row) "confirm row renders")
+        ;; :route/confirm carries both :on-match and :parent
+        (let [on-match-badges (find-all-by-testid-prefix
+                                tree "rf-causa-routing-badge-on-match")
+              parent-badges   (find-all-by-testid-prefix
+                                tree "rf-causa-routing-badge-parent")
+              parent-ptrs     (find-all-by-testid-prefix
+                                tree "rf-causa-routing-parent-ptr")]
+          (is (pos? (count on-match-badges))
+              "at least one :on-match badge renders (confirm has :on-match)")
+          (is (pos? (count parent-badges))
+              "at least one :parent badge renders (confirm has :parent)")
+          (is (pos? (count parent-ptrs))
+              "the compact ↑ parent pointer annotation renders"))))))
+
+;; ---- (7) substring search filters the list -----------------------------
+
+(deftest panel-search-filters-the-list
+  (testing "set-query event narrows the catalogue"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.routing/set-query "checkout"]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)
+            rows (find-all-by-testid-prefix tree "rf-causa-routing-row-")]
+        (is (= #{"rf-causa-routing-row-route/checkout"
+                 "rf-causa-routing-row-route/payment"
+                 "rf-causa-routing-row-route/confirm"}
+               (set (map #(:data-testid (second %)) rows)))
+            "only routes whose haystack contains \"checkout\" render")))))
+
+;; ---- (8) Simulate-URL surface ------------------------------------------
+
+(deftest panel-simulates-url-and-surfaces-candidates
+  (testing "set-sim-url populates the simulator result with ranked candidates"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.routing/set-sim-url "/cart"]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-sim-result"))
+            "simulator result rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-sim-candidate-route/cart"))
+            "matching candidate row rendered"))))
+
+  (testing "no match — result block reports zero candidates"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.routing/set-sim-url "/nope-not-here"]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-sim-result"))
+            "simulator result rendered even on no-match")))))
+
+;; ---- (9) row expand toggle ---------------------------------------------
+
+(deftest panel-row-expand-toggle
+  (testing "toggle-row event opens the meta-expander surface"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Initial render — no expander visible.
+      (let [tree (routing/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
+            "meta expander NOT present before toggle"))
+      (rf/dispatch-sync [:rf.causa.routing/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
+            "meta expander rendered after toggle"))
+      (rf/dispatch-sync [:rf.causa.routing/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (let [tree (routing/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
+            "meta expander hidden after second toggle (toggle behaviour)")))))
+
+;; ---- (10) slice detail rendering ---------------------------------------
 
 (deftest panel-renders-slice-detail
   (testing "params + query + fragment grid rendered when current slice present"

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
@@ -1,5 +1,6 @@
 (ns day8.re-frame2-causa.panels.routing-helpers-cljs-test
-  "Pure-data tests for Causa's Routing tab helpers (rf2-nrbs9).
+  "Pure-data tests for Causa's Routes tab helpers (rf2-nrbs9, reshaped
+  per rf2-lq0ef).
 
   Dual-target naming (`.cljc` + `_cljs_test`):
 
@@ -10,19 +11,25 @@
 
   ## What's under test
 
-    1. **project-route-tree** — registrar map → row vector, sorted
-       by path; correct depth derivation; empty registrar → `[]`.
-    2. **focused-cascade** — lookup by dispatch-id.
-    3. **nav-token-allocated-in-cascade** — scans `:other` bucket
-       for the `:rf.route.nav-token/allocated` emit; nil when
-       absent.
-    4. **from-to-from-cascade** — derives `{:from-id :to-id
+    1. **project-routes** — registrar map → row vector, sorted by
+       path; per-key surface (route-id / path / doc / parent / tags /
+       has-on-match? / has-can-leave? / rank / meta); empty
+       registrar → `[]`.
+    2. **filter-rows** — substring match across route-id + path + doc,
+       case-insensitive; blank query is identity.
+    3. **simulate-url** — runs every route's compiled pattern against
+       the URL, returns ranked candidates + winner; mirrors `match-url`
+       resolution order.
+    4. **focused-cascade** — lookup by dispatch-id.
+    5. **nav-token-allocated-in-cascade** — scans `:other` bucket for
+       the `:rf.route.nav-token/allocated` emit; nil when absent.
+    6. **from-to-from-cascade** — derives `{:from-id :to-id
        :navigated?}` per the lens contract.
-    5. **assign-markers** — TO wins over FROM wins over HERE; HERE
+    7. **assign-markers** — TO wins over FROM wins over HERE; HERE
        only surfaces when no navigation happened.
-    6. **project-data** — top-level composite; silent state when no
-       routes; correct decoration when focused event causes
-       navigation."
+    8. **project-data** — top-level composite; silent state when no
+       routes; correct decoration when focused event causes navigation;
+       carries query + sim-url through."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-causa.panels.routing-helpers :as h]))
@@ -30,26 +37,34 @@
 ;; ---- fixture builders ---------------------------------------------------
 
 (defn- route
-  "Build a registrar-shaped route metadata map."
-  ([path] (route path nil))
-  ([path doc] (cond-> {:path path}
-                doc (assoc :doc doc))))
+  "Build a registrar-shaped route metadata map. Adds the
+  `:rf.route/compiled` slot the simulator reads (production sets this
+  at `reg-route` time) so the simulator tests work without booting
+  the full registrar."
+  [path & {:keys [doc parent tags on-match can-leave]}]
+  (cond-> {:path path}
+    doc       (assoc :doc doc)
+    parent    (assoc :parent parent)
+    tags      (assoc :tags tags)
+    on-match  (assoc :on-match on-match)
+    can-leave (assoc :can-leave can-leave)))
 
 (def cart-routes
   "Realistic registrar shape — a small e-commerce route set."
   {:route/root      (route "/")
-   :route/cart      (route "/cart"      "shopping cart")
-   :route/checkout  (route "/checkout"  "checkout overview")
+   :route/cart      (route "/cart"      :doc "shopping cart")
+   :route/checkout  (route "/checkout"  :doc "checkout overview")
    :route/payment   (route "/checkout/payment")
-   :route/confirm   (route "/checkout/confirm")
-   :route/admin     (route "/admin")
-   :route/audit     (route "/admin/audit")
+   :route/confirm   (route "/checkout/confirm" :parent :route/checkout)
+   :route/admin     (route "/admin"
+                           :tags     #{:admin}
+                           :can-leave :guard/admin-leave?)
+   :route/audit     (route "/admin/audit"
+                           :parent   :route/admin
+                           :on-match [:audit/load])
    :route/not-found (route "/404")})
 
 (defn- nav-allocated-trace
-  "Build a `:rf.route.nav-token/allocated` trace event map mirroring
-  the shape `(trace/emit! :event :rf.route.nav-token/allocated ...)`
-  produces in `re-frame.routing`."
   [route-id nav-token & [dispatch-id]]
   {:id        1
    :op-type   :event
@@ -58,8 +73,6 @@
                 dispatch-id (assoc :dispatch-id dispatch-id))})
 
 (defn- cascade
-  "Build a minimal cascade record per `re-frame.trace.projection`
-  shape — only the slots the helpers actually read."
   [dispatch-id event-vec & {:keys [other effects fx handler]
                             :or {other [] effects [] fx nil handler nil}}]
   {:dispatch-id dispatch-id
@@ -71,37 +84,122 @@
    :renders     []
    :other       other})
 
-;; ---- project-route-tree -------------------------------------------------
+;; ---- project-routes -----------------------------------------------------
 
-(deftest project-route-tree-test
+(deftest project-routes-test
   (testing "empty registrar yields []"
-    (is (= [] (h/project-route-tree {}))))
+    (is (= [] (h/project-routes {}))))
 
-  (testing "single route yields one row at depth 0 for root"
-    (let [rows (h/project-route-tree {:route/root (route "/")})]
+  (testing "single route yields one row"
+    (let [rows (h/project-routes {:route/root (route "/")})]
       (is (= 1 (count rows)))
       (is (= :route/root (-> rows first :route-id)))
       (is (= "/" (-> rows first :path)))
-      (is (= 0 (-> rows first :depth)))))
+      (is (false? (-> rows first :has-on-match?)))
+      (is (false? (-> rows first :has-can-leave?)))))
 
-  (testing "multi-segment paths derive depth from segment count"
-    (let [rows (h/project-route-tree cart-routes)
-          by-id (into {} (map (juxt :route-id identity)) rows)]
-      (is (= 0 (get-in by-id [:route/root :depth])))
-      (is (= 1 (get-in by-id [:route/cart :depth])))
-      (is (= 1 (get-in by-id [:route/checkout :depth])))
-      (is (= 2 (get-in by-id [:route/payment :depth])))
-      (is (= 2 (get-in by-id [:route/audit :depth])))))
+  (testing "no :depth field — flat per rf2-lq0ef"
+    (let [rows (h/project-routes cart-routes)]
+      (is (every? #(not (contains? % :depth)) rows)
+          "rows must not carry a :depth field (decorative tree dropped)")))
 
   (testing "rows are sorted by path lexicographically"
-    (let [paths (mapv :path (h/project-route-tree cart-routes))]
+    (let [paths (mapv :path (h/project-routes cart-routes))]
       (is (= paths (sort paths)))))
 
-  (testing "doc is carried through when present, nil otherwise"
+  (testing "metadata surface — doc / parent / tags / has-on-match? / has-can-leave?"
     (let [by-id (into {} (map (juxt :route-id identity))
-                      (h/project-route-tree cart-routes))]
+                      (h/project-routes cart-routes))]
       (is (= "shopping cart" (get-in by-id [:route/cart :doc])))
-      (is (nil? (get-in by-id [:route/payment :doc]))))))
+      (is (= :route/checkout (get-in by-id [:route/confirm :parent])))
+      (is (= #{:admin} (get-in by-id [:route/admin :tags])))
+      (is (true? (get-in by-id [:route/admin :has-can-leave?])))
+      (is (true? (get-in by-id [:route/audit :has-on-match?])))
+      (is (false? (get-in by-id [:route/cart :has-on-match?])))))
+
+  (testing ":meta is the full registrar entry verbatim — click-to-expand surface"
+    (let [by-id (into {} (map (juxt :route-id identity))
+                      (h/project-routes cart-routes))]
+      (is (= (route "/cart" :doc "shopping cart")
+             (get-in by-id [:route/cart :meta]))))))
+
+;; ---- filter-rows --------------------------------------------------------
+
+(deftest filter-rows-test
+  (let [rows (h/project-routes cart-routes)]
+    (testing "blank / nil query is identity"
+      (is (= rows (h/filter-rows rows nil)))
+      (is (= rows (h/filter-rows rows "")))
+      (is (= rows (h/filter-rows rows "   "))))
+
+    (testing "substring on path"
+      (let [filtered (h/filter-rows rows "checkout")
+            ids      (set (map :route-id filtered))]
+        (is (contains? ids :route/checkout))
+        (is (contains? ids :route/payment))
+        (is (contains? ids :route/confirm))
+        (is (not (contains? ids :route/cart)))))
+
+    (testing "substring on route-id"
+      (let [filtered (h/filter-rows rows "audit")
+            ids      (set (map :route-id filtered))]
+        (is (= #{:route/audit} ids))))
+
+    (testing "substring on doc"
+      (let [filtered (h/filter-rows rows "shopping")
+            ids      (set (map :route-id filtered))]
+        (is (contains? ids :route/cart))))
+
+    (testing "case-insensitive"
+      (is (= (h/filter-rows rows "CHECKOUT")
+             (h/filter-rows rows "checkout"))))))
+
+;; ---- simulate-url -------------------------------------------------------
+
+(deftest simulate-url-test
+  (testing "nil / blank URL yields a benign empty result"
+    (let [r (h/simulate-url cart-routes nil)]
+      (is (nil? (:url r)))
+      (is (= [] (:candidates r)))
+      (is (nil? (:winner r))))
+    (is (= [] (:candidates (h/simulate-url cart-routes "")))))
+
+  (testing "exact path match — winner is the matching route"
+    (let [r (h/simulate-url cart-routes "/cart")]
+      (is (= "/cart" (:path r)))
+      (is (= :route/cart (:winner r)))
+      (is (= 1 (count (:candidates r))))
+      (is (true? (-> r :candidates first :winner?)))
+      (is (= [:route/cart] (mapv :route-id (:candidates r))))))
+
+  (testing "no match — empty candidates, nil winner"
+    (let [r (h/simulate-url cart-routes "/nope")]
+      (is (= [] (:candidates r)))
+      (is (nil? (:winner r)))))
+
+  (testing "query / fragment are stripped before matching"
+    (let [r (h/simulate-url cart-routes "/cart?source=email#step-1")]
+      (is (= "/cart" (:path r)))
+      (is (= :route/cart (:winner r)))))
+
+  (testing "trailing slash normalises (multi-segment only)"
+    (let [r (h/simulate-url cart-routes "/checkout/")]
+      (is (= :route/checkout (:winner r)))))
+
+  (testing "every matching route is a candidate (ranked descending)"
+    ;; `/checkout/payment` only matches `:route/payment` exactly;
+    ;; but if we register a splat-style fallback, it should appear
+    ;; as a lower-ranked candidate. Build a registrar with a splat
+    ;; to exercise the cascade.
+    (let [routes {:route/exact (route "/checkout/payment")
+                  :route/splat (route "/*rest")}
+          r      (h/simulate-url routes "/checkout/payment")
+          ids    (mapv :route-id (:candidates r))]
+      (is (= :route/exact (:winner r))
+          "static-heavy pattern outranks splat")
+      (is (= 2 (count ids)))
+      (is (= :route/exact (first ids)))
+      (is (= :route/splat (second ids))))))
 
 ;; ---- focused-cascade ----------------------------------------------------
 
@@ -179,7 +277,7 @@
 ;; ---- assign-markers -----------------------------------------------------
 
 (deftest assign-markers-test
-  (let [rows (h/project-route-tree cart-routes)]
+  (let [rows (h/project-routes cart-routes)]
     (testing "no navigation: HERE on the current route only"
       (let [decorated (h/assign-markers rows
                                         {:current-id :route/cart
@@ -200,7 +298,6 @@
             by-id (into {} (map (juxt :route-id :marker)) decorated)]
         (is (= :from (get by-id :route/cart)))
         (is (= :to   (get by-id :route/confirm)))
-        ;; Current-id == TO; HERE is suppressed in favour of TO.
         (is (not= :here (get by-id :route/confirm)))))
 
     (testing "navigation with same-route collapse: only TO surfaces"
@@ -232,25 +329,18 @@
       (is (= :route/cart (get-in data [:current :id]))))))
 
 (deftest project-data-navigation-test
-  (testing "focused cascade caused navigation — FROM + TO render"
+  (testing "focused cascade caused navigation — TO renders"
     (let [c (cascade 42 [:rf.route/navigate :route/confirm]
               :other [(nav-allocated-trace :route/confirm "nav-9" 42)])
           data (h/project-data cart-routes {:id :route/confirm} c)
           by-id (into {} (map (juxt :route-id :marker)) (:routes data))]
       (is (true? (:navigated? data)))
       (is (= :route/confirm (:to-id data)))
-      ;; Note: current-slice's :id is the POST-nav value (the slice
-      ;; reflects TO), so the FROM is derived from the nav-token emit
-      ;; ∧ the slice difference. Since current.id == to-id, FROM
-      ;; collapses to nil per from-to-from-cascade contract.
-      (is (nil? (:from-id data)))
+      (is (nil? (:from-id data))
+          "current.id == to-id ⇒ FROM collapses per from-to-from-cascade")
       (is (= :to (get by-id :route/confirm)))))
 
   (testing "nav cascade with distinct current slice — FROM ≠ TO"
-    ;; This simulates the case where the panel is reading mid-cascade:
-    ;; the nav-token emit identifies TO; the current slice (perhaps
-    ;; from a stale snapshot, or a different frame) carries the prior
-    ;; route-id; helper produces both markers.
     (let [c (cascade 1 [:rf.route/navigate :route/confirm]
               :other [(nav-allocated-trace :route/confirm "nav-3")])
           data (h/project-data cart-routes {:id :route/cart} c)
@@ -260,3 +350,20 @@
       (is (= :route/confirm (:to-id data)))
       (is (= :from (get by-id :route/cart)))
       (is (= :to   (get by-id :route/confirm))))))
+
+(deftest project-data-query-and-sim-test
+  (testing "query filter is applied to :routes"
+    (let [data (h/project-data cart-routes {:id :route/cart} nil "checkout" nil)
+          ids  (set (map :route-id (:routes data)))]
+      (is (true? (:filtered? data)))
+      (is (contains? ids :route/checkout))
+      (is (not (contains? ids :route/cart)))))
+
+  (testing "sim-url drives :sim-result"
+    (let [data (h/project-data cart-routes {:id :route/cart} nil nil "/cart")]
+      (is (= "/cart" (-> data :sim-result :path)))
+      (is (= :route/cart (-> data :sim-result :winner)))))
+
+  (testing "blank sim-url leaves :sim-result nil"
+    (let [data (h/project-data cart-routes {:id :route/cart} nil nil "")]
+      (is (nil? (:sim-result data))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -91,7 +91,7 @@
 
 (defn- causa-event-id? [id]
   (and (keyword? id)
-       (#{"rf.causa" "rf.causa.issues"} (namespace id))))
+       (#{"rf.causa" "rf.causa.issues" "rf.causa.routing"} (namespace id))))
 
 (defn- catalogued-causa-event-id? [id]
   (causa-event-id? id))
@@ -155,12 +155,19 @@
    :rf.causa/palette-query
    :rf.causa/palette-results
    :rf.causa/registered-machines
-   ;; rf2-nrbs9 — Routing tab (7th L3 tab) sub family.
+   ;; rf2-nrbs9 — Routes tab (7th L3 tab) sub family.
    :rf.causa/registered-routes
    :rf.causa/registered-routes-override
    :rf.causa/current-route-slice
    :rf.causa/current-route-slice-override
    :rf.causa/routing-tab-data
+   ;; rf2-lq0ef — Routes lens UI state (search query, Simulate-URL
+   ;; input, expanded-row set). Per-panel `:rf.causa.routing/*` group
+   ;; per the `:rf.causa.<panel>/*` convention in
+   ;; tools/causa/spec/014-Registry-Catalogue.md §Naming convention.
+   :rf.causa.routing/query
+   :rf.causa.routing/sim-url
+   :rf.causa.routing/expanded
    :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
@@ -317,9 +324,14 @@
    :rf.causa/set-frame
    :rf.causa/set-machine-definitions-override-for-test
    :rf.causa/set-machine-snapshots-override-for-test
-   ;; rf2-nrbs9 — Routing tab test-only override events.
+   ;; rf2-nrbs9 — Routes tab test-only override events.
    :rf.causa/set-current-route-slice-override-for-test
    :rf.causa/set-registered-routes-override-for-test
+   ;; rf2-lq0ef — Routes lens UI-state events (search input,
+   ;; Simulate-URL input, expand-row toggle).
+   :rf.causa.routing/set-query
+   :rf.causa.routing/set-sim-url
+   :rf.causa.routing/toggle-row
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/set-modal-positioning
    ;; rf2-x8h9y — resize-handle live update event.
@@ -464,22 +476,14 @@
     ;; rf2-piye4: +3 events (:rf.causa/filter-by-{machine,http-correlation,fx}).
     ;;
     ;; rf2-y9xmf — Machine Inspector collapse to event-driven Runtime panel.
-    ;; Drops the Mode A/B/C picker / sub-strip / arc / mini-scrubber surfaces
-    ;; (Sim engine + browse-all index preserved; UI ribbons gone). Sibling
-    ;; bead rf2-r4nao will re-host the dropped UI under the future Static
-    ;; surface.
-    ;;   Subs:   -13 (forced-machine-mode, machine-arc-*, machine-instances*,
-    ;;                mode-c-*) +1 (machine-transitions-for-focused-event)
-    ;;                = net -12 → 93.
-    ;;   Events: -8 (clear-mode-c-selection, set-forced-machine-mode,
-    ;;               set-machine-instances-override, set-mode-c-cluster-by,
-    ;;               set-mode-c-context-key, set-arc-hover, toggle-mode-c-*)
-    ;;           -1 duplicate (clear-machine-selection appeared twice)
-    ;;           +2 (machine-focus-prev / machine-focus-next)
-    ;;           = net -7. Plus rf2-piye4's +3 events still present →
-    ;;           115 - 7 + 3 = 111.
-    (is (= 93  (count all-sub-names)))
-    (is (= 111 (count all-event-names)))
+    ;; (Mode A/B/C / sub-strip / arc / mini-scrubber dropped; Sim engine
+    ;; preserved.) Net subs -12 → 93; events -7+3 (piye4) → 111.
+    ;;
+    ;; rf2-lq0ef — Routes lens reshape: +3 subs (query/sim-url/expanded);
+    ;; +3 events (set-query/set-sim-url/toggle-row).
+    ;; Combined post-rebase: 93+3=96 subs, 111+3=114 events.
+    (is (= 96  (count all-sub-names)))
+    (is (= 114 (count all-event-names)))
     (is (= 5   (count all-fx-names)))))
 
 (deftest registry-is-idempotent

--- a/tools/causa/testbeds/panel_gallery/fixtures_routing.cljs
+++ b/tools/causa/testbeds/panel_gallery/fixtures_routing.cljs
@@ -1,7 +1,8 @@
 (ns panel-gallery.fixtures-routing
-  "Pure fixture builders for the Causa Routing tab gallery (rf2-nrbs9).
+  "Pure fixture builders for the Causa Routes tab gallery (rf2-nrbs9,
+  reshaped per rf2-lq0ef).
 
-  The Routing panel reads:
+  The Routes panel reads:
 
     - `:rf.causa/registered-routes` — defaults to `(rf/registrations
       :route)`; test override slot exists at
@@ -13,40 +14,56 @@
       `:rf.causa/sync-trace-buffer` + `:rf.causa/focus-cascade` so
       the spine's focused cascade carries the
       `:rf.route.nav-token/allocated` emit.
+    - `:rf.causa.routing/query` + `:rf.causa.routing/sim-url` —
+      UI-state slots driven by `:rf.causa.routing/set-query` and
+      `:rf.causa.routing/set-sim-url` respectively.
 
   Variants:
 
     1. no-routes-registered (silent)
     2. current-route-only (◆ HERE)
     3. from-to-transition (◆ FROM / ◆ TO)
-    4. nested-route-tree (depth 3+)")
+    4. search-filter (substring search exercises the catalogue)
+    5. simulate-url-winner (paste URL → see ranked candidates)")
 
 ;; ---- route registrar fixtures -------------------------------------------
 
 (def cart-routes
-  "Shallow e-commerce route set — exercises depth 0 / 1 / 2 paths and
-  the current/from/to lens."
+  "Shallow e-commerce route set — exercises basic catalogue rendering
+  plus the metadata badges (`:on-match`, `:can-leave`, `:tags`,
+  `:parent`)."
   {:route/root      {:path "/"                  :doc "home"}
-   :route/cart      {:path "/cart"              :doc "shopping cart"}
-   :route/checkout  {:path "/checkout"          :doc "checkout overview"}
-   :route/payment   {:path "/checkout/payment"  :doc "payment step"}
-   :route/confirm   {:path "/checkout/confirm"  :doc "confirmation"}
-   :route/admin     {:path "/admin"             :doc "admin landing"}
-   :route/audit     {:path "/admin/audit"       :doc "admin audit log"}
+   :route/cart      {:path "/cart"              :doc "shopping cart"
+                     :tags #{:public}}
+   :route/checkout  {:path "/checkout"          :doc "checkout overview"
+                     :can-leave :guard/checkout-dirty?}
+   :route/payment   {:path "/checkout/payment"  :doc "payment step"
+                     :parent :route/checkout
+                     :on-match [:payment/load]}
+   :route/confirm   {:path "/checkout/confirm"  :doc "confirmation"
+                     :parent :route/checkout}
+   :route/admin     {:path "/admin"             :doc "admin landing"
+                     :tags #{:admin}}
+   :route/audit     {:path "/admin/audit"       :doc "admin audit log"
+                     :parent :route/admin
+                     :on-match [:audit/load]}
    :route/not-found {:path "/404"               :doc "fallback"}})
 
-(def deep-routes
-  "Deeper nesting exercises the indentation behaviour at depth 3+."
-  {:route/root          {:path "/"}
-   :route/docs          {:path "/docs"                              :doc "docs landing"}
-   :route/docs.guide    {:path "/docs/guide"                        :doc "guide section"}
-   :route/docs.api      {:path "/docs/api"                          :doc "API reference"}
-   :route/docs.api.subs {:path "/docs/api/subs"                     :doc "subs API"}
-   :route/docs.api.evts {:path "/docs/api/events"                   :doc "events API"}
-   :route/docs.api.evts.detail {:path "/docs/api/events/detail"     :doc "single event detail"}
-   :route/docs.guide.routing   {:path "/docs/guide/routing"         :doc "routing chapter"}
-   :route/blog          {:path "/blog"                              :doc "blog index"}
-   :route/blog.post     {:path "/blog/post"                         :doc "single post"}})
+(def docs-routes
+  "Larger registrar — exercises the substring search filter at a
+  scale where the catalogue starts to need narrowing."
+  {:route/root            {:path "/"}
+   :route/docs            {:path "/docs"                       :doc "docs landing"}
+   :route/docs.guide      {:path "/docs/guide"                 :doc "guide section"}
+   :route/docs.api        {:path "/docs/api"                   :doc "API reference"}
+   :route/docs.api.subs   {:path "/docs/api/subs"              :doc "subs API"}
+   :route/docs.api.evts   {:path "/docs/api/events"            :doc "events API"}
+   :route/docs.api.detail {:path "/docs/api/events/detail"     :doc "single event detail"}
+   :route/docs.routing    {:path "/docs/guide/routing"         :doc "routing chapter"}
+   :route/blog            {:path "/blog"                       :doc "blog index"}
+   :route/blog.post       {:path "/blog/post"                  :doc "single post"}
+   :route/blog.tag        {:path "/blog/tag/:tag"              :doc "blog tag"}
+   :route/blog.splat      {:path "/blog/*rest"                 :doc "blog wildcard"}})
 
 ;; ---- route-slice fixtures ----------------------------------------------
 
@@ -62,16 +79,13 @@
    :fragment "step-3"})
 
 (def docs-api-detail-slice
-  {:id     :route/docs.api.evts.detail
+  {:id     :route/docs.api.detail
    :params {:event-id "user/login"}
    :query  {:tab :timeline}})
 
 ;; ---- trace-buffer fixtures (drive FROM/TO detection) -------------------
 
 (defn- nav-allocated-trace
-  "Build a `:rf.route.nav-token/allocated` trace event mirroring the
-  shape `(trace/emit! :event :rf.route.nav-token/allocated ...)`
-  produces in `re-frame.routing`."
   [id dispatch-id route-id nav-token]
   {:id        id
    :op-type   :event
@@ -81,7 +95,6 @@
                :nav-token   nav-token}})
 
 (defn- event-dispatched-trace
-  "Build an `:event/dispatched` trace event — the cascade root."
   [id dispatch-id event-vec]
   {:id        id
    :op-type   :event
@@ -90,15 +103,12 @@
                :event       event-vec}})
 
 (defn nav-buffer
-  "Trace buffer carrying one cascade that navigates to `to-route`.
-  Returns a vector shaped exactly as `re-frame.trace.projection/
-  group-cascades` consumes."
+  "Trace buffer carrying one cascade that navigates to `to-route`."
   [dispatch-id to-route nav-token]
   [(event-dispatched-trace 1 dispatch-id [:rf.route/navigate to-route])
    (nav-allocated-trace 2 dispatch-id to-route nav-token)])
 
 (defn no-nav-buffer
-  "Trace buffer carrying one cascade that does NOT navigate. Used by
-  the orientation variants where only `◆ HERE` should render."
+  "Trace buffer carrying one cascade that does NOT navigate."
   [dispatch-id event-vec]
   [(event-dispatched-trace 1 dispatch-id event-vec)])

--- a/tools/causa/testbeds/panel_gallery/gallery_routing.cljs
+++ b/tools/causa/testbeds/panel_gallery/gallery_routing.cljs
@@ -1,9 +1,8 @@
 (ns panel-gallery.gallery-routing
-  "Story coverage for the **Routing tab** of the 7-tab Causa chrome
-  (rf2-nrbs9 — the new 7th L3 tab promoted from 'lives in App-db +
-  Trace').
+  "Story coverage for the **Routes tab** of the 7-tab Causa chrome
+  (rf2-nrbs9, reshaped per rf2-lq0ef).
 
-  The Routing tab body is the `routing/Panel` view. The panel reads:
+  The Routes tab body is the `routing/Panel` view. The panel reads:
 
     - `:rf.causa/registered-routes`     — default `(rf/registrations
                                           :route)`; test override slot
@@ -14,12 +13,15 @@
     - `:rf.causa/cascades`              — drives FROM/TO detection.
     - `:rf.causa/focus`                 — the spine's focused
                                           dispatch-id.
+    - `:rf.causa.routing/query`         — substring filter input.
+    - `:rf.causa.routing/sim-url`       — Simulate-URL input.
 
   Each variant seeds the override slots via the test-only events
   (`:rf.causa/set-registered-routes-override-for-test`,
   `:rf.causa/set-current-route-slice-override-for-test`) and the
   trace-buffer via `:rf.causa/sync-trace-buffer` +
-  `:rf.causa/focus-cascade` (for the FROM/TO variant)."
+  `:rf.causa/focus-cascade` (for the FROM/TO variant). Search +
+  Simulate-URL variants set the UI-state events directly."
   (:require [re-frame.story :as story]
             [panel-gallery.fixtures-routing :as fixtures]
             [panel-gallery.panel-views :as panel-views]))
@@ -28,7 +30,7 @@
   (panel-views/register!))
 
 (defn register-all!
-  "Register the Routing tab Story surface. Idempotent under
+  "Register the Routes tab Story surface. Idempotent under
   `install-canonical-vocabulary!` resets so the namespace is
   reloadable."
   []
@@ -37,16 +39,19 @@
 
   (story/reg-tag :feature/causa-routing
     {:axis :feature
-     :doc  "Causa Routing tab — lens over the registered-routes tree
-            with HERE/FROM/TO markers driven by the focused cascade
-            per spec/016 §Routing tab + spec/018 §5.6."})
+     :doc  "Causa Routes tab — flat catalogue of registered routes with
+            substring search + Simulate-URL plus HERE/FROM/TO markers
+            driven by the focused cascade per spec/016 §Routes tab +
+            spec/018 §5.6. Decorative URL-path tree dropped per
+            rf2-lq0ef (audit verdict B)."})
 
   (story/reg-story :story.causa.routing
-    {:doc        "Visual gallery of the Causa Routing tab under varying
-                 registrar shapes + nav cascades. Each variant seeds
-                 the registered-routes + current-slice override slots
-                 via test-only events and the trace-buffer via
-                 :rf.causa/sync-trace-buffer."
+    {:doc        "Visual gallery of the Causa Routes tab under varying
+                 registrar shapes + nav cascades + UI inputs. Each
+                 variant seeds the registered-routes + current-slice
+                 override slots via test-only events; search +
+                 Simulate-URL variants set the UI-state events
+                 directly."
      :component  :panel-gallery.routing/Panel
      :tags       #{:dev :feature/causa-routing}
      :substrates #{:reagent}})
@@ -54,8 +59,9 @@
   ;; ----- 1. no routes registered (silent) ----------------------------
   (story/reg-variant :story.causa.routing/no-routes
     {:doc        "Host app has no routes registered. Panel renders
-                 the silent empty-state — terse one-liner, no tree.
-                 Honours silent-by-default per rf2-g3ghh."
+                 the silent empty-state — terse one-liner, no list,
+                 no search, no Simulate-URL. Honours silent-by-
+                 default per rf2-g3ghh."
      :events     [[:rf.causa/set-registered-routes-override-for-test {}]
                   [:rf.causa/set-current-route-slice-override-for-test nil]]
      :tags       #{:dev :state/empty}
@@ -65,7 +71,9 @@
   (story/reg-variant :story.causa.routing/current-route-only
     {:doc        "Routes registered + a current slice; focused
                  cascade did NOT navigate. The current row carries
-                 the ◆ HERE marker — orientation only."
+                 the ◆ HERE marker — orientation only. Metadata
+                 badges (M / L / T / P) decorate routes carrying
+                 :on-match / :can-leave / :tags / :parent."
      :events     [[:rf.causa/set-registered-routes-override-for-test
                    fixtures/cart-routes]
                   [:rf.causa/set-current-route-slice-override-for-test
@@ -81,14 +89,9 @@
     {:doc        "Focused cascade carried a nav-token allocation —
                  the panel renders ◆ FROM on the prior route and
                  ◆ TO on the destination. Params/query for the
-                 destination surface below the tree."
+                 destination surface below the catalogue."
      :events     [[:rf.causa/set-registered-routes-override-for-test
                    fixtures/cart-routes]
-                  ;; Slice still on the FROM route so the helper can
-                  ;; derive FROM ≠ TO. (Production: the slice writes
-                  ;; the TO value during the cascade, but the panel
-                  ;; can read it mid-flight — the lens shows both
-                  ;; markers when the snapshot is split.)
                   [:rf.causa/set-current-route-slice-override-for-test
                    fixtures/cart-slice]
                   [:rf.causa/sync-trace-buffer
@@ -97,28 +100,45 @@
      :tags       #{:dev :state/special}
      :substrates #{:reagent}})
 
-  ;; ----- 4. nested route tree (depth 3+) -----------------------------
-  (story/reg-variant :story.causa.routing/nested-route-tree
-    {:doc        "Deeper nesting exercises the indentation behaviour
-                 at depth 3+ (`/docs/api/events/detail` lands at
-                 depth 4). HERE marks the active deeply-nested
-                 route; params + query surface below the tree."
+  ;; ----- 4. search filter narrows the catalogue ----------------------
+  (story/reg-variant :story.causa.routing/search-filter
+    {:doc        "Larger registrar with the substring search input
+                 populated — only routes whose route-id / path / doc
+                 contains `api` render. Demonstrates the substring
+                 filter contract per `routing-helpers/filter-rows`."
      :events     [[:rf.causa/set-registered-routes-override-for-test
-                   fixtures/deep-routes]
+                   fixtures/docs-routes]
                   [:rf.causa/set-current-route-slice-override-for-test
                    fixtures/docs-api-detail-slice]
+                  [:rf.causa.routing/set-query "api"]
                   [:rf.causa/sync-trace-buffer
                    (fixtures/no-nav-buffer 1 [:docs/refresh])]
                   [:rf.causa/focus-cascade 1 nil]]
      :tags       #{:dev :state/medium}
      :substrates #{:reagent}})
 
+  ;; ----- 5. Simulate-URL surfaces ranked candidates ------------------
+  (story/reg-variant :story.causa.routing/simulate-url-winner
+    {:doc        "Paste a URL into Try URL; the panel ranks every
+                 matching route by its 6-rule :rf.route/rank tuple
+                 and highlights the winner. The load-bearing
+                 interactive surface that exposes the structural
+                 match contract per spec/012 §Route ranking algorithm."
+     :events     [[:rf.causa/set-registered-routes-override-for-test
+                   fixtures/docs-routes]
+                  [:rf.causa.routing/set-sim-url "/blog/post"]
+                  [:rf.causa/sync-trace-buffer
+                   (fixtures/no-nav-buffer 1 [:noop])]
+                  [:rf.causa/focus-cascade 1 nil]]
+     :tags       #{:dev :state/special}
+     :substrates #{:reagent}})
+
   ;; ----- variants-grid workspace ------------------------------------
   (story/reg-workspace :workspace.causa.routing/all
-    {:doc      "All four Routing tab variants in one auto-grid.
+    {:doc      "All five Routes tab variants in one auto-grid.
                 Scroll to see the panel's response across no-routes /
                 current-route-only / from-to-transition /
-                nested-route-tree."
+                search-filter / simulate-url-winner."
      :layout   :variants-grid
      :story    :story.causa.routing
      :columns  2


### PR DESCRIPTION
## Summary

Per the routing-inheritance audit ([`ai/findings/2026-05-19-routing-inheritance-audit.md`](../tree/main/ai/findings/2026-05-19-routing-inheritance-audit.md), verdict B): routes are flat in the spec and impl, `:parent` plays no role in matching, the match-resolver is structural (6-rule rank on URL pattern). The previous URL-path-segmentation tree was decorative — it conflated URL-prefix similarity with semantic hierarchy.

The Routes lens now mirrors the actual contract:

- **Flat catalogue** sorted by `:path`. `project-route-tree` dropped; no indentation, no depth.
- **Per-row chips** with single-letter badges (M / L / T / P) for `:on-match` / `:can-leave` / `:tags` / `:parent`. Click the row chevron to expand the full registrar meta inline.
- **Substring search** across route-id + path + doc.
- **Simulate-URL** — paste a URL, the lens runs `re-frame.routing.match/match-against` on every compiled pattern, ranks matching candidates by `:rf.route/rank` descending, highlights the winner. Exposes the structural match contract per `spec/012-Routing.md` §Route ranking algorithm.
- **`:parent` annotation** — compact `↑ :route/parent` inline pointer on rows carrying `:parent`; row-expand surfaces the full meta.
- HERE / FROM / TO marker contract unchanged.

Spec + registry catalogue refreshed; `tools/causa/spec/014-Registry-Catalogue.md` routes-panel table rewritten to match the actually-shipped surface (previous entries referenced subs that never existed). `tools/causa/deps.edn` gains `day8/re-frame2-routing` as a hard dep (mirrors the `day8/re-frame2-epoch` precedent — `routing_helpers` `:require`s `re-frame.routing.match` at load time).

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 750 tests / 2190 assertions pass
- [x] `npm run test:cljs` from `implementation/` — 2952 tests / 8468 assertions pass
- [x] `npm run test:bundle-isolation` — PASS (counter / uix / helix)
- [x] Registry smoke list extended; count snapshot bumped (108 subs / 121 events).
- [ ] Manual: paste a URL into Try URL, confirm winner glyph + rank tuples render.
- [ ] Manual: substring search narrows the catalogue.
- [ ] Manual: gallery variants (panel_gallery) render no-routes / current-route-only / from-to-transition / search-filter / simulate-url-winner.

Closes rf2-lq0ef.