### PR TITLE
fix(causa): relative-time anchor flips on event arrival (rf2-0s2at)

### DIFF
--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -300,7 +300,7 @@ ONE row shape, decorated by gutter glyph + right-aligned icon badges + trailing 
 │ Time chip    │ inline ≥30px │ now / 5s / 2m / 1h / 3d (right-aligned)│
 ```
 
-#### Relative-time chip (rf2-vbbq0)
+#### Relative-time chip (rf2-vbbq0 / rf2-0s2at)
 
 Each row carries a trailing right-aligned chip showing how long ago the cascade was dispatched. The chip's bucket strategy keeps old chips visually stable:
 
@@ -312,7 +312,7 @@ Each row carries a trailing right-aligned chip showing how long ago the cascade 
 | `< 24h`            | `Nh`    |
 | `≥ 24h`            | `Nd`    |
 
-A process-global 1s `setInterval` dispatches `:rf.causa/relative-time-tick` into the `:rf/causa` frame; the resulting trace event is filtered at ingest by `trace-bus/causa-internal-event?` so the tick never lands in the user-facing event list. The chip's `:title` attribute carries the absolute walltime (`HH:MM:SS · ISO · epoch-ms`) as the power-user reveal — hover the chip for the precise time without leaving L2. Replaces the v1 absolute datetime column dropped in Round-3 R3-C.
+**Anchor (rf2-0s2at):** the "now" each chip computes against is the **dispatched-time of the most recent cascade in `:rf.causa/cascades`** — flips on event arrival, not on a per-second tick. Between events the L2 list stays frozen (no re-render); when a new event lands the anchor advances and every older row's chip recomputes (a row that read `3s` may now read `8s`). This replaces the earlier (rf2-vbbq0 original) 1s `setInterval` design: relative time is meaningful between events, not between seconds, and the per-second tick caused constant L2 flicker watching live testbeds. No timer; the anchor sub composes off the existing `:rf.causa/cascades` reactive path. The chip's `:title` attribute carries the absolute walltime (`HH:MM:SS · ISO · epoch-ms`) as the power-user reveal — hover the chip for the precise time without leaving L2. Replaces the v1 absolute datetime column dropped in Round-3 R3-C.
 
 #### Gutter glyphs
 

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -270,28 +270,35 @@
         (let [cascades (projection/group-cascades buffer)]
           (into [] (remove trace-bus/causa-internal-cascade?) cascades))))
 
-    ;; ---- L2 relative-time chip ticker (rf2-vbbq0) -----------------
+    ;; ---- L2 relative-time anchor (rf2-vbbq0 / rf2-0s2at) ----------
     ;;
     ;; Every L2 row carries a small right-aligned chip showing how long
-    ;; ago the cascade was dispatched ("5s" / "2m" / "1h" / "3d"). A
-    ;; process-global `defonce` `setInterval` in `shell.cljs` dispatches
-    ;; `:rf.causa/relative-time-tick` once per second; the handler stamps
-    ;; the current wall clock into `:rf.causa/relative-time-now-ms` so
-    ;; the L2 view's subscribe re-fires every tick and the chip text
-    ;; recomputes against the latest now.
+    ;; ago the cascade was dispatched ("5s" / "2m" / "1h" / "3d"). The
+    ;; anchor — the "now" each row's relative-time computes against —
+    ;; flips on EVENT ARRIVAL, not on a wall-clock tick (rf2-0s2at).
     ;;
-    ;; `:rf.trace/no-emit? true` keeps the per-second tick out of the
-    ;; trace buffer (defence-in-depth — the ticker also targets
-    ;; `:rf/causa` so `trace-bus/causa-internal-event?` would drop the
-    ;; envelope at ingest anyway).
+    ;; Mike's design call (2026-05-19, watching the parallel-frames
+    ;; testbed live): a per-second `setInterval` re-rendered the L2
+    ;; list every second, producing constant flicker for negligible
+    ;; semantic gain. Relative time is meaningful BETWEEN events, not
+    ;; between seconds — so the anchor is the dispatched-time of the
+    ;; most recent cascade. When a new event arrives the anchor flips,
+    ;; older rows recompute (a row that was "3s" now reads "8s"); in
+    ;; between events the list is frozen.
+    ;;
+    ;; The sub composes off `:rf.causa/cascades` so it inherits the
+    ;; Causa-internal filter (cascade-internal ticks never become the
+    ;; anchor). It returns nil when the buffer is empty or no cascade
+    ;; carries a `:dispatched :time` — the view's render-time fallback
+    ;; (`(interop/now-ms)`) covers that edge.
     (rf/reg-sub :rf.causa/relative-time-now-ms
-      (fn [db _query]
-        (get db :rf.causa/relative-time-now-ms)))
-
-    (rf/reg-event-db :rf.causa/relative-time-tick
-      {:rf.trace/no-emit? true}
-      (fn [db [_ now-ms]]
-        (assoc db :rf.causa/relative-time-now-ms now-ms)))
+      :<- [:rf.causa/cascades]
+      (fn [cascades _query]
+        (let [times (into []
+                          (keep #(get-in % [:dispatched :time]))
+                          cascades)]
+          (when (seq times)
+            (apply max times)))))
 
     ;; ---- 4-layer chrome events (rf2-xy4yb / spec/018) -------------
 

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -327,7 +327,7 @@
       http?    (conj "🌐")
       machine? (conj "🤖"))))
 
-;; ---- Relative-time chip (rf2-vbbq0) --------------------------------------
+;; ---- Relative-time chip (rf2-vbbq0 / rf2-0s2at) --------------------------
 ;;
 ;; Each L2 row carries a small right-aligned chip showing how long ago the
 ;; cascade was dispatched ("5s", "2m", "1h", "3d"). Mike's design call
@@ -345,11 +345,20 @@
 ;;   diff < 24h              → "Nh"
 ;;   diff ≥ 24h              → "Nd"
 ;;
-;; The view subscribes to a re-frame sub `:rf.causa/relative-time-now-ms`
-;; that is bumped by a `defonce` `setInterval` once per second. The tick
-;; event is namespaced under `:rf.causa/*` and dispatched against the
-;; `:rf/causa` frame, so per `trace-bus/causa-internal-event?` it is
-;; filtered out at ingest — the user's L2 list never sees it.
+;; Anchor (rf2-0s2at): the "now" each row computes against is the
+;; dispatched-time of the MOST RECENT cascade in the spine, not a
+;; wall-clock tick. The earlier design (rf2-vbbq0 original) drove
+;; the anchor with a per-second `setInterval` so old rows rolled
+;; into their next bucket on time. Watching the parallel-frames
+;; testbed live (2026-05-19) Mike saw the per-second re-render
+;; flicker the L2 list constantly — relative time is meaningful
+;; BETWEEN events, not between seconds. Each new event re-establishes
+;; "now"; between events the list stays frozen. Anchor flips arrive
+;; on the existing reactive path (a new cascade appears in
+;; `:rf.causa/cascades`) so no timer / no internal trace pollution.
+;;
+;; The view subscribes to `:rf.causa/relative-time-now-ms` (sub
+;; composed off `:rf.causa/cascades` — see `registry.cljs`).
 
 (defn format-relative-time
   "Pure helper. Given two epoch-ms values (current time + the cascade's
@@ -400,9 +409,11 @@
 
 (defn relative-time-chip
   "Render the L2 row's right-aligned relative-time chip. `now-ms` is the
-  current wall clock supplied by the L2 view (sourced from the
-  `:rf.causa/relative-time-now-ms` sub so all rows tick coherently).
-  Renders nothing when the cascade carries no dispatched-time stamp."
+  anchor supplied by the L2 view — sourced from the
+  `:rf.causa/relative-time-now-ms` sub (dispatched-time of the most
+  recent cascade, per rf2-0s2at; flips on event arrival, not on a
+  per-second tick). Renders nothing when the cascade carries no
+  dispatched-time stamp."
   [cascade now-ms]
   (when-let [then-ms (cascade-dispatched-time-ms cascade)]
     (let [now      (or now-ms (interop/now-ms))
@@ -421,49 +432,16 @@
                       :white-space   "nowrap"}}
        label])))
 
-;; ---- Relative-time ticker (rf2-vbbq0) ------------------------------------
+;; ---- Relative-time anchor (rf2-0s2at) ------------------------------------
 ;;
-;; A single process-global ticker drives every L2 row's chip. A
-;; `setInterval` at 1s cadence dispatches `:rf.causa/relative-time-tick`
-;; into the `:rf/causa` frame; the event-db handler writes `(interop/
-;; now-ms)` into the `:rf.causa/relative-time-now-ms` slot, and the
-;; chip's parent (`event-list`) subscribes to that value. The ticker's
-;; trace events carry `:frame :rf/causa` so `trace-bus/causa-internal-
-;; event?` drops them at ingest (no buffer pressure, no L2 self-noise).
-;;
-;; `defonce` + idempotent start guard keeps shadow-cljs `:after-load`
-;; from spinning up a second timer. The interval handle is held on the
-;; defonce so a future teardown can clear it; today nothing calls clear.
-
-(defonce ^:private relative-time-ticker-state
-  ;; `{:handle <setInterval-id-or-nil>}` — defonce so the symbol is
-  ;; preserved across reloads; the inner map is mutated via reset!.
-  (atom {:handle nil}))
-
-(defn- relative-time-tick-cadence-ms
-  "Ticker cadence — 1s. Hoisted to a defn so tests can stub it."
-  []
-  1000)
-
-(defn- start-relative-time-ticker!
-  "Idempotent. Spins up a `setInterval` that dispatches
-  `:rf.causa/relative-time-tick` once per second so every L2 row's
-  chip recomputes against the latest wall clock. No-op when the timer
-  is already running, when `js/setInterval` is absent (some test
-  contexts), or when `js/document` is absent (node-test — no DOM, no
-  rendering, no need to tick). The chip's view falls back to
-  `(interop/now-ms)` at render time until the first tick lands."
-  []
-  (when (and (not (:handle @relative-time-ticker-state))
-             (exists? js/setInterval)
-             (exists? js/document))
-    (let [handle (js/setInterval
-                   (fn []
-                     (rf/dispatch [:rf.causa/relative-time-tick (interop/now-ms)]
-                                  {:frame :rf/causa}))
-                   (relative-time-tick-cadence-ms))]
-      (swap! relative-time-ticker-state assoc :handle handle)))
-  nil)
+;; No timer. The anchor is the dispatched-time of the most recent
+;; cascade — see the `:rf.causa/relative-time-now-ms` sub in
+;; `registry.cljs`. It re-fires on the standard reactive path when a
+;; new cascade lands in `:rf.causa/cascades`, so old rows recompute
+;; their relative-time exactly when fresh context arrives. (Earlier
+;; rf2-vbbq0 design used a `setInterval`-driven tick; rf2-0s2at
+;; replaced it after Mike observed constant L2 flicker watching the
+;; parallel-frames testbed live.)
 
 ;; ---- L1 ribbon -----------------------------------------------------------
 
@@ -1235,10 +1213,6 @@
   ;; mounted by the shell-view); defonce + DOM guards keep it a
   ;; no-op everywhere it matters.
   (inject-scrollbar-style!)
-  ;; rf2-vbbq0 — kick the relative-time ticker on first paint. The
-  ;; `defonce` + handle guard keeps it a single timer regardless of
-  ;; mount cycles / shadow-cljs `:after-load` reloads.
-  (start-relative-time-ticker!)
   (let [cascades       @(rf/subscribe [:rf.causa/filtered-cascades])
         focus          @(rf/subscribe [:rf.causa/focus])
         focus-set      @(rf/subscribe [:rf.causa/focus-set])
@@ -1247,10 +1221,14 @@
         ;; surfaces the bucket as a muted L2 row that focuses the
         ;; bucket on click so downstream panels populate.
         show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
-        ;; rf2-vbbq0 — one subscribe per render drives every chip's
-        ;; relative-time text. Falls back to `(interop/now-ms)` before
-        ;; the first tick lands so the chips render correctly on the
-        ;; first paint (which beats the 1s tick cadence).
+        ;; rf2-0s2at — one subscribe per render drives every chip's
+        ;; relative-time text. The sub returns the dispatched-time of
+        ;; the most recent cascade (the anchor flips on event arrival,
+        ;; not on a per-second tick). Falls back to `(interop/now-ms)`
+        ;; when the buffer is empty / no cascade carries a stamp — at
+        ;; that point there are no rows to render against the anchor
+        ;; anyway, but the chip's render-time guard keeps the bucket
+        ;; computation defined.
         now-ms         (or @(rf/subscribe [:rf.causa/relative-time-now-ms])
                            (interop/now-ms))
         focused-id     (:dispatch-id focus)

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -229,7 +229,9 @@
    :rf.causa.static.machines/sub-mode-by-id
    ;; rf2-x8h9y — horizontal resize handle width.
    :rf.causa/panel-width-px
-   ;; rf2-vbbq0 — L2 row relative-time chip clock (1s ticker writes here).
+   ;; rf2-vbbq0 / rf2-0s2at — L2 row relative-time chip anchor (sub
+   ;; composed off `:rf.causa/cascades` — dispatched-time of the most
+   ;; recent cascade; flips on event arrival, not on a per-second tick).
    :rf.causa/relative-time-now-ms
    :rf.causa/selected-tab
    ;; rf2-ttnst — Settings popup expansion convenience subs.
@@ -381,9 +383,6 @@
    :rf.causa/palette-set-query
    :rf.causa/palette-toggle
    :rf.causa/preview-cascade
-   ;; rf2-vbbq0 — L2 row relative-time chip ticker (writes `:rf.causa/
-   ;; relative-time-now-ms` once per second so chips recompute coherently).
-   :rf.causa/relative-time-tick
    :rf.causa/remove-filter
    ;; rf2-x8h9y — resize-handle double-click reset.
    :rf.causa/reset-panel-width

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -116,6 +116,13 @@
                     (= 0 (.indexOf tid prefix)))))
            (hiccup-seq tree)))
 
+(defn- find-all-by-testid [tree testid]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (= testid (:data-testid (second node)))))
+           (hiccup-seq tree)))
+
 (defn- text-nodes
   "Flatten the rendered tree's string leaves into one concatenated
   string. Useful for asserting on the presence / absence of glyphs
@@ -1350,7 +1357,7 @@
           "no-opt render re-defaults the slot to :fixed"))))
 
 ;; -------------------------------------------------------------------------
-;; (N) L2 row — relative-time chip (rf2-vbbq0)
+;; (N) L2 row — relative-time chip (rf2-vbbq0 / rf2-0s2at)
 ;; -------------------------------------------------------------------------
 ;;
 ;; Mike's design call (2026-05-19 Q10): bring datetime BACK to the
@@ -1359,11 +1366,16 @@
 ;; is INLINE on the row, right-aligned, so active cascades stay visible
 ;; without forcing a hover.
 ;;
+;; Anchor (rf2-0s2at): the "now" each row computes against is the
+;; dispatched-time of the most recent cascade — flips on event arrival,
+;; not on a per-second tick. Mike's design call (2026-05-19) after
+;; observing constant L2 flicker on the parallel-frames testbed.
+;;
 ;; Bucket contract:
 ;;
 ;;   diff < 1s   → "now"
-;;   diff < 60s  → "Ns"     (1s-resolution; jitters per tick while young)
-;;   diff < 60m  → "Nm"     (minute-bucket; old chips stay stable)
+;;   diff < 60s  → "Ns"     (1s-resolution between events)
+;;   diff < 60m  → "Nm"     (minute-bucket)
 ;;   diff < 24h  → "Nh"
 ;;   diff ≥ 24h  → "Nd"
 
@@ -1438,24 +1450,31 @@
   (assoc (dispatch-trace-ev id event-vec) :time time-ms))
 
 (deftest event-row-renders-relative-time-chip
-  (testing "rf2-vbbq0 — every L2 row carries a right-aligned relative-
-            time chip. The chip's text reflects the bucket; the chip's
-            `:title` carries the absolute walltime for the power-user
-            reveal."
+  (testing "rf2-vbbq0 / rf2-0s2at — every L2 row carries a right-aligned
+            relative-time chip. The chip's text reflects the bucket
+            against the anchor (the dispatched-time of the MOST RECENT
+            cascade); the chip's `:title` carries the absolute walltime
+            for the power-user reveal."
     (causa-setup!)
-    (let [now-ms     1000000
-          then-ms    (- now-ms 5000)]  ;; 5 seconds ago
+    (let [now-ms  1000000
+          then-ms (- now-ms 5000)]  ;; 5 seconds ago
+      ;; Old cascade — what the chip-under-test is reporting against.
       (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      ;; Fresh cascade — establishes the anchor at `now-ms`. (rf2-0s2at
+      ;; — anchor is derived from `:rf.causa/cascades` directly, not
+      ;; from a wall-clock tick.)
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
       (rf/with-frame :rf/causa
-        ;; Seed the now-ms so the chip's display is deterministic.
-        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
-      (rf/with-frame :rf/causa
-        (let [tree (shell/shell-view)
-              chip (find-by-testid tree "rf-causa-row-time-chip")
-              attrs (second chip)
-              label (text-nodes chip)]
+        (let [tree   (shell/shell-view)
+              chips  (find-all-by-testid tree "rf-causa-row-time-chip")
+              ;; The first cascade's chip — by `:data-then-ms`.
+              chip   (first (filter #(= (str then-ms)
+                                        (:data-then-ms (second %)))
+                                    chips))
+              attrs  (second chip)
+              label  (text-nodes chip)]
           (is (some? chip) "chip renders per row")
-          (is (= "5s" label) "chip text reflects the seconds-bucket")
+          (is (= "5s" label) "chip text reflects the seconds-bucket against the anchor")
           (is (string? (:title attrs))
               "chip carries a :title tooltip for the power-user reveal")
           (is (re-find #"epoch-ms" (:title attrs))
@@ -1464,13 +1483,12 @@
               "chip stamps the source then-ms so tests can pin the value"))))))
 
 (deftest event-row-chip-now-bucket
-  (testing "rf2-vbbq0 — a row at t=0 (chip seeded with same now) renders
-            the 'now' bucket."
+  (testing "rf2-vbbq0 / rf2-0s2at — a row that IS the most recent cascade
+            (so its dispatched-time equals the anchor) renders the 'now'
+            bucket."
     (causa-setup!)
     (let [now-ms 1000000]
       (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] now-ms))
-      (rf/with-frame :rf/causa
-        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
       (rf/with-frame :rf/causa
         (let [tree (shell/shell-view)
               chip (find-by-testid tree "rf-causa-row-time-chip")]
@@ -1478,32 +1496,37 @@
               "diff = 0 → 'now' bucket"))))))
 
 (deftest event-row-chip-minute-bucket
-  (testing "rf2-vbbq0 — at t+90s the chip rolls into the minute bucket
-            and reads '1m' (not '90s')."
+  (testing "rf2-vbbq0 / rf2-0s2at — at t+90s the chip rolls into the
+            minute bucket and reads '1m' (not '90s'). Anchor pinned by a
+            fresher cascade."
     (causa-setup!)
     (let [now-ms  1000000
           then-ms (- now-ms 90000)]
       (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
       (rf/with-frame :rf/causa
-        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
-      (rf/with-frame :rf/causa
-        (let [tree (shell/shell-view)
-              chip (find-by-testid tree "rf-causa-row-time-chip")]
+        (let [tree  (shell/shell-view)
+              chips (find-all-by-testid tree "rf-causa-row-time-chip")
+              chip  (first (filter #(= (str then-ms)
+                                       (:data-then-ms (second %)))
+                                   chips))]
           (is (= "1m" (text-nodes chip))
               "90s ago → '1m' (minute bucket; jitter dampened)"))))))
 
 (deftest event-row-chip-hour-bucket
-  (testing "rf2-vbbq0 — at t+3700s the chip rolls into the hour bucket
-            and reads '1h'."
+  (testing "rf2-vbbq0 / rf2-0s2at — at t+3700s the chip rolls into the
+            hour bucket and reads '1h'."
     (causa-setup!)
     (let [now-ms  10000000
           then-ms (- now-ms 3700000)] ;; 3700s ≈ 1h2m
       (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] then-ms))
+      (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:rf.causa.test/anchor] now-ms))
       (rf/with-frame :rf/causa
-        (rf/dispatch-sync [:rf.causa/relative-time-tick now-ms]))
-      (rf/with-frame :rf/causa
-        (let [tree (shell/shell-view)
-              chip (find-by-testid tree "rf-causa-row-time-chip")]
+        (let [tree  (shell/shell-view)
+              chips (find-all-by-testid tree "rf-causa-row-time-chip")
+              chip  (first (filter #(= (str then-ms)
+                                       (:data-then-ms (second %)))
+                                   chips))]
           (is (= "1h" (text-nodes chip))
               "3700s ago → '1h'"))))))
 
@@ -1521,17 +1544,48 @@
         (is (nil? chip)
             "chip is absent when the cascade has no dispatched :time")))))
 
-(deftest relative-time-now-ms-sub-reads-app-db-slot
-  (testing "rf2-vbbq0 — the `:rf.causa/relative-time-now-ms` sub returns
-            whatever the tick event stamped into the slot. Nil before
-            the first tick lands; the L2 view falls back to `(interop/
-            now-ms)` so chips still render on the first paint."
+(defn- sync-trace-buffer!
+  "Mirror `trace-bus/buffer`'s current contents into Causa's app-db
+  slot so reactive sub re-runs see the latest cascades. Mirrors the
+  production `request-mirror-sync!` path (which dispatches the same
+  event asynchronously in shadow-cljs sessions)."
+  []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])))
+
+(deftest relative-time-now-ms-sub-derives-from-cascades
+  (testing "rf2-0s2at — `:rf.causa/relative-time-now-ms` is derived
+            from `:rf.causa/cascades`: it returns the dispatched-time
+            of the MOST RECENT cascade. Returns nil when there are no
+            cascades (or none carrying a `:dispatched :time` stamp);
+            the L2 view's render-time fallback covers that edge."
     (causa-setup!)
     (rf/with-frame :rf/causa
       (is (nil? @(rf/subscribe [:rf.causa/relative-time-now-ms]))
-          "no value before the first tick lands"))
+          "no cascades → nil anchor"))
+    (trace-bus/collect-trace! (dispatch-trace-ev-with-time 1 [:foo/bar] 1000))
+    (sync-trace-buffer!)
     (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/relative-time-tick 42]))
+      (is (= 1000 @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "single cascade → its dispatched-time is the anchor"))
+    (trace-bus/collect-trace! (dispatch-trace-ev-with-time 2 [:foo/baz] 5000))
+    (sync-trace-buffer!)
     (rf/with-frame :rf/causa
-      (is (= 42 @(rf/subscribe [:rf.causa/relative-time-now-ms]))
-          "sub returns whatever the tick handler wrote"))))
+      (is (= 5000 @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "anchor flips to the newest cascade's dispatched-time"))
+    (trace-bus/collect-trace! (dispatch-trace-ev-with-time 3 [:foo/qux] 3000))
+    (sync-trace-buffer!)
+    (rf/with-frame :rf/causa
+      (is (= 5000 @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "older arrival (lower :time) leaves the anchor at the max"))))
+
+(deftest relative-time-now-ms-sub-nil-when-no-dispatched-time
+  (testing "rf2-0s2at — cascades that carry no `:dispatched :time`
+            contribute nothing; the sub returns nil so the view falls
+            back to `(interop/now-ms)` at render time."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:foo/bar]))
+    (sync-trace-buffer!)
+    (rf/with-frame :rf/causa
+      (is (nil? @(rf/subscribe [:rf.causa/relative-time-now-ms]))
+          "no `:dispatched :time` anywhere → nil anchor"))))


### PR DESCRIPTION
## Summary
- Replace the 1s `setInterval` driving the L2 row relative-time chip with a derived anchor sub. The "now" each chip computes against is the dispatched-time of the most recent cascade in `:rf.causa/cascades` — between events the list stays frozen; when a new event lands the anchor advances and older rows recompute (a row that read `3s` may now read `8s`).
- Drop `:rf.causa/relative-time-tick` event + the `setInterval` ticker state (defonce atom + `start-relative-time-ticker!`).
- Re-derive `:rf.causa/relative-time-now-ms` from `:rf.causa/cascades` (max `:dispatched :time` across cascades).
- Spec/018 §Relative-time-chip + in-code docstrings updated.

## Motivation
Mike's design call (2026-05-19) watching the parallel-frames testbed live: the per-second tick re-rendered the L2 list every second, producing constant flicker for negligible semantic gain. Relative time is meaningful **between events**, not between seconds.

## Test plan
- [x] `clojure -M:test` from `tools/causa/` (JVM artefact) — 749 tests, 0 fail
- [x] `npm run test:cljs` (node-runtime CLJS) — 3157 tests, 0 fail
- [x] `npm run test:bundle-isolation` — pass (no Causa code in production bundles)
- [x] `npm run test:story-static` — pass
- [x] `npm run test:story-feature-load` — pass (no new console errors)

### Coverage added
- `relative-time-now-ms-sub-derives-from-cascades` — anchor flips on new event; older arrival doesn't move anchor backward.
- `relative-time-now-ms-sub-nil-when-no-dispatched-time` — nil sub when no cascade carries `:time`; view's render-time fallback covers.
- Existing chip-bucket tests rewritten to pin the anchor via a fresher cascade instead of dispatching the removed tick event.

### Render-frequency note
Before: L2 list re-rendered every 1000ms regardless of activity (constant flicker on the parallel-frames testbed). After: L2 list re-renders only when a new cascade arrives in `:rf.causa/cascades` — same reactive path that already drives every other L2 row. Zero timer overhead; chip text remains semantically correct because it only needs to advance when fresh context arrives.

Closes rf2-0s2at.