### PR TITLE
feat(causa): tag App-db diff path origins (handler-effect vs flow-output) (rf2-s8r6c)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/diff/render.cljs
@@ -41,7 +41,8 @@
   `large-chip` renderers — the diff layer never overrides them. The
   diff layer's chrome (gutter colour + glyph) wraps the chip without
   reveal."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as string]
+            [re-frame.core :as rf]
             [day8.re-frame2-causa.diff.annotated-tree :as at]
             ;; Phase 3 (rf2-i39w2) — hiccup-diff micro-engine renderer.
             ;; Additive dispatch: when this renderer encounters a
@@ -50,6 +51,7 @@
             ;; renderer; the generic ops still resolve here.
             [day8.re-frame2-causa.diff.hiccup-render :as hd-render]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.panels.app-db-diff-helpers :as h]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
@@ -182,18 +184,111 @@
                                     :text-decoration-color (:border-default tokens)}}
                (pr-str seg)])))))
 
+;; ---- rf2-s8r6c — per-section origin tag chip ---------------------------
+;;
+;; Each section header carries an origin chip identifying the writer(s)
+;; that mutated paths under this section:
+;;
+;;   `[fx :db]`        — the handler's `:db` effect (no flow covers it)
+;;   `[flow :flow-id]` — a single flow's `:output` wrote here
+;;   `[flow :a :b] + [fx :db]` — coalesced mixed section
+;;
+;; The chip is rendered next to the path breadcrumb at the LEFT end of
+;; the header's affordance row, so it sits in the developer's eye-path
+;; as they read "this section is the cart, written by …". Computation
+;; is a pure helper (`app-db-diff-helpers/path-origin-tag`); the
+;; renderer just turns the tag into hiccup.
+
+(defn- origin-tag-label
+  "Render an origin-tag map (the output of `path-origin-tag`) as a
+  human-readable label string. Pure data → string. Used by tests as
+  well as the chip renderer."
+  [tag]
+  (case (:kind tag)
+    :fx    "[fx :db]"
+    :flow  (str "[flow " (pr-str (:flow-id tag)) "]")
+    :mixed (let [flow-part (str "[flow "
+                                (string/join " " (map pr-str (:flow-ids tag)))
+                                "]")]
+             (if (:fx? tag)
+               (str flow-part " + [fx :db]")
+               flow-part))))
+
+(defn- origin-tag-tone
+  "Pick the chip's accent colour. Flow writes use `:accent-violet`
+  (mirrors §8 FLOWS row colour in the Event lens); pure-fx writes use
+  the muted `:text-tertiary` (handler `:db` is the ambient writer);
+  mixed uses `:yellow` to flag the coalesced case."
+  [tag]
+  (case (:kind tag)
+    :fx    (:text-tertiary tokens)
+    :flow  (:accent-violet tokens)
+    :mixed (:yellow tokens)))
+
+(defn- origin-tag-tooltip
+  [tag]
+  (case (:kind tag)
+    :fx    (str "Handler `:db` effect wrote here. "
+                "(No flow's :output covers this section.)")
+    :flow  (str "Flow " (pr-str (:flow-id tag))
+                " wrote here via its :output. "
+                "Per Spec 013, flows fire automatically after the handler's "
+                "effects, writing their computed value to the registered "
+                ":path.")
+    :mixed (str "Coalesced section — multiple writers contributed: "
+                (origin-tag-label tag) ". Each flow listed wrote via "
+                "its :output; the [fx :db] tag (when present) indicates "
+                "additional handler-effect writes inside this section.")))
+
+(defn origin-tag-chip
+  "Render the origin-tag chip for one section. Always returns a hiccup
+  vector (the chip is mandatory per the rf2-s8r6c design — every diff
+  row has an attributable writer).
+
+  `section-path` is included in the `data-testid` so tests can target
+  individual section chips."
+  [section-path tag]
+  (let [label   (origin-tag-label tag)
+        colour  (origin-tag-tone tag)
+        kind    (name (:kind tag))]
+    [:span {:data-testid (str "rf-causa-diff-section-origin-"
+                              (pr-str section-path))
+            :data-origin kind
+            :title       (origin-tag-tooltip tag)
+            :style       {:display       "inline-flex"
+                          :align-items   "center"
+                          :gap           "4px"
+                          :padding       "1px 6px"
+                          :background    (:bg-2 tokens)
+                          :border        (str "1px solid "
+                                              (:border-subtle tokens))
+                          :border-radius "3px"
+                          :color         colour
+                          :font-family   mono-stack
+                          :font-size     "10px"
+                          :font-weight   600
+                          :user-select   "none"
+                          :cursor        "help"}}
+     label]))
+
 (defn breadcrumb
   "Sticky path-header breadcrumb (per design §5.1) carrying the section
   path + the per-section affordance row (rf2-ykjl5):
 
-      [:cart :items]  ⟨Show me when this changed⟩
-                      ⟨Copy path⟩ ⟨Copy value⟩
+      [:cart :items]  [flow :cart-total]  ⟨Show me when this changed⟩
+                                          ⟨Copy path⟩ ⟨Copy value⟩
                                             ◴ 3 changes
 
   Path segments are individually clickable (rf2-e9tb0) — clicking any
   segment opens the App-DB segment-inspector popup at the path-prefix
   up to and including that segment. Discoverable via a dotted
   underline + pointer cursor on hover.
+
+  The origin-tag chip (rf2-s8r6c) sits between the breadcrumb and the
+  affordance row. It identifies the writer(s) that mutated paths under
+  this section — `[fx :db]` for the handler's `:db` effect,
+  `[flow :flow-id]` for a flow's `:output`, or mixed for coalesced
+  sections.
 
   The Pin affordance is dropped (rf2-e9tb0 — pinned-watches replaced
   by on-demand segment inspection); the diff already identifies
@@ -206,12 +301,16 @@
   anchor in a long diff tree.
 
   `subtree-value` is the unwrapped 'after' (or fallback) value at the
-  section's path, used as the payload for the Copy-value button. Older
-  callers that pass only `[path child-summary]` still work — the
-  Copy-value button copies `nil` in that case."
+  section's path, used as the payload for the Copy-value button.
+  `origin-tag` is the writer-attribution map (output of
+  `app-db-diff-helpers/path-origin-tag`); when nil the chip is
+  omitted (older test callers that pass `[path child-summary]` or
+  `[path child-summary subtree-value]` still work)."
   ([section-path child-summary]
-   (breadcrumb section-path child-summary nil))
+   (breadcrumb section-path child-summary nil nil))
   ([section-path child-summary subtree-value]
+   (breadcrumb section-path child-summary subtree-value nil))
+  ([section-path child-summary subtree-value origin-tag]
    (let [{:keys [added removed modified children]
           :or   {added 0 removed 0 modified 0 children 0}} child-summary
          total-changes (+ added removed modified children)
@@ -234,6 +333,12 @@
                        :color          (:text-primary tokens)
                        :font-weight    600}}
       (breadcrumb-segments section-path)
+      ;; rf2-s8r6c — origin-tag chip identifying the writer(s) for the
+      ;; paths under this section. Always rendered when `origin-tag`
+      ;; is supplied; older callers (tests) that omit it get no chip,
+      ;; preserving the legacy hiccup shape.
+      (when origin-tag
+        (origin-tag-chip section-path origin-tag))
       ;; Affordance row — Show-me-when / Copy path / Copy value.
       ;; Pin was dropped under rf2-e9tb0 when pinned-watches was
       ;; superseded by the clickable-segment inspector popup.
@@ -519,41 +624,61 @@
   The breadcrumb carries the per-section affordances (Pin /
   Show-me-when / Copy-path / Copy-value, rf2-ykjl5). The Copy-value
   payload is the subtree's after-value (or fallback) extracted via
-  `subtree->after-value`."
-  [{:keys [path subtree]} surface]
-  (let [child-summary (if (= :children (at/op-of subtree))
-                        (:child-summary subtree)
-                        nil)
-        after-value   (subtree->after-value subtree)]
-    [:section {:data-testid (str "rf-causa-diff-section-"
-                                 (pr-str path))
-               :style {:margin         "8px 12px"
-                       :background     (:bg-3 tokens)
-                       :border         (str "1px solid "
-                                            (:border-subtle tokens))
-                       :border-radius  "4px"
-                       :overflow       "hidden"}}
-     (breadcrumb path child-summary after-value)
-     [:div {:style {:padding "8px 12px"
-                    :font-family mono-stack
-                    :font-size "12px"
-                    :color (:text-primary tokens)
-                    :line-height "1.5"}}
-      (render-annotated subtree path [] surface 0)]]))
+  `subtree->after-value`.
+
+  `origin-tag` (optional) is the writer-attribution map (output of
+  `app-db-diff-helpers/path-origin-tag`) the breadcrumb renders as a
+  chip. When omitted (older callers, test rigs), no chip renders."
+  ([s surface] (section s surface nil))
+  ([{:keys [path subtree]} surface origin-tag]
+   (let [child-summary (if (= :children (at/op-of subtree))
+                         (:child-summary subtree)
+                         nil)
+         after-value   (subtree->after-value subtree)]
+     [:section {:data-testid (str "rf-causa-diff-section-"
+                                  (pr-str path))
+                :style {:margin         "8px 12px"
+                        :background     (:bg-3 tokens)
+                        :border         (str "1px solid "
+                                             (:border-subtle tokens))
+                        :border-radius  "4px"
+                        :overflow       "hidden"}}
+      (breadcrumb path child-summary after-value origin-tag)
+      [:div {:style {:padding "8px 12px"
+                     :font-family mono-stack
+                     :font-size "12px"
+                     :color (:text-primary tokens)
+                     :line-height "1.5"}}
+       (render-annotated subtree path [] surface 0)]])))
 
 (defn render-sections
   "Top-level entry: a vector of `[:section ...]` blocks. The empty-state
   signaller is the caller's job — when sections is empty, this returns
-  an empty wrapper div so the caller can switch on the parent layout."
-  [sections surface]
-  (if (empty? sections)
-    [:div {:data-testid "rf-causa-diff-empty"
-           :style {:padding "12px"
-                   :color (:text-tertiary tokens)
-                   :font-family sans-stack
-                   :font-size "12px"}}
-     "No structural changes in the selected epoch."]
-    (into [:div {:data-testid "rf-causa-diff-sections"}]
-          (for [s sections]
-            ^{:key (pr-str (:path s))}
-            (section s surface)))))
+  an empty wrapper div so the caller can switch on the parent layout.
+
+  `opts` (optional) supplies the inputs the rf2-s8r6c origin-tag chip
+  computation needs:
+
+      {:flow-writes  [{:flow-id <kw> :write-path <vec>} ...]
+       :diff-triples [{:op … :path … :before … :after …} ...]}
+
+  When `opts` is omitted (older callers, test rigs), no origin chip
+  renders — the legacy hiccup shape is preserved."
+  ([sections surface] (render-sections sections surface nil))
+  ([sections surface {:keys [flow-writes diff-triples] :as _opts}]
+   (if (empty? sections)
+     [:div {:data-testid "rf-causa-diff-empty"
+            :style {:padding "12px"
+                    :color (:text-tertiary tokens)
+                    :font-family sans-stack
+                    :font-size "12px"}}
+      "No structural changes in the selected epoch."]
+     (let [origin-for (fn [section-path]
+                        (when (or (seq flow-writes) (seq diff-triples))
+                          (h/path-origin-tag section-path
+                                             (or flow-writes [])
+                                             (or diff-triples []))))]
+       (into [:div {:data-testid "rf-causa-diff-sections"}]
+             (for [s sections]
+               ^{:key (pr-str (:path s))}
+               (section s surface (origin-for (:path s)))))))))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff.cljs
@@ -45,7 +45,9 @@
                 changed-reserved
                 focused-path
                 focused-hits
