### PR TITLE
feat(story): design system Phase 2-3 — sidebar + toolbar + Causa-in-Story integration (3 beads from rf2-s1r9a)

### DIFF
--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -304,33 +304,35 @@
          true))))
 
 #?(:cljs
+   (defn wire-cross-host!
+     "rf2-v1ach: bridge Story's configuration into Causa's config
+     slots without mounting the full shell. Fires the three
+     cross-host bridges (project-root + keybinding disable + listener
+     detach) so the popout escape hatch + Causa's source-coord chips
+     resolve against Story's environment, but does NOT drive
+     `mount/open!` — under the per-panel embed the RHS panel-host
+     component owns the mount lifecycle on its own.
+
+     Idempotent / feature-detect-safe — every bridge is a no-op when
+     Causa is not on the classpath."
+     []
+     (when (and config/enabled? (causa-available?))
+       (propagate-project-root!)
+       (disable-keybinding!)
+       (detach-keybinding!))))
+
+#?(:cljs
    (defn ensure-causa-mounted!
-     "Always-on entry point used by the Story shell (rf2-sgdd3) to drive
-     Causa's `mount/open!` regardless of a per-story preset. Feature-
-     detect-safe: when Causa is not on the classpath the call is a
-     silent no-op.
+     "DEPRECATED — pre-rf2-v1ach the Story shell drove the full Causa
+     4-layer shell into a `[data-rf-causa-host]` 320px column. The
+     per-panel embed (`re-frame.story.ui.causa-embed`) replaced this
+     mount path; the new shape mounts one panel at a time via the
+     `panels/mount-<panel>!` contract.
 
-     The shell's right-panel ships a `[data-rf-causa-host]` slot;
-     `mount/open!` finds the slot and mounts the Causa shell into it.
-     Idempotent — Causa's own singleton state guarantees only one
-     mount per process, subsequent calls flip visibility back to
-     visible if the user closed the shell.
-
-     rf2-r1uod: also propagates Story's configured `:project-root`
-     into Causa's config slot so the Causa-as-RHS source-coord chips
-     resolve absolute on-disk paths. The propagator is no-op-safe when
-     Story has no `:project-root` configured.
-
-     rf2-q7who.1: also disables Causa's global keybinding listener via
-     `:launch.keybinding/enabled? false` so Story's own Cmd/Ctrl+K
-     command palette is not swallowed by Causa's capture-phase
-     listener. The slot is idempotent on every variant edge.
-
-     rf2-ycrt2: also calls `keybinding/detach!` AFTER the slot flip so
-     the listener Causa's preload installed (under the default-true
-     posture, before Story's mount-time bridge fires) is removed at
-     runtime — the slot alone is read only at attach time and would
-     leave the listener installed without this step."
+     Kept for back-compat callers that drove the whole-shell shape
+     explicitly. New code should let the embed own its mount and use
+     `wire-cross-host!` above for the project-root / keybinding
+     bridges."
      []
      (when (and config/enabled? (causa-available?))
        (propagate-project-root!)
@@ -417,6 +419,14 @@
 
      Re-applies the preset on every selection edge so a story author
      who edits `:causa` and hot-reloads sees the change without
-     remount."
+     remount.
+
+     rf2-v1ach: the RHS chip-row's user-override is shell-wide and
+     sticky across variant changes — `causa-embed/effective-panel`
+     prefers the user click when set, falling back to
+     `resolve-panel` otherwise. Authors who want a different
+     default per story declare it on the variant body
+     (`:causa-panel <kw>`); the user can swap at runtime via the
+     chip-row."
      [variant-id]
      (apply-preset! variant-id)))

--- a/tools/story/src/re_frame/story/schemas.cljc
+++ b/tools/story/src/re_frame/story/schemas.cljc
@@ -257,10 +257,32 @@
   filters API, no-opping gracefully when absent.
 
   - `:open?`   — when truthy, auto-open the Causa shell on variant mount.
-  - `:tab`     — registered Causa panel-id keyword to pre-focus
-                 (e.g. `:event-detail :time-travel :app-db :issues
-                 :machines :trace :subs :fx :flows :routes :performance
-                 :hydration :causality :mcp-server :schemas`).
+                 Under the per-panel embed (rf2-v1ach) this is largely
+                 superseded by `:panel` — the chip-row + selected panel
+                 are the default RHS surface; `:open?` survives for the
+                 popout / whole-shell escape hatch only.
+  - `:panel`   — rf2-v1ach. The Causa panel to mount in the RHS Causa
+                 host. One of:
+                   `:event-detail` (default)
+                   `:app-db`
+                   `:views`
+                   `:trace`
+                   `:machines`
+                   `:routing`
+                   `:issues`
+                 Authors choose the panel-id that fits the story's
+                 diagnostic question (`:counter/at-five` → `:app-db`,
+                 `:routing-demo/*` → `:routing`, etc.). The user can
+                 swap at runtime via the RHS chip-row; the user's
+                 manual click overrides for the session.
+  - `:tab`     — DEPRECATED in v1. Was the Causa full-shell tab-id;
+                 pre-rf2-v1ach the RHS hosted the full 4-layer shell
+                 and `:tab` pre-focused a panel inside it. Under the
+                 per-panel embed the chip-row is the panel selector;
+                 `:panel` carries the same intent. `:tab` still
+                 accepted by the preset runtime for back-compat with
+                 the popout escape hatch but new authors should use
+                 `:panel`.
   - `:filters` — `{:out [event-id ...] :in [event-id ...]}` — Causa
                  auto-filter pills to pre-populate. Both axes are
                  optional. Skipped with a console warning when
