### PR TITLE
spec(story): lock Causa-in-RHS per-panel embed contract (rf2-oqah0 + rf2-6qm77 + rf2-sgwor)

### DIFF
--- a/tools/story/spec/001-Authoring.md
+++ b/tools/story/spec/001-Authoring.md
@@ -72,13 +72,77 @@ no fn-slots):
  :args->events          {<arg-key> <event-id>}   ; arg → app-db mapping (spec/007 §Args mapping)
  :platforms             #{:server :client}
  :substrates            #{:reagent :uix ...}
- :modes                 #{<mode-id> ...}}        ; cell = (variant × mode)
+ :modes                 #{<mode-id> ...}         ; cell = (variant × mode)
+ :causa-panel           <panel-kw>               ; (rf2-v1ach) default Causa panel for the RHS embed
+ :causa                 {:panel <panel-kw>       ;   nested form (same slot, alongside other :causa keys)
+                         :open?  <bool>          ;   per-story Causa preset — see §Causa preset slot
+                         :tab    <kw>            ;   (deprecated alias for :panel)
+                         :filters {...}
+                         :focus   {...}}}
 ```
 
 The `:rf/variant` schema (in
 [`spec/Spec-Schemas.md`](../../../spec/Spec-Schemas.md)) enforces the
 no-fn-slots rule. Stage 2 macros validate the body against this schema
 and reject with `:rf.error/variant-shape` on miss.
+
+#### `:causa-panel` — RHS Causa embed default (rf2-v1ach)
+
+The optional `:causa-panel` slot declares which Causa panel renders
+by default in the RHS Causa embed (per
+[`003-Render-Shell.md`](003-Render-Shell.md) §Right-hand pane). The
+slot's value is one of the seven canonical Causa panel ids:
+
+| `:causa-panel` value | Causa panel rendered (chip label)             | Typical use case                                  |
+|----------------------|-----------------------------------------------|---------------------------------------------------|
+| `:event-detail`      | Event — six-domino cascade view (default)     | "What happened on the last event?"                |
+| `:app-db`            | App-db — structural diff across the cascade   | State-shape stories (counter, settings, modals)   |
+| `:views`             | Views — per-view sub-invalidation surface     | Reactive-graph debugging, sub-fan-out stories     |
+| `:trace`             | Trace — trace-buffer feed for the cascade     | Side-effect / fx-heavy stories                    |
+| `:machines`          | Machines — chart + arc/ring overlays          | Statechart-driven UIs                             |
+| `:routing`           | Routing — registered routes + simulate-URL    | Routing demos, deep-link stories                  |
+| `:issues`            | Issues — cascade-scoped issues feed           | Stories that exercise issue / warning surfaces    |
+
+The slot resolves variant-first, then story-level, then the framework
+default `:event-detail`. The user can swap panels at runtime via the
+chip-row picker in the RHS — their click is sticky for the session
+and overrides the declared default. Unknown keywords fall back to
+`:event-detail` so a typo doesn't blank the embed. The canonical id
+list lives in
+[`re-frame.story.ui.causa-embed/panel-catalog`](../src/re_frame/story/ui/causa_embed.cljs);
+the Causa-side mount surface (one `mount-<panel>!` per id) lives at
+[`day8.re-frame2-causa.panels`](../../causa/src/day8/re_frame2_causa/panels.cljs).
+
+Two equivalent forms are accepted on the variant (or story) body:
+
+```clojure
+;; Top-level form — recommended when there's no other :causa preset.
+(story/reg-variant :story.counter/at-five
+  {:events       [[:counter/initialise 5]]
+   :causa-panel  :app-db})              ; "state-shape story → app-db lens"
+
+;; Nested form — recommended when the variant also carries other
+;; :causa preset slots (`:open?` / `:filters` / `:focus`). Lets the
+;; author group all Causa-side configuration in one map.
+(story/reg-variant :story.routing/deep-link
+  {:events [[:router/navigate "/checkout/42"]]
+   :causa  {:panel   :routing
+            :filters {:out [:router/url-change]}}})
+```
+
+Both forms read the same logical slot — `:causa-panel` on the body
+beats `[:causa :panel]` nested. The variant body's `:causa-panel`
+also wins over the parent story's; the resolver lives in
+`re-frame.story.ui.causa-embed/resolve-panel`.
+
+Both the cross-package `:rf/variant` schema in
+[`Spec-Schemas.md`](../../../spec/Spec-Schemas.md) and Story's local
+`Variant` schema (`tools/story/src/re_frame/story/schemas.cljc`) are
+open by convention — the top-level `:causa-panel` keyword passes
+validation as an open-shape addition, and the nested form rides the
+`:causa` slot's `CausaPreset` schema (whose `:panel` key is locked
+there). See [`003-Render-Shell.md`](003-Render-Shell.md) §Right-hand
+pane and §Mount lifecycle for how the RHS embed consumes the slot.
 
 ### `(reg-workspace id metadata)`
 

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -209,19 +209,65 @@ change; Stage 4 also adds the "Save layout" affordance.
 form. Rationale: see [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md)
 §both-workspace-persistence.
 
-## Right-hand pane (rf2-sgdd3)
+## Right-hand pane (rf2-sgdd3 · rewritten per rf2-v1ach)
 
 The RHS stacks four regions vertically:
 
-1. **Causa** — primary always-on inspector. Mounted into a
-   `[data-rf-causa-host]` slot at the top of the pane; opens via
-   `day8.re-frame2-causa.mount/open!` on every variant-selection
-   edge. Feature-detected through `re-frame.story.causa-preset/
-   causa-available?` — if Causa is not on the host build's classpath
-   the slot stays empty. Covers what the retired scrubber + trace +
-   actions panels did: L1 ribbon (◀ ▶ ⏭) + L2 event list replace the
-   scrubber; the Trace tab replaces the trace panel; the Event-tab
-   cascade view + filtered Trace replace the actions panel.
+1. **Causa — per-panel embed** (rf2-v1ach). Story's RHS hosts ONE
+   Causa panel at a time, picked by the user via a chip-row above
+   the panel slot. The embed is rendered by
+   [`re-frame.story.ui.causa-embed/causa-embed-panel`](../src/re_frame/story/ui/causa_embed.cljs)
+   and supersedes the pre-rf2-v1ach whole-shell `[data-rf-causa-host]`
+   mount: the 4-layer Causa chrome (L1 ribbon + L2 event list +
+   tab-bar + detail panel) needs ~720px to render usefully and
+   Story's RHS column is 320px, so the per-panel embed renders one
+   Causa panel cleanly at column width and exposes the rest via the
+   pop-out escape hatch. See §Mount lifecycle below for the lock on
+   the contract between Story (the host) and Causa (the panel
+   provider).
+
+   The region renders three things:
+
+   - **Chip-row picker.** A horizontal strip of chips
+     `[Event] [App-db] [Views] [Trace] [Machines] [Routing] [Issues]`
+     wearing the seven Causa panel ids in the canonical
+     debugging-frequency order. The active chip carries the warm
+     amber accent; clicking a chip swaps which panel mounts below
+     and the user's click is sticky for the session (it overrides
+     the variant's declared default per §Authoring `:causa-panel`
+     slot). At the right edge of the chip-row sits a `[Pop out ↗]`
+     chip — clicking it opens the full Causa 4-layer shell in a
+     second window via `day8.re-frame2-causa.mount/popout!`, the
+     escape hatch for the chrome the per-panel embed elides.
+   - **Panel host.** A `<div data-rf-causa-panel-host=<panel-id>>`
+     into which one of Causa's `panels/mount-<panel>!` fns
+     ([`day8.re-frame2-causa.panels`](../../causa/src/day8/re_frame2_causa/panels.cljs))
+     mounts a Reagent tree. The host is owned by a Reagent class-3
+     component (see §Mount lifecycle) that drives the
+     mount/unmount round-trip on every panel-id swap.
+   - **Empty / no-Causa states.** When no variant is focused, the
+     region renders an italic placeholder ("Select a variant to
+     inspect via Causa."). When Causa is not on the host build's
+     classpath the region renders a distinct empty state ("Causa
+     is not loaded in this build — embed surface unavailable.")
+     so the chrome stays honest about what's available rather than
+     blanking silently.
+
+   Feature-detection rides
+   `re-frame.story.causa-preset/causa-available?`. The selection-
+   watcher seam in [`shell.cljs`](../src/re_frame/story/ui/shell.cljs)
+   calls `causa-preset/wire-cross-host!` on every variant-selection
+   edge to bridge Story's configuration into Causa's slots
+   (`:project-root`, `:launch.keybinding/enabled?`, listener
+   detach) — but does NOT mount Causa; the embed's panel-host owns
+   the mount lifecycle. See §Mount lifecycle for the full sequencing.
+
+   The diagnostic surface area the embed covers is the same as the
+   pre-rf2-v1ach whole-shell mount: L1 ribbon + L2 event list (under
+   the Event panel) replace the retired scrubber; the Trace panel
+   replaces the retired trace panel; the Event-tab cascade view +
+   filtered Trace replace the retired actions panel. The chip-row
+   makes the panel selection explicit at the column level.
 
 2. **Controls** — per-variant args editor (Story-unique).
 
@@ -237,6 +283,147 @@ The shell's `:panel-visibility` map drives Stage-6 registered
 `reg-story-panel` panels (a11y, schema-validation, layout-debug)
 underneath; they keep their late-bind contract per §Panel
 registration contract.
+
+## Mount lifecycle (rf2-v1ach)
+
+The Causa-in-RHS embed (region 1 of §Right-hand pane) is the canonical
+Story-Causa mount surface. This section locks the public contract
+between Story (the host) and Causa (the panel provider). Third-party
+panels that want to compose alongside Causa (future statechart-viz,
+custom inspectors) key against this same shape.
+
+### The contract — `panels/mount-<panel>!`
+
+Causa exposes seven per-panel mount fns under the
+[`day8.re-frame2-causa.panels`](../../causa/src/day8/re_frame2_causa/panels.cljs)
+namespace (locked in
+[`tools/causa/spec/008-Embedding-Contract.md`](../../causa/spec/008-Embedding-Contract.md)
+§Per-panel mount API and
+[`tools/causa/spec/007-UX-IA.md`](../../causa/spec/007-UX-IA.md)
+§Mountable panel contract):
+
+| Panel id        | Mount fn                                                  | Causa Panel view                                  |
+|-----------------|-----------------------------------------------------------|---------------------------------------------------|
+| `:event-detail` | `(mount-event-detail!       mount-point opts) → unmount`  | Six-domino cascade view for the focused event     |
+| `:app-db`       | `(mount-app-db-diff!        mount-point opts) → unmount`  | Structural diff of app-db across the cascade      |
+| `:views`        | `(mount-views!              mount-point opts) → unmount`  | Per-view sub-invalidation surface                 |
+| `:trace`        | `(mount-trace!              mount-point opts) → unmount`  | Trace-buffer feed for the focused cascade         |
+| `:machines`     | `(mount-machine-inspector!  mount-point opts) → unmount`  | State-machine chart + arcs/rings/cluster overlays |
+| `:routing`      | `(mount-routing!            mount-point opts) → unmount`  | Registered routes + simulate-URL surface          |
+| `:issues`       | `(mount-issues-ribbon!      mount-point opts) → unmount`  | Cascade-scoped issues feed + escape-hatch lane    |
+
+Each mount fn:
+
+1. Installs Causa's handler registry (idempotent).
+2. Ensures the `:rf/causa` frame exists (idempotent
+   `rf/reg-frame`).
+3. Wraps the panel view in `[rf/frame-provider {:frame :rf/causa}
+   [<Panel>]]` so the panel's `:rf.causa/*` subscribes resolve to
+   Causa's state-isolation frame regardless of host React-context.
+4. Delegates to the host's `substrate-adapter/render` to mount the
+   tree at `mount-point`.
+5. Returns an `unmount` fn so the caller owns lifecycle.
+
+The seven panel ids are also the chip ids in §Right-hand pane's
+chip-row picker.
+
+### Story's panel-host — Reagent class-3 driver
+
+Story drives the mount/unmount lifecycle from a Reagent class-3
+component (`panel-host-component` in
+[`causa_embed.cljs`](../src/re_frame/story/ui/causa_embed.cljs)).
+Its job is to translate panel-id changes into mount/unmount round-
+trips against the active panel's `mount-<panel>!`:
+
+| React lifecycle hook       | Action                                                                                      |
+|----------------------------|---------------------------------------------------------------------------------------------|
+| `:component-did-mount`     | call `(mount-fn-for active-panel host-div)`; stash the returned unmount fn.                 |
+| `:component-did-update`    | when the panel-id changed, call the stashed unmount fn, then mount the new panel.           |
+| `:component-will-unmount`  | call the stashed unmount fn; clear the ref.                                                 |
+| `:reagent-render`          | render `<div data-rf-causa-panel-host=<panel-id> ref=... />` — stable across re-renders.    |
+
+The component is keyed on `<variant-id>::<panel-id>` in the parent
+hiccup so a variant or panel change forces a fresh React mount
+(belt-and-braces — the lifecycle handlers cover it, but the key
+guarantees no state leaks across Causa-internal bugs).
+
+`mount-fn-for` does a feature-detect symbol → fn lookup against the
+`panel-id->mount-fn-sym` map (e.g. `:event-detail` → `'day8.re-
+frame2-causa.panels/mount-event-detail!`) — a nil result is a clean
+no-op render, so Causa absence never throws.
+
+### Chip-click → swap sequence
+
+A user click on a chip in the picker:
+
+1. Mutates `:causa-panel` in
+   `re-frame.story.ui.state/shell-state-atom` via
+   `state/swap-state!`.
+2. Re-renders `causa-embed-panel` (the atom is a Reagent ratom).
+3. `effective-panel` resolves the new panel-id (user override
+   wins over story/variant `:causa-panel` slot).
+4. The parent hiccup's React key changes — `panel-host-component`
+   remounts cleanly; the previous panel's unmount fn fires; the
+   new panel's mount fn fires.
+
+The user's chip click is sticky for the session — it overrides any
+declared `:causa-panel` until the user picks a different chip or
+the shell unmounts.
+
+### `wire-cross-host!` — bridges-only, no mount
+
+[`re-frame.story.causa-preset/wire-cross-host!`](../src/re_frame/story/causa_preset.cljc)
+fires from the selection-watcher on every variant-selection edge.
+It does THREE things — all configuration bridges, none of which
+mount anything:
+
+1. **`:project-root`** — read Story's configured root via
+   `story/configure!` and propagate to
+   `day8.re-frame2-causa.config/configure!` so Causa's source-
+   coord chips resolve against the same on-disk root Story uses
+   (rf2-r1uod, symmetric to shop's rf2-6jyf6).
+2. **`:launch.keybinding/enabled? false`** — flip Causa's
+   keybinding config slot so Story's `Cmd/Ctrl+K` reaches Story's
+   own command palette without Causa's global capture-phase
+   listener swallowing the key (rf2-q7who.1).
+3. **`day8.re-frame2-causa.keybinding/detach!`** — runtime removal
+   of the listener Causa's preload already installed under the
+   default-true posture (rf2-ycrt2 — closes the gap rf2-q7who.1
+   declared but did not close).
+
+This replaces the legacy `ensure-causa-mounted!` whose name
+implied a mount but in practice fired the same three bridges PLUS
+called `mount/open!` on Causa's whole-shell mount path. Under the
+per-panel embed the panel-host owns the mount; `wire-cross-host!`
+fires the bridges only. `ensure-causa-mounted!` survives in the
+ns as a deprecated alias for callers that explicitly want the
+whole-shell shape (vanishingly rare; the popout escape hatch is
+the supported route).
+
+### Adding a third-party panel
+
+A future tool (statechart-viz, profiler-overlay, etc.) that wants
+to compose into the same RHS picker would:
+
+1. Expose `(mount-<panel-id>! mount-point opts) → unmount-fn`
+   from its own namespace, following Causa's
+   `panels/mount-<panel>!` shape.
+2. Register the panel-id in Story's `panel-catalog` (rf2-v1ach
+   reserves the seven Causa ids; additions follow the same vector
+   shape).
+3. Map the panel-id to its mount-fn symbol in
+   `panel-id->mount-fn-sym`.
+
+The chip-row picker, the panel-host's lifecycle, and the user-
+override stickiness all work identically — the contract is panel-
+provider-agnostic because it keys against the public mount-fn
+shape rather than Causa-specific internals.
+
+The detailed Causa-side contract — every mount fn's input subs,
+write events, and embedding `opts` — lives in
+[`tools/causa/spec/008-Embedding-Contract.md`](../../causa/spec/008-Embedding-Contract.md)
+and the per-panel Causa specs in
+[`tools/causa/spec/007-UX-IA.md`](../../causa/spec/007-UX-IA.md).
 
 ## Trace bus consumption
 
@@ -290,12 +477,18 @@ no parallel mounting protocol. Five rules govern panel hosting:
    (e.g. Causa's epoch view, future statechart-viz panels) registers
    from its own boot.
 
-5. **The Causa embed.** The built-in `:rf.story.panel/epoch` panel
-   registers against a STUB view. The Causa library
-   ([`tools/causa/`](../../causa/)) registers the live view under the
-   same `:rf.story.panel/epoch-view` id when present; the shell's
-   late-bind `rf/view` lookup picks Causa's view automatically. If
-   Causa is absent the stub renders documenting the contract.
+5. **Causa is NOT a `reg-story-panel` registration.** Pre-rf2-v1ach
+   the spec described a `:rf.story.panel/epoch` panel that late-bound
+   to a Causa-registered view. That model is superseded by the
+   per-panel embed locked in §Right-hand pane and §Mount lifecycle —
+   Story embeds Causa via a direct require of `causa-embed-panel`
+   and per-panel `mount-<panel>!` calls, not via `reg-story-panel`.
+   The five-rule panel contract above still governs other tooling
+   embeds (a11y, schema-validation, layout-debug, future third-party
+   panels that do NOT participate in the Causa chip-row); the Causa
+   surface has its own dedicated contract because the chip-row
+   picker + Causa's mount-fn family are richer than `reg-story-
+   panel`'s single-view-per-panel shape.
 
 See [`006-MCP-Surface.md`](006-MCP-Surface.md) for how the agent
 surface re-uses this contract.


### PR DESCRIPTION
## Summary

Closes three Story P1 spec follow-ons from the rf2-9puyf currency audit
(`ai/findings/2026-05-19-story-spec-currency-audit.md` F1/F2/F3). All
three describe a single normative surface — the Causa-in-RHS per-panel
embed shipped in rf2-v1ach (#1566) — so they ride one PR.

- **rf2-oqah0** — 003-Render-Shell.md §RHS rewrite. Region 1 now
  describes the per-panel embed (chip-row picker · panel-host ·
  empty/no-Causa states) instead of the superseded whole-shell
  `[data-rf-causa-host]` mount via `ensure-causa-mounted!`.
- **rf2-6qm77** — 001-Authoring.md §reg-variant. The variant body
  shape table now carries `:causa-panel <kw>` (and its nested
  `:causa {:panel ...}` form) with the canonical seven-id panel
  table, worked examples, and the open-shape validation note.
- **rf2-sgwor** — 003-Render-Shell.md §Mount lifecycle (new). Locks
  the public seam between Story and Causa: the
  `panels/mount-<panel>!` family, the Reagent class-3 panel-host
  lifecycle, the chip-click swap sequence, `wire-cross-host!` as
  the bridges-only replacement for `ensure-causa-mounted!`, and
  the "adding a third-party panel" path so the contract reads as
  Causa-agnostic.

Also updated 003 §Panel registration contract rule #5 — the Causa
embed is NOT a `reg-story-panel` registration any more; the five-rule
contract still governs other tooling embeds (a11y / schema-validation
/ layout-debug).

## Test plan

- [x] `mkdocs build --strict` clean.
- [x] `scripts/check_doc_slugs.py` clean (exit 0).
- [x] `clojure -M:test` from tools/story/ — 781 tests, 2317
      assertions, 0 failures, 0 errors.
- [x] Spec-only PR; no source-code / test changes (write scope
      respected per bead dispatch).

## Source-of-truth references

- `tools/story/src/re_frame/story/ui/causa_embed.cljs` (399 LoC,
  #1566 + #1577) — chip-row picker, panel-host class-3 component,
  `mount-fn-for` / `panel-id->mount-fn-sym` dispatch.
- `tools/causa/src/day8/re_frame2_causa/panels.cljs` — the public
  `mount-<panel>!` family Causa exposes.
- `tools/story/src/re_frame/story/causa_preset.cljc` —
  `wire-cross-host!` (bridges-only) and the deprecated
  `ensure-causa-mounted!`.