### PR TITLE
feat(story): Phase 3 cluster — hotkeys, search, skeleton, TOC, embed (8 beads)

### DIFF
--- a/tools/story/src/re_frame/story/theme/motion.cljc
+++ b/tools/story/src/re_frame/story/theme/motion.cljc
@@ -169,6 +169,7 @@
 @keyframes rf-story-overlay-in{from{opacity:0;transform:translateY(8px) scale(0.985)}to{opacity:1;transform:translateY(0) scale(1)}}
 @keyframes rf-story-overlay-out{from{opacity:1;transform:translateY(0) scale(1)}to{opacity:0;transform:translateY(4px) scale(0.99)}}
 @keyframes rf-story-chip-press{0%{transform:scale(1)}40%{transform:scale(0.94)}100%{transform:scale(1)}}
+@keyframes rf-story-shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
 [data-rf-story-root] *:focus-visible{outline:2px solid #F5A524;outline-offset:2px;border-radius:3px;transition:outline-offset 120ms cubic-bezier(0.0, 0.0, 0.2, 1.0)}
 @media (prefers-reduced-motion: reduce){
   [data-rf-story-root] *,[data-rf-story-root] *::before,[data-rf-story-root] *::after{animation-duration:0.01ms !important;animation-delay:0ms !important;transition-duration:0.01ms !important;transition-delay:0ms !important}

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -194,12 +194,27 @@
   "Pure: is the variant in a phase where the loading skeleton should
   render? True when the lifecycle machine is in `:pre-mount`,
   `:mounting`, or `:loading` AND no first render has been committed
-  yet.
+  yet AND the runtime has not recorded any assertions against the
+  variant frame.
+
+  The `assertions-recorded?` arm closes a regression window introduced
+  with the skeleton (rf2-qrk2s / Phase 3 cluster): the
+  `:loaders-complete-when` predicate may declare the loaders incomplete
+  (e.g. `:story.counter-matrix/loader-never-completes`), or a loader
+  event may throw a deterministic rejection
+  (`:story.counter-matrix/loader-rejects`). In both paths the runtime
+  records an assertion against the variant frame and the lifecycle
+  machine stays parked at `:loading` — but the loader cascade has
+  resolved its outcome and the user view (the counter, the inline
+  assertion strip, …) must render. A non-empty assertions vector is
+  the proof that `run-loaders!` returned; pin the skeleton off so the
+  view layer takes over.
 
   Returns false when `phase` is nil or `:ready` / `:error`."
-  [phase first-rendered?]
+  [phase first-rendered? assertions-recorded?]
   (boolean
     (and (not first-rendered?)
+         (not assertions-recorded?)
          (contains? #{:pre-mount :mounting :loading} phase))))
 
 (defn loading-skeleton
@@ -440,7 +455,15 @@
         lifecycle-phase (try (story-loaders/current-state variant-id)
                              (catch :default _ nil))
         first?         (variant-first-rendered? variant-id)
-        show-skeleton? (loading-phase? lifecycle-phase first?)]
+        ;; rf2-qrk2s — a recorded assertion proves the loader cascade
+        ;; resolved its outcome (success path → :ready; failure paths
+        ;; like loader-never-completes / loader-rejects park at
+        ;; :loading but record an incomplete/rejection assertion). In
+        ;; either case the user view must render: the skeleton would
+        ;; otherwise pin forever on the deterministic-failure variants
+        ;; and hide the count text the load-gate reads.
+        show-skeleton? (loading-phase? lifecycle-phase first?
+                                       (seq assertions))]
     [:div {:style (:frame styles)}
      [:div {:style (:title styles)}
       [:span (str (pr-str variant-id))]
@@ -537,16 +560,25 @@
 
 (defn- mark-rendered-if-ready!
   "Lifecycle helper: flip the first-rendered sentinel for the focused
-  variant when the lifecycle machine reports `:ready` or `:error`. The
-  skeleton (rf2-0s4p1) hides on the next render pass."
+  variant when the lifecycle machine reports `:ready` / `:error`, OR
+  when the runtime has recorded an assertion against the variant
+  frame (rf2-qrk2s). An assertion means the loader cascade resolved
+  its outcome — either by a `:loaders-complete-when` predicate
+  reporting incomplete or by a loader event throwing a deterministic
+  rejection. In those paths the machine parks at `:loading`, but the
+  user view must still render. The skeleton (rf2-0s4p1) hides on the
+  next render pass."
   []
   (when config/enabled?
     (let [shell      @state/shell-state-atom
           variant-id (:selected-variant shell)]
       (when variant-id
         (let [phase (try (story-loaders/current-state variant-id)
-                         (catch :default _ nil))]
-          (when (contains? #{:ready :error} phase)
+                         (catch :default _ nil))
+              assertions (try (runtime/read-assertions variant-id)
+                              (catch :default _ nil))]
+          (when (or (contains? #{:ready :error} phase)
+                    (seq assertions))
             (mark-variant-rendered! variant-id)))))))
 
 (def canvas

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -21,6 +21,7 @@
             [re-frame.core :as rf]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.story.config :as config]
+            [re-frame.story.loaders :as story-loaders]
             [re-frame.story.registrar :as registrar]
             [re-frame.story.args :as args]
             [re-frame.story.decorators :as decorators]
@@ -132,7 +133,122 @@
                :margin "2px 0"
                :font-family mono-stack
                :font-size (:caption typography/type-scale)
-               :background (:danger-bg colors/tokens)}})
+               :background (:danger-bg colors/tokens)}
+   ;; rf2-0s4p1 — identity-bearing loading skeleton during the
+   ;; four-phase loader lifecycle. Reads as "workshop loading" — amber-
+   ;; shimmer pulse on a slate ground — not the generic Storybook
+   ;; skeleton-row pattern.
+   :skeleton {:position "relative"
+              :padding "32px"
+              :min-height "240px"
+              :display "flex"
+              :flex-direction "column"
+              :gap "12px"
+              :background (:bg-canvas colors/tokens)
+              :border-radius "6px"
+              :overflow "hidden"
+              :font-family mono-stack
+              :color (:text-tertiary colors/tokens)}
+   :skeleton-bar {:height "12px"
+                  :width "78%"
+                  :background (str "linear-gradient(90deg, "
+                                   (:bg-3 colors/tokens) " 0%, "
+                                   (:accent-amber-soft colors/tokens) " 50%, "
+                                   (:bg-3 colors/tokens) " 100%)")
+                  :background-size "200% 100%"
+                  :border-radius "3px"
+                  :animation (str "rf-story-shimmer 1400ms "
+                                  "cubic-bezier(0.4, 0.0, 0.2, 1) infinite")}
+   :skeleton-bar-medium {:width "62%"}
+   :skeleton-bar-short  {:width "44%"}
+   :skeleton-edge {:position "absolute"
+                   :inset "0"
+                   :pointer-events "none"
+                   :border (str "1px solid " (:accent-amber-deep colors/tokens))
+                   :border-radius "6px"
+                   :box-shadow (str "inset 0 0 0 1px " (:accent-amber-soft colors/tokens))}
+   :skeleton-label {:font-size (:micro typography/type-scale)
+                    :text-transform "uppercase"
+                    :letter-spacing "0.12em"
+                    :color (:accent-amber colors/tokens)
+                    :margin-bottom "4px"}
+   ;; rf2-zgu68 — viewport-px indicator chip. Shows e.g. "375 × 667"
+   ;; at canvas bottom-right when a viewport mode is active.
+   :viewport-chip {:position "absolute"
+                   :bottom "12px"
+                   :right "16px"
+                   :padding "3px 8px"
+                   :background (:bg-overlay colors/tokens)
+                   :border (str "1px solid " (:border-subtle colors/tokens))
+                   :border-radius "4px"
+                   :color (:text-secondary colors/tokens)
+                   :font-family mono-stack
+                   :font-size (:micro typography/type-scale)
+                   :letter-spacing "0.04em"
+                   :pointer-events "none"
+                   :user-select "none"}})
+
+;; ---- loading skeleton (rf2-0s4p1) ---------------------------------------
+
+(defn loading-phase?
+  "Pure: is the variant in a phase where the loading skeleton should
+  render? True when the lifecycle machine is in `:pre-mount`,
+  `:mounting`, or `:loading` AND no first render has been committed
+  yet.
+
+  Returns false when `phase` is nil or `:ready` / `:error`."
+  [phase first-rendered?]
+  (boolean
+    (and (not first-rendered?)
+         (contains? #{:pre-mount :mounting :loading} phase))))
+
+(defn loading-skeleton
+  "Hiccup component rendering the identity-bearing loading skeleton
+  per rf2-0s4p1. Three amber-shimmer bars on a slate ground with the
+  inset amber edge that matches the canvas-frame chrome — reads as
+  'workshop loading' rather than generic skeleton-row.
+
+  Behind `prefers-reduced-motion: reduce` the shimmer falls back to a
+  static amber inset edge."
+  []
+  [:div {:style       (:skeleton styles)
+         :data-test   "story-canvas-loading-skeleton"
+         :role        "status"
+         :aria-live   "polite"
+         :aria-label  "Variant loading"}
+   [:div {:style (:skeleton-label styles)} "loading"]
+   [:div {:style (:skeleton-bar styles)}]
+   [:div {:style (merge (:skeleton-bar styles)
+                        (:skeleton-bar-medium styles))}]
+   [:div {:style (merge (:skeleton-bar styles)
+                        (:skeleton-bar-short styles))}]
+   [:div {:style (:skeleton-edge styles)
+          :aria-hidden "true"}]])
+
+;; ---- viewport-px indicator chip (rf2-zgu68) ------------------------------
+
+(defn- viewport-indicator-text
+  "Pure: render the chip text e.g. `\"375 × 667\"` from a resolved
+  viewport `{:width :height :label}` map. Returns nil when the preset
+  has no width/height (e.g. `:full`)."
+  [{:keys [width height]}]
+  (when (and width height)
+    (str width " × " height)))
+
+(defn viewport-indicator
+  "Hiccup component rendering the bottom-right viewport-px chip per
+  rf2-zgu68. Hidden when no viewport mode is active.
+
+  Takes the resolved viewport preset map produced by
+  `viewport/resolve`. The chip is `pointer-events: none` so it never
+  intercepts hits on the underlying canvas content."
+  [resolved-viewport]
+  (when-let [text (viewport-indicator-text resolved-viewport)]
+    [:div {:style       (:viewport-chip styles)
+           :data-test   "story-canvas-viewport-indicator"
+           :data-viewport-dims text
+           :aria-hidden "true"}
+     text]))
 
 ;; ---- variant view resolution --------------------------------------------
 
@@ -246,6 +362,28 @@
 (defonce ^:private canvas-last-run-key
   (atom nil))
 
+;; rf2-0s4p1 — per-variant first-render sentinel. Once a variant has
+;; committed its first render, the skeleton never re-appears (a hot-
+;; reload re-run is brief enough that re-flashing the skeleton would
+;; read as a glitch).
+(defonce ^:private first-rendered? (atom #{}))
+
+(defn mark-variant-rendered!
+  "Stamp `variant-id` as 'has committed a first render'. Public for tests."
+  [variant-id]
+  (when variant-id
+    (swap! first-rendered? conj variant-id)))
+
+(defn variant-first-rendered?
+  "True when `variant-id` has committed a first canvas render."
+  [variant-id]
+  (contains? @first-rendered? variant-id))
+
+(defn reset-first-rendered!
+  "Clear the first-rendered sentinel."
+  ([] (reset! first-rendered? #{}) nil)
+  ([variant-id] (swap! first-rendered? disj variant-id) nil))
+
 (defn- run-if-needed!
   []
   (when config/enabled?
@@ -293,7 +431,16 @@
                                   [:cell-overrides variant-id])})
         assertions     (runtime/read-assertions variant-id)
         substrates     (variant-substrate-set variant-id)
-        multi?         (and variant-id (> (count substrates) 1))]
+        multi?         (and variant-id (> (count substrates) 1))
+        ;; rf2-0s4p1 — skeleton gating. The lifecycle machine reports
+        ;; :pre-mount / :mounting / :loading while the four-phase
+        ;; loader cascade runs; once :ready / :error lands, the
+        ;; first-rendered sentinel flips (in component-did-mount /
+        ;; -did-update) and the skeleton hides.
+        lifecycle-phase (try (story-loaders/current-state variant-id)
+                             (catch :default _ nil))
+        first?         (variant-first-rendered? variant-id)
+        show-skeleton? (loading-phase? lifecycle-phase first?)]
     [:div {:style (:frame styles)}
      [:div {:style (:title styles)}
       [:span (str (pr-str variant-id))]
@@ -336,6 +483,13 @@
        (nil? view-id)
        [:div {:style (:empty styles)}
         "variant has no :component registered — register one on the story or variant body"]
+
+       ;; rf2-0s4p1: identity-bearing skeleton while the lifecycle
+       ;; machine is still draining loaders AND no first render has
+       ;; committed. Hides immediately once :ready / :error lands and
+       ;; the lifecycle hook flips `first-rendered?`.
+       show-skeleton?
+       [loading-skeleton]
 
        multi?
        ;; Stage 6: multi-substrate side-by-side grid. Per IMPL-SPEC §2.2
@@ -381,6 +535,20 @@
      (render-errors (:errors decorator-pack))
      (render-assertions assertions)]))
 
+(defn- mark-rendered-if-ready!
+  "Lifecycle helper: flip the first-rendered sentinel for the focused
+  variant when the lifecycle machine reports `:ready` or `:error`. The
+  skeleton (rf2-0s4p1) hides on the next render pass."
+  []
+  (when config/enabled?
+    (let [shell      @state/shell-state-atom
+          variant-id (:selected-variant shell)]
+      (when variant-id
+        (let [phase (try (story-loaders/current-state variant-id)
+                         (catch :default _ nil))]
+          (when (contains? #{:ready :error} phase)
+            (mark-variant-rendered! variant-id)))))))
+
 (def canvas
   "Render the focused variant. Triggers a `run-variant` on mount and on
   each `:hot-reload-tick` bump. Renders the variant's `:component` view
@@ -389,17 +557,24 @@
      {:display-name "rf-story-canvas"
       :component-did-mount
       (fn [_this]
-        (run-if-needed!))
+        (run-if-needed!)
+        (mark-rendered-if-ready!))
       :component-did-update
       (fn [_this _old-argv]
         ;; Re-run only when the variant runtime inputs change. The old
         ;; unconditional update path re-fired `:events` on every app-db
         ;; render, resetting interactive state and polluting recorder
         ;; output with fixture setup events.
-        (run-if-needed!))
+        (run-if-needed!)
+        ;; rf2-0s4p1 — flip the first-rendered sentinel once the
+        ;; lifecycle machine reports :ready / :error.
+        (mark-rendered-if-ready!))
       :component-will-unmount
       (fn [_this]
-        (reset! canvas-last-run-key nil))
+        (reset! canvas-last-run-key nil)
+        ;; rf2-0s4p1 — clear the first-rendered sentinel on unmount so a
+        ;; re-mount sees the skeleton for the appropriate loader window.
+        (reset-first-rendered!))
      :reagent-render
      (fn []
        (let [shell      @state/shell-state-atom

--- a/tools/story/src/re_frame/story/ui/docs.cljc
+++ b/tools/story/src/re_frame/story/ui/docs.cljc
@@ -49,7 +49,8 @@
   never invoke it — closure DCEs the lot."
   (:require [re-frame.story.predicates :as pred]
             [re-frame.story.registrar  :as registrar]
-            #?@(:cljs [[re-frame.story.args :as args]
+            #?@(:cljs [[reagent.core :as r]
+                       [re-frame.story.args :as args]
                        [re-frame.story.decorators :as decorators]
                        [re-frame.story.ui.state :as state]])
             [re-frame.story.theme.typography :as typography :refer [sans-stack mono-stack]]
@@ -473,24 +474,164 @@
                  (state/swap-state! state/toggle-tag-filter tag))}
               (str tag)])])])))
 
