### PR TITLE
fix(machines): :rf.machine/transition trace carries :frame tag (rf2-hwuki)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/registration.cljc
@@ -328,8 +328,15 @@
                              (transition/final-on-leaf? machine (:state next-snapshot)))
                         (finalize/all-regions-final? machine (:state next-snapshot)))
           new-db    (assoc-in db path next-snapshot)]
+      ;; Per rf2-hwuki: `:frame` tag is REQUIRED for epoch-capture
+      ;; admission (`re-frame.epoch.capture/capture-event!` silently
+      ;; drops trace events whose tags lack `:frame`). Without this
+      ;; tag the headline machine-transition trace never reaches the
+      ;; cascade's `:trace-events` slot, leaving the Causa Machine
+      ;; Inspector chart blank for cascades that DID drive a transition.
       (trace/emit! :machine :rf.machine/transition
-                   {:machine-id machine-id
+                   {:frame      frame-id
+                    :machine-id machine-id
                     :event      inner-event
                     :before     snapshot
                     :after      next-snapshot})

--- a/implementation/machines/test/re_frame/transition_frame_tag_test.clj
+++ b/implementation/machines/test/re_frame/transition_frame_tag_test.clj
@@ -1,0 +1,79 @@
+(ns re-frame.transition-frame-tag-test
+  "Per rf2-hwuki: `:rf.machine/transition` MUST carry the `:frame` tag so
+  `re-frame.epoch.capture/capture-event!` admits it into the cascade's
+  trace buffer.
+
+  Discovered by the Causa matrix P1 gaps worker (rf2-bz72m chart-render
+  scenario) while building a chart-render assertion: the framework
+  emitted `:rf.machine/transition` WITHOUT `:frame`, so the epoch
+  capture gate (`(when (and frame-id ...) (state/buffer-event! ...))`)
+  silently dropped the event. The trace fanned out to direct trace
+  listeners (so unit tests that registered a `register-trace-cb!`
+  observed it) but never reached the epoch-history `:trace-events`
+  slot the Causa Machine Inspector reads from. The chart 'never
+  rendered' for real cascades; Causa's own unit tests sidestepped it
+  via a `:rf.causa/set-epoch-history-for-test` injection seam.
+
+  This test lives in the machines artefact (which does not depend on
+  epoch) so the site contract is exercised even when the epoch artefact
+  isn't on the test classpath. The end-to-end harvested-record
+  assertion lives upstack in the epoch / Causa gates — they read the
+  same `:tags :frame` slot we lock here, so a future regression that
+  drops the tag fails at this site test first (clear cause)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- shared spec ----------------------------------------------------------
+
+(def ^:private traffic-light
+  {:initial :red
+   :states  {:red    {:on {:tick {:target :green}}}
+             :green  {:on {:tick {:target :yellow}}}
+             :yellow {:on {:tick {:target :red}}}}})
+
+(defn- record-traces!
+  []
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    [seen #(rf/remove-trace-cb! ::rec)]))
+
+(defn- transitions-of [evs]
+  (filterv #(= :rf.machine/transition (:operation %)) evs))
+
+;; ---- :rf.machine/transition tags carry :frame -----------------------------
+
+(deftest transition-tags-carry-frame
+  (testing ":rf.machine/transition tags carry `:frame` so the epoch-capture
+   gate admits the event into the cascade buffer (rf2-hwuki — the gate
+   silently drops trace events whose tags lack `:frame`)"
+    (rf/reg-machine :rf2-hwuki/tl traffic-light)
+    (let [[seen unreg] (record-traces!)]
+      (try
+        (rf/dispatch-sync [:rf2-hwuki/tl [:tick]])
+        (let [[t] (transitions-of @seen)]
+          (is (some? t) "one :rf.machine/transition fired")
+          (is (contains? (:tags t) :frame)
+              ":frame tag is present on the trace's tags map")
+          (is (= :rf/default (-> t :tags :frame))
+              ":frame tag value is the dispatching frame's id (:rf/default for the bare dispatch)"))
+        (finally (unreg))))))
+
+(deftest transition-frame-matches-explicit-dispatch-frame
+  (testing "explicit `{:frame <id>}` on dispatch flows through to the tag —
+   verifies the tag tracks the live dispatching frame, not a hard-coded
+   default"
+    (rf/reg-frame :rf2-hwuki/frame-A {:doc "explicit dispatch frame"})
+    (rf/reg-machine :rf2-hwuki/tl traffic-light)
+    (let [[seen unreg] (record-traces!)]
+      (try
+        (rf/dispatch-sync [:rf2-hwuki/tl [:tick]] {:frame :rf2-hwuki/frame-A})
+        (let [[t] (transitions-of @seen)]
+          (is (some? t))
+          (is (= :rf2-hwuki/frame-A (-> t :tags :frame))
+              ":frame tag tracks the dispatching frame id, not :rf/default"))
+        (finally (unreg))))))


### PR DESCRIPTION
## Summary

- `re-frame.epoch.capture/capture-event!` filters trace events by `:frame` — events whose tags lack `:frame` are silently dropped (they can't be tied to a specific cascade).
- The headline `:rf.machine/transition` emit at `lifecycle_fx/registration.cljc:331` omitted the tag. Machine-transition traces fanned out to direct `register-trace-cb!` listeners but never reached the cascade's `:trace-events` slot.
- Consequence: the Causa Machine Inspector chart never rendered for real cascades — Causa unit tests sidestepped this via the `:rf.causa/set-epoch-history-for-test` injection seam.
- Fix: add `:frame frame-id` to the trace's tags map (`frame-id` is already in scope from `prepare-machine-ctx`).

## Test

- New `implementation/machines/test/re_frame/transition_frame_tag_test.clj` locks the site-level contract — `:rf.machine/transition`'s tags carry `:frame`, with both the default-frame and explicit-`{:frame <id>}` dispatch paths covered.
- The machines artefact does not depend on epoch, so the end-to-end harvested-record assertion lives upstack in the epoch / Causa gates (which read the same tag this test locks).

## Test plan

- [x] `clojure -M:test` from `implementation/machines/` (211 tests, 751 assertions, 0 failures)
- [x] `npm run test:cljs` from `implementation/` (3170 tests, 9121 assertions, 0 failures)
- [x] `npm run test:causa-feature-gate` from `implementation/` (14 scenarios, 0 failures, 13 matrix rows covered)

## Related

- Discovered by the Causa matrix P1 gaps worker (rf2-bz72m chart-render scenario) on 2026-05-19.
- Closes rf2-hwuki.