### PR TITLE
feat(causa): hardened L1 frame-switcher slot (rf2-iwwou)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -238,6 +238,27 @@ dropped; LIVE/RETRO surfaces in the L2 event-list spine itself.)
 Full anatomy + filter-pill edit popup in
 [`018-Event-Spine.md`](./018-Event-Spine.md) §3 + §7.
 
+### Frame slot contract (rf2-iwwou)
+
+The **Frame** cluster is the L1 frame-switcher slot — the single
+contractually-anchored surface every frame-aware feature reaches
+through. The slot lives in `tools/causa/src/day8/re_frame2_causa/
+frame_switcher.cljs`; the ribbon mounts the view as one delegate. The
+contract:
+
+| Surface | Id | Role |
+|---|---|---|
+| Sub | `:rf.causa/current-frame` | Returns the frame id the user has focused (or nil pre-selection). |
+| Sub | `:rf.causa/available-frames` | First-seen-order vec of selectable frames; tool frames filtered by default per §I1 below. |
+| Event-fx | `:rf.causa/select-frame <frame-id>` | Canonical write. Dispatches the spine's `:rf.causa/set-frame` (which re-seeds `:target-frame` + `:epoch-history` — see [`018-Event-Spine.md`](./018-Event-Spine.md) §6) AND fires `:rf.causa.frame-switcher/persist` for localStorage. |
+| Fx | `:rf.causa.frame-switcher/persist` | localStorage write under `re-frame2.causa.frame-switcher.v1` (per-instance overridable via `(causa-config/configure! {:frame-switcher/storage-key …})`). |
+
+Every frame-aware feature — the L1 ribbon picker, the Cmd-K palette's
+`:palette/select-frame` verb, future panel-by-frame surfaces — MUST
+dispatch `:rf.causa/select-frame`. Reaching the spine's `:rf.causa/
+set-frame` primitive directly bypasses the persistence + future
+instrumentation layers attached to the canonical event.
+
 ## The default landing view
 
 On page load after `rf/init!`, when `[data-rf-causa-host]` exists:

--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -1,0 +1,405 @@
+(ns day8.re-frame2-causa.frame-switcher
+  "Causa's hardened L1 frame-switcher slot (rf2-iwwou) — the single
+  contractually-anchored surface every frame-aware feature reaches
+  through.
+
+  ## Why a dedicated ns
+
+  Causa is increasingly frame-aware: App-DB Diff, Views, Routing, the
+  machine-inspector scrubber, and the Cmd-K palette's `:select-frame`
+  verb all need to read 'which frame is the user currently focused on?'
+  and need to write that selection back when the user picks a
+  different frame. Pre-bead the picker lived inline in `shell.cljs`'s
+  ribbon and the spine's `:rf.causa/set-frame` event was the de-facto
+  write surface; the palette dispatched the same event. That worked,
+  but the contract was implicit — nothing in source said 'this is THE
+  way to read / write frame focus' and new frame-aware features had no
+  obvious primitive to require.
+
+  This ns formalises the contract.
+
+  ## The contract
+
+  Three public symbols make up the slot's external surface — every
+  frame-aware feature SHOULD reach through these only:
+
+  - **Sub `:rf.causa/current-frame`** — returns the frame id the user
+    has focused (or the default when no explicit selection has been
+    made). Composes off the spine's `:rf.causa/focus-slot` so the
+    sub re-fires automatically when the spine flips frames via any
+    code path (ribbon picker, palette, headless test driver).
+
+  - **Sub `:rf.causa/available-frames`** — returns a first-seen-order
+    vec of distinct frames present in the live cascade list, filtered
+    by the `show-tool-frames?` setting (spec/018 §8 I1). The single
+    source of truth for 'which frames is it meaningful to pick right
+    now'. Composes off `:rf.causa/cascades` so the list re-fires as
+    new frames appear in the trace stream.
+
+  - **Event-fx `:rf.causa/select-frame <frame-id>`** — canonical write
+    surface. Dispatches the spine's `:rf.causa/set-frame` (which
+    re-seeds `:target-frame` + `:epoch-history`, see
+    `spine/set-frame-reducer` docstring for the full propagation
+    story) AND persists the selection to localStorage so the next
+    Causa session restores the same focus. The Cmd-K palette's
+    `:palette/select-frame` verb dispatches THIS event, not the spine
+    primitive directly — that way every persistence / instrumentation
+    layer we add lives in one place.
+
+  The L1 ribbon picker reads `:rf.causa/current-frame` +
+  `:rf.causa/available-frames`, dispatches `:rf.causa/select-frame`.
+  No ad-hoc frame access from the ribbon view code — the picker is
+  one thin call site against the canonical contract.
+
+  ## Pure helpers
+
+  `distinct-frames` + `internal-frames` are pure data ops the sub
+  composer + tests both reach through. Exported so tests can hit them
+  without bouncing through a subscribe.
+
+  ## Persistence shape
+
+  localStorage key `re-frame2.causa.frame-switcher.v1` (per-instance
+  overridable via `causa-config/configure! {:frame-switcher/storage-key
+  …}`). Value is a one-key EDN map `{:frame :rf/cart-frame}` — wrapping
+  a bare keyword would force callers to handle 'literal nil means no
+  selection' vs 'no entry means no selection' separately; the map
+  envelope keeps room for future fields (e.g. last-N-frames history,
+  per-frame UI state) without a versioned migration.
+
+  ## Hydration
+
+  `hydrate!` runs at install time (preload) AND from
+  `mount/ensure-causa-frame!` on first open. Re-entrant — the dispatch
+  is a wholesale `(assoc db :focus (assoc focus :frame …))`. Guards
+  on `(frame/frame :rf/causa)` so the pre-mount call short-circuits
+  cleanly. Mirrors the `filters/hydrate!` shape so the two surfaces
+  share an ergonomic pattern."
+  (:require [cljs.reader :as reader]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale sans-stack]]))
+
+;; ---- public contract: which frames Causa filters out by default ---------
+
+(def internal-frames
+  "Frames Causa filters out of the picker by default per spec/018 §8 I1.
+  `:rf/causa` is Causa's own state; `:rf/re-frame2-pair` is the future
+  MCP-pair frame. A future Settings 'Show tool frames in picker' toggle
+  will re-include them under a `── Power user ──` divider; the toggle
+  UI is not built yet, so the picker is hardcoded to exclude them.
+
+  Public so a future Settings ns can read the canonical set when it
+  surfaces the toggle, and so tests can assert the membership without
+  duplicating the literal."
+  #{:rf/causa :rf/re-frame2-pair})
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn distinct-frames
+  "Pure helper — returns the distinct frames present in `cascades` in
+  first-seen order. Drives the `:rf.causa/available-frames` sub.
+
+  Filters `:rf/causa` (and other tool frames per `internal-frames`)
+  out by default per spec/018 §8 I1 — passing `show-tool-frames?` true
+  reincludes them. nil-frame cascades are dropped (an `:ungrouped`
+  cascade carries nil `:frame`)."
+  [cascades show-tool-frames?]
+  (let [seen (volatile! #{})]
+    (reduce
+      (fn [acc cascade]
+        (let [f (:frame cascade)]
+          (cond
+            (nil? f)                              acc
+            (contains? @seen f)                   acc
+            (and (not show-tool-frames?)
+                 (contains? internal-frames f))   acc
+            :else (do (vswap! seen conj f)
+                      (conj acc f)))))
+      []
+      cascades)))
+
+;; ---- persistence ---------------------------------------------------------
+
+(def default-storage-key
+  "Default localStorage key Causa writes the frame-switcher selection
+  under. Hosts override via `(causa-config/configure! {:frame-
+  switcher/storage-key …})` for per-instance isolation (Story testbeds
+  use this so per-scenario picks don't leak between scenarios)."
+  "re-frame2.causa.frame-switcher.v1")
+
+(defonce ^:private storage-key
+  (atom default-storage-key))
+
+(defn set-storage-key!
+  "Replace the localStorage key Causa uses for frame-switcher
+  persistence. `nil` resets to the default."
+  [k]
+  (reset! storage-key (or k default-storage-key))
+  nil)
+
+(defn get-storage-key
+  "Return the current localStorage key for frame-switcher persistence."
+  []
+  @storage-key)
+
+(defn- storage-available?
+  "True when `js/window.localStorage` is reachable. JVM / node tests
+  without jsdom land in the no-op branch."
+  []
+  (and (exists? js/window)
+       (some? (.-localStorage js/window))))
+
+(defn- read-raw
+  "Read the raw EDN string Causa wrote under `storage-key`. Returns nil
+  when the slot is empty or localStorage is unavailable."
+  []
+  (when (storage-available?)
+    (try
+      (.getItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil))))
+
+(defn- write-raw!
+  "Write `s` (an EDN string) under `storage-key`. No-op when
+  localStorage is unavailable. Swallows any throw — a quota error
+  must not poison the dispatch chain."
+  [s]
+  (when (storage-available?)
+    (try
+      (.setItem (.-localStorage js/window) (get-storage-key) s)
+      (catch :default _ nil)))
+  nil)
+
+(defn clear!
+  "Remove the persisted selection. No-op when localStorage is
+  unavailable. Hosts use this when tearing down per-scenario state in
+  Story testbeds."
+  []
+  (when (storage-available?)
+    (try
+      (.removeItem (.-localStorage js/window) (get-storage-key))
+      (catch :default _ nil)))
+  nil)
+
+(defn ->edn
+  "Serialise `frame-id` (a keyword or nil) into a stable EDN string.
+  Wraps in a `{:frame …}` envelope so the round-trip distinguishes
+  'no entry' (no key) from 'explicit nil' (key present, value nil) —
+  the latter is reserved as a 'clear selection' marker."
+  [frame-id]
+  (pr-str {:frame frame-id}))
+
+(defn <-edn
+  "Parse a stored EDN string. Returns the parsed frame-id keyword on
+  success, or nil on parse failure / unrecognised shape — the load
+  path never throws into init."
+  [s]
+  (let [parsed (try (reader/read-string s)
+                    (catch :default _ nil))]
+    (when (map? parsed)
+      (let [f (:frame parsed)]
+        (when (keyword? f) f)))))
+
+(defn load
+  "Read + parse the persisted frame selection. Returns the frame-id
+  keyword, or nil when:
+    - localStorage is unavailable (no browser, no jsdom)
+    - the slot is empty (first session)
+    - the stored EDN is malformed
+    - the stored value isn't a keyword"
+  []
+  (when-let [raw (read-raw)]
+    (<-edn raw)))
+
+(defn save!
+  "Write `frame-id` into localStorage. No-op when localStorage is
+  unavailable. Swallows quota / serialisation errors."
+  [frame-id]
+  (write-raw! (->edn frame-id))
+  nil)
+
+;; ---- re-frame fx ---------------------------------------------------------
+
+(defn install-fx!
+  "Install the `:rf.causa.frame-switcher/persist` effect. Idempotent
+  (re-frame's registrar replaces in place). The `:rf.causa/select-
+  frame` handler attaches this fx so the localStorage write happens in
+  one place instead of being repeated at every call site.
+
+  Handler signature is `(fn [ctx args])` per the v2 reg-fx contract
+  (Spec 002 §`:fx` ordering). `ctx` is the frame-scoped envelope;
+  `args` is the second element of the `[id args]` pair emitted by the
+  event handler — here the frame id keyword."
+  []
+  (rf/reg-fx :rf.causa.frame-switcher/persist
+    (fn [_ctx frame-id]
+      (save! frame-id)))
+  nil)
+
+;; ---- hydration -----------------------------------------------------------
+
+(defn hydrate!
+  "Drive the localStorage → `:focus :frame` slot hydration so the next
+  Causa session restores the user's last picked frame.
+
+  Re-entrant. Safe to call from `install!` (preload-time, before the
+  frame is registered) AND from `mount.cljs/ensure-causa-frame!`
+  (first open, frame registered). Both invocations converge on the
+  same slot because:
+
+  - the load read is pure;
+  - the hydrate dispatch is a wholesale `(assoc-in db [:focus :frame]
+    …)` so re-running with the same source produces the same slot;
+  - the frame guard short-circuits the pre-mount call without losing
+    state — the localStorage value is still readable at the second
+    call.
+
+  Returns nil. No-op when localStorage has no stored selection."
+  []
+  (when-let [frame-id (load)]
+    (when (some? (frame/frame :rf/causa))
+      (rf/with-frame :rf/causa
+        ;; Dispatch the canonical event so any future side-effects
+        ;; (analytics, instrumentation, undo-stack) all run through
+        ;; the same path. dispatch-sync because we're at boot — the
+        ;; first subscribe needs to see the hydrated value.
+        (rf/dispatch-sync [:rf.causa/select-frame frame-id])))
+    nil))
+
+;; ---- view ----------------------------------------------------------------
+
+(rf/reg-view frame-switcher-view
+  "L1 ribbon frame-switcher — STRICTLY single-select per spec/018 §1
+  Non-goals + §3 Frame dropdown + Round-3 rf2-i74n7. No 'All frames
+  (merged)' option; no `:multiple` attribute on the `<select>`.
+  Excludes `:rf/causa` by default per spec/018 §8 I1. When the only
+  available frame is the current selection, the dropdown collapses to
+  a flat label (no chevron — no click target).
+
+  Reads `:rf.causa/current-frame` + `:rf.causa/available-frames`;
+  writes via `:rf.causa/select-frame <frame-id>` — the canonical
+  contract documented at ns-top. Other frame-aware features (Cmd-K
+  palette, future panels) reach through the same surface.
+
+  `reg-view`-registered (rf2-in6l2) so its rendered React component
+  carries `:contextType frame-context` and the closest enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` flows through React-context
+  — subscribes resolve to `:rf/causa`."
+  [_props]
+  (let [selected-frame  @(rf/subscribe [:rf.causa/current-frame])
+        frames          @(rf/subscribe [:rf.causa/available-frames])
+        label-style     {:color       (:text-primary tokens)
+                         :font-family sans-stack
+                         :font-size   (:body type-scale)}]
+    (if (<= (count frames) 1)
+      [:span {:data-testid "rf-causa-ribbon-frame"
+              :style (merge label-style {:color (:text-secondary tokens)})}
+       (str "Frame: " (or selected-frame (first frames) ":rf/default"))]
+      [:select {:data-testid "rf-causa-ribbon-frame-picker"
+                :value       (str (or selected-frame (first frames)))
+                :on-change   (fn [^js e]
+                               (let [v   (.. e -target -value)
+                                     kw  (when (and v (.startsWith v ":"))
+                                           (keyword (subs v 1)))]
+                                 (when kw
+                                   (rf/dispatch [:rf.causa/select-frame kw]
+                                                {:frame :rf/causa}))))
+                :style       (merge label-style
+                               {:background    (:bg-2 tokens)
+                                :border        (str "1px solid "
+                                                    (:border-default tokens))
+                                :border-radius "4px"
+                                :padding       "2px 6px"})}
+       (for [f frames]
+         ^{:key (str f)}
+         [:option {:value (str f)} (str "Frame: " f)])])))
+
+;; ---- install -------------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the frame-switcher subsystem's Causa-side
+  surface. Wires:
+
+    - Subs:   `:rf.causa/current-frame`, `:rf.causa/available-frames`.
+    - Events: `:rf.causa/select-frame <frame-id>` (event-fx) — the
+              canonical write surface. Dispatches the spine's
+              `:rf.causa/set-frame` so every per-frame composite re-
+              fires off the new frame's slot AND fires the
+              `:rf.causa.frame-switcher/persist` fx so localStorage
+              records the choice.
+    - Effects: `:rf.causa.frame-switcher/persist` — localStorage
+              write fx.
+    - Side-effect: hydrate `[:focus :frame]` from localStorage at
+              first install via `hydrate!`.
+
+  Called from `registry/register-causa-handlers!` after `spine/install!`
+  so the canonical event-fx's `[:dispatch [:rf.causa/set-frame ...]]`
+  resolves at install time. The sub/event sub-graph itself doesn't
+  require any specific install order — re-frame resolves `:<-` lazily.
+
+  ## Why event-fx (not event-db)
+
+  We want THREE side-effects on every selection write:
+
+    1. spine state mutation (target-frame + epoch-history re-seeding)
+    2. localStorage persistence
+    3. (future) instrumentation / undo-stack
+
+  An event-fx lets us declaratively chain `[:dispatch …]` for #1 and
+  fire `:rf.causa.frame-switcher/persist` for #2 from one handler,
+  with room for #3 later without rewriting the call sites."
+  []
+  (install-fx!)
+
+  ;; ---- subs ----------------------------------------------------------
+  ;;
+  ;; `:rf.causa/current-frame` composes off `:rf.causa/focus-slot` (the
+  ;; spine's raw stored frame slot). This indirection means the sub re-
+  ;; fires when ANY code path mutates the slot — the ribbon picker, the
+  ;; palette, headless test drivers, the spine's auto-snap on first
+  ;; cascade. Reading the composed `:rf.causa/focus` sub here would
+  ;; introduce a circular dependency since the spine's `:focus` sub
+  ;; already pulls in `:rf.causa/cascades`; the raw slot is the right
+  ;; primitive.
+
+  (rf/reg-sub :rf.causa/current-frame
+    :<- [:rf.causa/focus-slot]
+    (fn [focus _query]
+      (:frame focus)))
+
+  ;; `:rf.causa/available-frames` is the canonical 'which frames is it
+  ;; meaningful to pick right now' list. Composes off `:rf.causa/
+  ;; cascades` so it re-fires as new frames appear in the trace
+  ;; stream. The `show-tool-frames?` toggle isn't a sub yet — when the
+  ;; Settings UI for it lands (follow-on), this sub will :<- onto the
+  ;; toggle's slot. Today the parameter is hardcoded to `false` to
+  ;; match the pre-bead picker behaviour.
+
+  (rf/reg-sub :rf.causa/available-frames
+    :<- [:rf.causa/cascades]
+    (fn [cascades _query]
+      ;; show-tool-frames? hardcoded false — see ns docstring.
+      (distinct-frames cascades false)))
+
+  ;; ---- events --------------------------------------------------------
+  ;;
+  ;; `:rf.causa/select-frame <frame-id>` is the canonical write surface.
+  ;; The Cmd-K palette's `:palette/select-frame` verb dispatches THIS
+  ;; event (not the spine's `:rf.causa/set-frame` primitive directly)
+  ;; so every persistence / instrumentation layer we add lives in one
+  ;; place. See `palette/events.cljs`'s `:palette/select-frame` clause.
+
+  (rf/reg-event-fx :rf.causa/select-frame
+    (fn [_ctx [_ frame-id]]
+      {:fx [[:dispatch [:rf.causa/set-frame frame-id]]
+            [:rf.causa.frame-switcher/persist frame-id]]}))
+
+  ;; Hydrate from localStorage. The actual logic lives in `hydrate!`
+  ;; above so first-mount (`mount/ensure-causa-frame!`) can call the
+  ;; same fn to converge.
+  (hydrate!)
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/events.cljs
@@ -318,16 +318,21 @@
            :fx base-fx}
 
           :palette/select-frame
-          ;; rf2-ybjkx — drive the frame-picker spine event so the
-          ;; user's choice flows through every per-frame composite
+          ;; rf2-ybjkx — drive the frame-picker selection event so
+          ;; the user's choice flows through every per-frame composite
           ;; (App-DB Diff, Views, Routing). The pre-bead behaviour
           ;; just stamped `:selected-target-frame` into Causa's app-db
-          ;; with no plumb-through; this dispatches the canonical
-          ;; `:rf.causa/set-frame` event the L1 frame-picker uses so
-          ;; the palette is wire-compatible with the rest of the
-          ;; chrome.
+          ;; with no plumb-through.
+          ;;
+          ;; Per rf2-iwwou this dispatches the canonical `:rf.causa/
+          ;; select-frame` event-fx (NOT the spine's `:rf.causa/set-
+          ;; frame` primitive directly) — every persistence /
+          ;; instrumentation layer attached to the frame-switcher
+          ;; contract lives behind the one event surface, so the
+          ;; palette + the L1 ribbon picker + headless tests all
+          ;; share the same write path.
           {:db close-db
-           :fx (conj base-fx [:dispatch [:rf.causa/set-frame (first args)]])}
+           :fx (conj base-fx [:dispatch [:rf.causa/select-frame (first args)]])}
 
           :palette/inspect-handler
           ;; Phase 1: route to a Causa-side store of the inspected

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -36,6 +36,7 @@
             [day8.re-frame2-causa.defaults :as defaults]
             [day8.re-frame2-causa.epoch :as epoch]
             [day8.re-frame2-causa.filters :as filters]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
             [day8.re-frame2-causa.open-in-editor :as open-in-editor]
             [day8.re-frame2-causa.palette :as palette]
             [day8.re-frame2-causa.settings.effects :as settings-effects]
@@ -615,6 +616,15 @@
     ;; legacy selection events shim writes through the spine slot,
     ;; and the slot's reducer helpers live in spine.cljs.
     (spine/install!)
+    ;; Frame-switcher slot (rf2-iwwou) — hardened L1 frame-switcher
+    ;; contract. MUST install AFTER `spine/install!` so the canonical
+    ;; `:rf.causa/select-frame` event-fx's `[:dispatch [:rf.causa/set-
+    ;; frame ...]]` resolves at hydration time. Registers the
+    ;; `:rf.causa/current-frame` + `:rf.causa/available-frames` subs,
+    ;; the `:rf.causa/select-frame` event-fx, the `:rf.causa.frame-
+    ;; switcher/persist` localStorage write fx, and hydrates the
+    ;; `[:focus :frame]` slot from localStorage at first install.
+    (frame-switcher/install!)
     (app-db-diff/install!)
     ;; App-DB segment-inspector popup (rf2-e9tb0) — opens when any
     ;; path-segment in the App-DB Diff breadcrumb is clicked. Installs

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -105,6 +105,7 @@
             [day8.re-frame2-causa.filters :as filters]
             [day8.re-frame2-causa.filters.pills :as filter-pills]
             [day8.re-frame2-causa.focus-helpers :as fh]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.app-db-segment-inspector
              :as app-db-segment-inspector]
@@ -127,15 +128,13 @@
              :as t
              :refer [tokens type-scale layout sans-stack mono-stack]]))
 
-;; ---- internal frames + tab inventory ------------------------------------
-
-(def ^:private internal-frames
-  "Frames Causa filters out of the picker by default per spec/018 §8 I1.
-  `:rf/causa` is Causa's own state; `:rf/re-frame2-pair` is the future MCP-pair
-  frame. A future Settings 'Show tool frames in picker' toggle will
-  re-include them under a `── Power user ──` divider; the toggle UI
-  is not built yet, so the picker is hardcoded to exclude them."
-  #{:rf/causa :rf/re-frame2-pair})
+;; ---- tab inventory ------------------------------------------------------
+;;
+;; Frame-switcher concerns (the internal-frames filter set, distinct-frames
+;; helper, ribbon picker view) live in `frame_switcher.cljs` per rf2-iwwou
+;; — the L1 ribbon's frame slot is a single contractually-anchored surface
+;; every frame-aware feature reaches through. The ribbon's `[frame-
+;; switcher/frame-switcher-view]` is the only call site here.
 
 (def ^:private tabs
   "The seven L3 tabs per spec/018 §5 The 7 tabs. Order is the canonical
@@ -163,30 +162,6 @@
 (def ^:private default-tab :event)
 
 ;; ---- helpers (pure, exported for tests) ---------------------------------
-
-(defn distinct-frames
-  "Pure helper. Returns the distinct frames present in `cascades` in
-  first-seen order. Used by the ribbon frame dropdown to populate
-  selectable options.
-
-  Filters `:rf/causa` (and other tool frames) out by default per
-  spec/018 §8 I1 — passing `show-tool-frames?` true reincludes them.
-  nil-frame cascades are dropped (an `:ungrouped` cascade carries
-  nil `:frame`)."
-  [cascades show-tool-frames?]
-  (let [seen (volatile! #{})]
-    (reduce
-      (fn [acc cascade]
-        (let [f (:frame cascade)]
-          (cond
-            (nil? f)                              acc
-            (contains? @seen f)                   acc
-            (and (not show-tool-frames?)
-                 (contains? internal-frames f))   acc
-            :else (do (vswap! seen conj f)
-                      (conj acc f)))))
-      []
-      cascades)))
 
 (defn event-id-of-cascade
   "Best-effort pluck of the event-id from a cascade's `:event` slot.
@@ -501,40 +476,13 @@
                :style       btn-style}
       "⏭"]]))
 
-(defn- ribbon-frame-picker
-  "Frame dropdown — STRICTLY single-select per spec/018 §1 Non-goals
-  + §3 Frame dropdown + Round-3 rf2-i74n7. No 'All frames (merged)'
-  option; no `:multiple` attribute on the `<select>`. Excludes
-  `:rf/causa` by default per §8 I1. When the only available frame
-  is the current selection, the dropdown collapses to a flat label
-  (no chevron — no click target).
-
-  Writes via `:rf.causa/set-frame <frame-id>` — single frame id, no
-  aggregate / merged value path."
-  [{:keys [selected-frame frames]}]
-  (let [label-style {:color       (:text-primary tokens)
-                     :font-family sans-stack
-                     :font-size   (:body type-scale)}]
-    (if (<= (count frames) 1)
-      [:span {:data-testid "rf-causa-ribbon-frame"
-              :style (merge label-style {:color (:text-secondary tokens)})}
-       (str "Frame: " (or selected-frame (first frames) ":rf/default"))]
-      [:select {:data-testid "rf-causa-ribbon-frame-picker"
-                :value       (str (or selected-frame (first frames)))
-                :on-change   (fn [^js e]
-                               (let [v   (.. e -target -value)
-                                     kw  (when (and v (.startsWith v ":"))
-                                           (keyword (subs v 1)))]
-                                 (when kw
-                                   (rf/dispatch [:rf.causa/set-frame kw] {:frame :rf/causa}))))
-                :style       (merge label-style
-                               {:background    (:bg-2 tokens)
-                                :border        (str "1px solid " (:border-default tokens))
-                                :border-radius "4px"
-                                :padding       "2px 6px"})}
-       (for [f frames]
-         ^{:key (str f)}
-         [:option {:value (str f)} (str "Frame: " f)])])))
+;; The L1 frame-switcher slot lives in `frame_switcher.cljs` per rf2-iwwou
+;; — the ribbon mounts `[frame-switcher/frame-switcher-view]` and reaches
+;; the picker's contract surface through `:rf.causa/current-frame` /
+;; `:rf.causa/available-frames` / `:rf.causa/select-frame`. Cmd-K's
+;; `:palette/select-frame` verb dispatches through the same canonical
+;; event so the ribbon picker + the palette + any future frame-aware
+;; feature flows through one source of truth.
 
 (defn- ribbon-filter-pills
   "Filter pills cluster per spec/018 §3 + §7 Ribbon pills. Thin
@@ -670,14 +618,12 @@
   (let [focus           @(rf/subscribe [:rf.causa/focus])
         cascades        @(rf/subscribe [:rf.causa/cascades])
         focus-set       @(rf/subscribe [:rf.causa/focus-set])
-        show-tool?      false   ; Hardcoded — Power-user toggle UI not built yet
         ;; rf2-r9lyy — opt-in for the `:ungrouped` pseudo-cascade
         ;; bucket. Default OFF preserves silent-by-default; ON
         ;; includes the bucket in L2 + the ribbon's boundary walk
         ;; so the nav cluster's `[◀ ▶ ⏭]` agrees with what the user
         ;; sees in L2.
         show-ungrouped? @(rf/subscribe [:rf.causa/show-ungrouped?])
-        frames          (distinct-frames cascades show-tool?)
         redacted-count  @(rf/subscribe [:rf.causa/suppressed-sensitive-count])
         filters         @(rf/subscribe [:rf.causa/active-filters])
         focused-id      (:dispatch-id focus)
@@ -734,8 +680,12 @@
        [mode-pill/mode-pill])
      [ribbon-nav-cluster {:at-head? at-head? :at-tail? at-tail?}]
      [ribbon-focus-chip {:focus-set focus-set}]
-     [ribbon-frame-picker {:selected-frame (:frame focus)
-                           :frames frames}]
+     ;; L1 frame-switcher slot (rf2-iwwou) — single contractually-
+     ;; anchored surface. The view itself reads `:rf.causa/current-
+     ;; frame` + `:rf.causa/available-frames` and writes via
+     ;; `:rf.causa/select-frame` — no ad-hoc frame access from the
+     ;; ribbon. See `frame_switcher.cljs` for the contract.
+     [frame-switcher/frame-switcher-view]
      [ribbon-filter-pills {:filters filters}]
      [:div {:style {:display "flex" :align-items "center" :gap "8px"}}
       [ribbon-redacted-indicator redacted-count]]

--- a/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs
@@ -1,0 +1,338 @@
+(ns day8.re-frame2-causa.frame-switcher-cljs-test
+  "CLJS coverage for the hardened L1 frame-switcher slot (rf2-iwwou).
+
+  Verifies the public contract documented in `frame_switcher.cljs`:
+
+  1. Pure helpers (`internal-frames`, `distinct-frames`) — JVM-runnable
+     shape, no re-frame machinery.
+  2. Subs `:rf.causa/current-frame` + `:rf.causa/available-frames`
+     resolve through the canonical chain (spine focus-slot + cascades
+     projection).
+  3. Event `:rf.causa/select-frame` writes through the spine + fires
+     the persistence fx.
+  4. EDN round-trip (`->edn` / `<-edn`) survives malformed inputs.
+  5. Hydration restores the persisted frame at install-time.
+  6. The Cmd-K palette's `:palette/select-frame` verb dispatches
+     through the canonical `:rf.causa/select-frame` event — the
+     ribbon, the palette, and any future frame-aware feature share
+     one write path."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- causa-init! []
+  (preload/reset-for-test!)
+  (registry/reset-for-test!)
+  (trace-bus/clear-buffer!)
+  (frame-switcher/clear!)
+  (frame-switcher/set-storage-key! nil))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- causa-db []
+  (rf/get-frame-db :rf/causa))
+
+;; -------------------------------------------------------------------------
+;; (1) Pure helpers — distinct-frames + internal-frames
+;; -------------------------------------------------------------------------
+
+(deftest internal-frames-includes-causa-and-pair
+  (testing "spec/018 §8 I1 — the canonical filter set excludes Causa's
+            own frame plus the future re-frame2-pair frame"
+    (is (contains? frame-switcher/internal-frames :rf/causa))
+    (is (contains? frame-switcher/internal-frames :rf/re-frame2-pair))
+    (is (not (contains? frame-switcher/internal-frames :rf/default))
+        ":rf/default is a meaningful user frame; never filtered out")))
+
+(deftest distinct-frames-excludes-internal-frames-by-default
+  (testing "spec/018 §8 I1 — `:rf/causa` and other tool frames are
+            filtered out of the picker option list unless the power-
+            user toggle re-includes them"
+    (let [cascades [{:dispatch-id 1 :frame :rf/default}
+                    {:dispatch-id 2 :frame :rf/causa}
+                    {:dispatch-id 3 :frame :app/main}
+                    {:dispatch-id 4 :frame :rf/re-frame2-pair}]
+          default-frames (frame-switcher/distinct-frames cascades false)
+          power-frames   (frame-switcher/distinct-frames cascades true)]
+      (is (= [:rf/default :app/main] default-frames)
+          "default — :rf/causa and :rf/re-frame2-pair are excluded")
+      (is (= [:rf/default :rf/causa :app/main :rf/re-frame2-pair] power-frames)
+          "power-user — tool frames included in first-seen order"))))
+
+(deftest distinct-frames-drops-nil-frame-cascades
+  (testing "an :ungrouped cascade has nil :frame — it must NOT show
+            up in the picker (the picker labels would render `nil`)"
+    (let [cascades [{:dispatch-id 1 :frame :rf/default}
+                    {:dispatch-id 2 :frame nil}
+                    {:dispatch-id 3 :frame :app/main}]]
+      (is (= [:rf/default :app/main]
+             (frame-switcher/distinct-frames cascades false))
+          "nil frame is filtered out"))))
+
+(deftest distinct-frames-preserves-first-seen-order
+  (testing "the helper preserves first-seen order so the picker's
+            option list reads stably — re-orderings would shuffle the
+            user's selection visually on every new cascade"
+    (let [cascades [{:dispatch-id 1 :frame :app/b}
+                    {:dispatch-id 2 :frame :app/a}
+                    {:dispatch-id 3 :frame :app/b}  ;; duplicate
+                    {:dispatch-id 4 :frame :app/c}
+                    {:dispatch-id 5 :frame :app/a}]] ;; duplicate
+      (is (= [:app/b :app/a :app/c]
+             (frame-switcher/distinct-frames cascades false))
+          "duplicates collapse, order preserved"))))
+
+;; -------------------------------------------------------------------------
+;; (2) EDN round-trip — persistence (de)serialisation
+;; -------------------------------------------------------------------------
+
+(deftest edn-round-trips-keyword
+  (let [edn (frame-switcher/->edn :rf/cart-frame)]
+    (is (string? edn))
+    (is (= :rf/cart-frame (frame-switcher/<-edn edn))
+        "round-trip keeps the keyword intact")))
+
+(deftest edn-load-tolerates-malformed-input
+  (testing "the load path NEVER throws into init — malformed EDN
+            yields nil; the caller treats nil as 'no selection'"
+    (is (nil? (frame-switcher/<-edn "garbage"))
+        "non-EDN string parses to nil")
+    (is (nil? (frame-switcher/<-edn ""))
+        "empty string parses to nil")
+    (is (nil? (frame-switcher/<-edn "[1 2 3]"))
+        "wrong shape (vector) parses to nil")
+    (is (nil? (frame-switcher/<-edn "{:other :foo}"))
+        "map without `:frame` key parses to nil")
+    (is (nil? (frame-switcher/<-edn "{:frame \"not-a-keyword\"}"))
+        "non-keyword `:frame` value parses to nil")))
+
+;; -------------------------------------------------------------------------
+;; (3) Subs — :rf.causa/current-frame + :rf.causa/available-frames
+;; -------------------------------------------------------------------------
+
+(defn- dispatch-trace
+  "Seed the trace-bus with a single `:event/dispatched` cascade row so
+  the spine projection produces a cascade entry for the picker subs.
+  Mirrors `shell_cljs_test.cljs`'s `dispatch-trace-ev` shape — the
+  cascade key is `[frame dispatch-id]` and both must live under
+  `:tags`."
+  [dispatch-id frame-id]
+  (trace-bus/collect-trace!
+    {:id          dispatch-id
+     :op-type     :event
+     :operation   :event/dispatched
+     :tags        {:event       [:app/touch]
+                   :frame       frame-id
+                   :dispatch-id dispatch-id}}))
+
+(deftest current-frame-sub-resolves-the-spine-slot
+  (testing "the sub reads through `:rf.causa/focus-slot` so it re-fires
+            on any code path that writes through the spine — picker,
+            palette, headless drivers"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (is (nil? @(rf/subscribe [:rf.causa/current-frame]))
+          "pre-selection — sub returns nil (no :focus slot written)")
+      (rf/dispatch-sync [:rf.causa/select-frame :rf/cart-frame])
+      (is (= :rf/cart-frame @(rf/subscribe [:rf.causa/current-frame]))
+          "post-selection — sub returns the frame the user picked"))))
+
+(deftest available-frames-sub-empty-with-no-cascades
+  (testing "no cascades yet — the sub returns an empty vec"
+    (setup!)
+    (rf/with-frame :rf/causa
+      (is (= [] @(rf/subscribe [:rf.causa/available-frames]))
+          "empty list, no picker options"))))
+
+(deftest available-frames-sub-filters-tool-frames-and-preserves-order
+  (testing "the sub composes off `:rf.causa/cascades` so it picks up
+            every frame present in the trace stream — minus the
+            internal-frames filter set (spec/018 §8 I1)"
+    ;; Seed BEFORE setup! so the sub's first compute reads the populated
+    ;; trace-bus atom (the sub falls back to `(trace-bus/buffer)` when
+    ;; the db's `:trace-buffer` slot is unwritten). Mirrors the shell
+    ;; tests' seed-then-subscribe order.
+    (dispatch-trace 1 :rf/default)
+    (dispatch-trace 2 :app/main)
+    (dispatch-trace 3 :rf/causa)              ;; tool frame, filtered
+    (setup!)
+    (rf/with-frame :rf/causa
+      (is (= [:rf/default :app/main]
+             @(rf/subscribe [:rf.causa/available-frames]))
+          "tool frames filtered, first-seen order"))))
+
+;; -------------------------------------------------------------------------
+;; (4) Event — :rf.causa/select-frame
+;; -------------------------------------------------------------------------
+
+(deftest select-frame-writes-through-spine
+  (testing "the canonical event-fx dispatches the spine's `:rf.causa/
+            set-frame` so every per-frame composite (App-DB Diff,
+            Views, Routing) re-fires off the new frame's slot"
+    (setup!)
+    ;; Register a frame so the spine's epoch-history lookup doesn't
+    ;; throw — the canonical handler queries rf/epoch-history.
+    (frame/reg-frame :rf/cart-frame {})
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/select-frame :rf/cart-frame])
+      (is (= :rf/cart-frame (get-in (causa-db) [:focus :frame]))
+          "the spine's :focus :frame slot lands on the picked frame")
+      (is (= :rf/cart-frame (:target-frame (causa-db)))
+          "the spine's :target-frame slot follows (rf2-ug1r6)"))))
+
+(deftest select-frame-fires-persistence-fx
+  (testing "the canonical event-fx fires the `:rf.causa.frame-switcher/
+            persist` fx so the user's selection survives a reload"
+    (setup!)
+    (frame/reg-frame :rf/cart-frame {})
+    (let [persisted (atom nil)]
+      ;; Swap the fx with a counting stub so we don't touch
+      ;; localStorage in the test runtime (Node has no jsdom).
+      (rf/reg-fx :rf.causa.frame-switcher/persist
+        (fn [_ctx frame-id]
+          (reset! persisted frame-id)))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/select-frame :rf/cart-frame]))
+      (is (= :rf/cart-frame @persisted)
+          "the persist fx fired with the new frame id"))))
+
+;; -------------------------------------------------------------------------
+;; (5) Cmd-K palette routes through the canonical contract (rf2-iwwou)
+;; -------------------------------------------------------------------------
+;;
+;; The palette's `:palette/select-frame` verb MUST dispatch the canonical
+;; `:rf.causa/select-frame` event-fx — NOT the spine's `:rf.causa/set-
+;; frame` primitive directly. That way every persistence /
+;; instrumentation layer attached to the frame-switcher contract lives
+;; behind one event surface, so the ribbon + the palette + any future
+;; frame-aware feature share the same write path.
+
+(deftest palette-select-frame-routes-through-canonical-contract
+  (testing "the Cmd-K palette's `:palette/select-frame` invocation
+            dispatches `:rf.causa/select-frame`, NOT the spine's
+            `:rf.causa/set-frame` primitive directly. The end state
+            (focus :frame + :target-frame + persistence) is identical
+            to a ribbon picker click."
+    (setup!)
+    (frame/reg-frame :rf/cart-frame {})
+    (let [persisted (atom nil)]
+      (rf/reg-fx :rf.causa.frame-switcher/persist
+        (fn [_ctx frame-id]
+          (reset! persisted frame-id)))
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/palette-open])
+        (rf/dispatch-sync
+          [:rf.causa/palette-invoke
+           {:source :frame
+            :id     :rf/cart-frame
+            :label  "Switch focus to frame :rf/cart-frame"
+            :action [:palette/select-frame :rf/cart-frame]}
+           false]))
+      (is (= :rf/cart-frame (get-in (causa-db) [:focus :frame]))
+          "palette write lands on the same spine slot the ribbon picker uses")
+      (is (= :rf/cart-frame (:target-frame (causa-db)))
+          ":target-frame is also written — every per-frame composite re-fires")
+      (is (= :rf/cart-frame @persisted)
+          "the persist fx fired — palette writes are persisted too")
+      (is (false? (boolean (:palette-open? (causa-db))))
+          "palette closes on invocation as usual"))))
+
+;; -------------------------------------------------------------------------
+;; (6) View — frame-switcher-view reads the contract
+;; -------------------------------------------------------------------------
+
+(defn- expand-tree
+  "Walk `tree` and replace every fn-component vector with its rendered
+  result. Mirror of the shell tests' walker — keeps the hiccup-only
+  assertions terse."
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(deftest view-collapses-to-label-when-only-one-frame
+  (testing "the view renders a flat label (no dropdown) when only one
+            distinct frame is available — there's nothing to pick"
+    (dispatch-trace 1 :app/main)
+    (setup!)
+    (rf/with-frame :rf/causa
+      (let [tree (frame-switcher/frame-switcher-view {})]
+        (is (some? (find-by-testid tree "rf-causa-ribbon-frame"))
+            "label-only branch renders")
+        (is (nil? (find-by-testid tree "rf-causa-ribbon-frame-picker"))
+            "no <select> when only one frame is selectable")))))
+
+(deftest view-renders-dropdown-when-multiple-frames
+  (testing "the view renders a strictly-single-select <select> when
+            multiple distinct frames are present"
+    (dispatch-trace 1 :app/main)
+    (dispatch-trace 2 :app/admin)
+    (setup!)
+    (rf/with-frame :rf/causa
+      (let [tree   (frame-switcher/frame-switcher-view {})
+            picker (find-by-testid tree "rf-causa-ribbon-frame-picker")]
+        (is (some? picker) "dropdown renders for multi-frame")
+        (is (= :select (first picker))
+            "it's a <select>, not a custom multi-select")
+        (is (nil? (:multiple (second picker)))
+            "strictly single-select — no :multiple attribute")))))
+
+;; -------------------------------------------------------------------------
+;; (7) Storage-key plumbing — per-instance isolation
+;; -------------------------------------------------------------------------
+
+(deftest storage-key-defaults-to-canonical-value
+  (testing "the default storage key matches the documented canonical
+            string — hosts that don't override get a stable slot"
+    (is (= "re-frame2.causa.frame-switcher.v1"
+           frame-switcher/default-storage-key))
+    (is (= frame-switcher/default-storage-key
+           (frame-switcher/get-storage-key))
+        "the runtime key matches the default at boot")))
+
+(deftest storage-key-set-then-clear-round-trips
+  (testing "Story testbeds override the key for per-scenario isolation;
+            passing nil resets to the default"
+    (frame-switcher/set-storage-key! "story.scenario-1.causa.frame.v1")
+    (is (= "story.scenario-1.causa.frame.v1"
+           (frame-switcher/get-storage-key)))
+    (frame-switcher/set-storage-key! nil)
+    (is (= frame-switcher/default-storage-key
+           (frame-switcher/get-storage-key))
+        "nil resets to the canonical default")))

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -138,6 +138,12 @@
    ;; rf2-a1z3b — focus-navigation primitive slot sub.
    :rf.causa/focus-set
    :rf.causa/focus-slot
+   ;; rf2-iwwou — hardened L1 frame-switcher slot. Public contract
+   ;; every frame-aware feature reaches through: the ribbon picker,
+   ;; the Cmd-K palette's `:select-frame` verb, future panel-by-frame
+   ;; surfaces. See `frame_switcher.cljs` for the full contract.
+   :rf.causa/current-frame
+   :rf.causa/available-frames
    :rf.causa/focused-slice-path
    :rf.causa/issues-filters
    :rf.causa/issues-ribbon
@@ -391,6 +397,13 @@
    :rf.causa/save-edit-popup
    :rf.causa/select-dispatch-id
    :rf.causa/select-epoch
+   ;; rf2-iwwou — canonical frame-switcher write surface. Dispatches
+   ;; the spine's `:rf.causa/set-frame` + fires `:rf.causa.frame-
+   ;; switcher/persist` for localStorage. The L1 ribbon picker and the
+   ;; Cmd-K palette's `:palette/select-frame` verb both dispatch this
+   ;; event so every persistence / instrumentation layer lives in one
+   ;; place.
+   :rf.causa/select-frame
    :rf.causa/select-machine-id
    :rf.causa/select-tab
    ;; rf2-o5f5f.1 — Runtime ↔ Static mode events + Static-scoped tab.
@@ -507,6 +520,11 @@
    ;; save-edit-popup / delete-edit-popup) — every mutation round-trips
    ;; to localStorage in one place.
    :rf.causa.filters/persist
+   ;; rf2-iwwou — frame-switcher slot persistence side-effect. Bound to
+   ;; the `:rf.causa/select-frame` handler so the user's last-picked
+   ;; frame survives a reload. Lives under the frame-switcher-specific
+   ;; prefix (mirror of the filter-persistence shape).
+   :rf.causa.frame-switcher/persist
    ;; rf2-y3l8z — interactive Machines canvas view-mode persistence
    ;; side-effect. Writes the per-machine view-mode-by-id map to
    ;; localStorage on every `:set-view-mode` mutation so the user's

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -1173,30 +1173,13 @@
 ;; -------------------------------------------------------------------------
 ;; (6) Frame picker — excludes tool frames by default (spec/018 §8 I1)
 ;; -------------------------------------------------------------------------
-
-(deftest distinct-frames-excludes-internal-frames-by-default
-  (testing "spec/018 §8 I1 — `:rf/causa` and other tool frames are
-            filtered out of the picker option list unless the power-
-            user toggle re-includes them"
-    (let [cascades [{:dispatch-id 1 :frame :rf/default}
-                    {:dispatch-id 2 :frame :rf/causa}
-                    {:dispatch-id 3 :frame :app/main}
-                    {:dispatch-id 4 :frame :rf/re-frame2-pair}]
-          default-frames (shell/distinct-frames cascades false)
-          power-frames   (shell/distinct-frames cascades true)]
-      (is (= [:rf/default :app/main] default-frames)
-          "default — :rf/causa and :rf/re-frame2-pair are excluded")
-      (is (= [:rf/default :rf/causa :app/main :rf/re-frame2-pair] power-frames)
-          "power-user — tool frames included in first-seen order"))))
-
-(deftest distinct-frames-drops-nil-frame-cascades
-  (testing "an :ungrouped cascade has nil :frame — it must NOT show
-            up in the picker (the picker labels would render `nil`)"
-    (let [cascades [{:dispatch-id 1 :frame :rf/default}
-                    {:dispatch-id 2 :frame nil}
-                    {:dispatch-id 3 :frame :app/main}]]
-      (is (= [:rf/default :app/main] (shell/distinct-frames cascades false))
-          "nil frame is filtered out"))))
+;;
+;; The pure `distinct-frames` helper + the `internal-frames` set moved to
+;; `day8.re-frame2-causa.frame-switcher` per rf2-iwwou (the L1 frame-
+;; switcher slot is a single contractually-anchored ns every frame-aware
+;; feature reaches through). Pure-helper coverage now lives in
+;; `frame_switcher_cljs_test.cljs`; the shell-level smokes below verify
+;; the ribbon still mounts the picker via the contract.
 
 (deftest frame-picker-is-strictly-single-select
   (testing "Round-3 rf2-i74n7 + spec/018 §1 Non-goals — the frame


### PR DESCRIPTION
## Summary

Extract the L1 ribbon frame-picker into a single contractually-anchored ns
every frame-aware feature reaches through (per rf2-vtd5z follow-on
rf2-iwwou). Previously the picker lived inline in shell.cljs and the
spine's :rf.causa/set-frame event was the de-facto write surface; nothing
in source said 'this is THE way to read/write frame focus' and new
frame-aware features had no obvious primitive to require.

Now the contract is formalised, persisted, and documented.

### Public contract (tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs)

| Surface | Id | Role |
|---|---|---|
| Sub | \`:rf.causa/current-frame\` | The frame id the user has focused (or nil pre-selection). |
| Sub | \`:rf.causa/available-frames\` | First-seen-order vec of selectable frames; tool frames filtered per spec/018 §8 I1. |
| Event-fx | \`:rf.causa/select-frame <frame-id>\` | Canonical write. Dispatches the spine's \`:rf.causa/set-frame\` + fires \`:rf.causa.frame-switcher/persist\` for localStorage. |
| Fx | \`:rf.causa.frame-switcher/persist\` | localStorage write under \`re-frame2.causa.frame-switcher.v1\` (per-instance overridable). |

The Cmd-K palette's \`:palette/select-frame\` verb now dispatches
\`:rf.causa/select-frame\` (not the spine primitive directly), so every
persistence + future instrumentation layer lives behind one event
surface.

### Changes
- NEW \`tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs\` — the slot
- NEW \`tools/causa/test/day8/re_frame2_causa/frame_switcher_cljs_test.cljs\` — full contract coverage
- \`tools/causa/src/day8/re_frame2_causa/shell.cljs\` — ribbon mounts \`[frame-switcher/frame-switcher-view]\`; \`distinct-frames\` + \`internal-frames\` + inline picker removed
- \`tools/causa/src/day8/re_frame2_causa/registry.cljs\` — install! chains \`frame-switcher/install!\` after \`spine/install!\`
- \`tools/causa/src/day8/re_frame2_causa/palette/events.cljs\` — \`:palette/select-frame\` dispatches \`:rf.causa/select-frame\`
- \`tools/causa/spec/007-UX-IA.md\` — Frame slot contract section under §The L1 ribbon
- \`tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs\` — sub/event/fx snapshot drift updated
- \`tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs\` — pure-helper tests moved to the new test file

## Test plan
- [x] \`npm run test:cljs\` (3177 tests, 9138 assertions, 0 failures)
- [x] \`clojure -M:test\` in tools/causa/ (749 tests, 2263 assertions, 0 failures)
- [x] \`npm run test:bundle-isolation\` (passes)
- [x] \`npm run test:causa-feature-gate\` (passes on retry; first failure was a flaky http-server connection)
- [x] Cmd-K palette \`:palette/select-frame\` still writes through \`:focus :frame\` + \`:target-frame\` + persistence
- [x] Visual smoke — picker testid \`rf-causa-ribbon-frame-picker\` preserved; the strict-single-select assertion in \`shell_cljs_test.cljs\` still resolves the same DOM shape