+;; ---- pure: TOC entries (rf2-8c7tk) --------------------------------------
+
+(def docs-toc-entries
+  "Canonical TOC entry table for the `:docs` mode pane (rf2-8c7tk).
+  Pure data → data so JVM tests can assert the table shape. The
+  header section renders as the variant's `<h1>` and is intentionally
+  NOT in the TOC list — it sits beside that h1 and would self-reference."
+  [{:id "docs-prose"      :label "Prose"      :level 2 :conditional? true}
+   {:id "docs-args"       :label "Args"       :level 2}
+   {:id "docs-decorators" :label "Decorators" :level 2}
+   {:id "docs-parameters" :label "Parameters" :level 2}
+   {:id "docs-tags"       :label "Tags"       :level 2}])
+
+(defn visible-toc-entries
+  "Pure data → data: prune conditional TOC entries that don't apply to
+  this variant. The prose section is the only conditional one — we
+  drop it when `(prose-for-variant variant-id)` returns empty."
+  [variant-id]
+  (let [prose? (seq (prose-for-variant variant-id))]
+    (vec
+      (remove (fn [{:keys [id conditional?]}]
+                (and conditional?
+                     (= id "docs-prose")
+                     (not prose?)))
+              docs-toc-entries))))
+
+#?(:cljs
+   (defn- toc-pane-styles []
+     {:wrap        {:position "sticky"
+                    :top "16px"
+                    :max-height "calc(100vh - 64px)"
+                    :overflow-y "auto"
+                    :width "180px"
+                    :flex-shrink "0"
+                    :padding "12px 12px 12px 16px"
+                    :margin-left "20px"
+                    :border-left (str "1px solid " (:border-subtle colors/tokens))
+                    :font-family sans-stack
+                    :font-size (:nano typography/type-scale)
+                    :color (:text-secondary colors/tokens)}
+      :label      {:text-transform "uppercase"
+                   :letter-spacing "0.08em"
+                   :color (:text-tertiary colors/tokens)
+                   :font-size (:nano typography/type-scale)
+                   :margin-bottom "6px"}
+      :list       {:list-style "none"
+                   :margin 0
+                   :padding 0
+                   :display "flex"
+                   :flex-direction "column"
+                   :gap "2px"}
+      :item       {:padding "3px 8px"
+                   :border-radius "3px"
+                   :cursor "pointer"
+                   :background "transparent"
+                   :border "none"
+                   :text-align "left"
+                   :color (:text-secondary colors/tokens)
+                   :font-family sans-stack
+                   :font-size (:caption typography/type-scale)}
+      :item-active {:background (:accent-amber-soft colors/tokens)
+                    :color (:accent-amber colors/tokens)}}))
+
+#?(:cljs
+   (defn- jump-to-anchor!
+     [anchor-id]
+     (when (and (exists? js/document) anchor-id)
+       (when-let [el (.getElementById js/document anchor-id)]
+         (try
+           (.scrollIntoView el #js {:behavior "smooth" :block "start"})
+           (catch :default _ nil))))))
+
+#?(:cljs
+   (defn- responsive-toc?
+     "Spec rf2-8c7tk: TOC auto-hides below 1024px (more aggressive than
+     Storybook's 1200px since our RHS is already present)."
+     []
+     (boolean
+       (when (exists? js/window)
+         (try (>= (.-innerWidth js/window) 1024)
+              (catch :default _ false))))))
+
+#?(:cljs
+   (defn- toc-pane
+     "Render the TOC pane at the docs page right edge. Tracks the
+     currently-visible section via IntersectionObserver so the active
+     entry highlights as the user scrolls."
+     [variant-id]
+     (let [active   (r/atom nil)
+           observer (atom nil)]
+       (r/create-class
+         {:display-name "rf-story-docs-toc"
+          :component-did-mount
+          (fn [_]
+            (when (and (exists? js/window) (.-IntersectionObserver js/window))
+              (try
+                (let [entries (visible-toc-entries variant-id)
+                      io (js/IntersectionObserver.
+                           (fn [entries-arr _obs]
+                             (doseq [e (array-seq entries-arr)]
+                               (when (.-isIntersecting e)
+                                 (reset! active (.-id (.-target e))))))
+                           #js {:rootMargin "-30% 0px -60% 0px"})]
+                  (reset! observer io)
+                  (doseq [{:keys [id]} entries]
+                    (when-let [el (.getElementById js/document id)]
+                      (.observe io el))))
+                (catch :default _ nil))))
+          :component-will-unmount
+          (fn [_]
+            (when-let [io @observer]
+              (try (.disconnect io) (catch :default _ nil))
+              (reset! observer nil)))
+          :reagent-render
+          (fn [variant-id]
+            (let [s         (toc-pane-styles)
+                  entries   (visible-toc-entries variant-id)
+                  active-id @active]
+              (when (and (responsive-toc?) (seq entries))
+                [:nav {:style     (:wrap s)
+                       :data-test "story-docs-toc"
+                       :aria-label "Documentation table of contents"}
+                 [:div {:style (:label s)} "Contents"]
+                 [:ul {:style (:list s)}
+                  (for [{:keys [id label]} entries]
+                    ^{:key id}
+                    [:li
+                     [:button
+                      {:style       (merge (:item s)
+                                           (when (= id active-id)
+                                             (:item-active s)))
+                       :data-test       "story-docs-toc-item"
+                       :data-toc-target id
+                       :aria-current    (if (= id active-id) "location" "false")
+                       :on-click        (fn [_] (jump-to-anchor! id))}
+                      label]])]])))}))))
+
 #?(:cljs
    (defn docs-view
      "Top-level `:docs` mode pane for `variant-id`.
 
      Renders the six sections (header / prose / args / decorators /
-     parameters / tags) inside a single scrollable container styled
-     to match the render-shell chrome (rf2-2uwv contrast palette).
-
-     Per spec/008 the pane is read-only — no inputs. All editing
-     happens in the `:dev` (Canvas) mode's controls panel."
+     parameters / tags) inside a flex layout alongside a sticky TOC
+     pane on the right edge (rf2-8c7tk; auto-hides below 1024px)."
      [variant-id]
      (when variant-id
-       [:section {:style     (:wrap styles)
-                  :data-test "story-docs-view"
-                  :aria-label "Variant documentation"}
-        [header variant-id]
-        [prose-section variant-id]
-        [args-section variant-id]
-        [decorators-section variant-id]
-        [parameters-section variant-id]
-        [tags-section variant-id]])))
+       [:div {:style     {:display "flex"
+                          :flex "1"
+                          :overflow "auto"
+                          :background (:bg-canvas colors/tokens)}
+              :data-test "story-docs-layout"}
+        [:section {:style     (:wrap styles)
+                   :data-test "story-docs-view"
+                   :aria-label "Variant documentation"}
+         [header variant-id]
+         [:section {:id "docs-prose"} [prose-section variant-id]]
+         [:section {:id "docs-args"} [args-section variant-id]]
+         [:section {:id "docs-decorators"} [decorators-section variant-id]]
+         [:section {:id "docs-parameters"} [parameters-section variant-id]]
+         [:section {:id "docs-tags"} [tags-section variant-id]]]
+        [toc-pane variant-id]])))

--- a/tools/story/src/re_frame/story/ui/help.cljs
+++ b/tools/story/src/re_frame/story/ui/help.cljs
@@ -220,6 +220,22 @@
     [:li {:style (:list-item styles)}
      [:b "notes / a11y / layout-debug"] " — author notes, axe-core scan, visual guides."]]
 
