### PR TITLE
feat(causa): Cmd-K palette — mode-aware commands + recents + motion override (rf2-ybjkx)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -769,7 +769,19 @@
                :density                :cosy           ; #{:cosy :compact}
                :show-tool-frames?      false
                :show-ungrouped?        false           ; rf2-r9lyy opt-in pseudo-cascade surface
-               :long-keyword-threshold 24}
+               :long-keyword-threshold 24
+               ;; rf2-ybjkx — user-side override of the OS-level
+               ;; `prefers-reduced-motion: reduce` media query. Three
+               ;; values:
+               ;;   :os      — defer to the OS pref (the historic
+               ;;              behaviour; CSS media query alone)
+               ;;   :always  — force reduced motion regardless of OS
+               ;;   :never   — force full motion regardless of OS
+               ;; Drives the `rf-causa-motion-override-{always,never}`
+               ;; body class which `theme/global-styles/motion-css`
+               ;; reads to override the media-query-derived
+               ;; `--rf-causa-motion-scale`.
+               :reduced-motion-override :os}
    :theme     :dark                                  ; :dark | :light
    :diff      {:highlight-fn-ref-changes? false}
    :buffer    {:retained-epochs                    200

--- a/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
@@ -30,7 +30,10 @@
   dispatcher of a single uniform event id."
   (:require [goog.object :as gobj]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
+            [day8.re-frame2-causa.palette.recents :as recents]
             [day8.re-frame2-causa.palette.sources :as sources]))
 
 ;; ---- effect: mount-level pop-out -----------------------------------------
@@ -90,6 +93,78 @@
       (assoc :palette-query "")
       (reset-cursor)))
 
+;; ---- rf2-ybjkx — recents ------------------------------------------------
+
+(defn- record-recent
+  "Pure reducer. Update `db`'s `:palette-recents` slot to put
+  `command-id` at the head (dedup'd, capped). Returns the new db.
+  No-op for nil ids."
+  [db command-id]
+  (if (nil? command-id)
+    db
+    (assoc db :palette-recents
+              (recents/record (get db :palette-recents []) command-id))))
+
+;; ---- rf2-ybjkx — snapshot app-db ---------------------------------------
+;;
+;; Snapshot the focused frame's app-db onto the JS console as a single
+;; `console.log(value)` call. Side effect; never blocks. Reads the
+;; focused frame via Causa's app-db `:target-frame` slot (the frame
+;; the user picked in the L1 frame-picker) — defaulting to `:rf/default`
+;; when unset. We also try to copy a pretty-printed EDN string to the
+;; clipboard via `navigator.clipboard.writeText` when available so the
+;; user can paste into a teammate's chat / a gist. Clipboard writes
+;; can reject (insecure context, no permission); we swallow the throw
+;; so the console log lands either way.
+
+(defn- snapshot-app-db!
+  "Side-effect: drop `(rf/get-frame-db target-frame)` onto the JS
+  console and copy a pr-str of it to the clipboard when reachable.
+  No-op when neither console nor clipboard is present (test
+  runtimes). Returns nil."
+  [target-frame]
+  (try
+    (let [tf  (or target-frame :rf/default)
+          db  (when (some? (frame/frame tf))
+                (rf/get-frame-db tf))
+          tag (str "[rf2-causa] palette snapshot · frame "
+                   (pr-str tf))]
+      (when (and (exists? js/console) (.-log js/console))
+        (try
+          (.log js/console tag db)
+          (catch :default _ nil)))
+      (when (and (exists? js/navigator)
+                 (.-clipboard js/navigator)
+                 (.-writeText (.-clipboard js/navigator)))
+        (try
+          (.writeText (.-clipboard js/navigator) (pr-str db))
+          (catch :default _ nil))))
+    (catch :default _ nil))
+  nil)
+
+;; ---- rf2-ybjkx — theme cycle -------------------------------------------
+
+(defn- next-theme
+  "Pure helper. Cycle `:dark → :light → :dark`. Anything unknown lands
+  on `:dark` (the canonical default per `config/default-settings`)."
+  [current]
+  (case current
+    :dark  :light
+    :light :dark
+    :dark))
+
+;; ---- rf2-ybjkx — reduced-motion cycle ----------------------------------
+
+(defn- next-motion-override
+  "Pure helper. Cycle `:os → :always → :never → :os`. Unknown lands on
+  `:os` (the conservative default)."
+  [current]
+  (case current
+    :os      :always
+    :always  :never
+    :never   :os
+    :os))
+
 ;; ---- install --------------------------------------------------------------
 
 (defn install!
@@ -102,14 +177,38 @@
 
   (rf/reg-fx :rf.causa.palette.fx/popout popout-fx!)
 
+  ;; rf2-ybjkx — snapshot app-db fx. Side-effect handler; reads the
+  ;; focused frame's db and ships it to the JS console + clipboard.
+  ;; Late-bound through the framework's `frame/frame` registry so a
+  ;; nil-frame ctx is a silent no-op rather than a throw.
+  (rf/reg-fx :rf.causa.palette.fx/snapshot-app-db
+    (fn [_ctx {:keys [target-frame]}]
+      (snapshot-app-db! target-frame)))
+
+  ;; rf2-ybjkx — recents persistence fx. The pure reducer writes the
+  ;; vector into app-db; this fx mirrors the same vector into
+  ;; localStorage so a reload surfaces the user's recents. Best-effort
+  ;; — `recents/save!` swallows quota / availability failures.
+  (rf/reg-fx :rf.causa.palette.fx/persist-recents
+    (fn [_ctx recents-vec]
+      (recents/save! recents-vec)))
+
   ;; ---- open / close / toggle --------------------------------------------
+  ;;
+  ;; rf2-ybjkx — on open we ensure the `:palette-recents` slot is
+  ;; seeded from localStorage. Open is rare (user-driven keystroke)
+  ;; so the load cost is negligible; lazy-seed means we don't have to
+  ;; thread a preload hook through every test that drives the registry.
 
   (rf/reg-event-db :rf.causa/palette-open
     (fn [db _event]
-      (-> db
-          (assoc :palette-open? true)
-          (assoc :palette-query "")
-          (reset-cursor))))
+      (let [seeded (if (contains? db :palette-recents)
+                     db
+                     (assoc db :palette-recents (recents/load)))]
+        (-> seeded
+            (assoc :palette-open? true)
+            (assoc :palette-query "")
+            (reset-cursor)))))
 
   (rf/reg-event-db :rf.causa/palette-close
     (fn [db _event]
@@ -119,10 +218,13 @@
     (fn [db _event]
       (if (get db :palette-open? false)
         (close-palette db)
-        (-> db
-            (assoc :palette-open? true)
-            (assoc :palette-query "")
-            (reset-cursor)))))
+        (let [seeded (if (contains? db :palette-recents)
+                       db
+                       (assoc db :palette-recents (recents/load)))]
+          (-> seeded
+              (assoc :palette-open? true)
+              (assoc :palette-query "")
+              (reset-cursor))))))
 
   ;; ---- query / cursor ---------------------------------------------------
 
