### PR TITLE
refactor(testbed/parallel-frames): drop auto-tick chain; on-demand Tick buttons (rf2-gxgmt)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -170,7 +170,13 @@
  ;; index.html is found without a copy step; per-file requests like
  ;; /main.js fall through to the second root automatically.
  :dev-http {8765 ["../tools/causa/testbeds/panel_gallery"
-                  "out/testbeds/panel-gallery"]}
+                  "out/testbeds/panel-gallery"]
+            ;; Parallel-Frames testbed (rf2-gxgmt). Source dir first so
+            ;; the hand-written index.html resolves at `/`; the compiled
+            ;; main.js falls through to out/examples/parallel-frames per
+            ;; the same cascade as :testbeds/panel-gallery above.
+            8030 ["../tools/causa/testbeds/parallel_frames"
+                  "out/examples/parallel-frames"]}
 
  :builds
  {:node-test

--- a/tools/causa/testbeds/parallel_frames/README.md
+++ b/tools/causa/testbeds/parallel_frames/README.md
@@ -39,7 +39,7 @@ isolated frames.
 | Feature       | Wiring                                                                                  | Causa lens that lights up                                |
 |---------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------|
 | **Counter**   | `+ / −` buttons. Events: `::counter-inc`, `::counter-dec`. Sub: `::counter`.            | Event list; App-db diff (`:counter` slot)                |
-| **Clock**     | Self-perpetuating tick chain via `:dispatch-later` @ 1s. Sub: `::clock-ticks`.          | Trace lens (`:event/dispatched` rows); App-db diff       |
+| **Clock**     | Per-frame **Tick** button — each click dispatches `::clock-tick` once against the surrounding frame. Sub: `::clock-ticks`. (rf2-gxgmt: the auto-tick chain was retired — spine pollution outweighed teaching value.) | Event list (one row per click); App-db diff (`:clock :ticks` slot) |
 | **Title HTTP**| Refresh / Force-error buttons. Drives `:title/flow` machine through `:idle → :loading → :loaded / :error`. Mock fx resolves ~600ms after dispatch. | Machines lens (state chart + transitions); Trace lens (HTTP-shaped rows); Issues lens (slow effect, ~600ms) |
 
 ## Frame isolation — the load-bearing rule
@@ -80,10 +80,14 @@ HTTP, Issues, Trace) panel between observing `:above` and `:below`.
    list is empty for `:below`; the App-db diff shows no `:counter`
    movement.
 
