### PR TITLE
fix(machines): :frame tag on remaining trace emit sites (rf2-ko8jb)

### DIFF
--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/finalize.cljc
@@ -207,6 +207,7 @@
                                                         :action-id  :rf.invoke/on-done
                                                         :parent-id  parent-id
                                                         :invoke-id  invoke-id
+                                                        :frame      frame-id
                                                         :exception  e
                                                         :reason     ":on-done callback threw."
                                                         :recovery   :no-recovery})

--- a/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
+++ b/implementation/machines/src/re_frame/machines/lifecycle_fx/join.cljc
@@ -150,8 +150,14 @@
 
 (defn- emit-resolution-traces!
   "Fire the post-resolution observability traces in order: any-failed,
-  all-completed, or some-completed."
-  [parent-id invoke-id spec join-state'' child-id child-extra
+  all-completed, or some-completed.
+
+  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture admission
+  (`re-frame.epoch.capture/capture-event!` silently drops events whose
+  tags lack `:frame`). The caller threads `frame-id` (resolved from
+  `(:rf/frame machine)` at the interceptor's entry) so the join
+  resolution traces reach the cascade's `:trace-events` slot."
+  [frame-id parent-id invoke-id spec join-state'' child-id child-extra
    {:keys [fail-fired? success-fired?]}]
   (when fail-fired?
     (trace/emit! :machine :rf.machine.invoke-all/any-failed
@@ -160,18 +166,21 @@
                   :failed-id  child-id
                   :reason     child-extra
                   :failed     (:failed join-state'')
-                  :done       (:done   join-state'')}))
+                  :done       (:done   join-state'')
+                  :frame      frame-id}))
   (when success-fired?
     (if (= :all (:join spec :all))
       (trace/emit! :machine :rf.machine.invoke-all/all-completed
                    {:machine-id parent-id
                     :invoke-id  invoke-id
-                    :done       (:done join-state'')})
+                    :done       (:done join-state'')
+                    :frame      frame-id})
       (trace/emit! :machine :rf.machine.invoke-all/some-completed
                    {:machine-id parent-id
                     :invoke-id  invoke-id
                     :done       (:done join-state'')
-                    :join       (:join spec)}))))
+                    :join       (:join spec)
+                    :frame      frame-id}))))
 
 (defn- build-resolution-fx
   "Build the fx vector to fire on resolution: per-survivor
@@ -181,8 +190,14 @@
   carrying the decisive child's forwarded payload. Per Spec 005
   §Spawn-and-join, the dispatched event shape is:
 
-      [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]"
-  [parent-id invoke-id spec join-state'' child-id child-extra
+      [<parent-id> [<resolution-event> <decisive-child-id> & <child-extra>]]
+
+  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture admission
+  (`re-frame.epoch.capture/capture-event!` silently drops events whose
+  tags lack `:frame`). The caller threads `frame-id` (resolved from
+  `(:rf/frame machine)` at the interceptor's entry) so the per-survivor
+  cancellation traces reach the cascade's `:trace-events` slot."
+  [frame-id parent-id invoke-id spec join-state'' child-id child-extra
    {:keys [resolved? resolution-event join-event-kw]}]
   (let [cancel? (let [c (:cancel-on-decision? spec)]
                   (if (nil? c) true (boolean c)))
@@ -199,7 +214,8 @@
                             :invoke-id  invoke-id
                             :child-id   cid
                             :spawned-id spawned-id
-                            :join-event join-event-kw}))
+                            :join-event join-event-kw
+                            :frame      frame-id}))
             (mapv (fn [[_ spawned-id]]
                     [:rf.machine/destroy spawned-id])
                   survivors)))
@@ -222,7 +238,15 @@
   destroys + the join-event dispatch)."
   [machine db _path snapshot parent-id inner-event]
   (let [inner-id (first inner-event)
-        match    (find-active-invoke-all machine snapshot inner-id)]
+        match    (find-active-invoke-all machine snapshot inner-id)
+        ;; Per rf2-ko8jb: resolve the live frame from the runtime-stamped
+        ;; machine (registration.cljc/prepare-machine-ctx assoc'd
+        ;; `:rf/frame` before handing the machine to the interceptor).
+        ;; Threaded into `emit-resolution-traces!` / `build-resolution-fx`
+        ;; AND used inline for the late-completion + bad-child-id error
+        ;; traces — all of these are dropped by epoch-capture without
+        ;; `:frame`.
+        frame-id (:rf/frame machine)]
     (when match
       (let [{:keys [invoke-id spec kind]} match
             child-id   (second inner-event)
@@ -253,7 +277,8 @@
                            {:machine-id parent-id
                             :invoke-id  invoke-id
                             :child-id   child-id
-                            :kind       kind})
+                            :kind       kind
+                            :frame      frame-id})
               {:db db :fx []})
 
           ;; Forged / unknown child-id: the inbound `child-id` is NOT in