@@ -160,24 +262,49 @@
   (rf/reg-event-fx :rf.causa/palette-invoke
     (fn [{:keys [db]} [_ item popout?]]
       (let [[verb & args]    (:action item)
-            close-db         (close-palette db)
+            ;; rf2-ybjkx — record recents for `:command` source items
+            ;; only. Panels / frames / handlers / settings already
+            ;; have their own recency surface (the recent-event source
+            ;; and the user's session memory); the palette's recents
+            ;; track command verbs.
+            recent-id        (when (= :command (:source item)) (:id item))
+            db-with-recent   (record-recent db recent-id)
+            close-db         (close-palette db-with-recent)
             ;; Pop-out is gated on the item's own opt-in (per
             ;; sources/popoutable?) — Ctrl+Enter on a non-popoutable
             ;; item invokes normally so the user never gets surprised
             ;; with a no-op.
             popout-now?      (and popout? (sources/popoutable? item))
+            ;; rf2-ybjkx — persist the recents vector on every command
+            ;; invoke so the next session surfaces the user's history.
+            ;; Pure recents reads (no command invoked) skip this.
             base-fx          (cond-> []
                                popout-now?
-                               (conj [:rf.causa.palette.fx/popout {}]))]
+                               (conj [:rf.causa.palette.fx/popout {}])
+                               (some? recent-id)
+                               (conj [:rf.causa.palette.fx/persist-recents
+                                      (get db-with-recent :palette-recents)]))]
         (case verb
           :palette/select-panel
-          ;; Panel ids in `palette-panels` are the 6 L3 tab ids per
+          ;; Panel ids in `palette-panels` are the 7 L3 tab ids per
           ;; spec/018 §5 (rf2-qy0nu trimmed the 14-id legacy list).
           ;; Dispatch into `:rf.causa/select-tab` so the visible tab
           ;; flips; the legacy `:rf.causa/select-panel` slot is no
           ;; longer read by the 4-layer shell.
           {:db close-db
            :fx (conj base-fx [:dispatch [:rf.causa/select-tab (first args)]])}
+
+          :palette/select-static-tab
+          ;; rf2-ybjkx — Static-mode L3 tab jump. Routes through
+          ;; `:rf.causa.static/select-tab` (the Static-scoped tab slot
+          ;; that the static shell's tab-bar reads). The dispatch is
+          ;; safe even when `:experimental/static-mode?` is OFF — the
+          ;; event handler is registered regardless; the surface
+          ;; composer just doesn't read the slot until the flag flips
+          ;; on. The palette filter prevents Static jumps from
+          ;; surfacing in Runtime mode in the first place.
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa.static/select-tab (first args)]])}
 
           :palette/select-event
           ;; Future: route to event-detail with the event pre-
@@ -191,12 +318,16 @@
            :fx base-fx}
 
           :palette/select-frame
-          ;; Frame focus is a Causa-side annotation today (rf2-wm7z4
-          ;; Phase 1 — frame picker UI lives at the top strip per
-          ;; spec/007-UX-IA.md). Store the choice; a follow-on bead
-          ;; wires the picker UI to read it.
-          {:db (assoc close-db :selected-target-frame (first args))
-           :fx base-fx}
+          ;; rf2-ybjkx — drive the frame-picker spine event so the
+          ;; user's choice flows through every per-frame composite
+          ;; (App-DB Diff, Views, Routing). The pre-bead behaviour
+          ;; just stamped `:selected-target-frame` into Causa's app-db
+          ;; with no plumb-through; this dispatches the canonical
+          ;; `:rf.causa/set-frame` event the L1 frame-picker uses so
+          ;; the palette is wire-compatible with the rest of the
+          ;; chrome.
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/set-frame (first args)]])}
 
           :palette/inspect-handler
           ;; Phase 1: route to a Causa-side store of the inspected
@@ -227,16 +358,87 @@
             {:db close-db
              :fx base-fx})
 
+          :palette/clear-epoch-history
+          ;; rf2-ybjkx — drop Causa's epoch ring. The slot lives in
+          ;; Causa's app-db at `:epoch-history`; clearing it lets the
+          ;; user start a fresh session without restarting the host
+          ;; app. App-DB Diff + Views read off this slot so the next
+          ;; epoch lands cleanly.
+          {:db (dissoc close-db :epoch-history)
+           :fx base-fx}
+
           :palette/reset-suppressed-counters
           {:db close-db
            :fx (conj base-fx [:dispatch [:rf.causa/reset-suppressed-counters]])}
 
-          :palette/open-popout
+          :palette/snapshot-app-db
+          ;; rf2-ybjkx — Snapshot the FOCUSED frame's app-db onto the
+          ;; console + clipboard. The focused-frame is the slot the
+          ;; L1 frame-picker writes (`:target-frame`); falling back to
+          ;; `:rf/default` when unset.
           {:db close-db
-           :fx [[:rf.causa.palette.fx/popout {}]]}
+           :fx (conj base-fx
+                     [:rf.causa.palette.fx/snapshot-app-db
+                      {:target-frame
+                       (or (get db-with-recent :target-frame) :rf/default)}])}
+
+          :palette/toggle-theme
+          ;; rf2-ybjkx — flip the Settings popup's theme slot via the
+          ;; existing settings-update event. Routes through the same
+          ;; reducer that the popup's radio uses so the popup's
+          ;; reactive sub re-fires + the localStorage round-trip
+          ;; lands + `apply-theme!` flips the `<html>` class. Reads
+          ;; the current theme from `config/get-setting` (the live
+          ;; atom; the popup-seeded app-db slot mirrors the same
+          ;; value but reading the atom keeps the toggle pure on the
+          ;; cold path — no settings-open prerequisite).
+          {:db close-db
+           :fx (conj base-fx
+                     [:dispatch
+                      [:rf.causa/settings-update :theme nil
+                       (next-theme (config/get-setting :theme nil))]])}
+
+          :palette/cycle-reduced-motion
+          ;; rf2-ybjkx — cycle the user-side reduced-motion override
+          ;; (:os → :always → :never → :os). Routes through the
+          ;; settings-update event so the apply-fn + persist path are
+          ;; the canonical ones — no parallel state.
+          {:db close-db
+           :fx (conj base-fx
+                     [:dispatch
+                      [:rf.causa/settings-update :general
+                       :reduced-motion-override
+                       (next-motion-override
+                         (config/get-setting :general :reduced-motion-override))]])}
+
+          :palette/jump-to-settings
+          ;; rf2-ybjkx — open the Settings popup. Routes through the
+          ;; existing `:rf.causa/settings-open` event so the popup's
+          ;; open path is the canonical one (lifts the atom snapshot
+          ;; into app-db, defaults the active-tab to `:general`).
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/settings-open]])}
+
+          :palette/toggle-mode
+          ;; rf2-ybjkx — flip Runtime ↔ Static. Routes through the
+          ;; existing `:rf.causa/toggle-mode` event (also bound to
+          ;; Cmd/Ctrl+Shift+M). Single source of truth for the
+          ;; mode-flip + persistence side-effect.
+          {:db close-db
+           :fx (conj base-fx [:dispatch [:rf.causa/toggle-mode]])}
+
+          :palette/open-popout
+          ;; The :open-popout verb always pops out — guard against
+          ;; double-fire when the user also held Ctrl/Meta (popout-now?
+          ;; would have appended the popout fx to `base-fx`).
+          {:db close-db
+           :fx (cond-> base-fx
+                 (not popout-now?)
+                 (conj [:rf.causa.palette.fx/popout {}]))}
 
           :palette/close
-          {:db close-db}
+          {:db close-db
+           :fx base-fx}
 
           ;; Unknown verb — close the palette and log to console so
           ;; the dev sees the gap. Never silently swallow.
@@ -245,6 +447,7 @@
               (.warn js/console
                      (str "[rf2-causa] palette: unknown action verb "
                           (pr-str verb))))
