### PR TITLE
fix(spec): drop ai/findings link in tools/causa/spec/016-Auxiliary-Panels.md

### DIFF
--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -279,9 +279,8 @@ in posture — always-on registered topology + per-focused-event lens.
 
 The lens is a **flat catalogue sorted by `:path`** — never a tree.
 The previous URL-path-segmentation indentation (`project-route-tree`)
-was decorative: the audit
-([`ai/findings/2026-05-19-routing-inheritance-audit.md`](../../../ai/findings/2026-05-19-routing-inheritance-audit.md))
-found that routes are flat in the spec + impl, `:parent` plays no
+was decorative: the routing-inheritance audit (2026-05-19) found that
+routes are flat in the spec + impl, `:parent` plays no
 role in matching, and the match-resolver is structural (6-rule rank
 on URL pattern). Indenting routes by URL-segment count conflated
 URL-prefix similarity with semantic hierarchy — those are independent


### PR DESCRIPTION
## Summary
Pre-existing broken target from rf2-lq0ef PR #1542 — ai/findings/ is gitignored, MkDocs link validator blocks. Same pattern as earlier rf2-mxkq7 spec/View-Hierarchy-Capture fix.

Currently blocks #1533, #1549, #1550 MkDocs gate.

## Test plan
- [x] check_doc_slugs.py clean for changed file