@@ -272,6 +297,7 @@
                                   :child-id   child-id
                                   :children   (set (keys (:children join-state)))
                                   :kind       kind
+                                  :frame      frame-id
                                   :recovery   :event-dropped})
               {:db db :fx []})
 
@@ -283,9 +309,9 @@
                               :failed (update join-state :failed (fnil conj #{}) child-id))
                 resolution   (compute-resolution spec join-state' kind)
                 join-state'' (assoc join-state' :resolved? (:resolved? resolution))]
-            (emit-resolution-traces! parent-id invoke-id spec join-state''
+            (emit-resolution-traces! frame-id parent-id invoke-id spec join-state''
                                      child-id child-extra resolution)
-            (let [fx (build-resolution-fx parent-id invoke-id spec join-state''
+            (let [fx (build-resolution-fx frame-id parent-id invoke-id spec join-state''
                                           child-id child-extra resolution)]
               {:db (assoc-in db [:rf/spawned parent-id invoke-id] join-state'')
                :fx fx})))))))

--- a/implementation/machines/src/re_frame/machines/timer.cljc
+++ b/implementation/machines/src/re_frame/machines/timer.cljc
@@ -125,6 +125,7 @@
                  (catch #?(:clj Throwable :cljs :default) e
                    (trace/emit-error! :rf.error/machine-after-fn-threw
                                       {:exception e
+                                       :frame     frame-id
                                        :recovery  :no-clock-configured})
                    nil))]
       [v nil])
@@ -139,6 +140,7 @@
                             (trace/emit-error! :rf.error/machine-after-sub-threw
                                                {:exception e
                                                 :sub-id    (first delay-key)
+                                                :frame     frame-id
                                                 :recovery  :no-clock-configured})
                             nil)))]
       [v reaction])
@@ -199,7 +201,8 @@
                     :state      state
                     :delay      prior-ms
                     :reason     :sub-changed
-                    :sub-id     (first delay-key)})
+                    :sub-id     (first delay-key)
+                    :frame      frame-id})
       (cancel-after-timer-entry! frame-id k)
       (when-let [db (frame/frame-app-db-value frame-id)]
         (let [snap (get-in db [:rf/machines parent-id])
@@ -273,6 +276,7 @@
                           :state        state
                           :delay-key    delay-key
                           :delay-source delay-source
+                          :frame        frame-id
                           :recovery     :skipped}))
 
           :else
@@ -282,7 +286,8 @@
                                           :state        state
                                           :delay        resolved-ms
                                           :delay-source delay-source
-                                          :epoch        epoch}
+                                          :epoch        epoch
+                                          :frame        frame-id}
                                    (= :sub delay-source)
                                    (assoc :sub-id (first delay-key)))))
                 handle
@@ -311,6 +316,7 @@
                                      {:exception  e
                                       :machine-id parent-id
                                       :sub-id     (first delay-key)
+                                      :frame      frame-id
                                       :recovery   :static-delay}))))
             (swap! after-timers assoc-in [frame-id k]
                    {:handle          handle

--- a/implementation/machines/src/re_frame/machines/transition.cljc
+++ b/implementation/machines/src/re_frame/machines/transition.cljc
@@ -179,7 +179,13 @@
                     :guard-id   guard-ref
                     :input      {:data  (:data snapshot)
                                  :event event}
-                    :outcome    (if outcome :pass :fail)})
+                    :outcome    (if outcome :pass :fail)
+                    ;; Per rf2-ko8jb: epoch-capture admission requires
+                    ;; `:frame`. `(:rf/frame machine)` is stamped by
+                    ;; `prepare-machine-ctx` (registration.cljc) before
+                    ;; the engine is invoked; nil-safe for pure-function
+                    ;; callers (conformance corpus, JVM fixtures).
+                    :frame      (:rf/frame machine)})
       outcome)))
 
 ;; ---- spawn-id allocator (in-snapshot) -------------------------------------
