### PR TITLE
test(causa): live-follow Phase 3 — panel-control interactions (rf2-mpqxn)

### DIFF
--- a/tools/causa/testbeds/feature_matrix/helpers/live_follow.cjs
+++ b/tools/causa/testbeds/feature_matrix/helpers/live_follow.cjs
@@ -634,6 +634,464 @@ async function assertPanelReflectsFocus(page, panelId, focus, opts = {}) {
   return sig;
 }
 
+// ---------------------------------------------------------------------------
+// Panel-control interactions (rf2-mpqxn — Phase 3)
+// ---------------------------------------------------------------------------
+//
+// Phase 1+2 (rf2-rwhat) covered the auto-follow refresh axis: "fire event
+// while Causa is live → cursor auto-follows → each panel reflects the new
+// focused event". Phase 3 covers the orthogonal axis: "the user clicks a
+// panel control → the rendered surface updates accordingly". The bug
+// class this catches is rf2-dodq2 (Views Group-By stuck on Component
+// pill), rf2-i40us (density radio with no font-size effect), and broken
+// Cmd-K palette dispatch (rf2-wm7z4 + rf2-ybjkx).
+//
+// The helpers below are organised by control. Each helper is a single
+// observable round-trip — click control, read the visible side-effect,
+// return a JSON-friendly snapshot the scenario asserts against. Phase 3
+// scenarios chain these into "cycle through every state" sweeps.
+
+// ---- Views Group-By pill cycle (rf2-dodq2) -------------------------------
+
+/*
+ * Group-By has three pills, one per grouping mode:
+ *   `:component` → renders `[data-testid="rf-causa-views-groups"]`
+ *   `:sub`       → renders `[data-testid="rf-causa-views-sub-grouped"]`
+ *   `:tree`      → renders `[data-testid="rf-causa-views-tree"]`
+ *
+ * Each pill carries `aria-pressed="true"|"false"` driven by the
+ * `:rf.causa/views-data` sub's `:group-by` key. A pill click dispatches
+ * `:rf.causa/views-set-group-by <value>`; the reducer flips `:group-by`
+ * on Causa's app-db and the Views panel re-renders. rf2-dodq2's symptom
+ * was the click landing but the panel not re-rendering — the pill's
+ * pressed state and the body's mode-specific testid are the two
+ * observable surfaces that catch the bug.
+ *
+ * The body cascades through three branches in `views-panel`
+ * (panels/views_view.cljs §panel root). When there are no cascades the
+ * panel renders `rf-causa-views-empty`; the mode-specific bodies only
+ * render once a cascade exists. Phase 3 scenarios fire the host event
+ * BEFORE cycling Group-By so the body has data to project.
+ */
+
+const GROUP_BY_MODES = [
+  {
+    value: 'component',
+    pillTestId: 'rf-causa-views-group-by-component',
+    bodyTestId: 'rf-causa-views-groups',
+  },
+  {
+    value: 'sub',
+    pillTestId: 'rf-causa-views-group-by-sub',
+    bodyTestId: 'rf-causa-views-sub-grouped',
+  },
+  {
+    value: 'tree',
+    pillTestId: 'rf-causa-views-group-by-tree',
+    bodyTestId: 'rf-causa-views-tree',
+  },
+];
+
+/**
+ * Read the Views Group-By state — which pill is `aria-pressed="true"`,
+ * which mode-specific body testid is mounted, and whether the empty-
+ * state surface is up instead.
+ */
+async function readGroupByState(page) {
+  return page.evaluate((modes) => {
+    const root = document.getElementById('rf-causa-root');
+    if (!root) return { present: false, reason: 'rf-causa-root missing' };
+    const pressed = {};
+    let activePill = null;
+    for (const mode of modes) {
+      const pill = root.querySelector(`[data-testid="${mode.pillTestId}"]`);
+      const ap   = pill ? pill.getAttribute('aria-pressed') : null;
+      pressed[mode.value] = ap;
+      if (ap === 'true') activePill = mode.value;
+    }
+    const bodies = {};
+    let activeBody = null;
+    for (const mode of modes) {
+      const body = root.querySelector(`[data-testid="${mode.bodyTestId}"]`);
+      bodies[mode.value] = Boolean(body);
+      if (body) activeBody = mode.value;
+    }
+    const empty = root.querySelector('[data-testid="rf-causa-views-empty"]');
+    return {
+      present:    true,
+      pressed,
+      activePill,
+      bodies,
+      activeBody,
+      empty:      Boolean(empty),
+    };
+  }, GROUP_BY_MODES);
+}
+
+/**
+ * Click the Group-By pill for `mode` and wait for the pill's
+ * `aria-pressed` to flip to `"true"` AND the mode-specific body testid
+ * to surface (unless the panel is in the empty state, in which case
+ * only the pressed-state flip is asserted — see `signatureMayMatch`-
+ * style escape for cascade-less panels).
+ *
+ * Returns the post-click `readGroupByState` snapshot.
+ *
+ * The body-mounted assertion is the regression-catching path for
+ * rf2-dodq2: the bug's symptom was "pill press registers but body
+ * stays on the Component grouping". Here we explicitly require the
+ * sub-grouped / tree body to mount.
+ */
+async function clickGroupByPill(page, mode, opts = {}) {
+  const def = GROUP_BY_MODES.find((m) => m.value === mode);
+  if (!def) {
+    throw new Error(
+      `clickGroupByPill: unknown mode ${JSON.stringify(mode)}; ` +
+      `known: ${GROUP_BY_MODES.map((m) => m.value).join(', ')}`,
+    );
+  }
+  const timeoutMs = opts.timeoutMs || 5000;
+  const requireBody = opts.requireBody !== false;
+  await page.locator(`[data-testid="${def.pillTestId}"]`).click();
+  return waitForValue(
+    () => readGroupByState(page),
+    (snap) => {
+      if (!snap.present) return false;
+      if (snap.pressed[mode] !== 'true') return false;
+      if (requireBody && !snap.empty && snap.activeBody !== mode) return false;
+      return true;
+    },
+    {
+      timeoutMs,
+      description:
+        `Group-By pill ${mode} → aria-pressed=true ` +
+        `+ body ${def.bodyTestId} mounted (unless empty-state)`,
+    },
+  );
+}
+
+// ---- Density radio cycle (rf2-i40us) ------------------------------------
+
+/*
+ * The density radio surfaces under the Settings popup's General tab.
+ * v1 ships two pills (rf2-ttnst dropped the third `:comfy` tier from
+ * the spec brief; the data is still catalogued in `density->font-size-
+ * px` for forward compat):
+ *
+ *   :compact → 12px
+ *   :cosy    → 13px (default; matches `tokens/font-size-default`)
+ *
+ * The radio writes the resolved px value into the canonical
+ * `--rf-causa-font-size` CSS custom property on BOTH the Causa shell
+ * root AND `<html>` (settings/effects.cljs §apply-density-font-size!),
+ * so every type-scale entry — every typographic surface in the chrome
+ * — rescales on the next paint. The test reads the `<html>`-scoped
+ * inline declaration as the canonical post-click side-effect signal;
+ * if the radio click landed without the apply-fn firing, the inline
+ * declaration on `<html>` will be missing or stale and the assertion
+ * trips.
+ *
+ * Density value list lives in `density-radio-modes` rather than
+ * hard-coded so a future un-drop of `:comfy` re-enables the third
+ * cycle entry without re-touching the helper.
+ */
+
+const DENSITY_RADIO_MODES = [
+  { value: 'cosy',    testId: 'rf-causa-settings-density-cosy',    expectedPx: 13 },
+  { value: 'compact', testId: 'rf-causa-settings-density-compact', expectedPx: 12 },
+];
+
+/**
+ * Read `--rf-causa-font-size` from both the shell root and `<html>`.
+ * Returns the inline-style value (which is what `apply-density-font-
+ * size!` writes via `setProperty`). Either root may be absent in some
+ * launch modes; the per-element value is reported separately so the
+ * assertion can target the layer it cares about.
+ */
+async function readDensityFontSize(page) {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    const shellRoot = document.getElementById('rf-causa-root');
+    const htmlInline = html
+      ? html.style.getPropertyValue('--rf-causa-font-size') || null
+      : null;
+    const shellInline = shellRoot
+      ? shellRoot.style.getPropertyValue('--rf-causa-font-size') || null
+      : null;
+    // The computed value is what the cascade resolves; useful for
+    // diagnostics but the canonical assertion target is the inline
+    // declaration the apply-fn writes.
+    const htmlComputed = html
+      ? getComputedStyle(html).getPropertyValue('--rf-causa-font-size').trim() || null
+      : null;
+    return {
+      htmlInline,
+      shellInline,
+      htmlComputed,
+    };
+  });
+}
+
+/**
+ * Open the Settings popup by dispatching `:rf.causa/settings-toggle`
+ * directly into the `:rf/causa` frame. Mirrors the dispatch path the
+ * `,` keybinding takes — `keybinding.cljs §handle-keydown` calls
+ * `(rf/with-frame :rf/causa (rf/dispatch [...]))` so this helper drops
+ * the keyboard-listener leg and lands the same reducer.
+ *
+ * Direct dispatch (vs keyboard) is the robust path: the `,` listener
+ * filters events on `target-inside-causa?` (the event target must walk
+ * up to an element with `data-testid="rf-causa-shell"`). Synthetic
+ * keypresses from Playwright land on `document.body` unless an
+ * element inside the shell has focus AND the user-agent allows
+ * `keydown` events to retain that target — neither invariant is
+ * guaranteed across browsers / shadow-root mounts. The dispatch-vector
+ * path is invariant.
+ *
+ * Idempotent — `settings-toggle` flips the open/close slot; we read
+ * the dialog testid first and bail if it's already mounted.
+ */
+async function openSettingsPopup(page) {
+  const dialog = page.locator('[data-testid="rf-causa-settings-dialog"]');
+  if ((await dialog.count()) > 0) return;
+  const result = await page.evaluate(() => {
+    const cljs = window.cljs && window.cljs.core;
+    const rf   = window.re_frame && window.re_frame.core;
+    const dispatch = rf && (rf.dispatch_STAR_ ||
+      (window.re_frame.router && window.re_frame.router.dispatch_BANG_));
+    if (!cljs || typeof dispatch !== 'function') {
+      return {
+        ok: false,
+        reason: 'cljs.core or re_frame.core.dispatch_STAR_ unavailable',
+      };
+    }
+    function keyword(s) {
+      const trimmed = String(s).replace(/^:/, '');
+      const parts = trimmed.split('/');
+      if (parts.length === 2) {
+        return cljs.keyword.call
+          ? cljs.keyword.call(null, parts[0], parts[1])
+          : cljs.keyword(parts[0], parts[1]);
+      }
+      return cljs.keyword.call
+        ? cljs.keyword.call(null, trimmed)
+        : cljs.keyword(trimmed);
+    }
+    const event = cljs.PersistentVector.fromArray(
+      [keyword(':rf.causa/settings-toggle')], true);
+    const opts = cljs.hash_map(keyword(':frame'), keyword(':rf/causa'));
+    if (dispatch.cljs$core$IFn$_invoke$arity$2) {
+      dispatch.cljs$core$IFn$_invoke$arity$2(event, opts);
+    } else {
+      dispatch(event, opts);
+    }
+    return { ok: true };
+  });
+  if (!result.ok) {
+    throw new Error(
+      `openSettingsPopup: could not dispatch :rf.causa/settings-toggle: ${result.reason}`,
+    );
+  }
+  await waitForValue(
+    () => dialog.count(),
+    (n) => n > 0,
+    { timeoutMs: 5000, description: 'Settings popup mounts after settings-toggle dispatch' },
+  );
+}
+
+/**
+ * Click a density radio and wait for `--rf-causa-font-size` on `<html>`
+ * to flip to the expected px value. Returns the post-click font-size
+ * snapshot from `readDensityFontSize`.
+ *
+ * The assertion target is `<html>` (NOT the shell root) because the
+ * `<html>` write is the one that survives a popout / fullscreen mount
+ * where the shell root may differ from the inline-host root. The shell
+ * root is also written but is reported alongside for diagnostics.
+ */
+async function clickDensityRadio(page, value, opts = {}) {
+  const def = DENSITY_RADIO_MODES.find((m) => m.value === value);
+  if (!def) {
+    throw new Error(
+      `clickDensityRadio: unknown density ${JSON.stringify(value)}; ` +
+      `known: ${DENSITY_RADIO_MODES.map((m) => m.value).join(', ')}`,
+    );
+  }
+  const timeoutMs = opts.timeoutMs || 5000;
+  await page.locator(`[data-testid="${def.testId}"]`).click();
+  const expected = `${def.expectedPx}px`;
+  return waitForValue(
+    () => readDensityFontSize(page),
+    (snap) => snap.htmlInline === expected,
+    {
+      timeoutMs,
+      description:
+        `Density radio ${value} → --rf-causa-font-size = ${expected} on <html>`,
+    },
+  );
+}
+
+// ---- Cmd-K palette execute (rf2-wm7z4 + rf2-ybjkx) ----------------------
+
+/*
+ * The palette is opened by Cmd/Ctrl+K (per `keybinding.cljs §palette-
+ * toggle-key?`). Once open the input owns key handling:
+ *   - typing into the input updates `:palette-query` and re-ranks the
+ *     fuzzy index
+ *   - ArrowDown/Up moves the cursor across result rows
+ *   - Enter dispatches `:rf.causa/palette-invoke <item> <popout?>` which
+ *     lowers the item's `:action` into the canonical Causa-side
+ *     dispatch (theme toggle / reduced-motion cycle / cycle-density /
+ *     …)
+ *   - the first result is selected by default (cursor = 0)
+ *
+ * Verifying the round-trip means: open palette, type query, assert the
+ * top result is the verb we wanted, press Enter, assert the verb's
+ * side-effect landed (e.g. `<html>` theme class flipped), AND when we
+ * re-open the palette the same verb's recents-boost (`:palette-recents`
+ * slot) lifts it to position 0 even on an empty query. Recents-boost-
+ * max = 60 outranks the static `:command` boost of 40, so the recent
+ * command sorts strictly first.
+ */
+
+/**
+ * Read the current theme class on `<html>` — one of `dark` / `light`
+ * (the only two configured in `apply-theme!`). Returns null when no
+ * theme class is present.
+ */
+async function readThemeClass(page) {
+  return page.evaluate(() => {
+    const html = document.documentElement;
+    if (!html) return null;
+    const cl = html.classList;
+    if (cl.contains('rf-causa-theme-dark')) return 'dark';
+    if (cl.contains('rf-causa-theme-light')) return 'light';
+    return null;
+  });
+}
+
+/**
+ * Read the palette-list state — open?, query, result rows (testid +
+ * data-source + label text). The label text is read from the row
+ * itself (the icon glyph + label span concatenate; we drop the leading
+ * icon glyph by trimming).
+ */
+async function readPaletteState(page) {
+  return page.evaluate(() => {
+    const root = document.getElementById('rf-causa-root');
+    const dialog = root && root.querySelector(
+      '[data-testid="rf-causa-palette-dialog"]');
+    if (!dialog) return { open: false };
+    const input = root.querySelector(
+      '[data-testid="rf-causa-palette-input"]');
+    const list = root.querySelector(
+      '[data-testid="rf-causa-palette-list"]');
+    const rows = list
+      ? Array.from(list.querySelectorAll('[data-testid^="rf-causa-palette-row-"]'))
+      : [];
+    const rowData = rows.map((el) => ({
+      testId:  el.getAttribute('data-testid'),
+      source:  el.getAttribute('data-source'),
+      active:  el.getAttribute('data-active'),
+      text:    (el.textContent || '').replace(/\s+/g, ' ').trim(),
+    }));
+    return {
+      open:     true,
+      query:    input ? input.value : null,
+      rowCount: rows.length,
+      rows:     rowData.slice(0, 10),
+    };
+  });
+}
+
+/**
+ * Open the palette via Ctrl+K (works on every host — see `palette-
+ * toggle-key?` accepting Cmd XOR Ctrl). Idempotent — re-opening when
+ * already open would dispatch toggle and close the palette; we guard
+ * by reading the dialog testid first.
+ */
+async function openPalette(page) {
+  const dialog = page.locator('[data-testid="rf-causa-palette-dialog"]');
+  if ((await dialog.count()) > 0) return;
+  await page.keyboard.press('Control+K');
+  await waitForValue(
+    () => dialog.count(),
+    (n) => n > 0,
+    { timeoutMs: 5000, description: 'Palette dialog mounts after Ctrl+K' },
+  );
+}
+
+/**
+ * Close the palette by pressing Escape inside the input. Idempotent.
+ */
+async function closePalette(page) {
+  const dialog = page.locator('[data-testid="rf-causa-palette-dialog"]');
+  if ((await dialog.count()) === 0) return;
+  const input = page.locator('[data-testid="rf-causa-palette-input"]');
+  if ((await input.count()) > 0) {
+    await input.press('Escape');
+  } else {
+    await page.keyboard.press('Escape');
+  }
+  await waitForValue(
+    () => dialog.count(),
+    (n) => n === 0,
+    { timeoutMs: 5000, description: 'Palette dialog dismisses after Escape' },
+  );
+}
+
+/**
+ * Type `query` into the palette input + wait for the top row's text to
+ * include `expectedTopLabelSubstr` (case-insensitive). Returns the
+ * post-type palette snapshot. The substring match lets the caller pin
+ * "the result I expected ranked first" without depending on the exact
+ * label glyph (Cmd-Enter pop-out arrow, etc.). Asserts at least one
+ * row is present — empty result sets surface `rf-causa-palette-empty`
+ * (the `data-testid` prefix does NOT match `rf-causa-palette-row-`)
+ * so `rowCount === 0` indicates the query has no hits.
+ */
+async function typePaletteQuery(page, query, expectedTopLabelSubstr, opts = {}) {
+  const timeoutMs = opts.timeoutMs || 5000;
+  const input = page.locator('[data-testid="rf-causa-palette-input"]');
+  await input.fill(query);
+  return waitForValue(
+    () => readPaletteState(page),
+    (snap) => {
+      if (!snap.open) return false;
+      if (snap.rowCount === 0) return false;
+      const top = snap.rows[0];
+      const text = (top.text || '').toLowerCase();
+      return text.includes(expectedTopLabelSubstr.toLowerCase());
+    },
+    {
+      timeoutMs,
+      description:
+        `Palette query ${JSON.stringify(query)} ` +
+        `→ top row label contains ${JSON.stringify(expectedTopLabelSubstr)}`,
+    },
+  );
+}
+
+/**
+ * Press Enter on the palette input to invoke the cursor's current row.
+ * Waits for the palette to dismiss (the `:rf.causa/palette-invoke`
+ * reducer closes the modal as part of every verb branch). Returns the
+ * post-invoke palette snapshot (which is `{ open: false }`).
+ */
+async function executePaletteCursor(page, opts = {}) {
+  const timeoutMs = opts.timeoutMs || 5000;
+  const input = page.locator('[data-testid="rf-causa-palette-input"]');
+  await input.press('Enter');
+  return waitForValue(
+    () => readPaletteState(page),
+    (snap) => !snap.open,
+    {
+      timeoutMs,
+      description: 'Palette dismisses after Enter (post invoke)',
+    },
+  );
+}
+
 module.exports = {
   PANEL_SIGNATURE_PROBES,
   readCausaFocus,
@@ -643,4 +1101,18 @@ module.exports = {
   clickPanelTab,
   panelFocusSignature,
   assertPanelReflectsFocus,
+  // rf2-mpqxn — Phase 3 panel-control interactions
+  GROUP_BY_MODES,
+  DENSITY_RADIO_MODES,
+  readGroupByState,
+  clickGroupByPill,
+  readDensityFontSize,
+  openSettingsPopup,
+  clickDensityRadio,
+  readThemeClass,
+  readPaletteState,
+  openPalette,
+  closePalette,
+  typePaletteQuery,
+  executePaletteCursor,
 };

--- a/tools/causa/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/causa/testbeds/feature_matrix/scenarios.cjs
@@ -15,6 +15,18 @@ const {
   panelFocusSignature,
   clickPanelTab,
   assertPanelReflectsFocus,
+  // rf2-mpqxn — Phase 3 panel-control interactions
+  readGroupByState,
+  clickGroupByPill,
+  readDensityFontSize,
+  openSettingsPopup,
+  clickDensityRadio,
+  readThemeClass,
+  readPaletteState,
+  openPalette,
+  closePalette,
+  typePaletteQuery,
+  executePaletteCursor,
 } = require('./helpers/live_follow.cjs');
 
 // Post rf2-xy4yb (4-layer chrome refactor): the legacy 15-panel
@@ -1956,6 +1968,245 @@ async function runLiveFollowDeepMachine(page, state) {
   ] };
 }
 
