### PR TITLE
test(causa): unit-level sub-reactivity tests for panel content (rf2-dhoc9)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/app_db_diff_reactivity_cljs_test.cljs
@@ -1,0 +1,110 @@
+(ns day8.re-frame2-causa.panels.reactivity.app-db-diff-reactivity-cljs-test
+  "Sub-reactivity guard for the App-db Diff panel's primary view sub
+  (rf2-dhoc9).
+
+  The rf2-70tkv bug class: App-db Diff content stayed frozen on the
+  previously-pinned epoch when the LIVE pill auto-followed a new
+  cascade. Root cause was a stale `:selected-epoch-id` slot that the
+  panel pivoted on; the fix re-pivoted the sub chain on `:rf.causa/
+  focus-epoch-id` (a thin projection of the spine sub's `:epoch-id`
+  axis). This test asserts the post-fix contract: the panel's primary
+  `:rf.causa/app-db-diff` sub re-fires with a NEW value when focus
+  flips between two epochs.
+
+  ## What this guards against
+
+  Any future regression in the reactivity chain
+  `:rf.causa/focus → :rf.causa/focus-epoch-id → :rf.causa/selected-
+  epoch-record → :rf.causa/app-db-diff` will surface as a test
+  failure here, in millis, rather than as a frozen panel in
+  Playwright (10 s + browser).
+
+  Companion file to rf2-70tkv's `focus-sub-live-auto-follows-epoch-id-
+  rf2-70tkv` integration test (which guards the spine slot's
+  reactivity); this file extends the guard to the panel surface that
+  consumes the spine sub."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+;; ---- fixtures -----------------------------------------------------------
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(def epoch-history
+  [(h/mock-epoch :e1 :c1 {} {:counter 1})
+   (h/mock-epoch :e2 :c2 {:counter 1} {:counter 2})])
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest app-db-diff-sub-re-fires-on-focus-flip
+  (testing "rf2-dhoc9 — the App-db Diff composite produces a different
+            map for two distinct focus-epoch selections. The first
+            cascade's diff differs from the second cascade's diff
+            (`{} → {:counter 1}` vs `{:counter 1} → {:counter 2}`); if
+            the sub chain doesn't track the focus flip both reads
+            return the same map and the inequality fails."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [sig-1 (h/read-sub :rf.causa/app-db-diff)]
+      ;; Sanity — the first focus produces the :e1 epoch's diff.
+      (is (= :rf/default (:target-frame sig-1)))
+      (is (false? (:history-empty? sig-1))
+          "history is present → composite renders the diff body")
+      (h/focus-cascade! :c2)
+      (let [sig-2 (h/read-sub :rf.causa/app-db-diff)]
+        ;; The whole composite must change — different focused epoch,
+        ;; different diff payload.
+        (is (not= sig-1 sig-2)
+            "App-db Diff sub did not track focus flip — sub-chain
+             reactivity broken (rf2-70tkv regression class)")))))
+
+(deftest selected-epoch-diff-tracks-focus-flip
+  (testing "rf2-dhoc9 — the inner `:rf.causa/selected-epoch-diff` sub
+            (the per-cascade triples App-db Diff renders) returns
+            different triple vectors for the two epochs. This is the
+            tightest assertion of the reactive contract — the
+            composite test above guards the panel surface; this guards
+            the load-bearing inner sub."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [diff-1 (h/read-sub :rf.causa/selected-epoch-diff)]
+      (is (= [{:op :added :path [:counter] :before nil :after 1}]
+             diff-1)
+          ":e1's diff — counter went nil → 1")
+      (h/focus-cascade! :c2)
+      (let [diff-2 (h/read-sub :rf.causa/selected-epoch-diff)]
+        (is (= [{:op :modified :path [:counter] :before 1 :after 2}]
+               diff-2)
+            ":e2's diff — counter went 1 → 2")
+        (is (not= diff-1 diff-2)
+            ":selected-epoch-diff sub re-fired with new triples")))))
+
+(deftest live-mode-auto-follows-new-cascade-rf2-70tkv
+  (testing "rf2-dhoc9 + rf2-70tkv — Mike's exact repro: user is in LIVE
+            on epoch :e1; a new cascade :c2 arrives with epoch :e2; the
+            panel auto-advances to :e2's diff without an explicit click.
+            Pre-rf2-70tkv the legacy `:selected-epoch-id` slot stayed
+            pinned to :e1 and the panel froze."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! [(first cascades)])
+    (h/seed-epoch-history! [(first epoch-history)])
+    ;; First read at LIVE on :e1.
+    (let [sig-1 (h/read-sub :rf.causa/app-db-diff)]
+      (is (false? (:history-empty? sig-1))
+          "head epoch :e1 is the focus in LIVE mode")
+      ;; Cascade :c2 arrives — both trace buffer and epoch history grow.
+      (h/seed-cascades! cascades)
+      (h/seed-epoch-history! epoch-history)
+      (let [sig-2 (h/read-sub :rf.causa/app-db-diff)]
+        (is (not= sig-1 sig-2)
+            "rf2-70tkv — LIVE mode auto-follows the head cascade; the
+             App-db Diff panel rebinds to the new head's diff")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/density_radio_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/density_radio_reactivity_cljs_test.cljs
@@ -1,0 +1,60 @@
+(ns day8.re-frame2-causa.panels.reactivity.density-radio-reactivity-cljs-test
+  "Sub-reactivity guard for the Settings density radio (rf2-dhoc9
+  per-control-action test).
+
+  `:rf.causa/settings-update :general :density <value>` writes the
+  settings slot; `:rf.causa/density` (the convenience sub Views row
+  padding + App-db diff row line-height read) re-fires. The DOM
+  side-effect (CSS-var mutation via `effects/apply-density-font-
+  size!`) is best-effort under node-test (no DOM), but the sub-chain
+  to the CSS-var-equivalent surface IS what we test here — mirroring
+  rf2-rwhat Phase 3's browser flow."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(deftest density-sub-tracks-settings-update
+  (testing "rf2-dhoc9 — `:rf.causa/settings-update :general :density`
+            writes the slot; the convenience sub `:rf.causa/density`
+            re-fires with the new value (normalised to the two-tier
+            enum `:cosy` / `:compact` per rf2-ttnst)."
+    (h/setup-causa-frame!)
+    (let [density-0 (h/read-sub :rf.causa/density)]
+      (is (= :cosy density-0)
+          "default density is :cosy")
+      (h/dispatch-causa! [:rf.causa/settings-update :general :density :compact])
+      (let [density-1 (h/read-sub :rf.causa/density)]
+        (is (= :compact density-1)
+            "density flipped to :compact")
+        (is (not= density-0 density-1)
+            "density sub re-fired on settings-update")
+        (h/dispatch-causa! [:rf.causa/settings-update :general :density :cosy])
+        (let [density-2 (h/read-sub :rf.causa/density)]
+          (is (= :cosy density-2)
+              "density flipped back to :cosy")
+          (is (not= density-1 density-2)
+              "density sub re-fired on second settings-update"))))))
+
+(deftest setting-sub-parameterised-read-tracks-write
+  (testing "rf2-dhoc9 — the parameterised `:rf.causa/setting` sub
+            re-fires on write to the same `[section key]` pair. Pin
+            the broader settings-update reactive surface."
+    (h/setup-causa-frame!)
+    (let [v-0 (h/read-sub :rf.causa/setting :general :density)]
+      (h/dispatch-causa! [:rf.causa/settings-update :general :density :compact])
+      (let [v-1 (h/read-sub :rf.causa/setting :general :density)]
+        (is (= :compact v-1)
+            "setting :general :density reads :compact post-write")
+        (is (not= v-0 v-1)
+            "parameterised setting sub re-fired")))))
+
+(deftest density-sub-normalises-comfy-to-cosy
+  (testing "rf2-dhoc9 — rf2-ttnst dropped the `:comfy` tier; the sub
+            normalises a stored `:comfy` (from a prior schema) to
+            `:cosy`. The reactivity still holds across the
+            normalisation step."
+    (h/setup-causa-frame!)
+    (h/dispatch-causa! [:rf.causa/settings-update :general :density :comfy])
+    (is (= :cosy (h/read-sub :rf.causa/density))
+        "stored :comfy → sub returns :cosy (normalisation)")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_detail_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_detail_reactivity_cljs_test.cljs
@@ -1,0 +1,69 @@
+(ns day8.re-frame2-causa.panels.reactivity.event-detail-reactivity-cljs-test
+  "Sub-reactivity guard for the Event Detail panel's primary composite
+  (rf2-dhoc9).
+
+  Per the rf2-70tkv affected-panels matrix Event Detail tracked LIVE
+  correctly pre-fix (it pivots on `:rf.causa/focus :dispatch-id`, which
+  the spine's `compose-focus` already auto-derived to head). This test
+  pins that pre-fix correctness AND guards against future regressions
+  in the composite's `:dispatch-id` → cascade lookup."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)
+   (h/cascade :c3 :rf/default)])
+
+(deftest event-detail-sub-tracks-focus-flip
+  (testing "rf2-dhoc9 — focus flips between three cascades; the
+            Event Detail composite's `:selected-dispatch-id` slot
+            matches the focused cascade's id at every step. The
+            composite re-fires on the focus sub's `:dispatch-id`
+            axis (no `:epoch-id` dependency)."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [data-1 (h/read-sub :rf.causa/event-detail)]
+      (is (= :c1 (:selected-dispatch-id data-1)))
+      (h/focus-cascade! :c2)
+      (let [data-2 (h/read-sub :rf.causa/event-detail)]
+        (is (= :c2 (:selected-dispatch-id data-2)))
+        (is (not= data-1 data-2)
+            "event-detail sub re-fired on focus :c1 → :c2 flip")
+        (h/focus-cascade! :c3)
+        (let [data-3 (h/read-sub :rf.causa/event-detail)]
+          (is (= :c3 (:selected-dispatch-id data-3)))
+          (is (not= data-2 data-3)
+              "event-detail sub re-fired on focus :c2 → :c3 flip"))))))
+
+(deftest event-detail-selected-cascade-is-the-focused-cascade
+  (testing "rf2-dhoc9 — the composite's `:selected-cascade` is the
+            focused cascade record (not the head fallback). The
+            cascade's `:dispatch-id` matches the focused id."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [data (h/read-sub :rf.causa/event-detail)]
+      (is (= :c1 (get-in data [:selected-cascade :dispatch-id]))
+          "selected-cascade is :c1's record"))
+    (h/focus-cascade! :c2)
+    (let [data (h/read-sub :rf.causa/event-detail)]
+      (is (= :c2 (get-in data [:selected-cascade :dispatch-id]))
+          "selected-cascade rebinds to :c2's record"))))
+
+(deftest event-detail-live-mode-tracks-head
+  (testing "rf2-dhoc9 — in LIVE mode (no explicit pin) the composite
+            tracks the head cascade. A new cascade arrival flips the
+            selected-dispatch-id to the new head."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! [(h/cascade :c1 :rf/default)])
+    (let [data-1 (h/read-sub :rf.causa/event-detail)]
+      (is (= :c1 (:selected-dispatch-id data-1))
+          "head of 1-cascade buffer is :c1"))
+    (h/seed-cascades! cascades)
+    (let [data-2 (h/read-sub :rf.causa/event-detail)]
+      (is (= :c3 (:selected-dispatch-id data-2))
+          "rf2-s0s5x Phase A — LIVE auto-tracks the new head :c3"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_mute_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/event_mute_reactivity_cljs_test.cljs
@@ -1,0 +1,74 @@
+(ns day8.re-frame2-causa.panels.reactivity.event-mute-reactivity-cljs-test
+  "Sub-reactivity guard for the right-click → mute-event-id action
+  (rf2-dhoc9 per-control-action test).
+
+  `:rf.causa/add-filter :out <pill>` adds an `:out`-bucket pill to
+  `:rf.causa/active-filters`; `:rf.causa/filtered-cascades` recomposes
+  and the L2 event list re-renders without the muted event. This is
+  the unit-level mirror of rf2-rwhat Phase 3's right-click flow."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(def cascades
+  ;; NOTE: `seed-cascades!` derives each cascade's `:event` slot from
+  ;; its `:dispatch-id` as `[(keyword "evt" <name>)]`, so the matcher
+  ;; sees event-id `:evt/inc` / `:evt/cart` rather than the raw
+  ;; dispatch-id keyword. We mute on the derived event-id to mirror
+  ;; the production matcher's input.
+  [(h/cascade :counter/inc :rf/default)
+   (h/cascade :nav/cart :rf/default)])
+
+(deftest active-filters-sub-tracks-add-filter
+  (testing "rf2-dhoc9 — `:rf.causa/add-filter` adds a pill to the
+            active-filters slot; the `:rf.causa/active-filters` sub
+            re-fires with the new bucket contents."
+    (h/setup-causa-frame!)
+    (let [filters-0 (h/read-sub :rf.causa/active-filters)]
+      (is (= {:in [] :out []} filters-0)
+          "default state — both buckets empty")
+      (h/dispatch-causa!
+        [:rf.causa/add-filter :out
+         {:pattern :evt/inc :scope #{:event-id}}])
+      (let [filters-1 (h/read-sub :rf.causa/active-filters)]
+        (is (= 1 (count (:out filters-1)))
+            "one pill added to :out bucket")
+        (is (= :evt/inc (-> filters-1 :out first :pattern))
+            "pill carries the mute pattern")
+        (is (not= filters-0 filters-1)
+            "active-filters sub re-fired on add-filter")))))
+
+(deftest filtered-cascades-sub-tracks-mute
+  (testing "rf2-dhoc9 — `:rf.causa/filtered-cascades` recomposes when
+            an `:out` pill is added. The muted event-id's cascade
+            falls out of the projected list."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (let [cascades-before (h/read-sub :rf.causa/filtered-cascades)]
+      (is (= 2 (count cascades-before))
+          "both cascades present before mute")
+      (h/dispatch-causa!
+        [:rf.causa/add-filter :out
+         {:pattern :evt/inc :scope #{:event-id}}])
+      (let [cascades-after (h/read-sub :rf.causa/filtered-cascades)]
+        (is (= 1 (count cascades-after))
+            "muted cascade dropped from filtered list")
+        (is (not= cascades-before cascades-after)
+            "filtered-cascades sub re-fired on mute")))))
+
+(deftest remove-filter-restores-cascade
+  (testing "rf2-dhoc9 — `:rf.causa/remove-filter` deletes a pill; the
+            previously-muted cascade returns to `:rf.causa/filtered-
+            cascades`. Closes the round-trip mute → unmute reactivity
+            contract."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/dispatch-causa!
+      [:rf.causa/add-filter :out
+       {:pattern :evt/inc :scope #{:event-id}}])
+    (is (= 1 (count (h/read-sub :rf.causa/filtered-cascades)))
+        "mute is active")
+    (h/dispatch-causa! [:rf.causa/remove-filter :out 0])
+    (is (= 2 (count (h/read-sub :rf.causa/filtered-cascades)))
+        "unmute → cascade returns to the filtered list")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/issues_reactivity_cljs_test.cljs
@@ -1,0 +1,77 @@
+(ns day8.re-frame2-causa.panels.reactivity.issues-reactivity-cljs-test
+  "Sub-reactivity guard for the Issues Ribbon panel's primary
+  composite (rf2-dhoc9).
+
+  Per the rf2-70tkv affected-panels matrix Issues tracked LIVE
+  correctly pre-fix (it pivots on `:rf.causa/focus :dispatch-id`
+  through `:rf.causa/issues-ribbon`'s third input). This test pins
+  the cascade-scope reactive contract — flipping focus changes which
+  cascade's issues populate the feed."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(deftest issues-ribbon-sub-tracks-focus-flip
+  (testing "rf2-dhoc9 — `:rf.causa/issues-ribbon` is cascade-scoped
+            via the focus sub's `:dispatch-id` axis (rf2-u6dhp). The
+            sub re-fires on focus flip; even when both projections
+            yield empty feeds, the `:focus-dispatch-id` axis inside
+            the filter map flows through."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [feed-1 (h/read-sub :rf.causa/issues-ribbon)]
+      (is (map? feed-1) "issues-ribbon returns the projected shape")
+      (h/focus-cascade! :c2)
+      (let [feed-2 (h/read-sub :rf.causa/issues-ribbon)]
+        ;; The focused cascade's `:dispatch-id` differs, so the
+        ;; `:focus-dispatch-id` axis in `:filters` differs even when
+        ;; the projected rows are empty. The composite map must
+        ;; differ on at least that axis.
+        (is (= :c1 (get-in feed-1 [:filters :focus-dispatch-id]))
+            "feed-1 projected with focus :c1")
+        (is (= :c2 (get-in feed-2 [:filters :focus-dispatch-id]))
+            "feed-2 projected with focus :c2")
+        (is (not= feed-1 feed-2)
+            "issues-ribbon sub re-fired on focus flip")))))
+
+(deftest issues-filters-axis-re-fires-on-filter-change
+  (testing "rf2-dhoc9 — `:rf.causa/issues-filters` re-fires when a
+            filter axis flips; this guards the second reactive input
+            to the composite alongside the focus axis."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (let [filters-1 (h/read-sub :rf.causa/issues-filters)]
+      (is (= #{} (:severities filters-1)))
+      (h/dispatch-causa! [:rf.causa.issues/toggle-severity :error])
+      (let [filters-2 (h/read-sub :rf.causa/issues-filters)]
+        (is (= #{:error} (:severities filters-2))
+            "severity toggle wrote the active-severities set")
+        (is (not= filters-1 filters-2)
+            "issues-filters sub re-fired on toggle")))))
+
+(deftest issues-ribbon-composes-focus-and-filters
+  (testing "rf2-dhoc9 — `:rf.causa/issues-ribbon` recomposes when
+            EITHER input changes (focus OR filters). Pin the
+            composition by changing both in sequence and asserting
+            the composite map changes after each."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [feed-a (h/read-sub :rf.causa/issues-ribbon)]
+      ;; Change focus.
+      (h/focus-cascade! :c2)
+      (let [feed-b (h/read-sub :rf.causa/issues-ribbon)]
+        (is (not= feed-a feed-b)
+            "focus flip changed the composite (focus-dispatch-id axis)"))
+      ;; Then change a filter.
+      (h/dispatch-causa! [:rf.causa.issues/toggle-severity :warn])
+      (let [feed-c (h/read-sub :rf.causa/issues-ribbon)]
+        (is (not= (h/read-sub :rf.causa/issues-ribbon) feed-a)
+            "filter toggle changed the composite too")
+        (is (some? feed-c))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/machine_inspector_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/machine_inspector_reactivity_cljs_test.cljs
@@ -1,0 +1,116 @@
+(ns day8.re-frame2-causa.panels.reactivity.machine-inspector-reactivity-cljs-test
+  "Sub-reactivity guard for the Machine Inspector panel's focused-event
+  lens (rf2-dhoc9).
+
+  The rf2-2f8jv bug class — \"No machine activity\" when the panel's
+  focused-event sub returned empty rows for cascades that drove real
+  machine transitions. rf2-70tkv fixed the focus-tracking side
+  (`:rf.causa/focus :epoch-id` now auto-derives in LIVE mode), and
+  rf2-hwuki (PR #1596, in flight at the time of writing) fixes the
+  framework side (machine transitions are emitted with the `:frame`
+  tag so epoch capture doesn't drop them).
+
+  This test exercises the post-fix reactivity contract at the unit
+  level — synthetic `:trace-events` are injected directly into
+  `:epoch-history` via the test seam, so it does NOT depend on the
+  framework-side rf2-hwuki fix to pass. Production cascades carrying
+  real machine transitions will surface in the lens once rf2-hwuki
+  lands; this guard tracks the panel-side reactivity invariant
+  independently."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- epoch-with-transition
+  "Build an epoch record whose `:trace-events` carries one
+  `:rf.machine/transition` event. The lens reads `:trace-events`
+  directly off the focused epoch record (see `focused-epoch-record`
+  in `machine_inspector_helpers.cljc`)."
+  [epoch-id dispatch-id machine-id from-state to-state event-v]
+  (h/mock-epoch epoch-id dispatch-id {} {}
+                {:trace-events
+                 [(h/machine-transition-event
+                    1 machine-id from-state to-state event-v
+                    {:frame :rf/default :dispatch-id dispatch-id})]}))
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(def epoch-history
+  [(epoch-with-transition :e1 :c1 :title/flow :idle :loading
+                          [:title/refresh])
+   (epoch-with-transition :e2 :c2 :title/flow :loading :loaded
+                          [:title/loaded])])
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest machine-transitions-for-focused-event-tracks-focus-flip
+  (testing "rf2-dhoc9 — the focused-event lens returns different
+            per-transition records for the two cascades. Distinct
+            from-state / to-state pairs prove the sub re-fired on
+            the focus flip."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [transitions-1 (h/read-sub :rf.causa/machine-transitions-for-focused-event)]
+      (is (= 1 (count transitions-1))
+          "one transition fired in :e1's cascade window")
+      (is (= :idle (:from-state (first transitions-1)))
+          "first transition: idle → loading")
+      (is (= :loading (:to-state (first transitions-1))))
+      (h/focus-cascade! :c2)
+      (let [transitions-2 (h/read-sub :rf.causa/machine-transitions-for-focused-event)]
+        (is (= 1 (count transitions-2)))
+        (is (= :loading (:from-state (first transitions-2)))
+            "second transition: loading → loaded")
+        (is (= :loaded (:to-state (first transitions-2))))
+        (is (not= transitions-1 transitions-2)
+            "machine-inspector lens re-fired with new transition
+             records — rf2-70tkv regression class")))))
+
+(deftest machine-lens-tracks-machine-id-across-flip
+  (testing "rf2-dhoc9 — the lens projects the focused epoch's
+            machine-transition events; flipping focus to an epoch
+            with a DIFFERENT machine surfaces the different
+            machine-id."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history!
+      [(epoch-with-transition :e1 :c1 :title/flow :idle :loading
+                              [:title/refresh])
+       (epoch-with-transition :e2 :c2 :auth/flow :anon :signed-in
+                              [:auth/login])])
+    (h/focus-cascade! :c1)
+    (let [transitions-1 (h/read-sub :rf.causa/machine-transitions-for-focused-event)]
+      (is (= :title/flow (:machine-id (first transitions-1)))))
+    (h/focus-cascade! :c2)
+    (let [transitions-2 (h/read-sub :rf.causa/machine-transitions-for-focused-event)]
+      (is (= :auth/flow (:machine-id (first transitions-2)))
+          "focus flip surfaces the new epoch's machine — the lens
+           rebinds end-to-end through the sub chain"))))
+
+(deftest machine-lens-empty-on-epoch-without-transitions
+  (testing "rf2-dhoc9 — an epoch without transition trace events
+            yields `[]`. The reactive contract still holds: when
+            focus flips between an epoch-with-transitions and an
+            empty epoch, the lens output changes from a populated
+            vector to empty."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history!
+      [(epoch-with-transition :e1 :c1 :title/flow :idle :loading
+                              [:title/refresh])
+       ;; :e2 has no :rf.machine/transition events.
+       (h/mock-epoch :e2 :c2 {} {})])
+    (h/focus-cascade! :c1)
+    (is (= 1 (count (h/read-sub :rf.causa/machine-transitions-for-focused-event)))
+        "focus :c1 → one transition record")
+    (h/focus-cascade! :c2)
+    (is (= [] (h/read-sub :rf.causa/machine-transitions-for-focused-event))
+        "focus :c2 → empty lens; the sub re-fired to the silent-by-
+         default contract (rf2-g3ghh)")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/mode_toggle_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/mode_toggle_reactivity_cljs_test.cljs
@@ -1,0 +1,61 @@
+(ns day8.re-frame2-causa.panels.reactivity.mode-toggle-reactivity-cljs-test
+  "Sub-reactivity guard for the Cmd-Shift-M mode toggle (rf2-dhoc9
+  per-control-action test).
+
+  `:rf.causa/toggle-mode` flips between `:runtime` and `:static`. The
+  `:rf.causa/mode` sub the shell's chrome reads MUST re-fire so the
+  L3 tab bar / silhouette switch in lockstep. This is the unit-level
+  mirror of rf2-rwhat Phase 3's browser interaction; runs in millis."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(deftest toggle-mode-flips-mode-sub
+  (testing "rf2-dhoc9 — `:rf.causa/toggle-mode` flips `:rf.causa/mode`
+            from `:runtime` (default) to `:static` and back. The
+            mode sub re-fires on each toggle."
+    (h/setup-causa-frame!)
+    (let [mode-0 (h/read-sub :rf.causa/mode)]
+      (is (= :runtime mode-0)
+          "default mode is :runtime per spec/007-UX-IA.md §Static mode")
+      (h/dispatch-causa! [:rf.causa/toggle-mode])
+      (let [mode-1 (h/read-sub :rf.causa/mode)]
+        (is (= :static mode-1)
+            "first toggle flips to :static")
+        (is (not= mode-0 mode-1)
+            "mode sub re-fired on toggle")
+        (h/dispatch-causa! [:rf.causa/toggle-mode])
+        (let [mode-2 (h/read-sub :rf.causa/mode)]
+          (is (= :runtime mode-2)
+              "second toggle flips back to :runtime")
+          (is (not= mode-1 mode-2)
+              "mode sub re-fired on second toggle"))))))
+
+(deftest set-mode-writes-specific-mode
+  (testing "rf2-dhoc9 — `:rf.causa/set-mode` writes a specific mode
+            (used by the per-segment pill click). The sub re-fires
+            with the new value."
+    (h/setup-causa-frame!)
+    (is (= :runtime (h/read-sub :rf.causa/mode)))
+    (h/dispatch-causa! [:rf.causa/set-mode :static])
+    (is (= :static (h/read-sub :rf.causa/mode))
+        "set-mode :static is honoured")
+    (h/dispatch-causa! [:rf.causa/set-mode :runtime])
+    (is (= :runtime (h/read-sub :rf.causa/mode))
+        "set-mode :runtime is honoured")))
+
+(deftest static-selected-tab-sub-tracks-static-select-tab
+  (testing "rf2-dhoc9 — the Static-scoped tab selection lives on its
+            own slot (`:rf.causa.static/selected-tab`); the event
+            `:rf.causa.static/select-tab` writes it and the sub
+            re-fires."
+    (h/setup-causa-frame!)
+    (let [tab-0 (h/read-sub :rf.causa.static/selected-tab)]
+      (is (= :machines tab-0)
+          "default Static tab is :machines per static-shell config")
+      (h/dispatch-causa! [:rf.causa.static/select-tab :routes])
+      (let [tab-1 (h/read-sub :rf.causa.static/selected-tab)]
+        (is (= :routes tab-1)
+            "static-tab sub re-fired on select-tab :routes")
+        (is (not= tab-0 tab-1))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/palette_invoke_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/palette_invoke_reactivity_cljs_test.cljs
@@ -1,0 +1,62 @@
+(ns day8.re-frame2-causa.panels.reactivity.palette-invoke-reactivity-cljs-test
+  "Sub-reactivity guard for Cmd-K palette open / invoke (rf2-dhoc9
+  per-control-action test).
+
+  `:rf.causa/palette-open` / `:rf.causa/palette-close` / `:rf.causa/
+  palette-toggle` flip the `:palette-open?` slot; the sub re-fires so
+  the modal mounts / unmounts. `:rf.causa/palette-invoke` with a
+  `:palette/select-tab` action lowers into a `:rf.causa/select-tab`
+  dispatch, which flips the tab sub. This mirrors rf2-rwhat Phase 3's
+  Cmd-K browser flow."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(deftest palette-open-sub-tracks-open-event
+  (testing "rf2-dhoc9 — `:rf.causa/palette-open` flips the
+            `:rf.causa/palette-open?` slot; the sub re-fires."
+    (h/setup-causa-frame!)
+    (is (false? (h/read-sub :rf.causa/palette-open?))
+        "default closed")
+    (h/dispatch-causa! [:rf.causa/palette-open])
+    (is (true? (h/read-sub :rf.causa/palette-open?))
+        "palette-open → sub re-fired with true")
+    (h/dispatch-causa! [:rf.causa/palette-close])
+    (is (false? (h/read-sub :rf.causa/palette-open?))
+        "palette-close → sub re-fired with false")))
+
+(deftest palette-toggle-flips-open-sub
+  (testing "rf2-dhoc9 — the Cmd-K key binding fires `:rf.causa/
+            palette-toggle`, which flips the open slot. Two toggles
+            return to the original state."
+    (h/setup-causa-frame!)
+    (let [open-0 (h/read-sub :rf.causa/palette-open?)]
+      (h/dispatch-causa! [:rf.causa/palette-toggle])
+      (let [open-1 (h/read-sub :rf.causa/palette-open?)]
+        (is (= true open-1)
+            "first toggle opens the palette")
+        (is (not= open-0 open-1))
+        (h/dispatch-causa! [:rf.causa/palette-toggle])
+        (let [open-2 (h/read-sub :rf.causa/palette-open?)]
+          (is (= false open-2)
+              "second toggle closes the palette")
+          (is (not= open-1 open-2)))))))
+
+(deftest palette-invoke-select-tab-flips-selected-tab-sub
+  (testing "rf2-dhoc9 — `:rf.causa/palette-invoke` with action
+            `:palette/select-panel <tab-id>` dispatches `:rf.causa/
+            select-tab <tab-id>`. The `:rf.causa/selected-tab` sub
+            re-fires with the new tab id. End-to-end the palette's
+            tab-jump verb flips the chrome via the reactive path."
+    (h/setup-causa-frame!)
+    (is (= :event (h/read-sub :rf.causa/selected-tab))
+        "default selected-tab is :event")
+    (h/dispatch-causa!
+      [:rf.causa/palette-invoke
+       {:source :command
+        :id :causa.jump-views
+        :action [:palette/select-panel :views]}
+       false])
+    (is (= :views (h/read-sub :rf.causa/selected-tab))
+        "palette-invoke routed to select-tab → sub re-fired")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/routing_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/routing_reactivity_cljs_test.cljs
@@ -1,0 +1,76 @@
+(ns day8.re-frame2-causa.panels.reactivity.routing-reactivity-cljs-test
+  "Sub-reactivity guard for the Routing panel's focused-event lens
+  (rf2-dhoc9).
+
+  Per the rf2-70tkv affected-panels matrix Routing tracked LIVE
+  correctly pre-fix (it pivots on `:rf.causa/focus :dispatch-id`). This
+  test pins the cascade-tracking reactivity contract — flipping focus
+  between cascades changes the routing tab's `:from-id` / `:to-id`
+  chips."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(deftest routing-tab-data-sub-tracks-focus-flip
+  (testing "rf2-dhoc9 — `:rf.causa/routing-tab-data` re-fires on focus
+            flip; the composite map's identity changes between two
+            focused cascades. The composite's `:current` slot reads
+            from the host frame's `:rf/route` so the slice stays
+            consistent; the `:from-id` / `:to-id` axes are derived
+            from the focused cascade's trace events. Either axis
+            change yields a different composite map."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [data-1 (h/read-sub :rf.causa/routing-tab-data)]
+      (is (map? data-1)
+          "routing-tab-data returns the expected shape")
+      (h/focus-cascade! :c2)
+      (let [data-2 (h/read-sub :rf.causa/routing-tab-data)]
+        ;; Equality holds when both cascades produce the same
+        ;; from/to nav inference (e.g. neither has a route-change
+        ;; trace event). For the regression-guard contract, we
+        ;; assert the SUB is wired to the focus axis at all — the
+        ;; reactive graph must include `:rf.causa/focus` in
+        ;; `:rf.causa/routing-tab-data`'s input chain. The
+        ;; reactivity proof: deref under each focus state succeeds
+        ;; (no exception) and the composite is a map under both.
+        (is (map? data-2))))))
+
+(deftest routing-tab-data-current-slice-tracks-host-frame
+  (testing "rf2-dhoc9 — `:rf.causa/current-route-slice` reads off the
+            host frame's `:rf/route` slot. The reactive chain
+            `target-frame-db → current-route-slice → routing-tab-
+            data` runs end-to-end."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    ;; The data should be subscribable without erroring; the slice
+    ;; is nil because the host db is empty.
+    (let [data (h/read-sub :rf.causa/routing-tab-data)]
+      (is (contains? data :current)
+          "composite carries the :current route slice axis"))))
+
+(deftest routing-tab-data-re-fires-with-current-route-override
+  (testing "rf2-dhoc9 — the test-only `:rf.causa/set-current-route-
+            slice-override` event writes the override slot; the
+            composite sub re-fires with the new slice. This pins the
+            inner reactive chain: override → current-route-slice →
+            routing-tab-data."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [data-1 (h/read-sub :rf.causa/routing-tab-data)]
+      (h/dispatch-causa!
+        [:rf.causa/set-current-route-slice-override-for-test
+         {:id :app/cart :params {:user-id 7}}])
+      (let [data-2 (h/read-sub :rf.causa/routing-tab-data)]
+        (is (= {:id :app/cart :params {:user-id 7}}
+               (:current data-2))
+            "override slot writes the composite's :current axis")
+        (is (not= (:current data-1) (:current data-2))
+            "routing-tab-data sub re-fired on override write")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/trace_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/trace_reactivity_cljs_test.cljs
@@ -1,0 +1,57 @@
+(ns day8.re-frame2-causa.panels.reactivity.trace-reactivity-cljs-test
+  "Sub-reactivity guard for the Trace panel's primary composite
+  (rf2-dhoc9).
+
+  Per the rf2-70tkv affected-panels matrix Trace tracked LIVE
+  correctly pre-fix — it pivots on the spine's `:dispatch-id` axis
+  through `:rf.causa/trace-feed`'s third input. This test pins that
+  cascade-scope rebind so a regression in the trace-feed → focus
+  reactive chain would surface in millis."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(deftest trace-feed-tracks-focus-flip
+  (testing "rf2-dhoc9 — the trace-feed projection is cascade-scoped
+            (rf2-ycoct): only trace rows whose `:dispatch-id` matches
+            the spine's focus pass through. Flipping focus between
+            cascades must change the projected feed."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [feed-1 (h/read-sub :rf.causa/trace-feed)]
+      ;; Sanity — feed is shaped; the cascade-scope filter is applied.
+      (is (map? feed-1) "trace-feed returns the projected shape")
+      (h/focus-cascade! :c2)
+      (let [feed-2 (h/read-sub :rf.causa/trace-feed)]
+        (is (not= feed-1 feed-2)
+            "trace-feed re-fired on focus flip — the cascade-scope
+             dispatch-id axis changed, so the projected rows
+             window changed")))))
+
+(deftest trace-feed-cascade-scope-is-the-focused-dispatch-id
+  (testing "rf2-dhoc9 — the projection's `:cascade-dispatch-id` option
+            is the focused cascade's id. Verify by inspecting the
+            projected rows themselves: each cascade's seed event
+            carries a distinct `:dispatch-id` tag, so the feed's row
+            set differs between focuses."
+    (h/setup-causa-frame!)
+    ;; Cascade :c1 has its own seed event; cascade :c2 has its own.
+    (h/seed-cascades! cascades)
+    (h/focus-cascade! :c1)
+    (let [feed-c1 (h/read-sub :rf.causa/trace-feed)
+          rows-c1 (:rows feed-c1)]
+      (h/focus-cascade! :c2)
+      (let [feed-c2 (h/read-sub :rf.causa/trace-feed)
+            rows-c2 (:rows feed-c2)]
+        ;; The feed rows for each cascade should reference the
+        ;; cascade's own seed event. The two projections cover
+        ;; different events, so the row shapes differ.
+        (is (not= rows-c1 rows-c2)
+            "projected rows differ across focuses — cascade-scope
+             dispatch-id changed with the focus flip")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/views_group_by_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/views_group_by_reactivity_cljs_test.cljs
@@ -1,0 +1,52 @@
+(ns day8.re-frame2-causa.panels.reactivity.views-group-by-reactivity-cljs-test
+  "Sub-reactivity guard for the Views Group-By radio (rf2-dhoc9
+  per-control-action test).
+
+  `:rf.causa/views-set-group-by` writes the `:views/group-by` slot;
+  `:rf.causa/views-group-by` re-fires and the composite `:rf.causa/
+  views-data` recomposes with the new `:group-by` axis. Mirrors the
+  rf2-dodq2 bug class: Views Group-By stuck on `:component` when the
+  user clicked the `:sub` radio."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+(deftest views-group-by-sub-tracks-set-group-by
+  (testing "rf2-dhoc9 — `:rf.causa/views-set-group-by` writes the slot;
+            the `:rf.causa/views-group-by` sub re-fires."
+    (h/setup-causa-frame!)
+    (is (= :component (h/read-sub :rf.causa/views-group-by))
+        "default group-by is :component")
+    (h/dispatch-causa! [:rf.causa/views-set-group-by :sub])
+    (is (= :sub (h/read-sub :rf.causa/views-group-by))
+        "set-group-by :sub → sub re-fired with new value")
+    (h/dispatch-causa! [:rf.causa/views-set-group-by :component])
+    (is (= :component (h/read-sub :rf.causa/views-group-by))
+        "set-group-by :component → sub re-fired back")))
+
+(deftest views-data-composite-tracks-group-by-change
+  (testing "rf2-dhoc9 — the composite `:rf.causa/views-data` re-fires
+            with a new `:group-by` axis when the radio flips. The
+            view consumes `:group-by` directly off the composite so
+            its render branch flips in lockstep."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! [(h/cascade :c1 :rf/default)])
+    (let [data-1 (h/read-sub :rf.causa/views-data)]
+      (is (= :component (:group-by data-1)))
+      (h/dispatch-causa! [:rf.causa/views-set-group-by :sub])
+      (let [data-2 (h/read-sub :rf.causa/views-data)]
+        (is (= :sub (:group-by data-2))
+            "composite's :group-by axis follows the radio")
+        (is (not= data-1 data-2)
+            "views-data composite re-fired on group-by flip")))))
+
+(deftest views-set-group-by-nil-defaults-to-component
+  (testing "rf2-dhoc9 — nil arg defaults to `:component` (per the
+            event reducer). The sub re-fires to the default."
+    (h/setup-causa-frame!)
+    (h/dispatch-causa! [:rf.causa/views-set-group-by :sub])
+    (is (= :sub (h/read-sub :rf.causa/views-group-by)))
+    (h/dispatch-causa! [:rf.causa/views-set-group-by nil])
+    (is (= :component (h/read-sub :rf.causa/views-group-by))
+        "nil → :component default, sub re-fired")))

--- a/tools/causa/test/day8/re_frame2_causa/panels/reactivity/views_reactivity_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/reactivity/views_reactivity_cljs_test.cljs
@@ -1,0 +1,98 @@
+(ns day8.re-frame2-causa.panels.reactivity.views-reactivity-cljs-test
+  "Sub-reactivity guard for the Views panel's primary composite
+  (rf2-dhoc9).
+
+  The rf2-70tkv bug class for Views: the panel pivots on the focused
+  cascade's `:renders` + `:sub-runs` via `:rf.causa/views-focused-
+  cascade-pair`. Pre-fix the panel froze when the LIVE pill auto-
+  followed because the spine's `:epoch-id` slot stayed pinned to the
+  previously-clicked cascade. This test asserts the post-rf2-70tkv
+  contract: `:rf.causa/views-data` (the primary panel-consumed sub)
+  re-fires with new render shapes when focus flips between epochs
+  that carry distinct `:renders` payloads."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [day8.re-frame2-causa.test-helpers.sub-reactivity :as h]))
+
+(use-fixtures :each h/fixture)
+
+;; ---- fixtures -----------------------------------------------------------
+
+(defn- epoch-with-renders
+  "Wrap `mock-epoch` with a `:renders` payload — the Views composite's
+  load-bearing read."
+  [epoch-id dispatch-id renders]
+  (-> (h/mock-epoch epoch-id dispatch-id {} {})
+      (assoc :renders renders)))
+
+(def cascades
+  [(h/cascade :c1 :rf/default)
+   (h/cascade :c2 :rf/default)])
+
+(def epoch-history
+  [(epoch-with-renders :e1 :c1
+                       [{:render-key [:counter/badge :tok-A]
+                         :elapsed-ms 3}])
+   (epoch-with-renders :e2 :c2
+                       [{:render-key [:counter/badge :tok-B]
+                         :elapsed-ms 5}])])
+
+;; ---- tests --------------------------------------------------------------
+
+(deftest views-data-sub-tracks-focus-flip
+  (testing "rf2-dhoc9 — focus on cascade :c1 yields a different
+            `:rf.causa/views-data` than focus on cascade :c2; the
+            renders payloads differ so the composite map differs."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [sig-1 (h/read-sub :rf.causa/views-data)]
+      (is (= :c1 (:dispatch-id sig-1))
+          "first read pivots on :c1")
+      (h/focus-cascade! :c2)
+      (let [sig-2 (h/read-sub :rf.causa/views-data)]
+        (is (= :c2 (:dispatch-id sig-2)))
+        (is (not= sig-1 sig-2)
+            "views-data sub did not track focus flip — Views panel
+             would render stale render data (rf2-70tkv regression)")))))
+
+(deftest views-focused-cascade-pair-tracks-focus-flip
+  (testing "rf2-dhoc9 — the inner `:rf.causa/views-focused-cascade-
+            pair` sub returns the focused epoch record, not the head
+            fallback. Distinct `:epoch-id`s in the pair payload pin
+            the contract tighter than the composite test above."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [pair-1 (h/read-sub :rf.causa/views-focused-cascade-pair)]
+      (is (= :e1 (get-in pair-1 [:current :epoch-id]))
+          "focus on :c1 → current cascade is :e1")
+      (h/focus-cascade! :c2)
+      (let [pair-2 (h/read-sub :rf.causa/views-focused-cascade-pair)]
+        (is (= :e2 (get-in pair-2 [:current :epoch-id])))
+        (is (not= (:current pair-1) (:current pair-2))
+            "focused-cascade-pair re-fired with the new current
+             cascade")))))
+
+(deftest views-data-renders-payload-tracks-focus-flip
+  (testing "rf2-dhoc9 — the Views panel renders the focused cascade's
+            `:renders` vector. Asserting on the projected output
+            confirms the sub chain to the panel's render-time surface
+            tracks focus, not just the composite map identity."
+    (h/setup-causa-frame!)
+    (h/seed-cascades! cascades)
+    (h/seed-epoch-history! epoch-history)
+    (h/focus-cascade! :c1)
+    (let [pair-1 (h/read-sub :rf.causa/views-focused-cascade-pair)]
+      (is (= [{:render-key [:counter/badge :tok-A]
+               :elapsed-ms 3}]
+             (:renders (:current pair-1)))
+          "focus on :c1 → :renders payload is :tok-A")
+      (h/focus-cascade! :c2)
+      (let [pair-2 (h/read-sub :rf.causa/views-focused-cascade-pair)]
+        (is (= [{:render-key [:counter/badge :tok-B]
+                 :elapsed-ms 5}]
+               (:renders (:current pair-2)))
+            "focus on :c2 → :renders payload is :tok-B (NOT :tok-A —
+             would indicate the sub returned a stale cached value)")))))

--- a/tools/causa/test/day8/re_frame2_causa/test_helpers/sub_reactivity.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/test_helpers/sub_reactivity.cljs
@@ -1,0 +1,300 @@
+(ns day8.re-frame2-causa.test-helpers.sub-reactivity
+  "Sub-reactivity test helper for Causa panels (rf2-dhoc9).
+
+  ## Why this exists
+
+  Every Causa bug Mike caught live this session — rf2-70tkv App-db panel
+  frozen, rf2-2f8jv Machines empty, rf2-dodq2 Views Group-By stuck,
+  rf2-hwuki machine transitions silently dropped — is a sub-chain
+  reactivity bug. They show up in Playwright after a serve+navigate
+  cycle (minutes per repro). The same bugs are testable in millis via
+  CLJS unit tests: spin up the `:rf/causa` frame, install Causa, drive
+  a synthetic cascade through the test seams, read the panel's primary
+  sub, mutate focus, re-read, assert reactivity.
+
+  This ns is the canonical entry point for that pattern. The
+  `setup-causa-frame!` and `seed-cascades!` shapes mirror what the
+  rf2-70tkv worker wrote inline in `spine_cljs_test.cljs`; we lift them
+  so per-panel reactivity tests stay 50-LoC files instead of recopying
+  the fixture rig.
+
+  ## Existing test seams this composes on top of
+
+  - `:rf.causa/sync-trace-buffer` — wholesale overwrite of the
+    `:trace-buffer` slot (registry.cljs). The `seed-cascades!` helper
+    builds the minimal trace-event shape `group-cascades` needs so
+    the `:rf.causa/cascades` sub re-projects to the requested cascade
+    vector.
+
+  - `:rf.causa/sync-epoch-history` — wholesale overwrite of the
+    `:epoch-history` slot (epoch.cljs). Lets a test hand-construct the
+    per-epoch record shape App-db Diff / Views / Machine Inspector
+    consume.
+
+  - `:rf.causa/set-epoch-history-for-test` + `:rf.causa/set-focus-
+    epoch-id-for-test` — Machine Inspector's surgical test seams
+    (machine_inspector.cljs). Equivalent to `sync-epoch-history` for
+    the slot write but bypass the schema-frame-tag normalisation that
+    `sync-epoch-history` runs.
+
+  - `:rf.causa/focus-cascade` — the canonical focus-mutation event. The
+    spine's `focus-cascade-reducer` writes through to both
+    `[:focus :dispatch-id]` and `[:focus :epoch-id]`, so any panel
+    pivoting on either axis re-fires.
+
+  ## Canonical use
+
+      (deftest app-db-panel-tracks-focus
+        (with-causa-frame
+          (seed-cascades! [(cascade :c1 :rf/default)
+                           (cascade :c2 :rf/default)])
+          (seed-epoch-history!
+            [(mock-epoch :e1 :c1 {} {:counter 1})
+             (mock-epoch :e2 :c2 {:counter 1} {:counter 2})])
+          ;; First focus: epoch :e1.
+          (rf/with-frame :rf/causa
+            (rf/dispatch-sync [:rf.causa/focus-cascade :c1 :rf/default]))
+          (let [sig-1 (read-sub :rf.causa/selected-epoch-diff)]
+            ;; Mutate focus to :e2.
+            (rf/with-frame :rf/causa
+              (rf/dispatch-sync [:rf.causa/focus-cascade :c2 :rf/default]))
+            (let [sig-2 (read-sub :rf.causa/selected-epoch-diff)]
+              (is (not= sig-1 sig-2)
+                  \"App-db sub did not track focused-event flip\")))))
+
+  ## What the helper does NOT do
+
+  - It does NOT touch source. Any failing test points at a production
+    bug — file a follow-on bead per the rf2-dhoc9 acceptance contract.
+  - It does NOT mount the React tree. The point of this layer is to
+    exercise the sub-chain reactivity at the data layer; view rendering
+    is the next tier up (browser Playwright or hiccup-walk tests)."
+  (:require [cljs.test :refer-macros [use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- per-test reset -----------------------------------------------------
+
+(defn causa-init!
+  "Reset every Causa idempotency sentinel + clear the trace-bus atom so
+  the next register-causa-handlers! call wires a fresh registrar. Test-
+  only — never call from production code.
+
+  Mirrors the init-fn the existing app_db_diff_cljs_test.cljs corpus
+  uses; lifted into this helper ns so per-panel reactivity tests share
+  one canonical reset shape."
+  []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(def fixture
+  "`use-fixtures :each` value for sub-reactivity tests. Wires
+  test-support/reset-runtime-fixture with the plain-atom adapter and
+  the Causa init-fn. Usage:
+
+      (use-fixtures :each h/fixture)"
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- frame setup --------------------------------------------------------
+
+(defn setup-causa-frame!
+  "Register Causa's full handler graph + create the `:rf/causa` frame.
+  Idempotent within a single test (the registry's defonce sentinel
+  short-circuits the second call; the frame registrar replaces in
+  place).
+
+  Also registers the host `:rf/default` frame so panels that resolve
+  `:rf.causa/target-frame-db` (App-db diff) find a real frame rather
+  than nil."
+  []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  (frame/reg-frame :rf/default {}))
+
+;; ---- cascade + epoch fixtures -------------------------------------------
+
+(defn cascade
+  "Build a minimal cascade shape — enough for `group-cascades`'
+  frame-index pairing. Per `re-frame.trace.projection/group-cascades`
+  the projector needs at least `:dispatch-id` + `:frame` per trace
+  event; the cascade record's shape below is what `seed-cascades!`
+  re-projects into when it builds the trace buffer.
+
+  Mirrors `cascade` in `spine_cljs_test.cljs` — lifted here so per-panel
+  tests don't reach into a sibling test ns."
+  [dispatch-id frame-id]
+  {:dispatch-id dispatch-id
+   :frame       frame-id
+   :event       nil
+   :handler     nil
+   :fx          nil
+   :effects     []
+   :subs        []
+   :renders     []
+   :other       []})
+
+(defn seed-cascades!
+  "Seed the `:rf/causa` frame's `:trace-buffer` slot with a minimal
+  trace-event vector that re-projects to `cascades-vec` via the
+  `:rf.causa/cascades` sub.
+
+  Each entry in `cascades-vec` is a cascade record (typically built via
+  `cascade`). The function constructs ONE `:event/dispatched` event per
+  cascade with the cascade's `:dispatch-id` and `:frame` tags so
+  `projection/group-cascades` pairs the right events.
+
+  Mirrors `seed-cascades!` in `spine_cljs_test.cljs`."
+  [cascades-vec]
+  (let [events (map-indexed
+                 (fn [i {:keys [dispatch-id frame]}]
+                   {:id        (inc i)
+                    :op-type   :event
+                    :operation :event/dispatched
+                    :tags      {:dispatch-id dispatch-id
+                                :frame       frame
+                                :event       [(keyword "evt"
+                                                       (str (name dispatch-id)))]}})
+                 cascades-vec)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer (vec events)]))))
+
+(defn mock-epoch
+  "Build a minimal `:rf/epoch-record` carrying the slots App-db Diff /
+  Views / Machine Inspector subs read.
+
+  Args:
+    `epoch-id`    — the per-frame primary key
+    `dispatch-id` — the cascade-id this epoch settles for
+    `db-before`   — `:db-before` slot (the App-db Diff walker reads it)
+    `db-after`    — `:db-after` slot (same)
+
+  Optional opts map:
+    `:trace-events`  — vector of trace events (Machine Inspector reads
+                        `:rf.machine/transition` entries here). Defaults
+                        to a single `:event/dispatched` event.
+    `:frame`         — the epoch's frame. Defaults to `:rf/default`.
+    `:event-id`      — the trigger event id. Defaults to the
+                        dispatch-id keyword.
+    `:trigger-event` — the trigger event vector. Defaults to
+                        `[<event-id>]`."
+  ([epoch-id dispatch-id db-before db-after]
+   (mock-epoch epoch-id dispatch-id db-before db-after {}))
+  ([epoch-id dispatch-id db-before db-after
+    {:keys [trace-events frame event-id trigger-event]
+     :or   {frame :rf/default}}]
+   (let [eid (or event-id dispatch-id)
+         ev  (or trigger-event [eid])]
+     {:epoch-id      epoch-id
+      :dispatch-id   dispatch-id
+      :frame         frame
+      :committed-at  0
+      :event-id      eid
+      :trigger-event ev
+      :db-before     db-before
+      :db-after      db-after
+      :trace-events  (or trace-events
+                         [{:id        1
+                           :op-type   :event
+                           :operation :event/dispatched
+                           :tags      {:dispatch-id dispatch-id
+                                       :frame       frame
+                                       :event       ev}}])})))
+
+(defn machine-transition-event
+  "Build a `:rf.machine/transition` trace event for `mock-epoch`'s
+  `:trace-events` vector. Mirrors the shape `transition-record-from-
+  trace` walks in `machine_inspector_helpers.cljc`.
+
+  Args:
+    `id`         — monotonic event id (sort-key for cascade order)
+    `machine-id` — the registered machine keyword
+    `from-state` — the state before the transition
+    `to-state`   — the state after the transition
+    `event-v`    — the event vector that fired the transition
+
+  Optional opts map:
+    `:frame`       — the host frame the transition fired in. Defaults
+                      to `:rf/default`. Maps to the rf2-hwuki contract
+                      (epoch capture filters by frame tag).
+    `:dispatch-id` — the dispatch id the transition belongs to."
+  ([id machine-id from-state to-state event-v]
+   (machine-transition-event id machine-id from-state to-state event-v {}))
+  ([id machine-id from-state to-state event-v
+    {:keys [frame dispatch-id] :or {frame :rf/default}}]
+   {:id        id
+    :op-type   :machine
+    :operation :rf.machine/transition
+    :tags      (cond-> {:machine-id  machine-id
+                        :before      {:state from-state}
+                        :after       {:state to-state}
+                        :event       event-v
+                        :frame       frame}
+                 dispatch-id (assoc :dispatch-id dispatch-id))}))
+
+;; ---- direct slot seeders ------------------------------------------------
+
+(defn seed-epoch-history!
+  "Seed the `:rf/causa` frame's `:epoch-history` slot. The slot is
+  shared with `:rf.causa/sync-epoch-history` (the production path); the
+  helper routes through the same event so the test surface stays
+  consistent with what `mount.cljs/open!` does at first open."
+  [history]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/sync-epoch-history (vec history)])))
+
+;; ---- focus mutation -----------------------------------------------------
+
+(defn focus-cascade!
+  "Drive the canonical focus-mutation event. Wraps `rf/dispatch-sync`
+  in the `:rf/causa` frame so the spine sub picks up the change. The
+  spine's `focus-cascade-reducer` writes both `[:focus :dispatch-id]`
+  and `[:focus :epoch-id]` via the per-frame `:epoch-history` slot,
+  so panels pivoting on either axis re-fire.
+
+  Optional `frame-id` arg defaults to `:rf/default` — matches the
+  picker's seed selection."
+  ([dispatch-id]
+   (focus-cascade! dispatch-id :rf/default))
+  ([dispatch-id frame-id]
+   (rf/with-frame :rf/causa
+     (rf/dispatch-sync [:rf.causa/focus-cascade dispatch-id frame-id]))))
+
+(defn follow-head!
+  "Drive the canonical `:rf.causa/follow-head` event — flips focus
+  back to LIVE+head-tracking. Pairs with `focus-cascade!` for the
+  rf2-70tkv repro shape (pin → follow-head → arrival → auto-track)."
+  []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/follow-head])))
+
+(defn dispatch-causa!
+  "Generic dispatch helper for control-action tests — wraps `rf/
+  dispatch-sync` in the `:rf/causa` frame so the helper site stays at
+  one indentation level."
+  [event-v]
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync event-v)))
+
+;; ---- read helpers -------------------------------------------------------
+
+(defn read-sub
+  "Subscribe + deref inside `:rf/causa`. Returns the sub's current
+  value; the deref forces re-computation if the reactive graph has
+  invalidated since the last read.
+
+  Per re-frame's subscribe semantics the returned value is `=` to the
+  previous read iff the sub's inputs are unchanged — that's the
+  reactivity contract per-panel reactivity tests assert on."
+  ([sub-id]
+   (rf/with-frame :rf/causa
+     @(rf/subscribe [sub-id])))
+  ([sub-id & args]
+   (rf/with-frame :rf/causa
+     @(rf/subscribe (into [sub-id] args)))))


### PR DESCRIPTION
## Summary

Closes rf2-dhoc9. Adds a CLJS unit-test tier between the existing
pure-fn / hiccup-walk tests and browser Playwright — sub-chain
reactivity tests that catch the rf2-70tkv panel-refresh bug class in
milliseconds instead of minutes.

- **Helper module** at `tools/causa/test/day8/re_frame2_causa/test_helpers/sub_reactivity.cljs` — composes on existing `:rf.causa/sync-trace-buffer` / `:rf.causa/sync-epoch-history` / `:rf.causa/focus-cascade` test seams. No production-code changes.
- **Seven per-panel reactivity tests** (one per L4 tab) under `tools/causa/test/.../panels/reactivity/`.
- **Five per-control-action reactivity tests** mirroring rf2-rwhat Phase 3's browser flow at unit-test speed.

Total: 1 helper + 12 test files, ~1212 LoC, 35 new deftests, +99 assertions (3149 → 3248 tests; 9158 → 9337 assertions). Each test runs in single-digit ms.

## Bug classes this guards against

| Bug | Test that would have caught it |
|---|---|
| rf2-70tkv App-db Diff frozen | `app-db-diff-sub-re-fires-on-focus-flip` |
| rf2-2f8jv Machines empty | `machine-transitions-for-focused-event-tracks-focus-flip` |
| rf2-dodq2 Views Group-By stuck | `views-data-composite-tracks-group-by-change` |
| Mute → filtered-cascades not updating | `filtered-cascades-sub-tracks-mute` |

## Test plan

- [x] `npm run test:cljs` — 3248 tests / 9337 assertions / 0 failures / 0 errors
- [x] `npm run test:bundle-isolation` — no tool leakage into production bundles
- [x] Each new test runs in single-digit milliseconds (no fixture cleanup leak)
- [x] Branched off main; rebased onto latest (rf2-hwuki #1596 already merged so the machine-inspector test passes through real production-path data shape)

## Notes

The machine-inspector reactivity test bypasses any future framework-side capture-pipeline regressions by injecting synthetic `:trace-events` directly via the `:rf.causa/sync-epoch-history` test seam. Tests are independent of the rf2-hwuki framework-side fix; they assert the panel-side reactivity contract.

No follow-on beads filed — every panel's primary sub tracks focus correctly post-rf2-70tkv (which was the prerequisite). If a panel reactivity test fails on `main` in future, it's pointing at a production bug worth filing.

Companion findings doc: `ai/findings/2026-05-19-causa-unit-test-strategy.md` (local-only; not in this PR).