### PR TITLE
docs(skills): cluster cleanup — comfy/causality/panel-count/aside-side (rf2-3np3n + rf2-ruplr + rf2-3r3ao + rf2-a56gu)

### DIFF
--- a/skills/causa/SKILL.md
+++ b/skills/causa/SKILL.md
@@ -3,7 +3,7 @@ name: causa
 description: >
   Read-only tour of **Causa** — the re-frame2 devtools panel. Use when the
   user wants to know how to *launch* Causa (in-app inline panel, pop-out
-  window, programmatic mount, or the two wired hotkeys), which of its 16
+  window, programmatic mount, or the two wired hotkeys), which of its 13
   panels surfaces the data they're looking for, or what each panel is
   *for*. Trigger phrases: "open Causa", "where is X in Causa",
   "which Causa panel shows…", "Ctrl+Shift+C", "Causa hotkey",
@@ -35,7 +35,7 @@ This skill answers two questions, and only two:
 
 1. **How do I launch Causa?** — the inline panel, the pop-out, the
    programmatic entry points, the wired hotkeys.
-2. **Which panel shows X?** — a one-line purpose for each of the 16
+2. **Which panel shows X?** — a one-line purpose for each of the 13
    panels Causa ships.
 
 Workflow procedures (find-wrong-sub, scrub-bad-epoch, click-to-source,
@@ -55,7 +55,7 @@ gate — zero bytes ship to consumers.
 
 Causa consumes re-frame2's instrumentation surface (Spec 009 trace bus,
 Tool-Pair epoch history, the registrar query API) — it adds nothing the
-framework didn't already expose. The 16 panels are *presentation* of an
+framework didn't already expose. The 13 panels are *presentation* of an
 already-structured runtime.
 
 For an AI agent surface against the running app, use `tools/re-frame2-pair-mcp/`
@@ -102,9 +102,9 @@ on the launcher pill.
 
 ---
 
-## The 15 panels — what each surfaces
+## The 13 panels — what each surfaces
 
