### PR TITLE
feat(causa): Static Routes panel + narrow Runtime Routing (rf2-o5f5f.3)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing.cljs
@@ -1,59 +1,60 @@
 (ns day8.re-frame2-causa.panels.routing
-  "Routes tab — the 7th L4 tab (rf2-nrbs9, reshaped per rf2-lq0ef).
+  "Routing tab — focused-event lens (rf2-o5f5f.3 narrows from rf2-lq0ef).
 
-  Per Mike's design call (2026-05-18 16:35): Routes earns its own
-  top-level tab in the Causa shell rather than piling into App-db
-  (`app-db panel gets busy`). Routing slices are a cohesive sub-domain
-  — the route catalogue + the current match + nav transitions — and
-  the bd memory `cohesive-subdomains-get-their-own-tab` codifies the
-  posture: cohesive sub-domains earn their own lens tab.
+  ## Two verbs, two homes (Mike's decision, 2026-05-19)
 
-  ## Lens model (post-rf2-lq0ef reshape)
+  Routes appears in BOTH Runtime AND Static surfaces with different
+  verbs:
 
-  Routes are FLAT in the spec + impl. The previous tree projection
-  indented rows by URL-path-segment depth — purely decorative, no
-  semantic load (audit verdict B,
-  `ai/findings/2026-05-19-routing-inheritance-audit.md`). The new
-  lens mirrors the actual contract:
+    - **Static Routes** — browse-all + Simulate-URL + per-row inline
+      expand + hermetic Simulate-navigation preview. Lives at
+      `static/routes/panel.cljs`.
+    - **Runtime Routing** — focused-event lens. Surfaces the
+      routing-related slice of the focused event's cascade: FROM/TO
+      chips when the focused event triggered navigation; empty state
+      otherwise. THIS NAMESPACE.
 
-  - **Flat catalogue** sorted by `:path` (lexicographic). No
-    indentation, no depth derivation.
-  - **Per-row chips**: route-id + path + doc, with small letter
-    badges (`M` / `L` / `T` / `P`) for routes carrying `:on-match` /
-    `:can-leave` / `:tags` / `:parent`. Click the row to expand the
-    full registrar meta inline.
-  - **Substring search** across route-id + path + doc.
-  - **Simulate-URL** — paste a URL, see every route that matches
-    plus its 6-rule `:rf.route/rank` tuple; the winner is the
-    first row by rank-descending (mirrors `match-url`).
-  - **`:parent` annotation** — when a row carries `:parent`, render
-    a compact `↑ → :route/account` inline pointer; expanding the row
-    surfaces the full `:rf.route/chain`.
+  Industry pattern (React Router / Tanstack / Vue Router / Next.js
+  Devtools): event-driven panels showcase the navigation cascade in
+  context; static catalogues live in their own browser. The
+  promote-narrow split mirrors that division.
 
-  Per-focused-event highlighting (unchanged from rf2-nrbs9):
+  ## Lens surface (post-narrow)
 
-  - `◆ HERE` on the current matched route (always — orientation).
-  - `◆ FROM` / `◆ TO` arrow when the focused cascade caused
-    navigation (the cascade carries a
-    `:rf.route.nav-token/allocated` trace event).
-  - Params + query for the active route surface below the catalogue.
-  - When the app has no routing registered: tab content silent
-    (no `(none)` placeholder per rf2-g3ghh silent-by-default).
+      ┌──────────────────────────────────────────────────┐
+      │ Routing — focused-event lens                     │
+      ├──────────────────────────────────────────────────┤
+      │ no nav?  →  'Focused event did not navigate.'    │
+      │           +  hint to open Static Routes for      │
+      │              registry browse.                    │
+      │ nav?     →  FROM chip · TO chip · TO id          │
+      │           +  params + query + fragment grid      │
+      └──────────────────────────────────────────────────┘
+
+  When the focused cascade carries a `:rf.route.nav-token/allocated`
+  trace event, FROM and TO chips render with the prior route + the
+  new route id. When the slice carries no navigation context (the
+  focused event was not a navigation event), the lens shows an
+  empty-orientation state — the user is reminded that BROWSE lives
+  on the Static surface.
 
   ## Pure hiccup (rf2-tijr)
 
   Same contract as every other Causa panel — the view is pure
-  hiccup, no Reagent / UIx / Helix references. Frame isolation
-  comes from the enclosing `[rf/frame-provider {:frame :rf/causa}]`
-  in `shell.cljs`. Every `subscribe` / `dispatch` here resolves to
+  hiccup, no Reagent / UIx / Helix references. Frame isolation comes
+  from the enclosing `[rf/frame-provider {:frame :rf/causa}]` in
+  `shell.cljs`. Every `subscribe` / `dispatch` here resolves to
   `:rf/causa`.
 
   ## Helpers
 
-  Pure-data projection (`project-routes`, `project-data`,
-  `from-to-from-cascade`, `assign-markers`, `filter-rows`,
-  `simulate-url`) lives in `routing_helpers.cljc` so the algebra runs
-  under the JVM unit-test target."
+  Pure-data projection (`focused-cascade`,
+  `nav-token-allocated-in-cascade`, `from-to-from-cascade`) lives in
+  `routing_helpers.cljc` so the algebra runs under the JVM unit-test
+  target. The catalogue / search / Simulate-URL helpers
+  (`project-routes`, `filter-rows`, `simulate-url`) live there too
+  and now power the Static Routes panel — same shared primitives,
+  per the parent-epic findings §5.1."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.routing-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
@@ -63,353 +64,64 @@
 ;; ---- visual primitives --------------------------------------------------
 
 (defn- marker-chip
-  "Render the `◆ HERE` / `◆ FROM` / `◆ TO` marker chip for a route row.
-  Returns nil when no marker — the row aligns naturally with its
-  siblings (the chip column is empty)."
+  "Render the `◆ FROM` / `◆ TO` marker chip. Returns nil when no
+  marker — used inline alongside the route-id."
   [marker]
   (when marker
     (let [{:keys [label colour]}
           (case marker
-            :here {:label "◆ HERE" :colour (:accent-violet tokens)}
             :from {:label "◆ FROM" :colour (:cyan tokens)}
             :to   {:label "◆ TO"   :colour (:green tokens)}
             nil)]
       (when label
         [:span {:data-testid (str "rf-causa-routing-marker-" (name marker))
-                :style       {:color         colour
-                              :font-weight   600
-                              :font-family   sans-stack
-                              :font-size     "11px"
+                :style       {:color          colour
+                              :font-weight    600
+                              :font-family    sans-stack
+                              :font-size      "11px"
                               :letter-spacing "0.3px"
-                              :margin-left   "8px"
-                              :white-space   "nowrap"}}
+                              :margin-right   "6px"
+                              :white-space    "nowrap"}}
          label]))))
 
-(defn- meta-badge
-  "Single-letter badge surfacing presence of a metadata key. Letters
-  are deliberate one-glyph hints — `M` = `:on-match`, `L` =
-  `:can-leave`, `T` = `:tags`, `P` = `:parent`. The colour scheme
-  maps to the semantic palette: `:can-leave` is yellow (guard),
-  `:on-match` is cyan (event), `:tags` is magenta (user labels),
-  `:parent` is violet (hierarchy hint)."
-  [kind]
-  (let [{:keys [letter colour title]}
-        (case kind
-          :on-match  {:letter "M" :colour (:cyan tokens)         :title ":on-match"}
-          :can-leave {:letter "L" :colour (:yellow tokens)       :title ":can-leave"}
-          :tags      {:letter "T" :colour (:magenta tokens)      :title ":tags"}
-          :parent    {:letter "P" :colour (:accent-violet tokens) :title ":parent"}
-          nil)]
-    (when letter
-      [:span {:data-testid (str "rf-causa-routing-badge-" (name kind))
-              :title       title
-              :style       {:display         "inline-block"
-                            :min-width       "14px"
-                            :height          "14px"
-                            :line-height     "14px"
-                            :padding         "0 3px"
-                            :margin-right    "4px"
-                            :background      (:bg-3 tokens)
-                            :color           colour
-                            :border          (str "1px solid " colour)
-                            :border-radius   "3px"
-                            :font-family     mono-stack
-                            :font-size       "9px"
-                            :font-weight     700
-                            :text-align      "center"}}
-       letter])))
-
-(defn- parent-annotation
-  "Compact inline `↑ :route/account` pointer rendered next to a row
-  with `:parent`. The audit found this is the ONLY semantically
-  load-bearing `:parent` axis (`:rf.route/chain` for view-shell
-  composition); the lens surfaces it as a per-row hint rather than
-  a tree-defining structure."
-  [parent-id]
-  (when parent-id
-    [:span {:data-testid "rf-causa-routing-parent-ptr"
-            :style       {:color       (:text-tertiary tokens)
-                          :font-family mono-stack
-                          :font-size   "11px"
-                          :margin-left "8px"
-                          :white-space "nowrap"}}
-     (str "↑ " parent-id)]))
-
-(defn- meta-expander
-  "Click-to-expand registrar meta map. Renders the full meta as
-  `pr-str` text, indented under the row. Used when the user has
-  clicked the row's chevron to drill in."
-  [row]
-  [:pre {:data-testid (str "rf-causa-routing-meta-"
-                           (subs (pr-str (:route-id row)) 1))
-         :style       {:margin "4px 0 8px 24px"
-                       :padding "8px 12px"
-                       :background (:bg-1 tokens)
-                       :border-left (str "2px solid " (:border-default tokens))
-                       :color (:text-secondary tokens)
-                       :font-family mono-stack
-                       :font-size "11px"
-                       :white-space "pre-wrap"
-                       :overflow-x "auto"
-                       :max-height "200px"
-                       :overflow-y "auto"}}
-   (with-out-str
-     (println "; route" (:route-id row))
-     (println (pr-str (:meta row))))])
-
-(defn- route-row
-  "One row in the catalogue. No indentation — routes are flat.
-  Each row carries: chevron (expand toggle), marker chip column,
-  badges, route-id (mono), path (highlighted), doc (italic), and
-  the parent pointer when present."
-  [{:keys [route-id path marker doc parent has-on-match? has-can-leave? tags]
-    :as row}
-   {:keys [expanded? on-toggle]}]
-  ;; testid uses the fully-qualified keyword (namespace + name) so two
-  ;; routes whose simple names collide (e.g. `:cart/edit` and
-  ;; `:admin/edit`) render with distinct testids.
-  [:li {:data-testid (str "rf-causa-routing-row-" (subs (pr-str route-id) 1))
-        :data-marker (when marker (name marker))
-        :style       {:display        "block"
-                      :padding        "0"
-                      :font-family    mono-stack
-                      :font-size      "12px"
-                      :color          (:text-primary tokens)
-                      :background     (case marker
-                                        :to   (:bg-active tokens)
-                                        :from (:bg-2 tokens)
-                                        :here (:bg-2 tokens)
-                                        "transparent")
-                      :border-left    (case marker
-                                        :to   (str "2px solid " (:green tokens))
-                                        :from (str "2px solid " (:cyan tokens))
-                                        :here (str "2px solid " (:accent-violet tokens))
-                                        "2px solid transparent")
-                      :border-radius  "2px"
-                      :line-height    "20px"}}
-   [:div {:style {:display "flex"
-                  :align-items "center"
-                  :gap "8px"
-                  :padding "3px 8px"
-                  :cursor "pointer"
-                  :white-space "nowrap"
-                  :overflow "hidden"}
-          :on-click on-toggle}
-    [:span {:data-testid (str "rf-causa-routing-chevron-"
-                              (subs (pr-str route-id) 1))
-            :style {:color (:text-tertiary tokens)
-                    :font-size "10px"
-                    :min-width "12px"
-                    :user-select "none"}}
-     (if expanded? "▾" "▸")]
-    [:span {:style {:color (:accent-violet tokens)
-                    :font-weight 500
-                    :min-width "120px"}}
-     path]
-    [:span {:style {:color (:text-tertiary tokens)
-                    :font-size "11px"
-                    :min-width "140px"}}
-     (str route-id)]
-    [:span {:style {:display "inline-flex"
-                    :align-items "center"
-                    :margin-left "4px"}}
-     (when has-on-match?  (meta-badge :on-match))
-     (when has-can-leave? (meta-badge :can-leave))
-     (when (seq tags)     (meta-badge :tags))
-     (when parent         (meta-badge :parent))]
-    (when doc
-      [:span {:style {:color (:text-secondary tokens)
-                      :font-size "11px"
-                      :font-style "italic"
-                      :font-family sans-stack
-                      :overflow "hidden"
-                      :text-overflow "ellipsis"
-                      :flex 1}}
-       doc])
-    (parent-annotation parent)
-    (marker-chip marker)]
-   (when expanded?
-     (meta-expander row))])
-
-;; ---- search box ---------------------------------------------------------
-
-(defn- search-box
-  "Substring filter input. Matches against route-id + path + doc per
-  `routing_helpers/filter-rows`."
-  [query total-routes filtered?]
-  [:div {:data-testid "rf-causa-routing-search"
-         :style       {:display "flex"
+(defn- nav-chip-row
+  "FROM → TO chip row rendered when the focused cascade triggered
+  navigation."
+  [{:keys [from-id to-id]}]
+  [:div {:data-testid "rf-causa-routing-nav-row"
+         :style       {:padding     "10px 16px"
+                       :display     "flex"
                        :align-items "center"
-                       :gap "8px"
-                       :padding "8px 16px"
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :font-family sans-stack}}
-   [:label {:style {:color (:text-tertiary tokens)
-                    :font-size "10px"
-                    :text-transform "uppercase"
-                    :letter-spacing "0.5px"
-                    :min-width "60px"}}
-    "Search"]
-   [:input {:type        "text"
-            :data-testid "rf-causa-routing-search-input"
-            :placeholder "route-id, path, or doc…"
-            :value       (or query "")
-            :on-change   (fn [e]
-                           (rf/dispatch [:rf.causa.routing/set-query
-                                         (-> e .-target .-value)]
-                                        {:frame :rf/causa}))
-            :style       {:flex 1
-                          :background (:bg-3 tokens)
-                          :color (:text-primary tokens)
-                          :border (str "1px solid " (:border-default tokens))
-                          :border-radius "3px"
-                          :padding "4px 8px"
-                          :font-family mono-stack
-                          :font-size "12px"}}]
-   [:span {:data-testid "rf-causa-routing-search-count"
-           :style {:color (:text-tertiary tokens)
-                   :font-family mono-stack
-                   :font-size "11px"
-                   :min-width "60px"
-                   :text-align "right"}}
-    (cond
-      filtered?              (str "match")
-      (= 1 total-routes)     "1 route"
-      :else                  (str total-routes " routes"))]])
-
-;; ---- Simulate-URL -------------------------------------------------------
-
-(defn- rank-cell
-  "Render a single rank tuple as compact mono text. The 6-tuple is
-  `[static total -splat catch-all? -optional -reg-index]` per
-  `parse-pattern`; we surface it verbatim — the lens is about exposing
-  the cascade, not interpreting it."
-  [rank]
-  [:span {:style {:font-family mono-stack
-                  :font-size "11px"
-                  :color (:text-secondary tokens)}}
-   (pr-str rank)])
-
-(defn- sim-candidate-row
-  "One row in the Simulate-URL result table — winner highlighted."
-  [{:keys [route-id rank params winner? path]}]
-  [:li {:data-testid (str "rf-causa-routing-sim-candidate-"
-                          (subs (pr-str route-id) 1))
-        :data-winner (when winner? "true")
-        :style       {:display "flex"
-                      :align-items "center"
-                      :gap "8px"
-                      :padding "3px 8px"
-                      :background (if winner? (:bg-active tokens) "transparent")
-                      :border-left (if winner?
-                                     (str "2px solid " (:green tokens))
-                                     "2px solid transparent")
-                      :border-radius "2px"
-                      :font-family mono-stack
-                      :font-size "12px"
-                      :white-space "nowrap"}}
-   [:span {:style {:color (if winner? (:green tokens) (:text-tertiary tokens))
-                   :font-weight 600
-                   :font-size "10px"
-                   :min-width "50px"}}
-    (if winner? "WINNER" "")]
-   [:span {:style {:color (:accent-violet tokens)
-                   :min-width "140px"}}
-    path]
-   [:span {:style {:color (:text-tertiary tokens)
-                   :font-size "11px"
-                   :min-width "160px"}}
-    (str route-id)]
-   (rank-cell rank)
-   (when (seq params)
-     [:span {:style {:color (:text-secondary tokens)
-                     :font-size "11px"
-                     :margin-left "8px"}}
-      (pr-str params)])])
-
-(defn- simulate-url-section
-  "URL simulator surface — paste a URL, see every matching route and
-  its rank tuple, winner highlighted."
-  [sim-url sim-result]
-  [:div {:data-testid "rf-causa-routing-sim"
-         :style       {:padding "10px 16px"
-                       :border-top (str "1px solid " (:border-subtle tokens))
-                       :border-bottom (str "1px solid " (:border-subtle tokens))
-                       :background (:bg-1 tokens)}}
-   [:div {:style {:display "flex"
-                  :align-items "center"
-                  :gap "8px"
-                  :font-family sans-stack}}
-    [:label {:style {:color (:text-tertiary tokens)
-                     :font-size "10px"
-                     :text-transform "uppercase"
-                     :letter-spacing "0.5px"
-                     :min-width "60px"}}
-     "Try URL"]
-    [:input {:type        "text"
-             :data-testid "rf-causa-routing-sim-input"
-             :placeholder "/cart  or  /checkout/payment?step=2"
-             :value       (or sim-url "")
-             :on-change   (fn [e]
-                            (rf/dispatch [:rf.causa.routing/set-sim-url
-                                          (-> e .-target .-value)]
-                                         {:frame :rf/causa}))
-             :style       {:flex 1
-                           :background (:bg-3 tokens)
-                           :color (:text-primary tokens)
-                           :border (str "1px solid " (:border-default tokens))
-                           :border-radius "3px"
-                           :padding "4px 8px"
-                           :font-family mono-stack
-                           :font-size "12px"}}]
-    (when (and sim-url (not= "" sim-url))
-      [:button {:data-testid "rf-causa-routing-sim-clear"
-                :on-click (fn [_]
-                            (rf/dispatch [:rf.causa.routing/set-sim-url ""]
-                                         {:frame :rf/causa}))
-                :style {:background "transparent"
-                        :border (str "1px solid " (:border-default tokens))
-                        :border-radius "3px"
-                        :color (:text-tertiary tokens)
-                        :padding "3px 8px"
-                        :font-family sans-stack
-                        :font-size "11px"
-                        :cursor "pointer"}}
-       "clear"])]
-   (when sim-result
-     (let [{:keys [path candidates winner]} sim-result]
-       [:div {:data-testid "rf-causa-routing-sim-result"
-              :style {:margin-top "8px"}}
-        [:div {:style {:font-family mono-stack
-                       :font-size "11px"
-                       :color (:text-tertiary tokens)
-                       :padding "0 8px 4px 8px"}}
-         (str "matched against path " (pr-str path) " — "
-              (cond
-                (empty? candidates) "no route matches (match-url → nil)"
-                :else (str (count candidates)
-                           (if (= 1 (count candidates)) " candidate" " candidates")
-                           "; winner = " winner)))]
-        (when (seq candidates)
-          [:div {:style {:display "grid"
-                         :grid-template-columns "50px 140px 160px 1fr"
-                         :column-gap "8px"
-                         :padding "0 8px 2px 8px"
-                         :font-family sans-stack
-                         :font-size "10px"
-                         :color (:text-tertiary tokens)
-                         :text-transform "uppercase"
-                         :letter-spacing "0.4px"}}
-           [:span ""] [:span "path"] [:span "route-id"] [:span "rank · params"]])
-        (into [:ul {:style {:list-style "none"
-                            :margin "0"
-                            :padding "0"
-                            :display "flex"
-                            :flex-direction "column"
-                            :gap "1px"}}]
-              (for [c candidates]
-                ^{:key (str (:route-id c))}
-                [sim-candidate-row c]))]))])
+                       :gap         "8px"
+                       :font-family mono-stack
+                       :font-size   "13px"
+                       :color       (:text-primary tokens)}}
+   (when from-id
+     [:span {:data-testid "rf-causa-routing-from-cell"
+             :style       {:display     "inline-flex"
+                           :align-items "center"
+                           :padding     "4px 10px"
+                           :background  (:bg-2 tokens)
+                           :border-left (str "2px solid " (:cyan tokens))
+                           :border-radius "2px"
+                           :gap         "6px"}}
+      (marker-chip :from)
+      [:span {:style {:color (:text-primary tokens)}} (str from-id)]])
+   (when (and from-id to-id)
+     [:span {:style {:color       (:text-tertiary tokens)
+                     :font-family sans-stack}}
+      "→"])
+   (when to-id
+     [:span {:data-testid "rf-causa-routing-to-cell"
+             :style       {:display     "inline-flex"
+                           :align-items "center"
+                           :padding     "4px 10px"
+                           :background  (:bg-active tokens)
+                           :border-left (str "2px solid " (:green tokens))
+                           :border-radius "2px"
+                           :gap         "6px"}}
+      (marker-chip :to)
+      [:span {:style {:color (:text-primary tokens)}} (str to-id)]])])
 
 ;; ---- header / slice-detail / empty-state --------------------------------
 
