### PR TITLE
fix(causa): align :after rings + spec/007 doc for Machines canvas (rf2-y3l8z follow-ons)

### DIFF
--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -365,6 +365,97 @@ browse-all entry point under a future Static surface; the registered
 re-implement engine algebra. Until that lands, programmatic callers
 can drive Sim against `:rf/causa` directly.
 
+### Interactive Machines canvas (rf2-y3l8z)
+
+Every per-machine section in the Runtime Machines panel wraps its
+chart in an interactive viewport adapter (`panels/machine_canvas.cljs`
+→ `chart/controls.cljc`). The chart is no longer a static SVG paint;
+it pans, zooms, and fits to viewport.
+
+```
+┌─ :auth/login   :idle → :authing                          [:auth/submit] ─┐
+│ ┌─[Canvas|List]──────────────────────────────────[− 100% +] [Fit][Reset]┐│
+│ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
+│ │ · · ▢ idle ──→ ▣ authing · · · · · · · · · · · · · · · · · · · · · · ││
+│ │ · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · · ││
+│ │ · · · · · · · ◔ :after rings track node centres under zoom + pan · · ││
+│ └─────────────────────────────────────────────────────────────────────┘│
+│ Guards   ✓ :session-fresh?                                              │
+│ Actions  ✓ :clear-form                                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Toolbar (top-right of every canvas):**
+
+- `−` / `+` — Zoom out / Zoom in about the viewport centre.
+- `NN%` chip — current zoom level, integer percentage.
+- `Fit` — fits the laid-out content into the viewport with padding
+  on all sides; centred. (Toolbar emits `:fit-request` which the
+  Causa-side handler expands to a full `:fit` using the measured
+  viewport dims + the content dims from `chart/layout`.)
+- `Reset` — zoom 100%, pan (0, 0).
+
+**View-mode toggle (top-left of every canvas):**
+
+A two-button pill — **Canvas** | **List**. Per-machine slot,
+persisted to localStorage under
+`causa.machine-canvas.view-mode-by-id`. Canvas is the default; List
+opt-out renders the section without the chart (guards + actions
+only) for users who want a leaner per-event read or who prefer the
+old text-first surface.
+
+**Direct manipulation:**
+
+- **Mouse wheel** zooms toward the cursor (wheel-toward-cursor
+  invariant — the chart-world coord under the cursor is fixed
+  through the zoom transition). Trackpad pinch arrives as a wheel
+  event with `ctrlKey=true`; both are accepted.
+- **Click-drag** anywhere on canvas background (not on a state
+  node) pans. The drag handler walks up to 5 DOM ancestors looking
+  for `data-testid` starting `rf-causa-chart-node-` /
+  `rf-causa-chart-edge-`; clicks that hit a node fall through to
+  the node's own `:on-click` (state-click event).
+
+**Keyboard shortcuts** (chart canvas must hold focus — `tabIndex=0`
+on the canvas host):
+
+| Key | Action |
+|---|---|
+| `+` / `=`  | Zoom in (about viewport centre) |
+| `-` / `_`  | Zoom out (about viewport centre) |
+| `0`        | Reset (100%, pan 0,0) |
+| `f` / `F`  | Fit to viewport |
+| `←` / `→`  | Pan horizontally (20px / press) |
+| `↑` / `↓`  | Pan vertically (20px / press) |
+
+**Bounds:** zoom is clamped to `[0.2, 4.0]`. Wheel notches step
+×1.1; toolbar +/- and `+`/`-` keys step ×1.2.
+
+**`:after` rings track the canvas (rf2-obp4z).** The countdown-ring
+overlay receives the same viewport-transform the chart applies and
+wraps its rings group in `translate(tx,ty) scale(s)`. Rings stay
+anchored to their bearing-state node centres at every zoom + pan.
+
+**Reduced motion.** Toolbar buttons + the canvas transform ride
+Causa's `--rf-causa-motion-scale` seam — no extra wiring here;
+motion shrinks to ~0 under `prefers-reduced-motion: reduce` along
+with the rest of Causa's surface.
+
+**State (app-db slots under `:rf.causa/machine-canvas`):**
+
+| Slot | Shape | Purpose |
+|---|---|---|
+| `:viewports {<machine-id> {:scale :tx :ty}}` | per-machine `{:scale s :tx tx :ty ty}` | current viewport |
+| `:view-mode-by-id {<machine-id> :canvas|:list}` | per-machine | view-mode toggle; localStorage-persisted |
+| `:viewport-dims {<machine-id> {:width :height}}` | per-machine | last-measured viewport box (drives `:fit`, keyboard) |
+| `:drag {:machine-id … :dragging? :origin-x :origin-y :origin-viewport}` | transient | mouse-down pan accumulator; cleared on mouseup |
+
+Subscriptions exposed for tools / tests:
+`:rf.causa.machine-canvas/viewport-for`,
+`:rf.causa.machine-canvas/view-mode-for`,
+`:rf.causa.machine-canvas/view-mode-by-id`,
+`:rf.causa.machine-canvas/viewport-dims-for`.
+
 ## IN/OUT filter pills
 
 Live in the L1 ribbon (NOT a separate L1.5 strip; NOT a sidebar).
@@ -686,6 +777,21 @@ active panel). `Esc` always returns focus to the event list.
 |---|---|
 | `Tab` / `Shift+Tab` | Cycle focusables |
 | `Esc` | Return focus to event list |
+
+### Machines canvas (when chart canvas holds focus — rf2-y3l8z)
+
+| Key | Action |
+|---|---|
+| `+` / `=` | Zoom in (about viewport centre) |
+| `-` / `_` | Zoom out (about viewport centre) |
+| `0` | Reset to 100%, pan 0,0 |
+| `f` / `F` | Fit to viewport |
+| `←` `→` `↑` `↓` | Pan 20px / press |
+
+The canvas shortcuts only fire while the canvas host (`tabIndex=0`)
+is the active focus target — they are scoped to a clicked-into chart
+and do not collide with the global Causa keymap. Wheel-zoom +
+click-drag pan have no keyboard equivalent.
 
 ### Retired keys (from pre-rewrite spec)
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_after_rings.cljs
@@ -272,68 +272,103 @@
   "Renders the focused machine's `:after` countdown rings as an SVG
   overlay positioned over the chart's `<svg>` viewport. Takes the
   chart's positioned graph (so it can resolve timer states to node-
-  centres + radii) as the only arg; subscribes to the timers + now-ms
-  internally.
+  centres + radii); subscribes to the timers + now-ms internally.
+
+  Accepts the positioned graph either as the first positional arg
+  (legacy single-arity call site) OR as the `:positioned` key in an
+  options map. The map form additionally accepts:
+
+    :viewport-transform — rf2-obp4z. Optional `{:scale s :tx tx :ty ty}`
+                          map carrying the chart's current zoom + pan.
+                          When supplied (non-identity), the rings group
+                          is wrapped in `<g transform=\"translate(tx,ty)
+                          scale(s)\">` so the rings track the chart
+                          nodes as the user zooms / pans. nil / absent
+                          leaves the overlay at 1:1 (back-compat for
+                          callers that don't have a viewport — the
+                          legacy single-arity Inspector path takes
+                          this branch).
 
   Returns nil when the projection has no active timers (the SVG layer
   drops out of the chart so unrelated chart hover handlers aren't
   shadowed)."