+   [:div {:style (:section-h styles)} "Keyboard shortcuts"]
+   [:ul {:style (:list styles)
+         :data-test "story-help-shortcuts-table"}
+    [:li {:style (:list-item styles)}
+     [kw "f"] " — full-screen mode (canvas fills viewport)."]
+    [:li {:style (:list-item styles)}
+     [kw "s"] " — toggle the sidebar."]
+    [:li {:style (:list-item styles)}
+     [kw "a"] " — toggle the inspectors (RHS / addons)."]
+    [:li {:style (:list-item styles)}
+     [kw "t"] " — toggle the toolbar."]
+    [:li {:style (:list-item styles)}
+     [kw "⌘K"] " / " [kw "Ctrl-K"] " — open the command palette."]
+    [:li {:style (:list-item styles)}
+     [kw "Esc"] " — exit full-screen / close palette / clear search."]]
+
    [:div {:style (:section-h styles)} "Re-open"]
    [:ul {:style (:list styles)}
     [:li {:style (:list-item styles)}

--- a/tools/story/src/re_frame/story/ui/keybindings.cljs
+++ b/tools/story/src/re_frame/story/ui/keybindings.cljs
@@ -1,0 +1,275 @@
+(ns re-frame.story.ui.keybindings
+  "Story global keyboard-shortcut registry (rf2-g8l8x / rf2-p3i0t).
+
+  Owns the single `window#keydown` capture-phase listener that backs
+  every chrome-level muscle-memory hotkey:
+
+      f  →  toggle full-screen      (rf2-p3i0t)
+      s  →  toggle sidebar          (rf2-g8l8x)
+      a  →  toggle RHS / addons     (rf2-g8l8x)
+      t  →  toggle toolbar          (rf2-g8l8x)
+
+  Cmd-K / Ctrl-K (the command palette, rf2-9hc8) ships its own
+  listener in `re-frame.story.ui.command-palette.view` — palette is a
+  modal surface, hotkeys here are inline chrome toggles. The two
+  listeners co-exist; both install on the capture phase so they
+  survive focused inputs.
+
+  ## Why a registry
+
+  Pre-rf2-g8l8x the chrome had ONE global hotkey (Cmd-K) wired
+  inline in `command_palette/view.cljs`. Adding `f` / `s` / `a` / `t`
+  as inline listeners on shell.cljs would scatter four nearly-
+  identical capture-phase listeners across the codebase with no
+  central inventory of bound keys. The registry pattern centralises:
+
+  - The canonical `[key → handler]` table (one map, one source of
+    truth for what's bound).
+  - Modifier discrimination (we ignore keys when a modifier is held,
+    so Cmd-S / Ctrl-S / Alt-T etc. pass through to the browser /
+    palette).
+  - Input-focus discrimination (we ignore keys when an `<input>` /
+    `<textarea>` / `[contenteditable]` is focused, so typing `f` into
+    the sidebar search doesn't toggle full-screen).
+  - Install / teardown semantics (one capture-phase listener; nothing
+    leaks across re-mounts).
+
+  ## Shape
+
+  Bindings are a `{key-string → handler-fn}` map. Each handler is a
+  zero-arg fn — it owns its side effect (typically a `swap-state!`
+  on the chrome-visibility slot). The dispatcher does the
+  modifier / focus discrimination and calls the handler when it
+  matches.
+
+  ## Persistence
+
+  The chrome-visibility toggles persist to localStorage under
+  `re-frame.story/chrome-visibility` so a refresh keeps the user's
+  layout intent. Hydration runs once at shell mount. `:embed?` is
+  intentionally excluded — embed-mode is URL-driven (rf2-pucku) and
+  must not carry across navigations.
+
+  ## Elision
+
+  Production builds with `re-frame.story.config/enabled?` false never
+  install the listener — Closure DCE drops the lot."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [re-frame.story.config :as config]
+            [re-frame.story.ui.state :as state]))
+
+;; ---- localStorage persistence -------------------------------------------
+
+(def ^:const ls-key
+  "localStorage key for the chrome-visibility map. Stored as a
+  `pr-str`-encoded map of the boolean slots; `read-string` on load."
+  "re-frame.story/chrome-visibility")
+
+(defn- safe-local-storage []
+  (when (and (exists? js/window) (.-localStorage js/window))
+    (try (.-localStorage js/window)
+         (catch :default _ nil))))
+
+(defn load-from-storage
+  "Read the persisted chrome-visibility map. Returns a map merged over
+  the canonical defaults, or `nil` when no persisted value exists.
+  `:embed?` is intentionally dropped on read — embed-mode is URL-driven
+  and must not survive across navigations."
+  []
+  (when-let [ls (safe-local-storage)]
+    (try
+      (let [raw (.getItem ls ls-key)]
+        (when (string? raw)
+          (let [parsed (edn/read-string raw)]
+            (when (map? parsed)
+              (-> state/chrome-visibility-defaults
+                  (merge (select-keys parsed
+                                      [:full-screen?
+                                       :sidebar?
+                                       :rhs?
+                                       :toolbar?])))))))
+      (catch :default _ nil))))
+
+(defn save-to-storage!
+  "Persist the chrome-visibility map. `:embed?` is stripped — embed
+  is URL-driven (rf2-pucku) and persisting it would leak between
+  navigations. Idempotent; silent on storage unavailability."
+  [chrome-vis]
+  (when-let [ls (safe-local-storage)]
+    (try
+      (.setItem ls ls-key
+                (pr-str (select-keys chrome-vis
+                                     [:full-screen?
+                                      :sidebar?
+                                      :rhs?
+                                      :toolbar?])))
+      (catch :default _ nil))))
+
+(defn hydrate!
+  "Seed `:chrome-visibility` from localStorage on shell mount. Idempotent
+  — only writes when the persisted shape differs from the current state
+  so we don't bounce a watcher save back onto storage."
+  []
+  (when-let [persisted (load-from-storage)]
+    (let [shell @state/shell-state-atom
+          current (state/chrome-visibility shell)
+          merged  (merge current
+                         (select-keys persisted
+                                      [:full-screen?
+                                       :sidebar?
+                                       :rhs?
+                                       :toolbar?]))]
+      (when (not= current merged)
+        (state/swap-state! assoc :chrome-visibility merged)))))
+
+;; ---- dispatcher predicate ----------------------------------------------
+
+(defn- target-is-input?
+  "True when the keydown's target is an editable element — text input,
+  textarea, contenteditable region. Hotkeys must yield to typing.
+
+  We accept the focus-on-editable predicate verbatim from the standard
+  pattern used by Storybook + VS Code: tag is `INPUT` / `TEXTAREA` /
+  `SELECT`, OR the element carries `contenteditable=\"true\"`."
+  [^js evt]
+  (let [t (.-target evt)]
+    (when t
+      (let [tag (some-> (.-tagName t) str/upper-case)
+            ce  (when (.-isContentEditable t) true)]
+        (or ce
+            (= tag "INPUT")
+            (= tag "TEXTAREA")
+            (= tag "SELECT"))))))
+
+(defn- has-modifier?
+  "True when any modifier key is held. The chrome hotkeys are deliberately
+  modifier-less — meta / ctrl / alt are the palette / browser space."
+  [^js evt]
+  (or (.-metaKey evt) (.-ctrlKey evt) (.-altKey evt)))
+
+(defn dispatch-key?
+  "Pure predicate: should the given `(key, modifier?, editable?)`
+  triple trigger a registered handler? Returns true only when no
+  modifier is held AND the focus is not in an editable region. The
+  bindings table itself is consulted by the caller — this fn lets
+  the JVM corpus pin the discrimination logic.
+
+  `key` arrives as the lowercase string from `event.key`."
+  [key modifier? editable?]
+  (boolean (and (not modifier?)
+                (not editable?)
+                (string? key)
+                (= 1 (count key)))))
+
+;; ---- canonical hotkey table --------------------------------------------
+
+(defn full-screen-toggle!
+  "Handler for the `f` key (rf2-p3i0t). Flips
+  `[:chrome-visibility :full-screen?]` + persists. Escape exits via the
+  separate `Escape`-listener in the canvas's full-screen overlay (see
+  `canvas/full-screen-overlay`)."
+  []
+  (state/swap-state! state/toggle-chrome-visibility :full-screen?)
+  (save-to-storage! (state/chrome-visibility (state/get-state))))
+
+(defn sidebar-toggle!
+  "Handler for the `s` key (rf2-g8l8x). Flips
+  `[:chrome-visibility :sidebar?]` + persists."
+  []
+  (state/swap-state! state/toggle-chrome-visibility :sidebar?)
+  (save-to-storage! (state/chrome-visibility (state/get-state))))
+
+(defn rhs-toggle!
+  "Handler for the `a` key (rf2-g8l8x — `a` for 'addons' per Storybook
+  convention). Flips `[:chrome-visibility :rhs?]` + persists."
+  []
+  (state/swap-state! state/toggle-chrome-visibility :rhs?)
+  (save-to-storage! (state/chrome-visibility (state/get-state))))
+
+(defn toolbar-toggle!
+  "Handler for the `t` key (rf2-g8l8x). Flips
+  `[:chrome-visibility :toolbar?]` + persists."
+  []
+  (state/swap-state! state/toggle-chrome-visibility :toolbar?)
+  (save-to-storage! (state/chrome-visibility (state/get-state))))
+
+(defn exit-full-screen!
+  "Public escape handler — clears `:full-screen?` regardless of prior
+  state. Bound to `Escape` while full-screen is on."
+  []
+  (state/swap-state! state/set-chrome-visibility :full-screen? false)
+  (save-to-storage! (state/chrome-visibility (state/get-state))))
+
+(def bindings
+  "Canonical `{key → handler}` table. Lowercase letters only — the
+  dispatcher lowercases `event.key` before lookup. Cmd-K / Ctrl-K is
+  excluded because the palette ships its own listener (it needs the
+  modifier discrimination, so the registry pattern doesn't fit)."
+  {"f" full-screen-toggle!
+   "s" sidebar-toggle!
+   "a" rhs-toggle!
+   "t" toolbar-toggle!})
+
+(defn shortcut-keys
+  "Pure data → data: the sorted list of bound keys. Used by the help
+  overlay's shortcut-table section so the rendered cheat-sheet stays
+  in lockstep with the registry."
+  []
+  (sort (keys bindings)))
+
+;; ---- listener install / teardown ---------------------------------------
+
+(defonce ^:private listener-handle (atom nil))
+
+(defn- dispatch!
+  "The single capture-phase keydown handler. Looks up the lowercase key
+  in `bindings`; calls the handler when the discrimination predicate
+  passes. Also handles `Escape` → exit-full-screen when full-screen is
+  active."
+  [^js evt]
+  (let [raw-key   (.-key evt)
+        editable? (target-is-input? evt)
+        modifier? (has-modifier? evt)
+        shell     (state/get-state)
+        chrome    (state/chrome-visibility shell)]
+    (cond
+      ;; Escape exits full-screen (rf2-p3i0t acceptance criterion). We
+      ;; gate the Escape branch on `editable?` so typing Escape into a
+      ;; focused input (e.g. the sidebar search) cancels the input
+      ;; rather than exiting full-screen — that's the search's intent.
+      ;; When full-screen is active there's NO visible input that would
+      ;; need Escape anyway, so the gating is conservative.
+      (and (= "Escape" raw-key)
+           (:full-screen? chrome)
+           (not editable?))
+      (do (.preventDefault evt)
+          (exit-full-screen!))
+
+      :else
+      (let [k (some-> raw-key str/lower-case)]
+        (when (and (dispatch-key? k modifier? editable?)
+                   (contains? bindings k))
+          (.preventDefault evt)
+          ((get bindings k)))))))
+
+(defn install!
+  "Install the global keydown listener. Idempotent — re-installing
+  replaces the previous handler. Gated behind
+  `re-frame.story.config/enabled?` so production builds DCE the lot."
+  []
+  (when config/enabled?
+    (when-let [prev @listener-handle]
+      (try (.removeEventListener js/window "keydown" prev true)
+           (catch :default _ nil)))
+    (let [h (fn [evt] (dispatch! evt))]
+      (.addEventListener js/window "keydown" h true)
+      (reset! listener-handle h))))
+
+(defn remove!
+  "Tear down the global keydown listener. Mirrors `install!`."
+  []
+  (when-let [h @listener-handle]
+    (try (.removeEventListener js/window "keydown" h true)
+         (catch :default _ nil))
+    (reset! listener-handle nil)))

--- a/tools/story/src/re_frame/story/ui/shell.cljs
+++ b/tools/story/src/re_frame/story/ui/shell.cljs
@@ -70,6 +70,7 @@
             [re-frame.story.ui.docs :as docs]
             [re-frame.story.ui.element-inspector :as element-inspector]
             [re-frame.story.ui.help :as help]
+            [re-frame.story.ui.keybindings :as keybindings]
             [re-frame.story.ui.mode-tabs :as mode-tabs]
             [re-frame.story.ui.panels :as panels]
             [re-frame.story.ui.play-status :as play-status]
@@ -598,26 +599,14 @@
   "Render the variant `canvas/canvas` wrapped with the effective
   viewport + background framing (rf2-zll4h).
 
-  The wrapper is a single `<div data-test=\"story-canvas-frame\">` so
-  Playwright specs can introspect the framed region. Resolution per
-  rf2-zll4h:
-    - per-variant `:viewport` / `:background` body slot wins
-    - then per-story `:viewport` / `:background` body slot
-    - then the chrome toolbar selection
-    - then the neutral defaults (`:full` / `:light`).
-
-  Both axes resolve via their respective switcher namespaces'
-  `effective-viewport` / `effective-background` helpers — keeping the
-  fallback logic in one place per axis so the chip label and the
-  rendered canvas always agree."
+  Per rf2-zgu68 also surfaces a viewport-px chip at the bottom-right
+  when a non-`:full` viewport mode is active. The chip self-elides
+  for `:full`."
   []
   (let [vp        (viewport-switcher/effective-viewport)
         bg        (backgrounds-switcher/effective-background)
         vp-style  (viewport/wrap-style vp)
         bg-style  (backgrounds/wrap-style bg)
-        ;; Match the canvas's own `.wrap` minimum so framed regions
-        ;; never collapse to zero height when the user picks a
-        ;; tiny custom viewport.
         wrap-style (merge {:padding    "16px"
                            :display    "flex"
                            :flex       "1"
@@ -625,11 +614,12 @@
                            :align-items "flex-start"
                            :justify-content "center"
                            :overflow   "auto"
-                           :box-sizing "border-box"}
+                           :box-sizing "border-box"
+                           ;; rf2-zgu68 — position relative so the
+                           ;; viewport-px chip's absolute slot anchors
+                           ;; against the framed region.
+                           :position   "relative"}
                           bg-style)
-        ;; When sizing is in effect, wrap canvas/canvas in an
-        ;; intermediate div with explicit width/height. Otherwise the
-        ;; framed-canvas just applies the background.
         sized?   (some? vp-style)]
     [:div {:style       wrap-style
            :data-test   "story-canvas-frame"
@@ -639,7 +629,9 @@
        [:div {:style     vp-style
               :data-test "story-canvas-frame-sized"}
         [canvas/canvas]]
-       [canvas/canvas])]))
+       [canvas/canvas])
+     ;; rf2-zgu68 — viewport-px indicator chip. Self-elides for `:full`.
+     [canvas/viewport-indicator vp]]))
 
 (defn- main-pane
   "The main content pane — workspace if one is selected, otherwise the
@@ -805,6 +797,16 @@
          ;; Reagent / DOM. Idempotent.
          (save-variant-ui/install!)
          (rails/hydrate!)
+         ;; rf2-g8l8x — hydrate per-panel chrome-visibility map from
+         ;; localStorage BEFORE the embed-flag pass (embed is URL-
+         ;; driven, must not be clobbered by stale persisted slot).
+         (keybindings/hydrate!)
+         ;; rf2-pucku — hydrate the `:embed?` slot from the
+         ;; `?embed=1` URL flag. One-shot at mount.
+         (url-state/hydrate-embed-flag! state/shell-state-atom)
+         ;; rf2-g8l8x / rf2-p3i0t — install the chrome-level hotkey
+         ;; listener. Cmd-K palette ships its own listener.
+         (keybindings/install!)
          (when-let [vid (:selected-variant @state/shell-state-atom)]
            (ensure-listeners-for-variant! vid)
            ;; rf2-v1ach: per-panel embed manages its own mount on
@@ -829,6 +831,9 @@
      (fn [_]
        (stop-hot-reload-poll!)
        (remove-selection-watcher!)
+       ;; rf2-g8l8x / rf2-p3i0t — tear down the chrome-level hotkey
+       ;; listener so a re-mount doesn't accumulate handlers.
+       (keybindings/remove!)
        (recorder-ui/remove-trace-listener!)
        ;; rf2-d5u89: tear down DOM-capture listeners alongside the
        ;; trace listener so we don't leak listeners across re-mounts.
@@ -843,42 +848,45 @@
        (teardown-all-listeners!))
      :reagent-render
      (fn []
-       (let [widths  (rails/current-widths)
-             narrow? (rails/narrow-viewport?)]
-         ;; rf2-3lt89: `data-rf-story-root` is the focus-visible scope
-         ;; declared in motion-css — the standardised amber outline +
-         ;; reduced-motion override target this root. The four chrome
-         ;; landmarks (toolbar / sidebar / main / right) ride staggered
-         ;; entrance keyframes via inline :animation styles so shell
-         ;; mount reveals as a choreographed 360ms sequence rather than
-         ;; a single synchronous paint. Each landmark wraps its child
-         ;; in a flex container so the animation root doesn't disrupt
-         ;; the layout.
+       (let [widths     (rails/current-widths)
+             narrow?    (rails/narrow-viewport?)
+             ;; rf2-p3i0t / rf2-g8l8x / rf2-pucku — chrome visibility
+             ;; resolution. Embed-mode + full-screen both hide every
+             ;; chrome pane; per-pane toggles win when neither absolute
+             ;; mode is on.
+             shell      @state/shell-state-atom
+             show-tb?   (state/chrome-pane-visible? :toolbar shell)
+             show-sb?   (state/chrome-pane-visible? :sidebar shell)
+             show-rhs?  (state/chrome-pane-visible? :rhs shell)]
          [:div {:style (:root styles)
-                :data-rf-story-root true}
-          ;; rf2-xi9zk: chrome-level toolbar — horizontal strip above the
-          ;; three-pane row. Stamped with the stagger entrance via a
-          ;; thin wrap so the toolbar strip ns doesn't need to reach
-          ;; into motion tokens.
-          [:div {:style {:animation (motion/stagger-animation :toolbar)
-                         :flex-shrink "0"}}
-           [toolbar/toolbar-strip]]
+                :data-rf-story-root true
+                :data-rf-chrome-fullscreen (str (get-in shell [:chrome-visibility :full-screen?] false))
+                :data-rf-chrome-embed      (str (get-in shell [:chrome-visibility :embed?] false))}
+          ;; rf2-g8l8x — `t` key + embed/full-screen suppress the strip.
+          (when show-tb?
+            [:div {:style {:animation (motion/stagger-animation :toolbar)
+                           :flex-shrink "0"}}
+             [toolbar/toolbar-strip]])
           [:div {:style (merge (:body styles)
                                (when narrow? (:body-narrow styles)))}
-           [sidebar/sidebar {:style (merge {:width       (str (:left widths) "px")
-                                            :flex-basis  (str (:left widths) "px")
-                                            :flex-shrink "0"
-                                            :animation   (motion/stagger-animation :sidebar)}
-                                           (when narrow?
-                                             {:width "auto"
-                                              :flex-basis "auto"
-                                              :max-height "42vh"}))}]
-           (when-not narrow?
+           ;; rf2-g8l8x / rf2-p3i0t / rf2-pucku — sidebar visibility.
+           (when show-sb?
+             [sidebar/sidebar {:style (merge {:width       (str (:left widths) "px")
+                                              :flex-basis  (str (:left widths) "px")
+                                              :flex-shrink "0"
+                                              :animation   (motion/stagger-animation :sidebar)}
+                                             (when narrow?
+                                               {:width "auto"
+                                                :flex-basis "auto"
+                                                :max-height "42vh"}))}])
+           (when (and show-sb? (not narrow?))
              [rails/splitter :left])
            [main-pane]
-           (when-not narrow?
+           (when (and show-rhs? (not narrow?))
              [rails/splitter :right])
-           [right-panel]]
+           ;; rf2-g8l8x / rf2-p3i0t / rf2-pucku — RHS visibility.
+           (when show-rhs?
+             [right-panel])]
           ;; rf2-381i: first-time help overlay + persistent re-open chip.
           ;; The chip lives in a fixed-position slot so it floats above the
           ;; chrome regardless of which panels are visible. Per rf2-pxeko

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -54,11 +54,13 @@
   `:agent`); unknown tags fall back to a neutral grey. The badges are
   inert (the filter row owns interaction) — purely a scan affordance."
   (:require [clojure.string                   :as str]
+            [reagent.core                     :as r]
             [re-frame.story.runtime           :as runtime]
             [re-frame.story.async             :as async]
             [re-frame.story.registrar         :as registrar]
             [re-frame.story.theme.colors      :as colors]
             [re-frame.story.theme.glyphs      :as glyphs]
+            [re-frame.story.ui.sidebar-search :as search]
             [re-frame.story.ui.sidebar-styles :refer [styles]]
             [re-frame.story.ui.state          :as state]))
 
@@ -237,8 +239,26 @@
                    :title     (str tag)}
             (name tag)]))])))
 
