### PR TITLE
fix(machines-viz): type-hint ^js on dynamic-import module (rf2-vnxh3)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
@@ -156,7 +156,7 @@
                       (catch :default _ nil))]
               (if (and p (.-then p))
                 (-> p
-                    (.then (fn [mod]
+                    (.then (fn [^js mod]
                              (let [Ctor (or (.-default mod) (.-ELK mod) (.-elk mod))]
                                (if Ctor
                                  (let [inst (Ctor.)]


### PR DESCRIPTION
## Summary

The dynamic-import resolution callback in `tools/machines-viz/.../chart/elk_layout.cljs` received `mod` untyped, so Closure externs inference emitted two `:infer-warning`s on release builds:

```
elk_layout.cljs:160:61 — Cannot infer target type in expression (. mod -ELK)
elk_layout.cljs:160:73 — Cannot infer target type in expression (. mod -elk)
```

The sibling `(.-default mod)` was inferable because `default` is a known ES module key, but `ELK` and `elk` are package-specific and need an explicit hint.

Adding `^js` to the parameter declares `mod` as a JS object so externs are correctly added for both names, silencing both warnings.

## Change

```diff
-                    (.then (fn [mod]
+                    (.then (fn [^js mod]
                              (let [Ctor (or (.-default mod) (.-ELK mod) (.-elk mod))]
```

1 LoC delta.

## Verification

- Repro on a clean shadow cache (`rm -rf .shadow-cljs && npx shadow-cljs release story-static/counter-with-stories`) without the fix: emits exactly the two `:infer-warning` lines above.
- After the fix on a clean cache: zero `:infer-warning`s. Sole remaining build warning is the unrelated `@keyframes` JSDoc parse warning in `chart/svg.cljc:86` (filed separately, out of scope).

## Test plan

- [x] `clojure -M:test` from `tools/machines-viz/` — 97 tests, 233 assertions, 0 failures, 0 errors
- [x] `npm run test:cljs` — 3213 tests, 9238 assertions, 0 failures, 0 errors
- [x] `npm run test:bundle-isolation` — pass
- [x] `npm run test:story-static` — pass
- [x] Clean `shadow-cljs release story-static/counter-with-stories` — 322 files compiled, 0 :infer-warnings