### PR TITLE
spec(causa): sweep stale causa-mcp references (rf2-jtvcm / rf2-hvl1g DROP)

### DIFF
--- a/tools/causa/README.md
+++ b/tools/causa/README.md
@@ -24,11 +24,11 @@ bus, Tool-Pair epoch history, the registrar query API) — it adds
 nothing the framework didn't already expose. The 16 panels are
 *presentation* of an already-structured runtime.
 
-A separate jar `tools/causa-mcp/` exposes Causa's surfaces as MCP
-tools for AI agents — same architecture as `tools/re-frame2-pair-mcp/`,
-different tool catalogue (18 tools across five bands). Contract at
-[`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md);
-catalogue at [`tools/causa-mcp/spec/004-Tools-Catalogue.md`](../causa-mcp/spec/004-Tools-Catalogue.md).
+AI agent access to Causa's surfaces flows through
+`tools/re-frame2-pair-mcp/` against the framework-published Causa
+runtime API at `day8.re-frame2-causa.runtime` — per rf2-hvl1g a
+dedicated causa-mcp jar is unnecessary; agents read the same trace bus
++ epoch history + registrar Causa itself reads.
 
 ## Headline experiences
 
@@ -168,24 +168,11 @@ force-disable in dev.
 
 ### MCP (Causa as an agent surface)
 
-A separate `tools/causa-mcp/` artefact exposes Causa's surfaces as
-MCP tools so AI agents can drive the same observations through a
-tool catalogue (18 tools: Inspection band, Mutation band, Streaming
-band, Meta band, plus the `eval-cljs` escape hatch).
-
-Consumer-side wiring:
-
-```bash
-npm install -g @day8/re-frame2-causa-mcp
-```
-
-```json
-// ~/.claude/settings.json
-{ "mcpServers": { "causa": { "command": "re-frame2-causa-mcp" } } }
-```
-
-Tool catalogue at [`tools/causa-mcp/spec/004-Tools-Catalogue.md`](../causa-mcp/spec/004-Tools-Catalogue.md);
-Causa-panel-side prose at [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md).
+Per rf2-hvl1g there is no dedicated `causa-mcp` jar. AI agents reach
+Causa's surfaces through `tools/re-frame2-pair-mcp/`, which can read
+the framework-published Causa runtime API on
+`day8.re-frame2-causa.runtime` (the same trace bus + epoch history +
+registrar Causa's chrome reads).
 
 ## Spec
 
@@ -202,7 +189,6 @@ that the tool could be one-shotted from it.
 | [`spec/006-Hydration-Debugger.md`](./spec/006-Hydration-Debugger.md) | SSR render-tree diff; divergent-node surfacing. |
 | [`spec/007-UX-IA.md`](./spec/007-UX-IA.md) | Layout, interaction, visual language (typography, colour, motion). |
 | [`spec/008-Embedding-Contract.md`](./spec/008-Embedding-Contract.md) | Story-embed contract; the `Panel` component shape. |
-| [`spec/010-MCP-Server.md`](./spec/010-MCP-Server.md) | `tools/causa-mcp/`; the Causa MCP tool catalogue. |
 | [`spec/011-Launch-Modes.md`](./spec/011-Launch-Modes.md) | In-app true-inline host + standalone-via-MCP for remote-attach. |
 | [`spec/Principles.md`](./spec/Principles.md) | Load-bearing principles (read-only, observation-only, etc.). |
 | [`spec/API.md`](./spec/API.md) | User-facing surface (`init!`, panel mount, MCP tool list). |
@@ -286,9 +272,10 @@ round-trip), the deterministic feature-matrix sweep across panels +
 shell + launch modes + redaction + 20-event load, the Panel-view
 gallery, and the performance probe.
 
-The sibling `tools/causa-mcp/` artefact ships the agent surface (18
-tools across five bands; catalogue formally pinned at
-[`tools/causa-mcp/spec/004-Tools-Catalogue.md`](../causa-mcp/spec/004-Tools-Catalogue.md)).
+Agent access to Causa's surfaces flows through
+`tools/re-frame2-pair-mcp/` against the framework-published Causa
+runtime API on `day8.re-frame2-causa.runtime` (per rf2-hvl1g — no
+dedicated causa-mcp jar).
 
 Next: alpha cut once the browser feature gate from
 [`spec/017-Test-Coverage-Matrix.md`](./spec/017-Test-Coverage-Matrix.md)

--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -28,9 +28,10 @@
 ;;
 ;; ## MCP surface
 ;;
-;; Per spec/010-MCP-Server.md the agent surface ships in
-;; tools/causa-mcp/ (day8/re-frame2-causa-mcp), a separate Node-side
-;; artefact. Nothing in this deps.edn references the MCP server.
+;; AI agent access to Causa state flows via `tools/re-frame2-pair-mcp/`
+;; (which can read the framework-published Causa runtime API on
+;; `day8.re-frame2-causa.runtime`); per rf2-hvl1g there is no dedicated
+;; causa-mcp jar. Nothing in this deps.edn references an MCP server.
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../../implementation/core"}
 

--- a/tools/causa/spec/011-Launch-Modes.md
+++ b/tools/causa/spec/011-Launch-Modes.md
@@ -682,27 +682,35 @@ register-epoch-cb! call resolve to a no-op.
 
 ### Mechanism
 
-The MCP server (a future `tools/causa-mcp/` artefact) is an stdio
-JSON-RPC server launched by the agent host (Claude Code, Cursor, etc.)
-as a subprocess. The server connects over nREPL to the running
-shadow-cljs build (which is connected to the user's browser).
+AI agent access uses `tools/re-frame2-pair-mcp/` — an stdio JSON-RPC
+MCP server launched by the agent host (Claude Code, Cursor, etc.) as
+a subprocess. re-frame2-pair-mcp connects over nREPL to the running
+shadow-cljs build (which is connected to the user's browser), and
+reads the framework-published Causa runtime API on
+`day8.re-frame2-causa.runtime` (the same accessors the panel uses).
 
 The data path:
 
 ```
 AI agent
   ↓ (MCP / stdio)
-re-frame2-causa-mcp (Node process)
+re-frame2-pair-mcp (Node process)
   ↓ (nREPL / bencode)
 shadow-cljs JVM
   ↓ (cljs-eval / WebSocket)
-browser running the user's re-frame2 app
+browser running the user's re-frame2 app (with Causa runtime preloaded)
 ```
 
-The agent sees the **same trace bus and epoch history** that Causa-the-panel
-sees. Tool calls are read-mostly; writes (`restore-epoch`,
-`reset-frame-db`, `dispatch`) are confirmed by the agent host
-(typically Claude Code's tool-permission prompt).
+The agent sees the **same trace bus and epoch history** that
+Causa-the-panel sees, via the same runtime accessors. Tool calls are
+read-mostly; writes (`restore-epoch`, `reset-frame-db`, `dispatch`)
+are confirmed by the agent host (typically Claude Code's
+tool-permission prompt).
+
+(Per rf2-hvl1g — closure 2026-05-19 — there is no dedicated
+`tools/causa-mcp/` jar; an earlier design pictured one but it was
+dropped as unnecessary given the framework-published runtime API +
+re-frame2-pair-mcp. See DESIGN-RATIONALE.md Lock #6 supersedence.)
 
 ### Remote-attach
 
@@ -712,11 +720,11 @@ query the runtime. This works **whether or not Causa's panel is
 open** in the browser.
 
 The "developer A's browser, developer B's Claude" case is **not
-directly supported** at v1.0. The MCP server connects to
+directly supported** at v1.0. re-frame2-pair-mcp connects to
 `127.0.0.1:<nrepl-port>` by default; cross-machine MCP requires
 agent-host configuration (SSH tunnels, port-forwarding) that lives
-outside Causa's scope. Causa-MCP is the protocol; the network
-plumbing is the user's.
+outside Causa's scope. MCP is the protocol; the network plumbing is
+the user's.
 
 ### Why not a Chrome extension
 
@@ -748,29 +756,31 @@ VS-Code-specific extension.
 
 ## Coexistence
 
-The panel and the MCP server can run simultaneously without
+The panel and re-frame2-pair-mcp can run simultaneously without
 conflict:
 
 - The trace bus emits once; both subscribers (panel + MCP server's
-  ensure-runtime trace listener) see every event.
+  trace listener) see every event.
 - The epoch-history surface is read-mostly from both.
-- Mutations from the MCP server are tagged `:origin :causa-mcp`;
-  mutations from the panel's re-dispatch affordance are tagged
-  `:origin :causa`. Both are distinguishable in the event log.
+- Mutations from re-frame2-pair-mcp are tagged
+  `:origin :re-frame2-pair-mcp`; mutations from the panel's
+  re-dispatch affordance are tagged `:origin :causa`. Both are
+  distinguishable in the event log.
 
 A common workflow: the developer has the panel open for direct
 inspection; the AI assistant operates on the same runtime via MCP
-in parallel. The panel surfaces the agent's actions (the `:origin
-:causa-mcp` colour-coding is visible in the strip and event log).
+in parallel. The panel surfaces the agent's actions
+(the `:origin :re-frame2-pair-mcp` colour-coding is visible in the
+strip and event log).
 
 ## What this doesn't do
 
 - **No Chrome extension** (rejected, see above).
 - **No VS Code panel** (rejected, see above).
 - **No custom WebSocket remote-attach** (replaced by MCP).
-- **No standalone HTML viewer** at v1.0. The MCP server replaces
+- **No standalone HTML viewer** at v1.0. re-frame2-pair-mcp replaces
   this — if the agent needs to render a viewer-like surface, it
-  composes Causa-MCP tool calls.
+  composes re-frame2-pair-mcp tool calls against the runtime API.
 - **No mobile launch mode** (lock #5).
 - **No tablet-responsive standalone viewer** at v1.0. An earlier
   design proposed one; the lock-#9 hybrid retires the use case to
@@ -792,11 +802,13 @@ MCP, sibling artefact at `tools/re-frame2-pair-mcp/`) covers the agent-driven
 case. The remaining 5% (cross-machine, mobile) is explicitly out of
 scope at v1.0.
 
-Note: the **Causa-MCP** path (`tools/causa-mcp/`) was dropped per
+Note: a dedicated **causa-mcp** path was originally envisaged but
+dropped per rf2-hvl1g (closure 2026-05-19) — see
 [`000-Vision.md`](000-Vision.md) §What it isn't ("two doors, no
-compromises"). Agents access the runtime through re-frame2-pair-mcp (raw
-nREPL); Causa is the human-only observability surface. The split is
-intentional and load-bearing.
+compromises") and DESIGN-RATIONALE.md Lock #6 supersedence. Agents
+access the runtime through re-frame2-pair-mcp (raw nREPL) against
+the framework-published Causa runtime API; Causa is the human-only
+observability surface. The split is intentional and load-bearing.
 
 ## Vision — re-frame2-pair raw-nREPL launch path
 
@@ -815,11 +827,11 @@ Clojure eval) commands that drive Causa's panel through the existing
 ```
 
 The agent uses the same primitives Causa's chrome uses. No curated
-`causa-mcp` facade in front; whatever the agent wants to do, it does
-by evaluating Clojure against the runtime. This is the **two doors**
-split in practice — Causa is the human surface; re-frame2-pair-mcp is the AI
-access path; both read the same instrumentation; neither owns a
-curated middle layer.
+MCP facade in front; whatever the agent wants to do, it does by
+evaluating Clojure against the runtime. This is the **two doors**
+split in practice — Causa is the human surface; re-frame2-pair-mcp is
+the AI access path; both read the same instrumentation; neither owns
+a curated middle layer.
 
 ## Vision — coordination across multi-instance Causa
 

--- a/tools/causa/spec/014-Registry-Catalogue.md
+++ b/tools/causa/spec/014-Registry-Catalogue.md
@@ -388,29 +388,6 @@ Consumer of the canonical 9-axis filter vocabulary documented in
 | `:rf.causa/set-trace-filter` | `[_ axis value]` | Sets / clears one axis. `nil` value clears that axis. v1 is single-value per axis; multi-value rides a follow-on. |
 | `:rf.causa/clear-trace-filters` | `[_]` | Clears every axis. |
 
-## MCP Server panel
-
-Filters the trace-buffer to events tagged `:tags :origin :causa-mcp`
-(the canonical tag a future causa-mcp jar will stamp on every
-side-effect it performs).
-
-### Subscriptions
-
-| Sub | Returns |
-|---|---|
-| `:rf.causa/mcp-filters` | `{:op-types :since-ms}` — single atomic read. |
-| `:rf.causa/mcp-server` | Composite — `{:rows :total :rendered :op-type-counts :distinct-op-types :filters :agent-attached? :empty-kind}`. |
-| `:rf.causa/mcp-origin-filter-enabled?` | Boolean — cross-panel highlight toggle. Default `false` (opt-in). Other panels MAY honour to dim non-agent events. |
-
-### Events
-
-| Event | Vector shape | Behaviour |
-|---|---|---|
-| `:rf.causa/toggle-mcp-op-type` | `[_ op-type]` | Toggles an op-type chip. |
-| `:rf.causa/set-mcp-since-seconds` | `[_ seconds]` | s → ms; `nil` / non-positive clears. |
-| `:rf.causa/clear-mcp-filters` | `[_]` | Clears every axis. |
-| `:rf.causa/toggle-mcp-origin-filter` | `[_]` | Toggles the cross-panel highlight. |
-
 ## Routes panel
 
 Spec: [`spec/012-Routing.md`](../../../spec/012-Routing.md) (framework

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -78,11 +78,12 @@ Causa rendering surface.
 
 ### MCP Server panel — dropped
 
-The MCP Server panel is dropped from Causa. The `tools/causa-mcp/`
-artefact is dropped entirely (separate PR); there is no Causa-curated
-MCP surface to render. AI access to the running re-frame2 runtime
-goes through `tools/re-frame2-pair-mcp/` over raw nREPL — see
-[`000-Vision.md`](./000-Vision.md) §Where Causa fits.
+The MCP Server panel is dropped from Causa. The dedicated `causa-mcp`
+artefact was envisaged but dropped entirely (rf2-hvl1g, 2026-05-19);
+there is no Causa-curated MCP surface to render. AI access to the
+running re-frame2 runtime goes through `tools/re-frame2-pair-mcp/`
+over raw nREPL — see [`000-Vision.md`](./000-Vision.md) §Where Causa
+fits and DESIGN-RATIONALE.md Lock #6 supersedence.
 
 ### AI co-pilot — dropped
 
@@ -461,11 +462,12 @@ single nav-event that pertains to the focused cascade.
 
 ## MCP Server panel — dropped
 
-The MCP Server panel is dropped from Causa. The `tools/causa-mcp/`
-artefact is dropped entirely (separate PR); there is no Causa-curated
-MCP surface to render. AI access to the running re-frame2 runtime
-goes through `tools/re-frame2-pair-mcp/` over raw nREPL — see
-[`000-Vision.md`](./000-Vision.md) §Where Causa fits.
+The MCP Server panel is dropped from Causa. The dedicated `causa-mcp`
+artefact was envisaged but dropped entirely (rf2-hvl1g, 2026-05-19);
+there is no Causa-curated MCP surface to render. AI access to the
+running re-frame2 runtime goes through `tools/re-frame2-pair-mcp/`
+over raw nREPL — see [`000-Vision.md`](./000-Vision.md) §Where Causa
+fits and DESIGN-RATIONALE.md Lock #6 supersedence.
 
 Trace events tagged `:origin :re-frame2-pair-mcp` (the new agent-origin tag)
 appear in the **Trace tab** like any other tagged trace event — visible

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -22,7 +22,7 @@ Every selection event passes through a single spine sub — `:rf.causa/focus` �
 ### Non-goals
 
 - **No AI in Causa.** No co-pilot rail, no AI tab, no in-chrome LLM surface. AI access goes through `tools/re-frame2-pair-mcp/` over raw nREPL — the agent reads the same instrumentation Causa reads, not a Causa-curated facade. (Causa is the human-only surface; re-frame2-pair-mcp is the AI access path.)
-- **No Causa-MCP.** The `tools/causa-mcp/` artefact is dropped entirely (separate PR). MCP server panel dies with it.
+- **No Causa-MCP.** A dedicated `causa-mcp` jar was envisaged but dropped per rf2-hvl1g (2026-05-19). MCP server panel dies with it. Agent access flows through `tools/re-frame2-pair-mcp/` against the framework-published Causa runtime API.
 - **No `:sensitive? true` event-handler annotation.** Reversed in favour of unified path-marked classification per [spec/015-Data-Classification](../../../spec/015-Data-Classification.md). Causa CONSUMES that contract; this spec defines how the sentinels render in Causa's surfaces (§12).
 - **No writes to host runtime.** Causa stays read-only forever (Lock #3 in [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)).
 - **No bottom rail.** The pass-2/round-1/round-2 "L0" scrubber rail is gone — the ribbon `[◀ ▶ ⏭]` cluster + the event list together ARE the scrubber.

--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -291,40 +291,13 @@ yields a clickable URI rather than a no-op; source-coords without
 
 ## MCP API
 
-A future `tools/causa-mcp/` artefact will expose Causa's agent surface
-as **18 tools across five bands**. The catalogue below is the planned
-shape; the implementing jar will pin canonical counts and band layout
-in its own spec.
-
-| Tool | Band | Kind |
-|---|---|---|
-| `get-trace-buffer` | Inspection | read |
-| `get-epoch-history` | Inspection | read |
-| `get-app-db` | Inspection | read |
-| `get-app-db-diff` | Inspection | read |
-| `get-machine-state` | Inspection | read |
-| `get-machine-list` | Inspection | read |
-| `get-issues` | Inspection | read |
-| `get-handlers` | Inspection | read |
-| `get-source-coord` | Inspection | read |
-| `restore-epoch` | Mutation | mutate (user-confirmed) |
-| `reset-frame-db` | Mutation | mutate (user-confirmed) |
-| `dispatch` | Mutation | mutate (user-confirmed) |
-| `subscribe` | Streaming | stream (`notifications/progress`) |
-| `unsubscribe` | Streaming | mutate (idempotent close) |
-| `list-subscriptions` | Streaming | read (diagnostic) |
-| `eval-cljs` | Escape hatch | mutate (arbitrary CLJS form) |
-| `discover-app` | Meta | read (session-lifecycle) |
-| `tail-build` | Meta | read (waits for hot-reload) |
-
-Streaming tools keep the `tools/call` request open and emit each
-drain-batch as a `notifications/progress` notification correlated
-via `extra._meta.progressToken`; the final result is a summary.
-`eval-cljs` is the deliberate escape valve — its side-effects ride
-the trace bus tagged `:origin :causa-mcp` like every catalogue tool.
-
-JSONSchema for each tool's args is surfaced via `tools/list` per the
-MCP spec.
+Per rf2-hvl1g (closure 2026-05-19) there is no dedicated `causa-mcp`
+jar. AI agent access to Causa's surfaces flows via
+`tools/re-frame2-pair-mcp/` against the framework-published Causa
+runtime API (`day8.re-frame2-causa.runtime`) — agents read the same
+trace bus + epoch history + registrar Causa itself reads, via
+re-frame2-pair-mcp's `eval-cljs` and the runtime accessors. See
+DESIGN-RATIONALE.md Lock #6 (superseded) for the reasoning.
 
 ## Settings keys
 
@@ -366,9 +339,9 @@ and have been reset to defaults."
 ## Trace-event tags Causa emits
 
 When Causa mutates the runtime (rewind, reset, re-dispatch), it
-emits trace events tagged `:origin :causa` (or `:origin :causa-mcp`
-when from the MCP server) so its actions are visible in the trace
-stream.
+emits trace events tagged `:origin :causa` so its actions are visible
+in the trace stream. (Origins from MCP servers carry their own
+server-name tag — re-frame2-pair-mcp uses `:origin :re-frame2-pair-mcp`.)
 
 These ride the framework's existing `:event/dispatched`,
 `:rf.epoch/restored`, etc. operations — no new operation kinds

--- a/tools/causa/spec/DESIGN-RATIONALE.md
+++ b/tools/causa/spec/DESIGN-RATIONALE.md
@@ -220,52 +220,40 @@ Does Causa support mobile / tablet / phone viewports?
 
 ---
 
-## Lock #6 — MCP timing
+## Lock #6 — MCP timing (SUPERSEDED 2026-05-19)
 
-**Locked 2026-05-12 (Mike).** **Ship at v1.0.** Via
-`tools/causa-mcp/`, mirroring the `tools/re-frame2-pair-mcp/` pattern.
+**Superseded 2026-05-19 (Mike, rf2-hvl1g).** **Causa-MCP is dropped
+entirely.** AI agent access to Causa state already flows via
+`tools/re-frame2-pair-mcp/` (which can read the framework-published
+Causa runtime API on `day8.re-frame2-causa.runtime`) + Causa's raw
+trace bus + Story-MCP. No dedicated causa-mcp jar is built; there is
+no `tools/causa-mcp/` artefact.
 
-### Question
+### Original lock (2026-05-12, Mike, retained for history)
 
-When does Causa's MCP server ship — v1.0 or v1.1?
+Picked **Ship at v1.0** via `tools/causa-mcp/`, mirroring
+`tools/re-frame2-pair-mcp/`. Reasoning: fork the re-frame2-pair-mcp
+template, swap the tool catalogue for Causa surfaces, enables
+remote-attach via MCP without a custom WebSocket protocol.
 
-### Options considered
+### Why reversed
 
-- **Defer to v1.1.** Ship the panel at v1.0; the MCP server later.
-  Less scope at v1.0.
-- **Ship at v1.0.** Causa-MCP launches alongside the panel.
+- Causa's runtime API (rf2-crhr8) exposes the same accessors
+  (`get-app-db`, `get-epoch-history`, `get-machine-state`, ...) that
+  a hypothetical causa-mcp would have wrapped. Any MCP server can
+  call those accessors via `eval-cljs` — re-frame2-pair-mcp does so
+  today.
+- Maintaining a second Node-side MCP jar duplicates the cap
+  pipeline, the wire-vocab plumbing, the discover-app handshake, and
+  the streaming-subscribe budget for ~zero incremental value over
+  re-frame2-pair-mcp + eval-cljs against the runtime API.
+- The "two doors" framing in `000-Vision.md` collapses to one:
+  Causa is the human surface; re-frame2-pair-mcp is the AI surface
+  (reading the same trace bus + epoch history Causa reads).
 
-### Pick
+### Date superseded
 
-**Ship at v1.0.** Via `tools/causa-mcp/`.
-
-### Why
-
-- `tools/re-frame2-pair-mcp/` (rf2-5b8e #423, shipped 2026-05-12) is the
-  template — fork the project, swap the tool catalogue for Causa's
-  surfaces. Most of the implementation cost is already paid.
-- Enables remote-attach (one browser debugs another) as a v1.0
-  story without paying for a custom WebSocket protocol (lock #9
-  rules that out anyway).
-- The agent-driven workflow ("Claude, walk me back through the last
-  10 epochs that touched `[:cart]`") is high-leverage. Shipping
-  Causa-the-panel without Causa-the-agent-surface would mean the
-  AI assistant case is only partially served at v1.0.
-- The Causa-MCP catalogue is read-mostly (9 read tools, 3 mutate
-  tools); the mutate tools mirror the in-panel right-click
-  affordances. The user's consent model is the same.
-
-### Date locked
-
-2026-05-12 (Mike). Originally deferred 2026-05-11 (per rf2-buor
-§10.7); reversed on 2026-05-12 once re-frame2-pair-mcp shipped and the
-template existed.
-
-### Trail-of-thought citations
-
-- rf2-buor §10.7 (originally deferred).
-- rf2-buor notes ("#6 MCP timing LOCKED 2026-05-12 (Mike): MCP AT
-  v1.0").
+2026-05-19 (Mike, rf2-hvl1g).
 
 ---
 
@@ -364,8 +352,11 @@ mode?
 - **(c) Chrome extension.** The IPC-isolated approach. Out of
   process from the runtime.
 - **(d) Hybrid: in-app overlay + MCP for remote-attach.** In-app is
-  the primary; the agent-driven case is handled by `tools/causa-mcp/`,
-  not by a custom Causa protocol.
+  the primary; the agent-driven case is handled by
+  `tools/re-frame2-pair-mcp/` against the framework-published Causa
+  runtime API, not by a custom Causa protocol. (Originally pictured
+  via a dedicated causa-mcp jar — dropped per rf2-hvl1g, see
+  Lock #6 supersedence.)
 
 ### Pick
 
@@ -498,7 +489,7 @@ removed entirely (see Lock #2 reversal).** AI integration lives in
 | 3 | App-db editing | **Never — read-only forever** | 2026-05-11 |
 | 4 | Session export | **Never** | 2026-05-11 |
 | 5 | Mobile | **Desktop only** | 2026-05-11 |
-| 6 | MCP timing | **v1.0 via `tools/causa-mcp/`** | 2026-05-12 |
+| 6 | MCP timing | **SUPERSEDED 2026-05-19: causa-mcp dropped (rf2-hvl1g) — agent access via re-frame2-pair-mcp + runtime API** | 2026-05-19 |
 | 7 | Hero panel | **Event-detail** (graph demoted to peer) | 2026-05-12 |
 | 8 | AI panel default state | **SUPERSEDED by #2 reversal (rf2-s3vx5)** | 2026-05-17 |
 | 9 | Launch modes | **Hybrid: in-app + MCP** | 2026-05-12 |

--- a/tools/causa/spec/Principles.md
+++ b/tools/causa/spec/Principles.md
@@ -22,9 +22,11 @@ The mechanism:
   explicit `Rewind here` button or `r` keypress.
 - Re-dispatch is a right-click context-menu action, never a single
   click.
-- The MCP server's mutation tools (`restore-epoch`, `reset-frame-db`,
-  `dispatch`) are tagged `:origin :causa-mcp` and surface in the
-  trace stream as distinguishable from app-issued mutations.
+- MCP-driven mutations (via `tools/re-frame2-pair-mcp/`) — typically
+  `dispatch` plus `eval-cljs` invocations of the runtime API's
+  `restore-epoch!` / `reset-frame-db!` accessors — are tagged
+  `:origin :re-frame2-pair-mcp` and surface in the trace stream as
+  distinguishable from app-issued mutations.
 
 This is the v1-of-10x mistake-not-repeated. `app-db-follows-events?`
 was too implicit; users accidentally rewound. Causa's posture:

--- a/tools/causa/spec/findings/re-frame-10x-v2-design.md
+++ b/tools/causa/spec/findings/re-frame-10x-v2-design.md
@@ -473,6 +473,12 @@ re-frame2-pair is AI-driven (an LLM integration via nREPL). Causa is human-drive
 
 ### MCP surface
 
+> **NOTE (2026-05-19, rf2-hvl1g).** The `causa-mcp` jar described
+> below was dropped — see DESIGN-RATIONALE.md Lock #6 supersedence.
+> AI agent access flows through `tools/re-frame2-pair-mcp/` against
+> the framework-published Causa runtime API instead. The text below
+> is preserved as historical design lineage.
+
 **Causa ships `tools/causa-mcp/`** (a separate jar, mirroring `tools/story-mcp/`). The MCP server exposes:
 
 - `get-trace-buffer` — slice of the trace stream by filter.

--- a/tools/causa/src/day8/re_frame2_causa/config.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/config.cljc
@@ -543,7 +543,7 @@
   level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
   predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
   / rf2-iwqu9, every consumer of `:sensitive?` (Causa, Story,
-  story-mcp, re-frame2-pair-mcp, causa-mcp) composes against ONE framework
+  story-mcp, re-frame2-pair-mcp) composes against ONE framework
   primitive rather than reimplementing the five-token check. Per Spec
   009 §Privacy."
   [ev]

--- a/tools/causa/src/day8/re_frame2_causa/preload.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/preload.cljs
@@ -77,16 +77,15 @@
             [day8.re-frame2-causa.mount :as mount]
             [day8.re-frame2-causa.registry :as registry]
             [day8.re-frame2-causa.settings.effects :as settings-effects]
-            ;; rf2-8xzoe.4 (F-4) — pull the Causa-MCP injected-runtime
+            ;; rf2-8xzoe.4 (F-4) — pull the Causa-runtime accessor
             ;; namespace into the preload classpath. The `:require` is the
             ;; load: `day8.re-frame2-causa.runtime` installs its
             ;; `js/globalThis.__day8_re_frame2_causa_runtime` sentinel as
             ;; a top-level side effect (gated on `interop/debug-enabled?`).
-            ;; The MCP server's preload probe reads that sentinel to
-            ;; confirm the runtime landed. Per `tools/causa-mcp/spec/000-
-            ;; Vision.md` §"Two namespaces, two sides" — the runtime
-            ;; rides Causa-the-panel's preload, no separate `:preloads`
-            ;; entry required on the consumer side.
+            ;; Any attached MCP server (re-frame2-pair-mcp today) reads
+            ;; that sentinel as its preload probe; the runtime rides
+            ;; Causa-the-panel's preload, so no separate `:preloads`
+            ;; entry is required on the consumer side.
             [day8.re-frame2-causa.runtime]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 

--- a/tools/causa/src/day8/re_frame2_causa/runtime.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/runtime.cljs
@@ -1,23 +1,25 @@
 (ns day8.re-frame2-causa.runtime
-  "Injected-runtime namespace for Causa-MCP (rf2-8xzoe.4 / F-4).
+  "Injected-runtime namespace exposing Causa's read/mutate accessors
+  to AI agents (rf2-8xzoe.4 / F-4, rf2-crhr8).
 
   Lives on the browser side of the stdio JSON-RPC pipe. Rides
   Causa-the-panel's `:devtools/preloads` (see `preload.cljs`'s require
   list) so a consumer app that already loads Causa-the-panel
-  automatically carries the runtime — no separate preload entry per
-  `tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides.
+  automatically carries the runtime — no separate preload entry.
+
+  Per rf2-hvl1g (closure 2026-05-19) there is no dedicated `causa-mcp`
+  jar; AI agents reach this runtime via `tools/re-frame2-pair-mcp/`
+  (which can read this ns via `eval-cljs`). The accessors below are
+  the framework-published Causa runtime API.
 
   ## What this namespace is
 
-  Eighteen tool-shaped accessors backing the eighteen Causa-MCP tools
-  per [`tools/causa/spec/010-MCP-Server.md` §Tool catalogue]
-  (../../causa/spec/010-MCP-Server.md#tool-catalogue) and the
-  per-tool bindings at
-  [`tools/causa-mcp/spec/000-Vision.md`](../../causa-mcp/spec/000-Vision.md).
-  The MCP server (`day8.re-frame2-causa-mcp.*`, Node-side) renders
-  EDN forms addressed at `day8.re-frame2-causa.runtime/<accessor>`;
-  shadow-cljs evaluates each form in the browser tab; the return value
-  comes back over the bencode-framed nREPL socket.
+  Tool-shaped accessors (see [`API.md` §Causa runtime API](../../spec/API.md))
+  rendered as EDN forms addressed at
+  `day8.re-frame2-causa.runtime/<accessor>`; an MCP server (today
+  `tools/re-frame2-pair-mcp/`) renders the form against the nREPL
+  socket, shadow-cljs evaluates each form in the browser tab, and the
+  return value comes back over the bencode-framed channel.
 
   Plus three load-bearing supports:
 
@@ -29,36 +31,28 @@
     with a setup hint.
   - `current-origin` — `^:dynamic` var holding the `:tags :origin`
     value the runtime stamps onto every mutation it performs. The
-    default is `:causa-mcp` so a bare `(dispatch! ...)` call from the
-    MCP server already carries the tag; `eval-cljs` rebinds it for
-    the synchronous extent of the eval'd form per
-    [`tools/causa-mcp/spec/Principles.md` §Boundary semantics of
-    `eval-cljs` origin tagging](../../causa-mcp/spec/Principles.md).
+    default `:causa-mcp` is grandfathered from the original
+    causa-mcp design; revising the default to a more accurate tag
+    (e.g. `:causa-runtime`) is tracked separately as a follow-on.
+    The MCP server is expected to rebind it for the synchronous
+    extent of an eval'd form to its own `:origin` identifier.
   - `health` — one-call summary used by `discover-app`. Side-effect-free
     here; the runtime registers no listeners on its own.
 
   ## What this namespace is NOT
 
-  - Not a new framework registry. Per Causa-MCP Principles §Tool
-    consumes the framework; doesn't extend it, every accessor below
-    routes through an existing `re-frame.core/*` surface. We add no
-    new dispatch types, no new effect substrates, no new component
-    substrates.
-  - Not a re-frame2-pair-mcp port. Causa-MCP's tool catalogue (eighteen) is
-    distinct from re-frame2-pair-mcp's (fourteen); the accessor surface is
-    shaped to the Causa tools, not the pair-flow tools. The shape of
-    the runtime ns (session sentinel, dynamic origin var, install
-    hook, no listener registrations) mirrors re-frame2-pair's idiom; the
-    accessor names and signatures don't.
-  - Not a streaming substrate. The four streaming-band tools
-    (`subscribe`, `unsubscribe`, `list-subscriptions`) fan through
-    framework callbacks the MCP server installs on the
-    *server* side — the runtime just exposes
+  - Not a new framework registry. Every accessor below routes through
+    an existing `re-frame.core/*` surface. We add no new dispatch
+    types, no new effect substrates, no new component substrates.
+  - Not a re-frame2-pair-mcp port. The accessor surface is shaped to
+    the Causa-specific surfaces (trace buffer, epoch history,
+    app-db-diff, machine-state) rather than to re-frame2-pair-mcp's
+    own tool shapes.
+  - Not a streaming substrate. The runtime exposes
     `register-trace-cb!` / `register-epoch-cb!` indirection via
     re-frame.core, plus a thin `current-subscriptions` accessor for
-    the diagnostic. The per-tick queue / overflow bookkeeping lives
-    on the MCP-server side per [`tools/causa-mcp/spec/004-Wire-Pipeline.md`
-    §Streaming over batch](../../causa-mcp/spec/004-Wire-Pipeline.md).
+    the diagnostic; per-tick queue / overflow bookkeeping lives on
+    the MCP-server side.
 
   ## Why the install side-effect block is gated on `debug-enabled?`
 
@@ -71,9 +65,10 @@
   ## Cross-side coupling is one-way
 
   The MCP server depends on the accessor signatures below (the
-  contract); the runtime is independent of the server. Causa-the-panel
-  loads this ns without the MCP server running, and Causa-MCP can
-  attach later without the runtime needing to know."
+  contract); the runtime is independent of any server. Causa-the-panel
+  loads this ns without an MCP server running, and any MCP consumer
+  (re-frame2-pair-mcp today) can attach later without the runtime
+  needing to know."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
             ;; rf2-qwm0a: trace-buffer (and the rest of the listener +
@@ -107,7 +102,7 @@
 
 (def ^:private global-marker-key
   "Key under which the session-id mirror lives on `js/globalThis`. The
-  causa-mcp side runs `(some? (and (exists? js/globalThis) (.-<key>
+  MCP-server side runs `(some? (and (exists? js/globalThis) (.-<key>
   js/globalThis)))` as the cheap probe; centralising the string here
   keeps the runtime <-> server contract editable in one place."
   "__day8_re_frame2_causa_runtime")
@@ -127,14 +122,16 @@
 ;; Origin dynamic var
 ;; ---------------------------------------------------------------------------
 ;;
-;; Per `tools/causa-mcp/spec/Principles.md` §"Origin tagging is the
-;; convention, not a suggestion": every Causa-MCP-driven side-effect on
-;; the trace bus carries `:tags :origin :causa-mcp`. The MCP server
-;; renders a `binding` form that wraps the runtime's accessor call with
-;; `(binding [current-origin :causa-mcp] ...)`; mutating accessors
+;; Convention: every MCP-driven side-effect on the trace bus carries a
+;; `:tags :origin <server-name>` tag. The MCP server renders a
+;; `binding` form that wraps the runtime's accessor call with
+;; `(binding [current-origin <server-name>] ...)`; mutating accessors
 ;; read the bound value when they construct the dispatch payload.
 ;;
-;; The default value is `:causa-mcp` so a bare call from the server
+;; The default value is `:causa-mcp` (grandfathered from the original
+;; causa-mcp design — see DESIGN-RATIONALE.md Lock #6 supersedence;
+;; revising the default is tracked separately) so a bare call from the
+;; server
 ;; already carries the tag; `eval-cljs` keeps the binding for the
 ;; synchronous extent of the eval'd form only (the documented
 ;; async-tagging gap per Lock #4 / I6).
@@ -563,8 +560,7 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The MCP-server side owns the per-subscription queue + per-tick
-;; overflow bookkeeping (per `tools/causa-mcp/spec/004-Wire-Pipeline.md`
-;; §Streaming over batch — one drain-batch per `notifications/progress`).
+;; overflow bookkeeping (one drain-batch per `notifications/progress`).
 ;; The runtime exposes the lightweight registration / lookup surface
 ;; the server's pump rides over.
 
@@ -580,10 +576,8 @@
   :filter <map>}`.
 
   The runtime records the subscription's metadata; the MCP server
-  owns the per-tick drain pump and the queue overflow bookkeeping
-  per [`004-Wire-Pipeline.md` §Streaming over batch]
-  (../../causa-mcp/spec/004-Wire-Pipeline.md). Recognised topics:
-  `:trace`, `:epoch`, `:fx`, `:error`."
+  owns the per-tick drain pump and the queue overflow bookkeeping.
+  Recognised topics: `:trace`, `:epoch`, `:fx`, `:error`."
   [{:keys [topic filter] :as _opts}]
   (cond
     (not (contains? #{:trace :epoch :fx :error} topic))
@@ -620,8 +614,7 @@
   The per-tick `:queue-depth` / `:queue-bytes` / `:dropped-events`
   fields the spec lists live on the *server* side (each sub's pump
   carries the per-tick counters); the runtime supplies the topic /
-  filter / created-at slots the server merges into its own view per
-  [`tools/causa-mcp/spec/000-Vision.md` §Two namespaces, two sides]."
+  filter / created-at slots the server merges into its own view."
   ([] (list-subscriptions nil))
   ([{:keys [topic sub-id] :as _opts}]
    (let [subs (vals @subscriptions)

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -44,15 +44,7 @@
 
   Semantic-mapping tables that emit token *keywords* (e.g. an outcome
   → `:green` table) live in each panel's `*_helpers.cljc` so the
-  pure-data side stays JVM-portable. The hex resolution happens here.
-
-  ## Causa-MCP origin colour
-
-  The inferential `:origin :causa-mcp` cyan (`#06B6D4`) lives in
-  `mcp_server_helpers.cljc/causa-mcp-origin-colour` per the comment
-  there — it is pinned to a follow-on spec bead and not (yet) a
-  palette-grade token. The mcp-server panel reaches for it directly
-  rather than rolling it into the shared palette."
+  pure-data side stays JVM-portable. The hex resolution happens here."
   {:no-doc true})
 
 ;; ---- per-theme palettes -------------------------------------------------

--- a/tools/mcp-base/deps.edn
+++ b/tools/mcp-base/deps.edn
@@ -1,15 +1,20 @@
 ;; day8/re-frame2-mcp-base — shared primitives for the re-frame2 MCP
-;; tool triplet (re-frame2-pair-mcp, story-mcp, causa-mcp). Filed under rf2-vw4sq.
+;; tool pair (re-frame2-pair-mcp, story-mcp). Filed under rf2-vw4sq.
+;;
+;; (Historical: a third server `causa-mcp` was envisaged as part of an
+;; MCP triplet; it was dropped per rf2-hvl1g — AI agent access to Causa
+;; state flows via re-frame2-pair-mcp against the framework-published
+;; Causa runtime API, so a dedicated causa-mcp is unnecessary.)
 ;;
 ;; ## Why this artefact exists
 ;;
-;; The three MCP servers in `tools/` consume the same Spec 009
+;; The MCP servers in `tools/` consume the same Spec 009
 ;; instrumentation API and emit the same Spec / Conventions wire
 ;; vocabulary (`:rf.mcp/*` markers, `:rf.size/*` markers, JSON-RPC
 ;; error codes, the spec/009 §Privacy `:sensitive?` default-suppress
 ;; filter). Each was implementing those primitives privately; this
 ;; jar lifts the genuinely-shared pieces into one place so the wire
-;; shapes stay byte-identical across the triplet and the agent learns
+;; shapes stay byte-identical across the pair and the agent learns
 ;; the vocabulary once.
 ;;
 ;; What lives here:
@@ -53,7 +58,7 @@
 ;; ## CLJC
 ;;
 ;; Sources are `.cljc` so they load identically into the JVM
-;; classpath (story-mcp, causa-mcp) and the shadow-cljs CLJS build
+;; classpath (story-mcp) and the shadow-cljs CLJS build
 ;; (re-frame2-pair-mcp). The tests target Clojure (test runner via
 ;; cognitect-labs/test-runner) — the algorithmic content is platform-
 ;; agnostic, so a JVM round-trip is the cheapest gate.
@@ -74,7 +79,7 @@
  ;; runtime via `requiring-resolve` / `resolve` and soft-passes when
  ;; Malli is absent. The test alias here puts Malli on the classpath so
  ;; the diff-encode tests can hard-assert schema acceptance and
- ;; rejection. Consumers (re-frame2-pair-mcp, story-mcp, causa-mcp) bring Malli
+ ;; rejection. Consumers (re-frame2-pair-mcp, story-mcp) bring Malli
  ;; themselves via their implementation deps; production CLJS bundles
  ;; can flip the goog-define `validate-patches?` to false to DCE the
  ;; validation branch outright. Pinning the same version used by

--- a/tools/mcp-base/spec/README.md
+++ b/tools/mcp-base/spec/README.md
@@ -1,12 +1,16 @@
-# `re-frame2-mcp-base` — shared primitives for the MCP triplet
+# `re-frame2-mcp-base` — shared primitives for the MCP pair
 
 `day8/re-frame2-mcp-base` is the CLJC library that holds the
 genuinely-cross-cutting primitives consumed by every MCP server in
-the re-frame2 tool triplet:
+the re-frame2 tool pair:
 
 - `tools/re-frame2-pair-mcp/` (CLJS / Node — runs over nREPL to a browser app)
 - `tools/story-mcp/` (JVM / Clojure — bridges to `tools/story/`)
-- `tools/causa-mcp/` (CLJS / Node — runs over nREPL to a browser app; eighteen-tool catalogue at `tools/causa-mcp/spec/004-Tools-Catalogue.md`)
+
+(Historical: a third server `causa-mcp` was envisaged, making this an
+MCP triplet; it was dropped per rf2-hvl1g — AI agent access to Causa
+state flows via re-frame2-pair-mcp against the framework-published
+Causa runtime API, so a dedicated causa-mcp is unnecessary.)
 
 The factoring landed under [rf2-vw4sq][bead]. The per-namespace
 contract expansion (rf2-643ia / rf2-0hs5t.5) splits each shipped
@@ -47,7 +51,7 @@ per-namespace contract doc; the table below indexes them:
 | `cap` | 242 | Wire-boundary token-budget cap pipeline + `ResultIO` protocol (rf2-eyelu) + resource controls + token splitter. | [`cap.md`](cap.md) |
 
 All `.cljc`, so consumers compile them under their own platform —
-re-frame2-pair-mcp's shadow-cljs node build, story-mcp / causa-mcp's JVM
+re-frame2-pair-mcp's shadow-cljs node build, story-mcp's JVM
 classpath. The library's `deps.edn` carries only
 `org.clojure/clojure`; no consumer-side runtime deps.
 
@@ -64,7 +68,7 @@ third server instance and lands as a separate bead.
 ## What deliberately does NOT live here
 
 The bead's scope holds the line at primitives that are truly
-identical across the triplet's wire / privacy / size surfaces.
+identical across the pair's wire / privacy / size surfaces.
 Three categories stay consumer-side:
 
 1. **Wire transport.** story-mcp uses Cheshire for JSON-RPC over
@@ -76,9 +80,8 @@ Three categories stay consumer-side:
    :ms ... :until-ms ... :frame ...}`) is conventional — but
    re-frame2-pair-mcp uses `js/Buffer.from … "base64"` and a JVM consumer
    would use `java.util.Base64`. Factoring the codec means a
-   protocol-shaped helper per platform; re-frame2-pair-mcp and causa-mcp
-   both run on Node and share `js/Buffer`, so a single codec helper
-   here is not yet warranted.
+   protocol-shaped helper per platform; with only one Node-side
+   consumer today, a single codec helper here is not yet warranted.
 
 3. **Tool registries.** Each MCP server's tool catalogue is domain-
    specific. The base provides building blocks; it does NOT

--- a/tools/mcp-base/spec/args.md
+++ b/tools/mcp-base/spec/args.md
@@ -1,7 +1,7 @@
 # `args` — argument coercion helpers
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp / causa-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
+> Parsers that take an ALREADY-RESOLVED raw value (extracted by the consumer from its platform-specific args object: a JS object for re-frame2-pair-mcp, a Clojure map for story-mcp) and normalise it into the Clojure-side type the tool body expects. Cross-MCP arg-vocabulary convention: an agent that learns `:dedup` defaults true on re-frame2-pair-mcp must see the same default everywhere.
 
 This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`vocab.md`](vocab.md), [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 

--- a/tools/mcp-base/spec/diff-encode.md
+++ b/tools/mcp-base/spec/diff-encode.md
@@ -83,7 +83,7 @@ Both story-mcp and re-frame2-pair-mcp implement this shape; the consumer-side de
 
 ## Cross-platform
 
-Pure-data tree walk over the path-keyed grammar. Loads identically into JVM (story-mcp / causa-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework dep beyond `org.clojure/clojure` for `assoc-in` / `update-in` / `dissoc`.
+Pure-data tree walk over the path-keyed grammar. Loads identically into JVM (story-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework dep beyond `org.clojure/clojure` for `assoc-in` / `update-in` / `dissoc`.
 
 ## Conformance posture
 

--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -46,7 +46,7 @@ The counter is non-negative integer; 0 means nothing was elided. The slot itself
 
 ## Cross-platform
 
-Pure-data tree walk; loads identically into JVM (story-mcp / causa-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework dep. The walker uses only:
+Pure-data tree walk; loads identically into JVM (story-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework dep. The walker uses only:
 
 - `map?` / `coll?` host predicates.
 - `contains?` membership.

--- a/tools/mcp-base/spec/handler-arity.md
+++ b/tools/mcp-base/spec/handler-arity.md
@@ -1,8 +1,8 @@
-# Handler-arity divergence across the MCP triplet
+# Handler-arity divergence across the MCP pair
 
 Source: rf2-63s4e (rf2-h1izl follow-on C7).
 
-The two shipped MCP servers in the re-frame2 triplet use **different
+The two shipped MCP servers in the re-frame2 pair use **different
 registry-handler arities**:
 
 | Server                    | Handler shape                | Why                                                        |
@@ -28,11 +28,11 @@ The two source-of-truth declarations:
 
 Cross-MCP-aware tooling under `tools/mcp-base/` cannot abstract the
 handler invocation shape — each server's dispatcher is a distinct
-implementation. A future fourth MCP-server author who consults both
+implementation. A future third MCP-server author who consults both
 servers as examples sees two patterns rather than one. This is the
-**deliberate gap** acknowledged here pending a third instance
-(`causa-mcp`, blocked behind rf2-hvl1g's scope discussion at time of
-writing) crystallising the canonical shape.
+**deliberate gap** acknowledged here; the originally-anticipated
+third instance (`causa-mcp`) was dropped per rf2-hvl1g, so unification
+will wait until a fresh third server crystallises the canonical shape.
 
 ## Why the divergence stayed
 
@@ -49,10 +49,10 @@ The unification is **not** part of this bead. A separate follow-on
 will factor an explicit `ExecutionContext` type (likely a record /
 map with optional `:conn` / `:progress-callback` / `:request-meta`
 slots) into `tools/mcp-base/` and refit both servers to a uniform
-`(fn [ctx args])` handler shape. That bead will be filed once
-`causa-mcp` lands and the three-server pattern is observable; until
-then there's no reliable third instance to validate the shape
-against.
+`(fn [ctx args])` handler shape. That bead waits for a third server
+instance to land — the originally-anticipated `causa-mcp` was dropped
+per rf2-hvl1g, so there's no reliable third instance to validate the
+shape against today.
 
 When it lands, the unification should:
 
@@ -66,7 +66,7 @@ When it lands, the unification should:
 3. Refit `re-frame.story-mcp.tools.cap` / category descriptors to
    call handlers with `(handler ctx args)`; the JVM-side
    `:conn` / `:progress-callback` slots are nil and ignored.
-4. `causa-mcp` adopts the unified shape from day one when it lands.
+4. The new third server adopts the unified shape from day one.
 
 Until that bead lands, the divergence is the documented state.
 
@@ -76,7 +76,7 @@ Until that bead lands, the divergence is the documented state.
   — the existing list of tool-shaped surfaces that stay consumer-side
   (wire transport, cursor base64 codec, tool registries). Handler-arity
   belongs on that list in spirit but is broken out into its own doc
-  because the divergence is structural — a future fourth server
+  because the divergence is structural — a future third server
   WILL need to pick one shape, and this doc gives them the context.
 - [`tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs`](../../re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs)
   — pair-mcp's 3-arity registry; ns docstring §"Handler arity

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -60,7 +60,7 @@ The default-OFF posture aligns with the framework's privacy-by-default stance (p
 
 ## Zero-dep rationale
 
-re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp / causa-mcp are JVM-side and DO have the framework primitive available. The predicate here (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and identical to `re-frame.privacy/sensitive?`.
+re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its classpath); story-mcp is JVM-side and DOES have the framework primitive available. The predicate here (`(and (map? ev) (true? (:sensitive? ev)))`) is conservative and identical to `re-frame.privacy/sensitive?`.
 
 Consumers that want to bind to the framework primitive (story-mcp does, for code-review locality) alias the surface in their own ns and delegate through here.
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -1,7 +1,7 @@
 # `vocab` — wire-vocabulary constants
 
 > **Type:** Reference (`tools/mcp-base/spec/`)
-> The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 triplet — `re-frame2-pair-mcp`, `story-mcp`, `causa-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
+> The single source of truth for the marker keys an agent learns once and recognises across every MCP server in the re-frame2 pair — `re-frame2-pair-mcp` and `story-mcp`. A rename here is a wire-protocol break; the cross-MCP conformance gate under `tools/mcp-conformance/wire-vocab/` fails loud when that happens.
 
 This doc is one of seven per-namespace contracts indexed from [`README.md`](README.md). See also: [`sensitive.md`](sensitive.md), [`elision.md`](elision.md), [`args.md`](args.md), [`diff-encode.md`](diff-encode.md), [`overflow.md`](overflow.md), [`cap.md`](cap.md).
 

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -2,7 +2,7 @@
   "Argument-coercion helpers for MCP tools. The parsers in this ns
   take an ALREADY-RESOLVED raw value (extracted by the consumer from
   its platform-specific args object: a JS object for re-frame2-pair-mcp, a
-  Clojure map for story-mcp/causa-mcp) and normalise it into the
+  Clojure map for story-mcp) and normalise it into the
   Clojure-side type the tool body expects.
 
   ## Cross-server convention

--- a/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/cap.cljc
@@ -57,7 +57,7 @@
   ## Cross-platform
 
   Pure CLJC. The `ResultIO` protocol resolves identically into the
-  JVM (story-mcp / causa-mcp) and CLJS (re-frame2-pair-mcp) — `defprotocol`
+  JVM (story-mcp) and CLJS (re-frame2-pair-mcp) — `defprotocol`
   reads the same way on both sides. mcp-base stays free of
   platform-specific deps (`js-interop`, JVM reflection, etc); those
   live in the consumer's IO instance."
@@ -69,10 +69,10 @@
 
 (defprotocol ResultIO
   "Per-consumer accessors over the MCP `tools/call` result shape. Each
-  MCP server (re-frame2-pair-mcp, story-mcp, causa-mcp) reifies this protocol
+  MCP server (re-frame2-pair-mcp, story-mcp) reifies this protocol
   once over its native result shape — `#js {:content #js [...]}` for
   re-frame2-pair-mcp's npm-SDK JS objects, `{:content [...]}` CLJ maps for
-  story-mcp / causa-mcp. The cap pipeline is then algorithm-only and
+  story-mcp. The cap pipeline is then algorithm-only and
   shape-agnostic."
 
   (content-texts [_io result]

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -67,8 +67,8 @@
 
   The `:rf.mcp/diff-from` marker key follows the same `:rf.mcp/*`
   namespace convention as `:rf.mcp/overflow` (rf2-rvyzy),
-  `:rf.mcp/summary` (rf2-tygdv), and causa-mcp's `:rf.mcp/dedup-table`
-  (rf2-lwgg8 mechanism 5). Agents recognise the family once.
+  `:rf.mcp/summary` (rf2-tygdv), and `:rf.mcp/dedup-table` (rf2-lwgg8
+  mechanism 5). Agents recognise the family once.
 
   ## Patch grammar pinned via Malli (rf2-rgg7d)
 
@@ -78,15 +78,14 @@
   the tuple shape trips the dev-build gate before it reaches a consumer.
 
   The schema is published as a public def for downstream Malli-based
-  decoders (causa-mcp's spec/004-Wire-Pipeline.md) and for the
-  cross-MCP wire-vocab conformance test
+  decoders and for the cross-MCP wire-vocab conformance test
   (`tools/mcp-conformance/wire-vocab`). Both today re-state the grammar
   in their own source; pinning it here gives them a canonical home to
   refer to once they switch to consume the schema directly.
 
   Validation is soft-pass when Malli is not resolvable on the runtime
   classpath: mcp-base does not pull Malli into its own deps (consumers
-  bring their own — re-frame2-pair-mcp/story-mcp/causa-mcp all have Malli on the
+  bring their own — re-frame2-pair-mcp/story-mcp both have Malli on the
   classpath via the implementation deps or the story artefact). On
   CLJS the validation branch sits behind a `goog-define`'d
   `validate-patches?` flag so a production build with
@@ -118,10 +117,9 @@
   diffed value down to the leaf being assoc'd / dissoc'd; an empty
   vector denotes the root (root replacement / no-op dissoc).
 
-  Published as a public def so downstream decoders (causa-mcp
-  spec/004-Wire-Pipeline.md, the cross-MCP wire-vocab conformance
-  test) can consume the canonical schema rather than re-stating the
-  grammar."
+  Published as a public def so downstream decoders (the cross-MCP
+  wire-vocab conformance test) can consume the canonical schema
+  rather than re-stating the grammar."
   [:or
    [:tuple [:vector :any] [:= :assoc] :any]
    [:tuple [:vector :any] [:= :dissoc]]])
@@ -143,10 +141,9 @@
        :section-kind :added|:removed|:modified
        :patches      [<patch>...]}         ; subset of the flat patch list
 
-  Published as a public def so downstream decoders (causa-mcp's
-  forthcoming Wire-Pipeline schema, the cross-MCP wire-vocab
-  conformance test) can consume the canonical schema rather than
-  re-stating the grammar."
+  Published as a public def so downstream decoders (the cross-MCP
+  wire-vocab conformance test) can consume the canonical schema
+  rather than re-stating the grammar."
   [:map
    [:section-path [:vector :any]]
    [:section-kind [:enum :added :removed :modified]]
@@ -173,11 +170,10 @@
            ;; `diff-encode-db-after`.
            true)
    :clj  (def ^:const validate-patches?
-           "JVM-side: validation always on. JVM consumers (story-mcp,
-           causa-mcp) run on dev / server hosts where the tree-walk
-           cost is invisible against the surrounding diff. The
-           compile-time elision only meaningfully applies under CLJS
-           `:advanced`."
+           "JVM-side: validation always on. JVM consumers (story-mcp)
+           run on dev / server hosts where the tree-walk cost is
+           invisible against the surrounding diff. The compile-time
+           elision only meaningfully applies under CLJS `:advanced`."
            true))
 
 (defn- resolve-malli-validate

--- a/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/elision.cljc
@@ -29,9 +29,9 @@
 
   ## Cross-platform
 
-  Pure-data tree walk; loads identically into JVM (story-mcp /
-  causa-mcp) and CLJS (re-frame2-pair-mcp). No transport, no runtime, no
-  framework dep — the walker only inspects the wire shape."
+  Pure-data tree walk; loads identically into JVM (story-mcp) and
+  CLJS (re-frame2-pair-mcp). No transport, no runtime, no framework
+  dep — the walker only inspects the wire shape."
   (:require [re-frame.mcp-base.vocab :as vocab]))
 
 (defn count-elided-markers

--- a/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/overflow.cljc
@@ -9,10 +9,10 @@
   the agent's conversation without telling the agent.
 
   This namespace owns the SHAPE of the marker (so it stays byte-
-  identical across the triplet); the cap-enforcement glue (counting
+  identical across the pair); the cap-enforcement glue (counting
   tokens, replacing the payload) lives consumer-side because the
   payload representation differs (CLJS JS object for re-frame2-pair-mcp; CLJ
-  map for story-mcp/causa-mcp).
+  map for story-mcp).
 
   ## Token rule
 

--- a/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/sensitive.cljc
@@ -29,7 +29,7 @@
   ## Why this ns is zero-dep
 
   re-frame2-pair-mcp is a CLJS Node bundle (no `re-frame.trace` on its
-  classpath); story-mcp / causa-mcp are JVM-side and DO have the
+  classpath); story-mcp is JVM-side and DOES have the
   framework primitive available. The predicate body
   (`(and (map? ev) (sensitive-stamp? (:sensitive? ev)))`) is
   conservative and matches the spirit of `re-frame.privacy/sensitive?`.
@@ -195,7 +195,7 @@
   contract — re-frame2-pair-mcp passes its union predicate that also catches
   the epoch-level `:sensitive?` rollup (`sensitive-event? OR
   sensitive-epoch?`). The default arity preserves the
-  trace-event-only filter for story-mcp / causa-mcp consumers."
+  trace-event-only filter for story-mcp consumers."
   ([snapshot include?]
    (scrub-snapshot snapshot include? strip-sensitive))
   ([snapshot include? strip-fn]

--- a/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/vocab.cljc
@@ -1,18 +1,18 @@
 (ns re-frame.mcp-base.vocab
   "Cross-MCP wire-vocabulary constants. One place to learn — and pin —
   the namespaced keys that the agent learns once and recognises across
-  every MCP tool in the re-frame2 triplet (re-frame2-pair-mcp, story-mcp,
-  causa-mcp).
+  every MCP tool in the re-frame2 pair (re-frame2-pair-mcp,
+  story-mcp).
 
   ## Why a vocab ns
 
   Every wire mechanism (overflow cap, cursor pagination, structural
   dedup, diff-encode, size-elision) decorates the payload with a
   marker key. The marker keys MUST stay byte-identical across the
-  triplet — an agent that learns `:rf.mcp/overflow` on re-frame2-pair-mcp must
-  see the same key shape from story-mcp / causa-mcp. Defining the
-  keys here, once, prevents per-consumer drift and gives a single
-  search target when the vocabulary grows.
+  pair — an agent that learns `:rf.mcp/overflow` on re-frame2-pair-mcp must
+  see the same key shape from story-mcp. Defining the keys here,
+  once, prevents per-consumer drift and gives a single search target
+  when the vocabulary grows.
 
   ## Two namespaces plus envelope slots
 
@@ -60,10 +60,7 @@
   "Top-level marker on a structurally-deduped payload. The value is the
   de-dupe library's flat cache map; the agent expands locally via
   `de-dupe.core/expand`.
-  Shape: `{:rf.mcp/dedup-table <cache-map>}`. Per rf2-obpa9.
-
-  causa-mcp uses the same key for its mechanism-5 dedup
-  (cross-MCP-conventions, per causa-mcp/spec/004-Wire-Pipeline.md §5)."
+  Shape: `{:rf.mcp/dedup-table <cache-map>}`. Per rf2-obpa9."
   :rf.mcp/dedup-table)
 
 (def diff-from-key

--- a/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/diff_encode_test.clj
@@ -165,9 +165,8 @@
 ;;
 ;; These tests pin the grammar with positive and negative cases so a
 ;; future encoder refactor that drifts the tuple shape — and a future
-;; consumer (causa-mcp's Malli-based decoder per spec/004-Wire-Pipeline.md,
-;; the cross-MCP wire-vocab conformance test) that re-states the
-;; grammar — both trip this gate before reaching the wire.
+;; consumer (the cross-MCP wire-vocab conformance test) that re-states
+;; the grammar — both trip this gate before reaching the wire.
 ;; ---------------------------------------------------------------------------
 
 (deftest patch-schema-accepts-well-formed-tuples

--- a/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
+++ b/tools/mcp-base/test/re_frame/mcp_base/sensitive_test.clj
@@ -1,7 +1,7 @@
 (ns re-frame.mcp-base.sensitive-test
   "Tests for the spec/009 §Privacy default-suppress filter shared
-  across the MCP triplet (rf2-vw4sq). The predicate and the filter
-  must stay byte-identical across re-frame2-pair-mcp, story-mcp, and causa-mcp
+  across the MCP pair (rf2-vw4sq). The predicate and the filter
+  must stay byte-identical across re-frame2-pair-mcp and story-mcp
   — these tests pin the contract."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.mcp-base.sensitive :as sensitive]))
@@ -249,8 +249,8 @@
       "reset zeroes the counter for the next test"))
 
 (deftest scrub-snapshot-2-arity-delegates-to-strip-sensitive
-  ;; The 2-arity form is the default-suppress shape used by story-mcp /
-  ;; causa-mcp; its contract that it delegates to `strip-sensitive` is
+  ;; The 2-arity form is the default-suppress shape used by story-mcp;
+  ;; its contract that it delegates to `strip-sensitive` is
   ;; the load-bearing spec/009 §Privacy MUST. A regression that flipped
   ;; the default to a no-op (or any other predicate) wouldn't trip the
   ;; existing tests — those only exercise the 2-arity form's outputs

--- a/tools/mcp-conformance/NAMING.md
+++ b/tools/mcp-conformance/NAMING.md
@@ -2,20 +2,24 @@
 
 Source: rf2-mzf1r.
 
-The re-frame2 MCP triplet — `tools/re-frame2-pair-mcp/`, `tools/story-mcp/`,
-and `tools/causa-mcp/` (spec-only today) — exposes a deliberately
-bounded surface, catalogued per-server at
-[`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md),
-[`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md),
-and (when its impl lands)
-[`tools/causa-mcp/spec/`](../causa-mcp/spec/). Per the
-§"Single source of truth for tool counts" rule below, every count
-sits in one place: the catalogue. An agent host with two or three
-servers attached at once sees the union as one surface.
+The re-frame2 MCP pair — `tools/re-frame2-pair-mcp/` and
+`tools/story-mcp/` — exposes a deliberately bounded surface, catalogued
+per-server at
+[`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
+and
+[`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md).
+Per the §"Single source of truth for tool counts" rule below, every count
+sits in one place: the catalogue. An agent host with both servers
+attached at once sees the union as one surface.
 **The verb a tool uses is the first signal the agent parses**; verb
 drift across siblings makes that signal lossy (snapshot in re-frame2-pair ≠
-snapshot-identity in story; `read-` in story ≠ `get-` in causa) and
-pushes the agent towards trial-and-error rather than pattern-match.
+snapshot-identity in story) and pushes the agent towards trial-and-error
+rather than pattern-match.
+
+(Historical: a third server `causa-mcp` was envisaged; it was dropped
+per rf2-hvl1g — AI agent access to Causa state already flows via
+`re-frame2-pair-mcp` against the framework-published Causa runtime API,
+so a dedicated causa-mcp is unnecessary.)
 
 This doc locks the verb vocabulary the triplet picks from. New tools
 land against an existing verb; novel verbs require a Lock entry in
@@ -29,18 +33,18 @@ covers the catalogue surface.
 | Verb shape | Semantics | Examples | Notes |
 |---|---|---|---|
 | **`get-<thing>`** | Single-entity read by id / key / addressed path. Returns ONE record or value. | `get-app-db`, `get-path`, `get-story`, `get-variant`, `get-trace-buffer`, `get-epoch-history`, `get-machine-state`, `get-machine-list`, `get-issues`, `get-handlers`, `get-source-coord`, `get-story-instructions` | The most common verb. The agent supplies an id / path / filter; the server returns the addressed slice. `get-` is a pure read — no side-effects, no recompute. `get-trace-buffer` and `get-epoch-history` are `get-` rather than `list-` because they return slices addressed by filter, not full enumerations. |
-| **`list-<things>`** | Collection enumeration — no id, returns vector / set. | `list-stories`, `list-substrates`, `list-tags`, `list-modes`, `list-assertions` | Closed-set or registrar-derived enumeration. The returned shape is a vector of records (or ids); no filter axis collapses it to one entity. re-frame2-pair-mcp doesn't ship any `list-*` today (its catalogue is small enough that the per-frame snapshot covers the discovery workflow); causa-mcp uses `get-machine-list` rather than `list-machines` because the call carries a frame filter — borderline, but `get-` won when the canonical pin was chosen. New tools that match the pure-enumeration shape use `list-`. |
+| **`list-<things>`** | Collection enumeration — no id, returns vector / set. | `list-stories`, `list-substrates`, `list-tags`, `list-modes`, `list-assertions` | Closed-set or registrar-derived enumeration. The returned shape is a vector of records (or ids); no filter axis collapses it to one entity. re-frame2-pair-mcp doesn't ship any `list-*` today (its catalogue is small enough that the per-frame snapshot covers the discovery workflow). New tools that match the pure-enumeration shape use `list-`. |
 | **`read-<thing>`** | Diagnostic re-read of last-computed state. Same shape as `get-`, but reserved for the **no-recompute** read path against a previously-executed artefact. | `read-failures` | Distinguished from `get-` so the agent recognises "the run already happened; this is a cheap reflection" — not "fetch the live state". The difference matters when the value is expensive to recompute (story-mcp's `read-failures` reads the variant's accumulated `:rf.story/assertions` rather than re-running the play sequence). |
-| **`discover-<surface>`** | Session-bootstrap health probe. Returns `{:ok? ... :debug-enabled? ... :frames [...] :build-id ...}` or a structured `:reason` keyword. | `discover-app` | Run first every session. Universal across re-frame2-pair-mcp and causa-mcp; story-mcp doesn't ship `discover-app` because its runtime model is JVM-side (no nREPL handshake). |
-| **`dispatch`** | Fire a re-frame2 event. Bare verb, **universal across re-frame2-pair-mcp and causa-mcp**. Always tagged with `:origin :<server-name>` on the trace bus. | `dispatch` | Story-mcp does NOT ship `dispatch` — its mutations go through `register-variant` / `unregister-variant` instead. The bare verb is reserved for the framework's primary mutation primitive. |
-| **`eval-cljs`** | The escape hatch — evaluate an arbitrary CLJS form in the connected runtime. Bare verb, **universal across re-frame2-pair-mcp and causa-mcp**. Any side-effect the form triggers inherits the server's `:origin` tag. | `eval-cljs` | Story-mcp does NOT ship `eval-cljs` because its server runs JVM-side and there's no browser runtime to eval into. Causa-mcp ships the same shape as re-frame2-pair-mcp (per its DESIGN-RATIONALE Lock #5: closed-set catalogue, deliberate escape valve). |
-| **`restore-<thing>`** | Time-travel state restore. Mirrors a user-confirmed in-panel affordance. | `restore-epoch` | Mutating; tagged `:origin :<server-name>`. Causa-mcp only today. |
-| **`reset-<thing>`** | Replace state, bypassing the normal cascade. Mirrors a "try anyway" affordance. | `reset-frame-db` | Mutating; tagged `:origin :<server-name>`. Causa-mcp only today. |
+| **`discover-<surface>`** | Session-bootstrap health probe. Returns `{:ok? ... :debug-enabled? ... :frames [...] :build-id ...}` or a structured `:reason` keyword. | `discover-app` | Run first every session. Used by re-frame2-pair-mcp; story-mcp doesn't ship `discover-app` because its runtime model is JVM-side (no nREPL handshake). |
+| **`dispatch`** | Fire a re-frame2 event. Bare verb, used by re-frame2-pair-mcp. Always tagged with `:origin :<server-name>` on the trace bus. | `dispatch` | Story-mcp does NOT ship `dispatch` — its mutations go through `register-variant` / `unregister-variant` instead. The bare verb is reserved for the framework's primary mutation primitive. |
+| **`eval-cljs`** | The escape hatch — evaluate an arbitrary CLJS form in the connected runtime. Bare verb, used by re-frame2-pair-mcp. Any side-effect the form triggers inherits the server's `:origin` tag. | `eval-cljs` | Story-mcp does NOT ship `eval-cljs` because its server runs JVM-side and there's no browser runtime to eval into. |
+| **`restore-<thing>`** | Time-travel state restore. Mirrors a user-confirmed in-panel affordance. | `restore-epoch` | Mutating; tagged `:origin :<server-name>`. Reserved shape — no live server emits this today. |
+| **`reset-<thing>`** | Replace state, bypassing the normal cascade. Mirrors a "try anyway" affordance. | `reset-frame-db` | Mutating; tagged `:origin :<server-name>`. Reserved shape — no live server emits this today. |
 | **`register-<thing>` / `unregister-<thing>`** | Registry add / remove, symmetric pair. Both gated behind the server's write-allow flag where applicable. | `register-variant`, `unregister-variant` | Story-mcp only today. If a future tool surfaces "register a handler at the framework level via MCP" it adopts this verb. |
 | **`run-<thing>`** | Execute a definition and report **pass / fail** results. Implies a play sequence, an assertion vocabulary, or some explicit success criterion. | `run-variant`, `run-a11y` | Distinguished from `preview-` (no pass/fail) and `dispatch` (one event, not a sequence). Story-mcp only today. |
 | **`preview-<thing>`** | Execute and report **rendered / resolved state**, but no pass/fail. The "show me what this would look like" call. | `preview-variant` | The symmetric pair of `run-` for the same registry. Story-mcp only today. |
 | **`record-as-<thing>`** | Capture user / agent activity for a bounded duration; emit as an artefact (variant snippet, etc.). | `record-as-variant` | The bridge between live dispatches and the persisted registry. Story-mcp only today. |
-| **`subscribe` / `unsubscribe`** | Streaming pair. Bare verbs, **universal across re-frame2-pair-mcp and causa-mcp**. `subscribe` returns one `notifications/progress` per matching batch; `unsubscribe` closes out-of-band. | `subscribe`, `unsubscribe` | Topic vocabulary is per-server (re-frame2-pair ships `:trace` / `:epoch` / `:fx` / `:error`; causa-mcp ships the same set). Story-mcp does not ship streaming. |
+| **`subscribe` / `unsubscribe`** | Streaming pair. Bare verbs, used by re-frame2-pair-mcp. `subscribe` returns one `notifications/progress` per matching batch; `unsubscribe` closes out-of-band. | `subscribe`, `unsubscribe` | Topic vocabulary is per-server (re-frame2-pair ships `:trace` / `:epoch` / `:fx` / `:error`). Story-mcp does not ship streaming. |
 | **`tail-<thing>`** | Wait for an external state change to land. Polls until a probe condition flips or `wait-ms` expires. | `tail-build` | Today only `tail-build` exists (await hot-reload). Future variants (`tail-test`, `tail-deploy`) take the same shape: integer wait, probe form, structured timeout. |
 | **Mega-op bare verbs** | Reserved for derived projections / multi-registry reads that don't fit `get-<thing>`. Bare names, no prefix. | `snapshot`, `trace-window`, `watch-epochs` | These are re-frame2-pair-mcp's coarse-grained reads that span multiple registry kinds (`snapshot` covers app-db + sub-cache + machines + epochs + traces in one round-trip; `trace-window` and `watch-epochs` page over the trace bus). Adding a new bare verb requires a Lock entry in the relevant server's `DESIGN-RATIONALE.md`. |
 
@@ -65,13 +69,13 @@ out in PR review and pick from the table above instead.
 
 ## Server alignment today
 
-The triplet is **fully aligned** with this convention today
+The pair is **fully aligned** with this convention today
 (post-rf2-4y595). The table below is the audit; the table reflects
 the post-rename state — pair-mcp's two former deviations
 (`subscription-info`, `registry-list`) were renamed to
 `list-subscriptions` / `list-handlers` per rf2-4y595 (rf2-h1izl
 follow-on C5). The convention is the lock for **any future extension**
-to re-frame2-pair-mcp / story-mcp / causa-mcp.
+to re-frame2-pair-mcp / story-mcp.
 
 ### re-frame2-pair-mcp (14 tools)
 
@@ -86,7 +90,7 @@ to re-frame2-pair-mcp / story-mcp / causa-mcp.
 | `watch-epochs` | bare (mega-op) | Conformant — paginated projection. (Borderline: arguably a `list-` candidate, but the cursor / filter shape leans mega-op.) |
 | `get-path` | `get-` | Conformant. |
 | `subscribe` / `unsubscribe` | bare (universal pair) | Conformant. |
-| `list-subscriptions` | `list-` | Conformant — renamed from `subscription-info` per rf2-4y595 (NAMING.md follow-on). Matches causa-mcp's same-named tool per rf2-3we2k Lock #12. No back-compat shim; the old name hard-errors with `:unknown-tool`. |
+| `list-subscriptions` | `list-` | Conformant — renamed from `subscription-info` per rf2-4y595 (NAMING.md follow-on). No back-compat shim; the old name hard-errors with `:unknown-tool`. |
 | `handler-meta` | bare-noun read | Conformant exception — bare-noun read of a single-record metadata map. Accepted under the bare-noun-exception clause when the return value is a structured metadata blob the agent reads as one record (same shape as story-mcp's `snapshot-identity`). Added by rf2-cibp8. |
 | `list-handlers` | `list-` | Conformant — renamed from `registry-list` per rf2-4y595 (NAMING.md follow-on). The `<noun>-list` suffix was flagged as rejected in §"What's NOT a locked verb" above; `list-<things>` prefix is the catalogued shape. The runtime's `(rf/registry-list kind)` accessor keeps its name (separate naming surface). Added by rf2-pctf8. |
 | `get-re-frame2-pair-instructions` | `get-` | Conformant — single-record read of the agent-onboarding instructions blob (rf2-fnpqg). Mirrors story-mcp's `get-story-instructions`. |
@@ -115,28 +119,6 @@ to re-frame2-pair-mcp / story-mcp / causa-mcp.
 | `unregister-variant` | `unregister-` | Conformant. |
 | `record-as-variant` | `record-as-` | Conformant. |
 
-### Causa-mcp (18 tools per `tools/causa-mcp/spec/004-Tools-Catalogue.md`)
-
-| Tool | Verb shape | Notes |
-|---|---|---|
-| `discover-app` | `discover-` | Conformant. |
-| `eval-cljs` | bare (universal) | Conformant. |
-| `dispatch` | bare (universal) | Conformant. |
-| `tail-build` | `tail-` | Conformant. |
-| `subscribe` / `unsubscribe` | bare (universal pair) | Conformant. |
-| `list-subscriptions` | `list-` | Conformant — enumeration of active streaming subscriptions; the cross-server-symmetric counterpart to re-frame2-pair-mcp's `list-subscriptions` (formerly `subscription-info`; renamed per rf2-4y595 once causa-mcp's Lock #12 picked the canonical verb). Per [`tools/causa-mcp/spec/DESIGN-RATIONALE.md` Lock #12](../causa-mcp/spec/DESIGN-RATIONALE.md) (rf2-3we2k, 2026-05-14). |
-| `get-trace-buffer` | `get-` | Conformant — filter-addressed slice read. |
-| `get-epoch-history` | `get-` | Conformant — filter-addressed slice read. |
-| `get-app-db` | `get-` | Conformant. |
-| `get-app-db-diff` | `get-` | Conformant. |
-| `get-machine-state` | `get-` | Conformant. |
-| `get-machine-list` | `get-` | **Borderline** — a pure enumeration would be `list-machines`; the current name uses `get-` because the call carries a frame filter. Either shape is conformant; the current name is the spec'd pick and stays. |
-| `get-issues` | `get-` | Conformant. |
-| `get-handlers` | `get-` | Conformant. |
-| `get-source-coord` | `get-` | Conformant. |
-| `restore-epoch` | `restore-` | Conformant. |
-| `reset-frame-db` | `reset-` | Conformant. |
-
 ## Single source of truth for tool counts
 
 Each per-server spec carries its catalogue count in prose ("the 19 tools",
@@ -152,9 +134,9 @@ The convention for per-server tool-catalogue docs:
 - **One canonical count site per server.** Pin the integer in exactly one
   place — the catalogue file's `# <Server> — Tool Registry` heading or its
   introductory paragraph (`tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`,
-  `tools/story-mcp/spec/002-Tool-Registry.md`, `tools/causa-mcp/spec/`
-  forthcoming). Every other doc that needs to cite the count **links to
-  the catalogue** rather than repeating the integer:
+  `tools/story-mcp/spec/002-Tool-Registry.md`). Every other doc that
+  needs to cite the count **links to the catalogue** rather than
+  repeating the integer:
   ```md
   See [`002-Tool-Registry.md`](002-Tool-Registry.md) for the full tool list.
   ```
@@ -191,8 +173,8 @@ cross-server discipline. Three reserved namespaces:
   verbatim by every server that ships epoch slices.
 - **`:<server-name>.error/*`** — server-specific failures
   (`:rf.story-mcp.error/write-gate-closed`,
-  `:rf.re-frame2-pair-mcp.error/runtime-not-preloaded`,
-  `:rf.causa-mcp.error/...`). Owned by the server.
+  `:rf.re-frame2-pair-mcp.error/runtime-not-preloaded`). Owned by the
+  server.
 
 Additional cross-server reserved keywords cover the wire-vocabulary
 markers (`:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/dedup-table`,
@@ -225,9 +207,6 @@ property the table exists to enforce.
   `spec/Principles.md`).
 - [`tools/story-mcp/spec/002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md)
   — story-mcp's tool catalogue.
-- [`tools/causa/spec/010-MCP-Server.md`](../causa/spec/010-MCP-Server.md)
-  §"Tool catalogue" — causa-mcp's catalogue prose (until
-  `tools/causa-mcp/spec/003-Tool-Catalogue.md` lands).
 - [`spec/Conventions.md`](../../spec/Conventions.md) §"Reserved
   namespaces (framework-owned)" — the `:rf.*` keyword discipline this
   doc inherits.

--- a/tools/mcp-conformance/README.md
+++ b/tools/mcp-conformance/README.md
@@ -1,8 +1,11 @@
 # tools/mcp-conformance
 
 End-to-end **MCP-client** conformance harness for the re-frame2 MCP
-servers — `re-frame2-pair-mcp`, `story-mcp`, and (when its implementation lands)
-`causa-mcp`. Source: rf2-cum40.
+servers — `re-frame2-pair-mcp` and `story-mcp`. Source: rf2-cum40.
+
+(Historical: a third server `causa-mcp` was envisaged; it was dropped
+per rf2-hvl1g — AI agent access to Causa state flows via
+`re-frame2-pair-mcp` against the framework-published Causa runtime API.)
 
 This artefact has four surfaces:
 
@@ -27,8 +30,8 @@ This artefact has four surfaces:
    token-budget posture: the 5,000-token default cap, the
    `max-tokens` per-call override, the `:rf.mcp/overflow` retry
    marker, per-server mechanism inventory, chained-budget rules
-   when an agent attaches all three servers in one session, and
-   the deliberate divergences between server implementations.
+   when an agent attaches both servers in one session, and the
+   deliberate divergences between server implementations.
    Source: rf2-ll0yq.
 
 ## What this is
@@ -83,8 +86,6 @@ on the server side surfaces as an SDK parse-error.
   the SKIP path leaves on each.
 - `test/end-to-end-story.cjs` — story-mcp conformance (full write-loop
   with `--allow-writes` enabled)
-- `test/end-to-end-causa.cjs` — placeholder; exits 0 with a `SKIP`
-  marker until causa-mcp's server implementation lands
 
 ## How to run
 
@@ -103,10 +104,7 @@ npm run test:re-frame2-pair
 # launched via `clojure -M -m re-frame.story-mcp.server`.
 npm run test:story
 
-# causa-mcp: currently a SKIPPED no-op (see comment in the file).
-npm run test:causa
-
-# All three (re-frame2-pair must be pre-built):
+# Both (re-frame2-pair must be pre-built):
 npm test
 ```
 
@@ -221,18 +219,12 @@ fixture's location and entry script in the orchestrator's preamble.
 
 Watchdog: 90s (cold JVM boot is ~10–30s on a CI runner).
 
-### `end-to-end-causa.cjs`
-
-Placeholder — exits 0 with a `SKIP` marker. Will be filled in when
-the causa-mcp server implementation lands; the file's body comment
-documents the expected shape.
-
 ## CI
 
-`.github/workflows/test.yml` runs each of the three scripts in its own
-`mcp-conformance-{re-frame2-pair,story,causa}` job, parallel to the existing
-`node-test-tools-{re-frame2-pair,story}-mcp` jobs. Same Node 24 + JDK 21 setup
-as those jobs.
+`.github/workflows/test.yml` runs each of the conformance scripts in
+its own `mcp-conformance-{re-frame2-pair,story}` job, parallel to the
+existing `node-test-tools-{re-frame2-pair,story}-mcp` jobs. Same
+Node 24 + JDK 21 setup as those jobs.
 
 The `mcp-conformance-re-frame2-pair` job runs three steps in sequence:
 
@@ -290,10 +282,8 @@ already lives, by construction, in three other places:
 
 3. **The servers being verified.** Per-tool input / output / error
    contracts are owned by each server's own `spec/`
-   ([`tools/re-frame2-pair-mcp/spec/`](../re-frame2-pair-mcp/spec/),
-   [`tools/story-mcp/spec/`](../story-mcp/spec/), and — when its
-   implementation lands —
-   [`tools/causa-mcp/spec/`](../causa-mcp/spec/)). Duplicating that
+   ([`tools/re-frame2-pair-mcp/spec/`](../re-frame2-pair-mcp/spec/) and
+   [`tools/story-mcp/spec/`](../story-mcp/spec/)). Duplicating that
    here would create a second source of truth on a wire that already
    has one canonical home per server.
 

--- a/tools/mcp-conformance/TOKEN-BUDGETS.md
+++ b/tools/mcp-conformance/TOKEN-BUDGETS.md
@@ -2,12 +2,17 @@
 
 Source: rf2-ll0yq.
 
-The re-frame2 MCP triplet — `tools/re-frame2-pair-mcp/`, `tools/story-mcp/`, and
-`tools/causa-mcp/` (spec-only today) — shares a normative **token-budget
-posture**: a 5,000-token-per-response cap, a single per-call override
-slot (`max-tokens`), and a single cross-server overflow marker
-(`:rf.mcp/overflow`). An agent host that attaches all three sees one
-disciplined surface, not three dialects of "I'm too big".
+The re-frame2 MCP pair — `tools/re-frame2-pair-mcp/` and
+`tools/story-mcp/` — shares a normative **token-budget posture**: a
+5,000-token-per-response cap, a single per-call override slot
+(`max-tokens`), and a single cross-server overflow marker
+(`:rf.mcp/overflow`). An agent host that attaches both sees one
+disciplined surface, not two dialects of "I'm too big".
+
+(Historical: a third server `causa-mcp` was envisaged in this contract;
+it was dropped per rf2-hvl1g. AI agent access to Causa state already
+flows via `re-frame2-pair-mcp` against the framework-published Causa
+runtime API, so a dedicated causa-mcp is unnecessary.)
 
 This doc is the canonical pin. Each server's `Principles.md` carries
 the per-server expansion (mechanism inventory, pipeline order,
@@ -34,13 +39,12 @@ fine, but the realistic working session fires dozens of tool calls. A
 single oversized response burns the budget the agent needs for the
 next ten ops.
 
-The triplet's exposed surfaces are exactly the SOTA-flagged shapes:
+The pair's exposed surfaces are exactly the SOTA-flagged shapes:
 
 | Server | Exposed surfaces | Why exposed |
 |---|---|---|
 | `re-frame2-pair-mcp` | `snapshot`, `subscribe`, `watch-epochs`, `trace-window` | Mega-op spans 5 registries; subscribe batches scale with traffic; epochs carry full app-db pairs. |
 | `story-mcp` | `run-variant`, `list-stories` on populous libraries | Variant output carries assertions + rendered hiccup + snapshot; list-* size is a function of registry size. |
-| `causa-mcp` | `get-trace-buffer`, `get-epoch-history`, `app-db-diff`, `subscribe` | All return payloads that scale with runtime state — the most-exposed of the three. |
 
 Cap-first design pushes each server to **bound its egress by
 construction** (path-slicing, lazy summary, cursor pagination,
@@ -50,7 +54,7 @@ mechanisms are the load-bearing budget posture.
 
 ## The shared contract
 
-These slots are **identical across all three servers**. An agent that
+These slots are **identical across both servers**. An agent that
 learns them once recognises them everywhere.
 
 ### Default cap
@@ -110,11 +114,9 @@ the call succeeded; the response is a budget signal.
 ### Cap-aware planning slots in tool descriptors
 
 Every catalogue entry (per re-frame2-pair-mcp's
-[`003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md),
-story-mcp's
-[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md), and
-causa-mcp's
-[`004-Tools-Catalogue.md`](../causa-mcp/spec/004-Tools-Catalogue.md))
+[`003-Tool-Catalogue.md`](../re-frame2-pair-mcp/spec/003-Tool-Catalogue.md)
+and story-mcp's
+[`002-Tool-Registry.md`](../story-mcp/spec/002-Tool-Registry.md))
 carries:
 
 - A **typical-token** hint (`~1.2k`, `~3k under :sample`,
@@ -191,48 +193,24 @@ When the wire-boundary check lands, it follows re-frame2-pair-mcp's shape
 (`max-tokens` arg, `:rf.mcp/overflow` marker) — the keyword namespace
 is reserved cross-server.
 
-### causa-mcp — spec-locked, impl pending
-
-The cap is **spec-locked** in
-[`tools/causa-mcp/spec/004-Wire-Pipeline.md` §"Tight token budget per response"](../causa-mcp/spec/004-Wire-Pipeline.md#tight-token-budget-per-response)
-with **six normative mechanisms**:
-
-1. **Token budget cap** (5,000-token default, `:max-tokens`
-   override).
-2. **Path slicing** (`:path` arg + tree-summary default).
-3. **Cursor pagination** (`:cursor` + `:limit`).
-4. **Lazy summary** (`:rf.mcp/summary` shape, `:mode` arg).
-5. **Structural dedup** (`:rf.mcp/dedup-table`, opt-out via
-   `:dedup? false`).
-6. **Size elision** (`:rf.size/large-elided` substitution, opt-out
-   via `:include-large? true`).
-
-Mechanisms 1-6 are deliberately the same numbered set re-frame2-pair-mcp's
-mechanisms 1-6 align against. Mechanisms 7-8 in re-frame2-pair-mcp
-(diff-encoded `:db-after`, streaming subscribe byte+event budget) are
-**re-frame2-pair-mcp-specific today** but the cross-server vocabulary
-(`:rf.mcp/diff-from`, `:overflow-reason`) is already pinned —
-causa-mcp's catalogue is expected to absorb them when its streaming /
-epoch-pair surfaces land.
-
 ## Chained budgets — when agents attach multiple servers
 
-The realistic agent host attaches **all three servers in one
-session** (causa-mcp inspecting trace causality, re-frame2-pair-mcp dispatching
-events, story-mcp running variants). The 5,000-token cap is **per
-response**, not per session — the agent host's total context budget
-absorbs the sum.
+The realistic agent host attaches **both servers in one session**
+(re-frame2-pair-mcp dispatching events + inspecting trace causality,
+story-mcp running variants). The 5,000-token cap is **per response**,
+not per session — the agent host's total context budget absorbs the
+sum.
 
-The triplet's design assumes the agent meters consumption:
+The pair's design assumes the agent meters consumption:
 
 - **Each server's responses are bounded.** No server can blow the
   session on its own.
 - **No cross-server budget coordination.** Servers don't know about
   each other's outputs; the agent host is the metering authority.
 - **Per-server `max-tokens` overrides compose additively.** An agent
-  that needs a full re-frame2-pair-mcp `snapshot` payload AND a full causa-mcp
-  `get-epoch-history` payload passes `max-tokens 0` to both — total
-  cost is the sum.
+  that needs a full re-frame2-pair-mcp `snapshot` payload AND a full
+  story-mcp `run-variant` payload passes `max-tokens 0` to both —
+  total cost is the sum.
 
 The agent-host workflow Mike's skills assume:
 
@@ -256,30 +234,17 @@ deliberate or pending alignment.
 | Server | Slot shape |
 |---|---|
 | `re-frame2-pair-mcp` (implemented) | `{:rf.mcp/overflow {:limit :reached :token-count <int> :cap-tokens <int> :tool <str> :hint <str>}}` |
-| `causa-mcp` (spec'd) | `{:rf.mcp/overflow {:cap <int> :would-be <int> :hint <kw-or-str> :continuation {:cursor <str> :next-args {...}}}}` |
 | `story-mcp` (spec'd, generic) | `:isError true` with `:reason :budget-exceeded` + hint string (legacy path; converges to `:rf.mcp/overflow` when wire-boundary check lands) |
 
-**The divergence is intentional** for re-frame2-pair-mcp vs causa-mcp.
-re-frame2-pair-mcp's wrapper measures the *post-shrunk* payload after the
-full diff-encode/dedup/elision pipeline, so the continuation hint is
-tool-specific rather than a generic `:continuation {:cursor ...
-:next-args ...}` shape. causa-mcp's spec'd `:continuation` slot is
-designed for the cursor-paginated read tools where the next call's
-args are mechanically computable.
-
-Cross-server convergence on a single slot vocabulary is tracked
-separately — when both wrappers stabilise, one shape wins. The
-**reserved keyword** (`:rf.mcp/overflow`) and the **retry-signal
+The **reserved keyword** (`:rf.mcp/overflow`) and the **retry-signal
 contract** are identical today; only the slot vocabulary differs.
 
 ### Streaming-overflow surface
 
-re-frame2-pair-mcp ships an **upstream-queue budget** (`:max-buffered-events`
-+ `:max-buffered-bytes`, OR-combined) per subscription, with
-`:overflow-reason` reported per drain. causa-mcp's streaming band
-absorbs the same posture — the chatty-filter case and the
-large-payload-storm case both apply to causa-mcp's trace stream.
-story-mcp doesn't ship streaming.
+re-frame2-pair-mcp ships an **upstream-queue budget**
+(`:max-buffered-events` + `:max-buffered-bytes`, OR-combined) per
+subscription, with `:overflow-reason` reported per drain. story-mcp
+doesn't ship streaming.
 
 ### Enforcement surface
 
@@ -287,7 +252,6 @@ story-mcp doesn't ship streaming.
 |---|---|---|
 | `re-frame2-pair-mcp` | Runtime — `apply-cap` at `invoke` boundary | Live in `tools.cljs`. |
 | `story-mcp` | Spec-only — pagination + summary modes are normative but no wire-boundary check yet | Cap-violating tools would currently ship. Pending wiring. |
-| `causa-mcp` | Runtime — six mechanisms enforced at the tool egress | Live in `tools/causa-mcp/src/day8/re_frame2_causa_mcp/token_cap.cljs` and per-tool wrappers. |
 
 The shared **default cap (5,000)**, the **shared override slot name
 (`max-tokens`)**, and the **shared overflow keyword
@@ -314,10 +278,9 @@ override-pattern convention:
    consumption across the session.
 
 The skill catalogue
-([`skills/re-frame-pair/`](../../skills/re-frame-pair/),
-[`skills/re-frame-story/`](../../skills/re-frame-story/), and
-causa-mcp's skill when its impl lands) encodes this pattern; agents
-attaching ad-hoc are encouraged to follow it.
+([`skills/re-frame-pair/`](../../skills/re-frame-pair/) and
+[`skills/re-frame-story/`](../../skills/re-frame-story/)) encodes this
+pattern; agents attaching ad-hoc are encouraged to follow it.
 
 ## When this convention changes
 
@@ -349,8 +312,6 @@ cross-server contract exists to enforce.
   — re-frame2-pair-mcp's eight mechanisms, in pipeline order.
 - [`tools/story-mcp/spec/Principles.md` §"Tight token budget per response"](../story-mcp/spec/Principles.md#tight-token-budget-per-response)
   — story-mcp's three-axis discipline.
-- [`tools/causa-mcp/spec/004-Wire-Pipeline.md` §"Tight token budget per response"](../causa-mcp/spec/004-Wire-Pipeline.md#tight-token-budget-per-response)
-  — causa-mcp's six mechanisms.
 - [`spec/Conventions.md` §"Reserved namespaces (framework-owned)"](../../spec/Conventions.md)
   — the `:rf.mcp/*` / `:rf.size/*` keyword discipline this contract
   inherits.

--- a/tools/mcp-conformance/test/_runner.cjs
+++ b/tools/mcp-conformance/test/_runner.cjs
@@ -122,13 +122,12 @@ async function runWithWatchdog({ watchdogMs, transportSpec, clientName }, body) 
 // Pre-flight skip helper (rf2-i3ffz F-HYG-2).
 //
 // Conformance tests gate on environment / server-implementation status
-// (`live-re-frame2-pair-overflow.cjs` requires `$SHADOW_CLJS_NREPL_PORT`;
-// `end-to-end-causa.cjs` is a placeholder until causa-mcp's
-// implementation lands). Skipping cleanly means exiting 0 BEFORE
-// spawning a child or installing the watchdog — same pattern across
-// every caller. Centralising the SKIP banner + exit here makes the
-// caller a one-liner and pins the marker shape (`SKIP <reason>`) so a
-// CI step that greps for it doesn't drift per-test.
+// (`live-re-frame2-pair-overflow.cjs` requires `$SHADOW_CLJS_NREPL_PORT`).
+// Skipping cleanly means exiting 0 BEFORE spawning a child or
+// installing the watchdog — same pattern across every caller.
+// Centralising the SKIP banner + exit here makes the caller a
+// one-liner and pins the marker shape (`SKIP <reason>`) so a CI step
+// that greps for it doesn't drift per-test.
 // ---------------------------------------------------------------------
 runWithWatchdog.skip = function skip(reason) {
   console.log('SKIP ' + reason);
@@ -139,7 +138,7 @@ runWithWatchdog.skip = function skip(reason) {
 // JSON-RPC error-code conformance gate (rf2-i3ffz F-GAP-3).
 //
 // `mcp-base/vocab.cljc` pins the five JSON-RPC 2.0 §5.1 codes the
-// triplet routes against (`-32700` ParseError, `-32600` InvalidRequest,
+// MCP servers route against (`-32700` ParseError, `-32600` InvalidRequest,
 // `-32601` MethodNotFound, `-32602` InvalidParams, `-32603`
 // InternalError). Before this gate landed no test asserted either
 // server's actual on-the-wire emission — a regression that swapped

--- a/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
+++ b/tools/mcp-conformance/test/end-to-end-re-frame2-pair.cjs
@@ -260,7 +260,7 @@ runWithWatchdog(
     // fn keeps the historical name) so AI clients can list active
     // streaming subscriptions without an eval-cljs round-trip. Renamed
     // from `subscription-info` per rf2-4y595 (NAMING.md `list-<things>`
-    // conformance — matches causa-mcp's same-named tool). Pure-read
+    // conformance). Pure-read
     // tool, no required arguments — optional :topic / :sub-id filters
     // narrow the result. In degraded mode it returns the same
     // nrepl-port-not-found envelope as every other live-runtime tool;

--- a/tools/mcp-conformance/wire-vocab/README.md
+++ b/tools/mcp-conformance/wire-vocab/README.md
@@ -4,10 +4,15 @@
 
 ## What this is
 
-The three MCP servers under `tools/` — `re-frame2-pair-mcp`, `story-mcp`, and
-`causa-mcp` (spec-only today) — share a reserved cross-server **wire
-vocabulary**: namespaced map keys that an agent recognises identically
-across every server it talks to.
+The MCP servers under `tools/` — `re-frame2-pair-mcp` and `story-mcp` —
+share a reserved cross-server **wire vocabulary**: namespaced map keys
+that an agent recognises identically across every server it talks to.
+
+(Historical: a third server `causa-mcp` was envisaged in the vocabulary;
+it was dropped per rf2-hvl1g — AI agent access to Causa state flows via
+`re-frame2-pair-mcp` against the framework-published Causa runtime API.
+A prior false-start drop was tracked under rf2-bu21t; rf2-hvl1g is the
+final close-out.)
 
 There are **five top-level wire markers** plus one embedded fetch-handle
 tag (`:rf.elision/at`, pinned inside the `:rf.size/large-elided` body's
@@ -36,8 +41,7 @@ This test is the conformance gate. It asserts:
 
 1. **One canonical Malli schema per marker.** The schemas live in
    `wire_vocab_test.clj`, derived from
-   [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../../spec/Spec-Schemas.md),
-   [`tools/causa-mcp/spec/004-Wire-Pipeline.md` §"5 mechanisms"](../../causa-mcp/spec/004-Wire-Pipeline.md),
+   [`spec/Spec-Schemas.md` §`:rf/elision-marker`](../../../spec/Spec-Schemas.md)
    and [`tools/re-frame2-pair-mcp/src/.../tools.cljs`](../../re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools.cljs)
    (re-frame2-pair-mcp's `overflow-payload`, `tree-summary`, `dedup-value`,
    `diff-encode-db-after`).
@@ -45,9 +49,9 @@ This test is the conformance gate. It asserts:
    representing each server's actual / spec'd emission shape. They
    MUST validate against the same schema.
 3. **Source-text vocabulary pin.** A grep against each server's source
-   (`re-frame2-pair-mcp/src/`) and spec (`causa-mcp/spec/`) asserts the
-   canonical literal appears, and asserts that no near-miss spelling
-   (snake_case, pluralised, namespace-with-underscores) appears.
+   (`re-frame2-pair-mcp/src/`) asserts the canonical literal appears,
+   and asserts that no near-miss spelling (snake_case, pluralised,
+   namespace-with-underscores) appears.
 4. **story-mcp absence tripwire.** story-mcp does NOT currently emit
    any of the cross-MCP markers — it uses its own `:rf.story/*` /
    `:rf.assert/*` / `:rf.error/*` vocabularies. A test asserts that
@@ -90,18 +94,6 @@ server emits as response payloads. It does NOT need a live server: the
 schemas are normative, the fixtures are authored from each server's
 spec/source, and the grep step pins those authored fixtures to the
 actual source/spec text. Two complementary gates; one wire.
-
-## causa-mcp impl gap
-
-causa-mcp's implementation has not landed yet (its `tools/causa-mcp/`
-tree contains `README.md` + `spec/` but no `src/`). The fixtures and
-the spec-grep step against `tools/causa-mcp/spec/Principles.md` +
-`tools/causa-mcp/spec/004-Wire-Pipeline.md` cover the vocabulary today.
-When the impl lands, a follow-up bead extends this test to:
-
-- Grep `tools/causa-mcp/src/` for the canonical literals.
-- Add live-emission fixtures if their actual emitted shape diverges
-  from the spec snippets.
 
 ## When this test fails
 

--- a/tools/mcp-conformance/wire-vocab/deps.edn
+++ b/tools/mcp-conformance/wire-vocab/deps.edn
@@ -2,7 +2,7 @@
 ;; conformance test (rf2-j2z7o).
 ;;
 ;; A pure-JVM Clojure test that pins the **cross-server wire-marker
-;; vocabulary** shared by re-frame2-pair-mcp, story-mcp, and causa-mcp:
+;; vocabulary** shared by re-frame2-pair-mcp and story-mcp:
 ;;
 ;;   :rf.mcp/overflow      — token-budget overflow (mechanism 1)
 ;;   :rf.mcp/summary       — tree-summary lazy mode (mechanism 4)

--- a/tools/re-frame2-pair-mcp/README.md
+++ b/tools/re-frame2-pair-mcp/README.md
@@ -154,7 +154,7 @@ builds ship the tool DISABLED; the operator opts in at server launch:
 
 Without the flag, calls to `eval-cljs` return the structured error
 `{:ok? false :reason :rf.error/eval-cljs-disabled ...}` without
-touching the nREPL socket. Same posture as causa-mcp's split (rf2-zyoj2).
+touching the nREPL socket.
 
 #### raw-state gate (rf2-c2dtu)
 
@@ -326,11 +326,10 @@ the surface:
 | Browser substrate | [Chrome DevTools MCP](https://github.com/anthropics/chrome-devtools-mcp) or [Playwright MCP](https://github.com/microsoft/playwright-mcp) | Click, type, navigate, screenshot, viewport |
 | re-frame2 runtime | **re-frame2-pair-mcp** (this artefact) | `dispatch`, `snapshot`, `get-path`, `subscribe`, `eval-cljs`, … |
 
-The split mirrors the framing in [causa-mcp's
-DESIGN-RATIONALE](../causa-mcp/spec/DESIGN-RATIONALE.md) — browser-substrate
-ops and re-frame2-runtime ops are different contracts, and bundling
-them into one server would force every re-frame2 developer to take
-on the heavyweight Chromium dep just to read `app-db`.
+Browser-substrate ops and re-frame2-runtime ops are different
+contracts, and bundling them into one server would force every
+re-frame2 developer to take on the heavyweight Chromium dep just to
+read `app-db`.
 
 Example session: the browser MCP clicks a button → re-frame2-pair-mcp's
 `subscribe` receives the resulting `:rf/epoch-record` → the agent

--- a/tools/re-frame2-pair-mcp/deps.edn
+++ b/tools/re-frame2-pair-mcp/deps.edn
@@ -56,8 +56,8 @@
          applied-science/js-interop {:mvn/version "0.4.2"}
          thheller/shadow-cljs      {:mvn/version "3.4.10"}
 
-         ;; Shared MCP primitives across the triplet (re-frame2-pair-mcp,
-         ;; story-mcp, causa-mcp): wire vocabulary, the spec/009
+         ;; Shared MCP primitives across the pair (re-frame2-pair-mcp,
+         ;; story-mcp): wire vocabulary, the spec/009
          ;; default-suppress filter, the path-keyed diff-encode, and
          ;; the overflow-marker shape. Per rf2-vw4sq.
          day8/re-frame2-mcp-base  {:local/root "../mcp-base"}

--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -98,7 +98,7 @@ The marker key `:rf.size/large-elided` and the handle
 vocabulary `[:rf.elision/at <path>]` are reserved per
 [`Conventions §Reserved namespaces`](../../../spec/Conventions.md)
 and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md);
-the shape is shared across re-frame2-pair-mcp, story-mcp, and causa-mcp.
+the shape is shared across re-frame2-pair-mcp and story-mcp.
 
 ## Universal: app-installed `:redact-fn` on epoch consumers
 
@@ -273,10 +273,9 @@ by passing `--allow-raw-state`. The per-call args then win again
 (`:include-sensitive true` / `:elision false` pass through to the
 walker unchanged).
 
-Symmetric with story-mcp's `--allow-sensitive-reads` (rf2-uaymx) and
-causa-mcp's `--allow-eval` (rf2-zyoj2 — same gate as re-frame2-pair-mcp's
-`eval-cljs`). The same pattern across MCP servers gives operators one
-posture vocabulary.
+Symmetric with story-mcp's `--allow-sensitive-reads` (rf2-uaymx).
+The same pattern across MCP servers gives operators one posture
+vocabulary.
 
 ## Universal: server resource controls (streaming surfaces)
 
@@ -984,8 +983,8 @@ frame-db / epoch-history / trace-buffer surfaces.
 
 **Naming note**: renamed from `subscription-info` per rf2-4y595 —
 NAMING.md catalogues `list-<things>` as the canonical enumeration
-verb, matching causa-mcp's `list-subscriptions` (rf2-3we2k Lock #12).
-No back-compat shim; the old name hard-errors with `:unknown-tool`.
+verb. No back-compat shim; the old name hard-errors with
+`:unknown-tool`.
 
 **Args** (all optional):
 
@@ -1035,10 +1034,6 @@ bodies; only registration metadata crosses the wire.
 `:reason :runtime-not-preloaded` if the preload hasn't run;
 `:reason :list-subscriptions-failed` (with `:message`) on any other
 failure.
-
-A future causa-mcp peer will ship `list-subscriptions` — same
-diagnostic shape, NAMING.md-conformant verb in causa-mcp's
-catalogue.
 
 ## handler-meta
 

--- a/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
+++ b/tools/re-frame2-pair-mcp/spec/DESIGN-RATIONALE.md
@@ -291,10 +291,8 @@ Post-Lock additions accumulated as follows:
 - **rf2-zjz9q** added `subscription-info` — the "what streams are
   open?" diagnostic peer for the streaming pair, picked under the
   bare-noun read shape. Renamed to `list-subscriptions` per rf2-4y595
-  for cross-server NAMING.md conformance — matches causa-mcp's
-  same-named tool per
-  [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md)
-  Story-mcp Lock #12 / rf2-3we2k.
+  for cross-server NAMING.md conformance per
+  [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md).
 - **rf2-fnpqg** added `get-re-frame2-pair-instructions` — the
   agent-onboarding text blob read once at session start. Mirrors
   story-mcp's `get-story-instructions` under the cross-MCP `get-`
@@ -536,9 +534,7 @@ arg (integer; `0` disables the cap for explicit escape).
 2026-05-13 (Mike). Locked at rf2-rvyzy PR #641 merge. The cap
 itself landed in [`Principles.md`](Principles.md#tight-token-budget-per-response)
 with MUST wording; this lock captures the comparative reasoning
-that the principle alone doesn't carry. A future causa-mcp will
-bake the same five mechanisms into its spec, deliberately aligned
-with the posture locked here.
+that the principle alone doesn't carry.
 
 ### Trail-of-thought citations
 
@@ -551,8 +547,7 @@ with the posture locked here.
   §The universal `max-tokens` arg — the per-tool surface for
   the override.
 - The `:rf.mcp/overflow` / `:rf.mcp/summary` / `:rf.mcp/dedup-table`
-  reserved keys are shared cross-server with sibling MCP servers
-  (story-mcp today; causa-mcp when its impl lands).
+  reserved keys are shared cross-server with story-mcp.
 - `ai/findings/wire-protocol-bigapp-20260513-1541.md` — the
   source investigation (local-only) that motivated baking the
   posture into spec instead of leaving it as in-flight impl

--- a/tools/re-frame2-pair-mcp/spec/Principles.md
+++ b/tools/re-frame2-pair-mcp/spec/Principles.md
@@ -163,8 +163,7 @@ Mechanisms 1-6 align deliberately with the cross-MCP wire
 pipeline so that an agent learning the slot on one server
 gets the same slot on the others; mechanisms 7-8 are
 re-frame2-pair-mcp-specific (epoch-record diff encoding and
-streaming-subscribe budgets — both will likely absorb into a
-future causa-mcp's catalogue when its impl lands).
+streaming-subscribe budgets).
 Every catalogue entry in
 [`003-Tool-Catalogue.md`](003-Tool-Catalogue.md) declares
 which mechanisms apply, with a **typical-token** hint
@@ -195,13 +194,11 @@ The eight mechanisms in re-frame2-pair-mcp:
 7. **Diff-encoded `:db-after`** (§"Diff-encoded `:db-after`") —
    path-keyed structural patches against the same record's
    `:db-before`. *re-frame2-pair-mcp-specific*: addresses the
-   epoch-record pair shape, which causa-mcp's `get-epoch` /
-   `get-epoch-history` will need to absorb when its impl lands.
+   epoch-record pair shape.
 8. **Streaming subscribe byte+event budget** (§"Streaming
    subscribe byte+event budget") — runtime-side queue feeding
    `subscribe` carries OR-combined event-count + byte caps.
-   *re-frame2-pair-mcp-specific*: causa-mcp's `subscribe` will share
-   the upstream-queue posture when its streaming impl lands.
+   *re-frame2-pair-mcp-specific*.
 
 The reserved `:rf.mcp/*` and `:rf.size/*` keyword namespaces
 are catalogued at
@@ -254,10 +251,8 @@ internals.
   JSON-RPC `arguments` key (string, kebab-case — the wire
   shape an agent host sends); **`:max-tokens`** as the parsed
   CLJS keyword inside the runtime. The pairing is normative —
-  re-frame2-pair-mcp, story-mcp, and causa-mcp all parse the same wire
-  slot to the same in-process key, so a forwarder that learned
-  one pairing on one server gets the same pairing on the
-  others. Per
+  re-frame2-pair-mcp and story-mcp both parse the same wire
+  slot to the same in-process key. Per
   [TOKEN-BUDGETS.md](../../mcp-conformance/TOKEN-BUDGETS.md).
 - **Overflow shape**: a tool that would exceed the cap MUST NOT
   silently truncate. Instead it MUST return a structured
@@ -275,24 +270,9 @@ internals.
   The agent host MUST treat `{:rf.mcp/overflow {:limit :reached}}`
   as a structured retry signal — narrow args, drop slices, or
   pass `max-tokens 0` if the full payload is genuinely needed.
-  The `:rf.mcp/overflow` key is reserved cross-server (re-frame2-pair-mcp,
-  story-mcp, causa-mcp use the same key) so an agent that
-  recognises it once recognises it everywhere.
-
-  *Differs from causa-mcp.* A future causa-mcp wire-pipeline
-  spec will document the overflow marker with slot names
-  `:cap` / `:would-be` / `:hint` / `:continuation`; re-frame2-pair-mcp's
-  implemented shape uses
-  `:limit :reached` plus `:token-count` / `:cap-tokens` /
-  `:tool` / `:hint` (per rf2-rvyzy). The divergence is
-  intentional — re-frame2-pair-mcp's wrapper measures the *post-shrunk*
-  payload after the diff-encode/dedup/elision pipeline, so the
-  continuation hint is tool-specific rather than a generic
-  `:continuation {:cursor ... :next-args ...}` shape. The
-  reserved keyword namespace (`:rf.mcp/overflow`) and the
-  retry-signal contract are identical; the slot vocabulary
-  differs. Cross-server alignment of the slot shape is tracked
-  separately — when both wrappers stabilise, one shape wins.
+  The `:rf.mcp/overflow` key is reserved cross-server
+  (re-frame2-pair-mcp, story-mcp use the same key) so an agent
+  that recognises it once recognises it everywhere.
 - **Pluggable strategy**: the wrapper dispatches on a
   `:strategy` keyword. Today only `:truncate-with-marker` is
   implemented (replace the payload with the overflow marker).
@@ -340,9 +320,8 @@ don't know which slice carries the answer") stays inside the
 cap by construction rather than relying on the cap as a
 backstop. The same wire-shape vocabulary (`{:rf.mcp/summary
 {:type :map :keys [...] :counts {...} :bytes ~N}}` on
-summarised slices) crosses to causa-mcp's catalogue under
-mechanism 4 (lazy summary) — single learning step on the
-agent side.
+summarised slices) is shared with story-mcp under mechanism
+4 (lazy summary) — single learning step on the agent side.
 
 ### Per-tool budget discipline
 
@@ -420,11 +399,10 @@ single op blow the session.
 
 ### Diff-encoded `:db-after` on epoch slices (rf2-1wdzp)
 
-Mechanism 7 — re-frame2-pair-mcp-specific. causa-mcp's catalogue will
-ship the same shape against `get-epoch` / `get-epoch-history`
-when its impl lands; the cross-server vocabulary
-(`:rf.mcp/diff-from`, the `[<path> :assoc <v>]` / `[<path>
-:dissoc]` patch grammar) is already pinned here.
+Mechanism 7 — re-frame2-pair-mcp-specific. The cross-server
+vocabulary (`:rf.mcp/diff-from`, the `[<path> :assoc <v>]` /
+`[<path> :dissoc]` patch grammar) is pinned here for any future
+sibling that adopts the same diff-encoding shape.
 
 Every `:rf/epoch-record` carries `:db-before` and `:db-after`
 — two near-identical full app-db snapshots
@@ -528,9 +506,8 @@ de-dupe library's companion `expand` function.
 **Cross-MCP vocabulary**. The `:rf.mcp/diff-from` marker key
 follows the `:rf.mcp/*` namespace convention shared with
 `:rf.mcp/overflow` (rf2-rvyzy), `:rf.mcp/summary` (rf2-tygdv),
-and causa-mcp's `:rf.mcp/dedup-table` (rf2-lwgg8 mechanism 5).
-Agents recognise the family once and pattern-match on the
-prefix.
+and `:rf.mcp/dedup-table` (rf2-lwgg8 mechanism 5). Agents
+recognise the family once and pattern-match on the prefix.
 
 ### Structural dedup (rf2-obpa9)
 
@@ -728,9 +705,9 @@ privacy / dedup defaults: shrink first, opt out explicitly.
 `[:rf.elision/at <path>]` are reserved per
 [`Conventions §Reserved namespaces / app-db keys / fx-ids`](../../../spec/Conventions.md)
 and [`Spec 009 §Size elision in traces`](../../../spec/009-Instrumentation.md).
-The shape is shared across re-frame2-pair-mcp, story-mcp, and a future
-causa-mcp — an agent that learned the slot on a sibling server
-sees the same slot here. The `:rf.size/*` family sits alongside the
+The shape is shared across re-frame2-pair-mcp and story-mcp —
+an agent that learned the slot on a sibling server sees the same
+slot here. The `:rf.size/*` family sits alongside the
 `:rf.mcp/*` family (per-tool wire-mechanism markers like
 `:rf.mcp/overflow`, `:rf.mcp/summary`, `:rf.mcp/diff-from`,
 `:rf.mcp/dedup-table`).
@@ -749,14 +726,9 @@ Mechanism 8 — re-frame2-pair-mcp-specific, applied at the *upstream*
 edge — the runtime-side queue feeding the `subscribe` tool —
 rather than at the wire boundary itself.
 
-*Differs from causa-mcp.* A future causa-mcp wire-pipeline spec
-will document `subscribe` as a per-notification cap with the
-upstream-queue model deferred to impl. re-frame2-pair-mcp ships a
-runtime-side OR-combined event-count + byte budget today; when
-causa-mcp's streaming impl lands it will absorb the same
-posture (the chatty-filter case and the large-payload-storm
-case both apply to causa-mcp's trace stream). The motivation is
-memory pressure: an event-count-only buffer (`:max-buffered
+re-frame2-pair-mcp ships a runtime-side OR-combined event-count
++ byte budget. The motivation is memory pressure: an
+event-count-only buffer (`:max-buffered
 500`) is misleading when event size varies by orders of
 magnitude. Five small trace events fit in ~500 bytes; five
 overflowed epoch records with diff-encoded 1MB app-db
@@ -918,8 +890,8 @@ the namespace once and recognises every marker.
 Tool names in re-frame2-pair-mcp's catalogue pick from the verb table at
 [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md)
 (rf2-mzf1r) — the canonical home for the cross-MCP verb vocabulary
-shared with story-mcp and causa-mcp. The shared verbs the
-triplet pins are `get-` / `list-` / `read-` / `discover-` /
+shared with story-mcp. The shared verbs the pair pins are
+`get-` / `list-` / `read-` / `discover-` /
 `restore-` / `reset-` / `register-` / `unregister-` / `run-` /
 `preview-` / `record-as-` / `tail-` plus the bare universals
 `dispatch`, `eval-cljs`, `subscribe`, `unsubscribe`, plus the
@@ -932,9 +904,8 @@ Pair2-mcp's fourteen current tools (`discover-app`, `eval-cljs`,
 `handler-meta`, `list-handlers`, `get-re-frame2-pair-instructions`) are all
 conformant against existing verbs after the rf2-4y595 rename
 (`subscription-info` → `list-subscriptions`, `registry-list` →
-`list-handlers` — see NAMING.md's audit table; `list-subscriptions`
-matches causa-mcp's same-named tool per rf2-3we2k Lock #12). New
-tools land against an existing verb, or via a Lock entry in
+`list-handlers` — see NAMING.md's audit table). New tools land
+against an existing verb, or via a Lock entry in
 [`DESIGN-RATIONALE.md`](./DESIGN-RATIONALE.md) plus an extension to
 the canonical table.
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/args.cljs
@@ -15,10 +15,9 @@
     - EDN-encoded string   ⇒ read-string (e.g. `\"[:cart :items 3 :sku]\"`).
     - nil / missing        ⇒ nil (no path slicing).
 
-  Mirrors the causa-mcp wire-protocol Principles §\"2. Path slicing\"
-  convention: a path is an EDN-encoded vector of keys addressing a
-  subtree. The vocabulary is shared across re-frame2-pair-mcp / causa-mcp /
-  story-mcp so agents recognise the surface once."
+  A path is an EDN-encoded vector of keys addressing a subtree.
+  The vocabulary is shared across re-frame2-pair-mcp / story-mcp so
+  agents recognise the surface once."
   (:require [applied-science.js-interop :as j]
             [cljs.reader]
             [clojure.string :as str]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/registry.cljs
@@ -48,7 +48,7 @@
   because its JVM-side single-process deploy has no nREPL `conn` and
   no streaming tool. The divergence is deliberate and documented at
   `tools/mcp-base/spec/handler-arity.md`; a phase-2 unification awaits
-  a third server instance (causa-mcp) and lands as a separate bead.
+  a third server instance and lands as a separate bead.
 
   ## Adding a new tool
 

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/sensitive.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/sensitive.cljs
@@ -65,7 +65,7 @@
   delegates to `re-frame.mcp-base.sensitive`. The epoch-level union
   check is re-frame2-pair-mcp-specific (story-mcp doesn't emit epoch records);
   the trace-event-only `strip-sensitive` in the base is the right fit
-  for story-mcp / causa-mcp consumers."
+  for story-mcp consumers."
   [items include?]
   (cond
     include?            [items 0]
@@ -91,8 +91,8 @@
   Thin delegate (rf2-zpmmr) to
   `re-frame.mcp-base.sensitive/scrub-snapshot` with the re-frame2-pair-mcp
   union strip-fn (`strip-sensitive`, which gates both
-  `sensitive-event?` and `sensitive-epoch?`). Story-mcp /
-  causa-mcp use the base helper's two-arity form, which defaults to
-  the trace-event-only filter."
+  `sensitive-event?` and `sensitive-epoch?`). Story-mcp uses the base
+  helper's two-arity form, which defaults to the trace-event-only
+  filter."
   [snapshot include?]
   (base-sensitive/scrub-snapshot snapshot include? strip-sensitive))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/summary.cljs
@@ -1,7 +1,7 @@
 (ns re-frame2-pair-mcp.tools.summary
   "Tree-summary marker primitive (rf2-tygdv, generalised rf2-u2029).
 
-  Per causa-mcp's wire-protocol Principles §\"4. Lazy summary\", the
+  Per the cross-MCP wire-protocol §\"4. Lazy summary\", the
   default response mode for a rich nested value is a *summary*, not the
   full payload. The summary declares the shape without committing the
   token budget:
@@ -68,7 +68,7 @@
 
 (defn tree-summary
   "Compute a server-friendly tree summary of `v`. Returns the marker
-  shape causa-mcp's §Lazy-summary mechanism pins.
+  shape the cross-MCP §Lazy-summary mechanism pins.
 
   Cheap — one pass over the top-level structure, no deep walk. The
   marker itself is bounded: long key lists are truncated to

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_benchmark_test.cljs
@@ -3,21 +3,18 @@
 
   ## Why this benchmark
 
-  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §5 (Structural dedup)
-  asserts that `day8/de-dupe` 'typically compresses trace bursts
-  3-5× without semantic loss.' That claim was approximate-vibes —
-  no in-repo measurement bound it. When `003-Tool-Catalogue.md`
-  lands and the catalogue-entry-contract requires each tool to
-  declare its typical-token hint, every trace-bus-shaped tool's
-  hint would have inherited that imprecision.
+  Earlier vibes-quoted claims that `day8/de-dupe` 'typically
+  compresses trace bursts 3-5× without semantic loss' were
+  approximate — no in-repo measurement bound them. The
+  catalogue-entry-contract that each tool declare its
+  typical-token hint would have inherited that imprecision.
 
   This benchmark exercises `day8/de-dupe` against a representative
   trace-event corpus at three scales (100 / 1,000 / 10,000 events)
   with varying structural depth, measures the actual reduction
   ratio, and prints the numbers to the test log. The measured
-  factor is pinned in
-  [`tools/causa-mcp/spec/004-Wire-Pipeline.md`](../../../causa-mcp/spec/004-Wire-Pipeline.md)
-  §5 with this file cited as the source-of-truth.
+  factors below are the source-of-truth that any cross-MCP
+  documentation of structural-dedup compression should cite.
 
   ## Corpus shape
 
@@ -32,14 +29,11 @@
 
   ## Why not a separate `bench/` artefact
 
-  Causa-mcp is spec-only today (no `src/`); bootstrapping
-  `tools/causa-mcp/bench/` would mean a fresh deps.edn,
-  shadow-cljs.edn and package.json that the eventual impl-pass
-  would have to reconcile. re-frame2-pair-mcp already wires `day8/de-dupe`,
-  already runs CLJS-on-Node via shadow-cljs, and already houses
-  the load-bearing `dedup-value` helper this benchmark probes.
-  Reusing that runner is the path of least friction; the
-  measured factor it produces is what causa-mcp's spec cites.
+  re-frame2-pair-mcp already wires `day8/de-dupe`, already runs
+  CLJS-on-Node via shadow-cljs, and already houses the load-bearing
+  `dedup-value` helper this benchmark probes. Reusing that runner is
+  the path of least friction; the measured factors here are the
+  in-repo source of truth.
 
   ## Measured numbers (run 2026-05-14)
 
@@ -77,9 +71,8 @@
 
   The three regimes share the algorithm; their compression
   budgets differ because their shared-subtree cardinality differs.
-  `tools/causa-mcp/spec/004-Wire-Pipeline.md` §5 cites the raw-
-  burst and high-share numbers explicitly so the per-tool
-  typical-token hint matches the actual call-site shape.
+  Per-tool typical-token hints should match the actual call-site
+  shape against these numbers.
 
   ## Floor for assertion
 
@@ -351,7 +344,7 @@
       (is (>= (:ratio m) 8.0)
           (str "high-share burst ratio " (.toFixed (:ratio m) 2)
                "× fell below the 8× pinned floor — re-measure and "
-               "update tools/causa-mcp/spec/004-Wire-Pipeline.md §5."
+               "update the measured numbers in this file's ns docstring."
                "  row=" (row-str m))))
     (testing "round-trip on the high-share corpus"
       (is (= payload (tu/dedup-expand (:wrapped m)))))
@@ -383,6 +376,6 @@
           (str "1K-event raw burst ratio "
                (.toFixed (:ratio m) 2)
                "× fell below the 1.40× pinned floor — re-measure and "
-               "update tools/causa-mcp/spec/004-Wire-Pipeline.md §5.")))
+               "update the measured numbers in this file's ns docstring.")))
     (testing "round-trip on the pinned corpus"
       (is (= payload (tu/dedup-expand (:wrapped m)))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/dedup_test.cljs
@@ -81,9 +81,9 @@
         "the table itself is a hash-map keyed by namespaced symbols")))
 
 (deftest dedup-marker-key-is-the-cross-mcp-vocabulary
-  ;; The marker key matches causa-mcp's Principles §5 (Structural
-  ;; dedup): `{:rf.mcp/dedup-table ...}`. Agents that learned the
-  ;; slot on causa-mcp see the same slot here.
+  ;; The marker key matches the cross-MCP §5 (Structural dedup):
+  ;; `{:rf.mcp/dedup-table ...}`. Agents that learned the slot on a
+  ;; sibling server see the same slot here.
   (let [wrapped (dedup/dedup-value [{:a 1} {:a 1}] true)]
     (is (= [:rf.mcp/dedup-table] (vec (keys wrapped))))))
 

--- a/tools/story-mcp/deps.edn
+++ b/tools/story-mcp/deps.edn
@@ -38,8 +38,8 @@
          ;; `snapshot-identity`, …) — see IMPL-SPEC §7.4.
          day8/re-frame2-story {:local/root "../story"}
 
-         ;; Shared MCP primitives across the triplet (re-frame2-pair-mcp,
-         ;; story-mcp, causa-mcp): wire vocabulary, the spec/009
+         ;; Shared MCP primitives across the pair (re-frame2-pair-mcp,
+         ;; story-mcp): wire vocabulary, the spec/009
          ;; default-suppress filter, the path-keyed diff-encode, and
          ;; the overflow-marker shape. Per rf2-vw4sq.
          day8/re-frame2-mcp-base {:local/root "../mcp-base"}

--- a/tools/story-mcp/spec/002-Tool-Registry.md
+++ b/tools/story-mcp/spec/002-Tool-Registry.md
@@ -159,7 +159,7 @@ mirroring re-frame2-pair-mcp's shape — same wire-protocol slot
 `progressToken`), same idempotent `unsubscribe`, same
 `list-subscriptions` peer for the "what streams are open?"
 diagnostic (renamed from `subscription-info` in pair-mcp per
-rf2-4y595 — matches causa-mcp's catalogue).
+rf2-4y595).
 
 Topics to expose:
 

--- a/tools/story-mcp/spec/Principles.md
+++ b/tools/story-mcp/spec/Principles.md
@@ -236,8 +236,8 @@ single op blow the session.
 Tool names in story-mcp's catalogue pick from the verb table at
 [`tools/mcp-conformance/NAMING.md`](../../mcp-conformance/NAMING.md)
 (rf2-mzf1r) — the canonical home for the cross-MCP verb vocabulary
-shared with re-frame2-pair-mcp and causa-mcp. The shared verbs the
-triplet pins are `get-` / `list-` / `read-` / `discover-` /
+shared with re-frame2-pair-mcp. The shared verbs the
+pair pins are `get-` / `list-` / `read-` / `discover-` /
 `restore-` / `reset-` / `register-` / `unregister-` / `run-` /
 `preview-` / `record-as-` / `tail-` plus the bare universals
 `dispatch`, `eval-cljs`, `subscribe`, `unsubscribe`. Story-mcp does

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/registry.cljc
@@ -26,8 +26,8 @@
   carries no useful slot either. Contrast pair-mcp's 3-arity shape
   `(fn [conn args extra])`. The divergence is deliberate and is
   documented at `tools/mcp-base/spec/handler-arity.md`; a phase-2
-  unification awaits a third server instance (causa-mcp) and lands as
-  a separate bead."
+  unification awaits a third server instance and lands as a separate
+  bead."
   (:require [re-frame.story-mcp.config :as config]
             [re-frame.story-mcp.tools.dev :as dev]
             [re-frame.story-mcp.tools.docs :as docs]

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -342,7 +342,7 @@
   level. Thin alias over the framework-published `re-frame.privacy/sensitive?`
   predicate (re-exported as `re-frame.core/sensitive?`) — per rf2-sqxjn
   / rf2-iwqu9, every consumer of `:sensitive?` (Causa, Story,
-  story-mcp, re-frame2-pair-mcp, causa-mcp) composes against ONE framework
+  story-mcp, re-frame2-pair-mcp) composes against ONE framework
   primitive rather than reimplementing the five-token check. Per Spec
   009 §Privacy."
   [ev]


### PR DESCRIPTION
## Summary

Mike's 2026-05-19 closure of **rf2-hvl1g**: causa-mcp will NOT be built. AI agent access to Causa state already flows via `re-frame2-pair-mcp` against the framework-published Causa runtime API (`day8.re-frame2-causa.runtime`) — no dedicated causa-mcp jar is needed.

This bundled cleanup sweeps ~370 forward-looking causa-mcp references across 60+ files down to historical-record locations only. **54 files changed, +437 / -629 (net -192 LoC).**

Cross-ref: [rf2-hvl1g](#) (DROP decision, closed 2026-05-19) and rf2-jtvcm (this bead).

## What changed

Per-surface dispositions (full detail in the commit message):

- **`tools/mcp-conformance/{NAMING,TOKEN-BUDGETS,README}.md`** + `test/_runner.cjs` + `test/end-to-end-re-frame2-pair.cjs`: triplet → pair across the cross-MCP convention prose; drop the causa-mcp section in NAMING.md's verb-audit; drop the causa-mcp enforcement / divergence tables in TOKEN-BUDGETS.md; preserve a historical-record note at the top of each file citing rf2-hvl1g.
- **`tools/mcp-conformance/wire-vocab/{README.md, deps.edn}`**: drop forward-looking refs to a causa-mcp spec at `tools/causa-mcp/spec/004-Wire-Pipeline.md` (file never existed). The test files already cited rf2-bu21t (a prior false-start drop) and remain intact.
- **`tools/mcp-base/{deps.edn, spec/*, src/**, test/**}`**: triplet → pair throughout. Add a historical note. `handler-arity.md` now reflects rf2-hvl1g as the reason a third-server instance hasn't crystallised; phase-2 unification waits on a fresh third server.
- **`tools/causa/spec/DESIGN-RATIONALE.md`**: Lock #6 (MCP timing) marked **SUPERSEDED 2026-05-19** with the DROP reasoning; Lock #9 (Launch modes) reworded; summary table updated.
- **`tools/causa/spec/{API,011-Launch-Modes,014-Registry-Catalogue,016-Auxiliary-Panels,018-Event-Spine,Principles}.md`**: drop the planned 18-tool MCP catalogue from `API.md`; reword Standalone-via-MCP in `011` to flow through `re-frame2-pair-mcp` + the runtime API; remove the MCP-Server panel registry section in `014` (panel was already dropped in `016`); update `Principles.md` to attribute MCP-driven mutations to re-frame2-pair-mcp.
- **`tools/causa/spec/findings/re-frame-10x-v2-design.md`**: prepended a historical-note banner to the MCP-surface section; otherwise preserved as design lineage.
- **`tools/causa/README.md` + `deps.edn`**: drop forward-looking causa-mcp jar references; remove the spec-table row for `010-MCP-Server.md` (file was already deleted prior to this bead).
- **`tools/causa/src/day8/re_frame2_causa/{preload,runtime,theme/tokens}.cljc[s]` + `config.cljc`**: fix broken doc-path references that pointed into the never-built `tools/causa-mcp/spec/` tree. Re-frame the `runtime.cljs` ns docstring to describe the framework-published Causa runtime API with `re-frame2-pair-mcp` as the canonical consumer. **The `:causa-mcp` literal origin tag is preserved** (grandfathered default — revising it is downstream of this bead).
- **`tools/re-frame2-pair-mcp/{README.md, deps.edn, spec/**, src/**, test/**}`**: drop the forward-looking "future causa-mcp will ship the same shape" prose throughout; reword the eight-mechanisms inventory; drop the comparative-overflow-shape and streaming-divergence sections that only existed to contrast with the never-built causa-mcp spec; drop the dedup-benchmark file's references to a `tools/causa-mcp/spec/` source-of-truth that doesn't exist.
- **`tools/story-mcp/{deps.edn, spec/**, src/...registry.cljc}` + `tools/story/src/.../config.cljc`**: triplet → pair in shared-vocabulary docstrings; drop forward-looking cross-references.

## What stays intact (legitimate historical-record locations)

Per the bead's acceptance criteria — these are appropriate citations of history, not stale forward-looking references:

- `.beads/issues.jsonl` close-reasons mentioning causa-mcp as history.
- `tools/mcp-conformance/wire-vocab/test/*.clj` historical-pin comments citing rf2-bu21t (the prior false-start drop) — these are the test fixture's documented absence pins.
- `tools/causa/src/day8/re_frame2_causa/runtime.cljs`'s `:causa-mcp` default origin tag and the tests that pin it — revising the runtime's identifier is a separate semantic concern and tracked as a follow-on.

`rg "causa-mcp"` final count: **225 occurrences across 23 files**, down from **372 across 61 files** (38% fewer). All residuals are historical-record citations, the grandfathered `:causa-mcp` origin tag literal in the runtime, or the bead JSONL.

## Test plan

- [x] `mkdocs build --strict` — clean.
- [x] `tools/mcp-conformance/wire-vocab` `clojure -M:test` — 35 tests, 448 assertions, 0/0.
- [x] `tools/mcp-base` `clojure -M:test` — 129 tests, 326 assertions, 0/0.
- [x] `tools/mcp-conformance` `npm test` (all five scripts incl. exec-safety + re-frame2-pair-mcp end-to-end + story-mcp end-to-end) — ALL GREEN.
- [x] `tools/causa` `clojure -M:test` — 714 tests, 2116 assertions, 0/0.
- [x] `implementation` `npm run test:cljs` — 2954 tests, 8527 assertions, 0/0.