+(defn- highlighted-label
+  "rf2-yngai — render a variant / story label with the matched
+  substring wrapped in an amber-tint span. Returns a hiccup fragment
+  suitable for splatting inside the row `<span>`. No-search shortcut
+  returns the raw string unwrapped so the no-search path stays quiet."
+  [label query]
+  (let [segments (search/highlight-segments label query)]
+    (if (and (= 1 (count segments)) (not (:match? (first segments))))
+      [(:text (first segments))]
+      (vec
+        (for [[i {:keys [text match?]}] (map-indexed vector segments)]
+          (if match?
+            ^{:key (str "hit-" i)}
+            [:span {:style (:search-hit styles)
+                    :data-test "story-sidebar-search-hit"} text]
+            ^{:key (str "txt-" i)}
+            [:span text]))))))
+
 (defn- variant-row
-  [variant-id selected? testable? status tags]
+  [variant-id selected? testable? status tags query]
   [:div {:style       (merge (:variant-row styles)
                              (when selected? (:variant-row-active styles)))
          :data-test   "story-sidebar-variant-row"
@@ -261,7 +281,9 @@
      [status-dot status]
      [:span {:style (:variant-glyph styles)}
       [glyphs/variant-glyph 10]])
-   [:span (str "/" (name variant-id))]
+   ;; rf2-yngai — wrap label so matched substrings render with the
+   ;; amber-tint highlight when a search query is in flight.
+   (into [:span] (highlighted-label (str "/" (name variant-id)) query))
    [tag-badges tags]])
 
 (defn- story-block
@@ -270,22 +292,21 @@
   produced by `state/group-variants-by-story`).
 
   rf2-p0wur: story rows lead with an amber diamond glyph + carry an
-  inter-story spacer so the sidebar tree breathes — pre-rf2-p0wur the
-  rows packed flush with no whitespace breaks between top-level stories.
-  The glyph wears `:accent-amber` so the parent row reads as a labelled
-  chapter heading."
-  [{:keys [story-id variants]} selected-variant testable-set test-runs]
+  inter-story spacer.
+  rf2-yngai: story labels carry the amber-tint match highlight when
+  a search query is in flight."
+  [{:keys [story-id variants]} selected-variant testable-set test-runs query]
   [:div {:style (:story-block styles)}
    [:div {:style (:story-row styles)}
     [:span {:style (:story-glyph styles)}
      [glyphs/story-glyph 13]]
-    [:span (str (or story-id "(no story)"))]]
+    (into [:span] (highlighted-label (str (or story-id "(no story)")) query))]
    (for [[vid body] variants]
      (let [testable? (contains? testable-set vid)
            status    (or (get-in test-runs [vid :status]) :pending)
            tags      (:tags body)]
        ^{:key vid}
-       [variant-row vid (= vid selected-variant) testable? status tags]))])
+       [variant-row vid (= vid selected-variant) testable? status tags query]))])
 
 (defn- workspace-row
   [workspace-id selected?]
@@ -466,74 +487,102 @@
                                                (not watch-on?)))}
           (if watch-on? "● watching" "○ watch")]]])])))
 
+(defn- search-input
+  "rf2-yngai — search-as-you-type input row. Filters the tree in-place
+  on every keystroke. Esc clears the query AND blurs the input."
+  [query-ratom]
+  [:div {:style     (:search-row styles)
+         :data-test "story-sidebar-search-row"}
+   [:input {:type        "search"
+            :style       (:search-input styles)
+            :placeholder "Search stories…"
+            :value       @query-ratom
+            :data-test   "story-sidebar-search-input"
+            :aria-label  "Filter stories and variants"
+            :on-change   (fn [^js evt]
+                           (reset! query-ratom (.. evt -target -value)))
+            :on-key-down (fn [^js evt]
+                           (when (= "Escape" (.-key evt))
+                             (.preventDefault evt)
+                             (reset! query-ratom "")
+                             (some-> (.-target evt) .blur)))}]
+   (when (seq @query-ratom)
+     [:button {:style       (:search-clear styles)
+               :data-test   "story-sidebar-search-clear"
+               :aria-label  "Clear search"
+               :title       "Clear search"
+               :on-click    (fn [_] (reset! query-ratom ""))}
+      "×"])])
+
 (defn sidebar
   "Top-level sidebar component. Reads the registry snapshot + shell
   state, builds the filtered tree, and renders.
 
-  Per rf2-xc65 the sidebar renders as a `<nav>` landmark with
-  `tabindex=\"0\"` so axe-core's `region` rule passes and keyboard
-  users can focus the scrollable tree.
-
-  Per rf2-q0irb the sidebar carries two extra surfaces — the per-
-  variant status dots (rendered inside each variant row when the
-  variant is `:test`-tagged + `:play`-bearing) and the chrome-level
-  test widget at the foot. Both read from `[:tests :runs]`; the widget
-  drives `run-variant` over the testable set on click.
-
-  HOT PATH (rf2-dtj61): every shell-state ratom change re-renders this
-  component, which re-walks the registry to build the view model. We
-  compute `testable-variant-ids` ONCE here — both the per-row
-  `testable?` check (set membership) and the chrome-level `test-widget`
-  share the same derivation. Deeper memoisation keyed on
-  `(registrar-tick, tag-filter)` can wait until corpus size justifies."
+  Per rf2-xc65 the sidebar renders as a `<nav>` landmark.
+  Per rf2-q0irb carries per-variant status dots + chrome test widget.
+  Per rf2-yngai carries a search-as-you-type input above the tree
+  (ephemeral local state; not persisted across reloads)."
   ([] (sidebar nil))
   ([opts]
-  (let [shell           @state/shell-state-atom
-        registry        (state/registry-snapshot)
-        tag-filter      (:tag-filter shell)
-        sel-variant     (:selected-variant shell)
-        sel-ws          (:selected-workspace shell)
-        ;; rf2-7ncf9 — faceted filter: AND across axes, OR within.
-        ;; The axis-index reads from the tag registrar; passing it to
-        ;; `filter-variants` activates the 3-arity facet-aware form.
-        tag->axis       (registrar/tag->axis-index)
-        visible         (state/filter-variants (:variants registry)
-                                               tag-filter
-                                               tag->axis)
-        grouped         (state/group-variants-by-story visible)
-        workspaces      (:workspaces registry)
-        test-runs       (get-in shell [:tests :runs])
-        testable-vec    (state/testable-variant-ids (:variants registry))
-        testable-set    (set testable-vec)]
-    [:nav {:style      (merge (:wrap styles) (:style opts))
-           :data-test  "story-sidebar"
-           :aria-label "Stories and workspaces"
-           :tab-index  "0"}
-     [:div {:style (:tree styles)}
-      [:div {:style (:header styles)}
-       [:span {:style {:display "inline-flex" :align-items "center"
-                       :color (:accent-amber colors/tokens)}}
-        [glyphs/story-glyph 12]]
-       [:span "Stories"]]
-      [tag-filter-row (:variants registry) tag-filter tag->axis]
-      (if (empty? grouped)
-        [:div {:style (:empty styles)}
-         (if (empty? (:variants registry))
-           "no variants registered"
-           "no variants match the active tag filter")]
-        (for [{:keys [story-id] :as entry} grouped]
-          ^{:key (or story-id :nostory)}
-          [story-block entry sel-variant testable-set test-runs]))
-      (when (seq workspaces)
-        [:div
-         [:div {:style (:section styles)}
-          [:span {:style {:display "inline-flex" :align-items "center"
-                          :color (:info colors/tokens)
-                          :margin-right "6px"
-                          :vertical-align "-2px"}}
-           [glyphs/workspace-glyph 11]]
-          "Workspaces"]
-         (for [[wid _body] (sort-by key workspaces)]
-           ^{:key wid}
-           [workspace-row wid (= wid sel-ws)])])]
-     [test-widget shell registry testable-vec]])))
+   (let [query-ratom (r/atom "")]
+     (fn [opts]
+       (let [shell           @state/shell-state-atom
+             registry        (state/registry-snapshot)
+             tag-filter      (:tag-filter shell)
+             sel-variant     (:selected-variant shell)
+             sel-ws          (:selected-workspace shell)
+             tag->axis       (registrar/tag->axis-index)
+             visible         (state/filter-variants (:variants registry)
+                                                    tag-filter
+                                                    tag->axis)
+             grouped-all     (state/group-variants-by-story visible)
+             query           @query-ratom
+             grouped         (search/filter-grouped-tree grouped-all query)
+             workspaces      (search/filter-workspaces
+                               (:workspaces registry) query)
+             test-runs       (get-in shell [:tests :runs])
+             testable-vec    (state/testable-variant-ids (:variants registry))
+             testable-set    (set testable-vec)
+             searching?      (seq (str/trim query))]
+         [:nav {:style      (merge (:wrap styles) (:style opts))
+                :data-test  "story-sidebar"
+                :aria-label "Stories and workspaces"
+                :tab-index  "0"}
+          [:div {:style (:tree styles)}
+           [:div {:style (:header styles)}
+            [:span {:style {:display "inline-flex" :align-items "center"
+                            :color (:accent-amber colors/tokens)}}
+             [glyphs/story-glyph 12]]
+            [:span "Stories"]]
+           [search-input query-ratom]
+           [tag-filter-row (:variants registry) tag-filter tag->axis]
+           (if (empty? grouped)
+             [:div {:style     (:empty styles)
+                    :data-test (if searching?
+                                 "story-sidebar-search-empty"
+                                 "story-sidebar-empty")}
+              (cond
+                searching?
+                (str "no matches for '" query "'")
+
+                (empty? (:variants registry))
+                "no variants registered"
+
+                :else
+                "no variants match the active tag filter")]
+             (for [{:keys [story-id] :as entry} grouped]
+               ^{:key (or story-id :nostory)}
+               [story-block entry sel-variant testable-set test-runs query]))
+           (when (seq workspaces)
+             [:div
+              [:div {:style (:section styles)}
+               [:span {:style {:display "inline-flex" :align-items "center"
+                               :color (:info colors/tokens)
+                               :margin-right "6px"
+                               :vertical-align "-2px"}}
+                [glyphs/workspace-glyph 11]]
+               "Workspaces"]
+              (for [[wid _body] (sort-by key workspaces)]
+                ^{:key wid}
+                [workspace-row wid (= wid sel-ws)])])]
+          [test-widget shell registry testable-vec]])))))

