### PR TITLE
fix(causa): Views panel dispatches carry {:frame :rf/causa} (rf2-83d4x)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -403,14 +403,20 @@
   dispatch on context-menu; no separate context-menu UI surface).
   `preventDefault` suppresses the browser's native menu so the
   developer's right-click lands on Causa's affordance, not the host
-  page's menu. The dispatch resolves to `:rf/causa` via React-context
-  (the panel mounts inside Causa's frame-provider — the same way
-  every other in-panel `rf/dispatch` here resolves)."
+  page's menu.
+
+  Per rf2-83d4x: the dispatch must carry `{:frame :rf/causa}` —
+  React's `_currentValue` for the frame-provider pops back to
+  `:rf/default` between render and click-time, so any sub-resolution
+  via the React-context tier fails and the event routes to the host's
+  app-db (where the handler isn't registered). Same root cause +
+  fix-shape as the rf2-w8lxg / rf2-smvvz palette + Settings sweep."
   [view-id]
   (fn [^js e]
     (when view-id
       (.preventDefault e)
-      (rf/dispatch [:rf.causa/views-set-component-filter view-id]))))
+      (rf/dispatch [:rf.causa/views-set-component-filter view-id]
+                   {:frame :rf/causa}))))
 
 (defn- single-row
   "One render row in either Mounted, Re-rendered, or Unmounted. The
@@ -423,7 +429,8 @@
         struck?    (= group :unmounted)]
     [:div {:data-testid (str "rf-causa-views-row-" (name group))
            :on-click    #(rf/dispatch [:rf.causa/views-toggle-row
-                                       (pr-str (:render-key r))])
+                                       (pr-str (:render-key r))]
+                                      {:frame :rf/causa})
            :on-context-menu (right-click-filter-handler view-id)
            :title       (when view-id
                           (str "Right-click → filter Views panel to "
@@ -498,7 +505,8 @@
        [:button {:data-testid (str "rf-causa-views-cluster-toggle-"
                                    (h/format-view-id view-id))
                  :on-click #(rf/dispatch
-                             [:rf.causa/views-toggle-cluster ckey])
+                             [:rf.causa/views-toggle-cluster ckey]
+                             {:frame :rf/causa})
                  :style {:background "transparent"
                          :border (str "1px solid " (:border-default tokens))
                          :color (:text-secondary tokens)
@@ -702,7 +710,8 @@
   pill reads at a glance."
   [{:keys [value selected? label]}]
   [:button {:data-testid (str "rf-causa-views-group-by-" (name value))
-            :on-click #(rf/dispatch [:rf.causa/views-set-group-by value])
+            :on-click #(rf/dispatch [:rf.causa/views-set-group-by value]
+                                    {:frame :rf/causa})
             :aria-pressed (if selected? "true" "false")
             :style (cond-> group-by-pill-base-style
                      selected?
@@ -761,7 +770,8 @@
       "Filtered to:"]
      [:button {:data-testid "rf-causa-views-filter-chip-clear"
                :on-click #(rf/dispatch
-                            [:rf.causa/views-set-component-filter nil])
+                            [:rf.causa/views-set-component-filter nil]
+                            {:frame :rf/causa})
                :aria-label (str "Clear filter on "
                                 (h/format-view-id view-id))
                :title "Clear filter"
@@ -799,7 +809,8 @@
      (when cf
        [:button {:data-testid "rf-causa-views-clear-filter"
                  :on-click #(rf/dispatch
-                             [:rf.causa/views-set-component-filter nil])
+                             [:rf.causa/views-set-component-filter nil]
+                             {:frame :rf/causa})
                  :style {:background "transparent"
                          :border (str "1px solid " (:border-default tokens))
                          :color (:text-secondary tokens)

--- a/tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs
@@ -191,7 +191,11 @@
          (fn [^js e]
            (when (keyword? view-id)
              (.preventDefault e)
-             (rf/dispatch [:rf.causa/views-set-component-filter view-id])))
+             ;; rf2-83d4x — explicit :frame opt; click-time React
+             ;; `_currentValue` pop falls through to `:rf/default`
+             ;; otherwise (same root cause as rf2-w8lxg/rf2-smvvz).
+             (rf/dispatch [:rf.causa/views-set-component-filter view-id]
+                          {:frame :rf/causa})))
          :style (assoc row-base-style
                        :padding-left (str (+ 16 (* depth 16)) "px"))}
    [:span {:style {:color (get tokens (get status-colour status))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_dispatch_routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_dispatch_routing_cljs_test.cljs
@@ -1,0 +1,188 @@
+(ns day8.re-frame2-causa.panels.views-view-dispatch-routing-cljs-test
+  "Click-time frame-routing tests for the Causa Views panel (rf2-83d4x).
+
+  Sibling to `popup_dispatch_routing_cljs_test.cljs` (rf2-smvvz) and
+  `palette/dispatch_routing_cljs_test.cljs` (rf2-w8lxg). Same bug
+  class — every `rf/dispatch` from a deferred handler (`:on-click`,
+  `:on-context-menu`) inside the Views panel MUST carry the explicit
+  `{:frame :rf/causa}` opt, because React's `_currentValue` for the
+  frame-provider pops back to `:rf/default` between render and
+  click-time, so the 3-tier resolve chain otherwise lands on
+  `:rf/default` and the panel-local handler reduces the WRONG db.
+
+  ## The Views-specific symptom (rf2-83d4x)
+
+  - Group-By pill click → `:rf.causa/views-set-group-by` runs against
+    `:rf/default`'s db, leaving `:rf/causa`'s `:views/group-by` slot
+    untouched → the panel never re-renders into sub-grouped / tree
+    mode (rf2-dodq2 'Views Group-By stuck on Component').
+  - Filter-chip clear / bottom-controls clear → same shape.
+  - Row-toggle click → same shape (per-row expansion never opens).
+  - Cluster-toggle click → same shape.
+  - Right-click context menu (`right-click-filter-handler`) → same
+    shape.
+
+  ## How these tests reproduce the click-time path
+
+  Each test plucks the handler off the rendered hiccup and invokes it
+  OUTSIDE any `with-frame` binding — simulating the browser's
+  click-fires-after-render reality. Asserts that the dispatch landed
+  on `:rf/causa`'s app-db and NOT on `:rf/default`'s — the exact
+  invariant the explicit `{:frame :rf/causa}` opt guarantees."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.adapter :as substrate-adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.panels.views :as facade]
+            [day8.re-frame2-causa.panels.views-view :as view]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture (map shape per cljs.test/async requirement) ---------------
+
+(def ^:private fixture-snap (atom nil))
+
+(defn- setup-runtime! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (reset! fixture-snap (test-support/snapshot-registrar))
+  (reset! frame/frames {})
+  (substrate-adapter/dispose-adapter!)
+  (substrate-adapter/install-adapter! plain-atom/adapter)
+  (frame/ensure-default-frame!)
+  ;; Views panel's :rf.causa/* registrations + the :rf/causa frame.
+  (facade/install!)
+  (frame/reg-frame :rf/causa {}))
+
+(defn- teardown-runtime! []
+  (when-let [snap @fixture-snap]
+    (test-support/restore-registrar! snap)
+    (reset! fixture-snap nil))
+  (reset! frame/frames {}))
+
+(use-fixtures :each
+  {:before setup-runtime!
+   :after  teardown-runtime!})
+
+;; ---- click-time helpers ------------------------------------------------
+
+(defn- fake-event []
+  #js {:preventDefault  (fn [])
+       :stopPropagation (fn [])})
+
+(defn- await-causa-db
+  "Poll until `pred` of `:rf/causa`'s app-db returns truthy. Settles
+  the async router drain that queued click-dispatches go through."
+  [pred label]
+  (test-support/poll-until
+    #(pred (rf/get-frame-db :rf/causa))
+    {:label label :timeout-ms 1000}))
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest group-by-pill-click-flips-causa-not-default
+  (testing "rf2-83d4x — clicking the Group-By `sub` pill from OUTSIDE
+            the :rf/causa frame-provider's render context flips
+            :rf/causa's :views/group-by to :sub. Without the explicit
+            `{:frame :rf/causa}` opt, the click would land on
+            :rf/default and Causa's slot would stay :component
+            (root cause of rf2-dodq2)."
+    (let [;; Render the pill directly (private fn — same surface the
+          ;; panel mounts). `:value :sub` is the pill we want to click.
+          pill    (#'view/group-by-pill {:value :sub
+                                         :selected? false
+                                         :label "sub"})
+          attrs   (second pill)
+          handler (:on-click attrs)]
+      (is (fn? handler) "group-by pill exposes an :on-click handler")
+      (handler (fake-event)) ; outside any with-frame — same as a browser click
+      (async done
+        (-> (await-causa-db #(= :sub (:views/group-by %))
+                            ":views/group-by flips to :sub after pill click")
+            (.then (fn [_]
+                     (is (= :sub (:views/group-by (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :views/group-by flips to :sub")
+                     (is (nil? (:views/group-by (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest filter-chip-clear-click-flips-causa-not-default
+  (testing "rf2-83d4x — clicking the filter-chip `×` clear button from
+            OUTSIDE the :rf/causa frame-provider's render context
+            dissocs :rf/causa's :views/component-filter. Without the
+            explicit frame opt, the click would land on :rf/default
+            and the chip would stay rendered."
+    ;; Seed the filter on :rf/causa so there's something to clear.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/views-set-component-filter :cart/list]))
+    (let [chip    (#'view/filter-chip :cart/list)
+          ;; chip is [:div … [:span …] [:button { :data-testid "...-clear" } …]]
+          ;; — find the clear button by walking the tree.
+          clear   (some (fn [node]
+                          (when (and (vector? node)
+                                     (map? (second node))
+                                     (= "rf-causa-views-filter-chip-clear"
+                                        (:data-testid (second node))))
+                            node))
+                        (tree-seq (some-fn vector? seq?) seq chip))
+          handler (:on-click (second clear))]
+      (is (fn? handler) "filter-chip clear exposes an :on-click handler")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(not (contains? % :views/component-filter))
+                            ":views/component-filter dissoced after clear")
+            (.then (fn [_]
+                     (is (nil? (:views/component-filter (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :views/component-filter is dissoced")
+                     (is (nil? (:views/component-filter (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest right-click-row-handler-routes-to-causa
+  (testing "rf2-83d4x — the `right-click-filter-handler` dispatch
+            routes to :rf/causa even when invoked outside any
+            with-frame binding (the exact click-time React-context-
+            popped scenario)."
+    (let [handler (#'view/right-click-filter-handler ::comp-a)]
+      (is (fn? handler) "right-click-filter-handler returns a fn")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(= ::comp-a (:views/component-filter %))
+                            ":views/component-filter set on :rf/causa after right-click")
+            (.then (fn [_]
+                     (is (= ::comp-a (:views/component-filter (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :views/component-filter set to the view-id")
+                     (is (nil? (:views/component-filter (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))
+
+(deftest row-toggle-click-flips-causa-not-default
+  (testing "rf2-83d4x — clicking a row's body fires
+            `:rf.causa/views-toggle-row` against :rf/causa, NOT
+            :rf/default. Asserts :views/expanded-rows on :rf/causa
+            after the click."
+    (let [item    {:kind   :single
+                   :render {:render-key   [::comp 0]
+                            :triggered-by ::sub
+                            :elapsed-ms   1.0}
+                   :invalidated-by [{:sub-id ::sub :trigger? true}]}
+          row     (#'view/single-row item :rendered false)
+          attrs   (second row)
+          handler (:on-click attrs)]
+      (is (fn? handler) "single-row exposes an :on-click handler")
+      (handler (fake-event))
+      (async done
+        (-> (await-causa-db #(seq (:views/expanded-rows %))
+                            ":views/expanded-rows populated on :rf/causa after row click")
+            (.then (fn [_]
+                     (is (seq (:views/expanded-rows (rf/get-frame-db :rf/causa)))
+                         ":rf/causa's :views/expanded-rows is populated")
+                     (is (nil? (:views/expanded-rows (rf/get-frame-db :rf/default)))
+                         ":rf/default's db is NOT polluted by the dispatch")
+                     (done)))
+            (.catch (fn [e] (is false (.-message e)) (done))))))))


### PR DESCRIPTION
## Summary

Mechanical sweep — every `rf/dispatch` from a deferred handler (`:on-click`, `:on-context-menu`) inside the Views panel now carries the explicit `{:frame :rf/causa}` opt so click-time events land on `:rf/causa`'s db, not `:rf/default`'s. Same root cause + fix-shape as rf2-w8lxg (palette + causality popover, PR #1466) and rf2-smvvz (Settings popup, PR #1465).

Root cause: React's `_currentValue` for the frame-provider pops back to `:rf/default` between render and click-time, so the 3-tier frame-resolution chain (dynamic var → React-context tier → `:rf/default`) falls through to `:rf/default` at click time and the panel-local handler reduces the WRONG db. The explicit opt sets the envelope's `:frame` at call time, independent of React-context state.

This is the root cause of **rf2-dodq2** ("Views Group-By stuck on Component"): the Group-By pill click never flipped `:rf/causa`'s `:views/group-by` slot, so the panel never re-rendered into sub-grouped / tree mode.

## Sites fixed

`tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs`:

| Line (post-edit) | Surface                                | Event                                       |
|------------------|----------------------------------------|---------------------------------------------|
| 418              | `right-click-filter-handler`           | `:rf.causa/views-set-component-filter`      |
| 432              | `single-row` :on-click                 | `:rf.causa/views-toggle-row`                |
| 508              | cluster-row toggle :on-click           | `:rf.causa/views-toggle-cluster`            |
| 713              | `group-by-pill` :on-click (rf2-dodq2)  | `:rf.causa/views-set-group-by`              |
| 773              | `filter-chip` clear :on-click          | `:rf.causa/views-set-component-filter`      |
| 812              | `bottom-controls` clear :on-click      | `:rf.causa/views-set-component-filter`      |

`tools/causa/src/day8/re_frame2_causa/views/group_by_tree.cljs`:

| Line | Surface                              | Event                                       |
|------|--------------------------------------|---------------------------------------------|
| 197  | `tree-row` :on-context-menu          | `:rf.causa/views-set-component-filter`      |

## Full Causa view-file audit

Every other `rf/dispatch` in `tools/causa/src/day8/re_frame2_causa/**/*.cljs` was checked:

- **panels/event_detail.cljs, panels/issues_ribbon.cljs, panels/trace.cljs, panels/cancellation_cascade.cljs, panels/managed_fx_template.cljs, panels/machine_inspector.cljs, panels/machine_canvas.cljs, panels/machine_after_rings.cljs, panels/app_db_diff_sections.cljs, panels/app_db_diff_slices.cljs, panels/app_db_segment_inspector.cljs** — all dispatches already carry `:frame :rf/causa`.
- **palette/view.cljs, settings/view.cljs** — fixed under rf2-w8lxg / rf2-smvvz (already closed).
- **filters/edit_popup.cljs, filters/pills.cljs, diff/render.cljs, frame_switcher.cljs, resize_handle.cljs, share.cljs, share_modal.cljs, shell.cljs** — all clean.
- **static/machines/{browse_list,definition_detail,sim,topology,instances_jump,persistence}.cljs, static/routes/{browse_list,row_expand,simulate_url,simulate_nav}.cljs, static/mode_pill.cljs, static/shell.cljs, theme/data_inspector.cljs** — all clean.
- **core.cljs, config.cljc, keybinding.cljs, preload.cljs, trace_bus.cljc** — these wrap their dispatches in `(rf/with-frame :rf/causa ...)` which is the equivalent dynamic-binding mechanism (sets the frame at call site independent of React context). Correct as-is.
- **runtime.cljs:478** — the framework dispatcher itself; uses the resolved `fid` from its opts. Correct.

## Sibling beads' status

- **rf2-w8lxg** — CLOSED (PR #1466, 2026-05-18). Palette + causality popover fixed.
- **rf2-smvvz** — CLOSED (PR #1465, 2026-05-18). Settings popup fixed.

No remaining sites carry the bug pattern in any Causa view file.

## Test plan

- [x] `npm run test:cljs` — 3188 tests / 9170 assertions, 0 failures, 0 errors
- [x] `npm run test:causa-feature-gate` — 16 scenarios, 0 failures, 15 matrix rows
- [x] `npm run test:bundle-isolation` — PASS (11 artefact entries, 26 internal sentinels absent)
- [x] `clojure -M:test` from tools/causa/ — 749 tests / 2263 assertions, 0 failures
- [x] New test ns `views_view_dispatch_routing_cljs_test.cljs` — 4 click-time tests asserting each handler routes to `:rf/causa` and does NOT pollute `:rf/default`

Closes rf2-83d4x. Unblocks rf2-dodq2.