### PR TITLE
fix(implementation): 2 correctness fixes from rf2-fva6c audit (rf2-cos61 + rf2-fva6c.1)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -432,6 +432,14 @@
             ;; Bind n once — `(empty? inputs)` then `(= 1 (count inputs))`
             ;; counted twice on the multi-input path (rf2-r1rma).
             n       (count inputs)]
+        ;; Per Spec 009 §Error contract — body throws emit
+        ;; :rf.error/sub-exception and recover to nil. Mirrors
+        ;; `subs.memo/validate-and-trace` (the reactive sibling), so
+        ;; SSR + JVM-runnable consumers driving subs through
+        ;; `compute-sub` get the same debuggable signal the reactive
+        ;; path produces. The `:where :compute-sub` tag distinguishes
+        ;; this emission site from the reactive memo path; the rest of
+        ;; the envelope mirrors the sibling exactly (rf2-cos61).
         (try
           (let [v (cond
                     (zero? n)
@@ -443,7 +451,20 @@
                     :else
                     (body-fn (mapv #(compute-sub % db) inputs) query-v))]
             (subs-memo/maybe-validate-sub-return! v query-v query-id meta))
-          (catch #?(:clj Throwable :cljs :default) _
+          (catch #?(:clj Throwable :cljs :default) e
+            (let [msg #?(:clj (.getMessage ^Throwable e) :cljs (.-message e))]
+              (trace/emit-error!
+                :rf.error/sub-exception
+                {:failing-id        query-id
+                 :sub-id            query-id
+                 :sub-query         query-v
+                 :where             :compute-sub
+                 :exception         e
+                 :exception-message msg
+                 :reason            (str "Subscription `" query-id
+                                         "` threw while computing: "
+                                         msg ". Returning nil.")
+                 :recovery          :replaced-with-default}))
             nil))))))
 
 (defn unsubscribe

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -101,6 +101,50 @@
     ;; Unknown sub returns nil instead of throwing.
     (is (nil? (rf/compute-sub [:no-such-sub] {})))))
 
+(deftest compute-sub-emits-sub-exception-on-body-throw
+  ;; rf2-cos61: prior to the fix, compute-sub silently swallowed body
+  ;; throws and returned nil — diverging from the reactive sibling
+  ;; (`subs.memo/validate-and-trace`) which emits :rf.error/sub-exception
+  ;; per Spec 009 §Error contract. Pin parity here: SSR + JVM-runnable
+  ;; consumers must see the same debuggable signal the reactive path
+  ;; produces.
+  (testing "compute-sub emits :rf.error/sub-exception when the sub body throws (layer-1)"
+    (rf/reg-sub :boom (fn [_db _q] (throw (ex-info "boom" {:k :v}))))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::boom (fn [ev] (swap! traces conj ev)))
+      (is (nil? (rf/compute-sub [:boom] {}))
+          "compute-sub still returns nil (recovery :replaced-with-default)")
+      (rf/remove-trace-cb! ::boom)
+      (let [ev (some (fn [e]
+                       (when (= :rf.error/sub-exception (:operation e)) e))
+                     @traces)]
+        (is (some? ev) "an :rf.error/sub-exception trace was emitted")
+        (when ev
+          (is (= :error (:op-type ev)) "op-type is :error")
+          ;; `:recovery` is hoisted onto the envelope by build-event.
+          (is (= :replaced-with-default (:recovery ev)))
+          (let [t (:tags ev)]
+            (is (= :boom (:failing-id t)))
+            (is (= :boom (:sub-id t)))
+            (is (= [:boom] (:sub-query t)))
+            (is (= :compute-sub (:where t))
+                ":where distinguishes the pure-compute call site from the reactive memo path")
+            (is (instance? Throwable (:exception t)))
+            (is (= "boom" (:exception-message t))))))))
+  (testing "compute-sub emits :rf.error/sub-exception when a layer-2 body throws"
+    (rf/reg-sub :n   (fn [db _] (:n db)))
+    (rf/reg-sub :n*2 :<- [:n] (fn [_n _q] (throw (ex-info "kaboom" {}))))
+    (let [traces (atom [])]
+      (rf/register-trace-cb! ::boom2 (fn [ev] (swap! traces conj ev)))
+      (is (nil? (rf/compute-sub [:n*2] {:n 7})))
+      (rf/remove-trace-cb! ::boom2)
+      (is (some (fn [e]
+                  (and (= :rf.error/sub-exception (:operation e))
+                       (= :n*2 (:sub-id (:tags e)))
+                       (= :compute-sub (:where (:tags e)))))
+                @traces)
+          "layer-2 throw also emits :rf.error/sub-exception via compute-sub"))))
+
 (deftest subscribe-handles-missing-frame
   (testing "subscribe / subscribe-once against a missing frame don't throw"
     (rf/reg-sub :n (fn [db _] (:n db)))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -254,12 +254,26 @@
           (or (not (number? resolved-ms))
               (not (pos? resolved-ms)))
           ;; Bad delay resolution — emit advisory and skip.
-          (trace/emit! :machine :rf.warning/no-clock-configured
-                       {:machine-id   parent-id
-                        :state        state
-                        :delay-key    delay-key
-                        :delay-source delay-source
-                        :recovery     :skipped})
+          ;;
+          ;; Per rf2-fva6c.1: `resolve-delay-ms` for a subscription-vector
+          ;; delay calls `subs/subscribe` (bumping the sub-cache ref-count)
+          ;; BEFORE we know whether the resolved value is usable. The bad-
+          ;; delay branch short-circuits and stores nothing in
+          ;; `after-timers`, so no future `cancel-after-timer-entry!` will
+          ;; ever run `release-entry-resources!` to drop the ref. Pair the
+          ;; subscribe with an `unsubscribe` here so every exit path
+          ;; balances the ref-count. Per Spec 006 §Reference counting and
+          ;; disposal.
+          (do
+            (when (and reaction (vector? delay-key))
+              (try (subs/unsubscribe frame-id delay-key)
+                   (catch #?(:clj Throwable :cljs :default) _ nil)))
+            (trace/emit! :machine :rf.warning/no-clock-configured
+                         {:machine-id   parent-id
+                          :state        state
+                          :delay-key    delay-key
+                          :delay-source delay-source
+                          :recovery     :skipped}))
 
           :else
           (let [_ (when emit-scheduled-trace?

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -21,6 +21,8 @@
   exercised by machines_cljs_test.cljs."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.subs.cache :as subs-cache]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace]))
@@ -305,3 +307,85 @@
                 ":recovery hoisted to the envelope top-level")))
         (finally
           (re-frame.trace/remove-trace-cb! ::after-fn-trace))))))
+
+;; ---- sub-cache ref-count balance on bad-delay early-return (rf2-fva6c.1) ---
+
+(defn- default-sub-cache []
+  @(:sub-cache (frame/frame :rf/default)))
+
+(deftest after-sub-vec-bad-delay-does-not-leak-subscription
+  ;; rf2-fva6c.1: `schedule-after-timer!` resolves a subscription-vector
+  ;; `:after` delay by calling `subs/subscribe`, which bumps the sub-cache
+  ;; ref-count BEFORE we know whether the resolved value is positive. When
+  ;; the resolved value is nil / 0 / negative, the bad-delay branch
+  ;; previously emitted :rf.warning/no-clock-configured and short-circuited
+  ;; — without unsubscribing. No entry was stored in `after-timers`, so no
+  ;; future cancellation path would ever drop the ref. Long-running CLJS
+  ;; processes with repeated bad delays accumulated sub-cache slots.
+  ;;
+  ;; Use grace-period-ms 0 so the paired unsubscribe disposes the slot
+  ;; synchronously and we can observe the cache state without timing.
+  (testing "sub-vec :after delay resolving to 0 unsubscribes (no sub-cache leak)"
+    (try
+      (subs-cache/configure! {:grace-period-ms 0})
+      (rf/reg-event-db :a/seed-bad (fn [db _] (assoc db :timeout-config 0)))
+      (rf/reg-sub :a/timeout-config-0 (fn [db _] (:timeout-config db)))
+      (rf/dispatch-sync [:a/seed-bad])
+      (let [m {:initial :idle
+               :data    {:rf/after-epoch 0}
+               :states
+               {:idle    {:on {:go :running}}
+                :running {:after {[:a/timeout-config-0] :timeout}}
+                :timeout {}}}
+            traces (atom [])]
+        (rf/reg-machine :a/sub-bad m)
+        (rf/register-trace-cb! ::no-clock (fn [ev] (swap! traces conj ev)))
+        (rf/dispatch-sync [:a/sub-bad [:go]])
+        (rf/remove-trace-cb! ::no-clock)
+        (is (some (fn [ev]
+                    (and (= :rf.warning/no-clock-configured (:operation ev))
+                         (= :sub (-> ev :tags :delay-source))))
+                  @traces)
+            ":rf.warning/no-clock-configured emitted for the bad delay")
+        (is (not (contains? (default-sub-cache) [:a/timeout-config-0]))
+            "sub-cache has no leaked entry for the resolved-to-0 :after sub"))
+      (finally
+        (subs-cache/configure! {:grace-period-ms 50}))))
+  (testing "sub-vec :after delay resolving to nil also unsubscribes"
+    (try
+      (subs-cache/configure! {:grace-period-ms 0})
+      (rf/reg-sub :a/timeout-config-nil (fn [_db _] nil))
+      (let [m {:initial :idle
+               :data    {:rf/after-epoch 0}
+               :states
+               {:idle    {:on {:go :running}}
+                :running {:after {[:a/timeout-config-nil] :timeout}}
+                :timeout {}}}]
+        (rf/reg-machine :a/sub-nil m)
+        (rf/dispatch-sync [:a/sub-nil [:go]])
+        (is (not (contains? (default-sub-cache) [:a/timeout-config-nil]))
+            "sub-cache has no leaked entry for the resolved-to-nil :after sub"))
+      (finally
+        (subs-cache/configure! {:grace-period-ms 50}))))
+  (testing "repeated bad-delay schedules do not accumulate ref-count"
+    (try
+      (subs-cache/configure! {:grace-period-ms 0})
+      (rf/reg-sub :a/timeout-config-neg (fn [_db _] -1))
+      (let [m {:initial :idle
+               :data    {:rf/after-epoch 0}
+               :states
+               {:idle    {:on {:go :running :reset :idle}}
+                :running {:after {[:a/timeout-config-neg] :timeout}
+                          :on    {:reset :idle}}
+                :timeout {}}}]
+        (rf/reg-machine :a/sub-neg m)
+        ;; Cycle several entries into :running so the schedule path runs
+        ;; multiple times. Each entry subscribes; if the unsubscribe is
+        ;; missing the ref-count would accumulate.
+        (dotimes [_ 5]
+          (rf/dispatch-sync [:a/sub-neg [:go]])
+          (rf/dispatch-sync [:a/sub-neg [:reset]]))
+        (is (not (contains? (default-sub-cache) [:a/timeout-config-neg]))
+            "sub-cache remains clean after 5 bad-delay schedules"))
+      (finally
+        (subs-cache/configure! {:grace-period-ms 50})))))


### PR DESCRIPTION
## Summary

Two surgical correctness fixes surfaced by the rf2-fva6c /implementation audit. One PR, one commit per bead.

### rf2-cos61 (P1 HIGH) — `compute-sub` silently swallowed body throws

`compute-sub` (the JVM-runnable / SSR pure-compute path) caught every exception thrown by a user sub body and returned `nil` without emitting any trace. The reactive sibling `subs.memo/validate-and-trace` correctly emits `:rf.error/sub-exception` on the same throw shape per Spec 009 §Error contract — `compute-sub` diverged.

Fix mirrors the sibling exactly: emit `:rf.error/sub-exception` with `:failing-id` / `:sub-id` / `:sub-query` / `:exception` / `:exception-message` / `:reason` and `:recovery :replaced-with-default`. Adds a new `:where :compute-sub` tag so consumers can distinguish the pure-compute call site from the reactive memo path. The `nil` return contract is unchanged.

### rf2-fva6c.1 (P2 MED) — `schedule-after-timer!` sub-cache ref leak on bad delays

For `:after` delays expressed as a subscription vector, `resolve-delay-ms` calls `subs/subscribe` (bumping the ref-count) BEFORE the resolved value is checked. When the value resolved to `nil` / `0` / negative, the bad-delay branch emitted `:rf.warning/no-clock-configured` and short-circuited — no entry stored in `after-timers`, no future cancellation path to drop the ref. Long-running CLJS processes with repeated bad delays accumulated sub-cache slots.

Fix pairs the subscribe with an explicit `subs/unsubscribe` on the bad-delay exit per Spec 006 §Reference counting and disposal.

## Test plan

- [x] `clojure -M:test` from `implementation/core/` — 586 tests / 2986 assertions / 0 failures
- [x] `clojure -M:test` from `implementation/machines/` — 207 tests / 735 assertions / 0 failures
- [x] `npm run test:cljs` from `implementation/` — 2875 tests / 8204 assertions / 0 failures
- [x] New tests added:
  - `core/test/re_frame/smoke_test.clj` — `compute-sub-emits-sub-exception-on-body-throw` (layer-1 + layer-2 throw paths)
  - `machines/test/re_frame/after_test.clj` — `after-sub-vec-bad-delay-does-not-leak-subscription` (0 / nil / negative resolution + repeated-schedule accumulation guard)

Closes rf2-cos61.
Closes rf2-fva6c.1.