-2. **Independent clocks.** Watch the App-db diff under `:above` vs
-   `:below`. Each frame's `:clock :ticks` advances on its own cadence;
-   the two are not synchronised (each `:dispatch-later` chain runs in
-   its own frame's router).
+2. **Independent clocks.** Click **Tick** in `:above` a few times,
+   then click **Tick** in `:below` once. Watch the App-db diff under
+   `:above` vs `:below`: only the frame whose Tick button you clicked
+   sees its `:clock :ticks` advance. The same `::clock-tick` handler
+   is registered once globally and resolves against whichever frame
+   the dispatch envelope targets via the frame-provider context —
+   proving on-demand per-frame isolation without continuous spine
+   noise. (rf2-gxgmt — the previous auto-tick chain was retired.)
 
 3. **Per-frame machine state.** Click Refresh on `:below`. Open the
    Machines tab — `:title/flow` reads `:loading`. Switch frame picker
@@ -123,8 +127,10 @@ shop testbed's deletion now that this clean exemplar lands.
 - `index.html` — minimal static host with the standard
   `[data-rf-causa-host]` aside so the Causa preload auto-mounts inline.
 - `spec.cjs` — Playwright smoke that asserts both frames mount, the
-  counters are isolated, Refresh on `:below` doesn't move `:above`,
-  Force-error on `:above` doesn't disturb `:below`'s `:loaded` state.
+  counters are isolated, the per-frame Tick buttons advance only
+  their own `:clock :ticks` slot, Refresh on `:below` doesn't move
+  `:above`, and Force-error on `:above` doesn't disturb `:below`'s
+  `:loaded` state.
 
 ## Running
 

--- a/tools/causa/testbeds/parallel_frames/core.cljs
+++ b/tools/causa/testbeds/parallel_frames/core.cljs
@@ -31,11 +31,15 @@
 
     Counter        — `+ / −` buttons. Demonstrates events, app-db
                      evolution, simple sub recomputation.
-    Clock          — auto-ticking every second via `:dispatch-later`.
-                     Demonstrates continuous events + sub recomputation
-                     and (because the two frames start their tick chains
-                     at slightly different points in time) the two
-                     clocks naturally drift out of phase across reloads.
+    Clock          — per-frame Tick button increments the local
+                     `:ticks` counter once per click. Demonstrates
+                     event-driven sub recomputation cleanly on demand,
+                     and (because each frame's `:ticks` slot is
+                     independent) the parallel-frame isolation: ticking
+                     :above does not move :below's counter and vice
+                     versa. The auto-tick dispatch chain that used to
+                     drive this was retired in rf2-gxgmt — spine
+                     pollution outweighed teaching value.
     Title (HTTP)   — Refresh button dispatches an event that, via the
                      `:title/flow` state machine, fires an in-process
                      mock-HTTP effect. The mock resolves ~600ms after
@@ -88,9 +92,10 @@
 ;; ============================================================================
 
 (def CLOCK-TICK-MS
-  "Clock tick period. One second matches a wall-clock display
-  cleanly; the dispatch-later chain self-perpetuates so each frame
-  ticks at its own cadence."
+  "Clock tick period — referenced only by the parked `::clock-start`
+  handler (currently unused; see rf2-gxgmt). Kept so any future
+  opt-in auto-tick toggle can re-enable the self-perpetuating chain
+  without re-introducing the magic number."
   1000)
 
 (def HTTP-MOCK-DELAY-MS
@@ -112,24 +117,40 @@
 (rf/reg-event-fx ::initialise
   ;; Single `:on-create` boot event per Spec 002 §Frame creation —
   ;; `:on-create` accepts ONE event vector; multi-step initialisation
-  ;; fans out via the effect map. We seed app-db, start the clock
-  ;; tick chain, AND ping the title machine (so its `:idle` snapshot
-  ;; materialises immediately rather than lazily-on-first-refresh —
-  ;; the Causa Machines panel and the smoke's :idle assertion both
-  ;; want the snapshot live on first paint). The `:rf/init` ping is
-  ;; not declared on the `:idle` state's `:on` map, so it is a no-op
-  ;; transition — but the runtime synthesises the initial snapshot
-  ;; on first dispatch (Spec 005 §Initial-state cascading), which is
-  ;; exactly the side-effect we want.
+  ;; fans out via the effect map. We seed app-db AND ping the title
+  ;; machine (so its `:idle` snapshot materialises immediately rather
+  ;; than lazily-on-first-refresh — the Causa Machines panel and the
+  ;; smoke's :idle assertion both want the snapshot live on first
+  ;; paint). The `:rf/init` ping is not declared on the `:idle`
+  ;; state's `:on` map, so it is a no-op transition — but the runtime
+  ;; synthesises the initial snapshot on first dispatch (Spec 005
+  ;; §Initial-state cascading), which is exactly the side-effect we
+  ;; want.
+  ;;
+  ;; rf2-gxgmt — the clock-tick chain is no longer started here. The
+  ;; per-frame Tick button dispatches `::clock-tick` on demand
+  ;; instead, demonstrating parallel-frame isolation without
+  ;; continuous spine pollution.
   (fn [_ctx _ev]
     {:db {:counter   0
+          ;; rf2-gxgmt — `:clock {:tick-gen 0 :ticks 0}` still seeded
+          ;; here so the per-frame Tick button (which dispatches
+          ;; `[::clock-tick 0]`) finds both slots present on first
+          ;; click. `:tick-gen` stays at 0 in on-demand mode; it's
+          ;; the parking spot for a future Reset/Pause toggle.
           :clock     {:tick-gen 0
                       :ticks    0}
           :title     {:value    "Parallel-Frames (untouched)"
                       :error    nil
                       :requests 0}}
-     :fx [[:dispatch [::clock-start]]
-          [:dispatch [:title/flow [:rf/init]]]]}))
+     ;; Clock-tick chain disabled (rf2-gxgmt — annoying + low value;
+     ;; spine pollution from recursive ::clock-tick dispatch). The
+     ;; per-frame Tick buttons drive `::clock-tick` on demand instead —
+     ;; isolation visible without continuous spine noise.
+     ;; ::clock-start / ::clock-tick / ::clock-ticks remain registered
+     ;; below; ::clock-start is now unused (kept for a future opt-in
+     ;; "auto-tick" toggle if it ever becomes useful again).
+     :fx [[:dispatch [:title/flow [:rf/init]]]]}))
 
 ;; ============================================================================
 ;; COUNTER — events + sub
@@ -144,37 +165,42 @@
 (rf/reg-sub ::counter (fn [db _] (:counter db)))
 
 ;; ============================================================================