-            {:db close-db})))))
+            {:db close-db
+             :fx base-fx})))))
 
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/palette/recents.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/recents.cljs
@@ -1,0 +1,129 @@
+(ns day8.re-frame2-causa.palette.recents
+  "localStorage round-trip for the Causa command palette's
+  last-used-commands list (rf2-ybjkx).
+
+  Per the bead's acceptance contract: the palette persists the top-3
+  recently-invoked commands to localStorage so a reload surfaces the
+  user's recent verbs first. The open-state itself is transient and
+  NEVER persisted — only the recents list.
+
+  ## Shape
+
+  Storage value (raw string — EDN-encoded vector of command ids):
+
+      ;; localStorage value
+      \"[:rf.causa.cmd/toggle-theme :rf.causa.cmd/jump-tab-event ...]\"
+
+  Most-recent-first order. The list is capped at 3 entries (per the
+  bead — top-3 recent). `record!` dedups on identity so re-invoking
+  the same command bubbles it back to position 0 without growing the
+  list.
+
+  ## Why a small bounded list
+
+  Three is the sweet spot Vue DevTools and Linear converge on: enough
+  to surface the user's last meaningful gestures, not so many that the
+  recents block crowds out fresh fuzzy hits. The cap is a `def` so a
+  future tuning bead can flip it without re-touching every call site.
+
+  ## Production posture
+
+  Mirrors `static/persistence.cljs` — `storage-available?` guard so
+  the JVM test path (which loads this ns transitively via the
+  registry) doesn't blow up on classpath load. All writes swallow
+  throws so quota / serialisation failures never poison the dispatch
+  chain that drove the record."
+  (:require [cljs.reader :as reader]))
+
+(def storage-key
+  "Canonical localStorage key for the palette's recents list. Versioned
+  so a future shape change (e.g. carrying timestamps alongside the ids
+  for time-decay weighting) can ignore stale payloads cleanly."
+  "re-frame2.causa.palette.recents.v1")
+
+(def max-recents
+  "Cap on the recents list. Three matches Vue DevTools / Linear /
+  GitHub command palettes — enough to surface the user's recent
+  gestures without crowding fuzzy hits. A `def` so a future tuning
+  bead can flip the cap in one place."
+  3)
+
+;; ---- localStorage helpers -----------------------------------------------
+
+(defn- storage-available?
+  "True when `js/window.localStorage` is reachable. Node test runtimes
+  return false here so the load/save fns no-op silently."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn- read-raw
+  []
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) storage-key)
+      (catch :default _ nil))))
+
+(defn- write-raw!
+  [s]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) storage-key s)
+      (catch :default _ nil)))
+  nil)
+
+(defn clear!
+  "Remove the persisted slot. Test-only — fixtures reset between
+  scenarios."
+  []
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) storage-key)
+      (catch :default _ nil)))
+  nil)
+
+;; ---- public API ---------------------------------------------------------
+
+(defn- sanitise
+  "Drop any non-keyword entries from `v`. The persisted payload is
+  authored by `record!` (keywords only), but a hand-edited storage
+  slot or a stale schema could carry non-keyword garbage; treat the
+  list as best-effort and drop the rest rather than throwing on
+  first paint."
+  [v]
+  (vec (take max-recents (filter keyword? v))))
+
+(defn load
+  "Read the persisted recents list. Always returns a vector of command
+  ids (most-recent-first). Empty vector when the slot is empty, the
+  payload is malformed, or localStorage is unavailable."
+  []
+  (try
+    (if-let [raw (read-raw)]
+      (let [parsed (reader/read-string raw)]
+        (if (sequential? parsed)
+          (sanitise parsed)
+          []))
+      [])
+    (catch :default _ [])))
+
+(defn save!
+  "Persist `recents` (a seq of command ids). Caps at `max-recents`
+  before write so the payload never exceeds the contract."
+  [recents]
+  (write-raw! (pr-str (sanitise recents)))
+  nil)
+
+(defn record
+  "Pure helper. Prepend `command-id` to `current` (a seq of command
+  ids), dedup by identity, cap at `max-recents`. The freshly-invoked
+  command always lands at index 0 — re-invoking an existing recent
+  bubbles it back to the head.
+
+  Returns a vector. Empty / nil `command-id` returns `current`
+  unchanged (no-op for non-recordable invokes)."
+  [current command-id]
+  (if (nil? command-id)
+    (vec current)
+    (let [rest-keep (remove #(= command-id %) (or current []))]
+      (vec (take max-recents (cons command-id rest-keep))))))

--- a/tools/causa/src/day8/re_frame2_causa/palette/sources.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/palette/sources.cljc
@@ -77,9 +77,13 @@
 ;; ---- source builders -----------------------------------------------------
 
 (defn panel-items
-  "One row per sidebar panel. The action dispatches into `:rf/causa`
-  via the wrapping events fn (palette events resolve `[:panel id]`
-  into `[:rf.causa/select-panel id]`)."
+  "One row per Runtime sidebar panel. The action dispatches into
+  `:rf/causa` via the wrapping events fn (palette events resolve
+  `[:panel id]` into `[:rf.causa/select-tab id]`).
+
+  Per rf2-ybjkx each row carries `:modes #{:runtime}` so the mode
+  filter excludes Runtime tab jumps when the palette opens in Static
+  mode. Static-mode tab jumps are produced by `static-tab-items`."
   [panel-entries]
   (mapv
     (fn [{:keys [id label]}]
@@ -90,6 +94,7 @@
        :icon   (icon-table :panel)
        :boost  (boost-table :panel)
        :action [:palette/select-panel id]
+       :modes  #{:runtime}
        :popout? false})
     panel-entries))
 
@@ -136,6 +141,7 @@
               :recency-rank rank
               :boost        (boost-table :recent-event)
               :action       [:palette/select-event ev-id]
+              :modes        #{:runtime}
               :popout?      true}))
          taken)))))
 
@@ -154,6 +160,7 @@
                 :icon   (icon-table :frame)
                 :boost  (boost-table :frame)
                 :action [:palette/select-frame fid]
+                :modes  #{:runtime}
                 :popout? false}))))
 
 (defn handler-items
@@ -180,6 +187,7 @@
                  :icon   (icon-table :handler)
                  :boost  (boost-table :handler)
                  :action [:palette/inspect-handler kind id]
+                 :modes  #{:runtime :static}
                  :popout? true})))))
 
 (defn setting-items
@@ -192,12 +200,52 @@
     :icon   (icon-table :setting)
     :boost  (boost-table :setting)
     :action [:palette/cycle-density]
+    :modes  #{:runtime :static}
     :popout? false}])
 
