### PR TITLE
fix(scripts+template): mayor-method safety net upgrades (rf2-l7yj8 + rf2-ku5f1)

### DIFF
--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -69,6 +69,13 @@ checkout — only specific known files; never broad destructive resets.
 You are implementing bead **<BEAD_ID>** in <project description>.
 
 <project stance, obtained from operator — pre-alpha, production-stable, etc.>
+
+NEVER link to ai/findings/* from committed files (spec/*, docs/*, tools/*/spec/*,
+skills/*, migration/*, README.md). The /ai/ tree is gitignored; mkdocs strict's
+link-validator catches it at CI time and blocks unrelated PRs in cascade.
+If you need to cite a finding, inline a 1-sentence summary in the committed
+prose. The pre-PR lint `python scripts/check_doc_slugs.py` flags violations
+under defect category AI_FINDINGS_LINK (rf2-l7yj8).
 ```
 
 ## Worktree path convention
@@ -112,7 +119,9 @@ gaps, cross-artefact coupling); reference (surface paths, relevant spec
 docs, recent landings that changed the surface, prior audit findings to
 avoid re-discovering); worktree + boundary block + `--status=in_progress`;
 **WRITE THE FINDINGS DOC FIRST** to `ai/findings/<surface>-audit-YYYY-MM-DD.md`
-(gitignored — never commit findings); file follow-on beads ONE AT A TIME
+(gitignored — never commit findings, and never link to them from committed
+files — see Common preamble policy + `check_doc_slugs.py` AI_FINDINGS_LINK);
+file follow-on beads ONE AT A TIME
 after the doc lands, appending each bead ID to the audit-bead's notes so
 partial progress is durable across a watchdog timeout; close audit-bead
 with verdict + cross-refs; no PR by default (trivial one-line obvious

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -15,6 +15,24 @@ the mayor checkout instead of the assigned worktree. "Use your worktree" is
 not a strong enough prompt. Workers must verify before each edit and check
 both checkouts after the first one.
 
+**The path-resolution leak failure mode.** Observed twice (audit worker
+rf2-zszmu; PowerShell-tool incidents in rf2-causa-spec-cleanup): the worker
+correctly ran the worktree guard and got the right `WORKTREE_ROOT`, then a
+file `Write` (especially of a new `ai/findings/<name>.md` file) landed in the
+mayor checkout because the edit tool resolved a repo-relative path against
+the agent's session root instead of the worker's git root. Symptoms:
+
+- `git status` inside the worker worktree shows no new findings file.
+- `git status` inside the mayor checkout shows a new untracked file under
+  `ai/findings/` that the worker thinks it wrote to its worktree.
+- The findings file is gitignored so neither side commits it — the boundary
+  fails *silently*.
+
+**Defence:** any `Write` of a brand-new file (especially under `ai/findings/`)
+must be IMMEDIATELY followed by `Test-Path <ASSIGNED_WORKTREE>\<rel>` AND
+`Test-Path <MAYOR_CHECKOUT>\<rel>`. If the mayor-side Test-Path returns True,
+the worker has leaked and must stop without further edits.
+
 **Paste verbatim into every editing-worker prompt:**
 
 ```text
@@ -28,8 +46,11 @@ The mayor checkout is:
 
 Never edit the mayor checkout.
 
-Shell workdir is not enough protection. apply_patch has no workdir, so
-relative patch paths can land in the mayor checkout.
+Shell workdir is not enough protection. apply_patch and Write tools have no
+workdir, so relative patch / write paths can land in the mayor checkout.
+This is the path-resolution leak failure mode (rf2-zszmu, rf2-ku5f1) — the
+worktree guard at session start does NOT catch it, because the leak happens
+mid-session in a single tool call.
 
 Before every file edit, run:
 
@@ -38,9 +59,10 @@ Get-Location; git rev-parse --show-toplevel; git status --short --branch
 Only edit if git rev-parse --show-toplevel prints exactly:
 <ASSIGNED_WORKTREE>
 
-When using apply_patch or any edit tool, use absolute file paths under
-<ASSIGNED_WORKTREE> if the tool accepts them. If not, use paths relative to
-the session root that explicitly target the worker worktree —
+When using apply_patch, Write, or any edit tool, use ABSOLUTE file paths
+under <ASSIGNED_WORKTREE> wherever the tool accepts them. If the tool only
+accepts relative paths, use paths relative to the session root that
+explicitly target the worker worktree —
 <WORKTREE_ROOT>/<WORKTREE_NAME>/<repo-relative-path>. Never use bare
 repo-relative paths unless `git rev-parse --show-toplevel` for the agent
 session root is itself the assigned worktree.
@@ -53,15 +75,49 @@ git -C <MAYOR_CHECKOUT> status --short --branch
 Continue only if the worker worktree is dirty and the mayor checkout did
 not receive code edits.
 
+NEW-FILE EXTRA CHECK (path-resolution leak — rf2-ku5f1).  When you Write
+a brand-new file (most-common offender: ai/findings/<name>.md from an
+audit), the path-resolution leak silently routes the write into the mayor
+checkout because the file did not previously exist in either tree. The
+worker-worktree `git status` then shows nothing new (the leak landed
+elsewhere) and the gitignored `/ai/` tree masks the symptom on both
+sides.  After every new-file Write, run BOTH:
+
+  Test-Path <ASSIGNED_WORKTREE>\<repo-relative-path>
+  Test-Path <MAYOR_CHECKOUT>\<repo-relative-path>
+
+Only the first should be True. If the mayor-side Test-Path returns True,
+STOP — you've leaked.  Do not retry the write, do not delete the leaked
+file, do not commit. Report the leak with both Test-Path results and let
+the mayor decide.
+
 If any edit lands outside <ASSIGNED_WORKTREE>, stop immediately and report
 it. Do not repair, restore, commit, or push until the mayor tells you what
 to do.
 ```
 
 **Mayor checks after dispatch.** `git status --short --branch` in the mayor
-checkout. If the mayor checkout gains unexpected code edits, interrupt the
-worker, preserve the edits into the worker worktree, then restore the mayor
-checkout — only specific known files; never broad destructive resets.
+checkout, AND `Get-ChildItem <MAYOR_CHECKOUT>\ai\findings\ -ErrorAction
+SilentlyContinue` to spot leaked gitignored findings the worker meant to put
+in its own worktree. If the mayor checkout gains unexpected files (committed
+or gitignored), interrupt the worker, preserve the edits into the worker
+worktree, then restore the mayor checkout — only specific known files; never
+broad destructive resets.
+
+**TODO (rf2-ku5f1 escalation).** If this strengthened reminder proves
+insufficient and the leak continues to happen, escalate to one of:
+
+- **Canary protocol (option A):** `scripts/assert-worker-worktree.ps1`
+  writes a sentinel under `<worktree>/.worker-canary.txt` with timestamp +
+  expected path; mayor-side post-dispatch reads it back and asserts the
+  canary landed in the worker worktree, not the mayor checkout.
+- **Mayor-side leak detector (option B):** new
+  `scripts/assert-mayor-clean.ps1` that runs `git status --short` plus an
+  `ai/findings/` untracked-file scan against the mayor checkout and warns
+  if new files appeared during the dispatch window.
+
+Both are larger investments than the documentation patch above; ship them
+only if the reminder + new-file Test-Path check don't close the gap.
 
 ## Common preamble (every dispatch)
 
@@ -162,6 +218,9 @@ log shows — test the hypothesis before applying the fix.
 - Agents adding back-compat shims by default → stance must be explicit in every preamble.
 - Same-file races between concurrent workers → enumerate in-flight workers + surfaces.
 - Workers leaking edits into the mayor checkout → worktree-boundary block.
+- Path-resolution leak on new-file Write (especially `ai/findings/*` from
+  an audit) routes the file into the mayor checkout silently → new-file
+  Test-Path double-check in the worktree-boundary block (rf2-ku5f1).
 - Stalled agents losing analysis → findings-first protocol; one-bead-at-a-time bd creates.
 - Clusters splitting when they should be one PR → cluster reviewer pre-validates shape.
 - Hot-zone merge conflicts → explicit hot-zone list in every prompt.

--- a/scripts/_test_fixtures/check_doc_slugs/ai_findings_dir_link_flagged/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/ai_findings_dir_link_flagged/docs/index.md
@@ -1,0 +1,7 @@
+# Index
+
+This page links to the working-notes directory —
+[see the findings](../../ai/findings/) — rather than to a specific file.
+rf2-l7yj8 says bare-directory links into the gitignored `/ai/findings/`
+tree are still policy violations: the directory itself is gitignored, so
+the link is invisible in CI clones and silently rots.

--- a/scripts/_test_fixtures/check_doc_slugs/ai_findings_dir_link_flagged/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/ai_findings_dir_link_flagged/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/_test_fixtures/check_doc_slugs/ai_findings_link_flagged/docs/index.md
+++ b/scripts/_test_fixtures/check_doc_slugs/ai_findings_link_flagged/docs/index.md
@@ -1,0 +1,8 @@
+# Index
+
+This page links to a working note —
+[the audit finding](../../ai/findings/some-audit-2026-05-19.md) — under
+the gitignored `/ai/findings/` tree.  rf2-l7yj8 says the validator must
+flag this even though the target may exist locally (developers' working
+copies do contain it), because the file is invisible in fresh CI clones
+and mkdocs strict's link validator trips on the missing reference.

--- a/scripts/_test_fixtures/check_doc_slugs/ai_findings_link_flagged/mkdocs.yml
+++ b/scripts/_test_fixtures/check_doc_slugs/ai_findings_link_flagged/mkdocs.yml
@@ -1,0 +1,2 @@
+# Self-test fixture marker.  Empty config is fine — the validator only
+# checks for this file's existence as the repo-root guard.

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -312,12 +312,40 @@ def _resolve_target(linker: Path, dest_path: str, repo_root: Path) -> Path | Non
     return target
 
 
+def _is_ai_findings_link(path_part: str) -> bool:
+    """Return True if a link path resolves under the gitignored ai/findings/ tree.
+
+    The repo's `/ai/` directory is gitignored at the root, so committed markdown
+    that links into `ai/findings/<file>.md` (or the bare directory) creates an
+    invisible-on-CI broken target — mkdocs strict's link validator catches it,
+    blocking unrelated PRs in cascade.  rf2-l7yj8 promotes this from a
+    mkdocs-only failure to a fast pre-PR lint.
+
+    The check is path-component-sensitive: it matches `ai/findings/` only as a
+    whole pair of path components, so casual prose links to (say)
+    `vai/findings.md` or `ai-findings.md` are not mis-flagged.  Both root-anchored
+    (`/ai/findings/...`) and relative (`../../ai/findings/...`) forms are caught.
+    """
+    # Normalise to forward slashes so the path-component test is OS-agnostic.
+    normalised = path_part.replace("\\", "/")
+    # Split into segments and search for the consecutive pair ("ai", "findings").
+    segments = [s for s in normalised.split("/") if s not in ("", ".")]
+    for i in range(len(segments) - 1):
+        if segments[i] == "ai" and segments[i + 1] == "findings":
+            return True
+    return False
+
+
 def check(repo_root: Path, verbose: bool = False) -> int:
     """Validate every in-repo markdown link.  Return broken-link count.
 
-    Flags two distinct defects:
-        * BROKEN TARGET — link points at an .md file that doesn't exist.
-        * BROKEN ANCHOR — file exists but the #anchor doesn't resolve.
+    Flags three distinct defects:
+        * BROKEN TARGET     — link points at an .md file that doesn't exist.
+        * BROKEN ANCHOR     — file exists but the #anchor doesn't resolve.
+        * AI_FINDINGS_LINK  — link points into the gitignored ai/findings/ tree
+                              (rf2-l7yj8).  Committed files must not reference
+                              gitignored working artefacts; inline a sentence
+                              summary instead.
     """
     files = list(_iter_markdown(repo_root))
     if verbose:
@@ -334,6 +362,7 @@ def check(repo_root: Path, verbose: bool = False) -> int:
 
     broken_anchor: list[tuple[Path, int, str, str]] = []
     broken_target: list[tuple[Path, int, str, str]] = []
+    ai_findings: list[tuple[Path, int, str]] = []
     for path in files:
         for line_no, dest in _extract_links(path):
             # External / non-file references — out of scope.
@@ -345,6 +374,13 @@ def check(repo_root: Path, verbose: bool = False) -> int:
 
             # Strip any query string from path-part (rare in markdown but safe).
             path_part = path_part.split("?", 1)[0]
+
+            # rf2-l7yj8: any link into the gitignored ai/findings/ tree is a
+            # policy violation regardless of whether the target happens to
+            # exist locally.  Flag and continue so further checks still run.
+            if _is_ai_findings_link(path_part):
+                ai_findings.append((path, line_no, dest))
+                continue
 
             # Same-file anchor (`[text](#foo)`).  No target-file check; anchor
             # only.  Empty anchor (just `#` with no fragment) is meaningless
@@ -381,7 +417,7 @@ def check(repo_root: Path, verbose: bool = False) -> int:
                     (path, line_no, dest, str(target.relative_to(repo_root.resolve())))
                 )
 
-    total = len(broken_anchor) + len(broken_target)
+    total = len(broken_anchor) + len(broken_target) + len(ai_findings)
 
     if broken_target:
         sys.stderr.write(
@@ -411,6 +447,24 @@ def check(repo_root: Path, verbose: bool = False) -> int:
         sys.stderr.write(
             "\nFix: confirm the heading still exists in the target file and "
             "update the link, or rename the heading and re-link.\n"
+        )
+
+    if ai_findings:
+        sys.stderr.write(
+            f"\n{len(ai_findings)} link(s) into gitignored ai/findings/ tree "
+            "found (rf2-l7yj8):\n\n"
+        )
+        for src, line_no, dest in ai_findings:
+            rel = src.relative_to(repo_root)
+            sys.stderr.write(
+                f"  AI_FINDINGS_LINK: {rel}:{line_no} -> {dest}\n"
+            )
+        sys.stderr.write(
+            "\nFix: the /ai/ tree is gitignored — committed files must not "
+            "link into it.  Replace the markdown link with a 1-sentence inline "
+            "summary of the finding (and a date) so the committed prose is "
+            "self-contained and mkdocs strict's link validator doesn't trip "
+            "on a missing target in CI.\n"
         )
 
     if total == 0 and verbose:
@@ -497,6 +551,8 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("relative_dotdot_ok",               0),
         ("inline_code_placeholder_ignored",  0),  # rf2-mqv8s
         ("inline_code_negative_control",     1),  # rf2-mqv8s
+        ("ai_findings_link_flagged",         1),  # rf2-l7yj8
+        ("ai_findings_dir_link_flagged",     1),  # rf2-l7yj8
     ]
 
     failures = 0

--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -132,10 +132,11 @@ exports:
 - **Not** a visualiser-as-product. The Stately Visualizer +
   Stately Studio occupy that lane — paste-and-render editors,
   saved-machine registries, multiplayer canvases, commercial
-  SaaS shells. Per [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/),
-  Stately's own Visualizer is officially deprecated within their
-  docs (replaced by the commercial Stately Editor); investing in
-  the visualiser-as-product lane chases a sunsetted product.
+  SaaS shells. Per `ai/findings/xstate-advanced-features-2026-05-13.md`
+  (gitignored working note), Stately's own Visualizer is officially
+  deprecated within their docs (replaced by the commercial Stately
+  Editor); investing in the visualiser-as-product lane chases a
+  sunsetted product.
   Machines-Viz is the **component the framework's own tools
   embed**, plus a read-only viewer for shared URLs. See
   [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) §Lock #1.

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -129,9 +129,8 @@ Source: lifted from
 
 This section is **load-bearing and conformance-level**, not guidance.
 The chart's runtime hot path is the single largest regression
-surface for Machines-Viz (per
-[`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
-findings 1+2; audit-bead rf2-j3iwt). Once an implementation couples
+surface for Machines-Viz (per `ai/findings/perf-audit-machines-viz-2026-05-14.md`
+findings 1+2 — gitignored working note; audit-bead rf2-j3iwt). Once an implementation couples
 live snapshot / trace ticks to graph recompute, the coupling is hard
 to remove without rewriting the rendering pipeline. The MUSTs below
 exist so that coupling never lands.

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -58,8 +58,8 @@ What surface does Machines-Viz ship at v1.0?
 ### Why
 
 - **Stately's own Visualizer is officially deprecated** within
-  their docs (per
-  [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/)).
+  their docs (per `ai/findings/xstate-advanced-features-2026-05-13.md`,
+  a gitignored working note).
   The commercial Stately Editor is the recommended replacement.
   Investing in the deprecated-product lane is chasing a sunset.
 - **Restraint principle** — a chart component the framework's own
@@ -574,9 +574,9 @@ as load-bearing, citing that section and this lock.
   risk regression in this jar is a future impl coupling
   trace-tick or snapshot deref to layout; once that coupling
   lands it is hard to remove without rewriting the rendering
-  pipeline (per
-  [`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
-  finding 1; audit-bead rf2-j3iwt). The MUST in
+  pipeline (per `ai/findings/perf-audit-machines-viz-2026-05-14.md`
+  finding 1 — gitignored working note; audit-bead rf2-j3iwt).
+  The MUST in
   [API.md §Performance invariants](./API.md#performance-invariants)
   exists so that coupling cannot accidentally land.
 - **Hot-reload** triggers a registry-change event, which triggers
@@ -728,9 +728,8 @@ The exhaustive normative rules live in
   timer respects it. Lock #8 codifies the visibility gating; this
   lock codifies the single-clock posture.
 
-Per
-[`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/)
-findings 1+2; audit-bead rf2-j3iwt.
+Per `ai/findings/perf-audit-machines-viz-2026-05-14.md` findings 1+2
+(gitignored working note; audit-bead rf2-j3iwt).
 
 ---
 
@@ -763,7 +762,7 @@ as a bead against this jar.
 
 - [`tools/causa/spec/003-Machine-Inspector.md`](../../causa/spec/003-Machine-Inspector.md) — the source spec these locks migrated from; embedding-host contract.
 - [`tools/causa/spec/DESIGN-RATIONALE.md`](../../causa/spec/DESIGN-RATIONALE.md) — Causa's locks; #4 (no session export) is lifted into Lock #5 above.
-- [`ai/findings/xstate-advanced-features-2026-05-13.md`](../../../ai/findings/) — visualizer-as-product deprecation rationale.
-- [`ai/findings/sweep-tools-vs-sota-2026-05-13.md`](../../../ai/findings/) §machines-viz — peer-comparison + gap analysis.
-- [`ai/findings/perf-audit-machines-viz-2026-05-14.md`](../../../ai/findings/) — perf audit findings 1+2 underpinning Lock #11 + the API.md §Performance invariants MUSTs; audit-bead rf2-j3iwt.
+- `ai/findings/xstate-advanced-features-2026-05-13.md` — visualizer-as-product deprecation rationale (gitignored working note).
+- `ai/findings/sweep-tools-vs-sota-2026-05-13.md` §machines-viz — peer-comparison + gap analysis (gitignored working note).
+- `ai/findings/perf-audit-machines-viz-2026-05-14.md` — perf audit findings 1+2 underpinning Lock #11 + the API.md §Performance invariants MUSTs; audit-bead rf2-j3iwt (gitignored working note).
 - [`spec/005-StateMachines.md`](../../../spec/005-StateMachines.md) §Future — `(machine->mermaid)` exporter forward-pointer.

--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -36,7 +36,7 @@ a `dev/` tree
 `(rf/dispatch …)` experiments), and a minimal plain stylesheet at
 [`resources/public/css/app.css`](../src/clj/new/re_frame2/shared/resources/public/css/app.css).
 Rationale: see
-[ai/findings re-frame2-template-design §6](../../../ai/findings/) (Mike-locked SHIP 2026-05-12).
+`ai/findings/re-frame2-template-design.md` §6 (gitignored working note; Mike-locked SHIP 2026-05-12).
 
 ## Lineage
 


### PR DESCRIPTION
## Summary

Two-commit cluster tightening the mayor-method's safety nets to catch issues we hit twice this session.

**Commit 1 — rf2-l7yj8: detect spec/* -> ai/findings/* broken links pre-PR**

- Extends `scripts/check_doc_slugs.py` with a new defect category `AI_FINDINGS_LINK`. Any committed `.md` file linking into the gitignored `/ai/findings/` tree is flagged with a clear remediation message.
- Path-component-sensitive: matches consecutive `ai/findings` segments only — casual prose links to neighbours like `vai/findings.md` are NOT mis-flagged. Both root-anchored (`/ai/findings/...`) and relative (`../../ai/findings/...`) forms are caught.
- Two new self-test fixtures registered: `ai_findings_link_flagged` (file link) + `ai_findings_dir_link_flagged` (bare directory link).
- Worker prompt addendum lands in `docs/the-mayor-method/dispatch-prompt-template.md` Common preamble — inherited by all five dispatch shapes. Audit shape's findings-doc step cross-links it.
- Cleaned up 9 pre-existing instances (1 in `tools/template/spec/000-Vision.md`, 8 across `tools/machines-viz/spec/*.md`) by converting markdown links into backtick-quoted plain prose with "(gitignored working note)" annotation.

**Commit 2 — rf2-ku5f1: strengthen worker worktree boundary detection**

- Chose option C (documentation strengthening). Options A (canary protocol in `assert-worker-worktree.ps1`) and B (mayor-side leak detector) noted as escalation TODOs if C alone proves insufficient.
- Worktree-boundary block now names the path-resolution leak failure mode explicitly (observed in rf2-zszmu + PowerShell-tool incidents), lists symptoms (silent because `/ai/` is gitignored on both sides), and prescribes a defence: every new-file `Write` must be followed by `Test-Path` against BOTH the worker worktree AND the mayor checkout.
- Mayor post-dispatch checks now include a `Get-ChildItem` scan of `<MAYOR_CHECKOUT>\ai\findings\` to spot leaked gitignored findings.
- Common failure modes list gains an entry for the leak, cross-linked to rf2-ku5f1.

## Test plan

- [x] `python scripts/check_doc_slugs.py --self-test` — 11/11 pass (including 2 new rf2-l7yj8 fixtures)
- [x] `python scripts/check_doc_slugs.py` (full corpus) — zero broken links
- [x] `python -m mkdocs build` — clean (1 pre-existing unrelated warning)
- [x] `scripts/assert-worker-worktree.ps1` smoke-test — passes (file unchanged in commit 2 since option C was doc-only)
- [x] 9 pre-existing `ai/findings/` link violations remediated (tools/template + tools/machines-viz)

## Beads closed by this PR

- rf2-l7yj8 (`AI_FINDINGS_LINK` defect category + worker prompt addendum + 9 pre-existing remediations)
- rf2-ku5f1 (worktree-boundary doc strengthening — option C + A/B TODO escalation)