### PR TITLE
fix(story): causa-embed mount-fn-for resolves via direct require (rf2-senbl)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
@@ -17,8 +17,8 @@
   time would inflate every Causa dev session whether the user opens
   the Machine Inspector or not. The loader:
 
-    - First call from the panel triggers a `js/import` of
-      `elkjs/lib/elk.bundled.js`.
+    - First call from the panel triggers a `shadow.esm/dynamic-import`
+      of `elkjs/lib/elk.bundled.js`.
     - Subsequent calls fast-path off a `defonce` atom that tracks
       `nil → :loading → {:elk <inst>} | {:failed <msg>}`.
     - If the import rejects (node-test rig, CSP block, offline) the
@@ -26,6 +26,19 @@
       the layered placement.
     - Tests can pre-stub `js/window.ELK` to short-circuit the import
       (sync wrap path) without bundling ELK into the test rig.
+
+  ### Why `shadow.esm/dynamic-import` (not raw `js/import`)
+
+  shadow-cljs's `:infer-externs` walks every form in the build and
+  emits a JS extern for any unknown `js/<global>` reference. Raw
+  `(js/import \"...\")` would emit `var import;` into externs.shadow.js
+  — `import` is a JS reserved keyword, which the Closure compiler
+  rejects with a parse error (`externs.shadow.js:10 Parse error.
+  'identifier' expected`). shadow-cljs ships
+  `shadow.esm/dynamic-import` for exactly this case: it routes through
+  the build's `js/shadow_esm_import` runtime helper (a non-reserved
+  identifier shadow-cljs's compiler knows about), so externs
+  inference produces valid JS.
 
   ## Async layout, sync consumer
 
@@ -58,7 +71,8 @@
 
   Both deferrals keep the data shape stable so the SVG renderer keeps
   rendering without per-engine branching."
-  (:require [day8.re-frame2-machines-viz.chart.layout :as layout]))
+  (:require [day8.re-frame2-machines-viz.chart.layout :as layout]
+            [shadow.esm :as shadow-esm]))
 
 ;; ---- ELK lazy-load state -------------------------------------------------
 
@@ -108,8 +122,9 @@
   Three load paths:
 
     1. Pre-stubbed `js/window.ELK` — sync wrap, no import.
-    2. `js/import` resolves `\"elkjs/lib/elk.bundled.js\"` — production
-       browser session.
+    2. `shadow.esm/dynamic-import` resolves `\"elkjs/lib/elk.bundled.js\"`
+       — production browser session. See the ns docstring §Why
+       `shadow.esm/dynamic-import` for why we don't use raw `js/import`.
     3. Both fail → state flips to `{:failed ...}` and `done-fn` fires
        with nil; subsequent calls fast-path with nil."
   [done-fn]