+;; ---- per-source mode visibility ----------------------------------------
+;;
+;; rf2-ybjkx — mode-aware command surface. Each command carries a
+;; `:modes` set declaring which Causa modes (`:runtime` / `:static`)
+;; surface it. Commands meaningful in both modes (theme toggle,
+;; reduced-motion, jump-to-settings, toggle-mode) carry `#{:runtime
+;; :static}`. Commands that only make sense in one mode (spine clear,
+;; Runtime L4 jumps; Static sub-tab jumps) carry the appropriate
+;; single-mode set.
+;;
+;; The aggregator filters by `:modes` membership when `:mode` is
+;; non-nil in the inputs map; nil mode preserves the pre-bead
+;; behaviour (every command surfaced).
+
 (defn command-items
-  "Causa command verbs (Phase 1 subset). Each carries a stable id +
-  an action dispatch — the events ns owns the actual side-effect
-  fns; the aggregator just describes the choices."
+  "Causa command verbs. Each carries a stable id + an action dispatch
+  (the events ns owns the actual side-effect fns; the aggregator just
+  describes the choices) + a `:modes` set declaring mode visibility
+  per rf2-ybjkx (see §per-source mode visibility above).
+
+  ## Runtime-only verbs
+
+  Trace buffer / suppressed counters / pop-out / select-panel — every
+  Runtime-mode command operates against the event-coupled spine or the
+  4-layer chrome. Static mode is event-INDEPENDENT (per
+  `static/shell.cljs`); these verbs have no meaning there.
+
+  ## Static-only verbs
+
+  Jump-to-static-tab — selects one of the 5 Static L3 tabs (Machines /
+  Routes / Schemas / Views / Events). Static has no spine so the
+  Runtime tab jumps don't apply.
+
+  ## Mode-agnostic verbs (rf2-ybjkx)
+
+  - `:toggle-theme`            — Dark ↔ Light cycle of the theme class.
+  - `:cycle-reduced-motion`    — `:os → :always → :never → :os`.
+  - `:snapshot-app-db`         — Drop the focused frame's app-db onto
+                                 the JS console as a snapshot.
+  - `:jump-to-settings`        — Open the Settings popup at the General
+                                 tab.
+  - `:toggle-mode`             — Flip Runtime ↔ Static (chord parity
+                                 with `Cmd-Shift-M`)."
   []
   [{:source :command
     :id     :clear-trace-buffer
@@ -206,6 +254,16 @@
     :icon   (icon-table :command)
     :boost  (boost-table :command)
     :action [:palette/clear-trace-buffer]
+    :modes  #{:runtime}
+    :popout? false}
+   {:source :command
+    :id     :clear-epoch-history
+    :label  "Clear epoch history"
+    :hint   "drops Causa's epoch snapshots"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/clear-epoch-history]
+    :modes  #{:runtime}
     :popout? false}
    {:source :command
     :id     :reset-suppressed-counters
@@ -214,6 +272,7 @@
     :icon   (icon-table :command)
     :boost  (boost-table :command)
     :action [:palette/reset-suppressed-counters]
+    :modes  #{:runtime}
     :popout? false}
    {:source :command
     :id     :open-popout
@@ -222,6 +281,66 @@
     :icon   (icon-table :command)
     :boost  (boost-table :command)
     :action [:palette/open-popout]
+    :modes  #{:runtime :static}
+    :popout? false}
+   ;; rf2-ybjkx — Snapshot the focused frame's app-db onto the JS
+   ;; console for clipboard capture / share with a teammate.
+   {:source :command
+    :id     :snapshot-app-db
+    :label  "Snapshot app-db"
+    :hint   "→ console.log + clipboard"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/snapshot-app-db]
+    :modes  #{:runtime :static}
+    :popout? false}
+   ;; rf2-ybjkx — Theme toggle. The popup's radio is still the
+   ;; canonical UI; the palette is the keyboard-first ergonomic
+   ;; shortcut.
+   {:source :command
+    :id     :toggle-theme
+    :label  "Toggle theme (dark ↔ light)"
+    :hint   "Settings · Theme"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/toggle-theme]
+    :modes  #{:runtime :static}
+    :popout? false}
+   ;; rf2-ybjkx — Reduced-motion cycle. Three states: `:os` (OS pref
+   ;; alone), `:always` (force reduce), `:never` (force full). Cycles
+   ;; through them so a single command covers every transition.
+   {:source :command
+    :id     :cycle-reduced-motion
+    :label  "Cycle reduced-motion override (OS → always → never)"
+    :hint   "user override of prefers-reduced-motion"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/cycle-reduced-motion]
+    :modes  #{:runtime :static}
+    :popout? false}
+   ;; rf2-ybjkx — Jump to settings. Equivalent to the `,` / `s`
+   ;; bare-key shortcut but available from the palette so the user
+   ;; can fuzzy-find the gesture without leaving the keyboard.
+   {:source :command
+    :id     :jump-to-settings
+    :label  "Jump to Settings"
+    :hint   ","
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/jump-to-settings]
+    :modes  #{:runtime :static}
+    :popout? false}
+   ;; rf2-ybjkx — Toggle Runtime ↔ Static. Chord parity with
+   ;; `Cmd/Ctrl-Shift-M` (see `keybinding.cljs`). Surfaced in BOTH
+   ;; modes — the user can flip in either direction from the palette.
+   {:source :command
+    :id     :toggle-mode
+    :label  "Toggle mode (Runtime ↔ Static)"
+    :hint   "Cmd/Ctrl+Shift+M"
+    :icon   (icon-table :command)
+    :boost  (boost-table :command)
+    :action [:palette/toggle-mode]
+    :modes  #{:runtime :static}
     :popout? false}
    {:source :command
     :id     :close-palette
@@ -230,9 +349,73 @@
     :icon   (icon-table :command)
     :boost  (boost-table :command)
     :action [:palette/close]
+    :modes  #{:runtime :static}
     :popout? false}])
 
+(defn static-tab-items
+  "Static-mode sub-tab jumps (rf2-ybjkx). Five entries mirroring the
+  `static/shell.cljs/tabs` inventory: Machines / Routes / Schemas /
+  Views / Events. Each carries `:modes #{:static}` so the aggregator
+  filters them out when the palette opens in Runtime mode."
+  [static-tab-entries]
+  (mapv
+    (fn [{:keys [id label]}]
+      {:source :panel
+       :id     [:static id]
+       :label  (str "Open " label " (Static)")
+       :hint   (str "static/" (name id))
+       :icon   (icon-table :panel)
+       :boost  (boost-table :panel)
+       :action [:palette/select-static-tab id]
+       :modes  #{:static}
+       :popout? false})
+    static-tab-entries))
+
 ;; ---- aggregator ----------------------------------------------------------