-                redacted-modified-count]}
+                redacted-modified-count
+                flow-writes
+                diff-triples]}
         @(rf/subscribe [:rf.causa/app-db-diff])]
     [:section {:data-testid "rf-causa-app-db-diff"
                :style       {:height         "100%"
@@ -78,7 +80,16 @@
          ;; cascade actually involved redacted slots in mutated
          ;; subtrees.
          (sections/redacted-modified-chip redacted-modified-count)
-         (diff-render/render-sections changed-sections "app-db-diff")
+         ;; rf2-s8r6c — per-section origin tag chip is computed here:
+         ;; the renderer takes the full per-leaf `diff-triples` + the
+         ;; per-epoch `flow-writes` and attributes each section's
+         ;; writer(s). When no flow fired, every section gets
+         ;; `[fx :db]`; when flows fired, sections covering a flow's
+         ;; `:write-path` get `[flow :flow-id]` (or mixed if
+         ;; coalesced).
+         (diff-render/render-sections changed-sections "app-db-diff"
+                                       {:flow-writes  flow-writes
+                                        :diff-triples diff-triples})
          (sections/reserved-group changed-reserved)])]]))
 
 (defn install!

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_helpers.cljc
@@ -520,3 +520,176 @@
   lookup without duplicating the key shape."
   [epoch-record]
   (:epoch-id epoch-record))