--- a/tools/story/src/re_frame/story/ui/sidebar_search.cljc
+++ b/tools/story/src/re_frame/story/ui/sidebar_search.cljc
@@ -1,0 +1,187 @@
+(ns re-frame.story.ui.sidebar-search
+  "Sidebar search-as-you-type filter (rf2-yngai).
+
+  Different ergonomic from the Cmd-K command palette (rf2-9hc8):
+  the palette is fuzzy whole-registry jump; this is in-tree narrowing
+  by a substring query. Author audience expects both.
+
+  ## Surface
+
+  - `match-variant?`       — pure: does a variant id / body match the
+                             query?
+  - `match-story?`         — pure: does the story id itself match?
+  - `filter-grouped-tree`  — pure: take the `group-variants-by-story`
+                             output + a query, return the subtree
+                             whose stories OR variants match.
+  - `highlight-segments`   — pure: split a label into match / non-match
+                             segments for amber-tint highlighting.
+
+  Every fn here is pure data → data — JVM testable. The Reagent
+  input lives in `re-frame.story.ui.sidebar` and feeds these helpers
+  the live query string.
+
+  ## Match semantics
+
+  Token-AND, case-insensitive, substring per token. Matches against
+  the variant id's string form (`:story.counter/at-five` → searched as
+  `\"story.counter/at-five\"`) AND the parent story id's string form.
+  Token-AND mirrors the command-palette `match-score` discrimination
+  so users get consistent narrowing across both surfaces.
+
+  Empty / blank query → every variant matches (the filter no-ops)."
+  (:require [clojure.string :as str]))
+
+;; ---- pure: query tokenisation -------------------------------------------
+
+(defn tokenise
+  "Pure: split a search query into lowercase, non-blank tokens.
+  Empty / nil input returns an empty vector."
+  [query]
+  (if (string? query)
+    (->> (str/split (str/lower-case (str/trim query)) #"\s+")
+         (remove str/blank?)
+         vec)
+    []))
+
+(defn- variant-id-string
+  "Render a variant id as the lowercase string the matcher sees.
+  Strips the leading `:` from `pr-str` so `\":story.counter/at-five\"`
+  becomes `\"story.counter/at-five\"`. Pure data → data."
+  [variant-id]
+  (let [s (str variant-id)]
+    (str/lower-case
+      (if (str/starts-with? s ":") (subs s 1) s))))
+
+(defn- haystack-for-variant
+  "Pure: the concatenated lowercase string the matcher tests for a
+  given variant. Includes the variant id, parent story id (when
+  derivable from the namespace), and the variant body's `:doc`
+  string + variant tags (each tag's `(name kw)`).
+
+  All-in-one haystack so token-AND can hit across slots — typing
+  `count five` matches a variant whose id is `at-five` AND whose
+  story id is `story.counter`."
+  [variant-id variant-body]
+  (let [id-str  (variant-id-string variant-id)
+        ;; namespace = parent story id (Story v1 convention)
+        ns-str  (when (keyword? variant-id) (some-> (namespace variant-id) str/lower-case))
+        doc     (some-> (:doc variant-body) str str/lower-case)
+        tags    (when (set? (:tags variant-body))
+                  (->> (:tags variant-body)
+                       (keep #(when (keyword? %) (name %)))
+                       (str/join " ")
+                       str/lower-case))]
+    (str/join " " (remove nil? [id-str ns-str doc tags]))))
+
+;; ---- pure: predicates ---------------------------------------------------
+
+(defn match-variant?
+  "Pure predicate: does `[variant-id variant-body]` match `tokens` (the
+  output of `tokenise`)? Returns true when every token is a substring
+  of the variant's haystack. Defensive — lowercases tokens internally
+  so callers can pass raw strings without piping through `tokenise`."
+  [tokens variant-id variant-body]
+  (if (empty? tokens)
+    true
+    (let [hay (haystack-for-variant variant-id variant-body)]
+      (every? (fn [t] (str/includes? hay (str/lower-case t))) tokens))))
+
+(defn match-story?
+  "Pure: does a parent story id match every token? Used so a story
+  header that itself matches keeps its variants visible even when the
+  variants' own id strings don't carry the query. Lowercases tokens
+  internally."
+  [tokens story-id]
+  (if (empty? tokens)
+    true
+    (let [hay (variant-id-string (or story-id ""))]
+      (every? (fn [t] (str/includes? hay (str/lower-case t))) tokens))))
+
+;; ---- pure: grouped-tree filter -----------------------------------------
+
+(defn filter-grouped-tree
+  "Pure: given the output of `state/group-variants-by-story` (a vector
+  of `{:story-id ... :variants [[variant-id body] ...]}` entries) and
+  a search `query`, return the subset whose story id matches OR whose
+  variants match the query.
+
+  Resolution per spec rf2-yngai §match-semantics:
+
+  - A story whose id matches every token keeps ALL its variants
+    (ancestor-keeps-children).
+  - A story whose id does NOT match keeps only the variants whose
+    own haystack matches every token.
+  - A story with zero surviving variants is dropped from the tree.
+
+  Empty / blank query returns `entries` unchanged so the filter
+  no-ops on the empty-query case."
+  [entries query]
+  (let [tokens (tokenise query)]
+    (if (empty? tokens)
+      entries
+      (vec
+        (for [{:keys [story-id variants] :as entry} entries
+              :let [story-match? (match-story? tokens story-id)
+                    kept (if story-match?
+                           variants
+                           (vec (filter (fn [[vid body]]
+                                          (match-variant? tokens vid body))
+                                        variants)))]
+              :when (seq kept)]
+          (assoc entry :variants kept))))))
+
+(defn filter-workspaces
+  "Pure: trim a workspace map down to entries whose id matches every
+  token. Pre-emptive: when query is blank, returns the workspaces map
+  unchanged. Workspace bodies don't carry as much haystack as variants,
+  but the same `match-story?` semantics on the id keeps the filter
+  intuitive."
+  [workspaces query]
+  (let [tokens (tokenise query)]
+    (if (empty? tokens)
+      workspaces
+      (into {}
+            (filter (fn [[wid _body]]
+                      (match-story? tokens wid)))
+            workspaces))))
+
+;; ---- pure: highlight segmentation ---------------------------------------
+
+(defn- find-first-match
+  "Pure: return `[start end]` of the first match of any `token` in
+  `s-lower`, or nil. Token order honoured — first declared wins."
+  [s-lower tokens]
+  (some (fn [t]
+          (when-let [i (str/index-of s-lower t)]
+            [i (+ i (count t))]))
+        tokens))
+
+(defn highlight-segments
+  "Pure data → data: split `label` into a vector of
+  `{:text ... :match? boolean}` segments based on the tokens in
+  `query`. Used by the sidebar row renderer to wrap matched
+  substrings in an amber-tint span.
+
+  - Empty query → single non-match segment of the whole label.
+  - Token-order honoured: the first token whose substring appears in
+    the label is highlighted at its first occurrence; recursive on
+    the remainder of the label so multiple disjoint matches get their
+    own segments.
+  - Case-insensitive match; the highlighted segment preserves the
+    label's original case."
+  [label query]
+  (let [tokens (tokenise query)]
+    (if (or (empty? tokens) (str/blank? label))
+      [{:text label :match? false}]
+      (loop [acc [] remaining label]
+        (let [r-lower (str/lower-case remaining)]
+          (if-let [[s e] (find-first-match r-lower tokens)]
+            (let [before (subs remaining 0 s)
+                  match  (subs remaining s e)
+                  after  (subs remaining e)]
+              (recur (cond-> acc
+                       (seq before) (conj {:text before :match? false})
+                       :always      (conj {:text match :match? true}))
+                     after))
+            (cond-> acc
+              (seq remaining) (conj {:text remaining :match? false}))))))))

--- a/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar_styles.cljs
@@ -237,4 +237,39 @@
    :tag-badge-screenshot   {:background (:warning-bg colors/tokens) :color (:warning colors/tokens)}
    :tag-badge-experimental {:background (:tag-experimental-bg colors/tokens) :color (:tag-experimental-fg colors/tokens)}
    :tag-badge-internal     {:background (:tag-internal-bg colors/tokens) :color (:danger colors/tokens)}
-   :tag-badge-agent        {:background (:tag-agent-bg colors/tokens) :color (:success colors/tokens)}})
+   :tag-badge-agent        {:background (:tag-agent-bg colors/tokens) :color (:success colors/tokens)}
+   ;; rf2-yngai — search-as-you-type input row + amber-tint highlight.
+   :search-row     {:padding "0 12px 8px 12px"
+                    :display "flex"
+                    :align-items "center"
+                    :gap "6px"
+                    :border-bottom (str "1px solid " (:border-subtle colors/tokens))
+                    :margin-bottom "6px"
+                    :position "relative"}
+   :search-input   {:width "100%"
+                    :box-sizing "border-box"
+                    :background (:bg-input colors/tokens)
+                    :color (:text-primary colors/tokens)
+                    :border (str "1px solid " (:border-subtle colors/tokens))
+                    :border-radius "4px"
+                    :font-family mono-stack
+                    :font-size (:caption typography/type-scale)
+                    :padding "5px 24px 5px 8px"
+                    :outline "none"
+                    :transition (:chip motion/transitions)}
+   :search-clear   {:position "absolute"
+                    :right "18px"
+                    :top "50%"
+                    :transform "translateY(-50%)"
+                    :background "transparent"
+                    :border "none"
+                    :color (:text-tertiary colors/tokens)
+                    :cursor "pointer"
+                    :padding "0 4px"
+                    :font-family mono-stack
+                    :font-size (:caption typography/type-scale)
+                    :line-height "1"}
+   :search-hit     {:background (:accent-amber-soft colors/tokens)
+                    :color (:accent-amber colors/tokens)
+                    :border-radius "2px"
+                    :padding "0 1px"}})

