### PR TITLE
fix(causa): focus auto-tracks :epoch-id in LIVE mode (rf2-70tkv)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_diff_subs.cljs
@@ -92,9 +92,32 @@
     (fn [[target _epoch-history] _query]
       (rf/get-frame-db target)))
 
+  ;; rf2-70tkv — derive the panel's epoch-id from the spine sub
+  ;; `:rf.causa/focus` rather than the legacy `:rf.causa/selected-
+  ;; epoch-id` slot. The spine sub auto-tracks head in LIVE mode
+  ;; (deriving `:epoch-id` from the head cascade via
+  ;; `epoch-id-for-cascade` against `:epoch-history`); the legacy
+  ;; slot is only written by user clicks (L2 row select, epoch
+  ;; chip, prev/next step) and so stays pinned to the last user
+  ;; action.
+  ;;
+  ;; Mike repro: user clicks an L2 row (legacy slot → pinned
+  ;; epoch); user clicks Follow-head (focus :mode flips to :live);
+  ;; new arrivals advance the focus's :dispatch-id correctly, but
+  ;; pre-fix the legacy slot was untouched so every App-DB diff
+  ;; sub kept resolving to the pinned epoch — the panel froze.
+  ;; Pivoting these subs on focus's :epoch-id closes the gap
+  ;; without changing the legacy slot's role (still authoritative
+  ;; under RETRO + LIVE-paused via the spine's compose-focus
+  ;; passthrough).
+  (rf/reg-sub :rf.causa/focus-epoch-id
+    :<- [:rf.causa/focus]
+    (fn [focus _query]
+      (:epoch-id focus)))
+
   (rf/reg-sub :rf.causa/selected-epoch-record
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[history selected-id] _query]
       (when selected-id
         (find-epoch-in-history history selected-id))))
