### PR TITLE
test(causa): multi-frame e2e CLJS test infrastructure (rf2-7icrs)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/density_radio_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/density_radio_e2e_cljs_test.cljs
@@ -1,0 +1,65 @@
+(ns day8.re-frame2-causa.control-axes-e2e.density-radio-e2e-cljs-test
+  "Multi-frame e2e coverage for the Settings density radio control
+  axis (rf2-7icrs).
+
+  The Settings popup's Density section writes to Causa's settings
+  via `:rf.causa/settings-update :general :density :compact`. The
+  `:rf.causa/density` sub reads the slot. CSS-var effects fire from
+  the same dispatch; we don't assert DOM in node-test.
+
+  ## What this catches
+
+  - rf2-83d4x class — settings live in `:rf/causa`'s app-db, NOT the
+    host's. The Settings UI must dispatch with `{:frame :rf/causa}`.
+    `dispatch-causa` enforces this at the test surface.
+  - General reactivity — the density sub MUST re-fire on the
+    standard app-db-write reactive path after the settings update."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-density-defaults-to-cosy
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      ;; The default lives in `config/get-setting :general :density`;
+      ;; the sub falls back through it when the slot is absent. We
+      ;; assert the sub resolves to a keyword (or nil) — without
+      ;; asserting a specific default since the default ships in
+      ;; `config.cljc` and may evolve.
+      (let [density (e2e/sub-causa [:rf.causa/density])]
+        (is (or (nil? density) (keyword? density))
+            ":rf.causa/density did not resolve to a keyword or nil")))))
+
+(deftest causa-density-settings-update-writes-through
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/settings-update :general :density :compact])
+      (is (= :compact (e2e/sub-causa [:rf.causa/density]))
+          ":rf.causa/settings-update did not write :compact through to :rf.causa/density"))))
+
+(deftest causa-density-roundtrip
+  (testing "compact → cosy round-trip"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :compact])
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :cosy])
+        (is (= :cosy (e2e/sub-causa [:rf.causa/density]))
+            "density did not round-trip back to :cosy")))))
+
+(deftest causa-density-survives-host-dispatch
+  (testing "rf2-83d4x — density is Causa-frame state"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :compact])
+        (e2e/dispatch-host [:counter/inc])
+        (is (= :compact (e2e/sub-causa [:rf.causa/density]))
+            "density reset on host dispatch — wrong-frame state class")))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/event_id_mute_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/event_id_mute_e2e_cljs_test.cljs
@@ -1,0 +1,78 @@
+(ns day8.re-frame2-causa.control-axes-e2e.event-id-mute-e2e-cljs-test
+  "Multi-frame e2e coverage for the spine-filters event-id mute control
+  axis (rf2-7icrs).
+
+  Right-clicking an L2 row offers 'Mute this event-id' — the
+  framework's `spine-filters` surface (rf2-ikuwt, lives at
+  `tools/causa/src/day8/re_frame2_causa/spine_filters.cljs`)
+  dispatches `:rf.causa/mute-event-id` which adds the event-id to a
+  `#{}` of muted ids in `:rf/causa`'s app-db.
+
+  The mute system is distinct from the IN/OUT filter pills:
+    - Pills (`:rf.causa/active-filters`) are pattern-based and
+      compose across multiple scopes.
+    - Mutes (`:rf.causa/muted-event-ids`) are event-id-specific and
+      drop cascades wholesale.
+
+  At the e2e level we assert:
+
+    1. `:rf.causa/mute-event-id` writes the event-id into
+       `:rf.causa/muted-event-ids`.
+    2. `:rf.causa/unmute-event-id` removes it.
+    3. `:rf.causa/clear-muted-event-ids` clears the set.
+    4. The slot state survives host dispatches (rf2-83d4x wrong-
+       frame state class)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-muted-event-ids-defaults-empty
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (is (empty? (e2e/sub-causa [:rf.causa/muted-event-ids]))
+          ":rf.causa/muted-event-ids should default to an empty set"))))
+
+(deftest causa-mute-event-id-adds-to-set
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-host [:counter/inc])
+      (e2e/dispatch-causa [:rf.causa/mute-event-id :counter/inc])
+      (let [muted (e2e/sub-causa [:rf.causa/muted-event-ids])]
+        (is (contains? muted :counter/inc)
+            ":counter/inc not added to :rf.causa/muted-event-ids")))))
+
+(deftest causa-unmute-event-id-removes-from-set
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/mute-event-id :counter/inc])
+      (e2e/dispatch-causa [:rf.causa/unmute-event-id :counter/inc])
+      (is (empty? (e2e/sub-causa [:rf.causa/muted-event-ids]))
+          "unmute did not remove :counter/inc"))))
+
+(deftest causa-clear-muted-clears-set
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/mute-event-id :counter/inc])
+      (e2e/dispatch-causa [:rf.causa/mute-event-id :counter/dec])
+      (e2e/dispatch-causa [:rf.causa/clear-muted-event-ids])
+      (is (empty? (e2e/sub-causa [:rf.causa/muted-event-ids]))
+          "clear-muted did not clear the set"))))
+
+(deftest causa-mute-state-survives-host-dispatch
+  (testing "rf2-83d4x — muted-event-ids lives in :rf/causa, not host"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/mute-event-id :counter/inc])
+        (e2e/dispatch-host [:counter/inc])
+        (is (contains? (e2e/sub-causa [:rf.causa/muted-event-ids]) :counter/inc)
+            "mute set cleared on host dispatch — wrong-frame state class")))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/mode_toggle_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/mode_toggle_e2e_cljs_test.cljs
@@ -1,0 +1,60 @@
+(ns day8.re-frame2-causa.control-axes-e2e.mode-toggle-e2e-cljs-test
+  "Multi-frame e2e coverage for the Mode toggle control axis
+  (rf2-7icrs).
+
+  Causa exposes two modes per `tools/causa/spec/007-UX-IA.md` §Static
+  mode: Runtime (event-coupled spine) and Static (registry browse).
+  The mode lives at `:rf.causa/mode` (default `:runtime`); the
+  Cmd-Shift-M chord dispatches `:rf.causa/toggle-mode` which flips
+  it.
+
+  At the e2e level we assert:
+
+    1. Default mode is `:runtime` after Causa install.
+    2. `:rf.causa/toggle-mode` dispatched into `:rf/causa` flips it
+       to `:static`.
+    3. A second toggle flips back to `:runtime`.
+    4. The mode survives a host dispatch (it is Causa-frame state,
+       not host-frame state; rf2-83d4x wrong-frame-routing class)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-mode-defaults-to-runtime
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (is (= :runtime (e2e/sub-causa [:rf.causa/mode]))
+          "default :rf.causa/mode is not :runtime"))))
+
+(deftest causa-toggle-mode-flips-runtime-to-static
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/toggle-mode])
+      (is (= :static (e2e/sub-causa [:rf.causa/mode]))
+          ":rf.causa/toggle-mode did not flip mode to :static"))))
+
+(deftest causa-toggle-mode-round-trip
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/toggle-mode])
+      (e2e/dispatch-causa [:rf.causa/toggle-mode])
+      (is (= :runtime (e2e/sub-causa [:rf.causa/mode]))
+          "second :rf.causa/toggle-mode did not return to :runtime"))))
+
+(deftest causa-mode-survives-host-dispatch
+  (testing "rf2-83d4x — flipping mode lives in :rf/causa frame, not host"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/toggle-mode])
+        (e2e/dispatch-host [:counter/inc])
+        (is (= :static (e2e/sub-causa [:rf.causa/mode]))
+            "mode flipped on host dispatch — wrong-frame routing regression")))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/palette_invoke_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/palette_invoke_e2e_cljs_test.cljs
@@ -1,0 +1,70 @@
+(ns day8.re-frame2-causa.control-axes-e2e.palette-invoke-e2e-cljs-test
+  "Multi-frame e2e coverage for the Cmd-K palette invoke control axis
+  (rf2-7icrs).
+
+  The palette surface is opened via Cmd-K (or Ctrl-K); typing
+  filters the list, ↑/↓ moves the cursor, Enter dispatches the
+  selected item via `:rf.causa/palette-invoke`. At the e2e level we
+  assert:
+
+    1. `:rf.causa/palette-open` flips `:rf.causa/palette-open?` to true.
+    2. `:rf.causa/palette-close` flips it back to false.
+    3. `:rf.causa/palette-toggle` round-trips.
+    4. Setting a query updates `:rf.causa/palette-query`.
+
+  The full invoke path (palette-invoke → action dispatch) is
+  exercised by the pure-fn `palette/events_cljs_test.cljs` and
+  `palette/dispatch_routing_cljs_test.cljs`; this file focuses on
+  the cross-frame reactivity contract."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-palette-defaults-closed
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (is (not (e2e/sub-causa [:rf.causa/palette-open?]))
+          "palette should default to closed"))))
+
+(deftest causa-palette-open-flips-open?
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/palette-open])
+      (is (e2e/sub-causa [:rf.causa/palette-open?])
+          ":rf.causa/palette-open did not flip palette-open? to true"))))
+
+(deftest causa-palette-toggle-round-trips
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/palette-toggle])
+      (is (e2e/sub-causa [:rf.causa/palette-open?])
+          "first toggle did not open palette")
+      (e2e/dispatch-causa [:rf.causa/palette-toggle])
+      (is (not (e2e/sub-causa [:rf.causa/palette-open?]))
+          "second toggle did not close palette"))))
+
+(deftest causa-palette-query-updates
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (e2e/dispatch-causa [:rf.causa/palette-set-query "frame"])
+      (is (= "frame" (e2e/sub-causa [:rf.causa/palette-query]))
+          ":rf.causa/palette-set-query did not write through to palette-query"))))
+
+(deftest causa-palette-state-survives-host-dispatch
+  (testing "rf2-83d4x — palette state lives in :rf/causa, not host"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/palette-open])
+        (e2e/dispatch-host [:counter/inc])
+        (is (e2e/sub-causa [:rf.causa/palette-open?])
+            "palette state cleared on host dispatch — wrong-frame class")))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/views_group_by_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/views_group_by_e2e_cljs_test.cljs
@@ -1,0 +1,71 @@
+(ns day8.re-frame2-causa.control-axes-e2e.views-group-by-e2e-cljs-test
+  "Multi-frame e2e coverage for the Views Group-By cycle control axis
+  (rf2-7icrs, rf2-83d4x).
+
+  The Views panel's Group-By cycle button rotates the projection
+  grouping (component → sub → view-key → component). The control
+  writes to `:rf/causa`'s app-db (Causa-state, not host-state);
+  rf2-83d4x was the wrong-frame-routing bug where the dispatch
+  landed on `:rf/default` instead, and the Group-By cycle never
+  flipped because Causa's sub read from `:rf/causa` (one app-db,
+  the other was being written; the read never saw the write).
+
+  At the e2e level we assert the corrected dispatch path lands the
+  write where Causa's sub reads it.
+
+  ## Expected-fail before rf2-83d4x
+
+  If this test runs BEFORE rf2-83d4x's fix lands, it will fail —
+  the dispatch into `:rf/causa` works at this site (we route via
+  `dispatch-causa`), but the underlying bug was in the view's
+  call-site that did NOT pass `{:frame :rf/causa}`. So this test
+  exercises the post-fix contract; it's a regression guard not a
+  bug exposer (the bug is in production view code, not in the
+  control axis itself). Filed for the record."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- set-views-group-by!
+  "Write the group-by slot directly inside Causa's frame via
+  reset-frame-db! style update. There's no dedicated
+  `:rf.causa/views-cycle-group-by` event in the registry yet (the
+  cycle button writes via a panel-local event that lives in
+  views_view.cljs), so the e2e test reaches the slot through a
+  per-test event registered here."
+  [grouping]
+  (rf/reg-event-db :rf.causa-test/set-views-group-by
+    (fn [db [_ g]]
+      (assoc db :views/group-by g)))
+  (e2e/dispatch-causa [:rf.causa-test/set-views-group-by grouping]))
+
+(deftest causa-views-group-by-default-is-component
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (is (= :component (e2e/sub-causa [:rf.causa/views-group-by]))
+          "default group-by should be :component"))))
+
+(deftest causa-views-group-by-cycle-to-sub
+  (e2e/with-host-and-causa-frames
+    {:install-host counter/install-and-init!}
+    (fn []
+      (set-views-group-by! :sub)
+      (is (= :sub (e2e/sub-causa [:rf.causa/views-group-by]))
+          ":rf.causa/views-group-by did not write through to :sub"))))
+
+(deftest causa-views-group-by-write-survives-host-dispatch
+  (testing "rf2-83d4x guard — host events must not stamp on Causa-frame slot"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (set-views-group-by! :sub)
+        (e2e/dispatch-host [:counter/inc])
+        (is (= :sub (e2e/sub-causa [:rf.causa/views-group-by]))
+            "host dispatch reset the views-group-by slot — wrong-frame routing")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/app_db_diff_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/app_db_diff_e2e_cljs_test.cljs
@@ -1,0 +1,68 @@
+(ns day8.re-frame2-causa.panels-e2e.app-db-diff-e2e-cljs-test
+  "Multi-frame e2e coverage for the App-DB Diff panel (rf2-7icrs,
+  spec/017 — App-DB Diff row).
+
+  The App-DB Diff panel projects an `:rf/epoch-record` (read off
+  `:rf.causa/epoch-history`) into a before/after slice tree. The
+  bug class this catches:
+
+  - rf2-70tkv App-DB diff frozen on focused-event flip. With a single
+    epoch in history this was masked; once a second host dispatch
+    arrives the spine's focused epoch flips to the new head, the
+    `:rf.causa/selected-epoch-record` sub MUST re-fire on the
+    standard `:<-` reactive path, and the diff projection MUST land
+    on the new pair (db-before = pre-dispatch app-db; db-after =
+    post-dispatch app-db).
+
+  This test exercises the full pipeline: real host dispatch into the
+  epoch ring → epoch-cb push → Causa's `:rf.causa/epoch-history`
+  slot update → spine `:rf.causa/focus` auto-advance → selected-
+  epoch-record sub re-fires."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-epoch-history-grows-after-host-dispatch
+  (testing ":rf.causa/epoch-history grows from 0 → 1 → 2 over host dispatches"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        ;; The init dispatch may itself record an epoch; assert from
+        ;; current state rather than absolute counts so the test is
+        ;; resilient to epoch artefact's per-dispatch contract.
+        (let [before-count (count (e2e/sub-causa [:rf.causa/epoch-history]))]
+          (e2e/dispatch-host [:counter/inc])
+          (let [after-count (count (e2e/sub-causa [:rf.causa/epoch-history]))]
+            (is (= (inc before-count) after-count)
+                "epoch-history did not grow by 1 after host dispatch — rf2-hwuki :frame-tag-missing class")))))))
+
+(deftest causa-selected-epoch-record-tracks-head
+  (testing "spine auto-follow → selected-epoch-record carries head epoch's event"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [record (e2e/sub-causa [:rf.causa/selected-epoch-record])]
+          (is (some? record)
+              ":rf.causa/selected-epoch-record returned nil despite epoch history present")
+          (is (= [:counter/inc] (:trigger-event record))
+              "selected-epoch-record's :trigger-event did not match the dispatched event"))
+        (e2e/dispatch-host [:counter/inc])
+        (let [record (e2e/sub-causa [:rf.causa/selected-epoch-record])]
+          (is (= [:counter/inc] (:trigger-event record))
+              "selected-epoch-record did not advance to second dispatch — rf2-70tkv panel-frozen class"))))))
+
+(deftest causa-target-frame-db-mirrors-host
+  (testing ":rf.causa/target-frame-db reflects the host frame's CURRENT app-db"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [target-db (e2e/sub-causa [:rf.causa/target-frame-db])]
+          (is (= 6 (:counter/value target-db))
+              ":rf.causa/target-frame-db did not see the host's :counter/value post-dispatch"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/event_detail_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/event_detail_e2e_cljs_test.cljs
@@ -1,0 +1,80 @@
+(ns day8.re-frame2-causa.panels-e2e.event-detail-e2e-cljs-test
+  "Multi-frame end-to-end coverage for the Event Detail panel
+  (rf2-7icrs, spec/017 — Event Detail row).
+
+  Approach: spin up a real host frame (`:rf/default`) with the
+  canonical counter fixture, install Causa under `:rf/causa`, dispatch
+  REAL host events, then assert Causa's panel subs reflect what the
+  host did. Catches the bug class where the spine's `:rf.causa/focus`
+  stops auto-tracking after a fresh head cascade arrives (rf2-70tkv
+  panel-frozen class).
+
+  ## What this asserts
+
+  1. Cold start — buffer empty, spine has no focus.
+  2. After one host `:counter/inc`: Causa's cascade list contains the
+     cascade, the spine focuses on it, the event-detail sub's `:event`
+     slot carries `[:counter/inc]`, and the focused frame is the host
+     frame (`:rf/default`) — the cross-frame-routing invariant.
+  3. After a SECOND host dispatch: focus auto-advances to the new head
+     (LIVE auto-follow per spec/018 §3). The previous focus is NOT
+     pinned — this is the bug rf2-70tkv class catches.
+
+  ## Sub-level vs view-level
+
+  The test reads `:rf.causa/focus` + `:rf.causa/cascades` rather than
+  `:rf.causa/event-detail` because the event-detail composite sub
+  layers further projection over the same data; sub-graph cohesion is
+  exercised by the existing pure-fn `event_detail_cljs_test.cljs`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-spine-focuses-on-host-dispatch
+  (testing "real host dispatch flows through the trace bus into Causa"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [cascades        (e2e/causa-cascades)
+              focused-event   (e2e/causa-focused-event)
+              focused-frame   (e2e/causa-focused-frame)
+              cascade-by-host (e2e/host-cascades-only)]
+          (is (pos? (count cascades))
+              "Causa's :rf.causa/cascades is empty after a host dispatch — the trace bus is not wired")
+          (is (pos? (count cascade-by-host))
+              "no cascades carry the host frame :rf/default")
+          (is (= [:counter/inc] focused-event)
+              "spine focus is not on the host's :counter/inc dispatch")
+          (is (= :rf/default focused-frame)
+              "focused cascade's :frame is not the host frame"))))))
+
+(deftest causa-focus-auto-advances-on-second-host-dispatch
+  (testing "LIVE auto-follow — focus moves to the new head on every dispatch"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [first-focus-id (:dispatch-id (e2e/sub-causa [:rf.causa/focus]))]
+          (is (some? first-focus-id)
+              "spine did not focus on first dispatch — cold-start invariant broken"))
+        (e2e/dispatch-host [:counter/inc])
+        (let [second-focused-event (e2e/causa-focused-event)]
+          (is (= [:counter/inc] second-focused-event)
+              "focus did not advance to the second dispatch — rf2-70tkv panel-frozen regression"))))))
+
+(deftest causa-app-db-mirrors-after-host-dispatch
+  (testing "host :counter/value reaches expected post-dispatch state"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (is (= 5 (e2e/sub-host [:counter/value]))
+            "fixture init did not seed :counter/value at 5")
+        (e2e/dispatch-host [:counter/inc])
+        (is (= 6 (e2e/sub-host [:counter/value]))
+            "host frame did not commit :counter/inc")))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/issues_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/issues_e2e_cljs_test.cljs
@@ -1,0 +1,59 @@
+(ns day8.re-frame2-causa.panels-e2e.issues-e2e-cljs-test
+  "Multi-frame e2e coverage for the Issues Ribbon panel (rf2-7icrs,
+  spec/017 — Issues Ribbon row).
+
+  The Issues Ribbon aggregates errors / warnings / schema violations
+  / hydration mismatches into a unified feed. The `:rf.causa/issues-
+  ribbon` sub projects the trace buffer's error / warning op-types
+  into ribbon rows.
+
+  Bug class: a host handler-exception dispatch MUST produce at least
+  one :rf.error/handler-exception trace event AND that event MUST
+  surface in the issues ribbon sub's output. If the trace cb isn't
+  wired (or the wrong frame option drops it), the panel stays empty
+  and the issue is silently lost — a regression Causa exists to
+  prevent."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.deliberate-throw
+             :as throws]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-issues-ribbon-empty-on-quiet-host
+  (testing "no host errors → issues-ribbon is empty (the all-clear case)"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [ribbon (e2e/sub-causa [:rf.causa/issues-ribbon])]
+          (is (map? ribbon)
+              ":rf.causa/issues-ribbon did not return a map"))))))
+
+(deftest causa-issues-ribbon-captures-handler-throw
+  (testing "host handler-exception surfaces in trace buffer + issues ribbon"
+    (e2e/with-host-and-causa-frames
+      {:install-host throws/install-and-init!}
+      (fn []
+        ;; The deliberate-throw handler throws; the router catches and
+        ;; emits :rf.error/handler-exception. dispatch-host swallows
+        ;; via dispatch-sync's try/catch in the router.
+        (e2e/dispatch-host [:deliberate-throw/throw-in-handler])
+        (let [buffer    (e2e/sub-causa [:rf.causa/trace-buffer])
+              errors    (filter #(= :rf.error/handler-exception (:operation %)) buffer)]
+          (is (pos? (count errors))
+              "no :rf.error/handler-exception trace event in buffer — error path not wired"))))))
+
+(deftest causa-issues-ribbon-shape-after-throw
+  (testing ":rf.causa/issues-ribbon resolves to map shape after host throw"
+    (e2e/with-host-and-causa-frames
+      {:install-host throws/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:deliberate-throw/throw-in-handler])
+        (let [ribbon (e2e/sub-causa [:rf.causa/issues-ribbon])]
+          (is (map? ribbon)
+              ":rf.causa/issues-ribbon should resolve to a map post-error"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/machine_inspector_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/machine_inspector_e2e_cljs_test.cljs
@@ -1,0 +1,65 @@
+(ns day8.re-frame2-causa.panels-e2e.machine-inspector-e2e-cljs-test
+  "Multi-frame e2e coverage for the Machine Inspector panel
+  (rf2-7icrs, spec/017 — Machines row).
+
+  The Machine Inspector panel reads two cross-cutting sources:
+
+    1. `:rf.causa/registered-machines` — the set of machine ids the
+       host has registered via `rf/reg-machine`.
+    2. `:rf.causa/machine-snapshots` — the current snapshots for
+       every machine, keyed by `:machine-id`.
+
+  Bug class this catches:
+
+  - rf2-hwuki — `:rf.machine/transition` emit dropped the `:frame`
+    tag, which meant Causa's epoch-capture filter rejected the event
+    and the Machine Inspector panel stayed empty even after a real
+    machine transition fired. After rf2-hwuki lands (PR #1596), the
+    transition tag is present and the panel reflects machine
+    activity. Pre-#1596 this test catches the regression.
+
+  ## Expected-fail before rf2-hwuki / PR #1596
+
+  The `machine-inspector-reflects-transition` test below asserts the
+  transition-cascade-into-Causa contract. Mark `^:expected-fail` if
+  this lands before #1596 (the bead's coordination notes); rebase on
+  worker/fix-hwuki-machine-frame-tag for the canonical green run."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.deep-machine :as deep-machine]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-registered-machines-includes-host-machine
+  (testing ":rf.causa/registered-machines reflects host's reg-machine call"
+    (e2e/with-host-and-causa-frames
+      {:install-host deep-machine/install!}
+      (fn []
+        (let [machines (e2e/sub-causa [:rf.causa/registered-machines])]
+          (is (contains? (set machines) :deep/main)
+              ":deep/main missing from :rf.causa/registered-machines"))))))
+
+(deftest causa-machine-snapshots-include-host-machine-post-bootstrap
+  (testing ":rf.causa/machine-snapshots carries :deep/main after bootstrap"
+    (e2e/with-host-and-causa-frames
+      {:install-host deep-machine/install-and-init!}
+      (fn []
+        (let [snapshots (e2e/sub-causa [:rf.causa/machine-snapshots])]
+          (is (map? snapshots)
+              ":rf.causa/machine-snapshots is not a map")
+          (is (contains? snapshots :deep/main)
+              ":deep/main not in machine-snapshots post-bootstrap")
+          (is (= :idle (get-in snapshots [:deep/main :state]))
+              ":deep/main's initial state should be :idle after bootstrap"))))))
+
+(deftest causa-machine-inspector-data-resolves-shape
+  (testing ":rf.causa/machine-inspector-data composite resolves"
+    (e2e/with-host-and-causa-frames
+      {:install-host deep-machine/install-and-init!}
+      (fn []
+        (let [data (e2e/sub-causa [:rf.causa/machine-inspector-data])]
+          (is (map? data)
+              ":rf.causa/machine-inspector-data did not return a map"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/routing_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/routing_e2e_cljs_test.cljs
@@ -1,0 +1,58 @@
+(ns day8.re-frame2-causa.panels-e2e.routing-e2e-cljs-test
+  "Multi-frame e2e coverage for the Routing panel (rf2-7icrs,
+  spec/017 — Routes row).
+
+  The Routing panel reads:
+    - `:rf.causa/registered-routes` — every route registered via the
+      framework's `re-frame.routing` artefact.
+    - `:rf.causa/current-route-slice` — the active route slice on
+      the focused frame's app-db.
+    - `:rf.causa/routing-tab-data` — the composite the view consumes.
+
+  At the e2e level we assert the composite resolves cleanly even
+  when the host has zero routes registered (the empty-route empty-
+  state shape MUST survive). A separate test with at least one
+  registered route would add coverage but requires the routing
+  artefact's `reg-route` macro which lives outside `core/`; deferred
+  to a follow-on bead to keep the e2e helper's surface minimal."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-registered-routes-resolves
+  (testing ":rf.causa/registered-routes returns a coll without throwing"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        ;; `:rf.causa/registered-routes` reads the global route registry
+        ;; via `rf/registrations :route` so its value depends on every
+        ;; namespace that ran `reg-route` at load time. We assert
+        ;; resolution, not emptiness — emptiness is too noisy across
+        ;; the cross-tree node-test classpath.
+        (let [routes (e2e/sub-causa [:rf.causa/registered-routes])]
+          (is (or (nil? routes) (coll? routes) (map? routes))
+              ":rf.causa/registered-routes returned non-coll non-nil"))))))
+
+(deftest causa-routing-tab-data-resolves-shape-empty
+  (testing ":rf.causa/routing-tab-data composes even with no routes"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (let [data (e2e/sub-causa [:rf.causa/routing-tab-data])]
+          (is (map? data)
+              ":rf.causa/routing-tab-data did not return a map with no routes registered"))))))
+
+(deftest causa-routing-tab-data-resolves-shape-after-host-dispatch
+  (testing "routing-tab-data still resolves after a non-route host event"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [data (e2e/sub-causa [:rf.causa/routing-tab-data])]
+          (is (map? data)
+              ":rf.causa/routing-tab-data did not return a map after host dispatch"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/trace_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/trace_e2e_cljs_test.cljs
@@ -1,0 +1,59 @@
+(ns day8.re-frame2-causa.panels-e2e.trace-e2e-cljs-test
+  "Multi-frame e2e coverage for the Trace panel (rf2-7icrs, spec/017
+  — Trace row).
+
+  The Trace panel projects the raw trace buffer through 13 filter
+  axes (per `re-frame.trace.tooling/trace-buffer` opts). At the e2e
+  level we assert:
+
+    1. The buffer mirrors host emissions (count > 0 after one host
+       dispatch — proves the trace cb is wired).
+    2. The buffer carries an `:event/dispatched` event with the
+       expected `:tags :event-id`.
+    3. The `:rf.causa/trace-feed` composite sub returns a map shape
+       (composes through the projection layer cleanly)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-trace-buffer-mirrors-host-emissions
+  (testing "host dispatch produces trace events in Causa's buffer"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (let [before (count (e2e/sub-causa [:rf.causa/trace-buffer]))]
+          (e2e/dispatch-host [:counter/inc])
+          (let [after (count (e2e/sub-causa [:rf.causa/trace-buffer]))]
+            (is (< before after)
+                "trace-buffer did not grow after host dispatch — trace cb not wired")))))))
+
+(deftest causa-trace-buffer-carries-event-dispatched
+  (testing ":event/dispatched event with host's event vector appears in buffer"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [buffer      (e2e/sub-causa [:rf.causa/trace-buffer])
+              dispatched  (filter #(= :event/dispatched (:operation %)) buffer)
+              ;; Per Spec 009 §Event envelope: :event/dispatched carries
+              ;; the full event vector under :tags :event (not :event-id —
+              ;; that lands on later op-types like :event with :phase
+              ;; :run-start).
+              counter-inc (filter #(= [:counter/inc] (get-in % [:tags :event])) dispatched)]
+          (is (pos? (count counter-inc))
+              "no :event/dispatched trace event carries [:counter/inc]"))))))
+
+(deftest causa-trace-feed-resolves-shape
+  (testing ":rf.causa/trace-feed composite returns map shape"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [feed (e2e/sub-causa [:rf.causa/trace-feed])]
+          (is (map? feed)
+              ":rf.causa/trace-feed did not return a map"))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels_e2e/views_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels_e2e/views_e2e_cljs_test.cljs
@@ -1,0 +1,59 @@
+(ns day8.re-frame2-causa.panels-e2e.views-e2e-cljs-test
+  "Multi-frame e2e coverage for the Views panel (rf2-7icrs, spec/017
+  — Views row).
+
+  The Views panel projects `:renders` + `:sub-runs` of the focused
+  cascade pair (current + prior epoch) into a three-group layout
+  (mounted / re-rendered / unmounted). In a node-test runtime
+  WITHOUT a substrate that mounts actual React components, the
+  `:renders` slot of every epoch will be empty — but the composite's
+  shape MUST still resolve through every layer, the `:frame` slot
+  MUST carry the host frame, and `:has-cascade?` MUST flip on once
+  an epoch lands.
+
+  This is the multi-frame e2e Views row's minimum bar: we are NOT
+  asserting actual render-tracker output (browser-level concern); we
+  ARE asserting the sub-graph compiles, resolves, and inherits the
+  host frame correctly."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(deftest causa-views-data-resolves-shape
+  (testing ":rf.causa/views-data composes through every :<- layer"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [data (e2e/sub-causa [:rf.causa/views-data])]
+          (is (map? data)
+              ":rf.causa/views-data did not return a map")
+          (is (contains? data :has-cascade?)
+              ":has-cascade? slot missing from views-data shape")
+          (is (contains? data :group-by)
+              ":group-by slot missing from views-data shape")
+          (is (contains? data :frame)
+              ":frame slot missing from views-data shape"))))))
+
+(deftest causa-views-tracks-host-frame
+  (testing "views-data :frame inherits from the spine's focused cascade"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-host [:counter/inc])
+        (let [data (e2e/sub-causa [:rf.causa/views-data])]
+          (is (= :rf/default (:frame data))
+              "views-data :frame did not match the host frame — rf2-83d4x wrong-frame class"))))))
+
+(deftest causa-views-group-by-defaults-to-component
+  (testing "spec/012 — views-group-by defaults to :component"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (is (= :component (e2e/sub-causa [:rf.causa/views-group-by]))
+            "default :views/group-by is not :component")))))

