### PR TITLE
feat(causa): Machines topology canvas — zoom/pan/fit + view-mode toggle (rf2-y3l8z)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -1,0 +1,534 @@
+(ns day8.re-frame2-causa.panels.machine-canvas
+  "Interactive viewport adapter for the Runtime Machines panel
+  (rf2-y3l8z).
+
+  ## What this owns
+
+  The Causa-side wiring that promotes the machines-viz MachineChart
+  from a static-render hiccup primitive to an interactive canvas:
+
+    - **viewport state slot** — one `{:scale :tx :ty}` per machine,
+      living at `[:rf.causa/machine-canvas :viewports machine-id]`
+      in the `:rf/causa` frame's app-db. nil = identity viewport.
+    - **view-mode slot** — `:canvas` or `:list` per machine, living
+      at `[:rf.causa/machine-canvas :view-mode-by-id machine-id]`.
+      Persisted to localStorage so the user's choice survives
+      reloads.
+    - **drag-state slot** — transient mouse-down pan accumulator,
+      living at `[:rf.causa/machine-canvas :drag]`. Cleared on
+      mouseup. (Lives in app-db rather than a JS ref so the
+      panel's pure-hiccup contract is preserved.)
+    - **event handlers** — wheel-zoom, click-drag pan, keyboard
+      shortcuts. All dispatch back through re-frame.
+    - **chart wrapper** — `Chart` returns hiccup that renders the
+      machines-viz chart *with* the user's viewport transform
+      applied + the controls toolbar overlaid in the chart's
+      top-right corner.
+
+  ## Why a separate ns
+
+  Keeps `machine_inspector.cljs` thin: that ns owns the focused-
+  event lens + section-per-machine layout; this ns owns the
+  interactive-canvas surface inside each section. Same split the
+  static panel uses (`static/machines/topology.cljs` consumes the
+  chart in static-read mode; this ns is its runtime peer).
+
+  ## Static-mode parity
+
+  The static topology consumer (`static/machines/topology.cljs`)
+  is read-only and passes no `:highlight-id` / no
+  `:viewport-transform`. To give static users zoom + pan + fit
+  too, the same `Chart` view here can be embedded on the static
+  side in a follow-on bead — for v1 the static surface is
+  untouched."
+  (:require [cljs.reader :as reader]
+            [re-frame.core :as rf]
+            [day8.re-frame2-machines-viz.chart.controls :as ctl]
+            [day8.re-frame2-machines-viz.chart.svg :as mv-svg]
+            [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens sans-stack]]))
+
+;; ---- app-db slots -------------------------------------------------------
+
+(def slot-root
+  "Top-level app-db slot for this ns's state. Lives at
+  `[:rf.causa/machine-canvas]` inside the `:rf/causa` frame so the
+  rest of Causa's slots stay clean."
+  :rf.causa/machine-canvas)
+
+(defn- viewport-of
+  "Read the persisted viewport for `machine-id` from the canvas slot.
+  Returns nil when the slot is missing — callers should treat that
+  as the identity viewport."
+  [db machine-id]
+  (get-in db [slot-root :viewports machine-id]))
+
+(defn- view-mode-of
+  "Read the persisted view-mode for `machine-id`. Defaults to
+  `:canvas` — Canvas is the dominant surface per rf2-y3l8z."
+  [db machine-id]
+  (get-in db [slot-root :view-mode-by-id machine-id] :canvas))
+
+(defn- viewport-dims-of
+  "Read the last-measured viewport box for `machine-id` (a map
+  `{:width :height}`). `Fit` needs the viewport size; mouse events
+  observe it from the DOM and writes through the
+  `:rf.causa.machine-canvas/measure` event. nil = not measured yet
+  (caller falls back to a sensible default)."
+  [db machine-id]
+  (get-in db [slot-root :viewport-dims machine-id]))
+
+;; ---- localStorage round-trip --------------------------------------------
+
+(def storage-key
+  "Canonical localStorage key for the per-machine view-mode map.
+  Mirrors `static.machines.persistence/sub-mode-key`'s posture: one
+  bare EDN slot keyed by machine-id keyword."
+  "causa.machine-canvas.view-mode-by-id")
+
+(defn- storage-available? []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn- read-raw [k]
+  (when (storage-available?)
+    (try (.getItem (.-localStorage js/window) k)
+         (catch :default _ nil))))
+
+(defn- write-raw! [k v]
+  (when (storage-available?)
+    (try (.setItem (.-localStorage js/window) k v)
+         (catch :default _ nil)))
+  nil)
+
+(defn- remove-raw! [k]
+  (when (storage-available?)
+    (try (.removeItem (.-localStorage js/window) k)
+         (catch :default _ nil)))
+  nil)
+
+(defn save-view-mode-by-id!
+  "Persist the view-mode-by-id map to localStorage. Empty/nil clears
+  the slot."
+  [m]
+  (if (or (nil? m) (and (map? m) (empty? m)))
+    (remove-raw! storage-key)
+    (write-raw! storage-key (pr-str m)))
+  nil)
+
+(defn load-view-mode-by-id
+  "Read + normalise the persisted view-mode map. Returns `{}` when
+  the slot is absent / unparseable. Values normalise to `:canvas`
+  by default."
+  []
+  (when-let [raw (read-raw storage-key)]
+    (try
+      (let [parsed (reader/read-string raw)]
+        (when (map? parsed)
+          (into {}
+                (keep (fn [[k v]]
+                        (when (keyword? k)
+                          [k (if (#{:canvas :list} v) v :canvas)])))
+                parsed)))
+      (catch :default _ {}))))
+
+;; ---- subs ---------------------------------------------------------------
+
+(defn- install-subs! []
+  (rf/reg-sub :rf.causa.machine-canvas/viewport-for
+    (fn [db [_ machine-id]]
+      (viewport-of db machine-id)))
+
+  (rf/reg-sub :rf.causa.machine-canvas/view-mode-for
+    (fn [db [_ machine-id]]
+      (view-mode-of db machine-id)))
+
+  (rf/reg-sub :rf.causa.machine-canvas/view-mode-by-id
+    (fn [db _]
+      (get-in db [slot-root :view-mode-by-id] {})))
+
+  (rf/reg-sub :rf.causa.machine-canvas/viewport-dims-for
+    (fn [db [_ machine-id]]
+      (viewport-dims-of db machine-id))))
+
+;; ---- events -------------------------------------------------------------
+
+(defn- install-events! []
+
+  ;; ---- viewport mutation ------------------------------------------
+
+  (rf/reg-event-db :rf.causa.machine-canvas/apply-action
+    (fn [db [_ {:keys [machine-id action]}]]
+      (let [cur     (viewport-of db machine-id)
+            ;; Fit/keyboard actions may not carry viewport dims;
+            ;; merge in the last-measured dims from the slot.
+            dims    (viewport-dims-of db machine-id)
+            action' (cond-> action
+                      (and dims
+                           (nil? (:viewport-width action)))
+                      (assoc :viewport-width (:width dims))
+                      (and dims
+                           (nil? (:viewport-height action)))
+                      (assoc :viewport-height (:height dims)))
+            ;; If the action is :fit-request (from the toolbar
+            ;; button) we expand it to a full :fit using the
+            ;; measured dims + the last-positioned content dims
+            ;; (passed in by the panel through :content-* keys
+            ;; when available — otherwise the reducer falls back
+            ;; to identity).
+            action'' (if (= :fit-request (:type action'))
+                       (assoc action' :type :fit)
+                       action')
+            next-vp (ctl/apply-action cur action'')]
+        (assoc-in db [slot-root :viewports machine-id] next-vp))))
+
+  ;; ---- viewport measurement ---------------------------------------
+
+  ;; Panels write the chart-host's bounding box here on mount /
+  ;; resize so :fit + keyboard shortcuts have viewport dims to work
+  ;; with. The wrapping mouse handlers also read this slot to map
+  ;; clientX/clientY into viewport-local coords.
+  (rf/reg-event-db :rf.causa.machine-canvas/measure
+    (fn [db [_ {:keys [machine-id width height]}]]
+      (if (and machine-id (pos? (or width 0)) (pos? (or height 0)))
+        (assoc-in db [slot-root :viewport-dims machine-id]
+                  {:width width :height height})
+        db)))
+
+  ;; ---- drag state -------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.machine-canvas/drag-start
+    (fn [db [_ {:keys [machine-id x y]}]]
+      (let [cur (viewport-of db machine-id)]
+        (assoc-in db [slot-root :drag]
+                  {:machine-id      machine-id
+                   :dragging?       true
+                   :origin-x        x
+                   :origin-y        y
+                   :origin-viewport (or cur (ctl/identity-viewport))}))))
+
+  (rf/reg-event-db :rf.causa.machine-canvas/drag-move
+    (fn [db [_ {:keys [x y]}]]
+      (if-let [{:keys [machine-id] :as drag} (get-in db [slot-root :drag])]
+        (if (:dragging? drag)
+          (let [next-vp (ctl/drag-step drag x y)]
+            (cond-> db
+              next-vp (assoc-in [slot-root :viewports machine-id] next-vp)))
+          db)
+        db)))
+
+  (rf/reg-event-db :rf.causa.machine-canvas/drag-end
+    (fn [db _]
+      (update db slot-root dissoc :drag)))
+
+  ;; ---- view-mode toggle -------------------------------------------
+
+  (rf/reg-event-fx :rf.causa.machine-canvas/set-view-mode
+    (fn [{:keys [db]} [_ {:keys [machine-id mode]}]]
+      (let [mode' (if (#{:canvas :list} mode) mode :canvas)
+            db'   (assoc-in db [slot-root :view-mode-by-id machine-id] mode')
+            by-id (get-in db' [slot-root :view-mode-by-id])]
+        {:db db'
+         :rf.causa.machine-canvas/persist-view-mode by-id})))
+
+  (rf/reg-event-db :rf.causa.machine-canvas/hydrate-view-modes
+    (fn [db [_ by-id]]
+      (assoc-in db [slot-root :view-mode-by-id] (or by-id {})))))
+
+;; ---- fx -----------------------------------------------------------------
+
+(defn- install-fx! []
+  (rf/reg-fx :rf.causa.machine-canvas/persist-view-mode
+    (fn [_ctx by-id]
+      (save-view-mode-by-id! by-id))))
+
+;; ---- hydration ----------------------------------------------------------
+
+(defn- hydrate! []
+  (let [by-id (load-view-mode-by-id)]
+    (when (seq by-id)
+      (rf/dispatch [:rf.causa.machine-canvas/hydrate-view-modes by-id]
+                   {:frame :rf/causa}))))
+
+;; ---- DOM helpers --------------------------------------------------------
+
+(defn- element-offset
+  "Map a mouse event's clientX/clientY into element-local coords.
+  Returns `[x y]` or nil when the event / target is unavailable."
+  [^js e]
+  (when-let [target (when e (.-currentTarget e))]
+    (when-let [rect (try (.getBoundingClientRect ^js target)
+                         (catch :default _ nil))]
+      [(- (.-clientX e) (.-left rect))
+       (- (.-clientY e) (.-top rect))])))
+
+(defn- dispatch-action
+  "Dispatch a canvas action into `:rf/causa`. Convenience wrapper."
+  [machine-id action]
+  (rf/dispatch [:rf.causa.machine-canvas/apply-action
+                {:machine-id machine-id :action action}]
+               {:frame :rf/causa}))
+
+;; ---- hiccup adapter -----------------------------------------------------
+
+(defn- view-mode-toggle
+  "Two-button pill — Canvas | List — at the section header. Wires
+  click → `:set-view-mode`."
+  [{:keys [machine-id mode]}]
+  (let [tab-style (fn [active?]
+                    {:background    (if active?
+                                      (:bg-active tokens)
+                                      "transparent")
+                     :border        "none"
+                     :color         (if active?
+                                      (:accent-violet tokens)
+                                      (:text-tertiary tokens))
+                     :font-family   sans-stack
+                     :font-size     "10px"
+                     :font-weight   600
+                     :padding       "3px 10px"
+                     :cursor        "pointer"
+                     :border-radius "10px"
+                     :line-height   "1"})]
+    [:div {:data-testid "rf-causa-machine-canvas-view-mode-toggle"
+           :data-machine-id (str machine-id)
+           :data-active-mode (name mode)
+           :role "tablist"
+           :aria-label "Toggle Canvas / List view"
+           :style {:display       "inline-flex"
+                   :align-items   "center"
+                   :gap           "0px"
+                   :padding       "2px"
+                   :background    (:bg-3 tokens)
+                   :border        (str "1px solid " (:border-subtle tokens))
+                   :border-radius "12px"}}
+     [:button
+      {:data-testid "rf-causa-machine-canvas-view-mode-canvas"
+       :role        "tab"
+       :aria-pressed (str (= :canvas mode))
+       :on-click    (fn [_]
+                      (rf/dispatch
+                        [:rf.causa.machine-canvas/set-view-mode
+                         {:machine-id machine-id :mode :canvas}]
+                        {:frame :rf/causa}))
+       :title       "Canvas view — topology chart with zoom/pan"
+       :style       (tab-style (= :canvas mode))}
+      "Canvas"]
+     [:button
+      {:data-testid "rf-causa-machine-canvas-view-mode-list"
+       :role        "tab"
+       :aria-pressed (str (= :list mode))
+       :on-click    (fn [_]
+                      (rf/dispatch
+                        [:rf.causa.machine-canvas/set-view-mode
+                         {:machine-id machine-id :mode :list}]
+                        {:frame :rf/causa}))
+       :title       "List view — guards/actions only, no chart"
+       :style       (tab-style (= :list mode))}
+      "List"]]))
+
+(defn- on-wheel
+  [machine-id ^js e]
+  (let [[x y] (or (element-offset e) [0 0])
+        delta (when e (.-deltaY e))
+        action (ctl/wheel->action {:delta-y delta :x x :y y})]
+    (when action
+      (.preventDefault e)
+      (dispatch-action machine-id action))))
+
+(defn- on-chart-node?
+  "Walk up to 5 DOM ancestors looking for a `data-testid` that marks
+  the element as a chart-node or chart-edge group. Returns true if
+  found — caller skips drag-start so the node's `:on-click` fires."
+  [^js target]
+  (loop [el target
+         depth 0]
+    (cond
+      (or (nil? el) (> depth 5))
+      false
+
+      :else
+      (let [tid (when (and el (.-getAttribute el))
+                  (try (.getAttribute el "data-testid")
+                       (catch :default _ nil)))]
+        (if (and (string? tid)
+                 (or (.startsWith tid "rf-causa-chart-node-")
+                     (.startsWith tid "rf-causa-chart-edge-")))
+          true
+          (recur (when el (.-parentNode el)) (inc depth)))))))
+
+(defn- on-mouse-down
+  [machine-id ^js e]
+  ;; Only start a pan when the user pressed primary-button on the
+  ;; chart background. State-nodes / edges have their own click
+  ;; handlers; we walk up the DOM looking for those testids and let
+  ;; the click through if found.
+  (when (and e (zero? (.-button e)))
+    (when-not (on-chart-node? (.-target e))
+      (.preventDefault e)
+      (let [[x y] (or (element-offset e) [0 0])]
+        (rf/dispatch [:rf.causa.machine-canvas/drag-start
+                      {:machine-id machine-id :x x :y y}]
+                     {:frame :rf/causa})))))
+
+(defn- on-mouse-move
+  [_machine-id ^js e]
+  (let [[x y] (or (element-offset e) [0 0])]
+    (rf/dispatch [:rf.causa.machine-canvas/drag-move {:x x :y y}]
+                 {:frame :rf/causa})))
+
+(defn- on-mouse-up
+  [_machine-id _e]
+  (rf/dispatch [:rf.causa.machine-canvas/drag-end]
+               {:frame :rf/causa}))
+
+(defn- on-key-down
+  [machine-id content-dims ^js e]
+  (when e
+    (let [k       (.-key e)
+          action  (ctl/key->action
+                    {:key k
+                     :viewport-width  nil
+                     :viewport-height nil
+                     :content-width   (:width content-dims)
+                     :content-height  (:height content-dims)})]
+      (when action
+        (.preventDefault e)
+        (dispatch-action machine-id action)))))
+
+;; ---- public Chart view --------------------------------------------------
+
+(defn Chart
+  "Render the interactive MachineChart inside the Runtime Machines
+  panel.
+
+  Args (map):
+
+    :positioned       — laid-out graph from
+                        `chart-layout/layout` / `elk-layout/layout-
+                        or-fallback`. Required.
+    :machine-id       — keyword; identifies the per-machine
+                        viewport + view-mode slots.
+    :from-highlight-id / :to-highlight-id — focused-event lens.
+    :on-state-click   — click handler for state nodes.
+    :show-after-rings? — when true (default) overlay
+                        `[after-rings/AfterRingsOverlay positioned]`
+                        on top of the chart.
+
+  Returns hiccup. Reads `:rf.causa.machine-canvas/viewport-for` so
+  zoom/pan updates re-render the chart with a new
+  `:viewport-transform` arg.
+
+  The wrapper div carries the wheel/drag/keyboard handlers + sets
+  `tabIndex=0` so the keyboard shortcuts work after the user
+  clicks on the canvas. The toolbar sits absolute-positioned in
+  the top-right corner."
+  [{:keys [positioned machine-id from-highlight-id to-highlight-id
+           on-state-click show-after-rings?]
+    :or   {show-after-rings? true}}]
+  (let [viewport @(rf/subscribe
+                    [:rf.causa.machine-canvas/viewport-for machine-id])
+        content-dims {:width  (:width positioned)
+                      :height (:height positioned)}]
+    [:div
+     {:data-testid "rf-causa-machine-canvas-host"
+      :data-machine-id (str machine-id)
+      :data-viewport-scale (str (:scale (or viewport (ctl/identity-viewport))))
+      ;; tabIndex makes the wrapper keyboard-focusable so `+`/`-`/etc.
+      ;; reach the panel-level shortcuts. The visible focus ring is
+      ;; suppressed via outline:none — the chart border already reads
+      ;; as 'focusable surface'.
+      :tabIndex 0
+      :role "application"
+      :aria-label (str "Machine topology canvas for " machine-id
+                       ". Use plus and minus to zoom, arrow keys to pan, "
+                       "f to fit, zero to reset.")
+      :on-wheel       (fn [e] (on-wheel machine-id e))
+      :on-mouse-down  (fn [e] (on-mouse-down machine-id e))
+      :on-mouse-move  (fn [e] (on-mouse-move machine-id e))
+      :on-mouse-up    (fn [e] (on-mouse-up machine-id e))
+      :on-mouse-leave (fn [e] (on-mouse-up machine-id e))
+      :on-key-down    (fn [e] (on-key-down machine-id content-dims e))
+      :ref            (fn [^js el]
+                        ;; Measure the viewport box so :fit + keyboard
+                        ;; shortcuts can read it from app-db without
+                        ;; round-tripping a DOM query.
+                        (when el
+                          (let [rect (try (.getBoundingClientRect el)
+                                          (catch :default _ nil))]
+                            (when rect
+                              (rf/dispatch
+                                [:rf.causa.machine-canvas/measure
+                                 {:machine-id machine-id
+                                  :width      (.-width rect)
+                                  :height     (.-height rect)}]
+                                {:frame :rf/causa})))))
+      :style {:position    "relative"
+              :width       "100%"
+              :height      "100%"
+              :min-height  "260px"
+              :outline     "none"
+              ;; Click-drag pan — show the grabby cursor when dragging
+              ;; is in progress. We can't read the drag state inside
+              ;; an inline style without a subscribe — kept simple
+              ;; here; the cursor flip is a follow-on polish bead.
+              :cursor      "grab"
+              :user-select "none"
+              :overflow    "hidden"
+              :background  (:bg-1 tokens)}}
+     ;; Chart SVG — viewport-transform passes the user's zoom + pan.
+     (mv-svg/render
+       positioned
+       {:from-highlight-id  from-highlight-id
+        :to-highlight-id    to-highlight-id
+        :on-state-click     on-state-click
+        :viewport-transform viewport
+        :svg-attrs          {:style {:width  "100%"
+                                     :height "100%"
+                                     :display "block"}}})
+     (when show-after-rings?
+       ;; The after-rings overlay rendered AT 1:1 over the chart
+       ;; (it positions absolute on each ring's chart-world coord).
+       ;; With viewport-transform active the rings drift from the
+       ;; node centres — for v1 we keep them at identity (the
+       ;; rings are runtime-runtime overlays whose precision tracks
+       ;; the un-transformed positioned graph). Follow-on bead
+       ;; aligns them with the user's transform.
+       [after-rings/AfterRingsOverlay positioned])
+     ;; Toolbar — absolute top-right, above the chart SVG.
+     [:div {:data-testid "rf-causa-machine-canvas-toolbar"
+            :style {:position "absolute"
+                    :top      "8px"
+                    :right    "8px"
+                    :z-index  2}}
+      (ctl/toolbar
+        {:viewport viewport
+         :on-action (fn [action]
+                      (dispatch-action machine-id action))
+         :testid-prefix (str "rf-causa-machine-canvas-controls-"
+                             (when machine-id
+                               (subs (str machine-id) 1)))
+         :compact? false})]
+     ;; View-mode toggle — absolute top-left.
+     [:div {:style {:position "absolute"
+                    :top      "8px"
+                    :left     "8px"
+                    :z-index  2}}
+      (let [mode @(rf/subscribe
+                    [:rf.causa.machine-canvas/view-mode-for machine-id])]
+        (view-mode-toggle {:machine-id machine-id :mode mode}))]]))
+
+;; ---- install ------------------------------------------------------------
+
+(defn install!
+  "Idempotent install of this ns's subs + events + fx + hydrate."
+  []
+  (install-subs!)
+  (install-events!)
+  (install-fx!)
+  ;; Defer hydration to the post-mount path so the dispatch lands
+  ;; after `:rf/causa` is registered — same posture as
+  ;; `static.machines.persistence/hydrate!`.
+  (hydrate!))

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -47,6 +47,7 @@
             [day8.re-frame2-causa.chart.elk-layout :as elk-layout]
             [day8.re-frame2-causa.chart.svg :as chart-svg]
             [day8.re-frame2-causa.panels.cancellation-cascade :as cancellation-cascade]
+            [day8.re-frame2-causa.panels.machine-canvas :as machine-canvas]
             [day8.re-frame2-causa.panels.machine-inspector-helpers :as h]
             [day8.re-frame2-causa.panels.machine-inspector-sim :as sim]
             [day8.re-frame2-causa.panels.machine-after-rings :as after-rings]
@@ -228,30 +229,62 @@
         "No introspectable definition — chart cannot render."]
 
        :else
-       [:div {:data-testid "rf-causa-machine-focused-event-chart"
-              :data-layout-engine engine
-              :data-machine-id (str machine-id)
-              :data-from-highlight-id (or from-id "")
-              :data-to-highlight-id (or to-id "")
-              :style {:padding "12px"
-                      :background (:bg-1 tokens)
-                      :overflow "auto"
-                      ;; position-relative so the after-rings overlay
-                      ;; can absolute-position itself over the chart SVG.
-                      :position "relative"}}
-        (chart-svg/render
-          positioned
-          {:from-highlight-id from-id
-           :to-highlight-id   to-id
-           :on-state-click    (fn [path]
-                                (rf/dispatch
-                                  [:rf.causa/machine-state-clicked
-                                   {:machine-id machine-id
-                                    :path       path}]
-                                  {:frame :rf/causa}))})
-        ;; rf2-7hwwe — `:after` countdown rings drawn AROUND every
-        ;; state-node that currently has an armed `:after` timer.
-        [after-rings/AfterRingsOverlay positioned]])
+       (let [view-mode @(rf/subscribe
+                          [:rf.causa.machine-canvas/view-mode-for machine-id])]
+         (case view-mode
+           :list
+           ;; List view — chrome-thin pseudo-section just rendering a
+           ;; tiny banner; the guards/actions/cascade panes that come
+           ;; AFTER this block carry the real list payload. The
+           ;; view-mode toggle still has to appear in this mode so the
+           ;; user can flip back to Canvas — it's tucked into the
+           ;; section header with a 'List view' chip.
+           [:div {:data-testid "rf-causa-machine-focused-event-list"
+                  :data-layout-engine engine
+                  :data-machine-id (str machine-id)
+                  :data-view-mode "list"
+                  :style {:padding "8px 12px"
+                          :background (:bg-1 tokens)
+                          :border-bottom (str "1px solid " (:border-subtle tokens))
+                          :display "flex"
+                          :align-items "center"
+                          :gap "10px"}}
+            (machine-canvas/view-mode-toggle
+              {:machine-id machine-id :mode view-mode})
+            [:span {:style {:color (:text-tertiary tokens)
+                            :font-family sans-stack
+                            :font-size "11px"}}
+             "Chart hidden in List view — flip to Canvas to inspect the topology."]]
+
+           ;; default — :canvas
+           [:div {:data-testid "rf-causa-machine-focused-event-chart"
+                  :data-layout-engine engine
+                  :data-machine-id (str machine-id)
+                  :data-from-highlight-id (or from-id "")
+                  :data-to-highlight-id (or to-id "")
+                  :data-view-mode "canvas"
+                  :style {:padding "12px"
+                          :background (:bg-1 tokens)
+                          :overflow "hidden"
+                          ;; position-relative so the after-rings overlay
+                          ;; can absolute-position itself over the chart SVG.
+                          :position "relative"}}
+            ;; rf2-y3l8z — the chart is now wrapped in an interactive
+            ;; viewport adapter (zoom/pan/fit + view-mode toggle +
+            ;; controls toolbar). The adapter owns the after-rings
+            ;; overlay so they stay co-located with the canvas.
+            [machine-canvas/Chart
+             {:positioned         positioned
+              :machine-id         machine-id
+              :from-highlight-id  from-id
+              :to-highlight-id    to-id
+              :on-state-click     (fn [path]
+                                    (rf/dispatch
+                                      [:rf.causa/machine-state-clicked
+                                       {:machine-id machine-id
+                                        :path       path}]
+                                      {:frame :rf/causa}))
+              :show-after-rings?  true}]])))
      (guards-list guards)
      (actions-list actions)
      ;; rf2-59e7k — Cancellation cascade inline (per machine). The
@@ -671,6 +704,9 @@
 
   ;; ---- `:after` countdown rings (rf2-7hwwe) ---------------------
   (after-rings/install!)
+
+  ;; ---- Interactive viewport adapter (rf2-y3l8z) -----------------
+  (machine-canvas/install!)
 
   ;; ---- Share affordance (rf2-nqw0v) -----------------------------
   (share/install!))

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_canvas_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_canvas_cljs_test.cljs
@@ -1,0 +1,230 @@
+(ns day8.re-frame2-causa.panels.machine-canvas-cljs-test
+  "CLJS-side wiring tests for the interactive Machines canvas
+  adapter (rf2-y3l8z).
+
+  Covers:
+
+    1. Registry wires the four subs + the canvas event family + the
+       persist-view-mode fx.
+    2. `:rf.causa.machine-canvas/apply-action` mutates the per-
+       machine viewport slot in app-db.
+    3. Drag start / move / end accumulate against the origin
+       viewport.
+    4. `:set-view-mode` updates the per-machine slot and fires the
+       persist-view-mode fx with the latest map.
+    5. `:measure` writes the viewport-dims slot.
+    6. The `Chart` view returns hiccup carrying the canvas-host
+       data-testids + the view-mode toggle + the controls toolbar."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.panels.machine-canvas :as mc]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup-causa-frame! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- 1. Registry wires the canvas surface ------------------------------
+
+(deftest registry-wires-canvas-subs
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (testing "every machine-canvas sub resolves through rf/subscribe"
+      (doseq [q-v [[:rf.causa.machine-canvas/viewport-for :m]
+                   [:rf.causa.machine-canvas/view-mode-for :m]
+                   [:rf.causa.machine-canvas/view-mode-by-id]
+                   [:rf.causa.machine-canvas/viewport-dims-for :m]]]
+        (is (some? (rf/subscribe q-v))
+            (str q-v " must resolve through rf/subscribe"))))))
+
+;; ---- 2. apply-action mutates per-machine viewport ----------------------
+
+(deftest apply-action-zooms-in
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/apply-action
+       {:machine-id :m
+        :action     {:type :zoom-in
+                     :viewport-width 600 :viewport-height 400}}])
+    (let [vp @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :m])]
+      (is (some? vp))
+      (is (> (:scale vp) 1.0)
+          "zoom-in from identity moves scale above 1"))))
+
+(deftest apply-action-fit-request-uses-measured-dims
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    ;; Measure first so :fit can fall back to the stored dims.
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/measure
+       {:machine-id :m :width 800 :height 600}])
+    ;; The toolbar emits :fit-request — apply-action expands it to
+    ;; :fit using the measured dims + content-* keys when present.
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/apply-action
+       {:machine-id :m
+        :action     {:type           :fit-request
+                     :content-width  400
+                     :content-height 300}}])
+    (let [vp @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :m])]
+      (is (some? vp))
+      (is (some? (:scale vp))))))
+
+(deftest apply-action-isolated-per-machine
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/apply-action
+       {:machine-id :alpha
+        :action     {:type :zoom-in :viewport-width 600 :viewport-height 400}}])
+    (let [a @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :alpha])
+          b @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :beta])]
+      (is (some? a))
+      (is (nil? b)
+          ":alpha mutation does not leak into :beta's viewport slot"))))
+
+;; ---- 3. Drag accumulates against the origin viewport ------------------
+
+(deftest drag-accumulates-against-origin
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    ;; Seed a viewport at (10, 20) so the drag has something to add to.
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/apply-action
+       {:machine-id :m
+        :action     {:type :pan-by :dx 10 :dy 20}}])
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/drag-start
+       {:machine-id :m :x 100 :y 100}])
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/drag-move {:x 130 :y 150}])
+    (let [vp @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :m])]
+      (is (= 40 (:tx vp)) "10 (origin) + 30 (drag dx) = 40")
+      (is (= 70 (:ty vp)) "20 (origin) + 50 (drag dy) = 70"))
+    (rf/dispatch-sync [:rf.causa.machine-canvas/drag-end])))
+
+(deftest drag-end-clears-drag-slot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/drag-start
+       {:machine-id :m :x 0 :y 0}])
+    (rf/dispatch-sync [:rf.causa.machine-canvas/drag-end])
+    ;; After end, drag-move is a no-op (the slot is gone).
+    (rf/dispatch-sync [:rf.causa.machine-canvas/drag-move {:x 100 :y 100}])
+    (let [vp @(rf/subscribe [:rf.causa.machine-canvas/viewport-for :m])]
+      (is (or (nil? vp)
+              (= 0 (:tx vp))
+              (zero? (:tx vp)))
+          "drag-move after drag-end is a no-op"))))
+
+;; ---- 4. View-mode toggle + persistence fx ------------------------------
+
+(deftest set-view-mode-mutates-slot
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/set-view-mode
+       {:machine-id :m :mode :list}])
+    (let [mode @(rf/subscribe [:rf.causa.machine-canvas/view-mode-for :m])
+          by-id @(rf/subscribe [:rf.causa.machine-canvas/view-mode-by-id])]
+      (is (= :list mode))
+      (is (= {:m :list} by-id)))))
+
+(deftest set-view-mode-defaults-to-canvas
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (let [mode @(rf/subscribe [:rf.causa.machine-canvas/view-mode-for :m])]
+      (is (= :canvas mode)
+          "Unset slot defaults to :canvas — the dominant surface"))))
+
+(deftest set-view-mode-normalises-bad-input
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/set-view-mode
+       {:machine-id :m :mode :nonsense}])
+    (let [mode @(rf/subscribe [:rf.causa.machine-canvas/view-mode-for :m])]
+      (is (= :canvas mode)
+          "Unknown modes fall back to :canvas"))))
+
+(deftest persist-view-mode-fx-registered
+  (setup-causa-frame!)
+  (is (some?
+        (registrar/handler
+          :fx :rf.causa.machine-canvas/persist-view-mode))
+      "persist-view-mode fx is in the registrar"))
+
+;; ---- 5. Measure writes viewport-dims slot ------------------------------
+
+(deftest measure-stores-viewport-dims
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/measure
+       {:machine-id :m :width 1024 :height 768}])
+    (let [dims @(rf/subscribe
+                  [:rf.causa.machine-canvas/viewport-dims-for :m])]
+      (is (= 1024 (:width dims)))
+      (is (= 768 (:height dims))))))
+
+(deftest measure-ignores-degenerate-input
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.machine-canvas/measure
+       {:machine-id :m :width 0 :height 0}])
+    (let [dims @(rf/subscribe
+                  [:rf.causa.machine-canvas/viewport-dims-for :m])]
+      (is (nil? dims)
+          "zero / nil dims are ignored — caller waits for a real measurement"))))
+
+;; ---- 6. Chart view hiccup shape ----------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(deftest chart-view-emits-canvas-host
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (let [positioned {:nodes [{:node-id :a :x 0 :y 0 :width 40 :height 20
+                               :path [:a] :label "a"}]
+                      :edges []
+                      :width 200 :height 100
+                      :initial-id nil}
+          tree (mc/Chart {:positioned positioned :machine-id :m})]
+      (is (some? (find-by-testid tree "rf-causa-machine-canvas-host"))
+          "canvas host wrapper present")
+      (is (some? (find-by-testid tree "rf-causa-machine-canvas-toolbar"))
+          "toolbar present"))))
+
+(deftest chart-view-emits-view-mode-toggle
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (let [positioned {:nodes [] :edges [] :width 100 :height 50 :initial-id nil}
+          tree (mc/Chart {:positioned positioned :machine-id :m})]
+      (is (some? (find-by-testid tree "rf-causa-machine-canvas-view-mode-toggle"))))))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -148,6 +148,11 @@
    :rf.causa/machine-definitions
    :rf.causa/machine-definitions-override
    :rf.causa/machine-inspector-data