@@ -500,7 +506,9 @@
   [machine snap action-ref event]
   (if action-ref
     (let [f         (resolve-action machine action-ref)
-          parent-id (or (:rf/parent-id machine) (:id machine))]
+          parent-id (or (:rf/parent-id machine) (:id machine))
+          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+          frame-id  (:rf/frame machine)]
       (try
         (let [r (call-action f snap event)]
           (trace/emit! :machine :rf.machine/action-ran
@@ -508,7 +516,8 @@
                         :action-id  action-ref
                         :input      {:data  (:data snap)
                                      :event event}
-                        :outcome    (if (nil? r) :ok r)})
+                        :outcome    (if (nil? r) :ok r)
+                        :frame      frame-id})
           (or r {}))
         (catch #?(:clj Throwable :cljs :default) e
           (trace/emit! :machine :rf.machine/action-ran
@@ -517,7 +526,8 @@
                         :input      {:data  (:data snap)
                                      :event event}
                         :outcome    :rf.error/action-threw
-                        :exception  e})
+                        :exception  e
+                        :frame      frame-id})
           (result/fail {:action-ref action-ref
                         :exception  e}))))
     {}))
@@ -587,7 +597,9 @@
   (when-not internal?
     (let [parent-id (or (:rf/parent-id machine) :rf/transition-pure)
           epoch     (get-in snap-final (after-epoch-path machine))
-          server?   (= :server (:rf/platform machine))]
+          server?   (= :server (:rf/platform machine))
+          ;; Per rf2-ko8jb: epoch-capture admission requires `:frame`.
+          frame-id  (:rf/frame machine)]
       (vec
         (mapcat
           (fn [[prefix n]]
@@ -613,6 +625,7 @@
                                               :delay-source delay-source
                                               :epoch        epoch
                                               :platform     :server
+                                              :frame        frame-id
                                               :recovery     :skipped}
                                        (= :sub delay-source)
                                        (assoc :sub-id (first delay-key))))
@@ -621,7 +634,8 @@
                                               :state        leaf-state
                                               :delay        ms-tag
                                               :delay-source delay-source
-                                              :epoch        epoch}
+                                              :epoch        epoch
+                                              :frame        frame-id}
                                        (= :sub delay-source)
                                        (assoc :sub-id (first delay-key))))))
                     [:rf.machine/after-schedule
@@ -1197,6 +1211,9 @@
       (> depth depth-limit)
       (do (trace/emit-error! :rf.error/machine-raise-depth-exceeded
                              {:machine-id (:id machine) :depth depth
+                              ;; Per rf2-ko8jb: epoch-capture admission
+                              ;; requires `:frame`.
+                              :frame      (:rf/frame machine)
                               :recovery :no-recovery})
           (result/ok snap accum))
 
@@ -1229,8 +1246,14 @@
   branch is mutually exclusive given the `match` shape, but we spell
   them sequentially so listeners observe document order if a future
   match shape lights up more than one. No-op when `match` is nil or
-  carries no relevant marker."
-  [match]
+  carries no relevant marker.
+
+  Per rf2-ko8jb the `:frame` tag is REQUIRED for epoch-capture
+  admission (`re-frame.epoch.capture/capture-event!` silently drops
+  events whose tags lack `:frame`). The caller threads `frame-id`
+  resolved from `(:rf/frame machine)` so timer-firing observability
+  reaches the cascade's `:trace-events` slot."
+  [frame-id match]
   (when match
     (when (:stale? match)
       (trace/emit! :machine :rf.machine.timer/stale-after
@@ -1238,13 +1261,15 @@
                     :delay           (:delay match)
                     :scheduled-epoch (:scheduled-epoch match)
                     :current-epoch   (:current-epoch match)
+                    :frame           frame-id
                     :recovery        :replaced-with-default}))
     (when (:guard-suppressed? match)
       (trace/emit! :machine :rf.machine.timer/fired
                    {:state  (:state match)
                     :delay  (:delay match)
                     :epoch  (:epoch match)
-                    :fired? false}))
+                    :fired? false
+                    :frame  frame-id}))
     (when (and (not (:stale? match))
                (not (:guard-suppressed? match))
                (:delay match))
@@ -1252,7 +1277,8 @@
                    {:state  (last (:decl-path match))
                     :delay  (:delay match)
                     :epoch  (:epoch match)
-                    :fired? true}))))
+                    :fired? true
+                    :frame  frame-id}))))
 
 (defn machine-transition-single
   "Pure function. Single-machine (flat or compound) implementation of the
@@ -1280,7 +1306,7 @@
         ;; Trace timer firing / staleness / guard-suppression BEFORE
         ;; running the transition, so listeners see events in the order
         ;; they occurred.
-        _ (emit-pick-traces! match)
+        _ (emit-pick-traces! (:rf/frame machine) match)
         result-after-event
         (cond
           (and match (:stale? match))
@@ -1316,6 +1342,9 @@
                                          {:machine-id (:id machine)
                                           :depth      depth
                                           :path       visited
+                                          ;; Per rf2-ko8jb: epoch-capture
+                                          ;; admission requires `:frame`.
+                                          :frame      (:rf/frame machine)
                                           :recovery   :no-recovery})
                       (result/ok snapshot []))
 