+// ---- rf2-mpqxn — Phase 3 panel-control interaction scenarios -----------
+//
+// Phase 1+2 (rf2-rwhat) covered the auto-follow refresh axis (host fires
+// event → Causa spine follows → panel re-renders). Phase 3 covers the
+// orthogonal axis: user clicks a control on a panel → the panel updates
+// accordingly. The bug class:
+//
+//   - rf2-dodq2 (Views Group-By stuck on Component pill) — pill press
+//     registers but panel body never flips off the Component grouping.
+//   - rf2-i40us (density radio with no font-size effect) — radio updates
+//     persistence but `--rf-causa-font-size` is never set, so the type
+//     scale doesn't rescale.
+//   - rf2-wm7z4 + rf2-ybjkx (Cmd-K palette dispatch round-trip) — the
+//     palette opens but Enter doesn't lower the verb's :action into the
+//     side-effect, OR the recent-command boost doesn't bubble the just-
+//     executed verb back to position 0.
+//
+// Each scenario lives on `/counter/` so the host is a known minimal
+// surface with a single `+` button to seed the cascade buffer.
+
+async function runViewsGroupByCycle(page, state) {
+  // Seed the Views panel with at least one cascade so the body
+  // surfaces (`views-panel` shows `rf-causa-views-empty` until the
+  // first cascade-bearing event lands). Counter's `+` is the
+  // minimum-viable seed; firing it in live mode lets us reuse the
+  // Phase 1+2 helper.
+  await expectHostCounterEquals(page, 5, 10000);
+  await openCausa(page);
+  await fireEventInLiveMode(page, '+');
+
+  // Land on the Views tab. The tab click also asserts the
+  // `rf-causa-views` canvas surfaced (clickPanelTab includes this
+  // wait).
+  await clickPanelTab(page, 'views');
+
+  // Cycle Component → sub → tree → back to Component, asserting the
+  // pill's aria-pressed flips + the mode-specific body testid mounts
+  // on every step. `clickGroupByPill` enforces both invariants;
+  // here we additionally snapshot the state across the cycle for the
+  // run-state report.
+  const sequence = ['sub', 'tree', 'component'];
+  const initial = await readGroupByState(page);
+  // Sanity: on first mount we expect Component pressed by default
+  // (the `(or group-by :component)` fallback in `views-panel`).
+  if (initial.activePill !== 'component') {
+    failWithDetails(
+      'Views Group-By initial pill is not component — pre-rf2-mpqxn ' +
+      'snapshot drift; the panel should default to Component grouping',
+      { initial },
+    );
+  }
+
+  const cycle = [];
+  for (const mode of sequence) {
+    const snap = await clickGroupByPill(page, mode);
+    cycle.push({ mode, snap });
+    // The body assertion inside `clickGroupByPill` is the main
+    // catch — but defend in depth: assert the pill we expected is
+    // the only one pressed.
+    const otherPressed = Object.entries(snap.pressed)
+      .filter(([k, v]) => v === 'true' && k !== mode);
+    if (otherPressed.length > 0) {
+      failWithDetails(
+        `Views Group-By cycle: more than one pill is aria-pressed ` +
+        `after clicking ${mode}`,
+        { mode, snap, otherPressed },
+      );
+    }
+  }
+
+  state.viewsGroupByCycle = { initial, cycle };
+}
+
+async function runDensityRadioCycle(page, state) {
+  // Settings popup is the host surface for the density radio. We
+  // press the `,` keybinding (the spine `:rf.causa/settings-toggle`
+  // shortcut) which is the canonical user path; clicking through the
+  // Cmd-K palette's "Jump to Settings" verb is the alternative but
+  // adds an extra round-trip that this scenario doesn't need.
+  await openCausa(page);
+  await openSettingsPopup(page);
+
+  // The General tab is the default landing for the popup
+  // (`settings-toggle` reducer seeds `:settings-active-tab :general`).
+  // The density radio lives directly under General.
+
+  // Read baseline. The settings effects ns runs `apply-density-font-
+  // size!` on settings-open so the CSS var is published BEFORE the
+  // first radio click — we capture this as the baseline so the cycle
+  // assertion catches a stuck-at-default bug too.
+  const baseline = await readDensityFontSize(page);
+
+  // Cycle cosy → compact → cosy. v1 only ships two pills (rf2-ttnst
+  // dropped :comfy from the brief's three-tier list; the data is
+  // still catalogued for forward compat). The cycle exercises every
+  // transition the radio surfaces: cosy → compact (font-size 13 → 12)
+  // and compact → cosy (12 → 13) so a missing apply-fn in either
+  // direction trips the assertion.
+  const sequence = [
+    { value: 'compact', expectedPx: '12px' },
+    { value: 'cosy',    expectedPx: '13px' },
+  ];
+
+  const transitions = [];
+  for (const entry of sequence) {
+    const snap = await clickDensityRadio(page, entry.value);
+    // `clickDensityRadio` already waits for `htmlInline ===
+    // expectedPx`; re-assert here for the diagnostic shape and pin
+    // the shell-root mirror too (apply-density-font-size! writes
+    // both roots).
+    if (snap.htmlInline !== entry.expectedPx) {
+      failWithDetails(
+        `Density radio ${entry.value}: --rf-causa-font-size on <html> ` +
+        `is ${JSON.stringify(snap.htmlInline)}, expected ` +
+        `${JSON.stringify(entry.expectedPx)}`,
+        { entry, snap },
+      );
+    }
+    if (snap.shellInline !== entry.expectedPx) {
+      failWithDetails(
+        `Density radio ${entry.value}: --rf-causa-font-size on shell ` +
+        `root is ${JSON.stringify(snap.shellInline)}, expected ` +
+        `${JSON.stringify(entry.expectedPx)} (the apply-fn writes ` +
+        `BOTH roots so popout / fullscreen mounts inherit either way)`,
+        { entry, snap },
+      );
+    }
+    transitions.push({ value: entry.value, snap });
+  }
+
+  state.densityRadioCycle = { baseline, transitions };
+}
+
+async function runPaletteCmdKExecute(page, state) {
+  // The palette's `:toggle-theme` verb is the easiest invariant to
+  // verify: it dispatches `:rf.causa/settings-update :theme nil <next>`
+  // which calls `apply-theme!` (settings/effects.cljs) to flip the
+  // `rf-causa-theme-*` class on `<html>`. Reading the classList after
+  // Enter is a clean per-invoke side-effect check.
+  await openCausa(page);
+
+  // Baseline theme — read BEFORE opening the palette so the snapshot
+  // matches what the user sees. `apply-theme!` is called on shell
+  // mount with the persisted theme; default is :dark per
+  // `config/default-settings`.
+  const themeBefore = await readThemeClass(page);
+  if (themeBefore !== 'dark' && themeBefore !== 'light') {
+    failWithDetails(
+      'Palette Cmd-K execute: baseline theme class on <html> is not ' +
+      'one of dark / light — the shell did not run apply-theme! on ' +
+      'mount, or some other class is masking the theme class',
+      { themeBefore },
+    );
+  }
+
+  // ── 1. Open palette + fuzzy-filter to `:toggle-theme` ────────────
+  await openPalette(page);
+  // Fuzzy: typing "theme" should bring "Toggle theme (dark ↔ light)"
+  // to position 0. `:command` items have static boost 40 + matching
+  // every char of "theme" in the label gives a high fuzzy score.
+  const filtered = await typePaletteQuery(page, 'theme', 'Toggle theme');
+  if (filtered.rows.length === 0) {
+    failWithDetails(
+      'Palette Cmd-K execute: no results for query "theme"',
+      { filtered },
+    );
+  }
+  if (filtered.rows[0].source !== 'command') {
+    failWithDetails(
+      'Palette Cmd-K execute: top result for query "theme" is not a ' +
+      ':command source row — fuzzy ranking changed or a higher-boost ' +
+      'item is masking the verb',
+      { topRow: filtered.rows[0] },
+    );
+  }
+
+  // ── 2. Press Enter — palette dismisses + theme flips ─────────────
+  await executePaletteCursor(page);
+  // Wait for the apply-theme! side-effect to land (the settings-
+  // update dispatch chains through reg-event-db → effects/apply-
+  // theme! synchronously in the same tick; the wait is a defensive
+  // assertion against async-render reorderings).
+  const themeAfter = await waitForValue(
+    () => readThemeClass(page),
+    (cls) => cls != null && cls !== themeBefore,
+    {
+      timeoutMs: 5000,
+      description:
+        `theme class on <html> flips off ${themeBefore} after :toggle-theme`,
+    },
+  );
+
+  // ── 3. Re-open palette + assert recents-boost lifts ──────────────
+  //
+  // `:palette-recents` is persisted via fx after every command invoke
+  // (`palette/events.cljs` §`:rf.causa.palette.fx/persist-recents`).
+  // The aggregator (`palette/sources.cljc` §`recents-boost-for-id`)
+  // adds +60 to position 0 — strictly more than the static `:command`
+  // boost of 40 — so on the next palette open the toggle-theme verb
+  // ranks above every other :command item even on the empty query.
+  await openPalette(page);
+  // The input opens with empty query; the result list still surfaces
+  // (every item with non-zero boost passes the empty-query rank).
+  // The recent verb should be position 0.
+  const recents = await waitForValue(
+    () => readPaletteState(page),
+    (snap) => {
+      if (!snap.open) return false;
+      if (snap.rowCount === 0) return false;
+      const top = snap.rows[0];
+      return (top.text || '').toLowerCase().includes('toggle theme');
+    },
+    {
+      timeoutMs: 5000,
+      description:
+        'recently-invoked :toggle-theme bubbles to position 0 on ' +
+        'palette re-open (recents-boost-max=60 > command boost=40)',
+    },
+  );
+
+  // ── 4. Clean up — close the palette + restore theme ─────────────
+  //
+  // Restoring theme is courtesy so subsequent scenarios in the same
+  // gate run aren't surprised by a leftover light/dark flip. The
+  // palette gate uses fresh contexts per scenario (see
+  // `serve-and-run-causa-feature-gate.cjs` §runScenarios — `await
+  // browser.newContext()` for each scenario), so this is belt-and-
+  // braces.
+  await closePalette(page);
+
+  state.paletteCmdK = {
+    themeBefore,
+    themeAfter,
+    topResultAfterFilter: filtered.rows[0],
+    topResultAfterRecents: recents.rows[0],
+    recentsRowCount: recents.rowCount,
+  };
+}
+
 const SCENARIOS = [
   {
     name: 'feature matrix shell and panel handoff',
@@ -2188,6 +2439,71 @@ const SCENARIOS = [
     panels: ['machines'],
     coveredRows: ['Machines'],
     run: runLiveFollowDeepMachine,
+  },
+  {
+    // rf2-mpqxn — Phase 3 panel-control interactions: Views Group-By
+    // cycle. Cycles the three Group-By pills (Component → sub → tree
+    // → back to Component), asserting each click flips the pill's
+    // aria-pressed AND mounts the mode-specific body testid
+    // (rf-causa-views-groups / rf-causa-views-sub-grouped /
+    // rf-causa-views-tree).
+    //
+    // EXPECTED-FAIL until rf2-83d4x lands. rf2-83d4x is the follow-on
+    // bug bead filed from this scenario's first run: the Group-By
+    // pill's on-click dispatches WITHOUT `{:frame :rf/causa}`, so
+    // the event lands on `:rf/default` instead of `:rf/causa` (same
+    // shape as rf2-w8lxg / rf2-smvvz which fixed the palette +
+    // settings popup). The handler reduces the wrong db, Causa's
+    // `:group-by` slot stays on `:component`, the panel never flips.
+    // rf2-dodq2 (Views Group-By stuck) was the user-visible symptom;
+    // rf2-83d4x is the root-cause bead. Tests-only PR — the fix
+    // lands in views_view.cljs (and audit of sibling Causa view dispatch
+    // sites) under rf2-83d4x.
+    name: 'panel control: Views Group-By cycle (rf2-mpqxn)',
+    url: '/counter/',
+    panels: ['views'],
+    coveredRows: ['Views'],
+    run: runViewsGroupByCycle,
+  },
+  {
+    // rf2-mpqxn — Phase 3 panel-control interactions: density radio
+    // cycle. Opens Settings popup via `,` keybinding, then cycles the
+    // density radio cosy ↔ compact, asserting `--rf-causa-font-size`
+    // on `<html>` AND the shell root flips to the expected px value
+    // on each transition (12 for compact, 13 for cosy). Validates
+    // rf2-i40us's wire-up: the radio writes via `apply-density-font-
+    // size!` which sets the CSS custom property the entire
+    // `type-scale` resolves through. Note: v1 ships two pills only
+    // (rf2-ttnst dropped :comfy from the spec brief's three-tier
+    // list); the helper's DENSITY_RADIO_MODES catalog covers both
+    // pills.
+    name: 'panel control: density radio cycle (rf2-mpqxn)',
+    url: '/counter/',
+    panels: [],
+    coveredRows: [
+      'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
+    ],
+    run: runDensityRadioCycle,
+  },
+  {
+    // rf2-mpqxn — Phase 3 panel-control interactions: Cmd-K palette
+    // execute round-trip. Ctrl+K opens palette → type "theme" fuzzy-
+    // filters to `:toggle-theme` (the verb's label "Toggle theme
+    // (dark ↔ light)" matches every char + the `:command` source
+    // boost of 40 ranks it first) → Enter invokes → assert the
+    // `rf-causa-theme-*` class on `<html>` flipped → re-open palette
+    // → assert the just-executed verb is at position 0 of the empty-
+    // query result list (recents-boost-max=60 > command boost=40,
+    // so the recent command strictly outranks every other :command
+    // item). Validates rf2-wm7z4 (palette dispatch round-trip) +
+    // rf2-ybjkx (recents persistence + sort).
+    name: 'panel control: Cmd-K palette execute (rf2-mpqxn)',
+    url: '/counter/',
+    panels: [],
+    coveredRows: [
+      'Shell, Keybinding, Config, Preload, Settings, and Production Elision',
+    ],
+    run: runPaletteCmdKExecute,
   },
 ];
 


### PR DESCRIPTION
## Summary

Phase 3 follow-on to rf2-rwhat (live-follow panel-refresh suite, PR #1588). Extends the live-follow helpers module + adds 3 scenarios focused on **panel-CONTROL interactions** (not the auto-follow axis Phase 1+2 covered).

This PR is stacked on #1588 — base branch is `worker/causa-live-follow-panel-test`. When #1588 merges, this PR's base will retarget to `main` automatically; the diff stays small.

## What's in the PR

### `tools/causa/testbeds/feature_matrix/helpers/live_follow.cjs` (+472 LoC)

Extends the Phase 1+2 helper module with panel-control interaction primitives:

- **Views Group-By** — `GROUP_BY_MODES` catalog + `readGroupByState(page)` + `clickGroupByPill(page, mode)`. Asserts pill aria-pressed flips AND mode-specific body testid mounts (`rf-causa-views-groups` / `-sub-grouped` / `-tree`).
- **Density radio** — `DENSITY_RADIO_MODES` catalog + `readDensityFontSize(page)` + `openSettingsPopup(page)` + `clickDensityRadio(page, value)`. Reads `--rf-causa-font-size` inline declaration on `<html>` AND shell root.
- **Cmd-K palette** — `readPaletteState(page)` + `openPalette` / `closePalette` / `typePaletteQuery` / `executePaletteCursor`. Round-trip: open via Ctrl+K, type query, assert top row, Enter, assert side-effect, re-open, assert recents bubble.

### `tools/causa/testbeds/feature_matrix/scenarios.cjs` (+316 LoC)

Three new scenarios:

| # | Name | URL | Assertion shape |
|---|---|---|---|
| 1 | `panel control: Views Group-By cycle (rf2-mpqxn)` | `/counter/` | sub → tree → component; each pill click ⇒ `aria-pressed=\"true\"` + body testid mounted; only ONE pill pressed per step |
| 2 | `panel control: density radio cycle (rf2-mpqxn)` | `/counter/` | compact → cosy; each click ⇒ `--rf-causa-font-size` on `<html>` AND shell root flips between `12px` / `13px` |
| 3 | `panel control: Cmd-K palette execute (rf2-mpqxn)` | `/counter/` | Ctrl+K → type `theme` → top row is `:command` source containing 'Toggle theme' → Enter → `rf-causa-theme-*` class on `<html>` flips → re-open → :toggle-theme at position 0 (recents-boost=60 > command boost=40) |

## Gate result (post-#1589, current main)

```
PASS panel control: density radio cycle (rf2-mpqxn)
PASS panel control: Cmd-K palette execute (rf2-mpqxn)
FAIL panel control: Views Group-By cycle (rf2-mpqxn)  ← EXPECTED-FAIL, see below
```

### Group-By is expected-fail until rf2-83d4x lands

The scenario caught a previously-latent bug. Trace bus output during the failing run:

```
{:operation :event/dispatched, :event [:rf.causa/views-set-group-by :sub], :frame :rf/default, ...}
                                                                            ^^^^^^^^^^^^^^^
```

The dispatch lands on `:rf/default`, not `:rf/causa`. The `:rf.causa/views-set-group-by` handler is registered against `:rf/causa`'s db (`panels/views_events.cljs §50`), so it reduces the wrong frame's db. Causa's `:group-by` slot stays on `:component` and the panel never flips.

Root cause is in `panels/views_view.cljs §704-705`:

```clojure
(defn- group-by-pill
  [{:keys [value selected? label]}]
  [:button {:data-testid (str \"rf-causa-views-group-by-\" (name value))
            :on-click #(rf/dispatch [:rf.causa/views-set-group-by value])  ; ← missing {:frame :rf/causa}
            ...
```

Same shape as rf2-w8lxg (palette) and rf2-smvvz (settings popup). Filed as **rf2-83d4x** — root-cause bug bead for rf2-dodq2.

PR #1589 (rf2-70tkv panel refresh) merged but did NOT fix this — it fixed App-db panel refresh, a different code path. rf2-dodq2 was the user-visible symptom; rf2-83d4x is the root-cause bug to fix.

## Coordination

- **PR #1588 (Phase 1+2, base of this stack)** — this PR's base. When #1588 merges, GitHub auto-retargets this PR to `main`.
- **PR #1592 (Causa matrix P1 gaps)** — also edits `scenarios.cjs`. Possible collision; resolve via PR-body cross-ref + small rebase if both land same day.

## Test plan

- [x] `npm run test:causa-feature-gate` — 2 of 3 new scenarios pass post-rf2-70tkv + rf2-i40us; Group-By scenario expected-fail until rf2-83d4x lands.
- [x] Existing scenarios green (no regressions introduced).
- [ ] After rf2-83d4x lands, all 3 new scenarios should pass.

Closes rf2-mpqxn. Discovered rf2-83d4x.