### PR TITLE
chore(causa): drop :comfy residue from comments + examples (rf2-leywx)

### DIFF
--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -148,7 +148,7 @@ test harnesses, and Settings UIs.
 (causa/init! opts)
 ;; opts: {:default-frame :app/main
 ;;        :theme         :dark / :light / :high-contrast
-;;        :density       :compact / :cosy / :comfy
+;;        :density       :compact / :cosy
 ;;        :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
 ;;                        :api-key  "sk-..."     ;; localStorage only; never sent to Day8
 ;;                        :model    "claude-3-5-sonnet"
@@ -337,7 +337,7 @@ wires per-instance panel state). Shape (validated by Malli):
 
 ```clojure
 {:theme         :dark / :light / :high-contrast
- :density       :compact / :cosy / :comfy
+ :density       :compact / :cosy
  :ai-provider   {:provider :claude / :openai / :gemini / :local / :custom
                  :api-key      "sk-..."
                  :model        "claude-3-5-sonnet"

--- a/tools/causa/src/day8/re_frame2_causa/core.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/core.cljs
@@ -106,7 +106,7 @@
 
       {:default-frame :app/main          ;; target-frame for the scrubber
        :theme         :dark              ;; / :light / :high-contrast
-       :density       :compact           ;; / :cosy / :comfy
+       :density       :compact           ;; / :cosy
        :ai-provider   {:provider :claude ;; ...}
        :buffer-depths {:trace 200 :epoch 50}}
 


### PR DESCRIPTION
## Summary
3 small prose drifts found by the skills audit (rf2-puvtl): `tools/causa` source listed `:comfy` as a valid density tier even though Spec 015 dropped it. Cleanup.

## Why
The skills layer is now clean (#1546). This is the cross-ref the audit flagged at the source layer.

## Files
- `tools/causa/src/day8/re_frame2_causa/core.cljs:109` — comment
- `tools/causa/spec/API.md:151` — example
- `tools/causa/spec/API.md:340` — example

(`spec/015-Configuration.md` retains the historical drop-note. `settings/subs.cljs` retains the coercion comment.)