### PR TITLE
spec(causa): Lock #14 Two modes + 018 §Static + 003 §Static Machines (rf2-byd1f + rf2-swjbi + rf2-wg6sq)

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -118,20 +118,116 @@ tools/causa/  ─requires→  implementation/machines/
   machines per [`018-Event-Spine.md`](018-Event-Spine.md) §8 I3.
 
 <!-- ============================================================ -->
-<!--  STATIC RE-HOST REFERENCE (rf2-r4nao — deferred)               -->
+<!--  STATIC MACHINES SURFACE (normative; shipped per rf2-o5f5f.2)  -->
 <!-- ============================================================ -->
 
-> **Static re-host reference (rf2-r4nao — deferred).** The sections
-> below describe the UC1 Sim engine and UC2 Mode A/B/C dynamic-instance
-> UI as they existed pre-collapse (rf2-y9xmf). They are preserved as
-> design-reference for the future **Static** surface re-host effort
-> (rf2-r4nao). **They DO NOT describe what the Runtime Machines panel
-> renders today** — the Runtime panel is event-driven only (see the
-> collapse note at the top of this doc and the "Post-collapse Runtime
-> panel shape" section above).
+## Static Machines surface
+
+The Static-mode Machines surface is **a peer** to the post-collapse Runtime Machines panel described above, **not a successor**. Static is the event-INDEPENDENT registry browse — what's REGISTERED — and runs alongside the Runtime panel within Causa's two-mode chrome. The architectural contract for the Two-modes split lives in [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 + [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Static surface; this section owns the concrete Static Machines surface description.
+
+### Tab placement
+
+The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-IA.md`](007-UX-IA.md) §Static mode sub-tab inventory). Mnemonic `m` (mode-scoped — see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule: `m` in Runtime opens the instance inspector, `m` in Static opens the registry browse). Static Machines is the **default Static tab** because the Machines registry is the densest Static surface; opening Static on a fresh slate lands on the highest-value tab.
+
+### Master-detail layout
+
+```
+┌──────────────────────────┬───────────────────────────────────────────────┐
+│ L4-left  (280px fixed)   │ L4-right  (fills)                             │
+│                          │                                               │
+│ ─ search box             │ <machine-id> · src/cart/.../checkout.cljs:42 ↗│
+│ ─ sort cycle (Name /     │   · 6 states · 2 live (→ Runtime)             │
+│   States / Live)         │                                               │
+│ ─ scrollable rows:       │ ─ 4-mode sub-strip [T][S][I][C]               │
+│   ◉ :checkout    src:42  │ ─ per-mode body (Topology · Sim placeholder · │
+│   ○ :auth/main   src:18  │   Instances JUMP · Cascade dimmed)            │
+│   ○ :wizard      src:90  │                                               │
+│   …                      │                                               │
+│   each row carries:      │                                               │
+│   - selection glyph      │                                               │
+│   - mono machine-id      │                                               │
+│   - source-coord chip    │                                               │
+│   - state-count chip     │                                               │
+│   - live-instance pips   │                                               │
+│   - → Runtime JUMP chip  │                                               │
+└──────────────────────────┴───────────────────────────────────────────────┘
+```
+
+**Left pane — browse-all list.** Scrollable list of every registered machine; search box + sort-cycle button (`Name → States → Live → Name`) at the top. Each row carries: a selection glyph (`◉` active / `○` inactive — same vocabulary as the Static tab-bar), the machine-id rendered in monospace accent-violet, a source-coord chip (jump-to-source via the existing open-in-editor affordance), a state-count chip, a live-instance pip cluster (capped at 12; beyond that → textual count), and a per-row `→ Runtime` JUMP chip. Empty-state: "No machines registered. `rf/reg-machine` to add the first."
+
+**Right pane — definition detail.** Header carries `<machine-id> · <source-coord ↗> · <N> states · <M> live`. Below the header, the **4-mode sub-strip** drives the per-mode body.
+
+### 4-mode sub-strip
+
+```
+┌────────────┬────────────┬───────────────┬─────────────────────┐
+│ [Topology] │ [Sim]      │ [Instances]   │ [Cascade]           │
+│  (t)       │  (s)       │  (i — JUMP)   │  (c — DIMMED)       │
+└────────────┴────────────┴───────────────┴─────────────────────┘
+```
+
+The 4 sub-modes (mnemonic letters `t/s/i/c` surfaced in each pill's `title`) live inside the same DOM shape the Runtime Machines sub-strip used pre-collapse — same pill DOM, same letter mnemonics — so muscle-memory carries between the two modes. The Static-mode behaviours differ:
+
+| Pill | Behaviour in Static | Body renderer |
+|---|---|---|
+| **Topology** (`t`, default) | Static-read of the machine's state graph — the SAME `chart/svg` MachineChart primitive the Runtime panel uses (single implementation), but with **NO `:highlight-id`** because Static is event-INDEPENDENT (there is no active state to spotlight). Click on a state node fires `:rf.causa.static.machines/state-clicked` for a per-state metadata rail (follow-on bead). Carries an "Open chart in pop-out" affordance. | inline SVG chart |
+| **Sim** (`s`) | Sibling bead **rf2-r4nao** — the Sim machinery re-host. v1 ships the strip cell and a placeholder card ("rf2-r4nao will fill this") so the strip stays complete. The Sim engine (`:rf.causa/sim-*` subs/events) remains registered in code; only the Static-side UI re-host is deferred. | placeholder card pointing at rf2-r4nao |
+| **Instances** (`i`) | **JUMP to Runtime.** Clicking the pill (or the per-row `→ Runtime` chip in the browse-list) dispatches three events against `:rf/causa`: `:rf.causa/set-mode :runtime` · `:rf.causa/select-tab :machines` · `:rf.causa/select-machine-id <mid>`. The user lands on the Runtime Machines tab with this machine pre-selected. Mode B/C auto-detection (Mode B for 2-8 live, Mode C for ≥8) is the Runtime panel's responsibility — the Static-side JUMP just lands the selection. | no body — the click is the surface |
+| **Cascade** (`c`) | **Dimmed + disabled** with a tooltip: *"Cancellation cascade is a Runtime-only surface. Switch to Runtime mode to view."* The pill renders for muscle-memory consistency with the Runtime sub-strip (same DOM, same letter mnemonic) but is non-interactive — `disabled` + `aria-disabled="true"` + dashed border + 0.5 opacity. The cancellation cascade composes against the trace ring buffer which is event-coupled — there is no spine in Static mode, so the surface has no source data. | no body — the pill IS the surface |
+
+The sub-strip mnemonics are mode-scoped under the same rule the L3 tabs follow (see [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Mnemonic mode-scoping rule).
+
+### Per-row → Runtime chip
+
+Every browse-list row carries a trailing `→ Runtime` chip that fires the same three-dispatch JUMP the Instances pill fires (centralised in one handler so the two surfaces never drift). Click semantics: stop propagation on the row's own select-handler; flip mode to Runtime; surface the Runtime Machines tab; select this machine. The user gets a per-row shortcut from Static into the Runtime instance inspector without first having to select the row in Static.
+
+### localStorage persistence
+
+The user's Static-Machines state survives reloads via **two** localStorage slots under the `causa.static.machines.*` prefix (the broader Static mode slot is `causa.mode` per [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 localStorage persistence):
+
+| Slot | Type | Notes |
+|---|---|---|
+| `causa.static.machines.selected-id` | bare string (machine-id keyword name; namespaced ids store as `ns/name`) | currently selected machine-id; mirrors the `causa.mode` pattern — bare string keeps it cheap to inspect from devtools |
+| `causa.static.machines.sub-mode-by-id` | EDN map `{machine-id sub-mode}` | per-machine sub-mode choice. EDN because the map will grow new keys as new sub-modes land; modes are an enum but the per-machine keying needs structured serialisation |
+
+`hydrate!` is called on Static-Machines `install!` so the first render after a reload restores the prior selection + per-machine sub-mode choices. Test fixtures call `clear!` in their `:each` setup.
+
+### Frame isolation
+
+Same discipline as the Runtime Machines panel (per §Tab placement above + [`018-Event-Spine.md`](018-Event-Spine.md) §8 I3). The Static Machines surface is wrapped in the Static shell's `[rf/frame-provider {:frame :rf/causa}]`; every subscribe + dispatch inside the surface resolves to `:rf/causa`. The browse-list, definition-detail, sub-strip pills, and Topology renderer are all `reg-view`-registered.
+
+### See also
+
+- [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 — the direction-setting decision behind Two modes (Runtime + Static).
+- [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Static surface — the architectural spine for the Static mode (3-layer chrome · 4 mode signals · mode-state lifecycle · localStorage `causa.mode` · feature flag · mnemonic mode-scoping).
+- [`007-UX-IA.md`](007-UX-IA.md) §Static mode — the visual-language details (mode pill chrome, edge stripe tokens, motion dampening, sub-tab inventory).
+- §Sim re-host reference (rf2-r4nao — deferred) below — the historical UC1 Sim + UC2 Mode A/B/C prose preserved as design-reference for the Sim re-host effort.
+
+<!-- ============================================================ -->
+<!--  SIM RE-HOST REFERENCE (rf2-r4nao — deferred)                  -->
+<!-- ============================================================ -->
+
+## Sim re-host reference (rf2-r4nao — deferred)
+
+> The sections below describe the UC1 Sim engine and UC2 Mode A/B/C
+> dynamic-instance UI as they existed pre-collapse (rf2-y9xmf). They
+> are preserved as design-reference for the **Sim re-host effort
+> (rf2-r4nao)** — the sibling bead that lands the Sim machinery under
+> the Static Machines surface's Sim sub-mode (the Sim pill currently
+> renders a placeholder card pointing at rf2-r4nao).
 >
-> Read everything below this divider as historical design-reference,
-> not as a normative description of the current Runtime panel.
+> **They DO NOT describe what the Runtime Machines panel renders
+> today** (see the collapse note at the top of this doc and the
+> "Post-collapse Runtime panel shape" section above) — that surface
+> is event-driven only. They also do NOT describe the shipped Static
+> Machines surface above (which is master-detail with a 4-mode
+> sub-strip, NOT the Mode A/B/C dynamic-instance UI sketched in the
+> following sections — Mode B/C live-instance views remain a
+> Runtime-side responsibility, reached from Static via the JUMP).
+>
+> Read everything below this divider as historical design-reference
+> for the deferred Sim re-host, not as a normative description of any
+> currently-shipped surface.
 
 ## Definition view — Mode A resting state
 

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -73,6 +73,99 @@ Layers are stacked top-to-bottom; only L2/L3 has a user-draggable resize handle.
 
 ---
 
+## §2.5 Static surface (3-layer chrome)
+
+Causa exposes **two modes** per Lock #14 in [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) — the **Runtime** surface specified in §2 above (event-coupled spine + 4-layer chrome) and a peer **Static** surface (event-INDEPENDENT registry browse + 3-layer chrome). This section owns the Static architectural contract; visual-language details (mode pill widget chrome, edge stripe colour tokens, motion dampening durations) live in [`007-UX-IA.md`](007-UX-IA.md) §Static mode.
+
+### 3-layer silhouette
+
+Runtime is 4 layers (L1 ribbon · L2 event list · L3 tab bar · L4 detail panel). **Static drops L2 — there is no spine in Static mode because Static is event-INDEPENDENT** — and renders 3 layers:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ LAYER 1  Top ribbon (56px) — mode pill + right icons                    │   scope controls
+├─────────────────────────────────────────────────────────────────────────┤
+│ LAYER 3  Tab bar (40px) — 5 tabs                                        │   projection selector
+├─────────────────────────────────────────────────────────────────────────┤
+│ LAYER 4  Detail panel (fills remaining canvas)                          │   per-tab content
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+L2's absence is itself a functional signal — see §The 4 mode signals below. The L1 ribbon retains the mode pill (ribbon-left) and the right-icons cluster (`⚙` settings · `✕` close); the Runtime ribbon's nav cluster, frame picker, and filter pills are HIDDEN because Static is event-independent — those clusters have no meaning here.
+
+### The 4 mode signals (chrome silhouette + 3 reinforcing)
+
+The user reads "Static" at a glance via **four stacked signals**; together they telegraph the mode without the user needing to look at any one widget. Lock #14 commits to all four, on the principle that mode confusion is the failure mode to defend against.
+
+| # | Signal | Runtime | Static |
+|---|---|---|---|
+| 1 | **Mode pill** at ribbon-left — two-segment radio (`[● Runtime] [○ Static]`), 160px total, accent-violet active segment, 200ms cross-fade. Lives in BOTH modes (it's the toggle, not the indicator). | `[● Runtime] [○ Static]` | `[○ Runtime] [● Static]` |
+| 2 | **2-px left-edge ribbon stripe.** | `:accent-violet` | `:cyan` (existing palette token — zero new tokens) |
+| 3 | **Motion dampening.** | LIVE pulse + machine-active pulse + 180ms tab fade | All continuous pulses dropped; tab fade collapses to 0ms instant. Honours `prefers-reduced-motion: reduce` via `--rf-causa-motion-scale`. |
+| 4 | **Chrome silhouette.** | 4-layer (L1 · L2 · L3 · L4) | 3-layer (L1 · L3 · L4 — no spine) |
+
+The pill is wired to the same handler the `Cmd-Shift-M` / `Ctrl+Shift+M` global chord (per §11 Keyboard map) fires — chord and pill share the toggle.
+
+### Mode-state lifecycle slots
+
+Two app-db slots on the `:rf/causa` frame carry the mode user-state:
+
+| Slot | Type | Default | Notes |
+|---|---|---|---|
+| `:rf.causa/mode` | `:runtime` \| `:static` | `:runtime` | Active mode. Drives the surface composer in `shell.cljs`. |
+| `:rf.causa.static/selected-tab` | `:machines` \| `:routes` \| `:schemas` \| `:views` \| `:events` | `:machines` | Static-scoped tab choice. **Separate from the Runtime `:rf.causa/active-tab` slot** so flipping modes preserves both choices. |
+
+Three event handlers drive the lifecycle:
+
+- **`:rf.causa/set-mode`** `(fn [{:keys [db]} [_ mode]] …)` — writes a specific mode. Used by the mode-pill segment-click path, hydration after localStorage read, and test fixtures.
+- **`:rf.causa/toggle-mode`** `(fn [{:keys [db]} _] …)` — flips between modes. Used by the `Cmd-Shift-M` chord (see `keybinding.cljs`) and as the canonical mode-flip path.
+- **`:rf.causa.static/select-tab`** `(fn [{:keys [db]} [_ tab-id]] …)` — flips the Static-scoped tab. Unknown values are rejected (validated against the registered Static tab inventory).
+
+`set-mode` and `toggle-mode` attach the `:rf.causa.static/persist-mode` fx so every mutation round-trips through localStorage in one place.
+
+### localStorage persistence — `causa.mode`
+
+The user's mode choice survives reloads via localStorage under the canonical key **`causa.mode`** (a bare string — `"runtime"` or `"static"`). A bare string keeps the slot cheap to read + cheap to inspect from browser devtools; modes are an enum, not a structured value. Unknown / malformed values normalise back to `:runtime` (the conservative default — the existing chrome).
+
+The namespace prefix is `causa.mode` (not `re-frame2.causa.mode.v1`) deliberately — it mirrors the spec-published name from the rf2-o5f5f findings doc, is short, and reads naturally in browser devtools. The filter-persistence slot uses the longer versioned form because its shape may evolve; the mode slot is a fixed enum, so versioning would be overkill.
+
+Sub-surface slots (e.g. Static Machines' selected-id and per-machine sub-mode) ride their own localStorage keys under the `causa.static.*` prefix — see [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface.
+
+### Feature flag — `:experimental/static-mode?`
+
+Static is gated behind the `:experimental/static-mode?` config flag (per [`015-Configuration.md`](015-Configuration.md)), **default `false`**. Hosts opt in via:
+
+```clojure
+(causa-config/configure! {:experimental/static-mode? true})
+```
+
+before the Causa preload runs.
+
+| Flag state | Mode pill | `Cmd-Shift-M` chord | Surface composer |
+|---|---|---|---|
+| OFF (default) | absent | falls through to host / browser | ALWAYS renders Runtime — byte-identical to the pre-Static chrome |
+| ON | mounts at ribbon-left | dispatches `:rf.causa/toggle-mode` against `:rf/causa` | composer switches on `:rf.causa/mode` |
+
+**Flip-to-default-on criterion.** The flag flips to default-on once sibling beads rf2-o5f5f.2 … .6 fill the placeholder Static sub-tabs (a separate decision; the v1.0 Static surface is the Machines tab + Routes tab landing — the other three remain placeholders until their re-host beads ship).
+
+### Mnemonic mode-scoping rule
+
+The 5-letter Static sub-tab mnemonics (`m` Machines · `r` Routes · `c` Schemas · `v` Views · `e` Events per [`007-UX-IA.md`](007-UX-IA.md) §Static mode) are **mode-scoped**: the same letter dispatches the active mode's tab, not a globally-fixed target. `m` in Runtime opens the Machines instance-inspector (per §5); `m` in Static opens the Machines registry browse (per [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface). The keybinding wiring rides the same chord-detection ns (`keybinding.cljs`) but routes through a mode-aware dispatcher.
+
+The mode-scoping rule is what lets the mnemonic vocabulary stay small (single letters) without colliding across modes — switching modes flips both the chrome AND the meaning of the letter keys, and the user reads which is active from the 4 stacked mode signals above.
+
+### Frame isolation
+
+Same discipline as the Runtime chrome (per §8 Frame-observation isolation invariants). The Static surface composer inside `shell.cljs` is wrapped in `[rf/frame-provider {:frame :rf/causa}]`; every subscribe + dispatch inside the surface resolves to `:rf/causa`. Each subscribing region is `reg-view`-registered so its rendered component carries `:contextType frame-context` (rf2-in6l2 + Spec 004 §Plain Reagent fns do not pick up the surrounding frame).
+
+### See also
+
+- [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 — the direction-setting decision behind Two modes (Runtime + Static).
+- [`007-UX-IA.md`](007-UX-IA.md) §Static mode — visual-language details (mode pill widget chrome, edge stripe colour tokens, motion dampening durations, sub-tab mnemonics, design language).
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface — concrete Static Machines surface description (4-mode sub-strip · Topology · Sim placeholder · Instances JUMP · Cascade dimmed).
+
+---
+
 ## §3 Top ribbon anatomy (Layer 1)
 
 Five clusters, fixed order left to right:
@@ -1162,7 +1255,7 @@ Complete map for the spine + chrome:
 | **Tab bar (L3)** | `1`–`7` jump to tab N · `Ctrl+→` / `Ctrl+←` next/prev tab · letter mnemonics: `e` Event · `a` App-db · `v` Views (incl. subs nested under each view) · `t` Trace · `m` Machines · `r` Routing · `i` Issues |
 | **Detail panel (L4)** | `Tab` / `Shift+Tab` cycle focusables · `Esc` returns focus to event list |
 | **Mode + scrubbing** | `Space` pause/resume LIVE · `L` snap to LIVE (jump to head) · `←` / `→` step one cascade (= `j`/`k`) · `Shift+←` / `Shift+→` step cascade root · `Home` / `End` oldest/newest. (The dedicated Mode pill widget was dropped — the L2 spine itself indicates LIVE / LIVE-paused / RETRO; only the widget is gone.) |
-| **Surface toggle** | `Cmd-Shift-M` / `Ctrl+Shift+M` toggle between **Runtime** and **Static** surfaces (rf2-r4nao — Static surface lands when the re-host effort lands; the chord is reserved). |
+| **Surface toggle** | `Cmd-Shift-M` (macOS) / `Ctrl+Shift+M` (every other host) toggles between **Runtime** and **Static** surfaces (per Lock #14 in [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) + §Static surface below). Gated on the `:experimental/static-mode?` config flag — when OFF the chord falls through to the host / browser; when ON it dispatches `:rf.causa/toggle-mode` against the `:rf/causa` frame. Mode pill at ribbon-left mirrors the toggle (chord + pill share the handler). |
 | **Global** | `Ctrl+Shift+C` toggle Causa visibility · `Cmd-K` / `Ctrl+K` palette · `?` cheat-sheet · `,` or `s` settings popup (= `⚙`) · `o` popout (= `⛶`) · `Esc` close modal / return to canvas |
 
 ### Retired keys (from pre-rewrite spec)
@@ -1361,8 +1454,9 @@ not Causa.
 
 ## §14 Cross-references
 
+- [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) — Lock #14 (Two modes — Runtime + Static) is the direction-setting decision behind §2.5 Static surface above.
 - [`000-Vision.md`](000-Vision.md) — 7-tab inventory; philosophy shift to human-only surface.
-- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) — event-driven Runtime Machines panel (rf2-y9xmf); UC1 Sim + UC2 Mode A/B/C are preserved as Static re-host reference (rf2-r4nao) below the §STATIC RE-HOST REFERENCE divider in that doc.
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) — event-driven Runtime Machines panel (rf2-y9xmf) + §Static Machines surface (the shipped Static-mode Machines surface — 4-mode sub-strip with Topology / Sim placeholder / Instances JUMP / Cascade dimmed-with-tooltip). The UC1 Sim engine and UC2 Mode A/B/C historical prose remain below as Sim re-host reference (rf2-r4nao — deferred).
 - [`004-App-DB-Diff.md`](004-App-DB-Diff.md) — diff renderer + changed-paths derivation used in L4 App-db tab content.
 - [`007-UX-IA.md`](007-UX-IA.md) — typography, colour tokens, density, keyboard map, editor protocol matrix.
 - [`012-Views.md`](012-Views.md) — Views tab three-group layout (mounted / re-rendered / unmounted); nested subs; cluster-large-grids.

--- a/tools/causa/spec/DESIGN-RATIONALE.md
+++ b/tools/causa/spec/DESIGN-RATIONALE.md
@@ -1,6 +1,6 @@
 # DESIGN-RATIONALE
 
-The 13 direction-setting decisions that shape Causa. Each entry
+The 14 direction-setting decisions that shape Causa. Each entry
 captures:
 
 - **The question** that was being decided.
@@ -480,6 +480,134 @@ removed entirely (see Lock #2 reversal).** AI integration lives in
 
 ---
 
+## Lock #14 — Two modes (Runtime + Static)
+
+**Locked 2026-05-19 (Mike).** **Two modes within one tool: Runtime
+(event-coupled spine + 4-layer chrome) and Static (event-INDEPENDENT
+registry browse + 3-layer chrome).** Chrome silhouette is the
+mode signal; the mode pill is the toggle.
+
+### Question
+
+Causa needs to answer two distinct bug-classes — the event-coupled
+"what just happened?" cascade (the five canonical questions answered
+by the spine / event list / per-tab projections) AND the event-
+INDEPENDENT "what's registered? · what would simulate?" browse
+(machines / routes / schemas / views / events catalogues). Should
+this be a single chrome with a tab pivot, two chromes within one
+tool, or two tools entirely?
+
+### Options considered
+
+- **(a) Single chrome with tab pivots.** One 4-layer chrome; add
+  "Registry" tabs alongside the existing 7 (Event / App-db / Views /
+  Trace / Machines / Routing / Issues). The event-coupled spine
+  always sits at L2 even when the user is browsing the schema
+  registry — every Registry tab carries L2's "current cascade"
+  context whether or not it's relevant.
+- **(b) Two modes within one tool — Causa is one package, two
+  chromes.** A mode pill at ribbon-left flips the surface; Runtime
+  renders the 4-layer chrome (L1 ribbon · L2 event list · L3 tab
+  bar · L4 detail), Static drops L2 (event-independent, no spine)
+  and renders 3 layers (L1 · L3 · L4). The mode user-state persists
+  to localStorage; a global chord toggles. Both chromes share the
+  full Causa design language — typography, palette, density,
+  spacing grid, glyph vocabulary.
+- **(c) Two tools entirely.** Ship `re-frame2-causa-runtime` +
+  `re-frame2-causa-static` as separate packages, each with its own
+  preload, its own jar, its own install path, its own keybinding.
+
+### Pick
+
+**(b) Two modes within one tool.** Causa is one package; the chrome
+silhouette differentiates the modes at a glance; the mode pill is
+the toggle, not the indicator.
+
+### Why
+
+- **Event-coupled and event-INDEPENDENT are different bug-classes.**
+  The Runtime spine answers the five canonical questions about a
+  specific cascade ("who fired this? · what did it write? · which
+  views recomputed? · what side-effects fired? · what went wrong?").
+  The Static browse answers a different family ("which machines does
+  this app define? · what would `/orders/42?tab=ship` route to? ·
+  which schemas govern this app-db slice? · which views are
+  registered?"). Carrying L2's "current cascade" into a registry
+  browse is noise — Static IS event-independent. Option (a) leaks
+  spine context into a surface where it has no meaning.
+- **The chrome shape IS the mode signal.** Static drops L2 entirely;
+  the 3-layer silhouette is unmistakable from the 4-layer Runtime
+  silhouette. A trained eye reads the mode without looking at any
+  widget. Option (a) gives the user no chrome-level signal that the
+  surface has changed; the only signal is which tab is active, and
+  the user mis-reads the spine row as "the current cascade" when
+  they're actually browsing a registry that has nothing to do with
+  it.
+- **Four stacked signals telegraph mode at a glance** (per the
+  shipped surface):
+  1. **Mode pill** at ribbon-left — two-segment radio (`[● Runtime]
+     [○ Static]`), 200ms accent-violet cross-fade. Lives in BOTH
+     modes — it's the toggle, not the indicator.
+  2. **2-px left-edge ribbon stripe** — `:accent-violet` in Runtime,
+     `:cyan` (existing palette token) in Static. Zero new tokens.
+  3. **Motion dampening** — Runtime ships the LIVE pulse + machine-
+     active pulse + 180ms tab fade. Static drops continuous pulses
+     entirely and collapses tab fades to instant. Honours
+     `prefers-reduced-motion: reduce` via the existing
+     `--rf-causa-motion-scale` seam.
+  4. **Chrome silhouette** — 4-layer (Runtime) vs 3-layer (Static).
+     The silhouette IS the mode.
+- **The mode pill is the toggle, not the indicator.** It lives at
+  ribbon-left in BOTH modes; clicking either segment dispatches the
+  same `:rf.causa/toggle-mode` event the `Cmd-Shift-M` chord (per
+  `keybinding.cljs` + 018 §11 Keyboard map) fires. The user reads
+  the mode from the chrome shape + stripe colour + motion
+  dampening; the pill is where they go to change it.
+- **One package, one install, one preload.** Option (c) doubles the
+  install surface (two preloads, two keybindings, two persisted-
+  state schemas) for zero benefit — the user wants both modes
+  available from one Ctrl+Shift+C. Option (b) gets the full
+  user-facing isolation (3 vs 4 layers; separate selected-tab slot
+  per mode) without the duplicated build / install surface.
+- **Cross-mode tab choice is preserved.** The Static-scoped tab
+  lives at `:rf.causa.static/selected-tab` (default `:machines`);
+  the Runtime-scoped tab lives at the existing `:rf.causa/active-
+  tab` (default `:event`). Flipping modes restores the prior
+  Runtime tab choice; it doesn't clobber it.
+
+### Cross-reference
+
+The architectural spine for this lock lives in
+[`018-Event-Spine.md`](018-Event-Spine.md) §Static surface
+(the 3-layer silhouette + the 4 mode signals + the mode-state
+lifecycle slots + the localStorage `causa.mode` key + the
+`:experimental/static-mode?` feature flag). The concrete Static
+sub-tab surfaces are catalogued in [`007-UX-IA.md`](007-UX-IA.md)
+§Static mode and (for Machines specifically)
+[`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static
+Machines surface — the 4-mode sub-strip
+`[Topology][Sim][Instances][Cascade]` with JUMP-to-Runtime
+semantics on Instances and Cascade-dimmed-with-tooltip on
+Cascade.
+
+### Date locked
+
+2026-05-19 (Mike).
+
+### Trail-of-thought citations
+
+- `ai/findings/2026-05-19-causa-explorer-mode.md` — the session
+  trail that walked through (a) / (b) / (c) and surfaced the
+  chrome-silhouette-as-mode-signal mechanism.
+- `ai/findings/2026-05-19-causa-spec-currency-audit.md` §H7 —
+  flagged the missing lock during the spec-currency sweep.
+- rf2-o5f5f epic — the implementation umbrella under which the
+  Static surface shipped (sub-beads rf2-o5f5f.1 chrome,
+  rf2-o5f5f.2 Machines, .3 Routes, .4 Schemas, .5 Views, .6
+  Events).
+
+---
+
 ## Summary table
 
 | # | Question | Pick | Date |
@@ -497,7 +625,8 @@ removed entirely (see Lock #2 reversal).** AI integration lives in
 | 11 | Source-coord fallback | **Handler-coord with `(?)` annotation** | 2026-05-12 |
 | 12 | Conversation persistence | **SUPERSEDED by #2 reversal (rf2-s3vx5)** | 2026-05-17 |
 | 13 | Voice STT | **SUPERSEDED by #2 reversal (rf2-s3vx5)** | 2026-05-17 |
+| 14 | Two modes (Runtime + Static) | **Two modes within one tool — chrome silhouette IS the signal; pill is the toggle** | 2026-05-19 |
 
-The 13 locks together define the v1.0 surface. Anything outside
+The 14 locks together define the v1.0 surface. Anything outside
 these decisions is up for design discussion; anything inside is
 direction-set and shipped.


### PR DESCRIPTION
## Summary

Bundles three interlocking Causa P1 spec edits surfaced by the 2026-05-19 currency audit (rf2-qfufu). All three lock in the **Two-modes** posture: one Causa, two chromes (Runtime 4-layer · Static 3-layer); chrome silhouette IS the mode signal; the pill is the toggle.

- **rf2-byd1f — DESIGN-RATIONALE.md Lock #14 (Two modes — Runtime + Static).** Adds the direction-setting lock. Walks through (a) single-chrome with tab pivots, (b) two-chromes within one tool, (c) two-tools-entirely — picks (b). Documents the 4 stacked mode signals (mode pill · cyan edge stripe · motion dampening · chrome silhouette) and the cross-links to 018 §2.5 + 003 §Static Machines surface. Summary table grows 13 → 14.

- **rf2-swjbi — 018-Event-Spine.md §2.5 Static surface.** New architectural section, peer to §2 The 4-layer chrome. Covers: 3-layer silhouette ASCII wireframe; the 4 mode signals as a comparison table; mode-state lifecycle slots (`:rf.causa/mode`, `:rf.causa.static/selected-tab`); the three handlers (`:rf.causa/set-mode`, `:rf.causa/toggle-mode`, `:rf.causa.static/select-tab`); localStorage persistence under `causa.mode`; the `:experimental/static-mode?` feature flag and its flip-to-default-on criterion; the mnemonic mode-scoping rule (`m/r/c/v/e` dispatch the active mode's tab). The §11 Keyboard-map "Surface toggle" row updates to reflect Cmd-Shift-M as shipped (not 'reserved').

- **rf2-wg6sq — 003-Machine-Inspector.md §Static Machines surface.** Replaces the historical STATIC RE-HOST REFERENCE divider with a normative §Static Machines surface section describing the shipped master-detail surface. Documents: browse-all list (left) + definition detail (right); the 4-mode sub-strip `[Topology][Sim][Instances][Cascade]` with mnemonics `t/s/i/c`; Topology as a Static-read of the shared `chart/svg` MachineChart primitive (NO `:highlight-id`); Sim as a placeholder pointing at rf2-r4nao; Instances as a three-dispatch JUMP into the Runtime Machines tab with the machine pre-selected; Cascade as dimmed-and-disabled with a Runtime-only tooltip; the per-row → Runtime chip; localStorage persistence under `causa.static.machines.selected-id` + `causa.static.machines.sub-mode-by-id`. The pre-collapse UC1 Sim + UC2 Mode A/B/C prose narrows to §Sim re-host reference (rf2-r4nao — deferred) — the Mode A/B/C live-instance views remain a Runtime responsibility reached from Static via the JUMP.

## Cross-links

The three sections form a triangle:

- DESIGN-RATIONALE.md Lock #14 cites 018 §2.5 + 003 §Static Machines surface (the architectural spine + the concrete first-shipped surface).
- 018 §2.5 cites DESIGN-RATIONALE.md Lock #14 (the lock) + 007 §Static mode (visual-language details) + 003 §Static Machines surface (the concrete sub-tab description).
- 003 §Static Machines surface cites DESIGN-RATIONALE.md Lock #14 + 018 §2.5 + 007 §Static mode.

018 §14 cross-references and 018 §11 Keyboard map updated accordingly.

## Scope discipline

- Spec-only — zero source / test / config touches.
- Three files; no new docs created. The bead briefly contemplated a separate `019-Static-Mode.md` but the architectural surface fits naturally in 018 as §2.5 and the Static Machines surface fits naturally in 003 as a normative section; no new top-level doc was warranted.
- 007 §Static mode is left untouched — it already carries the visual-language details and the bead description's instruction was to add §Static surface to 018 (architecture) without disturbing 007 (visual language). Cross-links between the two are explicit in both directions.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exit 0 (clean).
- [x] `python -m mkdocs build --strict` — clean build; no warnings on the three touched docs (one pre-existing INFO on `the-mayor-method.md` unchanged by this PR).
- [x] `cd tools/causa && clojure -M:test` — 749/749 tests pass.
- [x] Rebased onto current `origin/main` (2 sibling-worker commits absorbed cleanly).

LoC delta: 3 files, +334 / -15.

Resolves rf2-byd1f, rf2-swjbi, rf2-wg6sq.