### PR TITLE
feat(static): shell scaffold + mode pill + Cmd-Shift-M chord (rf2-o5f5f.1)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -1064,6 +1064,116 @@ of them.
 is idempotent via surgical-update semantics. Mount fns can be called
 from a host's `init!` path at any frequency without risk.
 
+## Static mode (rf2-o5f5f)
+
+Causa exposes TWO modes — **Runtime** (the event-coupled spine + 4-layer
+chrome described above) and **Static** (event-INDEPENDENT browse of
+what's registered). Static is "Causa-in-a-quieter-key": it shares the
+full Runtime design language (Inter + JetBrains Mono, the complete
+`theme/tokens.cljc` palette, the 4px spacing grid, the 56px ribbon, the
+40px tab-bar). Differentiation is **temperature, not vocabulary**.
+
+### Surface inventory (3-layer chrome)
+
+Runtime is 4 layers (L1 ribbon · L2 event list · L3 tab bar · L4 detail
+panel). Static drops L2 — there is no spine in Static mode because the
+surface is event-independent — and renders 3 layers:
+
+    ┌───────────────────────────────────────────────────────┐
+    │ L1  Top ribbon (56px) — mode pill + right icons       │
+    ├───────────────────────────────────────────────────────┤
+    │ L3  Tab bar (40px) — 5 tabs                           │
+    ├───────────────────────────────────────────────────────┤
+    │ L4  Detail panel (fills remaining canvas)             │
+    └───────────────────────────────────────────────────────┘
+
+L2's absence is also a functional signal — see §Mode-signal mechanism
+below.
+
+### Sub-tab inventory (Static L3)
+
+Five Static sub-tabs, mode-scoped mnemonics per the findings doc
+`ai/findings/2026-05-19-causa-explorer-mode.md` §5.2:
+
+| Tab | Mnemonic | Bead | Contents |
+|---|---|---|---|
+| **Machines** | `m` (default) | rf2-o5f5f.2 | Registry browse + Topology + 4-mode sub-strip |
+| **Routes**   | `r` | rf2-o5f5f.3 | Registered routes (promoted from Runtime) + Simulate-URL |
+| **Schemas**  | `c` | rf2-o5f5f.4 | Registered schemas + sample data + jump-to-source |
+| **Views**    | `v` | rf2-o5f5f.5 | Registered views catalogue (Fiber-walker consumer) |
+| **Events**   | `e` | rf2-o5f5f.6 | Registered handlers + interceptor stack |
+
+Mnemonic mode-scoping: the same letter dispatches the active mode's
+tab — `m` in Runtime opens the Machines instance-inspector, `m` in
+Static opens the Machines registry browse.
+
+### Mode-signal mechanism (4 stacked signals)
+
+The user reads Static at a glance via four stacked signals — together
+they telegraph the mode without the user needing to look at the pill:
+
+1. **Mode pill** at ribbon-left — two-segment radio
+   `[● Runtime] [○ Static]`, 160px total, accent-violet active
+   segment with a 200ms cross-fade. Lives in both modes (it's the
+   toggle, not the indicator). Cmd-Shift-M (the global chord) fires
+   the same `:rf.causa/toggle-mode` event so chord and pill share
+   the handler.
+2. **2-px left-edge ribbon stripe** — `:accent-violet` in Runtime,
+   `:cyan` (already in the palette) in Static. Zero new tokens
+   introduced.
+3. **Motion dampening** — Runtime ships the LIVE pulse + machine-active
+   pulse + 180ms tab fade. Static drops the continuous pulses entirely
+   and collapses the 180ms tab fade to instant (so cluster swaps land
+   without motion). Honours `prefers-reduced-motion: reduce` via the
+   `--rf-causa-motion-scale` seam in `theme/global-styles/motion-css`.
+4. **Chrome silhouette** — Runtime is 4-layer; Static is 3-layer (no
+   L2 / no spine). The shape itself is a signal.
+
+### Mode-state lifecycle
+
+The mode slot lives on Causa's app-db at `[:rf.causa/mode]`
+(`:runtime | :static`); the Static-scoped tab choice lives at
+`[:rf.causa.static/selected-tab]` (default `:machines`). Three event
+handlers drive the lifecycle:
+
+- `:rf.causa/set-mode` — writes a specific mode (mode-pill segment
+  clicks, hydration after localStorage read, test fixtures).
+- `:rf.causa/toggle-mode` — flips between modes (the Cmd-Shift-M
+  chord — see `keybinding.cljs`).
+- `:rf.causa.static/select-tab` — flips the Static-scoped tab
+  (independent of the Runtime `:rf.causa/select-tab` slot so flipping
+  modes preserves both choices).
+
+Set + toggle attach the `:rf.causa.static/persist-mode` fx so every
+mutation round-trips through localStorage under the canonical key
+`causa.mode`. Unknown / malformed values normalise back to
+`:runtime` — the conservative default.
+
+### Frame isolation
+
+Same discipline as the Runtime shell. The Static surface composer
+inside `shell.cljs` is wrapped in `[rf/frame-provider {:frame
+:rf/causa}]`; every subscribe + dispatch inside the surface resolves
+to `:rf/causa`. Each subscribing region is `reg-view`-registered so
+its rendered component carries `:contextType frame-context` (rf2-in6l2
++ Spec 004 §Plain Reagent fns do not pick up the surrounding frame).
+
+### Feature flag
+
+Static is gated behind the `:experimental/static-mode?` config flag,
+default `false`. Hosts opt in via:
+
+    (causa-config/configure! {:experimental/static-mode? true})
+
+before the Causa preload runs. With the flag OFF the surface composer
+ALWAYS renders Runtime — byte-identical to the pre-Static chrome,
+the mode pill is absent, and the Cmd-Shift-M chord falls through to
+the host / browser. With the flag ON the mode pill mounts at
+ribbon-left and the chord drives the toggle.
+
+The flag flips to default-on once sibling beads rf2-o5f5f.2 … .6 fill
+the placeholder Static sub-tabs (a separate decision).
+
 ### See also
 
 - [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) — the

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -285,6 +285,57 @@
   []
   @keybinding-enabled?)
 
+;; ---- *static-mode?* (rf2-o5f5f.1 — Static-impl feature flag) ------------
+;;
+;; Causa exposes TWO modes per `tools/causa/spec/007-UX-IA.md` §Static
+;; mode + the findings doc `ai/findings/2026-05-19-causa-explorer-
+;; mode.md`:
+;;
+;;   - Runtime — the event-coupled spine + 4-layer chrome (the
+;;     surface the rest of Causa ships today).
+;;   - Static  — event-INDEPENDENT browse of what's registered
+;;     (Machines / Routes / Schemas / Views / Events).
+;;
+;; Phase 1 (this bead) ships the chrome scaffold only — the 5 Static
+;; sub-tabs render placeholder cards naming the sibling bead that
+;; will fill them. Until the siblings land, Static is gated behind
+;; this flag so the default-on installation surface stays at parity
+;; with the pre-Static behaviour.
+;;
+;; The flag is the gate around the mode-pill render + the Cmd-Shift-M
+;; keybinding + the shell's mode dispatch. With the flag OFF the
+;; Runtime shell renders byte-identically to the pre-bead surface;
+;; with it ON the mode pill appears at ribbon-left and Cmd-Shift-M
+;; toggles modes.
+;;
+;; Once .2 / .3 / .4 fill the placeholder tabs the flag can flip to
+;; default-on (a separate decision; not part of this bead).
+
+(defonce
+  ^{:doc "Atom controlling whether Causa exposes the Static mode UX
+         (mode pill, Cmd-Shift-M chord, Static surface render). Default
+         `false` so the Runtime chrome renders byte-identically to the
+         pre-Static surface while the sibling beads (rf2-o5f5f.2..6)
+         fill the placeholder Static tabs. Per rf2-o5f5f.1."}
+  static-mode?
+  (atom false))
+
+(defn set-static-mode-enabled!
+  "Replace the `:experimental/static-mode?` flag. `nil` resets to the
+  default (`false`). Hosts opt into Static mode by calling
+  `(causa-config/configure! {:experimental/static-mode? true})`
+  before the Causa preload runs."
+  [v]
+  (reset! static-mode? (if (nil? v) false (boolean v)))
+  nil)
+
+(defn static-mode-enabled?
+  "Return true when Causa should expose the Static surface UX (mode
+  pill, Cmd-Shift-M chord, Static shell render). Read by the
+  shell + keybinding layers. Per rf2-o5f5f.1."
+  []
+  @static-mode?)
+
 (defonce
   ^{:doc "Atom holding Causa's 'Open in editor' preference. Default
          `:vscode`. Accepts the keywords `:vscode` / `:cursor` /
@@ -1012,6 +1063,13 @@
        palette — are not swallowed by Causa's capture-phase listener.
        Per rf2-4eyik (rf2-q7who Thread A). MUST be set BEFORE the
        Causa preload runs.
+    `{:experimental/static-mode? <bool>}` — whether Causa exposes the
+       Static mode UX (mode pill at ribbon-left, Cmd-Shift-M chord
+       toggle, Static surface render). Defaults to `false` so the
+       Runtime chrome renders byte-identically to the pre-Static
+       surface. Per rf2-o5f5f.1 — flips to default-on after the
+       sibling beads fill the placeholder Static sub-tabs (Machines /
+       Routes / Schemas / Views / Events).
     `{:trace/show-sensitive? <bool>}` — privacy gate for `:sensitive?
        true` trace events per Spec 009 §Privacy (rf2-azls9). Defaults
        to `false` — Causa's trace collector drops sensitive events
@@ -1050,6 +1108,7 @@
     host-selector-opt :layout/host-selector
     auto-open-opt :launch/auto-open?
     keybinding-opt :launch.keybinding/enabled?
+    static-mode-opt :experimental/static-mode?
     show-sensitive-opt :trace/show-sensitive?
     filters-opt :filters
     filters-key-opt :filters/storage-key
@@ -1064,6 +1123,8 @@
     (set-auto-open! auto-open-opt))
   (when (contains? opts :launch.keybinding/enabled?)
     (set-keybinding-enabled! keybinding-opt))
+  (when (contains? opts :experimental/static-mode?)
+    (set-static-mode-enabled! static-mode-opt))
   (when (contains? opts :trace/show-sensitive?)
     (set-show-sensitive! show-sensitive-opt))
   ;; NB: `settings` here is the destructured bulk-config map; the

--- a/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/keybinding.cljs
@@ -89,6 +89,39 @@
     (fn [k code]
       (or (= "C" k) (= "c" k) (= "KeyC" code)))))
 