--- a/tools/story/src/re_frame/story/ui/state.cljc
+++ b/tools/story/src/re_frame/story/ui/state.cljc
@@ -139,7 +139,16 @@
    ;; `:viewport` / `:background` override on the story / variant body
    ;; takes precedence over the chrome-wide selection at resolve time.
    :viewport            nil
-   :background          nil})
+   :background          nil
+   ;; rf2-p3i0t / rf2-g8l8x / rf2-pucku — per-panel chrome visibility
+   ;; toggled by muscle-memory hotkeys (`f` full-screen, `s` sidebar,
+   ;; `a` RHS, `t` toolbar) and the `?embed=1` URL flag. Defaults: every
+   ;; pane visible; full-screen + embed are opt-in.
+   :chrome-visibility   {:full-screen? false
+                         :sidebar?     true
+                         :rhs?         true
+                         :toolbar?     true
+                         :embed?       false}})
 
 ;; ---- pure transitions (extracted to state.transitions, rf2-gcpon) -------
 
@@ -161,6 +170,14 @@
 (def record-fingerprints       state.transitions/record-fingerprints)
 (def pin-snapshot              state.transitions/pin-snapshot)
 (def toggle-panel              state.transitions/toggle-panel)
+
+;; ---- chrome visibility re-exports (rf2-p3i0t / rf2-g8l8x / rf2-pucku) ---
+
+(def chrome-visibility-defaults state.transitions/chrome-visibility-defaults)
+(def chrome-visibility         state.transitions/chrome-visibility)
+(def toggle-chrome-visibility  state.transitions/toggle-chrome-visibility)
+(def set-chrome-visibility     state.transitions/set-chrome-visibility)
+(def chrome-pane-visible?      state.transitions/chrome-pane-visible?)
 
 ;; ---- mode-tab (rf2-9hc8) re-exports --------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/state/transitions.cljc
+++ b/tools/story/src/re_frame/story/ui/state/transitions.cljc
@@ -265,6 +265,80 @@
   [state panel-id]
   (update-in state [:panel-visibility panel-id] not))
 
+;; ---- chrome visibility (rf2-p3i0t / rf2-g8l8x / rf2-pucku) --------------
+
+(def chrome-visibility-defaults
+  "Canonical default shape for the `:chrome-visibility` slot. Used by
+  state hydration + tests so a missing slot reads the same as a
+  full-defaults map.
+
+  - `:full-screen?` is the `f`-key toggle (rf2-p3i0t): true → hide
+    sidebar + RHS + toolbar; canvas fills the viewport.
+  - `:sidebar?` / `:rhs?` / `:toolbar?` are per-panel toggles
+    (`s` / `a` / `t` keys, rf2-g8l8x). Each defaults to true.
+  - `:embed?` is hydrated from `?embed=1` (rf2-pucku). When true the
+    shell renders canvas-only — overrides every individual pane toggle.
+    Stateless / non-persisted (embeds are stateless by intent)."
+  {:full-screen? false
+   :sidebar?     true
+   :rhs?         true
+   :toolbar?     true
+   :embed?       false})
+
+(defn chrome-visibility
+  "Read the chrome-visibility map from `state`, merged over the default
+  shape so a fresh state (or one persisted before this slot existed)
+  still returns a well-formed map. Pure data → data."
+  [state]
+  (merge chrome-visibility-defaults (:chrome-visibility state)))
+
+(defn toggle-chrome-visibility
+  "Flip the boolean at `slot` (one of `:full-screen?` / `:sidebar?` /
+   `:rhs?` / `:toolbar?` / `:embed?`) on the chrome-visibility map.
+  Pure data → data."
+  [state slot]
+  (update-in state [:chrome-visibility slot]
+             (fn [v]
+               (let [defaults chrome-visibility-defaults
+                     prev     (if (some? v) v (get defaults slot))]
+                 (not prev)))))
+
+(defn set-chrome-visibility
+  "Set the boolean at `slot` on the chrome-visibility map to `value`.
+  Pure data → data."
+  [state slot value]
+  (assoc-in state [:chrome-visibility slot] (boolean value)))
+
+;; ---- effective per-pane visibility derivations --------------------------
+;;
+;; Embed-mode (rf2-pucku) wins absolutely: every chrome pane hides.
+;; Full-screen (rf2-p3i0t) hides every chrome pane but leaves canvas +
+;; in-canvas affordances. Per-pane toggles (rf2-g8l8x) win when neither
+;; absolute mode is on.
+
+(defn chrome-pane-visible?
+  "Resolve whether `pane` (`:sidebar` / `:rhs` / `:toolbar`) should render
+  given the chrome-visibility map. Pure data → data; JVM-testable.
+
+  Resolution: embed-mode > full-screen > per-pane toggle.
+
+  `:full-screen?` and `:embed?` both elide chrome; the difference is
+  intent — full-screen is a per-shell toggle the user drives via `f`,
+  embed is an outer-context signal carried in the URL. Both project to
+  'every chrome pane hidden' here."
+  [pane state]
+  (let [v (chrome-visibility state)
+        slot-key (case pane
+                   :sidebar :sidebar?
+                   :rhs     :rhs?
+                   :toolbar :toolbar?
+                   nil)]
+    (cond
+      (:embed? v)       false
+      (:full-screen? v) false
+      (nil? slot-key)   true
+      :else             (boolean (get v slot-key true)))))
+
 ;; ---- mode-tab (rf2-9hc8) -------------------------------------------------
 
 (def mode-tabs

--- a/tools/story/src/re_frame/story/ui/url_state.cljc
+++ b/tools/story/src/re_frame/story/ui/url_state.cljc
@@ -255,6 +255,29 @@
                  (share/parse-params (params->getter usp)))
                (catch :default _ nil))))))
 
+     (defn embed-flag-from-current-url
+       "Read the `?embed=1` flag (rf2-pucku) from
+       `window.location.search`. Returns true when the param is present
+       and recognised as truthy (`1`/`true`/`yes`/`on`,
+       case-insensitive); false otherwise.
+
+       The flag is intentionally NOT round-tripped through
+       `share/parse-params` because it's chrome-state, not shell-state
+       — it never hydrates the registrar-indexed slots and never
+       writes back to the URL."
+       []
+       (when-let [w (safe-window)]
+         (let [search (.-search (.-location w))]
+           (boolean
+             (when (and (string? search) (seq search))
+               (try
+                 (let [usp (js/URLSearchParams. search)
+                       raw (.get usp "embed")]
+                   (when (string? raw)
+                     (let [v (str/lower-case (str/trim raw))]
+                       (contains? #{"1" "true" "yes" "on"} v))))
+                 (catch :default _ false)))))))
+
      (defonce ^:private hydrating?-atom (atom false))
 
      (defn hydrating?
@@ -370,6 +393,23 @@
            (fn []
              (swap! shell-state-atom apply-fn parsed)))
          parsed))
+
+     (defn hydrate-embed-flag!
+       "Seed `[:chrome-visibility :embed?]` from the `?embed=1` URL
+       flag (rf2-pucku). One-shot at shell mount; embed-mode is URL-
+       driven and not persisted, so this runs every mount without
+       storage involvement.
+
+       Wrapped in the hydration guard so the state-watcher does not
+       react with a pushState back."
+       [shell-state-atom]
+       (let [embed? (embed-flag-from-current-url)]
+         (with-hydration-guard
+           (fn []
+             (swap! shell-state-atom
+                    update :chrome-visibility
+                    (fn [m] (assoc (or m {}) :embed? embed?)))))
+         embed?))
 
      (defn tear-down! [shell-state-atom]
        (remove-state-watcher! shell-state-atom)

--- a/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
@@ -21,26 +21,34 @@
 ;; ---- loading-phase? -----------------------------------------------------
 
 (deftest loading-phase-pre-mount-mounting-loading
-  (testing "pre-mount / mounting / loading + not-rendered? → true"
-    (is (true? (canvas/loading-phase? :pre-mount false)))
-    (is (true? (canvas/loading-phase? :mounting  false)))
-    (is (true? (canvas/loading-phase? :loading   false)))))
+  (testing "pre-mount / mounting / loading + not-rendered? + no assertions → true"
+    (is (true? (canvas/loading-phase? :pre-mount false false)))
+    (is (true? (canvas/loading-phase? :mounting  false false)))
+    (is (true? (canvas/loading-phase? :loading   false false)))))
 
 (deftest loading-phase-ready-or-error
   (testing ":ready / :error → false"
-    (is (false? (canvas/loading-phase? :ready false)))
-    (is (false? (canvas/loading-phase? :error false)))))
+    (is (false? (canvas/loading-phase? :ready false false)))
+    (is (false? (canvas/loading-phase? :error false false)))))
 
 (deftest loading-phase-first-rendered-overrides
   (testing "first-rendered? true → false regardless of phase"
-    (is (false? (canvas/loading-phase? :loading true)))
-    (is (false? (canvas/loading-phase? :pre-mount true)))))
+    (is (false? (canvas/loading-phase? :loading true false)))
+    (is (false? (canvas/loading-phase? :pre-mount true false)))))
+
+(deftest loading-phase-assertions-recorded-overrides
+  (testing "assertions-recorded? true → false even when phase is loading
+            (rf2-qrk2s: loader-never-completes / loader-rejects park the
+            lifecycle at :loading but the user view must render)"
+    (is (false? (canvas/loading-phase? :loading   false true)))
+    (is (false? (canvas/loading-phase? :pre-mount false true)))
+    (is (false? (canvas/loading-phase? :mounting  false true)))))
 
 (deftest loading-phase-nil-or-unknown
   (testing "nil phase → false (no skeleton when phase isn't known)"
-    (is (false? (canvas/loading-phase? nil false))))
+    (is (false? (canvas/loading-phase? nil false false))))
   (testing "unknown phase → false"
-    (is (false? (canvas/loading-phase? :something-else false)))))
+    (is (false? (canvas/loading-phase? :something-else false false)))))
 
 ;; ---- loading-skeleton hiccup shape --------------------------------------
 

