### PR TITLE
feat(causa): density radio writes --rf-causa-font-size (rf2-i40us)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/effects.cljs
@@ -65,7 +65,8 @@
   (:require [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
-            [day8.re-frame2-causa.config :as config]))
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- mount late-bind helpers --------------------------------------------
 
@@ -143,6 +144,78 @@
       (.setProperty (.-style root) text-size-css-var value))
     (when-let [html (html-root-element)]
       (.setProperty (.-style html) text-size-css-var value)))
+  nil)
+
+;; ---- density (rf2-i40us) ------------------------------------------------
+;;
+;; The density radio (Compact / Cosy in v1; Comfy is the spec's third
+;; tier kept here for forward compat) writes a px value to the canonical
+;; `--rf-causa-font-size` CSS custom property that anchors the whole
+;; `theme/tokens/type-scale`. Per rf2-n8i2c every `type-scale` entry
+;; resolves to `calc(var(--rf-causa-font-size, 13px) * <multiplier>)`;
+;; flipping the var rescales every typographic surface in lockstep on
+;; the next paint (no re-render needed). This completes the "one knob
+;; per density" loop the radio shipped without — until this commit the
+;; radio only persisted the value + drove the `:rf.causa/density` sub.
+;;
+;; ## Why we write here AND `theme/global-styles/motion-css` already
+;; publishes a default on `:root`
+;;
+;; `global-styles` writes the *default* value (`13px`) into the
+;; injected `<style>` block once at install time, so the var resolves
+;; for any descendant from first paint even before Causa mounts. The
+;; settings-driven apply fn here writes an *inline* declaration on
+;; `:root` / shell-root which OVERRIDES that selector-based default
+;; (inline > selector in the cascade). Removing the inline declaration
+;; on a return-to-cosy is therefore optional — re-asserting 13px is
+;; idempotent — but we re-assert anyway so the apply fn's contract is
+;; one-write-one-paint regardless of the prior state.
+
+(def density->font-size-px
+  "Pure-data map from density keyword → font-size pixel value to write
+  into `--rf-causa-font-size`. The v1 radio surfaces only `:compact`
+  and `:cosy` (Mike 2026-05-19); `:comfy` is catalogued so a future
+  un-drop of the third tier wires through without a code change.
+
+  - `:compact` → 12px (one step tighter than the historic baseline)
+  - `:cosy`    → 13px (the historic baseline; matches
+                 `tokens/font-size-default`)
+  - `:comfy`   → 14px (one step looser; spec/007 §Typography catalogues
+                 it as the third tier on the ±1px density knob)
+
+  JVM-portable pure data so the JVM test surface can assert the
+  mapping without touching the browser."
+  {:compact 12
+   :cosy    13
+   :comfy   14})
+
+(defn density->px
+  "Resolve a density keyword to its px value via `density->font-size-px`.
+  Falls back to the cosy default (13px) when the keyword is unknown
+  (a persisted `:comfy` payload pre-Mike-2026-05-19 lands here; the
+  `:rf.causa/density` sub coerces unknown values to `:cosy` for the
+  reactive surface, and this helper mirrors that posture)."
+  [density]
+  (or (get density->font-size-px density)
+      (get density->font-size-px :cosy)))
+
+(defn apply-density-font-size!
+  "Write the px value for `density` into `--rf-causa-font-size` on both
+  the Causa shell root (so the inline-style call sites that resolve
+  `calc(var(--rf-causa-font-size, 13px) * N)` from `type-scale` pick
+  it up via inheritance) and the `<html>` root (so popout / fullscreen
+  mounts that may not be inside the inline shell root still inherit).
+
+  No-op when neither element is present (test runtimes without a
+  `document`). Matches the `apply-text-size!` / `apply-theme!` /
+  `apply-panel-width!` write pattern — write to both roots so every
+  Causa-owned surface (inline, popout, fullscreen) honours the knob."
+  [density]
+  (let [value (str (density->px density) "px")]
+    (when-let [root (shell-root-element)]
+      (.setProperty (.-style root) tokens/font-size-var-name value))
+    (when-let [html (html-root-element)]
+      (.setProperty (.-style html) tokens/font-size-var-name value)))
   nil)
 
 ;; ---- theme --------------------------------------------------------------