-  [{:keys [nodes width height]}]
-  (let [timers   @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
-        now      @(rf/subscribe [:rf.causa/now-ms])
-        scrub    @(rf/subscribe [:rf.causa/machine-scrubber-position])
-        node-idx (nodes->index nodes)
-        ;; Kick the rAF loop iff ticking is needed (live mode + at
-        ;; least one armed timer). Cheap to call per render — the
-        ;; `:running?` sentinel collapses duplicate kicks.
-        _        (when (rings-h/needs-ticking? timers scrub)
-                   (kick-tick!))
-        rings    (rings-h/timers->ring-positions
-                   timers node-idx chart-layout/highlight-id)]
-    (when (seq rings)
-      [:svg {:data-testid "rf-causa-machine-inspector-after-rings-overlay"
-             :data-timer-count (count rings)
-             :viewBox (str "0 0 " (or width 0) " " (or height 0))
-             :width "100%"
-             :preserveAspectRatio "xMidYMin meet"
-             :style {:position "absolute"
-                     :top 0
-                     :left 0
-                     :width "100%"
-                     :height "100%"
-                     :pointer-events "none"   ;; rings opt in below
-                     :overflow "visible"}}
-       (into [:g {:data-testid "rf-causa-machine-inspector-after-rings"
-                  :style {:pointer-events "all"}}]
-             (for [{:keys [timer cx cy r]} rings
-                   :let [fraction (rings-h/ring-fraction timer now)
-                         color    (rings-h/timer-color timer now)
-                         cancelled? (= :cancelled (:status timer))
-                         tooltip  (rings-h/format-timer-tooltip timer now)
-                         state-id (if (keyword? (:state timer))
-                                    (name (:state timer))
-                                    (pr-str (:state timer)))
-                         testid   (str "rf-causa-machine-inspector-after-ring-"
-                                       state-id)]]
-               ^{:key (str (:state timer) "/" (:epoch timer))}
-               [:g {:on-mouse-enter
-                    (fn [_]
-                      (rf/dispatch [:rf.causa/timer-hover
-                                    {:machine-id (:machine-id timer)
-                                     :state      (:state timer)
-                                     :epoch      (:epoch timer)}]
-                                   {:frame :rf/causa}))
-                    :on-mouse-leave
-                    (fn [_]
-                      (rf/dispatch [:rf.causa/timer-hover nil]
-                                   {:frame :rf/causa}))}
-                (chart-svg/countdown-ring
-                  {:cx cx :cy cy :r r
-                   :fraction fraction
-                   :color    color
-                   :cancelled? cancelled?
-                   :testid   testid
-                   :tooltip  tooltip})]))])))
+  ([positioned]
+   (AfterRingsOverlay positioned nil))
+  ([{:keys [nodes width height]} {:keys [viewport-transform]}]
+   (let [timers   @(rf/subscribe [:rf.causa/active-timers-for-focused-machine])
+         now      @(rf/subscribe [:rf.causa/now-ms])
+         scrub    @(rf/subscribe [:rf.causa/machine-scrubber-position])
+         node-idx (nodes->index nodes)
+         ;; Kick the rAF loop iff ticking is needed (live mode + at
+         ;; least one armed timer). Cheap to call per render — the
+         ;; `:running?` sentinel collapses duplicate kicks.
+         _        (when (rings-h/needs-ticking? timers scrub)
+                    (kick-tick!))
+         rings    (rings-h/timers->ring-positions
+                    timers node-idx chart-layout/highlight-id)
+         ;; rf2-obp4z — align the rings with the chart's viewport
+         ;; transform. The chart wraps its body in `translate(tx,ty)
+         ;; scale(s)`; we mirror that transform on the rings group
+         ;; so the rings track their node centres under zoom + pan.
+         ;; When the viewport is identity (or absent) the transform
+         ;; attr is omitted entirely — back-compat: the legacy
+         ;; single-arity call site (Machine Inspector pre-canvas
+         ;; path) gets a byte-identical render.
+         {:keys [scale tx ty]
+          :or   {scale 1 tx 0 ty 0}}
+         (or viewport-transform {})
+         transform-applied? (or (not= 1 scale) (not= 0 tx) (not= 0 ty))
+         rings-transform    (when transform-applied?
+                              (str "translate(" tx "," ty ")"
+                                   " scale(" scale ")"))]
+     (when (seq rings)
+       [:svg {:data-testid "rf-causa-machine-inspector-after-rings-overlay"
+              :data-timer-count (count rings)
+              :data-viewport-scale (str scale)
+              :data-viewport-tx (str tx)
+              :data-viewport-ty (str ty)
+              :viewBox (str "0 0 " (or width 0) " " (or height 0))
+              :width "100%"
+              :preserveAspectRatio "xMidYMin meet"
+              :style {:position "absolute"
+                      :top 0
+                      :left 0
+                      :width "100%"
+                      :height "100%"
+                      :pointer-events "none"   ;; rings opt in below
+                      :overflow "visible"}}
+        (into [:g (cond-> {:data-testid "rf-causa-machine-inspector-after-rings"
+                           :style {:pointer-events "all"}}
+                    rings-transform (assoc :transform rings-transform))]
+              (for [{:keys [timer cx cy r]} rings
+                    :let [fraction (rings-h/ring-fraction timer now)
+                          color    (rings-h/timer-color timer now)
+                          cancelled? (= :cancelled (:status timer))
+                          tooltip  (rings-h/format-timer-tooltip timer now)
+                          state-id (if (keyword? (:state timer))
+                                     (name (:state timer))
+                                     (pr-str (:state timer)))
+                          testid   (str "rf-causa-machine-inspector-after-ring-"
+                                        state-id)]]
+                ^{:key (str (:state timer) "/" (:epoch timer))}
+                [:g {:on-mouse-enter
+                     (fn [_]
+                       (rf/dispatch [:rf.causa/timer-hover
+                                     {:machine-id (:machine-id timer)
+                                      :state      (:state timer)
+                                      :epoch      (:epoch timer)}]
+                                    {:frame :rf/causa}))
+                     :on-mouse-leave
+                     (fn [_]
+                       (rf/dispatch [:rf.causa/timer-hover nil]
+                                    {:frame :rf/causa}))}
+                 (chart-svg/countdown-ring
+                   {:cx cx :cy cy :r r
+                    :fraction fraction
+                    :color    color
+                    :cancelled? cancelled?
+                    :testid   testid
+                    :tooltip  tooltip})]))]))))
 
 ;; ---- public install entry -----------------------------------------------
 

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_canvas.cljs
@@ -489,14 +489,15 @@
                                      :height "100%"
                                      :display "block"}}})
      (when show-after-rings?
-       ;; The after-rings overlay rendered AT 1:1 over the chart
-       ;; (it positions absolute on each ring's chart-world coord).
-       ;; With viewport-transform active the rings drift from the
-       ;; node centres — for v1 we keep them at identity (the
-       ;; rings are runtime-runtime overlays whose precision tracks
-       ;; the un-transformed positioned graph). Follow-on bead
-       ;; aligns them with the user's transform.
-       [after-rings/AfterRingsOverlay positioned])
+       ;; rf2-obp4z — the after-rings overlay receives the same
+       ;; viewport-transform the chart applies. The overlay wraps
+       ;; its rings group in `<g transform="translate(tx,ty)
+       ;; scale(s)">` so each ring tracks its bearing node centre
+       ;; through the user's zoom + pan. Pre-fix the rings drifted
+       ;; off-node at any non-identity viewport.
+       [after-rings/AfterRingsOverlay
+        positioned
+        {:viewport-transform viewport}])
      ;; Toolbar — absolute top-right, above the chart SVG.
      [:div {:data-testid "rf-causa-machine-canvas-toolbar"
             :style {:position "absolute"

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_after_rings_cljs_test.cljs
@@ -245,6 +245,80 @@
       (is (some? (find-by-testid tree
                    "rf-causa-machine-inspector-after-ring-authing"))))))
 