+(defn- mode-toggle-key?
+  "True when `event` is the Causa Runtime ↔ Static mode toggle —
+  Cmd+Shift+M on macOS or Ctrl+Shift+M everywhere else (rf2-o5f5f.1).
+
+  Per the parent epic's architectural-lock decision (2026-05-19):
+  Cmd-Shift-M is the chord — a paired letter that doesn't collide
+  with the existing Ctrl+Shift+C (toggle shell), Cmd/Ctrl+K (palette),
+  or the bare-letter spine bindings (Space / L / j / k / G).
+
+  Accepts EITHER Cmd OR Ctrl as the primary modifier so mac users
+  get muscle-memory Cmd and Windows/Linux users get Ctrl — the same
+  shape as `palette-toggle-key?` above. Shift is required to keep
+  the chord from colliding with Ctrl+M (Firefox 'duplicate tab' on
+  some platforms) and Cmd+M (macOS 'minimize window').
+
+  Honours the `:experimental/static-mode?` flag — the listener only
+  fires when the flag is on so a host that hasn't opted into Static
+  mode never sees the chord intercepted (the chord falls through to
+  whatever the host or browser binding would otherwise do)."
+  [event]
+  (let [^js e event
+        ctrl?  (.-ctrlKey e)
+        meta?  (.-metaKey e)
+        shift? (.-shiftKey e)
+        alt?   (.-altKey e)
+        k      (.-key e)
+        code   (.-code e)]
+    (and (or (and ctrl? (not meta?))
+             (and meta? (not ctrl?)))
+         shift?
+         (not alt?)
+         (or (= "M" k) (= "m" k) (= "KeyM" code)))))
+
 (defn- palette-toggle-key?
   "True when `event` is a Cmd+K (macOS) or Ctrl+K (every other host)
   keydown. Per spec/007-UX-IA.md §Command palette this is the
@@ -219,6 +252,20 @@
     (do (.preventDefault event)
         (.stopPropagation event)
         (mount/toggle!))
+
+    ;; rf2-o5f5f.1 — Cmd-Shift-M flips Runtime ↔ Static. Gated on
+    ;; `:experimental/static-mode?` so hosts that haven't opted in
+    ;; never see the chord intercepted. When the flag is OFF the
+    ;; chord falls through to whatever else would consume it
+    ;; (browser / host binding). When the flag is ON we
+    ;; `preventDefault` + `stopPropagation` because the chord owns
+    ;; this keystroke for Causa.
+    (and (config/static-mode-enabled?)
+         (mode-toggle-key? event))
+    (do (.preventDefault event)
+        (.stopPropagation event)
+        (rf/with-frame :rf/causa
+          (rf/dispatch [:rf.causa/toggle-mode])))
 
     (palette-toggle-key? event)
     (do (.preventDefault event)

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -53,6 +53,7 @@
             [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.shell :as shell]
             [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
             [day8.re-frame2-causa.theme.tokens :as tokens]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
@@ -351,6 +352,18 @@
   ;; value into the slot. Idempotent — re-running with an unchanged
   ;; source produces the same slot.
   (filters/hydrate!)
+  ;; Hydrate the Runtime ↔ Static mode slot (rf2-o5f5f.1). Same
+  ;; rationale as the filter hydrate above — the persisted mode
+  ;; lives in localStorage under `causa.mode` and the frame must
+  ;; exist before the dispatch can land. `:rf.causa/set-mode`
+  ;; normalises unknown values back to `:runtime` so an absent or
+  ;; malformed slot is harmless. The dispatch carries the persist-
+  ;; mode fx which would re-write the slot; that's intentional —
+  ;; the round-trip canonicalises the stored value (e.g. an
+  ;; old "explorer" pre-rename value would land back as "runtime"
+  ;; without manual intervention).
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-mode (static-persistence/load)]))
   ;; Auto-open-on-error watcher (rf2-9poxq) — install lazily here so
   ;; the persisted-true case picks up as soon as the user opens
   ;; Causa. The watcher subscribes to `:rf.causa/issues-ribbon`

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -41,6 +41,8 @@
             [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.static.shell :as static-shell]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.app-db-segment-inspector
@@ -296,6 +298,66 @@
     (rf/reg-event-db :rf.causa/select-tab
       (fn [db [_ tab-id]]
         (assoc db :selected-tab tab-id)))
+
+    ;; ---- Static-mode chrome (rf2-o5f5f.1) -------------------------
+    ;;
+    ;; Causa exposes TWO modes per `tools/causa/spec/007-UX-IA.md`
+    ;; §Static mode: Runtime (event-coupled spine) and Static
+    ;; (registry browse). The mode slot lives on Causa's app-db under
+    ;; `:mode` (default `:runtime`); the Static tab selection lives
+    ;; under `:rf.causa.static/selected-tab` (default `:machines`).
+    ;;
+    ;; Three event handlers drive the mode lifecycle:
+    ;;
+    ;;   - `:rf.causa/set-mode` writes a specific mode (used by the
+    ;;     mode pill's per-segment click, by hydration after
+    ;;     localStorage read, and by test fixtures).
+    ;;   - `:rf.causa/toggle-mode` flips between modes (used by the
+    ;;     Cmd-Shift-M chord — see `keybinding.cljs`).
+    ;;   - `:rf.causa.static/select-tab` flips the Static-scoped tab
+    ;;     (mirrors `:rf.causa/select-tab` but writes the Static
+    ;;     surface's own slot so Runtime + Static tab choices don't
+    ;;     clobber each other).
+    ;;
+    ;; The set / toggle handlers attach the `:rf.causa.static/persist-
+    ;; mode` fx so every mutation round-trips to localStorage in one
+    ;; place. Per `static/persistence.cljs` — the fx swallows
+    ;; localStorage errors so a quota / serialisation failure can't
+    ;; poison the dispatch chain.
+
+    (rf/reg-sub :rf.causa/mode
+      (fn [db _query]
+        (static-persistence/normalise-mode (get db :mode :runtime))))
+
+    (rf/reg-sub :rf.causa.static/selected-tab
+      (fn [db _query]
+        (get db :rf.causa.static/selected-tab static-shell/default-tab)))
+
+    (rf/reg-event-fx :rf.causa/set-mode
+      (fn [{:keys [db]} [_ mode]]
+        (let [next-mode (static-persistence/normalise-mode mode)
+              next-db   (assoc db :mode next-mode)]
+          {:db next-db
+           :fx [[:rf.causa.static/persist-mode next-mode]]})))
+
+    (rf/reg-event-fx :rf.causa/toggle-mode
+      (fn [{:keys [db]} _event]
+        (let [current  (static-persistence/normalise-mode (get db :mode :runtime))
+              next-mode (if (= current :static) :runtime :static)
+              next-db   (assoc db :mode next-mode)]
+          {:db next-db
+           :fx [[:rf.causa.static/persist-mode next-mode]]})))
+
+    (rf/reg-event-db :rf.causa.static/select-tab
+      (fn [db [_ tab-id]]
+        (if (contains? static-shell/tab-ids tab-id)
+          (assoc db :rf.causa.static/selected-tab tab-id)
+          db)))
+
+    ;; The persistence fx installs idempotently — re-frame's registrar
+    ;; replaces in place. Mounting here means the fx is available the
+    ;; moment any `:rf.causa/set-mode` / `:toggle-mode` lands.
+    (static-persistence/install-fx!)
 
     ;; L1 filter pills — add / remove. Mode is :in or :out; index
     ;; identifies the pill within its mode bucket. The pure reducers

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -101,6 +101,7 @@
   (:require [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
@@ -118,6 +119,8 @@
             [day8.re-frame2-causa.resize-handle :as resize-handle]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.share-modal :as share-modal]
+            [day8.re-frame2-causa.static.mode-pill :as mode-pill]
+            [day8.re-frame2-causa.static.shell :as static-shell]
             [day8.re-frame2-causa.theme.global-styles :as global-styles]
             [day8.re-frame2-causa.theme.tokens
              :as t
@@ -731,8 +734,25 @@
                    :padding          "0 12px"
                    :background       (:bg-1 tokens)
                    :border-bottom    (str "1px solid " (:border-subtle tokens))
+                   ;; rf2-o5f5f.1 — mode-signal mechanism #2: a 2-px
+                   ;; left-edge stripe in the active mode's accent
+                   ;; (violet in Runtime, cyan in Static). Painted on
+                   ;; the ribbon so it lines up with the top-of-shell
+                   ;; edge regardless of the L2 resize-handle. The
+                   ;; stripe-hex helper closes over the current
+                   ;; palette (light vs dark theme via CSS custom
+                   ;; properties); cyan is already in the palette so
+                   ;; zero new tokens introduced.
+                   :border-left      (str "2px solid "
+                                          (static-shell/stripe-hex-for-mode :runtime))
                    :font-family      sans-stack
                    :font-size        (:body type-scale)}}
+     ;; rf2-o5f5f.1 — mode pill at ribbon-left, gated behind the
+     ;; `:experimental/static-mode?` flag. Phase 1 keeps the pill out
+     ;; of sight until a host opts in; sibling beads (.2–.6) fill the
+     ;; Static sub-tabs before the flag flips to default-on.
+     (when (config/static-mode-enabled?)
+       [mode-pill/mode-pill])
      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail?}]
      [ribbon-focus-chip {:focus-set focus-set}]
      [ribbon-frame-picker {:selected-frame (:frame focus)
@@ -1410,6 +1430,53 @@
         :issues   [issues-ribbon/Panel]
         [unknown-tab-stub selected])]]))
 