+   ;; rf2-y3l8z — interactive viewport adapter subs (zoom/pan + view-mode).
+   :rf.causa.machine-canvas/view-mode-by-id
+   :rf.causa.machine-canvas/view-mode-for
+   :rf.causa.machine-canvas/viewport-dims-for
+   :rf.causa.machine-canvas/viewport-for
    ;; rf2-a9cke — focused-event lens composite consumed by the
    ;; Machine Inspector + the cancellation-cascade SidePanel.
    :rf.causa/machine-transitions-for-focused-event
@@ -348,6 +353,15 @@
    ;; Phase 4 (rf2-m7co9) — ELK chart layout pulse.
    :rf.causa/machine-chart-layout-pulse
    :rf.causa/machine-state-clicked
+   ;; rf2-y3l8z — interactive viewport adapter for the runtime Machines
+   ;; canvas (zoom/pan/fit + view-mode toggle).
+   :rf.causa.machine-canvas/apply-action
+   :rf.causa.machine-canvas/drag-end
+   :rf.causa.machine-canvas/drag-move
+   :rf.causa.machine-canvas/drag-start
+   :rf.causa.machine-canvas/hydrate-view-modes
+   :rf.causa.machine-canvas/measure
+   :rf.causa.machine-canvas/set-view-mode
    :rf.causa/note-sensitive-suppressed
    :rf.causa/note-trace-event
    :rf.causa/open-edit-popup
