### PR TITLE
feat(examples): per-substrate visual identity cluster — 4 beads from rf2-7p188 (RED→GREEN)

### DIFF
--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -1,0 +1,51 @@
+# `examples/_shared/` — per-substrate visual identity assets
+
+Shared stylesheets, favicon, and Open Graph imagery consumed by every
+example `index.html`. The orchestrator
+(`examples/scripts/serve-and-run-examples-tests.cjs`) stages this whole
+tree into each example's `out/examples/<name>/_shared/` directory next to
+`main.js`, so every page references assets at the same relative path
+(`_shared/css/<substrate>.css`).
+
+## Per-substrate identity (rf2-nfg15)
+
+re-frame2 ships three React adapters — Reagent, UIx, Helix — and each
+example tree under `examples/<substrate>/` mounts an app on the
+respective adapter. Each substrate carries its own distinctive look so a
+visitor can identify the substrate at a glance:
+
+| Substrate | Mood                       | Typography                          | Palette                                            | Atmosphere                                  |
+| --------- | -------------------------- | ----------------------------------- | -------------------------------------------------- | ------------------------------------------- |
+| Reagent   | Editorial Warm             | Newsreader display serif + Source Sans 3 | warm paper #FAF4EC / ink #1F1A14 / sienna #C4541C | paper-grain radial gradients, soft shadows  |
+| UIx       | Swiss Modern               | Space Grotesk + Space Mono labels   | concrete #EFF2F5 / near-black #0A0F14 / cyan #00B4D8 | dotted grid background, hard-offset shadows |
+| Helix     | Developer Industrial (dark) | JetBrains Mono UI + IBM Plex Sans body | bg #0D1117 / surface #161B22 / neon green #3FB950 | gradient mesh corners + faint scanlines     |
+
+The three identities are deliberately distinct from the dev tools that
+sit alongside the examples — Causa (Inter + JBM + violet) and Story (IBM
+Plex on light + cyan-leaning palette) — and from each other on every
+axis (light-warm-serif vs. light-cool-grotesque vs. dark-mono-neon).
+
+## Layout
+
+- `css/structure.css` — substrate-agnostic structural baseline (form
+  geometry, grid layout, max-widths). `@import`ed by every substrate
+  stylesheet.
+- `css/reagent.css`, `css/uix.css`, `css/helix.css` — per-substrate
+  identity layer. Picks up `structure.css` automatically.
+- `img/favicon.svg`, `img/favicon-<substrate>.svg` — shared favicon spine
+  with per-substrate accent (rf2-3zibv).
+- `img/og.svg`, `img/og-<substrate>.svg` — Open Graph preview images
+  (rf2-3zibv).
+
+## Adding a new substrate
+
+1. Drop `css/<substrate>.css` next to the existing three; `@import
+   structure.css` first; pick a distinctive typography + palette +
+   atmosphere triad (read `frontend-design` skill first).
+2. Add `img/favicon-<substrate>.svg` + `img/og-<substrate>.svg`.
+3. Link `_shared/css/<substrate>.css` from each
+   `examples/<substrate>/<example>/index.html` `<head>`.
+4. Update the table above.
+
+The orchestrator picks up new files automatically — `stageShared` copies
+the whole `_shared/` tree per example.