+;; ---- (5b) rf2-obp4z viewport-transform alignment -----------------------
+;;
+;; Regression coverage for rf2-obp4z: when the chart's viewport-transform
+;; is non-identity, the rings group MUST carry the same transform so the
+;; rings track their node centres under zoom + pan. The legacy single-
+;; arity call site stays at 1:1 (back-compat).
+
+(defn- find-rings-group
+  "Walk the hiccup tree for the rings `<g>` (testid
+  `rf-causa-machine-inspector-after-rings`)."
+  [tree]
+  (find-by-testid tree "rf-causa-machine-inspector-after-rings"))
+
+(deftest overlay-omits-transform-without-viewport
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 2000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (testing "single-arity call site renders without a transform attr (back-compat)"
+      (let [tree     (after-rings/AfterRingsOverlay fixture-positioned)
+            rings-g  (find-rings-group tree)]
+        (is (some? rings-g))
+        (is (nil? (:transform (second rings-g)))
+            "no viewport-transform passed → rings group carries no transform attr")))
+    (testing "explicit nil viewport-transform also omits the transform attr"
+      (let [tree (after-rings/AfterRingsOverlay
+                   fixture-positioned
+                   {:viewport-transform nil})]
+        (is (nil? (:transform (second (find-rings-group tree)))))))
+    (testing "identity viewport (scale 1, tx 0, ty 0) omits the transform attr"
+      (let [tree (after-rings/AfterRingsOverlay
+                   fixture-positioned
+                   {:viewport-transform {:scale 1 :tx 0 :ty 0}})]
+        (is (nil? (:transform (second (find-rings-group tree)))))))))
+
+(deftest overlay-applies-viewport-transform-when-supplied
+  (setup-causa-frame!)
+  (rf/with-frame :rf/causa
+    (override-machines!    [:auth/login])
+    (override-definitions! {:auth/login fixture-definition})
+    (pin-now-ms! 2000)
+    (push-scheduled! 1000 :auth/login :idle 5000 0)
+    (testing "non-identity viewport-transform stamps a translate+scale transform on the rings group"
+      (let [tree    (after-rings/AfterRingsOverlay
+                      fixture-positioned
+                      {:viewport-transform {:scale 1.5 :tx 40 :ty -20}})
+            rings-g (find-rings-group tree)
+            attrs   (second rings-g)]
+        (is (some? rings-g))
+        (is (= "translate(40,-20) scale(1.5)"
+               (:transform attrs))
+            "transform attr matches the chart's translate(tx,ty) scale(s) order — same vector as the chart body")
+        (testing "the overlay svg root exposes the viewport for data-binding / inspection"
+          (let [overlay (find-by-testid tree
+                          "rf-causa-machine-inspector-after-rings-overlay")
+                a       (second overlay)]
+            (is (= "1.5" (:data-viewport-scale a)))
+            (is (= "40"  (:data-viewport-tx a)))
+            (is (= "-20" (:data-viewport-ty a)))))))
+    (testing "scale-only zoom (no pan) still stamps a transform"
+      (let [tree (after-rings/AfterRingsOverlay
+                   fixture-positioned
+                   {:viewport-transform {:scale 2.0 :tx 0 :ty 0}})]
+        (is (= "translate(0,0) scale(2)"
+               (:transform (second (find-rings-group tree)))))))
+    (testing "pan-only (no zoom) still stamps a transform"
+      (let [tree (after-rings/AfterRingsOverlay
+                   fixture-positioned
+                   {:viewport-transform {:scale 1 :tx 25 :ty 15}})]
+        (is (= "translate(25,15) scale(1)"
+               (:transform (second (find-rings-group tree)))))))))
+
 ;; ---- (6) frame isolation ----------------------------------------------
 
 (deftest now-ms-lives-on-causa-frame


### PR DESCRIPTION
## Summary

PR #1578 (rf2-y3l8z) landed the interactive Machines canvas (zoom/pan/fit + Canvas|List view-mode toggle + keyboard shortcuts + toolbar). This PR bundles four follow-on beads: two land here, two are deferred.

### Per-bead resolution

| Bead | Resolution | Notes |
|---|---|---|
| rf2-obp4z (P2 — `:after` rings drift) | **Shipped** | Real visual bug — fixed. |
| rf2-tj4of (P3 — spec/007 canvas affordances) | **Shipped** | Descriptive doc-only update. |
| rf2-md9oz (P3 — static Topology opts into interactive canvas) | **Deferred (decision-needed)** | Touches Static Machines panel architecture meaningfully — needs Mike's call before landing. Rationale below. |
| rf2-mkpnb (P3 — promote canvas to its own L4 tab) | **Deferred (tracker, no change)** | Bead's own description already says "defer until v1 usage signals demand." Keeping it open as a tracker matches that posture. |

### rf2-obp4z (`:after` rings under viewport-transform)

Before: `AfterRingsOverlay` rendered an SVG positioned absolute over the chart with its own viewBox at 1:1. When the user zoomed or panned, the chart `<g transform>` shifted but the rings stayed pinned to original chart-world coords — drifting off their bearing-state node centres. The pre-PR comment in `machine_canvas.cljs` already flagged this: *"for v1 we keep them at identity. Follow-on bead aligns them with the user's transform."*

After: `AfterRingsOverlay` accepts an optional `:viewport-transform` (the same `{:scale :tx :ty}` map the chart consumes) via a 2-arity form. When supplied non-identity, the rings group is wrapped in `<g transform="translate(tx,ty) scale(s)">` — same vector as the chart body. Identity / nil viewports omit the transform attr entirely → byte-identical render for the legacy single-arity inspector call site (back-compat).

`machine_canvas/Chart` threads the `viewport` it already subscribes to into the overlay via the new options-map call form.

Two new regression deftests cover the contract:

- `overlay-omits-transform-without-viewport` — 3 sub-cases (single-arity, explicit nil, identity {scale 1 :tx 0 :ty 0}) all confirm no transform attr present.
- `overlay-applies-viewport-transform-when-supplied` — 3 sub-cases (full zoom+pan, scale-only, pan-only) confirm the transform string is `translate(tx,ty) scale(s)` matching the chart body's order, plus the overlay svg root exposes `data-viewport-scale/tx/ty` for inspection.

### rf2-tj4of (spec/007-UX-IA.md descriptive update)

New `### Interactive Machines canvas (rf2-y3l8z)` subsection under the existing Runtime Machines panel shape. Covers:

- Toolbar (Zoom-/Zoom+/Fit/Reset + NN% chip)
- View-mode toggle (Canvas | List, default Canvas, localStorage-persisted under `causa.machine-canvas.view-mode-by-id`)
- Direct manipulation (wheel-toward-cursor, click-drag pan with node-click pass-through, ctrlKey trackpad pinch)
- Keyboard shortcuts table (+/-/0/f, arrows for pan)
- Zoom bounds [0.2, 4.0]; wheel step ×1.1; button/key step ×1.2
- rf2-obp4z note: `:after` rings track the canvas
- Reduced-motion seam reuses `--rf-causa-motion-scale`
- App-db slot table under `:rf.causa/machine-canvas` + exposed subs

New `### Machines canvas (when chart canvas holds focus — rf2-y3l8z)` subsection under "Detail panel (L4)" keyboard reference picks up the canvas-scoped shortcuts.

Descriptive only — no new normative contracts.

### rf2-md9oz deferral rationale

The bead is framed as a design decision: should Static Topology consume the interactive canvas? Landing the opt-in cleanly requires:

1. A new knob on `machine_canvas/Chart` (`:show-view-mode-toggle? false` — view-mode is meaningless in static)
2. Decision on whether Static + Runtime **share** the per-machine viewport slot (visual continuity if shared) or namespace separately
3. Decision on whether the static panel's existing chart-toolbar (Pop-out, source-coord chip) absorbs into the canvas toolbar area or stays above it
4. The on-state-click contract differs (Static dispatches `:rf.causa.static.machines/state-clicked`; Runtime navigates via inspector lens) — needs verification the canvas `Chart` argument path covers both

These are architectural calls that exceed the worker's "if you can ship cleanly" mandate. Filed back to Mike for a decision pass.

### rf2-mkpnb deferral rationale

The bead's own description: *"DECISION: defer until v1 usage signals demand. Filing this bead as a tracker so the question doesn't get lost."* The PR fixes a real bug + documents the new affordances; promoting the canvas to its own L4 tab is a 1-2 day restructure that should wait for usage signal from the just-landed v1 surface. Bead stays open as the tracker it was filed as.

## Test plan

- [x] `clojure -M:test` from `tools/causa/` — 749 tests, 0 failures
- [x] `clojure -M:test` from `tools/machines-viz/` — 97 tests, 0 failures
- [x] `npm run test:cljs` (node-test) — 3186 tests, 0 failures (includes 5 new sub-tests under `overlay-omits-transform-without-viewport` + `overlay-applies-viewport-transform-when-supplied`)
- [x] `npm run test:bundle-isolation` — PASS, no leakage
- [x] `npm run test:causa-feature-gate` — 14 scenarios, 0 failures (deep-machine still green)
- [ ] Manual: load Causa testbed with a machine carrying `:after`; zoom + pan; rings track node centres