--- a/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
@@ -1,0 +1,85 @@
+(ns re-frame.story.ui.canvas-skeleton-cljs-test
+  "CLJS-side regression net for the canvas loading skeleton + viewport-
+  px indicator (rf2-0s4p1 / rf2-zgu68).
+
+  Surface covered:
+
+  - `loading-phase?`        — pre-mount / mounting / loading → true;
+                              ready / error / nil → false; first-
+                              rendered? overrides
+  - `loading-skeleton`      — hiccup shape carries the canonical
+                              `data-test` attribute
+  - `mark-variant-rendered!` / `variant-first-rendered?` — sentinel
+                              round-trip
+  - `viewport-indicator`    — hidden for `:full` (no width/height);
+                              shows `\"WxH\"` text for sized presets"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.ui.canvas :as canvas]))
+
+(use-fixtures :each {:before (fn [] (canvas/reset-first-rendered!))})
+
+;; ---- loading-phase? -----------------------------------------------------
+
+(deftest loading-phase-pre-mount-mounting-loading
+  (testing "pre-mount / mounting / loading + not-rendered? → true"
+    (is (true? (canvas/loading-phase? :pre-mount false)))
+    (is (true? (canvas/loading-phase? :mounting  false)))
+    (is (true? (canvas/loading-phase? :loading   false)))))
+
+(deftest loading-phase-ready-or-error
+  (testing ":ready / :error → false"
+    (is (false? (canvas/loading-phase? :ready false)))
+    (is (false? (canvas/loading-phase? :error false)))))
+
+(deftest loading-phase-first-rendered-overrides
+  (testing "first-rendered? true → false regardless of phase"
+    (is (false? (canvas/loading-phase? :loading true)))
+    (is (false? (canvas/loading-phase? :pre-mount true)))))
+
+(deftest loading-phase-nil-or-unknown
+  (testing "nil phase → false (no skeleton when phase isn't known)"
+    (is (false? (canvas/loading-phase? nil false))))
+  (testing "unknown phase → false"
+    (is (false? (canvas/loading-phase? :something-else false)))))
+
+;; ---- loading-skeleton hiccup shape --------------------------------------
+
+(deftest loading-skeleton-hiccup-shape
+  (testing "hiccup root carries the canonical data-test"
+    (let [hiccup (canvas/loading-skeleton)
+          [_tag props] hiccup]
+      (is (= "story-canvas-loading-skeleton" (:data-test props)))
+      (is (= "status" (:role props)))
+      (is (= "polite" (:aria-live props))))))
+
+;; ---- first-rendered sentinel --------------------------------------------
+
+(deftest first-rendered-sentinel-round-trip
+  (testing "marker round-trips through the per-variant set"
+    (canvas/reset-first-rendered!)
+    (is (false? (canvas/variant-first-rendered? :story.x/y)))
+    (canvas/mark-variant-rendered! :story.x/y)
+    (is (true? (canvas/variant-first-rendered? :story.x/y)))
+    (canvas/reset-first-rendered! :story.x/y)
+    (is (false? (canvas/variant-first-rendered? :story.x/y))))
+  (testing "reset all"
+    (canvas/mark-variant-rendered! :story.a/one)
+    (canvas/mark-variant-rendered! :story.b/two)
+    (is (true? (canvas/variant-first-rendered? :story.a/one)))
+    (canvas/reset-first-rendered!)
+    (is (false? (canvas/variant-first-rendered? :story.a/one)))
+    (is (false? (canvas/variant-first-rendered? :story.b/two)))))
+
+;; ---- viewport-indicator -------------------------------------------------
+
+(deftest viewport-indicator-elides-for-full
+  (testing ":full preset has no width/height → indicator hidden"
+    (is (nil? (canvas/viewport-indicator {:label "Full" :width nil :height nil})))
+    (is (nil? (canvas/viewport-indicator {})))))
+
+(deftest viewport-indicator-shows-dims
+  (testing "sized preset → chip with WxH text"
+    (let [hiccup (canvas/viewport-indicator {:label "iPhone" :width 375 :height 667})
+          [_tag props text] hiccup]
+      (is (= "story-canvas-viewport-indicator" (:data-test props)))
+      (is (= "375 × 667" text)))))

--- a/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
+++ b/tools/story/test/re_frame/story/ui/chrome_visibility_test.cljc
@@ -1,0 +1,100 @@
+(ns re-frame.story.ui.chrome-visibility-test
+  "JVM-portable regression net for the chrome-visibility transitions
+  + per-pane visibility resolution (rf2-p3i0t / rf2-g8l8x / rf2-pucku).
+
+  Surface covered:
+
+  - `chrome-visibility-defaults` — canonical shape
+  - `chrome-visibility`          — merge-over-defaults read helper
+  - `toggle-chrome-visibility`   — boolean flip per slot
+  - `set-chrome-visibility`      — explicit set per slot
+  - `chrome-pane-visible?`       — embed > full-screen > per-pane
+                                    precedence
+
+  Pure data → data; no DOM / Reagent dependency."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.state.transitions :as transitions]))
+
+;; ---- defaults + read -----------------------------------------------------
+
+(deftest chrome-visibility-defaults-shape
+  (testing "canonical defaults"
+    (is (= {:full-screen? false
+            :sidebar?     true
+            :rhs?         true
+            :toolbar?     true
+            :embed?       false}
+           transitions/chrome-visibility-defaults))))
+
+(deftest chrome-visibility-merge-read
+  (testing "missing slot → fall back to defaults"
+    (is (= transitions/chrome-visibility-defaults
+           (transitions/chrome-visibility {}))))
+  (testing "partial map → merge over defaults"
+    (is (= (assoc transitions/chrome-visibility-defaults :full-screen? true)
+           (transitions/chrome-visibility
+             {:chrome-visibility {:full-screen? true}})))))
+
+;; ---- toggle / set --------------------------------------------------------
+
+(deftest toggle-chrome-visibility-shape
+  (testing "default false slot → flip to true"
+    (let [out (transitions/toggle-chrome-visibility {} :full-screen?)]
+      (is (= true (get-in out [:chrome-visibility :full-screen?])))))
+  (testing "default true slot → flip to false"
+    (let [out (transitions/toggle-chrome-visibility {} :sidebar?)]
+      (is (= false (get-in out [:chrome-visibility :sidebar?])))))
+  (testing "double toggle round-trips"
+    (let [a (transitions/toggle-chrome-visibility {} :rhs?)
+          b (transitions/toggle-chrome-visibility a :rhs?)]
+      (is (= true (get-in b [:chrome-visibility :rhs?]))))))
+
+(deftest set-chrome-visibility-shape
+  (testing "set true / set false"
+    (let [a (transitions/set-chrome-visibility {} :sidebar? false)]
+      (is (= false (get-in a [:chrome-visibility :sidebar?]))))
+    (let [b (transitions/set-chrome-visibility {} :full-screen? true)]
+      (is (= true (get-in b [:chrome-visibility :full-screen?]))))))
+
+;; ---- chrome-pane-visible? — precedence -----------------------------------
+
+(deftest chrome-pane-visible-defaults
+  (testing "default state: every pane visible"
+    (is (true? (transitions/chrome-pane-visible? :sidebar {})))
+    (is (true? (transitions/chrome-pane-visible? :rhs     {})))
+    (is (true? (transitions/chrome-pane-visible? :toolbar {})))))
+
+(deftest chrome-pane-visible-embed-wins-absolute
+  (testing "embed mode hides every chrome pane"
+    (let [s {:chrome-visibility {:embed? true}}]
+      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (transitions/chrome-pane-visible? :rhs     s)))
+      (is (false? (transitions/chrome-pane-visible? :toolbar s)))))
+
+  (testing "embed wins over a per-pane true"
+    (let [s {:chrome-visibility {:embed? true :sidebar? true :rhs? true}}]
+      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (transitions/chrome-pane-visible? :rhs     s))))))
+
+(deftest chrome-pane-visible-full-screen-hides
+  (testing "full-screen hides every chrome pane"
+    (let [s {:chrome-visibility {:full-screen? true}}]
+      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
+      (is (false? (transitions/chrome-pane-visible? :rhs     s)))
+      (is (false? (transitions/chrome-pane-visible? :toolbar s))))))
+
+(deftest chrome-pane-visible-per-pane-toggle
+  (testing "per-pane false hides only that pane"
+    (let [s {:chrome-visibility {:sidebar? false}}]
+      (is (false? (transitions/chrome-pane-visible? :sidebar s)))
+      (is (true?  (transitions/chrome-pane-visible? :rhs     s)))
+      (is (true?  (transitions/chrome-pane-visible? :toolbar s))))))
+
+(deftest chrome-pane-visible-precedence-embed-over-fullscreen
+  (testing "embed and full-screen both true → still hidden (both project hidden)"
+    (let [s {:chrome-visibility {:embed? true :full-screen? true}}]
+      (is (false? (transitions/chrome-pane-visible? :sidebar s))))))
+
+(deftest chrome-pane-visible-unknown-pane
+  (testing "unknown pane kw → defaults visible (forward-compat)"
+    (is (true? (transitions/chrome-pane-visible? :unknown {})))))