+
+;; ---- App-db path origin tags (rf2-s8r6c) --------------------------------
+;;
+;; The App-DB Diff panel renders one section per cluster of changed paths,
+;; but it does NOT distinguish the WRITER. Two writers can mutate app-db
+;; across a single epoch:
+;;
+;;   1. The event handler's `:db` effect — `[fx :db]`.
+;;   2. A flow's `:output` fn — `[flow :flow-id]`. Per Spec 013, flows
+;;      fire automatically AFTER the handler's effects run; each flow
+;;      writes its computed result back into app-db at its registered
+;;      `:path`.
+;;
+;; Without per-path attribution the developer sees "path X changed" and
+;; has to look elsewhere (the §8 FLOWS section in the Event lens) to
+;; figure out which subset of changes came from flow recomputes. The
+;; origin chip on each diff section closes that gap: the section header
+;; carries `[fx :db]` or `[flow :flow-id]` next to the breadcrumb.
+;;
+;; ## Source of truth
+;;
+;; Per rf2-lo37i (PR #1530) — `event-detail/flows-fired` projects each
+;; `:rf.flow/computed` trace event into `{:flow-id … :write-path … …}`.
+;; The same shape is the input to the helpers below, derived from the
+;; epoch record's `:trace-events` slot (not the cascade `:other` bucket
+;; — Causa's App-DB Diff panel is epoch-rooted, not cascade-rooted).
+;;
+;; ## Attribution rules
+;;
+;; Given a section path P and the vector of `{:flow-id … :write-path …}`
+;; flow-writes for the epoch, attribute as follows:
+;;
+;;   - When NO flow write covers P (P is neither equal to any
+;;     `:write-path` nor a prefix or suffix of any), origin is
+;;     `[:fx :db]` — the handler's `:db` effect is the only writer.
+;;
+;;   - When exactly one flow's `:write-path` equals P, OR P is a strict
+;;     ancestor of one flow's `:write-path`, OR P is a strict descendant
+;;     of one flow's `:write-path`, origin is `[:flow flow-id]`.
+;;
+;;   - When more than one flow write is covered by the section, OR a
+;;     flow write coexists with handler-only writes inside the section,
+;;     origin is `[:mixed flow-ids fx?]` — render as
+;;     `[flow :a :b] + [fx :db]` when `fx?` is true, else `[flow :a :b]`.
+;;
+;; The mixed case is unavoidable for coalesced sections (rf2-gfxmk's
+;; section grouping merges nearby change-points; a section headed
+;; `[:cart]` can cover both a handler-written `[:cart :items]` and a
+;; flow-written `[:cart :total]`). The chip surfaces both writers
+;; honestly rather than picking one.
+;;
+;; ## Detecting handler-only writes inside a section
+;;
+;; A section MAY also cover handler writes that aren't on any flow's
+;; write-path. We can't enumerate handler writes from traces (the `:db`
+;; effect doesn't trace per-leaf writes), so we approximate by checking
+;; whether the section's changed-paths span exceeds the union of flow
+;; write-paths. The diff triples for the section (already computed by
+;; `diff-paths`) are the input — for a section path P, if some triple's
+;; `:path` is under P but NOT under any flow write-path equal to or
+;; under P, then handler-only writes ALSO ride in this section.
+
+(defn flow-writes-from-trace-events
+  "Project `:rf.flow/computed` trace events into a vector of write
+  records:
+
+      [{:flow-id <kw> :write-path <vec>} ...]
+
+  Order preserved (firing order). Skips entries whose `:write-path` is
+  absent (defensive — Spec 013 guarantees `:path` on computed traces,
+  but older fixtures may omit it).
+
+  Pure data → data. JVM-runnable. Mirrors
+  `event-detail/flows-fired` (rf2-lo37i) but on the epoch record's
+  `:trace-events` slot directly rather than on the cascade `:other`
+  bucket — the App-DB Diff panel is epoch-rooted, not cascade-rooted."
+  [trace-events]
+  (vec
+    (keep (fn [ev]
+            (when (= :rf.flow/computed (:operation ev))
+              (let [tags (:tags ev)
+                    wp   (:path tags)
+                    fid  (:flow-id tags)]
+                (when (and (vector? wp) (keyword? fid))
+                  {:flow-id    fid
+                   :write-path wp}))))
+          (or trace-events []))))
+
+(defn- path-prefix?
+  "True when vector `a` is a prefix of (or equal to) vector `b`."
+  [a b]
+  (and (<= (count a) (count b))
+       (= a (subvec b 0 (count a)))))
+
+(defn- flow-covers-section?
+  "True when flow's `:write-path` is involved with `section-path` —
+  either equal, an ancestor of, or a descendant of `section-path`.
+  Bidirectional coverage so the chip fires for both 'section P sits
+  above flow write Q' AND 'section P sits inside flow write Q'."
+  [section-path write-path]
+  (or (path-prefix? write-path section-path)
+      (path-prefix? section-path write-path)))
+
+(defn- handler-only-write-in-section?
+  "True when at least one diff triple lives under `section-path` AND
+  its path is not covered by any of `flow-write-paths`. Detects the
+  mixed case where coalesced sections cover both flow writes and
+  handler-only writes.
+
+  `triples` is the canonical `diff-paths` output (vector of
+  `{:op :path …}`). `flow-write-paths` is a set of write-path
+  vectors."
+  [section-path triples flow-write-paths]
+  (boolean
+    (some (fn [{:keys [path]}]
+            (and (path-prefix? section-path path)
+                 (not-any? #(path-prefix? % path) flow-write-paths)))
+          triples)))
+
+(defn path-origin-tag
+  "Attribute one App-DB Diff section's writer(s).
+
+  Given:
+    - `section-path` (vec) — the section header path
+    - `flow-writes` (vec) — output of `flow-writes-from-trace-events`
+    - `triples`     (vec) — output of `diff-paths` (the full set of
+                            per-leaf changes for this epoch)
+
+  Returns one of:
+
+      {:kind :fx}                                ;; handler `:db` effect only
+      {:kind :flow :flow-id <kw>}                ;; single flow
+      {:kind :mixed :flow-ids [<kw>...] :fx? <bool>}
+
+  Pure data → data. JVM-runnable. The `:mixed` variant covers both
+  multi-flow sections (two+ flows writing under one coalesced section)
+  and flow+handler sections (one or more flows AND a handler-only
+  write under the same section).
+
+  Renderer choice: chip-label per case is built by `format-origin-tag`."
+  [section-path flow-writes triples]
+  (let [covering (filter #(flow-covers-section? section-path (:write-path %))
+                         flow-writes)
+        ids      (vec (distinct (map :flow-id covering)))
+        flow-wps (into #{} (map :write-path) covering)
+        fx?      (handler-only-write-in-section? section-path triples flow-wps)]
+    (cond
+      (and (empty? ids) (not fx?))
+      ;; No flow covers and no handler-only triples under the section
+      ;; — only happens for sections produced from triples that all sit
+      ;; OUTSIDE any flow write-path. That's the pure-fx case.
+      {:kind :fx}
+
+      (and (empty? ids) fx?)
+      {:kind :fx}
+
+      (and (= 1 (count ids)) (not fx?))
+      {:kind :flow :flow-id (first ids)}
+
+      :else
+      {:kind :mixed :flow-ids ids :fx? fx?})))
+
+(defn flow-writes-by-section
+  "Index `flow-writes` by their write-path for efficient lookup. Returns
+  `{write-path-vec flow-id}`. The map shape matches the consumer-
+  interface index Mike's bead spec calls for: 'index by `:write-path`'.
+
+  Pure data → data. Used as the seed for the renderer's chip
+  computation; tests assert the projection."
+  [flow-writes]
+  (into {}
+        (map (juxt :write-path :flow-id))
+        flow-writes))

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -60,6 +60,14 @@
   ;; between cases.
   (atom {}))
 
+(defonce flow-writes-cache
+  ;; Per-`:epoch-id` cache for the flow-writes projection computed by
+  ;; `:rf.causa/selected-epoch-flow-writes` (rf2-s8r6c). Mirrors
+  ;; `diff-cache`'s contract — the walk over `:trace-events` is O(N)
+  ;; in trace count, and cascades replay the same record across the
+  ;; inspector's life. Tests reset this atom between cases.
+  (atom {}))
+
 (defn install!
   "Install the App-DB Diff subscriptions."
   []
@@ -229,6 +237,39 @@
                 n)))
           0))))
 