@@ -407,6 +480,14 @@
   (let [s (config/get-settings)]
     (apply-text-size!  (get-in s [:general :text-size]))
     (apply-theme!      (get s :theme))
+    ;; rf2-i40us — restore the persisted density-driven font-size so
+    ;; the user's saved choice rescales the type scale BEFORE first
+    ;; paint. Default (`:cosy`) re-asserts 13px (the same value
+    ;; `theme/global-styles/motion-css` publishes on `:root` at install
+    ;; time); the inline write is idempotent on the cosy case and the
+    ;; cost of writing-anyway is one DOM setProperty per boot.
+    (apply-density-font-size!
+      (get-in s [:general :density]))
     ;; rf2-ybjkx — restore the reduced-motion override so the user's
     ;; saved choice survives reload BEFORE first paint. The default
     ;; `:os` writes nothing (the OS media query alone drives the

--- a/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/events.cljs
@@ -103,6 +103,18 @@
         (and (= section :general) (= key :panel-width-px))
         (effects/apply-panel-width! value)
 
+        ;; rf2-i40us — density radio writes the resolved px into
+        ;; `--rf-causa-font-size` so the whole `theme/tokens/type-scale`
+        ;; rescales in lockstep (every entry is
+        ;; `calc(var(--rf-causa-font-size, 13px) * <multiplier>)`).
+        ;; Mapping: compact 12 / cosy 13 / comfy 14 — see
+        ;; `effects/density->font-size-px`. The persisted value the
+        ;; settings atom carries also drives the `:rf.causa/density`
+        ;; sub (Views row padding + App-db diff-row line-height); the
+        ;; font-size write here is the one-knob loop's missing leg.
+        (and (= section :general) (= key :density))
+        (effects/apply-density-font-size! value)
+
         (and (= section :theme) (nil? key))
         (effects/apply-theme! value)
 

--- a/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/effects_cljs_test.cljs
@@ -27,6 +27,7 @@
             [day8.re-frame2-causa.settings.effects :as effects]
             [day8.re-frame2-causa.settings.view :as view]
             [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.theme.tokens :as tokens]
             [day8.re-frame2-causa.trace-bus :as trace-bus]))
 
 ;; ---- fixture -----------------------------------------------------------
@@ -241,3 +242,90 @@
       (is (= "700px"
              (.getPropertyValue (.-style html) "--rf-causa-inline-width"))
           "<html> --rf-causa-inline-width carries the persisted value"))))
