### PR TITLE
feat(causa): public per-panel mount API — 16 panels independently mountable (rf2-crhr8)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -894,3 +894,158 @@ In a non-elided dev build running in production-like conditions,
 Causa shows a yellow top banner: "Causa is enabled in this build.
 Disable for production." Single-click dismiss, remembered for the
 session.
+
+## Mountable panel contract (rf2-crhr8)
+
+Every Causa panel is **independently mountable**. The 4-layer shell
+COMPOSES panels but does NOT own them — panels are reachable as
+stand-alone mount targets so a host can drop one panel into Story
+ribbons, the Scittle playground (per rf2-i8mv option-c progressive
+disclosure), the docs / guide surface, or custom debugging setups
+without bringing along the rest of the shell chrome.
+
+The public mount surface lives in
+`day8.re-frame2-causa.panels` — one mount fn per public panel, plus
+a master `mount-shell!` for the full 4-layer chrome.
+
+### Mountable surface inventory
+
+The panel-surface inventory splits across four tiers, with 11
+surfaces independently mountable as standalone user-facing mount
+targets and the remainder living as internal sub-components that
+render under their owning panel.
+
+**Tier 1 — L3 tab panels (7):** one per `:rf.causa/selected-tab`
+value.
+
+| Panel | View | Mount fn |
+|---|---|---|
+| Event tab    | `event-detail/Panel`     | `mount-event-detail!` |
+| App-db tab   | `app-db-diff/Panel`      | `mount-app-db-diff!` |
+| Views tab    | `views/Panel`            | `mount-views!` |
+| Trace tab    | `trace/Panel`            | `mount-trace!` |
+| Machines tab | `machine-inspector/Panel`| `mount-machine-inspector!` |
+| Routing tab  | `routing/Panel`          | `mount-routing!` |
+| Issues tab   | `issues-ribbon/Panel`    | `mount-issues-ribbon!` |
+
+**Tier 2 — overlay / popup surfaces (3):** modal-light surfaces the
+shell composes at its root, each self-gating on a `:rf.causa/*-open?`
+sub (closed-state cost is one subscribe + a `when` short-circuit).
+
+| Panel | View | Mount fn |
+|---|---|---|
+| App-DB segment-inspector popup | `app-db-segment-inspector/Popup`   | `mount-segment-inspector!` |
+| Cancellation-cascade side-panel | `cancellation-cascade/SidePanel`  | `mount-cancellation-cascade-side-panel!` |
+| Cancellation-cascade popover    | `cancellation-cascade/Popover`    | `mount-cancellation-cascade-popover!` |
+
+**Tier 3 — inline content surface (1):** the managed-fx
+wire-boundary diff template that the Event tab embeds inline under
+its six-domino cascade view. Exposed standalone for Story ribbons
+that want JUST the managed-fx list for the focused cascade.
+
+| Panel | View | Mount fn |
+|---|---|---|
+| Managed-fx records list | `panels/ManagedFxList` | `mount-managed-fx!` |
+
+**Tier 4 — internal sub-components:** auxiliary inspectors that
+depend on `machine-inspector/Panel`'s positioned graph for their
+geometry — overlays anchor on chart node centres, side-rails run
+along the chart edge.
+
+| Sub-component | View |
+|---|---|
+| After-rings overlay | `machine-after-rings/AfterRingsOverlay` |
+| Sim side-rail       | `machine-inspector-sim/SimSideRail` |
+
+These render under `machine-inspector/Panel` and are NOT exposed as
+standalone mount fns. Mounting a ring overlay without a chart
+underneath is geometrically meaningless; they remain reachable via
+`mount-machine-inspector!`. (Per rf2-y9xmf the prior arc / cluster /
+scrubber sub-components were collapsed into the Runtime panel; the
+remaining sub-component surface is the two listed above.)
+
+### The mount-fn contract
+
+Every `mount-<panel>!` fn:
+
+1. Calls `(registry/register-causa-handlers!)` — idempotent install
+   of every panel's subs / events / fxs. The orchestrator's
+   `defonce`-guarded sentinel collapses repeat installs across
+   panel mounts and shadow-cljs `:after-load` cycles.
+2. Calls `(rf/reg-frame :rf/causa {})` — idempotent register of
+   Causa's state-isolation frame. `reg-frame`'s surgical-update-on-
+   re-register semantics (per Spec 002 §reg-frame) keep this
+   idempotent.
+3. Wraps the panel's view in `[rf/frame-provider {:frame :rf/causa}
+   [Panel]]` so descendant `subscribe` / `dispatch` re-anchor to
+   `:rf/causa` regardless of the host's React-context. The
+   `:rf/causa` default may be overridden via `opts {:frame
+   :my-app/frame}` per the embedding contract
+   ([008-Embedding-Contract.md](./008-Embedding-Contract.md) §State
+   isolation).
+4. Delegates to `substrate-adapter/render` with the wrapped tree +
+   `mount-point`. Causa is substrate-agnostic; the host installs
+   the adapter via `rf/init!` and the panels mount via that
+   adapter's render slot.
+5. Returns the substrate adapter's unmount fn so the host owns the
+   panel's teardown lifecycle.
+
+### Per-panel input axes (the coupling-map audit)
+
+Every panel reads its data via subscribes — no sibling-render
+assumptions, no shell-owned local state. The subs (registered by the
+panel's own `install!`) compose against the trace bus + epoch
+history + spine focus:
+
+| Panel | Reads (subs) | Writes (dispatches) |
+|---|---|---|
+| **event-detail**   | `:rf.causa/focus` · `:rf.causa/cascades` · `:rf.causa/target-frame-db` | `:rf.causa/focus-cascade` · `:rf.causa/focus-event` |
+| **app-db-diff**    | `:rf.causa/app-db-diff` (composite) | `:rf.causa/focus-slice-path` · `:rf.causa/open-segment-inspector` |
+| **views**          | `:rf.causa/views-focused-cascade-pair` · `:rf.causa/views-sub-diff` | view-row toggles · sub-diff selection |
+| **trace**          | `:rf.causa/trace-feed` (incremental projection) | `:rf.causa/select-dispatch-id` · `:rf.causa/open-in-editor` |
+| **machine-inspector** | `:rf.causa/machine-chart-data` · `:rf.causa/active-timers-for-focused-machine` · `:rf.causa/machine-scrubber-position` | scrubber events · `:rf.causa/focus-cascade` |
+| **routing**        | `:rf.causa/registered-routes` · `:rf.causa/current-route-slice` · `:rf.causa/routing-tab-data` | route-simulation events |
+| **issues-ribbon**  | `:rf.causa/issues-ribbon` (composite) · `:rf.causa.issues/ungrouped` | `:rf.causa.issues/toggle-severity` · `:rf.causa.issues/toggle-prefix` · `:rf.causa/select-dispatch-id` |
+| **segment-inspector** | `:rf.causa/segment-inspector-open?` · `:rf.causa/segment-inspector-value` | `:rf.causa/close-segment-inspector` |
+| **cancellation-cascade** | `:rf.causa/cancellation-cascade-for-focused-machine` · `:rf.causa/cancellation-cascade-for-focused-event` · `:rf.causa/cancellation-cascade-popover-open?` · `:rf.causa/modal-positioning` | `:rf.causa/cancellation-cascade-close` |
+| **managed-fx**     | `:rf.causa/managed-fx-for-focused-event` | `:rf.causa/focus-event` |
+
+No panel reads sibling-panel state directly. No panel assumes any
+particular frame-picker / tab-bar / event-list / spine-head value
+beyond what the spine sub `:rf.causa/focus` exposes — and `focus`
+itself defaults to head of the trace buffer when no row is selected.
+Each panel is fully driven by the trace bus + the host's
+`(rf/init!)` plumbing.
+
+### Shell composes, doesn't own
+
+The 4-layer shell (`shell.cljs`) **composes** panels by referencing
+each panel's `Panel` reg-view in the L4 detail-panel case-switch,
+and mounts the Tier 2 overlay surfaces at the shell-view root for
+modal layering. The shell does NOT own per-panel state — each panel
+reads and writes its own slice of `:rf/causa`'s app-db via its own
+`install!`-registered handlers.
+
+This separation is what makes per-panel mountability possible: any
+host that wants ONE panel mounts that panel directly via
+`mount-<panel>!`; the shell is just one specific composition of all
+of them.
+
+### Hot-reload + idempotency
+
+`register-causa-handlers!` is `defonce`-guarded so shadow-cljs
+`:after-load` cycles do not re-register handlers (which would emit
+`:rf.warning/handler-replaced` traces on every reload). `reg-frame`
+is idempotent via surgical-update semantics. Mount fns can be called
+from a host's `init!` path at any frequency without risk.
+
+### See also
+
+- [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — the
+  embedding contract for Story / first-party embeds (the `:compact?`
+  / `:scope` / `:on-event` props the panel views consume).
+- [`011-Launch-Modes.md`](./011-Launch-Modes.md) — the default
+  in-app shell-mount path via `[data-rf-causa-host]`.
+- [`Conventions.md`](./Conventions.md) §Panel facade + leaf split —
+  the canonical per-panel facade shape (`Panel` reg-view +
+  `install!`) every mount-fn target adheres to.

--- a/tools/causa/src/day8/re_frame2_causa/panels.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels.cljs
@@ -1,0 +1,288 @@
+(ns day8.re-frame2-causa.panels
+  "Public per-panel mount API — rf2-crhr8.
+
+  Every Causa panel is independently mountable: a host can mount one
+  panel in isolation without the surrounding 4-layer shell, without
+  sibling panels, and without any shell-owned chrome state. This
+  contract is the load-bearing surface that lets Causa be embedded
+  inside Story, inside the Scittle playground (rf2-i8mv option-c
+  progressive disclosure), inside custom debugging configurations,
+  and inside the docs / guide / examples surface.
+
+  ## The contract
+
+  Per `tools/causa/spec/008-Embedding-Contract.md` every panel exposes
+  a public mount fn:
+
+      (mount-event-detail!     mount-point opts) → unmount-fn
+      (mount-app-db-diff!      mount-point opts) → unmount-fn
+      (mount-views!            mount-point opts) → unmount-fn
+      (mount-trace!            mount-point opts) → unmount-fn
+      (mount-machine-inspector! mount-point opts) → unmount-fn
+      (mount-routing!          mount-point opts) → unmount-fn
+      (mount-issues-ribbon!    mount-point opts) → unmount-fn
+
+      ;; Overlay / popup surfaces — same contract.
+      (mount-segment-inspector! mount-point opts) → unmount-fn
+      (mount-cancellation-cascade-side-panel! mount-point opts) → unmount-fn
+      (mount-cancellation-cascade-popover!    mount-point opts) → unmount-fn
+
+      ;; Inline content surface — managed-fx wire-boundary diff. The
+      ;; canonical embed of the per-cascade managed-fx records list.
+      (mount-managed-fx! mount-point opts) → unmount-fn
+
+  Plus the master entry that mounts the full 4-layer shell:
+
+      (mount-shell! mount-point opts) → unmount-fn
+
+  ## What every mount fn does
+
+  1. Calls `(registry/register-causa-handlers!)` — idempotent, registers
+     every panel's subs + events + fxs under `:rf.causa/*`.
+  2. Calls `(rf/reg-frame :rf/causa {})` — idempotent, ensures the
+     state-isolation frame exists.
+  3. Wraps the panel's `Panel` (or equivalent) view in
+     `[rf/frame-provider {:frame :rf/causa} [<Panel>]]` so descendant
+     subscribes / dispatches re-anchor to `:rf/causa` regardless of
+     the host's React-context.
+  4. Delegates to `substrate-adapter/render` with the wrapped tree +
+     the supplied mount-point. The substrate adapter is the host's
+     (installed via `rf/init!`); the panels are substrate-agnostic
+     pure hiccup.
+  5. Returns the adapter's unmount fn so the host owns lifecycle.
+
+  ## Why the aggregator pattern
+
+  Each panel facade already follows the canonical shape — public
+  `Panel` reg-view + `install!` (per `tools/causa/spec/Conventions.md`
+  §Panel facade + leaf split). The mount-fns here are thin wrappers:
+  they delegate the chrome (frame-provider, registry install, adapter
+  render) to one place so every panel inherits the same contract by
+  construction. Adding a new panel = add a new `mount-<panel>!` line.
+
+  ## Per-panel inputs (the coupling-map audit, rf2-crhr8 §1)
+
+  Every panel reads its data via subscribes — no sibling-render
+  assumptions, no shell-owned local state. The subs (registered by
+  the panel's own `install!`) compose against:
+
+  | Panel | Reads | Writes (via dispatch) |
+  |---|---|---|
+  | **event-detail** | `:rf.causa/focus` · `:rf.causa/cascades` · `:rf.causa/target-frame-db` | `:rf.causa/focus-cascade` |
+  | **app-db-diff** | `:rf.causa/app-db-diff` (composite over target-frame + epoch history + focused slice path) | `:rf.causa/focus-slice-path` · `:rf.causa/open-segment-inspector` |
+  | **views** | `:rf.causa/views-focused-cascade-pair` · `:rf.causa/views-sub-diff` | view-row toggles + sub-diff selection |
+  | **trace** | `:rf.causa/trace-feed` (incremental projection over the buffer) | `:rf.causa/select-dispatch-id` · `:rf.causa/open-in-editor` |
+  | **machine-inspector** | `:rf.causa/machine-chart-data` · `:rf.causa/active-timers-for-focused-machine` · `:rf.causa/machine-scrubber-position` | scrubber events · `:rf.causa/focus-cascade` |
+  | **routing** | `:rf.causa/registered-routes` · `:rf.causa/current-route-slice` · `:rf.causa/routing-tab-data` | route-simulation events |
+  | **issues-ribbon** | `:rf.causa/issues-ribbon` (composite over trace buffer + filters + focus) | `:rf.causa.issues/toggle-severity` · `:rf.causa.issues/toggle-prefix` · `:rf.causa/select-dispatch-id` |
+  | **segment-inspector** | `:rf.causa/segment-inspector-open?` · `:rf.causa/segment-inspector-value` | `:rf.causa/close-segment-inspector` |
+  | **cancellation-cascade** (side-panel + popover) | `:rf.causa/cancellation-cascade-for-focused-machine` · `:rf.causa/cancellation-cascade-for-focused-event` · `:rf.causa/cancellation-cascade-popover-open?` · `:rf.causa/modal-positioning` | `:rf.causa/cancellation-cascade-close` |
+  | **managed-fx** | `:rf.causa/managed-fx-for-focused-event` | `:rf.causa/focus-event` |
+
+  No panel reads sibling-panel state directly. No panel assumes any
+  particular frame-picker / tab-bar / event-list / spine-head value
+  beyond what the spine sub `:rf.causa/focus` exposes — and `focus`
+  itself defaults to head of the trace buffer when no row is
+  selected. Each panel is fully driven by the trace bus + the host's
+  `(rf/init!)` plumbing.
+
+  ## Internal sub-components — not independently mountable
+
+  Five surfaces inside `machine-inspector/Panel` are auxiliary
+  inspectors that depend on the chart's positioned graph for their
+  geometry: `AfterRingsOverlay`, `ArcOverlay`, `ClusterView`,
+  `ScrubberStrip`, `SimSideRail`. These render under
+  `machine-inspector/Panel` (which owns the chart) and are not
+  exposed as standalone mount fns — mounting a ring overlay without
+  a chart underneath is geometrically meaningless. They remain
+  reachable via `machine-inspector/Panel` and document themselves
+  as internal sub-components.
+
+  ## Frame-provider opt — `:frame` defaults to `:rf/causa`
+
+  The default `opts` map is `{:frame :rf/causa}` — Causa's own
+  state-isolation frame. Hosts that embed a panel to observe a
+  specific app frame pass `{:frame :my-app/cart}` per the embedding
+  contract — the panel's subscribes still resolve to `:rf/causa` for
+  Causa's own UI state, while the panel-internal frame-selection sub
+  (`:rf.causa/observed-frame`) drives the data axis.
+
+  See `tools/causa/spec/007-UX-IA.md` §Mountable panel contract and
+  `tools/causa/spec/008-Embedding-Contract.md` for the full
+  embedding contract."
+  (:require [re-frame.core :as rf]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector :as segment-inspector]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
+            [day8.re-frame2-causa.panels.routing :as routing]
+            [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.panels.views :as views]
+            [day8.re-frame2-causa.shell :as shell]))
+
+;; ---- internal scaffolding -----------------------------------------------
+
+(defn- ensure-causa-handlers-installed!
+  "Idempotent — `register-causa-handlers!` carries its own sentinel so
+  multiple panel mounts collapse to one registration pass.
+
+  Note: we also `(rf/reg-frame :rf/causa {})` here so the frame the
+  wrapped `frame-provider` resolves to actually exists. `reg-frame`'s
+  surgical-update-on-re-register semantics (Spec 002 §reg-frame) keep
+  this idempotent across panel mounts and shadow-cljs reloads."
+  []
+  (registry/register-causa-handlers!)
+  (rf/reg-frame :rf/causa {}))
+
+(defn- render-panel!
+  "Internal helper. Wraps `panel-view` in `[rf/frame-provider {:frame
+  frame} [panel-view]]` and delegates to the substrate adapter's
+  render fn. Returns the adapter's unmount fn so the caller can
+  tear the mount down without going through this ns again.
+
+  - `panel-view` — the panel's `reg-view`-registered Var (e.g.
+    `event-detail/Panel`). Wrapped in a Reagent component-vector so
+    React-context flows correctly per Spec 006 §706 (a plain `defn`
+    invoked as a fn-call would skip the React-context tier and the
+    panel's subscribes would route to `:rf/default`).
+  - `mount-point` — a DOM element (or substrate-equivalent mount
+    target).
+  - `opts` — `{:frame <frame-id>}` minimum. Defaults to `:rf/causa`.
+    The frame the `frame-provider` resolves to. Hosts embedding a
+    panel to observe a specific app frame pass that frame id; the
+    panel's own Causa state still lives on `:rf/causa` (the panel
+    facade always opens with its own `frame-provider :rf/causa`
+    when its body subscribes to `:rf.causa/*` data)."
+  [panel-view mount-point opts]
+  (ensure-causa-handlers-installed!)
+  (let [frame (get opts :frame :rf/causa)
+        tree  [rf/frame-provider {:frame frame}
+               [panel-view]]]
+    (substrate-adapter/render tree mount-point nil)))
+
+;; ---- per-panel mount fns ------------------------------------------------
+;;
+;; All eleven public mount fns share the same shape — install handlers
+;; → wrap panel view in frame-provider → delegate to substrate adapter.
+;; The only per-panel axis is which `Panel` (or equivalent) view to
+;; render. This keeps the surface uniform — adding a panel = adding a
+;; line below; the chrome (registration, frame wiring, substrate
+;; delegation) lives in `render-panel!` exactly once.
+
+(defn mount-event-detail!
+  "Mount Causa's Event tab in isolation at `mount-point`. Renders the
+  six-domino cascade view for the current spine focus.
+
+  See ns docstring for `opts` shape + the embedding contract."
+  ([mount-point]      (mount-event-detail! mount-point nil))
+  ([mount-point opts] (render-panel! event-detail/Panel mount-point opts)))
+
+(defn mount-app-db-diff!
+  "Mount Causa's App-DB tab in isolation at `mount-point`. Renders the
+  sections-per-cluster structural diff for the focused cascade."
+  ([mount-point]      (mount-app-db-diff! mount-point nil))
+  ([mount-point opts] (render-panel! app-db-diff/Panel mount-point opts)))
+
+(defn mount-views!
+  "Mount Causa's Views tab in isolation at `mount-point`. Renders the
+  per-view sub-invalidation surface for the focused cascade."
+  ([mount-point]      (mount-views! mount-point nil))
+  ([mount-point opts] (render-panel! views/Panel mount-point opts)))
+
+(defn mount-trace!
+  "Mount Causa's Trace tab in isolation at `mount-point`. Renders the
+  trace-buffer feed for the focused cascade."
+  ([mount-point]      (mount-trace! mount-point nil))
+  ([mount-point opts] (render-panel! trace/Panel mount-point opts)))
+
+(defn mount-machine-inspector!
+  "Mount Causa's Machines tab in isolation at `mount-point`. Renders
+  the chart + arc/ring/cluster overlays for the focused machine.
+  The auxiliary inspectors (AfterRingsOverlay, ArcOverlay,
+  ClusterView, ScrubberStrip, SimSideRail) render under this Panel
+  — they are not independently mountable (see ns docstring §Internal
+  sub-components)."
+  ([mount-point]      (mount-machine-inspector! mount-point nil))
+  ([mount-point opts] (render-panel! machine-inspector/Panel mount-point opts)))
+
+(defn mount-routing!
+  "Mount Causa's Routing tab in isolation at `mount-point`. Renders
+  the registered-routes lens + simulate-URL surface."
+  ([mount-point]      (mount-routing! mount-point nil))
+  ([mount-point opts] (render-panel! routing/Panel mount-point opts)))
+
+(defn mount-issues-ribbon!
+  "Mount Causa's Issues tab in isolation at `mount-point`. Renders
+  the cascade-scoped issues feed + the ungrouped escape-hatch lane."
+  ([mount-point]      (mount-issues-ribbon! mount-point nil))
+  ([mount-point opts] (render-panel! issues-ribbon/Panel mount-point opts)))
+
+(defn mount-segment-inspector!
+  "Mount the App-DB segment-inspector popup in isolation at
+  `mount-point`. Self-gating — renders nil when no segment is open;
+  short-circuits on `:rf.causa/segment-inspector-open?`."
+  ([mount-point]      (mount-segment-inspector! mount-point nil))
+  ([mount-point opts] (render-panel! segment-inspector/Popup mount-point opts)))
+
+(defn mount-cancellation-cascade-side-panel!
+  "Mount the cancellation-cascade side-panel in isolation at
+  `mount-point`. Renders the destroy-waterfall when the focused
+  machine had a cancellation-anchor in the trace window; renders
+  nothing otherwise."
+  ([mount-point]      (mount-cancellation-cascade-side-panel! mount-point nil))
+  ([mount-point opts] (render-panel! cancellation-cascade/SidePanel mount-point opts)))
+
+(defn mount-cancellation-cascade-popover!
+  "Mount the cancellation-cascade popover overlay in isolation at
+  `mount-point`. Self-gating — renders nil when
+  `:rf.causa/cancellation-cascade-popover-open?` is false."
+  ([mount-point]      (mount-cancellation-cascade-popover! mount-point nil))
+  ([mount-point opts] (render-panel! cancellation-cascade/Popover mount-point opts)))
+
+(rf/reg-view ManagedFxList
+  "The managed-fx wire-boundary diff template's mountable wrapper —
+  reads `:rf.causa/managed-fx-for-focused-event` and renders the
+  records list. `managed-fx-template/records-list` is a pure fn over
+  a records vector; this reg-view ties it to the focused cascade's
+  managed-fx sub so consumers get the same content the Event tab
+  embeds inline under the six-domino cascade view.
+
+  Exposing this as a reg-view (rather than a plain fn) follows the
+  Conventions.md panel-facade contract — every public mount target
+  is a `reg-view` so the React-context tier resolves to the wrapping
+  frame-provider per Spec 006 §706."
+  []
+  (let [records @(rf/subscribe [:rf.causa/managed-fx-for-focused-event])]
+    (managed-fx/records-list records)))
+
+(defn mount-managed-fx!
+  "Mount the managed-fx wire-boundary diff list in isolation at
+  `mount-point`. Renders one record-panel per managed-fx invocation
+  inside the focused cascade's six-domino window. Empty when the
+  focused cascade had no managed-fx records."
+  ([mount-point]      (mount-managed-fx! mount-point nil))
+  ([mount-point opts] (render-panel! ManagedFxList mount-point opts)))
+
+;; ---- full-shell mount ---------------------------------------------------
+
+(defn mount-shell!
+  "Mount the full Causa 4-layer shell at `mount-point`. The master
+  entry — composes every panel inside the shell's ribbon + event-list
+  + tab-bar + detail-panel chrome.
+
+  This is the same mount path `mount.cljs/open!` uses for the
+  default in-app `[data-rf-causa-host]` mount; exposing it here lets
+  hosts that own their own DOM (Story, custom dev surfaces) mount
+  the shell at any element without going through Causa's auto-open
+  preload."
+  ([mount-point]      (mount-shell! mount-point nil))
+  ([mount-point opts]
+   (ensure-causa-handlers-installed!)
+   (let [mode (get opts :mode :inline)
+         tree [shell/shell-view {:mode mode}]]
+     (substrate-adapter/render tree mount-point nil))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs
@@ -1,0 +1,275 @@
+(ns day8.re-frame2-causa.panels-mount-cljs-test
+  "Per-panel standalone-mount tests — rf2-crhr8.
+
+  Pins the contract: every public `panels/mount-<panel>!` fn renders
+  its panel in isolation. No shell, no siblings, no shell-owned
+  chrome state. The mount fn:
+
+    1. Installs Causa's handlers (idempotent).
+    2. Registers `:rf/causa` (idempotent).
+    3. Wraps the panel view in `[rf/frame-provider {:frame _} [Panel]]`.
+    4. Delegates to `substrate-adapter/render` with the wrapped tree.
+    5. Returns the adapter's unmount fn.
+
+  ## Test strategy
+
+  We stub `substrate-adapter/render` so the test can capture the
+  rendered tree (the wrapped hiccup) without booting an actual
+  substrate. Each test:
+
+    - Calls the mount fn against a sentinel mount-point.
+    - Asserts the captured tree has the canonical
+      `[rf/frame-provider {:frame :rf/causa} [Panel]]` shape.
+    - Asserts the substrate-adapter render was invoked exactly once.
+    - Asserts the returned value is the (stubbed) unmount fn — the
+      host's lifecycle anchor.
+
+  Per-panel render-correctness (the actual view body) is covered by
+  the existing `panels/<panel>_cljs_test.cljs` suites; this file
+  pins the MOUNT API contract, not the view contract."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels :as panels]
+            [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector :as segment-inspector]
+            [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
+            [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
+            [day8.re-frame2-causa.panels.routing :as routing]
+            [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.panels.views :as views]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- render-stub helper -------------------------------------------------
+
+(defn- make-render-stub
+  "Build a stub for `substrate-adapter/render` that captures every
+  invocation. Returns `[capture-atom unmount-fn render-fn]` —
+
+    - `capture-atom` — `[{:tree _ :mount-point _ :opts _} ...]`
+    - `unmount-fn` — a sentinel fn the stub returns; tests assert the
+      mount fn passes it through unchanged.
+    - `render-fn` — the stub itself; pass to `with-redefs`."
+  []
+  (let [capture  (atom [])
+        unmount  (fn unmount-stub [] :unmount-called)
+        render-fn (fn [tree mount-point opts]
+                    (swap! capture conj {:tree tree
+                                         :mount-point mount-point
+                                         :opts opts})
+                    unmount)]
+    [capture unmount render-fn]))
+
+(defn- captured-tree
+  "Helper — return the first captured render tree."
+  [capture]
+  (-> @capture first :tree))
+
+(defn- frame-provider-wrap?
+  "True when the captured tree is the canonical
+  `[rf/frame-provider {:frame :rf/causa} [Panel]]` shape."
+  [tree expected-panel-view]
+  (and (vector? tree)
+       (= rf/frame-provider (first tree))
+       (= {:frame :rf/causa} (second tree))
+       (vector? (nth tree 2))
+       (= expected-panel-view (first (nth tree 2)))))
+
+;; ---- top-level L3-tab panels (7) ---------------------------------------
+
+(deftest mount-event-detail-wraps-in-frame-provider-and-delegates-to-adapter
+  (testing "rf2-crhr8 — mount-event-detail! installs handlers, wraps
+            event-detail/Panel in `[rf/frame-provider {:frame :rf/causa}
+            [Panel]]`, delegates to substrate-adapter/render, and
+            returns the adapter's unmount fn."
+    (let [[capture unmount-sentinel render-stub] (make-render-stub)
+          mount-point :mount-point-sentinel]
+      (with-redefs [substrate-adapter/render render-stub]
+        (let [unmount (panels/mount-event-detail! mount-point)]
+          (is (= 1 (count @capture))
+              "substrate-adapter/render invoked exactly once")
+          (is (frame-provider-wrap? (captured-tree capture) event-detail/Panel)
+              "tree is wrapped in rf/frame-provider :rf/causa around Panel")
+          (is (= mount-point (-> @capture first :mount-point))
+              "mount-point passed through unchanged")
+          (is (= unmount-sentinel unmount)
+              "adapter's unmount fn is returned to the caller"))
+        ;; Side-effect — handlers landed.
+        (is (some? (registrar/handler :sub :rf.causa/cascades))
+            "register-causa-handlers! ran as a side-effect of mount")
+        (is (some? (frame/frame :rf/causa))
+            ":rf/causa frame is registered as a side-effect of mount")))))
+
+(deftest mount-app-db-diff-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-app-db-diff! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) app-db-diff/Panel)))))
+
+(deftest mount-views-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-views! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) views/Panel)))))
+
+(deftest mount-trace-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-trace! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) trace/Panel)))))
+
+(deftest mount-machine-inspector-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-machine-inspector! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) machine-inspector/Panel)))))
+
+(deftest mount-routing-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-routing! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) routing/Panel)))))
+
+(deftest mount-issues-ribbon-wraps-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-issues-ribbon! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) issues-ribbon/Panel)))))
+
+;; ---- overlay / popup surfaces (3) --------------------------------------
+
+(deftest mount-segment-inspector-wraps-Popup-in-frame-provider
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-segment-inspector! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) segment-inspector/Popup)))))
+
+(deftest mount-cancellation-cascade-side-panel-wraps-SidePanel
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-cancellation-cascade-side-panel! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture)
+                                cancellation-cascade/SidePanel)))))
+
+(deftest mount-cancellation-cascade-popover-wraps-Popover
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-cancellation-cascade-popover! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture)
+                                cancellation-cascade/Popover)))))
+
+;; ---- inline content surface (managed-fx) -------------------------------
+
+(deftest mount-managed-fx-wraps-ManagedFxList
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-managed-fx! :mount-point)
+      (is (frame-provider-wrap? (captured-tree capture) panels/ManagedFxList)))))
+
+;; ---- full-shell mount --------------------------------------------------
+
+(deftest mount-shell-renders-shell-view-without-extra-wrapper
+  (testing "rf2-crhr8 — mount-shell! delegates the full 4-layer shell.
+            The shell-view itself owns its `frame-provider` (per the
+            shell docstring) so the mount fn renders [shell-view {:mode
+            :inline}] directly — no outer wrapper."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [substrate-adapter/render render-stub]
+        (panels/mount-shell! :mount-point)
+        (let [tree (captured-tree capture)]
+          (is (vector? tree))
+          (is (map? (second tree)))
+          (is (= :inline (:mode (second tree))))
+          ;; The shell mounts via a reg-view-registered view; the
+          ;; captured render-tree's first element is that view fn (not
+          ;; a frame-provider — the shell owns its own provider).
+          (is (not= rf/frame-provider (first tree))
+              "mount-shell! does NOT add an outer frame-provider — the
+               shell-view contains its own per spec/007 §The 4-layer
+               chrome"))))))
+
+(deftest mount-shell-supports-mode-opt
+  (let [[capture _ render-stub] (make-render-stub)]
+    (with-redefs [substrate-adapter/render render-stub]
+      (panels/mount-shell! :mount-point {:mode :overlay})
+      (is (= :overlay (-> (captured-tree capture) second :mode))))))
+
+;; ---- contract — frame opt --------------------------------------------
+
+(deftest mount-fn-honours-frame-opt-when-host-overrides-default
+  (testing "rf2-crhr8 — `opts {:frame ...}` overrides the default
+            `:rf/causa` frame the frame-provider wraps around. Pins
+            the embedding contract (008-Embedding-Contract.md §State
+            isolation) — a host can choose a different frame for the
+            React-context tier (e.g. a Story variant frame) and the
+            wrapper honours it. The panel's own Causa-state subs still
+            target `:rf.causa/*` registrations under whatever frame
+            actually carries them."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [substrate-adapter/render render-stub]
+        (panels/mount-event-detail! :mount-point {:frame :my-app/cart})
+        (let [tree (captured-tree capture)]
+          (is (= rf/frame-provider (first tree)))
+          (is (= {:frame :my-app/cart} (second tree))
+              "explicit :frame opt overrides the default :rf/causa"))))))
+
+;; ---- contract — idempotency under repeat mount ------------------------
+
+(deftest repeat-mount-is-idempotent-for-handler-registration
+  (testing "rf2-crhr8 — calling mount multiple times is safe; the
+            registry's `register-causa-handlers!` sentinel collapses
+            repeat installs into a single registration. The substrate
+            render is called each time (each mount creates a fresh
+            substrate render — that's the host's lifecycle choice;
+            the panels ns does not deduplicate)."
+    (let [[capture _ render-stub] (make-render-stub)]
+      (with-redefs [substrate-adapter/render render-stub]
+        (panels/mount-event-detail! :mount-1)
+        (panels/mount-app-db-diff! :mount-2)
+        (panels/mount-issues-ribbon! :mount-3)
+        (is (= 3 (count @capture))
+            "every mount call delegates to substrate-adapter/render")
+        ;; Handlers landed exactly once — :rf.causa/cascades is a
+        ;; cross-panel primitive registered inside the orchestrator's
+        ;; sentinel guard.
+        (is (some? (registrar/handler :sub :rf.causa/cascades)))))))
+
+;; ---- contract — every public mount fn exists --------------------------
+
+(deftest every-panel-mount-fn-is-public-and-callable
+  (testing "rf2-crhr8 — the eleven per-panel mount fns + the full-
+            shell mount fn are all present + ifn? — defensive guard
+            against accidental removal during refactor."
+    (let [fns [["mount-event-detail!"                       panels/mount-event-detail!]
+               ["mount-app-db-diff!"                        panels/mount-app-db-diff!]
+               ["mount-views!"                              panels/mount-views!]
+               ["mount-trace!"                              panels/mount-trace!]
+               ["mount-machine-inspector!"                  panels/mount-machine-inspector!]
+               ["mount-routing!"                            panels/mount-routing!]
+               ["mount-issues-ribbon!"                      panels/mount-issues-ribbon!]
+               ["mount-segment-inspector!"                  panels/mount-segment-inspector!]
+               ["mount-cancellation-cascade-side-panel!"    panels/mount-cancellation-cascade-side-panel!]
+               ["mount-cancellation-cascade-popover!"       panels/mount-cancellation-cascade-popover!]
+               ["mount-managed-fx!"                         panels/mount-managed-fx!]
+               ["mount-shell!"                              panels/mount-shell!]]]
+      (doseq [[sym-name f] fns]
+        (is (ifn? f)
+            (str sym-name " is callable"))))))


### PR DESCRIPTION
## Summary

Spinoff from rf2-i8mv (Scittle playground decision LOCKED option-c progressive disclosure). Every Causa panel is now standalone-mountable via the new `day8.re-frame2-causa.panels` aggregator ns — eleven per-panel mount fns plus a full-shell mount fn give hosts (Story ribbons, the future Scittle playground, docs surfaces, custom debug setups) a uniform contract:

```clojure
(panels/mount-event-detail!  mount-point opts) → unmount-fn
(panels/mount-app-db-diff!   mount-point opts) → unmount-fn
(panels/mount-views!         mount-point opts) → unmount-fn
(panels/mount-trace!         mount-point opts) → unmount-fn
(panels/mount-machine-inspector! mount-point opts) → unmount-fn
(panels/mount-routing!       mount-point opts) → unmount-fn
(panels/mount-issues-ribbon! mount-point opts) → unmount-fn

(panels/mount-segment-inspector!                 mount-point opts)
(panels/mount-cancellation-cascade-side-panel!   mount-point opts)
(panels/mount-cancellation-cascade-popover!      mount-point opts)
(panels/mount-managed-fx!                        mount-point opts)

(panels/mount-shell! mount-point opts)
```

Each mount fn idempotently installs Causa's handlers, registers the `:rf/causa` state-isolation frame, wraps the panel view in `[rf/frame-provider {:frame :rf/causa} [Panel]]`, and delegates to the host's substrate-adapter render slot.

## Coupling-map audit (the rf2-crhr8 audit ask)

Every panel reads its data via subscribes — no sibling-render assumptions, no shell-owned local state. Per-panel inputs surveyed in `tools/causa/spec/007-UX-IA.md` §Mountable panel contract. Highlights:

- **event-detail** → `:rf.causa/focus` · `:rf.causa/cascades` · `:rf.causa/target-frame-db`
- **app-db-diff** → `:rf.causa/app-db-diff` composite
- **views** → `:rf.causa/views-focused-cascade-pair` · `:rf.causa/views-sub-diff`
- **trace** → `:rf.causa/trace-feed` incremental projection
- **machine-inspector** → `:rf.causa/machine-chart-data` (+ family)
- **routing** → `:rf.causa/registered-routes` · `:rf.causa/current-route-slice`
- **issues-ribbon** → `:rf.causa/issues-ribbon` composite + `:rf.causa.issues/ungrouped`
- **segment-inspector** → `:rf.causa/segment-inspector-{open?,value}`
- **cancellation-cascade** → focused-machine + focused-event composites + `:modal-positioning`
- **managed-fx** → `:rf.causa/managed-fx-for-focused-event`

No panel reads sibling-panel state directly; no panel assumes any particular frame-picker / tab-bar / event-list value beyond `:rf.causa/focus`. Each panel is fully driven by the trace bus + the host's `(rf/init!)` plumbing.

## Surface inventory

16 panel surfaces split across four tiers — 11 independently mountable as standalone user-facing mount targets, 2 (Tier 4) internal sub-components that render under `machine-inspector/Panel` (mounting them standalone is geometrically meaningless without the chart underneath). Per rf2-y9xmf the prior arc / cluster / scrubber sub-components are gone with the Machine Inspector collapse — the remaining Tier 4 surface is `AfterRingsOverlay` + `SimSideRail`.

## Tests

`tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs` pins every mount fn:
- Wraps the right panel view in `[rf/frame-provider {:frame :rf/causa} [Panel]]`
- Delegates exactly once to `substrate-adapter/render` with the supplied mount-point
- Returns the adapter's unmount fn to the caller
- Honours `opts {:frame ...}` override per the embedding contract
- Stays idempotent under repeat-mount

## Shell composes, does not own

`shell.cljs` remains the canonical composition of all panels (L4 detail-panel case-switch + Tier 2 root-mounted overlays); this PR adds the standalone surface alongside, not in place of, the shell mount path.

## In-flight collision posture

Audit-only on `machine_inspector.cljs` (PR #1535 rf2-y9xmf — merged during this work; rebased onto the collapsed Runtime panel), `views_view.cljs` (PR #1533 still mid-air), `routing.cljs` (PR #1542 still mid-air). The new aggregator references their `Panel` view-vars by name; no panel file was edited. The collapsed Machine Inspector's `AfterRingsOverlay` + `SimSideRail` are documented as Tier 4 sub-components in the spec addendum.

## LoC delta

| File | Lines |
|---|---|
| `tools/causa/src/day8/re_frame2_causa/panels.cljs` (new) | 288 |
| `tools/causa/test/day8/re_frame2_causa/panels_mount_cljs_test.cljs` (new) | 275 |
| `tools/causa/spec/007-UX-IA.md` (addendum) | +156 |
| **Total** | **+719** |

Slightly above the bead's 200-400 LoC estimate; the extra surface area is per-panel mount tests + the spec contract table + comprehensive ns docstring carrying the coupling-map audit.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 2845 tests / 8095 assertions, 0 failures, 0 errors
- [x] `clojure -M:test` from `tools/causa/` — 747 tests / 2154 assertions, 0 failures, 0 errors
- [x] `npm run test:bundle-isolation` from `implementation/` — production bundles clean (Causa surface stays out)