+
+;; ---- recents boosts (rf2-ybjkx) -----------------------------------------
+
+(def recents-boost-max
+  "Max boost applied to the most-recently-used command. Decays linearly
+  with index so position 0 (most recent) gets `recents-boost-max`,
+  position 1 gets `recents-boost-max - recents-boost-step`, …, and
+  positions beyond the recents tail get 0. Sized so the most-recent
+  command outranks a fresh `:command` source item that fuzzy-matches
+  at parity (boost-table `:command` = 40, so 60 = +50% on top — enough
+  for the recent to sort first without dominating a typed query)."
+  60)
+
+(def recents-boost-step
+  "Decay-per-position for the recents boost. With `recents-boost-max =
+  60` and `max-recents = 3` this gives 60 / 40 / 20 for positions 0 /
+  1 / 2."
+  20)
+
+(defn- recents-boost-for-id
+  "Compute the recents boost for `command-id` against the recents
+  vector. Position 0 = `recents-boost-max`; each subsequent position
+  drops by `recents-boost-step`; absent ids get 0."
+  [recents command-id]
+  (let [idx (some (fn [[i v]] (when (= command-id v) i))
+                  (map-indexed vector recents))]
+    (if (nil? idx)
+      0
+      (max 0 (- recents-boost-max (* idx recents-boost-step))))))
+
+;; ---- aggregator ----------------------------------------------------------
+
+(defn- in-mode?
+  "Mode predicate. `:modes` membership filter — nil mode keeps every
+  item (pre-bead behaviour), a non-nil mode keeps only items whose
+  `:modes` set contains it. Items missing `:modes` default to both
+  modes (the legacy contract — every item used to be visible always)."
+  [mode item]
+  (if (nil? mode)
+    true
+    (let [modes (:modes item)]
+      (if (nil? modes)
+        true
+        (contains? modes mode)))))
 
 (defn build-index
   "Build the full searchable index from `inputs`. The result is a
@@ -241,30 +424,67 @@
 
   Inputs map shape:
 
-    {:panels            [{:id kw :label str} ...]
-     :trace-buffer      [trace ...]
-     :frame-ids         (keyword?)
-     :handlers          [{:id :kind :doc :file :line} ...]}
+    {:panels        [{:id kw :label str} ...]    ; Runtime L3 tabs
+     :static-tabs   [{:id kw :label str} ...]    ; Static L3 tabs (rf2-ybjkx)
+     :trace-buffer  [trace ...]
+     :frame-ids     (keyword?)
+     :handlers      [{:id :kind :doc :file :line} ...]
+     :mode          :runtime | :static | nil     ; filter (rf2-ybjkx)
+     :recents       [command-id ...]             ; recents boost (rf2-ybjkx)
+    }
 
   Missing keys default to empty inputs of that kind — partial drives
   (e.g. recency-rank dragons without a populated buffer) are
-  tolerable for the empty-state surface."
+  tolerable for the empty-state surface.
+
+  ## Mode-aware filter (rf2-ybjkx)
+
+  Items declare a `:modes` set; the aggregator drops items whose set
+  doesn't contain `:mode`. nil `:mode` preserves the pre-bead contract
+  (every item surfaced). The filter is applied AFTER source assembly
+  but BEFORE dedup so an item with the same `[:source :id]` in both
+  modes can still surface — but no source emits the same id under
+  both modes today.
+
+  ## Recents boost (rf2-ybjkx)
+
+  Items whose `:source = :command` AND whose `:id` is in `:recents`
+  receive an extra position-decayed boost added to their static
+  `:boost`. The boost is large enough to lift a recently-used command
+  above a fresh fuzzy peer but small enough that a tighter query
+  still wins. Pure-data composition — `score-item` reads the boost
+  from the item itself, so the recents bump rides the standard
+  scoring pipeline."
   [inputs]
-  (let [{:keys [panels trace-buffer frame-ids handlers]
+  (let [{:keys [panels static-tabs trace-buffer frame-ids handlers mode recents]
          :or   {panels             []
+                static-tabs        []
                 trace-buffer       []
                 frame-ids          []
-                handlers           []}} inputs
-        all      (concat
-                   (command-items)
-                   (panel-items panels)
-                   (setting-items)
-                   (recent-event-items trace-buffer)
-                   (frame-items frame-ids)
-                   (handler-items handlers))]
+                handlers           []
+                recents            []
+                mode               nil}} inputs
+        recents-vec (vec recents)
+        bump        (fn [item]
+                      (let [boost-add (cond
+                                        (= :command (:source item))
+                                        (recents-boost-for-id recents-vec (:id item))
+                                        :else 0)]
+                        (if (pos? boost-add)
+                          (update item :boost (fnil + 0) boost-add)
+                          item)))
+        all         (concat
+                      (map bump (command-items))
+                      (panel-items panels)
+                      (static-tab-items static-tabs)
+                      (setting-items)
+                      (recent-event-items trace-buffer)
+                      (frame-items frame-ids)
+                      (handler-items handlers))
+        filtered    (filter (partial in-mode? mode) all)]
     (loop [seen   (transient #{})
            out    (transient [])
-           items  all]
+           items  filtered]
       (if (empty? items)
         (persistent! out)
         (let [it   (first items)

--- a/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/subs.cljs
@@ -53,6 +53,18 @@
    {:id :routing  :label "Routing"}
    {:id :issues   :label "Issues"}])
 
+;; rf2-ybjkx — Static-mode L3 tabs (5 entries; mirrors `static/shell.cljs/
+;; tabs`). The palette holds its own copy so Static-mode tab jumps land
+;; without forming a `palette → static.shell → palette` cycle. The list
+;; is small (5 entries) and stable — Static is a sealed enumeration per
+;; the parent epic (rf2-o5f5f.1).
+(def palette-static-tabs
+  [{:id :machines :label "Machines"}
+   {:id :routes   :label "Routes"}
+   {:id :schemas  :label "Schemas"}
+   {:id :views    :label "Views"}
+   {:id :events   :label "Events"}])
+
 (defn- handler-entries
   "Flat seq of `{:id :kind :doc :file :line}` rows from the framework
   registrar. Kinds covered: :event, :sub, :fx, :cofx — the four the
@@ -90,21 +102,36 @@
     (fn [db _query]
       (max 0 (or (get db :palette-cursor) 0))))
 
+  ;; rf2-ybjkx — last-used commands. Vector of command keyword ids
+  ;; (most-recent first; capped at `recents/max-recents`). The slot is
+  ;; seeded from localStorage on first palette-open (see events.cljs
+  ;; `:rf.causa/palette-open`) and bumped on every `:command`
+  ;; invocation. Drives the recents boost in `sources/build-index`.
+  (rf/reg-sub :rf.causa/palette-recents
+    (fn [db _query]
+      (vec (get db :palette-recents []))))
+
   ;; Layer-2 — aggregates the searchable corpus. Depends on
-  ;; `:rf.causa/trace-buffer` (recent events) so it re-fires on every
-  ;; trace push; the registrar / frame snapshot lookups happen inside
-  ;; the body and ride that same recompute cadence.
+  ;; `:rf.causa/trace-buffer` (recent events) + `:rf.causa/mode`
+  ;; (rf2-ybjkx mode filter) + `:rf.causa/palette-recents` (rf2-ybjkx
+  ;; recents boost). The registrar / frame snapshot lookups happen
+  ;; inside the body and ride the same recompute cadence.
   (rf/reg-sub :rf.causa/palette-index
     :<- [:rf.causa/trace-buffer]
-    (fn [buffer _query]
+    :<- [:rf.causa/mode]
+    :<- [:rf.causa/palette-recents]
+    (fn [[buffer mode recents] _query]
       ;; The sub fn does not receive `db`; we reach into the registrar
       ;; (a process-global atom) + the framework's frame registry
       ;; via the public rf wrappers.
       (sources/build-index
         {:panels             palette-panels
+         :static-tabs        palette-static-tabs
          :trace-buffer       buffer
          :frame-ids          (rf/frame-ids)
-         :handlers           (handler-entries)})))
+         :handlers           (handler-entries)
+         :mode               mode
+         :recents            recents})))
 
   ;; Layer-3 — ranked results for the current query.
   (rf/reg-sub :rf.causa/palette-results

--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -169,6 +169,53 @@
         (try (.add cl klass) (catch :default _ nil)))))
   nil)
 
+;; ---- reduced-motion override (rf2-ybjkx) --------------------------------
+
+(def motion-override-class-prefix
+  "CSS class prefix the reduced-motion override writes onto `<html>`.
+  Three states:
+
+    :os      — no class set; OS media query alone drives the seam
+               (the historic behaviour preserved when the user has
+               never opted in).
+    :always  — `rf-causa-motion-override-always` — force the
+               vanishingly-small motion-scale regardless of OS pref.
+    :never   — `rf-causa-motion-override-never` — restore full motion
+               even when the OS prefers `reduce`.
+
+  The selector in `theme/global-styles/motion-css` matches a single
+  class on `:where(html, body)` so the override outranks the
+  media-query `:root` rule (single class beats element selector) and
+  authoring order plus `:where` keeps specificity low enough that
+  consumer styles can still override the var if they want to."
+  "rf-causa-motion-override-")
+
+(defn apply-reduced-motion-override!
+  "Drive the body / `<html>` class that overrides the OS-level
+  `prefers-reduced-motion: reduce` media query. Accepted values:
+
+    :os      — clear any prior override (defer to OS pref)
+    :always  — write `rf-causa-motion-override-always`
+    :never   — write `rf-causa-motion-override-never`
+
+  Idempotent — repeated calls with the same value leave the
+  classList in the same state. No-op when neither the shell root nor
+  `<html>` is present (test runtimes without a `document`)."
+  [override]
+  (let [target (or override :os)
+        klass  (when (contains? #{:always :never} target)
+                 (str motion-override-class-prefix (name target)))]
+    (doseq [el [(shell-root-element) (html-root-element)]
+            :when el]
+      (let [cl (.-classList el)]
+        ;; Drop both options first so the assertion below is exclusive.
+        (doseq [c [(str motion-override-class-prefix "always")
+                   (str motion-override-class-prefix "never")]]
+          (try (.remove cl c) (catch :default _ nil)))
+        (when klass
+          (try (.add cl klass) (catch :default _ nil))))))
+  nil)
+
 ;; ---- panel width (rf2-x8h9y resize handle) ------------------------------
 
 (def panel-width-css-var
@@ -360,6 +407,12 @@
   (let [s (config/get-settings)]
     (apply-text-size!  (get-in s [:general :text-size]))
     (apply-theme!      (get s :theme))
+    ;; rf2-ybjkx — restore the reduced-motion override so the user's
+    ;; saved choice survives reload BEFORE first paint. The default
+    ;; `:os` writes nothing (the OS media query alone drives the
+    ;; seam); `:always` / `:never` write the override class.
+    (apply-reduced-motion-override!
+      (get-in s [:general :reduced-motion-override]))
     ;; rf2-x8h9y — restore the persisted panel width so the user's
     ;; saved drag survives reload BEFORE first paint. No-op-safe
     ;; pre-mount (writes to `<html>` only when the layout host hasn't

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -106,6 +106,13 @@
         (and (= section :theme) (nil? key))
         (effects/apply-theme! value)
 
+        ;; rf2-ybjkx — reduced-motion override class flip. Three-value
+        ;; enum (`:os | :always | :never`). The apply-fn clears prior
+        ;; classes and writes the new one onto `<html>` so the next
+        ;; paint reads the updated `--rf-causa-motion-scale` seam.
+        (and (= section :general) (= key :reduced-motion-override))
+        (effects/apply-reduced-motion-override! value)
+
         ;; Auto-open-on-error toggle — install the sub-watcher on
         ;; flip-on, detach on flip-off. The install is also attempted
         ;; from `mount/ensure-causa-frame!` so the persisted-true case

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -395,6 +395,30 @@
     "@media (prefers-reduced-motion: reduce) {\n"
     "  :root { --rf-causa-motion-scale: 0.001; }\n"
     "}\n"
+    ;; rf2-ybjkx — user-side override of the OS media query. A body /
+    ;; <html> class set by `settings/effects.cljs/apply-reduced-motion-
+    ;; override!` overrides the media-query-derived value:
+    ;;
+    ;;   .rf-causa-motion-override-always  — always reduced (matches
+    ;;                                       the @media rule above)
+    ;;   .rf-causa-motion-override-never   — always full motion (even
+    ;;                                       when the OS prefers reduce)
+    ;;
+    ;; Higher specificity (a single class selector outranks `:root`)
+    ;; and authored AFTER the media-query rule so it wins on equal
+    ;; specificity collisions too — covers the legacy media rule
+    ;; injection order. The selector targets `:where(html, body)` so
+    ;; either node carrying the class flips the var without bumping
+    ;; specificity to the point that downstream consumer overrides
+    ;; can't beat it.
+    ".rf-causa-motion-override-always:where(html, body), \n"
+    ":where(html, body).rf-causa-motion-override-always {\n"
+    "  --rf-causa-motion-scale: 0.001;\n"
+    "}\n"
+    ".rf-causa-motion-override-never:where(html, body), \n"
+    ":where(html, body).rf-causa-motion-override-never {\n"
+    "  --rf-causa-motion-scale: 1;\n"
+    "}\n"
     ;; rf2-5kfxe.2 — diff-flash. Yellow tint at ~20% alpha (hex32 ≈ 20%)
     ;; holds for the first 12% of the run so the eye locks on, then
     ;; eases to transparent. The downstream `:animation-fill-mode:

--- a/tools/causa/test/day8/re_frame2_causa/palette/events_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/palette/events_cljs_test.cljs
@@ -16,6 +16,7 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.palette.recents :as recents]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
@@ -27,7 +28,11 @@
   (registry/reset-for-test!)
   (trace-bus/clear-buffer!)
   (config/reset-suppressed-count!)