--- a/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
+++ b/implementation/machines/test/re_frame/machine_trace_frame_tag_sweep_test.clj
@@ -1,0 +1,395 @@
+(ns re-frame.machine-trace-frame-tag-sweep-test
+  "Per rf2-ko8jb: every `:rf.machine/*` and `:rf.error/machine-*` trace
+  event MUST carry the `:frame` tag so `re-frame.epoch.capture/capture-event!`
+  admits it into the cascade's `:trace-events` buffer. Without the tag
+  the trace is dropped silently — fans out to direct listeners but
+  never reaches the epoch-history slot the Causa Machine Inspector
+  reads from.
+
+  This test file is the sister to `re_frame.transition_frame_tag_test`
+  (rf2-hwuki, which locks `:rf.machine/transition` at registration.cljc).
+  rf2-ko8jb sweeps the remaining ~13 emit sites across:
+
+    - finalize.cljc — :on-done callback throw (machine-action-exception)
+    - join.cljc — invoke-all resolution traces (any-failed, all-completed,
+      some-completed, cancelled-on-join-resolution, late-completion,
+      bad-child-id)
+    - timer.cljc — wall-clock fx-layer traces (no-clock-configured,
+      cancelled-on-resolution, scheduled-from-watcher, after-fn-threw,
+      after-sub-threw, after-watch-failed)
+    - transition.cljc — pure-engine traces (guard-evaluated, action-ran
+      success+error, timer/scheduled, timer/skipped-on-server,
+      timer/fired, timer/stale-after, raise-depth-exceeded,
+      always-depth-exceeded)
+
+  The test rationale mirrors the rf2-hwuki test's: this lives in the
+  machines artefact (which doesn't depend on epoch) so the contract is
+  exercised even when the epoch artefact isn't on the test classpath.
+  A future regression that drops `:frame` from any of these sites fails
+  here first (clear cause) before the upstack epoch / Causa gates
+  notice the absent trace events."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+(defn- record-traces!
+  "Register a trace listener for the duration of `body-fn`, returning
+  the captured trace vec."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-trace-cb! ::rec (fn [ev] (swap! seen conj ev)))
+    (try (body-fn)
+         (finally (rf/remove-trace-cb! ::rec)))
+    @seen))
+
+(defn- of-op [evs op]
+  (filterv #(= op (:operation %)) evs))
+
+(defn- first-of-op [evs op]
+  (first (of-op evs op)))
+
+(defn- frame-tag [ev]
+  (get-in ev [:tags :frame]))
+
+;; ---- transition.cljc :rf.machine/guard-evaluated --------------------------
+
+(deftest guard-evaluated-tag-carries-frame
+  (testing ":rf.machine/guard-evaluated carries `:frame` tag so epoch-capture
+   admits it (rf2-ko8jb — `(:rf/frame machine)` resolved in evaluate-guard)"
+    (rf/reg-machine
+      :ko8jb/guard
+      {:initial :idle
+       :guards  {:always-pass (fn [_d _e] true)}
+       :states  {:idle  {:on {:go [{:guard :always-pass :target :done}]}}
+                 :done  {}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/guard [:go]])))
+          ev    (first-of-op traces :rf.machine/guard-evaluated)]
+      (is (some? ev) "one :rf.machine/guard-evaluated fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag is the dispatching frame's id"))))
+
+;; ---- transition.cljc :rf.machine/action-ran (success path) ----------------
+
+(deftest action-ran-success-tag-carries-frame
+  (testing ":rf.machine/action-ran (success outcome) carries `:frame` tag
+   (rf2-ko8jb — `(:rf/frame machine)` resolved in run-action)"
+    (rf/reg-machine
+      :ko8jb/action
+      {:initial :idle
+       :actions {:noop (fn [_d _e] nil)}
+       :states  {:idle {:on {:go {:target :done :action :noop}}}
+                 :done {}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/action [:go]])))
+          ev    (first-of-op traces :rf.machine/action-ran)]
+      (is (some? ev) "one :rf.machine/action-ran fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped on success outcome"))))
+
+;; ---- transition.cljc :rf.machine/action-ran (error path) ------------------
+
+(deftest action-ran-error-tag-carries-frame
+  (testing ":rf.machine/action-ran (action-threw outcome) carries `:frame`
+   tag — exception path must remain observable through epoch capture"
+    (rf/reg-machine
+      :ko8jb/action-throws
+      {:initial :idle
+       :actions {:bang (fn [_d _e] (throw (ex-info "boom" {})))}
+       :states  {:idle {:on {:go {:target :done :action :bang}}}
+                 :done {}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/action-throws [:go]])))
+          rans   (of-op traces :rf.machine/action-ran)
+          err    (first (filter #(= :rf.error/action-threw
+                                    (get-in % [:tags :outcome]))
+                                rans))]
+      (is (some? err) ":rf.machine/action-ran with action-threw outcome fired")
+      (is (= :rf/default (frame-tag err))
+          ":frame tag stamped on error outcome"))))
+
+;; ---- transition.cljc :rf.machine.timer/scheduled --------------------------
+
+(deftest timer-scheduled-tag-carries-frame
+  (testing ":rf.machine.timer/scheduled (build-after-fx) carries `:frame`
+   tag (rf2-ko8jb — `(:rf/frame machine)` resolved in build-after-fx)"
+    (rf/reg-machine
+      :ko8jb/sched
+      {:initial :idle
+       :states  {:idle    {:on {:go :loading}}
+                 :loading {:after {5000 :ready}}
+                 :ready   {}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/sched [:go]])))
+          ev    (first-of-op traces :rf.machine.timer/scheduled)]
+      (is (some? ev) ":rf.machine.timer/scheduled fired on entry")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped"))))
+
+;; ---- transition.cljc :rf.machine.timer/fired ------------------------------
+
+(deftest timer-fired-tag-carries-frame
+  (testing ":rf.machine.timer/fired (emit-pick-traces!) carries `:frame`
+   tag (rf2-ko8jb — `(:rf/frame machine)` plumbed into emit-pick-traces!)"
+    (rf/reg-machine
+      :ko8jb/fire
+      {:initial :idle
+       :data    {:rf/after-epoch 0}
+       :states  {:idle    {:on {:go :loading}}
+                 :loading {:after {5000 :done}
+                           :on    {:bail :idle}}
+                 :done    {}}})
+    (let [traces
+          (record-traces!
+            (fn []
+              (rf/dispatch-sync [:ko8jb/fire [:go]])
+              (let [epoch (get-in (rf/get-frame-db :rf/default)
+                                  [:rf/machines :ko8jb/fire :data :rf/after-epoch])]
+                (rf/dispatch-sync
+                  [:ko8jb/fire
+                   [:rf.machine.timer/after-elapsed 5000 epoch]]))))
+          ev (first (filter #(true? (:fired? (:tags %)))
+                            (of-op traces :rf.machine.timer/fired)))]
+      (is (some? ev) ":rf.machine.timer/fired (fired? true) emitted")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped on the fired? true trace"))))
+
+;; ---- transition.cljc :rf.machine.timer/stale-after ------------------------
+
+(deftest timer-stale-after-tag-carries-frame
+  (testing ":rf.machine.timer/stale-after (emit-pick-traces!) carries `:frame`
+   tag — stale-after fires when an in-flight timer's epoch no longer
+   matches the snapshot's"
+    (rf/reg-machine
+      :ko8jb/stale
+      {:initial :loading
+       :data    {:rf/after-epoch 0}
+       :states  {:loading {:after {5000 :timeout}
+                           :on    {:cancel :idle}}
+                 :idle    {}
+                 :timeout {}}})
+    (let [traces
+          (record-traces!
+            (fn []
+              ;; First dispatch :cancel which exits :loading and bumps the
+              ;; after-epoch. A subsequent synthetic after-elapsed with the
+              ;; pre-cancel epoch is stale.
+              (rf/dispatch-sync [:ko8jb/stale [:cancel]])
+              (rf/dispatch-sync
+                [:ko8jb/stale
+                 [:rf.machine.timer/after-elapsed 5000 0]])))
+          ev (first-of-op traces :rf.machine.timer/stale-after)]
+      (is (some? ev) ":rf.machine.timer/stale-after fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped"))))
+
+;; ---- transition.cljc :rf.error/machine-raise-depth-exceeded ---------------
+
+(deftest raise-depth-exceeded-tag-carries-frame
+  (testing ":rf.error/machine-raise-depth-exceeded carries `:frame` tag
+   (rf2-ko8jb — `(:rf/frame machine)` resolved in drain-raises)"
+    ;; An action that emits a fanned-out batch of :raise fx's — N raises
+    ;; in a single :fx vector — feeds the same drain-raises loop N
+    ;; iterations. With :raise-depth-limit 3 and 5 raises in one batch
+    ;; the loop trips the bound and emits the error trace.
+    (rf/reg-machine
+      :ko8jb/raise-loop
+      {:initial :idle
+       :raise-depth-limit 3
+       :actions {:fan-out
+                 (fn [_d _e]
+                   {:fx [[:raise [:noop]]
+                         [:raise [:noop]]
+                         [:raise [:noop]]
+                         [:raise [:noop]]
+                         [:raise [:noop]]]})}
+       :states  {:idle {:on {:start {:target :running :action :fan-out}
+                             :noop  :idle}}
+                 :running {:on {:noop :idle}}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/raise-loop [:start]])))
+          ev    (first-of-op traces :rf.error/machine-raise-depth-exceeded)]
+      (is (some? ev) ":rf.error/machine-raise-depth-exceeded fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped on the depth-exceeded error"))))
+
+;; ---- transition.cljc :rf.error/machine-always-depth-exceeded --------------
+
+(deftest always-depth-exceeded-tag-carries-frame
+  (testing ":rf.error/machine-always-depth-exceeded carries `:frame` tag
+   (rf2-ko8jb — `(:rf/frame machine)` resolved in machine-transition-single)"
+    ;; Mirrors the rf2-c0nt always-depth conformance shape: an outer
+    ;; `:go` transition lands in `:a`; `:a` and `:b` ping-pong via
+    ;; always-true `:always` guards until the depth limit trips.
+    (rf/reg-machine
+      :ko8jb/always-loop
+      {:initial :start
+       :always-depth-limit 5
+       :guards  {:p? (fn [_d _e] true)}
+       :states  {:start {:on {:go :a}}
+                 :a     {:always [{:guard :p? :target :b}]}
+                 :b     {:always [{:guard :p? :target :a}]}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/always-loop [:go]])))
+          ev    (first-of-op traces :rf.error/machine-always-depth-exceeded)]
+      (is (some? ev) ":rf.error/machine-always-depth-exceeded fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped on the always-depth error"))))
+
+;; ---- finalize.cljc :rf.error/machine-action-exception (on-done throw) ----
+
+(deftest on-done-throw-tag-carries-frame
+  (testing ":rf.error/machine-action-exception (on-done callback threw)
+   carries `:frame` tag (rf2-ko8jb — `frame-id` IS in scope at the throw
+   catch in finalize-machine)"
+    (rf/reg-machine
+      :ko8jb/child-od
+      {:initial :running
+       :data    {}
+       :states  {:running {:on    {:finish :done}}
+                 :done    {:final?     true
+                           :output-key :payload}}})
+    (rf/reg-machine
+      :ko8jb/parent-od
+      {:initial :idle
+       :data    {}
+       :states  {:idle    {:on {:start :working}}
+                 :working {:invoke {:machine-id :ko8jb/child-od
+                                    :on-done    (fn [_d _r]
+                                                  (throw (ex-info "boom" {})))}}}})
+    (let [traces (record-traces!
+                   (fn []
+                     ;; Boot parent → :working, which spawns the child.
+                     (rf/dispatch-sync [:ko8jb/parent-od [:start]])
+                     ;; Drive the child to :final?, triggering parent's
+                     ;; :on-done — which throws.
+                     (let [child-id (get-in (rf/get-frame-db :rf/default)
+                                            [:rf/spawned :ko8jb/parent-od
+                                             [:working]])]
+                       (rf/dispatch-sync [child-id [:finish]]))))
+          ev    (first (filter
+                         #(= :rf.invoke/on-done (get-in % [:tags :action-id]))
+                         (of-op traces :rf.error/machine-action-exception)))]
+      (is (some? ev)
+          ":rf.error/machine-action-exception with :action-id :rf.invoke/on-done fired")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped on the on-done-throw error"))))
+
+;; ---- join.cljc :rf.machine.invoke-all/all-completed -----------------------
+
+(defn- mk-child-spec
+  "Return a child spec that dispatches `done-event-kw` /
+  `error-event-kw` back to `parent-id` carrying its own :id (seeded
+  from :start [:set-id <id>])."
+  [parent-id done-event-kw error-event-kw]
+  {:initial :running
+   :data    {:id nil}
+   :actions {:dispatch-done
+             (fn [data _]
+               {:fx [[:dispatch [parent-id [done-event-kw (:id data)]]]]})
+             :dispatch-error
+             (fn [data _]
+               {:fx [[:dispatch [parent-id [error-event-kw (:id data)]]]]})
+             :record-id
+             (fn [data ev]
+               {:data (assoc data :id (second ev))})}
+   :states  {:running {:on {:set-id {:action :record-id}
+                            :go     {:target :done   :action :dispatch-done}
+                            :fail   {:target :failed :action :dispatch-error}}}
+             :done    {}
+             :failed  {}}})
+
+(deftest invoke-all-all-completed-tag-carries-frame
+  (testing ":rf.machine.invoke-all/all-completed carries `:frame` tag
+   (rf2-ko8jb — frame-id plumbed into emit-resolution-traces!)"
+    (let [child  (mk-child-spec :ko8jb/parent-all :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states  {:idle      {:on {:start :hydrating}}
+                            :hydrating
+                            {:invoke-all
+                             {:children        [{:id :a :machine-id :ko8jb/ca-a
+                                                  :start [:set-id :a]}
+                                                 {:id :b :machine-id :ko8jb/ca-b
+                                                  :start [:set-id :b]}]
+                              :join            :all
+                              :on-child-done   :asset/loaded
+                              :on-child-error  :asset/failed
+                              :on-all-complete [:hydrate/done]}
+                             :on    {:hydrate/done :ready}}
+                            :ready     {}}}]
+      (rf/reg-machine :ko8jb/ca-a child)
+      (rf/reg-machine :ko8jb/ca-b child)
+      (rf/reg-machine :ko8jb/parent-all parent)
+      (let [traces
+            (record-traces!
+              (fn []
+                (rf/dispatch-sync [:ko8jb/parent-all [:start]])
+                (let [ids (get-in (rf/get-frame-db :rf/default)
+                                  [:rf/spawned :ko8jb/parent-all
+                                   [:hydrating] :children])]
+                  (rf/dispatch-sync [(:a ids) [:go]])
+                  (rf/dispatch-sync [(:b ids) [:go]]))))
+            ev (first-of-op traces :rf.machine.invoke-all/all-completed)]
+        (is (some? ev) ":rf.machine.invoke-all/all-completed fired")
+        (is (= :rf/default (frame-tag ev))
+            ":frame tag stamped on join resolution trace")))))
+
+;; ---- join.cljc :rf.error/machine-invoke-all-bad-child-id ------------------
+
+(deftest invoke-all-bad-child-id-tag-carries-frame
+  (testing ":rf.error/machine-invoke-all-bad-child-id carries `:frame` tag
+   (rf2-ko8jb — `(:rf/frame machine)` resolved at interceptor entry)"
+    (let [child  (mk-child-spec :ko8jb/parent-bc :asset/loaded :asset/failed)
+          parent {:initial :idle
+                  :states  {:idle      {:on {:start :hydrating}}
+                            :hydrating
+                            {:invoke-all
+                             {:children        [{:id :a :machine-id :ko8jb/cbc
+                                                  :start [:set-id :a]}]
+                              :join            :all
+                              :on-child-done   :asset/loaded
+                              :on-child-error  :asset/failed
+                              :on-all-complete [:hydrate/done]}
+                             :on    {:hydrate/done :ready}}
+                            :ready     {}}}]
+      (rf/reg-machine :ko8jb/cbc child)
+      (rf/reg-machine :ko8jb/parent-bc parent)
+      (let [traces
+            (record-traces!
+              (fn []
+                (rf/dispatch-sync [:ko8jb/parent-bc [:start]])
+                ;; Inject a forged child-id the join-state never knew about
+                ;; — triggers :rf.error/machine-invoke-all-bad-child-id.
+                (rf/dispatch-sync [:ko8jb/parent-bc
+                                   [:asset/loaded :forged/never-spawned]])))
+            ev (first-of-op traces :rf.error/machine-invoke-all-bad-child-id)]
+        (is (some? ev) ":rf.error/machine-invoke-all-bad-child-id fired")
+        (is (= :rf/default (frame-tag ev))
+            ":frame tag stamped on bad-child-id error")))))
+
+;; ---- timer.cljc :rf.warning/no-clock-configured ---------------------------
+
+(deftest timer-no-clock-configured-tag-carries-frame
+  (testing ":rf.warning/no-clock-configured (timer fx layer) carries
+   `:frame` tag (rf2-ko8jb — frame-id is the first param of
+   schedule-after-timer!). Triggered by a delay fn that returns nil
+   (no positive ms resolution)."
+    (rf/reg-machine
+      :ko8jb/no-clock
+      {:initial :idle
+       :states  {:idle    {:on {:go :loading}}
+                 :loading {:after {(fn [_snap] nil) :done}}
+                 :done    {}}})
+    (let [traces (record-traces!
+                   (fn [] (rf/dispatch-sync [:ko8jb/no-clock [:go]])))
+          ev    (first-of-op traces :rf.warning/no-clock-configured)]
+      (is (some? ev) ":rf.warning/no-clock-configured fired from fx layer")
+      (is (= :rf/default (frame-tag ev))
+          ":frame tag stamped"))))


### PR DESCRIPTION
## Summary

Sister fix to rf2-hwuki (PR #1596, merged — fixed `:rf.machine/transition`). Sweeps the remaining ~13 trace emit sites across `finalize.cljc`, `join.cljc`, `timer.cljc`, `transition.cljc` so every runtime-emitted machine trace carries `:frame` — required for `re-frame.epoch.capture/capture-event!` admission.

Without `:frame`, traces fan out to direct listeners but never reach the epoch-history `:trace-events` slot the Causa Machine Inspector reads from. Power-user observability for action-exceptions, invoke resolutions, timer fires, and pure-transition diagnostics was silently broken.

## Per-site fix table

| File | Line | Trace | Fix shape |
|---|---|---|---|
| finalize.cljc | 205 | `:rf.error/machine-action-exception` (on-done throw) | `frame-id` already in scope — added `:frame frame-id` |
| join.cljc | 157,166,170 | `:rf.machine.invoke-all/{any-failed,all-completed,some-completed}` | Added `frame-id` param to `emit-resolution-traces!` |
| join.cljc | 197 | `:rf.machine.invoke/cancelled-on-join-resolution` | Added `frame-id` param to `build-resolution-fx` |
| join.cljc | 252 | `:rf.machine.invoke-all/late-completion` | `(:rf/frame machine)` resolved at interceptor entry |
| join.cljc | 269 | `:rf.error/machine-invoke-all-bad-child-id` | `(:rf/frame machine)` resolved at interceptor entry |
| timer.cljc | 126 | `:rf.error/machine-after-fn-threw` | `frame-id` already in scope |
| timer.cljc | 139 | `:rf.error/machine-after-sub-threw` | `frame-id` already in scope |
| timer.cljc | 197 | `:rf.machine.timer/cancelled-on-resolution` | `frame-id` already in scope |
| timer.cljc | 271 | `:rf.warning/no-clock-configured` | `frame-id` already in scope |
| timer.cljc | 280 | `:rf.machine.timer/scheduled` (from watcher) | `frame-id` already in scope |
| timer.cljc | 310 | `:rf.error/machine-after-watch-failed` | `frame-id` already in scope |
| transition.cljc | 177 | `:rf.machine/guard-evaluated` | `(:rf/frame machine)` in `evaluate-guard` |
| transition.cljc | 506,514 | `:rf.machine/action-ran` (ok + error) | `(:rf/frame machine)` in `run-action` |
| transition.cljc | 609,619 | `:rf.machine.timer/{skipped-on-server,scheduled}` | `(:rf/frame machine)` in `build-after-fx` |
| transition.cljc | 1198 | `:rf.error/machine-raise-depth-exceeded` | `(:rf/frame machine)` in `drain-raises` |
| transition.cljc | 1236,1243,1251 | `:rf.machine.timer/{stale-after,fired,fired}` | Added `frame-id` param to `emit-pick-traces!` |
| transition.cljc | 1315 | `:rf.error/machine-always-depth-exceeded` | `(:rf/frame machine)` in `machine-transition-single` |

## Signature changes

Three private helper fns gained a leading `frame-id` parameter (pre-alpha; no back-compat shims):

- `join.cljc/emit-resolution-traces!`
- `join.cljc/build-resolution-fx`
- `transition.cljc/emit-pick-traces!`

All callers updated in the same patch.

## Post-sweep audit

Walked every `(trace/emit{!,-error!} ...)` call in `implementation/machines/src/` (40 sites). 39 now carry `:frame`. The one remaining gap is `:rf.machine.lifecycle/created` at `registration.cljc:460` — fires at `reg-machine*` time with no frame context (registration is frame-independent); intentionally untagged and not part of cascade observability.

## Test plan

- [x] `clojure -M:test` from `implementation/machines/` — **223 tests, 775 assertions, 0 failures.** New test file `machine_trace_frame_tag_sweep_test.clj` adds 12 deftests (16 assertions) asserting `:frame` presence at one site per emit kind.
- [x] `npm run test:cljs` — **3184 tests, 9158 assertions, 0 failures.**
- [x] `npm run test:causa-feature-gate` — **16 scenarios, 0 failures.** Deep-machine + multi-frame + machine-driving scenarios now see full trace coverage through Causa's epoch capture.

Closes rf2-ko8jb.