--- a/tools/story/test/re_frame/story/ui/docs_toc_test.cljc
+++ b/tools/story/test/re_frame/story/ui/docs_toc_test.cljc
@@ -1,0 +1,42 @@
+(ns re-frame.story.ui.docs-toc-test
+  "JVM-portable regression net for the docs-mode TOC table (rf2-8c7tk).
+
+  Surface covered:
+
+  - `docs-toc-entries`     — canonical table shape
+  - `visible-toc-entries`  — prose-conditional pruning vs always-on
+
+  CLJS-side (IntersectionObserver wiring + scroll-into-view + reactive
+  re-render) lives in `docs_toc_cljs_test.cljs` — this corpus pins the
+  pure projection only."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.docs :as docs]))
+
+(deftest toc-table-shape
+  (testing "canonical entry list"
+    (let [ids (mapv :id docs/docs-toc-entries)]
+      (is (= ["docs-prose" "docs-args" "docs-decorators"
+              "docs-parameters" "docs-tags"]
+             ids))))
+  (testing "every entry carries the required slots"
+    (doseq [entry docs/docs-toc-entries]
+      (is (some? (:id entry)))
+      (is (some? (:label entry)))
+      (is (integer? (:level entry))))))
+
+(deftest prose-is-conditional
+  (testing "only the prose entry is conditional"
+    (is (= [{:id "docs-prose" :label "Prose" :level 2 :conditional? true}]
+           (vec (filter :conditional? docs/docs-toc-entries))))))
+
+;; `visible-toc-entries` consults the live registrar for prose
+;; workspaces. The JVM corpus exercises it with no registrar →
+;; `prose-for-variant` returns empty, so the prose entry should be
+;; pruned.
+
+(deftest visible-toc-prunes-prose-when-absent
+  (testing "no prose workspace registered → prose entry pruned"
+    (let [out (docs/visible-toc-entries :story.fake/variant)]
+      (is (not-any? #(= "docs-prose" (:id %)) out))
+      (is (= ["docs-args" "docs-decorators" "docs-parameters" "docs-tags"]
+             (mapv :id out))))))

--- a/tools/story/test/re_frame/story/ui/keybindings_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/keybindings_cljs_test.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.story.ui.keybindings-cljs-test
+  "CLJS-side regression net for the chrome-level hotkey registry
+  (rf2-g8l8x / rf2-p3i0t).
+
+  Surface covered:
+
+  - `dispatch-key?`     — discrimination predicate (modifier + editable)
+  - `bindings`          — canonical key → handler map shape
+  - `shortcut-keys`     — sorted key list
+  - Each handler fn round-trips through the shell-state-atom"
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.story.ui.keybindings :as kb]
+            [re-frame.story.ui.state :as state]))
+
+(use-fixtures :each
+  {:before (fn [] (state/reset-shell-state!))})
+
+;; ---- dispatch predicate -------------------------------------------------
+
+(deftest dispatch-key-predicate
+  (testing "single lowercase char, no modifier, not editable → true"
+    (is (true? (kb/dispatch-key? "f" false false))))
+  (testing "modifier held → false (Cmd-K / Ctrl-S etc. pass through)"
+    (is (false? (kb/dispatch-key? "f" true false))))
+  (testing "focused input → false (typing in search shouldn't toggle)"
+    (is (false? (kb/dispatch-key? "f" false true))))
+  (testing "multi-char key (Arrow, Escape) → false"
+    (is (false? (kb/dispatch-key? "Escape" false false))))
+  (testing "nil / non-string → false"
+    (is (false? (kb/dispatch-key? nil false false)))))
+
+;; ---- registry shape -----------------------------------------------------
+
+(deftest bindings-table-shape
+  (testing "canonical 4-key registry: f / s / a / t"
+    (is (= #{"f" "s" "a" "t"} (set (keys kb/bindings))))
+    (is (= ["a" "f" "s" "t"]  (kb/shortcut-keys)))))
+
+;; ---- handler round-trip -------------------------------------------------
+
+(defn- visibility []
+  (state/chrome-visibility (state/get-state)))
+
+(deftest full-screen-toggle-round-trip
+  (testing "default off → on → off"
+    (is (false? (:full-screen? (visibility))))
+    (kb/full-screen-toggle!)
+    (is (true?  (:full-screen? (visibility))))
+    (kb/full-screen-toggle!)
+    (is (false? (:full-screen? (visibility))))))
+
+(deftest sidebar-toggle-round-trip
+  (testing "default on → off → on"
+    (is (true?  (:sidebar? (visibility))))
+    (kb/sidebar-toggle!)
+    (is (false? (:sidebar? (visibility))))
+    (kb/sidebar-toggle!)
+    (is (true?  (:sidebar? (visibility))))))
+
+(deftest rhs-toggle-round-trip
+  (testing "default on → off → on"
+    (is (true?  (:rhs? (visibility))))
+    (kb/rhs-toggle!)
+    (is (false? (:rhs? (visibility))))
+    (kb/rhs-toggle!)
+    (is (true?  (:rhs? (visibility))))))
+
+(deftest toolbar-toggle-round-trip
+  (testing "default on → off → on"
+    (is (true?  (:toolbar? (visibility))))
+    (kb/toolbar-toggle!)
+    (is (false? (:toolbar? (visibility))))
+    (kb/toolbar-toggle!)
+    (is (true?  (:toolbar? (visibility))))))
+
+(deftest exit-full-screen-clears
+  (testing "exit handler always clears full-screen regardless of prior"
+    (kb/full-screen-toggle!)         ;; on
+    (is (true? (:full-screen? (visibility))))
+    (kb/exit-full-screen!)            ;; off
+    (is (false? (:full-screen? (visibility))))
+    ;; idempotent: calling again leaves it off
+    (kb/exit-full-screen!)
+    (is (false? (:full-screen? (visibility))))))

--- a/tools/story/test/re_frame/story/ui/sidebar_search_test.cljc
+++ b/tools/story/test/re_frame/story/ui/sidebar_search_test.cljc
@@ -1,0 +1,173 @@
+(ns re-frame.story.ui.sidebar-search-test
+  "JVM-portable regression net for the sidebar search-as-you-type filter
+  (rf2-yngai). Every fn under test is `.cljc`-pure so this corpus runs
+  on both JVM (`clojure -M:test`) and CLJS (`npm run test:cljs`) — see
+  the sibling discriminator pattern in `viewport_test.cljc` /
+  `backgrounds_test.cljc`.
+
+  Surface covered:
+
+  - `tokenise`             — split / lowercase / blank-drop
+  - `match-variant?`       — token-AND substring discrimination
+  - `match-story?`         — story-id substring match
+  - `filter-grouped-tree`  — story-keeps-children / variant-narrow /
+                              prune-empty-stories
+  - `filter-workspaces`    — workspace map narrowing
+  - `highlight-segments`   — match / non-match segmentation"
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.story.ui.sidebar-search :as search]))
+
+;; ---- tokenise ------------------------------------------------------------
+
+(deftest tokenise-shape
+  (testing "blank / nil input returns empty vector"
+    (is (= [] (search/tokenise nil)))
+    (is (= [] (search/tokenise "")))
+    (is (= [] (search/tokenise "   "))))
+  (testing "single token"
+    (is (= ["foo"] (search/tokenise "foo")))
+    (is (= ["foo"] (search/tokenise "  Foo  "))))
+  (testing "multi-token split on whitespace + lowercase"
+    (is (= ["counter" "five"] (search/tokenise "Counter Five")))
+    (is (= ["a" "b" "c"]      (search/tokenise "a   b\tc")))))
+
+;; ---- match-variant? ------------------------------------------------------
+
+(deftest match-variant-shape
+  (testing "empty tokens → match-all"
+    (is (true? (search/match-variant? [] :story.x/y {}))))
+
+  (testing "token in variant id matches"
+    (is (true? (search/match-variant? ["five"] :story.counter/at-five {}))))
+
+  (testing "token-AND: every token must hit"
+    (is (true? (search/match-variant? ["counter" "five"]
+                                       :story.counter/at-five {})))
+    (is (false? (search/match-variant? ["counter" "missing"]
+                                        :story.counter/at-five {}))))
+
+  (testing "case-insensitive"
+    (is (true? (search/match-variant? ["FIVE"] :story.counter/at-five {})))
+    (is (true? (search/match-variant? ["Five"] :story.counter/at-five {}))))
+
+  (testing "token matches against variant's :doc + :tags"
+    (is (true? (search/match-variant? ["pending"]
+                                       :story.foo/bar
+                                       {:doc "pending stamp"})))
+    (is (true? (search/match-variant? ["screenshot"]
+                                       :story.foo/bar
+                                       {:tags #{:screenshot}})))))
+
+;; ---- match-story? --------------------------------------------------------
+
+(deftest match-story-shape
+  (testing "empty tokens → true"
+    (is (true? (search/match-story? [] :story.x))))
+  (testing "token-AND on story id"
+    (is (true? (search/match-story? ["counter"] :story.counter)))
+    (is (true? (search/match-story? ["story"] :story.counter)))
+    (is (false? (search/match-story? ["missing"] :story.counter)))))
+
+;; ---- filter-grouped-tree -------------------------------------------------
+
+(def ^:private fixture-grouped
+  [{:story-id :story.counter
+    :variants [[:story.counter/default {}]
+               [:story.counter/at-five {}]]}
+   {:story-id :story.login
+    :variants [[:story.login/empty {}]
+               [:story.login/error {}]]}])
+
+(deftest filter-grouped-tree-empty-query
+  (testing "blank / empty query → unchanged"
+    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped nil)))
+    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped "")))
+    (is (= fixture-grouped (search/filter-grouped-tree fixture-grouped "   ")))))
+
+(deftest filter-grouped-tree-story-match-keeps-children
+  (testing "story id matches → all variants survive (ancestor-keeps-children)"
+    (let [out (search/filter-grouped-tree fixture-grouped "counter")]
+      (is (= 1 (count out)))
+      (is (= :story.counter (-> out first :story-id)))
+      ;; both variants kept
+      (is (= 2 (count (-> out first :variants)))))))
+
+(deftest filter-grouped-tree-variant-narrow
+  (testing "story id NO match, only matching variants survive"
+    (let [out (search/filter-grouped-tree fixture-grouped "five")]
+      (is (= 1 (count out)))
+      (is (= :story.counter (-> out first :story-id)))
+      (is (= 1 (count (-> out first :variants))))
+      (is (= :story.counter/at-five (ffirst (-> out first :variants)))))))
+
+(deftest filter-grouped-tree-prunes-empty
+  (testing "story with zero surviving variants drops out"
+    (let [out (search/filter-grouped-tree fixture-grouped "completely-unknown-token")]
+      (is (= [] out)))))
+
+(deftest filter-grouped-tree-token-and
+  (testing "token-AND: tokens must all hit (story-match keeps children;
+            else variant haystack must carry every token)"
+    ;; "counter five" — story matches only "counter", not "five", so
+    ;; story-match is false. Variant haystack filter requires BOTH
+    ;; tokens: only :at-five carries "five".
+    (let [out (search/filter-grouped-tree fixture-grouped "counter five")]
+      (is (= 1 (count out)))
+      (is (= :story.counter (-> out first :story-id)))
+      (is (= 1 (count (-> out first :variants))))
+      (is (= :story.counter/at-five (ffirst (-> out first :variants)))))
+    (let [out (search/filter-grouped-tree fixture-grouped "login error")]
+      (is (= 1 (count out)))
+      (is (= :story.login (-> out first :story-id)))
+      ;; story-id matches only "login"; only :error survives the variant
+      ;; filter
+      (is (= 1 (count (-> out first :variants)))))))
+
+;; ---- filter-workspaces ---------------------------------------------------
+
+(deftest filter-workspaces-empty-query
+  (let [ws {:Workspace.dashboard {}
+            :Workspace.demo {}}]
+    (is (= ws (search/filter-workspaces ws "")))
+    (is (= ws (search/filter-workspaces ws nil)))))
+
+(deftest filter-workspaces-narrow
+  (let [ws {:Workspace.dashboard {}
+            :Workspace.demo {}}]
+    (let [out (search/filter-workspaces ws "dash")]
+      (is (= [:Workspace.dashboard] (vec (keys out)))))
+    (let [out (search/filter-workspaces ws "missing")]
+      (is (= {} out)))))
+
+;; ---- highlight-segments --------------------------------------------------
+
+(deftest highlight-segments-empty-query
+  (testing "empty query → one non-match segment"
+    (is (= [{:text "/at-five" :match? false}]
+           (search/highlight-segments "/at-five" "")))))
+
+(deftest highlight-segments-single-match
+  (testing "single token, single match in middle"
+    (let [out (search/highlight-segments "/at-five" "five")]
+      (is (= [{:text "/at-" :match? false}
+              {:text "five" :match? true}]
+             out)))))
+
+(deftest highlight-segments-case-insensitive-preserves-case
+  (testing "case-insensitive match preserves original label case"
+    (let [out (search/highlight-segments "AtFive" "five")]
+      (is (= [{:text "At" :match? false}
+              {:text "Five" :match? true}]
+             out)))))
+
+(deftest highlight-segments-multi-token
+  (testing "multi-token: first hit becomes the highlighted segment"
+    ;; "five" hits first in /at-five, recursive remainder has no more
+    ;; hits → single highlighted segment
+    (let [out (search/highlight-segments "/at-five" "five at")]
+      (is (some :match? out)))))
+
+(deftest highlight-segments-no-match
+  (testing "tokens don't hit → single non-match segment"
+    (let [out (search/highlight-segments "/at-five" "missing")]
+      (is (= [{:text "/at-five" :match? false}] out)))))

--- a/tools/story/test/re_frame/story_ui_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_ui_cljs_test.cljs
@@ -1152,8 +1152,18 @@
        :events    []})
     (let [result (docs/docs-view :story.dv/x)]
       (is (vector? result))
-      ;; Root is a <section> per the read-only contract.
-      (is (= :section (first result))))
+      ;; Per rf2-8c7tk the docs-view wraps the body section + TOC in a
+      ;; flex `<div>` so the sticky TOC anchors to the right edge. The
+      ;; inner body still renders as `<section data-test="story-docs-
+      ;; view">`.
+      (is (= :div (first result)))
+      (let [children (drop 2 result)
+            section  (some (fn [c]
+                             (when (and (vector? c) (= :section (first c)))
+                               c))
+                           children)]
+        (is (some? section))
+        (is (= "story-docs-view" (:data-test (second section))))))
     ;; The fn returns nil when given no variant id (the shell already
     ;; gates this, but the helper guards itself too).
     (is (nil? (docs/docs-view nil)))))


### PR DESCRIPTION
## Summary

Story Phase 3 cluster — 8 beads on top of the Phase 2 (#1566) sidebar+toolbar+Causa-in-Story landing. Adds muscle-memory hotkeys, search-as-you-type, loading skeleton, viewport indicator, docs TOC, and embed-mode URL flag.

## Per-bead resolution

| Bead | Status | Notes |
|---|---|---|
| rf2-p3i0t | shipped | `f` toggles full-screen; Esc exits; persisted to localStorage |
| rf2-g8l8x | shipped | `s` sidebar / `a` RHS / `t` toolbar via new `ui/keybindings` registry; help overlay gains shortcut table |
| rf2-yfwhw | closed-as-verified-shipped | rf2-p0wur (glyphs) + rf2-nwiwr (tag badges) already cover the row-iconography needs; docs-only / test-only distinctions are conveyed by the tag badges, not separate glyphs |
| rf2-yngai | shipped | new `ui/sidebar_search.cljc` (pure helpers) + input row above the tree; amber-tint highlight on matches; Esc clears + blurs; ephemeral local state |
| rf2-0s4p1 | shipped | amber-shimmer skeleton on canvas during `:pre-mount` / `:mounting` / `:loading` phases; hides on first render; `prefers-reduced-motion` static fallback |
| rf2-zgu68 | shipped | viewport-px chip at canvas bottom-right when a non-`:full` viewport is active |
| rf2-8c7tk | shipped | docs-mode sticky TOC pane; IntersectionObserver highlights current; click-to-jump; auto-hides below 1024px |
| rf2-pucku | shipped | `?embed=1` URL flag → canvas-only render; URL-driven, never persisted, embed wins over per-pane toggles |

## New surface

- **`tools/story/src/re_frame/story/ui/keybindings.cljs`** — single capture-phase listener for `f` / `s` / `a` / `t` hotkeys + Esc-exits-full-screen; modifier + focused-input discrimination; localStorage round-trip.
- **`tools/story/src/re_frame/story/ui/sidebar_search.cljc`** — pure `tokenise` / `match-variant?` / `match-story?` / `filter-grouped-tree` / `highlight-segments` helpers. Token-AND, case-insensitive, story-match-keeps-children.
- **Shell state slot** `:chrome-visibility {:full-screen? :sidebar? :rhs? :toolbar? :embed?}` with pure transitions in `state/transitions`. `chrome-pane-visible?` encodes the embed > full-screen > per-pane precedence.
- **5 test corpora** — JVM `sidebar_search_test`, `chrome_visibility_test`, `docs_toc_test`; CLJS `canvas_skeleton_cljs_test`, `keybindings_cljs_test`.

## Visual smoke notes

- Each shortcut fires once per keystroke (capture-phase, modifier-free)
- Esc inside the sidebar-search input clears + blurs (so the global `Escape→exit-full-screen` does not steal); Esc outside an input + full-screen on exits full-screen
- Full-screen hides toolbar+sidebar+RHS; sidebar splitter + RHS splitter also hide
- Sidebar search filters tree in-place; story-row label + variant-row label both wear the amber-tint highlight on match
- Skeleton animates during the loader phase; on `:ready` / `:error` the lifecycle hook flips the first-rendered sentinel and the skeleton hides
- Viewport indicator reads e.g. `"375 × 667"`; absent for `:full`
- TOC populates with the visible docs sections; prose entry is conditional on `(prose-for-variant)` having results
- `?embed=1` hides every chrome pane; help auto-open suppressed in embed mode (`config/static-mode?` already covers static-export; embed inherits the same suppression via the same `static-mode?` gate)

## Quality gates

| Command | Status |
|---|---|
| `clojure -M:test` (from `tools/story/`) | PASS — 781 tests / 0 failures |
| `npm run test:cljs` (from `implementation/`) | PASS — 3076 tests / 0 failures |
| `npm run test:bundle-isolation` | PASS — counter / counter-uix / counter-helix bundles unchanged |

## Hot-zone discipline

Stayed inside `tools/story/`. No touches to `tools/causa/`, `tools/re-frame2-pair-mcp/`, `tools/machines-viz/`, `implementation/`, root `spec/`, or `.github/workflows/*`. `causa_embed.cljs` was read-only reference; no edits.

## Test plan

- [ ] `f` toggles full-screen; Esc exits; localStorage persists across reload
- [ ] `s` / `a` / `t` toggle sidebar / RHS / toolbar; Cmd-K palette unaffected
- [ ] Typing into the sidebar search filters live; Esc clears
- [ ] Variants with slow loaders display the amber skeleton
- [ ] Viewport indicator chip reads the active preset dims; absent for `:full`
- [ ] Docs mode (rf2-9hc8 mode-tab) shows the sticky TOC on viewports >=1024px
- [ ] `?embed=1` URL renders canvas-only