### PR TITLE
test(causa): add :routing to PANEL_HANDOFFS (rf2-tgp6i)

### DIFF
--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -12,10 +12,11 @@ const {
 } = require('../../../../testbeds/spec-helpers.cjs');
 
 // Post rf2-xy4yb (4-layer chrome refactor): the legacy 15-panel
-// sidebar + bottom rail is dead. The L3 tab bar exposes 6 tabs only:
-// event / app-db / views / trace / machines / issues (spec/018 §5).
-// Panels without a tab no longer have a UI handoff and are dropped
-// from the shell-sweep scenario.
+// sidebar + bottom rail is dead. The L3 tab bar exposes 7 tabs:
+// event / app-db / views / trace / machines / routing / issues
+// (spec/018 §5; spec/007-UX-IA.md §L3). Panels without a tab no
+// longer have a UI handoff and are dropped from the shell-sweep
+// scenario.
 const PANEL_HANDOFFS = [
   ['event', 'rf-causa-event-detail'],
   ['app-db', 'rf-causa-app-db-diff'],
@@ -25,6 +26,10 @@ const PANEL_HANDOFFS = [
   ['views', 'rf-causa-views'],
   ['trace', 'rf-causa-trace'],
   ['machines', 'rf-causa-machine-inspector'],
+  // The :routing tab (promoted under rf2-nrbs9 + reshaped under
+  // rf2-lq0ef) is the focused-event navigation lens. Its root view
+  // renders the `rf-causa-routing` testid (panels/routing.cljs).
+  ['routing', 'rf-causa-routing'],
   ['issues', 'rf-causa-issues-ribbon'],
 ];
 


### PR DESCRIPTION
## Summary

- `PANEL_HANDOFFS` in `tools/causa/testbeds/feature_matrix/scenarios.cjs` covered 6 of the 7 L3 tabs. The Routing tab (promoted under rf2-nrbs9, reshaped under rf2-lq0ef) was missing, so the `feature matrix shell and panel handoff` scenario silently skipped it.
- Adds `['routing', 'rf-causa-routing']` between `:machines` and `:issues`, matching the canonical tab order in `shell.cljs:155-161` (`spec/007-UX-IA.md` §L3).
- Refreshes the leading comment from "6 tabs only" -> "7 tabs" and cites the spec sources for the new entry.

## Why

Closes a silent 7-tab-vs-6-tab drift in the canonical shell-feature-sweep. Without this entry, a Routing panel regression (missing `rf-causa-routing` testid, broken focused-event lens) would not surface in the matrix gate.

## Test plan

- [x] `npm run test:causa-feature-gate` -> 14 scenarios, 0 failures, 13 matrix rows covered. Exit 0.
- [x] Shell sweep now clicks all 7 L3 tabs and verifies each panel handoff (event / app-db / views / trace / machines / routing / issues).

## Cite

- rf2-tgp6i — bead
- rf2-nrbs9 — Routing promotion to its own L3 tab
- rf2-lq0ef (#1542) — Routes lens reshape
- rf2-4yxcf — discovering audit
- `spec/007-UX-IA.md` §L3 — canonical 7-tab list
- `tools/causa/src/.../panels/routing.cljs:224` — `rf-causa-routing` testid