@@ -271,6 +293,7 @@
                  want LIVE to track head."
   [:map
    [:open?   {:optional true} :boolean]
+   [:panel   {:optional true} :keyword]
    [:tab     {:optional true} :keyword]
    [:filters {:optional true}
     [:map

--- a/tools/story/src/re_frame/story/theme/glyphs.cljc
+++ b/tools/story/src/re_frame/story/theme/glyphs.cljc
@@ -1,0 +1,91 @@
+(ns re-frame.story.theme.glyphs
+  "Story iconography (rf2-p0wur).
+
+  Inline-SVG glyph set used by the sidebar (and elsewhere) so the
+  three sidebar row types parse visually without reading text:
+
+      ◆  story        — diamond glyph, the parent container
+      ●  variant      — solid dot, the renderable unit (also carries
+                        the per-variant status colour)
+      ▦  workspace    — grid glyph, the multi-variant composition
+
+  Every glyph is a stroke-based SVG drawn at a 16×16 viewBox with
+  `currentColor` so callers control the colour via CSS. Pure-data
+  hiccup — JVM-portable; no Reagent dependency.
+
+  ## Usage
+
+      (:require [re-frame.story.theme.glyphs :as glyphs])
+
+      [glyphs/story-glyph 14]      ; <- size in px
+      [glyphs/variant-glyph]       ; default 14px
+      [glyphs/workspace-glyph 12]
+
+  Glyph fns return hiccup. Wrap in a `<span>` if you need flex
+  alignment guarantees — the SVGs are `display: inline-block;
+  vertical-align: -2px` so they baseline-align with text naturally."
+  {:no-doc true})
+
+(defn- svg-wrap
+  "Common SVG attributes — viewBox / currentColor / inline alignment."
+  [size body]
+  (into [:svg {:viewBox        "0 0 16 16"
+               :width          size
+               :height         size
+               :fill           "none"
+               :stroke         "currentColor"
+               :stroke-width   "1.5"
+               :stroke-linecap "round"
+               :stroke-linejoin "round"
+               :aria-hidden    "true"
+               :style          {:display        "inline-block"
+                                :vertical-align "-2px"
+                                :flex-shrink    "0"}}]
+        body))
+
+(defn story-glyph
+  "Diamond outline — the story (parent container) glyph. Filled
+  variants (e.g. an expanded story) would set `:fill` at the
+  call-site."
+  ([] (story-glyph 14))
+  ([size]
+   (svg-wrap size
+     [[:path {:d "M8 1.75 L14.25 8 L8 14.25 L1.75 8 Z"}]])))
+
+(defn variant-glyph
+  "Filled dot — the variant (renderable unit) glyph. The fill
+  inherits via `currentColor`, so callers paint via `:color` for
+  consistency with the surrounding text."
+  ([] (variant-glyph 14))
+  ([size]
+   (svg-wrap size
+     [[:circle {:cx 8 :cy 8 :r 3 :fill "currentColor" :stroke "none"}]])))
+
+(defn workspace-glyph
+  "Grid glyph — the workspace (multi-variant composition) glyph.
+  Four cells in a 2×2 grid."
+  ([] (workspace-glyph 14))
+  ([size]
+   (svg-wrap size
+     [[:rect {:x 2.5 :y 2.5 :width 4.5 :height 4.5 :rx 0.5}]
+      [:rect {:x 9   :y 2.5 :width 4.5 :height 4.5 :rx 0.5}]
+      [:rect {:x 2.5 :y 9   :width 4.5 :height 4.5 :rx 0.5}]
+      [:rect {:x 9   :y 9   :width 4.5 :height 4.5 :rx 0.5}]])))
+
+(defn chevron-right
+  "Right-pointing chevron — used as a 'pop out' affordance on chips,
+  links, and the Causa-popout escape hatch."
+  ([] (chevron-right 12))
+  ([size]
+   (svg-wrap size
+     [[:path {:d "M6 3 L11 8 L6 13"}]])))
+
+(defn external-link
+  "External-link arrow — used on 'pop out full Causa' chip + open-in-
+  editor affordances."
+  ([] (external-link 12))
+  ([size]
+   (svg-wrap size
+     [[:path {:d "M6 3 H3 V13 H13 V10"}]
+      [:path {:d "M9 3 H13 V7"}]
+      [:path {:d "M13 3 L7 9"}]])))

--- a/tools/story/src/re_frame/story/ui/causa_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/causa_embed.cljs
@@ -1,0 +1,399 @@
+(ns re-frame.story.ui.causa-embed
+  "Causa-in-Story per-panel embed surface (rf2-v1ach).
+
+  Replaces the pre-rf2-v1ach `[data-rf-causa-host]` whole-shell mount
+  (the 320px column hosting Causa's 4-layer chrome). Per the audit
+  in `ai/findings/2026-05-19-story-design-causa-integration.md` §Part
+  B the per-panel embed is shape #3: Story's RHS hosts ONE Causa
+  panel at a time, configurable per story via the `:causa-panel` slot
+  (default `:event-detail`), with a chip-row picker letting the user
+  swap (`Event` / `App-db` / `Views` / `Trace` / `Machines` /
+  `Routing` / `Issues`) at runtime.
+
+  ## Why per-panel beats whole-shell
+
+  - **Width affordance.** Causa's 4-layer chrome (ribbon + L2 event
+    list + tab-bar + detail panel) needs ~720px to render usefully;
+    Story's RHS is 320px. Cramming the whole shell into the column
+    means horizontally-clipped chrome on every render. One panel
+    fits cleanly in the available column.
+  - **Focus alignment.** Story is a workshop; the user is hovering
+    over one component asking one diagnostic question. The full
+    4-layer chrome is overkill — one panel = one diagnostic lens
+    matches the cognitive load.
+  - **Author intent.** `:causa-panel` lets the story author pick the
+    most-likely-useful lens (`:app-db` for state-shape stories,
+    `:routing` for routing demos, `:trace` for debugging side
+    effects). Users can swap if they need a different lens.
+
+  ## Public surface
+
+  - `(causa-embed-panel)` — the RHS Causa-host component. Renders
+    the chip-row picker + the mounted panel slot + the popout chip.
+  - `(mount-fn-for panel-id)` — pure data → data: the Causa
+    `mount-<panel>!` fn for a panel-id. Used by the panel-host
+    React component to drive the mount on every panel-id change.
+  - `(resolve-panel variant-id)` — pure-ish: read the resolved
+    `:causa-panel` for `variant-id` (variant slot beats story
+    slot beats default `:event-detail`).
+
+  ## Frame isolation
+
+  Every mount path goes through `panels/mount-<panel>!` which wraps
+  the panel view in `[rf/frame-provider {:frame :rf/causa} …]` per
+  the rf2-crhr8 embedding contract — the panel's Causa-state
+  subscribes resolve to `:rf/causa` regardless of the host's
+  React-context. Story authors who want a panel observing a
+  specific app frame pass `{:frame :my-app/cart}` per the contract;
+  the wrapper still resolves Causa's own UI state on `:rf/causa`.
+
+  ## CLJS-only
+
+  Token data + pure helpers are .cljc-friendly; the React
+  component + mount-driving side effects are CLJS-only."
+  (:require [reagent.core :as r]
+            [re-frame.story.causa-preset :as causa-preset]
+            [re-frame.story.config :as config]
+            [re-frame.story.predicates :as pred]
+            [re-frame.story.registrar :as registrar]
+            [re-frame.story.theme.colors :as colors]
+            [re-frame.story.theme.glyphs :as glyphs]
+            [re-frame.story.theme.motion :as motion]
+            [re-frame.story.theme.typography :as typography :refer [sans-stack]]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- panel catalog -------------------------------------------------------
+
+(def panel-catalog
+  "Ordered vector of `{:panel <kw> :label <str> :title <str>}` maps
+  for every Causa panel exposed in the Story RHS chip-row. Order
+  matches the rough debugging-frequency rubric: event-detail first
+  (the default), state-shape lenses next (app-db / views), trace
+  next, then the specialised lenses (machines / routing / issues).
+
+  Pure data — JVM-portable. Tests assert ordering + completeness
+  against the rf2-crhr8 panel set."
+  [{:panel :event-detail :label "Event"    :title "Six-domino cascade view for the focused event"}
+   {:panel :app-db       :label "App-db"   :title "Structural diff of app-db across the focused cascade"}
+   {:panel :views        :label "Views"    :title "Per-view sub-invalidation surface for the focused cascade"}
+   {:panel :trace        :label "Trace"    :title "Trace-buffer feed for the focused cascade"}
+   {:panel :machines     :label "Machines" :title "State-machine chart + arcs/rings for the focused machine"}
+   {:panel :routing      :label "Routing"  :title "Registered-routes lens + simulate-URL surface"}
+   {:panel :issues       :label "Issues"   :title "Cascade-scoped issues feed + ungrouped escape-hatch lane"}])
+
+(def default-panel
+  "Default panel when neither story nor variant declares one."
+  :event-detail)
+
+(def panel-ids
+  "Set of valid `:panel` slot values. Pure data — used by the schema
+  + sanity-check in `resolve-panel`."
+  (set (map :panel panel-catalog)))
+
+;; ---- pure: panel resolution ----------------------------------------------
+
+(defn resolve-panel
+  "Read the resolved `:causa-panel` for `variant-id` from the
+  registrar. Variant body wins over story body wins over `default-panel`.
+
+  Pure-ish (reads the registrar). Returns one of `panel-ids`; an
+  unknown keyword in the slot falls back to `default-panel` so a
+  typo doesn't blank the RHS."
+  [variant-id]
+  (let [variant-body (registrar/handler-meta :variant variant-id)
+        story-id     (pred/parent-story-id variant-id)
+        story-body   (when story-id
+                       (registrar/handler-meta :story story-id))
+        ;; rf2-v1ach: the `:causa-panel` slot lives directly on the
+        ;; body for ergonomics (parallel to `:tags`, `:viewport`,
+        ;; `:background`). The legacy `:causa :panel` nested form is
+        ;; ALSO honoured so authors who already write a `:causa` map
+        ;; for filters / focus don't have to split it. Variant slot
+        ;; wins, then story slot, then default.
+        slot         (or (:causa-panel variant-body)
+                         (get-in variant-body [:causa :panel])
+                         (:causa-panel story-body)
+                         (get-in story-body [:causa :panel])
+                         default-panel)]
+    (if (contains? panel-ids slot)
+      slot
+      default-panel)))
+
+;; ---- mount-fn dispatch ---------------------------------------------------
+
+(defn- resolve-fn
+  "Feature-detect-safe symbol → fn lookup. Mirrors the
+  `causa-preset/resolve-fn` shape so Causa can be absent without
+  killing the shell render."
+  [sym]
+  (try
+    (let [ns-str   (namespace sym)
+          name-str (name sym)
+          ns-obj   (when ns-str (find-ns-obj (symbol ns-str)))]
+      (when ns-obj
+        (let [munged (-> name-str
+                         (.replace #"-" "_")
+                         (.replace #"\?" "_QMARK_")
+                         (.replace #"\!" "_BANG_"))
+              v      (aget ns-obj munged)]
+          (when (fn? v) v))))
+    (catch :default _ nil)))
+
+(def panel-id->mount-fn-sym
+  "Pure data → data: map a panel-id to the fully-qualified
+  `day8.re-frame2-causa.panels/mount-<panel>!` symbol. Used by the
+  mount-fn dispatch below; pure so JVM tests can assert the
+  contract without booting Reagent."
+  {:event-detail 'day8.re-frame2-causa.panels/mount-event-detail!
+   :app-db       'day8.re-frame2-causa.panels/mount-app-db-diff!
+   :views        'day8.re-frame2-causa.panels/mount-views!
+   :trace        'day8.re-frame2-causa.panels/mount-trace!
+   :machines     'day8.re-frame2-causa.panels/mount-machine-inspector!
+   :routing      'day8.re-frame2-causa.panels/mount-routing!
+   :issues       'day8.re-frame2-causa.panels/mount-issues-ribbon!})
+
+(defn mount-fn-for
+  "Return the Causa `mount-<panel>!` fn for `panel-id`, or nil
+  when Causa is not on the classpath / the panel-id is unknown.
+  Feature-detect-safe — every call site treats a nil result as a
+  no-op render."
+  [panel-id]
+  (when-let [sym (get panel-id->mount-fn-sym panel-id)]
+    (resolve-fn sym)))
+
+;; ---- popout escape hatch -------------------------------------------------
+
+(defn popout-full-shell!
+  "Pop out the full Causa 4-layer shell into a second window. Uses
+  `day8.re-frame2-causa.mount/popout!` per rf2-zkfiz Q1-8. The
+  popout carries the full chrome the per-panel embed elides so
+  power users have one click to the whole-shell shape.
+
+  Feature-detect-safe — when Causa is absent the chip click is a
+  console.warn breadcrumb."
+  []
+  (when (and config/enabled? (causa-preset/causa-available?))
+    (if-let [popout! (resolve-fn 'day8.re-frame2-causa.mount/popout!)]
+      (popout!)
+      (when (and (exists? js/console) (.-warn js/console))
+        (.warn js/console
+               "[re-frame.story.ui.causa-embed] popout! not loaded — "
+               "day8.re-frame2-causa.mount/popout! is the canonical "
+               "second-window mount surface")))))
+
+;; ---- styling -------------------------------------------------------------
+
+(def ^:private styles
+  {:wrap          {:display "flex"
+                   :flex-direction "column"
+                   :flex "1 1 auto"
+                   :min-height "320px"
+                   :overflow "hidden"
+                   :gap "8px"}
+   ;; rf2-v1ach — chip-row picker. Sits above the mounted panel slot;
+   ;; the user clicks a chip to swap which panel renders. Uses Causa's
+   ;; cool slate palette via a thin amber-tinted seam — the chip-row
+   ;; is Story chrome (warm amber accents) but the chips themselves
+   ;; visually point at the Causa panel below.
+   :chip-row      {:display "flex"
+                   :align-items "center"
+                   :gap "4px"
+                   :flex-wrap "wrap"
+                   :padding-bottom "6px"
+                   :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                   :font-family sans-stack}
+   :chip          {:padding "3px 10px"
+                   :background (:bg-3 colors/tokens)
+                   :color (:text-secondary colors/tokens)
+                   :border (str "1px solid " (:border-subtle colors/tokens))
+                   :border-radius "10px"
+                   :cursor "pointer"
+                   :font-family sans-stack
+                   :font-size (:caption typography/type-scale)
+                   :letter-spacing "0.01em"
+                   :user-select "none"
+                   :transition (:chip motion/transitions)}
+   :chip-active   {:background (:accent-amber colors/tokens)
+                   :color (:text-on-accent colors/tokens)
+                   :border (str "1px solid " (:accent-amber-deep colors/tokens))
+                   :font-weight (str (:semibold typography/weights))}
+   :spacer        {:flex "1"}
+   ;; rf2-v1ach — "pop out full Causa" escape hatch. Sits at the
+   ;; right edge of the chip-row so the user reads it as 'leave the
+   ;; embed for the full shell'. The chip wears the chevron-right /
+   ;; external-link glyph so its action is iconographically obvious.
+   :popout-chip   {:padding "3px 10px"
+                   :background "transparent"
+                   :color (:info colors/tokens)
+                   :border (str "1px solid " (:border-default colors/tokens))
+                   :border-radius "10px"
+                   :cursor "pointer"
+                   :font-family sans-stack
+                   :font-size (:caption typography/type-scale)
+                   :letter-spacing "0.01em"
+                   :display "inline-flex"
+                   :align-items "center"
+                   :gap "4px"
+                   :transition (:chip motion/transitions)}
+   ;; rf2-v1ach — the mounted-panel slot. Causa's panel mounts into
+   ;; this DOM element (a `<div>` with `data-rf-causa-panel-host`).
+   ;; `position: relative` + `flex: 1 1 auto` so the panel
+   ;; participates in normal flex flow.
+   :panel-host    {:position "relative"
+                   :display "flex"
+                   :flex "1 1 auto"
+                   :flex-direction "column"
+                   :min-height "240px"
+                   :overflow "hidden"
+                   :border-radius "4px"
+                   :background (:bg-canvas colors/tokens)}
+   :empty         {:padding "16px 8px"
+                   :color (:text-tertiary colors/tokens)
+                   :font-family sans-stack
+                   :font-size (:caption typography/type-scale)
+                   :font-style "italic"}})
+
+;; ---- chip rendering ------------------------------------------------------
+
+(defn chip
+  "Render a single chip for `panel-id`. Click handler dispatches the
+  panel selection via `state/swap-state!` so the RHS slot re-renders.
+  Public so tests can introspect the chip-level hiccup without
+  driving the full host."
+  [panel-id label title active?]
+  [:button
+   {:style (merge (:chip styles)
+                  (when active? (:chip-active styles)))
+    :role "button"
+    :aria-pressed (str active?)
+    :title title
+    :data-test "story-causa-panel-chip"
+    :data-causa-panel (name panel-id)
+    :on-click (fn [_]
+                (state/swap-state!
+                  (fn [s] (assoc s :causa-panel panel-id))))}
+   label])
+
+;; ---- panel-id resolution + user-override ---------------------------------
+
+(defn effective-panel
+  "Pure data → data: resolve the panel-id to mount given the shell
+  state + the focused variant. The user's `:causa-panel` override
+  (set by clicking a chip) beats the story/variant slot; if no
+  override is set OR the override is `:rf/auto`, fall back to
+  `resolve-panel`.
+
+  Public for the JVM test corpus."
+  [shell variant-id]
+  (let [override (:causa-panel shell)]
+    (cond
+      (contains? panel-ids override) override
+      :else                           (resolve-panel variant-id))))
+
+;; ---- React component: panel-host (drives mount on panel change) ----------
+
+(defn- panel-host-component
+  "Reagent class-3 component owning the DOM mount lifecycle for
+  ONE Causa panel. On mount + on panel-id change, calls the
+  Causa `mount-<panel>!` fn into our `<div>` ref; on unmount,
+  calls the unmount fn the mount returned.
+
+  Why a class-3 component: every panel swap is a full unmount →
+  mount round-trip. Reagent's :component-did-update + lifecycle
+  hooks give us a clean seam to drive this without a render-loop
+  race. The `<div>` ref is stable across re-renders so the
+  Causa adapter can find its mount-point reliably."
+  [_panel-id]
+  (let [host-ref    (atom nil)
+        unmount-ref (atom nil)
+        do-mount!   (fn [pid]
+                      (when-let [unmount! @unmount-ref]
+                        (try (unmount!) (catch :default _ nil))
+                        (reset! unmount-ref nil))
+                      (when-let [host @host-ref]
+                        (when-let [mount-fn (mount-fn-for pid)]
+                          (try
+                            (let [unmount! (mount-fn host)]
+                              (reset! unmount-ref unmount!))
+                            (catch :default e
+                              (when (and (exists? js/console)
+                                         (.-warn js/console))
+                                (.warn js/console
+                                       (str "[story.causa-embed] mount " pid " threw: "
+                                            (.-message e)))))))))]
+    (r/create-class
+      {:display-name "story-causa-embed-panel-host"
+       :component-did-mount
+       (fn [this]
+         (do-mount! (-> this r/argv second)))
+       :component-did-update
+       (fn [this old-argv]
+         (let [new-pid (-> this r/argv second)
+               old-pid (-> old-argv second)]
+           (when (not= new-pid old-pid)
+             (do-mount! new-pid))))
+       :component-will-unmount
+       (fn [_this]
+         (when-let [unmount! @unmount-ref]
+           (try (unmount!) (catch :default _ nil))
+           (reset! unmount-ref nil)))
+       :reagent-render
+       (fn [pid]
+         [:div {:ref (fn [node] (reset! host-ref node))
+                :data-rf-causa-panel-host (name pid)
+                :data-test "story-causa-panel-host"
+                :style (:panel-host styles)}])})))
+
+;; ---- public surface: the embed panel -------------------------------------
+
+(defn causa-embed-panel
+  "RHS Causa-host component. Renders a chip-row picker letting the
+  user swap between Causa panels at runtime, the mounted panel
+  itself, and the 'pop out full Causa' escape hatch.
+
+  Returns nil when no variant is focused — the panels are
+  cascade-scoped; without a variant there's nothing to inspect.
+  Returns a graceful empty state when Causa is not on the
+  classpath (preload absent / production build)."
+  []
+  (let [shell      @state/shell-state-atom
+        variant-id (:selected-variant shell)]
+    (cond
+      (not variant-id)
+      [:div {:style (:empty styles)
+             :data-test "story-causa-embed-empty"}
+       "Select a variant to inspect via Causa."]
+
+      (not (causa-preset/causa-available?))
+      [:div {:style (:empty styles)
+             :data-test "story-causa-embed-no-causa"}
+       "Causa is not loaded in this build — embed surface unavailable."]
+
+      :else
+      (let [active-panel (effective-panel shell variant-id)]
+        [:div {:style (:wrap styles)
+               :data-test "story-causa-embed"
+               :data-active-panel (name active-panel)}
+         ;; chip-row + popout
+         [:div {:style (:chip-row styles)
+                :role "tablist"
+                :aria-label "Causa panel picker"}
+          (for [{:keys [panel label title]} panel-catalog]
+            ^{:key panel}
+            [chip panel label title (= panel active-panel)])
+          [:span {:style (:spacer styles)}]
+          [:button
+           {:style (:popout-chip styles)
+            :data-test "story-causa-popout"
+            :title "Open the full Causa 4-layer shell in a new window"
+            :on-click (fn [_] (popout-full-shell!))}
+           [:span "Pop out"]
+           [glyphs/external-link 11]]]
+         ;; the panel-host — keyed by panel-id so a swap forces a
+         ;; fresh mount through the lifecycle. The component
+         ;; itself ALSO handles the swap via componentDidUpdate;
+         ;; the React key is belt-and-braces so a Causa internal
+         ;; bug (e.g. a panel that doesn't release its DOM)
+         ;; can't carry state across panel-ids.
+         ^{:key (str variant-id "::" active-panel)}
+         [panel-host-component active-panel]]))))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -63,6 +63,7 @@
             [re-frame.trace :as rf-trace]
             [re-frame.story.ui.backgrounds-switcher :as backgrounds-switcher]
             [re-frame.story.ui.canvas :as canvas]
+            [re-frame.story.ui.causa-embed :as causa-embed]
             [re-frame.story.ui.command-palette.view :as command-palette]
             [re-frame.story.ui.controls :as controls]
             [re-frame.story.ui.dispatch-console :as dispatch-console]
@@ -405,27 +406,22 @@
                      ;; would otherwise deref subscriptions against a
                      ;; non-existent frame.
                      (ensure-variant-frame! now)
-                     ;; rf2-sgdd3: Causa is always-on in the RHS by
-                     ;; default. Drive `mount/open!` on every variant-
-                     ;; selection edge so the user lands in a freshly-
-                     ;; opened Causa shell against the new variant's
-                     ;; frame. Feature-detect-safe; no-op when Causa
-                     ;; is not on the classpath. Deferred one tick via
-                     ;; setTimeout so React has committed the RHS
-                     ;; `[data-rf-causa-host]` slot before `mount/open!`
-                     ;; queries the DOM for it (the slot only mounts
-                     ;; on the first render that has a selected variant).
-                     (js/setTimeout
-                       (fn [] (causa-preset/ensure-causa-mounted!))
-                       0)
+                     ;; rf2-v1ach: Causa now mounts per-panel into the
+                     ;; RHS via `causa-embed/causa-embed-panel`. The
+                     ;; embed owns its own React lifecycle — selecting
+                     ;; a variant rebuilds the panel-host component
+                     ;; (keyed on `variant-id::panel-id`) which drives
+                     ;; the Causa mount-fn on commit. We retain the
+                     ;; per-variant project-root + keybinding bridges
+                     ;; so the popout escape hatch + Causa's source-
+                     ;; coord chips honour Story's configured
+                     ;; `:project-root`. Per-variant Causa bridges
+                     ;; live on a separate seam from the embed mount.
+                     (causa-preset/wire-cross-host!)
                      ;; rf2-q9kv5: apply any per-story Causa preset
                      ;; (focus tab, configure filters, focus a cascade
-                     ;; position). Feature-detect-safe; no-op when
-                     ;; Causa is not on the classpath. The `:open?`
-                     ;; slot of the preset is now redundant — Causa
-                     ;; is opened above unconditionally — but the rest
-                     ;; of the preset (tab / filters / focus) still
-                     ;; rides this hook.
+                     ;; position) + seed the RHS chip-row's user-
+                     ;; override slot from the story's `:causa-panel`.
                      (causa-preset/on-variant-selected! now)
                      ;; rf2-8i2a9: auto-run the variant's `:play-script`
                      ;; if `:auto-run?` is true. Best-effort — yields one
@@ -523,18 +519,16 @@
              :role       "complementary"
              :aria-label "Inspectors"
              :tab-index  "0"}
-     ;; rf2-sgdd3 — Causa mount slot. Causa's `mount/open!` finds
-     ;; `[data-rf-causa-host]` and renders its shell into a child div.
-     ;; Feature-detect-safe: when Causa is not on the classpath the
-     ;; slot stays empty (preload isn't loaded → `causa-preset/
-     ;; causa-available?` returns false → `ensure-causa-mounted!`
-     ;; short-circuits → nothing renders here).
+     ;; rf2-v1ach — Causa-in-Story per-panel embed. Replaces the
+     ;; pre-rf2-v1ach whole-shell mount that crammed Causa's 4-layer
+     ;; chrome into a 320px column. The new shape: ONE Causa panel
+     ;; mounted at a time, chip-row picker for runtime swap, popout
+     ;; chip for the full-shell escape hatch. Per-story author
+     ;; intent rides the `:causa-panel` slot (or legacy
+     ;; `:causa :panel`); user clicks override for the session.
      ;;
-     ;; rf2-8rvu4: wrap the Causa host in a labelled RHS section so
-     ;; the user sees 'CAUSA — diagnostic surface' above the embed
-     ;; instead of an unlabelled 320px column. Section header carries
-     ;; the amber accent variant since Causa is the RHS's primary
-     ;; tenant.
+     ;; Feature-detect-safe: `causa-embed-panel` renders a graceful
+     ;; empty state when Causa is not on the classpath.
      [:section {:style (:rhs-section styles)
                 :data-rf-rhs-section "causa"}
       [:div {:style (merge (:rhs-section-h styles)
@@ -544,19 +538,7 @@
                        :color (:text-tertiary colors/tokens)
                        :letter-spacing "0.04em"}}
         "diagnostic"]]
-      ;; The slot is `position: relative` + `flex` so Causa's `:inline`
-      ;; mode (which uses `position: relative` and fills its host)
-      ;; participates in normal flex flow rather than escaping to
-      ;; viewport-fixed. The `min-height` keeps the slot tall enough
-      ;; for Causa's 4-layer chrome to render usefully even before the
-      ;; user resizes the RHS rail.
-      [:div {:data-rf-causa-host true
-             :data-test          "story-rhs-causa-host"
-             :style              {:position    "relative"
-                                  :display     "flex"
-                                  :flex        "1 1 auto"
-                                  :min-height  "320px"
-                                  :overflow    "hidden"}}]]
+      [causa-embed/causa-embed-panel]]
      (when (:controls vis)
        [:section {:style (:rhs-section styles)
                   :data-rf-rhs-section "controls"}
@@ -825,15 +807,12 @@
          (rails/hydrate!)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
            (ensure-listeners-for-variant! vid)
-           ;; rf2-sgdd3: mount Causa on shell mount too — without this
-           ;; the deep-link / persisted-selection path would render
-           ;; an empty `[data-rf-causa-host]` slot until the user
-           ;; clicked a different variant. Same setTimeout discipline
-           ;; as the selection-watcher branch: defer one tick so the
-           ;; RHS host slot has committed before Causa queries the DOM.
-           (js/setTimeout
-             (fn [] (causa-preset/ensure-causa-mounted!))
-             0)
+           ;; rf2-v1ach: per-panel embed manages its own mount on
+           ;; commit. The cross-host bridges (project-root +
+           ;; keybinding detach) still need to fire so the popout
+           ;; escape hatch + Causa's source-coord chips resolve
+           ;; against Story's `:project-root`.
+           (causa-preset/wire-cross-host!)
            ;; rf2-q9kv5: apply per-story preset on the mount-time
            ;; selection too (the selection-watcher only fires on
            ;; change, so a pre-selected variant would otherwise miss

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -57,6 +57,8 @@
             [re-frame.story.runtime           :as runtime]
             [re-frame.story.async             :as async]
             [re-frame.story.registrar         :as registrar]
+            [re-frame.story.theme.colors      :as colors]
+            [re-frame.story.theme.glyphs      :as glyphs]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
             [re-frame.story.ui.state          :as state]))
 
@@ -251,18 +253,33 @@
                           (fn [s] (-> s
                                       (state/select-variant variant-id)
                                       (state/select-workspace nil)))))}
-   (when testable? [status-dot status])
+   ;; rf2-p0wur — per-row glyph affordance. Testable variants keep the
+   ;; status dot (it carries pass/fail/running colour); non-testable
+   ;; variants get a refined variant glyph so every row carries an
+   ;; iconographic prefix at a uniform indent.
+   (if testable?
+     [status-dot status]
+     [:span {:style (:variant-glyph styles)}
+      [glyphs/variant-glyph 10]])
    [:span (str "/" (name variant-id))]
    [tag-badges tags]])
 
 (defn- story-block
   "Render one story header + its variants. `entry` shape is
   `{:story-id ... :variants [[variant-id body] ...]}` (the shape
-  produced by `state/group-variants-by-story`)."
+  produced by `state/group-variants-by-story`).
+
+  rf2-p0wur: story rows lead with an amber diamond glyph + carry an
+  inter-story spacer so the sidebar tree breathes — pre-rf2-p0wur the
+  rows packed flush with no whitespace breaks between top-level stories.
+  The glyph wears `:accent-amber` so the parent row reads as a labelled
+  chapter heading."
   [{:keys [story-id variants]} selected-variant testable-set test-runs]
-  [:div
+  [:div {:style (:story-block styles)}
    [:div {:style (:story-row styles)}
-    (str (or story-id "(no story)"))]
+    [:span {:style (:story-glyph styles)}
+     [glyphs/story-glyph 13]]
+    [:span (str (or story-id "(no story)"))]]
    (for [[vid body] variants]
      (let [testable? (contains? testable-set vid)
            status    (or (get-in test-runs [vid :status]) :pending)
@@ -272,14 +289,18 @@
 
 (defn- workspace-row
   [workspace-id selected?]
-  [:div {:style    (merge (:variant-row styles)
-                          (when selected? (:variant-row-active styles)))
+  [:div {:style    (merge (:workspace-row styles)
+                          (when selected? (:workspace-row-active styles)))
+         :data-test   "story-sidebar-workspace-row"
+         :data-workspace (str workspace-id)
          :on-click (fn [_]
                      (state/swap-state!
                        (fn [s] (-> s
                                    (state/select-workspace workspace-id)
                                    (state/select-variant nil)))))}
-   (str workspace-id)])
+   [:span {:style (:workspace-glyph styles)}
+    [glyphs/workspace-glyph 12]]
+   [:span (str workspace-id)]])
 
 ;; ---- chrome-level test widget (rf2-q0irb) -------------------------------
 
@@ -489,7 +510,11 @@
            :aria-label "Stories and workspaces"
            :tab-index  "0"}
      [:div {:style (:tree styles)}
-      [:div {:style (:header styles)} "Stories"]
+      [:div {:style (:header styles)}
+       [:span {:style {:display "inline-flex" :align-items "center"
+                       :color (:accent-amber colors/tokens)}}
+        [glyphs/story-glyph 12]]
+       [:span "Stories"]]
       [tag-filter-row (:variants registry) tag-filter tag->axis]
       (if (empty? grouped)
         [:div {:style (:empty styles)}
@@ -501,7 +526,13 @@
           [story-block entry sel-variant testable-set test-runs]))
       (when (seq workspaces)
         [:div
-         [:div {:style (:section styles)} "Workspaces"]
+         [:div {:style (:section styles)}
+          [:span {:style {:display "inline-flex" :align-items "center"
+                          :color (:info colors/tokens)
+                          :margin-right "6px"
+                          :vertical-align "-2px"}}
+           [glyphs/workspace-glyph 11]]
+          "Workspaces"]
          (for [[wid _body] (sort-by key workspaces)]
            ^{:key wid}
            [workspace-row wid (= wid sel-ws)])])]

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -4,41 +4,61 @@
   sidebar ns trends toward the 250-LoC leaf-size ceiling (rf2-zkca8).
 
   CLJS-only."
-  (:require [re-frame.story.theme.typography :as typography :refer [mono-stack]]
+  (:require [re-frame.story.theme.typography :as typography :refer [mono-stack sans-stack]]
             [re-frame.story.theme.colors :as colors]
             [re-frame.story.theme.motion :as motion]))
 
 (def styles
   {:wrap         {:width "260px"
-                  :background (:bg-2 colors/tokens)
+                  :background (:bg-1 colors/tokens)
                   :color (:text-primary colors/tokens)
-                  :font-family mono-stack
+                  :font-family sans-stack
                   :font-size (:body-tight typography/type-scale)
-                  :border-right "1px solid #444"
+                  :border-right (str "1px solid " (:border-default colors/tokens))
                   :overflow "auto"
-                  :padding "8px 0"
+                  :padding "8px 0 0 0"
                   :display "flex"
                   :flex-direction "column"}
    :tree         {:flex "1"
                   :overflow "auto"
                   :display "flex"
-                  :flex-direction "column"}
-   :header       {:padding "8px 12px"
-                  :font-weight "bold"
-                  :color (:info colors/tokens)
-                  :border-bottom "1px solid #333"
-                  :margin-bottom "4px"}
-   :section      {:padding "12px 0 4px 12px"
-                  :font-weight "bold"
-                  :color (:text-secondary colors/tokens)
+                  :flex-direction "column"
+                  :padding-bottom "8px"}
+   ;; rf2-p0wur — the sidebar header reads as Story's "Stories" lens
+   ;; label, parity with the RHS section headers (rf2-8rvu4 §rhs-section-h
+   ;; in shell-styles). Uppercase + wide tracking + nano scale + a
+   ;; subtle amber underline so the sidebar matches the workshop
+   ;; chrome's section-label vocabulary.
+   :header       {:padding "10px 12px 8px 12px"
+                  :font-family sans-stack
+                  :font-weight (str (:semibold typography/weights))
+                  :font-size (:nano typography/type-scale)
                   :text-transform "uppercase"
-                  :font-size (:micro typography/type-scale)
-                  :letter-spacing "0.5px"}
+                  :letter-spacing (:label-wide typography/letter-spacing)
+                  :color (:accent-amber colors/tokens)
+                  :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                  :box-shadow (str "0 1px 0 " (:accent-amber-soft colors/tokens))
+                  :margin-bottom "6px"
+                  :display "flex"
+                  :align-items "center"
+                  :gap "8px"}
+   :section      {:padding "16px 0 6px 12px"
+                  :margin-top "4px"
+                  :border-top (str "1px solid " (:border-subtle colors/tokens))
+                  :font-family sans-stack
+                  :font-weight (str (:semibold typography/weights))
+                  :color (:text-tertiary colors/tokens)
+                  :text-transform "uppercase"
+                  :font-size (:nano typography/type-scale)
+                  :letter-spacing (:label-wide typography/letter-spacing)
+                  :display "flex"
+                  :align-items "center"}
    :tag-row      {:display "flex"
                   :flex-direction "column"
                   :gap "6px"
-                  :padding "8px 12px"
-                  :border-bottom "1px solid #333"}
+                  :padding "8px 12px 10px 12px"
+                  :margin-bottom "6px"
+                  :border-bottom (str "1px solid " (:border-subtle colors/tokens))}
    ;; rf2-7ncf9 — faceted tag-filter: one labelled chip row per axis.
    :axis-row     {:display "flex"
                   :flex-direction "column"
@@ -61,20 +81,67 @@
                   :transition (:chip motion/transitions)}
    :tag-active   {:background (:accent-amber colors/tokens)
                   :color (:text-on-accent colors/tokens)}
-   :story-row    {:padding "4px 12px"
-                  :color (:warning colors/tokens)
-                  :font-weight "bold"
-                  :cursor "default"}
-   :variant-row  {:padding "2px 12px 2px 24px"
-                  :cursor "pointer"
+   ;; rf2-p0wur — top-level story rows + a generous inter-block gap so
+   ;; the sidebar tree breathes. Story rows lead with the diamond
+   ;; glyph (`re-frame.story.theme.glyphs/story-glyph`) — the sidebar
+   ;; component renders the glyph inline; the glyph itself wears the
+   ;; amber accent so each story's parent row reads as a labelled
+   ;; chapter heading.
+   :story-block  {:margin-bottom "12px"
+                  :padding-bottom "2px"}
+   :story-row    {:padding "6px 12px 6px 10px"
+                  :font-family sans-stack
                   :color (:text-primary colors/tokens)
+                  :font-weight (str (:semibold typography/weights))
+                  :font-size (:body-tight typography/type-scale)
+                  :letter-spacing "0.01em"
+                  :cursor "default"
                   :display "flex"
                   :align-items "center"
-                  :gap "6px"
+                  :gap "8px"}
+   :story-glyph  {:flex-shrink "0"
+                  :display "inline-flex"
+                  :align-items "center"
+                  :color (:accent-amber colors/tokens)}
+   :variant-row  {:padding "3px 12px 3px 26px"
+                  :cursor "pointer"
+                  :color (:text-secondary colors/tokens)
+                  :font-family mono-stack
+                  :display "flex"
+                  :align-items "center"
+                  :gap "8px"
+                  :border-left (str "2px solid transparent")
                   :transition (:row motion/transitions)}
    :variant-row-active {:background (:bg-active colors/tokens)
                         :color (:accent-amber colors/tokens)
-                        :font-weight (str (:medium typography/weights))}
+                        :font-weight (str (:medium typography/weights))
+                        :border-left (str "2px solid " (:accent-amber colors/tokens))}
+   :variant-glyph {:flex-shrink "0"
+                   :display "inline-flex"
+                   :align-items "center"
+                   :justify-content "center"
+                   :width "10px"
+                   :height "10px"
+                   :opacity 0.55
+                   :color (:text-tertiary colors/tokens)}
+   :workspace-row {:padding "3px 12px 3px 14px"
+                   :cursor "pointer"
+                   :color (:text-secondary colors/tokens)
+                   :font-family mono-stack
+                   :display "flex"
+                   :align-items "center"
+                   :gap "8px"
+                   :border-left (str "2px solid transparent")
+                   :transition (:row motion/transitions)}
+   :workspace-row-active {:background (:bg-active colors/tokens)
+                          :color (:accent-amber colors/tokens)
+                          :font-weight (str (:medium typography/weights))
+                          :border-left (str "2px solid " (:accent-amber colors/tokens))}
+   :workspace-glyph {:flex-shrink "0"
+                     :display "inline-flex"
+                     :align-items "center"
+                     :color (:info colors/tokens)
+                     :opacity 0.75}
    :empty        {:color (:text-tertiary colors/tokens)
                   :font-style "italic"
                   :padding "8px 12px"}

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -205,38 +205,52 @@
 
 ;; ---- styling -------------------------------------------------------------
 ;;
-;; Matches the existing controls-panel chip vocabulary + the mode-tabs
-;; strip's chrome register (rf2-2uwv contrast lock). Spec/010 §Visual
-;; style: `#252526` background, `#444` bottom border, 8/12px padding,
-;; 6px chip gap, 10/11px text.
+;; Per rf2-v58dm the toolbar now reads as ~5 distinct affordance
+;; clusters separated by token-driven vertical dividers + a
+;; left-edge upper-cased cluster label so users scan groups rather
+;; than flat chips.  Tokens (rf2-2rwdc / rf2-i3i5j / rf2-3lt89)
+;; carry the surface vocabulary; no hex literals.
+;;
+;; Cluster shape:
+;;   [MODES axis-groups …]  divider  [DATA dispatch / play]  divider
+;;   [VIEW viewport / backgrounds]  divider  [DEBUG inspector]
+;;   divider  [REC recorder]  [reset]
+;;
+;; Modes occupy the left edge (variable width — registry-driven);
+;; everything else is right-aligned via the spacer slot. Wrapping
+;; preserves on narrow viewports: each `:cluster` is a self-contained
+;; flex-item so it stays cohesive across rows.
 
 (def ^:private styles
   {:strip       {:display        "flex"
                  :align-items    "center"
-                 :gap            "10px"
-                 :padding        "6px 12px"
+                 :gap            "6px"
+                 :padding        "6px 10px"
                  :background     (:bg-2 colors/tokens)
-                 :border-bottom  "1px solid #444"
+                 :border-bottom  (str "1px solid " (:border-default colors/tokens))
                  :font-family    mono-stack
                  :font-size      (:caption typography/type-scale)
                  :min-height     "32px"
                  :box-sizing     "border-box"
-                 :flex-wrap      "wrap"}
-   :axis-label  {:font-size       (:micro typography/type-scale)
+                 :flex-wrap      "wrap"
+                 :row-gap        "6px"}
+   :axis-label  {:font-family     typography/sans-stack
+                 :font-size       (:micro typography/type-scale)
+                 :font-weight     (str (:semibold typography/weights))
                  :text-transform  "uppercase"
                  :color           (:text-tertiary colors/tokens)
-                 :letter-spacing  "0.5px"
-                 :margin-right    "4px"}
+                 :letter-spacing  (:label-wide typography/letter-spacing)
+                 :margin-right    "6px"}
    :axis-group  {:display     "flex"
                  :align-items "center"
                  :gap         "4px"}
    :chip-row    {:display   "flex"
                  :gap       "4px"
                  :flex-wrap "wrap"}
-   :chip        {:padding         "3px 8px"
+   :chip        {:padding         "3px 9px"
                  :background      (:bg-3 colors/tokens)
                  :color           (:text-primary colors/tokens)
-                 :border          "none"
+                 :border          (str "1px solid " (:border-subtle colors/tokens))
                  :border-radius   "10px"
                  :cursor          "pointer"
                  :font-family     mono-stack
@@ -248,16 +262,43 @@
                  :user-select     "none"
                  :transition      (:chip motion/transitions)}
    :chip-active {:background (:accent-amber colors/tokens)
-                 :color      (:text-on-accent colors/tokens)}
+                 :color      (:text-on-accent colors/tokens)
+                 :border     (str "1px solid " (:accent-amber-deep colors/tokens))}
    :spacer      {:flex "1"}
-   :reset       {:padding       "3px 8px"
+   ;; rf2-v58dm — a `:cluster` is a self-contained flex-item carrying
+   ;; one logical group of affordances. The strip composes ~5 clusters
+   ;; separated by `:divider` strokes.
+   :cluster     {:display     "inline-flex"
+                 :align-items "center"
+                 :gap         "4px"
+                 :padding     "0 2px"}
+   ;; rf2-v58dm — left-edge upper-cased label per cluster. Mirrors the
+   ;; existing axis-label vocabulary so MODES / DATA / VIEW / DEBUG /
+   ;; REC all share the same small-caps grammar.
+   :cluster-label {:font-family    typography/sans-stack
+                   :font-size      (:micro typography/type-scale)
+                   :font-weight    (str (:semibold typography/weights))
+                   :text-transform "uppercase"
+                   :color          (:text-tertiary colors/tokens)
+                   :letter-spacing (:label-wide typography/letter-spacing)
+                   :margin-right   "6px"}
+   ;; rf2-v58dm — vertical divider between clusters. Token-driven
+   ;; hairline; carries an inline height so the rule sits centred on
+   ;; the strip rather than spanning it edge-to-edge.
+   :divider     {:width        "1px"
+                 :align-self   "stretch"
+                 :margin       "2px 4px"
+                 :background   (:border-subtle colors/tokens)
+                 :flex-shrink  "0"}
+   :reset       {:padding       "3px 9px"
                  :background    "transparent"
-                 :color         (:text-primary colors/tokens)
-                 :border        "1px solid #444"
-                 :border-radius "3px"
+                 :color         (:text-secondary colors/tokens)
+                 :border        (str "1px solid " (:border-default colors/tokens))
+                 :border-radius "10px"
                  :cursor        "pointer"
                  :font-family   mono-stack
-                 :font-size     (:micro typography/type-scale)}
+                 :font-size     (:micro typography/type-scale)
+                 :transition    (:chip motion/transitions)}
    :empty       {:color       (:text-tertiary colors/tokens)
                  :font-style  "italic"
                  :font-size   (:caption typography/type-scale)}})
@@ -294,6 +335,21 @@
   [axis]
   [:span {:style (:axis-label styles)} (str/upper-case (name axis))])
 
+(defn- cluster-label
+  "Render an upper-cased cluster label (`MODES` / `DATA` / `VIEW` /
+  `DEBUG` / `REC`). Per rf2-v58dm the toolbar reads as ~5 distinct
+  affordance clusters; this label leads each one."
+  [text]
+  [:span {:style (:cluster-label styles)
+          :aria-hidden "true"}
+   text])
+
+(defn- divider
+  "A token-driven vertical divider between clusters (rf2-v58dm)."
+  []
+  [:span {:style (:divider styles)
+          :aria-hidden "true"}])
+
 ;; ---- public component ----------------------------------------------------
 
 (defn toolbar-strip
@@ -305,101 +361,122 @@
   Spec/010 §Placement in the shell chrome — the strip lives ABOVE the
   three-pane row. Caller (`shell/shell`) wraps the strip in a
   `<header role=\"toolbar\">` landmark — the strip itself is a plain
-  hiccup `<div>` so axe-core's region rule sees the landmark."
+  hiccup `<div>` so axe-core's region rule sees the landmark.
+
+  rf2-v58dm: chips are organised into ~5 logical affordance clusters
+  separated by token-driven dividers — MODES (registry-driven axes /
+  unaxed modes), DATA (dispatch + play status), VIEW (viewport +
+  backgrounds), DEBUG (element inspector), REC (recorder + reset).
+  Each cluster carries a small-caps label so the strip reads as a
+  set of named groups rather than a flat chip row."
   []
   (let [shell    @state/shell-state-atom
         active   (set (:active-modes shell))
         modes    (registrar/registrations :mode)
-        {:keys [axes unaxed]} (state/group-modes-by-axis modes)]
+        variant  (:selected-variant shell)
+        {:keys [axes unaxed]} (state/group-modes-by-axis modes)
+        vis-flag (get-in shell [:panel-visibility :dispatch-console])
+        dc-effective? (cond
+                        (true?  vis-flag) true
+                        (false? vis-flag) false
+                        :else             false)]
     [:header
      {:style      (:strip styles)
       :role       "toolbar"
       :aria-label "Story modes"
       :data-test  "story-toolbar"}
+     ;; ── MODES cluster (left) ──────────────────────────────────────
      (if (empty? modes)
        [:span {:style (:empty styles)} "no modes registered"]
-       (doall
-         (concat
-           (for [[axis ids] axes]
-             ^{:key (str axis)}
-             [:span {:style (:axis-group styles)}
-              [axis-label axis]
-              [:span {:style (:chip-row styles)}
-               (for [mid ids]
-                 ^{:key mid}
-                 [chip mid (get modes mid) (contains? active mid)])]])
-           (when (seq unaxed)
-             [^{:key "unaxed"}
+       [:span {:style       (:cluster styles)
+               :data-test   "story-toolbar-cluster"
+               :data-cluster "modes"}
+        [cluster-label "Modes"]
+        (doall
+          (concat
+            (for [[axis ids] axes]
+              ^{:key (str axis)}
               [:span {:style (:axis-group styles)}
+               [axis-label axis]
                [:span {:style (:chip-row styles)}
-                (for [mid unaxed]
+                (for [mid ids]
                   ^{:key mid}
-                  [chip mid (get modes mid) (contains? active mid)])]]]))))
+                  [chip mid (get modes mid) (contains? active mid)])]])
+            (when (seq unaxed)
+              [^{:key "unaxed"}
+               [:span {:style (:axis-group styles)}
+                [:span {:style (:chip-row styles)}
+                 (for [mid unaxed]
+                   ^{:key mid}
+                   [chip mid (get modes mid) (contains? active mid)])]]])))])
      [:span {:style (:spacer styles)}]
+     ;; ── DATA cluster (variant-scoped affordances) ─────────────────
      ;; rf2-q9kv5 — Dispatch console toolbar toggle. The chip flips the
      ;; chrome-level visibility override; the right-panel resolves
-     ;; story-flag + chrome-toggle together. Shown only when a variant is
-     ;; focused (the panel is per-variant — no variant, nothing to
+     ;; story-flag + chrome-toggle together. Shown only when a variant
+     ;; is focused (the panel is per-variant — no variant, nothing to
      ;; dispatch into).
-     (when (:selected-variant shell)
-       (let [vis-flag (get-in shell [:panel-visibility :dispatch-console])
-             ;; Same default resolution as the right-panel — when the
-             ;; chrome-toggle is nil, the story body's `:dispatch-console?`
-             ;; takes over (defaults to FALSE — toolbar real-estate is
-             ;; precious; authors opt in via `:dispatch-console? true`).
-             ;; We surface the *effective* state on the chip so the user
-             ;; sees what's actually showing.
-             effective? (cond
-                          (true?  vis-flag) true
-                          (false? vis-flag) false
-                          :else             false)]
-         [:button
-          {:style     (merge (:chip styles)
-                             (when effective? (:chip-active styles)))
-           :data-test "story-toolbar-dispatch-console"
-           :aria-pressed (str effective?)
-           :title     (if effective?
-                        "Hide dispatch console"
-                        "Show dispatch console")
-           :on-click  (fn [_]
-                        (state/swap-state!
-                          (fn [s]
-                            (assoc-in s [:panel-visibility :dispatch-console]
-                                      (not effective?)))))}
-          (if effective? "Dispatch ▾" "Dispatch ▸")]))
      ;; rf2-8i2a9 — Play-script status chip. Visible only when a variant
-     ;; is focused AND the variant carries a `:play-script` body. Shows
-     ;; `IDLE / RUNNING (step N/M) / PASS / FAIL (N/M)` + a `[Re-run]`
-     ;; button. Self-elides when no script is present.
-     (when (:selected-variant shell)
-       [play-status/chip-when-enabled (:selected-variant shell)])
+     ;; is focused AND the variant carries a `:play-script` body.
+     (when variant
+       [:span {:style       (:cluster styles)
+               :data-test   "story-toolbar-cluster"
+               :data-cluster "data"}
+        [cluster-label "Data"]
+        [:button
+         {:style     (merge (:chip styles)
+                            (when dc-effective? (:chip-active styles)))
+          :data-test "story-toolbar-dispatch-console"
+          :aria-pressed (str dc-effective?)
+          :title     (if dc-effective?
+                       "Hide dispatch console"
+                       "Show dispatch console")
+          :on-click  (fn [_]
+                       (state/swap-state!
+                         (fn [s]
+                           (assoc-in s [:panel-visibility :dispatch-console]
+                                     (not dc-effective?)))))}
+         (if dc-effective? "Dispatch ▾" "Dispatch ▸")]
+        [play-status/chip-when-enabled variant]])
+     (when variant [divider])
+     ;; ── VIEW cluster (framing chips) ──────────────────────────────
      ;; rf2-zll4h — viewport + backgrounds switchers (Storybook addon-
      ;; viewport + addon-backgrounds parity). Both chips are chrome-wide
-     ;; dropdowns; they live before the recorder REC chip so the
-     ;; left-side chrome cluster reads:
-     ;;   [dispatch] [play-status] [viewport] [backgrounds] [REC] [reset]
-     ;; Each chip uses `aria-haspopup`/`aria-expanded` (NOT
-     ;; `aria-pressed`) so the toolbar reset assertion in story-feature-
-     ;; load (which counts `[aria-pressed="true"]` post-reset) is not
-     ;; tripped by viewport / background state.
-     [viewport-switcher/chip-when-enabled]
-     [backgrounds-switcher/chip-when-enabled]
+     ;; dropdowns. Each chip uses `aria-haspopup`/`aria-expanded`
+     ;; (NOT `aria-pressed`) so the toolbar reset assertion in
+     ;; story-feature-load (which counts `[aria-pressed="true"]`
+     ;; post-reset) is not tripped by viewport / background state.
+     [:span {:style       (:cluster styles)
+             :data-test   "story-toolbar-cluster"
+             :data-cluster "view"}
+      [cluster-label "View"]
+      [viewport-switcher/chip-when-enabled]
+      [backgrounds-switcher/chip-when-enabled]]
+     [divider]
+     ;; ── DEBUG cluster (pick-mode) ─────────────────────────────────
      ;; rf2-h0jc0 — element-level click-to-code inspector chip. Toggles
      ;; the React-Devtools-style pick mode that hovers / highlights any
      ;; rendered DOM element and opens its view-fn source on click.
-     ;; Lives between the viewport / backgrounds dropdowns and the REC
-     ;; chip so the chrome reads left-to-right as a "what you see, how
-     ;; you see it, who rendered it, what you do with it" cluster. Uses
-     ;; `aria-haspopup` (not `aria-pressed`) per rf2-zll4h convention so
-     ;; the reset gate is unaffected.
-     [element-inspector/inspect-chip]
+     ;; Uses `aria-haspopup` (not `aria-pressed`) per rf2-zll4h
+     ;; convention so the reset gate is unaffected.
+     [:span {:style       (:cluster styles)
+             :data-test   "story-toolbar-cluster"
+             :data-cluster "debug"}
+      [cluster-label "Debug"]
+      [element-inspector/inspect-chip]]
+     [divider]
+     ;; ── REC cluster (actions) ─────────────────────────────────────
      ;; rf2-5fc15 — Test Codegen REC chip. Lives just before the reset
-     ;; affordance so the chrome-wide recorder is reachable regardless of
-     ;; which variant the user has focused.
-     [ui-recorder/rec-chip]
-     (when (seq (:active-modes shell))
-       [:button
-        {:style     (:reset styles)
-         :data-test "story-toolbar-reset"
-         :on-click  (fn [_] (reset-modes!))}
-        "reset"])]))
+     ;; affordance so the chrome-wide recorder is reachable regardless
+     ;; of which variant the user has focused.
+     [:span {:style       (:cluster styles)
+             :data-test   "story-toolbar-cluster"
+             :data-cluster "rec"}
+      [cluster-label "Rec"]
+      [ui-recorder/rec-chip]
+      (when (seq (:active-modes shell))
+        [:button
+         {:style     (:reset styles)
+          :data-test "story-toolbar-reset"
+          :on-click  (fn [_] (reset-modes!))}
+         "reset"])]]))


### PR DESCRIPTION
## Summary

Three sequential commits delivering the Phase 2-3 deferrals from
the rf2-s1r9a Story design audit, picking up where Phase 1 (#1554)
left off.  Pre-alpha masterpiece posture — no back-compat shims;
the headline change replaces the whole-shell 320px Causa column
with a per-panel embed.

- **rf2-p0wur (commit 1)** — Story sidebar visual rhythm +
  iconography.  New `re-frame.story.theme.glyphs` ns ships an
  inline-SVG glyph set (story diamond / variant dot / workspace
  grid / chevron-right / external-link), with story rows leading
  with an amber-tinted glyph + inter-block margin breathing room.
  Sidebar header carries the workshop-chrome section-label
  vocabulary (uppercase + wide tracking + amber-underline) for
  parity with the RHS section headers (rf2-8rvu4).
- **rf2-v58dm (commit 2)** — Toolbar grouping affordance.  Chips
  reorganise into ~5 logical clusters separated by token-driven
  vertical hairlines:  MODES (registry-driven) | DATA (dispatch +
  play) | VIEW (viewport + backgrounds) | DEBUG (inspector) |
  REC (recorder + reset).  Each cluster wears a small-caps label
  so the strip reads as named groups instead of a flat chip row.
- **rf2-v1ach (commit 3)** — THE headline:  Causa-in-Story
  per-panel embed (shape #3).  Replaces the pre-rf2-v1ach
  whole-shell mount (`shell.cljs:521-540` — Causa's full 4-layer
  chrome crammed into a 320px column) with a chip-row + ONE
  mounted Causa panel + popout escape hatch.  New
  `re-frame.story.ui.causa-embed` ns; new schema slot
  `:causa-panel` (and `:causa {:panel ...}` nested form) selecting
  one of `:event-detail :app-db :views :trace :machines :routing
  :issues`.  Uses the `panels/mount-<panel>!` contract from
  rf2-crhr8 to mount panels in isolation; frame-isolation
  preserved via the `[rf/frame-provider {:frame :rf/causa} …]`
  wrapper every mount-fn carries.

## Cluster discipline

Three commits, ordered above.  Each commit ran its own quality
gates before landing:
- `clojure -M:test` from `tools/story/` (753 tests / 2228
  assertions) — passing.
- `npm run test:story-feature-load` (Phase 1 browser-gate) —
  passing.
- `npm run test:bundle-isolation` — passing.
- `npm run test:cljs` full sweep after all 3 (2922 tests / 8390
  assertions) — passing.

## Mid-7th-bead stash disposition

A pre-Phase-1 stash existed in the worktree
(`story-cluster-mid-7th-bead-rate-limit`, sidebar WIP from the
original Phase-1 worker).  Inspection showed a clean,
well-shaped sidebar diff referencing a `re-frame.story.theme.glyphs`
module that didn't yet exist.  Decision:  popped + reconciled the
sidebar.cljs/sidebar_styles.cljs WIP and shipped the missing
glyphs module alongside.  This gave a meaningful head start on
commit 1.

## Test plan

- [ ] Visual smoke:  Story workshop renders a component; the new
      chip-row appears above the Causa panel; clicking a chip
      swaps which Causa panel renders.
- [ ] Visual smoke:  toolbar reads as 5 distinct clusters at a
      glance (MODES / DATA / VIEW / DEBUG / REC).
- [ ] Visual smoke:  sidebar rows carry per-row glyphs; top-level
      stories breathe; section dividers are token-driven.
- [ ] Confirm the popout chip opens the full Causa 4-layer shell
      in a second window.
- [ ] Confirm `:causa-panel <kw>` on a story body lands the
      correct default panel on variant select.