-  (config/set-project-root! nil))
+  (config/set-project-root! nil)
+  ;; rf2-ybjkx — clear palette recents between tests so each scenario
+  ;; starts with a clean slate. localStorage degrades silently in Node
+  ;; runtimes (no window.localStorage); the clear is a no-op there.
+  (recents/clear!))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
@@ -234,3 +239,192 @@
         :action [:palette/close]}
        false]))
   (is (false? (boolean (:palette-open? (causa-db))))))
+
+;; ---- rf2-ybjkx — new commands ------------------------------------------
+
+(deftest invoke-clear-epoch-history-drops-slot
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    ;; Seed the slot so we can observe the clear.
+    (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                       [{:epoch-id 1} {:epoch-id 2}]])
+    (is (= 2 (count (:epoch-history (causa-db))))
+        "sanity check — slot is seeded before the clear")
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :clear-epoch-history
+        :label  "Clear epoch history"
+        :action [:palette/clear-epoch-history]}
+       false]))
+  (is (nil? (:epoch-history (causa-db)))
+      "clear-epoch-history dissocs the slot")
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-toggle-theme-flips-via-settings-update
+  (setup!)
+  ;; Reset the atom to a known starting theme so the cycle is deterministic.
+  (config/update-setting! :theme nil :dark)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :toggle-theme
+        :label  "Toggle theme (dark ↔ light)"
+        :action [:palette/toggle-theme]}
+       false]))
+  (is (= :light (config/get-setting :theme nil))
+      ":dark → :light cycles the canonical settings atom")
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-cycle-reduced-motion-walks-the-tri-state
+  (setup!)
+  (config/update-setting! :general :reduced-motion-override :os)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :cycle-reduced-motion
+        :label  "Cycle reduced-motion override"
+        :action [:palette/cycle-reduced-motion]}
+       false]))
+  (is (= :always (config/get-setting :general :reduced-motion-override))
+      "first cycle: :os → :always")
+  ;; Second invocation continues the cycle.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :cycle-reduced-motion
+        :label  "Cycle reduced-motion override"
+        :action [:palette/cycle-reduced-motion]}
+       false]))
+  (is (= :never (config/get-setting :general :reduced-motion-override))
+      "second cycle: :always → :never"))
+
+(deftest invoke-jump-to-settings-opens-popup
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :jump-to-settings
+        :label  "Jump to Settings"
+        :action [:palette/jump-to-settings]}
+       false]))
+  (is (true? (boolean (:settings-open? (causa-db))))
+      "jump-to-settings opens the Settings popup")
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-toggle-mode-flips-runtime-static
+  (setup!)
+  ;; Force-set the slot so the cycle is deterministic.
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/set-mode :runtime])
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :toggle-mode
+        :label  "Toggle mode (Runtime ↔ Static)"
+        :action [:palette/toggle-mode]}
+       false]))
+  (is (= :static (:mode (causa-db)))
+      ":runtime → :static via the canonical toggle-mode handler"))
+
+(deftest invoke-select-static-tab-flips-static-slot
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :panel
+        :id     [:static :routes]
+        :label  "Open Routes (Static)"
+        :action [:palette/select-static-tab :routes]}
+       false]))
+  (is (= :routes (:rf.causa.static/selected-tab (causa-db)))
+      "Static tab selection lands on the Static-scoped slot")
+  (is (false? (boolean (:palette-open? (causa-db))))))
+
+(deftest invoke-select-frame-drives-canonical-set-frame
+  (setup!)
+  ;; Ensure :rf/cart-frame exists so the spine handler resolves
+  ;; epoch-history without throwing — the canonical set-frame event
+  ;; queries `rf/epoch-history` for the new target.
+  (frame/reg-frame :rf/cart-frame {})
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :frame
+        :id     :rf/cart-frame
+        :label  "Switch focus to frame :rf/cart-frame"
+        :action [:palette/select-frame :rf/cart-frame]}
+       false]))
+  (is (= :rf/cart-frame (get-in (causa-db) [:focus :frame]))
+      "select-frame routes through :rf.causa/set-frame so every per-
+       frame composite (App-DB Diff, Views, Routing) re-fires off the
+       new frame's slot")
+  (is (= :rf/cart-frame (:target-frame (causa-db)))
+      ":target-frame is also written by the canonical handler"))
+
+;; ---- rf2-ybjkx — recents tracking --------------------------------------
+
+(deftest invoking-a-command-records-it-in-recents
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id     :toggle-theme
+        :label  "Toggle theme"
+        :action [:palette/toggle-theme]}
+       false]))
+  (is (= [:toggle-theme] (:palette-recents (causa-db)))
+      "command invocation bumps the recents vector"))
+
+(deftest invoking-twice-keeps-recents-unique
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command :id :toggle-theme
+        :action [:palette/toggle-theme]}
+       false])
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command :id :jump-to-settings
+        :action [:palette/jump-to-settings]}
+       false])
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :command :id :toggle-theme
+        :action [:palette/toggle-theme]}
+       false]))
+  (is (= [:toggle-theme :jump-to-settings]
+         (:palette-recents (causa-db)))
+      "re-invoking an existing recent bubbles it to the head;
+       it does not duplicate"))
+
+(deftest non-command-items-do-not-record-recents
+  (setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/palette-open])
+    (rf/dispatch-sync
+      [:rf.causa/palette-invoke
+       {:source :panel
+        :id     :trace
+        :action [:palette/select-panel :trace]}
+       false]))
+  (is (empty? (:palette-recents (causa-db)))
+      "panel jumps don't pollute the recents vector"))