@@ -137,7 +152,7 @@
               (done-fn nil)))
           (try
             (let [p (try
-                      (js/import "elkjs/lib/elk.bundled.js")
+                      (shadow-esm/dynamic-import "elkjs/lib/elk.bundled.js")
                       (catch :default _ nil))]
               (if (and p (.-then p))
                 (-> p
@@ -154,7 +169,7 @@
                               (reset! elk-state {:failed (or (.-message e) "import failed")})
                               (done-fn nil))))
                 (do
-                  (reset! elk-state {:failed "js/import unavailable"})
+                  (reset! elk-state {:failed "dynamic-import unavailable"})
                   (done-fn nil))))
             (catch :default e
               (reset! elk-state {:failed (or (.-message e) "import threw")})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
@@ -9,14 +9,14 @@
 
     2. **Lazy loader fallback** — `ensure-elk!` rolls into the
        `:failed` state when no `js/window.ELK` stub is present and
-       `js/import` is unavailable (the node-test rig). The
-       `layout-or-fallback` fn then returns the layered fallback so
-       the panel always has a renderable graph.
+       `shadow.esm/dynamic-import` is unavailable (the node-test
+       rig). The `layout-or-fallback` fn then returns the layered
+       fallback so the panel always has a renderable graph.
 
   Tests are CLJS-only (`.cljs`, `_cljs_test`) because the loader uses
-  `js/window` and `js/import`. The pure adapter helpers happen to be
-  CLJC-friendly but the loader pulls them into a CLJS-only consumer
-  so we colocate the test."
+  `js/window` and `shadow.esm/dynamic-import`. The pure adapter helpers
+  happen to be CLJC-friendly but the loader pulls them into a CLJS-only
+  consumer so we colocate the test."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.elk-layout :as elk-layout]))
@@ -202,7 +202,7 @@
 ;; ---- loader fallback ----------------------------------------------------
 
 (deftest ensure-elk-rolls-to-failed-without-stub-or-import
-  (testing "with no js/window.ELK stub and no working js/import the
+  (testing "with no js/window.ELK stub and no working dynamic-import the
             loader rolls into :failed state and the callback fires
             with nil — the panel then falls back to layered"
     (elk-layout/reset-elk-state-for-test!)

--- a/tools/story/src/re_frame/story/ui/causa_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/causa_embed.cljs
@@ -52,6 +52,8 @@
   Token data + pure helpers are .cljc-friendly; the React
   component + mount-driving side effects are CLJS-only."
   (:require [reagent.core :as r]
+            [day8.re-frame2-causa.mount :as causa-mount]
+            [day8.re-frame2-causa.panels :as causa-panels]
             [re-frame.story.causa-preset :as causa-preset]
             [re-frame.story.config :as config]
             [re-frame.story.predicates :as pred]
@@ -120,46 +122,35 @@
       default-panel)))
 
 ;; ---- mount-fn dispatch ---------------------------------------------------
-
-(defn- resolve-fn
-  "Feature-detect-safe symbol → fn lookup. Mirrors the
-  `causa-preset/resolve-fn` shape so Causa can be absent without
-  killing the shell render."
-  [sym]
-  (try
-    (let [ns-str   (namespace sym)
-          name-str (name sym)
-          ns-obj   (when ns-str (find-ns-obj (symbol ns-str)))]
-      (when ns-obj
-        (let [munged (-> name-str
-                         (.replace #"-" "_")
-                         (.replace #"\?" "_QMARK_")
-                         (.replace #"\!" "_BANG_"))
-              v      (aget ns-obj munged)]
-          (when (fn? v) v))))
-    (catch :default _ nil)))
-
-(def panel-id->mount-fn-sym
-  "Pure data → data: map a panel-id to the fully-qualified
-  `day8.re-frame2-causa.panels/mount-<panel>!` symbol. Used by the
-  mount-fn dispatch below; pure so JVM tests can assert the
-  contract without booting Reagent."
-  {:event-detail 'day8.re-frame2-causa.panels/mount-event-detail!
-   :app-db       'day8.re-frame2-causa.panels/mount-app-db-diff!
-   :views        'day8.re-frame2-causa.panels/mount-views!
-   :trace        'day8.re-frame2-causa.panels/mount-trace!
-   :machines     'day8.re-frame2-causa.panels/mount-machine-inspector!
-   :routing      'day8.re-frame2-causa.panels/mount-routing!
-   :issues       'day8.re-frame2-causa.panels/mount-issues-ribbon!})
+;;
+;; rf2-senbl: previously this ns used `find-ns-obj` + `aget` to feature-
+;; detect the Causa mount fns at runtime. That walk relied on top-level
+;; def'd fns being exposed as properties of the parent namespace's JS
+;; object — shadow-cljs's namespace organisation does not guarantee
+;; that (only sub-namespace refs hang off the parent), so every lookup
+;; returned nil and the panel-host never painted. The fix: direct
+;; `:require` of `day8.re-frame2-causa.panels` + a `case` dispatch on
+;; panel-id. Causa is on the same shadow-cljs source-path as Story (see
+;; implementation/shadow-cljs.edn :source-paths), so the require is a
+;; compile-time symbol resolution; bundle-isolation still holds because
+;; the gate only forbids `implementation/` → `tools/` requires, not
+;; `tools/story` → `tools/causa` (the inverse is explicitly fine — see
+;; this fix's PR body for the dep-arrow analysis).
 
 (defn mount-fn-for
-  "Return the Causa `mount-<panel>!` fn for `panel-id`, or nil
-  when Causa is not on the classpath / the panel-id is unknown.
-  Feature-detect-safe — every call site treats a nil result as a
-  no-op render."
+  "Return the Causa `mount-<panel>!` fn for `panel-id`, or nil when
+  `panel-id` is unknown. Compile-time symbol resolution via the
+  `case` dispatch — no runtime namespace walk."
   [panel-id]
-  (when-let [sym (get panel-id->mount-fn-sym panel-id)]
-    (resolve-fn sym)))
+  (case panel-id
+    :event-detail causa-panels/mount-event-detail!
+    :app-db       causa-panels/mount-app-db-diff!
+    :views        causa-panels/mount-views!
+    :trace        causa-panels/mount-trace!
+    :machines     causa-panels/mount-machine-inspector!
+    :routing      causa-panels/mount-routing!
+    :issues       causa-panels/mount-issues-ribbon!
+    nil))
 
 ;; ---- popout escape hatch -------------------------------------------------
 
@@ -169,17 +160,14 @@
   popout carries the full chrome the per-panel embed elides so
   power users have one click to the whole-shell shape.
 
-  Feature-detect-safe — when Causa is absent the chip click is a
-  console.warn breadcrumb."
+  Gated on `causa-available?` so the chip remains a graceful no-op
+  when Causa's preload is not on the build (e.g. a pre-rf2-v1ach
+  Story-only build); the direct `:require` of
+  `day8.re-frame2-causa.mount` above pulls the popout symbol onto
+  the compile classpath."
   []
   (when (and config/enabled? (causa-preset/causa-available?))
-    (if-let [popout! (resolve-fn 'day8.re-frame2-causa.mount/popout!)]
-      (popout!)
-      (when (and (exists? js/console) (.-warn js/console))
-        (.warn js/console
-               "[re-frame.story.ui.causa-embed] popout! not loaded — "
-               "day8.re-frame2-causa.mount/popout! is the canonical "
-               "second-window mount surface")))))
+    (causa-mount/popout!)))
 
 ;; ---- styling -------------------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/causa_embed.cljs
+++ b/tools/story/src/re_frame/story/ui/causa_embed.cljs
@@ -279,30 +279,126 @@
       :else                           (resolve-panel variant-id))))
 
 ;; ---- React component: panel-host (drives mount on panel change) ----------
+;;
+;; rf2-4l7t2: React 18+ throws "Attempted to synchronously unmount a root
+;; while React was already rendering" whenever a Causa-owned React root is
+;; torn down inside the outer Story-Reagent render cascade. The previous
+;; shape ("React key on the panel-host slot, sync unmount in
+;; componentWillUnmount") cycled the host React class on every chip click,
+;; which fired the inner root's unmount inside the parent's chip-click
+;; re-render commit — exactly what React 18+ refuses.
+;;
+;; The fix is the option-(b) shape from rf2-4l7t2: one persistent host
+;; class, panel-id drives an internal swap. The lifecycle invariants:
+;;
+;;   (1) The outer hiccup MUST NOT key `panel-host-component` on
+;;       `active-panel`. The host React class stays alive across panel-id
+;;       swaps; `:component-did-update` drives the internal mount/unmount
+;;       round-trip after the parent's commit phase has completed.
+;;
+;;   (2) Each panel-id swap mounts the new Causa root into a FRESH child
+;;       `<div>` inside the stable host element. The previous panel's
+;;       child node and its React root are released on the next microtask
+;;       (the child stays in the DOM until after `.unmount` so React's
+;;       commit-phase DOM walk sees what it expects; then we remove the
+;;       node).
+;;
+;;       Why a fresh child per mount and not the same host node:
+;;       `ReactDOMClient.createRoot()` REFUSES a container that already
+;;       has a root attached. With a single persistent container, even
+;;       deferring the prior `.unmount` to a microtask would race the
+;;       next `createRoot` call ("createRoot on a container that has
+;;       already been passed to createRoot before"). Per-panel child
+;;       containers sidestep that constraint entirely — each Causa
+;;       `mount-<panel>!` sees a clean node it owns exclusively.
+;;
+;;   (3) Every `.unmount` (the internal panel swap AND the host's own
+;;       `:component-will-unmount`) is deferred via `js/queueMicrotask`
+;;       so the React 18+ root API never sees a synchronous unmount
+;;       inside the outer render cycle.
+;;
+;; Pin: `tools/story/testbeds/causa_rhs_smoke/spec.cjs` asserts that the
+;; chip-click round-trip still flips `data-active-panel` AND paints the
+;; new panel's root — both behaviours survive because the new mount runs
+;; synchronously into the fresh child container; only the prior root's
+;; release is queued.
 
 (defn- panel-host-component
-  "Reagent class-3 component owning the DOM mount lifecycle for
-  ONE Causa panel. On mount + on panel-id change, calls the
-  Causa `mount-<panel>!` fn into our `<div>` ref; on unmount,
-  calls the unmount fn the mount returned.
+  "Reagent class-3 component owning the DOM mount lifecycle for the
+  Causa panel-host `<div>` across an arbitrary number of panel-id
+  swaps. On mount + on panel-id change, mounts the Causa
+  `mount-<panel>!` fn into a fresh child `<div>` of the host; on
+  unmount, releases every still-mounted Causa root via microtask
+  so the React 18+ root API never sees a synchronous unmount
+  inside the parent render cycle.
 
-  Why a class-3 component: every panel swap is a full unmount →
-  mount round-trip. Reagent's :component-did-update + lifecycle
-  hooks give us a clean seam to drive this without a render-loop
-  race. The `<div>` ref is stable across re-renders so the
-  Causa adapter can find its mount-point reliably."
+  Lifecycle invariants (rf2-4l7t2):
+
+  - The host React class persists across panel-id swaps —
+    `:component-did-update` drives the in-place mount/unmount
+    round-trip. The host `<div>` ref is stable so the Causa
+    adapter can rely on a known parent across swaps.
+  - Each `mount-<panel>!` call gets its own fresh child container,
+    so `ReactDOMClient.createRoot()` never sees a container that
+    already owns a root.
+  - Every Causa `unmount!` thunk + DOM node removal runs inside
+    `js/queueMicrotask` so the React 18+ root API never sees a
+    synchronous unmount inside the outer render cycle (the source
+    of the 'Attempted to synchronously unmount a root while React
+    was already rendering' warning that previously fired 17× per
+    Story-Causa browser-gate run)."
   [_panel-id]
   (let [host-ref    (atom nil)
-        unmount-ref (atom nil)
+        ;; `mounted-ref` holds `{:unmount fn :container <div>}` for the
+        ;; currently-mounted Causa root, or nil. Cleared eagerly when
+        ;; swapping; the actual `.unmount` + DOM node removal is queued
+        ;; on a microtask so React's outer commit phase has released
+        ;; before the inner root unmounts.
+        mounted-ref (atom nil)
+        release!    (fn []
+                      (when-let [{:keys [unmount container]} @mounted-ref]
+                        (reset! mounted-ref nil)
+                        (js/queueMicrotask
+                          (fn []
+                            (try (unmount) (catch :default _ nil))
+                            (when-let [parent (some-> container .-parentNode)]
+                              (try (.removeChild parent container)
+                                   (catch :default _ nil)))))))
         do-mount!   (fn [pid]
-                      (when-let [unmount! @unmount-ref]
-                        (try (unmount!) (catch :default _ nil))
-                        (reset! unmount-ref nil))
+                      (release!)
                       (when-let [host @host-ref]
                         (when-let [mount-fn (mount-fn-for pid)]
                           (try
-                            (let [unmount! (mount-fn host)]
-                              (reset! unmount-ref unmount!))
+                            (let [container (.createElement js/document "div")]
+                              ;; Mark the container so DOM-level
+                              ;; assertions / dev-tools can identify
+                              ;; which Causa panel owns it. The
+                              ;; outer host carries `data-test` /
+                              ;; `data-rf-causa-panel-host` already;
+                              ;; this attr is the inner counterpart
+                              ;; for the per-mount child container.
+                              (.setAttribute container
+                                             "data-rf-causa-panel-mount"
+                                             (name pid))
+                              ;; Make the inner container a transparent
+                              ;; flex passthrough — it inherits the host's
+                              ;; flex-column behaviour so the Causa panel
+                              ;; lays out as if it were a direct child of
+                              ;; the host. `display: contents` would
+                              ;; vanish from layout entirely but has
+                              ;; accessibility-tree quirks across
+                              ;; browsers; a plain flex-column passthrough
+                              ;; is more robust.
+                              (set! (.. container -style -display) "flex")
+                              (set! (.. container -style -flexDirection) "column")
+                              (set! (.. container -style -flex) "1 1 auto")
+                              (set! (.. container -style -minHeight) "0")
+                              (set! (.. container -style -overflow) "hidden")
+                              (.appendChild host container)
+                              (let [unmount! (mount-fn container)]
+                                (reset! mounted-ref
+                                        {:unmount unmount!
+                                         :container container})))
                             (catch :default e
                               (when (and (exists? js/console)
                                          (.-warn js/console))
@@ -322,9 +418,7 @@
              (do-mount! new-pid))))
        :component-will-unmount
        (fn [_this]
-         (when-let [unmount! @unmount-ref]
-           (try (unmount!) (catch :default _ nil))
-           (reset! unmount-ref nil)))
+         (release!))
        :reagent-render
        (fn [pid]
          [:div {:ref (fn [node] (reset! host-ref node))
@@ -377,11 +471,24 @@
             :on-click (fn [_] (popout-full-shell!))}
            [:span "Pop out"]
            [glyphs/external-link 11]]]
-         ;; the panel-host — keyed by panel-id so a swap forces a
-         ;; fresh mount through the lifecycle. The component
-         ;; itself ALSO handles the swap via componentDidUpdate;
-         ;; the React key is belt-and-braces so a Causa internal
-         ;; bug (e.g. a panel that doesn't release its DOM)
-         ;; can't carry state across panel-ids.
-         ^{:key (str variant-id "::" active-panel)}
+         ;; the panel-host. rf2-4l7t2: NO React key on this slot —
+         ;; the host class persists across panel-id swaps so
+         ;; `:component-did-update` handles the in-place mount round-
+         ;; trip. Keying the slot on `active-panel` (the pre-fix
+         ;; "belt-and-braces" shape) would force a full unmount/remount
+         ;; of the host on every chip click, and the synchronous
+         ;; `.unmount` of the Causa-owned React root would fire inside
+         ;; the parent's chip-click render cycle — exactly the
+         ;; "Attempted to synchronously unmount a root while React was
+         ;; already rendering" warning React 18+ guards against. The
+         ;; host's `:component-did-update` lifecycle keyed by panel-id
+         ;; argv-diff drives the swap; the inner unmount runs deferred
+         ;; (see `release!` inside `panel-host-component`).
+         ;;
+         ;; Variant focus changes still re-render this hiccup via the
+         ;; outer `effective-panel` resolution; the host's argv-diff
+         ;; in `:component-did-update` re-runs the mount when the
+         ;; resolved panel-id changes, and same-panel-id variant
+         ;; changes are absorbed by the Causa panel's own subs
+         ;; (`:rf.causa/focus` tracks the variant-driven cascade).
          [panel-host-component active-panel]]))))

--- a/tools/story/testbeds/causa_rhs_smoke/spec.cjs
+++ b/tools/story/testbeds/causa_rhs_smoke/spec.cjs
@@ -12,27 +12,27 @@
  *
  * Two scenarios cover the embed at the Story / Causa seam:
  *
- *   §1 Embed surface mounts. After a variant becomes focused the
- *      Story RHS renders the per-panel embed wrapper
- *      `[data-test="story-causa-embed"]` with `data-active-panel`
+ *   §1 Embed surface mounts AND the Causa panel paints. After a variant
+ *      becomes focused the Story RHS renders the per-panel embed
+ *      wrapper `[data-test="story-causa-embed"]` with `data-active-panel`
  *      reporting the resolved panel, the chip-row picker exposing one
- *      chip per Causa panel, and the panel-host mount target. Proves
- *      the rf2-v1ach Story-side seam is wired end-to-end.
+ *      chip per Causa panel, the panel-host mount target, AND Causa's
+ *      event-detail panel (`[data-testid="rf-causa-event-detail"]`)
+ *      actually paints inside the panel-host. Proves the rf2-v1ach
+ *      Story-side seam is wired end-to-end AND the rf2-senbl mount-fn
+ *      lookup resolves the Causa mount target.
  *
- *   §2 Chip-row picker retargets the embed. Clicking the App-db chip
- *      flips `data-active-panel` to `app-db`. Proves the chip-row
- *      runtime override (`state/swap-state!`) reaches `effective-panel`
- *      and re-renders the embed wrapper with the new selection.
+ *   §2 Chip-row picker retargets the embed AND the new panel paints.
+ *      Clicking the App-db chip flips `data-active-panel` to `app-db`
+ *      AND mounts Causa's app-db-diff panel into the host (proving the
+ *      panel-host's component-did-update unmount → mount round-trip is
+ *      driving real Causa fns, not nils).
  *
- * Why these two and not also a "panel actually renders" assertion:
- * the deeper "the mounted Causa panel paints its DOM" is covered by
- * Causa's own testbeds under tools/causa/testbeds/ — those run the
- * panel views in isolation against their mount-fns. From the Story
- * seam's perspective the contract is "Story drives Causa's
- * mount-<panel>! at the right place with the right panel-id"; the
- * embed wrapper + the resolved panel-id (data-active-panel attribute)
- * is the public surface Story owns. (See rf2-senbl for the separate
- * mount-fn-resolution bug surfaced during this work.)
+ * Before rf2-senbl shipped, the spec asserted only the Story-side seam
+ * (wrapper attrs + chip clicks) and skipped the panel-paint check —
+ * `mount-fn-for` was returning nil and the panel-host stayed empty.
+ * Now that the dispatch resolves the Causa fns at compile time the
+ * deeper assertion is meaningful here.
  *
  * The dedicated testbed exists rather than reusing
  * tools/story/testbeds/counter_with_stories/ because adding the Causa
@@ -129,13 +129,14 @@ module.exports = {
   name: 'causa-rhs-smoke (rf2-drprn)',
   url: '/causa-rhs-smoke/',
   run: async (page) => {
-    // ----- Scenario 1: embed surface mounts at the Story RHS ------------
+    // ----- Scenario 1: embed surface mounts + Causa event-detail paints --
     //
     // After variant focus the RHS renders the rf2-v1ach per-panel embed:
     //   - wrapper `[data-test="story-causa-embed"]`
     //   - resolved panel-id on the wrapper's `data-active-panel` attr
     //   - chip-row picker with one chip per Causa panel
     //   - mount target `[data-test="story-causa-panel-host"]`
+    //   - Causa's event-detail panel actually paints inside the host
     //
     // No story-side `:causa-panel` slot is declared on the testbed
     // story/variant, so the resolved panel is the embed's
@@ -156,12 +157,24 @@ module.exports = {
       },
     );
 
-    // ----- Scenario 2: chip-row picker retargets the embed --------------
+    // rf2-senbl: prove the panel-host actually mounted Causa content
+    // (not the pre-fix empty <div> from the nil mount-fn lookup).
+    // `rf-causa-event-detail` is Causa's Event-tab Panel root.
+    await expectVisible(
+      page
+        .locator('[data-test="story-causa-panel-host"]')
+        .locator('[data-testid="rf-causa-event-detail"]'),
+      5000,
+    );
+
+    // ----- Scenario 2: chip-row picker retargets + new panel paints ------
     //
     // Clicking the App-db chip dispatches `state/swap-state!` to set
     // `:causa-panel :app-db`; `effective-panel` then beats the
-    // story/variant slot with the user override and the wrapper
-    // re-renders with `data-active-panel="app-db"`.
+    // story/variant slot with the user override, the wrapper re-renders
+    // with `data-active-panel="app-db"`, and the panel-host's React
+    // lifecycle (component-did-update + the embed-side React key)
+    // unmounts event-detail and mounts the app-db-diff panel.
 
     const appDbChip = page.locator(
       '[data-test="story-causa-panel-chip"][data-causa-panel="app-db"]',
@@ -170,6 +183,16 @@ module.exports = {
     await appDbChip.click();
 
     await expectAttribute(embed, 'data-active-panel', 'app-db', 5000);
+
+    // rf2-senbl: prove the new panel-id maps to a live Causa mount-fn
+    // (not a `find-ns-obj` walk that returned nil). The app-db-diff
+    // panel's root carries `rf-causa-app-db-diff`.
+    await expectVisible(
+      page
+        .locator('[data-test="story-causa-panel-host"]')
+        .locator('[data-testid="rf-causa-app-db-diff"]'),
+      5000,
+    );
 
     // ----- Variant dispatch sanity (best-effort) ------------------------
     //


### PR DESCRIPTION
## Summary

- P0 fix: Causa-in-Story per-panel embed was never painting on `main` after PR #1566 (rf2-v1ach). `mount-fn-for` used a `find-ns-obj` + `aget` walk to look up `day8.re-frame2-causa.panels/mount-<panel>!` fns — shadow-cljs does not expose top-level def'd fns as properties of the parent namespace's JS object, so every lookup returned nil and the panel-host stayed empty.
- Switch to a direct `:require` of `day8.re-frame2-causa.panels` + a `case` dispatch on panel-id. Same fix applied to the popout chip's `mount/popout!` lookup.
- Smoke spec extended to assert the panel actually paints inside the host (the assertion deferred in PR #1573, now meaningful with the mount-fn fix in place).

## Fix chosen — option (a), direct require

Per the spec brief's worker recommendation. Bundle-isolation contract holds:

- `scripts/check-bundle-isolation.cjs` only forbids `implementation/` → `tools/` requires (verified by reading the script + the `tools/README.md` rationale). `tools/story` → `tools/causa` is explicitly fine and matches the dep direction the embed integration already carried implicitly via `re-frame.story.causa-preset` (which feature-detected Causa via the same broken find-ns-obj walk).
- Story-only builds that omit Causa's preload (`:examples/counter-with-stories`, `:story-static/counter-with-stories`) still short-circuit before mount via `causa-preset/causa-available?` (which checks for `mount/open!` — only present when the preload has loaded). The direct require pulls `panels.cljs` onto the compile classpath but nothing executes unless the preload has installed `:rf/causa`. The embedding collisions the counter-with-stories build deliberately avoids (Story nav vs Causa tab-bar, Ctrl+K palette overlap, frame-picker `<option>` ambiguity) remain unsurfaced because none of the Causa chrome mounts.
- `npm run test:bundle-isolation` (counter / counter-uix / counter-helix release bundles) still passes — 26 internal sentinels absent, allow-list budgets ok.

## Diff summary (~30 LoC functional change)

- `tools/story/src/re_frame/story/ui/causa_embed.cljs` — replace 18-line `resolve-fn` + 8-line `panel-id->mount-fn-sym` map + 6-line `mount-fn-for` indirection with a 12-line direct `case` dispatch on panel-id, and switch `popout-full-shell!` to call `causa-mount/popout!` directly.
- `tools/story/testbeds/causa_rhs_smoke/spec.cjs` — add two panel-paint assertions: `rf-causa-event-detail` visible inside the panel-host after default focus, and `rf-causa-app-db-diff` visible after clicking the App-db chip. Updated header comment.

## Relationship to PR #1573

PR #1573 (rf2-tig7u) merged to `main` while this fix was in flight. It updated the spec.cjs selectors to the rf2-v1ach surface but intentionally deferred the panel-paint assertion until the mount-fn-resolution bug was fixed — exactly what this PR closes. This PR layers cleanly on top of #1573; no rebase conflict, no supersede.

## Visual smoke

The extended smoke spec drives the visual proof: `expectVisible([data-test="story-causa-panel-host"] [data-testid="rf-causa-event-detail"])` after default variant focus, and the analogous app-db-diff assertion after the chip click. Both fail against pre-fix `main` (nil mount-fn → empty host); both pass after the fix.

## Test plan

- [x] `npm run test:cljs` from `implementation/` — 3061 tests, 8822 assertions, 0 failures.
- [x] `npm run test:examples --filter causa-rhs-smoke` — 1/1, 0 failures, 0 skipped.
- [x] `npm run test:examples` (full sweep) — 21/21, 0 failures, 0 skipped.
- [x] `npm run test:bundle-isolation` — clean.
- [ ] CI Examples gate green on this PR.

Closes rf2-senbl.