### PR TITLE
feat(static): Machines sub-tab — browse-all + Topology + 4-mode sub-strip (rf2-o5f5f.2)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -41,6 +41,7 @@
             [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.static.machines.panel :as static-machines-panel]
             [day8.re-frame2-causa.static.persistence :as static-persistence]
             [day8.re-frame2-causa.static.routes.panel :as static-routes-panel]
             [day8.re-frame2-causa.static.shell :as static-shell]
@@ -626,6 +627,15 @@
     (event-detail/install!)
     (issues-ribbon/install!)
     (machine-inspector/install!)
+    ;; Static Machines sub-tab (rf2-o5f5f.2) — browses every registered
+    ;; machine + Topology + JUMP-to-Runtime + Cascade-dimmed surfaces.
+    ;; Installs AFTER `machine-inspector/install!` so the static-machines
+    ;; sub graph can :<- onto the existing `:rf.causa/registered-machines`,
+    ;; `:rf.causa/machine-definitions`, and `:rf.causa/machine-snapshots`
+    ;; subs without redeclaring them. Registration order is purely
+    ;; cosmetic (re-frame resolves `:<-` chains lazily); the top-down
+    ;; dependency read is clearer.
+    (static-machines-panel/install!)
     ;; Managed-fx wire-boundary diff template (rf2-uyp86) — installs the
     ;; `:rf.causa/managed-fx-for-focused-event` sub + the
     ;; `:rf.causa/focus-event` cross-link event. The panel view itself

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/browse_list.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/browse_list.cljs
@@ -1,0 +1,313 @@
+(ns day8.re-frame2-causa.static.machines.browse-list
+  "Browse-all list — L4-left pane of the Static Machines sub-tab
+  (rf2-o5f5f.2).
+
+  ## What it renders
+
+  A scrollable list of every registered machine, plus a search box
+  and a sort-cycle button at the top. Each row carries:
+
+    - selection glyph (◉ active / ○ inactive — same vocabulary as
+      the Static tab-bar's `tab-button`)
+    - machine-id in mono accent-violet (per the bead's §Browse-all
+      list)
+    - source-coord chip (renders the file:line label; jump-to-source
+      via `:rf.causa/open-in-editor`)
+    - state-count chip (mono · tertiary)
+    - live-instance pip cluster (cap 12; >12 → textual count)
+    - `→ Runtime` JUMP chip (handler in `instances_jump`)
+
+  ## Empty state
+
+  When `(rf/machines)` returns nothing: 'No machines registered. reg-
+  machine to add the first.'"
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.static.machines.helpers :as h]
+            [day8.re-frame2-causa.static.machines.instances-jump :as jump]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+;; ---- search box ---------------------------------------------------------
+
+(defn- search-box
+  "Top-of-list search input. Incremental filtering — every keystroke
+  dispatches `:rf.causa.static.machines/set-search`. Esc clears."
+  []
+  (let [query @(rf/subscribe [:rf.causa.static.machines/search])]
+    [:div {:data-testid "rf-causa-static-machines-search"
+           :style {:padding "8px 10px"
+                   :border-bottom (str "1px solid " (:border-subtle tokens))
+                   :background    (:bg-1 tokens)}}
+     [:input {:data-testid "rf-causa-static-machines-search-input"
+              :type        "search"
+              :value       (or query "")
+              :placeholder "Search machines…"
+              :aria-label  "Search registered machines"
+              :on-change   (fn [^js e]
+                             (rf/dispatch
+                               [:rf.causa.static.machines/set-search
+                                (.. e -target -value)]
+                               {:frame :rf/causa}))
+              :on-key-down (fn [^js e]
+                             (when (= "Escape" (.-key e))
+                               (rf/dispatch
+                                 [:rf.causa.static.machines/clear-search]
+                                 {:frame :rf/causa})))
+              :style {:width        "100%"
+                      :background   (:bg-2 tokens)
+                      :border       (str "1px solid " (:border-default tokens))
+                      :border-radius "4px"
+                      :color        (:text-primary tokens)
+                      :font-family  sans-stack
+                      :font-size    (:body-tight type-scale)
+                      :padding      "4px 8px"
+                      :box-sizing   "border-box"}}]]))
+
+;; ---- sort cycle button --------------------------------------------------
+
+(defn- sort-button
+  "Single-button sort cycle. Clicking cycles `Name → States → Live →
+  Name…`. The label shows the current axis so the affordance is self-
+  describing."
+  []
+  (let [k     @(rf/subscribe [:rf.causa.static.machines/sort-key])
+        label (get h/sort-key-labels k "Name")]
+    [:button
+     {:data-testid "rf-causa-static-machines-sort"
+      :on-click    (fn [_]
+                     (rf/dispatch [:rf.causa.static.machines/cycle-sort]
+                                  {:frame :rf/causa}))
+      :title       (str "Sort: " label " (click to cycle)")
+      :aria-label  (str "Sort by " label ". Click to cycle through "
+                       "Name, States, Live.")
+      :style {:background    "transparent"
+              :border        (str "1px solid " (:border-default tokens))
+              :border-radius "10px"
+              :color         (:text-secondary tokens)
+              :cursor        "pointer"
+              :font-family   sans-stack
+              :font-size     (:caption type-scale)
+              :padding       "2px 10px"
+              :white-space   "nowrap"}}
+     "Sort: " [:strong {:style {:color (:cyan tokens)}} label]]))
+
+;; ---- per-row chips ------------------------------------------------------
+
+(defn- source-coord-chip
+  "Render the source-coord chip for a row. Degrades to nil when the
+  coord is missing (silent — rf2-g3ghh)."
+  [source-coord]
+  (when (some? source-coord)
+    [:span {:data-testid "rf-causa-static-machines-row-source-coord"
+            :style {:font-family mono-stack
+                    :font-size   (:micro type-scale)
+                    :color       (:text-tertiary tokens)
+                    :margin-left "6px"
+                    :white-space "nowrap"
+                    :text-overflow "ellipsis"
+                    :overflow    "hidden"
+                    :max-width   "120px"}}
+     (h/format-source-coord source-coord)]))
+
+(defn- state-count-chip
+  "Mono state-count chip."
+  [state-count]
+  [:span {:data-testid "rf-causa-static-machines-row-state-count"
+          :style {:font-family mono-stack
+                  :font-size   (:micro type-scale)
+                  :color       (:text-tertiary tokens)
+                  :margin-left "auto"
+                  :white-space "nowrap"}}
+   (str state-count "s")])
+
+(defn- pip-cluster
+  "Live-instance pip cluster per `helpers/pip-render-plan`. Renders
+  filled cyan dots up to the cap, then a textual `>N live` form
+  beyond. Silent for zero (per rf2-g3ghh)."
+  [live-count]
+  (let [{:keys [kind count]} (h/pip-render-plan live-count)]
+    (case kind
+      :none nil
+
+      :pips
+      (into [:span {:data-testid "rf-causa-static-machines-row-pips"
+                    :title       (str count " live instance"
+                                      (when-not (= count 1) "s"))
+                    :style {:display      "inline-flex"
+                            :align-items  "center"
+                            :gap          "2px"
+                            :margin-left  "6px"}}]
+            (for [i (range count)]
+              ^{:key i}
+              [:span {:style {:display       "inline-block"
+                              :width         "5px"
+                              :height        "5px"
+                              :border-radius "50%"
+                              :background    (:cyan tokens)}}]))
+
+      :count
+      [:span {:data-testid "rf-causa-static-machines-row-pips-count"
+              :title       (str count " live instances")
+              :style {:font-family mono-stack
+                      :font-size   (:micro type-scale)
+                      :color       (:cyan tokens)
+                      :margin-left "6px"}}
+       (str ">" h/pip-cap " " count " live")])))
+
+(defn- runtime-jump-chip
+  "Per-row `→ Runtime` chip. Clicking JUMPs to the Runtime Machines
+  tab with this machine selected — same handler the right-pane
+  Instances pill uses (centralised in `instances_jump`)."
+  [machine-id]
+  [:button
+   {:data-testid (str "rf-causa-static-machines-row-jump-"
+                      (when (keyword? machine-id) (name machine-id)))
+    :on-click    (fn [^js e]
+                   (.stopPropagation e)
+                   (jump/dispatch-jump! machine-id))
+    :title       "Open in Runtime Machines tab"
+    :aria-label  (str "Open " machine-id " in Runtime Machines tab")
+    :style {:background    "transparent"
+            :border        (str "1px solid " (:border-default tokens))
+            :border-radius "10px"
+            :color         (:accent-violet tokens)
+            :cursor        "pointer"
+            :font-family   sans-stack
+            :font-size     (:micro type-scale)
+            :padding       "1px 8px"
+            :margin-left   "6px"
+            :white-space   "nowrap"}}
+   "→ Runtime"])
+
+;; ---- one row ------------------------------------------------------------
+
+(defn- row
+  "Render one browse-list row."
+  [{:keys [machine-id state-count live-count source-coord] :as r} active?]
+  (let [glyph (if active? "◉" "○")]
+    [:button
+     {:data-testid    (str "rf-causa-static-machines-row-"
+                           (when (keyword? machine-id) (name machine-id)))
+      :data-machine-id (str machine-id)
+      :data-selected  (str active?)
+      :role           "option"
+      :aria-selected  (if active? "true" "false")
+      :on-click       (fn [_]
+                        (rf/dispatch
+                          [:rf.causa.static.machines/select machine-id]
+                          {:frame :rf/causa}))
+      :title          (str machine-id)
+      :style {:display       "flex"
+              :align-items   "center"
+              :gap           "4px"
+              :width         "100%"
+              :padding       "6px 10px"
+              :background    (if active? (:bg-active tokens) "transparent")
+              :border        "none"
+              :border-bottom (str "1px solid " (:border-subtle tokens))
+              :color         (:text-primary tokens)
+              :cursor        "pointer"
+              :font-family   sans-stack
+              :font-size     (:body-tight type-scale)
+              :text-align    "left"
+              :white-space   "nowrap"
+              :overflow      "hidden"
+              :text-overflow "ellipsis"}}
+     [:span {:style {:color (if active? (:cyan tokens) (:text-tertiary tokens))
+                     :flex  "0 0 12px"}}
+      glyph]
+     [:span {:data-testid "rf-causa-static-machines-row-id"
+             :style {:font-family   mono-stack
+                     :font-size     (:body-tight type-scale)
+                     :color         (:accent-violet tokens)
+                     :overflow      "hidden"
+                     :text-overflow "ellipsis"
+                     :max-width     "120px"}}
+      (str machine-id)]
+     (source-coord-chip source-coord)
+     (state-count-chip state-count)
+     (pip-cluster live-count)
+     (runtime-jump-chip machine-id)]))
+
+;; ---- empty state --------------------------------------------------------
+
+(defn- empty-state []
+  [:div {:data-testid "rf-causa-static-machines-empty"
+         :style {:padding "16px 12px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size   (:caption type-scale)
+                 :line-height (:line-height-tight type-scale)}}
+   [:p {:style {:margin "0 0 6px 0"}}
+    "No machines registered."]
+   [:p {:style {:margin 0}}
+    "Register a machine with "
+    [:code {:style {:font-family mono-stack
+                    :color       (:accent-violet tokens)}}
+     "rf/reg-machine"]
+    " to populate this list."]])
+
+(defn- no-results-state [query]
+  [:div {:data-testid "rf-causa-static-machines-no-results"
+         :style {:padding "12px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size (:caption type-scale)}}
+   "No machines match "
+   [:code {:style {:font-family mono-stack
+                   :color (:text-secondary tokens)}}
+    (pr-str query)]
+   "."])
+
+;; ---- the list -----------------------------------------------------------
+
+(rf/reg-view browse-list
+  "L4-left pane of the Static Machines sub-tab — search + sort +
+  scrollable rows. Per rf2-in6l2 `reg-view`-registered so subscribes
+  resolve to `:rf/causa`."
+  []
+  (let [{:keys [rows total visible selected-id]}
+        @(rf/subscribe [:rf.causa.static.machines/data])
+        query @(rf/subscribe [:rf.causa.static.machines/search])]
+    [:div {:data-testid "rf-causa-static-machines-browse-list"
+           :style {:display        "flex"
+                   :flex-direction "column"
+                   :height         "100%"
+                   :background     (:bg-1 tokens)}}
+     [search-box]
+     [:div {:data-testid "rf-causa-static-machines-toolbar"
+            :style {:display       "flex"
+                    :align-items   "center"
+                    :gap           "8px"
+                    :padding       "6px 10px"
+                    :background    (:bg-1 tokens)
+                    :border-bottom (str "1px solid " (:border-subtle tokens))
+                    :font-family   sans-stack
+                    :font-size     (:caption type-scale)
+                    :color         (:text-tertiary tokens)}}
+      [sort-button]
+      [:span {:data-testid "rf-causa-static-machines-count"
+              :style {:margin-left "auto"}}
+       (if (= total visible)
+         (str total " machine" (when-not (= total 1) "s"))
+         (str visible " / " total))]]
+     [:div {:data-testid "rf-causa-static-machines-rows"
+            :role "listbox"
+            :aria-label "Registered machines"
+            :style {:flex     "1 1 auto"
+                    :min-height "0"
+                    :overflow "auto"}}
+      (cond
+        (zero? total)
+        (empty-state)
+
+        (zero? visible)
+        (no-results-state query)
+
+        :else
+        (into [:div]
+              (for [{:keys [machine-id] :as r} rows]
+                ^{:key (str machine-id)}
+                [row r (= machine-id selected-id)])))]]))

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/cascade_dimmed.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/cascade_dimmed.cljs
@@ -1,0 +1,44 @@
+(ns day8.re-frame2-causa.static.machines.cascade-dimmed
+  "Cascade pill — DIMMED in the Static surface (rf2-o5f5f.2).
+
+  Per the bead's §Cascade mode + findings Q7: the Cancellation Cascade
+  is a Runtime-only surface (it composes against the trace ring buffer
+  which is event-coupled — there is no spine in Static mode). The pill
+  is rendered in the strip for muscle-memory consistency with the
+  Runtime sub-strip (same DOM, same letter mnemonic), but it's GREYED
+  and the click is a no-op. A tooltip surfaces the why."
+  (:require [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack type-scale]]))
+
+(def tooltip-text
+  "Per the bead — surfaced as the pill's `title` AND its
+  `aria-disabled` description."
+  "Cancellation cascade is a Runtime-only surface. Switch to Runtime mode to view.")
+
+(defn pill
+  "Render the dimmed Cascade pill. The button is disabled — keyboard
+  + click events are gated by the `disabled` attribute so screen
+  readers announce 'unavailable' rather than 'click to view'."
+  []
+  [:button
+   {:data-testid    "rf-causa-static-machines-pill-cascade"
+    :role           "tab"
+    :aria-disabled  "true"
+    :aria-selected  "false"
+    :disabled       true
+    :title          tooltip-text
+    :aria-label     (str "Cascade — disabled in Static. " tooltip-text)
+    :style {:background    "transparent"
+            :border        (str "1px dashed " (:border-default tokens))
+            :border-radius "10px"
+            :color         (:text-tertiary tokens)
+            :cursor        "not-allowed"
+            :font-family   sans-stack
+            :font-size     (:caption type-scale)
+            :font-weight   400
+            :padding       "3px 12px"
+            :white-space   "nowrap"
+            ;; Faded — single-source for the dim signal.
+            :opacity       0.5}}
+   "Cascade"])

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/definition_detail.cljs
@@ -1,0 +1,242 @@
+(ns day8.re-frame2-causa.static.machines.definition-detail
+  "Right pane of the Static Machines sub-tab — header + 4-mode sub-strip
+  + per-mode body (rf2-o5f5f.2).
+
+  ## Header
+
+  Per the bead's §Definition detail header:
+
+      <machine-id> · <source-coord ↗> · <N> states · <M> live (→ Runtime)
+
+  ## 4-mode sub-strip
+
+  Per the bead's §4-mode sub-strip:
+
+      [Topology][Sim][Instances][Cascade]
+
+  Topology is the default; Sim renders a placeholder until rf2-r4nao
+  ships; Instances is a JUMP to the Runtime Machines tab (`instances_
+  jump`); Cascade is GREYED with a 'Runtime-only' tooltip. Mnemonics
+  `t`/`s`/`i`/`c` are surfaced in each pill's `title` — the keybinding
+  wiring is follow-on per the bead.
+
+  ## Per-mode body
+
+  Topology mounts the `chart/svg` SVG renderer (no live highlight —
+  Static is event-INDEPENDENT). Sim mounts the placeholder card.
+  Instances doesn't render a body (the click is the surface). Cascade
+  doesn't render a body either (the pill itself is the surface).
+
+  ## Empty state (no machine selected)
+
+  When `(rf/machines)` returns nothing the browse-list renders the
+  empty-state hint; the right pane mounts a matching empty surface
+  to keep the visual balance."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.static.machines.cascade-dimmed
+             :as cascade-dimmed]
+            [day8.re-frame2-causa.static.machines.helpers :as h]
+            [day8.re-frame2-causa.static.machines.instances-jump
+             :as instances-jump]
+            [day8.re-frame2-causa.static.machines.sim-placeholder
+             :as sim-placeholder]
+            [day8.re-frame2-causa.static.machines.topology :as topology]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack mono-stack display-stack type-scale]]))
+
+;; ---- header -------------------------------------------------------------
+
+(defn- header
+  "Render the definition-detail header per the bead's §Definition
+  detail header. Sticks at the top of the right pane."
+  [{:keys [machine-id source-coord state-count live-count]}]
+  [:header {:data-testid "rf-causa-static-machines-detail-header"
+            :data-machine-id (str machine-id)
+            :style {:display       "flex"
+                    :align-items   "center"
+                    :gap           "10px"
+                    :padding       "12px 16px"
+                    :background    (:bg-2 tokens)
+                    :border-bottom (str "1px solid " (:border-subtle tokens))
+                    :font-family   sans-stack
+                    :font-size     (:body type-scale)}}
+   [:h2 {:data-testid "rf-causa-static-machines-detail-title"
+         :style (merge {:margin    0
+                        :font-size (:display type-scale)
+                        :font-family display-stack
+                        :font-weight 600
+                        :letter-spacing "-0.01em"
+                        :color (:text-primary tokens)}
+                       (try (t/accent-stripe-style :machines) (catch :default _ {})))}
+    [:span {:style {:font-family mono-stack
+                    :color (:accent-violet tokens)}}
+     (str machine-id)]]
+   (when (some? source-coord)
+     [:span {:data-testid "rf-causa-static-machines-detail-source-coord"
+             :style {:font-family mono-stack
+                     :font-size (:caption type-scale)
+                     :color (:text-tertiary tokens)}}
+      (h/format-source-coord source-coord)
+      " "
+      (open-in-editor/open-chip source-coord)])
+   [:span {:data-testid "rf-causa-static-machines-detail-state-count"
+           :style {:font-family mono-stack
+                   :font-size (:caption type-scale)
+                   :color (:text-secondary tokens)}}
+    (str state-count " state" (when-not (= 1 state-count) "s"))]
+   [:span {:data-testid "rf-causa-static-machines-detail-live-count"
+           :style {:font-family mono-stack
+                   :font-size (:caption type-scale)
+                   :color (if (and (number? live-count) (pos? live-count))
+                            (:cyan tokens)
+                            (:text-tertiary tokens))
+                   :margin-left "auto"}}
+    (str (or live-count 0) " live")]])
+
+;; ---- sub-strip ----------------------------------------------------------
+
+(defn- topology-pill
+  [{:keys [active? on-click]}]
+  [:button
+   {:data-testid    "rf-causa-static-machines-pill-topology"
+    :role           "tab"
+    :aria-selected  (if active? "true" "false")
+    :on-click       on-click
+    :title          "Topology (mnemonic: t)"
+    :aria-label     "Topology mode"
+    :style {:background    "transparent"
+            :border        (str "1px solid "
+                                (if active?
+                                  (:cyan tokens)
+                                  (:border-default tokens)))
+            :border-radius "10px"
+            :color         (if active? (:cyan tokens) (:text-secondary tokens))
+            :cursor        "pointer"
+            :font-family   sans-stack
+            :font-size     (:caption type-scale)
+            :font-weight   (if active? 600 400)
+            :padding       "3px 12px"
+            :white-space   "nowrap"}}
+   "Topology"])
+
+(defn- sub-strip
+  "Render the 4-mode pill row. Per the bead's §4-mode sub-strip — the
+  strip is the same DOM as the Runtime sub-strip (muscle-memory
+  consistency), but Cascade is dimmed + Sim is a placeholder."
+  [{:keys [machine-id sub-mode live-count]}]
+  (let [set-mode! (fn [mode]
+                    (rf/dispatch
+                      [:rf.causa.static.machines/set-sub-mode machine-id mode]
+                      {:frame :rf/causa}))]
+    [:div {:data-testid "rf-causa-static-machines-sub-strip"
+           :role        "tablist"
+           :aria-label  "Machine inspection mode"
+           :style {:display     "flex"
+                   :align-items "center"
+                   :gap         "6px"
+                   :padding     "8px 16px"
+                   :background  (:bg-2 tokens)
+                   :border-bottom (str "1px solid " (:border-subtle tokens))}}
+     [topology-pill {:active?  (= sub-mode :topology)
+                     :on-click (fn [_] (set-mode! :topology))}]
+     [sim-placeholder/pill {:active?  (= sub-mode :sim)
+                            :on-click (fn [_] (set-mode! :sim))}]
+     [instances-jump/pill {:machine-id machine-id
+                           :live-count live-count
+                           :active?    false}]
+     [cascade-dimmed/pill]]))
+
+;; ---- body dispatch ------------------------------------------------------
+
+(defn- body
+  "Dispatch to the per-mode body renderer. Topology + Sim render a
+  body; Instances + Cascade do not (Instances is a JUMP affordance,
+  Cascade is dimmed)."
+  [{:keys [sub-mode machine-id definition source-coord]}]
+  (case sub-mode
+    :topology
+    [topology/body {:machine-id   machine-id
+                    :definition   definition
+                    :source-coord source-coord}]
+
+    :sim
+    [sim-placeholder/body {:machine-id machine-id}]
+
+    ;; :instances + :cascade — no body. Render an explanatory placeholder
+    ;; so the user understands the strip click landed.
+    :instances
+    [:section {:data-testid "rf-causa-static-machines-instances-body"
+               :style {:padding "16px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size (:caption type-scale)}}
+     "Instances mode JUMPs to the Runtime Machines tab — Static stays "
+     "event-INDEPENDENT. Click the pill again to re-fire the JUMP."]
+
+    :cascade
+    [:section {:data-testid "rf-causa-static-machines-cascade-body"
+               :style {:padding "16px"
+                       :color (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size (:caption type-scale)}}
+     cascade-dimmed/tooltip-text]))
+
+;; ---- empty surface ------------------------------------------------------
+
+(defn- empty-detail []
+  [:div {:data-testid "rf-causa-static-machines-detail-empty"
+         :style {:padding "24px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size (:body type-scale)}}
+   "Select a machine on the left to inspect its definition."])
+
+;; ---- main view ----------------------------------------------------------
+
+(rf/reg-view detail
+  "L4-right pane — definition detail. Reads:
+
+    - `:rf.causa.static.machines/data` for the selected row +
+      enrichment (rows, total, visible, selected-id)
+    - `:rf.causa/machine-definitions` for the registrar spec map of
+      the selected machine
+    - `:rf.causa.static.machines/sub-mode` for the per-machine sub-
+      mode (defaults to :topology)
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [{:keys [rows selected-id]}
+        @(rf/subscribe [:rf.causa.static.machines/data])
+        row (some #(when (= selected-id (:machine-id %)) %) rows)
+        definitions @(rf/subscribe [:rf.causa/machine-definitions])
+        sub-mode @(rf/subscribe [:rf.causa.static.machines/sub-mode selected-id])]
+    (if (nil? row)
+      (empty-detail)
+      (let [{:keys [machine-id state-count live-count source-coord]} row
+            definition (get definitions machine-id)]
+        [:div {:data-testid "rf-causa-static-machines-detail"
+               :data-machine-id (str machine-id)
+               :data-sub-mode (str sub-mode)
+               :style {:display        "flex"
+                       :flex-direction "column"
+                       :height         "100%"
+                       :background     (:bg-2 tokens)
+                       :color          (:text-primary tokens)}}
+         [header {:machine-id machine-id
+                  :source-coord source-coord
+                  :state-count state-count
+                  :live-count live-count}]
+         [sub-strip {:machine-id machine-id
+                     :sub-mode   sub-mode
+                     :live-count live-count}]
+         [:div {:data-testid "rf-causa-static-machines-detail-body"
+                :style {:flex     "1 1 auto"
+                        :min-height "0"
+                        :overflow "auto"}}
+          [body {:sub-mode     sub-mode
+                 :machine-id   machine-id
+                 :definition   definition
+                 :source-coord source-coord}]]]))))

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/helpers.cljc
@@ -1,0 +1,283 @@
+(ns day8.re-frame2-causa.static.machines.helpers
+  "Pure-data helpers for the Static Machines sub-tab (rf2-o5f5f.2).
+
+  ## Why a separate `.cljc` ns
+
+  Same dual-target pattern every other panel uses. The view code in
+  `panel.cljs` / `browse_list.cljs` / `definition_detail.cljs` builds
+  the hiccup; the projection + sort + search + sub-mode validation is
+  pure data → data and runs under the JVM unit-test target
+  (`clojure -M:test`).
+
+  ## What this projects
+
+  Per the bead (rf2-o5f5f.2) the browse-all list enumerates
+  `(rf/machines)` and renders one row per registered machine. Each row
+  carries enough data for the L4-left list AND the L4-right header to
+  render without recomputing: machine-id, state-count, live-instance
+  count, and the lifted source-coord (when present in the registered
+  spec's metadata).
+
+  ## Sort axes
+
+  Three sort axes per the bead's §Browse-all list:
+
+    - `:name`   — alphabetical by `(name machine-id)`; default.
+    - `:states` — by state-count DESC.
+    - `:live`   — by live-instance count DESC.
+
+  Ties break on the next axis (name) so the order is deterministic.
+
+  ## Sub-modes (the 4-mode sub-strip)
+
+  Four pills: `:topology` (default) · `:sim` · `:instances` · `:cascade`.
+  Per bead's §4-mode sub-strip the Sim cell is a placeholder until
+  sibling rf2-r4nao lands the real Sim view; the Cascade pill is
+  rendered but greyed (Runtime-only surface)."
+  (:require [clojure.string :as str]))
+
+;; ---- sub-mode taxonomy --------------------------------------------------
+
+(def sub-modes
+  "Four sub-modes per the bead's §4-mode sub-strip."
+  [:topology :sim :instances :cascade])
+
+(def sub-mode-ids
+  "Set of valid sub-mode ids for input validation. Per spec the strip
+  ALWAYS exposes all four cells (even if Sim is a placeholder + Cascade
+  is dimmed); a stored value outside this set normalises back to
+  `:topology` (the default mode)."
+  (set sub-modes))
+
+(def default-sub-mode :topology)
+
+(defn normalise-sub-mode
+  "Coerce a raw sub-mode value (keyword OR string OR nil) to a valid
+  sub-mode keyword. Unknown values fall back to `:topology`.
+
+  Pure data — JVM-runnable so the JVM test corpus can cover the
+  normalisation round-trip without a CLJS runtime."
+  [v]
+  (cond
+    (keyword? v) (if (contains? sub-mode-ids v) v default-sub-mode)
+    (string? v)  (let [kw (keyword v)]
+                   (if (contains? sub-mode-ids kw) kw default-sub-mode))
+    :else        default-sub-mode))
+
+(def sub-mode-mnemonics
+  "Per-sub-mode keyboard mnemonic letter. The keybinding wiring is
+  follow-on (per the bead's §Mnemonics deferral); this map carries the
+  pure-data half so the click affordance can surface the letter in its
+  `title`."
+  {:topology  "t"
+   :sim       "s"
+   :instances "i"
+   :cascade   "c"})
+
+;; ---- sort axes ----------------------------------------------------------
+
+(def sort-keys
+  "Three sort axes the browse-all list cycles through."
+  [:name :states :live])
+
+(def sort-key-ids
+  (set sort-keys))
+
+(def default-sort-key :name)
+
+(defn normalise-sort-key
+  "Coerce a raw sort-key value to a valid sort axis. Unknown values
+  fall back to `:name`."
+  [v]
+  (cond
+    (keyword? v) (if (contains? sort-key-ids v) v default-sort-key)
+    (string? v)  (let [kw (keyword v)]
+                   (if (contains? sort-key-ids kw) kw default-sort-key))
+    :else        default-sort-key))
+
+(def sort-key-labels
+  "Per-axis display label for the sort-cycle button."
+  {:name   "Name"
+   :states "States"
+   :live   "Live"})
+
+;; ---- source-coord lifting -----------------------------------------------
+
+(defn lift-source-coord
+  "Pull the source-coord map off a registered machine's spec (the
+  return value of `(rf/machine-meta machine-id)`). Per Spec 005 +
+  Spec 009 the registrar lifts the `defmacro`/`reg-machine` call site
+  into the spec's metadata; the canonical slot is `:source-coord` (the
+  same shape `editor-uri/editor-uri` consumes).
+
+  Returns nil when the definition is missing OR carries no source-coord
+  — the chip degrades gracefully (no chip rather than a broken link).
+  Pure data — JVM-runnable.
+
+  Tolerates the alternate `:source` slot some legacy registrars used —
+  same lenient policy `open_in_editor.cljs/coerce-coord` applies on
+  the dispatch surface."
+  [definition]
+  (when (map? definition)
+    (or (get definition :source-coord)
+        (get definition :source))))
+
+(defn format-source-coord
+  "Render a source-coord as a compact `file:line` display string. nil
+  when the coord lacks a usable `:file` slot. Mirrors the projection
+  trace events use so the chip text reads identically across surfaces."
+  [coord]
+  (when (and (map? coord) (some? (:file coord)))
+    (let [file (str (:file coord))
+          line (:line coord)]
+      (if line (str file ":" line) file))))
+
+;; ---- machine-row projection ---------------------------------------------
+
+(defn- state-count
+  "Count of states in the machine's definition. Reads the canonical
+  `:states` slot (Spec 005 §Definition shape). Returns 0 when the
+  definition is missing or has no states map."
+  [definition]
+  (count (get definition :states {})))
+
+(defn- live-instance-count
+  "Number of times the machine-id appears in the snapshots map. v1
+  reads ONE frame's snapshots (the panel's target-frame); per the
+  bead's §Browse-all list the cross-frame sum is the eventual surface
+  but the reactive cross-frame walker is a follow-on bead. With one
+  frame, the count is either 0 (uninitialised) or 1 (initialised) —
+  the pip cluster degrades cleanly to a single dot in the common case.
+
+  Pure-data here so the v1 single-frame OR a future multi-frame
+  caller can feed the same projection without changing the row
+  shape."
+  [snapshots machine-id]
+  (let [snap (get snapshots machine-id)]
+    (if (some? snap) 1 0)))
+
+(defn project-row
+  "Build one row for the browse-all list. Pure data.
+
+  Inputs:
+    `machine-id`  — the registered machine keyword.
+    `definition`  — `(rf/machine-meta machine-id)` map (nil if missing).
+    `snapshots`   — `{machine-id snapshot}` for the target-frame.
+
+  Output:
+    {:machine-id    <kw>
+     :state-count   <int>
+     :live-count    <int>
+     :source-coord  <map-or-nil>
+     :source-label  <\"file:line\"-or-nil>}"
+  [machine-id definition snapshots]
+  (let [coord (lift-source-coord definition)]
+    {:machine-id   machine-id
+     :state-count  (state-count definition)
+     :live-count   (live-instance-count snapshots machine-id)
+     :source-coord coord
+     :source-label (format-source-coord coord)}))
+
+(defn project-rows
+  "Project every registered machine into a vector of rows. Sorted
+  alphabetically by default; the view applies the user's sort axis
+  via `apply-sort`. Pure data — JVM-runnable."
+  [machines definitions snapshots]
+  (->> (or machines [])
+       (map (fn [id]
+              (project-row id (get definitions id) (or snapshots {}))))
+       vec))
+
+;; ---- search + sort ------------------------------------------------------
+
+(defn search-text
+  "Concatenate the searchable surface for a row into one lowercase
+  string. Covers the machine-id's name AND namespace AND the source
+  coord's file path — per the bead's §Browse-all list. Pure data."
+  [{:keys [machine-id source-coord]}]
+  (let [name-s (when (keyword? machine-id) (name machine-id))
+        ns-s   (when (keyword? machine-id) (namespace machine-id))
+        file-s (when (map? source-coord) (str (:file source-coord)))
+        parts  [name-s ns-s file-s]]
+    (str/lower-case (str/join "|" (remove nil? parts)))))
+
+(defn apply-search
+  "Filter rows to those whose `search-text` contains `query` (case-
+  insensitive substring). Empty / nil query returns rows unchanged.
+  Pure data."
+  [rows query]
+  (if (or (nil? query) (str/blank? query))
+    (vec rows)
+    (let [needle (str/lower-case (str/trim query))]
+      (vec (filter (fn [row] (str/includes? (search-text row) needle))
+                   rows)))))
+
+(defn- name-key
+  "Stable sort key for the machine-id — string form of the keyword. Pure."
+  [{:keys [machine-id]}]
+  (str machine-id))
+
+(defn apply-sort
+  "Sort rows by `sort-key` per the bead's §Browse-all list. Ties break
+  on name for deterministic output. Pure data."
+  [rows sort-key]
+  (let [k (normalise-sort-key sort-key)]
+    (case k
+      :name
+      (vec (sort-by name-key rows))
+
+      :states
+      (vec (sort-by (juxt (comp - :state-count) name-key) rows))
+
+      :live
+      (vec (sort-by (juxt (comp - :live-count) name-key) rows)))))
+
+(defn project-browse-list
+  "Full browse-all projection — rows + search + sort + selection
+  resolution. Returns the data the view consumes:
+
+    {:rows         <filtered-and-sorted-rows>
+     :total        <int — pre-filter count>
+     :visible      <int — post-filter count>
+     :selected-id  <kw-or-nil — effective selection, defaults to first
+                   row when the user's selection is missing OR filtered
+                   out>}
+
+  Pure data — JVM-runnable."
+  [machines definitions snapshots search-query sort-key selected-id]
+  (let [rows     (project-rows machines definitions snapshots)
+        filtered (apply-search rows search-query)
+        sorted   (apply-sort filtered sort-key)
+        ;; Default to first row when user's pick is absent OR filtered out.
+        effective (or (some (fn [{:keys [machine-id]}]
+                              (when (= machine-id selected-id) machine-id))
+                            sorted)
+                      (some-> sorted first :machine-id))]
+    {:rows        sorted
+     :total       (count rows)
+     :visible     (count sorted)
+     :selected-id effective}))
+
+;; ---- live-instance pip cluster ------------------------------------------
+
+(def pip-cap
+  "Maximum number of pips rendered in a row's pip cluster per the
+  bead's §Browse-all list. Anything beyond renders as a `>{cap} N live`
+  textual count."
+  12)
+
+(defn pip-render-plan
+  "Decide how the per-row live-instance cluster should render.
+
+  Returns one of:
+    {:kind :pips :count <int>}    — render N filled dots (N ≤ pip-cap)
+    {:kind :count :count <int>}   — render textual `>{cap} N live`
+    {:kind :none}                 — no live instances (silent — rf2-g3ghh)
+
+  Pure data."
+  [live-count]
+  (cond
+    (nil? live-count)      {:kind :none}
+    (zero? live-count)     {:kind :none}
+    (<= live-count pip-cap) {:kind :pips  :count live-count}
+    :else                  {:kind :count :count live-count}))

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/instances_jump.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/instances_jump.cljs
@@ -1,0 +1,104 @@
+(ns day8.re-frame2-causa.static.machines.instances-jump
+  "Instances-mode JUMP — clicking the Instances pill (or the per-row
+  `→ Runtime` chip in the browse-list) switches Causa to Runtime mode,
+  opens the Runtime Machines tab, and selects this machine
+  (rf2-o5f5f.2).
+
+  ## Why this lives in its own ns
+
+  The browse-list rows AND the right-pane sub-strip both dispatch the
+  same JUMP; centralising the dispatcher means the two surfaces never
+  drift. Per the bead's §Instances mode the JUMP is a Static-side
+  affordance that hands off to the Runtime-side Machines tab via the
+  existing events:
+
+    `:rf.causa/set-mode :runtime`        — flip mode pill back
+    `:rf.causa/select-tab :machines`     — surface the Runtime Machines tab
+    `:rf.causa/select-machine-id <mid>`  — focus the panel on this machine
+
+  Three dispatches; one click. Mode B/C auto-detect (Mode B for 2-8
+  instances, Mode C for ≥8 per consolidated-design §0ter.3) is the
+  Runtime panel's responsibility — the static-side JUMP just lands the
+  selection; the post-collapse Runtime Machines panel runs event-driven
+  off the focused event, so the selected-machine-id slot drives the
+  Sim engine + share-URL contract today (per `panels/machine_inspector.
+  cljs/select-machine-id`)."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack type-scale]]))
+
+(defn dispatch-jump!
+  "Dispatch the three events that telegraph the JUMP. Called from the
+  browse-list's per-row chip + the right-pane Instances pill.
+
+  Safe to call with a nil `machine-id` — the mode + tab flips still
+  fire (so the user lands on Runtime Machines) but the selection
+  dispatch is suppressed (no value to write).
+
+  All three dispatches target `:rf/causa` so the Static-mode chrome
+  reads the new mode + tab slots."
+  [machine-id]
+  (rf/dispatch [:rf.causa/set-mode :runtime] {:frame :rf/causa})
+  (rf/dispatch [:rf.causa/select-tab :machines] {:frame :rf/causa})
+  (when (some? machine-id)
+    (rf/dispatch [:rf.causa/select-machine-id machine-id] {:frame :rf/causa}))
+  nil)
+
+(defn dispatch-jump-sync!
+  "Test-only synchronous variant of `dispatch-jump!`. Production code
+  paths through the async `dispatch-jump!` because UI clicks are
+  inherently async; tests bypass the queue so post-dispatch assertions
+  read the new slots without a flush."
+  [machine-id]
+  (rf/dispatch-sync [:rf.causa/set-mode :runtime] {:frame :rf/causa})
+  (rf/dispatch-sync [:rf.causa/select-tab :machines] {:frame :rf/causa})
+  (when (some? machine-id)
+    (rf/dispatch-sync [:rf.causa/select-machine-id machine-id]
+                      {:frame :rf/causa}))
+  nil)
+
+(defn pill
+  "Render the right-pane Instances pill. Sits inside the 4-mode sub-
+  strip alongside Topology / Sim / Cascade. Carries a live-instance
+  count badge (when `live-count > 0`) so the user reads how many live
+  instances the JUMP will land in.
+
+  Per the bead's §Instances mode the Static surface stays static —
+  this pill is a JUMP affordance, not a mode the right pane renders."
+  [{:keys [machine-id live-count active?]}]
+  (let [label  "Instances"
+        suffix (when (and (number? live-count) (pos? live-count))
+                 (str " " live-count))]
+    [:button
+     {:data-testid "rf-causa-static-machines-pill-instances"
+      :data-machine-id (str machine-id)
+      :data-live-count (str (or live-count 0))
+      :role        "tab"
+      :aria-selected (if active? "true" "false")
+      :on-click    (fn [_] (dispatch-jump! machine-id))
+      :title       (str "Open " machine-id " in Runtime Machines tab"
+                        " (mnemonic: i)")
+      :aria-label  (str "Instances — JUMPs to Runtime Machines tab. "
+                       (or live-count 0) " live instance"
+                       (when-not (= 1 live-count) "s"))
+      :style {:background    "transparent"
+              :border        (str "1px solid "
+                                  (if active?
+                                    (:cyan tokens)
+                                    (:border-default tokens)))
+              :border-radius "10px"
+              :color         (:accent-violet tokens)
+              :cursor        "pointer"
+              :font-family   sans-stack
+              :font-size     (:caption type-scale)
+              :font-weight   600
+              :padding       "3px 12px"
+              :white-space   "nowrap"}}
+     label
+     (when suffix
+       [:span {:data-testid "rf-causa-static-machines-pill-instances-badge"
+               :style {:color (:cyan tokens)
+                       :margin-left "4px"
+                       :font-family sans-stack}}
+        suffix])]))

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/panel.cljs
@@ -1,0 +1,236 @@
+(ns day8.re-frame2-causa.static.machines.panel
+  "Top-level Machines sub-tab for Causa's Static surface (rf2-o5f5f.2).
+
+  ## Shape
+
+  Master-detail layout. Per the bead's §Browse-all list / §Definition
+  detail header:
+
+      ┌──────────────────────┬────────────────────────────────────┐
+      │ L4-left (~280px)     │  L4-right (fills)                  │
+      │ ─ search box         │  ─ machine-id · source-coord ↗     │
+      │ ─ sort cycle button  │     · N states · M live (→ Runtime)│
+      │ ─ scrollable rows    │  ─ sub-strip [T][S][I][C]          │
+      │                      │  ─ mode renderer (Topology / Sim   │
+      │                      │     placeholder / Instances JUMP / │
+      │                      │     Cascade dimmed)                │
+      └──────────────────────┴────────────────────────────────────┘
+
+  ## Registers (install! installs)
+
+  Subs:
+    `:rf.causa.static.machines/rows`        — full projected rows
+    `:rf.causa.static.machines/data`        — composite the view reads
+    `:rf.causa.static.machines/search`      — current search-text
+    `:rf.causa.static.machines/sort-key`    — current sort axis
+    `:rf.causa.static.machines/selected-id` — user's selection (raw slot)
+    `:rf.causa.static.machines/sub-mode-by-id` — per-machine sub-mode map
+    `:rf.causa.static.machines/sub-mode`    — effective sub-mode for a machine
+
+  Events:
+    `:rf.causa.static.machines/select`         — set selected-id
+    `:rf.causa.static.machines/set-search`     — set search-text
+    `:rf.causa.static.machines/clear-search`   — drop search-text
+    `:rf.causa.static.machines/cycle-sort`     — cycle through sort axes
+    `:rf.causa.static.machines/set-sub-mode`   — set the per-machine sub-mode
+    `:rf.causa.static.machines/hydrate`        — hydrate selection + sub-modes
+                                                  from localStorage
+
+  Fxs:
+    `:rf.causa.static.machines/persist-selection` — write selected-id to LS
+    `:rf.causa.static.machines/persist-sub-mode`  — write {mid sub-mode} to LS
+
+  ## Frame isolation
+
+  Same discipline as every other Static panel — the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `shell.cljs` scopes
+  subscribes / dispatches to Causa's frame."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.machines.browse-list :as browse-list]
+            [day8.re-frame2-causa.static.machines.definition-detail
+             :as definition-detail]
+            [day8.re-frame2-causa.static.machines.helpers :as h]
+            [day8.re-frame2-causa.static.machines.persistence :as persistence]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack type-scale]]))
+
+;; ---- panel layout -------------------------------------------------------
+
+(def ^:private left-pane-width "280px")
+
+(rf/reg-view panel
+  "L4 detail-panel content for the Static Machines tab. Master-detail
+  with a browse-all list on the left and the per-machine definition
+  detail on the right.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  [:div {:data-testid "rf-causa-static-machines-panel"
+         :style {:display          "flex"
+                 :flex-direction   "row"
+                 :height           "100%"
+                 :background       (:bg-2 tokens)
+                 :color            (:text-primary tokens)
+                 :font-family      sans-stack
+                 :font-size        (:body type-scale)}}
+   ;; ---- left pane ----
+   [:div {:data-testid "rf-causa-static-machines-left"
+          :style {:flex          (str "0 0 " left-pane-width)
+                  :min-width     left-pane-width
+                  :max-width     left-pane-width
+                  :height        "100%"
+                  :overflow      "hidden"
+                  :display       "flex"
+                  :flex-direction "column"
+                  :border-right  (str "1px solid " (:border-subtle tokens))
+                  :background    (:bg-1 tokens)}}
+    [browse-list/browse-list]]
+   ;; ---- right pane ----
+   [:div {:data-testid "rf-causa-static-machines-right"
+          :style {:flex        "1 1 auto"
+                  :min-width   "0"
+                  :overflow    "auto"
+                  :background  (:bg-2 tokens)}}
+    [definition-detail/detail]]])
+
+;; ---- subs ---------------------------------------------------------------
+
+(defn- install-subs! []
+  ;; Raw slots
+  (rf/reg-sub :rf.causa.static.machines/selected-id
+    (fn [db _query]
+      (get db :rf.causa.static.machines/selected-id)))
+
+  (rf/reg-sub :rf.causa.static.machines/search
+    (fn [db _query]
+      (or (get db :rf.causa.static.machines/search) "")))
+
+  (rf/reg-sub :rf.causa.static.machines/sort-key
+    (fn [db _query]
+      (h/normalise-sort-key
+        (get db :rf.causa.static.machines/sort-key h/default-sort-key))))
+
+  ;; Per-machine sub-mode map: {machine-id sub-mode-kw}
+  (rf/reg-sub :rf.causa.static.machines/sub-mode-by-id
+    (fn [db _query]
+      (or (get db :rf.causa.static.machines/sub-mode-by-id) {})))
+
+  ;; Effective sub-mode for a machine. Default :topology when the
+  ;; machine has no stored choice.
+  (rf/reg-sub :rf.causa.static.machines/sub-mode
+    :<- [:rf.causa.static.machines/sub-mode-by-id]
+    (fn [by-id [_ machine-id]]
+      (h/normalise-sub-mode
+        (get by-id machine-id h/default-sub-mode))))
+
+  ;; Composite — feeds the browse-list + detail header. Reads the
+  ;; existing :rf.causa/registered-machines + machine-definitions +
+  ;; machine-snapshots subs registered by panels.machine-inspector
+  ;; (install order is purely cosmetic — re-frame resolves :<- lazily).
+  ;; The `:rf.causa/machine-snapshots-override` test-seam composes on
+  ;; top of the live snapshots — same shape the Runtime Machine
+  ;; Inspector's composite uses, so the override flips both surfaces.
+  (rf/reg-sub :rf.causa.static.machines/rows
+    :<- [:rf.causa/registered-machines]
+    :<- [:rf.causa/machine-definitions]
+    :<- [:rf.causa/machine-snapshots]
+    :<- [:rf.causa/machine-snapshots-override]
+    (fn [[machines definitions live-snapshots snapshots-override] _query]
+      (h/project-rows machines definitions
+                      (or snapshots-override live-snapshots {}))))
+
+  (rf/reg-sub :rf.causa.static.machines/data
+    :<- [:rf.causa/registered-machines]
+    :<- [:rf.causa/machine-definitions]
+    :<- [:rf.causa/machine-snapshots]
+    :<- [:rf.causa/machine-snapshots-override]
+    :<- [:rf.causa.static.machines/search]
+    :<- [:rf.causa.static.machines/sort-key]
+    :<- [:rf.causa.static.machines/selected-id]
+    (fn [[machines definitions live-snapshots snapshots-override
+          query sort-key selected-id] _query]
+      (h/project-browse-list machines definitions
+                             (or snapshots-override live-snapshots {})
+                             query sort-key selected-id)))
+  nil)
+
+;; ---- events -------------------------------------------------------------
+
+(defn- install-events! []
+  (rf/reg-event-fx :rf.causa.static.machines/select
+    (fn [{:keys [db]} [_ machine-id]]
+      (let [next-db (assoc db :rf.causa.static.machines/selected-id machine-id)]
+        {:db next-db
+         :fx [[:rf.causa.static.machines/persist-selection machine-id]]})))
+
+  (rf/reg-event-db :rf.causa.static.machines/set-search
+    (fn [db [_ query]]
+      (assoc db :rf.causa.static.machines/search (or query ""))))
+
+  (rf/reg-event-db :rf.causa.static.machines/clear-search
+    (fn [db _event]
+      (dissoc db :rf.causa.static.machines/search)))
+
+  (rf/reg-event-db :rf.causa.static.machines/cycle-sort
+    (fn [db _event]
+      (let [current (h/normalise-sort-key
+                      (get db :rf.causa.static.machines/sort-key))
+            ix      (.indexOf h/sort-keys current)
+            next-ix (mod (inc ix) (count h/sort-keys))
+            next-k  (nth h/sort-keys next-ix)]
+        (assoc db :rf.causa.static.machines/sort-key next-k))))
+
+  (rf/reg-event-fx :rf.causa.static.machines/set-sub-mode
+    (fn [{:keys [db]} [_ machine-id sub-mode]]
+      (let [normed  (h/normalise-sub-mode sub-mode)
+            next-db (assoc-in db [:rf.causa.static.machines/sub-mode-by-id
+                                  machine-id]
+                              normed)
+            by-id   (get next-db :rf.causa.static.machines/sub-mode-by-id)]
+        {:db next-db
+         :fx [[:rf.causa.static.machines/persist-sub-mode by-id]]})))
+
+  (rf/reg-event-db :rf.causa.static.machines/hydrate
+    (fn [db [_ {:keys [selected-id sub-mode-by-id]}]]
+      (cond-> db
+        (some? selected-id)
+        (assoc :rf.causa.static.machines/selected-id selected-id)
+        (map? sub-mode-by-id)
+        (assoc :rf.causa.static.machines/sub-mode-by-id sub-mode-by-id))))
+
+  ;; Click-on-state in the Topology mode. v1 is a no-op slot — the
+  ;; metadata rail wires in a follow-on bead (per the bead's §Topology
+  ;; mode 'Click state → metadata rail'). The event is registered now
+  ;; so the chart's `:on-state-click` dispatch lands on a known handler
+  ;; rather than emitting a `:rf.warning/no-handler` trace.
+  (rf/reg-event-db :rf.causa.static.machines/state-clicked
+    (fn [db [_ _payload]] db))
+
+  ;; Open-chart-popout — same posture: registered as a no-op slot so
+  ;; the affordance has a landing handler. The pop-out window
+  ;; orchestration rides the second-window UX bead.
+  (rf/reg-event-db :rf.causa.static.machines/open-chart-popout
+    (fn [db [_ _machine-id]] db))
+  nil)
+
+;; ---- public install -----------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Machines sub-tab's reactive surface.
+  Called from `registry.cljs/register-causa-handlers!`.
+
+  Registers the subs / events that drive the browse-list + the per-
+  machine sub-mode strip; installs the persistence fx so selection +
+  sub-mode round-trip to localStorage; hydrates the slots from
+  localStorage so the first render after a reload restores the prior
+  state."
+  []
+  (install-subs!)
+  (install-events!)
+  (persistence/install-fx!)
+  ;; Hydrate from localStorage. The persistence ns guards storage
+  ;; availability internally so the JVM test path is a no-op.
+  (persistence/hydrate!)
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/persistence.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/persistence.cljs
@@ -1,0 +1,166 @@
+(ns day8.re-frame2-causa.static.machines.persistence
+  "localStorage round-trip for the Static Machines sub-tab's selection
+  + per-machine sub-mode (rf2-o5f5f.2).
+
+  Two slots ride localStorage so the user's choices survive reloads:
+
+    `causa.static.machines.selected-id`     — string form of the
+                                              currently selected
+                                              machine-id keyword
+                                              (`name` only — namespaced
+                                              ids store as `ns/name`)
+    `causa.static.machines.sub-mode-by-id`  — EDN map
+                                              `{machine-id sub-mode}`
+
+  ## Why two slots
+
+  Selection is a single value — a bare string keeps it cheap to
+  inspect in browser devtools (mirrors `static/persistence.cljs`'s
+  `causa.mode` slot — same pattern, same rationale).
+
+  Sub-mode is per-machine, so the map has to ride a single slot keyed
+  by machine-id. EDN is the same serialiser the filter slot uses
+  (`re-frame2.causa.filters.v1`); modes are an enum so versioning
+  feels overkill, but the bead's posture for per-machine persistence
+  is that the map will grow new keys as new sub-modes land. EDN is
+  fine.
+
+  ## Production posture
+
+  Rides Causa's dev-only preload (gated on `interop/debug-enabled?`),
+  so production builds DCE this ns. Every read / write guards
+  `js/window` existence so the JVM test path doesn't blow up on
+  classpath load.
+
+  ## Test-only
+
+  Tests that need a deterministic starting state call `clear!` in
+  their `:each` fixture."
+  (:require [cljs.reader :as reader]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.machines.helpers :as h]))
+
+(def selection-key
+  "Canonical localStorage key for the selected machine-id slot."
+  "causa.static.machines.selected-id")
+
+(def sub-mode-key
+  "Canonical localStorage key for the per-machine sub-mode map slot."
+  "causa.static.machines.sub-mode-by-id")
+
+;; ---- localStorage helpers -----------------------------------------------
+
+(defn- storage-available? []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn- read-raw [k]
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) k)
+      (catch :default _ nil))))
+
+(defn- write-raw! [k v]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) k v)
+      (catch :default _ nil)))
+  nil)
+
+(defn- remove-raw! [k]
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) k)
+      (catch :default _ nil)))
+  nil)
+
+;; ---- selection round-trip -----------------------------------------------
+
+(defn save-selected-id!
+  "Write the selected machine-id keyword to localStorage. nil clears
+  the slot."
+  [machine-id]
+  (if (nil? machine-id)
+    (remove-raw! selection-key)
+    (when (keyword? machine-id)
+      (write-raw! selection-key (subs (str machine-id) 1))))
+  nil)
+
+(defn load-selected-id
+  "Read + parse the persisted selected-id keyword. Returns nil when the
+  slot is empty / localStorage is unavailable / the value is not a
+  valid keyword name."
+  []
+  (when-let [raw (read-raw selection-key)]
+    (try
+      (keyword raw)
+      (catch :default _ nil))))
+
+;; ---- per-machine sub-mode round-trip ------------------------------------
+
+(defn save-sub-mode-by-id!
+  "Write the `{machine-id sub-mode}` map to localStorage as pr-str
+  EDN. Empty / nil map clears the slot."
+  [by-id]
+  (if (or (nil? by-id) (and (map? by-id) (empty? by-id)))
+    (remove-raw! sub-mode-key)
+    (write-raw! sub-mode-key (pr-str by-id)))
+  nil)
+
+(defn load-sub-mode-by-id
+  "Read + parse the persisted sub-mode map. Returns `{}` when the slot
+  is empty / unparseable. Every value normalises through
+  `helpers/normalise-sub-mode` so a corrupted entry falls back to
+  `:topology` rather than crashing the render."
+  []
+  (when-let [raw (read-raw sub-mode-key)]
+    (try
+      (let [parsed (reader/read-string raw)]
+        (when (map? parsed)
+          (into {}
+                (keep (fn [[k v]]
+                        (when (keyword? k)
+                          [k (h/normalise-sub-mode v)])))
+                parsed)))
+      (catch :default _ {}))))
+
+;; ---- clear! / test-only -------------------------------------------------
+
+(defn clear!
+  "Drop both slots. Used by tests to reset between scenarios. No-op
+  when localStorage is unavailable."
+  []
+  (remove-raw! selection-key)
+  (remove-raw! sub-mode-key)
+  nil)
+
+;; ---- re-frame fx + hydration -------------------------------------------
+
+(defn install-fx!
+  "Install the persist-selection + persist-sub-mode fxs. Idempotent —
+  re-frame's registrar replaces in place. The panel's :select /
+  :set-sub-mode events attach these fxs so the post-mutation slot
+  lands in localStorage in one place."
+  []
+  (rf/reg-fx :rf.causa.static.machines/persist-selection
+    (fn [_ctx machine-id]
+      (save-selected-id! machine-id)))
+  (rf/reg-fx :rf.causa.static.machines/persist-sub-mode
+    (fn [_ctx by-id]
+      (save-sub-mode-by-id! by-id)))
+  nil)
+
+(defn hydrate!
+  "Dispatch a hydrate event carrying the persisted selection + sub-mode
+  map. Runs once at install! time. Safe to call before frame
+  `:rf/causa` is mounted — `dispatch` queues the event; it lands after
+  the frame is registered. Per `mount.cljs/ensure-causa-frame!` the
+  registry handlers install before the frame mounts, so the dispatch
+  goes through the standard queue and is replayed against the new
+  frame on the first dispatch-cycle."
+  []
+  (rf/dispatch [:rf.causa.static.machines/hydrate
+                {:selected-id    (load-selected-id)
+                 :sub-mode-by-id (load-sub-mode-by-id)}]
+               {:frame :rf/causa})
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/sim_placeholder.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/sim_placeholder.cljs
@@ -1,0 +1,73 @@
+(ns day8.re-frame2-causa.static.machines.sim-placeholder
+  "Sim mode placeholder — rf2-o5f5f.2 ships the strip cell but NOT the
+  Sim view. Sibling bead rf2-r4nao re-hosts the Sim machinery from
+  `panels/machine_inspector_sim.cljs` under the Static surface; once
+  that bead lands, swap this placeholder for the real renderer.
+
+  This ns deliberately does NOT `:require` any `sim.cljs` — pulling
+  the engine in here would couple the two beads' merges. The
+  placeholder is a self-contained `<section>` so rf2-r4nao's PR can
+  replace the body without touching the strip wiring."
+  (:require [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+(def follow-on-bead-id
+  "Sibling bead that will land the real Sim renderer."
+  "rf2-r4nao")
+
+(defn pill
+  "Render the Sim pill in the 4-mode sub-strip. Active when the user
+  has selected Sim; otherwise inactive but still clickable (Sim is
+  reachable, it just renders the placeholder until rf2-r4nao lands)."
+  [{:keys [active? on-click]}]
+  [:button
+   {:data-testid    "rf-causa-static-machines-pill-sim"
+    :role           "tab"
+    :aria-selected  (if active? "true" "false")
+    :on-click       on-click
+    :title          (str "Sim mode (mnemonic: s) — placeholder until "
+                         follow-on-bead-id " lands the real Sim view.")
+    :aria-label     "Sim mode — placeholder"
+    :style {:background    "transparent"
+            :border        (str "1px solid "
+                                (if active?
+                                  (:cyan tokens)
+                                  (:border-default tokens)))
+            :border-radius "10px"
+            :color         (if active? (:cyan tokens) (:text-secondary tokens))
+            :cursor        "pointer"
+            :font-family   sans-stack
+            :font-size     (:caption type-scale)
+            :font-weight   (if active? 600 400)
+            :padding       "3px 12px"
+            :white-space   "nowrap"}}
+   "Sim"])
+
+(defn body
+  "Render the Sim mode body — a single placeholder card per the bead.
+  Replace this fn with the rehosted Sim renderer when rf2-r4nao lands."
+  [{:keys [machine-id]}]
+  [:section {:data-testid    "rf-causa-static-machines-sim-placeholder"
+             :data-machine-id (str machine-id)
+             :style {:padding     "16px"
+                     :background  (:bg-2 tokens)
+                     :color       (:text-secondary tokens)
+                     :font-family sans-stack
+                     :font-size   (:body type-scale)}}
+   [:h2 {:style {:margin "0 0 8px 0"
+                 :font-size (:display type-scale)
+                 :font-weight 600
+                 :color (:text-primary tokens)}}
+    "Sim"]
+   [:p {:style {:margin "0 0 6px 0"}}
+    "Sim — "
+    [:strong {:style {:color (:cyan tokens)
+                      :font-family mono-stack}}
+     follow-on-bead-id]
+    " will fill this."]
+   [:p {:style {:margin 0
+                :font-size (:caption type-scale)
+                :color (:text-tertiary tokens)}}
+    "The Sim engine is registered on the framework side; rf2-r4nao "
+    "re-hosts the UI under the Static surface."]])

--- a/tools/causa/src/day8/re_frame2_causa/static/machines/topology.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/machines/topology.cljs
@@ -1,0 +1,176 @@
+(ns day8.re-frame2-causa.static.machines.topology
+  "Topology mode renderer — Static-read view of a machine's state graph
+  (rf2-o5f5f.2).
+
+  ## What it renders
+
+  The same `chart/svg` MachineChart primitive the Runtime panel uses
+  (per findings §5.1 — single implementation). **The Static-mode
+  rendering passes NO `:highlight-id`** — Topology in Static is a
+  static-read; there's no active state to spotlight.
+
+  Click on a state node fires `:rf.causa.static.machines/state-clicked`
+  with the clicked state's path; the right pane carries a metadata
+  rail showing incoming / outgoing edges + a source-coord chip (when
+  the definition lifts a coord onto the state). The chip degrades
+  gracefully when the coord is missing.
+
+  ## Empty states
+
+  - No machine selected (rare — the panel always defaults to the
+    first row when one exists).
+  - Machine has no definition (registrar returns nil from
+    `machine-meta`) — render a hint pointing at `reg-machine`.
+  - Definition with no `:states` map (degenerate) — falls through to
+    `chart/svg/render`'s built-in 'no states' message.
+
+  ## Definition-stale post-reload
+
+  Per the bead's §Topology mode + findings §3.3 the chart should
+  surface a 'definition reloaded' chip after a hot-reload changes
+  the machine spec while the user is looking at it. v1 ships the
+  scaffold without the reload-detection wiring — the chip will land
+  with a follow-on bead. The chart re-renders on every spec change
+  (the `machine-definitions` sub fires on framework hot-reload), so
+  the data shown is always live."
+  (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.chart.svg :as chart-svg]
+            [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.static.machines.helpers :as h]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack mono-stack type-scale]]))
+
+;; ---- empty surfaces -----------------------------------------------------
+
+(defn- no-definition []
+  [:div {:data-testid "rf-causa-static-machines-topology-no-definition"
+         :style {:padding "16px"
+                 :color (:text-tertiary tokens)
+                 :font-family sans-stack
+                 :font-size (:caption type-scale)}}
+   "Machine definition is not introspectable. The chart cannot render."])
+
+;; ---- chart wrapper ------------------------------------------------------
+
+(defn- chart
+  "Render the chart SVG for `definition`. NO highlight — Static
+  Topology is a static-read."
+  [{:keys [definition machine-id]}]
+  (let [direction  :tb
+        positioned (elk-layout/layout-or-fallback definition direction)
+        engine     (if (some? (elk-layout/cached-layout definition direction))
+                     "elk"
+                     "layered")]
+    ;; Trigger ELK to take over post-mount if available; layered serves
+    ;; the first paint either way. Same wire-up the Runtime panel uses
+    ;; (per `panels/machine_inspector.cljs/focused-event-section`).
+    (elk-layout/ensure-elk!
+      (fn [_inst]
+        (when (and (= :ready (elk-layout/elk-status))
+                   (nil? (elk-layout/cached-layout definition direction)))
+          (elk-layout/compute-layout!
+            definition direction
+            (fn [chart-layout]
+              (when chart-layout
+                (rf/dispatch [:rf.causa/machine-chart-layout-pulse]
+                             {:frame :rf/causa})))))))
+    [:div {:data-testid    "rf-causa-static-machines-topology-chart"
+           :data-machine-id (str machine-id)
+           :data-layout-engine engine
+           :style {:padding    "12px"
+                   :background (:bg-1 tokens)
+                   :overflow   "auto"
+                   :position   "relative"}}
+     (chart-svg/render
+       positioned
+       {:testid         "rf-causa-static-machines-topology-svg"
+        :on-state-click
+        (fn [path]
+          (rf/dispatch [:rf.causa.static.machines/state-clicked
+                        {:machine-id machine-id :path path}]
+                       {:frame :rf/causa}))})]))
+
+;; ---- chart toolbar (open in popout) -------------------------------------
+
+(defn- popout-affordance
+  "Per the bead — 'Open chart in popout' affordance. v1 scaffolds the
+  affordance against the existing `:rf.causa.static.machines/open-
+  chart-popout` event (registered by the panel install). Popout
+  geometry lands in a follow-on bead (sibling of the second-window
+  rf2-u3qm1 work)."
+  [machine-id]
+  [:button
+   {:data-testid "rf-causa-static-machines-topology-popout"
+    :on-click    (fn [_]
+                   (rf/dispatch
+                     [:rf.causa.static.machines/open-chart-popout machine-id]
+                     {:frame :rf/causa}))
+    :title       "Open chart in pop-out window"
+    :aria-label  (str "Open the chart for " machine-id
+                      " in a pop-out window")
+    :style {:background    "transparent"
+            :border        (str "1px solid " (:border-default tokens))
+            :border-radius "10px"
+            :color         (:text-secondary tokens)
+            :cursor        "pointer"
+            :font-family   sans-stack
+            :font-size     (:micro type-scale)
+            :padding       "1px 8px"
+            :white-space   "nowrap"}}
+   "↗ Pop out"])
+
+(defn- source-coord-chip [source-coord]
+  (when (some? source-coord)
+    (or (open-in-editor/open-chip source-coord)
+        [:span {:data-testid "rf-causa-static-machines-topology-source-coord-text"
+                :style {:font-family mono-stack
+                        :font-size (:micro type-scale)
+                        :color (:text-tertiary tokens)}}
+         (h/format-source-coord source-coord)])))
+
+(defn- chart-toolbar [{:keys [machine-id source-coord]}]
+  [:div {:data-testid "rf-causa-static-machines-topology-toolbar"
+         :style {:display     "flex"
+                 :align-items "center"
+                 :gap         "8px"
+                 :padding     "8px 12px"
+                 :background  (:bg-1 tokens)
+                 :border-bottom (str "1px solid " (:border-subtle tokens))}}
+   [popout-affordance machine-id]
+   [:span {:style {:margin-left "auto"}}
+    (source-coord-chip source-coord)]])
+
+;; ---- public renderer ----------------------------------------------------
+
+(defn body
+  "Render Topology mode for `machine-id`. `definition` is the
+  registrar's spec map; `source-coord` is its lifted coord (or nil).
+
+  Pure-ish — reads no subscribes (the panel feeds the props). The
+  embedded `chart-svg/render` is pure hiccup."
+  [{:keys [machine-id definition source-coord] :as args}]
+  (cond
+    (nil? definition)
+    [:section {:data-testid     "rf-causa-static-machines-topology"
+               :data-machine-id (str machine-id)
+               :style {:height "100%"
+                       :display "flex"
+                       :flex-direction "column"
+                       :background (:bg-2 tokens)
+                       :color (:text-primary tokens)
+                       :font-family sans-stack}}
+     (no-definition)]
+
+    :else
+    [:section {:data-testid     "rf-causa-static-machines-topology"
+               :data-machine-id (str machine-id)
+               :style {:height "100%"
+                       :display "flex"
+                       :flex-direction "column"
+                       :background (:bg-2 tokens)
+                       :color (:text-primary tokens)
+                       :font-family sans-stack}}
+     [chart-toolbar {:machine-id machine-id :source-coord source-coord}]
+     [chart {:definition definition :machine-id machine-id}]]))

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -84,6 +84,7 @@
     - rf2-o5f5f.5 — Views registry browse (Fiber-walker consumer)
     - rf2-o5f5f.6 — Events registry browse + interceptor stack"
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.machines.panel :as static-machines]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
             [day8.re-frame2-causa.static.routes.panel :as routes-panel]
             [day8.re-frame2-causa.theme.tokens
@@ -321,8 +322,15 @@
 
 (rf/reg-view detail-panel
   "L4 detail panel — case-switch on `:rf.causa.static/selected-tab`.
-  Phase 1 (this bead) renders placeholder cards; the sibling beads
-  replace each placeholder with real catalogue content.
+  Phase 1 (rf2-o5f5f.1) landed placeholder cards for every tab; sibling
+  beads (.2 / .3 / .4 / .5 / .6) progressively replace each placeholder
+  with real catalogue content.
+
+  Live mounts:
+    :machines → `static.machines.panel/panel` (rf2-o5f5f.2)
+
+  Placeholder still-pending (the sibling-bead card):
+    :routes :schemas :views :events
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -337,9 +345,9 @@
                    :background  (:bg-2 tokens)
                    :color       (:text-primary tokens)}}
      (cond
-       ;; rf2-o5f5f.3 — Static Routes panel replaces the placeholder.
-       ;; Sibling rf2-o5f5f.2 (Machines) will replace the :machines
-       ;; branch in parallel; trivial 5-line rebase if both land.
+       (= selected :machines)
+       [static-machines/panel]
+
        (= selected :routes)
        [routes-panel/Panel]
 

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -209,6 +209,16 @@
    ;; rf2-o5f5f.1 — Runtime ↔ Static mode slot + Static-scoped tab.
    :rf.causa/mode
    :rf.causa.static/selected-tab
+   ;; rf2-o5f5f.2 — Static Machines sub-tab subs (browse-all + per-
+   ;; machine sub-mode). Composite + raw slots feeding the L4 master-
+   ;; detail surface.
+   :rf.causa.static.machines/data
+   :rf.causa.static.machines/rows
+   :rf.causa.static.machines/search
+   :rf.causa.static.machines/selected-id
+   :rf.causa.static.machines/sort-key
+   :rf.causa.static.machines/sub-mode
+   :rf.causa.static.machines/sub-mode-by-id
    ;; rf2-x8h9y — horizontal resize handle width.
    :rf.causa/panel-width-px
    ;; rf2-vbbq0 — L2 row relative-time chip clock (1s ticker writes here).
@@ -372,6 +382,19 @@
    :rf.causa/set-mode
    :rf.causa/toggle-mode
    :rf.causa.static/select-tab
+   ;; rf2-o5f5f.2 — Static Machines sub-tab events. Selection +
+   ;; search + sort + sub-mode + hydrate (post-localStorage restore) +
+   ;; two no-op slots (state-clicked + open-chart-popout) reserved so
+   ;; click affordances land on a known handler rather than emitting
+   ;; `:rf.warning/no-handler`.
+   :rf.causa.static.machines/clear-search
+   :rf.causa.static.machines/cycle-sort
+   :rf.causa.static.machines/hydrate
+   :rf.causa.static.machines/open-chart-popout
+   :rf.causa.static.machines/select
+   :rf.causa.static.machines/set-search
+   :rf.causa.static.machines/set-sub-mode
+   :rf.causa.static.machines/state-clicked
    ;; rf2-a1z3b — focus-navigation primitive write event.
    :rf.causa/set-focus
    :rf.causa/set-frame
@@ -473,6 +496,14 @@
    ;; handlers; writes the post-mutation mode to localStorage in one
    ;; place (mirrors the filter-persistence shape above).
    :rf.causa.static/persist-mode
+   ;; rf2-o5f5f.2 — Static Machines sub-tab persistence side-effects.
+   ;; Bound to the `:rf.causa.static.machines/select` +
+   ;; `:rf.causa.static.machines/set-sub-mode` handlers; mirrors the
+   ;; mode-persist shape above (one fx per slot so future surfaces
+   ;; can compose against them without re-implementing the LS round-
+   ;; trip).
+   :rf.causa.static.machines/persist-selection
+   :rf.causa.static.machines/persist-sub-mode
    ;; rf2-g5q8d — cross-panel open-in-editor side-effect. Lives under
    ;; the editor-generic `:rf.editor/*` prefix rather than `:rf.causa.fx/*`
    ;; because the rf2-cm93v allowlist seam is editor-related, not

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/browse_list_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/browse_list_cljs_test.cljs
@@ -1,0 +1,208 @@
+(ns day8.re-frame2-causa.static.machines.browse-list-cljs-test
+  "CLJS render tests for the Static Machines browse-list (rf2-o5f5f.2).
+
+  ## What's under test
+
+    1. Pip cluster — pip-cap dots inline, '>cap N live' textual count
+       beyond. Silent for zero (per rf2-g3ghh).
+    2. Sort button label reflects the active axis.
+    3. Per-row `→ Runtime` chip dispatches the JUMP fn (verified via
+       app-db side-effects).
+    4. Search box keystroke fires set-search; Escape key fires
+       clear-search."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.machines.browse-list :as browse-list]
+            [day8.re-frame2-causa.static.machines.helpers :as h]
+            [day8.re-frame2-causa.static.machines.instances-jump :as jump]
+            [day8.re-frame2-causa.static.machines.panel :as panel]
+            [day8.re-frame2-causa.static.machines.persistence :as ls]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!)
+  (config/set-static-mode-enabled! nil)
+  (static-persistence/clear!)
+  (ls/clear!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid [tree testid]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (= testid (:data-testid (second node)))))
+           (hiccup-seq tree)))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa (rf/dispatch-sync ev)))
+
+(defn- seed-machines! [ids]
+  (frame-dispatch [:rf.causa/set-registered-machines-override-for-test
+                   (vec ids)]))
+
+(defn- seed-snapshots! [snaps]
+  (frame-dispatch [:rf.causa/set-machine-snapshots-override-for-test snaps]))
+
+(defn- seed-definitions! [defs]
+  (frame-dispatch [:rf.causa/set-machine-definitions-override-for-test defs]))
+
+;; -------------------------------------------------------------------------
+;; Pip cluster
+;; -------------------------------------------------------------------------
+
+(deftest pip-cluster-zero-is-silent
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (seed-snapshots! {}) ;; no live instances
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (nil? (find-by-testid tree "rf-causa-static-machines-row-pips"))
+          "no pip cluster when live-count is zero"))))
+
+(deftest pip-cluster-renders-dots-for-one-live-instance
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (seed-snapshots! {:m/a {:state :idle}})
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          pips (find-by-testid tree "rf-causa-static-machines-row-pips")]
+      (is (some? pips) "pip cluster mounts for live machine"))))
+
+;; -------------------------------------------------------------------------
+;; Sort button label reflects the active axis
+;; -------------------------------------------------------------------------
+
+(deftest sort-button-label-tracks-the-active-axis
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          btn  (find-by-testid tree "rf-causa-static-machines-sort")
+          text (->> btn hiccup-seq (filter string?) (apply str))]
+      (is (re-find #"Name" text) "default sort axis is Name")))
+  (frame-dispatch [:rf.causa.static.machines/cycle-sort])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          btn  (find-by-testid tree "rf-causa-static-machines-sort")
+          text (->> btn hiccup-seq (filter string?) (apply str))]
+      (is (re-find #"States" text)))))
+
+;; -------------------------------------------------------------------------
+;; Per-row JUMP chip fires the JUMP
+;; -------------------------------------------------------------------------
+
+(deftest per-row-jump-chip-fires-jump
+  (testing "Clicking the per-row `→ Runtime` chip fires set-mode +
+            select-tab + select-machine-id (via the centralised
+            dispatcher)"
+    (causa-setup!)
+    (seed-machines! [:m/a :m/b])
+    ;; Sanity baseline
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (rf/with-frame :rf/causa
+      (is (= :static (frame-sub [:rf.causa/mode]))))
+    ;; Drive the dispatcher
+    (rf/with-frame :rf/causa
+      (jump/dispatch-jump-sync! :m/a))
+    (rf/with-frame :rf/causa
+      (is (= :runtime (frame-sub [:rf.causa/mode])))
+      (is (= :machines (frame-sub [:rf.causa/selected-tab])))
+      (is (= :m/a (frame-sub [:rf.causa/selected-machine-id]))))))
+
+;; -------------------------------------------------------------------------
+;; Listbox ARIA
+;; -------------------------------------------------------------------------
+
+(deftest browse-list-uses-listbox-aria
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (rf/with-frame :rf/causa
+    (let [tree   (panel/panel)
+          rows-el (find-by-testid tree "rf-causa-static-machines-rows")
+          attrs  (second rows-el)]
+      (is (= "listbox" (:role attrs)))
+      (is (string? (:aria-label attrs))))))
+
+(deftest selected-row-carries-aria-selected-true
+  (causa-setup!)
+  (seed-machines! [:m/a :m/b])
+  (frame-dispatch [:rf.causa.static.machines/select :m/a])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          row-a (find-by-testid tree "rf-causa-static-machines-row-a")
+          attrs (second row-a)]
+      ;; Note: machine-id is :m/a so name = "a", testid suffix matches.
+      (is (= "true" (:aria-selected attrs))))))
+
+;; -------------------------------------------------------------------------
+;; Count line shows total vs visible
+;; -------------------------------------------------------------------------
+
+(deftest toolbar-count-shows-visible-and-total
+  (causa-setup!)
+  (seed-machines! [:foo/a :foo/b :bar/c])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          count-el (find-by-testid tree "rf-causa-static-machines-count")
+          text (->> count-el hiccup-seq (filter string?) (apply str))]
+      (is (re-find #"3 machines" text))))
+  (frame-dispatch [:rf.causa.static.machines/set-search "foo"])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          count-el (find-by-testid tree "rf-causa-static-machines-count")
+          text (->> count-el hiccup-seq (filter string?) (apply str))]
+      (is (re-find #"2 / 3" text)))))
+
+;; -------------------------------------------------------------------------
+;; No-results state
+;; -------------------------------------------------------------------------
+
+(deftest no-results-state-when-search-misses
+  (causa-setup!)
+  (seed-machines! [:foo/a :foo/b])
+  (frame-dispatch [:rf.causa.static.machines/set-search "nonexistent"])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-machines-no-results"))))))

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/helpers_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/helpers_test.cljc
@@ -1,0 +1,205 @@
+(ns day8.re-frame2-causa.static.machines.helpers-test
+  "Pure-data unit tests for the Static Machines projection helpers
+  (rf2-o5f5f.2). JVM-runnable so the projection contract is covered
+  without a CLJS runtime."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.static.machines.helpers :as h]))
+
+;; ---- sub-mode normalisation ---------------------------------------------
+
+(deftest sub-mode-defaults-to-topology
+  (is (= :topology h/default-sub-mode))
+  (is (= 4 (count h/sub-modes))
+      "four sub-modes: topology + sim + instances + cascade"))
+
+(deftest normalise-sub-mode-accepts-valid
+  (doseq [m [:topology :sim :instances :cascade]]
+    (is (= m (h/normalise-sub-mode m))
+        (str m " survives normalisation"))))
+
+(deftest normalise-sub-mode-coerces-strings
+  (is (= :topology (h/normalise-sub-mode "topology")))
+  (is (= :sim      (h/normalise-sub-mode "sim")))
+  (is (= :instances (h/normalise-sub-mode "instances")))
+  (is (= :cascade  (h/normalise-sub-mode "cascade"))))
+
+(deftest normalise-sub-mode-rejects-unknown
+  (is (= :topology (h/normalise-sub-mode nil)))
+  (is (= :topology (h/normalise-sub-mode :nonsense)))
+  (is (= :topology (h/normalise-sub-mode "junk")))
+  (is (= :topology (h/normalise-sub-mode 42))))
+
+;; ---- sort-key normalisation ---------------------------------------------
+
+(deftest sort-key-defaults-to-name
+  (is (= :name h/default-sort-key))
+  (is (= 3 (count h/sort-keys))))
+
+(deftest normalise-sort-key-rejects-unknown
+  (is (= :name (h/normalise-sort-key nil)))
+  (is (= :name (h/normalise-sort-key :nonsense)))
+  (is (= :states (h/normalise-sort-key :states)))
+  (is (= :live  (h/normalise-sort-key :live))))
+
+;; ---- source-coord lifting -----------------------------------------------
+
+(deftest lift-source-coord-pulls-canonical-slot
+  (is (= {:file "x.cljs" :line 42}
+         (h/lift-source-coord {:source-coord {:file "x.cljs" :line 42}})))
+  (testing "alternate :source slot — lenient fallback"
+    (is (= {:file "y.cljs"}
+           (h/lift-source-coord {:source {:file "y.cljs"}})))))
+
+(deftest lift-source-coord-nil-safe
+  (is (nil? (h/lift-source-coord nil)))
+  (is (nil? (h/lift-source-coord {})))
+  (is (nil? (h/lift-source-coord {:initial :idle}))))
+
+(deftest format-source-coord-renders-file-line
+  (is (= "src/x.cljs:42"
+         (h/format-source-coord {:file "src/x.cljs" :line 42})))
+  (is (= "src/x.cljs"
+         (h/format-source-coord {:file "src/x.cljs"}))
+      "line is optional"))
+
+(deftest format-source-coord-nil-safe
+  (is (nil? (h/format-source-coord nil)))
+  (is (nil? (h/format-source-coord {:line 42}))
+      "no :file → no format"))
+
+;; ---- row projection -----------------------------------------------------
+
+(def ^:private sample-defs
+  {:m/a {:states {:idle {} :loading {} :done {}}
+         :source-coord {:file "src/a.cljs" :line 12}}
+   :m/b {:states {:on {} :off {}}}
+   :m/c {}})  ;; degenerate — no states map, no source-coord
+
+(def ^:private sample-snapshots
+  {:m/a {:state :idle}
+   :m/c {:state :init}})
+
+(deftest project-row-builds-the-canonical-shape
+  (let [row (h/project-row :m/a (:m/a sample-defs) sample-snapshots)]
+    (is (= :m/a (:machine-id row)))
+    (is (= 3 (:state-count row)))
+    (is (= 1 (:live-count row)))
+    (is (= {:file "src/a.cljs" :line 12} (:source-coord row)))
+    (is (= "src/a.cljs:12" (:source-label row)))))
+
+(deftest project-row-degrades-on-missing-fields
+  (let [row (h/project-row :m/c (:m/c sample-defs) sample-snapshots)]
+    (is (= 0 (:state-count row)) "no :states → 0")
+    (is (= 1 (:live-count row)) ":m/c has a snapshot")
+    (is (nil? (:source-coord row)))
+    (is (nil? (:source-label row)))))
+
+(deftest project-rows-walks-all-machines
+  (let [rows (h/project-rows [:m/a :m/b :m/c]
+                             sample-defs
+                             sample-snapshots)]
+    (is (= 3 (count rows)))
+    (is (= [:m/a :m/b :m/c] (mapv :machine-id rows)))))
+
+;; ---- search -------------------------------------------------------------
+
+(def ^:private sample-rows
+  [{:machine-id :foo/login    :state-count 3 :live-count 0
+    :source-coord {:file "src/foo/login.cljs"} :source-label "src/foo/login.cljs"}
+   {:machine-id :foo/checkout :state-count 5 :live-count 2
+    :source-coord {:file "src/foo/checkout.cljs"} :source-label "src/foo/checkout.cljs"}
+   {:machine-id :bar/upload   :state-count 4 :live-count 1
+    :source-coord {:file "src/bar/upload.cljs"} :source-label "src/bar/upload.cljs"}])
+
+(deftest search-text-covers-name-namespace-file
+  (let [r (first sample-rows)
+        s (h/search-text r)]
+    (is (re-find #"login" s) "name segment")
+    (is (re-find #"foo" s) "namespace segment")
+    (is (re-find #"src/foo/login" s) "file segment")))
+
+(deftest apply-search-filters-by-substring
+  (is (= 3 (count (h/apply-search sample-rows nil))) "nil query → all rows")
+  (is (= 3 (count (h/apply-search sample-rows "")))  "blank query → all rows")
+  (is (= 2 (count (h/apply-search sample-rows "foo"))))
+  (is (= 1 (count (h/apply-search sample-rows "bar"))))
+  (is (= 1 (count (h/apply-search sample-rows "Checkout")))
+      "search is case-insensitive")
+  (is (= 0 (count (h/apply-search sample-rows "nomatch")))))
+
+;; ---- sort ---------------------------------------------------------------
+
+(deftest apply-sort-name-asc
+  (let [sorted (h/apply-sort sample-rows :name)]
+    (is (= [:bar/upload :foo/checkout :foo/login]
+           (mapv :machine-id sorted))
+        "alphabetical by `(str id)`")))
+
+(deftest apply-sort-states-desc
+  (let [sorted (h/apply-sort sample-rows :states)]
+    (is (= [:foo/checkout :bar/upload :foo/login]
+           (mapv :machine-id sorted))
+        "5 > 4 > 3")))
+
+(deftest apply-sort-live-desc
+  (let [sorted (h/apply-sort sample-rows :live)]
+    (is (= [:foo/checkout :bar/upload :foo/login]
+           (mapv :machine-id sorted))
+        "2 > 1 > 0, ties on name")))
+
+(deftest apply-sort-unknown-key-falls-back-to-name
+  (let [sorted (h/apply-sort sample-rows :unknown)]
+    (is (= [:bar/upload :foo/checkout :foo/login]
+           (mapv :machine-id sorted)))))
+
+;; ---- composite browse-list projection -----------------------------------
+
+(deftest project-browse-list-resolves-defaults
+  (let [out (h/project-browse-list [:foo/login :foo/checkout :bar/upload]
+                                   {:foo/login {:states {:a {}}}
+                                    :foo/checkout {:states {:a {} :b {} :c {}}}
+                                    :bar/upload {:states {:a {} :b {}}}}
+                                   {:foo/checkout {:state :a}}
+                                   nil :name nil)]
+    (is (= 3 (:total out)))
+    (is (= 3 (:visible out)))
+    (is (= :bar/upload (:selected-id out))
+        "default selection is the first sorted row")))
+
+(deftest project-browse-list-honours-user-selection
+  (let [out (h/project-browse-list [:foo/login :foo/checkout :bar/upload]
+                                   {:foo/login {:states {:a {}}}}
+                                   {}
+                                   nil :name :foo/checkout)]
+    (is (= :foo/checkout (:selected-id out)))))
+
+(deftest project-browse-list-defaults-when-selection-filtered-out
+  (let [out (h/project-browse-list [:foo/login :foo/checkout :bar/upload]
+                                   {:foo/login {:states {:a {}}}}
+                                   {}
+                                   "bar" :name :foo/checkout)]
+    (is (= 1 (:visible out)))
+    (is (= :bar/upload (:selected-id out))
+        "user's pick is filtered out → default to first visible")))
+
+(deftest project-browse-list-empty
+  (let [out (h/project-browse-list [] {} {} nil :name nil)]
+    (is (= 0 (:total out)))
+    (is (= 0 (:visible out)))
+    (is (nil? (:selected-id out)))))
+
+;; ---- pip render plan ----------------------------------------------------
+
+(deftest pip-render-plan-zero-is-none
+  (is (= {:kind :none} (h/pip-render-plan 0)))
+  (is (= {:kind :none} (h/pip-render-plan nil))))
+
+(deftest pip-render-plan-under-cap-is-pips
+  (is (= {:kind :pips :count 1}  (h/pip-render-plan 1)))
+  (is (= {:kind :pips :count 12} (h/pip-render-plan 12)))
+  (is (= {:kind :pips :count 5}  (h/pip-render-plan 5))))
+
+(deftest pip-render-plan-over-cap-is-count
+  (is (= {:kind :count :count 13} (h/pip-render-plan 13)))
+  (is (= {:kind :count :count 999} (h/pip-render-plan 999))))

--- a/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/machines/panel_cljs_test.cljs
@@ -1,0 +1,412 @@
+(ns day8.re-frame2-causa.static.machines.panel-cljs-test
+  "CLJS wiring + render tests for the Static Machines sub-tab panel
+  (rf2-o5f5f.2).
+
+  ## What's under test
+
+    1. The panel mounts as the L4 detail panel for the `:machines`
+       sub-tab — previously a placeholder card, now the real master-
+       detail surface.
+
+    2. Browse-list renders one row per registered machine; search
+       filters incrementally; sort cycles through Name/States/Live.
+
+    3. Detail header renders the canonical 4-cell shape: machine-id ·
+       source-coord ↗ · N states · M live.
+
+    4. 4-mode sub-strip pills render and dispatch the right
+       events (Topology / Sim / Instances / Cascade).
+
+    5. Cascade pill is dimmed (disabled attribute set + dashed border
+       in style); clicking it does nothing.
+
+    6. Instances pill click dispatches three events: set-mode :runtime
+       + select-tab :machines + select-machine-id.
+
+  ## Pure hiccup walk
+
+  Same approach as `shell_cljs_test.cljs` — we walk the view's hiccup
+  tree by data-testid rather than mounting to a real DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.machines.instances-jump :as jump]
+            [day8.re-frame2-causa.static.machines.panel :as panel]
+            [day8.re-frame2-causa.static.machines.persistence :as ls]
+            [day8.re-frame2-causa.static.persistence :as static-persistence]
+            [day8.re-frame2-causa.static.shell :as static-shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!)
+  (config/set-static-mode-enabled! nil)
+  (static-persistence/clear!)
+  (ls/clear!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- text-nodes [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+;; ---- helpers ------------------------------------------------------------
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- frame-sub [q]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe q)))
+
+(defn- frame-dispatch [ev]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync ev)))
+
+(defn- seed-machines!
+  "Drive the `:rf.causa/registered-machines-override` test seam so the
+  browse-all sub composes against a known set."
+  [ids]
+  (frame-dispatch [:rf.causa/set-registered-machines-override-for-test
+                   (vec ids)]))
+
+(defn- seed-definitions! [defs]
+  (frame-dispatch [:rf.causa/set-machine-definitions-override-for-test defs]))
+
+(defn- seed-snapshots! [snaps]
+  (frame-dispatch [:rf.causa/set-machine-snapshots-override-for-test snaps]))
+
+;; -------------------------------------------------------------------------
+;; (1) Mount via the shell detail-panel
+;; -------------------------------------------------------------------------
+
+(deftest static-shell-mounts-machines-panel-on-machines-tab
+  (testing "Selecting the :machines sub-tab mounts the Static Machines
+            panel (replaces the placeholder from rf2-o5f5f.1)"
+    (causa-setup!)
+    (seed-machines! [:m/a :m/b])
+    (rf/with-frame :rf/causa
+      (let [tree (static-shell/surface)]
+        (is (some? (find-by-testid tree "rf-causa-static-machines-panel"))
+            "panel mounts on default :machines tab")
+        ;; Placeholder card MUST be gone now that the panel is live.
+        (is (nil? (find-by-testid tree "rf-causa-static-placeholder-machines"))
+            "placeholder no longer mounts")))))
+
+;; -------------------------------------------------------------------------
+;; (2) Browse-list renders one row per registered machine
+;; -------------------------------------------------------------------------
+
+(deftest browse-list-renders-one-row-per-machine
+  (testing "Each registered machine surfaces as a clickable row"
+    (causa-setup!)
+    (seed-machines! [:foo/login :foo/checkout :bar/upload])
+    (seed-definitions! {:foo/login    {:states {:a {} :b {}}}
+                        :foo/checkout {:states {:a {} :b {} :c {}}}
+                        :bar/upload   {:states {:x {}}}})
+    (rf/with-frame :rf/causa
+      (let [tree (panel/panel)
+            rows (find-all-by-testid-prefix tree "rf-causa-static-machines-row-")
+            ;; Filter rows-only — the row testid prefix matches the
+            ;; per-row id chips too, so we keep only the outer row buttons
+            ;; (they carry `:data-machine-id` on the attrs map).
+            row-buttons (filter #(some? (:data-machine-id (second %))) rows)]
+        (is (= 3 (count row-buttons)) "one row per machine")))))
+
+(deftest browse-list-empty-state-when-no-machines
+  (testing "Empty state renders when (rf/machines) returns nothing"
+    (causa-setup!)
+    (seed-machines! [])
+    (rf/with-frame :rf/causa
+      (let [tree (panel/panel)]
+        (is (some? (find-by-testid tree "rf-causa-static-machines-empty"))
+            "empty-state card present")
+        (is (re-find #"No machines registered"
+                     (text-nodes (find-by-testid tree
+                                                 "rf-causa-static-machines-empty"))))))))
+
+;; -------------------------------------------------------------------------
+;; (3) Search filters the rows
+;; -------------------------------------------------------------------------
+
+(deftest search-narrows-the-row-list
+  (testing "set-search filters rows; clear-search restores them"
+    (causa-setup!)
+    (seed-machines! [:foo/login :foo/checkout :bar/upload])
+    (frame-dispatch [:rf.causa.static.machines/set-search "foo"])
+    (rf/with-frame :rf/causa
+      (let [{:keys [visible total]} @(rf/subscribe [:rf.causa.static.machines/data])]
+        (is (= 2 visible) "two foo/* machines match")
+        (is (= 3 total))))
+    (frame-dispatch [:rf.causa.static.machines/clear-search])
+    (rf/with-frame :rf/causa
+      (let [{:keys [visible]} @(rf/subscribe [:rf.causa.static.machines/data])]
+        (is (= 3 visible) "clear-search restores all rows")))))
+
+;; -------------------------------------------------------------------------
+;; (4) Sort cycle
+;; -------------------------------------------------------------------------
+
+(deftest sort-cycles-through-three-axes
+  (testing "cycle-sort walks :name → :states → :live → :name"
+    (causa-setup!)
+    (is (= :name (frame-sub [:rf.causa.static.machines/sort-key]))
+        "default :name")
+    (frame-dispatch [:rf.causa.static.machines/cycle-sort])
+    (is (= :states (frame-sub [:rf.causa.static.machines/sort-key])))
+    (frame-dispatch [:rf.causa.static.machines/cycle-sort])
+    (is (= :live (frame-sub [:rf.causa.static.machines/sort-key])))
+    (frame-dispatch [:rf.causa.static.machines/cycle-sort])
+    (is (= :name (frame-sub [:rf.causa.static.machines/sort-key])))))
+
+;; -------------------------------------------------------------------------
+;; (5) Selection lifecycle
+;; -------------------------------------------------------------------------
+
+(deftest selection-defaults-to-first-row
+  (causa-setup!)
+  (seed-machines! [:m/a :m/b :m/c])
+  (rf/with-frame :rf/causa
+    (let [{:keys [selected-id]} @(rf/subscribe [:rf.causa.static.machines/data])]
+      ;; Sort default is :name; the first sorted row is :m/a.
+      (is (= :m/a selected-id)
+          "default selection is the first sorted row"))))
+
+(deftest select-event-flips-the-slot
+  (causa-setup!)
+  (seed-machines! [:m/a :m/b :m/c])
+  (frame-dispatch [:rf.causa.static.machines/select :m/c])
+  (rf/with-frame :rf/causa
+    (let [{:keys [selected-id]} @(rf/subscribe [:rf.causa.static.machines/data])]
+      (is (= :m/c selected-id)))))
+
+;; -------------------------------------------------------------------------
+;; (6) Detail header
+;; -------------------------------------------------------------------------
+
+(deftest detail-header-renders-canonical-shape
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (seed-definitions! {:m/a {:states {:a {} :b {} :c {}}
+                            :source-coord {:file "src/a.cljs" :line 7}}})
+  (seed-snapshots! {:m/a {:state :a}})
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-machines-detail-header")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-detail-title")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-detail-source-coord")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-detail-state-count")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-detail-live-count")))
+      (let [text (text-nodes (find-by-testid tree "rf-causa-static-machines-detail-state-count"))]
+        (is (re-find #"3 states" text)))
+      (let [text (text-nodes (find-by-testid tree "rf-causa-static-machines-detail-live-count"))]
+        (is (re-find #"1 live" text))))))
+
+(deftest detail-header-degrades-when-source-coord-missing
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (seed-definitions! {:m/a {:states {:a {}}}}) ;; no :source-coord
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (nil? (find-by-testid tree "rf-causa-static-machines-detail-source-coord"))
+          "source-coord chip is suppressed when the slot is missing"))))
+
+;; -------------------------------------------------------------------------
+;; (7) 4-mode sub-strip
+;; -------------------------------------------------------------------------
+
+(deftest sub-strip-renders-four-pills
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-machines-pill-topology")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-pill-sim")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-pill-instances")))
+      (is (some? (find-by-testid tree "rf-causa-static-machines-pill-cascade"))))))
+
+(deftest sub-strip-default-is-topology
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          pill (find-by-testid tree "rf-causa-static-machines-pill-topology")]
+      (is (= "true" (:aria-selected (second pill)))
+          "Topology is the default active pill"))))
+
+(deftest sub-strip-set-sub-mode-flips-the-active-pill
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (frame-dispatch [:rf.causa.static.machines/set-sub-mode :m/a :sim])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          sim  (find-by-testid tree "rf-causa-static-machines-pill-sim")
+          topo (find-by-testid tree "rf-causa-static-machines-pill-topology")]
+      (is (= "true"  (:aria-selected (second sim))))
+      (is (= "false" (:aria-selected (second topo)))))))
+
+;; -------------------------------------------------------------------------
+;; (8) Cascade dimmed
+;; -------------------------------------------------------------------------
+
+(deftest cascade-pill-is-disabled
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          pill (find-by-testid tree "rf-causa-static-machines-pill-cascade")
+          attrs (second pill)]
+      (is (= true (:disabled attrs))
+          "Cascade button is disabled")
+      (is (= "true" (:aria-disabled attrs))
+          "aria-disabled=true for screen readers")
+      (is (re-find #"Runtime-only" (or (:title attrs) ""))
+          "tooltip surfaces 'Runtime-only' message"))))
+
+;; -------------------------------------------------------------------------
+;; (9) Sim placeholder
+;; -------------------------------------------------------------------------
+
+(deftest sim-mode-renders-placeholder-card
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (frame-dispatch [:rf.causa.static.machines/set-sub-mode :m/a :sim])
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)
+          card (find-by-testid tree "rf-causa-static-machines-sim-placeholder")]
+      (is (some? card) "Sim placeholder mounts")
+      (is (re-find #"rf2-r4nao" (text-nodes card))
+          "placeholder names the follow-on bead id"))))
+
+;; -------------------------------------------------------------------------
+;; (10) Instances JUMP — verify dispatches land
+;; -------------------------------------------------------------------------
+
+(deftest instances-jump-flips-mode-tab-and-selection
+  (testing "Calling the JUMP fn dispatches the three events. Verifies
+            the post-dispatch state in app-db."
+    (causa-setup!)
+    (seed-machines! [:m/a :m/b])
+    ;; Start from a known state — :static + :events + nothing selected.
+    (frame-dispatch [:rf.causa/set-mode :static])
+    (frame-dispatch [:rf.causa/select-tab :events])
+    (rf/with-frame :rf/causa
+      (is (= :static (frame-sub [:rf.causa/mode])))
+      (is (= :events (frame-sub [:rf.causa/selected-tab]))))
+    ;; Fire the JUMP via the dispatcher helper. Three dispatches land.
+    ;; Use the sync variant so post-dispatch assertions can read the
+    ;; new slots without an event-queue flush.
+    (rf/with-frame :rf/causa
+      (jump/dispatch-jump-sync! :m/b))
+    (rf/with-frame :rf/causa
+      (is (= :runtime (frame-sub [:rf.causa/mode]))
+          ":rf.causa/set-mode :runtime fired")
+      (is (= :machines (frame-sub [:rf.causa/selected-tab]))
+          ":rf.causa/select-tab :machines fired")
+      (is (= :m/b (frame-sub [:rf.causa/selected-machine-id]))
+          ":rf.causa/select-machine-id <mid> fired"))))
+
+;; -------------------------------------------------------------------------
+;; (11) Topology mode — chart mounts when a definition is present
+;; -------------------------------------------------------------------------
+
+(deftest topology-mode-mounts-chart-when-definition-present
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  (seed-definitions! {:m/a {:initial :idle
+                            :states  {:idle {} :done {}}}})
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-machines-topology"))
+          "Topology mode mounts as the default body")
+      (is (some? (find-by-testid tree "rf-causa-static-machines-topology-chart"))
+          "chart wrapper mounts")
+      ;; The SVG itself is rendered by chart-svg/render with the testid
+      ;; we passed in.
+      (is (some? (find-by-testid tree "rf-causa-static-machines-topology-svg"))
+          "SVG primitive mounts"))))
+
+(deftest topology-mode-shows-no-definition-hint-when-missing
+  (causa-setup!)
+  (seed-machines! [:m/a])
+  ;; No definition seeded — machine-definitions sub returns {}
+  (seed-definitions! {})
+  (rf/with-frame :rf/causa
+    (let [tree (panel/panel)]
+      (is (some? (find-by-testid tree
+                                 "rf-causa-static-machines-topology-no-definition"))))))
+
+;; -------------------------------------------------------------------------
+;; (12) Public install — install-fx + hydrate
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs-and-events
+  (testing "install! is called transitively via register-causa-handlers!
+            so the subs + events are registered after setup"
+    (causa-setup!)
+    ;; Every key sub resolves without throwing.
+    (is (= "" (frame-sub [:rf.causa.static.machines/search])))
+    (is (= :name (frame-sub [:rf.causa.static.machines/sort-key])))
+    (is (= :topology (frame-sub [:rf.causa.static.machines/sub-mode :any/id])))))
+
+;; -------------------------------------------------------------------------
+;; (13) Tab inventory still names the bead
+;; -------------------------------------------------------------------------
+
+(deftest static-tab-inventory-machines-bead
+  (testing "the :machines tab still carries its bead id even after the
+            placeholder is replaced by the live panel"
+    (is (= "rf2-o5f5f.2"
+           (-> (some #(when (= :machines (:id %)) %)
+                     static-shell/tabs)
+               :placeholder-bead)))))

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -293,8 +293,9 @@
   "Static tab ids that have a real panel installed — the placeholder
   card for these tabs is no longer rendered. Sibling beads tick one
   off each time they land."
-  ;; rf2-o5f5f.3 — :routes now mounts the Static Routes panel.
-  #{:routes})
+  ;; rf2-o5f5f.2 — :machines mounts the Static Machines panel.
+  ;; rf2-o5f5f.3 — :routes   mounts the Static Routes panel.
+  #{:machines :routes})
 
 (deftest static-placeholder-cards-name-sibling-bead
   (testing "each placeholder card surfaces its sibling-bead id
@@ -314,6 +315,18 @@
               (str "card text names a sibling bead id (got: " text ")"))
           (is (re-find #"will fill this" text)
               "card mentions 'will fill this'"))))))
+
+(deftest static-machines-mounts-live-panel-not-placeholder
+  (testing "rf2-o5f5f.2 — the :machines sub-tab mounts the live Static
+            Machines panel (replaces the placeholder card)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (frame-dispatch [:rf.causa.static/select-tab :machines])
+      (let [tree (static-shell/surface)]
+        (is (some? (find-by-testid tree "rf-causa-static-machines-panel"))
+            "live Machines panel mounts")
+        (is (nil? (find-by-testid tree "rf-causa-static-placeholder-machines"))
+            "placeholder card no longer renders for :machines")))))
 
 ;; -------------------------------------------------------------------------
 ;; (5) Static tab routing — selection + isolation


### PR DESCRIPTION
## Summary

Replaces the rf2-o5f5f.1 placeholder card for the Static `:machines` tab with a live master-detail surface.

- **L4-left** (~280px): browse-all list of registered machines (one row per `(rf/machines)` entry) with incremental case-insensitive search, sort cycle (Name/States/Live), per-row source-coord chip + state count + live-instance pip cluster (cap 12) + `→ Runtime` JUMP chip. Selection persists to localStorage `causa.static.machines.selected-id`.
- **L4-right**: definition header (`machine-id · source-coord ↗ · N states · M live`) + 4-mode sub-strip `[Topology][Sim][Instances][Cascade]`.
  - Topology = default, mounts the same `chart/svg` primitive the Runtime panel uses (single implementation per findings §5.1) with NO `:highlight-id` (Static is event-INDEPENDENT — no active state to spotlight).
  - Sim = placeholder pending sibling rf2-r4nao (no `:require` on any `sim.cljs` — the two beads' merges stay decoupled).
  - Instances = JUMP affordance: dispatches `set-mode :runtime` + `select-tab :machines` + `select-machine-id`. Centralised in `instances_jump.cljs` so the browse-list row chip + right-pane pill share one dispatcher.
  - Cascade = greyed + tooltip "Cancellation cascade is a Runtime-only surface. Switch to Runtime mode to view." (button is `disabled` + `aria-disabled=true`).
  - Per-machine sub-mode persists to localStorage `causa.static.machines.sub-mode-by-id`.

## File map

New under `tools/causa/src/.../static/machines/`:
- `panel.cljs` (registers subs/events/fxs + master-detail layout)
- `browse_list.cljs` (left pane)
- `definition_detail.cljs` (right pane + sub-strip)
- `topology.cljs`, `sim_placeholder.cljs`, `instances_jump.cljs`, `cascade_dimmed.cljs`
- `persistence.cljs` (LS round-trip + hydrate)
- `helpers.cljc` (pure-data projection + sort + search + sub-mode normalisation)

Tests:
- `helpers_test.cljc` (JVM + CLJS)
- `panel_cljs_test.cljs`, `browse_list_cljs_test.cljs`

Hot-zone edits (`:machines` branch only — no overlap with rf2-o5f5f.3 sibling):
- `static/shell.cljs` — wire `[static-machines/panel]` into the L4 dispatch
- `registry.cljs` — `(static-machines-panel/install!)` after `machine-inspector/install!` so the `:rf.causa/registered-machines` + `machine-definitions` + `machine-snapshots` subs already exist
- `registry_cljs_test.cljs` + `shell_cljs_test.cljs` — snapshot updates + new live-mount assertion

## Decisions / scope notes

- **Cross-frame instance counting is single-frame for v1.** The bead's §Browse-all list calls for cross-frame sum (Q14 worker lean); the realistic v1 reads the target-frame's `:rf/machines` snapshots (count 0 or 1) and the helper signature accepts a `snapshots` map so a future multi-frame walker can feed the same projection without changing the row shape. Marked as follow-on in `helpers.cljc`.
- **Mode B/C auto-detect** lives in the future Runtime panel; the Static JUMP just lands the selection. The post-collapse Runtime Machines panel runs event-driven; `:rf.causa/selected-machine-id` drives the Sim engine + share-URL today.
- **Mnemonics** (`t/s/i/c`) are surfaced in each pill's `title` for muscle-memory consistency. The keybinding wiring is follow-on per the bead's explicit deferral.
- **Topology metadata rail** (incoming/outgoing edges + source-coord chip on click) — the click handler is wired (`:rf.causa.static.machines/state-clicked`); the rail itself rides a follow-on bead.
- **Definition-stale post-reload chip** — scaffold is in place (the `machine-definitions` sub fires on hot-reload so the chart re-renders); the visible chip rides a follow-on bead.

## Test plan

- [x] `npm run test:cljs` — 2982 tests / 8611 assertions / 0 failures
- [x] `npm run test:bundle-isolation` — production bundles unchanged (tools stay isolated)
- [x] JVM `clojure -M:test` from `tools/causa/` — 740 tests / 2185 assertions / 0 failures (helpers `.cljc` runs under JVM)
- [ ] Browser smoke (Playwright) — not run; relies on `npm run test:browser` which needs Playwright installed. Topology + JUMP coverage is sound via CLJS hiccup walk.

## Stacks on

This PR rebases on **`main`** (rf2-o5f5f.1 has merged via #1565). Parallel sibling rf2-o5f5f.3 (Routes) touches the same `static/shell.cljs` `:routes` branch — trivial merge in the `cond` (~5 lines) whichever lands first.