### PR TITLE
feat(causa): font-relative type scale via --rf-causa-font-size CSS var (rf2-n8i2c)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -383,10 +383,14 @@
   (str
     ;; Root-level CSS custom-property defaults. The motion-scale is
     ;; the single seam every downstream animation reads through; the
-    ;; accent var is published for host stylesheets too (per
-    ;; config/default-accent-css-var).
+    ;; font-size knob (rf2-n8i2c) anchors the entire type scale —
+    ;; every `type-scale` entry resolves as
+    ;; `calc(var(--rf-causa-font-size, 13px) * <multiplier>)` so
+    ;; overriding the knob at `:root` (host stylesheet or DevTools)
+    ;; rescales the whole UI in lockstep.
     ":root {\n"
     "  --rf-causa-motion-scale: 1;\n"
+    "  " tokens/font-size-var-name ": " tokens/font-size-default ";\n"
     "}\n"
     ;; rf2-5kfxe.5 — reduced-motion override. Single rule, every
     ;; downstream calc(…ms * var(--rf-causa-motion-scale, 1)) collapses

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -216,8 +216,75 @@
   `local()` defaults."
   "Fraunces, ui-serif, Georgia, Cambria, Times, serif")
 
+(def font-size-var-name
+  "CSS custom-property name the whole type-scale interpolates through
+  (rf2-n8i2c). `theme/global-styles/motion-css` publishes a default
+  value of `13px` on `:root`; host pages, the settings panel's
+  density slider, or DevTools overrides can swap the value and the
+  entire shell's type rescales in lockstep.
+
+  Modelled on TanStack Query Devtools' `--tsqd-font-size` knob — one
+  variable, every size derived via `calc()` with relative multipliers.
+  The 357 inline-style call sites that read `(:body type-scale)`
+  continue to resolve to a CSS string; the browser does the
+  multiplication at paint time, so changing `:root { --rf-causa-font-
+  size: 16px }` rescales every typographic surface ~1.23x without a
+  code change."
+  "--rf-causa-font-size")
+
+(def font-size-default
+  "Default value of `--rf-causa-font-size` published on `:root` by
+  `theme/global-styles/motion-css`. This is the historical Causa
+  baseline (`:body` = 13px); the per-key multipliers below are
+  expressed RELATIVE to it (e.g. `:caption` = 0.85 → ~11px at the
+  default knob).
+
+  Catalogued here rather than only in the CSS string so the JVM
+  side has the literal default for tests / inspection without
+  parsing a calc() expression."
+  "13px")
+
+(def type-scale-multipliers
+  "Pure-data multipliers used to derive each `type-scale` entry from
+  the `--rf-causa-font-size` knob. Catalogued separately from the
+  emitted calc-strings so tests can assert the relationship without
+  re-parsing a CSS expression.
+
+  Each multiplier expresses the entry's size as a fraction of the
+  CSS-variable default. Anchored on `:body = 1.0`:
+
+  - `:display`     1.077  — panel titles (~14px at the 13px default)
+  - `:body`        1.000  — default UI text (the anchor)
+  - `:body-tight`  0.923  — sidebar entries, header chrome (~12px)
+  - `:mono-body`   0.923  — code, EDN (~12px)
+  - `:caption`     0.846  — hints, secondary labels (~11px)
+  - `:micro`       0.769  — badges, tabs (~10px; spec's refused floor)
+
+  Multipliers chosen so the emitted calc-strings round to the same
+  pixel values the previous fixed-px table shipped — no perceptual
+  shift at the default knob; downstream rescales are uniform."
+  {:display     1.077
+   :body        1.0
+   :body-tight  0.923
+   :mono-body   0.923
+   :caption     0.846
+   :micro       0.769})
+
+(defn font-size-css
+  "Build the canonical `calc(var(--rf-causa-font-size, 13px) * N)`
+  CSS string each `type-scale` entry uses. One knob — change `:root
+  { --rf-causa-font-size: 16px }` and every derived size rescales
+  in lockstep.
+
+  Pure data → string; JVM-portable so the .cljc test surface
+  exercises the calc shape on the JVM runner."
+  [multiplier]
+  (str "calc(var(" font-size-var-name ", " font-size-default ") * "
+       multiplier ")"))
+
 (def type-scale
-  "Causa shell typography sizes (rf2-pcitk).
+  "Causa shell typography sizes (rf2-pcitk + rf2-n8i2c font-size-var
+  migration).
 
   Causa is an info-dense dev surface. Mike's UX session against the
   testbed flagged the cosy baseline (body 14 / mono 13 / line-height
@@ -226,23 +293,39 @@
   tightens line-height to 1.35, which is the readability floor for
   monospaced data dumps.
 
+  ## One knob, whole scale (rf2-n8i2c)
+
+  Every size below resolves through the `--rf-causa-font-size` CSS
+  custom property (default `13px`, published on `:root` by
+  `theme/global-styles/motion-css`). Each entry is
+  `calc(var(--rf-causa-font-size, 13px) * <multiplier>)` where the
+  multiplier expresses the entry's RELATIVE size — `:body` is the
+  1.0 anchor, `:display` is 1.077, `:caption` is 0.846, and so on.
+
+  Modelled on TanStack Query Devtools' `--tsqd-font-size` knob: one
+  variable scales the entire UI. Override `--rf-causa-font-size` at
+  `:root` (or under a `.rf-causa-density-compact` / `-comfy` class
+  toggle once wired) and every typographic surface rescales together
+  without a single code change.
+
   spec/007-UX-IA.md §Typography catalogues the cosy baseline and a
-  ±1px density knob (compact/cosy/comfy). Rather than wire the
-  runtime density toggle now (a later v1.0 styling-pass bead), we
-  ship the denser scale as the default — closer to compact, but with
-  a few intermediate values that suit Causa's layout. Raise every
-  value 1px to revert to spec-cosy.
+  ±1px density knob (compact/cosy/comfy). The runtime density
+  toggle plumb-through lands as a follow-on; this commit ships the
+  CSS-variable foundation it builds on.
 
   Values are CSS strings so call sites can drop them straight into
-  inline `:style` maps without unit conversion."
+  inline `:style` maps. The browser resolves `calc(var(--…) * N)`
+  at paint time, so the knob takes effect on the next style flush
+  without a re-render."
   {;; Headings + prose
-   :display      "14px"     ; was 16 — panel titles
-   :body         "13px"     ; was 14 — default UI text
-   :body-tight   "12px"     ; sidebar entries, header chrome
-   :mono-body    "12px"     ; was 13 — code, EDN
-   :caption      "11px"     ; was 12 — hints, secondary labels
-   :micro        "10px"     ; was 11 — badges, tabs (refused-floor in spec is 10)
-   ;; Vertical rhythm
+   :display      (font-size-css (:display     type-scale-multipliers))
+   :body         (font-size-css (:body        type-scale-multipliers))
+   :body-tight   (font-size-css (:body-tight  type-scale-multipliers))
+   :mono-body    (font-size-css (:mono-body   type-scale-multipliers))
+   :caption      (font-size-css (:caption     type-scale-multipliers))
+   :micro        (font-size-css (:micro       type-scale-multipliers))
+   ;; Vertical rhythm — unitless ratios, unchanged by the font-size
+   ;; knob (line-height naturally scales with the resolved font-size).
    :line-height-tight 1.35   ; was 1.5 — denser blocks
    :line-height-mono  1.4    ; mono needs a touch more leading for ascender clearance
    })

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -121,6 +121,19 @@
     (let [css @#'gs/motion-css]
       (is (re-find #":root\s*\{[^}]*--rf-causa-motion-scale:\s*1" css)))))
 
+;; ---- rf2-n8i2c — font-size CSS var on :root ----------------------------
+
+(deftest motion-css-publishes-font-size-default-on-root
+  (testing "rf2-n8i2c — `:root` carries `--rf-causa-font-size: 13px`
+            as the type-scale anchor. Every entry in `tokens/type-
+            scale` resolves as `calc(var(--rf-causa-font-size, 13px)
+            * <multiplier>)` so overriding this one variable rescales
+            the entire shell in lockstep — same single-knob discipline
+            TanStack Query Devtools uses (`--tsqd-font-size`)."
+    (let [css @#'gs/motion-css]
+      (is (re-find #":root\s*\{[^}]*--rf-causa-font-size:\s*13px" css)
+          "root block carries the --rf-causa-font-size default"))))
+
 (deftest motion-css-declares-prefers-reduced-motion-override
   (testing "rf2-5kfxe.5 — under `prefers-reduced-motion: reduce` the
             `:root` motion-scale is overridden so every downstream

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -173,3 +173,93 @@
     (is (re-find #"Georgia" t/display-stack))
     (is (re-find #"serif$" t/display-stack)
         "the chain terminates at the generic `serif` family")))
+
+;; ---- rf2-n8i2c — font-size CSS var anchor ------------------------------
+
+(deftest font-size-var-name-matches-css-publication
+  (testing "rf2-n8i2c — `font-size-var-name` is the CSS custom property
+            that `theme/global-styles/motion-css` publishes on `:root`.
+            One knob — change it and every `type-scale` entry rescales
+            in lockstep."
+    (is (= "--rf-causa-font-size" t/font-size-var-name))))
+
+(deftest font-size-default-is-the-causa-baseline
+  (testing "rf2-n8i2c — the default knob value is the historical
+            `:body` size (13px). All multipliers are expressed
+            RELATIVE to this so the emitted pixel sizes match the
+            pre-migration fixed-px table at the default."
+    (is (= "13px" t/font-size-default))))
+
+(deftest type-scale-multipliers-anchor-body-at-one
+  (testing "rf2-n8i2c — `:body` is the 1.0 anchor; every other size
+            is a fraction of it. Display rises slightly above; mono,
+            caption, micro fall below."
+    (is (= 1.0 (:body t/type-scale-multipliers)))
+    (is (> (:display t/type-scale-multipliers) 1.0))
+    (is (< (:caption t/type-scale-multipliers) 1.0))
+    (is (< (:micro   t/type-scale-multipliers) 1.0))))
+
+(deftest type-scale-keys-stable
+  (testing "rf2-n8i2c — the migration changes VALUES (fixed px →
+            calc-strings) not KEYS. Every existing call site that
+            reads `(:body type-scale)` continues to resolve."
+    (let [expected #{:display :body :body-tight :mono-body :caption :micro
+                     :line-height-tight :line-height-mono}]
+      (is (= expected (set (keys t/type-scale)))))))
+
+(deftest type-scale-font-size-entries-are-calc-strings
+  (testing "rf2-n8i2c — every typographic size resolves through
+            `calc(var(--rf-causa-font-size, 13px) * <multiplier>)`
+            so a single `:root` override rescales the entire shell."
+    (doseq [k [:display :body :body-tight :mono-body :caption :micro]]
+      (let [v (get t/type-scale k)]
+        (is (string? v) (str k " is a CSS string"))
+        (is (re-find #"^calc\(" v)
+            (str k " starts with calc("))
+        (is (re-find #"var\(--rf-causa-font-size,\s*13px\)" v)
+            (str k " references the --rf-causa-font-size knob with
+                  the 13px fallback so unstyled consumers (no install
+                  of theme/global-styles) still see the baseline"))
+        (is (re-find #"\*\s*[0-9.]+\)" v)
+            (str k " carries a numeric multiplier so the relative
+                  scale is preserved across knob overrides"))))))
+
+(deftest type-scale-line-height-stays-unitless
+  (testing "rf2-n8i2c — line-height values are unitless ratios. They
+            scale with the resolved font-size automatically; the
+            calc-string migration is for absolute sizes only."
+    (is (= 1.35 (:line-height-tight t/type-scale)))
+    (is (= 1.4  (:line-height-mono  t/type-scale)))))
+
+(deftest font-size-css-builds-calc-with-var-and-fallback
+  (testing "rf2-n8i2c — `font-size-css` is the pure-data helper that
+            shapes each calc-string. Consumers (the `type-scale`
+            map) pipe their multiplier through it so the var name +
+            fallback default stay one source of truth.
+
+            The numeric literal is stringified by the host runtime
+            (`1.0` → `1` on CLJS, `1.0` on the JVM). We assert the
+            shape via regex rather than strict equality so both
+            runtimes pass."
+    (let [css (t/font-size-css 1.0)]
+      (is (string? css))
+      (is (re-find #"^calc\(var\(--rf-causa-font-size,\s*13px\)\s*\*\s*1(\.0+)?\)$" css)))))
+
+(deftest font-size-css-respects-distinct-multipliers
+  (testing "different multipliers produce distinct calc-strings —
+            the relative scale is preserved across the type table."
+    (let [body    (t/font-size-css (:body    t/type-scale-multipliers))
+          display (t/font-size-css (:display t/type-scale-multipliers))
+          caption (t/font-size-css (:caption t/type-scale-multipliers))]
+      (is (not= body display))
+      (is (not= body caption))
+      (is (not= display caption)))))
+
+(deftest type-scale-uses-font-size-css-helper
+  (testing "rf2-n8i2c — every size entry in `type-scale` is the
+            output of `font-size-css` applied to the matching
+            multiplier. Asserts the indirection is the only path to
+            the calc-string (no fixed-px regressions)."
+    (doseq [[k mult] t/type-scale-multipliers]
+      (is (= (t/font-size-css mult) (get t/type-scale k))
+          (str k " is font-size-css of its multiplier")))))


### PR DESCRIPTION
## Summary

- `tools/causa/src/.../theme/tokens.cljc` `type-scale` entries become `calc(var(--rf-causa-font-size, 13px) * <multiplier>)` — one knob now rescales every typographic surface in lockstep.
- `tools/causa/src/.../theme/global_styles.cljs` publishes `--rf-causa-font-size: 13px` on `:root` alongside the existing `--rf-causa-motion-scale` seam.
- New helper surface in `tokens.cljc` (`font-size-var-name` / `font-size-default` / `type-scale-multipliers` / `font-size-css`) keeps the var name + default + per-entry multiplier as one source of truth.

## Why

Audit `ai/findings/2026-05-19-causa-js-devtools-lessons.md` flagged TanStack Query Devtools' `--tsqd-font-size` knob — every entry derived via `calc(var(--tsqd-font-size) * N)`. Causa shipped fixed-px values so a UI rescale needed a code change. This commit lifts the foundation; the optional density-slider plumb-through is deferred to a follow-on bead (the existing density radio drives Views row-padding + App-db line-height, not font-size — conflating axes in this PR risked scope creep).

## What carries through

- The 357 inline-style call sites that read `(:body type-scale)` continue to resolve to a CSS string. The browser does the multiplication at paint time; no consumer needs touching.
- Multipliers chosen so emitted pixel sizes match the previous fixed-px table at the default — no perceptual shift; rescales are uniform.
- `:line-height-*` entries stay unitless ratios (they scale with the resolved font-size automatically).

## Test plan

- [x] `clojure -M:test` in `tools/causa/` — 731 tests / 2197 assertions / 0 failures
- [x] `npm run test:cljs` in `implementation/` — 2987 tests / 8662 assertions / 0 failures
- [x] `npm run test:bundle-isolation` — bundle-isolation + uix-helix-reagent-free both pass
- [x] New tests assert calc-string shape (per entry + helper round-trip) + `:root` publication of `--rf-causa-font-size: 13px` in `motion-css`
- [ ] Visual smoke (covered by reviewer): open Causa, override `:root { --rf-causa-font-size: 16px }` in DevTools — entire shell scales ~1.23x; smaller value shrinks.

## Follow-on

Wire the existing settings-panel density radio (Cosy/Compact) to also write `--rf-causa-font-size` so the runtime density slider takes the lockstep rescale path. Files separately.