### PR TITLE
docs(causa): bundle 3 Causa P1 spec follow-ons (rf2-g9j6w + rf2-293hh + rf2-4ku4b)

### DIFF
--- a/tools/causa/spec/000-Vision.md
+++ b/tools/causa/spec/000-Vision.md
@@ -134,6 +134,55 @@ that ran — the canonical questions answer themselves on first paint;
 deeper investigation is one tab away (`a` App-db · `v` Views · `t` Trace ·
 `m` Machines · `i` Issues).
 
+## The two modes — Runtime and Static
+
+Causa is **one tool, two modes** (per Lock #14 in
+[`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)). The two modes answer
+different families of question against the same registries; the
+**chrome silhouette IS the mode signal**.
+
+- **Runtime mode** — event-coupled. The four-layer chrome (ribbon ·
+  event list · tab bar · detail) described in [§What it is](#what-it-is)
+  above. Answers the **five canonical questions** about a specific
+  cascade: *what did this event change? · why is this sub returning
+  wrong? · why is this view re-rendering? · what fx fired? · what's
+  broken?* The L2 event-list spine is the load-bearing axis;
+  `:rf.causa/focus` binds every tab to one event.
+- **Static mode** — event-INDEPENDENT. A three-layer chrome (ribbon ·
+  tab bar · detail — no L2 spine, because Static doesn't pin to an
+  event). Answers a peer family: *what's registered? · what would
+  `/orders/42?tab=ship` simulate? · what's still mapped?* Browses the
+  machine registry, the route registry, the schema registry, the view
+  registry, the event-handler registry — the things that EXIST in the
+  app, not the things that just HAPPENED. Five Static sub-tabs
+  (Machines · Routes · Schemas · Views · Events); Static Machines is
+  the default landing.
+
+Mode is toggled by the **mode pill** at ribbon-left (a two-segment
+radio that lives in both modes — it's the toggle, not the indicator)
+or by the **`Cmd-Shift-M` / `Ctrl+Shift+M`** global chord. The mode
+choice persists to localStorage under `causa.mode` and survives
+reload. Static is currently gated behind the
+`:experimental/static-mode?` config flag (default off); it flips to
+default-on once the placeholder Static sub-tabs fill out.
+
+The five canonical questions remain the Runtime bar. Static carries
+its own posture — registry browse — and earns space alongside
+Runtime because **event-coupled and event-INDEPENDENT are different
+bug-classes**: carrying L2's current-cascade context into a registry
+browse is noise.
+
+See [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 for the
+direction-setting trail · [`018-Event-Spine.md`](018-Event-Spine.md)
+§2.5 Static surface for the architectural spine (3-layer silhouette,
+the 4 stacked mode signals, the mode-state lifecycle slots, the
+localStorage key, the feature flag) · [`007-UX-IA.md`](007-UX-IA.md)
+§Static mode for the visual-language details (mode pill chrome, edge
+stripe colour tokens, motion dampening, sub-tab inventory) ·
+[`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static
+Machines surface for the concrete Static Machines tab (master-detail
+browse + 4-mode sub-strip + JUMP-to-Runtime semantics).
+
 ## What it isn't
 
 - **Not the AI surface.** AI access to the running re-frame2 runtime goes
@@ -170,7 +219,7 @@ Each row is "new in re-frame2 → new tooling story Causa tells."
 | re-frame2 capability | Causa surface |
 |---|---|
 | **Multi-frame** (Spec 002) | Per-frame inspection; single-select frame picker in ribbon. |
-| **Machines** (Spec 005) | Stately-quality state-chart per machine in an **event-driven Runtime panel** (rf2-y9xmf) — BLANK when the focused event has no machine activity; per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it does. Cross-cutting Causa surfaces: **`:after`-timer countdown rings** with scrubber-aware retro-replay; **`:invoke-all` parallel-child viz + join inspector**; **cancellation-cascade visualiser**; **per-instance "why am I stuck" trace**; XState-parity supervision tree. ELK+SVG primitive ships Causa-internal. (UC1 interactive simulation + UC2 multi-instance Mode A/B/C are deferred to the Static re-host — rf2-r4nao.) |
+| **Machines** (Spec 005) | Stately-quality state-chart per machine in an **event-driven Runtime panel** (rf2-y9xmf) — BLANK when the focused event has no machine activity; per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it does. Cross-cutting Causa surfaces: **`:after`-timer countdown rings** with scrubber-aware retro-replay; **`:invoke-all` parallel-child viz + join inspector**; **cancellation-cascade visualiser**; **per-instance "why am I stuck" trace**; XState-parity supervision tree. The ELK+SVG chart primitive lives in `tools/machines-viz/` (its own tool jar, per rf2-o9arp); Causa re-exports the public chart API via thin shims. (UC1 interactive simulation + UC2 multi-instance Mode A/B/C are deferred to the Static re-host — rf2-r4nao.) |
 | **Flows** (Spec 013) | Surfaced in Views tab when a flow's downstream sub recomputed; **cascade-halt alarm** in Issues tab — names the downstream flows that did NOT run when an upstream flow's `:output` threw. |
 | **Source-coord stamping** (Spec 001 + 006) | Click-to-source on every node, view, machine guard, transition, fx-handler, schema declaration. |
 | **Trace bus** (Spec 009) | The substrate of everything. Causa does not invent its own trace shape. **Trace fattening** (carrying context-at-position on each event) enables the per-instance scrubber's Phase-5 replay-from-arbitrary-position affordance. |
@@ -210,7 +259,7 @@ cohesive sub-domains earn their own lens tab rather than overloading App-db.
 | 2 | **App-db** | `a` | Diff `:db-before` vs `:db-after` — slice-first · clickable path segments (rf2-e9tb0) · path-origin chips (rf2-s8r6c) · full-tree disclosure · branch-aware diff (for story sim-clones) · cross-frame diff (for multi-frame shared substates). | [`004-App-DB-Diff.md`](004-App-DB-Diff.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.2 |
 | 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; **subs nested under each view row** showing return values; **per-sub invalidation-chain drill** (why did this sub re-run); replaces the legacy Subs panel. | [`012-Views.md`](012-Views.md) |
 | 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to the focused cascade; **wall-clock axis** for timer rings, retry waterfalls, deferred-dispatch arrivals; trace-type toggle row + IN/OUT pills + sensible defaults. | [`013-Trace-Bus.md`](013-Trace-Bus.md) + [`018-Event-Spine.md`](018-Event-Spine.md) §5.3 |
-| 5 | **Machines** | `m` | **Event-driven Runtime panel** (rf2-y9xmf): BLANK when the focused event has no machine activity; one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it did. Cross-cutting Causa surfaces: **`:after`-timer countdown rings**; **cancellation-cascade visualiser**; **`:invoke-all` join inspector**; **per-instance "why am I stuck" trace strip**; supervision tree. UC1 Sim engine + UC2 Mode A/B/C dynamic-instance UI deferred to Static re-host (rf2-r4nao). MachineChart is Causa-internal. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
+| 5 | **Machines** | `m` | **Event-driven Runtime panel** (rf2-y9xmf): BLANK when the focused event has no machine activity; one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it did. Cross-cutting Causa surfaces: **`:after`-timer countdown rings**; **cancellation-cascade visualiser**; **`:invoke-all` join inspector**; **per-instance "why am I stuck" trace strip**; supervision tree. UC1 Sim engine + UC2 Mode A/B/C dynamic-instance UI deferred to Static re-host (rf2-r4nao). MachineChart lives in `tools/machines-viz/` (rf2-o9arp); Causa re-exports the public chart API via thin shims — see [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Architectural posture. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
 | 6 | **Routing** | `r` | **FLAT focused-event lens** (rf2-lq0ef) — current matched route + params/query/fragment + **Simulate-URL** input ranking every registered route via the 6-rule `:rf.route/rank` tuple with the rank explainer inline. Per-focused-event glyphs: **`◆ HERE`** on the current matched route · **`◆ FROM` / `◆ TO`** when the focused cascade caused navigation. Silent when no routes registered. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab + [`018-Event-Spine.md`](018-Event-Spine.md) §5.6 |
 | 7 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns + **flow cascade-halt alarms** + **open-redirect advisories** + **`:platforms` skip tallies** + **stale-suppression group**. | [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon + [`018-Event-Spine.md`](018-Event-Spine.md) §5.4 |
 
@@ -305,9 +354,16 @@ turns a captured Causa session into a Story-runnable script — the only
 "export" Causa offers, and it lands in Story's persistent layer, not
 Causa's.
 
-The dependency arrows: Causa → `implementation/machines/` (directly; no
-`tools/machines-viz/` hop). Story → Causa → `implementation/`. No cycles,
-no shared registries, no parent/child relationships among the tools.
+The dependency arrows (post rf2-o9arp / PR #1570): **Causa →
+`tools/machines-viz/` → `implementation/machines/`.** The chart
+primitive moved out of Causa into its own tool jar so Story
+(per-variant observability ribbons), the read-only viewer page, and
+any host-app drop-in can depend on the chart alone without bringing
+in Causa's panel chrome. Story → Causa → `implementation/` at the
+whole-tool level; Story → `tools/machines-viz/` directly when it
+embeds the chart. No cycles, no shared registries, no parent/child
+relationships among the tools. See [`003-Machine-Inspector.md`](003-Machine-Inspector.md)
+§Architectural posture for the re-export shim contract.
 
 ## Status
 

--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -27,8 +27,14 @@ state-chart per registered machine. Post-rf2-y9xmf the panel surfaces
 the focused event's machine activity only; the interactive simulation
 (UC1) + dynamic multi-instance views (UC2 Mode A/B/C) descriptions in
 later sections are normative for the Static re-host, NOT for the
-Runtime tab. The state-chart layout primitive lives Causa-internal at
-`tools/causa/src/day8/re_frame2_causa/chart/{layout,svg,interaction}.cljc`.
+Runtime tab. The state-chart layout primitive is **owned by
+`tools/machines-viz/`** as its own tool jar (canonical implementation
+at `tools/machines-viz/src/day8/re_frame2_machines_viz/chart/{layout,svg,interaction}.cljc`,
+per rf2-o9arp / PR #1570); Causa re-exports the public chart API via
+thin shim namespaces (`day8.re-frame2-causa.chart.svg/...` →
+`day8.re-frame2-machines-viz.chart.svg/...`) so the panel surface
+imports a Causa-namespaced public name while the implementation lives
+one tool over.
 
 The Machines tab is the **single most distinctive Causa surface** because
 re-frame2's machine substrate (Spec 005) carries the richest runtime
@@ -95,17 +101,60 @@ panel.
 
 ## Architectural posture
 
-**The `tools/machines-viz/` artefact is gone** (collapsed into Causa
-in a separate PR; this spec already reflects the post-collapse shape).
-The ELK+SVG layout primitive is Causa-internal. The Mermaid text
-emitter relocates to `implementation/machines/src/re_frame/machines/mermaid.cljc`
-so the framework can re-export `(rf/machine->mermaid <id>)` without a
+**`tools/machines-viz/` owns the chart.** Per rf2-o9arp / PR #1570 the
+MachineChart primitive (ELK+SVG layout, the layered fallback, the
+interaction layer) lives in its own tool jar at
+`tools/machines-viz/src/day8/re_frame2_machines_viz/chart/{layout,svg,interaction}.cljc`.
+Causa is a **consumer** of that primitive: the panel surface
+(`panels/machine_inspector*.cljs`) imports Causa-namespaced public
+names (e.g. `day8.re-frame2-causa.chart.svg/MachineChart`) which are
+thin re-export shims pointing at the machines-viz implementation
+(`day8.re-frame2-machines-viz.chart.svg/MachineChart`). One
+implementation, one layout cache, one ELK loader — re-used by Causa,
+Story (per-variant observability ribbons), the read-only viewer page,
+and any host-app drop-in that wants the chart without Causa's panel
+chrome.
+
+The Mermaid text emitter lives at
+`implementation/machines/src/re_frame/machines/mermaid.cljc` so the
+framework can re-export `(rf/machine->mermaid <id>)` without a
 tool-jar dependency.
 
 ```
-tools/causa/  ─requires→  implementation/machines/
-   (chart primitive: chart/{layout,svg,interaction}.cljc)
+tools/causa/  ─requires→  tools/machines-viz/  ─requires→  implementation/machines/
+   (panel surface)           (chart primitive:                (machine registry +
+   (chart re-export           chart/{layout,svg,interaction}    runtime substrate)
+    shims)                    .cljc)
 ```
+
+### Re-export shim contract
+
+The thin shims keep Causa's public surface stable while letting the
+chart move independently. The contract is one-for-one: every
+Causa-namespaced public name re-exports a single machines-viz
+implementation name; no shim adds behaviour. Adding a chart feature
+means landing it in machines-viz first and re-exporting from Causa
+second.
+
+| Causa-namespaced public | Re-exports |
+|---|---|
+| `day8.re-frame2-causa.chart.svg/MachineChart` | `day8.re-frame2-machines-viz.chart.svg/MachineChart` |
+| `day8.re-frame2-causa.chart.layout/layered-fallback` | `day8.re-frame2-machines-viz.chart.layout/layered-fallback` |
+| `day8.re-frame2-causa.chart.interaction/on-state-click` | `day8.re-frame2-machines-viz.chart.interaction/on-state-click` |
+
+(Indicative — the live shim ns enumerates the full surface; the
+machines-viz API itself is the source of truth.) Embedders who want
+the chart alone depend on `tools/machines-viz/` directly; embedders
+who want Causa's panel chrome get the chart transitively via Causa.
+
+### See also
+
+- [`000-Vision.md`](000-Vision.md) §Where Causa fits — the
+  Causa → machines-viz → implementation/ dependency arrow at the
+  whole-tool level.
+- [`008-Embedding-Contract.md`](008-Embedding-Contract.md) — the
+  embed surface for the chart (depend on `tools/machines-viz/`
+  directly when you don't need the panel chrome).
 
 ## Tab placement
 
@@ -573,6 +622,11 @@ per-machine in localStorage).
   scroll into view but are not retained in DOM.
 
 ## Layout engine — ELK with layered fallback
+
+The layout engine ships in **`tools/machines-viz/`** (per §Architectural
+posture above); the namespace paths below are relative to
+`tools/machines-viz/src/day8/re_frame2_machines_viz/`. Causa consumes
+them through the re-export shims (see §Re-export shim contract).
 
 Two layout engines flow through `chart/svg.cljc`'s renderer behind the
 same `{:nodes :edges :width :height :initial-id}` data shape:


### PR DESCRIPTION
## Summary

Three remaining Causa P1 spec-currency drifts from the 2026-05-19 audit, bundled because they share the same machines-viz re-extraction + Static-mode shipping context. Builds on PR #1581 (Lock #14 + 018 §Static + 003 §Static Machines).

- **rf2-g9j6w — 003 §Architectural posture.** Reverse the pre-rf2-o9arp claim that the chart primitive lives Causa-internal. Per PR #1570 the MachineChart primitive lives in `tools/machines-viz/` as its own tool jar; Causa re-exports the public chart API via thin shims. Adds a §Re-export shim contract sub-section with a one-for-one Causa → machines-viz mapping, corrects the §Layout engine intro so bare `chart/svg.cljc` paths read as machines-viz-relative, restates the dependency arrow as `tools/causa/ → tools/machines-viz/ → implementation/machines/`.
- **rf2-293hh — 000 §The two modes.** Static mode was completely missing from the vision document. Adds a §The two modes section between §What it is and §What it isn't framing Causa as Runtime (event-coupled, 5 canonical questions, 4-layer chrome) + Static (event-INDEPENDENT registry browse, 3-layer chrome). Cross-references Lock #14, 018 §2.5, 007 §Static mode, 003 §Static Machines surface. Five canonical questions stay Runtime-flavoured.
- **rf2-4ku4b — 000 machines-viz arrows (three places).** Three inverted dependency claims pre-rf2-o9arp: the "Machines" capability row in §What re-frame2 unlocks (line 173); the 7-tab inventory Machines row (line 213); the whole-tool dependency-arrows paragraph in §Where Causa fits (lines 308–310). All three now state `Causa → machines-viz → implementation/machines/`.

**rf2-1sov6 closed as verified-already-shipped** — PR #1581's §11 Keyboard map update already replaced the "reserved" Cmd-Shift-M row with the shipped description; no further edit required.

## Files

- `tools/causa/spec/003-Machine-Inspector.md` — §Architectural posture rewrite + §Re-export shim contract + §Layout engine clarifier.
- `tools/causa/spec/000-Vision.md` — new §The two modes section + three corrected machines-viz dependency-arrow claims.

LoC: +124 / -14.

## Test plan

- [x] `python scripts/check_doc_slugs.py` → exit 0
- [x] `python -m mkdocs build --strict` → built in 6.26s, informational nav warnings only (all pre-existing, unrelated)
- [x] `clojure -M:test` from `tools/causa/` → 749 tests, 2263 assertions, 0 failures, 0 errors
- [ ] CI green