### PR TITLE
feat(causa): event-lifecycle status-colour taxonomy (rf2-b76v4)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc
@@ -1,0 +1,229 @@
+(ns day8.re-frame2-causa.panels.event.event-status-colour
+  "Event-lifecycle status colour — the canonical TanStack-style pure fn
+  that maps a cascade's lifecycle state to a single palette token
+  (rf2-b76v4, parent rf2-vtd5z).
+
+  ## Why this lives in `panels/event/`
+
+  TanStack Query Devtools ships a single
+  `getQueryStatusColor(fetchStatus, observerCount, isStale)` → colour-key
+  pure fn. Sidebar dots, row backgrounds, badges, and tab counters all
+  consume the SAME fn so the devtool carries ONE lifecycle vocabulary
+  end-to-end. Pre-rf2-b76v4 Causa rolled its own colour decision at every
+  consumer site:
+
+    - `shell/event-row` switched bg/border on `focused?` + `ungrouped?`
+      with no notion of error/warning/in-flight at the row level.
+    - `panels/event-detail/outcome-colour` mapped `:ok` / `:error` /
+      `:warning` onto green / red / yellow at the Event header dot.
+    - `panels/trace` had no per-row cascade-status surface — every
+      trace row in the focused cascade rendered with the same neutral
+      chrome regardless of the cascade's terminal state.
+
+  This ns is the new central map. The hex-resolution wrapper
+  `event-status-colour` is the one fn three call sites consume; the
+  pure `classify-status` + `status->token` data layer underneath stays
+  JVM-portable so the lifecycle vocabulary is testable from
+  `clojure -M:test` without a CLJS runtime.
+
+  ## Lifecycle vocabulary
+
+  Five canonical states the devtool surfaces (mirroring the TanStack
+  semantic anchors; the colour anchors are chosen from the existing
+  Causa palette so no new tokens are introduced):
+
+      Status            Token            Hex (dark)  When
+      ----------------  ---------------  ----------  -----------------------
+      :in-flight        :accent-violet   #7C5CFF     cascade still building
+                                                     (LIVE head, not yet
+                                                     settled). Mirrors
+                                                     Causa's existing
+                                                     causal-chain accent.
+      :settled-success  :green           #4ADE80     handler ran, no
+                                                     exception, no warnings.
+      :settled-error    :red             #F87171     handler threw, or an
+                                                     :rf.error/* trace
+                                                     landed in the cascade.
+      :paused-by-tool   :cyan            #43C3D0     spine paused
+                                                     (LIVE+paused) — e.g.
+                                                     a tool has claimed
+                                                     the buffer. TanStack
+                                                     uses purple for
+                                                     paused; we already
+                                                     own violet for the
+                                                     causal chain so we
+                                                     pick cyan as the
+                                                     peer accent. Magenta
+                                                     is reserved for the
+                                                     `▥` whole-redacted
+                                                     row marker.
+      :stale            :yellow          #FBBF24     cascade replayed via
+                                                     time-travel / RETRO
+                                                     mode. The TanStack
+                                                     analog is the
+                                                     `isStale` flag; in
+                                                     Causa, a cascade in
+                                                     RETRO mode is the
+                                                     state being inspected
+                                                     out of LIVE order.
+
+  ## Input shape
+
+  The `event-status-colour` fn takes a map of the cascade's pertinent
+  lifecycle slots. Every field is optional; missing fields are treated
+  as falsey / unknown. Callers project off whatever they have:
+
+      {:outcome      :ok | :error | :warning | nil
+                                  ;; from `event-detail/cascade-outcome`
+       :focused?     <bool>       ;; spine focus is on this cascade
+       :paused?      <bool>       ;; spine :paused? slot
+       :mode         :live | :retro
+       :in-flight?   <bool>       ;; cascade dispatched but no terminal
+                                  ;; trace yet (rare in Causa today —
+                                  ;; cascades are buffer-projected after
+                                  ;; settle — but the slot is reserved
+                                  ;; for the live in-progress surface a
+                                  ;; follow-on bead will wire up)
+       :stale?       <bool>}      ;; explicit replayed-from-history flag
+
+  ## Mapping precedence
+
+  The classifier resolves in this order — first match wins:
+
+      :settled-error    when (= :error outcome)
+      :stale            when stale? OR (= :retro mode)
+      :in-flight        when in-flight? AND no terminal outcome
+      :paused-by-tool   when paused?
+      :settled-success  when (= :ok outcome) OR (= :warning outcome)
+      :in-flight        fallback (no signals — treat as live)
+
+  Notes:
+
+    - `:warning` outcomes resolve to `:settled-success`. The warning
+      glyph (`⚠`) ALREADY carries the warning signal at the Event
+      header glyph slot; the status colour reads the row as 'settled'
+      rather than re-amplifying the warning. (`outcome-colour` in
+      event-detail still uses yellow for the glyph itself; this fn
+      drives the broader row/header status, which the user reads
+      AS WELL AS the glyph.)
+    - `:error` always wins over `:stale` so a RETRO-replayed errored
+      cascade still surfaces as red.
+    - `:focused?` is captured by the caller's existing focus chrome
+      (bg-active, cyan border in `event-row`); the status fn does NOT
+      override the focus highlight — both can coexist in the row's
+      style map.
+
+  ## Pure data, JVM-portable
+
+  Everything here is pure data → pure data. `.cljc` so the JVM test
+  target exercises every state without a CLJS runtime. The hex
+  resolution happens through `theme/tokens` which is also JVM-loadable
+  pure data."
+  {:no-doc true}
+  (:require [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- vocabulary ---------------------------------------------------------
+
+(def statuses
+  "Render-order vector of the five lifecycle statuses. Useful for
+  enumerating chips / legends / tests."
+  [:in-flight :settled-success :settled-error :paused-by-tool :stale])
+
+(def status->token
+  "Pure semantic map from lifecycle status keyword to token keyword.
+  The hex resolution happens via `event-status-colour`, which looks
+  up `theme/tokens`. Splitting the semantic mapping from the hex
+  lookup keeps the map pure-data + tokens consolidated — mirrors the
+  `tier->token` / `op-type->token` shape used elsewhere in the
+  codebase."
+  {:in-flight       :accent-violet
+   :settled-success :green
+   :settled-error   :red
+   :paused-by-tool  :cyan
+   :stale           :yellow})
+
+;; ---- classification ------------------------------------------------------
+
+(defn classify-status
+  "Pure classifier: map a per-cascade lifecycle-state input map onto a
+  single status keyword. Returns one of `:in-flight` /
+  `:settled-success` / `:settled-error` / `:paused-by-tool` / `:stale`.
+
+  See the ns docstring for the precedence contract. Pure data →
+  keyword; JVM-runnable."
+  [{:keys [outcome paused? mode in-flight? stale?]
+    :or   {outcome     nil
+           paused?     false
+           mode        nil
+           in-flight?  false
+           stale?      false}}]
+  (cond
+    (= :error outcome)                         :settled-error
+    (or stale? (= :retro mode))                :stale
+    (and in-flight? (nil? outcome))            :in-flight
+    paused?                                    :paused-by-tool
+    (or (= :ok outcome) (= :warning outcome))  :settled-success
+    :else                                      :in-flight))
+
+;; ---- public colour resolver ---------------------------------------------
+
+(defn event-status-token
+  "Resolve the cascade's lifecycle state to a token KEYWORD (not the
+  hex). Useful for callers that want to colour-tag a span without
+  inlining the hex (e.g. data-testid suffixes, style-map composition
+  through `theme/tokens`).
+
+  Pure data → keyword; JVM-runnable."
+  [state]
+  (get status->token (classify-status state) :accent-violet))
+
+(defn event-status-colour
+  "Resolve the cascade's lifecycle state to a hex colour string,
+  routing through `status->token` + `theme/tokens` so the palette
+  has exactly one source of truth.
+
+  This is the ONE fn three call sites consume:
+
+    - `shell/event-row`     — L2 row left-border accent + dim bg tint
+    - `event-detail/Panel`  — Event L4 header status dot + label
+    - `panels/trace`        — per-row left-edge stripe when the row's
+                              parent dispatch-id is in the focused
+                              cascade
+
+  Pure data → string; JVM-runnable."
+  [state]
+  (get tokens/tokens (event-status-token state) (:accent-violet tokens/tokens)))
+
+;; ---- convenience: cascade → state map -----------------------------------
+
+(defn cascade->state
+  "Project a cascade record + focus map onto the lifecycle-state input
+  map `event-status-colour` consumes. Callers that already have the
+  cascade in hand can call this once per row rather than threading the
+  pieces by hand.
+
+  - `cascade`       — the projected cascade record (`:errors`, `:other`,
+                      `:event`, `:handler`)
+  - `focus`         — the spine focus map (`:dispatch-id`, `:mode`,
+                      `:paused?`); pass nil for callers that don't have
+                      it (e.g. JVM unit tests building the state map by
+                      hand)
+  - `outcome-fn`    — a fn `(cascade) -> :ok|:error|:warning`. Passed
+                      in by the caller (typically
+                      `event-detail/cascade-outcome` composed with
+                      `:outcome` selection) so this ns does NOT pull a
+                      circular dep on `panels/event-detail`.
+
+  Pure data → map; JVM-runnable."
+  [cascade focus outcome-fn]
+  (let [outcome   (some-> cascade outcome-fn :outcome)
+        focused?  (boolean
+                    (and cascade focus
+                         (= (:dispatch-id cascade) (:dispatch-id focus))))
+        stale?    (boolean (and focused? (= :retro (:mode focus))))]
+    {:outcome    outcome
+     :focused?   focused?
+     :paused?    (boolean (and focused? (:paused? focus)))
+     :mode       (when focused? (:mode focus))
+     :in-flight? false
+     :stale?     stale?}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/event_detail.cljs
@@ -65,6 +65,7 @@
     - tier-dot (reused in cascade-outcome + per-fx duration)"
   (:require [clojure.string :as string]
             [re-frame.core :as rf]
+            [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.managed-fx-helpers :as managed-fx-h]
             [day8.re-frame2-causa.panels.managed-fx-template :as managed-fx]
@@ -346,12 +347,33 @@
 
 (defn- cascade-outcome-line
   "Top-of-panel single-line health summary. Replaces the v1
-  literal 'Event detail' h1."
+  literal 'Event detail' h1.
+
+  ## rf2-b76v4 — lifecycle-status dot
+
+  The header carries a leading status dot rendered with the canonical
+  `event-status-colour` helper (the same fn the L2 row + Trace panel
+  consume). The dot signals the cascade's lifecycle vocabulary —
+  `:settled-error` / `:settled-success` / `:stale` (RETRO mode) /
+  `:paused-by-tool` / `:in-flight` — at a glance, without depending
+  on the trailing glyph cluster. The glyph itself stays semantic
+  (✓ / ✗ / ⚠) so colour-blind users have a shape signal; the dot
+  reinforces the same lifecycle state with the canonical colour."
   [cascade]
   (let [{:keys [event-id glyph outcome duration-ms dispatch-id ssr?]}
-        (cascade-outcome cascade)]
+        (cascade-outcome cascade)
+        ;; rf2-b76v4 — read the spine focus so the status fn can pick
+        ;; up :stale (RETRO mode) + :paused-by-tool. `:rf.causa/focus`
+        ;; is the canonical spine sub; nil-safe inside
+        ;; `event-status/cascade->state`.
+        focus       @(rf/subscribe [:rf.causa/focus])
+        status-state (event-status/cascade->state
+                       cascade focus cascade-outcome)
+        status-kw    (event-status/classify-status status-state)
+        status-hex   (event-status/event-status-colour status-state)]
     [:header {:data-testid "rf-causa-event-detail-outcome"
               :data-outcome (name outcome)
+              :data-rf-causa-status (name status-kw)
               :style {:display       "flex"
                       :align-items   "center"
                       :gap           "10px"
@@ -360,6 +382,24 @@
                       :border-bottom (str "1px solid " (:border-subtle tokens))
                       :font-family   sans-stack
                       :font-size     "13px"}}
+     ;; rf2-b76v4 — leading lifecycle-status dot. Rides the canonical
+     ;; vocabulary the L2 row + Trace panel also consume; one fn
+     ;; drives the colour across the whole devtool.
+     [:span {:data-testid (str "rf-causa-event-detail-status-dot-"
+                               (name status-kw))
+             :style {:display "inline-block"
+                     :width   "10px"
+                     :height  "10px"
+                     :border-radius "50%"
+                     :background status-hex
+                     :flex-shrink 0}
+             :title (case status-kw
+                      :in-flight       "in-flight"
+                      :settled-success "settled — success"
+                      :settled-error   "settled — error"
+                      :paused-by-tool  "paused by tool"
+                      :stale           "stale (replayed / RETRO)"
+                      (name status-kw))}]
      [:span {:data-testid "rf-causa-event-detail-outcome-event-id"
              :style {:color (:accent-violet tokens)
                      :font-family mono-stack

--- a/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/trace.cljs
@@ -85,6 +85,8 @@
   target."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as cch]
+            [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.overflow-indicator :as overflow]
             [day8.re-frame2-causa.panels.trace-helpers :as h]
             [day8.re-frame2-causa.theme.tokens
@@ -561,16 +563,69 @@
                            :font-size  "12px"}}
     "Clear filters"]])
 
+;; ---- cascade status timeline bar (rf2-b76v4) ---------------------------
+
+(defn- cascade-status-bar
+  "Render the focused cascade's lifecycle-status bar above the trace
+  ribbon. The Trace tab is cascade-scoped (rf2-ycoct) — every visible
+  row already belongs to the focused cascade — so the bar fills the
+  ribbon's full width with the canonical lifecycle colour. This is
+  the bead's 'Trace timeline bar fill' surface: ONE pure-fn-driven
+  bar that tells the user 'these rows are settled-success / errored /
+  stale / paused / in-flight' at a glance, before they scan the
+  per-row dots.
+
+  The fn consumes `event-status/event-status-colour` — the same
+  helper the L2 list rows + the Event L4 header dot consume — so the
+  whole devtool speaks ONE lifecycle vocabulary."
+  [{:keys [cascade focus]}]
+  (let [status-state (event-status/cascade->state
+                       cascade focus event-detail/cascade-outcome)
+        status-kw    (event-status/classify-status status-state)
+        status-hex   (event-status/event-status-colour status-state)]
+    [:div {:data-testid (str "rf-causa-trace-cascade-status-bar-"
+                             (name status-kw))
+           :data-rf-causa-status (name status-kw)
+           :title (case status-kw
+                    :in-flight       "Focused cascade — in-flight"
+                    :settled-success "Focused cascade — settled (success)"
+                    :settled-error   "Focused cascade — settled (error)"
+                    :paused-by-tool  "Focused cascade — paused by tool"
+                    :stale           "Focused cascade — stale (replayed / RETRO)"
+                    (str "Focused cascade — " (name status-kw)))
+           :style {:height        "3px"
+                   :background    status-hex
+                   :flex-shrink   0}}]))
+
 ;; ---- public view --------------------------------------------------------
 
 (rf/reg-view Panel
   "The Trace panel's root view. Subscribes to `:rf.causa/trace-feed`
-  and renders either the chip-filterable ribbon or the empty-state."
+  and renders either the chip-filterable ribbon or the empty-state.
+
+  ## rf2-b76v4 — cascade-status timeline bar
+
+  A 3px bar above the ribbon fills with the focused cascade's
+  lifecycle-status colour. The bar is the Trace tab's representation
+  of the bead's 'timeline bar fill' surface — ONE bar driven by
+  `event-status-colour`, the same fn the L2 row + Event header
+  consume. The Trace tab is cascade-scoped (rf2-ycoct), so the bar's
+  status reflects every visible row's parent cascade."
   []
   (let [{:keys [rows total rendered distinct counts filters
                 any-filter? empty-kind active-filters]
          :as _data}
-        @(rf/subscribe [:rf.causa/trace-feed])]
+        @(rf/subscribe [:rf.causa/trace-feed])
+        ;; rf2-b76v4 — pull the focused cascade + focus map so the
+        ;; cascade-status timeline bar can render with the canonical
+        ;; lifecycle colour. Both subs are cheap (constant-time
+        ;; selectors over the spine slot + the cascade list).
+        cascades       @(rf/subscribe [:rf.causa/cascades])
+        focus          @(rf/subscribe [:rf.causa/focus])
+        focused-id     (:dispatch-id focus)
+        focused-cascade (when focused-id
+                          (some #(when (= focused-id (:dispatch-id %)) %)
+                                cascades))]
     [:section {:data-testid "rf-causa-trace"
                :style       {:height         "100%"
                              :display        "flex"
@@ -585,6 +640,12 @@
               :counts      counts
               :filters     filters
               :any-filter? any-filter?})
+     ;; rf2-b76v4 — cascade-status timeline bar. Renders only when a
+     ;; cascade is in focus and the ribbon has rows; the empty-state
+     ;; branches don't carry a 'focused cascade' surface to colour.
+     (when (and focused-cascade (nil? empty-kind))
+       (cascade-status-bar {:cascade focused-cascade
+                            :focus   focus}))
      [:div {:style {:flex 1 :overflow "auto"}}
       (case empty-kind
         :no-events  (empty-state-no-events)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -110,6 +110,7 @@
              :as app-db-segment-inspector]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
             [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
             [day8.re-frame2-causa.panels.issues-ribbon :as issues-ribbon]
             [day8.re-frame2-causa.panels.machine-inspector :as machine-inspector]
             [day8.re-frame2-causa.panels.routing :as routing]
@@ -944,7 +945,7 @@
   focus-set is active, out-of-focus rows render at ~40% opacity and
   the gutter renders an OPEN `⦿` marker; the pivot row renders a
   FILLED `⦿` marker."
-  [{:keys [cascade focused-id auto-track? focus-set in-focus? now-ms]}]
+  [{:keys [cascade focused-id auto-track? focus-set in-focus? focus now-ms]}]
   (let [id          (:dispatch-id cascade)
         focused?    (= id focused-id)
         pivot?      (and focus-set (= id (:pivot-id focus-set)))
@@ -961,6 +962,18 @@
         badges      (row-badges cascade)
         ev-id       (event-id-of-cascade cascade)
         event-vec   (:event cascade)
+        ;; rf2-b76v4 — canonical event-lifecycle status colour. ONE
+        ;; helper drives the row's status accent (a 2px inset stripe on
+        ;; the trailing edge — sibling to the gutter's causal-chain
+        ;; thread on the leading edge). Replaces the pre-rf2-b76v4
+        ;; rolled-on-the-fly bg/border colour decisions. The status fn
+        ;; reads the cascade's terminal outcome (error / warning / ok)
+        ;; via `event-detail/cascade-outcome` so the L2 row, the L4
+        ;; Event header and the Trace row all consume ONE vocabulary.
+        status-state (event-status/cascade->state
+                       cascade focus event-detail/cascade-outcome)
+        status-kw    (event-status/classify-status status-state)
+        status-hex   (event-status/event-status-colour status-state)
         glyph-col   (cond
                       focused?                                (:cyan tokens)
                       (= "x" glyph)                           (:red tokens)
@@ -980,6 +993,14 @@
                       focused?   (str "1px solid " (:cyan tokens))
                       ungrouped? (str "1px dashed " (:border-subtle tokens))
                       :else      "1px solid transparent")
+        ;; rf2-b76v4 — the lifecycle-status accent rides as a 2px inset
+        ;; box-shadow on the row's TRAILING edge so it doesn't compete
+        ;; with the focused-row solid border (which paints the row
+        ;; outline) or the gutter's leading-edge causal-chain thread.
+        ;; The `:ungrouped` row suppresses the accent because the bucket
+        ;; has no lifecycle (no event vector, no cascade outcome).
+        status-shadow (when (and (not ungrouped?) status-hex)
+                        (str "inset -2px 0 0 0 " status-hex))
         ;; rf2-ieg6d Bug 1 — only the focused row in the LIVE-at-head
         ;; auto-tracking branch carries a ref. RETRO and non-focused rows
         ;; get nil (no DOM-side scroll work, no per-render cost).
@@ -1035,6 +1056,12 @@
                                             :else               "false")
                   :data-rf-causa-pivot    (if pivot? "true" "false")
                   :data-rf-causa-ungrouped (if ungrouped? "true" "false")
+                  ;; rf2-b76v4 — the resolved lifecycle status keyword
+                  ;; rides on a data attribute so tests + the
+                  ;; pure-hiccup walker can assert the row picked up
+                  ;; the right vocabulary without parsing inline
+                  ;; styles.
+                  :data-rf-causa-status   (name status-kw)
                   :style {:display       "flex"
                           :align-items   "center"
                           :gap           "6px"
@@ -1044,6 +1071,13 @@
                           :cursor        "pointer"
                           :background    bg
                           :border        border
+                          ;; rf2-b76v4 — the lifecycle-status accent is
+                          ;; a 2px inset shadow on the row's trailing
+                          ;; edge. Sibling to the gutter's leading-edge
+                          ;; causal-chain thread (rf2-5kfxe.10), and
+                          ;; non-overlapping with the focused-row solid
+                          ;; border.
+                          :box-shadow    (or status-shadow "none")
                           :border-radius "2px"
                           :font-family   mono-stack
                           :font-size     (:mono-body type-scale)
@@ -1264,6 +1298,11 @@
                            :auto-track? auto-track?
                            :focus-set   focus-set
                            :in-focus?   (focus-pred cascade)
+                           ;; rf2-b76v4 — pass the spine focus through
+                           ;; so the row's lifecycle-status classifier
+                           ;; can read `:mode` (RETRO → :stale) and
+                           ;; `:paused?` (paused-by-tool → :cyan).
+                           :focus       focus
                            :now-ms      now-ms}])))]))
 
 ;; ---- L3 tab bar ----------------------------------------------------------

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_cljs_test.cljc
@@ -1,0 +1,269 @@
+(ns day8.re-frame2-causa.panels.event.event-status-colour-cljs-test
+  "Pure-data tests for the canonical event-lifecycle status-colour map
+  (rf2-b76v4).
+
+  ## Why .cljc + _cljs_test naming
+
+  Same dual-target pattern as `perf_tier_cljs_test.cljc` /
+  `tokens_cljs_test.cljc` — Cognitect (`.*-test$` ns regex) + Shadow
+  `:node-test` (`cljs-test$`).
+
+  ## What's under test
+
+    - `classify-status` resolves every per-state input to the right
+      lifecycle keyword (`:in-flight` / `:settled-success` /
+      `:settled-error` / `:paused-by-tool` / `:stale`).
+    - The precedence contract — `:settled-error` always wins, `:stale`
+      wins over `:in-flight`, etc.
+    - `status->token` covers every status with a token keyword that
+      resolves to a non-nil hex through `theme/tokens` (no nil drop-
+      outs).
+    - `event-status-colour` is a pure passthrough through
+      `theme/tokens` (no inline hexes, one source of truth).
+    - `cascade->state` projects the cascade + focus pair onto the
+      input map consumed by the classifier."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-causa.panels.event.event-status-colour :as esc]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
+
+;; ---- vocabulary ---------------------------------------------------------
+
+(deftest statuses-enumeration-is-stable
+  (testing "the five canonical statuses ride in a stable render order
+            so callers (chip rows, legends) can enumerate them
+            deterministically."
+    (is (= [:in-flight :settled-success :settled-error
+            :paused-by-tool :stale]
+           esc/statuses))))
+
+(deftest status-token-map-covers-every-status
+  (testing "rf2-b76v4 — every status has a token keyword. No
+            unmapped status leaks a nil into the palette."
+    (is (= (set esc/statuses)
+           (set (keys esc/status->token))))))
+
+(deftest status-token-map-mirrors-tanstack-anchors
+  (testing "rf2-b76v4 — the per-status token assignments mirror the
+            TanStack devtool's semantic anchors with one peer-pick
+            substitution (paused-by-tool → :cyan rather than purple,
+            because Causa already owns :accent-violet for the causal
+            chain)."
+    (is (= :accent-violet  (esc/status->token :in-flight)))
+    (is (= :green          (esc/status->token :settled-success)))
+    (is (= :red            (esc/status->token :settled-error)))
+    (is (= :cyan           (esc/status->token :paused-by-tool)))
+    (is (= :yellow         (esc/status->token :stale)))))
+
+(deftest every-status-resolves-to-a-non-nil-hex
+  (testing "the indirection chain (status → token-kw → hex) lands on
+            a real hex for every status. No magenta-tinted gap, no
+            missing key in `theme/tokens`."
+    (doseq [status esc/statuses]
+      (let [token-kw (esc/status->token status)
+            hex      (get tokens/tokens token-kw)]
+        (is (string? hex) (str status " → " token-kw " resolves to a hex"))
+        (is (re-find #"^#[0-9A-Fa-f]+$" hex)
+            (str status " hex " hex " starts with #"))))))
+
+;; ---- classifier — per-state coverage ------------------------------------
+
+(deftest classify-status-settled-success
+  (testing ":ok outcome with no other signals → :settled-success."
+    (is (= :settled-success
+           (esc/classify-status {:outcome :ok})))))
+
+(deftest classify-status-settled-error
+  (testing ":error outcome → :settled-error regardless of any other
+            slot. Errors override RETRO mode, in-flight, paused — the
+            user MUST notice the red."
+    (is (= :settled-error (esc/classify-status {:outcome :error})))
+    (is (= :settled-error (esc/classify-status {:outcome :error :mode :retro})))
+    (is (= :settled-error (esc/classify-status {:outcome :error :paused? true})))
+    (is (= :settled-error (esc/classify-status {:outcome :error :stale? true})))
+    (is (= :settled-error (esc/classify-status {:outcome :error :in-flight? true})))))
+
+(deftest classify-status-settled-warning-resolves-to-success
+  (testing ":warning outcome → :settled-success. The yellow glyph
+            ALREADY signals warning at the Event header; the row
+            status colour reads 'settled' rather than re-amplifying
+            the warning."
+    (is (= :settled-success (esc/classify-status {:outcome :warning})))))
+
+(deftest classify-status-in-flight
+  (testing ":in-flight? true with no terminal outcome → :in-flight.
+            The LIVE-head cascade still building."
+    (is (= :in-flight (esc/classify-status {:in-flight? true})))
+    (is (= :in-flight (esc/classify-status {:in-flight? true :mode :live})))))
+
+(deftest classify-status-in-flight-clears-on-outcome
+  (testing "in-flight? + a settled outcome → the outcome wins. A
+            cascade in mid-build that has just landed its :event/
+            do-fx is logically settled."
+    (is (= :settled-success
+           (esc/classify-status {:in-flight? true :outcome :ok})))
+    (is (= :settled-error
+           (esc/classify-status {:in-flight? true :outcome :error})))))
+
+(deftest classify-status-paused-by-tool
+  (testing ":paused? true with no error → :paused-by-tool. A tool
+            (story, MCP, the user via the spine pause button) has
+            claimed the buffer; LIVE mode is paused."
+    (is (= :paused-by-tool (esc/classify-status {:paused? true})))
+    (is (= :paused-by-tool (esc/classify-status {:paused? true :mode :live})))))
+
+(deftest classify-status-stale-from-explicit-flag
+  (testing ":stale? true → :stale regardless of mode. Used for
+            cascades replayed via time-travel / dispatch-replay."
+    (is (= :stale (esc/classify-status {:stale? true})))
+    (is (= :stale (esc/classify-status {:stale? true :outcome :ok})))))
+
+(deftest classify-status-stale-from-retro-mode
+  (testing ":retro mode → :stale even without the explicit flag. A
+            user pinning a non-head cascade IS inspecting a stale
+            row; the colour reflects that."
+    (is (= :stale (esc/classify-status {:mode :retro})))
+    (is (= :stale (esc/classify-status {:mode :retro :outcome :ok})))))
+
+(deftest classify-status-error-wins-over-stale
+  (testing "error trumps stale — a RETRO-replayed errored cascade
+            still reads red so the user spots it among the yellow
+            history."
+    (is (= :settled-error
+           (esc/classify-status {:mode :retro :outcome :error})))
+    (is (= :settled-error
+           (esc/classify-status {:stale? true :outcome :error})))))
+
+(deftest classify-status-stale-wins-over-paused
+  (testing "stale wins over paused — if the user has scrubbed to a
+            historical cascade, the row is stale-by-virtue-of-mode
+            regardless of the paused? slot value the spine stamped
+            on the way past."
+    (is (= :stale
+           (esc/classify-status {:mode :retro :paused? true})))
+    (is (= :stale
+           (esc/classify-status {:stale? true :paused? true})))))
+
+(deftest classify-status-empty-input-defaults-to-in-flight
+  (testing "no signals at all → :in-flight. A cold-start row with
+            no outcome / mode / focus reads as still-in-progress —
+            the safest default (violet, the project's neutral
+            causal-chain colour) rather than a misleading green."
+    (is (= :in-flight (esc/classify-status {})))
+    (is (= :in-flight (esc/classify-status nil)))))
+
+;; ---- hex resolver --------------------------------------------------------
+
+(deftest event-status-colour-resolves-through-tokens
+  (testing "every state-input → hex matches the indirection
+            (state → status → token → tokens hex). No inline hexes
+            in the resolver path."
+    (doseq [[state expected-status]
+            [[{:outcome :ok}              :settled-success]
+             [{:outcome :error}           :settled-error]
+             [{:outcome :warning}         :settled-success]
+             [{:mode :retro}              :stale]
+             [{:stale? true}              :stale]
+             [{:in-flight? true}          :in-flight]
+             [{:paused? true}             :paused-by-tool]
+             [{}                          :in-flight]]]
+      (let [expected-hex (get tokens/tokens
+                              (get esc/status->token expected-status))]
+        (is (= expected-hex (esc/event-status-colour state))
+            (str "state " state " resolves to " expected-status " hex"))))))
+
+(deftest event-status-token-resolves-to-keyword
+  (testing "`event-status-token` is the keyword-side of the resolver
+            — useful for callers that compose styles through
+            `theme/tokens` rather than inlining the hex."
+    (is (= :red (esc/event-status-token {:outcome :error})))
+    (is (= :green (esc/event-status-token {:outcome :ok})))
+    (is (= :yellow (esc/event-status-token {:mode :retro})))
+    (is (= :cyan (esc/event-status-token {:paused? true})))
+    (is (= :accent-violet (esc/event-status-token {})))))
+
+(deftest event-status-colour-fallback
+  (testing "unknown status (shouldn't happen via the classifier, but
+            defence-in-depth) falls back to :accent-violet so the
+            row still renders a visible colour rather than nil."
+    ;; Defence-in-depth check: an out-of-band status keyword routed
+    ;; through the resolver fn surface still returns a usable hex.
+    ;; We test by reaching into the public API with a deliberately-
+    ;; malformed state shape — every key unrecognised — and ensure
+    ;; the violet fallback rides.
+    (is (string? (esc/event-status-colour {:outcome :unknown :mode :unknown})))))
+
+;; ---- cascade → state projection ----------------------------------------
+
+(defn- mock-outcome [outcome]
+  (fn [_cascade] {:outcome outcome}))
+
+(deftest cascade->state-projects-focused-error
+  (testing "a cascade that's focused + LIVE + errored → the state
+            map carries :outcome :error + :focused? true. The
+            classifier then resolves to :settled-error."
+    (let [cascade {:dispatch-id 42}
+          focus   {:dispatch-id 42 :mode :live :paused? false}
+          state   (esc/cascade->state cascade focus (mock-outcome :error))]
+      (is (= :error (:outcome state)))
+      (is (true? (:focused? state)))
+      (is (false? (:stale? state)))
+      (is (= :live (:mode state)))
+      (is (= :settled-error (esc/classify-status state))))))
+
+(deftest cascade->state-projects-retro-stale
+  (testing "a focused cascade in RETRO mode → :stale? true (derived
+            from :mode :retro)."
+    (let [cascade {:dispatch-id 7}
+          focus   {:dispatch-id 7 :mode :retro :paused? false}
+          state   (esc/cascade->state cascade focus (mock-outcome :ok))]
+      (is (true? (:stale? state)))
+      (is (= :retro (:mode state)))
+      (is (= :stale (esc/classify-status state))))))
+
+(deftest cascade->state-projects-non-focused-cascade
+  (testing "a cascade that's NOT the spine focus → :focused? false +
+            :mode nil. The classifier resolves to :settled-success
+            for an :ok outcome — non-focused rows are rendered with
+            their settled state, not the spine's RETRO scope."
+    (let [cascade {:dispatch-id 1}
+          focus   {:dispatch-id 99 :mode :retro :paused? true}
+          state   (esc/cascade->state cascade focus (mock-outcome :ok))]
+      (is (false? (:focused? state)))
+      (is (nil? (:mode state)))
+      (is (false? (:stale? state)))
+      (is (false? (:paused? state)))
+      (is (= :settled-success (esc/classify-status state))))))
+
+(deftest cascade->state-with-nil-focus
+  (testing "no focus map (e.g. test rig pre-mount) → :focused? false.
+            The fn still resolves cleanly so JVM-side fixture
+            builders can call it without a live spine."
+    (let [state (esc/cascade->state {:dispatch-id 1} nil (mock-outcome :ok))]
+      (is (false? (:focused? state)))
+      (is (= :settled-success (esc/classify-status state))))))
+
+;; ---- visual smoke — per-state hex landing on the right palette anchor --
+
+(deftest visual-smoke-per-state-colour-mapping
+  (testing "Visual smoke for the bead's acceptance criterion — each
+            lifecycle state surfaces in its expected anchor colour
+            across the dark palette. Failures here flag a palette
+            drift (token renamed) or a classifier regression."
+    (let [palette tokens/dark-palette]
+      (is (= (:accent-violet palette)
+             (esc/event-status-colour {:in-flight? true}))
+          "in-flight rides violet — the project's causal-chain accent")
+      (is (= (:green palette)
+             (esc/event-status-colour {:outcome :ok}))
+          "settled-success rides green")
+      (is (= (:red palette)
+             (esc/event-status-colour {:outcome :error}))
+          "settled-error rides red")
+      (is (= (:cyan palette)
+             (esc/event-status-colour {:paused? true}))
+          "paused-by-tool rides cyan (TanStack's purple was already
+           Causa's :accent-violet)")
+      (is (= (:yellow palette)
+             (esc/event-status-colour {:mode :retro}))
+          "stale rides yellow"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
@@ -1,0 +1,325 @@
+(ns day8.re-frame2-causa.panels.event.event-status-colour-view-cljs-test
+  "Render-path smoke for the canonical event-lifecycle status-colour
+  helper (rf2-b76v4).
+
+  ## What this suite covers
+
+  The pure-data layer (classifier + token map) is exercised in
+  `event_status_colour_cljs_test.cljc` against the JVM. THIS suite
+  asserts the three consumer sites in the rendered devtool pick up
+  the helper's output — without that walk-through, a future
+  refactor could leave the helper detached from its call sites and
+  the suite would still pass.
+
+  The three call sites (per the bead's contract):
+
+    1. **L2 event-list row** — `shell/event-row` carries
+       `data-rf-causa-status` + an inset `box-shadow` painted with
+       the lifecycle colour. Each lifecycle state surfaces in the
+       expected anchor colour.
+
+    2. **Event L4 header dot** — `panels/event-detail` renders a
+       leading status dot with `rf-causa-event-detail-status-dot-
+       <status>` testid + the lifecycle colour as its background.
+
+    3. **Trace timeline bar** — `panels/trace/Panel` renders a 3px
+       cascade-status bar above the ribbon (cascade-scoped per
+       rf2-ycoct so the bar represents every visible row's parent).
+
+  ## Pure hiccup walk
+
+  Same approach as the surrounding panel suites — we walk the
+  rendered tree by `data-testid` rather than mounting to a DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
+            [day8.re-frame2-causa.panels.event-detail :as event-detail]
+            [day8.re-frame2-causa.panels.trace :as trace]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.theme.tokens :as tokens]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-suppressed-count!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree
+  "Same expand-tree the surrounding suites use — invokes fn-headed
+  vectors so the walker descends through reg-view bodies."
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-by-testid-prefix [tree prefix]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (when-let [tid (:data-testid (second node))]
+                       (= 0 (.indexOf tid prefix))))
+            node))
+        (hiccup-seq tree)))
+
+;; ---- fixture builders --------------------------------------------------
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- dispatch-trace-ev
+  "Minimal :event/dispatched fixture — same shape the shell tests
+  use."
+  [id event-vec]
+  {:id        id
+   :op-type   :event
+   :operation :event/dispatched
+   :tags      {:event       event-vec
+               :frame       :rf/default
+               :dispatch-id id}})
+
+(defn- handler-exception-ev
+  "An :rf.error/handler-exception trace pinned to `dispatch-id`. The
+  cascade projection routes the trace into the cascade's `:errors`
+  slot — `cascade-outcome` resolves to :error / red."
+  [id dispatch-id]
+  {:id        id
+   :op-type   :error
+   :operation :rf.error/handler-exception
+   :tags      {:dispatch-id dispatch-id :event-id :foo}})
+
+(defn- warning-ev
+  "An :rf.warning/depth-exceeded trace pinned to `dispatch-id`. The
+  cascade projection routes the trace into the cascade's `:other`
+  bucket; `cascade-outcome` resolves to :warning / yellow."
+  [id dispatch-id]
+  {:id        id
+   :op-type   :warning
+   :operation :rf.warning/depth-exceeded
+   :tags      {:dispatch-id dispatch-id}})
+
+;; ---- (1) L2 event-list row pickups -------------------------------------
+
+(deftest l2-row-success-cascade-rides-green
+  (testing "rf2-b76v4 — a happy-path cascade carries
+            data-rf-causa-status='settled-success' on its <li> and the
+            row's box-shadow rides the canonical green token. ONE
+            helper drives the value at the row level."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            row    (find-by-testid tree "rf-causa-event-row-1")
+            attrs  (second row)
+            status (:data-rf-causa-status attrs)
+            shadow (get-in attrs [:style :box-shadow])]
+        (is (some? row) "L2 row renders for the cascade")
+        (is (= "settled-success" status)
+            "settled-success vocabulary lands on the row")
+        (is (string? shadow))
+        (is (re-find (re-pattern (:green tokens/tokens)) shadow)
+            "row's box-shadow accent uses the canonical :green hex")))))
+
+(deftest l2-row-errored-cascade-rides-red
+  (testing "rf2-b76v4 — an errored cascade carries
+            data-rf-causa-status='settled-error' + a red box-shadow
+            on the row. Error vocabulary trumps the default ok."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (handler-exception-ev 99 1))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            row    (find-by-testid tree "rf-causa-event-row-1")
+            attrs  (second row)
+            status (:data-rf-causa-status attrs)
+            shadow (get-in attrs [:style :box-shadow])]
+        (is (= "settled-error" status))
+        (is (re-find (re-pattern (:red tokens/tokens)) shadow)
+            "row's box-shadow accent uses the canonical :red hex")))))
+
+(deftest l2-row-warning-cascade-rides-green-not-yellow
+  (testing "rf2-b76v4 — :warning outcomes resolve to :settled-success
+            at the row level (the row stays green). The yellow glyph
+            ALREADY signals warning at the Event header glyph slot;
+            re-amplifying it on the row would double-up the signal."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (warning-ev 99 1))
+    (rf/with-frame :rf/causa
+      (let [tree   (shell/shell-view)
+            row    (find-by-testid tree "rf-causa-event-row-1")
+            attrs  (second row)
+            status (:data-rf-causa-status attrs)
+            shadow (get-in attrs [:style :box-shadow])]
+        (is (= "settled-success" status))
+        (is (re-find (re-pattern (:green tokens/tokens)) shadow))))))
+
+(deftest l2-row-status-comes-from-the-canonical-helper
+  (testing "rf2-b76v4 — the row's data-rf-causa-status MATCHES the
+            name of the keyword `classify-status` resolves for the
+            same input. ONE helper, ONE vocabulary."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (handler-exception-ev 99 1))
+    (rf/with-frame :rf/causa
+      (let [tree     (shell/shell-view)
+            row      (find-by-testid tree "rf-causa-event-row-1")
+            status   (:data-rf-causa-status (second row))
+            ;; Same state shape the row builds:
+            classify (event-status/classify-status {:outcome :error})]
+        (is (= (name classify) status)
+            "row's vocabulary matches the helper's classifier output")))))
+
+;; ---- (2) Event L4 header status-dot pickups ----------------------------
+
+(deftest event-header-status-dot-success
+  (testing "rf2-b76v4 — happy-path cascade → Event L4 header renders
+            a status dot with `rf-causa-event-detail-status-dot-
+            settled-success` testid + the green background."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [tree (event-detail/Panel)
+            dot  (find-by-testid tree
+                                 "rf-causa-event-detail-status-dot-settled-success")]
+        (is (some? dot) "status dot renders for the success-cascade")
+        (is (= (:green tokens/tokens)
+               (get-in (second dot) [:style :background]))
+            "dot's background is the canonical green hex")))))
+
+(deftest event-header-status-dot-error
+  (testing "rf2-b76v4 — errored cascade → red dot with the
+            settled-error testid suffix."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (handler-exception-ev 99 1))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [tree (event-detail/Panel)
+            dot  (find-by-testid tree
+                                 "rf-causa-event-detail-status-dot-settled-error")]
+        (is (some? dot) "settled-error dot renders for the error cascade")
+        (is (= (:red tokens/tokens)
+               (get-in (second dot) [:style :background])))))))
+
+(deftest event-header-carries-rf-causa-status-attribute
+  (testing "rf2-b76v4 — the <header> wrapper carries
+            data-rf-causa-status so smoke tests + the pure-hiccup
+            walker can assert the vocabulary without parsing inline
+            styles. Same shape as the L2 row's attribute."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [tree   (event-detail/Panel)
+            header (find-by-testid tree "rf-causa-event-detail-outcome")
+            attrs  (second header)]
+        (is (= "settled-success" (:data-rf-causa-status attrs)))))))
+
+;; ---- (3) Trace timeline bar pickups ------------------------------------
+
+(deftest trace-cascade-status-bar-renders-with-canonical-colour
+  (testing "rf2-b76v4 — the Trace tab's cascade-status bar fills the
+            ribbon with the focused cascade's lifecycle colour. Wins
+            its testid from the resolved status keyword so a future
+            classifier shift surfaces here without a colour assertion."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [tree (trace/Panel)
+            bar  (find-by-testid-prefix tree
+                                        "rf-causa-trace-cascade-status-bar-")]
+        (is (some? bar)
+            "cascade-status bar renders when a cascade is in focus")
+        (let [attrs (second bar)
+              tid   (:data-testid attrs)]
+          (is (re-find #"settled-success$" tid)
+              "bar's testid carries the resolved status vocabulary")
+          (is (= (:green tokens/tokens)
+                 (get-in attrs [:style :background]))
+              "bar's background is the canonical green hex"))))))
+
+(deftest trace-cascade-status-bar-error
+  (testing "rf2-b76v4 — an errored focused cascade flips the bar to
+            red. Same helper drives the colour the L2 row + Event
+            header pick up."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (handler-exception-ev 99 1))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [tree (trace/Panel)
+            bar  (find-by-testid tree
+                                 "rf-causa-trace-cascade-status-bar-settled-error")]
+        (is (some? bar))
+        (is (= (:red tokens/tokens)
+               (get-in (second bar) [:style :background])))))))
+
+;; ---- (4) cross-site consistency — ONE vocabulary ------------------------
+
+(deftest all-three-sites-agree-on-cascade-status
+  (testing "rf2-b76v4 — the L2 row, Event L4 header, and Trace
+            timeline bar ALL resolve to the SAME status keyword for
+            the same cascade. This is the bead's headline contract:
+            ONE canonical map, NO per-call-site rolling."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (trace-bus/collect-trace! (handler-exception-ev 99 1))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-dispatch-id 1])
+      (let [shell-tree   (shell/shell-view)
+            event-tree   (event-detail/Panel)
+            trace-tree   (trace/Panel)
+            l2-row       (find-by-testid shell-tree "rf-causa-event-row-1")
+            event-header (find-by-testid event-tree
+                                         "rf-causa-event-detail-outcome")
+            trace-bar    (find-by-testid-prefix
+                           trace-tree
+                           "rf-causa-trace-cascade-status-bar-")
+            l2-status    (:data-rf-causa-status (second l2-row))
+            event-status (:data-rf-causa-status (second event-header))
+            trace-status (:data-rf-causa-status (second trace-bar))]
+        (is (= l2-status event-status trace-status "settled-error")
+            (str "all three consumers ride the same vocabulary — "
+                 "l2: " l2-status
+                 " · event: " event-status
+                 " · trace: " trace-status))))))


### PR DESCRIPTION
## Summary

- New pure fn `event-status-colour` in `tools/causa/src/day8/re_frame2_causa/panels/event/event_status_colour.cljc` mirrors TanStack Query Devtools' `getQueryStatusColor` — ONE map drives the cascade lifecycle vocabulary across the whole devtool.
- Wired into three call sites that previously rolled their own colour decisions: **L2 event-list row**, **Event L4 header dot**, **Trace timeline bar**. Future colour shifts now flow through a single map.
- Reuses existing palette tokens (`:accent-violet` / `:green` / `:red` / `:cyan` / `:yellow`); no new colours introduced.

### Lifecycle vocabulary

| Status            | Token            | When                                     |
|-------------------|------------------|------------------------------------------|
| `:in-flight`      | `:accent-violet` | cascade still building / LIVE head       |
| `:settled-success`| `:green`         | handler ran cleanly (or warning)         |
| `:settled-error`  | `:red`           | handler threw / `:rf.error/*` in cascade |
| `:paused-by-tool` | `:cyan`          | spine paused (LIVE+paused)               |
| `:stale`          | `:yellow`        | RETRO mode / explicit replayed flag      |

Precedence: error always wins, stale wins over in-flight + paused. Warnings resolve to `:settled-success` (the yellow glyph already signals warning at the Event header).

### Wiring

- `shell/event-row` — row's `<li>` carries `data-rf-causa-status` + a 2px inset `box-shadow` on the trailing edge (sibling to the gutter's leading-edge causal-chain thread; non-overlapping with the focused-row border).
- `panels/event-detail/cascade-outcome-line` — leading status dot with testid `rf-causa-event-detail-status-dot-<status>` + `data-rf-causa-status` on the header wrapper.
- `panels/trace/Panel` — 3px cascade-status bar above the ribbon. The Trace tab is cascade-scoped (rf2-ycoct), so the bar represents every visible row's parent cascade.

## Test plan

- [x] JVM helper tests — 23 tests / 74 assertions covering `classify-status` per-state inputs + precedence + `status->token` + `cascade->state` projection + per-state visual smoke against the dark palette.
- [x] CLJS render-path smoke — 9 tests cover L2 row + Event header dot + Trace bar for happy-path / errored / warning cascades, plus a cross-site consistency check asserting all three consumers ride the same vocabulary.
- [x] `clojure -M:test` from `tools/causa/` — 749 tests / 2263 assertions / 0 failures.
- [x] `npm run test:cljs` — 3039 tests / 8759 assertions / 0 failures.
- [x] `npm run test:bundle-isolation` — passes (no tools leakage into production bundles).