@@ -110,7 +133,7 @@
   ;; that "the diff panel shows whatever just happened".
   (rf/reg-sub :rf.causa/selected-epoch-diff
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[history selected-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
@@ -140,7 +163,7 @@
   ;; `db-before`/`db-after` pair as the inspector navigates.
   (rf/reg-sub :rf.causa/selected-epoch-annotated-tree
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[history selected-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
@@ -209,7 +232,7 @@
   ;; `(peek history)` fallback applies.
   (rf/reg-sub :rf.causa/selected-epoch-redacted-modified-count
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[history selected-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
@@ -250,7 +273,7 @@
   ;; when the selected epoch is absent from history.
   (rf/reg-sub :rf.causa/selected-epoch-flow-writes
     :<- [:rf.causa/epoch-history]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[history selected-id] _query]
       (let [record (or (when selected-id
                          (find-epoch-in-history history selected-id))
@@ -297,7 +320,7 @@
     :<- [:rf.causa/epoch-history]
     :<- [:rf.causa/selected-epoch-redacted-modified-count]
     :<- [:rf.causa/selected-epoch-flow-writes]
-    :<- [:rf.causa/selected-epoch-id]
+    :<- [:rf.causa/focus-epoch-id]
     (fn [[target db diff-triples sections focused-path focused-hits
           history redacted-modified-count flow-writes selected-epoch-id]
          _query]

--- a/tools/causa/src/day8/re_frame2_causa/spine.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine.cljs
@@ -282,10 +282,35 @@
     - the head walk considers `:ungrouped` as a possible head;
     - a stored `:dispatch-id :ungrouped` is pinnable (does not snap
       to head).
-  When off (default 2-arity), the existing strict behaviour applies."
+  When off (default 2-arity), the existing strict behaviour applies.
+
+  ## rf2-70tkv — `:epoch-id` auto-follow in LIVE mode
+
+  The 4-arity takes `epoch-history` (the per-frame epoch ring) and
+  re-derives `:epoch-id` to the head cascade's settling epoch when in
+  LIVE+unpaused mode, mirroring how `:dispatch-id` auto-tracks head.
+  Pre-fix the composer always returned `(:epoch-id focus)` from the
+  stored slot, so a previously-pinned epoch (set by clicking an L2
+  row's epoch chip, by `:rf.causa/select-epoch`, by Time Travel
+  scrubbing) stayed wired into the focus map even after the user
+  resumed LIVE — every panel that pivots on focus `:epoch-id`
+  (Views' focused-cascade-pair, Machine Inspector's focused-event
+  lens, App-DB diff's selected-epoch chain via the shimmed
+  `:selected-epoch-id` slot) stayed frozen on the old epoch while
+  `:dispatch-id` correctly tracked head. The 3-arity (legacy / pre-
+  rf2-70tkv callers, test rigs that don't have the history handy)
+  preserves the original behaviour: `:epoch-id` stays as stored. The
+  reactive `:rf.causa/focus` sub in `install!` uses the 4-arity so
+  every panel auto-tracks `:epoch-id` for free.
+
+  RETRO + LIVE-paused continue to honour the stored `:epoch-id`:
+  retro pins the cascade and its settling epoch in lockstep, and
+  pausing LIVE is the explicit 'freeze inspection' gesture."
   ([focus cascades]
-   (compose-focus focus cascades false))
+   (compose-focus focus cascades false nil))
   ([focus cascades show-ungrouped?]
+   (compose-focus focus cascades show-ungrouped? nil))
+  ([focus cascades show-ungrouped? epoch-history]
   (let [focusable* (focusable-cascades cascades show-ungrouped?)
         slot-frame (:frame focus)
         focusable  (if slot-frame
@@ -338,9 +363,38 @@
                   ;; orphaned-state surface in the event-detail panel.
                   :else
                   slot-id)
-        cascade (cascade-by-id focusable eff-id slot-frame)]
+        cascade (cascade-by-id focusable eff-id slot-frame)
+        ;; rf2-70tkv — `:epoch-id` auto-follows head in LIVE+unpaused
+        ;; mode when `epoch-history` is supplied (the reactive
+        ;; `:rf.causa/focus` sub path). Mirrors the `eff-id` auto-
+        ;; track above so every panel that pivots on focus
+        ;; `:epoch-id` (Views, Machine Inspector, App-DB diff via
+        ;; the `:selected-epoch-id` shim) lights up the head cascade
+        ;; on every new arrival instead of staying pinned to a stale
+        ;; stored value. Retro / LIVE-paused / unsupplied-history
+        ;; preserve the stored slot — those modes have explicit
+        ;; pinning semantics.
+        ;;
+        ;; When the head cascade's settling epoch is NOT in
+        ;; `epoch-history` (eff-id is on a frame other than the one
+        ;; the history slot is keyed to — multi-frame apps where
+        ;; the picker's frame and the head cascade's frame disagree;
+        ;; epoch evicted from the ring) we return nil rather than
+        ;; the stored slot. Panels uniformly treat nil as 'no pin,
+        ;; use the head fallback' (App-DB Diff's `(peek history)`,
+        ;; Views' `(dec (count history))`, Machine Inspector's
+        ;; `(peek history)`) — keeping a stale stored id here would
+        ;; resurrect the very freeze the auto-track was meant to
+        ;; eliminate.
+        eff-epoch-id (cond
+                       (and (= :live mode) (not paused?)
+                            (some? eff-id)
+                            (some? epoch-history))
+                       (epoch-id-for-cascade epoch-history eff-id)
+                       :else
+                       (:epoch-id focus))]
     {:dispatch-id eff-id
-     :epoch-id    (:epoch-id focus)
+     :epoch-id    eff-epoch-id
      :frame       (or (:frame cascade) (:frame focus))
      :mode        mode
      :head?       (or (nil? eff-id)
@@ -661,12 +715,21 @@
     (fn [db _query]
       (get db :focus)))
 
+  ;; rf2-70tkv — `:rf.causa/epoch-history` joined so `compose-focus`
+  ;; can auto-derive `:epoch-id` to the head cascade's settling
+  ;; epoch in LIVE+unpaused mode. Without this seam the focus map's
+  ;; `:epoch-id` stayed wired to the stored slot (last :rf.causa/
+  ;; select-epoch / focus-cascade / focus-step write), and every
+  ;; panel pivoting on focus `:epoch-id` (Views, Machine Inspector,
+  ;; App-DB diff via the `:selected-epoch-id` shim) stayed frozen
+  ;; on the old epoch while `:dispatch-id` correctly tracked head.
   (rf/reg-sub :rf.causa/focus
     :<- [:rf.causa/focus-slot]
     :<- [:rf.causa/cascades]
     :<- [:rf.causa/show-ungrouped?]
-    (fn [[focus cascades show-ungrouped?] _query]
-      (compose-focus focus cascades show-ungrouped?)))
+    :<- [:rf.causa/epoch-history]
+    (fn [[focus cascades show-ungrouped? epoch-history] _query]
+      (compose-focus focus cascades show-ungrouped? epoch-history)))
 
   ;; ---- events ----------------------------------------------------------
   ;;

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -135,6 +135,11 @@
    :rf.causa/event-detail
    :rf.causa/filtered-cascades
    :rf.causa/focus
+   ;; rf2-70tkv — App-DB diff subs pivot off the spine's focus
+   ;; `:epoch-id` (which auto-tracks head in LIVE mode) instead of
+   ;; the legacy `:selected-epoch-id` slot (which only updates on
+   ;; explicit user clicks). This sub is the thin projection seam.
+   :rf.causa/focus-epoch-id
    ;; rf2-a1z3b — focus-navigation primitive slot sub.
    :rf.causa/focus-set
    :rf.causa/focus-slot

--- a/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/spine_cljs_test.cljs
@@ -430,6 +430,10 @@
 ;; (8) Registered :rf.causa/focus sub — reactive composition
 ;; -------------------------------------------------------------------------
 
+;; Forward-declare the `epoch` helper (defined in section 10) so the
+;; rf2-70tkv reactive test below can build epoch-history fixtures.
+(declare epoch)
+
 (defn- focus-sub []
   (rf/with-frame :rf/causa
     @(rf/subscribe [:rf.causa/focus])))
@@ -631,6 +635,56 @@
           ":retro pins the focus through arrivals")
       (is (= :retro (:mode r))))))
 
+(deftest focus-sub-live-auto-follows-epoch-id-rf2-70tkv
+  (testing "rf2-70tkv — the reactive :rf.causa/focus sub auto-derives
+            :epoch-id to the head cascade's settling epoch in LIVE
+            mode. Mike repro: user clicks an L2 row (writes
+            :selected-epoch-id + focus :epoch-id), then clicks
+            Follow-head. Pre-fix the focus sub left :epoch-id pinned
+            to the clicked epoch even after follow-head; every
+            epoch-keyed panel (Views, Machines, App-DB diff via
+            shim) stayed frozen. Post-fix the sub re-derives
+            :epoch-id from head."
+    (setup-causa-frame!)
+    (seed-cascades! fixture-cascades)
+    (rf/with-frame :rf/causa
+      ;; Seed an epoch-history covering all three cascades.
+      (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]])
+      ;; User clicks the earliest cascade — pins focus to :c1/:e1.
+      (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+    (let [r (focus-sub)]
+      (is (= :c1 (:dispatch-id r)))
+      (is (= :e1 (:epoch-id r)))
+      (is (= :retro (:mode r))))
+    ;; User clicks Follow-head — :mode flips to :live; the stored
+    ;; :focus slot's :dispatch-id is cleared, but pre-rf2-70tkv the
+    ;; legacy :selected-epoch-id stayed on :e1 AND the focus sub's
+    ;; :epoch-id stayed on :e1 too. Post-fix the sub re-derives
+    ;; from head.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/follow-head]))
+    (let [r (focus-sub)]
+      (is (= :c3 (:dispatch-id r))
+          "LIVE → :dispatch-id tracks head (existing behaviour)")
+      (is (= :live (:mode r)))
+      (is (= :e3 (:epoch-id r))
+          "rf2-70tkv — :epoch-id ALSO tracks head, so Views /
+           Machines / App-DB-diff rebind to the head cascade's
+           settling epoch"))
+    ;; A new cascade c4 arrives with epoch e4 — focus sub auto-
+    ;; advances both axes.
+    (seed-cascades! (conj fixture-cascades (cascade :c4 :rf/default)))
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-epoch-history
+                         [(epoch :e1 :c1) (epoch :e2 :c2)
+                          (epoch :e3 :c3) (epoch :e4 :c4)]]))
+    (let [r (focus-sub)]
+      (is (= :c4 (:dispatch-id r)))
+      (is (= :e4 (:epoch-id r))
+          "rf2-70tkv — auto-track keeps :epoch-id and :dispatch-id
+           in lockstep on every head arrival"))))
+
 (deftest focus-sub-paused-live-does-not-auto-follow
   (testing "paused LIVE freezes auto-follow — user paused to inspect,
             so new arrivals don't pull focus away."
@@ -696,6 +750,120 @@
     (is (nil? (spine/epoch-id-for-cascade [(epoch :e1 :c1)] :c-gone)))
     (is (nil? (spine/epoch-id-for-cascade nil :c1)))
     (is (nil? (spine/epoch-id-for-cascade [(epoch :e1 :c1)] nil)))))
+
+;; ---- compose-focus :epoch-id auto-follow (rf2-70tkv) --------------------
+;;
+;; Mike repro 2026-05-19 watching parallel-frames @ localhost:8030:
+;;   1. Click '+' in host app  →  new cascade lands
+;;   2. L2 list shows the new event  ✓
+;;   3. focus :mode is :live (the LIVE pill); :dispatch-id auto-tracks
+;;      head via rf2-s0s5x Phase A  ✓
+;;   4. BUT App-db Diff content does NOT update  ✗
+;;
+;; Root cause: compose-focus was hardcoded to return `(:epoch-id focus)`
+;; from the stored slot regardless of mode. So once an earlier event
+;; wrote :focus :epoch-id (any click on an L2 row, scrubbing in Time
+;; Travel, the :rf.causa/select-epoch chip in the diff), every panel
+;; pivoting on focus :epoch-id (Views' focused-cascade-pair, Machine
+;; Inspector's focused-event lens, App-DB Diff via the
+;; :selected-epoch-id shim slot) stayed wired to the stale epoch
+;; while :dispatch-id correctly tracked head.
+;;
+;; Fix: a 4-arity `compose-focus` accepts `epoch-history` and re-
+;; derives :epoch-id from the head cascade in LIVE+unpaused mode,
+;; mirroring how :dispatch-id auto-tracks head. The 3-arity (test
+;; rigs, back-compat callers) preserves the original passthrough
+;; behaviour. The reactive `:rf.causa/focus` sub in `install!` uses
+;; the 4-arity so every panel auto-tracks `:epoch-id` for free.
+
+(deftest compose-focus-3-arity-preserves-stored-epoch-id
+  (testing "rf2-70tkv — the 3-arity (no epoch-history input) preserves
+            the original behaviour for back-compat callers + test rigs"
+    (let [r (spine/compose-focus {:dispatch-id :c2 :mode :retro
+                                  :epoch-id :e-stale}
+                                 fixture-cascades
+                                 false)]
+      (is (= :e-stale (:epoch-id r))
+          "no epoch-history supplied → stored :epoch-id passes through"))))
+
+(deftest compose-focus-4-arity-live-auto-derives-epoch-id-from-head
+  (testing "rf2-70tkv — in LIVE+unpaused mode the 4-arity re-derives
+            :epoch-id to the head cascade's settling epoch. Bug repro
+            in pure-data form: a stored :focus :epoch-id of :e1 from a
+            prior L2 click must NOT survive a LIVE switch + head
+            arrival."
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
+          r       (spine/compose-focus {:dispatch-id nil :mode :live
+                                        :epoch-id :e1}
+                                       fixture-cascades false history)]
+      (is (= :c3 (:dispatch-id r))
+          ":dispatch-id tracks head (existing rf2-s0s5x Phase A)")
+      (is (= :e3 (:epoch-id r))
+          ":epoch-id ALSO tracks head — the stale stored :e1 is
+           overwritten so panels rebind on every new arrival"))))
+
+(deftest compose-focus-4-arity-live-paused-honours-stored-epoch-id
+  (testing "rf2-70tkv — LIVE-paused is the explicit 'freeze inspection'
+            gesture: the stored :epoch-id rides through untouched
+            (matching how :dispatch-id stays on the stored slot when
+            paused)"
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
+          r       (spine/compose-focus {:dispatch-id :c1 :mode :live
+                                        :epoch-id :e1 :paused? true}
+                                       fixture-cascades false history)]
+      (is (= :c1 (:dispatch-id r))
+          "paused → :dispatch-id pins to stored slot")
+      (is (= :e1 (:epoch-id r))
+          "paused → :epoch-id pins to stored slot"))))
+
+(deftest compose-focus-4-arity-retro-honours-stored-epoch-id
+  (testing "rf2-70tkv — RETRO mode pins the cascade and its settling
+            epoch in lockstep, so the stored :epoch-id is the
+            authoritative value (the focus-cascade-reducer / focus-step-
+            reducer already write it consistently with :dispatch-id)"
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2) (epoch :e3 :c3)]
+          r       (spine/compose-focus {:dispatch-id :c1 :mode :retro
+                                        :epoch-id :e1}
+                                       fixture-cascades false history)]
+      (is (= :c1 (:dispatch-id r)))
+      (is (= :e1 (:epoch-id r))
+          "retro pin honoured — picker / scrubber wrote both axes
+           together"))))
+
+(deftest compose-focus-4-arity-live-head-with-no-epoch-match-returns-nil
+  (testing "rf2-70tkv — multi-frame edge case. The picker's frame
+            (and thus the per-frame :epoch-history slot keyed off
+            :target-frame) can disagree with the head cascade's
+            frame in mid-transition states; the head's settling
+            epoch might also have been evicted from the ring buffer.
+            When the head's epoch is NOT in epoch-history we return
+            nil rather than the stored slot.
+
+            Every panel uniformly treats nil as 'no pin, use head
+            fallback' (App-DB Diff's `(peek history)`, Views'
+            `(dec (count history))`, Machine Inspector's `(peek
+            history)`). Keeping a stale stored id here would
+            resurrect the very freeze the auto-track was meant to
+            eliminate."
+    (let [history [(epoch :e1 :c1) (epoch :e2 :c2)]
+          r       (spine/compose-focus {:dispatch-id nil :mode :live
+                                        :epoch-id :e1}
+                                       fixture-cascades false history)]
+      (is (= :c3 (:dispatch-id r))
+          "head cascade is :c3")
+      (is (nil? (:epoch-id r))
+          ":e3 is not in history → nil (NOT the stale :e1)"))))
+
+(deftest compose-focus-4-arity-live-empty-history-returns-nil
+  (testing "rf2-70tkv — empty epoch-history (cold start; buffer-cleared)
+            in LIVE mode → :epoch-id nil so the App-DB Diff's
+            `(peek history)` fallback path resolves correctly."
+    (let [r (spine/compose-focus {:dispatch-id nil :mode :live
+                                  :epoch-id :e-stale}
+                                 fixture-cascades false [])]
+      (is (nil? (:epoch-id r))
+          "empty history → no resolution possible → nil overrides
+           any stale stored id"))))
 
 (deftest focus-cascade-reducer-4-arg-writes-epoch-id
   (testing "the 4-arg reducer writes :epoch-id into the :focus slot AND


### PR DESCRIPTION
## Summary

**P1 fix.** Mike caught this live in the parallel-frames testbed: clicking `+` in the host app showed the new event in L2, the LIVE pill said it was auto-following, but the App-DB Diff panel content stayed frozen on the previously-pinned epoch.

## Scope of bug

Pre-fix, per-panel auto-follow behaviour in LIVE+pinned-epoch scenarios:

| Panel             | Pre-fix     | Post-fix     |
|-------------------|-------------|--------------|
| Event Detail      | tracks LIVE | unchanged    |
| App-DB Diff       | **FROZEN**  | tracks LIVE  |
| Views             | **FROZEN**  | tracks LIVE  |
| Trace             | tracks LIVE | unchanged    |
| Machines          | **FROZEN**  | tracks LIVE  |
| Routing           | tracks LIVE | unchanged    |
| Issues            | tracks LIVE | unchanged    |

3 of 7 panels frozen — every panel that pivoted on focus `:epoch-id`.

## Root cause

`compose-focus` was hardcoded to passthrough `(:epoch-id focus)` from the stored slot regardless of mode. So once any user gesture wrote `:focus :epoch-id` (L2 row click via `focus-cascade-reducer`; epoch chip via `:rf.causa/select-epoch`; prev/next step via `focus-step-reducer`), every panel pivoting on focus `:epoch-id` stayed wired to the pinned epoch even after `follow-head` snapped `:dispatch-id` back to LIVE auto-tracking.

App-DB Diff was additionally pinned because its subs read `:rf.causa/selected-epoch-id` directly off the legacy slot — that slot is only written on explicit clicks and the LIVE auto-follow path doesn't touch it.

## The fix

Two layers, paralleling how `:dispatch-id` auto-tracks head (rf2-s0s5x Phase A):

1. **Spine — `compose-focus` 4-arity.** Takes `epoch-history` and re-derives `:epoch-id` from the head cascade via `epoch-id-for-cascade` in LIVE+unpaused mode. The reactive `:rf.causa/focus` sub joins `:rf.causa/epoch-history` and calls the 4-arity. Returns `nil` when the head's epoch isn't in history (multi-frame mid-transition; evicted from ring) so panels uniformly use the head fallback (`peek history`) rather than a stale stored id. The 3-arity preserves passthrough for back-compat callers + test rigs.

2. **App-DB Diff subs.** Pivot on a new thin projection sub `:rf.causa/focus-epoch-id` (reads focus's `:epoch-id` axis) instead of the legacy `:rf.causa/selected-epoch-id` slot. Views and Machine Inspector already read focus's `:epoch-id` directly with head fallback, so they auto-tracked once the spine sub was fixed.

RETRO and LIVE-paused continue to honour the stored slot — those are explicit pinning gestures.

## Test plan

- [x] 6 new `compose-focus` unit tests cover the auto-track shape: 3-arity passthrough, LIVE auto-derive, LIVE-paused honouring, RETRO honouring, multi-frame no-match returning nil, empty history returning nil.
- [x] 1 new reactive integration test (`focus-sub-live-auto-follows-epoch-id-rf2-70tkv`) drives the bead's exact repro through the spine sub: pin → follow-head → arrival → both axes auto-track.
- [x] Registry snapshot test updated for the new projection sub.
- [x] Full node-test suite: 3163 tests, 9108 assertions, 0 failures.
- [x] Causa JVM test suite: 749 tests, 2263 assertions, 0 failures.
- [x] Bundle isolation: PASS.
- [x] Live browser verification on the parallel-frames testbed: reproduced the exact bug (App-DB Diff frozen at `(root) 4 changes` after pinning epoch 2 + clicking Follow-head + new arrival), applied the fix, confirmed the diff now advances to `:counter 0→1` then `1→2` on subsequent clicks. Spine sub returns `:epoch-id` matching head's settling epoch; Views' `views-focused-cascade-pair` advances `:index` per arrival; RETRO continues to pin focus through arrivals.

Closes rf2-70tkv.