@@ -426,49 +138,49 @@
     ;; rf2-5kfxe.8 — domain-coloured accent stripe (:yellow for
     ;; Routing — side-channel attention tone, distinguished from
     ;; app-db's main colour).
-    [:h2 {:style (merge {:margin     "0"
-                         :font-size  "13px"
-                         :font-weight 600
+    [:h2 {:style (merge {:margin         "0"
+                         :font-size      "13px"
+                         :font-weight    600
                          :text-transform "uppercase"
                          :letter-spacing "0.5px"
-                         :color      (:text-primary tokens)}
+                         :color          (:text-primary tokens)}
                         (t/accent-stripe-style :routing))}
-     "Routes"]
-    [:p {:style {:margin "4px 0 0 0"
-                 :color  (:text-tertiary tokens)
-                 :font-size "11px"
+     "Routing"]
+    [:p {:style {:margin     "4px 0 0 0"
+                 :color      (:text-tertiary tokens)
+                 :font-size  "11px"
                  :line-height 1.4}}
-     "Flat catalogue of registered routes — search above, paste a URL "
-     "into Try URL to see the 6-rule rank cascade. "
-     [:span {:style {:color (:accent-violet tokens) :font-weight 600}} "◆ HERE"]
-     " marks the active route"
-     (when navigated?
-       [:span "; "
-        [:span {:style {:color (:cyan tokens) :font-weight 600}} "◆ FROM"]
-        " / "
-        [:span {:style {:color (:green tokens) :font-weight 600}} "◆ TO"]
-        " mark the navigation transition"])
-     "."]]
+     "Focused-event lens — surfaces the navigation slice of the focused "
+     "event's cascade. "
+     [:span {:style {:color (:cyan tokens) :font-weight 600}} "◆ FROM"]
+     " / "
+     [:span {:style {:color (:green tokens) :font-weight 600}} "◆ TO"]
+     " mark the transition when the focused event triggered "
+     "navigation. For the full route catalogue browse + Simulate-URL "
+     "surface, switch to Static mode."]]
    (when (and navigated? to-id)
      [:span {:data-testid "rf-causa-routing-nav-summary"
-             :style {:color (:green tokens)
-                     :font-size "11px"
-                     :font-family mono-stack}}
+             :style       {:color       (:green tokens)
+                           :font-size   "11px"
+                           :font-family mono-stack}}
       (str "→ " to-id)])])
 
 (defn- slice-detail
-  "Params / query / fragment breakdown for the current route slice."
+  "Params / query / fragment breakdown for the route slice. Surfaces
+  when the focused event navigated — the `current` slice carries the
+  post-navigation params + query, and the user wants to see what
+  landed."
   [{:keys [params query fragment] :as _current}]
   [:div {:data-testid "rf-causa-routing-slice-detail"
-         :style       {:padding     "10px 16px"
-                       :border-top  (str "1px dotted " (:border-subtle tokens))
-                       :font-family mono-stack
-                       :font-size   "12px"
-                       :color       (:text-primary tokens)
-                       :display     "grid"
+         :style       {:padding               "10px 16px"
+                       :border-top            (str "1px dotted " (:border-subtle tokens))
+                       :font-family           mono-stack
+                       :font-size             "12px"
+                       :color                 (:text-primary tokens)
+                       :display               "grid"
                        :grid-template-columns "80px 1fr"
-                       :row-gap     "4px"
-                       :column-gap  "12px"}}
+                       :row-gap               "4px"
+                       :column-gap            "12px"}}
    [:span {:style {:color (:text-tertiary tokens)}} "Params:"]
    [:span (if (seq params) (pr-str params) "—")]
    [:span {:style {:color (:text-tertiary tokens)}} "Query:"]
@@ -479,28 +191,36 @@
       [:span (pr-str fragment)]])])
 
 (defn- empty-state
+  "Renders when the focused event did NOT trigger navigation. The
+  lens is event-coupled — there is no 'current route' for browse;
+  that's the Static Routes verb."
   []
   [:div {:data-testid "rf-causa-routing-empty"
-         :style       {:padding "16px"
-                       :color   (:text-tertiary tokens)
+         :style       {:padding     "16px"
+                       :display     "flex"
+                       :flex-direction "column"
+                       :gap         "8px"
+                       :color       (:text-tertiary tokens)
                        :font-family sans-stack
-                       :font-size "11px"
-                       :font-style "italic"}}
-   "No routes registered."])
+                       :font-size   "11px"}}
+   [:span {:style {:font-style "italic"}}
+    "Focused event did not trigger navigation."]
+   [:span {:style {:color (:text-tertiary tokens)}}
+    "For browse + Simulate-URL, switch to "
+    [:strong {:style {:color (:cyan tokens)}} "Static"]
+    " mode (the Routes tab there lists every registered route)."]])
 
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
-  "The Routes tab's root view. Subscribes to
-  `:rf.causa/routing-tab-data` and renders the flat catalogue +
-  Simulate-URL + slice detail (or the silent state when no routes
-  are registered)."
+  "The Routing tab's root view — focused-event lens. Subscribes to
+  `:rf.causa/routing-tab-data` and renders FROM/TO chips + slice
+  detail when the focused cascade triggered navigation; otherwise
+  shows the empty orientation state pointing to Static Routes."
   []
-  (let [{:keys [silent? routes total-routes filtered? current to-id navigated?
-                query sim-url sim-result]
+  (let [{:keys [from-id to-id navigated? current]
          :as _data}
-        @(rf/subscribe [:rf.causa/routing-tab-data])
-        expanded @(rf/subscribe [:rf.causa.routing/expanded])]
+        @(rf/subscribe [:rf.causa/routing-tab-data])]
     [:section {:data-testid "rf-causa-routing"
                :style       {:height         "100%"
                              :display        "flex"
@@ -510,57 +230,37 @@
                              :font-family    sans-stack
                              :font-size      "14px"}}
      (header {:navigated? navigated? :to-id to-id})
-     (if silent?
+     (if-not navigated?
        (empty-state)
        [:<>
-        (search-box query total-routes filtered?)
-        (simulate-url-section sim-url sim-result)
-        [:div {:style {:flex 1 :overflow "auto"}}
-         (into [:ul {:data-testid "rf-causa-routing-list"
-                     :style       {:list-style "none"
-                                   :margin     "8px 0 0 0"
-                                   :padding    "0 8px"
-                                   :display    "flex"
-                                   :flex-direction "column"
-                                   :gap        "1px"}}]
-               (for [row routes]
-                 ^{:key (str (:route-id row))}
-                 [route-row row
-                  {:expanded? (contains? expanded (:route-id row))
-                   :on-toggle (fn [_]
-                                (rf/dispatch [:rf.causa.routing/toggle-row
-                                              (:route-id row)]
-                                             {:frame :rf/causa}))}]))
-         (when current
-           (slice-detail current))]])]))
+        (nav-chip-row {:from-id from-id :to-id to-id})
+        (when current
+          (slice-detail current))])]))
 
 ;; ---- registration entry --------------------------------------------------
 
 (defn install!
-  "Idempotent install for the Routes panel's Causa-side registrations
-  (rf2-nrbs9, reshaped per rf2-lq0ef). Registers:
+  "Idempotent install for the Routing panel's Causa-side
+  registrations. Registers:
 
     - `:rf.causa/registered-routes` — flat `{<route-id> <meta>}` map
-      sourced from `(rf/registrations :route)`. Falls back to a
-      test-only override slot so JVM / node-test fixtures can drive
-      the projection without booting a host that registers routes.
+      sourced from `(rf/registrations :route)`. The Static Routes
+      panel also reads this sub — process-global, frame-agnostic.
     - `:rf.causa/current-route-slice` — composite over the spine's
       target-frame app-db reading the `:rf/route` slice.
-    - `:rf.causa/routing-tab-data` — view-facing composite folding
-      registered-routes + current slice + focused cascade + search
-      query + Simulate-URL into the shape the view consumes (see
-      `routing_helpers/project-data`).
-    - `:rf.causa.routing/query` + `:rf.causa.routing/sim-url` +
-      `:rf.causa.routing/expanded` — UI state slots (search input,
-      Simulate-URL input, expanded-row set).
-    - `:rf.causa.routing/set-query`,
-      `:rf.causa.routing/set-sim-url`,
-      `:rf.causa.routing/toggle-row` — dispatch hooks the view fires.
-    - `:rf.causa/set-registered-routes-override-for-test` — test-only
-      override hook the gallery fixtures + JVM tests use to seed the
-      registered-routes slot without registering real routes.
-    - `:rf.causa/set-current-route-slice-override-for-test` — same
-      pattern for the current slice."
+    - `:rf.causa/routing-tab-data` — view-facing composite for the
+      Runtime Routing lens (focused-event scoped). Carries
+      `:from-id`, `:to-id`, `:navigated?`, `:current`.
+    - `:rf.causa/set-registered-routes-override-for-test`,
+      `:rf.causa/set-current-route-slice-override-for-test` —
+      test-only override hooks.
+
+  The browse / search / Simulate-URL slots (`:rf.causa.routing/
+  query`, `:rf.causa.routing/sim-url`, `:rf.causa.routing/expanded`,
+  `:rf.causa.routing/toggle-row`, etc.) were promoted to the Static
+  Routes panel per rf2-o5f5f.3 and now live under
+  `:rf.causa.static.routes/*` (installed by
+  `static/routes/panel/install!`)."
   []
 
   ;; Test-only override slots --------------------------------------------
@@ -585,40 +285,6 @@
     (fn [db _query]
       (get db :current-route-slice-override)))
 