-;; CLOCK — periodic tick via :dispatch-later
+;; CLOCK — on-demand tick via per-frame "Tick" button
 ;; ============================================================================
 ;;
-;; The clock tick chain self-perpetuates through `:dispatch-later`,
-;; matching the shape of `examples/reagent/7Guis/timer/timer.cljs`.
-;; Each tick carries the `:tick-gen` value it was scheduled with;
-;; future Reset support (or a Pause toggle) bumps `:tick-gen` so any
-;; stale in-flight tick from the previous generation no-ops. Today
-;; the testbed only ever runs one generation per frame, but the
-;; generation guard is idiomatic and costs nothing.
+;; rf2-gxgmt — the auto-ticking dispatch chain was removed. Each frame
+;; now exposes a "Tick" button that dispatches `::clock-tick` once
+;; against the surrounding frame. Clicking Tick on :above increments
+;; only :above's tick counter; clicking Tick on :below increments only
+;; :below's. The isolation is visible on demand without continuous
+;; spine pollution.
 ;;
-;; Because the two frames start ticking at slightly different points
-;; in time (`:on-create` runs once per `reg-frame` registration; the
-;; first `::clock-start` dispatch happens during the boot sequence
-;; for each), their tick chains naturally drift out of phase. Causa's
-;; frame-picker switching surfaces the divergence.
+;; ::clock-start is no longer wired (`:on-create` doesn't dispatch it
+;; any more) but stays registered as a parking spot for any future
+;; opt-in auto-tick toggle. The `:tick-gen` generation guard in
+;; ::clock-tick stays idiomatic — costs nothing and pairs with a
+;; future Reset/Pause affordance if one materialises.
 
 (rf/reg-event-fx ::clock-start
+  ;; Currently unused — the testbed runs in on-demand mode (rf2-gxgmt).
+  ;; Left registered so a future auto-tick toggle can re-enable the
+  ;; self-perpetuating chain without touching the registration graph.
   (fn [{:keys [db]} _ev]
     (let [gen (get-in db [:clock :tick-gen])]
       {:fx [[:dispatch-later {:ms    CLOCK-TICK-MS
                               :event [::clock-tick gen]}]]})))
 
 (rf/reg-event-fx ::clock-tick
+  ;; On-demand single-tick handler (rf2-gxgmt). The per-frame "Tick"
+  ;; button dispatches `[::clock-tick gen]` with the current
+  ;; `:tick-gen`; the handler increments `:ticks` and stops. The
+  ;; generation guard stays idiomatic — `:tick-gen` lets a future
+  ;; Reset bump the generation so any stale in-flight ticks no-op.
   (fn [{:keys [db]} [_ gen]]
     (if (not= gen (get-in db [:clock :tick-gen]))
       ;; Stale tick from a retired generation. Drop it silently.
       {}
-      {:db (update-in db [:clock :ticks] (fnil inc 0))
-       :fx [[:dispatch-later {:ms    CLOCK-TICK-MS
-                              :event [::clock-tick gen]}]]})))
+      {:db (update-in db [:clock :ticks] (fnil inc 0))})))
 
 (rf/reg-sub ::clock-ticks
   (fn [db _] (get-in db [:clock :ticks])))
@@ -363,14 +389,21 @@
        "+"]]
 
      ;; --- Clock ---------------------------------------------------------