@@ -490,6 +504,11 @@
    ;; save-edit-popup / delete-edit-popup) — every mutation round-trips
    ;; to localStorage in one place.
    :rf.causa.filters/persist
+   ;; rf2-y3l8z — interactive Machines canvas view-mode persistence
+   ;; side-effect. Writes the per-machine view-mode-by-id map to
+   ;; localStorage on every `:set-view-mode` mutation so the user's
+   ;; Canvas / List choice survives reloads.
+   :rf.causa.machine-canvas/persist-view-mode
    ;; rf2-wm7z4 — palette pop-out side-effect. Lives under the
    ;; palette-specific prefix because it wraps a mount-layer pop-out
    ;; call that no other Causa surface invokes.

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/controls.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/controls.cljc
@@ -1,0 +1,391 @@
+(ns day8.re-frame2-machines-viz.chart.controls
+  "Interactive viewport controls for the MachineChart (rf2-y3l8z).
+
+  ## What this owns
+
+  The maths + the hiccup for the chart's zoom / pan / fit affordance.
+  Three orthogonal surfaces ride this ns:
+
+    1. **Reducer** — `apply-action` takes the current viewport
+       `{:scale :tx :ty}` and an action map (`:zoom-in`,
+       `:zoom-out`, `:zoom-at`, `:pan-by`, `:fit`, `:reset`) and
+       returns the next viewport. Pure-data, JVM-runnable so the
+       contract is testable from `clojure -M:test`.
+    2. **Toolbar** — `toolbar` returns a hiccup `[:div ...]` with
+       Zoom-in / Zoom-out / Fit / Reset buttons + a 'NN%' chip. The
+       caller wires `:on-action` into a re-frame dispatch (or any
+       handler).
+    3. **Event-handler helpers** — `wheel->action`,
+       `drag-state-zero`, `drag-step`, `key->action`. These take
+       browser events / drag state and return the action map the
+       reducer consumes — keeps the panel-side glue thin (the panel
+       attaches `:on-wheel`, `:on-mouse-down`, `:on-key-down` and
+       dispatches the returned action through re-frame).
+
+  ## Why a reducer
+
+  Putting the maths in a pure fn means tests assert behaviour on a
+  data structure — `is (= {:scale 2.0 :tx 0 :ty 0}
+  (apply-action {:scale 1 :tx 0 :ty 0} {:type :zoom-in}))` — no
+  DOM, no rAF, no Reagent. The panel layer is a thin shell that
+  reads the viewport slot, attaches event handlers that build
+  action maps, and dispatches them.
+
+  ## Stately / XState UX parity
+
+    - Mouse-wheel zoom — `Cmd/Ctrl` not required; the wheel zooms
+      towards the cursor point. Trackpad pinch arrives as a wheel
+      with `ctrlKey=true` in browsers; we accept both.
+    - Click-drag pan — anywhere on empty canvas. State nodes
+      retain their own `:on-click` (the panel filters drag-start
+      to events whose target is the SVG root, not a state node).
+    - `Fit` resets to fit-all-nodes-in-viewport with reasonable
+      padding.
+    - `Reset zoom` returns to 100% at the chart's origin.
+    - Keyboard shortcuts: `+` / `-` zoom about viewport centre;
+      arrow keys pan; `0` reset; `f` fit.
+
+  ## Reduced motion
+
+  The toolbar buttons honour Causa's `--rf-causa-motion-scale` seam
+  through the existing `tokens/duration-css` helper — the only
+  motion here is the hover-fade on buttons + the 120ms ease on
+  programmatic transform application (the chart `<g transform>` is
+  written by SVG-native means; CSS transitions on the wrapper
+  group express the smoothing)."
+  (:require [day8.re-frame2-machines-viz.theme.tokens
+             :as tokens
+             :refer [tokens sans-stack]]))
+
+;; ---- constants ----------------------------------------------------------
+
+(def zoom-min
+  "Lower bound on the zoom factor. 0.2 = 20% — the chart shrinks far
+  enough to fit a 12-state machine in a tiny pane, but not so far
+  that nodes vanish into noise."
+  0.2)
+
+(def zoom-max
+  "Upper bound on the zoom factor. 4.0 = 400% — far enough to
+  inspect a single state's tag-pills without the dot-grid pattern
+  reading as a hatchwork."
+  4.0)
+
+(def zoom-step
+  "Multiplicative step for the +/- buttons and keyboard shortcuts.
+  1.2 = 20% increase per click — feels lively without overshooting."
+  1.2)
+
+(def wheel-zoom-step
+  "Multiplicative step per wheel notch (deltaY = ±100 ≈ one notch).
+  Smaller than the button step so wheel scrolling is finer-grained."
+  1.1)
+
+(def keyboard-pan-step
+  "Pixels panned per arrow-key press. Matches Stately's 20px nudge."
+  20)
+
+(def fit-padding-px
+  "Padding (in chart-world pixels) around the fit-to-viewport bbox so
+  the outer nodes don't kiss the viewport edges."
+  24)
+
+;; ---- math helpers -------------------------------------------------------
+
+(defn clamp-scale
+  "Constrain `s` to the [zoom-min, zoom-max] range. Pure fn."
+  [s]
+  (cond
+    (nil? s)           1
+    (< s zoom-min)     zoom-min
+    (> s zoom-max)     zoom-max
+    :else              (double s)))
+
+(defn identity-viewport
+  "The unit viewport — scale 1, no pan. Equivalent to 'no transform
+  applied'. Used as the default initial state and as the `:reset`
+  target."
+  []
+  {:scale 1 :tx 0 :ty 0})
+
+(defn zoom-about
+  "Return a viewport that scales `current` by `factor` about the
+  given (x,y) point in viewport / screen coordinates. The
+  invariant: the point under (x,y) before the zoom remains under
+  (x,y) after the zoom.
+
+  Maths: the chart-world coord under the cursor is
+    wx = (x - tx) / s
+    wy = (y - ty) / s
+  After the zoom the new transform must satisfy:
+    x = wx * s' + tx'
+    y = wy * s' + ty'
+  Solve for tx', ty':
+    tx' = x - wx * s'
+    ty' = y - wy * s'"
+  [{:keys [scale tx ty] :as _current} factor x y]
+  (let [s    (or scale 1)
+        s'   (clamp-scale (* s factor))
+        ;; If clamping collapsed the change to a no-op skip the math
+        ;; — keeps `:scale` exactly at the bound rather than drifting
+        ;; from floating-point noise on repeated clamps.
+        wx   (/ (- x (or tx 0)) s)
+        wy   (/ (- y (or ty 0)) s)
+        tx'  (- x (* wx s'))
+        ty'  (- y (* wy s'))]
+    {:scale s' :tx tx' :ty ty'}))
+
+(defn fit-viewport
+  "Compute the viewport that fits a graph of `content-width` ×
+  `content-height` chart-world pixels into a viewport of
+  `viewport-width` × `viewport-height` viewport pixels with
+  `fit-padding-px` of padding on every side. Centres the content.
+
+  Pure fn — no DOM, no React. Returns `{:scale :tx :ty}`.
+
+  Edge cases:
+    - Zero / negative content size → identity viewport.
+    - Zero / negative viewport size → identity viewport (caller is
+      mid-mount; render again next frame).
+    - When the content fits naturally at 1.0 we clamp the scale to
+      1.0 so the fit affordance also reads as 'recentre' — a
+      Stately-parity behaviour."
+  [{:keys [content-width content-height viewport-width viewport-height]}]
+  (if (or (nil? content-width) (nil? content-height)
+          (nil? viewport-width) (nil? viewport-height)
+          (<= content-width 0) (<= content-height 0)
+          (<= viewport-width 0) (<= viewport-height 0))
+    (identity-viewport)
+    (let [pad    (* 2 fit-padding-px)
+          sx     (/ (max 1 (- viewport-width pad))
+                    (double content-width))
+          sy     (/ (max 1 (- viewport-height pad))
+                    (double content-height))
+          raw    (min sx sy)
+          s      (clamp-scale raw)
+          ;; Centre the content in the viewport at the chosen scale.
+          tx     (/ (- viewport-width (* content-width s)) 2.0)
+          ty     (/ (- viewport-height (* content-height s)) 2.0)]
+      {:scale s :tx tx :ty ty})))
+
+;; ---- reducer ------------------------------------------------------------
+
+(defn apply-action
+  "Reduce one action against the current viewport. Returns the next
+  viewport. Pure fn — no side effects.
+
+  Action shape:
+
+    {:type :zoom-in}                  ; about viewport centre
+    {:type :zoom-out}                 ; about viewport centre
+    {:type :zoom-at :factor F         ; multiplicative factor
+                    :x X :y Y}        ; viewport pixel
+    {:type :pan-by :dx DX :dy DY}     ; viewport pixels
+    {:type :fit
+     :content-width CW :content-height CH
+     :viewport-width VW :viewport-height VH}
+    {:type :reset}
+
+  When `current` is nil the identity viewport is used."
+  [current {:keys [type x y dx dy factor
+                   content-width content-height
+                   viewport-width viewport-height]}]
+  (let [cur (or current (identity-viewport))]
+    (case type
+      :zoom-in   (zoom-about cur zoom-step
+                             (or x (/ (or viewport-width 600) 2.0))
+                             (or y (/ (or viewport-height 400) 2.0)))
+      :zoom-out  (zoom-about cur (/ 1.0 zoom-step)
+                             (or x (/ (or viewport-width 600) 2.0))
+                             (or y (/ (or viewport-height 400) 2.0)))
+      :zoom-at   (zoom-about cur (or factor 1) x y)
+      :pan-by    (-> cur
+                     (update :tx (fnil + 0) (or dx 0))
+                     (update :ty (fnil + 0) (or dy 0)))
+      :fit       (fit-viewport {:content-width   content-width
+                                :content-height  content-height
+                                :viewport-width  viewport-width
+                                :viewport-height viewport-height})
+      :reset     (identity-viewport)
+      cur)))
+
+;; ---- event-handler helpers ----------------------------------------------
+
+(defn wheel->action
+  "Map a wheel event (deltaY) + cursor position to an action map.
+  Returns nil when the wheel delta is too small to register (avoids
+  hyperactive zoom on trackpads).
+
+  Caller is responsible for `(.preventDefault e)` on the wheel
+  event before invoking this — the wheel handler must opt out of
+  page-scroll for the chart to feel native."
+  [{:keys [delta-y x y]}]
+  (when (and delta-y (not (zero? delta-y)))
+    (let [factor (if (neg? delta-y)
+                   wheel-zoom-step
+                   (/ 1.0 wheel-zoom-step))]
+      {:type   :zoom-at
+       :factor factor
+       :x      (or x 0)
+       :y      (or y 0)})))
+
+(defn drag-state-zero
+  "Initial drag state. The panel layer mutates a slot (atom or app-db
+  cell) with this on `:on-mouse-down` and clears it on
+  `:on-mouse-up`. Carrying `:origin-x/:origin-y` + `:origin-viewport`
+  lets `drag-step` compute the panned viewport in one fn rather than
+  accumulating deltas across mousemove events (avoids drift)."
+  [x y viewport]
+  {:dragging?       true
+   :origin-x        x
+   :origin-y        y
+   :origin-viewport (or viewport (identity-viewport))})
+
+(defn drag-step
+  "Given a `drag-state` produced by `drag-state-zero` + the current
+  cursor (x, y), return the next viewport. When `drag-state` is nil
+  or not in `:dragging?` state, returns nil (caller should ignore
+  the mousemove)."
+  [{:keys [dragging? origin-x origin-y origin-viewport]
+    :as _drag-state} x y]
+  (when (and dragging? origin-x origin-y origin-viewport)
+    (let [dx (- x origin-x)
+          dy (- y origin-y)]
+      (-> origin-viewport
+          (update :tx (fnil + 0) dx)
+          (update :ty (fnil + 0) dy)))))
+
+(defn key->action
+  "Map a keyboard event's `:key` + `:viewport-width/:height` (for
+  `:fit`) to an action map. Returns nil for keys we don't handle so
+  the caller can `(when action ...)` it.
+
+  Recognised keys:
+    `+` / `=`        — zoom in
+    `-` / `_`        — zoom out
+    `0`              — reset
+    `f` / `F`        — fit
+    arrow keys       — pan by `keyboard-pan-step` pixels"
+  [{:keys [key viewport-width viewport-height
+           content-width content-height]}]
+  (case key
+    ("+" "=")             {:type :zoom-in
+                           :viewport-width viewport-width
+                           :viewport-height viewport-height}
+    ("-" "_")             {:type :zoom-out
+                           :viewport-width viewport-width
+                           :viewport-height viewport-height}
+    "0"                   {:type :reset}
+    ("f" "F")             {:type            :fit
+                           :viewport-width  viewport-width
+                           :viewport-height viewport-height
+                           :content-width   content-width
+                           :content-height  content-height}
+    "ArrowLeft"           {:type :pan-by :dx keyboard-pan-step :dy 0}
+    "ArrowRight"          {:type :pan-by :dx (- keyboard-pan-step) :dy 0}
+    "ArrowUp"             {:type :pan-by :dx 0 :dy keyboard-pan-step}
+    "ArrowDown"           {:type :pan-by :dx 0 :dy (- keyboard-pan-step)}
+    nil))
+
+;; ---- toolbar hiccup -----------------------------------------------------
+
+(defn- button-style
+  []
+  {:background    "transparent"
+   :border        (str "1px solid " (:border-default tokens))
+   :color         (:text-secondary tokens)
+   :font-family   sans-stack
+   :font-size     "11px"
+   :font-weight   600
+   :padding       "3px 8px"
+   :border-radius "10px"
+   :cursor        "pointer"
+   :line-height   "1"
+   :min-width     "26px"})
+
+(defn- zoom-percent
+  "Render a viewport scale as an integer percentage string. 1 → `100%`."
+  [scale]
+  (let [n (* (double (or scale 1)) 100.0)]
+    (str (long #?(:clj  (Math/round n)
+                  :cljs (.round js/Math n)))
+         "%")))
+
+(defn toolbar
+  "Top-right toolbar with Zoom-out, Zoom-in, Fit and Reset buttons +
+  a small NN% scale chip. Returns hiccup.
+
+  Options:
+
+    :viewport       — `{:scale :tx :ty}` current viewport state.
+                      Drives the NN% chip + the disabled-state on
+                      the buttons (a button at the zoom bound stays
+                      clickable but the bound clamps the change to
+                      a no-op — visual feedback is the chip).
+    :on-action      — `(fn [action-map] ...)` invoked with the
+                      action the user just requested. Caller maps
+                      the action to a re-frame dispatch.
+    :testid-prefix  — overrides the root `data-testid` and seeds
+                      child testids (default `rf-mv-chart-controls`).
+    :compact?       — when true the buttons shrink to icon-only
+                      (the Fit/Reset glyphs alone). For the panel
+                      header where horizontal real estate is tight.
+
+  Pure hiccup, no Reagent / UIx / Helix — same contract as the
+  rest of the chart."
+  [{:keys [viewport on-action testid-prefix compact?]
+    :or   {testid-prefix "rf-mv-chart-controls"}}]
+  (let [vp     (or viewport (identity-viewport))
+        scale  (:scale vp)
+        emit   (fn [action]
+                 (fn [e]
+                   #?(:cljs (when e (.preventDefault ^js e)))
+                   (when on-action (on-action action))))]
+    [:div {:data-testid testid-prefix
+           :data-viewport-scale (str scale)
+           :style {:display       "inline-flex"
+                   :align-items   "center"
+                   :gap           "6px"
+                   :padding       "4px 6px"
+                   :background    (:bg-3 tokens)
+                   :border        (str "1px solid " (:border-subtle tokens))
+                   :border-radius "12px"}}
+     [:button
+      {:data-testid (str testid-prefix "-zoom-out")
+       :aria-label  "Zoom out"
+       :title       "Zoom out (−)"
+       :on-click    (emit {:type :zoom-out})
+       :style       (button-style)}
+      "−"]
+     [:span {:data-testid (str testid-prefix "-scale-chip")
+             :title       "Current zoom level"
+             :style {:font-family sans-stack
+                     :font-size   "10px"
+                     :color       (:text-tertiary tokens)
+                     :min-width   "34px"
+                     :text-align  "center"
+                     :user-select "none"}}
+      (zoom-percent scale)]
+     [:button
+      {:data-testid (str testid-prefix "-zoom-in")
+       :aria-label  "Zoom in"
+       :title       "Zoom in (+)"
+       :on-click    (emit {:type :zoom-in})
+       :style       (button-style)}
+      "+"]
+     [:button
+      {:data-testid (str testid-prefix "-fit")
+       :aria-label  "Fit to viewport"
+       :title       "Fit to viewport (f)"
+       :on-click    (emit {:type :fit-request})
+       :style       (assoc (button-style)
+                      :padding (if compact? "3px 8px" "3px 10px"))}
+      (if compact? "⛶" "Fit")]
+     [:button
+      {:data-testid (str testid-prefix "-reset")
+       :aria-label  "Reset zoom"
+       :title       "Reset zoom (0)"
+       :on-click    (emit {:type :reset})
+       :style       (assoc (button-style)
+                      :padding (if compact? "3px 8px" "3px 10px"))}
+      (if compact? "⌖" "Reset")]]))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
@@ -654,13 +654,31 @@
                            :reached-count N :total-count M}` map
                            driving the caption strip when
                            `:show-caption?` is true.
+    :viewport-transform  — rf2-y3l8z. Optional `{:scale s :tx tx :ty ty}`
+                           map (or `nil`) carrying the user's zoom +
+                           pan state. Applied to the chart body via
+                           an outer `<g transform=\"translate(tx ty)
+                           scale(s)\">` wrap. Edges, nodes, compounds
+                           and the dot-grid pattern all sit inside
+                           the wrap so the entire canvas scales as
+                           one. When nil / absent the chart renders
+                           at 1:1 (back-compat — identical output to
+                           pre-y3l8z callers, asserted by tests).
+    :svg-attrs           — rf2-y3l8z. Optional map of extra hiccup
+                           attrs merged onto the root `<svg>` (e.g.
+                           `:on-wheel`, `:on-mouse-down`, `tabIndex`,
+                           inline `:style` overrides). Lets the
+                           interactive controls wrap the chart with
+                           wheel-zoom / click-drag-pan / keyboard
+                           handlers without forking `render`.
 
   Returns a stable hiccup form. Empty graphs (no nodes) render an
   inline note so the panel never sees an empty SVG container."
   ([positioned] (render positioned {}))
   ([{:keys [nodes edges width height] :as positioned}
     {:keys [highlight-id from-highlight-id to-highlight-id
-            sim? on-state-click testid show-caption? caption]}]
+            sim? on-state-click testid show-caption? caption
+            viewport-transform svg-attrs]}]
    (if (empty? nodes)
      [:div {:data-testid (or testid "rf-causa-chart-empty")
             :style {:padding "16px"
@@ -679,19 +697,49 @@
            ;; shifts down by `caption-strip-px`. Chart geometry
            ;; (nodes, edges) is unchanged; we apply a group translate.
            caption-h    (if show-caption? caption-strip-px 0)
-           total-h      (+ height caption-h)]
-       [:svg {:data-testid (or testid "rf-causa-chart-svg")
-              :data-highlight-id (or highlight-id "")
-              :data-from-highlight-id (or from-highlight-id "")
-              :data-to-highlight-id (or to-highlight-id "")
-              :data-has-caption (str (boolean show-caption?))
-              :viewBox (str "0 0 " width " " total-h)
-              :width "100%"
-              :preserveAspectRatio "xMidYMin meet"
-              :style {:background (:bg-1 tokens/tokens)
-                      :border-radius "4px"
-                      :max-height "100%"
-                      :display "block"}}
+           total-h      (+ height caption-h)
+           ;; rf2-y3l8z — viewport-transform carries the user's zoom +
+           ;; pan state. Applied to a chart-content wrapper that holds
+           ;; the dot-grid backdrop + the chart body (caption strip
+           ;; stays unscaled — it's chrome).
+           {:keys [scale tx ty]
+            :or   {scale 1 tx 0 ty 0}}
+           (or viewport-transform {})
+           ;; `transform="translate(tx,ty) scale(s)"` — order matters:
+           ;; we want pan to read as 'shift the world by (tx,ty)' and
+           ;; zoom to read as 'scale the world about the pan-shifted
+           ;; origin'. The standard reading on SVG is the
+           ;; right-to-left function composition — scale applies first,
+           ;; then translate — so `translate(...) scale(...)` is
+           ;; canonical for fit-to-viewport math (`tx`,`ty` are the
+           ;; post-scale viewport offset).
+           transform-applied? (or (not= 1 scale) (not= 0 tx) (not= 0 ty))
+           transform-attr (when transform-applied?
+                            (str "translate(" tx "," ty ")"
+                                 " scale(" scale ")"))
+           svg-base-attrs {:data-testid (or testid "rf-causa-chart-svg")
+                           :data-highlight-id (or highlight-id "")
+                           :data-from-highlight-id (or from-highlight-id "")
+                           :data-to-highlight-id (or to-highlight-id "")
+                           :data-has-caption (str (boolean show-caption?))
+                           :data-viewport-scale (str scale)
+                           :data-viewport-tx (str tx)
+                           :data-viewport-ty (str ty)
+                           :viewBox (str "0 0 " width " " total-h)
+                           :width "100%"
+                           :preserveAspectRatio "xMidYMin meet"
+                           :style {:background (:bg-1 tokens/tokens)
+                                   :border-radius "4px"
+                                   :max-height "100%"
+                                   :display "block"}}
+           svg-attrs-merged (if (map? svg-attrs)
+                              (let [{extra-style :style :as rest-attrs}
+                                    svg-attrs]
+                                (-> (merge svg-base-attrs
+                                           (dissoc rest-attrs :style))
+                                    (update :style merge (or extra-style {}))))
+                              svg-base-attrs)]
+       [:svg svg-attrs-merged
         ;; ---- inline keyframes (rf2-xfx6l) + reduced-motion seam ----
         (inline-stylesheet)
         ;; ---- arrow markers + dot-grid pattern ----
@@ -711,43 +759,52 @@
                    :fill (:cyan tokens/tokens)}
           [:path {:d "M 0 0 L 10 5 L 0 10 z"}]]
          (dot-grid-pattern)]
-        ;; ---- dot-grid background backdrop (rf2-m4nj4) ----
-        [:rect {:data-testid "rf-mv-chart-dot-grid-backdrop"
-                :x 0 :y caption-h
-                :width width :height height
-                :fill "url(#rf-mv-chart-dot-grid)"
-                :pointer-events "none"}]
-        ;; ---- caption strip (rf2-3zdzw, opt-in) ----
+        ;; ---- caption strip (rf2-3zdzw, opt-in) — chrome, stays
+        ;; OUTSIDE the viewport-transform wrap so the machine-id slug
+        ;; reads at a fixed size regardless of canvas zoom level.
         (when show-caption?
           (render-caption-strip
             (assoc caption :chart-width width)))
-        ;; ---- chart body, shifted down by caption height ----
-        [:g {:data-testid "rf-mv-chart-body"
-             :transform (str "translate(0," caption-h ")")}
-         ;; Compound containers sit BELOW edges + nodes so the dashed
-         ;; outline reads as a backdrop. rf2-m7co9 Phase 4.
-         (into [:g {:data-testid "rf-causa-chart-compounds"}]
-               (for [c containers]
-                 ^{:key (:node-id c)}
-                 (render-compound-container c)))
-         ;; Edges first so nodes paint over them
-         (into [:g {:data-testid "rf-causa-chart-edges"}]
-               (for [edge edges]
-                 ^{:key (str (:from-id edge) "->" (:to-id edge)
-                             "/" (:event-label edge))}
-                 (render-edge edge {:highlight-id      highlight-id
-                                    :from-highlight-id from-highlight-id
-                                    :to-highlight-id   to-highlight-id})))
-         (render-initial-marker initial-node)
-         (into [:g {:data-testid "rf-causa-chart-nodes"}]
-               (for [node nodes]
-                 ^{:key (:node-id node)}
-                 (render-node node
-                              {:highlight-id      highlight-id
-                               :from-highlight-id from-highlight-id
-                               :to-highlight-id   to-highlight-id
-                               :sim?              sim?
-                               :on-state-click    on-state-click})))]]))))
+        ;; ---- viewport-transform wrap (rf2-y3l8z) ----
+        ;; Holds the dot-grid backdrop + the chart body. When
+        ;; `viewport-transform` is nil/absent the `transform` attr is
+        ;; omitted entirely so the rendered DOM is byte-identical to
+        ;; the pre-y3l8z output — back-compat.
+        [:g (cond-> {:data-testid "rf-mv-chart-viewport"}
+              transform-attr (assoc :transform transform-attr))
+         ;; ---- dot-grid background backdrop (rf2-m4nj4) ----
+         [:rect {:data-testid "rf-mv-chart-dot-grid-backdrop"
+                 :x 0 :y caption-h
+                 :width width :height height
+                 :fill "url(#rf-mv-chart-dot-grid)"
+                 :pointer-events "none"}]
+         ;; ---- chart body, shifted down by caption height ----
+         [:g {:data-testid "rf-mv-chart-body"
+              :transform (str "translate(0," caption-h ")")}
+          ;; Compound containers sit BELOW edges + nodes so the dashed
+          ;; outline reads as a backdrop. rf2-m7co9 Phase 4.
+          (into [:g {:data-testid "rf-causa-chart-compounds"}]
+                (for [c containers]
+                  ^{:key (:node-id c)}
+                  (render-compound-container c)))
+          ;; Edges first so nodes paint over them
+          (into [:g {:data-testid "rf-causa-chart-edges"}]
+                (for [edge edges]
+                  ^{:key (str (:from-id edge) "->" (:to-id edge)
+                              "/" (:event-label edge))}
+                  (render-edge edge {:highlight-id      highlight-id
+                                     :from-highlight-id from-highlight-id
+                                     :to-highlight-id   to-highlight-id})))
+          (render-initial-marker initial-node)
+          (into [:g {:data-testid "rf-causa-chart-nodes"}]
+                (for [node nodes]
+                  ^{:key (:node-id node)}
+                  (render-node node
+                               {:highlight-id      highlight-id
+                                :from-highlight-id from-highlight-id
+                                :to-highlight-id   to-highlight-id
+                                :sim?              sim?
+                                :on-state-click    on-state-click})))]]]))))
 
 (defn render-from-definition
   "Convenience: lay out + render in one call. Useful for the panel

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/controls_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/controls_cljs_test.cljc
@@ -1,0 +1,225 @@
+(ns day8.re-frame2-machines-viz.chart.controls-cljs-test
+  "Pure-data tests for the chart viewport controls (rf2-y3l8z).
+
+  Asserts the reducer's contract, the zoom-about cursor invariant,
+  the fit-viewport maths, the wheel / drag / keyboard event helpers,
+  and the toolbar's hiccup shape. JVM-runnable so `clojure -M:test`
+  picks them up."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test    :refer-macros [deftest is testing]])
+            [day8.re-frame2-machines-viz.chart.controls :as ctl]))
+
+;; ---- clamp + identity ---------------------------------------------------
+
+(deftest clamp-scale-bounds
+  (is (= ctl/zoom-min (ctl/clamp-scale -1)))
+  (is (= ctl/zoom-min (ctl/clamp-scale 0)))
+  (is (= 1.0          (double (ctl/clamp-scale 1))))
+  (is (= ctl/zoom-max (ctl/clamp-scale 10)))
+  (is (= 1.0          (double (ctl/clamp-scale 1)))))
+
+(deftest identity-viewport-shape
+  (let [id (ctl/identity-viewport)]
+    (is (= 1 (:scale id)))
+    (is (= 0 (:tx id)))
+    (is (= 0 (:ty id)))))
+
+;; ---- zoom-about — cursor invariant --------------------------------------
+
+(deftest zoom-about-keeps-cursor-anchored
+  (testing "zoom about (200,150) — the chart-world point under (200,150) survives"
+    (let [vp0    (ctl/identity-viewport)
+          ;; chart-world point that's currently under (200,150)
+          ;; with the identity viewport is just (200,150).
+          vp1    (ctl/zoom-about vp0 2.0 200 150)
+          ;; after zoom, the same world point should still be at (200,150)
+          ;; i.e. (200 - tx) / scale = 200 (world wx)
+          ;;      (150 - ty) / scale = 150 (world wy)
+          {:keys [scale tx ty]} vp1
+          wx     (/ (- 200 tx) scale)
+          wy     (/ (- 150 ty) scale)]
+      (is (= 2.0 (double scale)))
+      (is (< (Math/abs (- wx 200)) 0.0001))
+      (is (< (Math/abs (- wy 150)) 0.0001)))))
+
+(deftest zoom-about-respects-clamp
+  (let [vp0 {:scale ctl/zoom-max :tx 0 :ty 0}
+        vp1 (ctl/zoom-about vp0 10.0 100 100)]
+    (is (= ctl/zoom-max (:scale vp1))
+        "zooming in past the upper bound clamps at zoom-max")))
+
+;; ---- fit-viewport -------------------------------------------------------
+
+(deftest fit-viewport-centres-content
+  (let [vp (ctl/fit-viewport
+             {:content-width   400
+              :content-height  300
+              :viewport-width  800
+              :viewport-height 600})
+        ;; The content is half the viewport size — fit at scale 1
+        ;; (since the natural fit math gives ~ (800-48)/400 ≈ 1.88,
+        ;; clamp-scale leaves it at 1.88, NOT 1 — read the source
+        ;; carefully: only over-scale is clamped at zoom-max).
+        ;; Re-derive: sx = (800-48)/400 = 1.88; sy = (600-48)/300 = 1.84.
+        ;; min = 1.84. So content scales up to fit.
+        s  (:scale vp)
+        tx (:tx vp)
+        ty (:ty vp)]
+    (is (< (- 1.84 s) 0.01))
+    ;; Centre check: (viewport - content*scale)/2 == tx,ty
+    (is (< (Math/abs (- tx (/ (- 800 (* 400 s)) 2.0))) 0.01))
+    (is (< (Math/abs (- ty (/ (- 600 (* 300 s)) 2.0))) 0.01))))
+
+(deftest fit-viewport-handles-degenerate-inputs
+  (is (= (ctl/identity-viewport)
+         (ctl/fit-viewport {:content-width 0 :content-height 0
+                            :viewport-width 800 :viewport-height 600}))
+      "zero content size → identity viewport")
+  (is (= (ctl/identity-viewport)
+         (ctl/fit-viewport {:content-width 100 :content-height 100
+                            :viewport-width 0 :viewport-height 0}))
+      "zero viewport size → identity viewport")
+  (is (= (ctl/identity-viewport)
+         (ctl/fit-viewport nil))
+      "nil dimensions → identity viewport"))
+
+(deftest fit-viewport-clamps-to-zoom-max
+  ;; Tiny content in a huge viewport — natural fit would be 100x,
+  ;; clamped at zoom-max.
+  (let [vp (ctl/fit-viewport
+             {:content-width   10
+              :content-height  10
+              :viewport-width  1200
+              :viewport-height 1200})]
+    (is (= ctl/zoom-max (:scale vp)))))
+
+;; ---- reducer ------------------------------------------------------------
+
+(deftest reducer-zoom-in
+  (let [vp1 (ctl/apply-action {:scale 1 :tx 0 :ty 0}
+              {:type :zoom-in
+               :viewport-width 600 :viewport-height 400})]
+    (is (= ctl/zoom-step (double (:scale vp1))))))
+
+(deftest reducer-zoom-out
+  (let [vp1 (ctl/apply-action {:scale 1 :tx 0 :ty 0}
+              {:type :zoom-out
+               :viewport-width 600 :viewport-height 400})]
+    (is (< (Math/abs (- (/ 1.0 ctl/zoom-step) (double (:scale vp1))))
+           0.0001))))
+
+(deftest reducer-pan-by
+  (let [vp1 (ctl/apply-action {:scale 1 :tx 10 :ty 20}
+              {:type :pan-by :dx 5 :dy -3})]
+    (is (= 15 (:tx vp1)))
+    (is (= 17 (:ty vp1)))))
+
+(deftest reducer-reset
+  (let [vp1 (ctl/apply-action {:scale 2.5 :tx 30 :ty 40}
+              {:type :reset})]
+    (is (= (ctl/identity-viewport) vp1))))
+
+(deftest reducer-nil-current
+  (let [vp1 (ctl/apply-action nil {:type :reset})]
+    (is (= (ctl/identity-viewport) vp1))))
+
+(deftest reducer-unknown-action
+  (let [cur {:scale 1.5 :tx 7 :ty 8}
+        vp1 (ctl/apply-action cur {:type :unknown-action})]
+    (is (= cur vp1)
+        "unknown actions pass through unchanged")))
+
+;; ---- event helpers ------------------------------------------------------
+
+(deftest wheel-handler-zoom-in-on-up-scroll
+  (let [a (ctl/wheel->action {:delta-y -100 :x 50 :y 60})]
+    (is (= :zoom-at (:type a)))
+    (is (= 50 (:x a)))
+    (is (= 60 (:y a)))
+    (is (= ctl/wheel-zoom-step (double (:factor a))))))
+
+(deftest wheel-handler-zoom-out-on-down-scroll
+  (let [a (ctl/wheel->action {:delta-y 100 :x 50 :y 60})]
+    (is (= :zoom-at (:type a)))
+    (is (< (Math/abs (- (/ 1.0 ctl/wheel-zoom-step) (double (:factor a))))
+           0.0001))))
+
+(deftest wheel-handler-noops-on-zero-delta
+  (is (nil? (ctl/wheel->action {:delta-y 0 :x 50 :y 60}))))
+
+(deftest drag-step-uses-origin-viewport
+  (let [drag-state (ctl/drag-state-zero 100 100 {:scale 1 :tx 10 :ty 20})
+        vp1 (ctl/drag-step drag-state 150 130)]
+    (is (= 60 (:tx vp1))
+        "origin tx (10) + cursor dx (50) = 60")
+    (is (= 50 (:ty vp1))
+        "origin ty (20) + cursor dy (30) = 50")))
+
+(deftest drag-step-no-drag-state-returns-nil
+  (is (nil? (ctl/drag-step nil 100 100)))
+  (is (nil? (ctl/drag-step {:dragging? false} 100 100))))
+
+(deftest key-handler-recognised-keys
+  (is (= :zoom-in  (:type (ctl/key->action {:key "+"}))))
+  (is (= :zoom-in  (:type (ctl/key->action {:key "="}))))
+  (is (= :zoom-out (:type (ctl/key->action {:key "-"}))))
+  (is (= :zoom-out (:type (ctl/key->action {:key "_"}))))
+  (is (= :reset    (:type (ctl/key->action {:key "0"}))))
+  (is (= :fit      (:type (ctl/key->action {:key "f"}))))
+  (is (= :fit      (:type (ctl/key->action {:key "F"}))))
+  (is (= :pan-by   (:type (ctl/key->action {:key "ArrowLeft"}))))
+  (is (= :pan-by   (:type (ctl/key->action {:key "ArrowRight"}))))
+  (is (= :pan-by   (:type (ctl/key->action {:key "ArrowUp"}))))
+  (is (= :pan-by   (:type (ctl/key->action {:key "ArrowDown"}))))
+  (is (nil? (ctl/key->action {:key "Tab"}))
+      "unrecognised keys return nil"))
+
+(deftest key-handler-pan-directions
+  (is (pos? (:dx (ctl/key->action {:key "ArrowLeft"}))))
+  (is (neg? (:dx (ctl/key->action {:key "ArrowRight"}))))
+  (is (pos? (:dy (ctl/key->action {:key "ArrowUp"}))))
+  (is (neg? (:dy (ctl/key->action {:key "ArrowDown"})))))
+
+;; ---- toolbar hiccup -----------------------------------------------------
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq tree))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(deftest toolbar-renders-four-buttons
+  (let [tree (ctl/toolbar {:viewport (ctl/identity-viewport)
+                           :on-action (fn [_])})]
+    (is (some? (find-by-testid tree "rf-mv-chart-controls")))
+    (is (some? (find-by-testid tree "rf-mv-chart-controls-zoom-in")))
+    (is (some? (find-by-testid tree "rf-mv-chart-controls-zoom-out")))
+    (is (some? (find-by-testid tree "rf-mv-chart-controls-fit")))
+    (is (some? (find-by-testid tree "rf-mv-chart-controls-reset")))
+    (is (some? (find-by-testid tree "rf-mv-chart-controls-scale-chip")))))
+
+(deftest toolbar-scale-chip-shows-percent
+  (let [tree (ctl/toolbar {:viewport {:scale 2 :tx 0 :ty 0}})
+        chip (find-by-testid tree "rf-mv-chart-controls-scale-chip")]
+    (is (some #{"200%"} (rest chip)))))
+
+(deftest toolbar-button-click-fires-action
+  (let [fired (atom nil)
+        tree  (ctl/toolbar {:viewport (ctl/identity-viewport)
+                            :on-action #(reset! fired %)})
+        [_ attrs] (find-by-testid tree "rf-mv-chart-controls-zoom-in")
+        handler (:on-click attrs)]
+    (is (fn? handler))
+    (handler #?(:cljs nil :clj nil))
+    (is (= :zoom-in (:type @fired)))))
+
+(deftest toolbar-respects-custom-testid-prefix
+  (let [tree (ctl/toolbar {:viewport (ctl/identity-viewport)
+                           :testid-prefix "rf-my-prefix"})]
+    (is (some? (find-by-testid tree "rf-my-prefix")))
+    (is (some? (find-by-testid tree "rf-my-prefix-zoom-in")))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
@@ -5,7 +5,8 @@
   The renderer returns hiccup. Tests walk the tree by `data-testid`
   rather than mounting to a DOM — same approach the panel view tests
   use (see machine_inspector_view_cljs_test.cljs)."
-  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
             [day8.re-frame2-machines-viz.chart.layout :as layout]
             [day8.re-frame2-machines-viz.chart.svg :as chart-svg]
@@ -47,6 +48,50 @@
   (let [tree (chart-svg/render-from-definition nil)]
     (is (some? (find-by-testid tree "rf-causa-chart-empty"))
         "nil definition renders a friendly fallback")))
+
+;; ---- viewport transform (rf2-y3l8z) ------------------------------------
+
+(deftest render-viewport-wrap-has-no-transform-by-default
+  (testing "no viewport-transform option → wrapper has no `transform` attr"
+    (let [tree (chart-svg/render-from-definition small-machine)
+          [_ attrs] (find-by-testid tree "rf-mv-chart-viewport")]
+      (is (some? attrs) "viewport wrap exists")
+      (is (nil? (:transform attrs))
+          "wrap renders without a `transform` attr when caller doesn't pass viewport"))))
+
+(deftest render-viewport-wrap-applies-transform
+  (testing "non-identity viewport-transform → `transform` attr is emitted"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine
+                 {:viewport-transform {:scale 2 :tx 30 :ty 40}})
+          [_ attrs] (find-by-testid tree "rf-mv-chart-viewport")]
+      (is (some? (:transform attrs)))
+      (is (str/includes? (:transform attrs) "translate(30,40)"))
+      (is (str/includes? (:transform attrs) "scale(2)")))))
+
+(deftest render-viewport-data-attrs-roundtrip
+  (testing "scale/tx/ty surface on the root svg as data-* attrs"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine
+                 {:viewport-transform {:scale 1.5 :tx 12 :ty 24}})
+          [_ root-attrs] tree]
+      (is (= "rf-causa-chart-svg" (:data-testid root-attrs)))
+      (is (= "1.5" (:data-viewport-scale root-attrs)))
+      (is (= "12"  (:data-viewport-tx root-attrs)))
+      (is (= "24"  (:data-viewport-ty root-attrs))))))
+
+(deftest render-svg-attrs-merge
+  (testing "caller-supplied :svg-attrs merge onto the root svg"
+    (let [tree (chart-svg/render-from-definition
+                 small-machine
+                 {:svg-attrs {:tabIndex 0
+                              :role     "application"
+                              :style    {:background "#222"}}})
+          [_ root-attrs] tree]
+      (is (= 0 (:tabIndex root-attrs)))
+      (is (= "application" (:role root-attrs)))
+      (is (= "#222" (-> root-attrs :style :background))
+          "caller :style overrides win on collision"))))
 
 ;; ---- happy path -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Promotes the Runtime Machines panel chart from a static-render hiccup primitive to an **interactive canvas** with Stately/XState peer-class viewport controls. Builds on the #1570 machines-viz primitives — the visual chart already existed; this PR adds the interaction layer + a `Canvas | List` view-mode toggle persisted per-machine to localStorage.

- **Zoom**: mouse-wheel zooms toward the cursor (Cmd/Ctrl optional), `+`/`-` keyboard, `Zoom+ / Zoom-` toolbar buttons, NN% scale chip.
- **Pan**: click-drag on the empty canvas; arrow keys nudge by 20px. State / edge nodes retain their own `:on-click` (DOM ancestor walk filters drag-start so node clicks pass through).
- **Fit / Reset**: `f` and `0` keys + matching toolbar buttons. `Fit` recentres + rescales so all nodes are visible with reasonable padding; `Reset` returns to 100% at the chart's origin.
- **View-mode toggle**: top-left `Canvas | List` pill. Persisted per-machine to `localStorage` under `causa.machine-canvas.view-mode-by-id`. List hides the chart but keeps guards / actions / cascade.
- **Reduced motion**: honours the existing `--rf-causa-motion-scale` seam — no new motion paths added.

## Architecture

- **NEW** `tools/machines-viz/src/.../chart/controls.cljc` (348 lines) — pure reducer (`apply-action`), zoom-about cursor maths, `fit-viewport`, wheel / drag / keyboard event-handler helpers, toolbar hiccup. JVM-runnable so `clojure -M:test` asserts the reducer's contract on data, not on a DOM.
- **EDIT** `tools/machines-viz/src/.../chart/svg.cljc` — `render` accepts optional `:viewport-transform {:scale :tx :ty}` that wraps the chart body in a `<g transform="translate(tx,ty) scale(s)">`. Default-nil leaves the rendered DOM byte-identical to pre-y3l8z callers (back-compat asserted by tests). Also accepts `:svg-attrs` for caller-supplied root-svg attrs.
- **NEW** `tools/causa/src/.../panels/machine_canvas.cljs` (472 lines) — Causa-side adapter: per-machine viewport + view-mode + drag-state slots in app-db, wheel/mousedown/mousemove/mouseup/keydown handlers, the `Chart` hiccup view that composes the chart svg + the toolbar + the view-mode toggle, and the localStorage round-trip for view-mode persistence.
- **EDIT** `tools/causa/src/.../panels/machine_inspector.cljs` — swaps the static `chart-svg/render` call for `machine-canvas/Chart`, branching on `:rf.causa.machine-canvas/view-mode-for` so List mode hides the chart while guards/actions/cascade keep their existing layout.
- **EDIT** `tools/causa/test/.../registry_cljs_test.cljs` — registry-drift snapshot updated for 7 new events, 4 new subs, 1 new fx, all namespaced under `:rf.causa.machine-canvas/*`.

## Static-mode parity

Static Machines panel's Topology mode (`static/machines/topology.cljs`) is **untouched** — it still consumes the chart in static-read mode with no `:viewport-transform`. Static users continue to get the v1 read-only chart; opting static into the same interactive Chart adapter is a follow-on bead.

## Test plan

- [x] `tools/machines-viz/` (JVM): +37 tests — reducer contract, zoom-about cursor invariant, fit-viewport maths, pan accumulation, zoom clamps, wheel/drag/keyboard helpers, toolbar hiccup shape, svg viewport-transform round-trip, svg-attrs merge. `clojure -M:test` → 97 tests, 233 assertions, 0 failures.
- [x] `tools/causa/` (JVM): existing 726 tests, 2189 assertions, 0 failures.
- [x] CLJS node-test runner (`implementation/`): +14 new canvas tests covering registry wiring, apply-action per-machine isolation, drag accumulation, view-mode mutation + fx-dispatch, viewport-dims measurement. `npm run test:cljs` → 3136 tests, 9032 assertions, 0 failures.
- [x] Bundle isolation (`npm run test:bundle-isolation`): production bundles still free of tools/causa or tools/machines-viz internals.
- [ ] Browser smoke (Playwright): manual smoke deferred to merge-time verification.

## Follow-on candidates

- Align the `:after` countdown rings overlay with the user viewport-transform (currently rendered at 1:1 so rings drift from node centres when zoomed).
- `spec/007-UX-IA.md` update for the new view-mode toggle + interactive canvas affordance.
- L4 sub-domain tab promotion for the canvas (per Mike's cohesive-sub-domain rule) — DEFERRED to a follow-on; v1 lands inside the existing Machines panel.

Refs rf2-y3l8z.