-The sidebar lists 15 panels in three groups (always-active, conditional,
+The sidebar lists 13 panels in three groups (always-active, conditional,
 dormant). When the user asks "where is X?", route to the panel whose
 purpose covers it. For more detail on each — group membership, dormant
 state, activity badges, deeper "open it when…" guidance — see
@@ -125,7 +125,6 @@ state, activity badges, deeper "open it when…" guidance — see
 | **Issues** | Unified feed: errors + warnings + schema violations + hydration mismatches. Top-strip badge mirrors count. | "Anything broken?" / "Show me all schema failures." |
 | **Schemas** | One row per registered schema; coloured dot per failure with recovery-mode mapping. | "Has any schema violated this session?" / "When did `:user/profile` start failing?" |
 | **Hydration** *(dormant)* | Server-vs-client render-tree side-by-side with divergent node flagged and hash-bisector path highlighted. Dormant `◌` until the first `:rf.ssr/hydration-mismatch` trace lands. | "My SSR hydration is mismatching" — only visible when SSR runs. |
-| **MCP** | Live feed of MCP-server activity: tool calls in flight, recent results, per-origin colouring. | "What is my agent doing right now?" / "Did the MCP call land?" |
 
 The hero on first open is **Event detail**. AI integration lives in
 the separate `tools/re-frame2-pair-mcp/` jar — Causa itself is the human

--- a/skills/causa/reference/launch-modes.md
+++ b/skills/causa/reference/launch-modes.md
@@ -163,7 +163,7 @@ guarded so a second call is a no-op.
 (causa/init!
  {:default-frame :app/main          ; target-frame for the scrubber
   :theme         :dark              ; / :light / :high-contrast
-  :density       :compact           ; / :cosy / :comfy
+  :density       :compact           ; / :cosy
   :ai-provider   {:provider :claude}
   :buffer-depths {:trace 200 :epoch 50}})
 ```

--- a/skills/causa/reference/panels.md
+++ b/skills/causa/reference/panels.md
@@ -1,4 +1,4 @@
-# panels — the 14-panel tour
+# panels — the 13-panel tour
 
 Sources of truth: per-panel specs under
 [`tools/causa/spec/`](../../../tools/causa/spec/) (one `00N-*.md` per
@@ -197,4 +197,4 @@ error). Otherwise the panel has nothing to show.
 Spec: [`006-Hydration-Debugger.md`](../../../tools/causa/spec/006-Hydration-Debugger.md).
 
 For the user-question → panel routing table, see
-[`SKILL.md` §The 14 panels](../SKILL.md).
+[`SKILL.md` §The 13 panels](../SKILL.md).

--- a/skills/re-frame-migration/reference/causa-replaces-10x.md
+++ b/skills/re-frame-migration/reference/causa-replaces-10x.md
@@ -61,12 +61,12 @@ The preload registers Causa's listeners under `register-trace-cb!` and `register
 
 Causa's default launch is **true inline** (per spec `rf2-eehov`): it mounts into a host element the app provides, sharing the layout. No overlay, no body-padding dock, no popup. The app reserves space; Causa fills it.
 
-Add a left-side host to the app's HTML and CSS:
+Add a right-side host to the app's HTML and CSS (DOM order: `<main>` first, `<aside>` second — flex flow puts the aside on the right):
 
 ```html
 <div class="app-shell">
-  <aside data-rf-causa-host></aside>
   <main id="app"></main>
+  <aside data-rf-causa-host></aside>
 </div>
 ```
 

--- a/skills/re-frame2-pair/SKILL.md
+++ b/skills/re-frame2-pair/SKILL.md
@@ -190,7 +190,7 @@ A re-frame2-pair session and a running Causa panel are **complementary** surface
 | Pair2 just did | Open Causa to … |
 |---|---|
 | Rewound to an earlier epoch via `restore-epoch` | Scrub the bottom-rail time-travel scrubber to inspect adjacent epochs visually; pin slices in the App-DB Diff panel. |
-| Dispatched into a cascade you don't fully understand | Read the Causality graph for the dispatch-id tree; the Event Detail panel lands on the latest cascade. |
+| Dispatched into a cascade you don't fully understand | The Event Detail panel lands on the latest cascade and shows the dispatch-id tree. |
 | Hot-swapped a sub or reg-event handler | Watch the Subscriptions panel's invalidation-chain affordance recompute (`:cart/total` ← `:cart/items` ← `[:cart :items]`). |
 | Stepped into a machine transition | Open the Machine Inspector for the state-chart view with transition history. |
 | Triggered a schema violation | The Schema Violation Timeline surfaces it with recovery mode + source coord. |


### PR DESCRIPTION
## Summary

Cluster of four prose fixes from the rf2-puvtl skills audit (2026-05-19). Each lands as its own commit (smallest cleanup first):

1. **rf2-a56gu (P3)** — `skills/re-frame-migration/reference/causa-replaces-10x.md` showed `<aside>` on the LEFT (DOM order `<aside>` then `<main>`) and prose saying "left-side host". Every sibling skill (`skills/causa`, `skills/re-frame2`, `skills/re-frame2-setup`) shows it on the RIGHT. Realigned this leaf so all four skills converge on the right-side convention.

2. **rf2-3r3ao (P3)** — `skills/causa/` had three different panel counts (16 / 15 / 14) and a 14-row table that included a contradictory MCP row (its own prose two lines below said "AI integration lives in the separate `tools/re-frame2-pair-mcp/` jar — Causa itself is the human surface only"). Reconciled everything to **13** (matches the sidebar-items count for the architecture this skill still documents): SKILL.md description + heading + table; reference/panels.md title + cross-ref. MCP row removed. Note: spec/000-Vision now ships a 7-tab L3 detail panel that supersedes the legacy 16-panel sidebar — out of scope for this prose-only fix; tracked separately as a larger skills-vs-spec drift.

3. **rf2-3np3n (P2)** — `skills/causa/reference/launch-modes.md` showed `:density :compact / :cosy / :comfy` in the `(causa/init! opts)` example. Spec/015 dropped the `:comfy` tier and the coercion sub maps persisted `:comfy` → `:cosy`. Trimmed the example to the two tiers Causa actually ships.

4. **rf2-ruplr (P2)** — `skills/re-frame2-pair/SKILL.md` still pointed users at a "Causality graph" panel (rf2-y0z5b #1517 dropped the Causality surface entirely). Rewrote the cell to reference Event Detail, which already does both jobs the cell described.

## Hot-zone discipline

`skills/` is not a hot-zone. Allowed-tools blocks untouched (rf2-flzdp drift gate unaffected). No spec edits.

## Test plan

- [x] `python -m mkdocs build` (non-strict) — clean
- [x] `python scripts/check_doc_slugs.py` — passes
- [x] `python scripts/check_skill_mcp_drift.py` — passes (allowed-tools not touched)