+  ;; ---- rf2-s8r6c — flow-writes projection -----------------------------
+  ;;
+  ;; Project the selected epoch's `:rf.flow/computed` trace events into
+  ;; `[{:flow-id … :write-path …} …]`. Same shape rf2-lo37i's
+  ;; `event-detail/flows-fired` produces but sourced from the epoch
+  ;; record's `:trace-events` slot (the App-DB Diff panel is epoch-
+  ;; rooted, not cascade-rooted, so it reads the per-epoch raw trace
+  ;; list rather than going through the cascade projection).
+  ;;
+  ;; Same selection-stale fallback as the diff sub — `(peek history)`
+  ;; when the selected epoch is absent from history.
+  (rf/reg-sub :rf.causa/selected-epoch-flow-writes
+    :<- [:rf.causa/epoch-history]
+    :<- [:rf.causa/selected-epoch-id]
+    (fn [[history selected-id] _query]
+      (let [record (or (when selected-id
+                         (find-epoch-in-history history selected-id))
+                       (peek history))]
+        (when record
+          (let [epoch-id (:epoch-id record)
+                cached   (get @flow-writes-cache epoch-id ::miss)]
+            (if (not= ::miss cached)
+              cached
+              (let [writes (h/flow-writes-from-trace-events
+                             (:trace-events record))
+                    live   (into #{} (map :epoch-id) history)]
+                (swap! flow-writes-cache
+                       (fn [m]
+                         (-> m
+                             (select-keys live)
+                             (assoc epoch-id writes))))
+                writes)))))))
+
   (rf/reg-sub :rf.causa/focused-slice-path
     (fn [db _query]
       (get db :focused-slice-path)))
@@ -255,8 +296,9 @@
     :<- [:rf.causa/show-me-when-this-changed-result]
     :<- [:rf.causa/epoch-history]
     :<- [:rf.causa/selected-epoch-redacted-modified-count]
+    :<- [:rf.causa/selected-epoch-flow-writes]
     (fn [[target db diff-triples sections focused-path focused-hits
-          history redacted-modified-count]
+          history redacted-modified-count flow-writes]
          _query]
       (let [{:keys [non-reserved]} (h/partition-reserved
                                      (or diff-triples []))]
@@ -271,4 +313,10 @@
          ;; Count > 0 when an app `:redact-fn` substituted the
          ;; `:rf/redacted` sentinel into both `:db-before` /
          ;; `:db-after` at the same path inside a mutated subtree.
-         :redacted-modified-count   redacted-modified-count}))))
+         :redacted-modified-count   redacted-modified-count
+         ;; rf2-s8r6c — per-path origin attribution input. The renderer
+         ;; combines `:changed-sections` + the full triples + this vec
+         ;; to tag each section header with `[fx :db]` /
+         ;; `[flow :flow-id]` / mixed.
+         :flow-writes               (or flow-writes [])
+         :diff-triples              (or diff-triples [])}))))