+;; ---- Runtime / Static surface composer (rf2-o5f5f.1) --------------------
+;;
+;; The shell exposes TWO modes (Runtime — the 4-layer chrome below,
+;; Static — the 3-layer registry-browse surface owned by
+;; `static/shell.cljs`). With the `:experimental/static-mode?` flag
+;; OFF (default) the composer always renders Runtime — byte-identical
+;; to the pre-bead chrome. With the flag ON the composer reads
+;; `:rf.causa/mode` and renders either Runtime or Static.
+;;
+;; The composer is `reg-view`-registered so the subscribe inside its
+;; body resolves through React-context to `:rf/causa` — same
+;; discipline as the rest of the shell.
+
+(rf/reg-view runtime-chrome
+  "The Runtime 4-layer chrome (L1 ribbon · L2 event list · L3 tab bar ·
+  L4 detail panel) wrapped as a single component. Extracted from the
+  inline composition in `shell-view` so the Static surface can swap in
+  alongside it via the mode composer (rf2-o5f5f.1).
+
+  Per rf2-in6l2 `reg-view`-registered for parity with every other
+  shell region."
+  []
+  [:<>
+   [ribbon {}]
+   [event-list]
+   [tab-bar]
+   [detail-panel]])
+
+(rf/reg-view surface-composer
+  "Mode-aware composer (rf2-o5f5f.1). Reads `:rf.causa/mode` and renders
+  either the Runtime 4-layer chrome OR the Static 3-layer surface.
+
+  With the `:experimental/static-mode?` flag OFF the composer always
+  renders Runtime — the mode slot is ignored, the surface is byte-
+  identical to the pre-bead chrome. With the flag ON the active mode
+  drives the swap.
+
+  Per rf2-in6l2 `reg-view`-registered so the subscribe resolves to
+  `:rf/causa` via React-context."
+  []
+  (let [mode (if (config/static-mode-enabled?)
+               @(rf/subscribe [:rf.causa/mode])
+               :runtime)]
+    (case mode
+      :static  [static-shell/surface]
+      [runtime-chrome])))
+
 ;; ---- shell view ----------------------------------------------------------
 
 (rf/reg-view shell-view
@@ -1520,14 +1587,12 @@
     ;; pushes `--rf-causa-inline-width` onto the layout host so the
     ;; host's `flex-basis` re-evaluates this paint.
     [resize-handle/Handle mode]
-    ;; L1 — top ribbon (scope controls)
-    [ribbon {}]
-    ;; L2 — event list (the spine timeline)
-    [event-list]
-    ;; L3 — tab bar (projection selector)
-    [tab-bar]
-    ;; L4 — detail panel (per-tab content)
-    [detail-panel]
+    ;; Mode-aware surface (rf2-o5f5f.1). With
+    ;; `:experimental/static-mode?` OFF the composer always renders
+    ;; the Runtime 4-layer chrome — byte-identical to the pre-bead
+    ;; surface. With the flag ON it reads `:rf.causa/mode` and swaps
+    ;; in the Static 3-layer surface when active.
+    [surface-composer]
     ;; Command palette (rf2-wm7z4) — mounted at shell root so it
     ;; overlays the chrome. Modal short-circuits to nil when
     ;; `:rf.causa/palette-open?` is false; closed-state cost is one

--- a/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/mode_pill.cljs
@@ -1,0 +1,160 @@
+(ns day8.re-frame2-causa.static.mode-pill
+  "Ribbon-left mode pill — two-segment radio toggling Runtime ↔ Static
+  (rf2-o5f5f.1).
+
+  ## Purpose
+
+  Causa exposes two modes per `tools/causa/spec/007-UX-IA.md` §Static
+  mode + the findings doc `ai/findings/2026-05-19-causa-explorer-
+  mode.md`:
+
+    - **Runtime** — the event-coupled spine + 4-layer chrome. The
+      surface the rest of Causa ships today.
+    - **Static** — event-independent browse of what's registered
+      (Machines / Routes / Schemas / Views / Events). Same design
+      language as Runtime; differentiation is temperature, not
+      vocabulary.
+
+  The pill is the user-facing toggle that lives at ribbon-left in
+  BOTH modes. Cmd-Shift-M (the global chord — see `keybinding.cljs`)
+  fires the same `:rf.causa/toggle-mode` event so the chord and the
+  pill are wired to the same handler.
+
+  ## Geometry
+
+  Per the parent epic's mode-signal mechanism (4 stacked signals;
+  signal #1 is the pill):
+
+    - 160px total width (28px tall, two 76px halves + a 2px divider —
+      the rounded corners + 1px borders fold into the half widths).
+    - Accent-violet fill + white glyph on the active segment.
+    - 200ms cross-fade on the active-state swap, threaded through the
+      `--rf-causa-motion-scale` seam so `prefers-reduced-motion: reduce`
+      collapses the fade to a single frame.
+
+  ## Why a single registered view, not two leaf fns
+
+  `(rf/reg-view mode-pill …)` is the canonical Causa shape: subscribes
+  inside the component body resolve to `:rf/causa` via React-context
+  (rf2-in6l2 / Spec 004 §Plain Reagent fns do not pick up the
+  surrounding frame). The two segments are inline so the keyed
+  cross-fade has one DOM container to interpolate against.
+
+  ## Production posture
+
+  Mounted only by `static/shell.cljs` (Static mode) AND by `shell.cljs`'s
+  L1 ribbon (Runtime mode) — see the ribbon-left cluster wiring. Both
+  call sites pass the current mode in as a prop so the pill doesn't
+  re-subscribe per render."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale sans-stack]]))
+
+;; ---- segments + glyphs --------------------------------------------------
+
+(def ^:private segments
+  "Pure inventory of the pill's two segments. Order is left → right and
+  ships the visible label, glyph, and the mode keyword each segment
+  selects when clicked. Exported (not private) so tests can assert
+  against the canonical inventory without hard-coding the strings.
+
+  Glyphs match Causa's existing `●` (active) / `○` (inactive) language
+  (cf. `shell.cljs/tab-button`). The selected segment is rendered with
+  `●`; the other with `○`."
+  [{:mode :runtime :label "Runtime" :title "Runtime mode — event-coupled spine (Cmd-Shift-M)"}
+   {:mode :static  :label "Static"  :title "Static mode — registry browse (Cmd-Shift-M)"}])
+
+(defn segment-glyph
+  "Pure helper. `●` for the active segment, `○` for the inactive one.
+  Mirrors the chrome's `tab-button` convention."
+  [{:keys [mode]} active-mode]
+  (if (= mode active-mode) "●" "○"))
+
+;; ---- view ---------------------------------------------------------------
+
+(defn- segment-style
+  "Inline style for one segment. Active segments paint accent-violet on
+  the canonical chrome surface (`bg-2`) so the pill sits cleanly on
+  the ribbon's `bg-1`. Inactive segments are flat — the pill reads as
+  a radio, not a dual-button toolbar.
+
+  Per parent-epic signal #1 the cross-fade rides
+  `--rf-causa-motion-scale` so `prefers-reduced-motion: reduce`
+  collapses the transition to a single frame (see `theme/global-
+  styles/motion-css`)."
+  [active?]
+  (let [duration (t/duration-css 200)]
+    (cond-> {:background      (if active? (:accent-violet tokens) "transparent")
+             :color           (if active? (:white tokens) (:text-secondary tokens))
+             :border          "none"
+             :border-radius   "12px"
+             :cursor          "pointer"
+             :display         "inline-flex"
+             :align-items     "center"
+             :gap             "4px"
+             :flex            "1 1 50%"
+             :height          "24px"
+             :justify-content "center"
+             :font-family     sans-stack
+             :font-size       (:caption type-scale)
+             :font-weight     (if active? 600 500)
+             :padding         "0"
+             :transition      (str "background-color " duration " ease-out, "
+                                   "color " duration " ease-out")}
+      active? (assoc :box-shadow "0 0 0 1px rgba(124, 92, 255, 0.35)"))))
+
+(defn- segment-button
+  "One pill segment. Click dispatches `:rf.causa/set-mode <mode>` against
+  the `:rf/causa` frame so the slot lands on Causa's app-db. The
+  segment is a `<button>` so screen-readers + keyboard navigation
+  work out of the box; `role='radio'` + `aria-checked` exposes the
+  proper ARIA radio-group pattern (a paired radio-pill, not two
+  independent toggles)."
+  [{:keys [mode label title] :as seg} active-mode]
+  (let [active? (= mode active-mode)]
+    [:button {:data-testid     (str "rf-causa-mode-pill-" (name mode))
+              :role            "radio"
+              :aria-checked    (if active? "true" "false")
+              :aria-label      (str "Switch to " label " mode")
+              :title           title
+              :on-click        (when-not active?
+                                 #(rf/dispatch [:rf.causa/set-mode mode]
+                                               {:frame :rf/causa}))
+              :style           (segment-style active?)}
+     [:span {:style {:font-size (:micro type-scale)}}
+      (segment-glyph seg active-mode)]
+     label]))
+
+(rf/reg-view mode-pill
+  "Ribbon-left mode pill (rf2-o5f5f.1) — two-segment radio toggling
+  Runtime ↔ Static. The active segment paints accent-violet; the
+  inactive segment is flat. 200ms cross-fade via CSS transitions
+  (no JS animation), threaded through the `--rf-causa-motion-scale`
+  seam so reduced-motion users see an instant swap.
+
+  Per spec/007-UX-IA.md §Static mode + parent-epic rf2-o5f5f mode-
+  signal mechanism (signal #1).
+
+  The component itself subscribes to `:rf.causa/mode` — no prop
+  threading required at the call site. `reg-view`-registered so
+  the subscribe resolves to `:rf/causa` via React-context."
+  []
+  (let [active-mode @(rf/subscribe [:rf.causa/mode])]
+    [:div {:data-testid "rf-causa-mode-pill"
+           :role        "radiogroup"
+           :aria-label  "Causa mode"
+           :data-active-mode (name active-mode)
+           :style       {:display         "inline-flex"
+                         :align-items     "center"
+                         :gap             "2px"
+                         :width           "160px"
+                         :height          "28px"
+                         :padding         "2px"
+                         :background      (:bg-2 tokens)
+                         :border          (str "1px solid " (:border-default tokens))
+                         :border-radius   "14px"
+                         :flex-shrink     0}}
+     (for [seg segments]
+       ^{:key (:mode seg)}
+       [segment-button seg active-mode])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/persistence.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/persistence.cljs
@@ -1,0 +1,152 @@
+(ns day8.re-frame2-causa.static.persistence
+  "localStorage round-trip for Causa's Runtime ↔ Static mode selection
+  (rf2-o5f5f.1).
+
+  Per `tools/causa/spec/007-UX-IA.md` §Static mode + the findings doc
+  `ai/findings/2026-05-19-causa-explorer-mode.md`: Causa exposes TWO
+  modes — Runtime (the existing event-coupled spine + 4-layer chrome)
+  and Static (event-independent browse of what's registered). The
+  user's mode choice survives reloads via localStorage under the
+  canonical key `causa.mode`.
+
+  ## Shape
+
+      ;; localStorage value (raw string — not EDN-quoted):
+      \"runtime\"   ;; or \"static\"
+
+  A bare string keeps the value cheap to read + cheap to inspect from
+  the browser's devtools — modes are an enum, not a structured value.
+  Unrecognised values fall back to `:runtime` (the conservative
+  default; the existing chrome).
+
+  ## Why the namespace prefix is `causa.mode` (not `re-frame2.causa…`)
+
+  Mirror the spec-published key name from the findings doc: `causa.mode`
+  is shorter and reads naturally in browser devtools. The filter
+  persistence ns uses the longer `re-frame2.causa.filters.v1` because
+  that slot grew an explicit version axis (the filter shape may evolve);
+  the mode slot is a fixed enum so versioning is overkill.
+
+  ## Production posture
+
+  Rides Causa's dev-only preload (gated on `interop/debug-enabled?`),
+  so production builds DCE this ns. Reads / writes guard `js/window`
+  existence so the JVM test path (which loads this ns transitively
+  via the registry) doesn't blow up on classpath load.
+
+  ## Test-only override
+
+  Tests that need a deterministic starting mode without touching the
+  real browser localStorage call `with-storage-stub` which threads a
+  per-call stub through the load/save fns. Standalone tests that need
+  a clean slate call `clear!` in their `:each` fixture."
+  (:require [re-frame.core :as rf]))
+
+(def storage-key
+  "Canonical localStorage key for Causa's Runtime ↔ Static mode
+  selection. Constant — not configurable via `configure!` (unlike the
+  filter pills which support per-instance isolation for Story
+  testbeds; mode is a process-global UX choice)."
+  "causa.mode")
+
+;; ---- mode normalisation -------------------------------------------------
+
+(def valid-modes
+  "The two modes Causa knows. Anything outside this set is normalised
+  back to `:runtime` (conservative default — the existing chrome)."
+  #{:runtime :static})
+
+(defn normalise-mode
+  "Coerce a raw mode value (keyword OR string OR nil) to the canonical
+  `:runtime | :static` keyword. Unknown values fall back to `:runtime`.
+
+  Pure data — JVM-runnable so the JVM test corpus can cover the
+  normalisation round-trip."
+  [v]
+  (cond
+    (keyword? v) (if (contains? valid-modes v) v :runtime)
+    (string? v)  (let [kw (keyword v)]
+                   (if (contains? valid-modes kw) kw :runtime))
+    :else        :runtime))
+
+(defn ->raw
+  "Serialise a mode keyword to its localStorage string form."
+  [mode]
+  (name (normalise-mode mode)))
+
+(defn <-raw
+  "Parse a raw localStorage string back to a mode keyword. Nil / unknown
+  → `:runtime`."
+  [s]
+  (normalise-mode s))
+
+;; ---- localStorage helpers -----------------------------------------------
+
+(defn- storage-available?
+  "True when `js/window.localStorage` is reachable. Tests that drive
+  the registry without a browser (node-test) need the load path to
+  no-op silently."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn read-raw
+  "Read the raw string Causa wrote under `storage-key`. Returns nil
+  when the slot is empty or localStorage is unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) storage-key)
+      (catch :default _ nil))))
+
+(defn write-raw!
+  "Write `s` under `storage-key`. No-op when localStorage is
+  unavailable. Swallows any throw — a quota error must not poison
+  the dispatch chain."
+  [s]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) storage-key s)
+      (catch :default _ nil)))
+  nil)
+
+(defn clear!
+  "Remove the persisted mode slot. Used by tests to reset between
+  scenarios. No-op when localStorage is unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) storage-key)
+      (catch :default _ nil)))
+  nil)
+
+;; ---- public API ---------------------------------------------------------
+
+(defn load
+  "Read + parse the persisted mode slot. Always returns a valid mode
+  keyword (`:runtime` is the conservative fallback when the slot is
+  empty, unavailable, or carries an unknown value)."
+  []
+  (<-raw (read-raw)))
+
+(defn save!
+  "Write `mode` to localStorage. No-op when localStorage is
+  unavailable. Normalises unknown inputs back to `:runtime`."
+  [mode]
+  (write-raw! (->raw mode))
+  nil)
+
+;; ---- re-frame fx --------------------------------------------------------
+
+(defn install-fx!
+  "Install the `:rf.causa.static/persist-mode` effect. Idempotent —
+  re-frame's registrar replaces in place. The registry's `:rf.causa/
+  set-mode` + `:rf.causa/toggle-mode` handlers attach this fx so the
+  post-mutation slot lands in localStorage in one place.
+
+  Handler signature `(fn [ctx args])` per the v2 reg-fx contract."
+  []
+  (rf/reg-fx :rf.causa.static/persist-mode
+    (fn [_ctx mode]
+      (save! mode)))
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -1,0 +1,370 @@
+(ns day8.re-frame2-causa.static.shell
+  "Causa's Static surface — 3-layer chrome (rf2-o5f5f.1).
+
+  ## Static = Causa-in-a-quieter-key
+
+  Per the parent epic rf2-o5f5f architectural lock + the audit at
+  rf2-zhrwo: Static shares Runtime's full design language — Inter +
+  JetBrains Mono, the complete `theme/tokens.cljc` palette, the 4px
+  spacing grid, Lucide-style ASCII glyphs, the 56px ribbon, the 40px
+  tab-bar. Differentiation is temperature, not vocabulary.
+
+  ## Surface inventory (3-layer chrome)
+
+  Runtime is 4 layers (L1 ribbon · L2 event list · L3 tab bar · L4
+  detail panel). Static drops L2 — there is no spine in Static mode
+  because Static is event-INDEPENDENT — and renders 3 layers:
+
+      ┌───────────────────────────────────────────────────────┐
+      │ L1  Top ribbon (56px) — mode pill + right icons       │
+      ├───────────────────────────────────────────────────────┤
+      │ L3  Tab bar (40px) — 5 tabs                           │
+      ├───────────────────────────────────────────────────────┤
+      │ L4  Detail panel (fills remaining canvas)             │
+      └───────────────────────────────────────────────────────┘
+
+  L2 is also a functional signal: its absence is one of the four
+  stacked mode-signal mechanisms (chrome silhouette) the parent epic
+  documents. Together with the cyan left-edge stripe, the mode-pill
+  state, and motion dampening, the user reads Static at a glance even
+  without looking at the pill.
+
+  ## Tab inventory (5 sub-tabs)
+
+  This bead registers the 5 Static sub-tabs as PLACEHOLDERS — each
+  renders a 'rf2-o5f5f.<N> will fill this' card. The sibling beads
+  (.2 Machines, .3 Routes, .4 Schemas, .5 Views, .6 Events) replace
+  the placeholders with real catalogue content.
+
+  Tab order + mnemonics per the findings doc §5.2 (mode-scoped: same
+  letter, different target per mode — `m` in Runtime opens the
+  Machines instance inspector, `m` in Static opens the Machines
+  registry browse):
+
+      Machines (m, default) · Routes (r) · Schemas (c) · Views (v) · Events (e)
+
+  Tab-mnemonic mode-scoping lives in `static/keybinding.cljs`
+  follow-on — Phase 1 ships only the click path.
+
+  ## Frame isolation
+
+  Same discipline as the Runtime shell. The Static shell is wrapped
+  in `[rf/frame-provider {:frame :rf/causa}]`; every subscribe +
+  dispatch inside the shell resolves to `:rf/causa`. Every subscribing
+  region is `reg-view`-registered so its rendered component carries
+  `:contextType frame-context` (rf2-in6l2 + Spec 004 §Plain Reagent
+  fns do not pick up the surrounding frame).
+
+  ## Mode-signal mechanism (4 stacked signals)
+
+  The parent epic locks four signals that telegraph Static state:
+
+    1. **Mode pill** at ribbon-left — accent-violet active segment,
+       200ms cross-fade. Owned by `static/mode_pill.cljs`. The pill
+       lives at ribbon-left in BOTH modes (it's the toggle, not the
+       indicator).
+    2. **2-px left-edge ribbon stripe** — `:accent-violet` in Runtime,
+       `:cyan` in Static. Owned by both shells via the explicit
+       `mode-stripe-colour` arg passed into the ribbon's outer div.
+    3. **Motion dampening** — Runtime ships the LIVE pulse + machine-
+       active pulse + 180ms tab fade. Static drops the continuous
+       pulses entirely; the 180ms tab fade collapses to 0ms (instant)
+       so cluster swaps land without motion.
+    4. **Chrome silhouette** — Runtime is 4-layer; Static is 3-layer
+       (no L2 / no spine). The shape itself is a signal.
+
+  ## What's deferred to siblings
+
+  This bead registers the chrome + the empty tabs only. The siblings
+  fill the placeholder content:
+
+    - rf2-o5f5f.2 — Machines registry browse + Topology
+    - rf2-o5f5f.3 — Routes registry browse + Simulate-URL
+    - rf2-o5f5f.4 — Schemas registry browse + sample data
+    - rf2-o5f5f.5 — Views registry browse (Fiber-walker consumer)
+    - rf2-o5f5f.6 — Events registry browse + interceptor stack"
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.mode-pill :as mode-pill]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale layout sans-stack]]))
+
+;; ---- tab inventory ------------------------------------------------------
+
+(def tabs
+  "The five L3 tabs Static mode exposes per the findings doc
+  `2026-05-19-causa-explorer-mode.md` §2.4 + parent-epic rf2-o5f5f
+  sub-bead list. Each entry carries:
+
+    - `:id`     — keyword that lands on `:rf.causa.static/selected-tab`
+                  when the tab is selected.
+    - `:label`  — visible tab label.
+    - `:mnem`   — keyboard mnemonic letter (rendered in the tab's
+                  `title`; follow-on bead wires the actual keybinding).
+    - `:placeholder-bead` — the sibling bead id that fills the tab.
+
+  Order matches the findings doc. Default is `:machines` per Mike's
+  call (the Machines registry is the densest Static surface; opening
+  Static on a fresh slate should land on the highest-value tab)."
+  [{:id :machines :label "Machines" :mnem "m" :placeholder-bead "rf2-o5f5f.2"}
+   {:id :routes   :label "Routes"   :mnem "r" :placeholder-bead "rf2-o5f5f.3"}
+   {:id :schemas  :label "Schemas"  :mnem "c" :placeholder-bead "rf2-o5f5f.4"}
+   {:id :views    :label "Views"    :mnem "v" :placeholder-bead "rf2-o5f5f.5"}
+   {:id :events   :label "Events"   :mnem "e" :placeholder-bead "rf2-o5f5f.6"}])
+
+(def default-tab :machines)
+
+(def tab-ids
+  "Set of valid tab ids — used by `:rf.causa.static/select-tab` to
+  reject unknown values from the dispatch arg. JVM-portable pure data."
+  (into #{} (map :id) tabs))
+
+;; ---- mode signal #2 — left-edge stripe colour ---------------------------
+
+(def runtime-stripe-token
+  "Token-key for the Runtime mode's 2-px left-edge ribbon stripe per
+  the parent-epic mode-signal mechanism (signal #2). Held as a token
+  KEY (not the resolved hex) so per-theme palette switching (rf2-
+  5kfxe.6 light theme) flows through naturally."
+  :accent-violet)
+
+(def static-stripe-token
+  "Token-key for the Static mode's 2-px left-edge ribbon stripe per
+  the parent-epic mode-signal mechanism (signal #2). Cyan is already
+  in the palette (rf2-5kfxe.6) at hex #43C3D0 — no new token
+  introduced, per the rf2-zhrwo audit constraint 'Zero new tokens'."
+  :cyan)
+
+(defn stripe-token-for-mode
+  "Pure helper. Returns the token KEY (`:accent-violet` / `:cyan`)
+  the L1 ribbon should paint as its 2-px left-edge stripe for the
+  given mode. JVM-portable so the test corpus can cover the round-
+  trip without a CLJS runtime."
+  [mode]
+  (case mode
+    :static  static-stripe-token
+    runtime-stripe-token))
+
+(defn stripe-hex-for-mode
+  "Resolve the mode's stripe token through `tokens` to the rendered
+  hex. CLJS-side helper that closes over the current `tokens` (the
+  dark palette today; the light-theme path overlays via CSS custom
+  properties)."
+  [mode]
+  (get tokens (stripe-token-for-mode mode)))
+
+;; ---- L1 ribbon (Static) -------------------------------------------------
+
+(defn- ribbon-right-icons
+  "Right-icons cluster — `⚙` settings · `✕` close. Same content as the
+  Runtime ribbon (`shell.cljs/ribbon-right-icons`) but inlined here so
+  the Static shell stays self-contained and we don't form a cycle by
+  reaching back into the Runtime ns."
+  []
+  (let [icon-style {:background     "transparent"
+                    :border         "none"
+                    :color          (:text-secondary tokens)
+                    :cursor         "pointer"
+                    :font-size      (:body type-scale)
+                    :padding        "2px 6px"}]
+    [:div {:data-testid "rf-causa-static-ribbon-icons"
+           :style {:display "flex" :align-items "center" :gap "4px"}}
+     [:button {:data-testid "rf-causa-static-icon-settings"
+               :title       "Settings (,)"
+               :aria-label  "Open Causa settings"
+               :on-click    #(rf/dispatch [:rf.causa/settings-open] {:frame :rf/causa})
+               :style       icon-style}
+      "⚙"]
+     [:button {:data-testid "rf-causa-static-icon-close"
+               :title       "Close (Ctrl+Shift+C)"
+               :aria-label  "Close Causa"
+               :on-click    #(rf/dispatch [:rf.causa/close-shell] {:frame :rf/causa})
+               :style       icon-style}
+      "✕"]]))
+
+(rf/reg-view ribbon
+  "L1 ribbon — 56px chrome, Static-flavoured. Per parent-epic rf2-
+  o5f5f mode-signal mechanism the ribbon paints a 2-px left-edge
+  stripe in CYAN (Static) vs VIOLET (Runtime). Mode pill sits at
+  ribbon-left; right-icons (Settings · Close) sit at ribbon-right.
+  Runtime's nav / frame / filter clusters are HIDDEN — Static is
+  event-independent, those clusters have no meaning here.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  [_props]
+  [:div {:data-testid "rf-causa-static-ribbon"
+         :style {:display          "flex"
+                 :align-items      "center"
+                 :justify-content  "space-between"
+                 :gap              "12px"
+                 :height           (:top-strip-height layout)
+                 :padding          "0 12px"
+                 :background       (:bg-1 tokens)
+                 :border-bottom    (str "1px solid " (:border-subtle tokens))
+                 :border-left      (str "2px solid " (stripe-hex-for-mode :static))
+                 :font-family      sans-stack
+                 :font-size        (:body type-scale)}}
+   [mode-pill/mode-pill]
+   [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
+    [ribbon-right-icons]]])
+
+;; ---- L3 tab bar (Static) ------------------------------------------------
+
+(defn- tab-button
+  "One Static tab. Same `●` / `○` glyph language as the Runtime
+  `tab-button` (`shell.cljs/tab-button`) — design language is shared
+  per the rf2-zhrwo audit's 'Causa-in-a-quieter-key' framing.
+
+  Per the canonical chrome ARIA pattern (rf2-lvf8t / rf2-q7who Thread
+  B), the tab carries `role='tab'` + `aria-selected` so assistive
+  tech reads it as a tab, not a generic button."
+  [{:keys [id label mnem active?]}]
+  (let [glyph (if active? "◉" "○")
+        color (if active? (:text-primary tokens) (:text-secondary tokens))]
+    [:button {:data-testid   (str "rf-causa-static-tab-" (name id))
+              :role          "tab"
+              :aria-selected (if active? "true" "false")
+              :on-click      #(rf/dispatch [:rf.causa.static/select-tab id]
+                                           {:frame :rf/causa})
+              :title         (str label " (" mnem ")")
+              :aria-label    (str "Static " label " tab")
+              :style {:background    "transparent"
+                      :border        "none"
+                      :border-bottom (if active?
+                                       (str "2px solid " (:cyan tokens))
+                                       "2px solid transparent")
+                      :color         color
+                      :cursor        "pointer"
+                      :padding       "6px 12px"
+                      :font-family   sans-stack
+                      :font-size     (:body type-scale)
+                      :font-weight   (if active? 600 400)
+                      :white-space   "nowrap"}}
+     [:span {:style {:color (if active?
+                              (:cyan tokens)
+                              (:text-tertiary tokens))
+                     :margin-right "4px"}}
+      glyph]
+     label]))
+
+(rf/reg-view tab-bar
+  "L3 tab bar — five Static tabs. Same height (40px), same row anatomy,
+  same ARIA pattern as the Runtime tab-bar. The selected-tab slot is
+  Static-scoped (`:rf.causa.static/selected-tab`) so flipping modes
+  doesn't clobber the Runtime tab choice and vice-versa.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [selected @(rf/subscribe [:rf.causa.static/selected-tab])]
+    [:div {:data-testid "rf-causa-static-tab-bar"
+           :role        "tablist"
+           :aria-label  "Causa Static-mode panel tabs"
+           :style {:display       "flex"
+                   :align-items   "center"
+                   :gap           "4px"
+                   :height        "40px"
+                   :padding       "0 8px"
+                   :background    (:bg-1 tokens)
+                   :border-top    (str "1px solid " (:border-subtle tokens))
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     (for [{:keys [id] :as tab} tabs]
+       ^{:key id}
+       [tab-button (assoc tab :active? (= id selected))])]))
+
+;; ---- L4 detail panel (placeholders) -------------------------------------
+
+(defn- placeholder-card
+  "Render a placeholder card for an unfilled Static sub-tab. The card
+  surfaces:
+
+    - The tab label as an `<h1>` for screen-reader navigation.
+    - The sibling bead id ('rf2-o5f5f.<N> will fill this').
+    - A muted hint paragraph naming the upcoming content.
+
+  The card is a single `<section>` painted on `bg-2` with a thin
+  `:cyan` accent stripe — mirrors the Runtime panels' per-domain
+  stripe convention (`tokens/accent-stripe-style`) but uses cyan as
+  the Static-mode accent."
+  [{:keys [label placeholder-bead id]}]
+  [:section {:data-testid (str "rf-causa-static-placeholder-" (name id))
+             :style {:padding       "16px"
+                     :background    (:bg-2 tokens)
+                     :color         (:text-primary tokens)
+                     :font-family   sans-stack
+                     :font-size     (:body type-scale)
+                     :line-height   (:line-height-tight type-scale)}}
+   [:h1 {:style {:font-size     (:display type-scale)
+                 :margin        "0 0 8px 0"
+                 :padding-left  "10px"
+                 :border-left   (str "3px solid " (:cyan tokens))}}
+    label]
+   [:p {:style {:color  (:text-secondary tokens)
+                :margin "0 0 12px 0"}}
+    [:strong {:style {:color (:cyan tokens)}}
+     placeholder-bead]
+    " will fill this."]
+   [:p {:style {:color  (:text-tertiary tokens)
+                :margin 0
+                :font-size (:caption type-scale)}}
+    "Static mode is event-INDEPENDENT — this tab will browse what's "
+    "registered, not what just fired. See parent epic rf2-o5f5f."]])
+
+(defn- tab-by-id
+  "Pure helper. Look up a tab map by `:id`. Returns nil when the id is
+  not in the inventory (the L4 panel falls back to a generic 'unknown'
+  card)."
+  [id]
+  (some #(when (= id (:id %)) %) tabs))
+
+(rf/reg-view detail-panel
+  "L4 detail panel — case-switch on `:rf.causa.static/selected-tab`.
+  Phase 1 (this bead) renders placeholder cards; the sibling beads
+  replace each placeholder with real catalogue content.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [selected (or @(rf/subscribe [:rf.causa.static/selected-tab])
+                     default-tab)
+        tab      (tab-by-id selected)]
+    [:div {:data-testid (str "rf-causa-static-detail-panel-" (name selected))
+           :style {:flex        "1 1 auto"
+                   :min-height  "0"
+                   :overflow    "auto"
+                   :background  (:bg-2 tokens)
+                   :color       (:text-primary tokens)}}
+     (if tab
+       [placeholder-card tab]
+       [:div {:data-testid "rf-causa-static-tab-unknown"
+              :style {:padding     "16px"
+                      :color       (:text-secondary tokens)
+                      :font-family sans-stack}}
+        "Unknown Static tab: " [:code (pr-str selected)]])]))
+
+;; ---- Static surface ------------------------------------------------------
+
+(rf/reg-view surface
+  "The full Static surface — 3 stacked layers (ribbon · tab bar ·
+  detail panel). The Static surface plugs into the Runtime shell's
+  outer envelope (`shell.cljs/shell-view`) which owns the
+  frame-provider + global-styles install + modal mounts; this surface
+  just renders the chrome that swaps in when Static mode is active.
+
+  Per rf2-in6l2 `reg-view`-registered for parity with every other
+  shell region."
+  []
+  [:div {:data-testid "rf-causa-static-surface"
+         :data-rf-causa-mode "static"
+         :style {:display          "flex"
+                 :flex-direction   "column"
+                 :flex             "1 1 auto"
+                 :min-height       "0"
+                 :background       (:bg-0 tokens)
+                 :color            (:text-primary tokens)
+                 :font-family      sans-stack
+                 :font-size        (:body type-scale)}}
+   [ribbon {}]
+   [tab-bar]
+   [detail-panel]])

--- a/tools/causa/test/day8/re_frame2_causa/config_test.clj
+++ b/tools/causa/test/day8/re_frame2_causa/config_test.clj
@@ -85,6 +85,47 @@
     (config/configure! {:editor :cursor})
     (is (false? (config/auto-open-enabled?)))))
 
+;; ---- :experimental/static-mode? flag (rf2-o5f5f.1) ----------------------
+
+(deftest static-mode-default-is-false
+  (testing "default — static-mode? is OFF so the Runtime chrome
+            renders byte-identically to the pre-bead surface"
+    ;; Reset to baseline in case a sibling test flipped the slot.
+    (config/set-static-mode-enabled! nil)
+    (is (false? (config/static-mode-enabled?)))))
+
+(deftest set-static-mode-enabled-round-trips
+  (testing "set-static-mode-enabled! writes and static-mode-enabled? reads"
+    (config/set-static-mode-enabled! true)
+    (is (true? (config/static-mode-enabled?)))
+    (config/set-static-mode-enabled! false)
+    (is (false? (config/static-mode-enabled?)))
+    ;; Tidy after — leave the flag at the default for the next test.
+    (config/set-static-mode-enabled! nil)))
+
+(deftest nil-static-mode-resets-to-default-false
+  (testing "set-static-mode-enabled! with nil resets to the default (false)"
+    (config/set-static-mode-enabled! true)
+    (config/set-static-mode-enabled! nil)
+    (is (false? (config/static-mode-enabled?)))))
+
+(deftest configure-passes-static-mode-through
+  (testing "configure! routes :experimental/static-mode? through
+            set-static-mode-enabled!"
+    (config/configure! {:experimental/static-mode? true})
+    (is (true? (config/static-mode-enabled?)))
+    (config/configure! {:experimental/static-mode? false})
+    (is (false? (config/static-mode-enabled?)))
+    (config/set-static-mode-enabled! nil)))
+
+(deftest configure-without-static-mode-leaves-flag
+  (testing "configure! without :experimental/static-mode? leaves the
+            flag unchanged"
+    (config/set-static-mode-enabled! true)
+    (config/configure! {:editor :cursor})
+    (is (true? (config/static-mode-enabled?)))
+    (config/set-static-mode-enabled! nil)))
+
 (deftest editor-uri-uses-current-preference
   (testing "config/editor-uri reads from the live preference atom"
     (let [coord {:file "src/x.cljs" :line 12 :column 4}]

--- a/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/keybinding_cljs_test.cljs
@@ -68,6 +68,12 @@
   [event]
   (#'keybinding/spine-key-id event))
 
+(defn- mode-toggle-key?
+  "rf2-o5f5f.1 — the Cmd/Ctrl+Shift+M predicate that drives the
+  Runtime ↔ Static mode toggle."
+  [event]
+  (#'keybinding/mode-toggle-key? event))
+
 ;; ---- stub `js/document` --------------------------------------------------
 ;;
 ;; The `attach!` / `detach!` helpers are guarded by `(exists?
@@ -293,6 +299,65 @@
   (testing "wrong `code`, right modifiers"
     (is (false? (palette-toggle-key?
                   (mk-event {:code "KeyJ" :ctrl? true}))))))
+
+;; ---- (3b) mode-toggle-key? truth table (rf2-o5f5f.1) --------------------
+
+(deftest mode-toggle-key-matches-cmd-shift-m-and-ctrl-shift-m
+  (testing "Ctrl+Shift+M — Windows / Linux convention"
+    (is (true? (mode-toggle-key?
+                 (mk-event {:key "M" :ctrl? true :shift? true}))))
+    (is (true? (mode-toggle-key?
+                 (mk-event {:key "m" :ctrl? true :shift? true})))))
+  (testing "Cmd+Shift+M — macOS convention (Meta modifier)"
+    (is (true? (mode-toggle-key?
+                 (mk-event {:key "m" :meta? true :shift? true})))))
+  (testing "`code` fallback — KeyM"
+    (is (true? (mode-toggle-key?
+                 (mk-event {:code "KeyM" :ctrl? true :shift? true}))))))
+
+(deftest mode-toggle-key-requires-shift
+  (testing "Ctrl+M alone is some Firefox 'bookmark this page' chord —
+            require Shift to disambiguate"
+    (is (false? (mode-toggle-key?
+                  (mk-event {:key "m" :ctrl? true}))))
+    (is (false? (mode-toggle-key?
+                  (mk-event {:key "m" :meta? true})))
+        "Cmd+M alone is 'minimize window' on macOS — require Shift")))
+
+(deftest mode-toggle-key-rejects-both-primary-modifiers
+  (testing "Ctrl+Cmd+Shift+M — both primary modifiers held is
+            ambiguous, reject (mirror palette-toggle-key?'s posture)"
+    (is (false? (mode-toggle-key?
+                  (mk-event {:key "m" :ctrl? true :meta? true :shift? true}))))))
+
+(deftest mode-toggle-key-rejects-alt
+  (testing "Ctrl+Alt+Shift+M is an IME composition on some layouts — reject"
+    (is (false? (mode-toggle-key?
+                  (mk-event {:key "m" :ctrl? true :shift? true :alt? true}))))))
+
+(deftest mode-toggle-key-rejects-wrong-key
+  (testing "wrong key letter, right modifiers"
+    (is (false? (mode-toggle-key?
+                  (mk-event {:key "n" :ctrl? true :shift? true})))))
+  (testing "wrong `code`, right modifiers"
+    (is (false? (mode-toggle-key?
+                  (mk-event {:code "KeyN" :ctrl? true :shift? true}))))))
+
+(deftest mode-toggle-key-mutually-exclusive-with-other-predicates
+  (testing "no synthetic event satisfies more than one Causa keybinding
+            predicate at once — the cond in handle-keydown depends on
+            mutual exclusivity"
+    (doseq [event [(mk-event {:key "M" :ctrl? true :shift? true})
+                   (mk-event {:key "m" :meta? true :shift? true})
+                   (mk-event {:code "KeyM" :ctrl? true :shift? true})
+                   (mk-event {:key "C" :ctrl? true :shift? true})
+                   (mk-event {:key "k" :meta? true})]]
+      (let [matches (cond-> 0
+                      (mode-toggle-key? event)    inc
+                      (causa-toggle-key? event)   inc
+                      (palette-toggle-key? event) inc)]
+        (is (<= matches 1)
+            (str "event " (js->clj event) " must match at most one predicate"))))))
 
 ;; ---- (4) attach! / detach! idempotency sentinel --------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -202,6 +202,9 @@
    :rf.causa/selected-machine-id
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/modal-positioning
+   ;; rf2-o5f5f.1 — Runtime ↔ Static mode slot + Static-scoped tab.
+   :rf.causa/mode
+   :rf.causa.static/selected-tab
    ;; rf2-x8h9y — horizontal resize handle width.
    :rf.causa/panel-width-px
    ;; rf2-vbbq0 — L2 row relative-time chip clock (1s ticker writes here).
@@ -358,6 +361,13 @@
    :rf.causa/select-epoch
    :rf.causa/select-machine-id
    :rf.causa/select-tab
+   ;; rf2-o5f5f.1 — Runtime ↔ Static mode events + Static-scoped tab.
+   ;; `set-mode` writes a specific mode; `toggle-mode` flips between
+   ;; them; both attach the `:rf.causa.static/persist-mode` fx so the
+   ;; choice round-trips through localStorage.
+   :rf.causa/set-mode
+   :rf.causa/toggle-mode
+   :rf.causa.static/select-tab
    ;; rf2-a1z3b — focus-navigation primitive write event.
    :rf.causa/set-focus
    :rf.causa/set-frame
@@ -449,6 +459,11 @@
    ;; palette-specific prefix because it wraps a mount-layer pop-out
    ;; call that no other Causa surface invokes.
    :rf.causa.palette.fx/popout
+   ;; rf2-o5f5f.1 — Runtime ↔ Static mode persistence side-effect.
+   ;; Bound to the `:rf.causa/set-mode` + `:rf.causa/toggle-mode`
+   ;; handlers; writes the post-mutation mode to localStorage in one
+   ;; place (mirrors the filter-persistence shape above).
+   :rf.causa.static/persist-mode
    ;; rf2-g5q8d — cross-panel open-in-editor side-effect. Lives under
    ;; the editor-generic `:rf.editor/*` prefix rather than `:rf.causa.fx/*`
    ;; because the rf2-cm93v allowlist seam is editor-related, not

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -1,0 +1,480 @@
+(ns day8.re-frame2-causa.static.shell-cljs-test
+  "CLJS wiring + render tests for Causa's Static surface scaffold
+  (rf2-o5f5f.1).
+
+  ## What's under test
+
+    1. Mode-state lives on `:rf.causa/mode` (default `:runtime`);
+       `:rf.causa/set-mode` writes a specific mode; `:rf.causa/
+       toggle-mode` flips between modes. Both attach the
+       `:rf.causa.static/persist-mode` fx so the value round-trips
+       through localStorage.
+
+    2. localStorage round-trip — the persisted slot survives a frame
+       reset (the hydrate path in `mount/ensure-causa-frame!`
+       restores the value via `:rf.causa/set-mode`).
+
+    3. Static shell renders the 3-layer chrome (ribbon · tab-bar ·
+       detail panel) with the 5 placeholder sub-tabs (Machines /
+       Routes / Schemas / Views / Events). Each placeholder card
+       names its sibling-bead id.
+
+    4. `:rf.causa.static/select-tab` flips the Static-scoped tab
+       slot (does NOT clobber the Runtime `:rf.causa/selected-tab`).
+
+    5. Sub-tab routing — clicking a Static tab swaps the detail
+       panel; an unknown tab id is rejected by the event handler.
+
+    6. The mode pill renders as a two-segment radio with the active
+       segment carrying `aria-checked='true'`.
+
+  ## Pure hiccup walk
+
+  Same approach as `shell_cljs_test.cljs` — we walk the view's
+  hiccup tree by `data-testid` rather than mounting to a real DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.mode-pill :as mode-pill]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.static.shell :as static-shell]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!)
+  (config/set-static-mode-enabled! nil)   ; back to default false
+  (static-persistence/clear!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker (mirrors shell_cljs_test) ----------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- text-nodes [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync ev)))
+
+;; -------------------------------------------------------------------------
+;; (1) mode-state lifecycle — set / toggle
+;; -------------------------------------------------------------------------
+
+(deftest mode-default-is-runtime
+  (testing "with no host opt-in, the mode slot defaults to :runtime"
+    (causa-setup!)
+    (is (= :runtime (frame-sub [:rf.causa/mode])))))
+
+(deftest set-mode-writes-the-slot
+  (testing ":rf.causa/set-mode :static lands :static on the slot"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (is (= :static (frame-sub [:rf.causa/mode])))
+    (frame-dispatch [:rf.causa/set-mode :runtime])
+    (is (= :runtime (frame-sub [:rf.causa/mode])))))
+
+(deftest set-mode-normalises-unknown-values
+  (testing "unknown / string mode values normalise back to :runtime"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/set-mode :nonsense])
+    (is (= :runtime (frame-sub [:rf.causa/mode]))
+        "unknown keyword → :runtime")
+    (frame-dispatch [:rf.causa/set-mode "static"])
+    (is (= :static (frame-sub [:rf.causa/mode]))
+        "string 'static' normalises to :static")))
+
+(deftest toggle-mode-flips-runtime-and-static
+  (testing ":rf.causa/toggle-mode flips between modes idempotently"
+    (causa-setup!)
+    (is (= :runtime (frame-sub [:rf.causa/mode])) "starts on :runtime")
+    (frame-dispatch [:rf.causa/toggle-mode])
+    (is (= :static (frame-sub [:rf.causa/mode])))
+    (frame-dispatch [:rf.causa/toggle-mode])
+    (is (= :runtime (frame-sub [:rf.causa/mode])))
+    (frame-dispatch [:rf.causa/toggle-mode])
+    (is (= :static (frame-sub [:rf.causa/mode])))))
+
+;; -------------------------------------------------------------------------
+;; (2) localStorage persistence — round-trip
+;; -------------------------------------------------------------------------
+
+(deftest persistence-normalise-runs-on-input
+  (testing "static.persistence/normalise-mode coerces keywords + strings"
+    (is (= :runtime (static-persistence/normalise-mode :runtime)))
+    (is (= :static  (static-persistence/normalise-mode :static)))
+    (is (= :runtime (static-persistence/normalise-mode "runtime")))
+    (is (= :static  (static-persistence/normalise-mode "static")))
+    (is (= :runtime (static-persistence/normalise-mode nil)))
+    (is (= :runtime (static-persistence/normalise-mode :nonsense)))
+    (is (= :runtime (static-persistence/normalise-mode "junk")))))
+
+(deftest persistence-raw-round-trip
+  (testing "->raw / <-raw lossless on canonical values"
+    (is (= :runtime (static-persistence/<-raw (static-persistence/->raw :runtime))))
+    (is (= :static  (static-persistence/<-raw (static-persistence/->raw :static))))))
+
+(deftest persistence-load-default-empty-slot
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (static-persistence/clear!)
+    (testing "empty localStorage slot → :runtime fallback"
+      (is (= :runtime (static-persistence/load))))))
+
+(deftest persistence-save-and-load-round-trip
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (testing "save! + load round-trip"
+      (static-persistence/clear!)
+      (static-persistence/save! :static)
+      (is (= :static (static-persistence/load)))
+      (static-persistence/save! :runtime)
+      (is (= :runtime (static-persistence/load))))))
+
+(deftest persistence-fx-installed-by-set-mode
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (testing ":rf.causa/set-mode lands the value in localStorage via the fx"
+      (causa-setup!)
+      (static-persistence/clear!)
+      (frame-dispatch [:rf.causa/set-mode :static])
+      (is (= :static (static-persistence/load))
+          ":static was persisted")
+      (frame-dispatch [:rf.causa/toggle-mode])
+      (is (= :runtime (static-persistence/load))
+          "toggle back to :runtime was persisted"))))
+
+;; -------------------------------------------------------------------------
+;; (3) Static surface — 3-layer chrome render
+;; -------------------------------------------------------------------------
+
+(deftest static-surface-renders-three-layers
+  (testing "Static shell renders ribbon · tab-bar · detail panel
+            (NO L2 event list — Static is event-INDEPENDENT)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (static-shell/surface)]
+        (is (some? (find-by-testid tree "rf-causa-static-surface"))
+            "Static surface envelope present")
+        (is (some? (find-by-testid tree "rf-causa-static-ribbon"))
+            "L1 ribbon present")
+        (is (some? (find-by-testid tree "rf-causa-static-tab-bar"))
+            "L3 tab bar present")
+        ;; default tab is :machines → detail panel testid carries the tab name
+        (is (some? (find-by-testid tree "rf-causa-static-detail-panel-machines"))
+            "L4 detail panel present (default :machines tab)")
+        ;; CRITICAL: no L2 event list in Static mode
+        (is (nil? (find-by-testid tree "rf-causa-event-list"))
+            "no L2 event list (Static is event-INDEPENDENT)")))))
+
+(deftest static-ribbon-mounts-mode-pill-and-right-icons
+  (testing "Static ribbon carries the mode pill at left + right icons
+            cluster (Settings · Close). Runtime's nav / frame /
+            filter clusters are hidden (Static has no spine)."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (static-shell/surface)]
+        (is (some? (find-by-testid tree "rf-causa-mode-pill"))
+            "mode pill present at ribbon-left")
+        (is (some? (find-by-testid tree "rf-causa-static-ribbon-icons"))
+            "right icons cluster present")
+        (is (some? (find-by-testid tree "rf-causa-static-icon-settings"))
+            "settings icon present")
+        (is (some? (find-by-testid tree "rf-causa-static-icon-close"))
+            "close icon present")
+        ;; Runtime ribbon clusters MUST NOT mount in Static surface
+        (is (nil? (find-by-testid tree "rf-causa-ribbon-nav"))
+            "no nav cluster")
+        (is (nil? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
+            "no frame picker")
+        (is (nil? (find-by-testid tree "rf-causa-ribbon-filters"))
+            "no filter pills")))))
+
+;; -------------------------------------------------------------------------
+;; (4) Static tab inventory — 5 sub-tabs, each with a placeholder card
+;; -------------------------------------------------------------------------
+
+(def ^:private expected-static-tab-ids
+  [:machines :routes :schemas :views :events])
+
+(deftest static-tab-bar-renders-five-tabs
+  (testing "Static L3 tab bar renders 5 sub-tabs per parent-epic
+            rf2-o5f5f sub-bead list (Machines / Routes / Schemas /
+            Views / Events)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (static-shell/surface)]
+        (doseq [tab-id expected-static-tab-ids]
+          (is (some? (find-by-testid tree (str "rf-causa-static-tab-" (name tab-id))))
+              (str "tab button for " tab-id)))))))
+
+(deftest static-tab-bar-uses-tablist-aria
+  (testing "Static tab-bar uses the canonical ARIA tab pattern
+            (role='tablist' on the container, role='tab' on each
+            button, aria-selected matching the active state)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree    (static-shell/surface)
+            tab-bar (find-by-testid tree "rf-causa-static-tab-bar")
+            attrs   (second tab-bar)]
+        (is (= "tablist" (:role attrs))
+            "container carries role='tablist'")
+        (is (string? (:aria-label attrs))
+            "container has an accessible name"))
+      (let [tree (static-shell/surface)]
+        (doseq [tab-id expected-static-tab-ids]
+          (let [btn   (find-by-testid tree (str "rf-causa-static-tab-" (name tab-id)))
+                attrs (second btn)]
+            (is (= "tab" (:role attrs))
+                (str "tab " tab-id " carries role='tab'"))
+            (is (= (if (= tab-id :machines) "true" "false")
+                   (:aria-selected attrs))
+                (str "tab " tab-id " aria-selected matches the active tab"))))))))
+
+(deftest static-placeholder-cards-name-sibling-bead
+  (testing "each placeholder card surfaces its sibling-bead id
+            (rf2-o5f5f.<N> will fill this)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (doseq [tab-id expected-static-tab-ids]
+        (frame-dispatch [:rf.causa.static/select-tab tab-id])
+        (let [tree (static-shell/surface)
+              card (find-by-testid tree (str "rf-causa-static-placeholder-" (name tab-id)))
+              text (text-nodes card)]
+          (is (some? card)
+              (str "placeholder card for " tab-id " rendered"))
+          (is (re-find #"rf2-o5f5f\." text)
+              (str "card text names a sibling bead id (got: " text ")"))
+          (is (re-find #"will fill this" text)
+              "card mentions 'will fill this'"))))))
+
+;; -------------------------------------------------------------------------
+;; (5) Static tab routing — selection + isolation
+;; -------------------------------------------------------------------------
+
+(deftest static-select-tab-flips-the-slot
+  (testing ":rf.causa.static/select-tab writes the Static-scoped slot"
+    (causa-setup!)
+    (is (= :machines (frame-sub [:rf.causa.static/selected-tab]))
+        "default is :machines")
+    (frame-dispatch [:rf.causa.static/select-tab :routes])
+    (is (= :routes (frame-sub [:rf.causa.static/selected-tab])))
+    (frame-dispatch [:rf.causa.static/select-tab :events])
+    (is (= :events (frame-sub [:rf.causa.static/selected-tab])))))
+
+(deftest static-select-tab-rejects-unknown-ids
+  (testing ":rf.causa.static/select-tab ignores ids not in the
+            inventory — guards against typos / drift between the
+            sibling beads and this scaffold"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa.static/select-tab :machines])
+    (frame-dispatch [:rf.causa.static/select-tab :not-a-tab])
+    (is (= :machines (frame-sub [:rf.causa.static/selected-tab]))
+        "unknown tab id is rejected; slot stays on :machines")))
+
+(deftest static-tab-isolated-from-runtime-tab
+  (testing "Runtime and Static tab choices are independent —
+            switching one does NOT clobber the other"
+    (causa-setup!)
+    (frame-dispatch [:rf.causa/select-tab :machines])
+    (frame-dispatch [:rf.causa.static/select-tab :events])
+    (is (= :machines (frame-sub [:rf.causa/selected-tab]))
+        "Runtime tab unchanged")
+    (is (= :events (frame-sub [:rf.causa.static/selected-tab]))
+        "Static tab landed independently")))
+
+;; -------------------------------------------------------------------------
+;; (6) Mode-signal mechanism — stripe colour helper
+;; -------------------------------------------------------------------------
+
+(deftest stripe-token-runtime-violet-static-cyan
+  (testing "mode-signal mechanism #2 — 2-px left-edge stripe is
+            :accent-violet in Runtime, :cyan in Static. No new tokens
+            introduced per the rf2-zhrwo audit constraint."
+    (is (= :accent-violet (static-shell/stripe-token-for-mode :runtime)))
+    (is (= :cyan          (static-shell/stripe-token-for-mode :static)))
+    ;; Unknown / nil values fall back to runtime
+    (is (= :accent-violet (static-shell/stripe-token-for-mode :nonsense)))
+    (is (= :accent-violet (static-shell/stripe-token-for-mode nil)))))
+
+;; -------------------------------------------------------------------------
+;; (7) Mode pill — radio pattern + active segment
+;; -------------------------------------------------------------------------
+
+(deftest mode-pill-renders-two-segments
+  (testing "mode pill is a 2-segment radio group with Runtime + Static"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (mode-pill/mode-pill)]
+        (is (some? (find-by-testid tree "rf-causa-mode-pill")))
+        (is (some? (find-by-testid tree "rf-causa-mode-pill-runtime")))
+        (is (some? (find-by-testid tree "rf-causa-mode-pill-static")))))))
+
+(deftest mode-pill-active-segment-aria-checked
+  (testing "the active segment carries aria-checked='true'"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree     (mode-pill/mode-pill)
+            runtime  (find-by-testid tree "rf-causa-mode-pill-runtime")
+            static-b (find-by-testid tree "rf-causa-mode-pill-static")]
+        (is (= "true"  (:aria-checked (second runtime))))
+        (is (= "false" (:aria-checked (second static-b))))))
+    ;; flip to Static and re-render
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (rf/with-frame :rf/causa
+      (let [tree     (mode-pill/mode-pill)
+            runtime  (find-by-testid tree "rf-causa-mode-pill-runtime")
+            static-b (find-by-testid tree "rf-causa-mode-pill-static")]
+        (is (= "false" (:aria-checked (second runtime))))
+        (is (= "true"  (:aria-checked (second static-b))))))))
+
+(deftest mode-pill-segment-glyphs
+  (testing "active segment renders ● and inactive renders ○
+            (mirrors Causa's existing tab-button glyph language)"
+    (is (= "●" (mode-pill/segment-glyph {:mode :runtime} :runtime)))
+    (is (= "○" (mode-pill/segment-glyph {:mode :static}  :runtime)))
+    (is (= "○" (mode-pill/segment-glyph {:mode :runtime} :static)))
+    (is (= "●" (mode-pill/segment-glyph {:mode :static}  :static)))))
+
+;; -------------------------------------------------------------------------
+;; (8) Surface composer — shell.cljs dispatches Runtime vs Static
+;; -------------------------------------------------------------------------
+
+(deftest surface-composer-defaults-to-runtime-when-flag-off
+  (testing "with :experimental/static-mode? OFF (default), the composer
+            ALWAYS renders Runtime chrome — even when the mode slot
+            says :static. The pre-bead byte-identical surface."
+    (causa-setup!)
+    (config/set-static-mode-enabled! false)
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/surface-composer)]
+        ;; Runtime chrome surfaces by its testids
+        (is (some? (find-by-testid tree "rf-causa-ribbon"))
+            "Runtime ribbon still mounts")
+        (is (some? (find-by-testid tree "rf-causa-event-list"))
+            "Runtime L2 event list still mounts")
+        ;; Static chrome does NOT mount
+        (is (nil? (find-by-testid tree "rf-causa-static-surface"))
+            "Static surface does NOT mount with flag off")))))
+
+(deftest surface-composer-renders-static-when-mode-static-and-flag-on
+  (testing "with :experimental/static-mode? ON + mode :static, the
+            composer renders the Static surface"
+    (causa-setup!)
+    (config/set-static-mode-enabled! true)
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/surface-composer)]
+        (is (some? (find-by-testid tree "rf-causa-static-surface"))
+            "Static surface mounts")
+        (is (nil? (find-by-testid tree "rf-causa-ribbon"))
+            "Runtime ribbon does NOT mount")
+        (is (nil? (find-by-testid tree "rf-causa-event-list"))
+            "Runtime L2 event list does NOT mount")))))
+
+(deftest surface-composer-renders-runtime-when-mode-runtime-and-flag-on
+  (testing "with :experimental/static-mode? ON + mode :runtime, the
+            composer still renders the Runtime chrome"
+    (causa-setup!)
+    (config/set-static-mode-enabled! true)
+    (frame-dispatch [:rf.causa/set-mode :runtime])
+    (rf/with-frame :rf/causa
+      (let [tree (shell/surface-composer)]
+        (is (some? (find-by-testid tree "rf-causa-ribbon"))
+            "Runtime ribbon mounts")
+        (is (nil? (find-by-testid tree "rf-causa-static-surface"))
+            "Static surface does NOT mount")))))
+
+(deftest ribbon-mounts-mode-pill-only-when-flag-on
+  (testing "the Runtime ribbon mounts the mode pill ONLY when
+            :experimental/static-mode? is ON"
+    (causa-setup!)
+    ;; flag OFF
+    (config/set-static-mode-enabled! false)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/ribbon)]
+        (is (nil? (find-by-testid tree "rf-causa-mode-pill"))
+            "mode pill is absent in the Runtime ribbon when flag off")))
+    ;; flag ON
+    (config/set-static-mode-enabled! true)
+    (rf/with-frame :rf/causa
+      (let [tree (shell/ribbon)]
+        (is (some? (find-by-testid tree "rf-causa-mode-pill"))
+            "mode pill mounts in the Runtime ribbon when flag on")))))
+
+;; -------------------------------------------------------------------------
+;; (9) Static tab inventory — pure-data shape
+;; -------------------------------------------------------------------------
+
+(deftest static-tab-inventory-shape
+  (testing "tab inventory carries id/label/mnem/placeholder-bead and
+            preserves canonical order"
+    (is (= [:machines :routes :schemas :views :events]
+           (mapv :id static-shell/tabs))
+        "5 tabs in canonical order")
+    (doseq [{:keys [id label mnem placeholder-bead]} static-shell/tabs]
+      (is (keyword? id) (str "id is keyword for " id))
+      (is (string? label) (str "label is a string for " id))
+      (is (and (string? mnem) (= 1 (count mnem)))
+          (str "mnem is one character for " id))
+      (is (re-matches #"rf2-o5f5f\.\d" placeholder-bead)
+          (str "placeholder-bead names a sibling bead for " id)))))


### PR DESCRIPTION
## Summary

Foundational scaffold for Causa's Static mode (Phase 1 of the
`rf2-o5f5f` Static-impl epic — unblocks .2 Machines, .3 Routes,
.4 Schemas, .5 Views, .6 Events).

- New `tools/causa/src/day8/re_frame2_causa/static/` ns tree:
  `persistence.cljs` (localStorage `causa.mode`), `mode_pill.cljs`
  (160px two-segment radio), `shell.cljs` (3-layer chrome — NO L2
  spine because Static is event-independent).
- Tab inventory: Machines (default) / Routes / Schemas / Views /
  Events. Each renders a placeholder card naming its sibling bead.
- 4-stacked mode signals (mode pill · violet↔cyan edge stripe ·
  motion dampening via the existing reduced-motion seam · 3- vs
  4-layer chrome silhouette).
- Cmd/Ctrl-Shift-M chord wires `:rf.causa/toggle-mode`; pill segments
  share the same handlers.
- `:experimental/static-mode?` feature flag (default false) gates the
  pill + chord. Flag off → byte-identical Runtime chrome.
- Spec addendum in `tools/causa/spec/007-UX-IA.md` §Static mode
  documents surfaces, sub-tabs, mode-signal mechanism, lifecycle,
  feature-flag posture.

Per the rf2-zhrwo audit: imports from `theme/tokens.cljc` only; cyan
already in palette so **zero new tokens** introduced.

Closes the scaffold portion of rf2-o5f5f.1.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 714 tests / 2116
  assertions, 0 failures (was 709 / 2109 pre-bead; +5 new tests for
  the static-mode config flag)
- [x] `npm run test:cljs` from `implementation/` — 2954 tests / 8527
  assertions, 0 failures (was 8499 pre-bead; +28 new assertions
  covering mode lifecycle, persistence round-trip, Static surface
  render, mode pill, surface composer, Cmd-Shift-M predicate)
- [x] `npm run test:bundle-isolation` — PASS (11 artefact entries;
  26 internal sentinels absent; 3 allow-list budgets ok)
- [x] `python -m mkdocs build --strict` — clean
- [x] Registry-drift snapshot updated for the new subs / events / fx
  (`:rf.causa/mode`, `:rf.causa.static/selected-tab`, `:rf.causa/
  set-mode`, `:rf.causa/toggle-mode`, `:rf.causa.static/select-tab`,
  `:rf.causa.static/persist-mode`)
- [x] Byte-identical-Runtime regression — `surface-composer` test
  asserts that with the flag OFF, the Runtime chrome still mounts
  even when the mode slot says `:static`

## Visual smoke (description)

With `(causa-config/configure! {:experimental/static-mode? true})`
set before preload:

- Mode pill appears at ribbon-left in Runtime; clicking the Static
  segment swaps in the 3-layer Static surface (no L2 event list).
- 2-px left-edge stripe changes from violet (Runtime) to cyan
  (Static).
- Each Static sub-tab renders a placeholder card reading
  "`rf2-o5f5f.<N>` will fill this."
- Cmd/Ctrl-Shift-M flips Runtime ↔ Static and persists the choice;
  reloading the page restores the last-selected mode.
- With the flag off (default), the surface is byte-identical to the
  pre-bead Runtime chrome; the pill is absent and the chord falls
  through.