### PR TITLE
test(implementation): test-coverage follow-ons cluster — 7 beads from rf2-q1z1u

### DIFF
--- a/implementation/core/test/re_frame/disposable_cljs_test.cljs
+++ b/implementation/core/test/re_frame/disposable_cljs_test.cljs
@@ -1,0 +1,83 @@
+(ns re-frame.disposable-cljs-test
+  "Direct unit coverage for the re-frame-owned `IDisposable` protocol
+  (rf2-wx79g; follow-on from rf2-q1z1u F5).
+
+  Background. Per rf2-jicu2 / rf2-ykqee the `IDisposable` protocol was
+  lifted out of `reagent.ratom` into `re-frame.disposable` so the UIx
+  and Helix adapters can satisfy the sub-cache teardown contract
+  without dragging ~9KB of Reagent batching/ratom code into their
+  bundles. The spine reifies this protocol on its derived-value
+  containers; the substrate-spine integration test
+  `spine_dispose_cljs_test` exercises it via the cache walk; this
+  file pins the protocol contract directly at the function boundary so
+  an external user (or a future internal reify) that satisfies the
+  protocol gets a clean regression signal if the contract slips.
+
+  Contract surface from `re-frame.disposable`:
+  - `(-add-on-dispose this f)`: register a 0-arg callback. Multiple
+    callbacks accumulate; they fire in registration order at `-dispose`.
+  - `(-dispose this)`: tear down synchronously; fire every registered
+    on-dispose. Idempotent — a second `-dispose` is a no-op (callbacks
+    do NOT fire a second time).
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.disposable :as rf-disposable]))
+
+(defn- make-toy-disposable
+  "Build a minimal reify of `rf-disposable/IDisposable` that records
+  every registered on-dispose callback in a per-instance vector atom
+  and fires them in registration order on `-dispose`. After firing,
+  `:disposed?` flips true and subsequent `-dispose` calls no-op (the
+  callbacks are NOT re-fired) — mirroring the protocol's docstring
+  idempotence guarantee.
+
+  Returned map carries the reify object and the recording cells so
+  tests can assert against them."
+  []
+  (let [callbacks  (atom [])
+        fire-log   (atom [])
+        disposed?  (atom false)
+        obj        (reify rf-disposable/IDisposable
+                     (-add-on-dispose [_ f]
+                       (swap! callbacks conj f))
+                     (-dispose [_]
+                       (when-not @disposed?
+                         (reset! disposed? true)
+                         (doseq [f @callbacks]
+                           (f)))))]
+    {:obj       obj
+     :callbacks callbacks
+     :fire-log  fire-log
+     :disposed? disposed?}))
+
+(deftest add-on-dispose-then-dispose-fires-callback
+  (testing "a single registered on-dispose callback fires when -dispose is called"
+    (let [{:keys [obj fire-log]} (make-toy-disposable)]
+      (rf-disposable/-add-on-dispose obj #(swap! fire-log conj :cb-1))
+      (is (= [] @fire-log)
+          "precondition: no callback fired yet")
+      (rf-disposable/-dispose obj)
+      (is (= [:cb-1] @fire-log)
+          "the registered callback fired exactly once on -dispose"))))
+
+(deftest multiple-callbacks-fire-in-registration-order
+  (testing "multiple on-dispose callbacks fire in registration order"
+    (let [{:keys [obj fire-log]} (make-toy-disposable)]
+      (rf-disposable/-add-on-dispose obj #(swap! fire-log conj :cb-a))
+      (rf-disposable/-add-on-dispose obj #(swap! fire-log conj :cb-b))
+      (rf-disposable/-add-on-dispose obj #(swap! fire-log conj :cb-c))
+      (rf-disposable/-dispose obj)
+      (is (= [:cb-a :cb-b :cb-c] @fire-log)
+          "all three callbacks fired in registration order"))))
+
+(deftest dispose-is-idempotent
+  (testing "a second -dispose is a no-op: callbacks do not fire again"
+    (let [{:keys [obj fire-log]} (make-toy-disposable)]
+      (rf-disposable/-add-on-dispose obj #(swap! fire-log conj :only-once))
+      (rf-disposable/-dispose obj)
+      (is (= [:only-once] @fire-log)
+          "first -dispose fired the callback")
+      (rf-disposable/-dispose obj)
+      (is (= [:only-once] @fire-log)
+          "second -dispose did NOT re-fire the callback (idempotent per docstring)"))))

--- a/implementation/flows/test/re_frame/flows_topo_test.clj
+++ b/implementation/flows/test/re_frame/flows_topo_test.clj
@@ -103,3 +103,96 @@
         (is (= #{:error :where :recovery :reason :cycle}
                (set (keys data)))
             "ex-data carries exactly the standard slots + :cycle (no extras, no missing)")))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-m05md — depends-on? direct function-boundary tests
+;; (follow-on from rf2-q1z1u F4)
+;;
+;; `depends-on?` is the load-bearing helper that `topo-sort` consumes
+;; when building the dependency graph (each flow's set of dep ids is
+;; the set of OTHER flows it `depends-on?`). It is exercised
+;; transitively by the topo-sort tests above and by the integration
+;; tests in flows_test.clj — but a regression that flipped a base case
+;; (self-edge, missing dep, multi-hop transitive) would cascade into
+;; incorrect topo-sort output without a sharp signal at the helper's
+;; name.
+;;
+;; Per Spec 013 §Topological sort: B depends on A iff A's :path and
+;; any of B's :inputs share a path prefix in either direction.
+;; ---------------------------------------------------------------------------
+
+(deftest depends-on?-direct-prefix-match
+  (testing "rf2-m05md — depends-on? is true when one of B's :inputs IS
+            A's :path (the canonical case — B reads exactly the slot
+            A writes)"
+    (let [a {:id :a :path [:foo]   :inputs [[:other]]}
+          b {:id :b :path [:bar]   :inputs [[:foo]]}]
+      (is (true? (topo/depends-on? b a))
+          "B's :inputs include A's :path exactly → B depends on A"))))
+
+(deftest depends-on?-true-when-input-is-prefix-of-output-path
+  (testing "rf2-m05md — depends-on? is true when one of B's :inputs is
+            a PREFIX of A's :path (B reads a parent slot of what A
+            writes — Spec 013 'prefix in either direction')"
+    (let [a {:id :a :path [:foo :bar :baz] :inputs []}
+          b {:id :b :path [:other]         :inputs [[:foo]]}]
+      (is (true? (topo/depends-on? b a))
+          "B reads :foo (a prefix of A's :path [:foo :bar :baz])"))))
+
+(deftest depends-on?-true-when-output-path-is-prefix-of-input
+  (testing "rf2-m05md — depends-on? is true when A's :path is a PREFIX
+            of one of B's :inputs (B reads a CHILD slot of what A
+            writes — also covered by 'prefix in either direction')"
+    (let [a {:id :a :path [:foo]              :inputs []}
+          b {:id :b :path [:other]            :inputs [[:foo :bar :baz]]}]
+      (is (true? (topo/depends-on? b a))
+          "A writes [:foo] which is a prefix of B's input [:foo :bar :baz]"))))
+
+(deftest depends-on?-self-edge-via-overlapping-path
+  (testing "rf2-m05md — depends-on? returns true for a self-edge if a
+            flow's own :inputs share a prefix with its own :path. The
+            consumer (topo-sort) explicitly filters self-edges out via
+            `(not= id %)` so this only matters at the helper boundary
+            — pinning the truth of the helper's prefix rule
+            independent of its caller's self-edge guard."
+    (let [a {:id :a :path [:foo] :inputs [[:foo]]}]
+      (is (true? (topo/depends-on? a a))
+          "A's own :inputs include A's own :path → depends-on? returns
+           true; topo-sort filters this self-edge separately"))))
+
+(deftest depends-on?-false-when-no-overlap
+  (testing "rf2-m05md — depends-on? returns false when no input shares
+            a prefix with A's :path in either direction"
+    (let [a {:id :a :path [:foo :bar] :inputs []}
+          b {:id :b :path [:other]    :inputs [[:unrelated] [:other-thing]]}]
+      (is (false? (topo/depends-on? b a))
+          "B's inputs are disjoint from A's :path tree → no dependency"))))
+
+(deftest depends-on?-false-when-paths-share-no-prefix-but-share-element
+  (testing "rf2-m05md — depends-on? is PREFIX-based, not element-
+            membership-based: a shared NON-PREFIX element does NOT
+            create a dependency edge"
+    (let [a {:id :a :path [:foo :bar] :inputs []}
+          ;; B's input [:bar :foo] shares both elements with A's :path
+          ;; but neither is a prefix of the other → no dependency.
+          b {:id :b :path [:other]    :inputs [[:bar :foo]]}]
+      (is (false? (topo/depends-on? b a))
+          "shared elements without a prefix relationship → false"))))
+
+(deftest depends-on?-empty-inputs
+  (testing "rf2-m05md — depends-on? returns false when B has no :inputs
+            (cannot depend on anything if it reads nothing)"
+    (let [a {:id :a :path [:foo] :inputs []}
+          b {:id :b :path [:bar] :inputs []}]
+      (is (false? (topo/depends-on? b a))
+          "B has no :inputs → cannot depend on A (or anything else)"))))
+
+(deftest depends-on?-multiple-inputs-any-match-wins
+  (testing "rf2-m05md — depends-on? is an `or` across B's :inputs: a
+            single matching input is enough to establish the
+            dependency edge"
+    (let [a {:id :a :path [:foo] :inputs []}
+          b {:id :b :path [:bar] :inputs [[:unrelated] [:foo] [:other]]}]
+      (is (true? (topo/depends-on? b a))
+          "B's second input matches A's :path → dependency established
+           despite the surrounding non-matching inputs"))))

--- a/implementation/http/test/re_frame/http_encoding_test.clj
+++ b/implementation/http/test/re_frame/http_encoding_test.clj
@@ -1,0 +1,153 @@
+(ns re-frame.http-encoding-test
+  "Direct unit coverage for the pure-fn helpers in `re-frame.http-encoding`
+  (rf2-9dro2; follow-on from rf2-q1z1u F2).
+
+  Specifically pins `compute-backoff-ms` against Spec 014 §Retry and
+  backoff at the function boundary. The fn is currently exercised
+  only indirectly via the managed-HTTP retry integration tests in
+  `http_managed_test.clj`; a regression that bumped the jitter
+  constant, the clamp threshold, or the exponent base would not
+  surface at the helper's own test name today.
+
+  Per Spec 014 §Retry and backoff:
+   - default :base-ms 250, :factor 2, :max-ms 5000 (exponential)
+   - attempt is 1-based; raw delay = base-ms × factor^(attempt-1)
+   - clamp: raw is clamped to :max-ms before any jitter
+   - jitter (when true): ±25% offset uniformly distributed,
+     floor of zero (never negative)"
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.http-encoding :as encoding]))
+
+;; ---- attempt → delay (deterministic, jitter off) -------------------------
+
+(deftest compute-backoff-ms-defaults-exponential-curve
+  (testing "rf2-9dro2 — default config (base-ms 250, factor 2,
+            max-ms 5000) produces the documented exponential curve:
+            250, 500, 1000, 2000, 4000, then clamped to 5000."
+    (is (= 250  (encoding/compute-backoff-ms {} 1))
+        "attempt 1 = base-ms × factor^0 = 250 × 1 = 250")
+    (is (= 500  (encoding/compute-backoff-ms {} 2))
+        "attempt 2 = 250 × 2 = 500")
+    (is (= 1000 (encoding/compute-backoff-ms {} 3))
+        "attempt 3 = 250 × 4 = 1000")
+    (is (= 2000 (encoding/compute-backoff-ms {} 4))
+        "attempt 4 = 250 × 8 = 2000")
+    (is (= 4000 (encoding/compute-backoff-ms {} 5))
+        "attempt 5 = 250 × 16 = 4000")
+    (is (= 5000 (encoding/compute-backoff-ms {} 6))
+        "attempt 6 = 250 × 32 = 8000, clamped to max-ms 5000")
+    (is (= 5000 (encoding/compute-backoff-ms {} 10))
+        "attempt 10 = 250 × 512 = 128000, clamped to max-ms 5000")
+    (is (= 5000 (encoding/compute-backoff-ms {} 20))
+        "attempt 20 = very large, clamped to max-ms 5000")))
+
+(deftest compute-backoff-ms-custom-base-and-factor
+  (testing "rf2-9dro2 — caller-supplied :base-ms and :factor override
+            the defaults"
+    (is (= 100 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 1))
+        "attempt 1 with base=100, factor=3 → 100 × 3^0 = 100")
+    (is (= 300 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 2))
+        "attempt 2 with base=100, factor=3 → 100 × 3 = 300")
+    (is (= 900 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 3))
+        "attempt 3 with base=100, factor=3 → 100 × 9 = 900")
+    (is (= 2700 (encoding/compute-backoff-ms {:base-ms 100 :factor 3} 4))
+        "attempt 4 with base=100, factor=3 → 100 × 27 = 2700")))
+
+(deftest compute-backoff-ms-linear-when-factor-is-one
+  (testing "rf2-9dro2 — :factor 1 produces a LINEAR (constant) backoff:
+            every attempt waits :base-ms. Spec 014 §Retry config
+            allows :factor 1 as the linear escape hatch."
+    (let [cfg {:base-ms 500 :factor 1 :max-ms 10000}]
+      (is (= 500 (encoding/compute-backoff-ms cfg 1)))
+      (is (= 500 (encoding/compute-backoff-ms cfg 2)))
+      (is (= 500 (encoding/compute-backoff-ms cfg 5)))
+      (is (= 500 (encoding/compute-backoff-ms cfg 100))
+          "factor=1 produces a constant base-ms delay regardless of
+           attempt number — never grows, never clamps"))))
+
+(deftest compute-backoff-ms-max-ms-clamp
+  (testing "rf2-9dro2 — :max-ms is the upper clamp on the per-attempt
+            delay; once raw exceeds :max-ms the result is exactly
+            :max-ms (not bigger, not jittered)"
+    (let [cfg {:base-ms 1000 :factor 2 :max-ms 3000}]
+      (is (= 1000 (encoding/compute-backoff-ms cfg 1)))
+      (is (= 2000 (encoding/compute-backoff-ms cfg 2)))
+      (is (= 3000 (encoding/compute-backoff-ms cfg 3))
+          "raw 4000 clamped to max 3000")
+      (is (= 3000 (encoding/compute-backoff-ms cfg 4))
+          "raw 8000 clamped to max 3000")
+      (is (= 3000 (encoding/compute-backoff-ms cfg 50))
+          "raw 1000 × 2^49 clamped to max 3000"))))
+
+(deftest compute-backoff-ms-handles-low-attempt-numbers
+  (testing "rf2-9dro2 — attempt 0 / negative is guarded by `(max 0
+            (dec attempt))` in the exponent so it does not produce a
+            negative exponent / fractional delay"
+    (is (= 250 (encoding/compute-backoff-ms {} 0))
+        "attempt 0 → exponent (max 0 -1) = 0 → 250 × 1 = 250
+         (same as attempt 1; the floor is documented in the source)")
+    (is (= 250 (encoding/compute-backoff-ms {} -5))
+        "negative attempt → same floor at 250")))
+
+(deftest compute-backoff-ms-returns-long-integer
+  (testing "rf2-9dro2 — the return type is `long` (the source coerces
+            via `(long jittered)`), suitable for direct use as a
+            timeout argument"
+    (let [result (encoding/compute-backoff-ms {} 3)]
+      (is (integer? result))
+      (is (instance? Long result)))))
+
+;; ---- jitter — bounded range probe ----------------------------------------
+;;
+;; The jitter offset is `±25% × capped`, uniformly distributed. Pinning
+;; the EXACT result is not stable (rand-driven), but pinning the
+;; expected interval IS — `[0.75 × capped, 1.25 × capped]` with a
+;; floor of zero per the source.
+
+(deftest compute-backoff-ms-jitter-stays-within-spec-window
+  (testing "rf2-9dro2 — when :jitter true, the result sits in the
+            ±25% window around the capped raw value across many
+            samples"
+    (let [cfg     {:base-ms 1000 :factor 2 :max-ms 5000 :jitter true}
+          attempt 3
+          ;; Expected pre-jitter capped value: base × factor^(attempt-1)
+          ;; = 1000 × 4 = 4000 (no clamp at attempt 3 with max 5000).
+          capped  4000.0
+          low     (* capped 0.75)
+          high    (* capped 1.25)
+          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg attempt))]
+      (doseq [s samples]
+        (is (and (<= low s) (<= s high))
+            (str "jittered sample " s " sits in ±25% window ["
+                 low ", " high "]")))
+      ;; And the samples are not all identical — sanity check that
+      ;; jitter is actually being applied (catches a regression where
+      ;; `:jitter true` silently fell through to the un-jittered branch).
+      (is (> (count (set samples)) 1)
+          "jitter produces variance across samples (catches a regression
+           where the `:jitter true` arm was unreachable)"))))
+
+(deftest compute-backoff-ms-jitter-never-negative
+  (testing "rf2-9dro2 — the source caps jittered output at 0 via
+            `(max 0 ...)`. With max-ms small enough that 25% offset
+            could go negative, the floor protects the caller from a
+            negative timeout"
+    (let [cfg     {:base-ms 100 :factor 1 :max-ms 100 :jitter true}
+          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg 1))]
+      (doseq [s samples]
+        (is (<= 0 s)
+            (str "jittered sample " s " is non-negative (floor at 0)"))))))
+
+(deftest compute-backoff-ms-jitter-respects-clamp
+  (testing "rf2-9dro2 — clamp happens BEFORE jitter is applied (per
+            the source: `capped = min raw max-ms`, then jitter scales
+            `capped`). So a long-running retry at the clamp still
+            jitters around max-ms, not the raw-uncapped value."
+    (let [cfg     {:base-ms 1000 :factor 2 :max-ms 2000 :jitter true}
+          ;; attempt 10 — raw = 1000 × 512 = 512000, clamped to 2000.
+          ;; Jittered samples should sit in [1500, 2500] (±25% of 2000).
+          samples (repeatedly 200 #(encoding/compute-backoff-ms cfg 10))]
+      (doseq [s samples]
+        (is (and (<= 1500 s) (<= s 2500))
+            (str "post-clamp jittered sample " s " sits in ±25% window
+                  around clamp (1500..2500)"))))))

--- a/implementation/http/test/re_frame/util_json_cljs_test.cljs
+++ b/implementation/http/test/re_frame/util_json_cljs_test.cljs
@@ -1,0 +1,79 @@
+(ns re-frame.util-json-cljs-test
+  "CLJS-side unit coverage for `re-frame.util-json` (rf2-mih7n;
+  follow-on from rf2-q1z1u F3).
+
+  Background. The JVM `util_json_test.clj` covers the Cheshire branch
+  exhaustively (keyword cap, malformed-input throw shape, non-string
+  guard, empty-string fall-through). The CLJS branch is a separate
+  reader (`js/JSON.parse`) with materially different malformed-input
+  behaviour:
+
+  - `js/JSON.parse('')` throws SyntaxError — does NOT return nil like
+    Cheshire does. Empty input is malformed under V8/SpiderMonkey/
+    JavaScriptCore. The `:rf.http/managed` decode site catches.
+  - `js/JSON.parse('{not-json')` throws SyntaxError.
+  - `js/JSON.parse(nil)` is `JSON.parse('null')` (JS coercion) →
+    returns `null` (JS) → `(js->clj nil :keywordize-keys true)` is nil.
+    Counter-intuitive but consistent with the JS spec.
+
+  These per-platform differences matter for the `:rf.http/managed`
+  cascade: the CLJS decode site MUST classify the SyntaxError throws
+  as `:rf.http/decode-failure`. Pin the branch's behaviour directly
+  so a future runtime upgrade (or a refactor that adds a string-guard
+  wrapper around the CLJS branch) doesn't silently change the contract.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.util-json :as util-json]))
+
+(deftest cljs-json-parse-malformed-throws
+  (testing "rf2-mih7n — malformed JSON inputs throw under
+            `js/JSON.parse` on CLJS. The managed-HTTP decode site
+            catches and classifies as `:rf.http/decode-failure`."
+    (doseq [s ["{not-json"           ; unclosed object, bareword key
+               "[1,2,"               ; unterminated array
+               "\"unterminated"      ; unterminated string
+               "tru"                 ; truncated literal
+               "{\"a\":nul}"         ; misspelt null
+               "{\"x\":\"\\u\"}"]]   ; truncated unicode escape
+      (let [thrown (try (util-json/json-parse s) ::no-throw
+                        (catch :default e e))]
+        (is (not= ::no-throw thrown)
+            (str "expected a parse exception for " (pr-str s)
+                 " — got " (pr-str thrown)))))))
+
+(deftest cljs-json-parse-empty-string-throws
+  (testing "rf2-mih7n — the empty string is malformed JSON under
+            `js/JSON.parse` (DIFFERENT from the JVM Cheshire branch
+            which returns nil for end-of-stream). Pinning this
+            divergence prevents a refactor that 'normalises' the
+            CLJS branch by adding an empty-string short-circuit —
+            doing so would mask a transport-layer programmer error
+            that the current decode-failure path surfaces."
+    (let [thrown (try (util-json/json-parse "") ::no-throw
+                      (catch :default e e))]
+      (is (not= ::no-throw thrown)
+          (str "empty-string input must throw on CLJS — got "
+               (pr-str thrown))))))
+
+(deftest cljs-json-parse-nil-input-returns-nil
+  (testing "rf2-mih7n — `(util-json/json-parse nil)` returns nil on
+            CLJS. The JS engine coerces `nil` → `\"null\"` →
+            `js/JSON.parse` returns `null` → `js->clj` produces nil.
+            Counter-intuitive but spec-consistent. The JVM branch
+            short-circuits via `(when (string? s) ...)` and also
+            returns nil — the two branches produce the SAME observable
+            result for a nil input despite taking very different
+            paths."
+    (is (nil? (util-json/json-parse nil))
+        "nil input → nil (cross-platform consistent for this slot)")))
+
+(deftest cljs-json-stringify-happy-path
+  (testing "rf2-mih7n — sanity-check `json-stringify` on CLJS uses
+            `js/JSON.stringify` and produces standard JSON output
+            (no edn-isms, no host-specific encoding quirks)."
+    (is (= "{\"a\":1,\"b\":\"hello\"}"
+           (util-json/json-stringify {:a 1 :b "hello"})))
+    (is (= "[1,2,3]" (util-json/json-stringify [1 2 3])))
+    (is (= "true" (util-json/json-stringify true)))
+    (is (= "null" (util-json/json-stringify nil)))))

--- a/implementation/http/test/re_frame/util_json_test.clj
+++ b/implementation/http/test/re_frame/util_json_test.clj
@@ -125,3 +125,50 @@
     (is (= "[1,2,3]" (util-json/json-stringify [1 2 3])))
     (is (= "true" (util-json/json-stringify true)))
     (is (= "null" (util-json/json-stringify nil)))))
+
+;; ---- rf2-mih7n — non-string / empty input coverage -----------------------
+;;
+;; The JVM `json-parse` body opens with `(when (string? s) ...)`. That
+;; guard means a non-string `s` (nil, keyword, number, map, vector)
+;; returns nil cleanly rather than throwing — protecting the
+;; `:rf.http/managed` decode pipeline from a programmer error in the
+;; transport layer.
+;;
+;; The empty-string case `""` flows through Cheshire's `parse-string`
+;; which returns nil (Jackson's end-of-stream → nil for an empty
+;; document). A future Cheshire upgrade that changes that behaviour
+;; would surface here.
+;;
+;; Truthful-malformed inputs are covered above in
+;; `cheshire-rejects-malformed-input-cleanly` — those throw. This
+;; deftest is the no-throw counterpart that pins the
+;; "input simply has no JSON value to surface → return nil" path.
+
+(deftest jvm-json-parse-non-string-and-empty-return-nil
+  (testing "rf2-mih7n — `json-parse` returns nil (not a throw) for
+  non-string inputs and the empty string. The JVM body's `(when
+  (string? s) ...)` guard protects the managed-HTTP decode pipeline
+  from a programmer error in transport — a malformed input throws
+  through to `:rf.http/decode-failure`, a missing input is benign nil."
+    (is (nil? (util-json/json-parse nil))
+        "nil input → nil (string? guard short-circuits)")
+    (is (nil? (util-json/json-parse ""))
+        "empty string → nil (Cheshire's end-of-stream → nil)")
+    (is (nil? (util-json/json-parse :keyword))
+        "keyword input → nil (string? guard short-circuits)")
+    (is (nil? (util-json/json-parse 42))
+        "number input → nil (string? guard short-circuits)")
+    (is (nil? (util-json/json-parse {:already :clojure}))
+        "map input → nil (string? guard short-circuits — caller
+         passed an already-parsed value by mistake)")
+    (is (nil? (util-json/json-parse [1 2 3]))
+        "vector input → nil (same)")))
+
+(deftest jvm-json-parse-whitespace-only-returns-nil
+  (testing "rf2-mih7n — whitespace-only inputs (\" \", \"\\n\", \"\\t\")
+  are not valid JSON documents per RFC 8259, but Cheshire/Jackson
+  surfaces them as end-of-stream → nil (same as the empty-string
+  case). Pin the contract."
+    (is (nil? (util-json/json-parse "   ")))
+    (is (nil? (util-json/json-parse "\n")))
+    (is (nil? (util-json/json-parse "\t")))))

--- a/implementation/machines/test/re_frame/after_test.clj
+++ b/implementation/machines/test/re_frame/after_test.clj
@@ -389,3 +389,151 @@
             "sub-cache remains clean after 5 bad-delay schedules"))
       (finally
         (subs-cache/configure! {:grace-period-ms 50})))))
+
+;; ---- sub-vec :after exception observability arms (rf2-t4uo0) --------------
+;;
+;; Per rf2-q1z1u F1 (HIGH) — follow-on for rf2-c1tnr.
+;;
+;; `timer.cljc` has three error-emit arms in :after-delay resolution:
+;; - :rf.error/machine-after-fn-threw     (fn-form throw on `(delay-key snapshot)`)
+;; - :rf.error/machine-after-sub-threw    (sub-deref throw on `@reaction`)
+;; - :rf.error/machine-after-watch-failed (add-watch throw)
+;;
+;; The fn-form arm is pinned above by `after-fn-form-throw-surfaces-trace`.
+;; The other two arms are the SAFETY NET against the silent-swallow
+;; class of bug rf2-c1tnr fixed: pre-rf2-c1tnr a deref-throw or an
+;; add-watch-throw was silently caught and the resolution returned
+;; [nil nil], surfacing only as `:rf.warning/no-clock-configured`
+;; downstream with no signal the underlying reactive surface blew up.
+;;
+;; These tests pin those two cousin arms at the trace-emit boundary —
+;; mirroring the fn-form test's shape exactly so a regression that
+;; re-introduces the swallow on either arm fails at a clear test name.
+
+(deftest after-sub-vec-deref-throw-surfaces-trace
+  (testing "rf2-t4uo0 — sub-vec :after whose @reaction throws emits
+            :rf.error/machine-after-sub-threw with :sub-id +
+            :exception slots and :recovery :no-clock-configured"
+    ;; Pre-rf2-c1tnr the deref throw was silently caught and the
+    ;; resolution returned [nil nil], surfacing only as
+    ;; :rf.warning/no-clock-configured. The error arm makes the
+    ;; underlying sub failure observable.
+    ;;
+    ;; A USER-SPACE sub body throw is caught by `validate-and-trace`
+    ;; in re-frame.subs.memo BEFORE it reaches the timer's `try
+    ;; @reaction`; the sub-internal catch emits :rf.error/sub-exception
+    ;; and returns nil. The timer's defensive catch arm is for
+    ;; framework-internal failures (e.g. a misbehaving substrate's
+    ;; reaction reify whose deref throws synchronously without going
+    ;; through the sub-internal catch).
+    ;;
+    ;; To force the arm to fire we shadow `subs/subscribe` over the
+    ;; schedule path to return a reify whose deref throws — the timer
+    ;; code's `try @reaction (catch ...)` sees the throw directly.
+    (let [captured  (atom [])
+          listener  (fn [ev] (swap! captured conj ev))
+          throw-msg "reaction deref blew up"
+          ;; Reify that satisfies the IDeref shape but throws on deref.
+          throwing-reaction (reify clojure.lang.IDeref
+                              (deref [_]
+                                (throw (ex-info throw-msg {:where :test}))))]
+      (re-frame.trace/register-trace-cb! ::after-sub-trace listener)
+      (try
+        (rf/reg-sub :s/well-formed (fn [_db _] 1000))
+        (rf/reg-machine
+          :s/throws-machine
+          {:initial :idle
+           :data    {:rf/after-epoch 0}
+           :states  {:idle    {:on    {:go :running}}
+                     :running {:after {[:s/well-formed] :timeout}}
+                     :timeout {}}})
+        (with-redefs [re-frame.subs/subscribe
+                      (fn
+                        ([_query-v] throwing-reaction)
+                        ([_frame-id _query-v] throwing-reaction))]
+          (rf/dispatch-sync [:s/throws-machine [:go]]))
+        (let [errors (filter #(= :rf.error/machine-after-sub-threw
+                                 (:operation %))
+                             @captured)]
+          (is (seq errors)
+              "deref throw surfaces as :rf.error/machine-after-sub-threw")
+          (is (every? #(= :error (:op-type %)) errors)
+              "the trace event has :op-type :error")
+          (when-let [first-err (first errors)]
+            (is (some? (-> first-err :tags :exception))
+                ":exception slot is populated under :tags")
+            (is (= :s/well-formed (-> first-err :tags :sub-id))
+                ":sub-id slot names the offending subscription
+                 (first element of the :after delay-key vector)")
+            ;; Per Spec 009 §Error event shape, `:recovery` is hoisted
+            ;; off `:tags` to the envelope top-level.
+            (is (= :no-clock-configured (:recovery first-err))
+                ":recovery :no-clock-configured hoisted to top-level")))
+        (finally
+          (re-frame.trace/remove-trace-cb! ::after-sub-trace))))))
+
+(deftest after-sub-vec-watch-failure-surfaces-trace
+  (testing "rf2-t4uo0 — sub-vec :after where add-watch on the reaction
+            throws emits :rf.error/machine-after-watch-failed with
+            :sub-id + :exception slots and :recovery :static-delay"
+    ;; Pre-rf2-c1tnr an add-watch throw was silently swallowed; the
+    ;; sub-changed re-resolution watcher would not fire (so dynamic
+    ;; delays would silently stop re-resolving) without any signal.
+    ;; This arm makes the failure observable.
+    ;;
+    ;; To trigger the arm reliably we shadow `clojure.core/add-watch`
+    ;; over the schedule path. The shadow throws once for the
+    ;; :after-watch key (machines/timer.cljc:298 install site) and
+    ;; falls through otherwise — so the runtime's other add-watch call
+    ;; sites (substrate, late-bind, etc.) are not disturbed.
+    (let [captured     (atom [])
+          listener     (fn [ev] (swap! captured conj ev))
+          real-add     add-watch
+          ;; A real watchable sub so subscribe + deref succeed; only
+          ;; the add-watch on the resulting reaction throws.
+          throw-add    (fn [target key f]
+                         (if (and (vector? key)
+                                  (= :re-frame.machines.timer/after-watch
+                                     (first key)))
+                           (throw (ex-info "add-watch blew up on after-watch"
+                                           {:where :test :key key}))
+                           (real-add target key f)))]
+      (re-frame.trace/register-trace-cb! ::after-watch-trace listener)
+      (try
+        ;; A well-behaved sub returning a positive delay — subscribe
+        ;; succeeds, deref returns 1000 (so the bad-delay branch
+        ;; doesn't short-circuit before reaching add-watch).
+        (rf/reg-event-db :w/seed (fn [db _] (assoc db :delay-ms 1000)))
+        (rf/reg-sub :s/well-behaved (fn [db _] (:delay-ms db)))
+        (rf/dispatch-sync [:w/seed])
+        (rf/reg-machine
+          :w/throws-machine
+          {:initial :idle
+           :data    {:rf/after-epoch 0}
+           :states  {:idle    {:on    {:go :running}}
+                     :running {:after {[:s/well-behaved] :timeout}}
+                     :timeout {}}})
+        (with-redefs [clojure.core/add-watch throw-add]
+          (rf/dispatch-sync [:w/throws-machine [:go]]))
+        (let [errors (filter #(= :rf.error/machine-after-watch-failed
+                                 (:operation %))
+                             @captured)]
+          (is (seq errors)
+              "add-watch throw surfaces as :rf.error/machine-after-watch-failed")
+          (is (every? #(= :error (:op-type %)) errors)
+              "the trace event has :op-type :error")
+          (when-let [first-err (first errors)]
+            (is (some? (-> first-err :tags :exception))
+                ":exception slot is populated under :tags")
+            (is (= :s/well-behaved (-> first-err :tags :sub-id))
+                ":sub-id slot names the subscription whose reaction
+                 could not be watched")
+            (is (= :w/throws-machine (-> first-err :tags :machine-id))
+                ":machine-id slot names the owning machine")
+            ;; Per Spec 009 §Error event shape, `:recovery` is hoisted.
+            (is (= :static-delay (:recovery first-err))
+                ":recovery :static-delay hoisted to top-level — the
+                 timer still scheduled, just without dynamic-delay
+                 re-resolution")))
+        (finally
+          (re-frame.trace/remove-trace-cb! ::after-watch-trace))))))

--- a/implementation/routing/test/re_frame/routing_test.clj
+++ b/implementation/routing/test/re_frame/routing_test.clj
@@ -42,6 +42,7 @@
             ;; rf/reg-route call below would throw
             ;; :rf.error/routing-artefact-missing.
             [re-frame.routing :as routing]
+            [re-frame.routing.match :as routing.match]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -2261,3 +2262,90 @@
                         {:frame :story/variant-A})
       (is (empty? @pushed)
           "non-URL-bound frame's push is suppressed by the gated fx"))))
+
+;; ===========================================================================
+;; rf2-aleg9 — match-against direct function-boundary tests
+;; (follow-on from rf2-q1z1u F8)
+;;
+;; `match-against` is the pattern-matcher fn consumed by the routing
+;; facade's match-url. The facade-level tests above exercise it
+;; transitively via `:rf.route/navigate`, but a `match-against`-only
+;; regression that happens to be neutralised by the facade's URL
+;; normalisation (canonical-route-pattern, query-string parse,
+;; trailing-slash handling) would slip through the facade tests.
+;;
+;; These tests call `match-against` directly with a `parse-pattern`
+;; output and a path string. Pins:
+;;   - literal segments (exact match + non-match)
+;;   - :param capture
+;;   - :splat capture across multi-segment paths
+;;   - empty-pattern edge — `/` matches `/`
+;;   - non-matching URL returns nil cleanly (no throw, no error)
+;; ===========================================================================
+
+(deftest match-against-literal-segment-exact-match
+  (testing "rf2-aleg9 — literal-segment pattern matches its exact URL
+            and returns an empty params map; a sibling URL with the
+            same shape but different literal returns nil"
+    (let [compiled (routing.match/parse-pattern "/foo/bar")]
+      (is (= {} (routing.match/match-against compiled "/foo/bar"))
+          "exact literal URL → empty params map (no captures registered)")
+      (is (nil? (routing.match/match-against compiled "/foo/baz"))
+          "sibling literal that differs on last segment → nil (no-match)")
+      (is (nil? (routing.match/match-against compiled "/foo"))
+          "partial-prefix URL → nil (no-match; re-matches anchors both ends)")
+      (is (nil? (routing.match/match-against compiled "/foo/bar/extra"))
+          "URL longer than pattern → nil (anchored end)"))))
+
+(deftest match-against-named-param-extraction
+  (testing "rf2-aleg9 — a `:id` segment captures the URL segment value
+            into the params map under the keyword key"
+    (let [compiled (routing.match/parse-pattern "/users/:id")]
+      (is (= {:id "42"} (routing.match/match-against compiled "/users/42"))
+          "param captured under :id, value is the raw URL segment")
+      (is (= {:id "alice"} (routing.match/match-against compiled "/users/alice"))
+          "alphabetic param value captured")
+      (is (nil? (routing.match/match-against compiled "/users/"))
+          "empty param segment → nil (regex requires non-empty capture)")
+      (is (nil? (routing.match/match-against compiled "/users"))
+          "missing param segment → nil"))))
+
+(deftest match-against-splat-captures-multi-segment-tail
+  (testing "rf2-aleg9 — a `*rest` splat captures the entire trailing
+            path (slashes preserved) into the params map"
+    (let [compiled (routing.match/parse-pattern "/files/*path")]
+      (is (= {:path "a"}
+             (routing.match/match-against compiled "/files/a"))
+          "single-segment splat captured under :path")
+      (is (= {:path "a/b/c"}
+             (routing.match/match-against compiled "/files/a/b/c"))
+          "multi-segment splat captured with slashes preserved")
+      (is (nil? (routing.match/match-against compiled "/files/"))
+          "empty splat tail → nil (regex requires non-empty capture)")
+      (is (nil? (routing.match/match-against compiled "/files"))
+          "missing splat tail → nil"))))
+
+(deftest match-against-root-pattern-matches-root-path
+  (testing "rf2-aleg9 — the special `/` pattern matches the root URL
+            and returns an empty params map; a deeper URL returns nil"
+    (let [compiled (routing.match/parse-pattern "/")]
+      (is (= {} (routing.match/match-against compiled "/"))
+          "root pattern matches root path → empty params map")
+      (is (= {} (routing.match/match-against compiled ""))
+          "root pattern also matches the empty string (leading `/?` in regex)")
+      (is (nil? (routing.match/match-against compiled "/foo"))
+          "root pattern does NOT match a deeper path"))))
+
+(deftest match-against-no-match-returns-nil
+  (testing "rf2-aleg9 — when re-matches misses, match-against returns
+            nil cleanly (no throw, no exception)"
+    (let [compiled (routing.match/parse-pattern "/users/:id/posts/:post-id")]
+      (is (nil? (routing.match/match-against compiled "/unrelated/path"))
+          "completely unrelated URL → nil")
+      (is (nil? (routing.match/match-against compiled "/users/42/posts"))
+          "URL missing trailing capture segment → nil")
+      (is (= {:id "42" :post-id "9"}
+             (routing.match/match-against
+               compiled "/users/42/posts/9"))
+          "the same pattern DOES match when both captures are present —
+           sanity-check the test isn't accepting only the negative cases"))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -1712,3 +1712,53 @@
           (is (re-matches #"[^\d].*" (name fid))
               (str "the frame-id local-part starts with a non-numeric "
                    "character (saw " (pr-str fid) ")")))))))
+
+;; ===========================================================================
+;; rf2-zev2h — default-on-error direct positive assertion
+;; (follow-on from rf2-q1z1u F7)
+;;
+;; `default-on-error` is the Ring-layer fallback used when the SSR
+;; error projector cannot see the exception (handler-constructor throw,
+;; middleware throw ahead of the projector). The pre-existing
+;; render-time-throw tests (`handler-render-error-*` above) pin the
+;; projector path with negative assertions of the form
+;; `(not= "Internal error" body)` — they verify those paths DON'T fall
+;; through to this fixed shape.
+;;
+;; The literal `"Internal error"` body produced by `default-on-error`
+;; itself had no positive pin. A future refactor that changed the
+;; literal string (e.g. an i18n table, a richer template) would not
+;; surface today. This test pins the literal exact-string contract +
+;; the no-leak guarantee at the function boundary directly.
+;;
+;; rf2-kzvwq / security audit 2026-05-14 §P2.1 — the body MUST NOT
+;; carry .getMessage (JDBC URLs, file paths, SQL fragments).
+;; ===========================================================================
+
+(deftest default-on-error-fallback-shape-pinned
+  (testing "rf2-zev2h — default-on-error returns the fixed-shape 500
+            response with the literal `\"Internal error\"` body. The
+            throwable's .getMessage MUST NOT appear anywhere in the
+            response (status, headers, or body)."
+    (let [secret-msg "boom-jdbc-secret:postgres://internal-db.svc:5432/auth"
+          t          (ex-info secret-msg {})
+          req        {:uri "/anything" :request-method :get}
+          response   (ssr-ring/default-on-error req t)]
+      (is (= 500 (:status response))
+          "status pinned to 500 — Ring-layer fallback default")
+      (is (= {"Content-Type" "text/plain; charset=utf-8"}
+             (:headers response))
+          "headers pinned to text/plain with UTF-8 charset (no HTML,
+           no JSON, no leaked Server header)")
+      (is (= "Internal error" (:body response))
+          "body is the literal `\"Internal error\"` — exact string match
+           (a refactor that changes the literal surfaces here)")
+      ;; rf2-kzvwq no-leak — the throwable's message MUST NOT appear in
+      ;; ANY slot of the response. Asserted on every channel that could
+      ;; carry it (status is a number, but headers + body are strings).
+      (is (not (str/includes? (:body response) secret-msg))
+          "rf2-kzvwq §P2.1: body does NOT carry the throwable's
+           .getMessage text — topology disclosure surface closed")
+      (is (not (str/includes? (str (:headers response)) secret-msg))
+          "rf2-kzvwq §P2.1: headers do NOT carry the throwable's
+           .getMessage text either"))))


### PR DESCRIPTION
## Summary

Seven test-coverage follow-on commits filling leaf-level coverage gaps surfaced by audit **rf2-q1z1u** (GREEN-leaning-YELLOW). Test-only additions — NO src changes.

Commits (smallest → biggest, P3 LOW → P2 HIGH):

1. **rf2-wx79g** (P3 LOW) — `test(core)`: pin re-frame.disposable IDisposable protocol contract directly (callback registration / fire-order / idempotence). Previously exercised only indirectly via spine cache walk.
2. **rf2-zev2h** (P3 LOW) — `test(ssr-ring)`: positive assertion for default-on-error fallback (500 / text-plain / literal "Internal error" body + rf2-kzvwq §P2.1 no-leak). Existing tests pinned the projector path with negative asserts; the literal had no positive pin.
3. **rf2-aleg9** (P3 LOW) — `test(routing)`: five direct deftests on routing.match/match-against (literal, :id param, *splat, root pattern, no-match nil). Pins helper boundary independent of match-url's URL normalisation.
4. **rf2-mih7n** (P3 MED) — `test(http)`: per-platform malformed / empty / nil input pinning for util-json. JVM (Cheshire): non-string guard + end-of-stream → nil. CLJS (js/JSON.parse): malformed + empty → throw, nil → nil. Per-platform divergence pinned.
5. **rf2-m05md** (P3 MED) — `test(flows)`: eight direct deftests on flows.topo/depends-on? — Spec 013 "prefix in either direction" truth table at the function boundary.
6. **rf2-9dro2** (P3 MED) — `test(http)`: new http_encoding_test.clj — exhaustive direct unit-test of compute-backoff-ms (defaults / custom config / linear / clamp / floor / type / jitter window / jitter floor / clamp-before-jitter). 626 assertions across 9 deftests.
7. **rf2-t4uo0** (P2 HIGH) — `test(machines)`: cover the two previously-untested error arms in machines/timer.cljc — `:rf.error/machine-after-sub-threw` and `:rf.error/machine-after-watch-failed`. The fn-form sibling was already tested; these arms are the explicit safety net against the silent-swallow class of bug rf2-c1tnr fixed. User-space sub throws are caught by validate-and-trace before reaching the timer arm — tests use with-redefs to force the throw at the framework-internal boundary.

Note: rf2-05jxd is the 8th bead in the audit but it's a DECISION pending Mike's call on the rigorous-local gate — not part of this cluster.

## Test plan

- [x] `clojure -M:test` from each impacted implementation/<subdir>/
- [x] `npm run test:cljs` full sweep — 2882 tests / 8221 assertions, 0 failures / 0 errors
- [x] `npm run test:bundle-isolation` — 11 artefact entries, 26 internal sentinels absent, 3 allow-list budgets OK, UIx/Helix reagent-free
- [x] No src changes; test-only surface
- [x] No hot-zone touches (deps.edn / shadow-cljs.edn untouched)