--- a/tools/causa/test/day8/re_frame2_causa/palette/recents_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/palette/recents_cljs_test.cljs
@@ -1,0 +1,68 @@
+(ns day8.re-frame2-causa.palette.recents-cljs-test
+  "Tests for the palette recents persistence (rf2-ybjkx).
+
+  Covers:
+
+  - `record` pure helper — prepend, dedup, cap.
+  - `load` / `save!` localStorage round-trip (degrades silently in
+    Node test runtimes where window.localStorage is absent — the JVM
+    fixture path is exercised by the CLJC `sources` tests).
+  - `sanitise` drops non-keyword entries from a malformed payload."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.palette.recents :as recents]))
+
+(use-fixtures :each
+  {:before (fn [] (recents/clear!))
+   :after  (fn [] (recents/clear!))})
+
+;; ---- record -------------------------------------------------------------
+
+(deftest record-prepends-new-id
+  (is (= [:foo] (recents/record [] :foo)))
+  (is (= [:bar :foo] (recents/record [:foo] :bar))))
+
+(deftest record-dedups-by-id
+  (let [r1 (recents/record [:foo :bar] :foo)]
+    (is (= [:foo :bar] r1)
+        "re-invoking :foo moves it back to position 0 without growing
+         the list")))
+
+(deftest record-caps-at-max
+  (let [r (-> []
+              (recents/record :a)
+              (recents/record :b)
+              (recents/record :c)
+              (recents/record :d))]
+    (is (= recents/max-recents (count r)))
+    (is (= [:d :c :b] r)
+        "newest first; the cap drops the oldest entry")))
+
+(deftest record-nil-is-noop
+  (is (= [:foo] (recents/record [:foo] nil))
+      "nil command-id does not bump the list"))
+
+;; ---- save! / load round-trip --------------------------------------------
+;;
+;; Node test runtimes don't simulate `window.localStorage` — the round-
+;; trip tests gate on `js/window` so they cover the browser path when
+;; the runtime provides it and silently skip otherwise. The pure
+;; `record` / `sanitise` tests above cover the algorithm regardless.
+
+(deftest save-load-round-trip
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (recents/save! [:foo :bar])
+    (is (= [:foo :bar] (recents/load))
+        "browser-backed round-trip preserves the recents vector
+         (most-recent-first, capped at max-recents)")))
+
+(deftest load-empty-slot-returns-empty-vector
+  (recents/clear!)
+  (is (= [] (recents/load))
+      "empty / unreachable storage → empty vector (never nil)"))
+
+(deftest save-caps-at-max
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (recents/save! [:a :b :c :d :e])
+    (let [loaded (recents/load)]
+      (is (<= (count loaded) recents/max-recents)
+          "save! caps the persisted list at max-recents"))))

--- a/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/palette/sources_test.cljc
@@ -106,6 +106,45 @@
     (is (contains? ids :open-popout))
     (is (contains? ids :close-palette))))
 
+;; ---- rf2-ybjkx — mode-aware command surface ----------------------------
+
+(deftest command-items-include-rf2-ybjkx-verbs
+  ;; rf2-ybjkx — new commands per the bead's scope: theme toggle,
+  ;; reduced-motion cycle, snapshot, jump-to-settings, toggle-mode,
+  ;; clear-epoch-history.
+  (let [items (sources/command-items)
+        ids   (set (map :id items))]
+    (is (contains? ids :toggle-theme))
+    (is (contains? ids :cycle-reduced-motion))
+    (is (contains? ids :snapshot-app-db))
+    (is (contains? ids :jump-to-settings))
+    (is (contains? ids :toggle-mode))
+    (is (contains? ids :clear-epoch-history))))
+
+(deftest command-items-carry-modes-set
+  (let [items (sources/command-items)]
+    (is (every? #(set? (:modes %)) items)
+        "every command carries a `:modes` set per rf2-ybjkx")
+    (let [toggle (first (filter #(= :toggle-mode (:id %)) items))]
+      (is (= #{:runtime :static} (:modes toggle))
+          "toggle-mode surfaces in BOTH modes (chord parity)"))
+    (let [clear-trace (first (filter #(= :clear-trace-buffer (:id %)) items))]
+      (is (= #{:runtime} (:modes clear-trace))
+          "trace-buffer clear is Runtime-only"))))
+
+(deftest static-tab-items-shape
+  (let [tabs  [{:id :machines :label "Machines"}
+               {:id :routes   :label "Routes"}]
+        items (sources/static-tab-items tabs)]
+    (is (= 2 (count items)))
+    (is (every? #(= :panel (:source %)) items))
+    (is (every? #(= #{:static} (:modes %)) items)
+        "static tab jumps are Static-only")
+    (is (= [:palette/select-static-tab :machines]
+           (-> items first :action)))
+    (is (= [:static :machines] (-> items first :id))
+        "id namespaced under :static so it doesn't collide with Runtime panel ids")))
+
 ;; ---- build-index --------------------------------------------------------
 
 (deftest build-index-includes-every-source
@@ -189,3 +228,94 @@
   (is (false? (sources/popoutable? {:popout? false})))
   (is (false? (sources/popoutable? {}))
       "default: items are not popoutable unless they say so"))
+
+;; ---- rf2-ybjkx — build-index mode-awareness ----------------------------
+
+(deftest build-index-runtime-mode-filters-static-tabs
+  (let [index (sources/build-index
+                {:panels      sample-panels
+                 :static-tabs [{:id :machines :label "Machines"}
+                               {:id :routes   :label "Routes"}]
+                 :mode        :runtime})
+        static-ids (set (map :id (filter #(and (= :panel (:source %))
+                                               (vector? (:id %))
+                                               (= :static (first (:id %))))
+                                         index)))]
+    (is (empty? static-ids)
+        "Runtime mode hides Static-only items per rf2-ybjkx")))
+
+(deftest build-index-static-mode-hides-runtime-only-items
+  (let [index   (sources/build-index
+                  {:panels       sample-panels
+                   :static-tabs  [{:id :machines :label "Machines"}]
+                   :trace-buffer sample-trace-buffer
+                   :frame-ids    sample-frames
+                   :mode         :static})
+        ids     (set (map :id index))
+        sources (set (map :source index))]
+    (is (not (contains? ids :clear-trace-buffer))
+        "trace buffer clear is Runtime-only — hidden in Static")
+    (is (not (contains? sources :recent-event))
+        "recent-event source is event-coupled — hidden in Static")
+    (is (not (contains? sources :frame))
+        "frame-picker shortcuts are Runtime-only")
+    (is (contains? ids :toggle-mode)
+        "mode toggle surfaces in BOTH modes (chord parity)")
+    (is (contains? ids :toggle-theme))
+    (is (contains? ids :jump-to-settings))
+    (is (some #(= [:static :machines] (:id %)) index)
+        "Static tab jump surfaces in Static mode")))
+
+(deftest build-index-nil-mode-preserves-pre-bead-behaviour
+  ;; Backward-compat: a nil :mode keeps every item — the pre-bead
+  ;; contract before mode filtering shipped.
+  (let [index   (sources/build-index
+                  {:panels       sample-panels
+                   :trace-buffer sample-trace-buffer
+                   :frame-ids    sample-frames
+                   :handlers     sample-handlers})
+        sources (set (map :source index))]
+    (is (contains? sources :command))
+    (is (contains? sources :panel))
+    (is (contains? sources :recent-event))
+    (is (contains? sources :frame))))
+
+;; ---- rf2-ybjkx — recents boost -----------------------------------------
+
+(deftest build-index-recents-boost-bumps-recent-commands
+  (let [index-baseline (sources/build-index
+                         {:panels sample-panels})
+        index-with-rec (sources/build-index
+                         {:panels  sample-panels
+                          :recents [:toggle-theme]})
+        find-theme     (fn [idx]
+                         (first (filter #(= :toggle-theme (:id %)) idx)))
+        base-boost     (:boost (find-theme index-baseline))
+        bumped-boost   (:boost (find-theme index-with-rec))]
+    (is (> bumped-boost base-boost)
+        "a recent command's boost is higher than the baseline")
+    (is (= (+ base-boost sources/recents-boost-max) bumped-boost)
+        "position-0 (most recent) gets the full recents-boost-max bump")))
+
+(deftest build-index-recents-boost-decays-with-position
+  (let [index (sources/build-index
+                {:panels  sample-panels
+                 :recents [:toggle-theme :toggle-mode :jump-to-settings]})
+        boost (fn [id] (:boost (first (filter #(= id (:id %)) index))))]
+    (is (> (boost :toggle-theme) (boost :toggle-mode))
+        "position 0 beats position 1")
+    (is (> (boost :toggle-mode) (boost :jump-to-settings))
+        "position 1 beats position 2")))
+
+(deftest rank-empty-query-surfaces-recents-first
+  ;; The bead's "top-3 recent surfaced first" contract: with an empty
+  ;; query the recent commands should appear at the top of the
+  ;; results.
+  (let [index   (sources/build-index
+                  {:panels  sample-panels
+                   :recents [:toggle-theme]})
+        results (sources/rank index "" 100)
+        top     (first results)]
+    (is (= :command (:source top)))
+    (is (= :toggle-theme (:id top))
+        "the most recently invoked command surfaces at index 0")))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -173,6 +173,9 @@
    :rf.causa/palette-index
    :rf.causa/palette-open?
    :rf.causa/palette-query
+   ;; rf2-ybjkx — recents vector (last-used commands, persisted to
+   ;; localStorage).
+   :rf.causa/palette-recents
    :rf.causa/palette-results
    :rf.causa/registered-machines
    ;; rf2-nrbs9 — Routes tab (7th L3 tab) sub family.
@@ -468,6 +471,14 @@
    ;; palette-specific prefix because it wraps a mount-layer pop-out
    ;; call that no other Causa surface invokes.
    :rf.causa.palette.fx/popout
+   ;; rf2-ybjkx — palette snapshot-app-db side-effect. Drops the
+   ;; focused frame's app-db onto the JS console + clipboard so the
+   ;; user can share a session state.
+   :rf.causa.palette.fx/snapshot-app-db
+   ;; rf2-ybjkx — palette recents localStorage round-trip. Bound to
+   ;; every `:command` invocation so the persisted list is always
+   ;; current.
+   :rf.causa.palette.fx/persist-recents
    ;; rf2-o5f5f.1 — Runtime ↔ Static mode persistence side-effect.
    ;; Bound to the `:rf.causa/set-mode` + `:rf.causa/toggle-mode`
    ;; handlers; writes the post-mutation mode to localStorage in one


### PR DESCRIPTION
## Summary

Extends the existing palette (rf2-wm7z4) to land the rf2-ybjkx scope. This is the follow-on bead from the Vue/Vite-DevTools audit (rf2-vtd5z) that observed Cmd/Ctrl-K as the modern cross-panel nav primitive.

- **Six new command verbs**: theme toggle, reduced-motion cycle, snapshot app-db, jump to settings, toggle mode (Runtime ↔ Static), clear epoch history.
- **Mode-aware command surface**: every source item carries a ``:modes`` set so Runtime-only verbs (trace-buffer clear, recent-events, frame picker) hide in Static; Static tab jumps (Machines / Routes / Schemas / Views / Events) appear only in Static.
- **Recents tracking**: command invocations bubble through a top-3 ring persisted to localStorage. Boost is position-decayed so the most-recent verb sorts above a fresh fuzzy peer.
- **Reduced-motion override seam**: user-side override of OS ``prefers-reduced-motion: reduce``. Three states (``:os | :always | :never``) drive a body class that outranks the media-query ``:root`` rule for ``--rf-causa-motion-scale``.
- **Frame-picker action** now dispatches the canonical ``:rf.causa/set-frame`` so every per-frame composite re-fires off the new frame's slot (replaces the pre-bead stub that only wrote ``:selected-target-frame``).

## Design notes

- **No parallel state.** Theme + motion toggles route through the existing ``:rf.causa/settings-update`` reducer — same path the Settings popup's radios use. ``apply-theme!`` + ``apply-reduced-motion-override!`` are the canonical side-effects; the palette just dispatches the same event.
- **Mount unchanged.** The palette modal already mounts at ``shell.cljs`` shell-root above the surface composer, so it shows in both Runtime + Static. Cmd-K keybinding in ``keybinding.cljs`` is unchanged.
- **Static shell untouched.** The bead's sibling workers (.2 Static Machines, .3 Static Routes) are editing ``static/shell.cljs``'s ``:machines`` and ``:routes`` branches; this PR doesn't touch that file. Mount-from-Static works because the palette modal is rendered above the surface composer in the Runtime shell.

## Files

- NEW: ``palette/recents.cljs`` + test — localStorage round-trip for the last-used-commands list (capped at 3).
- ``palette/sources.cljc`` — new ``command-items`` entries; ``static-tab-items`` helper; ``:modes`` filter in ``build-index``; recents boost.
- ``palette/subs.cljs`` — ``:rf.causa/palette-recents`` sub; mode-aware ``:rf.causa/palette-index``.
- ``palette/events.cljs`` — invoke lowerings for new verbs; ``:rf.causa.palette.fx/snapshot-app-db`` + ``:rf.causa.palette.fx/persist-recents`` fxs; recents recording.
- ``settings/effects.cljs`` — ``apply-reduced-motion-override!`` + ``apply-all!`` wiring.
- ``settings/events.cljs`` — ``:reduced-motion-override`` dispatch path.
- ``theme/global_styles.cljs`` — body-class seam for the motion override.
- ``config.cljc`` — new ``:general :reduced-motion-override`` default setting.
- Tests: extended ``palette/sources_test.cljc``, ``palette/events_cljs_test.cljs``, ``registry_cljs_test.cljs``; new ``palette/recents_cljs_test.cljs``.

## Test plan

- [x] ``tools/causa`` JVM: ``clojure -M:test`` — 731 tests / 2185 assertions / 0 failures
- [x] Node CLJS: ``npm run test:cljs`` from ``implementation/`` — 2994 tests / 8645 assertions / 0 failures
- [x] Bundle isolation: ``npm run test:bundle-isolation`` — PASS (no production-bundle pollution from the tools/causa tree)
- [ ] Browser smoke (manual): Cmd-K opens, fuzzy filter narrows, Enter executes, theme toggle flips the radio + class, motion toggle cycles, Esc dismisses, reduced-motion override actually flattens the palette open/close animation