--- a/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/diff/render_cljs_test.cljs
@@ -448,3 +448,123 @@
                                        :modified 0 :children 0})]
       (is (vector? hdr))
       (is (some? (find-by-testid hdr "rf-causa-diff-section-copy-path-[:a]"))))))
+
+;; ---- rf2-s8r6c — origin-tag chip --------------------------------------
+
+(deftest render-sections-omits-origin-chip-by-default
+  (testing "rf2-s8r6c — back-compat: calling render-sections without
+            opts produces no origin chip (legacy hiccup shape preserved
+            for non-Causa-panel callers and tests)"
+    (let [tree     (at/diff-tree {:a 1} {:a 2})
+          sections (sg/group-into-sections tree)
+          hiccup   (render/render-sections sections "app-db-diff")]
+      (is (not (any-testid-prefix? hiccup "rf-causa-diff-section-origin-"))
+          "no origin chip when opts omitted"))))
+
+(deftest render-sections-pure-fx-section-tags-fx-db
+  (testing "rf2-s8r6c — section with no flow coverage gets the
+            `[fx :db]` chip"
+    (let [tree     (at/diff-tree {:counter 0} {:counter 1})
+          sections (sg/group-into-sections tree)
+          triples  [{:op :modified :path [:counter] :before 0 :after 1}]
+          hiccup   (render/render-sections
+                     sections "app-db-diff"
+                     {:flow-writes [] :diff-triples triples})
+          chip     (find-by-testid hiccup
+                                    "rf-causa-diff-section-origin-[:counter]")]
+      (is (some? chip) "origin chip renders for pure-fx section")
+      (is (= "fx" (:data-origin (second chip)))
+          "data-origin attribute is 'fx'")
+      (let [label (->> (tree-seq (some-fn vector? seq?) seq chip)
+                       (filter string?)
+                       (apply str))]
+        (is (re-find #"\[fx :db\]" label)
+            "chip label contains '[fx :db]'")))))
+
+(deftest render-sections-flow-section-tags-flow-id
+  (testing "rf2-s8r6c — section whose path equals a flow's :write-path
+            gets the `[flow :flow-id]` chip"
+    (let [tree     (at/diff-tree {:cart {:total 0}} {:cart {:total 52.5}})
+          sections (sg/group-into-sections tree)
+          writes   [{:flow-id :cart-total :write-path [:cart :total]}]
+          triples  [{:op :modified :path [:cart :total]
+                     :before 0 :after 52.5}]
+          hiccup   (render/render-sections
+                     sections "app-db-diff"
+                     {:flow-writes writes :diff-triples triples})]
+      ;; Section path may coalesce to [:cart] or stay [:cart :total]
+      ;; depending on grouping defaults — assert at least one origin
+      ;; chip carries the `:flow` attribution.
+      (let [chips (filter
+                    (fn [n]
+                      (and (vector? n) (map? (second n))
+                           (some-> (:data-testid (second n))
+                                   (.startsWith "rf-causa-diff-section-origin-"))))
+                    (tree-seq (some-fn vector? seq?) seq hiccup))]
+        (is (seq chips) "at least one origin chip renders")
+        (is (some #(= "flow" (:data-origin (second %))) chips)
+            "a chip carries data-origin='flow'")
+        (let [label (->> (tree-seq (some-fn vector? seq?)
+                                   seq (first chips))
+                         (filter string?)
+                         (apply str))]
+          (is (re-find #":cart-total" label)
+              "chip label names the flow id"))))))
+
+(deftest render-sections-mixed-section-tags-mixed
+  (testing "rf2-s8r6c — coalesced section covering one flow write AND
+            a handler-only sibling triple gets the mixed chip"
+    (let [;; Both writes occur under [:cart] — section coalesces.
+          tree     (at/diff-tree
+                     {:cart {:total 0 :items []}}
+                     {:cart {:total 52.5 :items [:apple]}})
+          sections (sg/group-into-sections tree)
+          writes   [{:flow-id :cart-total :write-path [:cart :total]}]
+          triples  [{:op :modified :path [:cart :total]
+                     :before 0 :after 52.5}
+                    {:op :modified :path [:cart :items]
+                     :before [] :after [:apple]}]
+          hiccup   (render/render-sections
+                     sections "app-db-diff"
+                     {:flow-writes writes :diff-triples triples})
+          chips    (filter
+                     (fn [n]
+                       (and (vector? n) (map? (second n))
+                            (some-> (:data-testid (second n))
+                                    (.startsWith "rf-causa-diff-section-origin-"))))
+                     (tree-seq (some-fn vector? seq?) seq hiccup))]
+      (is (seq chips) "origin chip(s) render for the mixed section")
+      ;; At least one chip must reflect the mixed attribution OR the
+      ;; flow-only attribution (depending on grouping coalescence).
+      ;; The contract: a chip with data-origin in #{"flow" "mixed"}
+      ;; exists; if mixed, label contains both the flow id and [fx :db].
+      (let [mixed (filter #(= "mixed" (:data-origin (second %))) chips)]
+        (when (seq mixed)
+          (let [label (->> (tree-seq (some-fn vector? seq?)
+                                     seq (first mixed))
+                           (filter string?)
+                           (apply str))]
+            (is (re-find #":cart-total" label)
+                "mixed chip label names the flow id")
+            (is (re-find #"\[fx :db\]" label)
+                "mixed chip label includes [fx :db]")))))))
+
+(deftest breadcrumb-omits-chip-when-no-origin-tag
+  (testing "rf2-s8r6c — calling breadcrumb without an origin-tag arg
+            (legacy 2-/3-arity) produces no chip"
+    (let [hdr (render/breadcrumb [:a]
+                                  {:added 1 :removed 0 :modified 0 :children 0}
+                                  nil)]
+      (is (nil? (find-by-testid hdr "rf-causa-diff-section-origin-[:a]"))
+          "no chip rendered when origin-tag arg omitted"))))
+
+(deftest breadcrumb-renders-chip-when-origin-tag-supplied
+  (testing "rf2-s8r6c — the 4-arity breadcrumb renders the chip"
+    (let [hdr (render/breadcrumb
+                [:cart :total]
+                {:added 0 :removed 0 :modified 1 :children 0}
+                nil
+                {:kind :flow :flow-id :cart-total})]
+      (is (some? (find-by-testid
+                   hdr "rf-causa-diff-section-origin-[:cart :total]"))
+          "chip renders next to the path breadcrumb"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_cljs_test.cljs
@@ -61,7 +61,10 @@
   ;; rf2-bz1cl — redacted-paths-modified cache mirrors the same
   ;; per-`:epoch-id` caching contract; reset between tests for
   ;; reproducibility.
-  (reset! app-db-diff-subs/redacted-modified-cache {}))
+  (reset! app-db-diff-subs/redacted-modified-cache {})
+  ;; rf2-s8r6c — flow-writes cache for the per-section origin-tag
+  ;; chip projection. Reset between tests for the same reason.
+  (reset! app-db-diff-subs/flow-writes-cache {}))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_helpers_cljs_test.cljc
@@ -398,3 +398,151 @@
   (testing "identical? whole dbs → 0 immediately (no walk)."
     (let [db {:auth {:token :rf/redacted}}]
       (is (= 0 (h/count-redacted-modified-paths db db))))))
+
+;; ---- rf2-s8r6c — flow-writes / path-origin-tag --------------------------
+;;
+;; The per-section origin chip's pure logic. Each section in the App-DB
+;; Diff panel is tagged `[fx :db]` / `[flow :flow-id]` / mixed based on
+;; the union of the epoch's `:rf.flow/computed` trace events and the
+;; canonical diff triples.
+
+(defn- flow-computed
+  "Build one `:rf.flow/computed` trace event matching the on-the-wire
+  shape Spec 013 + Spec 009 documents. Returned as a plain map so
+  `flow-writes-from-trace-events` can read it without runtime setup."
+  [flow-id write-path & [{:keys [frame input-values result]
+                          :or   {frame :rf/default
+                                 input-values []
+                                 result nil}}]]
+  {:op-type   :flow
+   :operation :rf.flow/computed
+   :tags      {:flow-id      flow-id
+               :path         write-path
+               :input-values input-values
+               :result       result
+               :frame        frame}})
+
+(deftest flow-writes-from-trace-events-empty
+  (testing "empty trace events → empty vector"
+    (is (= [] (h/flow-writes-from-trace-events [])))
+    (is (= [] (h/flow-writes-from-trace-events nil)))))
+
+(deftest flow-writes-from-trace-events-filters-non-computed
+  (testing "only :rf.flow/computed events project — skips
+            :rf.flow/skip + every other op-type"
+    (let [events [(flow-computed :cart-total [:cart :total])
+                  {:op-type :flow :operation :rf.flow/skip
+                   :tags {:flow-id :tax-due :reason :inputs-value-equal}}
+                  {:op-type :event :operation :event/dispatched
+                   :tags {:event [:foo]}}
+                  (flow-computed :tax-due [:tax :due])]
+          rows   (h/flow-writes-from-trace-events events)]
+      (is (= 2 (count rows)))
+      (is (= [:cart-total :tax-due] (mapv :flow-id rows))
+          "order preserved")
+      (is (= [[:cart :total] [:tax :due]] (mapv :write-path rows))))))
+
+(deftest flow-writes-from-trace-events-skips-malformed-writes
+  (testing "defensive — entries missing :path or :flow-id are skipped"
+    (let [events [(flow-computed :ok-flow [:a :b])
+                  {:op-type :flow :operation :rf.flow/computed
+                   :tags    {:flow-id nil :path [:c :d]}}
+                  {:op-type :flow :operation :rf.flow/computed
+                   :tags    {:flow-id :no-path :path nil}}]
+          rows   (h/flow-writes-from-trace-events events)]
+      (is (= [{:flow-id :ok-flow :write-path [:a :b]}] rows)))))
+
+(deftest flow-writes-by-section-indexes-by-write-path
+  (testing "the consumer-interface index — Mike's bead spec calls for
+            'index by :write-path'"
+    (let [writes [{:flow-id :cart-total :write-path [:cart :total]}
+                  {:flow-id :tax-due    :write-path [:tax :due]}]]
+      (is (= {[:cart :total] :cart-total
+              [:tax :due]    :tax-due}
+             (h/flow-writes-by-section writes))))))
+
+;; ---- path-origin-tag — the per-section attribution decision ------------
+
+(deftest path-origin-tag-pure-fx-no-flows
+  (testing "no flows fired → every section is [fx :db]"
+    (let [triples [{:op :modified :path [:counter] :before 0 :after 1}]]
+      (is (= {:kind :fx}
+             (h/path-origin-tag [:counter] [] triples))))))
+
+(deftest path-origin-tag-exact-flow-write-path
+  (testing "section path == one flow's :write-path → [flow :flow-id]"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}]
+          triples [{:op :modified :path [:cart :total]
+                    :before 0 :after 52.5}]]
+      (is (= {:kind :flow :flow-id :cart-total}
+             (h/path-origin-tag [:cart :total] writes triples))))))
+
+(deftest path-origin-tag-section-is-ancestor-of-flow-write
+  (testing "section coalesces above a flow's write-path → still
+            [flow :flow-id]"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}]
+          ;; section coalesced at [:cart], covering the flow write
+          triples [{:op :modified :path [:cart :total]
+                    :before 0 :after 52.5}]]
+      (is (= {:kind :flow :flow-id :cart-total}
+             (h/path-origin-tag [:cart] writes triples))))))
+
+(deftest path-origin-tag-section-is-descendant-of-flow-write
+  (testing "section sits inside a flow's write-path (deep subtree
+            inspection of a flow-written slice) → still
+            [flow :flow-id]"
+    (let [writes  [{:flow-id :cart-summary :write-path [:cart :summary]}]
+          ;; deep section under the flow's output slice
+          triples [{:op :modified
+                    :path [:cart :summary :total]
+                    :before 0 :after 52.5}]]
+      (is (= {:kind :flow :flow-id :cart-summary}
+             (h/path-origin-tag [:cart :summary :total]
+                                writes triples))))))
+
+(deftest path-origin-tag-section-uncovered-by-any-flow
+  (testing "section path is disjoint from every flow's write-path →
+            [fx :db]"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}]
+          triples [{:op :modified :path [:status] :before nil :after :ok}]]
+      (is (= {:kind :fx}
+             (h/path-origin-tag [:status] writes triples))))))
+
+(deftest path-origin-tag-mixed-multi-flow-section
+  (testing "coalesced section covers two flow writes → mixed with
+            both flow-ids"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}
+                   {:flow-id :cart-count :write-path [:cart :count]}]
+          triples [{:op :modified :path [:cart :total] :before 0 :after 1}
+                   {:op :modified :path [:cart :count] :before 0 :after 1}]
+          tag     (h/path-origin-tag [:cart] writes triples)]
+      (is (= :mixed (:kind tag)))
+      (is (= #{:cart-total :cart-count} (set (:flow-ids tag))))
+      (is (false? (:fx? tag))
+          "no handler-only writes inside the section"))))
+
+(deftest path-origin-tag-mixed-flow-and-fx
+  (testing "coalesced section covers ONE flow write AND a handler-only
+            triple → mixed with the one flow-id + :fx? true"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}]
+          triples [{:op :modified :path [:cart :total] :before 0 :after 1}
+                   ;; handler-only sibling write under the coalesced section
+                   {:op :modified :path [:cart :items] :before [] :after [:a]}]
+          tag     (h/path-origin-tag [:cart] writes triples)]
+      (is (= :mixed (:kind tag)))
+      (is (= [:cart-total] (:flow-ids tag)))
+      (is (true? (:fx? tag))
+          "handler-only triple at [:cart :items] surfaces as :fx? true"))))
+
+(deftest path-origin-tag-chained-flows-tag-the-downstream
+  (testing "chained flows — each lands as its own row and writes its
+            own output path; the section at the downstream path tags
+            it with the downstream flow's id (not the upstream's)"
+    (let [writes  [{:flow-id :cart-total :write-path [:cart :total]}
+                   {:flow-id :tax-due    :write-path [:tax :due]}]
+          triples [{:op :modified :path [:cart :total] :before 0 :after 50.0}
+                   {:op :modified :path [:tax :due]    :before 0 :after 5.25}]]
+      (is (= {:kind :flow :flow-id :cart-total}
+             (h/path-origin-tag [:cart :total] writes triples)))
+      (is (= {:kind :flow :flow-id :tax-due}
+             (h/path-origin-tag [:tax :due] writes triples))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/app_db_diff_subs_cljs_test.cljs
@@ -18,7 +18,8 @@
      :init-fn (fn []
                 (reset! subs/diff-cache {})
                 (reset! subs/annotated-tree-cache {})
-                (reset! subs/redacted-modified-cache {}))}))
+                (reset! subs/redacted-modified-cache {})
+                (reset! subs/flow-writes-cache {}))}))
 
 (deftest leaf-install-registers-the-active-subs
   (subs/install!)
@@ -35,6 +36,8 @@
   (is (some? (registrar/handler :sub :rf.causa/show-me-when-this-changed-result)))
   ;; rf2-bz1cl — redacted-paths-modified hint sub.
   (is (some? (registrar/handler :sub :rf.causa/selected-epoch-redacted-modified-count)))
+  ;; rf2-s8r6c — flow-writes projection sub for the origin-tag chip.
+  (is (some? (registrar/handler :sub :rf.causa/selected-epoch-flow-writes)))
   (is (some? (registrar/handler :sub :rf.causa/app-db-diff)))
   ;; rf2-e9tb0 — pinned-slices subs are gone.
   (is (nil? (registrar/handler :sub :rf.causa/pinned-slices-store)))
@@ -48,4 +51,8 @@
   ;; rf2-bz1cl — redacted-modified count cache mirrors the existing
   ;; per-`:epoch-id` caching contract.
   (is (some? subs/redacted-modified-cache))
-  (is (map? @subs/redacted-modified-cache)))
+  (is (map? @subs/redacted-modified-cache))
+  ;; rf2-s8r6c — flow-writes cache mirrors the same per-`:epoch-id`
+  ;; caching contract.
+  (is (some? subs/flow-writes-cache))
+  (is (map? @subs/flow-writes-cache)))


