### PR TITLE
feat(pair-mcp): self-healing ~/.claude.json path-drift probe (rf2-vsxgz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Well, beyond the novel parts, re-frame2 is state-of-the-art in various dimension
   - **[Schemas](https://day8.github.io/re-frame2/guide/04a-schemas/)** — Malli-backed boundary validation, opt-in, production-elidable via Closure dead-code elimination. Validate at every documented boundary — event vector, sub return, cofx, app-db slice. Pay for exactly what you turn on; production builds carry zero overhead.
   - **[Security](https://day8.github.io/re-frame2/guide/23a-privacy-secrets/)** — auth tokens shouldn't be leaked in logs or sent to tools. re-frame2 has first-class mechanisms to help here. There is also a spec-level [Security Contract](spec/Security.md).
   - **Large Things** — PDF blobs and other large things shouldn't accidentally get logged to Datadog. There are mechanisms for that too.
-  - **MCP servers** — two Model Context Protocol servers ([re-frame2-pair-mcp](tools/re-frame2-pair-mcp/) and [story-mcp](tools/story-mcp/)) that expose the running app and the story playground to AI clients. Shared `:rf.mcp/*` wire vocabulary; cross-server vocabulary conformance is gated in CI.
+  - **MCP servers** — two Model Context Protocol servers ([re-frame2-pair-mcp](tools/re-frame2-pair-mcp/) and [story-mcp](tools/story-mcp/)) that expose the running app and the story playground to AI clients. Shared `:rf.mcp/*` wire vocabulary; cross-server vocabulary conformance is gated in CI. If the re-frame2-pair MCP server fails to start after pulling a fresh `main`, run [`npm run probe-mcp-path`](tools/re-frame2-pair-mcp/#path-drift-probe-rf2-vsxgz) from `tools/re-frame2-pair-mcp/` — it surfaces stale `~/.claude.json` path references read-only.
 
 ## The Reference Implementation
 

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -74,6 +74,59 @@ The server auto-discovers the nREPL port from (in order):
 3. `.shadow-cljs/nrepl.port`
 4. `.nrepl-port`
 
+### Path-drift probe (rf2-vsxgz)
+
+After repo-side renames of this tool (e.g. PR #1504 `tools/pair2-mcp/`
+→ `tools/re-frame2-pair-mcp/`) your `~/.claude.json` keeps pointing at
+the old path until you edit it, and the MCP server then fails to start
+with no obvious clue why. A self-healing **read-only** probe ships in
+this directory to surface that drift on demand:
+
+```bash
+# From this directory:
+npm run probe-mcp-path
+
+# Or directly:
+node bin/probe-mcp-path.cjs
+```
+
+The probe:
+
+- Reads `~/.claude.json`, scans both top-level `mcpServers` and any
+  per-project `projects.<path>.mcpServers` entries.
+- For each entry whose `command`, `args`, `cwd`, or `env` value still
+  references the legacy `tools/pair2-mcp/` token, prints a clear
+  remediation message naming the stale field + the suggested
+  replacement.
+- **Never writes the file.** `~/.claude.json` is the operator's; the
+  probe only reads.
+- Silent on success — zero output if no drift is detected, the file
+  is absent, or there are no matching entries.
+
+Exit codes: `0` clean / absent / malformed (non-blocking); `1` drift
+detected. Suitable for CI / preflight scripts.
+
+Sample output when drift is present:
+
+```
+re-frame2-pair-mcp: stale path detected in ~/.claude.json
+
+PR #1504 (rf2-e2ufx) renamed the MCP source dir from
+  tools/pair2-mcp/  ->  tools/re-frame2-pair-mcp/
+but your ~/.claude.json still points at the old path. The MCP server
+will fail to start until the references are updated.
+
+Stale references:
+  [global] mcpServers.re-frame-pair2
+    - arg: C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js
+      suggested: C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js
+
+Remediation: open ~/.claude.json in an editor, replace each
+'tools/pair2-mcp/' fragment with 'tools/re-frame2-pair-mcp/',
+save, then restart Claude Code. This probe never writes the file;
+your editor is the source of truth.
+```
+
 ### Launch flags
 
 | Flag                  | Default | What it does                                                                         |
@@ -242,12 +295,15 @@ tools/re-frame2-pair-mcp/
 ├── shadow-cljs.edn                           ; build config
 ├── spec/                                     ; contract
 ├── pilot/                                    ; pre-port toolchain pilot
+├── bin/
+│   └── probe-mcp-path.cjs                    ; read-only ~/.claude.json drift probe (rf2-vsxgz)
 └── src/re_frame2_pair_mcp/
     ├── nrepl.cljs                            ; persistent socket + bencode
     ├── tools.cljs                            ; the fourteen MCP tools (per-op + snapshot + get-path + subscribe/unsubscribe/list-subscriptions + get-re-frame2-pair-instructions)
     └── server.cljs                           ; stdio JSON-RPC entry point
 └── test/
     ├── re_frame2_pair_mcp/nrepl_test.cljs    ; bencode framing unit tests
+    ├── probe-mcp-path-test.cjs               ; probe-mcp-path unit tests
     ├── stdio-roundtrip.js                    ; stdio integration test
     └── live-nrepl.js                         ; live-nREPL integration test
 ```

--- a/tools/re-frame2-pair-mcp/bin/probe-mcp-path.cjs
+++ b/tools/re-frame2-pair-mcp/bin/probe-mcp-path.cjs
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+/**
+ * probe-mcp-path.cjs — read-only drift detector for ~/.claude.json
+ *
+ * Background: the MCP server's source directory was renamed from
+ * `tools/pair2-mcp/` to `tools/re-frame2-pair-mcp/` in PR #1504
+ * (rf2-e2ufx, 2026-05-19). Operators' `~/.claude.json` mcpServers
+ * entries still point at the old path until they manually edit them
+ * + restart Claude Code. This probe surfaces that drift with a clear
+ * remediation suggestion.
+ *
+ * Posture (rf2-vsxgz):
+ *   - READ ONLY. Never writes ~/.claude.json — that is the user's
+ *     file. Remediation is operator-driven.
+ *   - Silent on success: zero output if no drift is detected and
+ *     ~/.claude.json is absent or has no relevant mcpServers entry.
+ *   - Cross-platform: pure Node, no shell dependencies. Runs on
+ *     Windows / macOS / Linux from `npm run probe-mcp-path`.
+ *   - Resilient: missing file is silent; malformed JSON prints a
+ *     one-line note to stderr (exit 0) so it never blocks workflows.
+ *
+ * Exit codes:
+ *   0 — no drift detected (or no relevant config present).
+ *   1 — drift detected; remediation printed to stdout.
+ *   Reserved: 2 — internal error (should not occur in normal use).
+ *
+ * Usage:
+ *   node tools/re-frame2-pair-mcp/bin/probe-mcp-path.cjs
+ *   npm run probe-mcp-path           # from tools/re-frame2-pair-mcp/
+ *
+ * The exported `probe` function is the unit-testable core; tests
+ * pass synthetic config shapes + an override home dir.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// The legacy directory name. Any mcpServers entry whose `command`,
+// `args`, `cwd`, or `env` value contains this token (followed by
+// either `/` or end-of-string) is stale post-#1504.
+const LEGACY_PATH_TOKEN = 'tools/pair2-mcp';
+const LEGACY_PATH_FRAGMENT = 'tools/pair2-mcp/'; // canonical rendered form
+
+// The current directory name — what stale references should be
+// rewritten to.
+const CURRENT_PATH_FRAGMENT = 'tools/re-frame2-pair-mcp/';
+
+// Match the legacy token at a directory boundary — followed by `/`
+// or end-of-string — so `tools/pair2-mcp-something` does NOT trip
+// the probe.
+const LEGACY_BOUNDARY_RE = /tools\/pair2-mcp(\/|$)/;
+
+// Normalise path separators for the substring check. mcpServers
+// values on Windows may carry either `/` or `\`; we compare against
+// forward-slash form so the check is platform-agnostic.
+function normaliseSeparators(s) {
+  return typeof s === 'string' ? s.replace(/\\/g, '/') : s;
+}
+
+// Return `true` iff a single string value (e.g. a command or one
+// element of an args array) contains the legacy path token at a
+// directory boundary.
+function isStaleString(value) {
+  if (typeof value !== 'string') return false;
+  return LEGACY_BOUNDARY_RE.test(normaliseSeparators(value));
+}
+
+// Walk one mcpServers entry. Returns an array of `{kind, value}`
+// stale-finding objects for any stale string found, or [] if clean.
+//
+// Recognised kinds: 'command', 'arg', 'cwd', 'env-value'. Unknown
+// keys are not inspected — we only flag the documented MCP-config
+// shape (see ~/.claude.json schema).
+function findStaleFieldsInEntry(entry) {
+  const findings = [];
+  if (!entry || typeof entry !== 'object') return findings;
+
+  if (isStaleString(entry.command)) {
+    findings.push({ kind: 'command', value: entry.command });
+  }
+
+  if (Array.isArray(entry.args)) {
+    for (const a of entry.args) {
+      if (isStaleString(a)) {
+        findings.push({ kind: 'arg', value: a });
+      }
+    }
+  }
+
+  if (isStaleString(entry.cwd)) {
+    findings.push({ kind: 'cwd', value: entry.cwd });
+  }
+
+  if (entry.env && typeof entry.env === 'object') {
+    for (const [k, v] of Object.entries(entry.env)) {
+      if (isStaleString(v)) {
+        findings.push({ kind: 'env-value', value: `${k}=${v}` });
+      }
+    }
+  }
+
+  return findings;
+}
+
+// Walk the full ~/.claude.json shape. mcpServers can appear at two
+// scopes: top-level (global, applies to every project) and per-project
+// under `projects.<path>.mcpServers`. We scan both.
+//
+// Returns an array of `{scope, server, findings}` objects, one per
+// stale server entry. Empty array means no drift.
+function scanConfig(config) {
+  const stale = [];
+  if (!config || typeof config !== 'object') return stale;
+
+  // Top-level mcpServers (global scope).
+  if (config.mcpServers && typeof config.mcpServers === 'object') {
+    for (const [serverName, entry] of Object.entries(config.mcpServers)) {
+      const findings = findStaleFieldsInEntry(entry);
+      if (findings.length > 0) {
+        stale.push({ scope: 'global', server: serverName, findings });
+      }
+    }
+  }
+
+  // Per-project mcpServers (scoped to a single project path).
+  if (config.projects && typeof config.projects === 'object') {
+    for (const [projectPath, projectCfg] of Object.entries(config.projects)) {
+      if (!projectCfg || typeof projectCfg !== 'object') continue;
+      const ms = projectCfg.mcpServers;
+      if (!ms || typeof ms !== 'object') continue;
+      for (const [serverName, entry] of Object.entries(ms)) {
+        const findings = findStaleFieldsInEntry(entry);
+        if (findings.length > 0) {
+          stale.push({
+            scope: `project:${projectPath}`,
+            server: serverName,
+            findings,
+          });
+        }
+      }
+    }
+  }
+
+  return stale;
+}
+
+// Suggested replacement string: swap the legacy token for the
+// current path's matching token. We do NOT apply this to the file —
+// printed only. Preserves a trailing `/` if the input had one;
+// preserves no trailing character if it didn't (e.g. a `cwd` that
+// ended exactly at the directory boundary).
+function suggestedReplacement(value) {
+  return normaliseSeparators(value).replace(
+    LEGACY_BOUNDARY_RE,
+    (_match, tail) =>
+      `tools/re-frame2-pair-mcp${tail}`,
+  );
+}
+
+// Render the human-readable remediation message for an array of
+// stale entries. Returns a string; caller prints it.
+function renderRemediation(staleEntries) {
+  const lines = [];
+  lines.push('');
+  lines.push('re-frame2-pair-mcp: stale path detected in ~/.claude.json');
+  lines.push('');
+  lines.push(
+    'PR #1504 (rf2-e2ufx) renamed the MCP source dir from',
+  );
+  lines.push(
+    `  ${LEGACY_PATH_FRAGMENT}  ->  ${CURRENT_PATH_FRAGMENT}`,
+  );
+  lines.push(
+    'but your ~/.claude.json still points at the old path. The MCP server',
+  );
+  lines.push('will fail to start until the references are updated.');
+  lines.push('');
+  lines.push('Stale references:');
+
+  for (const { scope, server, findings } of staleEntries) {
+    lines.push(`  [${scope}] mcpServers.${server}`);
+    for (const f of findings) {
+      lines.push(`    - ${f.kind}: ${f.value}`);
+      lines.push(`      suggested: ${suggestedReplacement(f.value)}`);
+    }
+  }
+
+  lines.push('');
+  lines.push(
+    'Remediation: open ~/.claude.json in an editor, replace each',
+  );
+  lines.push(
+    `'${LEGACY_PATH_FRAGMENT}' fragment with '${CURRENT_PATH_FRAGMENT}',`,
+  );
+  lines.push(
+    'save, then restart Claude Code. This probe never writes the file;',
+  );
+  lines.push('your editor is the source of truth.');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+// Core probe function — pure, no I/O side effects beyond the read.
+// Returns `{status, message, stale}`:
+//   status: 'clean' | 'stale' | 'absent' | 'malformed'
+//   message: string to print (may be empty for 'clean' / 'absent')
+//   stale: array of stale-entry findings (may be empty)
+//
+// Optional opts.homeDir overrides `os.homedir()` for tests.
+// Optional opts.configPath overrides the full path (takes precedence).
+function probe(opts) {
+  opts = opts || {};
+  const configPath =
+    opts.configPath ||
+    path.join(opts.homeDir || os.homedir(), '.claude.json');
+
+  let raw;
+  try {
+    raw = fs.readFileSync(configPath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      return { status: 'absent', message: '', stale: [] };
+    }
+    // Permission denied or other I/O error — surface a quiet note
+    // on stderr in the caller but do not block. We treat it as
+    // 'absent' for exit-code purposes; tests can distinguish via
+    // the status field.
+    return {
+      status: 'absent',
+      message: `probe-mcp-path: could not read ${configPath}: ${err.message}`,
+      stale: [],
+    };
+  }
+
+  let config;
+  try {
+    config = JSON.parse(raw);
+  } catch (err) {
+    return {
+      status: 'malformed',
+      message:
+        `probe-mcp-path: ${configPath} is not valid JSON ` +
+        `(${err.message}); skipping drift check.`,
+      stale: [],
+    };
+  }
+
+  const stale = scanConfig(config);
+  if (stale.length === 0) {
+    return { status: 'clean', message: '', stale: [] };
+  }
+
+  return {
+    status: 'stale',
+    message: renderRemediation(stale),
+    stale,
+  };
+}
+
+// CLI entry point. Only runs when invoked as a script, not when
+// required as a module (the tests require this file).
+function main() {
+  const result = probe();
+  switch (result.status) {
+    case 'clean':
+    case 'absent':
+      // Silent success. If the absent-branch carried a permission
+      // note, print it to stderr; otherwise emit nothing.
+      if (result.message) {
+        process.stderr.write(result.message + '\n');
+      }
+      process.exit(0);
+      return;
+    case 'malformed':
+      process.stderr.write(result.message + '\n');
+      process.exit(0); // non-blocking — operator workflows continue
+      return;
+    case 'stale':
+      process.stdout.write(result.message);
+      process.exit(1);
+      return;
+    default:
+      // Should not occur; defensive.
+      process.stderr.write(
+        `probe-mcp-path: unknown status '${result.status}'\n`,
+      );
+      process.exit(2);
+  }
+}
+
+module.exports = {
+  probe,
+  scanConfig,
+  findStaleFieldsInEntry,
+  isStaleString,
+  suggestedReplacement,
+  renderRemediation,
+  LEGACY_PATH_FRAGMENT,
+  CURRENT_PATH_FRAGMENT,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/tools/re-frame2-pair-mcp/package.json
+++ b/tools/re-frame2-pair-mcp/package.json
@@ -4,10 +4,12 @@
   "description": "MCP (Model Context Protocol) server for re-frame2-pair — pair-program with a live re-frame application over a persistent nREPL connection.",
   "license": "MIT",
   "bin": {
-    "re-frame2-pair-mcp": "./out/server.js"
+    "re-frame2-pair-mcp": "./out/server.js",
+    "re-frame2-pair-mcp-probe-path": "./bin/probe-mcp-path.cjs"
   },
   "files": [
     "out/server.js",
+    "bin/probe-mcp-path.cjs",
     "README.md",
     "LICENSE"
   ],
@@ -16,7 +18,9 @@
     "watch": "shadow-cljs watch server",
     "test": "shadow-cljs compile server-test && node out/server-test.js",
     "start": "node out/server.js",
-    "stdio-roundtrip": "node test/stdio-roundtrip.js"
+    "stdio-roundtrip": "node test/stdio-roundtrip.js",
+    "probe-mcp-path": "node bin/probe-mcp-path.cjs",
+    "test:probe-mcp-path": "node test/probe-mcp-path-test.cjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/tools/re-frame2-pair-mcp/test/README.md
+++ b/tools/re-frame2-pair-mcp/test/README.md
@@ -119,6 +119,18 @@ Diagnostic — invokes the bencode multi-frame walker against
 hand-constructed buffers. Used to debug regressions in the `nrepl@2`
 upgrade path. Not part of the gate.
 
+#### `probe-mcp-path-test.cjs` — `~/.claude.json` drift probe (rf2-vsxgz)
+
+Unit tests for `bin/probe-mcp-path.cjs`. The probe is a pure
+Node-side artefact (read-only scan of `~/.claude.json` for stale
+`tools/pair2-mcp/` references post-#1504); no CLJS source exists, so
+the tests live as a `.cjs` sibling here. Fixture-based: each test
+writes a synthetic `.claude.json` into a temp dir, points the probe
+at it via `opts.configPath`, asserts the `{status, message, stale}`
+return shape. The real `~/.claude.json` is never read.
+
+Run with: `npm run test:probe-mcp-path` (or `node test/probe-mcp-path-test.cjs`).
+
 ## Adding a new test — decision tree
 
 ```

--- a/tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs
+++ b/tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for bin/probe-mcp-path.cjs.
+ *
+ * Per the test-layering README in this directory: the probe is a
+ * pure Node-side artefact (no CLJS source of truth), so its tests
+ * live as `.cjs` siblings of the existing `stdio-roundtrip.js` /
+ * `live-nrepl.js` Node integration suites.
+ *
+ * Each test writes a synthetic fixture file under a temp dir, points
+ * the probe at it via `opts.configPath`, and asserts the returned
+ * `{status, message, stale}` shape. No real `~/.claude.json` is ever
+ * touched.
+ *
+ * Run with: node test/probe-mcp-path-test.cjs
+ *
+ * Exit code 0 on all-pass, 1 on any failure.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const probeModule = require('../bin/probe-mcp-path.cjs');
+const { probe, scanConfig, suggestedReplacement } = probeModule;
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assert(cond, label) {
+  if (cond) {
+    passed += 1;
+  } else {
+    failed += 1;
+    failures.push(label);
+  }
+}
+
+function deepEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// Create a one-off temp dir for a fixture; caller removes it after.
+function mkTempDir() {
+  const base = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'probe-mcp-path-test-'),
+  );
+  return base;
+}
+
+function writeFixture(dir, name, payload) {
+  const fp = path.join(dir, name);
+  fs.writeFileSync(fp, typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2));
+  return fp;
+}
+
+function cleanup(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (_e) {
+    /* best-effort */
+  }
+}
+
+// ------------------------------------------------------------------
+// Test 1 — stale global mcpServers entry: args carries legacy path
+// ------------------------------------------------------------------
+(function testStaleGlobalArgs() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      mcpServers: {
+        're-frame-pair2': {
+          command: 'node',
+          args: [
+            'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js',
+          ],
+          cwd: 'C:/Users/miket/code/re-frame2/implementation',
+          env: { SHADOW_CLJS_NREPL_PORT: '58376' },
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(result.status === 'stale', 'stale-global-args: status is stale');
+    assert(result.stale.length === 1, 'stale-global-args: one stale entry');
+    assert(
+      result.stale[0].scope === 'global',
+      'stale-global-args: scope is global',
+    );
+    assert(
+      result.stale[0].server === 're-frame-pair2',
+      'stale-global-args: server name is re-frame-pair2',
+    );
+    assert(
+      result.stale[0].findings.length === 1,
+      'stale-global-args: exactly one finding (the args entry)',
+    );
+    assert(
+      result.stale[0].findings[0].kind === 'arg',
+      'stale-global-args: finding kind is arg',
+    );
+    assert(
+      result.message.includes('tools/re-frame2-pair-mcp/'),
+      'stale-global-args: message suggests current path',
+    );
+    assert(
+      result.message.includes('Stale references:'),
+      'stale-global-args: message includes header',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 2 — clean global mcpServers entry: current path, no drift
+// ------------------------------------------------------------------
+(function testCleanGlobal() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      mcpServers: {
+        're-frame2-pair': {
+          command: 'node',
+          args: [
+            'C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js',
+          ],
+          cwd: 'C:/Users/miket/code/re-frame2/implementation',
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(result.status === 'clean', 'clean-global: status is clean');
+    assert(result.stale.length === 0, 'clean-global: no stale entries');
+    assert(result.message === '', 'clean-global: empty message');
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 3 — absent ~/.claude.json: silent success
+// ------------------------------------------------------------------
+(function testAbsent() {
+  const dir = mkTempDir();
+  try {
+    const fp = path.join(dir, '.claude.json'); // never written
+    const result = probe({ configPath: fp });
+    assert(result.status === 'absent', 'absent: status is absent');
+    assert(result.stale.length === 0, 'absent: no stale entries');
+    assert(result.message === '', 'absent: empty message');
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 4 — malformed JSON: non-blocking note, status reflects shape
+// ------------------------------------------------------------------
+(function testMalformed() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', '{not valid json,');
+    const result = probe({ configPath: fp });
+    assert(result.status === 'malformed', 'malformed: status is malformed');
+    assert(result.stale.length === 0, 'malformed: no stale entries');
+    assert(
+      result.message.includes('not valid JSON'),
+      'malformed: message describes the parse error',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 5 — stale per-project mcpServers entry
+// ------------------------------------------------------------------
+(function testStaleProjectScope() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      projects: {
+        'C:/Users/miket/code/re-frame2': {
+          mcpServers: {
+            'pair-old': {
+              command:
+                'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js',
+              args: [],
+            },
+          },
+        },
+        'C:/Users/miket/code/some-other-project': {
+          mcpServers: {
+            playwright: {
+              command: 'npx',
+              args: ['-y', '@playwright/mcp@latest'],
+            },
+          },
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(
+      result.status === 'stale',
+      'stale-project: status is stale',
+    );
+    assert(
+      result.stale.length === 1,
+      'stale-project: only the one stale entry surfaces (playwright is clean)',
+    );
+    assert(
+      result.stale[0].scope === 'project:C:/Users/miket/code/re-frame2',
+      'stale-project: scope identifies the project path',
+    );
+    assert(
+      result.stale[0].findings[0].kind === 'command',
+      'stale-project: finding kind is command',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 6 — Windows backslash separators are normalised before check
+// ------------------------------------------------------------------
+(function testBackslashSeparators() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      mcpServers: {
+        'pair-win': {
+          command: 'node',
+          args: [
+            'C:\\Users\\miket\\code\\re-frame2\\tools\\pair2-mcp\\out\\server.js',
+          ],
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(
+      result.status === 'stale',
+      'backslash-sep: status is stale (backslash form normalised)',
+    );
+    assert(
+      result.stale.length === 1,
+      'backslash-sep: one stale entry detected',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 7 — multiple stale references in one entry surface as separate
+//          findings (e.g. command + args both point at the old path)
+// ------------------------------------------------------------------
+(function testMultipleFindings() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      mcpServers: {
+        'pair-double': {
+          command: '/home/u/code/re-frame2/tools/pair2-mcp/out/server.js',
+          args: [
+            '--config',
+            '/home/u/code/re-frame2/tools/pair2-mcp/conf.json',
+          ],
+          cwd: '/home/u/code/re-frame2/tools/pair2-mcp',
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(
+      result.stale.length === 1,
+      'multi-finding: one server entry',
+    );
+    const findings = result.stale[0].findings;
+    assert(
+      findings.length === 3,
+      'multi-finding: three distinct findings (command + arg + cwd)',
+    );
+    const kinds = findings.map((f) => f.kind).sort();
+    assert(
+      deepEqual(kinds, ['arg', 'command', 'cwd']),
+      'multi-finding: kinds are command/arg/cwd',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 8 — config with empty mcpServers + no projects: clean
+// ------------------------------------------------------------------
+(function testEmptyConfig() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', { mcpServers: {} });
+    const result = probe({ configPath: fp });
+    assert(result.status === 'clean', 'empty-config: status is clean');
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 9 — env-value stale reference is detected
+// ------------------------------------------------------------------
+(function testStaleEnvValue() {
+  const dir = mkTempDir();
+  try {
+    const fp = writeFixture(dir, '.claude.json', {
+      mcpServers: {
+        'pair-envy': {
+          command: 'node',
+          args: ['some/clean/path.js'],
+          env: {
+            MCP_HOME: '/u/code/re-frame2/tools/pair2-mcp/',
+          },
+        },
+      },
+    });
+    const result = probe({ configPath: fp });
+    assert(
+      result.status === 'stale',
+      'stale-env: status is stale',
+    );
+    assert(
+      result.stale[0].findings[0].kind === 'env-value',
+      'stale-env: finding kind is env-value',
+    );
+  } finally {
+    cleanup(dir);
+  }
+})();
+
+// ------------------------------------------------------------------
+// Test 10 — suggestedReplacement swaps the fragment correctly
+// ------------------------------------------------------------------
+(function testSuggestedReplacement() {
+  const input =
+    'C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js';
+  const out = suggestedReplacement(input);
+  assert(
+    out ===
+      'C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js',
+    'suggested-replacement: legacy fragment swapped to current',
+  );
+  // Backslash input should also produce a normalised forward-slash
+  // suggestion (best practice — Node accepts either on Windows).
+  const win = suggestedReplacement(
+    'C:\\Users\\miket\\code\\re-frame2\\tools\\pair2-mcp\\out\\server.js',
+  );
+  assert(
+    win.includes('tools/re-frame2-pair-mcp/out/server.js'),
+    'suggested-replacement: backslash input normalises to forward-slash suggestion',
+  );
+})();
+
+// ------------------------------------------------------------------
+// Test 11 — scanConfig on null / non-object returns []
+// ------------------------------------------------------------------
+(function testScanConfigDefensive() {
+  assert(deepEqual(scanConfig(null), []), 'scan-config: null returns []');
+  assert(deepEqual(scanConfig(undefined), []), 'scan-config: undefined returns []');
+  assert(deepEqual(scanConfig('not-a-config'), []), 'scan-config: string returns []');
+  assert(deepEqual(scanConfig(42), []), 'scan-config: number returns []');
+})();
+
+// ------------------------------------------------------------------
+// Summary
+// ------------------------------------------------------------------
+process.stdout.write(`\nprobe-mcp-path-test: ${passed} passed, ${failed} failed\n`);
+if (failed > 0) {
+  process.stdout.write('\nFailures:\n');
+  for (const f of failures) {
+    process.stdout.write(`  - ${f}\n`);
+  }
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## Summary

- Adds a **read-only** Node probe at `tools/re-frame2-pair-mcp/bin/probe-mcp-path.cjs` that detects stale `tools/pair2-mcp/` references in `~/.claude.json` left over from PR #1504 (rf2-e2ufx)'s rename. The MCP server fails to start silently until the user updates `~/.claude.json`; this probe surfaces the drift on demand with a clear remediation message naming the stale field and suggested replacement.
- Wired as `npm run probe-mcp-path` from `tools/re-frame2-pair-mcp/`, plus a `re-frame2-pair-mcp-probe-path` package bin entry, plus a one-line cross-link in the root `README.md` MCP-servers bullet.
- 35 fixture-based unit tests covering stale-global / stale-per-project / clean / absent / malformed / Windows-backslash / multi-finding / env-value / defensive-null scenarios — all passing.

This closes the long-standing 'MCP restart post-#1504' operator-only item that has been carried on the dashboard for 10+ hours.

## Method chosen — (a) startup probe + (c) README cross-link

Per the bead's three-option menu, the worker picked the hybrid recommended in the brief: a probe script inside `tools/re-frame2-pair-mcp/` (option a) — keeps the drift-detection logic with the MCP project it serves, runs on demand without needing a CLJS rebuild — plus a one-line cross-link from the repo-root README (the discoverability slice of option c). Option (b) (`bd doctor mcp` check) was rejected: `bd` is a remote tracker (Beads); extending its check architecture for one project-specific concern would couple this drift to the wrong tool surface.

## Key posture decisions

- **Read-only.** The probe never writes `~/.claude.json` — that is the user's file. Remediation is operator-driven (open editor, find-and-replace, save, restart Claude Code). Per the bead brief and Mike's pre-alpha trust posture.
- **Silent on success.** Zero output when no drift is detected, the file is absent, or there are no relevant mcpServers entries. Suitable for CI / preflight.
- **Non-blocking on malformed JSON.** A parse error prints a one-line stderr note and exits 0 so a transient `.claude.json` glitch never blocks workflows.
- **Cross-platform.** Pure Node (`.cjs`), no shell dependencies. Backslash path separators on Windows are normalised before the substring check.
- **Directory-boundary match.** The legacy token `tools/pair2-mcp` is matched at a `/` boundary or end-of-string so a future `tools/pair2-mcp-something/` wouldn't false-trip.

## Sample probe output

### Stale path detected (exit 1)

```
re-frame2-pair-mcp: stale path detected in ~/.claude.json

PR #1504 (rf2-e2ufx) renamed the MCP source dir from
  tools/pair2-mcp/  ->  tools/re-frame2-pair-mcp/
but your ~/.claude.json still points at the old path. The MCP server
will fail to start until the references are updated.

Stale references:
  [global] mcpServers.re-frame-pair2
    - arg: C:/Users/miket/code/re-frame2/tools/pair2-mcp/out/server.js
      suggested: C:/Users/miket/code/re-frame2/tools/re-frame2-pair-mcp/out/server.js

Remediation: open ~/.claude.json in an editor, replace each
'tools/pair2-mcp/' fragment with 'tools/re-frame2-pair-mcp/',
save, then restart Claude Code. This probe never writes the file;
your editor is the source of truth.
```

### Good path / no drift (exit 0, silent)

_(no output)_

### Absent `~/.claude.json` (exit 0, silent)

_(no output)_

## Files

- `tools/re-frame2-pair-mcp/bin/probe-mcp-path.cjs` — probe + CLI entry point (308 lines)
- `tools/re-frame2-pair-mcp/test/probe-mcp-path-test.cjs` — 35 fixture-based unit tests (386 lines)
- `tools/re-frame2-pair-mcp/package.json` — `npm run probe-mcp-path` + `npm run test:probe-mcp-path` + bin entry
- `tools/re-frame2-pair-mcp/README.md` — new Path-drift probe section + file-layout entry
- `tools/re-frame2-pair-mcp/test/README.md` — new test-layer entry
- `README.md` (repo root) — one-line cross-link from MCP servers bullet

LoC delta: +769 / -3.

## Test plan

- [x] `npm run test:probe-mcp-path` — 35/35 passing.
- [x] Manual verification against the real `~/.claude.json` on this machine — probe correctly identified the `tools/pair2-mcp/out/server.js` stale arg and printed the `tools/re-frame2-pair-mcp/out/server.js` replacement. **File unchanged after the run** (read-only posture upheld).
- [x] `npm run probe-mcp-path` wraps the CLI; exit code propagates as expected.

## Worktree

`C:\Users\miket\code\re-frame2-worktrees\pair-mcp-self-heal`