+
+;; ---- density → font-size knob (rf2-i40us) ------------------------------
+
+(deftest density->font-size-px-mapping
+  (testing "density keyword resolves to the canonical px value the
+            radio writes into `--rf-causa-font-size`. Compact tightens
+            by 1px, cosy is the baseline (matches
+            `tokens/font-size-default`), comfy loosens by 1px."
+    (is (= 12 (:compact effects/density->font-size-px)))
+    (is (= 13 (:cosy    effects/density->font-size-px)))
+    (is (= 14 (:comfy   effects/density->font-size-px)))
+    (is (= "13px" tokens/font-size-default)
+        "cosy mapping matches the type-scale's baseline default")))
+
+(deftest density->px-falls-back-to-cosy-on-unknown
+  ;; The `:rf.causa/density` sub coerces unknown values to `:cosy`;
+  ;; the apply-fn mirrors that posture so a persisted pre-2026-05-19
+  ;; `:comfy` payload (now dropped from the radio enumeration) lands
+  ;; on a coherent px value rather than nil/throw.
+  (is (= 13 (effects/density->px :cosy)))
+  (is (= 12 (effects/density->px :compact)))
+  (is (= 14 (effects/density->px :comfy)))
+  (is (= 13 (effects/density->px :something-weird))
+      "unknown density coerces to the cosy default")
+  (is (= 13 (effects/density->px nil))
+      "nil density coerces to the cosy default"))
+
+(deftest apply-density-font-size-writes-css-var
+  (ensure-stub-shell-root!)
+  (effects/apply-density-font-size! :compact)
+  (when-let [el (shell-root)]
+    (is (= "12px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+        "shell root --rf-causa-font-size carries the compact value"))
+  (when-let [html (html-root)]
+    (is (= "12px" (.getPropertyValue (.-style html) "--rf-causa-font-size"))
+        "<html> --rf-causa-font-size carries the compact value"))
+  (effects/apply-density-font-size! :cosy)
+  (when-let [el (shell-root)]
+    (is (= "13px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+        "shell root rewrites to 13px on cosy flip"))
+  (effects/apply-density-font-size! :comfy)
+  (when-let [el (shell-root)]
+    (is (= "14px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+        "shell root rewrites to 14px on comfy")))
+
+(deftest apply-density-font-size-handles-missing-shell-root
+  (remove-stub-shell-root!)
+  (is (nil? (effects/apply-density-font-size! :compact))
+      "no-op when shell root absent; no throw"))
+
+(deftest update-event-applies-density-font-size-effect
+  (testing "Dispatching `[:rf.causa/settings-update :general :density
+            :compact]` flips `--rf-causa-font-size` to 12px so the
+            whole `type-scale` rescales on the next paint."
+    (setup!)
+    (ensure-stub-shell-root!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-update
+                         :general :density :compact]))
+    (when-let [el (shell-root)]
+      (is (= "12px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+          "dispatch writes 12px on compact"))
+    ;; Persistence — the dual-write goes to the in-memory atom +
+    ;; localStorage shim via `config/update-setting!`.
+    (is (= :compact (config/get-setting :general :density))
+        "settings atom carries the new density")
+    ;; Flip to cosy — verify the inline write rewrites (not just adds).
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-update
+                         :general :density :cosy]))
+    (when-let [el (shell-root)]
+      (is (= "13px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+          "dispatch writes 13px on cosy"))))
+
+(deftest apply-all-restores-density-font-size
+  (testing "rf2-i40us — boot path restores the persisted density so
+            the user's saved knob rescales the type scale BEFORE first
+            paint. The CSS var lands on the shell root + `<html>`."
+    (ensure-stub-shell-root!)
+    (config/update-setting! :general :density :compact)
+    (effects/apply-all!)
+    (when-let [el (shell-root)]
+      (is (= "12px" (.getPropertyValue (.-style el) "--rf-causa-font-size"))
+          "shell root --rf-causa-font-size carries the persisted compact value"))
+    (when-let [html (html-root)]
+      (is (= "12px" (.getPropertyValue (.-style html) "--rf-causa-font-size"))
+          "<html> --rf-causa-font-size carries the persisted compact value"))))


### PR DESCRIPTION
## Summary
- Completes the one-knob density loop the radio shipped without: compact -> 12px, cosy -> 13px, comfy -> 14px get written into `--rf-causa-font-size` on both shell root and `<html>`. Per rf2-n8i2c every `theme/tokens/type-scale` entry resolves to `calc(var(--rf-causa-font-size, 13px) * <multiplier>)`, so flipping the var rescales every typographic surface in lockstep on the next paint.
- `settings/effects.cljs` — add `density->font-size-px` pure-data map (compact/cosy/comfy; v1 radio surfaces only compact/cosy per Mike 2026-05-19, comfy catalogued for forward compat), `density->px` resolver (coerces unknown to cosy, mirroring `:rf.causa/density` sub), and `apply-density-font-size!` writer. Wired into `apply-all!` so persisted density survives reload before first paint.
- `settings/events.cljs` — route `[:rf.causa/settings-update :general :density v]` through `apply-density-font-size!`. Persistence via the existing `config/update-setting!` dual-write (atom + localStorage) is unchanged.

## Test plan
- [x] `clojure -M:test` from `tools/causa/` — 749 tests / 2263 assertions, 0 failures
- [x] `npm run test:cljs` — 3162 tests / 9099 assertions, 0 failures
- [x] `npm run test:bundle-isolation` — pass
- [x] New tests cover: pure-data mapping (compact=12 / cosy=13 / comfy=14, cosy matches `tokens/font-size-default`), unknown/nil fallback to cosy, writer drops on shell-root + `<html>`, no-op when shell-root absent, `:rf.causa/settings-update` dispatch path writes the CSS var, boot path (`apply-all!`) restores persisted density.

Acceptance:
- [x] Density radio writes `--rf-causa-font-size` on `:root`-equivalent (shell root + `<html>`) when changed
- [x] Compact -> 12px / Cosy -> 13px / Comfy -> 14px (Comfy honoured by the apply fn for forward compat; the v1 radio surfaces only Compact/Cosy)
- [x] Persists via existing `config/update-setting!` mechanism (atom + localStorage round-trip)
- [x] Existing density behaviour (`:rf.causa/density` sub for downstream consumers) unaffected

Closes rf2-i40us.