### PR DESCRIPTION
## Summary
- Tag each App-DB Diff section with its writer: `[fx :db]` (handler effect), `[flow :flow-id]` (flow output), or mixed for coalesced sections. Surfaces "where did this value come from?" inline next to the path breadcrumb.
- Pure attribution helper (`app_db_diff_helpers/path-origin-tag`) covers exact-match, ancestor-of-flow, descendant-of-flow, multi-flow, and flow+handler-only mixed cases. JVM-runnable.
- Consumes rf2-lo37i's locked `{:flow-id :write-path …}` shape (PR #1530), sourced from the selected epoch's `:trace-events` slot via new sub `:rf.causa/selected-epoch-flow-writes` (cached per `:epoch-id`).
- Renderer accepts an opts arg (`{:flow-writes :diff-triples}`) on `render-sections`; chip lives in the breadcrumb header next to the existing path segments. Legacy 2-/3-arity `breadcrumb` + opts-less `render-sections` still compile (test-rig back-compat preserved).

## Test plan
- [x] `clojure -M:test` in `tools/causa/` — 759 tests / 2174 assertions pass (12 new helper deftests)
- [x] `npm run test:cljs` from `implementation/` — 2962 tests / 8435 assertions pass (6 new renderer deftests)
- [x] `npm run test:bundle-isolation` — PASS (no production bundle leakage)
- [x] Pure-fx section gets `[fx :db]` chip
- [x] Flow-covered section gets `[flow :flow-id]` chip
- [x] Coalesced section with one flow + handler-only sibling gets mixed
- [x] Chained flows: each downstream section attributed to its own flow

Closes rf2-s8r6c.