+     ;; rf2-gxgmt — on-demand tick (auto-tick chain retired). Clicking
+     ;; the per-frame Tick button increments only this frame's :ticks
+     ;; slot; the other frame stays put. Parallel-frame isolation
+     ;; visible without continuous spine noise.
      [:div {:style {:margin "0.5em 0"
                     :display "flex" :gap "8px" :align-items "center"}}
       [:strong "Clock:"]
+      [:button {:data-testid (str frame-label "-clock-tick")
+                :on-click    #(dispatch [::clock-tick 0])}
+       "Tick"]
       [:span {:data-testid (str frame-label "-clock-ticks")
               :style       {:font-family "monospace"}}
        (str ticks " tick" (when (not= 1 ticks) "s"))]
       [:span {:style {:font-size "11px" :color "#888"}}
-       "auto-tick @ 1s"]]
+       "on-demand"]]
 
      ;; --- Title (HTTP) --------------------------------------------------
      [:div {:style {:margin "0.5em 0 0 0"
@@ -466,9 +499,10 @@
   (causa-config/configure! {:project-root (resolve-project-root)})
   (rf/init! reagent-adapter/adapter)
   ;; Register the two frames. Each `:on-create` seeds its own app-db
-  ;; synchronously and then kicks off its clock-tick chain. The
-  ;; `::initialise` and `::clock-start` handlers are registered once
-  ;; globally and resolve against whichever frame the dispatch
+  ;; synchronously (rf2-gxgmt — the clock-tick chain is no longer
+  ;; auto-started; the per-frame Tick button drives `::clock-tick` on
+  ;; demand instead). The `::initialise` handler is registered once
+  ;; globally and resolves against whichever frame the dispatch
   ;; envelope targets — per-frame state evolution is automatic.
   (rf/reg-frame frame-above {:on-create [::initialise]})
   (rf/reg-frame frame-below {:on-create [::initialise]})

--- a/tools/causa/testbeds/parallel_frames/spec.cjs
+++ b/tools/causa/testbeds/parallel_frames/spec.cjs
@@ -6,23 +6,30 @@
  * coupling. The smoke asserts:
  *
  *   1. Initial paint — both frame panels render, both counters read 0,
- *      both clocks have ticked at least once (auto-tick @ 1s).
+ *      both clock-tick counters read 0 (rf2-gxgmt: ticks are on-demand
+ *      via the per-frame Tick button; the auto-tick chain was retired).
  *
  *   2. Counter isolation — clicking + on :above increments :above's
  *      counter while :below's counter stays at 0. Clicking + on :below
  *      then advances only :below.
  *
- *   3. HTTP / machine isolation — clicking Refresh on :below drives
+ *   3. Clock-tick isolation (rf2-gxgmt) — clicking Tick on :above
+ *      increments only :above's tick counter; clicking Tick on :below
+ *      increments only :below's. The same `::clock-tick` handler is
+ *      registered once globally and resolves against whichever frame
+ *      the dispatch envelope targets via the frame-provider context.
+ *
+ *   4. HTTP / machine isolation — clicking Refresh on :below drives
  *      :below's :title/flow machine into :loading, the mock fx
  *      resolves ~600ms later into :loaded, and :below's title slot
  *      carries a non-empty value. :above's title state stays :idle
  *      throughout.
  *
- *   4. Force-error path — Force-error on :above drives the same
+ *   5. Force-error path — Force-error on :above drives the same
  *      machine into :error legitimately (request fails by design).
- *      :below's :loaded state from step 3 persists.
+ *      :below's :loaded state from step 4 persists.
  *
- *   5. Causa target-frame round-trip (rf2-qd5r6, ex-Tier-2 L-14).
+ *   6. Causa target-frame round-trip (rf2-qd5r6, ex-Tier-2 L-14).
  *      Spec 008 §State isolation (the rf2-tijr Option-C lock).
  *      Causa's panel-layer `:rf.causa/set-target-frame` event +
  *      `:rf.causa/target-frame-db` sub project the addressed frame's
@@ -54,6 +61,11 @@ module.exports = {
     await expectTextEquals(page.locator('[data-testid="above-counter-value"]'), '0');
     await expectTextEquals(page.locator('[data-testid="below-counter-value"]'), '0');
 
+    // Both clock-tick counters start at 0 (rf2-gxgmt — on-demand via
+    // the per-frame Tick button; no auto-tick chain).
+    await expectTextEquals(page.locator('[data-testid="above-clock-ticks"]'), '0 ticks');
+    await expectTextEquals(page.locator('[data-testid="below-clock-ticks"]'), '0 ticks');
+
     // Both machines start at :idle (the :title/flow :initial slot).
     await expectTextEquals(page.locator('[data-testid="above-title-state"]'), ':idle');
     await expectTextEquals(page.locator('[data-testid="below-title-state"]'), ':idle');
@@ -76,7 +88,25 @@ module.exports = {
     await expectTextEquals(page.locator('[data-testid="above-counter-value"]'), '3');
     await expectTextEquals(page.locator('[data-testid="below-counter-value"]'), '1');
 
-    // --- 2. HTTP / machine isolation — Refresh on :below --------------------
+    // --- 2. Clock-tick isolation (rf2-gxgmt) --------------------------------
+    //
+    // Click Tick on :above twice. :above's tick counter advances to 2;
+    // :below's stays at 0. Then click Tick on :below once. :below
+    // advances to 1; :above stays at 2. The same `::clock-tick`
+    // handler is registered once globally and resolves against
+    // whichever frame the dispatch envelope targets via the
+    // frame-provider context — proving on-demand per-frame isolation
+    // without the spine-pollution cost of the retired auto-tick chain.
+    await page.locator('[data-testid="above-clock-tick"]').click();
+    await page.locator('[data-testid="above-clock-tick"]').click();
+    await expectTextEquals(page.locator('[data-testid="above-clock-ticks"]'), '2 ticks');
+    await expectTextEquals(page.locator('[data-testid="below-clock-ticks"]'), '0 ticks');
+
+    await page.locator('[data-testid="below-clock-tick"]').click();
+    await expectTextEquals(page.locator('[data-testid="above-clock-ticks"]'), '2 ticks');
+    await expectTextEquals(page.locator('[data-testid="below-clock-ticks"]'), '1 tick');
+
+    // --- 3. HTTP / machine isolation — Refresh on :below --------------------
     //
     // Click Refresh on :below. The :title/flow machine in :below's app-db
     // transitions :idle → :loading. ~600ms later the mock fx resolves
@@ -107,13 +137,13 @@ module.exports = {
       );
     }
 
-    // --- 3. Force-error on :above — legitimate failure cascade --------------
+    // --- 4. Force-error on :above — legitimate failure cascade --------------
     //
     // The Force-error button dispatches the same :title-refresh event
     // with `:force-error? true`. The mock fx rejects on that flag (it's
     // not a bug — it's a normal request the user asked to fail), and
     // the machine transitions :idle → :loading → :error. :below's
-    // :loaded state from step 2 persists.
+    // :loaded state from step 3 persists.
     await page.locator('[data-testid="above-title-force-error"]').click();
     await expectTextEquals(
       page.locator('[data-testid="above-title-state"]'),
@@ -132,7 +162,7 @@ module.exports = {
       );
     }
 
-    // --- 5. Causa target-frame round-trip + multi-frame isolation -----------
+    // --- 6. Causa target-frame round-trip + multi-frame isolation -----------
     //     (rf2-qd5r6 ex-Tier-2 L-14)
     //
     // Spec 008 §State isolation (rf2-tijr Option-C frame-provider lock).


### PR DESCRIPTION
## Summary

- The recursive `::clock-tick` dispatch chain (CLOCK-TICK-MS interval, two frames out of phase) was polluting the event spine with infrastructure noise and adding little teaching value — parallel-frame isolation is the testbed's punchline and can be demonstrated cleanly on demand.
- Each frame now exposes a per-frame **Tick** button that dispatches `::clock-tick` once against the surrounding frame. Clicking Tick on `:above` increments only `:above`'s tick counter; clicking Tick on `:below` increments only `:below`'s. Isolation visible without continuous spine pollution.
- `::clock-start` / `::clock-tick` / `::clock-ticks` remain registered (parked for a future opt-in auto-tick toggle if one ever materialises); the recursive `:dispatch-later` self-perpetuation was removed.
- `spec.cjs` gains a new step 2 that exercises both Tick buttons and asserts per-frame `:ticks` isolation; the existing HTTP / Force-error steps are renumbered.
- `implementation/shadow-cljs.edn` adds an 8030 `:dev-http` entry so `npx shadow-cljs watch :examples/parallel-frames` serves the hand-written index.html with one command (matches the panel-gallery cascade).
- README updated to reflect the on-demand Tick model.

## Acceptance (per bead rf2-gxgmt)
- Auto-tick chain disabled (`:on-create` no longer dispatches `::clock-start`; `::clock-tick` no longer re-schedules).
- Two buttons "Tick Frame A" / "Tick Frame B" appear in the testbed UI (rendered per-frame via the same `reg-view`-driven panel).
- Each button click increments only its own frame's tick counter (asserted in spec.cjs step 2).
- `spec.cjs` updated to test the button-driven flow.
- `shadow-cljs.edn` dev-http entry retained for local live-reload.

## Test plan
- [x] `npm run test:cljs` — green (3156 tests, 9088 assertions, 0 failures)
- [x] `npm run test:bundle-isolation` — green
- [x] Causa JVM `clojure -M:test` — green (749 tests, 2263 assertions, 0 failures)
- [x] `:examples/parallel-frames` shadow-cljs compile — green (only pre-existing machines-viz externs warnings)
- [ ] Browser smoke (parallel-frames spec.cjs) deferred — port 8030 held by a parallel worker's orchestrator run in this session.

## Files
- `tools/causa/testbeds/parallel_frames/core.cljs` — drop auto-start, add per-frame Tick button, single-tick handler
- `tools/causa/testbeds/parallel_frames/spec.cjs` — add clock-tick isolation step; renumber subsequent steps
- `tools/causa/testbeds/parallel_frames/README.md` — reflect on-demand model
- `implementation/shadow-cljs.edn` — add 8030 dev-http entry for the testbed