-  ;; UI state (search query, simulate-URL input, expanded rows) ----------
-
-  (rf/reg-event-db :rf.causa.routing/set-query
-    (fn [db [_ q]]
-      (if (or (nil? q) (= "" q))
-        (dissoc db :rf.causa.routing/query)
-        (assoc db :rf.causa.routing/query q))))
-
-  (rf/reg-sub :rf.causa.routing/query
-    (fn [db _]
-      (get db :rf.causa.routing/query)))
-
-  (rf/reg-event-db :rf.causa.routing/set-sim-url
-    (fn [db [_ url]]
-      (if (or (nil? url) (= "" url))
-        (dissoc db :rf.causa.routing/sim-url)
-        (assoc db :rf.causa.routing/sim-url url))))
-
-  (rf/reg-sub :rf.causa.routing/sim-url
-    (fn [db _]
-      (get db :rf.causa.routing/sim-url)))
-
-  (rf/reg-event-db :rf.causa.routing/toggle-row
-    (fn [db [_ route-id]]
-      (let [expanded (or (:rf.causa.routing/expanded db) #{})]
-        (assoc db :rf.causa.routing/expanded
-               (if (contains? expanded route-id)
-                 (disj expanded route-id)
-                 (conj expanded route-id))))))
-
-  (rf/reg-sub :rf.causa.routing/expanded
-    (fn [db _]
-      (or (:rf.causa.routing/expanded db) #{})))
-
   ;; Production data subs -------------------------------------------------
 
   (rf/reg-sub :rf.causa/registered-routes
@@ -636,18 +302,19 @@
         (map? target-db) (:rf/route target-db)
         :else            nil)))
 
-  ;; View-facing composite -----------------------------------------------
+  ;; View-facing composite (focused-event lens) ---------------------------
 
   (rf/reg-sub :rf.causa/routing-tab-data
-    :<- [:rf.causa/registered-routes]
     :<- [:rf.causa/current-route-slice]
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/focus]
-    :<- [:rf.causa.routing/query]
-    :<- [:rf.causa.routing/sim-url]
-    (fn [[routes-map slice cascades focus query sim-url] _query]
+    (fn [[slice cascades focus] _query]
       (let [focused-cascade (h/focused-cascade cascades
-                                               (:dispatch-id focus))]
-        (h/project-data routes-map slice focused-cascade query sim-url))))
+                                               (:dispatch-id focus))
+            nav             (h/from-to-from-cascade focused-cascade slice)]
+        {:from-id    (:from-id nav)
+         :to-id      (:to-id nav)
+         :navigated? (:navigated? nav)
+         :current    slice})))
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/routing_helpers.cljc
@@ -223,6 +223,67 @@
          :candidates decorated
          :winner     winner-id}))))
 
+;; ---- hermetic Simulate-navigation preview -------------------------------
+;;
+;; The Static Routes panel surfaces a 'Simulate navigation' button per
+;; row that previews what would land if the user navigated to the
+;; given route — WITHOUT actually dispatching any framework event.
+;; That preview is structural: the matched params (derived from the
+;; row's pattern + the chosen URL), the registered `:on-match` event
+;; vector, and the expected app-db slot (`[:rf/route ...]`).
+
+(defn simulate-navigation-preview
+  "Pure data → data. Given a registered-routes map + a `route-id`, plus
+  an OPTIONAL `url` (the user's input from the row's Simulate-URL
+  surface), return a preview map describing what a real navigation
+  would carry:
+
+      {:route-id    <keyword>
+       :path        <string-or-nil>     ;; the route's registered pattern
+       :url         <string-or-nil>     ;; the simulated URL (or nil)
+       :matched?    <bool>              ;; did url match this route's pattern?
+       :params      <map-or-nil>        ;; matched params (nil when no url)
+       :on-match    <vector-or-nil>     ;; registered :on-match event vector
+       :db-slot     [:rf/route]         ;; where the slice would land
+       :slot-shape  <map>               ;; preview of the :rf/route map
+                                        ;; that would land in app-db
+       :unknown?    <bool>}             ;; true when route-id not registered
+
+  Hermetic — no dispatch, no fx, no app-db mutation. The shape mirrors
+  what the framework's `:rf.route/navigate` handler would write into
+  `[:rf/route]` so the user can reason about the cascade without
+  triggering it.
+
+  When `route-id` is not in `routes-map` returns `{:unknown? true
+  :route-id route-id}` — the view surfaces this as an unregistered
+  route hint."
+  ([routes-map route-id]
+   (simulate-navigation-preview routes-map route-id nil))
+  ([routes-map route-id url]
+   (if-let [meta (get routes-map route-id)]
+     (let [path     (:path meta)
+           on-match (:on-match meta)
+           sim      (when (and url (not (str/blank? url)))
+                      (simulate-url routes-map url))
+           winner   (some-> sim :candidates first)
+           matched? (and (some? winner)
+                         (= route-id (:route-id winner)))
+           params   (when matched? (:params winner))
+           slot     (cond-> {:id route-id}
+                      (some? path)   (assoc :path path)
+                      (some? params) (assoc :params params))]
+       {:route-id   route-id
+        :path       path
+        :url        url
+        :matched?   (boolean matched?)
+        :params     params
+        :on-match   on-match
+        :db-slot    [:rf/route]
+        :slot-shape slot
+        :unknown?   false})
+     {:route-id route-id
+      :unknown? true})))
+
 ;; ---- focused-cascade routing detection ----------------------------------
 
 (def ^:private nav-allocated-op
@@ -336,6 +397,44 @@
                          :else nil)]
             (assoc row :marker marker)))
         rows))
+
+;; ---- Static-surface composite projection -------------------------------
+;;
+;; The Static Routes panel is event-INDEPENDENT — no FROM/TO/HERE
+;; markers, no focused-cascade gating, no slice detail. Just a flat
+;; sorted catalogue + substring filter + Simulate-URL surface. Pure
+;; data → data so the JVM unit-test target can cover the projection.
+
+(defn project-static-data
+  "View-facing composite for the Static Routes panel. Folds the
+  registered-routes map + UI controls (search query + Simulate-URL)
+  into the shape `static/routes/panel.cljs` consumes:
+
+      {:silent?       <bool>             ;; true when no routes registered
+       :routes        [<row> ...]        ;; flat, sorted by :path, filtered
+       :total-routes  <count>            ;; pre-filter row count
+       :filtered?     <bool>             ;; query removed at least one row
+       :query         <string-or-nil>
+       :sim-url       <string-or-nil>
+       :sim-result    <map-or-nil>}
+
+  No `:current` / `:from-id` / `:to-id` / `:navigated?` slots — those
+  are Runtime concerns. Rows carry no `:marker` (the Static surface
+  shows no orientation chip; orientation lives on the Runtime
+  Routing lens)."
+  [routes-map query sim-url]
+  (let [rows       (project-routes routes-map)
+        silent?    (empty? rows)
+        filtered   (filter-rows rows query)
+        sim-result (when (and sim-url (not (str/blank? sim-url)))
+                     (simulate-url routes-map sim-url))]
+    {:silent?       silent?
+     :routes        filtered
+     :total-routes  (count rows)
+     :filtered?     (not= (count rows) (count filtered))
+     :query         query
+     :sim-url       sim-url
+     :sim-result    sim-result}))
 
 ;; ---- composite projection ----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -42,6 +42,7 @@
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.static.routes.panel :as static-routes-panel]
             [day8.re-frame2-causa.static.shell :as static-shell]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
@@ -631,13 +632,23 @@
     ;; mounts inline in event_detail.cljs under the six-domino cascade,
     ;; so no L3 tab is added.
     (managed-fx-subs/install!)
-    ;; Routing tab (rf2-nrbs9) — 7th L3 tab. Installs the registered-
+    ;; Routing tab (rf2-nrbs9, narrowed per rf2-o5f5f.3) — Runtime L3
+    ;; tab carrying the focused-event lens (FROM/TO chips when the
+    ;; focused event triggered navigation). Installs the registered-
     ;; routes / current-route-slice / routing-tab-data subs +
     ;; test-only overrides. Composes against `:rf.causa/target-frame-db`
     ;; (registered by `app-db-diff/install!` above) so the install
     ;; order is intentional, though re-frame's `:<-` resolution is
     ;; lazy and the order is purely cosmetic.
     (routing/install!)