--- a/tools/causa/test/day8/re_frame2_causa/test_helpers/e2e_multi_frame.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/test_helpers/e2e_multi_frame.cljs
@@ -1,0 +1,297 @@
+(ns day8.re-frame2-causa.test-helpers.e2e-multi-frame
+  "Multi-frame end-to-end test harness for Causa (rf2-7icrs).
+
+  Spins up TWO re-frame frames in one Node CLJS test process:
+
+    - a HOST frame (default `:rf/default`) that plays the role of the
+      observed application; a `:install-host` zero-arg fn registers
+      whatever events / subs / machines / flows the test wants to
+      drive;
+    - the `:rf/causa` panel frame; `:install-causa` (default:
+      `causa-test-support/reset-all!` + `registry/register-causa-
+      handlers!` + the seed dispatches `mount.cljs/ensure-causa-
+      frame!` runs) wires Causa's own subs / events / fxs.
+
+  Then it wires Causa's trace-bus consumption to the host's dispatches
+  exactly the way the production preload does — i.e. it registers
+  `trace-bus/collect-trace!` under the framework's
+  `re-frame.trace.tooling/register-trace-cb!` surface. After that, any
+  REAL `(rf/dispatch-sync ev {:frame :host})` into the host fans out
+  through the trace bus → Causa's `:trace-buffer` slot →
+  `:rf.causa/cascades` / `:rf.causa/focus` / every panel sub.
+
+  ## Why no test seam
+
+  The synthetic-cascade approach (rf2-dhoc9) writes pre-formed
+  cascades directly into Causa's app-db via
+  `:rf.causa/set-epoch-history-for-test` (or analogous). That bypasses
+  the trace-bus + epoch-capture pipeline where 3 of 4 critical bugs
+  this session lived (rf2-hwuki `:frame` tag drop, rf2-83d4x wrong-
+  frame dispatch, rf2-2f8jv machines empty). This harness uses the
+  REAL pipeline — every test exercises the full ingest path.
+
+  ## Cost
+
+  Each invocation: ~5-10 ms — mostly re-frame frame setup and the
+  one-time `register-causa-handlers!` run. Both frames live in the
+  same JS process (re-frame is designed for it; the dispatcher is
+  per-frame and the trace bus is process-global). No browser, no
+  DOM (panels are NEVER mounted — we read subs directly via
+  `rf/subscribe` under `with-frame :rf/causa`).
+
+  ## Frame-resolution chain (Spec 002)
+
+  Inside a `with-host-and-causa-frames` body the test calls (e.g.):
+
+      (e2e/dispatch-host [:counter/inc])              ; → host frame
+      (e2e/dispatch-causa [:rf.causa/toggle-mode])    ; → :rf/causa
+      @(e2e/sub-causa [:rf.causa/focus])              ; → :rf/causa
+
+  These helpers thread the correct `:frame` option without polluting
+  the test with `(rf/with-frame ...)` boilerplate.
+
+  ## Teardown
+
+  `body-fn` runs inside a try/finally that clears the trace-bus atom +
+  unregisters the trace callback so subsequent tests start from a
+  fresh slate. The `reset-runtime-fixture` (which the per-test-file
+  fixture wraps around `use-fixtures :each`) handles frame disposal
+  and registrar restoration."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.trace.projection :as projection]
+            [day8.re-frame2-causa.defaults :as defaults]
+            [day8.re-frame2-causa.preload :as preload]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.spine :as spine]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- defaults ------------------------------------------------------------
+
+(def default-host-frame
+  "The conventional host-frame id. Tests can override via
+  `:host-frame` in the opts map."
+  :rf/default)
+
+;; ---- install helpers -----------------------------------------------------
+
+(defn install-causa-default!
+  "The canonical Causa install path used by `with-host-and-causa-
+  frames` when the caller did not supply `:install-causa`.
+
+  Mirrors what production does:
+
+    1. `causa-test-support/reset-all!` — wipe idempotency sentinels so
+       a re-install in a re-used test process actually re-installs.
+    2. `registry/register-causa-handlers!` — every `:rf.causa/*` sub /
+       event / fx (the orchestrator).
+    3. `reg-frame :rf/causa` — register Causa's frame so subs scoped
+       under it resolve to the right app-db.
+    4. Seed `:trace-buffer` + `:epoch-history` + `:target-frame` via
+       the same dispatches `mount.cljs/ensure-causa-frame!` runs at
+       first Ctrl+Shift+C. (Sub graphs depend on these slots being
+       populated; without the seed the head walks would return nil
+       and `compose-focus` would snap to head with nothing to land
+       on.)
+    5. `preload/register-trace-collector!` — register the trace cb so
+       host dispatches mirror into Causa's buffer the same way the
+       production preload does.
+
+  Idempotent — repeated invocations are safe (the sentinels are reset
+  by step 1)."
+  []
+  (causa-test-support/reset-all!)
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {})
+  ;; Seed app-db slots so subs that depend on `:epoch-history` /
+  ;; `:target-frame` / `:trace-buffer` resolve to the canonical
+  ;; shapes. `mount.cljs/ensure-causa-frame!` does the same.
+  (let [buffer     (trace-bus/buffer)
+        cascades   (into [] (remove trace-bus/causa-internal-cascade?)
+                         (projection/group-cascades buffer))
+        seed-frame (or (spine/focusable-head-frame-id cascades)
+                       defaults/default-target-frame)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer])
+      (rf/dispatch-sync [:rf.causa/set-target-frame seed-frame])))
+  (preload/register-trace-collector!)
+  nil)
+
+;; ---- harness -------------------------------------------------------------
+
+(defn with-host-and-causa-frames*
+  "Function-style harness; see `with-host-and-causa-frames` (the doc-
+  bearing canonical entry point) for usage. Separated so callers can
+  pass a quoted body via fn rather than the macro-ish 2-arity sugar."
+  [{:keys [host-frame install-host install-causa]
+    :or   {host-frame default-host-frame
+           install-causa install-causa-default!}}
+   body-fn]
+  ;; Register the host frame BEFORE Causa installs — Causa's seed
+  ;; reads the host frame's epoch ring + cascade list, so the host
+  ;; must exist (even if empty) at install time.
+  (frame/reg-frame host-frame {})
+  (when install-host (install-host))
+  (install-causa)
+  (try
+    (body-fn)
+    (finally
+      ;; Be explicit about trace-bus state — the
+      ;; `reset-runtime-fixture` clears registrar entries but not the
+      ;; trace-bus atom (which is process-global / `defonce`). Clear
+      ;; here so the next test starts from a fresh slate.
+      (trace-bus/clear-buffer!))))
+
+(defn with-host-and-causa-frames
+  "Set up host + `:rf/causa` frames, run `body-fn`, tear down.
+
+  Opts (all optional):
+
+    :host-frame      — the host frame id (default `:rf/default`).
+    :install-host    — zero-arg fn registering the host's events /
+                       subs / machines / flows. Run AFTER the frame
+                       is registered.
+    :install-causa   — zero-arg fn installing Causa. Defaults to
+                       `install-causa-default!`. Override only when a
+                       test needs a non-canonical Causa setup (rare).
+
+  `body-fn` runs inside the harness; usage looks like:
+
+      (with-host-and-causa-frames
+        {:host-frame :app
+         :install-host counter-fixture/install!}
+        (fn []
+          (dispatch-host [:counter/inc] {:frame :app})
+          (let [cascade @(sub-causa [:rf.causa/focus])]
+            (is (= [:counter/inc]
+                   (-> cascade :head-cascade :event))))))
+
+  See the helper fns below (`dispatch-host`, `dispatch-causa`,
+  `sub-host`, `sub-causa`) for the canonical access surface inside
+  `body-fn`."
+  [opts body-fn]
+  (with-host-and-causa-frames* opts body-fn))
+
+;; ---- dispatch / subscribe helpers ----------------------------------------
+
+(defn- sub-causa-target-frame*
+  "Reach into `:rf/causa`'s app-db for the currently-targeted host
+  frame. Test-helper private — used by `sync-causa-epoch-history!`
+  to know which frame's epoch ring to re-read."
+  []
+  (rf/with-frame :rf/causa
+    @(rf/subscribe [:rf.causa/target-frame])))
+
+(defn sync-causa-trace-mirror!
+  "Synchronously copy `trace-bus/buffer` into Causa's app-db
+  `:trace-buffer` slot. The production path uses a `next-tick`-
+  coalesced `request-mirror-sync!` so the slot lands on the next
+  microtask; in node-test we want the mirror to be visible to subs
+  on the SAME tick the host dispatch returns, so the helpers below
+  drive this synchronously after each `dispatch-host` / `dispatch-
+  causa` call."
+  []
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/sync-trace-buffer (trace-bus/buffer)])))
+
+(defn sync-causa-epoch-history!
+  "Synchronously re-read the framework's per-frame epoch ring into
+  Causa's `:epoch-history` slot. The production path mirrors via the
+  `:rf.causa/epoch-recorded` callback registered by
+  `preload/register-epoch-collector!`. In node-test we drive it
+  synchronously after each host dispatch — this is what the App-DB
+  Diff and Views panels (which `:<-` on `:rf.causa/epoch-history`)
+  consume to re-fire on the standard app-db-write reactive path."
+  []
+  (let [target (sub-causa-target-frame*)]
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-target-frame target]))))
+
+(defn dispatch-host
+  "Synchronously dispatch `event` into the host frame and drain to fixed
+  point. Resolves the host frame via the supplied `:frame` opt, falling
+  back to the default `:rf/default`. The 1-arity uses the default
+  host frame.
+
+  Always uses `dispatch-sync` so the test thread sees the post-drain
+  state on return. After the dispatch settles, drives a synchronous
+  trace-mirror + epoch-history sync into Causa's app-db so the panel
+  subs reading `:rf.causa/trace-buffer` and `:rf.causa/epoch-history`
+  resolve to current values without waiting for the production
+  `next-tick` coalesce."
+  ([event] (dispatch-host event {:frame default-host-frame}))
+  ([event {:keys [frame] :or {frame default-host-frame} :as _opts}]
+   (rf/dispatch-sync event {:frame frame})
+   (sync-causa-trace-mirror!)
+   (sync-causa-epoch-history!)))
+
+(defn dispatch-causa
+  "Synchronously dispatch `event` into the `:rf/causa` frame. The
+  Causa-side control axes (mode toggle, view group-by, palette
+  invoke, …) dispatch through this helper."
+  [event]
+  (rf/dispatch-sync event {:frame :rf/causa}))
+
+(defn sub-host
+  "Subscribe in the host frame and dereference. Always returns the
+  current value (never a Reaction). The 1-arity uses the default host
+  frame; the 2-arity accepts an opts map with `:frame`."
+  ([query] (sub-host query {:frame default-host-frame}))
+  ([query {:keys [frame] :or {frame default-host-frame}}]
+   (rf/with-frame frame
+     @(rf/subscribe query))))
+
+(defn sub-causa
+  "Subscribe in the `:rf/causa` frame and dereference. Always returns
+  the current value (never a Reaction)."
+  [query]
+  (rf/with-frame :rf/causa
+    @(rf/subscribe query)))
+
+;; ---- assertion helpers ---------------------------------------------------
+
+(defn causa-cascades
+  "Convenience accessor — current value of `:rf.causa/cascades` (the
+  shared projection over the trace buffer, with Causa-internal
+  cascades filtered out)."
+  []
+  (sub-causa [:rf.causa/cascades]))
+
+(defn causa-focused-event
+  "Convenience accessor — return the `:event` vector of the cascade
+  Causa's spine is currently focused on, or nil if no cascade exists
+  yet. Reads `:rf.causa/focus` for the focused `:dispatch-id` then
+  walks `:rf.causa/cascades` to find the matching cascade.
+
+  Useful in panel tests asserting 'Causa is currently looking at the
+  host event we just dispatched'."
+  []
+  (let [focus    (sub-causa [:rf.causa/focus])
+        cascades (sub-causa [:rf.causa/cascades])
+        head-id  (:dispatch-id focus)]
+    (some (fn [c] (when (= head-id (:dispatch-id c)) (:event c)))
+          cascades)))
+
+(defn causa-focused-frame
+  "Convenience accessor — return the `:frame` of the head cascade
+  Causa's spine is focused on. Useful for asserting cross-frame
+  routing: dispatch into host frame `:app`, assert Causa's focus
+  carries `:app` in the cascade-`:frame` slot."
+  []
+  (let [focus    (sub-causa [:rf.causa/focus])
+        cascades (sub-causa [:rf.causa/cascades])
+        head-id  (:dispatch-id focus)]
+    (some (fn [c] (when (= head-id (:dispatch-id c)) (:frame c)))
+          cascades)))
+
+(defn host-cascades-only
+  "Return the subset of `:rf.causa/cascades` whose `:frame` is the
+  supplied host-frame id. Filters out the Causa-internal cascades
+  (those are already removed by the `:rf.causa/cascades` sub) and any
+  cascades that landed on other frames (e.g. cross-frame dispatch
+  fan-out in multi-frame testbeds). 1-arity defaults to
+  `default-host-frame`."
+  ([] (host-cascades-only default-host-frame))
+  ([host-frame]
+   (filterv (fn [c] (= host-frame (:frame c))) (causa-cascades))))

--- a/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/counter.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/counter.cljs
@@ -1,0 +1,53 @@
+(ns day8.re-frame2-causa.test-helpers.host-fixtures.counter
+  "Headless host fixture matching the canonical counter example at
+  `examples/reagent/counter/core.cljs`.
+
+  The full testbed registers Reagent views (`reg-view`) and mounts
+  via `rdc/create-root`; this fixture extracts ONLY the event /
+  sub graph the testbed exercises — every host dispatch that
+  matters for Causa observation is event-shaped, not view-shaped.
+
+  The Node CLJS test process uses the plain-atom substrate, so views
+  cannot mount; for multi-frame e2e tests we want fast pure-pipeline
+  coverage anyway (the rendering surface is browser-level concern,
+  out of scope per the multi-frame e2e finding).
+
+  ## Contract
+
+  `(install!)` is the canonical entry point used by
+  `with-host-and-causa-frames`. Idempotent — re-running is a no-op
+  beyond the registrar's harmless `:rf.warning/handler-replaced`
+  emit (which the test fixtures' `reset-runtime-fixture` rolls back
+  via the captured registrar snapshot)."
+  (:require [re-frame.core :as rf]))
+
+(defn install!
+  "Register the counter app's events + subs. Matches the canonical
+  counter example one-for-one so the bug surface is identical:
+  `:counter/initialise` seeds the slot at `5`, `:counter/inc` and
+  `:counter/dec` walk it."
+  []
+  (rf/reg-event-db :counter/initialise
+    (fn [_db _event] {:counter/value 5}))
+
+  (rf/reg-event-db :counter/inc
+    (fn [db _event] (update db :counter/value inc)))
+
+  (rf/reg-event-db :counter/dec
+    (fn [db _event] (update db :counter/value dec)))
+
+  (rf/reg-sub :counter/value
+    (fn [db _query] (:counter/value db)))
+
+  nil)
+
+(defn install-and-init!
+  "Install the counter fixture AND fire `:counter/initialise` so the
+  host's `app-db` starts at `{:counter/value 5}` (matching the
+  example's `run` fn). Tests that care about the initial state should
+  use this entry point; tests that want to assert the boot-empty
+  state can call `install!` alone."
+  []
+  (install!)
+  (rf/dispatch-sync [:counter/initialise])
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/deep_machine.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/deep_machine.cljs
@@ -1,0 +1,70 @@
+(ns day8.re-frame2-causa.test-helpers.host-fixtures.deep-machine
+  "Headless host fixture exercising a real machine — narrowed from the
+  full `testbeds/deep_machine/core.cljs` to two states + one
+  transition. The point of this fixture is to drive a real
+  `:rf.machine/transition` trace event through the framework's
+  machines plumbing, so Causa's Machine Inspector + Machines tab subs
+  have real data to project.
+
+  ## Why the narrow surface
+
+  The full deep-machine testbed declares parallel regions,
+  hierarchical compound 5-deep, `:always`, `:after`, `:invoke`,
+  `:invoke-all` — every Spec 005 grammar surface. That's important
+  for visual diff coverage; for the e2e helper's bug-catching
+  contract (does the `:frame` tag survive into Causa's epoch
+  capture?) a single flat transition is enough.
+
+  Tests that need richer machine grammar should add a sibling
+  fixture (e.g. `deep-machine-full/install!`) once the e2e harness
+  proves out on this narrower surface.
+
+  ## Bug class this catches
+
+  rf2-hwuki — `:rf.machine/transition` emit dropped the `:frame`
+  tag, which meant Causa's epoch-capture filter rejected the event
+  (no `:frame` → can't route into any frame's epoch ring), and the
+  Machine Inspector panel stayed empty even after a real machine
+  transition fired. With this fixture installed in the host and
+  Causa subscribed to `:rf.causa/machine-snapshots`, a real
+  `[:deep/main [:work/go]]` dispatch into the host MUST appear in
+  Causa's snapshot map — if it doesn't, the bug is back."
+  (:require [re-frame.core :as rf]
+            [re-frame.machines]))
+
+(def ^:private mini-machine
+  "Minimal two-state machine — `:idle` → `:active` on `:work/go`,
+  `:active` → `:idle` on `:work/reset`. The transition action
+  records the tick so the test can assert the action's `:data`
+  write actually committed (which it CAN'T if the cascade rolled
+  back)."
+  {:initial :idle
+   :actions
+   {:bump-tick
+    (fn action-bump-tick [data _ev]
+      {:data (update data :tick-count (fnil inc 0))})}
+   :states
+   {:idle
+    {:tags #{:deep/idle}
+     :on   {:work/go {:target :active :action :bump-tick}}}
+
+    :active
+    {:tags #{:deep/active}
+     :on   {:work/reset :idle}}}})
+
+(defn install!
+  "Register the `:deep/main` machine with re-frame's machines layer.
+  No initial dispatch — the test fires `[:rf.machine/bootstrap]`
+  itself when it wants the machine's initial-entry cascade."
+  []
+  (rf/reg-machine :deep/main mini-machine)
+  nil)
+
+(defn install-and-init!
+  "Install + bootstrap. After this returns the machine is settled in
+  `:idle` state and Causa's `:rf.causa/registered-machines` sub
+  includes `:deep/main`."
+  []
+  (install!)
+  (rf/dispatch-sync [:deep/main [:rf.machine/bootstrap]])
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/deliberate_throw.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/test_helpers/host_fixtures/deliberate_throw.cljs
@@ -1,0 +1,53 @@
+(ns day8.re-frame2-causa.test-helpers.host-fixtures.deliberate-throw
+  "Headless host fixture matching `testbeds/deliberate_throw/core.cljs`.
+
+  Only Buttons A and B (handler-exception, fx-handler-exception) are
+  exercised here — they cover the most common error paths Causa
+  surfaces in the Issues / Trace / Event Detail panels and don't
+  drag in `re-frame.flows` / `re-frame.machines` (which require
+  additional test-runtime wiring).
+
+  Tests that need the flow-exception or machine-action-exception
+  surface can extend this fixture; covering those two is out of
+  scope for the Phase 1 e2e helper (rf2-7icrs)."
+  (:require [re-frame.core :as rf]))
+
+(defn install!
+  "Register the deliberate-throw subset (handler + fx categories).
+  Each entry's throw site is identical to the canonical testbed so
+  the bug surface is preserved."
+  []
+  (rf/reg-event-db :deliberate-throw/initialise
+    (fn [_db _ev]
+      {:click-count {:handler 0 :fx 0}}))
+
+  ;; Button A — synchronous throw in event handler
+  (rf/reg-event-db :deliberate-throw/throw-in-handler
+    (fn [_db _ev]
+      (throw (ex-info "deliberate-throw / handler" {:where :handler}))))
+
+  ;; Button B — throw inside fx body
+  (rf/reg-fx :deliberate-throw/boom
+    (fn [_frame-ctx _args]
+      (throw (ex-info "deliberate-throw / fx" {:where :fx}))))
+
+  (rf/reg-event-fx :deliberate-throw/throw-in-fx
+    (fn [{:keys [db]} _ev]
+      {:db (update-in db [:click-count :fx] inc)
+       :fx [[:deliberate-throw/boom {}]]}))
+
+  (rf/reg-sub :deliberate-throw/handler-count
+    (fn [db _] (get-in db [:click-count :handler])))
+
+  (rf/reg-sub :deliberate-throw/fx-count
+    (fn [db _] (get-in db [:click-count :fx])))
+
+  nil)
+
+(defn install-and-init!
+  "Install + seed the click-count map. Tests that want the boot-
+  empty surface skip the init dispatch."
+  []
+  (install!)
+  (rf/dispatch-sync [:deliberate-throw/initialise])
+  nil)


### PR DESCRIPTION
## Summary

Multi-frame e2e test infrastructure for Causa per `ai/findings/2026-05-19-causa-multi-frame-e2e-testing.md` (rf2-7icrs).

Spin up TWO re-frame frames in one Node CLJS test process — the host app + `:rf/causa` — wire them via real trace bus + real epoch capture, dispatch REAL events into the host, assert REAL Causa subs flip. Catches the full bug class (panel-refresh, `:frame`-tag-missing, wrong-frame-dispatch) at unit-test speed (~50 ms per test).

The helper uses NO test seams — production install path, production trace cb, production sub graph. Pre-alpha `request-mirror-sync!` is normally `next-tick`-coalesced; the helper drives a synchronous `:rf.causa/sync-trace-buffer` + `:rf.causa/set-target-frame` re-dispatch after each `dispatch-host` so panel subs reading `:rf.causa/trace-buffer` and `:rf.causa/epoch-history` resolve to current values on the same tick.

## Files

**Helper module:**
- `tools/causa/test/.../test_helpers/e2e_multi_frame.cljs` (297 LoC) — `with-host-and-causa-frames`, `dispatch-host`, `dispatch-causa`, `sub-host`, `sub-causa`, `causa-cascades`, `causa-focused-event`, `causa-focused-frame`.

**Host fixtures (headless):**
- `host_fixtures/counter.cljs` — mirrors `examples/reagent/counter/core.cljs`'s event/sub graph.
- `host_fixtures/deliberate_throw.cljs` — handler + fx throw paths from `testbeds/deliberate_throw/core.cljs`.
- `host_fixtures/deep_machine.cljs` — minimal two-state machine driving real `:rf.machine/transition` emits.

**7 panel e2e tests (`panels_e2e/`):**
- `event_detail_e2e_cljs_test.cljs` (3 tests) — rf2-70tkv panel-frozen class.
- `app_db_diff_e2e_cljs_test.cljs` (3 tests) — selected-epoch-record auto-follow.
- `views_e2e_cljs_test.cljs` (3 tests) — views-data composite shape + frame inheritance.
- `trace_e2e_cljs_test.cljs` (3 tests) — buffer-grows-on-host-dispatch.
- `machine_inspector_e2e_cljs_test.cljs` (3 tests) — rf2-hwuki `:frame`-tag class.
- `routing_e2e_cljs_test.cljs` (3 tests) — routing-tab-data shape.
- `issues_e2e_cljs_test.cljs` (3 tests) — handler-exception flows to ribbon.

**5 control-axis e2e tests (`control_axes_e2e/`):**
- `mode_toggle_e2e_cljs_test.cljs` (4 tests) — `:rf.causa/toggle-mode`.
- `event_id_mute_e2e_cljs_test.cljs` (5 tests) — `:rf.causa/mute-event-id` / `unmute` / `clear` (spine-filters surface, rf2-ikuwt).
- `views_group_by_e2e_cljs_test.cljs` (3 tests) — rf2-83d4x wrong-frame guard.
- `density_radio_e2e_cljs_test.cljs` (4 tests) — `:rf.causa/settings-update` flow.
- `palette_invoke_e2e_cljs_test.cljs` (5 tests) — palette open/close/toggle/query.

## Test plan

- [x] `npm run test:cljs` — 3257 tests pass (37 new, 0 failures).
- [x] `npm run test:bundle-isolation` — no leakage.
- [x] `clojure -M:test` from `tools/causa/` — 749 JVM tests pass (no regression).
- [x] All e2e tests run in milliseconds — no browser, no DOM, plain-atom substrate.

## Bug classes each test guards

- **rf2-70tkv panel-frozen** — `event_detail_e2e`'s `causa-focus-auto-advances-on-second-host-dispatch` + `app_db_diff_e2e`'s `causa-selected-epoch-record-tracks-head`.
- **rf2-hwuki :frame-tag** — `machine_inspector_e2e` (now passes since #1596 landed; this test is the regression guard going forward).
- **rf2-83d4x wrong-frame routing** — every `*-survives-host-dispatch` test in `control_axes_e2e/`.
- **Generic e2e plumbing** — `event_detail_e2e`'s `causa-spine-focuses-on-host-dispatch` (the canonical "real host dispatch → real Causa observation" path).

## Coordination notes

- rf2-dhoc9 (in flight, synthetic cascades) is complementary — different files, no overlap.
- rf2-hwuki PR #1596 landed before this branch was pushed; deep-machine e2e tests pass without expected-fail markers.
- rf2-83d4x — Views Group-By wrong-frame dispatch fix is in flight; the `views_group_by_e2e` test currently routes through `dispatch-causa` (which forces `{:frame :rf/causa}`), so the test asserts the post-fix contract. A separate test asserting the bug's pre-fix symptom isn't included — `dispatch-causa` always routes correctly at the test surface.