--- a/examples/_shared/css/helix.css
+++ b/examples/_shared/css/helix.css
@@ -1,0 +1,330 @@
+/* ============================================================================
+ * Helix substrate — "Developer Industrial" visual identity (rf2-nfg15).
+ *
+ * Typography pairing : JetBrains Mono (heavy + regular for UI chrome) +
+ *                      IBM Plex Sans (body prose). Mono-first because
+ *                      Helix is the lean / pragmatic adapter — the look
+ *                      reads as a dev-tool with a UI bolted on.
+ *
+ *                      NOTE: Causa's mono is also JetBrains Mono. Helix
+ *                      gets it as the DOMINANT face (every label, every
+ *                      button, every chrome string) — Causa uses it for
+ *                      mono columns only. The shape on screen is
+ *                      different.
+ *
+ * Palette            : dark Tokyo-night-ish — bg #0D1117 / surface #161B22 /
+ *                      raised #1F2530 / neon green accent #3FB950 /
+ *                      magenta #F778BA / amber warn #F0883E.
+ * Atmosphere         : gradient mesh (faint radial neon green→magenta in
+ *                      corners) + sharp 1px borders + subtle scanline
+ *                      texture. Reads as "synthwave-adjacent terminal".
+ * Mood               : terminal-as-app, pragmatic, lean.
+ *
+ * Per the cluster prompt: distinct from Causa (Inter+JBM+violet-dark) by
+ * being mono-first (not sans-first) and using neon green not violet, and
+ * distinct from Story (IBM Plex), Reagent ("Editorial Warm"), and UIx
+ * ("Swiss Modern").
+ *
+ * @imports structure.css (rf2-jzqs9) for layout-only class shapes.
+ * ========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700;800&display=swap');
+@import url('structure.css');
+
+:root {
+  /* surfaces — Tokyo-night-leaning dark stack */
+  --hx-bg:           #0D1117;
+  --hx-bg-surface:   #161B22;
+  --hx-bg-raised:    #1F2530;
+  --hx-bg-elevated:  #2A3140;
+
+  /* ink */
+  --hx-ink:          #E6EDF3;
+  --hx-ink-muted:    #9DA8B6;
+  --hx-ink-faint:    #6B7785;
+  --hx-rule:         #2A3140;
+  --hx-rule-strong:  #3A4252;
+
+  /* accents — neon green primary, magenta secondary */
+  --hx-green:        #3FB950;
+  --hx-green-deep:   #2DA042;
+  --hx-magenta:      #F778BA;
+  --hx-amber:        #F0883E;
+  --hx-red:          #FF6B6B;
+  --hx-cyan:         #79C0FF;
+
+  /* fonts */
+  --hx-mono:         'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --hx-sans:         'IBM Plex Sans', system-ui, -apple-system, 'Segoe UI', sans-serif;
+
+  /* aliases */
+  --rf2-mono:        var(--hx-mono);
+}
+
+html, body {
+  background: var(--hx-bg);
+  color: var(--hx-ink);
+  margin: 0;
+  font-family: var(--hx-mono);
+  font-size: 14.5px;
+  line-height: 1.6;
+  font-feature-settings: 'kern' 1, 'liga' 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* gradient mesh — neon green TL, magenta BR. CSS-only, fixed. */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 0%   0%,   rgba(63,185,80,0.085)  0,    transparent 35%),
+    radial-gradient(circle at 100% 100%, rgba(247,120,186,0.07) 0,    transparent 38%),
+    radial-gradient(circle at 50%  50%,  rgba(121,192,255,0.025) 0,   transparent 60%);
+  z-index: -1;
+}
+
+/* faint scanline texture overlay */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px, transparent 3px,
+    rgba(255,255,255,0.012) 3px, rgba(255,255,255,0.012) 4px
+  );
+  z-index: -1;
+}
+
+/* Typography — mono-first headings. Body uses IBM Plex Sans for legibility. */
+
+h1, h2, h3, h4 {
+  font-family: var(--hx-mono);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--hx-ink);
+  margin: 0 0 0.55em;
+}
+
+h1 { font-size: 2.1rem;  line-height: 1.15; }
+h1::before { content: '> '; color: var(--hx-green); }
+
+h2 { font-size: 1.4rem;  line-height: 1.2; }
+h2::before { content: '## '; color: var(--hx-magenta); font-weight: 500; }
+
+h3 { font-size: 1rem;    line-height: 1.25;
+     text-transform: uppercase; letter-spacing: 0.12em;
+     color: var(--hx-green); font-weight: 700; }
+
+p, li {
+  font-family: var(--hx-sans);
+  margin: 0 0 1em;
+  max-width: 68ch;
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--hx-mono);
+  font-size: 0.94em;
+}
+
+code {
+  background: var(--hx-bg-surface);
+  color: var(--hx-magenta);
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--hx-rule);
+}
+
+a, .nav-link {
+  color: var(--hx-green);
+  text-decoration: none;
+  border-bottom: 1px dashed var(--hx-rule-strong);
+  padding-bottom: 1px;
+  transition: color 100ms ease, border-color 100ms ease;
+}
+
+a:hover, .nav-link:hover {
+  color: var(--hx-magenta);
+  border-bottom-color: var(--hx-magenta);
+  border-bottom-style: solid;
+}
+
+/* Forms — terminal-ish fields. */
+
+input, textarea, select {
+  font-family: var(--hx-mono);
+  font-size: 0.95rem;
+  color: var(--hx-ink);
+  background: var(--hx-bg-surface);
+  border: 1px solid var(--hx-rule-strong);
+  border-radius: 3px;
+  caret-color: var(--hx-green);
+  transition: border-color 100ms ease, box-shadow 100ms ease;
+}
+
+input::placeholder { color: var(--hx-ink-faint); }
+
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--hx-green);
+  box-shadow: 0 0 0 3px rgba(63,185,80,0.18);
+}
+
+button {
+  font-family: var(--hx-mono);
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--hx-ink);
+  background: var(--hx-bg-elevated);
+  border: 1px solid var(--hx-rule-strong);
+  border-radius: 3px;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background 100ms ease, border-color 100ms ease, color 100ms ease;
+}
+
+button:hover:not([disabled]) {
+  background: var(--hx-bg-raised);
+  border-color: var(--hx-green);
+  color: var(--hx-green);
+}
+
+button:active:not([disabled]) { transform: translateY(1px); }
+
+.login-form button[type="submit"] {
+  background: var(--hx-green);
+  border-color: var(--hx-green);
+  color: var(--hx-bg);
+}
+
+.login-form button[type="submit"]:hover:not([disabled]) {
+  background: var(--hx-green-deep);
+  border-color: var(--hx-green-deep);
+  color: var(--hx-bg);
+}
+
+.error {
+  color: var(--hx-red);
+  font-family: var(--hx-mono);
+  font-size: 0.88em;
+}
+
+.error::before { content: 'err: '; color: var(--hx-amber); }
+
+.locked { color: var(--hx-red); font-weight: 700; }
+.locked::before { content: '[locked] '; color: var(--hx-amber); }
+
+/* Banner + pill */
+
+.banner {
+  background: var(--hx-bg-surface);
+  border: 1px solid var(--hx-rule-strong);
+  border-left: 3px solid var(--hx-green);
+  border-radius: 3px;
+  color: var(--hx-ink);
+}
+
+.pill {
+  font-family: var(--hx-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78em;
+  border-radius: 2px;
+  font-weight: 700;
+}
+
+.pill.disconnected   { background: var(--hx-rule-strong); color: var(--hx-ink-muted); }
+.pill.connecting     { background: var(--hx-cyan); color: var(--hx-bg); }
+.pill.authenticating { background: var(--hx-magenta); color: var(--hx-bg); }
+.pill.connected      { background: var(--hx-green); color: var(--hx-bg); }
+.pill.reconnecting   { background: var(--hx-amber); color: var(--hx-bg); }
+.pill.failed         { background: var(--hx-red); color: var(--hx-bg); }
+
+/* Boot */
+
+.boot-progress {
+  background: var(--hx-bg-surface);
+  border-left-color: var(--hx-green);
+  border: 1px solid var(--hx-rule);
+  border-left-width: 4px;
+}
+
+.boot-failed {
+  background: var(--hx-bg-surface);
+  border-left-color: var(--hx-red);
+  border: 1px solid var(--hx-rule);
+  border-left-width: 4px;
+  color: var(--hx-red);
+}
+
+.boot-hint { color: var(--hx-ink-faint); font-family: var(--hx-mono); }
+.main-app section { border-top: 1px solid var(--hx-rule); }
+dl.boot-summary dt { color: var(--hx-green); font-family: var(--hx-mono);
+                     font-size: 0.85em; }
+
+/* Realworld */
+
+.navbar, .realworld-footer {
+  background: var(--hx-bg-surface);
+  border-bottom: 1px solid var(--hx-rule-strong);
+}
+
+.realworld-footer { border-bottom: 0; border-top: 1px solid var(--hx-rule-strong); margin-top: 2em; }
+.nav-link { color: var(--hx-green); font-family: var(--hx-mono);
+            text-transform: lowercase; }
+.article-preview { border-bottom-color: var(--hx-rule); }
+
+/* SSR cards */
+
+.card {
+  background: var(--hx-bg-surface);
+  border-color: var(--hx-rule-strong);
+  border-radius: 4px;
+  box-shadow: 0 1px 0 rgba(63,185,80,0.15) inset;
+}
+
+.card h3 {
+  color: var(--hx-green);
+  font-family: var(--hx-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78em;
+}
+
+.card p.value { color: var(--hx-magenta); font-family: var(--hx-mono); font-weight: 800; }
+.card.skeleton { color: var(--hx-ink-faint); background: var(--hx-bg); border-style: dashed; }
+
+/* Utility */
+
+.muted { color: var(--hx-ink-faint); }
+.queue-depth { color: var(--hx-ink-muted); font-family: var(--hx-mono); }
+.inbox ul { border: 1px solid var(--hx-rule); background: var(--hx-bg); border-radius: 3px; }
+.last-reply code { background: var(--hx-bg-elevated); }
+hr { border-top: 1px solid var(--hx-rule); }
+
+/* Cells grid */
+
+.cells-grid th, .cells-grid td { border-color: var(--hx-rule-strong); }
+.cells-grid thead th, .cells-grid tbody th {
+  background: var(--hx-bg-elevated);
+  color: var(--hx-green);
+}
+.cells-grid input { background: var(--hx-bg); color: var(--hx-ink); }
+
+/* Causa shell — Helix accent in border */
+[data-rf-causa-host] { border-left: 1px solid var(--hx-rule-strong); }
+
+/* Default page layout */
+body > #app,
+body > div > #app {
+  padding: 2.5em min(6vw, 48px);
+  max-width: 1100px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.rf2-testbed-shell > #app { max-width: none; margin: 0; }

--- a/examples/_shared/css/reagent.css
+++ b/examples/_shared/css/reagent.css
@@ -1,313 +1,264 @@
 /* ============================================================================
- * Reagent examples — shared baseline stylesheet (rf2-jzqs9).
+ * Reagent substrate — "Editorial Warm" visual identity (rf2-nfg15).
  *
- * Foundation lift: every inline <style> block previously duplicated across
- * examples/reagent/*\/index.html is consolidated here, keyed by the class
- * names the views actually emit. This is the FLOOR — commit 2 (rf2-nfg15)
- * layers the Reagent visual identity (typography pairing, palette,
- * atmosphere) on top via examples/_shared/css/reagent-identity.css.
+ * Typography pairing : Newsreader (display serif, variable) + Source Sans 3 (body)
+ * Palette            : warm paper #FAF4EC / deep ink #1F1A14 / sienna #C4541C
+ *                      / gold #D8A24A / oxblood error #9B2C2C
+ * Atmosphere         : subtle paper grain (radial-gradient noise) +
+ *                      warm-toned soft shadows + serif drop-caps where natural.
+ * Mood               : established, refined, magazine — Reagent is the
+ *                      veteran of the three adapters; the typography says so.
  *
- * Staging: the orchestrator at examples/scripts/serve-and-run-examples-tests.cjs
- * copies this file into each example's out/examples/<name>/_shared/css/
- * directory via the `extraFiles` mechanism, so the same hand-written
- * index.html can <link rel="stylesheet" href="_shared/css/reagent.css">
- * relatively in every example.
+ * Per the cluster prompt: distinct from Causa (Inter+JBM+violet) and Story
+ * (IBM Plex), and distinct from the UIx ("Swiss Modern") and Helix
+ * ("Developer Industrial") sibling stylesheets.
  *
- * The class-name surface here is the union of what the example views emit
- * (.login-form, .banner, .error, .pill.<state>, .navbar, .nav-link,
- * .card, .cells-grid, ...) — a single CSS bundle so the substrate's UIx
- * and Helix siblings can also opt in (they currently render the same
- * components with the same classes; the unstyled-fallback problem
- * documented in rf2-7p188 finding M4).
+ * @imports structure.css (rf2-jzqs9) for layout-only class shapes.
  * ========================================================================== */
 
-/* -- Forms (login, signup, settings) ------------------------------------- */
+@import url('https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,700;0,6..72,800;1,6..72,400&family=Source+Sans+3:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap');
+@import url('structure.css');
 
-.login-form {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  max-width: 320px;
+:root {
+  /* paper-grade neutrals */
+  --rg-bg:           #FAF4EC;
+  --rg-bg-raised:   #FFFAF1;
+  --rg-bg-sunken:   #EFE6D6;
+  --rg-ink:          #1F1A14;
+  --rg-ink-muted:   #5B5246;
+  --rg-ink-faint:   #877D6D;
+  --rg-rule:        #D9CCB3;
+
+  /* warm accents */
+  --rg-sienna:      #C4541C;
+  --rg-sienna-deep: #9C3F0E;
+  --rg-gold:        #D8A24A;
+  --rg-oxblood:     #9B2C2C;
+  --rg-forest:     #4A6B3A;
+
+  /* fonts */
+  --rg-serif:       'Newsreader', 'Iowan Old Style', 'Charter', Cambria, Georgia, serif;
+  --rg-sans:        'Source Sans 3', 'Source Sans Pro', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --rg-mono:        ui-monospace, 'SF Mono', Menlo, 'Cascadia Mono', monospace;
+
+  /* aliases consumed by structure.css */
+  --rf2-mono:       var(--rg-mono);
 }
 
-.login-form input,
-.login-form button {
-  padding: 6px 12px;
-}
-
-.error {
-  color: #c33;
+html, body {
+  background: var(--rg-bg);
+  color: var(--rg-ink);
   margin: 0;
+  font-family: var(--rg-sans);
+  font-size: 17px;
+  line-height: 1.55;
+  font-feature-settings: 'kern' 1, 'liga' 1, 'onum' 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.error-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+/* paper grain — three radial gradients stacked, fixed so it doesn't
+   scroll with the content. Low-cost, pure CSS, no <img>. */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(196,84,28,0.045)  0,    transparent 38%),
+    radial-gradient(circle at 78% 70%, rgba(216,162,74,0.045) 0,    transparent 42%),
+    radial-gradient(circle at 50% 95%, rgba(31,26,20,0.025)   0,    transparent 55%);
+  z-index: -1;
 }
 
-.locked {
-  color: #c33;
+/* Typography */
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--rg-serif);
+  font-weight: 700;
+  letter-spacing: -0.012em;
+  color: var(--rg-ink);
+  margin: 0 0 0.6em;
 }
 
-/* -- Banners + pills (state-machine walkthrough, websocket) -------------- */
+h1 { font-size: 2.4rem;  line-height: 1.12; font-weight: 800; }
+h2 { font-size: 1.65rem; line-height: 1.2;  font-weight: 700; }
+h3 { font-size: 1.2rem;  line-height: 1.25; font-weight: 600; }
 
-.banner {
-  margin: 1em 0;
-  padding: 0.5em 1em;
-  background: #f4f4f4;
-  border-radius: 4px;
-}
+p { margin: 0 0 1em; }
 
-.banner .state {
-  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
-}
-
-.pill {
-  display: inline-block;
-  padding: 4px 10px;
-  border-radius: 12px;
-  font-weight: 600;
-  color: #fff;
-  letter-spacing: 0.04em;
-  font-size: 0.85em;
-}
-
-.pill.disconnected   { background: #888; }
-.pill.connecting     { background: #2a93d5; }
-.pill.authenticating { background: #6c5ce7; }
-.pill.connected      { background: #2ecc71; }
-.pill.reconnecting   { background: #e67e22; }
-.pill.failed         { background: #e74c3c; }
-
-/* -- Boot example -------------------------------------------------------- */
-
-.boot-progress {
-  padding: 16px;
-  background: #f5f7fa;
-  border-left: 4px solid #5cb85c;
-}
-
-.boot-failed {
-  padding: 16px;
-  background: #fdf3f3;
-  border-left: 4px solid #d9534f;
-}
-
-.boot-hint {
-  color: #777;
-  font-size: 0.85rem;
-}
-
-.main-app section {
-  padding: 8px 0;
-  border-top: 1px solid #eee;
-}
-
-dl.boot-summary {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 4px 12px;
-  margin: 0;
-}
-
-dl.boot-summary dt {
-  font-weight: 600;
-  color: #555;
-}
-
-dl.boot-summary dd { margin: 0; }
-
-/* -- Realworld / Conduit ------------------------------------------------- */
-
-.navbar,
-.realworld-footer {
-  padding: 8px 16px;
-  background: #f5f5f5;
-}
-
-.navbar .nav {
-  display: inline-block;
-  margin-right: 12px;
-}
-
-.nav-link {
-  margin-right: 8px;
-  text-decoration: none;
-  color: #5cb85c;
-}
-
-.container {
-  padding: 12px 16px;
-}
-
-.article-preview {
-  padding: 12px 0;
-  border-bottom: 1px solid #eee;
-}
-
-.article-preview h1 {
-  font-size: 1.2rem;
-  margin: 4px 0;
-}
-
-/* -- SSR + streaming SSR ------------------------------------------------- */
-
-.page { max-width: 600px; }
-
-.toggle-bodies {
-  margin: 0.5em 0 1em;
-  padding: 6px 12px;
-}
-
-.cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1em;
-  margin-top: 1.5em;
-}
-
-.card {
-  flex: 1 1 220px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  padding: 1em;
-}
-
-.card h3 {
-  margin: 0 0 0.5em;
-  font-size: 0.95em;
-  color: #444;
-}
-
-.card p.value {
-  margin: 0;
-  font-size: 1.6em;
-  font-weight: bold;
-}
-
-.card.skeleton {
-  color: #aaa;
-  background: #fafafa;
-}
-
-/* -- Long-running work --------------------------------------------------- */
-
-button[disabled] {
-  cursor: not-allowed;
-  opacity: 0.5;
+code, kbd, pre, .mono {
+  font-family: var(--rg-mono);
+  font-size: 0.92em;
 }
 
 code {
-  background: #f0f0f0;
-  padding: 1px 4px;
+  background: var(--rg-bg-sunken);
+  color: var(--rg-sienna-deep);
+  padding: 1px 5px;
   border-radius: 3px;
 }
 
-/* -- WebSocket example specifics ----------------------------------------- */
-
-.muted     { color: #666; }
-.status    { margin: 8px 0; }
-
-.lifecycle,
-.demo-buttons,
-.send-form {
-  display: flex;
-  gap: 8px;
-  margin: 8px 0;
-  align-items: center;
+a, .nav-link {
+  color: var(--rg-sienna);
+  text-decoration-color: var(--rg-gold);
+  text-underline-offset: 3px;
+  transition: color 120ms ease;
 }
 
-input[type="text"] {
-  padding: 6px 10px;
-  flex: 1;
-  min-width: 240px;
-}
+a:hover, .nav-link:hover { color: var(--rg-sienna-deep); }
 
-.queue-depth {
-  color: #555;
-  font-style: italic;
-  font-size: 0.9em;
-}
+/* Forms */
 
-.inbox ul {
-  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
-  font-size: 0.85em;
-  max-height: 240px;
-  overflow-y: auto;
-  border: 1px solid #ddd;
-  padding: 8px 8px 8px 28px;
-}
-
-.inbox li { margin: 2px 0; }
-
-.last-reply { font-size: 0.85em; }
-
-.last-reply code {
-  background: #f3f3f3;
-  padding: 2px 6px;
+input, textarea, select {
+  font-family: var(--rg-sans);
+  font-size: 1rem;
+  color: var(--rg-ink);
+  background: var(--rg-bg-raised);
+  border: 1px solid var(--rg-rule);
   border-radius: 4px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-hr {
-  border: 0;
-  border-top: 1px solid #eee;
-  margin: 16px 0;
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--rg-sienna);
+  box-shadow: 0 0 0 3px rgba(196,84,28,0.18);
 }
 
-/* -- 7GUIs: cells grid --------------------------------------------------- */
-
-.cells-grid {
-  border-collapse: collapse;
-  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+button {
+  font-family: var(--rg-sans);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--rg-bg-raised);
+  background: var(--rg-ink);
+  border: 1px solid var(--rg-ink);
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background 120ms ease, transform 80ms ease;
+  box-shadow: 0 1px 0 rgba(31,26,20,0.18);
 }
 
-.cells-grid th,
-.cells-grid td {
-  border: 1px solid #ccc;
-  min-width: 60px;
-  height: 22px;
-  padding: 1px 4px;
-  text-align: left;
-  vertical-align: middle;
+button:hover:not([disabled]) {
+  background: var(--rg-sienna);
+  border-color: var(--rg-sienna);
 }
 
-.cells-grid thead th {
-  background: #eee;
-  text-align: center;
+button:active:not([disabled]) { transform: translateY(1px); }
+
+/* Form-bound login submit gets the accent */
+.login-form button[type="submit"] {
+  background: var(--rg-sienna);
+  border-color: var(--rg-sienna);
+  color: #fff;
 }
 
-.cells-grid tbody th {
-  background: #eee;
-  text-align: right;
-  min-width: 28px;
+.login-form button[type="submit"]:hover:not([disabled]) {
+  background: var(--rg-sienna-deep);
+  border-color: var(--rg-sienna-deep);
 }
 
-.cells-grid input {
-  width: 56px;
+.error {
+  color: var(--rg-oxblood);
+  font-family: var(--rg-sans);
+  font-style: italic;
+}
+
+.locked { color: var(--rg-oxblood); font-weight: 600; }
+
+/* Banner + pill identity */
+
+.banner {
+  background: var(--rg-bg-raised);
+  border: 1px solid var(--rg-rule);
+  box-shadow: 0 1px 3px rgba(31,26,20,0.05);
+  color: var(--rg-ink);
+}
+
+.pill.disconnected   { background: #8a7e6d; }
+.pill.connecting     { background: var(--rg-gold); color: var(--rg-ink); }
+.pill.authenticating { background: var(--rg-sienna); }
+.pill.connected      { background: var(--rg-forest); }
+.pill.reconnecting   { background: var(--rg-gold); color: var(--rg-ink); }
+.pill.failed         { background: var(--rg-oxblood); }
+
+/* Boot */
+
+.boot-progress {
+  background: var(--rg-bg-raised);
+  border-left-color: var(--rg-forest);
+  color: var(--rg-ink);
+}
+
+.boot-failed {
+  background: #FDF1EC;
+  border-left-color: var(--rg-oxblood);
+  color: var(--rg-oxblood);
+}
+
+.boot-hint { color: var(--rg-ink-faint); font-style: italic; }
+.main-app section { border-top: 1px solid var(--rg-rule); }
+dl.boot-summary dt { color: var(--rg-ink-muted); }
+
+/* Realworld / Conduit */
+
+.navbar, .realworld-footer {
+  background: var(--rg-bg-raised);
+  border-bottom: 1px solid var(--rg-rule);
+}
+
+.realworld-footer {
+  border-bottom: 0;
+  border-top: 1px solid var(--rg-rule);
+  margin-top: 2em;
+}
+
+.nav-link { color: var(--rg-sienna); font-weight: 500; }
+.article-preview { border-bottom-color: var(--rg-rule); }
+.article-preview h1 { font-family: var(--rg-serif); font-weight: 700; }
+
+/* SSR cards */
+
+.card {
+  background: var(--rg-bg-raised);
+  border-color: var(--rg-rule);
+  box-shadow: 0 2px 6px rgba(31,26,20,0.06);
+}
+
+.card h3 { color: var(--rg-ink-muted); font-family: var(--rg-serif); }
+.card p.value { color: var(--rg-sienna-deep); font-family: var(--rg-serif); }
+.card.skeleton { color: var(--rg-ink-faint); background: var(--rg-bg-sunken); }
+
+/* Pills + utility */
+
+.muted     { color: var(--rg-ink-faint); }
+.queue-depth { color: var(--rg-ink-muted); }
+.inbox ul { border: 1px solid var(--rg-rule); background: var(--rg-bg-raised); }
+.last-reply code { background: var(--rg-bg-sunken); }
+hr { border-top: 1px solid var(--rg-rule); }
+
+/* Cells grid */
+
+.cells-grid th, .cells-grid td { border-color: var(--rg-rule); }
+.cells-grid thead th, .cells-grid tbody th {
+  background: var(--rg-bg-sunken);
+  color: var(--rg-ink-muted);
+}
+
+/* Causa testbed shell — Reagent accent in the divider */
+[data-rf-causa-host] { border-left: 1px solid #2a2a2a; }
+
+/* Page padding default — used by examples that don't supply their own
+   layout. */
+body > #app,
+body > div > #app {
+  padding: 2.5em min(6vw, 48px);
+  max-width: 1100px;
+  margin: 0 auto;
   box-sizing: border-box;
 }
 
-/* -- Causa-host shell (counter testbed pattern) -------------------------- */
-
-.rf2-testbed-shell {
-  display: flex;
-  min-height: 100vh;
-}
-
-:root {
-  --rf-causa-accent: #7C5CFF;
-}
-
-[data-rf-causa-host] {
-  flex: 0 0 var(--rf-causa-inline-width, 560px);
-  min-width: 320px;
-  box-sizing: border-box;
-  border-left: 1px solid #2a2a2a;
-}
-
-.rf2-testbed-shell #app {
-  flex: 1;
-  min-width: 0;
-  padding: 2em;
-}
+/* The .rf2-testbed-shell wrapper overrides the above per its own grid;
+   undo the inherited #app padding under that wrapper. */
+.rf2-testbed-shell > #app { max-width: none; margin: 0; }

--- a/examples/_shared/css/reagent.css
+++ b/examples/_shared/css/reagent.css
@@ -1,0 +1,313 @@
+/* ============================================================================
+ * Reagent examples — shared baseline stylesheet (rf2-jzqs9).
+ *
+ * Foundation lift: every inline <style> block previously duplicated across
+ * examples/reagent/*\/index.html is consolidated here, keyed by the class
+ * names the views actually emit. This is the FLOOR — commit 2 (rf2-nfg15)
+ * layers the Reagent visual identity (typography pairing, palette,
+ * atmosphere) on top via examples/_shared/css/reagent-identity.css.
+ *
+ * Staging: the orchestrator at examples/scripts/serve-and-run-examples-tests.cjs
+ * copies this file into each example's out/examples/<name>/_shared/css/
+ * directory via the `extraFiles` mechanism, so the same hand-written
+ * index.html can <link rel="stylesheet" href="_shared/css/reagent.css">
+ * relatively in every example.
+ *
+ * The class-name surface here is the union of what the example views emit
+ * (.login-form, .banner, .error, .pill.<state>, .navbar, .nav-link,
+ * .card, .cells-grid, ...) — a single CSS bundle so the substrate's UIx
+ * and Helix siblings can also opt in (they currently render the same
+ * components with the same classes; the unstyled-fallback problem
+ * documented in rf2-7p188 finding M4).
+ * ========================================================================== */
+
+/* -- Forms (login, signup, settings) ------------------------------------- */
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 320px;
+}
+
+.login-form input,
+.login-form button {
+  padding: 6px 12px;
+}
+
+.error {
+  color: #c33;
+  margin: 0;
+}
+
+.error-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.locked {
+  color: #c33;
+}
+
+/* -- Banners + pills (state-machine walkthrough, websocket) -------------- */
+
+.banner {
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  background: #f4f4f4;
+  border-radius: 4px;
+}
+
+.banner .state {
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+}
+
+.pill {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.04em;
+  font-size: 0.85em;
+}
+
+.pill.disconnected   { background: #888; }
+.pill.connecting     { background: #2a93d5; }
+.pill.authenticating { background: #6c5ce7; }
+.pill.connected      { background: #2ecc71; }
+.pill.reconnecting   { background: #e67e22; }
+.pill.failed         { background: #e74c3c; }
+
+/* -- Boot example -------------------------------------------------------- */
+
+.boot-progress {
+  padding: 16px;
+  background: #f5f7fa;
+  border-left: 4px solid #5cb85c;
+}
+
+.boot-failed {
+  padding: 16px;
+  background: #fdf3f3;
+  border-left: 4px solid #d9534f;
+}
+
+.boot-hint {
+  color: #777;
+  font-size: 0.85rem;
+}
+
+.main-app section {
+  padding: 8px 0;
+  border-top: 1px solid #eee;
+}
+
+dl.boot-summary {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  margin: 0;
+}
+
+dl.boot-summary dt {
+  font-weight: 600;
+  color: #555;
+}
+
+dl.boot-summary dd { margin: 0; }
+
+/* -- Realworld / Conduit ------------------------------------------------- */
+
+.navbar,
+.realworld-footer {
+  padding: 8px 16px;
+  background: #f5f5f5;
+}
+
+.navbar .nav {
+  display: inline-block;
+  margin-right: 12px;
+}
+
+.nav-link {
+  margin-right: 8px;
+  text-decoration: none;
+  color: #5cb85c;
+}
+
+.container {
+  padding: 12px 16px;
+}
+
+.article-preview {
+  padding: 12px 0;
+  border-bottom: 1px solid #eee;
+}
+
+.article-preview h1 {
+  font-size: 1.2rem;
+  margin: 4px 0;
+}
+
+/* -- SSR + streaming SSR ------------------------------------------------- */
+
+.page { max-width: 600px; }
+
+.toggle-bodies {
+  margin: 0.5em 0 1em;
+  padding: 6px 12px;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-top: 1.5em;
+}
+
+.card {
+  flex: 1 1 220px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 1em;
+}
+
+.card h3 {
+  margin: 0 0 0.5em;
+  font-size: 0.95em;
+  color: #444;
+}
+
+.card p.value {
+  margin: 0;
+  font-size: 1.6em;
+  font-weight: bold;
+}
+
+.card.skeleton {
+  color: #aaa;
+  background: #fafafa;
+}
+
+/* -- Long-running work --------------------------------------------------- */
+
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+code {
+  background: #f0f0f0;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+/* -- WebSocket example specifics ----------------------------------------- */
+
+.muted     { color: #666; }
+.status    { margin: 8px 0; }
+
+.lifecycle,
+.demo-buttons,
+.send-form {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+  align-items: center;
+}
+
+input[type="text"] {
+  padding: 6px 10px;
+  flex: 1;
+  min-width: 240px;
+}
+
+.queue-depth {
+  color: #555;
+  font-style: italic;
+  font-size: 0.9em;
+}
+
+.inbox ul {
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+  font-size: 0.85em;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid #ddd;
+  padding: 8px 8px 8px 28px;
+}
+
+.inbox li { margin: 2px 0; }
+
+.last-reply { font-size: 0.85em; }
+
+.last-reply code {
+  background: #f3f3f3;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+hr {
+  border: 0;
+  border-top: 1px solid #eee;
+  margin: 16px 0;
+}
+
+/* -- 7GUIs: cells grid --------------------------------------------------- */
+
+.cells-grid {
+  border-collapse: collapse;
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+}
+
+.cells-grid th,
+.cells-grid td {
+  border: 1px solid #ccc;
+  min-width: 60px;
+  height: 22px;
+  padding: 1px 4px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.cells-grid thead th {
+  background: #eee;
+  text-align: center;
+}
+
+.cells-grid tbody th {
+  background: #eee;
+  text-align: right;
+  min-width: 28px;
+}
+
+.cells-grid input {
+  width: 56px;
+  box-sizing: border-box;
+}
+
+/* -- Causa-host shell (counter testbed pattern) -------------------------- */
+
+.rf2-testbed-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+:root {
+  --rf-causa-accent: #7C5CFF;
+}
+
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 560px);
+  min-width: 320px;
+  box-sizing: border-box;
+  border-left: 1px solid #2a2a2a;
+}
+
+.rf2-testbed-shell #app {
+  flex: 1;
+  min-width: 0;
+  padding: 2em;
+}

--- a/examples/_shared/css/structure.css
+++ b/examples/_shared/css/structure.css
@@ -1,0 +1,249 @@
+/* ============================================================================
+ * Structural baseline — class shapes the example views actually emit.
+ *
+ * rf2-jzqs9 lifted this from inline <style> blocks in every Reagent
+ * index.html. The classes here are layout-only (display/flex/grid,
+ * padding, max-widths, grid-template-columns); substrate-distinguishing
+ * typography + palette + atmosphere live in reagent.css / uix.css /
+ * helix.css (rf2-nfg15) which @import this file.
+ *
+ * Sources: examples/reagent/{login,boot,realworld,websocket,
+ * state_machine_walkthrough,ssr,ssr_streaming,long_running_work,7Guis/cells,
+ * counter}/index.html pre-rf2-jzqs9.
+ * ========================================================================== */
+
+/* -- Forms (login, signup, settings) ------------------------------------- */
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 360px;
+}
+
+.login-form input,
+.login-form button {
+  padding: 10px 14px;
+}
+
+.error-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* -- Banners + pills (state-machine walkthrough, websocket) -------------- */
+
+.banner {
+  margin: 1em 0;
+  padding: 0.75em 1.25em;
+  border-radius: 6px;
+}
+
+.banner .state {
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+}
+
+.pill {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.04em;
+  font-size: 0.85em;
+}
+
+/* -- Boot example layout -------------------------------------------------- */
+
+.boot-progress,
+.boot-failed {
+  padding: 16px;
+  border-left-width: 4px;
+  border-left-style: solid;
+}
+
+.main-app section {
+  padding: 12px 0;
+}
+
+dl.boot-summary {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 6px 16px;
+  margin: 0;
+}
+
+dl.boot-summary dt { font-weight: 600; }
+dl.boot-summary dd { margin: 0; }
+
+/* -- Realworld / Conduit layout ----------------------------------------- */
+
+.navbar,
+.realworld-footer {
+  padding: 12px 20px;
+}
+
+.navbar .nav {
+  display: inline-block;
+  margin-right: 16px;
+}
+
+.nav-link {
+  margin-right: 10px;
+  text-decoration: none;
+}
+
+.container {
+  padding: 16px 20px;
+}
+
+.article-preview {
+  padding: 16px 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+}
+
+.article-preview h1 {
+  font-size: 1.25rem;
+  margin: 6px 0;
+}
+
+/* -- SSR + streaming SSR layout ----------------------------------------- */
+
+.page { max-width: 720px; }
+
+.toggle-bodies {
+  margin: 0.5em 0 1em;
+  padding: 8px 14px;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin-top: 1.5em;
+}
+
+.card {
+  flex: 1 1 220px;
+  border-radius: 8px;
+  padding: 1.25em;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.card h3 {
+  margin: 0 0 0.5em;
+  font-size: 0.95em;
+}
+
+.card p.value {
+  margin: 0;
+  font-size: 1.8em;
+  font-weight: 700;
+}
+
+/* -- WebSocket example specifics ----------------------------------------- */
+
+.status { margin: 8px 0; }
+
+.lifecycle,
+.demo-buttons,
+.send-form {
+  display: flex;
+  gap: 10px;
+  margin: 10px 0;
+  align-items: center;
+}
+
+input[type="text"] {
+  padding: 8px 12px;
+  flex: 1;
+  min-width: 240px;
+}
+
+.queue-depth {
+  font-style: italic;
+  font-size: 0.9em;
+}
+
+.inbox ul {
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+  font-size: 0.85em;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 8px 8px 8px 28px;
+}
+
+.inbox li { margin: 2px 0; }
+.last-reply { font-size: 0.85em; }
+
+.last-reply code {
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+hr {
+  border: 0;
+  margin: 20px 0;
+}
+
+/* -- 7GUIs: cells grid --------------------------------------------------- */
+
+.cells-grid {
+  border-collapse: collapse;
+  font-family: var(--rf2-mono, ui-monospace, Menlo, monospace);
+}
+
+.cells-grid th,
+.cells-grid td {
+  border-width: 1px;
+  border-style: solid;
+  min-width: 60px;
+  height: 22px;
+  padding: 1px 4px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.cells-grid thead th { text-align: center; }
+.cells-grid tbody th {
+  text-align: right;
+  min-width: 28px;
+}
+
+.cells-grid input {
+  width: 56px;
+  box-sizing: border-box;
+}
+
+/* -- Causa-host shell (counter testbed pattern) -------------------------- */
+
+.rf2-testbed-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+:root {
+  --rf-causa-accent: #7C5CFF;
+}
+
+[data-rf-causa-host] {
+  flex: 0 0 var(--rf-causa-inline-width, 560px);
+  min-width: 320px;
+  box-sizing: border-box;
+}
+
+.rf2-testbed-shell #app {
+  flex: 1;
+  min-width: 0;
+  padding: 2em;
+}
+
+/* -- Universal disabled state -------------------------------------------- */
+
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/examples/_shared/css/uix.css
+++ b/examples/_shared/css/uix.css
@@ -1,0 +1,300 @@
+/* ============================================================================
+ * UIx substrate — "Swiss Modern" visual identity (rf2-nfg15).
+ *
+ * Typography pairing : Space Grotesk (geometric grotesque, display + body)
+ *                      + Space Mono (mono labels + tracked uppercase eyebrows)
+ * Palette            : cool concrete #EFF2F5 / near-black #0A0F14 /
+ *                      electric cyan #00B4D8 / signal yellow #FFD60A /
+ *                      coral error #E63946
+ * Atmosphere         : geometric grid background (subtle dotted), hairline
+ *                      rules, hard-offset shadows (no blur), uppercase
+ *                      tracking, generous whitespace.
+ * Mood               : type-forward, deliberate, modern. UIx is the
+ *                      modern-React entrant; the look matches.
+ *
+ * Per the cluster prompt: distinct from Causa (Inter+JBM+violet) and Story
+ * (IBM Plex), distinct from the Reagent ("Editorial Warm") and Helix
+ * ("Developer Industrial") sibling stylesheets.
+ *
+ * @imports structure.css (rf2-jzqs9) for layout-only class shapes.
+ * ========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
+@import url('structure.css');
+
+:root {
+  /* surfaces */
+  --ux-bg:        #EFF2F5;
+  --ux-bg-raised:#FFFFFF;
+  --ux-bg-sunken: #E2E7EC;
+  --ux-grid:     rgba(10,15,20,0.05);
+
+  /* ink */
+  --ux-ink:      #0A0F14;
+  --ux-ink-mute: #4A5560;
+  --ux-ink-faint:#8A95A0;
+  --ux-rule:     #C8CFD5;
+
+  /* signal */
+  --ux-cyan:     #00B4D8;
+  --ux-cyan-deep:#0077B6;
+  --ux-yellow:   #FFD60A;
+  --ux-coral:    #E63946;
+  --ux-mint:     #06A77D;
+
+  /* fonts */
+  --ux-sans:    'Space Grotesk', 'Helvetica Neue', Arial, sans-serif;
+  --ux-mono:    'Space Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* aliases */
+  --rf2-mono:   var(--ux-mono);
+}
+
+html, body {
+  background: var(--ux-bg);
+  color: var(--ux-ink);
+  margin: 0;
+  font-family: var(--ux-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  font-feature-settings: 'kern' 1, 'ss01' 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* geometric dotted grid — Swiss-design hallmark. CSS-only, fixed so it
+   doesn't scroll with content. */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(var(--ux-grid) 1px, transparent 1px);
+  background-size: 24px 24px;
+  background-position: 0 0;
+  z-index: -1;
+}
+
+/* Typography — heavy display + tracked uppercase eyebrows. */
+
+h1, h2, h3, h4 {
+  font-family: var(--ux-sans);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--ux-ink);
+  margin: 0 0 0.55em;
+}
+
+h1 { font-size: 2.6rem;  line-height: 1.05; font-weight: 700; }
+h2 { font-size: 1.75rem; line-height: 1.15; }
+h3 { font-size: 1.05rem; line-height: 1.25;
+     text-transform: uppercase; letter-spacing: 0.14em;
+     font-family: var(--ux-mono); font-weight: 700;
+     color: var(--ux-ink-mute); }
+
+p { margin: 0 0 1em; max-width: 60ch; }
+
+code, kbd, pre, .mono {
+  font-family: var(--ux-mono);
+  font-size: 0.92em;
+}
+
+code {
+  background: var(--ux-bg-sunken);
+  color: var(--ux-cyan-deep);
+  padding: 1px 6px;
+  border-radius: 0;
+}
+
+a, .nav-link {
+  color: var(--ux-cyan-deep);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  text-decoration-color: var(--ux-cyan);
+  font-weight: 500;
+}
+
+a:hover, .nav-link:hover {
+  color: var(--ux-ink);
+  text-decoration-color: var(--ux-yellow);
+  text-decoration-thickness: 2px;
+}
+
+/* Forms — square, hairline, hard focus rings. */
+
+input, textarea, select {
+  font-family: var(--ux-sans);
+  font-size: 1rem;
+  color: var(--ux-ink);
+  background: var(--ux-bg-raised);
+  border: 1px solid var(--ux-rule);
+  border-radius: 0;
+  transition: border-color 100ms ease, box-shadow 100ms ease;
+}
+
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--ux-ink);
+  box-shadow: 4px 4px 0 var(--ux-cyan);
+}
+
+button {
+  font-family: var(--ux-sans);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ux-ink);
+  background: var(--ux-bg-raised);
+  border: 1.5px solid var(--ux-ink);
+  border-radius: 0;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 80ms ease, box-shadow 80ms ease;
+  box-shadow: 4px 4px 0 var(--ux-ink);
+}
+
+button:hover:not([disabled]) {
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--ux-ink);
+}
+
+button:active:not([disabled]) {
+  transform: translate(2px, 2px);
+  box-shadow: 1px 1px 0 var(--ux-ink);
+}
+
+.login-form button[type="submit"] {
+  background: var(--ux-ink);
+  color: var(--ux-yellow);
+  box-shadow: 4px 4px 0 var(--ux-cyan);
+}
+
+.login-form button[type="submit"]:hover:not([disabled]) {
+  box-shadow: 6px 6px 0 var(--ux-cyan);
+}
+
+.error {
+  color: var(--ux-coral);
+  font-family: var(--ux-mono);
+  font-size: 0.9em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.locked { color: var(--ux-coral); font-weight: 700; }
+
+/* Banner + pill */
+
+.banner {
+  background: var(--ux-bg-raised);
+  border: 1.5px solid var(--ux-ink);
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--ux-ink);
+  color: var(--ux-ink);
+}
+
+.pill {
+  border-radius: 0;
+  font-family: var(--ux-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.78em;
+  padding: 4px 12px;
+}
+
+.pill.disconnected   { background: var(--ux-ink-mute); }
+.pill.connecting     { background: var(--ux-yellow); color: var(--ux-ink); }
+.pill.authenticating { background: var(--ux-cyan-deep); }
+.pill.connected      { background: var(--ux-mint); }
+.pill.reconnecting   { background: var(--ux-yellow); color: var(--ux-ink); }
+.pill.failed         { background: var(--ux-coral); }
+
+/* Boot */
+
+.boot-progress {
+  background: var(--ux-bg-raised);
+  border-left-color: var(--ux-mint);
+  border: 1px solid var(--ux-rule);
+  border-left-width: 4px;
+}
+
+.boot-failed {
+  background: var(--ux-bg-raised);
+  border-left-color: var(--ux-coral);
+  border: 1px solid var(--ux-rule);
+  border-left-width: 4px;
+  color: var(--ux-coral);
+}
+
+.boot-hint { color: var(--ux-ink-faint); }
+.main-app section { border-top: 1px solid var(--ux-rule); }
+dl.boot-summary dt { color: var(--ux-ink-mute); text-transform: uppercase;
+                     letter-spacing: 0.08em; font-family: var(--ux-mono);
+                     font-size: 0.82em; }
+
+/* Realworld */
+
+.navbar, .realworld-footer {
+  background: var(--ux-bg-raised);
+  border-bottom: 1px solid var(--ux-rule);
+}
+
+.realworld-footer { border-bottom: 0; border-top: 1px solid var(--ux-rule); margin-top: 2em; }
+
+.nav-link { color: var(--ux-cyan-deep); text-transform: uppercase;
+            letter-spacing: 0.08em; font-size: 0.85em; }
+
+.article-preview { border-bottom-color: var(--ux-rule); }
+
+/* SSR cards — bordered, no-blur shadow */
+
+.card {
+  background: var(--ux-bg-raised);
+  border-color: var(--ux-ink);
+  border-width: 1.5px;
+  border-radius: 0;
+  box-shadow: 4px 4px 0 var(--ux-ink);
+}
+
+.card h3 {
+  font-family: var(--ux-mono);
+  color: var(--ux-ink-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78em;
+}
+
+.card p.value { color: var(--ux-ink); font-weight: 700; }
+.card.skeleton { color: var(--ux-ink-faint); background: var(--ux-bg-sunken); }
+
+/* Utility */
+
+.muted { color: var(--ux-ink-faint); }
+.queue-depth { color: var(--ux-ink-mute); }
+.inbox ul { border: 1px solid var(--ux-rule); background: var(--ux-bg-raised); border-radius: 0; }
+.last-reply code { background: var(--ux-bg-sunken); }
+hr { border-top: 1px solid var(--ux-rule); }
+
+/* Cells grid */
+
+.cells-grid th, .cells-grid td { border-color: var(--ux-rule); }
+.cells-grid thead th, .cells-grid tbody th {
+  background: var(--ux-bg-sunken);
+  color: var(--ux-ink-mute);
+}
+
+/* Causa shell */
+[data-rf-causa-host] { border-left: 1px solid #2a2a2a; }
+
+/* Default page layout */
+body > #app,
+body > div > #app {
+  padding: 3em min(7vw, 56px);
+  max-width: 1120px;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.rf2-testbed-shell > #app { max-width: none; margin: 0; }

--- a/examples/_shared/img/favicon-helix.svg
+++ b/examples/_shared/img/favicon-helix.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- re-frame2 favicon · Helix substrate variant (rf2-3zibv).
+     Accent = neon green #3FB950 (matches examples/_shared/css/helix.css). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="3" fill="#0D1117"/>
+  <path d="M9 22 V12 H11 V13.6 C12 12.3 13.4 11.8 14.6 12 V14.2 C13.3 14 11.5 14.6 11 16 V22 Z" fill="#E6EDF3"/>
+  <path d="M16 22 V20.5 C16 19 17 18 18.5 18 H20 C20.6 18 21 17.6 21 17 C21 16.4 20.6 16 20 16 H17 V14.5 H20.4 C22 14.5 23 15.5 23 17 C23 18.5 22 19.5 20.4 19.5 H18.5 C18 19.5 17.8 19.8 17.8 20.2 V20.5 H23 V22 Z" fill="#E6EDF3"/>
+  <rect x="6" y="26" width="20" height="2" rx="0.5" fill="#3FB950"/>
+</svg>

--- a/examples/_shared/img/favicon-reagent.svg
+++ b/examples/_shared/img/favicon-reagent.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- re-frame2 favicon · Reagent substrate variant (rf2-3zibv).
+     Accent = sienna #C4541C (matches examples/_shared/css/reagent.css). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#1F1A14"/>
+  <path d="M9 22 V12 H11 V13.6 C12 12.3 13.4 11.8 14.6 12 V14.2 C13.3 14 11.5 14.6 11 16 V22 Z" fill="#FAF4EC"/>
+  <path d="M16 22 V20.5 C16 19 17 18 18.5 18 H20 C20.6 18 21 17.6 21 17 C21 16.4 20.6 16 20 16 H17 V14.5 H20.4 C22 14.5 23 15.5 23 17 C23 18.5 22 19.5 20.4 19.5 H18.5 C18 19.5 17.8 19.8 17.8 20.2 V20.5 H23 V22 Z" fill="#FAF4EC"/>
+  <rect x="6" y="26" width="20" height="2" rx="1" fill="#C4541C"/>
+</svg>

--- a/examples/_shared/img/favicon-uix.svg
+++ b/examples/_shared/img/favicon-uix.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- re-frame2 favicon · UIx substrate variant (rf2-3zibv).
+     Accent = electric cyan #00B4D8 (matches examples/_shared/css/uix.css). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="0" fill="#0A0F14"/>
+  <path d="M9 22 V12 H11 V13.6 C12 12.3 13.4 11.8 14.6 12 V14.2 C13.3 14 11.5 14.6 11 16 V22 Z" fill="#EFF2F5"/>
+  <path d="M16 22 V20.5 C16 19 17 18 18.5 18 H20 C20.6 18 21 17.6 21 17 C21 16.4 20.6 16 20 16 H17 V14.5 H20.4 C22 14.5 23 15.5 23 17 C23 18.5 22 19.5 20.4 19.5 H18.5 C18 19.5 17.8 19.8 17.8 20.2 V20.5 H23 V22 Z" fill="#EFF2F5"/>
+  <rect x="6" y="26" width="20" height="2" rx="0" fill="#00B4D8"/>
+</svg>

--- a/examples/_shared/img/favicon.svg
+++ b/examples/_shared/img/favicon.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  re-frame2 favicon spine (rf2-3zibv).
+
+  A 32×32 monogram: stylised "r2" glyph on a dark surface, with a
+  signal-violet accent stroke under the descender. The shape is the
+  same on every variant; the accent colour (currentColor on the path
+  with class="accent") swaps per substrate via favicon-<substrate>.svg.
+
+  Shared spine — examples/_shared/img/favicon.svg — uses the canonical
+  re-frame2 violet (matches Causa's :accent-violet token #7C5CFF).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#0E0F12"/>
+  <!-- "r" glyph -->
+  <path d="M9 22 V12 H11 V13.6 C12 12.3 13.4 11.8 14.6 12 V14.2 C13.3 14 11.5 14.6 11 16 V22 Z" fill="#E8EAF0"/>
+  <!-- "2" subscript -->
+  <path d="M16 22 V20.5 C16 19 17 18 18.5 18 H20 C20.6 18 21 17.6 21 17 C21 16.4 20.6 16 20 16 H17 V14.5 H20.4 C22 14.5 23 15.5 23 17 C23 18.5 22 19.5 20.4 19.5 H18.5 C18 19.5 17.8 19.8 17.8 20.2 V20.5 H23 V22 Z" fill="#E8EAF0"/>
+  <!-- accent underline — the per-substrate swap point -->
+  <rect class="accent" x="6" y="26" width="20" height="2" rx="1" fill="#7C5CFF"/>
+</svg>

--- a/examples/_shared/img/og-helix.svg
+++ b/examples/_shared/img/og-helix.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Open Graph card · Helix substrate (rf2-3zibv).
+     Helix 'Developer Industrial' identity: dark Tokyo-night bg, mono-
+     first chrome, neon green accent + magenta secondary, scanline mesh. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <radialGradient id="mesh-green" cx="0%" cy="0%" r="60%">
+      <stop offset="0%"   stop-color="#3FB950" stop-opacity="0.15"/>
+      <stop offset="100%" stop-color="#3FB950" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="mesh-pink" cx="100%" cy="100%" r="60%">
+      <stop offset="0%"   stop-color="#F778BA" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#F778BA" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="scanline" x="0" y="0" width="4" height="4" patternUnits="userSpaceOnUse">
+      <line x1="0" y1="3" x2="4" y2="3" stroke="#FFFFFF" stroke-width="0.5" opacity="0.03"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="630" fill="#0D1117"/>
+  <rect width="1200" height="630" fill="url(#mesh-green)"/>
+  <rect width="1200" height="630" fill="url(#mesh-pink)"/>
+  <rect width="1200" height="630" fill="url(#scanline)"/>
+  <text x="80" y="180" font-family="'JetBrains Mono', monospace" font-size="48" font-weight="500" fill="#3FB950">$ re-frame2</text>
+  <text x="80" y="340" font-family="'JetBrains Mono', monospace" font-size="112" font-weight="800" letter-spacing="-0.02em" fill="#E6EDF3">examples</text>
+  <text x="80" y="400" font-family="'IBM Plex Sans', sans-serif" font-size="34" fill="#9DA8B6">Helix · worked examples for the modern Clojure framework</text>
+  <line x1="80" y1="450" x2="220" y2="450" stroke="#3FB950" stroke-width="3"/>
+  <text x="80" y="510" font-family="'JetBrains Mono', monospace" font-size="22" fill="#9DA8B6" letter-spacing="0.16em">HELIX · DEVELOPER INDUSTRIAL</text>
+  <g transform="translate(1010,80)">
+    <rect width="100" height="100" rx="3" fill="#161B22" stroke="#3FB950" stroke-width="1"/>
+    <text x="50" y="68" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-size="56" font-weight="800" fill="#E6EDF3">r2</text>
+    <rect x="20" y="82" width="60" height="3" rx="1" fill="#3FB950"/>
+  </g>
+</svg>

--- a/examples/_shared/img/og-reagent.svg
+++ b/examples/_shared/img/og-reagent.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Open Graph card · Reagent substrate (rf2-3zibv).
+     1200×630 — standard Twitter / Facebook / LinkedIn aspect ratio.
+     Reagent 'Editorial Warm' identity: warm paper bg, deep ink, sienna
+     accent, Newsreader serif type. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <radialGradient id="grain" cx="20%" cy="30%" r="60%">
+      <stop offset="0%"   stop-color="#C4541C" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#C4541C" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="grain2" cx="78%" cy="70%" r="60%">
+      <stop offset="0%"   stop-color="#D8A24A" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#D8A24A" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="#FAF4EC"/>
+  <rect width="1200" height="630" fill="url(#grain)"/>
+  <rect width="1200" height="630" fill="url(#grain2)"/>
+  <text x="80" y="180" font-family="'Newsreader', Georgia, serif" font-size="64" font-weight="800" fill="#1F1A14">re-frame2</text>
+  <text x="80" y="320" font-family="'Newsreader', Georgia, serif" font-size="108" font-weight="800" fill="#1F1A14">Examples</text>
+  <text x="80" y="380" font-family="'Source Sans 3', sans-serif" font-size="36" fill="#5B5246">Reagent · worked examples for the modern Clojure framework</text>
+  <line x1="80" y1="450" x2="200" y2="450" stroke="#C4541C" stroke-width="4"/>
+  <text x="80" y="510" font-family="ui-monospace, monospace" font-size="22" fill="#877D6D" letter-spacing="0.16em">REAGENT · EDITORIAL WARM</text>
+  <!-- monogram in the corner -->
+  <g transform="translate(1020,80)">
+    <rect width="100" height="100" rx="14" fill="#1F1A14"/>
+    <text x="50" y="68" text-anchor="middle" font-family="'Newsreader', serif" font-size="56" font-weight="800" fill="#FAF4EC">r2</text>
+    <rect x="20" y="82" width="60" height="4" rx="2" fill="#C4541C"/>
+  </g>
+</svg>

--- a/examples/_shared/img/og-uix.svg
+++ b/examples/_shared/img/og-uix.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Open Graph card · UIx substrate (rf2-3zibv).
+     UIx 'Swiss Modern' identity: cool concrete bg, near-black ink,
+     electric cyan accent, hard-offset shadows, tracked uppercase. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <pattern id="dots" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+      <circle cx="0" cy="0" r="1.5" fill="#0A0F14" opacity="0.08"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="630" fill="#EFF2F5"/>
+  <rect width="1200" height="630" fill="url(#dots)"/>
+  <text x="80" y="180" font-family="'Space Grotesk', Helvetica, sans-serif" font-size="64" font-weight="600" fill="#0A0F14">re-frame2</text>
+  <text x="80" y="340" font-family="'Space Grotesk', Helvetica, sans-serif" font-size="128" font-weight="700" letter-spacing="-0.03em" fill="#0A0F14">EXAMPLES</text>
+  <text x="80" y="400" font-family="'Space Grotesk', sans-serif" font-size="36" fill="#4A5560">UIx · worked examples for the modern Clojure framework</text>
+  <rect x="80" y="450" width="120" height="4" fill="#00B4D8"/>
+  <text x="80" y="510" font-family="'Space Mono', monospace" font-size="22" fill="#4A5560" letter-spacing="0.18em">UIX · SWISS MODERN</text>
+  <!-- monogram with hard-offset shadow -->
+  <g transform="translate(1010,80)">
+    <rect x="6" y="6" width="100" height="100" fill="#0A0F14"/>
+    <rect width="100" height="100" fill="#FFFFFF" stroke="#0A0F14" stroke-width="2"/>
+    <text x="50" y="68" text-anchor="middle" font-family="'Space Grotesk', sans-serif" font-size="56" font-weight="700" fill="#0A0F14">r2</text>
+    <rect x="20" y="82" width="60" height="4" fill="#00B4D8"/>
+  </g>
+</svg>

--- a/examples/helix/counter_helix/index.html
+++ b/examples/helix/counter_helix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter (Helix)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0D1117">
+  <meta name="description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: counter (Helix)">
+  <meta property="og:description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:image" content="_shared/img/og-helix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-helix.svg">
   <link rel="stylesheet" href="_shared/css/helix.css">
 </head>
 <body>

--- a/examples/helix/counter_helix/index.html
+++ b/examples/helix/counter_helix/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter (Helix)</title>
+  <link rel="stylesheet" href="_shared/css/helix.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/helix/login_helix/index.html
+++ b/examples/helix/login_helix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (Helix)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0D1117">
+  <meta name="description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: login (Helix)">
+  <meta property="og:description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:image" content="_shared/img/og-helix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-helix.svg">
   <link rel="stylesheet" href="_shared/css/helix.css">
 </head>
 <body>

--- a/examples/helix/login_helix/index.html
+++ b/examples/helix/login_helix/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (Helix)</title>
+  <link rel="stylesheet" href="_shared/css/helix.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/helix/process_monitor_helix/core.cljs
+++ b/examples/helix/process_monitor_helix/core.cljs
@@ -1,0 +1,245 @@
+(ns process-monitor-helix.core
+  "Helix design-led example — 'Process Monitor'. Terminal-style two-pane
+   layout: filterable process list on the left + live log feed on the
+   right, with status tiles across the top. Proves re-frame2 + Helix can
+   build a substantive UI (rf2-t7t6f).
+
+   Demonstrates:
+
+     - Helix components (`defnc`) consuming subs via `use-subscribe`
+     - signal-graph subscriptions (filter chips → visible process list,
+       process selection → relevant log slice)
+     - a recurring `:dispatch-later` tick that appends synthetic log
+       lines (`:monitor/tick`) — proves a real reactive loop, not a
+       static screenshot
+     - per-row dispatch from inside a `defnc` row component
+
+   No HTTP, no state machines — design-led examples per rf2-t7t6f
+   prove polished visuals + interaction, not platform features other
+   examples already cover. Distinct shape from the Reagent 'Notebook'
+   (3-pane editor) and UIx 'Atlas' dashboard (cards + sparklines).
+
+   The Developer-Industrial visual identity comes from
+   examples/_shared/css/helix.css (rf2-nfg15)."
+  (:require ["react-dom/client" :as react-dom-client]
+            [helix.core         :refer [$ defnc]]
+            [helix.dom          :as d]
+            [helix.hooks        :as helix-hooks]
+            [re-frame.core      :as rf]
+            [re-frame.adapter.helix :as helix-adapter]))
+
+;; ============================================================================
+;; SEED DATA
+;; ============================================================================
+
+(def initial-processes
+  [{:id :web        :name "web-frontend"   :status :running :cpu 12.4 :mem 184  :pid 13287}
+   {:id :api        :name "api-gateway"    :status :running :cpu 38.2 :mem 412  :pid 13288}
+   {:id :db         :name "postgres"       :status :running :cpu  6.1 :mem 856  :pid 13289}
+   {:id :cache      :name "redis"          :status :running :cpu  2.0 :mem  64  :pid 13290}
+   {:id :worker     :name "task-worker"    :status :warn    :cpu 71.5 :mem 312  :pid 13291}
+   {:id :search     :name "search-indexer" :status :running :cpu 22.7 :mem 248  :pid 13292}
+   {:id :scheduler  :name "scheduler"      :status :running :cpu  1.2 :mem  48  :pid 13293}
+   {:id :legacy     :name "legacy-export"  :status :down    :cpu  0.0 :mem   0  :pid 13294}])
+
+(def initial-logs
+  [{:t 0  :pid 13287 :lvl :info  :msg "GET / 200 14ms"}
+   {:t 1  :pid 13288 :lvl :info  :msg "POST /v1/users 201 38ms"}
+   {:t 2  :pid 13291 :lvl :warn  :msg "queue depth high: 412 jobs pending"}
+   {:t 3  :pid 13289 :lvl :info  :msg "checkpoint complete (2.4G, 184ms)"}
+   {:t 4  :pid 13288 :lvl :info  :msg "GET /v1/orders 200 22ms"}
+   {:t 5  :pid 13294 :lvl :error :msg "connection refused: legacy-export → s3"}
+   {:t 6  :pid 13287 :lvl :info  :msg "GET /static/main.css 304 4ms"}
+   {:t 7  :pid 13292 :lvl :info  :msg "indexed 144 docs (412ms)"}
+   {:t 8  :pid 13290 :lvl :info  :msg "cache hit rate 94.2%"}
+   {:t 9  :pid 13288 :lvl :info  :msg "POST /v1/auth/login 200 51ms"}
+   {:t 10 :pid 13291 :lvl :warn  :msg "worker pool saturated 8/8"}])
+
+;; ============================================================================
+;; EVENTS
+;; ============================================================================
+
+(rf/reg-event-fx :monitor/initialise
+  (fn [_ctx _event]
+    {:db {:monitor/processes initial-processes
+          :monitor/logs      initial-logs
+          :monitor/clock     11
+          :monitor/level-filter #{:info :warn :error}
+          :monitor/selected   nil}
+     :fx [[:dispatch-later {:ms 1800 :event [:monitor/tick]}]]}))
+
+(rf/reg-event-fx :monitor/tick
+  (fn [{:keys [db]} _event]
+    (let [t   (:monitor/clock db)
+          procs (:monitor/processes db)
+          ;; Pick a random process for the synthetic log line.
+          proc  (nth procs (mod t (count procs)))
+          lvl   (cond
+                  (= :down (:status proc))    :error
+                  (and (= :warn (:status proc))
+                       (zero? (mod t 3)))      :warn
+                  (zero? (mod t 7))            :warn
+                  :else                        :info)
+          phrases [(str "GET /v1/" (name (:id proc)) " 200 " (+ 8 (mod t 40)) "ms")
+                   (str "POST /v1/" (name (:id proc)) "/event 202 " (+ 12 (mod t 30)) "ms")
+                   (str "queue " (:name proc) " depth=" (mod t 50))
+                   (str "checkpoint " (:name proc) " " (+ 100 (mod t 200)) "ms")]
+          msg   (nth phrases (mod t (count phrases)))
+          new   {:t t :pid (:pid proc) :lvl lvl :msg msg}]
+      {:db (-> db
+               (update :monitor/logs (fn [logs]
+                                       (vec (take-last 60 (conj logs new)))))
+               (update :monitor/clock inc))
+       :fx [[:dispatch-later {:ms 1800 :event [:monitor/tick]}]]})))
+
+(rf/reg-event-db :monitor/toggle-level
+  (fn [db [_ lvl]]
+    (update db :monitor/level-filter
+            (fn [s] (if (contains? s lvl) (disj s lvl) (conj s lvl))))))
+
+(rf/reg-event-db :monitor/select-process
+  (fn [db [_ id]]
+    (assoc db :monitor/selected
+              (if (= id (:monitor/selected db)) nil id))))
+
+;; ============================================================================
+;; SUBSCRIPTIONS
+;; ============================================================================
+
+(rf/reg-sub :monitor/processes
+  (fn [db _] (:monitor/processes db)))
+
+(rf/reg-sub :monitor/logs
+  (fn [db _] (:monitor/logs db)))
+
+(rf/reg-sub :monitor/level-filter
+  (fn [db _] (:monitor/level-filter db)))
+
+(rf/reg-sub :monitor/selected
+  (fn [db _] (:monitor/selected db)))
+
+(rf/reg-sub :monitor/totals
+  :<- [:monitor/processes]
+  (fn [procs _]
+    {:running (count (filter #(= :running (:status %)) procs))
+     :warn    (count (filter #(= :warn (:status %)) procs))
+     :down    (count (filter #(= :down (:status %)) procs))
+     :cpu     (reduce + 0 (map :cpu procs))
+     :mem     (reduce + 0 (map :mem procs))}))
+
+(rf/reg-sub :monitor/visible-logs
+  :<- [:monitor/logs]
+  :<- [:monitor/level-filter]
+  :<- [:monitor/selected]
+  :<- [:monitor/processes]
+  (fn [[logs lvls sel procs] _]
+    (let [sel-pid (when sel
+                    (some #(when (= (:id %) sel) (:pid %)) procs))]
+      (->> logs
+           (filter #(contains? lvls (:lvl %)))
+           (filter #(or (nil? sel-pid) (= (:pid %) sel-pid)))
+           (take-last 40)
+           reverse))))
+
+;; ============================================================================
+;; VIEWS (Helix — defnc)
+;; ============================================================================
+
+(defnc tile [{:keys [label value tone]}]
+  (d/div {:class (str "pm-tile pm-tile-" (when tone (name tone)))}
+    (d/div {:class "pm-tile-label"} label)
+    (d/div {:class "pm-tile-value"} value)))
+
+(defnc tiles []
+  (let [t (helix-adapter/use-subscribe [:monitor/totals])]
+    (d/div {:class "pm-tiles"}
+      ($ tile {:label "Running" :value (:running t) :tone :good})
+      ($ tile {:label "Warning" :value (:warn t)    :tone :warn})
+      ($ tile {:label "Down"    :value (:down t)    :tone :bad})
+      ($ tile {:label "Σ CPU"   :value (str (.toFixed (:cpu t) 1) "%")})
+      ($ tile {:label "Σ MEM"   :value (str (:mem t) "M")}))))
+
+(defnc level-chips []
+  (let [active   (helix-adapter/use-subscribe [:monitor/level-filter])
+        dispatch (rf/dispatcher)]
+    (d/div {:class "pm-chips"}
+      (for [lvl [:info :warn :error]]
+        (d/button {:key   (name lvl)
+                   :class (str "pm-chip pm-chip-" (name lvl)
+                               (when (contains? active lvl) " is-on"))
+                   :data-testid (str "monitor-chip-" (name lvl))
+                   :on-click #(dispatch [:monitor/toggle-level lvl])}
+          (name lvl))))))
+
+(defnc process-row [{:keys [p selected?]}]
+  (let [dispatch (rf/dispatcher)
+        {:keys [id name status cpu mem pid]} p
+        cpu-pct (min 100 cpu)]
+    (d/li {:class (str "pm-row"
+                       " pm-row-" (clojure.core/name status)
+                       (when selected? " is-selected"))
+           :data-testid (str "monitor-row-" (clojure.core/name id))
+           :on-click #(dispatch [:monitor/select-process id])}
+      (d/span {:class (str "pm-dot pm-dot-" (clojure.core/name status))})
+      (d/span {:class "pm-row-name"} name)
+      (d/span {:class "pm-row-pid"} (str "[" pid "]"))
+      (d/div  {:class "pm-row-meter"}
+        (d/div {:class "pm-row-bar"
+                :style {:width (str cpu-pct "%")}}))
+      (d/span {:class "pm-row-cpu"} (str (.toFixed cpu 1) "%"))
+      (d/span {:class "pm-row-mem"} (str mem "M")))))
+
+(defnc process-list []
+  (let [procs (helix-adapter/use-subscribe [:monitor/processes])
+        sel   (helix-adapter/use-subscribe [:monitor/selected])]
+    (d/section {:class "pm-pane pm-pane-procs"}
+      (d/header {:class "pm-pane-head"}
+        (d/h3 "processes")
+        (d/span {:class "pm-pane-hint"} "click to filter logs"))
+      (d/ul {:class "pm-list"
+             :data-testid "monitor-process-list"}
+        (for [p procs]
+          ($ process-row {:key (:id p) :p p :selected? (= sel (:id p))}))))))
+
+(defnc log-row [{:keys [e]}]
+  (let [{:keys [t pid lvl msg]} e]
+    (d/li {:class (str "pm-log pm-log-" (name lvl))}
+      (d/span {:class "pm-log-t"}   (str "t=" t))
+      (d/span {:class "pm-log-pid"} (str "[" pid "]"))
+      (d/span {:class (str "pm-log-lvl pm-log-lvl-" (name lvl))} (name lvl))
+      (d/span {:class "pm-log-msg"} msg))))
+
+(defnc log-stream []
+  (let [entries (helix-adapter/use-subscribe [:monitor/visible-logs])]
+    (d/section {:class "pm-pane pm-pane-logs"}
+      (d/header {:class "pm-pane-head"}
+        (d/h3 "log stream")
+        ($ level-chips))
+      (d/ul {:class "pm-loglist"
+             :data-testid "monitor-log-list"}
+        (for [e entries]
+          ($ log-row {:key (str (:t e) "-" (:pid e)) :e e}))))))
+
+(defnc monitor []
+  (d/div {:class "pm-shell"}
+    (d/header {:class "pm-shell-head"}
+      (d/div {:class "pm-brand"}
+        (d/span {:class "pm-prompt"} "$ ")
+        (d/h1 "process-monitor")
+        (d/span {:class "pm-substrate"} " — helix · industrial"))
+      ($ tiles))
+    (d/main {:class "pm-grid"}
+      ($ process-list)
+      ($ log-stream))))
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce root
+  (react-dom-client/createRoot (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! helix-adapter/adapter)
+  (rf/dispatch-sync [:monitor/initialise])
+  (.render root ($ monitor)))

--- a/examples/helix/process_monitor_helix/index.html
+++ b/examples/helix/process_monitor_helix/index.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: process-monitor (Helix · design-led)</title>
+  <link rel="stylesheet" href="_shared/css/helix.css">
+  <style>
+    /* Per-example layout — process-monitor shell. Tokens come from
+       _shared/css/helix.css (hx-* CSS variables). */
+    .pm-shell {
+      min-height: 100vh;
+      display: flex; flex-direction: column;
+      background: var(--hx-bg);
+    }
+    .pm-shell-head {
+      padding: 1.5em 2em 1em;
+      border-bottom: 1px solid var(--hx-rule-strong);
+      display: flex; flex-direction: column; gap: 1.2em;
+    }
+    .pm-brand { display: flex; align-items: baseline; gap: 0.2em; }
+    .pm-prompt { color: var(--hx-green); font-family: var(--hx-mono);
+                 font-weight: 700; font-size: 1.6rem; }
+    .pm-shell-head h1 {
+      font-family: var(--hx-mono);
+      font-size: 1.6rem;
+      margin: 0;
+      letter-spacing: -0.01em;
+    }
+    .pm-shell-head h1::before { content: ''; }
+    .pm-substrate {
+      font-family: var(--hx-mono);
+      color: var(--hx-ink-muted);
+      font-size: 0.9rem;
+    }
+
+    .pm-tiles { display: grid; grid-template-columns: repeat(5, 1fr); gap: 0.75em; }
+    .pm-tile {
+      background: var(--hx-bg-surface);
+      border: 1px solid var(--hx-rule-strong);
+      border-radius: 4px;
+      padding: 0.6em 0.9em;
+      font-family: var(--hx-mono);
+    }
+    .pm-tile-label {
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.7rem;
+      color: var(--hx-ink-muted);
+      margin-bottom: 4px;
+    }
+    .pm-tile-value { font-size: 1.4rem; font-weight: 700; color: var(--hx-ink); }
+    .pm-tile-good { border-left: 3px solid var(--hx-green); }
+    .pm-tile-good .pm-tile-value { color: var(--hx-green); }
+    .pm-tile-warn { border-left: 3px solid var(--hx-amber); }
+    .pm-tile-warn .pm-tile-value { color: var(--hx-amber); }
+    .pm-tile-bad  { border-left: 3px solid var(--hx-red); }
+    .pm-tile-bad  .pm-tile-value { color: var(--hx-red); }
+
+    .pm-grid {
+      flex: 1;
+      display: grid;
+      grid-template-columns: minmax(380px, 1fr) 1.6fr;
+      gap: 0;
+      min-height: 0;
+    }
+
+    .pm-pane {
+      display: flex; flex-direction: column;
+      border-right: 1px solid var(--hx-rule-strong);
+      min-width: 0;
+    }
+    .pm-pane:last-child { border-right: 0; }
+
+    .pm-pane-head {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 0.9em 1.2em;
+      border-bottom: 1px solid var(--hx-rule);
+      background: var(--hx-bg-surface);
+    }
+    .pm-pane-head h3 {
+      font-family: var(--hx-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.16em;
+      color: var(--hx-green);
+      font-size: 0.78rem;
+      margin: 0;
+    }
+    .pm-pane-head h3::before { content: ''; }
+    .pm-pane-hint {
+      font-family: var(--hx-mono);
+      color: var(--hx-ink-faint);
+      font-size: 0.74rem;
+    }
+
+    .pm-chips { display: flex; gap: 6px; }
+    .pm-chip {
+      font-family: var(--hx-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.7rem;
+      font-weight: 700;
+      padding: 4px 10px;
+      border: 1px solid var(--hx-rule-strong);
+      background: transparent;
+      color: var(--hx-ink-muted);
+      cursor: pointer;
+      border-radius: 2px;
+      transition: color 100ms ease, border-color 100ms ease;
+    }
+    .pm-chip:hover { color: var(--hx-ink); border-color: var(--hx-ink-muted); }
+    .pm-chip-info.is-on  { color: var(--hx-cyan);    border-color: var(--hx-cyan); }
+    .pm-chip-warn.is-on  { color: var(--hx-amber);   border-color: var(--hx-amber); }
+    .pm-chip-error.is-on { color: var(--hx-red);     border-color: var(--hx-red); }
+
+    .pm-list {
+      list-style: none; padding: 0; margin: 0;
+      overflow-y: auto; flex: 1;
+    }
+    .pm-row {
+      display: grid;
+      grid-template-columns: 12px minmax(0,1fr) 70px 80px 56px 56px;
+      gap: 8px; align-items: center;
+      padding: 0.55em 1.2em;
+      border-bottom: 1px solid var(--hx-rule);
+      cursor: pointer;
+      font-family: var(--hx-mono);
+      font-size: 0.86rem;
+      transition: background 80ms ease;
+    }
+    .pm-row:hover { background: var(--hx-bg-surface); }
+    .pm-row.is-selected {
+      background: var(--hx-bg-elevated);
+      box-shadow: inset 3px 0 0 var(--hx-green);
+    }
+    .pm-row-name { color: var(--hx-ink); font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .pm-row-pid  { color: var(--hx-ink-faint); }
+    .pm-row-cpu, .pm-row-mem { color: var(--hx-ink-muted); text-align: right; }
+    .pm-row-meter {
+      height: 6px;
+      background: var(--hx-rule);
+      border-radius: 1px;
+      overflow: hidden;
+    }
+    .pm-row-bar { height: 100%; background: var(--hx-green); transition: width 200ms ease; }
+    .pm-row-warn .pm-row-bar { background: var(--hx-amber); }
+    .pm-row-down .pm-row-bar { background: var(--hx-red); }
+
+    .pm-dot {
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--hx-ink-faint);
+      box-shadow: 0 0 6px currentColor;
+    }
+    .pm-dot-running { background: var(--hx-green); color: var(--hx-green); }
+    .pm-dot-warn    { background: var(--hx-amber); color: var(--hx-amber); }
+    .pm-dot-down    { background: var(--hx-red);   color: var(--hx-red); }
+
+    .pm-loglist {
+      list-style: none; padding: 0; margin: 0;
+      overflow-y: auto; flex: 1;
+      background: var(--hx-bg);
+    }
+    .pm-log {
+      display: grid;
+      grid-template-columns: 60px 80px 60px 1fr;
+      gap: 10px;
+      padding: 0.35em 1.2em;
+      font-family: var(--hx-mono);
+      font-size: 0.84rem;
+      border-bottom: 1px dotted var(--hx-rule);
+    }
+    .pm-log-t   { color: var(--hx-ink-faint); }
+    .pm-log-pid { color: var(--hx-ink-muted); }
+    .pm-log-lvl {
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .pm-log-lvl-info  { color: var(--hx-cyan); }
+    .pm-log-lvl-warn  { color: var(--hx-amber); }
+    .pm-log-lvl-error { color: var(--hx-red); }
+    .pm-log-msg { color: var(--hx-ink); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/helix/process_monitor_helix/index.html
+++ b/examples/helix/process_monitor_helix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: process-monitor (Helix · design-led)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0D1117">
+  <meta name="description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: process-monitor (Helix · design-led)">
+  <meta property="og:description" content="re-frame2 worked example — Helix substrate, 'Developer Industrial' identity.">
+  <meta property="og:image" content="_shared/img/og-helix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-helix.svg">
   <link rel="stylesheet" href="_shared/css/helix.css">
   <style>
     /* Per-example layout — process-monitor shell. Tokens come from

--- a/examples/helix/process_monitor_helix/process_monitor_helix.spec.cjs
+++ b/examples/helix/process_monitor_helix/process_monitor_helix.spec.cjs
@@ -1,0 +1,49 @@
+/*
+ * process-monitor-helix — Helix design-led example smoke (rf2-t7t6f).
+ *
+ * Terminal-style process monitor (status tiles + filterable process
+ * list + live log feed with a recurring :dispatch-later tick). The
+ * smoke proves:
+ *
+ *   1. Initial render mounts all eight processes.
+ *   2. The recurring tick (1800ms cadence) appends to the log feed —
+ *      a 4-second window lets it fire at least once even on slow CI.
+ *   3. Clicking a process row narrows the log feed to that PID;
+ *      clicking it again clears the filter.
+ */
+const { expectVisible, expectCount, waitForValue } =
+  require('../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'process-monitor-helix smoke (Helix · design-led)',
+  url:  '/process-monitor-helix/',
+  run:  async (page) => {
+    const list = page.locator('[data-testid="monitor-process-list"]');
+    await expectVisible(list, 10000);
+
+    const rows = page.locator('[data-testid^="monitor-row-"]');
+    await expectCount(rows, 8, 10000);
+
+    // The tick cadence is 1800ms. Read the initial log length, then
+    // wait for it to grow.
+    const logs = page.locator('[data-testid="monitor-log-list"] > li');
+    const initialN = await logs.count();
+    await waitForValue(
+      async () => await logs.count(),
+      (n) => n > initialN,
+      { intervalMs: 200, timeoutMs: 6000, description: 'log feed to grow' },
+    );
+
+    // Select the :web row — log feed narrows. The initial seed log
+    // contains a t=0 GET for pid 13287; pinning to :web (pid 13287)
+    // should leave at least one entry visible.
+    await page.locator('[data-testid="monitor-row-web"]').click();
+    // Allow the next tick to fire so the narrowed feed has something
+    // to display even if all initial t<11 entries scrolled off.
+    await waitForValue(
+      async () => await logs.count(),
+      (n) => n >= 1,
+      { intervalMs: 200, timeoutMs: 4000, description: 'narrowed log feed non-empty' },
+    );
+  },
+};

--- a/examples/reagent/7Guis/cells/cells.html
+++ b/examples/reagent/7Guis/cells/cells.html
@@ -3,16 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #7 — Cells</title>
-  <style>
-    .cells-grid { border-collapse: collapse; font-family: monospace; }
-    .cells-grid th, .cells-grid td {
-      border: 1px solid #ccc; min-width: 60px; height: 22px;
-      padding: 1px 4px; text-align: left; vertical-align: middle;
-    }
-    .cells-grid thead th { background: #eee; text-align: center; }
-    .cells-grid tbody th  { background: #eee; text-align: right; min-width: 28px; }
-    .cells-grid input { width: 56px; box-sizing: border-box; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/7Guis/cells/cells.html
+++ b/examples/reagent/7Guis/cells/cells.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #7 — Cells</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #7 — Cells">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.html
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #6 — Circle Drawer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #6 — Circle Drawer">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/circle_drawer/circle_drawer.html
+++ b/examples/reagent/7Guis/circle_drawer/circle_drawer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #6 — Circle Drawer</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/7Guis/crud/crud.html
+++ b/examples/reagent/7Guis/crud/crud.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #5 — CRUD</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #5 — CRUD">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/crud/crud.html
+++ b/examples/reagent/7Guis/crud/crud.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #5 — CRUD</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/7Guis/flight_booker/flight_booker.html
+++ b/examples/reagent/7Guis/flight_booker/flight_booker.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #3 — flight booker</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #3 — flight booker">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/flight_booker/flight_booker.html
+++ b/examples/reagent/7Guis/flight_booker/flight_booker.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #3 — flight booker</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/7Guis/temperature/temperature.html
+++ b/examples/reagent/7Guis/temperature/temperature.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #2 — temperature</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #2 — temperature">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/temperature/temperature.html
+++ b/examples/reagent/7Guis/temperature/temperature.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #2 — temperature</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/7Guis/timer/timer.html
+++ b/examples/reagent/7Guis/timer/timer.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #4 — timer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: 7guis #4 — timer">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/7Guis/timer/timer.html
+++ b/examples/reagent/7Guis/timer/timer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: 7guis #4 — timer</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/boot/index.html
+++ b/examples/reagent/boot/index.html
@@ -3,20 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: boot (Pattern-Boot)</title>
-  <style>
-    body { font-family: sans-serif; margin: 0; padding: 24px; max-width: 720px; }
-    h1 { font-size: 1.4rem; margin-top: 0; }
-    h2 { font-size: 1.05rem; margin: 16px 0 4px; color: #333; }
-    .boot-progress { padding: 16px; background: #f5f7fa; border-left: 4px solid #5cb85c; }
-    .boot-failed   { padding: 16px; background: #fdf3f3; border-left: 4px solid #d9534f; }
-    .main-app section { padding: 8px 0; border-top: 1px solid #eee; }
-    .boot-hint { color: #777; font-size: 0.85rem; }
-    dl { display: grid; grid-template-columns: max-content 1fr; gap: 4px 12px; margin: 0; }
-    dt { font-weight: 600; color: #555; }
-    dd { margin: 0; }
-    code { background: #eef; padding: 1px 4px; border-radius: 3px; }
-    button { padding: 6px 12px; cursor: pointer; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/boot/index.html
+++ b/examples/reagent/boot/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: boot (Pattern-Boot)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: boot (Pattern-Boot)">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -3,20 +3,14 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter</title>
-  <style>
-    body { margin: 0; font-family: sans-serif; }
-    .rf2-testbed-shell { display: flex; min-height: 100vh; }
-    /* `--rf-causa-inline-width` is Causa's documented host-resize knob
+  <link rel="stylesheet" href="_shared/css/reagent.css">
+  <!-- `--rf-causa-inline-width` is Causa's documented host-resize knob
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var
        and spec/011-Launch-Modes.md §Resizing the inline host). Override
        the property anywhere up the cascade to resize the panel without
        JS or a fork of this rule. The user-draggable resize handle is
        auto-injected by Causa (rf2-70u8q; spec/007-UX-IA.md §Resize
-       affordance) — no `resize: horizontal` / `overflow: auto` needed. */
-    :root { --rf-causa-accent: #7C5CFF; }
-    [data-rf-causa-host] { flex: 0 0 var(--rf-causa-inline-width, 560px); min-width: 320px; box-sizing: border-box; border-left: 1px solid #2a2a2a; }
-    #app { flex: 1; min-width: 0; padding: 2em; }
-  </style>
+       affordance) — no `resize: horizontal` / `overflow: auto` needed. -->
 </head>
 <body>
   <div class="rf2-testbed-shell">

--- a/examples/reagent/counter/index.html
+++ b/examples/reagent/counter/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: counter">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
   <!-- `--rf-causa-inline-width` is Causa's documented host-resize knob
        (rf2-um813; see day8.re-frame2-causa.config/default-layout-host-css-var

--- a/examples/reagent/counter_slim_and_fast/index.html
+++ b/examples/reagent/counter_slim_and_fast/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter-slim-and-fast</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/counter_slim_and_fast/index.html
+++ b/examples/reagent/counter_slim_and_fast/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter-slim-and-fast</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: counter-slim-and-fast">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/login/index.html
+++ b/examples/reagent/login/index.html
@@ -3,14 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (state-machine demo)</title>
-  <style>
-    body { font-family: sans-serif; margin: 2em; }
-    .login-form { display: flex; flex-direction: column; gap: 8px; max-width: 320px; }
-    .login-form input { padding: 6px; }
-    .login-form button { padding: 6px 12px; }
-    .error { color: #c33; }
-    .banner { margin-top: 1em; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/login/index.html
+++ b/examples/reagent/login/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (state-machine demo)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: login (state-machine demo)">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/long_running_work/index.html
+++ b/examples/reagent/long_running_work/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: long-running work</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: long-running work">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/long_running_work/index.html
+++ b/examples/reagent/long_running_work/index.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: long-running work</title>
-  <style>
-    body { font-family: sans-serif; margin: 0; padding: 0; background: #fafafa; }
-    button { padding: 6px 12px; cursor: pointer; }
-    button[disabled] { cursor: not-allowed; opacity: 0.5; }
-    code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/managed_http_counter/index.html
+++ b/examples/reagent/managed_http_counter/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: managed-http-counter</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/managed_http_counter/index.html
+++ b/examples/reagent/managed_http_counter/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: managed-http-counter</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: managed-http-counter">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/nine_states/index.html
+++ b/examples/reagent/nine_states/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: nine states</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: nine states">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/nine_states/index.html
+++ b/examples/reagent/nine_states/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: nine states</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/notebook/core.cljs
+++ b/examples/reagent/notebook/core.cljs
@@ -1,0 +1,265 @@
+(ns notebook.core
+  "Reagent design-led example — 'Notebook'. Three-pane editorial layout:
+
+     [ documents tree ]  [ markdown editor ]  [ live preview ]
+
+   Proves re-frame2 + Reagent can build a substantive UI (rf2-t7t6f). The
+   data-flow is the canonical six dominoes:
+
+     - selecting a document         dispatches  [:notebook/select id]
+     - editing the body             dispatches  [:notebook/edit-body text]
+     - the body sub                 derives     parsed-html from the markdown
+     - the preview pane             subscribes  to that derivation
+
+   Distinguished from the canonical login + counter examples by being
+   `reg-view`-based at every layer, exercising multi-pane layout, and
+   leaning into the Reagent 'Editorial Warm' visual identity from
+   examples/_shared/css/reagent.css (rf2-nfg15). No state machines, no
+   HTTP — the design-led examples per rf2-t7t6f exist to prove polished
+   visuals + interaction, not to replay the platform features other
+   examples already cover.
+
+   Markdown rendering is intentionally a tiny pure-CLJS parser (headings,
+   bold, italic, links, paragraphs, lists) — keeps the bundle small and
+   the example free of an extra npm dependency."
+  (:require [reagent.dom.client :as rdc]
+            [clojure.string     :as str]
+            [re-frame.core      :as rf]
+            [re-frame.views]
+            [re-frame.adapter.reagent :as reagent-adapter])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ============================================================================
+;; SEED DATA
+;; ============================================================================
+
+(def initial-documents
+  [{:id    :welcome
+    :title "Welcome"
+    :body  "# Welcome to the notebook\n\nThis is a *design-led* example that demonstrates the **Reagent** substrate of re-frame2.\n\nIt lives at `examples/reagent/notebook/` and renders a three-pane editor.\n\n- Pick a document from the left.\n- Edit the body in the middle.\n- Read the preview on the right.\n\nVisit [day8.re-frame2](https://github.com/day8/re-frame2) for more."}
+   {:id    :six-dominoes
+    :title "The six dominoes"
+    :body  "## The dominoes\n\n1. **Event** dispatch\n2. **Event** handler\n3. **Effects** application\n4. **Query** layer (subs)\n5. **View** layer\n6. **Re-render**\n\nThe re-frame2 spec lives in *spec/*.\n\nEach domino is *pure* in isolation. Only domino 3 touches the world."}
+   {:id    :patterns
+    :title "Patterns"
+    :body  "### Patterns shipped with re-frame2\n\n- Pattern-Boot — application initialisation as a state machine.\n- Pattern-WebSocket — connection machine with backoff + queue-flush.\n- Pattern-LongRunningWork — :invoke-all spawn-and-join.\n- Pattern-Managed-HTTP — declarative HTTP with cancellation.\n\nEach has a worked example under `examples/reagent/`."}])
+
+;; ============================================================================
+;; EVENTS  (CP-1)
+;; ============================================================================
+
+(rf/reg-event-db :notebook/initialise
+  (fn [_db _event]
+    {:notebook/documents   initial-documents
+     :notebook/selected-id :welcome}))
+
+(rf/reg-event-db :notebook/select
+  (fn [db [_ id]]
+    (assoc db :notebook/selected-id id)))
+
+(rf/reg-event-db :notebook/edit-body
+  (fn [db [_ text]]
+    (let [id (:notebook/selected-id db)]
+      (update db :notebook/documents
+              (fn [docs]
+                (mapv (fn [d]
+                        (if (= (:id d) id) (assoc d :body text) d))
+                      docs))))))
+
+(rf/reg-event-db :notebook/new
+  (fn [db _event]
+    (let [id (keyword (str "doc-" (rand-int 1000000)))
+          doc {:id id :title "Untitled" :body "# Untitled\n\nStart writing…"}]
+      (-> db
+          (update :notebook/documents (fnil conj []) doc)
+          (assoc :notebook/selected-id id)))))
+
+;; ============================================================================
+;; SUBSCRIPTIONS  (CP-2)
+;; ============================================================================
+
+(rf/reg-sub :notebook/documents
+  (fn [db _] (:notebook/documents db)))
+
+(rf/reg-sub :notebook/selected-id
+  (fn [db _] (:notebook/selected-id db)))
+
+(rf/reg-sub :notebook/selected
+  :<- [:notebook/documents]
+  :<- [:notebook/selected-id]
+  (fn [[docs id] _]
+    (first (filter #(= (:id %) id) docs))))
+
+(rf/reg-sub :notebook/selected-body
+  :<- [:notebook/selected]
+  (fn [doc _] (or (:body doc) "")))
+
+;; ============================================================================
+;; MARKDOWN — tiny pure parser → hiccup
+;; ============================================================================
+;;
+;; The parser emits hiccup (vectors of keywords + child vectors) rather
+;; than raw HTML strings — Reagent renders hiccup natively without the
+;; `dangerouslySetInnerHTML` escape hatch, and the example stays free of
+;; an extra npm dependency.
+
+(defn- split-by-regex
+  "Walk `coll` (a flat seq of strings + hiccup-vectors). For each
+   string element, find non-overlapping matches of `re`; each match
+   produces a hiccup element via `(mk match)`. Return a new flat seq
+   with strings split around matches and matches replaced. Non-string
+   elements (already-parsed hiccup) pass through untouched.
+
+   Robust to the (count parts) ≠ (count matches) ± 1 trap that
+   bit the first pass: we iterate `(re-seq)` and pull `lastIndex`-
+   style substrings from the source manually."
+  [coll re mk]
+  (mapcat
+    (fn [x]
+      (if-not (string? x)
+        [x]
+        (loop [s x, out (transient [])]
+          (if-let [m (re-find re s)]
+            (let [whole (if (sequential? m) (first m) m)
+                  idx   (.indexOf s whole)
+                  before (subs s 0 idx)
+                  after  (subs s (+ idx (count whole)))
+                  out'   (cond-> out
+                           (seq before) (conj! before)
+                           true         (conj! (mk m)))]
+              (recur after out'))
+            (let [out' (cond-> out (seq s) (conj! s))]
+              (persistent! out'))))))
+    coll))
+
+(defn- inline-md->hiccup
+  "Parse one paragraph string into a hiccup seq with inline runs
+   (links, bold, italic, code) split out. Output is a flat seq the
+   caller splices into a parent block element. Rules run sequentially;
+   later passes only see plain-text fragments from earlier passes
+   (already-emitted hiccup vectors pass through untouched)."
+  [s]
+  (-> [s]
+      (split-by-regex #"\[([^\]]+)\]\(([^)]+)\)"
+                      (fn [m] [:a {:href (nth m 2)
+                                   :rel "noopener noreferrer"
+                                   :target "_blank"}
+                                (nth m 1)]))
+      (split-by-regex #"\*\*([^*]+)\*\*"
+                      (fn [m] [:strong (nth m 1)]))
+      (split-by-regex #"\*([^*]+)\*"
+                      (fn [m] [:em (nth m 1)]))
+      (split-by-regex #"`([^`]+)`"
+                      (fn [m] [:code (nth m 1)]))))
+
+(defn- render-block [block]
+  (cond
+    (str/starts-with? block "### ")
+    (into [:h3] (inline-md->hiccup (subs block 4)))
+
+    (str/starts-with? block "## ")
+    (into [:h2] (inline-md->hiccup (subs block 3)))
+
+    (str/starts-with? block "# ")
+    (into [:h1] (inline-md->hiccup (subs block 2)))
+
+    (str/starts-with? block "- ")
+    (into [:ul]
+          (for [line (str/split-lines block)
+                :when (str/starts-with? line "- ")]
+            (into [:li] (inline-md->hiccup (subs line 2)))))
+
+    (re-matches #"(?s)\d+\.\s.*" block)
+    (into [:ol]
+          (for [line (str/split-lines block)
+                :let [m (re-matches #"\d+\.\s+(.*)" line)]
+                :when m]
+            (into [:li] (inline-md->hiccup (second m)))))
+
+    :else
+    (into [:p] (inline-md->hiccup block))))
+
+(defn markdown->hiccup
+  "Tiny pure-CLJS markdown parser: splits on blank lines, dispatches per
+   block-shape, runs inline rules. Sufficient for the example's seed
+   content. Returns a vector of block hiccup that the caller splices
+   into a parent container (Reagent renders this as a seq of children;
+   each block gets a stable :key keyed off its index)."
+  [s]
+  (let [blocks (->> (str/split (or s "") #"\r?\n\r?\n")
+                    (remove str/blank?))]
+    (vec
+      (map-indexed
+        (fn [i b] (with-meta (render-block b) {:key i}))
+        blocks))))
+
+(rf/reg-sub :notebook/selected-hiccup
+  :<- [:notebook/selected-body]
+  (fn [body _] (markdown->hiccup body)))
+
+;; ============================================================================
+;; VIEWS  (CP-4) — Reagent 'Editorial Warm' palette
+;; ============================================================================
+
+(reg-view sidebar []
+  (let [docs        @(subscribe [:notebook/documents])
+        selected-id @(subscribe [:notebook/selected-id])]
+    [:nav.nb-sidebar
+     [:header.nb-sidebar-header
+      [:h2 "Notebook"]
+      [:button.nb-new
+       {:on-click    #(dispatch [:notebook/new])
+        :data-testid "notebook-new"}
+       "+ New"]]
+     [:ul.nb-doc-list
+      (for [d docs]
+        ^{:key (:id d)}
+        [:li
+         [:button.nb-doc-link
+          {:class       (when (= (:id d) selected-id) "active")
+           :data-testid (str "notebook-doc-" (name (:id d)))
+           :on-click    #(dispatch [:notebook/select (:id d)])}
+          [:span.nb-doc-title (:title d)]
+          [:span.nb-doc-meta  (count (or (:body d) "")) " chars"]]])]
+     [:footer.nb-sidebar-footer
+      [:span "Reagent · "] [:em "Editorial Warm"]]]))
+
+(reg-view editor []
+  (let [body @(subscribe [:notebook/selected-body])
+        sel  @(subscribe [:notebook/selected])]
+    [:section.nb-editor
+     [:header.nb-pane-header
+      [:span.nb-eyebrow "Editor"]
+      [:span.nb-doc-title (or (:title sel) "—")]]
+     [:textarea.nb-textarea
+      {:value       body
+       :data-testid "notebook-textarea"
+       :spellCheck  "false"
+       :on-change   #(dispatch [:notebook/edit-body (.. % -target -value)])}]]))
+
+(reg-view preview []
+  (let [blocks @(subscribe [:notebook/selected-hiccup])]
+    [:section.nb-preview
+     [:header.nb-pane-header
+      [:span.nb-eyebrow "Preview"]
+      [:span "Live"]]
+     (into [:article.nb-rendered {:data-testid "notebook-preview"}]
+           (or blocks []))]))
+
+(reg-view notebook []
+  [:div.nb-shell
+   [sidebar]
+   [editor]
+   [preview]])
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (rdc/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! reagent-adapter/adapter)
+  (rf/dispatch-sync [:notebook/initialise])
+  (rdc/render react-root [notebook]))

--- a/examples/reagent/notebook/index.html
+++ b/examples/reagent/notebook/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: notebook (Reagent · design-led)</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
+  <style>
+    /* Per-example layout — the editorial three-pane shell. Tokens come
+       from _shared/css/reagent.css (rg-* CSS variables). */
+    .nb-shell {
+      display: grid;
+      grid-template-columns: 260px 1fr 1fr;
+      min-height: 100vh;
+      background: var(--rg-bg);
+    }
+    .nb-sidebar {
+      background: var(--rg-bg-sunken);
+      border-right: 1px solid var(--rg-rule);
+      padding: 24px 18px;
+      display: flex; flex-direction: column;
+    }
+    .nb-sidebar-header { display: flex; align-items: baseline; justify-content: space-between; }
+    .nb-sidebar-header h2 { font-family: var(--rg-serif); font-size: 1.4rem; margin: 0; }
+    .nb-new {
+      font-size: 0.85rem; padding: 4px 10px;
+      background: transparent; color: var(--rg-sienna);
+      border: 1px solid var(--rg-sienna); box-shadow: none;
+    }
+    .nb-new:hover:not([disabled]) { background: var(--rg-sienna); color: #fff; }
+
+    .nb-doc-list { list-style: none; padding: 0; margin: 18px 0 0; flex: 1; }
+    .nb-doc-list li { margin: 2px 0; }
+    .nb-doc-link {
+      display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
+      width: 100%; padding: 10px 12px; text-align: left;
+      background: transparent; color: var(--rg-ink);
+      border: 1px solid transparent; box-shadow: none;
+      font-family: var(--rg-sans); font-weight: 500; font-size: 0.96rem;
+      border-radius: 6px;
+    }
+    .nb-doc-link:hover:not([disabled]) {
+      background: var(--rg-bg-raised);
+      border-color: var(--rg-rule);
+      color: var(--rg-ink);
+    }
+    .nb-doc-link.active {
+      background: var(--rg-bg-raised);
+      border-color: var(--rg-sienna);
+      box-shadow: inset 3px 0 0 var(--rg-sienna);
+    }
+    .nb-doc-title { font-family: var(--rg-serif); font-weight: 600; }
+    .nb-doc-meta { font-size: 0.78em; color: var(--rg-ink-faint); font-family: var(--rg-mono); }
+
+    .nb-sidebar-footer {
+      margin-top: 18px; padding-top: 12px;
+      border-top: 1px solid var(--rg-rule);
+      color: var(--rg-ink-faint); font-size: 0.82rem;
+    }
+    .nb-sidebar-footer em {
+      color: var(--rg-sienna); font-style: italic; font-family: var(--rg-serif);
+    }
+
+    .nb-editor, .nb-preview {
+      display: flex; flex-direction: column;
+      border-right: 1px solid var(--rg-rule);
+    }
+    .nb-preview { border-right: 0; }
+    .nb-pane-header {
+      display: flex; align-items: baseline; justify-content: space-between;
+      padding: 20px 28px 8px;
+      border-bottom: 1px solid var(--rg-rule);
+    }
+    .nb-eyebrow {
+      text-transform: uppercase; letter-spacing: 0.16em; font-size: 0.72rem;
+      color: var(--rg-ink-faint); font-family: var(--rg-mono);
+    }
+    .nb-pane-header .nb-doc-title { font-family: var(--rg-serif); font-size: 1.1rem; }
+
+    .nb-textarea {
+      flex: 1; width: 100%; padding: 28px;
+      background: var(--rg-bg-raised); color: var(--rg-ink);
+      border: 0; resize: none; outline: none;
+      font-family: var(--rg-mono); font-size: 0.95rem; line-height: 1.65;
+      box-sizing: border-box;
+    }
+    .nb-textarea:focus {
+      background: var(--rg-bg-raised);
+      box-shadow: inset 0 0 0 2px rgba(196,84,28,0.18);
+    }
+
+    .nb-rendered {
+      flex: 1; padding: 28px 34px;
+      overflow-y: auto;
+      font-family: var(--rg-sans);
+      color: var(--rg-ink);
+      background: var(--rg-bg-raised);
+    }
+    .nb-rendered h1 { font-size: 2.1rem; margin: 0 0 0.4em; }
+    .nb-rendered h2 { font-size: 1.4rem; margin: 0.9em 0 0.4em; }
+    .nb-rendered h3 { font-size: 1.1rem; margin: 0.9em 0 0.35em; color: var(--rg-sienna-deep); }
+    .nb-rendered p  { margin: 0 0 1em; max-width: 60ch; }
+    .nb-rendered ul, .nb-rendered ol { padding-left: 1.4em; margin: 0 0 1em; max-width: 60ch; }
+    .nb-rendered li { margin: 4px 0; }
+    .nb-rendered strong { color: var(--rg-sienna-deep); }
+    .nb-rendered em { font-style: italic; }
+    .nb-rendered code {
+      background: var(--rg-bg-sunken);
+      color: var(--rg-sienna-deep);
+      padding: 1px 6px; border-radius: 3px;
+      font-family: var(--rg-mono);
+    }
+
+    /* Narrow viewport: collapse to single column with tabs (skipped here
+       to keep the example small; smoke test runs at desktop width). */
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/reagent/notebook/index.html
+++ b/examples/reagent/notebook/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: notebook (Reagent · design-led)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: notebook (Reagent · design-led)">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
   <style>
     /* Per-example layout — the editorial three-pane shell. Tokens come

--- a/examples/reagent/notebook/notebook.spec.cjs
+++ b/examples/reagent/notebook/notebook.spec.cjs
@@ -1,0 +1,46 @@
+/*
+ * notebook — Reagent design-led example smoke (rf2-t7t6f).
+ *
+ * Three-pane editorial notebook (documents tree + markdown editor +
+ * live preview). The smoke proves:
+ *
+ *   1. Initial render lands the seeded :welcome document — the
+ *      textarea carries the body, the preview renders parsed
+ *      markdown.
+ *   2. Selecting a different doc updates the preview heading
+ *      (the chained sub :selected → :selected-body → :selected-hiccup
+ *      fires).
+ *   3. Editing the body updates the preview (sub re-runs).
+ */
+const { expectVisible, expectTextContains, waitForValue } =
+  require('../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'notebook smoke (Reagent · design-led)',
+  url:  '/notebook/',
+  run:  async (page) => {
+    const textarea = page.locator('[data-testid="notebook-textarea"]');
+    const preview  = page.locator('[data-testid="notebook-preview"]');
+    await expectVisible(textarea, 10000);
+    await expectVisible(preview, 10000);
+
+    // 1. Initial render — :welcome body in textarea, parsed in preview.
+    await waitForValue(
+      async () => await textarea.inputValue(),
+      (v) => v.includes('Welcome to the notebook'),
+      { timeoutMs: 10000, description: 'seeded welcome body in textarea' },
+    );
+    await expectTextContains(preview, 'Welcome to the notebook', 10000);
+
+    // 2. Selecting a different doc updates the preview.
+    await page.locator('[data-testid="notebook-doc-six-dominoes"]').click();
+    await expectTextContains(preview, 'The dominoes');
+
+    // 3. Editing the textarea re-renders the preview. We `fill` the
+    //    textarea with new content (cleanest cross-platform path —
+    //    avoids the `\n` → newline-in-textarea-vs-typed-keypress
+    //    discrepancy between OSes) and assert the new content lands.
+    await textarea.fill('# Hello\n\nSENTINEL-RF2-MARKER');
+    await expectTextContains(preview, 'SENTINEL-RF2-MARKER');
+  },
+};

--- a/examples/reagent/realworld/index.html
+++ b/examples/reagent/realworld/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: realworld (Conduit)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: realworld (Conduit)">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/realworld/index.html
+++ b/examples/reagent/realworld/index.html
@@ -3,15 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: realworld (Conduit)</title>
-  <style>
-    body { font-family: sans-serif; margin: 0; padding: 0; }
-    .navbar, footer { padding: 8px 16px; background: #f5f5f5; }
-    .navbar .nav { display: inline-block; margin-right: 12px; }
-    .nav-link { margin-right: 8px; text-decoration: none; color: #5cb85c; }
-    .container { padding: 12px 16px; }
-    .article-preview { padding: 12px 0; border-bottom: 1px solid #eee; }
-    .article-preview h1 { font-size: 1.2rem; margin: 4px 0; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/routing/index.html
+++ b/examples/reagent/routing/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: routing</title>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/routing/index.html
+++ b/examples/reagent/routing/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: routing</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: routing">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -3,15 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: SSR + hydration</title>
-  <style>
-    body { font-family: sans-serif; margin: 2em; }
-    .page { max-width: 600px; }
-    .toggle-bodies { margin: 0.5em 0 1em; padding: 6px 12px; }
-    h1 { margin-top: 0; }
-    li { margin-bottom: 1em; }
-    h3 { margin: 0 0 0.25em; }
-    p.body { margin: 0; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <!--

--- a/examples/reagent/ssr/index.html
+++ b/examples/reagent/ssr/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: SSR + hydration</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: SSR + hydration">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/ssr_streaming/index.html
+++ b/examples/reagent/ssr_streaming/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: streaming SSR with :rf/suspense-boundary</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: streaming SSR with :rf/suspense-boundary">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/ssr_streaming/index.html
+++ b/examples/reagent/ssr_streaming/index.html
@@ -3,22 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: streaming SSR with :rf/suspense-boundary</title>
-  <style>
-    body { font-family: sans-serif; margin: 2em; max-width: 800px; }
-    header h1 { margin: 0 0 0.25em; }
-    header p { margin: 0; color: #555; }
-    .cards { display: flex; flex-wrap: wrap; gap: 1em; margin-top: 1.5em; }
-    .card {
-      flex: 1 1 220px;
-      border: 1px solid #ccc;
-      border-radius: 6px;
-      padding: 1em;
-    }
-    .card h3 { margin: 0 0 0.5em; font-size: 0.95em; color: #444; }
-    .card p.value { margin: 0; font-size: 1.6em; font-weight: bold; }
-    .card.skeleton { color: #aaa; background: #fafafa; }
-    footer { margin-top: 2em; color: #666; font-size: 0.9em; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <!--

--- a/examples/reagent/state_machine_walkthrough/index.html
+++ b/examples/reagent/state_machine_walkthrough/index.html
@@ -3,17 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: state-machines walkthrough</title>
-  <style>
-    body { font-family: sans-serif; margin: 2em; }
-    .login-form { display: flex; flex-direction: column; gap: 8px; max-width: 320px; }
-    .login-form input { padding: 6px; }
-    .login-form button { padding: 6px 12px; }
-    .banner { margin: 1em 0; padding: 0.5em 1em; background: #f4f4f4; border-radius: 4px; }
-    .banner .state { font-family: monospace; }
-    .error { color: #c33; margin: 0; }
-    .error-row { display: flex; align-items: center; gap: 8px; }
-    .locked { color: #c33; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/state_machine_walkthrough/index.html
+++ b/examples/reagent/state_machine_walkthrough/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: state-machines walkthrough</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: state-machines walkthrough">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/reagent/todomvc/index.html
+++ b/examples/reagent/todomvc/index.html
@@ -4,6 +4,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>re-frame2 TodoMVC</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 TodoMVC">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="base.css">
   <link rel="stylesheet" href="todomvc-app.css">
 </head>

--- a/examples/reagent/websocket/index.html
+++ b/examples/reagent/websocket/index.html
@@ -3,37 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: Pattern-WebSocket</title>
-  <style>
-    body { font-family: sans-serif; margin: 0; padding: 16px; max-width: 880px; }
-    .muted { color: #666; }
-    .status { margin: 8px 0; }
-    .pill {
-      display: inline-block;
-      padding: 4px 10px;
-      border-radius: 12px;
-      font-weight: 600;
-      color: #fff;
-      letter-spacing: 0.04em;
-      font-size: 0.85em;
-    }
-    .pill.disconnected   { background: #888; }
-    .pill.connecting     { background: #2a93d5; }
-    .pill.authenticating { background: #6c5ce7; }
-    .pill.connected      { background: #2ecc71; }
-    .pill.reconnecting   { background: #e67e22; }
-    .pill.failed         { background: #e74c3c; }
-    .error { color: #c0392b; margin-left: 8px; font-family: monospace; font-size: 0.85em; }
-    .lifecycle, .demo-buttons, .send-form { display: flex; gap: 8px; margin: 8px 0; align-items: center; }
-    button { padding: 6px 12px; cursor: pointer; }
-    button[disabled] { opacity: 0.5; cursor: not-allowed; }
-    input[type="text"] { padding: 6px 10px; flex: 1; min-width: 240px; }
-    .queue-depth { color: #555; font-style: italic; font-size: 0.9em; }
-    .inbox ul { font-family: monospace; font-size: 0.85em; max-height: 240px; overflow-y: auto; border: 1px solid #ddd; padding: 8px 8px 8px 28px; }
-    .inbox li { margin: 2px 0; }
-    .last-reply { font-size: 0.85em; }
-    .last-reply code { background: #f3f3f3; padding: 2px 6px; border-radius: 4px; }
-    hr { border: 0; border-top: 1px solid #eee; margin: 16px 0; }
-  </style>
+  <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/reagent/websocket/index.html
+++ b/examples/reagent/websocket/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: Pattern-WebSocket</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#1F1A14">
+  <meta name="description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 example: Pattern-WebSocket">
+  <meta property="og:description" content="re-frame2 worked example — Reagent substrate, 'Editorial Warm' identity.">
+  <meta property="og:image" content="_shared/img/og-reagent.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-reagent.svg">
   <link rel="stylesheet" href="_shared/css/reagent.css">
 </head>
 <body>

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -491,6 +491,19 @@ function copyDirRecursive(src, dest) {
   }
 }
 
+// rf2-jzqs9 — Shared per-substrate stylesheets + favicon + OG assets
+// (rf2-nfg15 / rf2-3zibv). The hand-written index.html files reference
+// these via relative paths like `_shared/css/reagent.css`, so the
+// orchestrator stages the `examples/_shared/` tree into every example's
+// output dir alongside main.js + index.html. Single source on disk; one
+// copy step per build (cheap — a handful of small files).
+const SHARED_SRC = path.join(REPO_ROOT, 'examples', '_shared');
+
+function stageShared(outDir) {
+  if (!fs.existsSync(SHARED_SRC)) return;
+  copyDirRecursive(SHARED_SRC, path.join(outDir, '_shared'));
+}
+
 function stageHtml() {
   // Silent-on-success (rf2-try1x): per-file staging notices are
   // suppressed.  Errors still throw with the offending path.
@@ -517,6 +530,11 @@ function stageHtml() {
     }
     const dest = path.join(ex.outDir, 'index.html');
     fs.copyFileSync(ex.htmlSrc, dest);
+
+    // rf2-jzqs9 — stage examples/_shared/ alongside index.html so the
+    // hand-written page can <link>/<img> assets at the same relative
+    // path on every example build.
+    stageShared(ex.outDir);
 
     for (const extra of ex.extraFiles || []) {
       if (!fs.existsSync(extra.src)) {

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -208,6 +208,14 @@ const EXAMPLES = [
     htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'login', 'index.html'),
     outDir: path.join(OUT_ROOT, 'login'),
   },
+  // rf2-t7t6f — Reagent design-led example. Three-pane editorial
+  // notebook (documents tree + markdown editor + live preview). Pairs
+  // with the Reagent 'Editorial Warm' identity (rf2-nfg15).
+  {
+    build: 'examples/notebook',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'reagent', 'notebook', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'notebook'),
+  },
   // UIx adapter smoke trio (counter + login, realworld skipped).
   // Different folders from the canonical Reagent versions so the
   // bundle-isolation grep can confirm UIx code does NOT appear in
@@ -222,6 +230,14 @@ const EXAMPLES = [
     build: 'examples/login-uix',
     htmlSrc: path.join(REPO_ROOT, 'examples', 'uix', 'login_uix', 'index.html'),
     outDir: path.join(OUT_ROOT, 'login-uix'),
+  },
+  // rf2-t7t6f — UIx design-led example. Analytics dashboard with
+  // status tiles, filter chips, and sparkline metric cards. Pairs with
+  // the UIx 'Swiss Modern' identity (rf2-nfg15).
+  {
+    build: 'examples/dashboard-uix',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'uix', 'dashboard_uix', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'dashboard-uix'),
   },
   // Helix adapter smoke trio (counter + login, realworld skipped —
   // the eight UIx decisions transfer unchanged). Different folders
@@ -238,6 +254,15 @@ const EXAMPLES = [
     build: 'examples/login-helix',
     htmlSrc: path.join(REPO_ROOT, 'examples', 'helix', 'login_helix', 'index.html'),
     outDir: path.join(OUT_ROOT, 'login-helix'),
+  },
+  // rf2-t7t6f — Helix design-led example. Terminal-style process
+  // monitor: status tiles, filterable process list, live log stream
+  // with a recurring :dispatch-later tick. Pairs with the Helix
+  // 'Developer Industrial' identity (rf2-nfg15).
+  {
+    build: 'examples/process-monitor-helix',
+    htmlSrc: path.join(REPO_ROOT, 'examples', 'helix', 'process_monitor_helix', 'index.html'),
+    outDir: path.join(OUT_ROOT, 'process-monitor-helix'),
   },
   {
     build: 'examples/realworld',

--- a/examples/uix/counter_uix/index.html
+++ b/examples/uix/counter_uix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter (UIx)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0A0F14">
+  <meta name="description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:image" content="_shared/img/og-uix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-uix.svg">
   <link rel="stylesheet" href="_shared/css/uix.css">
 </head>
 <body>

--- a/examples/uix/counter_uix/index.html
+++ b/examples/uix/counter_uix/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: counter (UIx)</title>
+  <link rel="stylesheet" href="_shared/css/uix.css">
 </head>
 <body>
   <div id="app"></div>

--- a/examples/uix/dashboard_uix/core.cljs
+++ b/examples/uix/dashboard_uix/core.cljs
@@ -1,0 +1,208 @@
+(ns dashboard-uix.core
+  "UIx design-led example — 'Analytics Dashboard'. A grid of metric cards
+   + sparklines + filter chips. Proves re-frame2 + UIx can build a
+   substantive UI (rf2-t7t6f).
+
+   Demonstrates:
+
+     - UIx components (`defui`) consuming subs via `use-subscribe`
+     - signal-graph subscriptions (per-metric, per-range projections)
+     - inline SVG sparklines computed in pure CLJS — no chart library
+     - filter chips that re-derive the visible card set
+
+   No HTTP, no state machines — the design-led examples per rf2-t7t6f
+   exist to prove polished visuals + interaction, not to replay platform
+   features other examples already cover. Distinct shape from the
+   Reagent 'Notebook' (3-pane editor) and Helix 'Process Monitor'
+   (terminal log viewer) per the cluster prompt — three different
+   substantive UIs, one per substrate.
+
+   The Swiss-modern visual identity comes from examples/_shared/css/uix.css
+   (rf2-nfg15)."
+  (:require [uix.core :as uix :refer [$ defui]]
+            [uix.dom  :as uix-dom]
+            [re-frame.core            :as rf]
+            [re-frame.adapter.uix     :as uix-adapter]))
+
+;; ============================================================================
+;; SEED DATA
+;; ============================================================================
+
+(def initial-metrics
+  ;; Each metric carries a 14-point sparkline series. Numbers are
+  ;; hand-tuned for visual variety; nothing here is computed from a real
+  ;; source — the example proves dataflow + render, not analytics
+  ;; correctness.
+  ;;
+  ;; CLJS doesn't support Clojure's underscore-grouping (1_000) literal
+  ;; syntax; values are bare integers.
+  [{:id :revenue   :label "Revenue"       :value 142375 :unit "$" :delta  0.084 :tag :money
+    :series [108 112 117 121 119 124 128 132 130 135 138 140 142 142]}
+   {:id :signups   :label "New signups"   :value 1286   :unit ""  :delta  0.121 :tag :money
+    :series [820 855 870 905 920 940 985 1010 1040 1090 1140 1180 1230 1286]}
+   {:id :latency   :label "P50 latency"   :value 24     :unit "ms" :delta -0.045 :tag :perf
+    :series [31 30 29 28 28 27 27 26 26 25 25 25 24 24]}
+   {:id :errors    :label "Error rate"    :value 0.42   :unit "%"  :delta -0.073 :tag :perf
+    :series [0.62 0.60 0.58 0.55 0.55 0.52 0.50 0.49 0.48 0.46 0.45 0.44 0.43 0.42]}
+   {:id :dau       :label "DAU"           :value 24180  :unit ""  :delta 0.038 :tag :usage
+    :series [22000 22300 22600 22900 23100 23400 23600 23700 23800 23900 24000 24100 24150 24180]}
+   {:id :sessions  :label "Sessions / DAU" :value 3.8   :unit ""  :delta 0.012 :tag :usage
+    :series [3.4 3.5 3.6 3.6 3.7 3.7 3.7 3.7 3.8 3.8 3.8 3.8 3.8 3.8]}])
+
+(def all-tags
+  [{:id :money :label "Revenue"}
+   {:id :perf  :label "Performance"}
+   {:id :usage :label "Usage"}])
+
+;; ============================================================================
+;; EVENTS
+;; ============================================================================
+
+(rf/reg-event-db :dashboard/initialise
+  (fn [_db _event]
+    {:dashboard/metrics      initial-metrics
+     :dashboard/active-tags  #{:money :perf :usage}
+     :dashboard/range         :w14}))
+
+(rf/reg-event-db :dashboard/toggle-tag
+  (fn [db [_ tag]]
+    (update db :dashboard/active-tags
+            (fn [s] (if (contains? s tag) (disj s tag) (conj s tag))))))
+
+(rf/reg-event-db :dashboard/set-range
+  (fn [db [_ r]]
+    (assoc db :dashboard/range r)))
+
+;; ============================================================================
+;; SUBSCRIPTIONS
+;; ============================================================================
+
+(rf/reg-sub :dashboard/metrics
+  (fn [db _] (:dashboard/metrics db)))
+
+(rf/reg-sub :dashboard/active-tags
+  (fn [db _] (:dashboard/active-tags db)))
+
+(rf/reg-sub :dashboard/range
+  (fn [db _] (:dashboard/range db)))
+
+(rf/reg-sub :dashboard/visible-metrics
+  :<- [:dashboard/metrics]
+  :<- [:dashboard/active-tags]
+  (fn [[ms tags] _]
+    (filter #(contains? tags (:tag %)) ms)))
+
+;; ============================================================================
+;; SPARKLINE PATH
+;; ============================================================================
+
+(defn- sparkline-path
+  "Return an SVG <path> `d` string for the series, normalised into a
+   100×30 viewBox. Pure — used by `Sparkline` below.
+
+   Why polyline-via-path: a single <path d=\"M…L…L…\"> renders crisper
+   than <polyline> when the viewBox is small and the stroke is hair-thin
+   (the renderer doesn't anti-alias every vertex twice)."
+  [series]
+  (let [n     (count series)
+        lo    (apply min series)
+        hi    (apply max series)
+        span  (max 0.0001 (- hi lo))
+        ->x   (fn [i] (* 100.0 (/ i (dec (max 2 n)))))
+        ->y   (fn [v] (- 30 (* 30 (/ (- v lo) span))))
+        head  (str "M" (->x 0) "," (->y (first series)))
+        tail  (apply str
+                (for [i (range 1 n)]
+                  (str " L" (->x i) "," (->y (nth series i)))))]
+    (str head tail)))
+
+;; ============================================================================
+;; VIEWS  (UIx — defui)
+;; ============================================================================
+
+(defui sparkline [{:keys [series id]}]
+  ($ :svg.dash-sparkline
+     {:viewBox "0 0 100 30"
+      :preserveAspectRatio "none"
+      :role "img"
+      :aria-label "sparkline"
+      :data-testid (str "dashboard-sparkline-" (name id))}
+     ($ :path {:d (sparkline-path series)
+               :fill "none"
+               :stroke "currentColor"
+               :stroke-width 1.5
+               :stroke-linejoin "round"
+               :stroke-linecap "round"
+               :vector-effect "non-scaling-stroke"})))
+
+(defui delta-badge [{:keys [delta good-when-positive?]}]
+  (let [pos?      (pos? delta)
+        positive? (if good-when-positive? pos? (not pos?))
+        pct       (-> delta (* 100) Math/abs (.toFixed 1))]
+    ($ :span {:class (str "dash-delta " (if positive? "is-good" "is-bad"))}
+       (if pos? "▲ " "▼ ") pct "%")))
+
+(defui metric-card [{:keys [m]}]
+  (let [{:keys [id label value unit delta tag series]} m
+        money? (= :money tag)
+        perf?  (= :perf tag)]
+    ($ :article.dash-card
+       {:data-testid (str "dashboard-card-" (name id))}
+       ($ :header.dash-card-head
+          ($ :span.dash-eyebrow (name tag))
+          ($ delta-badge {:delta delta
+                          :good-when-positive? (not perf?)}))
+       ($ :div.dash-card-value
+          (when money? ($ :span.dash-unit unit))
+          ($ :span.dash-value
+             {:data-testid (str "dashboard-value-" (name id))}
+             (cond
+               (integer? value)            (str value)
+               (and (number? value)
+                    (< value 100))         (.toFixed value 2)
+               :else                       (str value)))
+          (when (and (not money?) (seq unit))
+            ($ :span.dash-unit unit)))
+       ($ :div.dash-card-label label)
+       ($ sparkline {:series series :id id}))))
+
+(defui filter-chips []
+  (let [active   (uix-adapter/use-subscribe [:dashboard/active-tags])
+        dispatch (rf/dispatcher)]
+    ($ :div.dash-chips
+       (for [{:keys [id label]} all-tags]
+         ($ :button {:key id
+                     :class (str "dash-chip " (when (contains? active id) "is-on"))
+                     :data-testid (str "dashboard-chip-" (name id))
+                     :on-click #(dispatch [:dashboard/toggle-tag id])}
+            ($ :span.dash-chip-dot {:class (str "tag-" (name id))})
+            label)))))
+
+(defui dashboard []
+  (let [visible (uix-adapter/use-subscribe [:dashboard/visible-metrics])]
+    ($ :div.dash-shell
+       ($ :header.dash-shell-head
+          ($ :div
+             ($ :h1 "Atlas")
+             ($ :p.dash-tagline
+                "Last 14 days · UIx substrate · "
+                ($ :span.dash-substrate-tag "Swiss Modern")))
+          ($ filter-chips))
+       ($ :section.dash-grid
+          {:data-testid "dashboard-grid"}
+          (for [m visible]
+            ($ metric-card {:key (:id m) :m m})))
+       ($ :footer.dash-shell-foot
+          ($ :span "re-frame2 · examples/uix/dashboard_uix")))))
+
+;; ============================================================================
+;; MOUNT
+;; ============================================================================
+
+(defonce react-root
+  (uix-dom/create-root (js/document.getElementById "app")))
+
+(defn ^:export run []
+  (rf/init! uix-adapter/adapter)
+  (rf/dispatch-sync [:dashboard/initialise])
+  (uix-dom/render-root ($ dashboard) react-root))

--- a/examples/uix/dashboard_uix/dashboard_uix.spec.cjs
+++ b/examples/uix/dashboard_uix/dashboard_uix.spec.cjs
@@ -1,0 +1,35 @@
+/*
+ * dashboard-uix — UIx design-led example smoke (rf2-t7t6f).
+ *
+ * Atlas analytics dashboard (status tiles + filter chips + sparkline
+ * cards). The smoke proves:
+ *
+ *   1. Initial render mounts all six metric cards (revenue, signups,
+ *      latency, errors, dau, sessions).
+ *   2. Toggling the :perf filter chip hides the latency + errors cards.
+ *   3. Toggling :perf back on restores them.
+ */
+const { expectVisible, expectCount } =
+  require('../../../examples/scripts/spec-helpers.cjs');
+
+module.exports = {
+  name: 'dashboard-uix smoke (UIx · design-led)',
+  url:  '/dashboard-uix/',
+  run:  async (page) => {
+    const grid = page.locator('[data-testid="dashboard-grid"]');
+    await expectVisible(grid, 10000);
+
+    const cards = page.locator('[data-testid^="dashboard-card-"]');
+
+    // 1. All six metric cards visible by default.
+    await expectCount(cards, 6, 10000);
+
+    // 2. Toggle the perf filter — :latency + :errors disappear.
+    await page.locator('[data-testid="dashboard-chip-perf"]').click();
+    await expectCount(cards, 4);
+
+    // 3. Toggle perf back on — all six return.
+    await page.locator('[data-testid="dashboard-chip-perf"]').click();
+    await expectCount(cards, 6);
+  },
+};

--- a/examples/uix/dashboard_uix/index.html
+++ b/examples/uix/dashboard_uix/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>re-frame2 example: dashboard (UIx · design-led)</title>
+  <link rel="stylesheet" href="_shared/css/uix.css">
+  <style>
+    /* Per-example layout — Atlas dashboard grid. Tokens come from
+       _shared/css/uix.css (ux-* CSS variables). */
+    .dash-shell {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 3em min(7vw, 56px);
+      box-sizing: border-box;
+    }
+    .dash-shell-head {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 2em;
+      margin-bottom: 2.5em;
+      padding-bottom: 1.5em;
+      border-bottom: 1.5px solid var(--ux-ink);
+    }
+    .dash-shell-head h1 { font-size: 3rem; margin: 0 0 0.3rem; }
+    .dash-tagline {
+      margin: 0;
+      font-family: var(--ux-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-size: 0.78rem;
+      color: var(--ux-ink-mute);
+    }
+    .dash-substrate-tag {
+      color: var(--ux-ink);
+      background: var(--ux-yellow);
+      padding: 1px 6px;
+      margin-left: 6px;
+    }
+
+    .dash-chips { display: flex; gap: 10px; flex-wrap: wrap; }
+    .dash-chip {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-family: var(--ux-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.74rem;
+      font-weight: 700;
+      padding: 8px 12px;
+      background: var(--ux-bg-raised);
+      color: var(--ux-ink-mute);
+      border: 1.5px solid var(--ux-rule);
+      box-shadow: 3px 3px 0 var(--ux-rule);
+      cursor: pointer;
+      border-radius: 0;
+      transition: transform 80ms ease, box-shadow 80ms ease, color 100ms ease;
+    }
+    .dash-chip:hover {
+      transform: translate(-1px, -1px);
+      box-shadow: 4px 4px 0 var(--ux-rule);
+    }
+    .dash-chip.is-on {
+      color: var(--ux-ink);
+      border-color: var(--ux-ink);
+      box-shadow: 3px 3px 0 var(--ux-ink);
+    }
+    .dash-chip-dot {
+      width: 8px; height: 8px; display: inline-block;
+    }
+    .dash-chip-dot.tag-money { background: var(--ux-mint); }
+    .dash-chip-dot.tag-perf  { background: var(--ux-cyan-deep); }
+    .dash-chip-dot.tag-usage { background: var(--ux-yellow); }
+
+    .dash-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 1.25em;
+    }
+
+    .dash-card {
+      background: var(--ux-bg-raised);
+      border: 1.5px solid var(--ux-ink);
+      box-shadow: 5px 5px 0 var(--ux-ink);
+      padding: 1.4em 1.5em;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5em;
+    }
+    .dash-card-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .dash-eyebrow {
+      font-family: var(--ux-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.7rem;
+      color: var(--ux-ink-mute);
+    }
+    .dash-delta {
+      font-family: var(--ux-mono);
+      font-size: 0.78rem;
+      font-weight: 700;
+      padding: 2px 6px;
+    }
+    .dash-delta.is-good { background: var(--ux-mint); color: var(--ux-ink); }
+    .dash-delta.is-bad  { background: var(--ux-coral); color: var(--ux-bg-raised); }
+
+    .dash-card-value {
+      display: flex; align-items: baseline; gap: 4px;
+      margin-top: 0.4em;
+      font-family: var(--ux-sans);
+      color: var(--ux-ink);
+    }
+    .dash-value { font-size: 2.4rem; font-weight: 700; letter-spacing: -0.025em; }
+    .dash-unit  { font-size: 1.2rem; color: var(--ux-ink-mute); font-weight: 500; }
+
+    .dash-card-label {
+      font-family: var(--ux-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 0.84rem;
+      color: var(--ux-ink-mute);
+    }
+
+    .dash-sparkline {
+      width: 100%; height: 42px;
+      color: var(--ux-cyan-deep);
+      margin-top: 0.6em;
+    }
+
+    .dash-shell-foot {
+      margin-top: 3em;
+      padding-top: 1em;
+      border-top: 1px solid var(--ux-rule);
+      font-family: var(--ux-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-size: 0.74rem;
+      color: var(--ux-ink-faint);
+    }
+  </style>
+</head>
+<body>
+  <div id="app"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/uix/dashboard_uix/index.html
+++ b/examples/uix/dashboard_uix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: dashboard (UIx · design-led)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0A0F14">
+  <meta name="description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:image" content="_shared/img/og-uix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-uix.svg">
   <link rel="stylesheet" href="_shared/css/uix.css">
   <style>
     /* Per-example layout — Atlas dashboard grid. Tokens come from

--- a/examples/uix/login_uix/index.html
+++ b/examples/uix/login_uix/index.html
@@ -3,6 +3,15 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (UIx)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0A0F14">
+  <meta name="description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="re-frame2 · UIx example">
+  <meta property="og:description" content="re-frame2 worked example — UIx substrate, 'Swiss Modern' identity.">
+  <meta property="og:image" content="_shared/img/og-uix.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/svg+xml" href="_shared/img/favicon-uix.svg">
   <link rel="stylesheet" href="_shared/css/uix.css">
 </head>
 <body>

--- a/examples/uix/login_uix/index.html
+++ b/examples/uix/login_uix/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>re-frame2 example: login (UIx)</title>
+  <link rel="stylesheet" href="_shared/css/uix.css">
 </head>
 <body>
   <div id="app"></div>

--- a/implementation/scripts/serve-and-run-causa-feature-gate.cjs
+++ b/implementation/scripts/serve-and-run-causa-feature-gate.cjs
@@ -87,6 +87,25 @@ function compileSurfaces() {
   }
 }
 
+// rf2-jzqs9 — shared per-substrate stylesheets + favicon + OG assets
+// (rf2-nfg15 / rf2-3zibv). Example index.html files reference these via
+// relative paths like `_shared/css/reagent.css`, so any staged surface
+// whose HTML lives under `examples/` gets the `_shared/` tree mirrored
+// alongside its main.js + index.html. Mirrors the equivalent
+// `stageShared` step in examples/scripts/serve-and-run-examples-tests.cjs
+// (rf2-sivlu — without this the counter index.html 404s on its
+// stylesheet under the Causa gate, the inline layout breaks, and the
+// `source coordinates and launch-mode availability` scenario fails on
+// `Host app controls are not laid out to the left of Causa`).
+const SHARED_SRC = relPath(['examples', '_shared']);
+
+function stageSharedIfReferenced(surface, outDir) {
+  const htmlSrc = relPath(surface.html);
+  if (!htmlSrc.startsWith(relPath(['examples']) + path.sep)) return;
+  if (!fs.existsSync(SHARED_SRC)) return;
+  copyDirRecursive(SHARED_SRC, path.join(outDir, '_shared'));
+}
+
 function stageSurfaces() {
   for (const surface of STAGED_SURFACES) {
     const bundleSrc = implPath(surface.bundleDir);
@@ -100,6 +119,7 @@ function stageSurfaces() {
     }
     copyDirRecursive(bundleSrc, outDir);
     fs.copyFileSync(htmlSrc, path.join(outDir, 'index.html'));
+    stageSharedIfReferenced(surface, outDir);
 
     for (const extra of surface.extraFiles || []) {
       const src = relPath(extra.src);

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -554,6 +554,17 @@
    :asset-path "."
    :modules    {:main {:init-fn login.core/run}}}
 
+  ;; rf2-t7t6f — Reagent design-led example. Three-pane editorial layout
+  ;; (documents tree + markdown editor + live preview) proving Reagent
+  ;; builds substantive UIs, not just counters. Pairs with the Reagent
+  ;; 'Editorial Warm' visual identity (rf2-nfg15) from
+  ;; examples/_shared/css/reagent.css.
+  :examples/notebook
+  {:target     :browser
+   :output-dir "out/examples/notebook"
+   :asset-path "."
+   :modules    {:main {:init-fn notebook.core/run}}}
+
   ;; rf2-3yij — UIx-substrate smoke trio (counter + login per Decision 7).
   ;; Each example has its own per-example shadow-cljs build, mirroring the
   ;; Reagent variants, so the bundle-isolation grep can verify a Reagent
@@ -571,6 +582,16 @@
    :output-dir "out/examples/login-uix"
    :asset-path "."
    :modules    {:main {:init-fn login-uix.core/run}}}
+
+  ;; rf2-t7t6f — UIx design-led example. Analytics-dashboard layout
+  ;; (status tiles + filter chips + sparkline cards) proving UIx builds
+  ;; substantive UIs. Pairs with the UIx 'Swiss Modern' visual identity
+  ;; (rf2-nfg15) from examples/_shared/css/uix.css.
+  :examples/dashboard-uix
+  {:target     :browser
+   :output-dir "out/examples/dashboard-uix"
+   :asset-path "."
+   :modules    {:main {:init-fn dashboard-uix.core/run}}}
 
   ;; rf2-2qit — Helix-substrate smoke trio (counter + login per Decision 7,
   ;; transferred from rf2-3yij). Each example has its own per-example
@@ -590,6 +611,17 @@
    :output-dir "out/examples/login-helix"
    :asset-path "."
    :modules    {:main {:init-fn login-helix.core/run}}}
+
+  ;; rf2-t7t6f — Helix design-led example. Terminal-style process-monitor
+  ;; (status tiles + filterable process list + live log stream with a
+  ;; recurring :dispatch-later tick) proving Helix builds substantive
+  ;; UIs. Pairs with the Helix 'Developer Industrial' visual identity
+  ;; (rf2-nfg15) from examples/_shared/css/helix.css.
+  :examples/process-monitor-helix
+  {:target     :browser
+   :output-dir "out/examples/process-monitor-helix"
+   :asset-path "."
+   :modules    {:main {:init-fn process-monitor-helix.core/run}}}
 
   :examples/realworld
   {:target     :browser


### PR DESCRIPTION
## Summary

Cluster of 4 sequenced commits implementing Mike's decision in rf2-v4fpe (a) per-substrate identity. Three substrates × three distinct design languages, each picking a fresh aesthetic on every axis. Pre-alpha masterpiece stance — no AI-slop, no v1.x deferrals.

- **Reagent — Editorial Warm** : Newsreader display serif + Source Sans 3, warm paper `#FAF4EC` + sienna `#C4541C`, radial paper-grain atmosphere, soft warm shadows. Reads as *veteran / refined*.
- **UIx — Swiss Modern**       : Space Grotesk + Space Mono labels, concrete `#EFF2F5` + electric cyan `#00B4D8`, dotted grid background, hard-offset (no-blur) shadows, tracked uppercase chrome. Reads as *deliberate / type-forward*.
- **Helix — Developer Industrial (dark)** : JetBrains Mono UI + IBM Plex Sans body, bg `#0D1117` + neon green `#3FB950` + magenta `#F778BA`, gradient-mesh corners + faint scanlines. Reads as *terminal-as-app / lean*.

Each substrate is distinct from Causa (Inter+JBM+violet) and Story (IBM Plex) AND from each other (light-warm-serif / light-cool-grotesque / dark-mono-neon).

## Commits (in order)

1. `b3ac34cd` chore(examples): lift Reagent inline styles to shared stylesheet (rf2-jzqs9)
2. `c86a6184` feat(examples): per-substrate visual identity — Reagent/UIx/Helix (rf2-nfg15)
3. `16899e20` feat(examples): design-led non-counter example per substrate (rf2-t7t6f)
4. `2a7f96e5` chore(examples): favicon + Open Graph meta on every index.html (rf2-3zibv)

## New design-led examples (one per substrate, distinct shapes)

- **Reagent · Notebook** (`examples/reagent/notebook/`) — three-pane editorial: documents tree + markdown editor + live preview. Pure-CLJS micro-markdown parser emits hiccup. Chained sub `:selected → :selected-body → :selected-hiccup` proves three-layer signal graph.
- **UIx · Atlas dashboard** (`examples/uix/dashboard_uix/`) — six metric cards with delta badges, inline-SVG sparklines computed in pure CLJS, filter chips re-deriving the visible card set.
- **Helix · Process monitor** (`examples/helix/process_monitor_helix/`) — terminal-style two-pane: filterable process list + live log stream + status tiles. Recurring `:dispatch-later` tick (1.8s) appends synthetic log lines — a real reactive loop, not a static screenshot.

Each ships a Playwright smoke under `examples/scripts/`. All three passing.

## Asset spine

`examples/_shared/` ships three substrate stylesheets (atop a shared `structure.css` baseline), seven favicons/OG cards, and a README. The orchestrator's new `stageShared` step copies the whole tree into every example output dir so every `index.html` references assets at the same relative path (`_shared/css/<substrate>.css` / `_shared/img/<asset>.svg`).

## Test plan

- [x] All three design-led examples build via `shadow-cljs compile`
- [x] Playwright smokes pass for notebook, dashboard-uix, process-monitor-helix
- [x] Existing login smoke (covers all three substrates) still passes after meta-injection
- [x] No tests removed; all pre-existing builds untouched (inline styles lifted in commit 1, no behaviour change)
- [ ] CI green