+    ;; Static Routes panel (rf2-o5f5f.3) — Static-surface browse +
+    ;; Simulate-URL + per-row inline expand + hermetic Simulate-
+    ;; navigation preview. Installs the UI-state slots under
+    ;; `:rf.causa.static.routes/*` + the `:rf.causa.static.routes/
+    ;; tab-data` composite. Reads `:rf.causa/registered-routes` (just
+    ;; registered above) — order is cosmetic since re-frame resolves
+    ;; `:<-` chains lazily.
+    (static-routes-panel/install!)
     (views/install!)
     (trace/install!))
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/browse_list.cljs
@@ -1,0 +1,226 @@
+(ns day8.re-frame2-causa.static.routes.browse-list
+  "Flat list + search + per-row inline expand for the Static Routes
+  tab (rf2-o5f5f.3).
+
+  ## Shape (post-rf2-lq0ef + Static reshape)
+
+  Routes are flat (no tree). Sort: `:path` ascending default. Search
+  is substring across route-id + path + doc — shared with the Runtime
+  Routing lens via `routing-helpers/filter-rows`.
+
+  Per row:
+    - path / pattern (mono violet)
+    - route-id keyword (mono violet, smaller)
+    - source-coord chip (when present)
+    - doc-string ellipsis
+
+  Click row → inline expand surface unfolds below it
+  (`row_expand/render`). No master-detail; no modal.
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup, no Reagent /
+  UIx / Helix references. Subscribes resolve to `:rf/causa` via the
+  enclosing frame-provider in `static/shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.routes.row-expand :as row-expand]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- meta-badge
+  "Single-letter badge surfacing presence of a metadata key — same
+  letters as the Runtime Routing lens (`M` `L` `T` `P`)."
+  [kind]
+  (let [{:keys [letter colour title]}
+        (case kind
+          :on-match  {:letter "M" :colour (:cyan tokens)          :title ":on-match"}
+          :can-leave {:letter "L" :colour (:yellow tokens)        :title ":can-leave"}
+          :tags      {:letter "T" :colour (:magenta tokens)       :title ":tags"}
+          :parent    {:letter "P" :colour (:accent-violet tokens) :title ":parent"}
+          nil)]
+    (when letter
+      [:span {:data-testid (str "rf-causa-static-routes-badge-" (name kind))
+              :title       title
+              :style       {:display       "inline-block"
+                            :min-width     "14px"
+                            :height        "14px"
+                            :line-height   "14px"
+                            :padding       "0 3px"
+                            :margin-right  "4px"
+                            :background    (:bg-3 tokens)
+                            :color         colour
+                            :border        (str "1px solid " colour)
+                            :border-radius "3px"
+                            :font-family   mono-stack
+                            :font-size     "9px"
+                            :font-weight   700
+                            :text-align    "center"}}
+       letter])))
+
+(defn- search-box
+  "Substring filter. Matches against route-id + path + doc via
+  `routing-helpers/filter-rows`. State on
+  `:rf.causa.static.routes/query`."
+  [query total-routes filtered?]
+  [:div {:data-testid "rf-causa-static-routes-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-routes-search-input"
+            :placeholder "route-id, path, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.routes/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-routes-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "60px"
+                         :text-align  "right"}}
+    (cond
+      filtered?              "match"
+      (= 1 total-routes)     "1 route"
+      :else                  (str total-routes " routes"))]])
+
+(defn- route-row
+  "One row in the flat catalogue. No marker chip, no `:here` glyph —
+  Static is event-INDEPENDENT. Clicking the row toggles the expand
+  surface."
+  [{:keys [route-id path doc parent has-on-match? has-can-leave? tags meta]
+    :as row}
+   {:keys [expanded? sim-open? routes-map on-toggle]}]
+  [:li {:data-testid (str "rf-causa-static-routes-row-"
+                          (subs (pr-str route-id) 1))
+        :style       {:display       "block"
+                      :padding       "0"
+                      :font-family   mono-stack
+                      :font-size     "12px"
+                      :color         (:text-primary tokens)
+                      :background    (if expanded? (:bg-2 tokens) "transparent")
+                      :border-left   (if expanded?
+                                       (str "2px solid " (:cyan tokens))
+                                       "2px solid transparent")
+                      :border-radius "2px"
+                      :line-height   "20px"}}
+   [:div {:style    {:display     "flex"
+                     :align-items "center"
+                     :gap         "8px"
+                     :padding     "3px 8px"
+                     :cursor      "pointer"
+                     :white-space "nowrap"
+                     :overflow    "hidden"}
+          :on-click on-toggle}
+    [:span {:data-testid (str "rf-causa-static-routes-chevron-"
+                              (subs (pr-str route-id) 1))
+            :style       {:color       (:text-tertiary tokens)
+                          :font-size   "10px"
+                          :min-width   "12px"
+                          :user-select "none"}}
+     (if expanded? "▾" "▸")]
+    [:span {:style {:color       (:accent-violet tokens)
+                   :font-weight 500
+                   :min-width   "160px"}}
+     path]
+    [:span {:style {:color     (:text-tertiary tokens)
+                    :font-size "11px"
+                    :min-width "180px"}}
+     (str route-id)]
+    [:span {:style {:display     "inline-flex"
+                    :align-items "center"
+                    :margin-left "4px"}}
+     (when has-on-match?  (meta-badge :on-match))
+     (when has-can-leave? (meta-badge :can-leave))
+     (when (seq tags)     (meta-badge :tags))
+     (when parent         (meta-badge :parent))]
+    (when doc
+      [:span {:style {:color         (:text-secondary tokens)
+                      :font-size     "11px"
+                      :font-style    "italic"
+                      :font-family   sans-stack
+                      :overflow      "hidden"
+                      :text-overflow "ellipsis"
+                      :flex          1}}
+       doc])]
+   (when expanded?
+     [row-expand/render row
+      {:sim-open?  sim-open?
+       :routes-map routes-map}])])
+
+(defn- empty-state
+  "Renders when no routes are registered."
+  []
+  [:div {:data-testid "rf-causa-static-routes-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No routes registered."])
+
+(defn- empty-filtered
+  "Renders when the search query filters out every row."
+  [query]
+  [:div {:data-testid "rf-causa-static-routes-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No routes match " (pr-str query) ".")])
+
+(defn render
+  "Top-level renderer for the flat-list area of the Static Routes
+  panel. `data` is the projection from
+  `routing-helpers/project-static-data`; `expanded` is the set of
+  expanded row ids; `sim-open` is the set of route-ids whose
+  hermetic preview is open; `routes-map` is threaded through for the
+  preview projection."
+  [{:keys [silent? routes total-routes filtered? query] :as _data}
+   {:keys [expanded sim-open routes-map]}]
+  (cond
+    silent?
+    (empty-state)
+
+    :else
+    [:<>
+     (search-box query total-routes filtered?)
+     (if (empty? routes)
+       (empty-filtered query)
+       (into [:ul {:data-testid "rf-causa-static-routes-list"
+                   :style       {:list-style     "none"
+                                 :margin         "8px 0 0 0"
+                                 :padding        "0 8px"
+                                 :display        "flex"
+                                 :flex-direction "column"
+                                 :gap            "1px"}}]
+             (for [row routes]
+               ^{:key (str (:route-id row))}
+               [route-row row
+                {:expanded?  (contains? expanded (:route-id row))
+                 :sim-open?  (contains? sim-open (:route-id row))
+                 :routes-map routes-map
+                 :on-toggle  (fn [_]
+                               (rf/dispatch [:rf.causa.static.routes/toggle-row
+                                             (:route-id row)]
+                                            {:frame :rf/causa}))}])))]))

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/panel.cljs
@@ -1,0 +1,220 @@
+(ns day8.re-frame2-causa.static.routes.panel
+  "Top-level Routes tab on Causa's Static surface (rf2-o5f5f.3).
+
+  ## Two verbs, two homes (Mike's decision, 2026-05-19)
+
+  Routes appears in BOTH Runtime AND Static surfaces with different
+  verbs. **Static gets BROWSE** — flat catalogue + Simulate-URL + per-
+  row inline expand + hermetic Simulate-navigation preview. Runtime
+  gets the FOCUSED-EVENT LENS — FROM/TO markers when the focused
+  event triggered navigation; otherwise an empty state.
+
+  This panel is the Static-side surface. The Runtime-side lens lives
+  at `panels/routing.cljs` and is narrowed to the focused-event lens
+  per the parent epic.
+
+  ## Surface anatomy
+
+      ┌───────────────────────────────────────────────────┐
+      │ Routes — header + descriptive prose               │
+      ├───────────────────────────────────────────────────┤
+      │ Simulate URL: [____________________]  [clear]     │
+      │   → result block (when input non-blank)           │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]            12 routes    │
+      ├───────────────────────────────────────────────────┤
+      │ ▸ /cart         :route/cart        M  …doc…       │
+      │ ▾ /checkout     :route/checkout                   │
+      │   ╾─────── expand panel ─────────╼                │
+      │   chips + matched-keys + schema + Simulate-nav    │
+      │ ▸ /checkout/payment :route/payment                │
+      │   …                                               │
+      └───────────────────────────────────────────────────┘
+
+  ## State slots (all under `:rf.causa.static.routes/*`)
+
+    - `:rf.causa.static.routes/query` — search input value.
+    - `:rf.causa.static.routes/sim-url` — Simulate-URL input value.
+    - `:rf.causa.static.routes/expanded` — set of expanded route-ids.
+    - `:rf.causa.static.routes/sim-nav-open` — set of route-ids whose
+      hermetic Simulate-navigation preview is open.
+    - `:rf.causa.static.routes/tab-data` — view-facing composite.
+
+  ## Cross-link to Runtime Routing
+
+  The per-row `→ Runtime` chip fires
+  `:rf.causa.static.routes/jump-to-runtime` which:
+
+    1. Flips Causa to Runtime mode (`:rf.causa/set-mode :runtime`).
+    2. Selects the Runtime Routing tab (`:rf.causa/select-tab :routing`).
+
+  The Runtime side picks up the focused event automatically — there
+  is no per-route routing-scope filter on the lens (the lens IS the
+  focused event's slice of routing concerns).
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup, no Reagent / UIx
+  / Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `static/shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.routing-helpers :as h]
+            [day8.re-frame2-causa.static.routes.browse-list :as browse-list]
+            [day8.re-frame2-causa.static.routes.simulate-url :as simulate-url]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale sans-stack]]))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-routes-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Routes"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every registered route. Paste a URL into "
+    [:strong {:style {:color (:cyan tokens)}} "Simulate URL"]
+    " to see the 6-rule rank cascade resolve. Click any row for the "
+    "full registrar meta + a hermetic Simulate-navigation preview."]])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Routes panel root view. Subscribes to the static-routes
+  composite + UI-state slots and composes the header + Simulate-URL
+  surface + browse list.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data       @(rf/subscribe [:rf.causa.static.routes/tab-data])
+        expanded   @(rf/subscribe [:rf.causa.static.routes/expanded])
+        sim-open   @(rf/subscribe [:rf.causa.static.routes/sim-nav-open])
+        routes-map @(rf/subscribe [:rf.causa/registered-routes])
+        {:keys [sim-url sim-result silent?]} data]
+    [:section {:data-testid "rf-causa-static-routes"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (if silent?
+       [browse-list/render data {:expanded   expanded
+                                 :sim-open   sim-open
+                                 :routes-map routes-map}]
+       [:<>
+        (simulate-url/header sim-url sim-result)
+        [:div {:style {:flex 1 :overflow "auto"}}
+         [browse-list/render data {:expanded   expanded
+                                   :sim-open   sim-open
+                                   :routes-map routes-map}]]])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Routes panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.routes/query`,
+      `:rf.causa.static.routes/sim-url`,
+      `:rf.causa.static.routes/expanded`,
+      `:rf.causa.static.routes/sim-nav-open` — UI state slots.
+
+    - `:rf.causa.static.routes/set-query`,
+      `:rf.causa.static.routes/set-sim-url`,
+      `:rf.causa.static.routes/toggle-row`,
+      `:rf.causa.static.routes/toggle-sim-nav` — dispatch hooks.
+
+    - `:rf.causa.static.routes/jump-to-runtime` — cross-link from
+      Static to the Runtime Routing tab (flips mode + selects tab).
+
+    - `:rf.causa.static.routes/tab-data` — view-facing composite over
+      `:rf.causa/registered-routes` (registered by
+      `panels/routing/install!`) + the UI-state slots."
+  []
+
+  ;; ---- UI-state slots --------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.routes/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.routes/query)
+        (assoc db :rf.causa.static.routes/query q))))
+
+  (rf/reg-sub :rf.causa.static.routes/query
+    (fn [db _]
+      (get db :rf.causa.static.routes/query)))
+
+  (rf/reg-event-db :rf.causa.static.routes/set-sim-url
+    (fn [db [_ url]]
+      (if (or (nil? url) (= "" url))
+        (dissoc db :rf.causa.static.routes/sim-url)
+        (assoc db :rf.causa.static.routes/sim-url url))))
+
+  (rf/reg-sub :rf.causa.static.routes/sim-url
+    (fn [db _]
+      (get db :rf.causa.static.routes/sim-url)))
+
+  (rf/reg-event-db :rf.causa.static.routes/toggle-row
+    (fn [db [_ route-id]]
+      (let [expanded (or (:rf.causa.static.routes/expanded db) #{})]
+        (assoc db :rf.causa.static.routes/expanded
+               (if (contains? expanded route-id)
+                 (disj expanded route-id)
+                 (conj expanded route-id))))))
+
+  (rf/reg-sub :rf.causa.static.routes/expanded
+    (fn [db _]
+      (or (:rf.causa.static.routes/expanded db) #{})))
+
+  (rf/reg-event-db :rf.causa.static.routes/toggle-sim-nav
+    (fn [db [_ route-id]]
+      (let [open (or (:rf.causa.static.routes/sim-nav-open db) #{})]
+        (assoc db :rf.causa.static.routes/sim-nav-open
+               (if (contains? open route-id)
+                 (disj open route-id)
+                 (conj open route-id))))))
+
+  (rf/reg-sub :rf.causa.static.routes/sim-nav-open
+    (fn [db _]
+      (or (:rf.causa.static.routes/sim-nav-open db) #{})))
+
+  ;; ---- cross-link to Runtime Routing -----------------------------------
+
+  ;; Per the parent epic findings §4.4: the `→ Runtime` chip jumps to
+  ;; Runtime + opens the Routing lens. No route-id is plumbed down to
+  ;; the Runtime side — the lens IS the focused-event slice; the
+  ;; orientation comes from whatever event is currently focused.
+  (rf/reg-event-fx :rf.causa.static.routes/jump-to-runtime
+    (fn [_ [_ _route-id]]
+      {:fx [[:dispatch [:rf.causa/set-mode :runtime]]
+            [:dispatch [:rf.causa/select-tab :routing]]]}))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.routes/tab-data
+    :<- [:rf.causa/registered-routes]
+    :<- [:rf.causa.static.routes/query]
+    :<- [:rf.causa.static.routes/sim-url]
+    (fn [[routes-map query sim-url] _query]
+      (h/project-static-data routes-map query sim-url)))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/row_expand.cljs
@@ -1,0 +1,227 @@
+(ns day8.re-frame2-causa.static.routes.row-expand
+  "Per-row inline expand renderer for the Static Routes flat list
+  (rf2-o5f5f.3).
+
+  ## Shape
+
+  Click a row in the flat list → the expand surface unfolds below it
+  in-place (no master-detail split). Surfaces:
+
+    - pattern (the registered URL pattern)
+    - matched-keys (segment / wildcard / catch-all / optional keys
+      derived from the pattern at registration time)
+    - handler chip (the registered `:on-match` event vector)
+    - schema (when `:params` / `:query` Malli schemas are registered)
+    - source-coord chip (`open-in-editor`-style coord)
+    - the hermetic 'Simulate navigation' button — clicking it toggles
+      the per-row `simulate_nav/preview` surface (no real dispatch).
+
+  ## Frame discipline
+
+  This ns is the view layer; dispatches target the
+  `:rf.causa.static.routes/*` slots. The hermetic preview itself is
+  pure data (lives in `routing_helpers`) so JVM tests cover the
+  contract.
+
+  ## Source coords
+
+  Source-coord rendering reuses Causa's `open-in-editor` chip
+  rendering when the registrar meta carries the optional
+  `:rf.route/registered-at` slot. Absent → no chip (silent-by-
+  default per rf2-g3ghh / rf2-yn86j)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.routes.simulate-nav :as sim-nav]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- section-label
+  [label]
+  [:div {:style {:color          (:text-tertiary tokens)
+                 :font-family    sans-stack
+                 :font-size      "10px"
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :margin         "8px 0 2px 0"}}
+   label])
+
+(defn- code-block
+  "Render a mono block with `pr-str` text."
+  [testid value]
+  [:pre {:data-testid testid
+         :style       {:margin        "0"
+                       :padding       "6px 8px"
+                       :background    (:bg-1 tokens)
+                       :border-left   (str "2px solid " (:border-default tokens))
+                       :color         (:text-primary tokens)
+                       :font-family   mono-stack
+                       :font-size     "11px"
+                       :white-space   "pre-wrap"
+                       :max-height    "200px"
+                       :overflow-y    "auto"
+                       :overflow-x    "auto"}}
+   (with-out-str (binding [*print-length* nil] (println (pr-str value))))])
+
+(defn- chip
+  [text colour]
+  [:span {:style {:display       "inline-block"
+                  :padding       "1px 6px"
+                  :background    (:bg-3 tokens)
+                  :color         colour
+                  :border        (str "1px solid " colour)
+                  :border-radius "3px"
+                  :font-family   mono-stack
+                  :font-size     "10px"
+                  :margin-right  "4px"}}
+   text])
+
+(defn- on-match-summary
+  "Compact chip for the `:on-match` event vector (event-id keyword
+  only). Returns nil when absent."
+  [on-match]
+  (when (vector? on-match)
+    (let [ev-id (first on-match)]
+      [:span {:data-testid "rf-causa-static-routes-on-match-chip"}
+       (chip (str ev-id) (:cyan tokens))])))
+
+(defn- segment-keys-from-meta
+  "Extract segment keys from the route meta's `:rf.route/compiled`
+  parser output when present. Falls back to `nil` so the view shows
+  no entry when the compiled form isn't seeded (test fixtures that
+  pass bare `{:path ...}` maps)."
+  [meta]
+  (when-let [compiled (:rf.route/compiled meta)]
+    (:keys compiled)))
+
+(defn jump-button
+  "Cross-link chip `→ Runtime Routing` per the parent-epic findings
+  §4.4 — fires the cross-link event the registry installs so the
+  user lands on the Runtime Routing lens scoped to this route."
+  [route-id]
+  [:button {:data-testid (str "rf-causa-static-routes-jump-runtime-"
+                              (subs (pr-str route-id) 1))
+            :on-click    (fn [e]
+                           ;; Prevent the row-toggle click from
+                           ;; bubbling up — the jump is its own action.
+                           (.stopPropagation e)
+                           (rf/dispatch [:rf.causa.static.routes/jump-to-runtime
+                                         route-id]
+                                        {:frame :rf/causa}))
+            :title       "Open Runtime Routing scoped to this route"
+            :style       {:background    "transparent"
+                          :border        (str "1px solid " (:accent-violet tokens))
+                          :border-radius "3px"
+                          :color         (:accent-violet tokens)
+                          :padding       "1px 6px"
+                          :margin-left   "8px"
+                          :font-family   sans-stack
+                          :font-size     "10px"
+                          :cursor        "pointer"
+                          :white-space   "nowrap"}}
+   "→ Runtime"])
+
+(defn- sim-nav-toggle
+  "The hermetic 'Simulate navigation' button. Toggles the
+  `simulate_nav/preview` surface below it. State lives in the
+  per-row preview-open set on `:rf.causa.static.routes/sim-nav-open`."
+  [route-id sim-open?]
+  [:button {:data-testid (str "rf-causa-static-routes-sim-nav-toggle-"
+                              (subs (pr-str route-id) 1))
+            :on-click    (fn [e]
+                           (.stopPropagation e)
+                           (rf/dispatch [:rf.causa.static.routes/toggle-sim-nav
+                                         route-id]
+                                        {:frame :rf/causa}))
+            :style       {:background    (if sim-open? (:bg-active tokens) "transparent")
+                          :border        (str "1px solid " (:cyan tokens))
+                          :border-radius "3px"
+                          :color         (:cyan tokens)
+                          :padding       "2px 8px"
+                          :font-family   sans-stack
+                          :font-size     "11px"
+                          :font-weight   500
+                          :cursor        "pointer"
+                          :white-space   "nowrap"}}
+   (if sim-open? "Hide preview" "Simulate navigation")])
+
+(defn- source-coord-chip
+  "Render the `:rf.route/registered-at` source coord when present."
+  [meta]
+  (when-let [coord (:rf.route/registered-at meta)]
+    [:span {:data-testid "rf-causa-static-routes-source-coord"
+            :style       {:font-family mono-stack
+                          :font-size   "10px"
+                          :color       (:text-tertiary tokens)
+                          :margin-left "8px"}}
+     (str (:file coord) ":" (:line coord))]))
+
+(defn render
+  "Render the per-row expand surface for `row` (a routing-helpers
+  catalogue row). `sim-open?` is true when the hermetic preview is
+  toggled open; `routes-map` is threaded down for the preview
+  projection."
+  [row {:keys [sim-open? routes-map]}]
+  (let [{:keys [route-id path doc meta on-match-event]} row
+        on-match (or on-match-event (:on-match meta))
+        params   (:params meta)
+        query    (:query meta)
+        keys     (segment-keys-from-meta meta)]
+    [:div {:data-testid (str "rf-causa-static-routes-expand-"
+                             (subs (pr-str route-id) 1))
+           :style       {:margin       "0 0 8px 24px"
+                         :padding      "10px 12px"
+                         :background   (:bg-1 tokens)
+                         :border-left  (str "2px solid " (:border-default tokens))
+                         :font-family  sans-stack
+                         :font-size    "12px"
+                         :color        (:text-primary tokens)}}
+     [:div {:style {:display       "flex"
+                    :align-items   "center"
+                    :flex-wrap     "wrap"
+                    :gap           "6px"
+                    :margin-bottom "6px"}}
+      (chip (str route-id) (:accent-violet tokens))
+      (when path (chip path (:cyan tokens)))
+      (on-match-summary on-match)
+      (source-coord-chip meta)
+      [sim-nav-toggle route-id sim-open?]
+      [jump-button route-id]]
+     (when doc
+       [:p {:data-testid (str "rf-causa-static-routes-doc-"
+                              (subs (pr-str route-id) 1))
+            :style       {:margin     "0 0 6px 0"
+                          :color      (:text-secondary tokens)
+                          :font-size  "11px"
+                          :font-style "italic"}}
+        doc])
+     (when (seq keys)
+       [:div {:data-testid (str "rf-causa-static-routes-keys-"
+                                (subs (pr-str route-id) 1))
+              :style       {:margin "4px 0"}}
+        (section-label "Matched keys")
+        [:div {:style {:font-family mono-stack
+                       :font-size   "11px"
+                       :color       (:text-secondary tokens)}}
+         (pr-str (vec keys))]])
+     (when params
+       [:div {:data-testid (str "rf-causa-static-routes-params-schema-"
+                                (subs (pr-str route-id) 1))
+              :style       {:margin "4px 0"}}
+        (section-label ":params schema")
+        (code-block (str "rf-causa-static-routes-params-schema-block-"
+                         (subs (pr-str route-id) 1))
+                    params)])
+     (when query
+       [:div {:data-testid (str "rf-causa-static-routes-query-schema-"
+                                (subs (pr-str route-id) 1))
+              :style       {:margin "4px 0"}}
+        (section-label ":query schema")
+        (code-block (str "rf-causa-static-routes-query-schema-block-"
+                         (subs (pr-str route-id) 1))
+                    query)])
+     (section-label "Registrar meta")
+     (code-block (str "rf-causa-static-routes-meta-"
+                      (subs (pr-str route-id) 1))
+                 meta)
+     (when sim-open?
+       [sim-nav/preview routes-map route-id nil])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_nav.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_nav.cljs
@@ -1,0 +1,123 @@
+(ns day8.re-frame2-causa.static.routes.simulate-nav
+  "Hermetic 'Simulate navigation' preview for Causa's Static Routes
+  tab (rf2-o5f5f.3).
+
+  ## Purpose
+
+  Per the parent epic decision (option (a): two-verbs-two-homes) and
+  the findings doc §4.3 option (a): the per-row 'Simulate navigation'
+  button is HERMETIC — NO real dispatch into the host app, NO fx, NO
+  app-db mutation. It surfaces a preview of what would land:
+
+    - matched params (derived from the row's pattern + the optional
+      URL from the row's simulate-URL input);
+    - the registered `:on-match` event vector;
+    - the expected app-db slot (`[:rf/route ...]`) shape.
+
+  The hermetic posture is the spec point — Causa is a lens, not a
+  remote control. Real navigation lives behind `:rf.route/navigate`
+  + `rf.route/url-requested` and is reachable from the host UI.
+
+  ## Pure helper, view-thin
+
+  The pure-data projection lives in
+  `panels/routing-helpers/simulate-navigation-preview` — JVM-portable
+  so the unit-test target covers the cascade. This ns is the view
+  layer only."
+  (:require [day8.re-frame2-causa.panels.routing-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- field-row
+  "One `<label> : <value>` row in the preview grid."
+  [{:keys [label value testid mono?]}]
+  [:<>
+   [:span {:style {:color       (:text-tertiary tokens)
+                   :font-family sans-stack
+                   :font-size   "10px"
+                   :text-transform "uppercase"
+                   :letter-spacing "0.4px"}}
+    label]
+   [:span {:data-testid testid
+           :style       {:color       (:text-primary tokens)
+                         :font-family (if mono? mono-stack sans-stack)
+                         :font-size   "12px"
+                         :white-space "pre-wrap"
+                         :word-break  "break-word"}}
+    value]])
+
+(defn preview
+  "Render the hermetic Simulate-navigation preview for `route-id`. The
+  optional `url` is the row's local Simulate-URL input — when present
+  the preview shows matched params (when the URL actually matches the
+  row's pattern); when absent the preview shows the route's
+  registered shape (path / on-match / db-slot).
+
+  `routes-map` is the registered-routes map passed in from the panel
+  so this view stays pure (no subscribes; the panel composes against
+  the registry sub and threads the data down)."
+  [routes-map route-id url]
+  (let [pv (h/simulate-navigation-preview routes-map route-id url)]
+    [:div {:data-testid (str "rf-causa-static-routes-sim-nav-"
+                             (subs (pr-str route-id) 1))
+           :style       {:padding       "10px 16px"
+                         :margin        "8px 0 4px 24px"
+                         :background    (:bg-1 tokens)
+                         :border-left   (str "2px solid " (:cyan tokens))
+                         :border-radius "2px"
+                         :display       "grid"
+                         :grid-template-columns "100px 1fr"
+                         :row-gap       "6px"
+                         :column-gap    "12px"
+                         :font-size     "12px"}}
+     (if (:unknown? pv)
+       [:span {:data-testid "rf-causa-static-routes-sim-nav-unknown"
+               :style       {:color       (:red tokens)
+                             :font-family sans-stack
+                             :font-size   "11px"
+                             :grid-column "1 / -1"}}
+        "Route-id " (pr-str route-id) " is not registered."]
+       [:<>
+        [:span {:style {:grid-column "1 / -1"
+                        :color       (:text-tertiary tokens)
+                        :font-family sans-stack
+                        :font-size   "10px"
+                        :font-style  "italic"
+                        :margin-bottom "4px"}}
+         "Hermetic preview — nothing is dispatched. Shows what would land "
+         "in app-db if the host navigated to this route."]
+        (field-row {:label  "Path"
+                    :value  (or (:path pv) "—")
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-path"})
+        (field-row {:label  "URL"
+                    :value  (cond
+                              (nil? url)       "—"
+                              (= "" url)       "—"
+                              (:matched? pv)   (str url "  (matched)")
+                              :else            (str url "  (no match)"))
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-url"})
+        (field-row {:label  "Params"
+                    :value  (if (and (:matched? pv) (seq (:params pv)))
+                              (pr-str (:params pv))
+                              "—")
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-params"})
+        (field-row {:label  ":on-match"
+                    :value  (if (some? (:on-match pv))
+                              (pr-str (:on-match pv))
+                              "—")
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-on-match"})
+        (field-row {:label  "DB slot"
+                    :value  (pr-str (:db-slot pv))
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-db-slot"})
+        (field-row {:label  "Slot shape"
+                    :value  (with-out-str
+                              (binding [*print-length* nil]
+                                (println (pr-str (:slot-shape pv)))))
+                    :mono?  true
+                    :testid "rf-causa-static-routes-sim-nav-slot-shape"})])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_url.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/routes/simulate_url.cljs
@@ -1,0 +1,167 @@
+(ns day8.re-frame2-causa.static.routes.simulate-url
+  "Simulate-URL header surface for Causa's Static Routes tab
+  (rf2-o5f5f.3).
+
+  ## Purpose
+
+  Promoted from `panels/routing.cljs` per the two-verbs-two-homes
+  decision (Mike, 2026-05-19): the URL → route resolver is a Static
+  surface verb (browse), not a Runtime cascade lens. Paste a URL,
+  see every route that matches plus its 6-rule `:rf.route/rank`
+  tuple; the winner is the first row by rank-descending (mirrors
+  `match-url`).
+
+  The implementation reuses the existing
+  `panels.routing-helpers/simulate-url` pure helper — the 6-rule
+  rank cascade lives there, JVM-portable. This ns is the view +
+  dispatch layer only.
+
+  ## State slot
+
+  Lives at `:rf.causa.static.routes/sim-url` on Causa's frame
+  (`:rf/causa`). Its companion `set` event is
+  `:rf.causa.static.routes/set-sim-url`.
+
+  ## Pure hiccup
+
+  Same contract as every other Causa view — pure hiccup, no Reagent
+  / UIx / Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `static/shell.cljs`."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens mono-stack sans-stack]]))
+
+(defn- rank-cell
+  "Render a single rank tuple as compact mono text. The 6-tuple is
+  `[static total -splat catch-all? -optional -reg-index]` per
+  `parse-pattern`; surface it verbatim — the lens is about exposing
+  the cascade, not interpreting it."
+  [rank]
+  [:span {:style {:font-family mono-stack
+                  :font-size   "11px"
+                  :color       (:text-secondary tokens)}}
+   (pr-str rank)])
+
+(defn- candidate-row
+  "One row in the Simulate-URL result table — winner highlighted."
+  [{:keys [route-id rank params winner? path]}]
+  [:li {:data-testid (str "rf-causa-static-routes-sim-candidate-"
+                          (subs (pr-str route-id) 1))
+        :data-winner (when winner? "true")
+        :style       {:display        "flex"
+                      :align-items    "center"
+                      :gap            "8px"
+                      :padding        "3px 8px"
+                      :background     (if winner? (:bg-active tokens) "transparent")
+                      :border-left    (if winner?
+                                        (str "2px solid " (:green tokens))
+                                        "2px solid transparent")
+                      :border-radius  "2px"
+                      :font-family    mono-stack
+                      :font-size      "12px"
+                      :white-space    "nowrap"}}
+   [:span {:style {:color       (if winner? (:green tokens) (:text-tertiary tokens))
+                   :font-weight 600
+                   :font-size   "10px"
+                   :min-width   "50px"}}
+    (if winner? "WINNER" "")]
+   [:span {:style {:color     (:accent-violet tokens)
+                   :min-width "140px"}}
+    path]
+   [:span {:style {:color     (:text-tertiary tokens)
+                   :font-size "11px"
+                   :min-width "160px"}}
+    (str route-id)]
+   (rank-cell rank)
+   (when (seq params)
+     [:span {:style {:color       (:text-secondary tokens)
+                     :font-size   "11px"
+                     :margin-left "8px"}}
+      (pr-str params)])])
+
+(defn header
+  "The 'Simulate URL: [____] [Resolve]' header surface — paste a URL,
+  see every matching route ranked. `sim-url` is the current input
+  value; `sim-result` is the projection from
+  `routing-helpers/simulate-url` (nil when input is blank)."
+  [sim-url sim-result]
+  [:div {:data-testid "rf-causa-static-routes-sim"
+         :style       {:padding       "10px 16px"
+                       :border-top    (str "1px solid " (:border-subtle tokens))
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :background    (:bg-1 tokens)}}
+   [:div {:style {:display     "flex"
+                  :align-items "center"
+                  :gap         "8px"
+                  :font-family sans-stack}}
+    [:label {:style {:color          (:text-tertiary tokens)
+                     :font-size      "10px"
+                     :text-transform "uppercase"
+                     :letter-spacing "0.5px"
+                     :min-width      "80px"}}
+     "Simulate URL"]
+    [:input {:type        "text"
+             :data-testid "rf-causa-static-routes-sim-input"
+             :placeholder "/cart  or  /checkout/payment?step=2"
+             :value       (or sim-url "")
+             :on-change   (fn [e]
+                            (rf/dispatch [:rf.causa.static.routes/set-sim-url
+                                          (-> e .-target .-value)]
+                                         {:frame :rf/causa}))
+             :style       {:flex          1
+                           :background    (:bg-3 tokens)
+                           :color         (:text-primary tokens)
+                           :border        (str "1px solid " (:border-default tokens))
+                           :border-radius "3px"
+                           :padding       "4px 8px"
+                           :font-family   mono-stack
+                           :font-size     "12px"}}]
+    (when (and sim-url (not= "" sim-url))
+      [:button {:data-testid "rf-causa-static-routes-sim-clear"
+                :on-click    (fn [_]
+                               (rf/dispatch [:rf.causa.static.routes/set-sim-url ""]
+                                            {:frame :rf/causa}))
+                :style       {:background    "transparent"
+                              :border        (str "1px solid " (:border-default tokens))
+                              :border-radius "3px"
+                              :color         (:text-tertiary tokens)
+                              :padding       "3px 8px"
+                              :font-family   sans-stack
+                              :font-size     "11px"
+                              :cursor        "pointer"}}
+       "clear"])]
+   (when sim-result
+     (let [{:keys [path candidates winner]} sim-result]
+       [:div {:data-testid "rf-causa-static-routes-sim-result"
+              :style       {:margin-top "8px"}}
+        [:div {:style {:font-family mono-stack
+                       :font-size   "11px"
+                       :color       (:text-tertiary tokens)
+                       :padding     "0 8px 4px 8px"}}
+         (str "matched against path " (pr-str path) " — "
+              (cond
+                (empty? candidates) "no route matches (match-url → nil)"
+                :else (str (count candidates)
+                           (if (= 1 (count candidates)) " candidate" " candidates")
+                           "; winner = " winner)))]
+        (when (seq candidates)
+          [:div {:style {:display                "grid"
+                         :grid-template-columns  "50px 140px 160px 1fr"
+                         :column-gap             "8px"
+                         :padding                "0 8px 2px 8px"
+                         :font-family            sans-stack
+                         :font-size              "10px"
+                         :color                  (:text-tertiary tokens)
+                         :text-transform         "uppercase"
+                         :letter-spacing         "0.4px"}}
+           [:span ""] [:span "path"] [:span "route-id"] [:span "rank · params"]])
+        (into [:ul {:style {:list-style     "none"
+                            :margin         "0"
+                            :padding        "0"
+                            :display        "flex"
+                            :flex-direction "column"
+                            :gap            "1px"}}]
+              (for [c candidates]
+                ^{:key (str (:route-id c))}
+                [candidate-row c]))]))])

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -85,6 +85,7 @@
     - rf2-o5f5f.6 — Events registry browse + interceptor stack"
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
+            [day8.re-frame2-causa.static.routes.panel :as routes-panel]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale layout sans-stack]]))
@@ -335,8 +336,17 @@
                    :overflow    "auto"
                    :background  (:bg-2 tokens)
                    :color       (:text-primary tokens)}}
-     (if tab
+     (cond
+       ;; rf2-o5f5f.3 — Static Routes panel replaces the placeholder.
+       ;; Sibling rf2-o5f5f.2 (Machines) will replace the :machines
+       ;; branch in parallel; trivial 5-line rebase if both land.
+       (= selected :routes)
+       [routes-panel/Panel]
+
+       tab
        [placeholder-card tab]
+
+       :else
        [:div {:data-testid "rf-causa-static-tab-unknown"
               :style {:padding     "16px"
                       :color       (:text-secondary tokens)

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_cljs_test.cljs
@@ -1,34 +1,32 @@
 (ns day8.re-frame2-causa.panels.routing-cljs-test
-  "CLJS-side wiring + view tests for Causa's Routes tab (rf2-nrbs9,
-  reshaped per rf2-lq0ef).
+  "CLJS-side wiring + view tests for Causa's Runtime Routing tab —
+  the focused-event lens (rf2-o5f5f.3 narrows from rf2-lq0ef).
 
-  ## What's under test (in addition to the pure-data tests in
-  `routing_helpers_cljs_test.cljc`)
+  ## Scope (post-narrow)
 
-    1. **Registry wires the subs** — every sub the panel reads gets
-       installed by `register-causa-handlers!`, plus the new UI-state
-       subs/events (`:rf.causa.routing/query`,
-       `:rf.causa.routing/sim-url`, `:rf.causa.routing/expanded`,
-       `:rf.causa.routing/toggle-row`, etc.) — and the `:routing` tab
-       id is in the L3 tabs vector + the palette panel list.
+  Per Mike's two-verbs-two-homes decision (2026-05-19), the Runtime
+  Routing tab is a focused-event lens: it surfaces the routing slice
+  of the focused event's cascade — FROM/TO chips when navigation
+  fired; otherwise an empty state pointing to Static Routes for the
+  browse verb.
 
-    2. **Render contract** — root container + header + search box +
-       Simulate-URL section + flat list (or empty state).
+  The browse + search + Simulate-URL surface was promoted to the
+  Static Routes panel (see
+  `static/routes/panel_cljs_test.cljs`).
 
-    3. **Silent state** — when no routes are registered the panel
-       renders the empty body (`No routes registered.`), no list, no
-       search.
+  ## What's under test
 
-    4. **Orientation HERE marker** — when routes are registered and
-       a current route slice exists, the current row carries the
-       `:here` marker.
+    1. **Registry wires the lens subs** — every sub the panel reads
+       gets installed by `register-causa-handlers!`. The promoted
+       browse / search / Simulate-URL slots (now under
+       `:rf.causa.static.routes/*`) are NOT registered by
+       `routing/install!` anymore.
 
-    5. **FROM / TO markers** — when the focused cascade carries a
-       `:rf.route.nav-token/allocated` trace event the corresponding
-       rows carry `:from` / `:to` markers.
+    2. **Empty / oriented states** — no-nav focused event renders the
+       empty state; nav-allocated focused cascade renders the FROM/TO
+       chip row + slice detail.
 
-    6. **Frame isolation** — every read targets `:rf/causa`'s frame;
-       the panel never reads the host frame's app-db directly."
+    3. **Frame isolation** — every read targets `:rf/causa`'s frame."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -78,14 +76,6 @@
             node))
         (hiccup-seq tree)))
 
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filter (fn [node]
-            (and (vector? node)
-                 (map? (second node))
-                 (some-> (:data-testid (second node))
-                         (.startsWith prefix))))
-          (hiccup-seq tree)))
-
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {}))
@@ -108,11 +98,11 @@
 
 ;; ---- (1) registry wiring + tab inventory --------------------------------
 
-(deftest registry-installs-routing-subs
-  (testing "register-causa-handlers! installs every Routes-tab sub"
+(deftest registry-installs-routing-lens-subs
+  (testing "register-causa-handlers! installs the focused-event lens subs"
     (registry/register-causa-handlers!)
     (is (some? (registrar/handler :sub :rf.causa/registered-routes))
-        ":rf.causa/registered-routes sub registered")
+        ":rf.causa/registered-routes sub registered (shared with Static)")
     (is (some? (registrar/handler :sub :rf.causa/registered-routes-override))
         "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.causa/current-route-slice))
@@ -120,23 +110,26 @@
     (is (some? (registrar/handler :sub :rf.causa/current-route-slice-override))
         "test-only override sub registered")
     (is (some? (registrar/handler :sub :rf.causa/routing-tab-data))
-        "view-facing composite sub registered")
-    (is (some? (registrar/handler :sub :rf.causa.routing/query))
-        ":rf.causa.routing/query sub registered (search input)")
-    (is (some? (registrar/handler :sub :rf.causa.routing/sim-url))
-        ":rf.causa.routing/sim-url sub registered (Simulate-URL input)")
-    (is (some? (registrar/handler :sub :rf.causa.routing/expanded))
-        ":rf.causa.routing/expanded sub registered (row expansion)")
-    (is (some? (registrar/handler :event :rf.causa.routing/set-query))
-        "search-input event registered")
-    (is (some? (registrar/handler :event :rf.causa.routing/set-sim-url))
-        "Simulate-URL event registered")
-    (is (some? (registrar/handler :event :rf.causa.routing/toggle-row))
-        "toggle-row event registered")
+        "view-facing focused-event-lens composite sub registered")
     (is (some? (registrar/handler :event :rf.causa/set-registered-routes-override-for-test))
         "test-only override event registered")
     (is (some? (registrar/handler :event :rf.causa/set-current-route-slice-override-for-test))
-        "test-only override event registered")))
+        "test-only override event registered"))
+  (testing "rf2-o5f5f.3 — browse + search + Simulate-URL slots NO LONGER live
+            under :rf.causa.routing/* (promoted to :rf.causa.static.routes/*)"
+    (registry/register-causa-handlers!)
+    (is (nil? (registrar/handler :sub :rf.causa.routing/query))
+        ":rf.causa.routing/query removed (moved to static.routes/query)")
+    (is (nil? (registrar/handler :sub :rf.causa.routing/sim-url))
+        ":rf.causa.routing/sim-url removed (moved to static.routes/sim-url)")
+    (is (nil? (registrar/handler :sub :rf.causa.routing/expanded))
+        ":rf.causa.routing/expanded removed (moved to static.routes/expanded)")
+    (is (nil? (registrar/handler :event :rf.causa.routing/set-query))
+        ":rf.causa.routing/set-query removed (moved to static.routes/set-query)")
+    (is (nil? (registrar/handler :event :rf.causa.routing/set-sim-url))
+        ":rf.causa.routing/set-sim-url removed (moved to static.routes/set-sim-url)")
+    (is (nil? (registrar/handler :event :rf.causa.routing/toggle-row))
+        ":rf.causa.routing/toggle-row removed (moved to static.routes/toggle-row)")))
 
 (deftest palette-includes-routing
   (testing "the palette's canonical panel list carries the :routing entry"
@@ -145,13 +138,16 @@
       (is (= 7 (count palette-subs/palette-panels))
           "exactly 7 entries — Event / App DB / Views / Trace / Machines / Routing / Issues"))))
 
-;; ---- (2) silent state ---------------------------------------------------
+;; ---- (2) empty state ---------------------------------------------------
 
-(deftest panel-renders-silent-state-when-no-routes
-  (testing "no routes registered → empty-state body, no list, no search"
+(deftest panel-renders-empty-state-without-nav-cascade
+  (testing "no focused-event nav → empty orientation pointing to Static Routes"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
                         {:frame :rf/causa})
       (let [tree (routing/Panel)]
         (is (some? (find-by-testid tree "rf-causa-routing"))
@@ -159,64 +155,64 @@
         (is (some? (find-by-testid tree "rf-causa-routing-header"))
             "header always renders")
         (is (some? (find-by-testid tree "rf-causa-routing-empty"))
-            "silent state body present")
+            "empty orientation rendered when focused event did not navigate")
+        (is (nil? (find-by-testid tree "rf-causa-routing-nav-row"))
+            "FROM/TO row NOT rendered without nav cascade")
+        ;; Promoted browse surfaces MUST NOT be present anymore
         (is (nil? (find-by-testid tree "rf-causa-routing-list"))
-            "flat list NOT rendered")
+            "flat list NOT rendered (promoted to Static Routes)")
         (is (nil? (find-by-testid tree "rf-causa-routing-search"))
-            "search NOT rendered in silent state")
+            "search NOT rendered (promoted to Static Routes)")
         (is (nil? (find-by-testid tree "rf-causa-routing-sim"))
-            "simulator NOT rendered in silent state")))))
+            "Simulate-URL NOT rendered (promoted to Static Routes)")))))
 
-;; ---- (3) flat-list rendering + chrome ----------------------------------
-
-(deftest panel-renders-flat-list-when-routes-present
-  (testing "routes present → flat list + search + simulator + slice detail"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
-                         {:id :route/cart :params {} :query {}}]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-list"))
-            "flat list rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-search"))
-            "search box rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-sim"))
-            "Simulate-URL section rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
-            "slice detail rendered for active slice")
-        (is (nil? (find-by-testid tree "rf-causa-routing-empty"))
-            "empty state NOT rendered when routes present")))))
-
-;; ---- (4) orientation HERE marker ----------------------------------------
-
-(deftest panel-renders-here-marker-without-navigation
-  (testing "current slice present + no nav cascade → HERE on the active row"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
-                         {:id :route/cart :params {} :query {}}]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)
-            cart-row (find-by-testid tree "rf-causa-routing-row-route/cart")]
-        (is (some? cart-row) "current route row renders")
-        (is (= "here" (:data-marker (second cart-row)))
-            "current route row carries the HERE marker")
-        (is (some? (find-by-testid tree "rf-causa-routing-marker-here"))
-            "HERE chip text rendered")))))
-
-;; ---- (5) FROM / TO markers ---------------------------------------------
+;; ---- (3) FROM / TO chip row when focused cascade navigated -------------
 
 (deftest panel-renders-from-to-when-cascade-navigated
-  (testing "focused cascade with nav-token emit → FROM + TO markers"
+  (testing "focused cascade with nav-token emit → FROM + TO chip row + slice detail"
     (setup-causa-frame!)
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
                         {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id     :route/confirm
+                          :params {:order-id "ord-1234"}
+                          :query  {:source "cart"}}]
+                        {:frame :rf/causa})
+      (let [nav-event (nav-allocated :route/confirm)
+            buffer [{:id 99 :op-type :event :operation :event/dispatched
+                     :tags {:dispatch-id 99
+                            :event [:rf.route/navigate :route/confirm]}}
+                    (assoc nav-event :tags
+                           (assoc (:tags nav-event) :dispatch-id 99))]]
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer]
+                          {:frame :rf/causa})
+        (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-row"))
+            "FROM/TO chip row rendered")
+        ;; FROM cell does NOT render here — no prior slice id distinct
+        ;; from confirm, so from-to-from-cascade collapses :from-id.
+        ;; The TO cell + nav marker chips MUST render.
+        (is (some? (find-by-testid tree "rf-causa-routing-to-cell"))
+            "TO cell rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-marker-to"))
+            "TO marker chip text rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
+            "header nav summary surfaces the TO id")
+        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
+            "slice detail grid rendered alongside nav row")
+        (is (nil? (find-by-testid tree "rf-causa-routing-empty"))
+            "empty state NOT rendered when navigation triggered")))))
+
+(deftest panel-renders-from-and-to-when-prior-slice-differs
+  (testing "focused cascade with nav-token emit + distinct prior slice → FROM + TO"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Prior slice = :route/cart (will be the FROM after the nav lands on
+      ;; :route/confirm).
       (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
                          {:id :route/cart :params {} :query {}}]
                         {:frame :rf/causa})
@@ -229,129 +225,12 @@
         (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer]
                           {:frame :rf/causa})
         (rf/dispatch-sync [:rf.causa/focus-cascade 99 nil] {:frame :rf/causa}))
-
-      (let [tree (routing/Panel)
-            cart-row    (find-by-testid tree "rf-causa-routing-row-route/cart")
-            confirm-row (find-by-testid tree "rf-causa-routing-row-route/confirm")]
-        (is (some? cart-row)    "cart row present")
-        (is (some? confirm-row) "confirm row present")
-        (is (= "from" (:data-marker (second cart-row)))
-            "cart row carries the FROM marker")
-        (is (= "to" (:data-marker (second confirm-row)))
-            "confirm row carries the TO marker")
+      (let [tree (routing/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-routing-from-cell"))
+            "FROM cell rendered (prior slice = :route/cart)")
         (is (some? (find-by-testid tree "rf-causa-routing-marker-from"))
-            "FROM chip text rendered")
+            "FROM marker chip rendered")
+        (is (some? (find-by-testid tree "rf-causa-routing-to-cell"))
+            "TO cell rendered (nav destination = :route/confirm)")
         (is (some? (find-by-testid tree "rf-causa-routing-marker-to"))
-            "TO chip text rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-nav-summary"))
-            "header nav summary surfaces the TO id")))))
-
-;; ---- (6) metadata badges + parent annotation ---------------------------
-
-(deftest panel-renders-meta-badges
-  (testing "routes carrying :on-match / :parent surface their badges"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)
-            confirm-row (find-by-testid tree "rf-causa-routing-row-route/confirm")]
-        (is (some? confirm-row) "confirm row renders")
-        ;; :route/confirm carries both :on-match and :parent
-        (let [on-match-badges (find-all-by-testid-prefix
-                                tree "rf-causa-routing-badge-on-match")
-              parent-badges   (find-all-by-testid-prefix
-                                tree "rf-causa-routing-badge-parent")
-              parent-ptrs     (find-all-by-testid-prefix
-                                tree "rf-causa-routing-parent-ptr")]
-          (is (pos? (count on-match-badges))
-              "at least one :on-match badge renders (confirm has :on-match)")
-          (is (pos? (count parent-badges))
-              "at least one :parent badge renders (confirm has :parent)")
-          (is (pos? (count parent-ptrs))
-              "the compact ↑ parent pointer annotation renders"))))))
-
-;; ---- (7) substring search filters the list -----------------------------
-
-(deftest panel-search-filters-the-list
-  (testing "set-query event narrows the catalogue"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa.routing/set-query "checkout"]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)
-            rows (find-all-by-testid-prefix tree "rf-causa-routing-row-")]
-        (is (= #{"rf-causa-routing-row-route/checkout"
-                 "rf-causa-routing-row-route/payment"
-                 "rf-causa-routing-row-route/confirm"}
-               (set (map #(:data-testid (second %)) rows)))
-            "only routes whose haystack contains \"checkout\" render")))))
-
-;; ---- (8) Simulate-URL surface ------------------------------------------
-
-(deftest panel-simulates-url-and-surfaces-candidates
-  (testing "set-sim-url populates the simulator result with ranked candidates"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa.routing/set-sim-url "/cart"]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-sim-result"))
-            "simulator result rendered")
-        (is (some? (find-by-testid tree "rf-causa-routing-sim-candidate-route/cart"))
-            "matching candidate row rendered"))))
-
-  (testing "no match — result block reports zero candidates"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa.routing/set-sim-url "/nope-not-here"]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-sim-result"))
-            "simulator result rendered even on no-match")))))
-
-;; ---- (9) row expand toggle ---------------------------------------------
-
-(deftest panel-row-expand-toggle
-  (testing "toggle-row event opens the meta-expander surface"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      ;; Initial render — no expander visible.
-      (let [tree (routing/Panel)]
-        (is (nil? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
-            "meta expander NOT present before toggle"))
-      (rf/dispatch-sync [:rf.causa.routing/toggle-row :route/cart]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
-            "meta expander rendered after toggle"))
-      (rf/dispatch-sync [:rf.causa.routing/toggle-row :route/cart]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (nil? (find-by-testid tree "rf-causa-routing-meta-route/cart"))
-            "meta expander hidden after second toggle (toggle behaviour)")))))
-
-;; ---- (10) slice detail rendering ---------------------------------------
-
-(deftest panel-renders-slice-detail
-  (testing "params + query + fragment grid rendered when current slice present"
-    (setup-causa-frame!)
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
-                        {:frame :rf/causa})
-      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
-                         {:id     :route/confirm
-                          :params {:order-id "ord-1234"}
-                          :query  {:source "cart"}}]
-                        {:frame :rf/causa})
-      (let [tree (routing/Panel)]
-        (is (some? (find-by-testid tree "rf-causa-routing-slice-detail"))
-            "slice detail grid present")))))
+            "TO marker chip rendered")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/routing_helpers_cljs_test.cljc
@@ -367,3 +367,87 @@
   (testing "blank sim-url leaves :sim-result nil"
     (let [data (h/project-data cart-routes {:id :route/cart} nil nil "")]
       (is (nil? (:sim-result data))))))
+
+;; ---- project-static-data (rf2-o5f5f.3) ---------------------------------
+
+(deftest project-static-data-empty-test
+  (testing "silent state — no routes registered"
+    (let [data (h/project-static-data {} nil nil)]
+      (is (true? (:silent? data)))
+      (is (= [] (:routes data)))
+      (is (= 0 (:total-routes data)))
+      (is (false? (:filtered? data)))
+      (is (nil? (:sim-result data))))))
+
+(deftest project-static-data-rows-test
+  (testing "rows are projected + sorted + carry no :marker"
+    (let [data (h/project-static-data cart-routes nil nil)]
+      (is (false? (:silent? data)))
+      (is (= (count cart-routes) (:total-routes data)))
+      (is (= (count cart-routes) (count (:routes data))))
+      (is (every? #(not (contains? % :marker)) (:routes data))
+          "Static rows MUST NOT carry :marker (event-INDEPENDENT)"))))
+
+(deftest project-static-data-query-test
+  (testing "query narrows the row list + flips :filtered?"
+    (let [data (h/project-static-data cart-routes "checkout" nil)
+          ids  (set (map :route-id (:routes data)))]
+      (is (true? (:filtered? data)))
+      (is (contains? ids :route/checkout))
+      (is (not (contains? ids :route/cart)))))
+
+  (testing "blank query is identity"
+    (let [data (h/project-static-data cart-routes "" nil)]
+      (is (false? (:filtered? data)))
+      (is (= (count cart-routes) (count (:routes data)))))))
+
+(deftest project-static-data-sim-url-test
+  (testing "non-blank sim-url drives :sim-result"
+    (let [data (h/project-static-data cart-routes nil "/cart")]
+      (is (= "/cart" (-> data :sim-result :path)))
+      (is (= :route/cart (-> data :sim-result :winner)))))
+
+  (testing "blank sim-url leaves :sim-result nil"
+    (let [data (h/project-static-data cart-routes nil "")]
+      (is (nil? (:sim-result data))))))
+
+;; ---- simulate-navigation-preview (rf2-o5f5f.3) -------------------------
+
+(deftest simulate-navigation-preview-unknown-test
+  (testing "unknown route-id returns the unknown shape"
+    (let [pv (h/simulate-navigation-preview cart-routes :route/nope nil)]
+      (is (true? (:unknown? pv)))
+      (is (= :route/nope (:route-id pv))))))
+
+(deftest simulate-navigation-preview-no-url-test
+  (testing "registered route, no URL → path / on-match / slot shape; no params"
+    (let [pv (h/simulate-navigation-preview cart-routes :route/audit nil)]
+      (is (false? (:unknown? pv)))
+      (is (= :route/audit (:route-id pv)))
+      (is (= "/admin/audit" (:path pv)))
+      (is (= [:audit/load] (:on-match pv)))
+      (is (= [:rf/route] (:db-slot pv)))
+      (is (false? (:matched? pv)))
+      (is (nil? (:params pv)))
+      (is (= {:id :route/audit :path "/admin/audit"} (:slot-shape pv))))))
+
+(deftest simulate-navigation-preview-with-matching-url-test
+  (testing "matching URL → :matched? true + params surfaced + slot shape carries params"
+    ;; cart-routes uses bare paths (no compiled pattern) — the helper
+    ;; compiles on-demand. A literal /cart matches :route/cart.
+    (let [pv (h/simulate-navigation-preview cart-routes :route/cart "/cart")]
+      (is (false? (:unknown? pv)))
+      (is (true? (:matched? pv)))
+      (is (= "/cart" (:url pv)))
+      (is (= [:rf/route] (:db-slot pv)))
+      (is (contains? (:slot-shape pv) :id))
+      (is (= :route/cart (-> pv :slot-shape :id))))))
+
+(deftest simulate-navigation-preview-with-mismatching-url-test
+  (testing "URL does not match this route's pattern → :matched? false"
+    (let [pv (h/simulate-navigation-preview cart-routes :route/cart "/checkout")]
+      (is (false? (:matched? pv)))
+      (is (nil? (:params pv)))
+      ;; Slot shape still carries path (registered) but no params (no match).
+      (is (= "/cart" (:path pv)))
+      (is (not (contains? (:slot-shape pv) :params))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -181,13 +181,17 @@
    :rf.causa/current-route-slice
    :rf.causa/current-route-slice-override
    :rf.causa/routing-tab-data
-   ;; rf2-lq0ef — Routes lens UI state (search query, Simulate-URL
-   ;; input, expanded-row set). Per-panel `:rf.causa.routing/*` group
-   ;; per the `:rf.causa.<panel>/*` convention in
-   ;; tools/causa/spec/014-Registry-Catalogue.md §Naming convention.
-   :rf.causa.routing/query
-   :rf.causa.routing/sim-url
-   :rf.causa.routing/expanded
+   ;; rf2-o5f5f.3 — Routes browse + Simulate-URL state lives under
+   ;; the Static Routes panel (promoted from `:rf.causa.routing/*` per
+   ;; the two-verbs-two-homes split). The Runtime Routing lens narrows
+   ;; to the focused-event surface and no longer owns these slots.
+   :rf.causa.static.routes/query
+   :rf.causa.static.routes/sim-url
+   :rf.causa.static.routes/expanded
+   ;; rf2-o5f5f.3 — Static Routes hermetic Simulate-navigation toggle
+   ;; set + view-facing composite.
+   :rf.causa.static.routes/sim-nav-open
+   :rf.causa.static.routes/tab-data
    :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
@@ -376,11 +380,16 @@
    ;; rf2-nrbs9 — Routes tab test-only override events.
    :rf.causa/set-current-route-slice-override-for-test
    :rf.causa/set-registered-routes-override-for-test
-   ;; rf2-lq0ef — Routes lens UI-state events (search input,
-   ;; Simulate-URL input, expand-row toggle).
-   :rf.causa.routing/set-query
-   :rf.causa.routing/set-sim-url
-   :rf.causa.routing/toggle-row
+   ;; rf2-o5f5f.3 — Static Routes UI-state events (search input,
+   ;; Simulate-URL input, expand-row toggle, hermetic Simulate-nav
+   ;; toggle, cross-link to Runtime Routing). Promoted from the
+   ;; Runtime `:rf.causa.routing/*` group per the two-verbs-two-homes
+   ;; split.
+   :rf.causa.static.routes/set-query
+   :rf.causa.static.routes/set-sim-url
+   :rf.causa.static.routes/toggle-row
+   :rf.causa.static.routes/toggle-sim-nav
+   :rf.causa.static.routes/jump-to-runtime
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/set-modal-positioning
    ;; rf2-x8h9y — resize-handle live update event.

--- a/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/routes/panel_cljs_test.cljs
@@ -1,0 +1,346 @@
+(ns day8.re-frame2-causa.static.routes.panel-cljs-test
+  "CLJS wiring + view tests for Causa's Static Routes panel
+  (rf2-o5f5f.3).
+
+  ## Scope
+
+  Per Mike's two-verbs-two-homes decision: the BROWSE verb (flat
+  list + Simulate-URL + per-row inline expand + hermetic Simulate-
+  navigation preview + cross-link to Runtime Routing) lives on the
+  Static surface. This file covers:
+
+    1. **Registry wires the Static Routes subs + events** under
+       `:rf.causa.static.routes/*`.
+
+    2. **Silent state** — no routes registered → empty body.
+
+    3. **Flat-list rendering** — every registered route surfaces as
+       a row; sort by path ascending.
+
+    4. **Search filter** — substring across route-id + path + doc;
+       reuses `routing-helpers/filter-rows`.
+
+    5. **Simulate-URL** — header surface resolves the URL via the
+       6-rule rank cascade (`routing-helpers/simulate-url`) and the
+       winner is highlighted.
+
+    6. **Per-row inline expand** — click → expand surface unfolds in
+       place; pattern + matched-keys + handler chip + Simulate-nav
+       toggle + cross-link chip.
+
+    7. **Cross-link** — `:rf.causa.static.routes/jump-to-runtime`
+       flips mode + selects the Runtime Routing tab.
+
+    8. **Frame isolation** — every read targets `:rf/causa`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.routes.panel :as panel]
+            [day8.re-frame2-causa.static.shell :as static-shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers -----------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def cart-routes
+  {:route/cart      {:path "/cart"      :doc "shopping cart"}
+   :route/checkout  {:path "/checkout"  :doc "checkout"}
+   :route/payment   {:path "/checkout/payment"}
+   :route/confirm   {:path "/checkout/confirm"
+                     :parent :route/checkout
+                     :on-match [:confirm/load]}})
+
+;; ---- (1) registry wires the subs + events -----------------------------
+
+(deftest registry-installs-static-routes-handlers
+  (testing "register-causa-handlers! installs every Static Routes sub + event"
+    (registry/register-causa-handlers!)
+    (is (some? (registrar/handler :sub :rf.causa.static.routes/query))
+        ":rf.causa.static.routes/query sub registered")
+    (is (some? (registrar/handler :sub :rf.causa.static.routes/sim-url))
+        ":rf.causa.static.routes/sim-url sub registered")
+    (is (some? (registrar/handler :sub :rf.causa.static.routes/expanded))
+        ":rf.causa.static.routes/expanded sub registered")
+    (is (some? (registrar/handler :sub :rf.causa.static.routes/sim-nav-open))
+        ":rf.causa.static.routes/sim-nav-open sub registered")
+    (is (some? (registrar/handler :sub :rf.causa.static.routes/tab-data))
+        "view-facing composite registered")
+    (is (some? (registrar/handler :event :rf.causa.static.routes/set-query))
+        "set-query event registered")
+    (is (some? (registrar/handler :event :rf.causa.static.routes/set-sim-url))
+        "set-sim-url event registered")
+    (is (some? (registrar/handler :event :rf.causa.static.routes/toggle-row))
+        "toggle-row event registered")
+    (is (some? (registrar/handler :event :rf.causa.static.routes/toggle-sim-nav))
+        "toggle-sim-nav event registered")
+    (is (some? (registrar/handler :event :rf.causa.static.routes/jump-to-runtime))
+        "jump-to-runtime cross-link event registered")))
+
+;; ---- (2) silent state ---------------------------------------------------
+
+(deftest panel-renders-silent-state-when-no-routes
+  (testing "no routes → empty body, no list, no search, no Simulate-URL"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test {}]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes"))
+            "panel root present")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-header"))
+            "header always renders")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-empty"))
+            "silent empty state rendered")
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-list"))
+            "flat list NOT rendered when silent")
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-sim"))
+            "Simulate-URL NOT rendered when silent")
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-search"))
+            "search NOT rendered when silent")))))
+
+;; ---- (3) flat-list + search rendering -----------------------------------
+
+(deftest panel-renders-flat-list-when-routes-present
+  (testing "routes present → flat list + search + Simulate-URL"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-list"))
+            "flat list rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-search"))
+            "search box rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim"))
+            "Simulate-URL header rendered")
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-empty"))
+            "empty state NOT rendered when routes present")
+        (let [rows (find-all-by-testid-prefix tree "rf-causa-static-routes-row-")]
+          (is (= (count cart-routes) (count rows))
+              "one row per registered route"))))))
+
+;; ---- (4) search filter --------------------------------------------------
+
+(deftest panel-search-filters-the-list
+  (testing "set-query event narrows the catalogue"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-query "checkout"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)
+            rows (find-all-by-testid-prefix tree "rf-causa-static-routes-row-")]
+        (is (= #{"rf-causa-static-routes-row-route/checkout"
+                 "rf-causa-static-routes-row-route/payment"
+                 "rf-causa-static-routes-row-route/confirm"}
+               (set (map #(:data-testid (second %)) rows)))
+            "only routes whose haystack contains \"checkout\" render"))))
+
+  (testing "filter that matches nothing → empty-filtered state"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-query "zzz-not-found"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-empty-filtered"))
+            "empty-filtered surface rendered when the query matches no rows")))))
+
+;; ---- (5) Simulate-URL header --------------------------------------------
+
+(deftest panel-simulates-url-and-surfaces-candidates
+  (testing "set-sim-url populates the simulator result with ranked candidates"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/cart"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-result"))
+            "simulator result rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-candidate-route/cart"))
+            "matching candidate row rendered"))))
+
+  (testing "no match — result block reports zero candidates"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/nope-not-here"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-result"))
+            "simulator result rendered even on no-match")))))
+
+;; ---- (6) per-row inline expand -----------------------------------------
+
+(deftest panel-row-expand-toggle
+  (testing "toggle-row event unfolds the inline expand surface in place"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Initial render — expand absent.
+      (let [tree (panel/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-expand-route/cart"))
+            "expand surface absent before toggle"))
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-expand-route/cart"))
+            "expand surface rendered after toggle")
+        ;; Inline expand carries the meta + jump button + sim-nav toggle.
+        (is (some? (find-by-testid tree "rf-causa-static-routes-meta-route/cart"))
+            "registrar meta block rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-jump-runtime-route/cart"))
+            "→ Runtime cross-link chip rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-toggle-route/cart"))
+            "Simulate-navigation toggle rendered"))
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-expand-route/cart"))
+            "expand surface hidden after second toggle")))))
+
+(deftest panel-expand-surfaces-schema-when-present
+  (testing "rows whose registrar meta carries :params / :query schemas render the schema blocks"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (let [routes-with-schema
+            {:route/article
+             {:path     "/articles/:slug"
+              :params   [:map [:slug :string]]
+              :query    [:map [:page :int]]
+              :on-match [:article/load]}}]
+        (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test
+                           routes-with-schema]
+                          {:frame :rf/causa})
+        (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/article]
+                          {:frame :rf/causa})
+        (let [tree (panel/Panel)]
+          (is (some? (find-by-testid tree "rf-causa-static-routes-params-schema-route/article"))
+              ":params schema block rendered")
+          (is (some? (find-by-testid tree "rf-causa-static-routes-query-schema-route/article"))
+              ":query schema block rendered"))))))
+
+;; ---- (7) hermetic Simulate-navigation preview --------------------------
+
+(deftest panel-sim-nav-preview-is-hermetic
+  (testing "Simulate-navigation toggle reveals the preview WITHOUT dispatching navigation"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Set a baseline current slice so we can assert it doesn't change.
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/cart :params {} :query {}}]
+                        {:frame :rf/causa})
+      ;; Expand the row so the toggle is reachable, then flip the preview.
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/confirm]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-sim-nav :route/confirm]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-route/confirm"))
+            "preview surface rendered")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-on-match"))
+            "preview shows registered :on-match")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-db-slot"))
+            "preview shows the [:rf/route] db slot")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-slot-shape"))
+            "preview shows the slot shape that would land"))
+      ;; The current slice MUST still be the baseline — no real navigation.
+      (let [slice @(rf/subscribe [:rf.causa/current-route-slice])]
+        (is (= :route/cart (:id slice))
+            "current slice unchanged — preview did NOT mutate app-db")))))
+
+;; ---- (8) cross-link to Runtime Routing ----------------------------------
+
+(deftest panel-jump-to-runtime-flips-mode-and-tab
+  (testing ":rf.causa.static.routes/jump-to-runtime → mode :runtime + tab :routing"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      ;; Start in :static, on the Static :routes tab.
+      (rf/dispatch-sync [:rf.causa/set-mode :static] {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static/select-tab :routes] {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/jump-to-runtime :route/cart]
+                        {:frame :rf/causa})
+      (is (= :runtime @(rf/subscribe [:rf.causa/mode]))
+          "mode flipped to :runtime")
+      (is (= :routing @(rf/subscribe [:rf.causa/selected-tab]))
+          "Runtime tab set to :routing"))))
+
+;; ---- (9) Static tab inventory exposes :routes --------------------------
+
+(deftest static-shell-routes-tab-is-in-inventory
+  (testing ":routes is in the Static tab inventory + the shell can render it"
+    (is (contains? (set (map :id static-shell/tabs)) :routes)
+        ":routes is in the Static tab inventory")
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa.static/select-tab :routes] {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree (static-shell/surface)]
+        ;; When the :routes tab is selected the Static shell mounts the
+        ;; Static Routes panel (not the placeholder card).
+        (is (some? (find-by-testid tree "rf-causa-static-routes"))
+            "Static Routes panel mounted via the shell's :routes branch")
+        (is (nil? (find-by-testid tree "rf-causa-static-placeholder-routes"))
+            "the :routes placeholder card is no longer rendered")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/routes/simulate_nav_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/routes/simulate_nav_cljs_test.cljs
@@ -1,0 +1,134 @@
+(ns day8.re-frame2-causa.static.routes.simulate-nav-cljs-test
+  "View tests for the hermetic Simulate-navigation preview
+  (rf2-o5f5f.3).
+
+  ## Hermetic posture
+
+  The Simulate-navigation preview MUST NOT mutate app-db, dispatch
+  navigation, or fire fx. Pure preview — params + handler + db slot
+  shape. This file pins the contract.
+
+  Pure-data tests for the projection live in
+  `routing_helpers_cljs_test.cljc`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.routes.panel :as panel]
+            [day8.re-frame2-causa.static.routes.simulate-nav :as simulate-nav]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers -----------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- text-of [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(def routes
+  {:route/cart    {:path "/cart"
+                   :on-match [:cart/load]}
+   :route/article {:path     "/articles/:slug"
+                   :on-match [:article/load]
+                   :params   [:map [:slug :string]]}})
+
+;; ---- direct view tests (pure render path) ------------------------------
+
+(deftest preview-unknown-route-renders-the-unknown-block
+  (testing "unknown route-id → red unknown block"
+    (let [tree (simulate-nav/preview routes :route/nope nil)]
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-unknown"))
+          "unknown surface rendered"))))
+
+(deftest preview-registered-no-url
+  (testing "registered route, no URL → path + on-match + db-slot + slot-shape"
+    (let [tree (simulate-nav/preview routes :route/cart nil)]
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-route/cart")))
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-path")))
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-on-match")))
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-db-slot")))
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-slot-shape"))))))
+
+(deftest preview-renders-hermetic-marker
+  (testing "the preview surface labels itself hermetic (no dispatch)"
+    (let [tree (simulate-nav/preview routes :route/cart nil)]
+      (is (re-find #"Hermetic preview" (text-of tree))
+          "the preview surface labels itself 'Hermetic preview'"))))
+
+(deftest preview-with-matching-url-shows-matched-marker
+  (testing "URL that matches the route's pattern surfaces (matched) in the URL row"
+    (let [tree (simulate-nav/preview routes :route/cart "/cart")]
+      (is (some? (find-by-testid tree "rf-causa-static-routes-sim-nav-url"))))))
+
+;; ---- integration through the panel (hermetic posture) ------------------
+
+(deftest panel-sim-nav-does-not-touch-app-db
+  (testing "opening + closing the Simulate-navigation preview leaves the
+            current route slice untouched"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa/set-current-route-slice-override-for-test
+                         {:id :route/article :params {:slug "old"} :query {}}]
+                        {:frame :rf/causa})
+      ;; Expand row + toggle preview for :route/cart — the preview targets
+      ;; a different route than the current slice, so a real navigation
+      ;; would change the slice. The preview MUST NOT.
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-row :route/cart]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-sim-nav :route/cart]
+                        {:frame :rf/causa})
+      (let [slice @(rf/subscribe [:rf.causa/current-route-slice])]
+        (is (= :route/article (:id slice))
+            "current slice unchanged after opening the preview")
+        (is (= {:slug "old"} (:params slice))
+            "params unchanged"))
+      ;; Toggle closed — still unchanged.
+      (rf/dispatch-sync [:rf.causa.static.routes/toggle-sim-nav :route/cart]
+                        {:frame :rf/causa})
+      (let [slice @(rf/subscribe [:rf.causa/current-route-slice])]
+        (is (= :route/article (:id slice))
+            "current slice still unchanged after closing the preview")))))

--- a/tools/causa/test/day8/re_frame2_causa/static/routes/simulate_url_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/routes/simulate_url_cljs_test.cljs
@@ -1,0 +1,165 @@
+(ns day8.re-frame2-causa.static.routes.simulate-url-cljs-test
+  "View tests for the Static Routes Simulate-URL header surface
+  (rf2-o5f5f.3).
+
+  ## Scope
+
+  The 6-rule rank cascade itself lives in
+  `panels/routing-helpers/simulate-url` and is covered by
+  `routing_helpers_cljs_test.cljc`. This file covers the VIEW layer:
+
+    - input bound to `:rf.causa.static.routes/sim-url`;
+    - clear button visible when input non-blank;
+    - result block renders one candidate row per match, with the
+      winner highlighted.
+
+  Drives the view via the `panel/Panel` root so the dispatch round-
+  trip lands through the registered subs/events."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.routes.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walkers -----------------------------------------------------
+
+(declare expand-fn-component)
+
+(defn- expand-children [node]
+  (cond
+    (vector? node) (mapv expand-fn-component node)
+    (seq? node)    (map  expand-fn-component node)
+    :else          node))
+
+(defn- expand-fn-component [node]
+  (if (and (vector? node) (fn? (first node)))
+    (expand-children (apply (first node) (rest node)))
+    (expand-children node)))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (and (vector? node)
+                 (map? (second node))
+                 (some-> (:data-testid (second node))
+                         (.startsWith prefix))))
+          (hiccup-seq tree)))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(def cart-routes
+  {:route/cart      {:path "/cart"      :doc "cart"}
+   :route/checkout  {:path "/checkout"  :doc "checkout"}
+   :route/payment   {:path "/checkout/payment"}})
+
+;; ---- input chrome -------------------------------------------------------
+
+(deftest simulate-url-input-renders
+  (testing "Simulate-URL input + label render when routes are present"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim"))
+            "Simulate-URL section present")
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-input"))
+            "Simulate-URL input present")
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-sim-clear"))
+            "clear button absent when input blank")))))
+
+(deftest simulate-url-clear-button-visible-when-input-set
+  (testing "clear button surfaces when sim-url is non-blank"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/cart"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-clear"))
+            "clear button surfaces when input is non-blank")))))
+
+;; ---- result block -------------------------------------------------------
+
+(deftest simulate-url-renders-winner-candidate-row
+  (testing "/cart resolves to :route/cart as winner"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/cart"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)
+            winner (find-by-testid tree "rf-causa-static-routes-sim-candidate-route/cart")]
+        (is (some? winner) "winner candidate row rendered")
+        (is (= "true" (:data-winner (second winner)))
+            "winner row carries data-winner=\"true\"")))))
+
+(deftest simulate-url-renders-result-block-on-no-match
+  (testing "result block still surfaces when no routes match — informs the user"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/no-such-path"]
+                        {:frame :rf/causa})
+      (let [tree (panel/Panel)
+            candidates (find-all-by-testid-prefix
+                         tree "rf-causa-static-routes-sim-candidate-")]
+        (is (some? (find-by-testid tree "rf-causa-static-routes-sim-result"))
+            "result surface still renders")
+        (is (= 0 (count candidates))
+            "no candidate rows when nothing matches")))))
+
+(deftest simulate-url-blank-input-no-result
+  (testing "blank input → result block absent"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      ;; Default — no sim-url set.
+      (let [tree (panel/Panel)]
+        (is (nil? (find-by-testid tree "rf-causa-static-routes-sim-result"))
+            "no result block when input is blank")))))
+
+(deftest simulate-url-clear-event-empties-input
+  (testing "set-sim-url with empty string drops the slot"
+    (setup-causa-frame!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-registered-routes-override-for-test cart-routes]
+                        {:frame :rf/causa})
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url "/cart"]
+                        {:frame :rf/causa})
+      (is (= "/cart" @(rf/subscribe [:rf.causa.static.routes/sim-url])))
+      (rf/dispatch-sync [:rf.causa.static.routes/set-sim-url ""]
+                        {:frame :rf/causa})
+      (is (nil? @(rf/subscribe [:rf.causa.static.routes/sim-url]))
+          "empty input drops the slot"))))

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -289,12 +289,21 @@
                    (:aria-selected attrs))
                 (str "tab " tab-id " aria-selected matches the active tab"))))))))
 
+(def ^:private filled-static-tab-ids
+  "Static tab ids that have a real panel installed — the placeholder
+  card for these tabs is no longer rendered. Sibling beads tick one
+  off each time they land."
+  ;; rf2-o5f5f.3 — :routes now mounts the Static Routes panel.
+  #{:routes})
+
 (deftest static-placeholder-cards-name-sibling-bead
   (testing "each placeholder card surfaces its sibling-bead id
-            (rf2-o5f5f.<N> will fill this)"
+            (rf2-o5f5f.<N> will fill this) — except for tabs already
+            replaced by a real panel (filled-static-tab-ids)"
     (causa-setup!)
     (rf/with-frame :rf/causa
-      (doseq [tab-id expected-static-tab-ids]
+      (doseq [tab-id expected-static-tab-ids
+              :when (not (contains? filled-static-tab-ids tab-id))]
         (frame-dispatch [:rf.causa.static/select-tab tab-id])
         (let [tree (static-shell/surface)
               card (find-by-testid tree (str "rf-causa-static-placeholder-" (name tab-id)))


### PR DESCRIPTION
## Summary

Per Mike's two-verbs-two-homes decision (2026-05-19): Routes appears in **both** Runtime and Static surfaces with different verbs.

- **Static Routes (this bead)** — browse-all + Simulate-URL + per-row inline expand + hermetic Simulate-navigation preview + cross-link to Runtime Routing. NEW namespace tree under `tools/causa/src/day8/re_frame2_causa/static/routes/`.
- **Runtime Routing (narrowed)** — focused-event lens: FROM/TO chips when the focused event triggered navigation; empty state pointing at Static Routes otherwise. The browse / search / Simulate-URL chrome that rf2-lq0ef shipped has been promoted out.

The shared algebra (`project-routes`, `filter-rows`, `simulate-url`) lives in `panels/routing_helpers.cljc` — no duplication. Two new pure helpers were added (`project-static-data` and `simulate-navigation-preview`) so the JVM unit test target covers the Static composite + the hermetic-preview contract.

## File map

### New
- `static/routes/panel.cljs` — top-level Routes tab (`reg-view` + `install!`)
- `static/routes/browse_list.cljs` — flat list with sort + search + inline expand
- `static/routes/simulate_url.cljs` — header `Simulate URL` resolver
- `static/routes/row_expand.cljs` — per-row pattern + matched-keys + handler + schema + Simulate-nav + → Runtime
- `static/routes/simulate_nav.cljs` — hermetic preview view (no real dispatch)
- Tests: `static/routes/{panel,simulate_url,simulate_nav}_cljs_test.cljs`

### Edited
- `panels/routing.cljs` — narrowed to the focused-event lens (~270 LoC down from 654); keeps `Panel` `reg-view` registration alive (Runtime still wants this tab)
- `panels/routing_helpers.cljc` — adds `project-static-data` + `simulate-navigation-preview`
- `static/shell.cljs` — `:routes` branch of `detail-panel` mounts `[routes-panel/Panel]` instead of the placeholder card
- `registry.cljs` — calls `(static-routes-panel/install!)` after `(routing/install!)`
- `panels/routing_cljs_test.cljs` — narrowed test surface (focused-event lens only)
- `panels/routing_helpers_cljs_test.cljc` — coverage for the new helpers
- `registry_cljs_test.cljs` — snapshot moves promoted ids from `:rf.causa.routing/*` to `:rf.causa.static.routes/*`
- `static/shell_cljs_test.cljs` — skips `:routes` placeholder card (real panel now mounts)

## Hot-zone discipline

- `static/shell.cljs` — touched ONLY the `:routes` branch + the require (sibling rf2-o5f5f.2 Machines is editing the `:machines` branch in parallel; trivial 5-line rebase if both land).
- `panels/routing.cljs` — fully narrowed; not parallel with any other in-flight PR (the rf2-lq0ef impl this builds on already landed in #1542).
- No top-level hot-zone files touched.

## Decisions (locked, no Mike ping)

- **Tree mode dropped** — deferred to a follow-on (per findings §4.5).
- **Hermetic Simulate-navigation only** — no real-dispatch toggle in v1 (findings Q9 option (a)).
- **Cross-link → Runtime** — `jump-to-runtime` flips mode + selects the Runtime Routing tab; no per-route scope filter on the Runtime side (the lens IS the focused-event slice).

## Test plan

- [x] `npm run test:cljs` — 2977 tests, 8617 assertions, **0 failures / 0 errors**
- [x] `npm run test:browser` — 2968 tests, 8575 assertions, **0 failures / 0 errors**
- [x] `npm run test:bundle-isolation` — PASS (tools/causa code stays out of production bundles; uix-helix-reagent-free 6 sentinel checks)
- [x] `clojure -M:test` (tools/causa JVM) — 722 tests, 2153 assertions, **0 failures / 0 errors**

Base PR #1565 (`worker/static-shell-rf2-o5f5f-1`) has merged; this branch was rebased onto current `main`.