### PR TITLE
feat(re-frame2): app-developer test ergonomics — re-frame.test-helpers + docs + skill (rf2-irp6j)

### DIFF
--- a/docs/guide/13-testing.md
+++ b/docs/guide/13-testing.md
@@ -138,6 +138,92 @@ Two pieces are doing work here:
 - **`dispatch-sync` drains synchronously to fixed point.** The whole event cascade — including any follow-up `:dispatch` fxs — settles before `dispatch-sync` returns. Assertions immediately after see committed state, no race.
 - **`:fx-overrides`** redirects a registered fx for one dispatch (or one frame, if specified on `reg-frame`). The override is an id-redirect, not a mock — the same dispatch shape the real `:rf.http/managed` produces lands in the test handler. No JSDOM, no fake fetch.
 
+### Asserting the view shows the right thing
+
+Up to this point every test has driven events and read `app-db`. That's the bulk of what re-frame2 testing covers — handlers and subs and machines are pure, and pure tests are cheap. But two classes of bug live in the gap between state and screen:
+
+1. **State-correct, view-broken.** The handler updated `app-db`, the sub computes the right value — and the view reads from the wrong path, or formats it wrong, or forgets to render one branch. Every state assertion stays green; the user sees a broken screen.
+2. **Wrong-frame dispatch.** The view wires `:on-click` to dispatch into the wrong frame (or no frame at all). State assertions in the host frame stay green; the click in production fires into a sibling and nothing happens.
+
+Both are caught by **calling the view-fn directly and walking its returned hiccup**. The view-fn is a function; the hiccup is a vector. No React, no JSDOM, no `act()` — JVM and CLJS pay the same low cost.
+
+`re-frame.test-helpers` ships the walker and the handler-pluck:
+
+```clojure
+(:require [re-frame.test-helpers :as h])
+```
+
+It exposes a small surface: `find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix` to anchor on stable elements, `text-content` to read what the user would see, `extract-handler` / `invoke-handler` to read or fire `:on-click` (and friends), and `testid` as a small authoring-side convenience for views that want a tidy attrs map. All of it operates on plain hiccup data and recursively expands nested function components, so a parent view-fn that mounts a child function-component is fully walked from one call site.
+
+#### Pattern 1 — state-and-view assertion
+
+Dispatch, call the view-fn, walk the result. Catches the "state correct, view broken" class:
+
+```clojure
+(deftest counter-view-shows-current-count
+  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+    (rf/dispatch-sync [:counter/inc])
+    (rf/dispatch-sync [:counter/inc])
+    ;; state assertion — the handler updated the db
+    (is (= 2 (:n (rf/get-frame-db f))))
+    ;; view assertion — the view actually shows that value
+    (let [tree  (counter-view {:n (:n (rf/get-frame-db f))})
+          label (h/find-by-testid tree "counter-label")]
+      (is (= "Count: 2" (h/text-content label))))))
+```
+
+The view-fn is just a function in your `views.cljs`. Its `:data-testid` is a stable handle that survives layout changes — search for `"counter-label"` in code and you find both the view and every test that references it.
+
+#### Pattern 2 — drive a click, assert the dispatch
+
+Pull `:on-click` off the hiccup node and invoke it. Catches the "wrong-frame dispatch" class — if the handler dispatches into the wrong frame, the assertion against the host frame fails:
+
+```clojure
+(deftest counter-button-fires-inc
+  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+    (let [tree (counter-view {:n 0})
+          btn  (h/find-by-testid tree "counter-inc")]
+      (h/invoke-handler btn :on-click nil)            ;; fires :on-click
+      (is (= 1 (:n (rf/get-frame-db f)))))))         ;; state moved
+```
+
+`invoke-handler` finds the testid'd element, pulls the handler off the attrs map, and calls it with the supplied args. If the view's `:on-click` is `#(rf/dispatch [:counter/inc])`, the dispatch threads through whatever frame is currently bound by `with-frame`, the cascade drains synchronously, and the next-line assertion sees the result. If the view dispatched to the wrong frame, the host-frame assertion fails — the bug is loud and reproducible without a browser.
+
+#### Authoring side — the `testid` helper
+
+A view that wants to be testable benefits from carrying a `:data-testid` on its outer element (or any element a test will want to anchor on). The `h/testid` helper standardises the attrs fragment:
+
+```clojure
+;; views.cljs
+(defn counter-view [{:keys [n]}]
+  [:div (h/testid "counter-root")
+   [:span (h/testid "counter-label") (str "Count: " n)]
+   [:button (h/testid "counter-inc"
+                      {:on-click #(rf/dispatch [:counter/inc])})
+    "+"]])
+```
+
+Equivalent to writing `{:data-testid "counter-inc" :on-click ...}` by hand. Pick whichever reads better in your view; both work with `find-by-testid`.
+
+#### When to use this vs. `render-to-string`
+
+Two flavours of view-content testing coexist:
+
+- `render-to-string` (covered in [chapter 11 — Server-side](11-server-side.md)) emits HTML. Best when the assertion is about the rendered markup — "is the `<button>` disabled?", "does the `<h1>` carry the right class?". Output is a string.
+- The hiccup-walk pattern in this section operates on hiccup data. Best when the assertion is about **structure** ("is the testid present?") or **handlers** ("what does the button fire?"), or when the test wants to drive interaction by invoking `:on-click` directly.
+
+Reach for `render-to-string` when the test cares about HTML; reach for hiccup-walk when the test cares about handlers or testid-keyed structure.
+
+#### Single-frame vs. multi-frame setups
+
+The patterns above are for a **single application frame** — the host frame is the only frame; views are application views; tests assert against the same frame the events fire into. That's the canonical shape for testing your own app and the one this section is about.
+
+A different shape exists for tool / observer code — code that runs in one frame and observes another (re-frame-10x, Causa, custom dashboards). Those tests need *two* frames in one process: the application frame plus the observer frame, with a trace path between them. That shape — the harness, the trace-bus wiring, the cross-frame subscribe — is exercised by the framework's own tool suite ([`tools/causa/test/.../test_helpers/e2e_multi_frame.cljs`](https://github.com/day8/re-frame2/blob/main/tools/causa/test/day8/re_frame2_causa/test_helpers/e2e_multi_frame.cljs)) and is **not** the right shape for testing your application's views. Single-app tests stay in a single frame; reach for the multi-frame harness only when you're building observer-side tooling.
+
+#### Runnable companion
+
+The code shapes in this section are exercised end-to-end by [`implementation/core/test/re_frame/test_helpers_cljs_test.cljc`](https://github.com/day8/re-frame2/blob/main/implementation/core/test/re_frame/test_helpers_cljs_test.cljc) — the helper's own unit suite uses the same `counter-view` / `counter-button` shape these snippets sketch. Copy from there if you want a working template.
+
 ### Subscriptions
 
 Two ways to test a sub:

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -1,0 +1,289 @@
+(ns re-frame.test-helpers
+  "View-assertion test helpers — walk a hiccup tree by `:data-testid`,
+  read out content and event-handlers, invoke an attached handler.
+
+  ## Why this ns exists (rf2-irp6j)
+
+  re-frame2's testing surface (Spec 008, [`re-frame.test-support`]
+  (test_support.cljc)) covers events, fxs, subs, machines, and whole
+  dispatch cascades cheaply on the JVM. None of that, by itself,
+  proves the **view** shows the right thing. Two classes of bug live
+  in the view-vs-state gap:
+
+    1. **State-correct, view-broken** (Causa rf2-70tkv class) — the
+       handler updated `app-db`, the sub computes the right value, but
+       the view reads from the wrong path / formats it wrong / forgets
+       to render one branch. State-only assertions pass; the user sees
+       a broken screen.
+
+    2. **Wrong-frame dispatch** (Causa rf2-83d4x class) — the view
+       wires `:on-click` to dispatch into the wrong frame (or no
+       frame at all). State-assertions in the host frame stay green;
+       the click in production fires into a sibling and nothing
+       happens.
+
+  Both are caught by a single test shape:
+
+      dispatch → call the view-fn → walk the returned hiccup →
+      assert on content (catches class 1) or invoke `:on-click`
+      (catches class 2)
+
+  The view-fn is just a function — call it directly. The returned
+  hiccup is just a vector — walk it like any other tree. No JSDOM,
+  no React, no `act()`. Runs on JVM and Node-CLJS equally.
+
+  ## Hiccup-walk vs render-to-string
+
+  Two flavours of view-content test exist:
+
+    - **`render-to-string`** (Spec 011) — renders the whole view to
+      an HTML string. Best when the assertion is about the rendered
+      markup (\"is the `<button>` disabled?\", \"does the `<h1>` carry
+      the right class?\"). Output is a string.
+
+    - **hiccup-walk** (this ns) — calls the view-fn directly and
+      walks the returned hiccup data. Best when the assertion is
+      about the **structure** of the view (\"is the testid present?\",
+      \"what handler does the button carry?\") or when the test wants
+      to **invoke** a handler to drive interaction. Output is hiccup
+      data; assertions read keys.
+
+  Reach for `render-to-string` when the test cares about HTML;
+  reach for hiccup-walk when the test cares about handlers or
+  testid-keyed structure.
+
+  ## Function-component expansion
+
+  Reagent hiccup admits a function in the first slot of a vector —
+  `[my-component {...}]` — and lazily invokes it during render. The
+  walkers in this ns expand those nested function components by
+  calling them with their args (just like Reagent's renderer
+  would) before walking, so a test that calls a parent view-fn
+  sees the leaf hiccup the user sees. The expansion is recursive
+  but terminating: a non-vector / non-fn leaf is a fixed point.
+
+  ## Authoring side — the `testid` helper
+
+  Tests benefit from views that **carry** a `:data-testid` on the
+  outer attrs map. The [[testid]] helper standardises the attrs
+  fragment so the convention reads at every call site:
+
+      [:button (testid \"counter-inc\" {:on-click #(rf/dispatch [:counter/inc])})
+       \"+\"]
+
+  Equivalent to writing `{:data-testid \"counter-inc\" :on-click ...}`
+  by hand; pick whichever reads better in your view.
+
+  ## Public API
+
+  ### Walking
+  - [[find-by-testid]] — first node with the given testid, or nil.
+  - [[find-all-by-testid]] — all nodes with the given testid.
+  - [[find-by-testid-prefix]] — all nodes whose testid starts with
+    the given prefix.
+
+  ### Reading
+  - [[text-content]] — concatenate string leaves under a node.
+  - [[attrs]] — return the attrs map for a hiccup node (or nil).
+  - [[children]] — return the child elements (everything after attrs).
+  - [[extract-handler]] — pluck an event handler (e.g. `:on-click`)
+    off a node.
+
+  ### Driving
+  - [[invoke-handler]] — find a handler and call it. Returns the
+    handler's return value (or throws if no handler is present).
+
+  ### Authoring
+  - [[testid]] — build a `:data-testid`-carrying attrs map at the
+    view call site. Optional `extra` map merges additional attrs."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; Hiccup-tree expansion
+;; ---------------------------------------------------------------------------
+
+(declare expand-tree)
+
+(defn expand-tree
+  "Recursively expand a hiccup tree, invoking any function components
+  with their args. After expansion, every vector's first element is a
+  keyword tag or a non-component value, never a fn.
+
+  Mirrors what Reagent's renderer does at mount time: a vector whose
+  first element is a fn is treated as `[component-fn & args]` and
+  invoked. Non-vector branches (strings, numbers, maps, nil) are
+  returned unchanged. Lazy sequences are walked through `map`; vectors
+  through `mapv`.
+
+  Public so test files mid-walk can re-expand a sub-tree if needed."
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else
+    tree))
+
+(defn- hiccup-seq
+  "Return a seq of every node in the expanded hiccup tree, in
+  depth-first order. Each yielded node is either a hiccup vector,
+  a child seq, or a leaf (string / number / nil)."
+  [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+;; ---------------------------------------------------------------------------
+;; Reading hiccup nodes
+;; ---------------------------------------------------------------------------
+
+(defn attrs
+  "Return the attrs map of a hiccup node, or nil if the node has no
+  attrs map. A hiccup vector's second element is an attrs map iff it
+  is a map; otherwise the second element is a child.
+
+  Returns nil for any input that isn't a hiccup vector with an
+  attrs-map slot."
+  [node]
+  (when (and (vector? node)
+             (>= (count node) 2)
+             (map? (second node)))
+    (second node)))
+
+(defn children
+  "Return the child elements of a hiccup node — everything after the
+  tag (and optional attrs map). Always returns a vector (empty if the
+  node has no children). Returns nil for non-hiccup input."
+  [node]
+  (cond
+    (not (vector? node)) nil
+    (and (>= (count node) 2) (map? (second node))) (vec (drop 2 node))
+    :else (vec (drop 1 node))))
+
+(defn text-content
+  "Recursively collect string leaves under `node` and return them
+  joined into a single string. Numbers are coerced to strings; nils
+  are skipped. Empty result is the empty string.
+
+  Useful for assertions like:
+
+      (is (= \"Count: 5\" (text-content (find-by-testid tree \"counter-label\"))))"
+  [node]
+  (->> (hiccup-seq node)
+       (filter (some-fn string? number?))
+       (map str)
+       (str/join)))
+
+(defn extract-handler
+  "Return the value of `event-key` (e.g. `:on-click`, `:on-change`)
+  from `node`'s attrs map, or nil if the node has no such attr.
+  Equivalent to `(get (attrs node) event-key)` but reads better at
+  call sites."
+  [node event-key]
+  (get (attrs node) event-key))
+
+;; ---------------------------------------------------------------------------
+;; Finding by testid
+;; ---------------------------------------------------------------------------
+
+(defn- testid-of
+  "Return the `:data-testid` value of a hiccup node, or nil."
+  [node]
+  (when (vector? node)
+    (when-let [a (attrs node)]
+      (:data-testid a))))
+
+(defn find-by-testid
+  "Walk `tree` (expanding function components) and return the FIRST
+  hiccup node whose attrs map carries `:data-testid == test-id`, or
+  nil if no node matches.
+
+  Use to anchor on a stable element from a view:
+
+      (let [tree (counter-view {:n 5})
+            label (find-by-testid tree \"counter-label\")]
+        (is (= \"Count: 5\" (text-content label))))"
+  [tree test-id]
+  (some (fn [node]
+          (when (= test-id (testid-of node))
+            node))
+        (hiccup-seq tree)))
+
+(defn find-all-by-testid
+  "Like [[find-by-testid]] but returns a vector of EVERY matching
+  node, in depth-first order. Empty vector when no match."
+  [tree test-id]
+  (filterv (fn [node] (= test-id (testid-of node)))
+           (hiccup-seq tree)))
+
+(defn find-by-testid-prefix
+  "Return a vector of every hiccup node whose `:data-testid` STARTS
+  with `prefix`. Useful for view layouts that mint a family of testids
+  off a stable stem (e.g. `\"counter-row-1\"`, `\"counter-row-2\"`,
+  …)."
+  [tree prefix]
+  (filterv (fn [node]
+             (when-let [tid (testid-of node)]
+               (str/starts-with? tid prefix)))
+           (hiccup-seq tree)))
+
+;; ---------------------------------------------------------------------------
+;; Driving handlers
+;; ---------------------------------------------------------------------------
+
+(defn invoke-handler
+  "Find the handler under `event-key` on `node` and call it with the
+  supplied args. Returns the handler's return value (typically nil for
+  re-frame `:on-click` handlers that `dispatch` for side effects).
+
+  Throws (CLJS: `js/Error`, JVM: `ex-info`) when:
+    - `node` is nil or not a hiccup vector
+    - the node has no attrs map
+    - no handler is registered under `event-key`
+
+  The throwing failure mode is intentional — a missing handler is
+  almost always a test bug (wrong testid, wrong key, view changed),
+  not a passing case.
+
+  Use to drive a click and assert state changed downstream:
+
+      (let [tree (counter-view {:n 0})
+            btn  (find-by-testid tree \"counter-inc\")]
+        (invoke-handler btn :on-click)
+        (is (= 1 (get-frame-db [:n]))))"
+  [node event-key & args]
+  (when-not (vector? node)
+    (throw (ex-info "invoke-handler: node must be a hiccup vector"
+                    {:node node :event-key event-key})))
+  (let [h (extract-handler node event-key)]
+    (when-not (fn? h)
+      (throw (ex-info (str "invoke-handler: no handler under " event-key)
+                      {:node node :event-key event-key :handler h})))
+    (apply h args)))
+
+;; ---------------------------------------------------------------------------
+;; Authoring side
+;; ---------------------------------------------------------------------------
+
+(defn testid
+  "Build an attrs map carrying `:data-testid id`. Optional `extra`
+  map merges additional attrs (its keys win on collision EXCEPT for
+  `:data-testid`, which is always set to `id`).
+
+  Use at the view call site:
+
+      [:button (testid \"counter-inc\" {:on-click #(rf/dispatch [:counter/inc])})
+       \"+\"]
+
+  Reads as one assertion-friendly fragment instead of inline
+  `{:data-testid \"...\" :on-click ...}`. Pick whichever style is
+  clearer in context — both work with [[find-by-testid]]."
+  ([id]
+   {:data-testid id})
+  ([id extra]
+   (assoc extra :data-testid id)))

--- a/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
@@ -1,0 +1,233 @@
+(ns re-frame.test-helpers-cljs-test
+  "Unit coverage for `re-frame.test-helpers` (rf2-irp6j).
+
+  Dual-runtime: the file is named `*_cljs_test.cljc` so both the JVM
+  test runner and the shadow-cljs `:node-test` build pick it up.
+  Every assertion runs identically under both runtimes because the
+  helpers walk plain hiccup data — no React, no DOM."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.test-helpers :as h]))
+
+;; ---------------------------------------------------------------------------
+;; Tiny view fns used as fixtures
+;; ---------------------------------------------------------------------------
+
+(defn- counter-button
+  "Form-1 leaf — a `[:button ...]` carrying `:data-testid` +
+  `:on-click`."
+  [{:keys [n on-click]}]
+  [:button {:data-testid "counter-inc"
+            :on-click    on-click}
+   (str "Count: " n)])
+
+(defn- counter-view
+  "Form-1 parent that nests `counter-button` as a function component
+  in the hiccup. Exercises the `expand-tree` recursion."
+  [{:keys [n on-inc]}]
+  [:div {:data-testid "counter-root"}
+   [:span {:data-testid "counter-label"} "Counter"]
+   [counter-button {:n n :on-click on-inc}]])
+
+(defn- list-view
+  "Form-1 view emitting a homogeneous family of testid'd rows. Used to
+  exercise `find-all-by-testid` and `find-by-testid-prefix`."
+  [items]
+  [:ul {:data-testid "items"}
+   (for [{:keys [id label]} items]
+     [:li {:data-testid (str "item-" id)
+           :key         id}
+      label])])
+
+;; ---------------------------------------------------------------------------
+;; expand-tree
+;; ---------------------------------------------------------------------------
+
+(deftest expand-tree-passes-through-keyword-tags
+  (testing "vectors with a keyword tag are walked, not invoked"
+    (let [tree [:div {:k 1} [:span "hi"]]
+          out  (h/expand-tree tree)]
+      (is (= [:div {:k 1} [:span "hi"]] out)))))
+
+(deftest expand-tree-invokes-function-components
+  (testing "a vector starting with a fn is invoked with its args"
+    (let [tree [counter-button {:n 7 :on-click identity}]
+          out  (h/expand-tree tree)]
+      (is (vector? out))
+      (is (= :button (first out)))
+      (is (= "counter-inc" (:data-testid (second out)))))))
+
+(deftest expand-tree-recurses-into-nested-function-components
+  (testing "a parent view with a child fn-component expands both"
+    (let [tree (counter-view {:n 3 :on-inc identity})
+          out  (h/expand-tree tree)]
+      ;; outer :div
+      (is (= :div (first out)))
+      ;; inner button was a fn-component — should be expanded to :button
+      (let [inner (some #(when (and (vector? %) (= :button (first %))) %)
+                        (tree-seq vector? seq out))]
+        (is (some? inner) "nested function component was not expanded")))))
+
+(deftest expand-tree-handles-leaves
+  (testing "non-vector/non-seq inputs are returned unchanged"
+    (is (= "hi"      (h/expand-tree "hi")))
+    (is (= 42        (h/expand-tree 42)))
+    (is (= nil       (h/expand-tree nil)))
+    (is (= {:a 1}    (h/expand-tree {:a 1})))))
+
+;; ---------------------------------------------------------------------------
+;; attrs / children
+;; ---------------------------------------------------------------------------
+
+(deftest attrs-returns-map-when-present
+  (is (= {:k 1} (h/attrs [:div {:k 1} "child"]))))
+
+(deftest attrs-returns-nil-when-second-is-child
+  (testing "no attrs map — second element is a child"
+    (is (nil? (h/attrs [:div "child"]))))
+  (testing "non-hiccup"
+    (is (nil? (h/attrs "string")))
+    (is (nil? (h/attrs nil)))))
+
+(deftest children-returns-after-attrs
+  (is (= ["a" "b"] (h/children [:div {:k 1} "a" "b"]))))
+
+(deftest children-returns-after-tag-when-no-attrs
+  (is (= ["a" "b"] (h/children [:div "a" "b"]))))
+
+(deftest children-empty-when-no-children
+  (is (= [] (h/children [:div {:k 1}])))
+  (is (= [] (h/children [:div]))))
+
+;; ---------------------------------------------------------------------------
+;; find-by-testid family
+;; ---------------------------------------------------------------------------
+
+(deftest find-by-testid-finds-outer-node
+  (let [tree (counter-view {:n 0 :on-inc identity})
+        hit  (h/find-by-testid tree "counter-root")]
+    (is (some? hit))
+    (is (= :div (first hit)))))
+
+(deftest find-by-testid-walks-into-function-components
+  (testing "the testid lives inside a nested function component — the
+            walker expands the component to reach it"
+    (let [tree (counter-view {:n 0 :on-inc identity})
+          hit  (h/find-by-testid tree "counter-inc")]
+      (is (some? hit) "find-by-testid did not expand the nested fn-component")
+      (is (= :button (first hit))))))
+
+(deftest find-by-testid-returns-nil-when-no-match
+  (let [tree (counter-view {:n 0 :on-inc identity})]
+    (is (nil? (h/find-by-testid tree "does-not-exist")))))
+
+(deftest find-by-testid-returns-first-match
+  (testing "multiple matches → only the first is returned"
+    (let [tree [:div
+                [:span {:data-testid "dup"} "first"]
+                [:span {:data-testid "dup"} "second"]]
+          hit  (h/find-by-testid tree "dup")]
+      (is (= "first" (last hit))))))
+
+(deftest find-all-by-testid-returns-every-match
+  (let [tree [:div
+              [:span {:data-testid "dup"} "first"]
+              [:span {:data-testid "dup"} "second"]
+              [:span {:data-testid "other"} "third"]]
+        hits (h/find-all-by-testid tree "dup")]
+    (is (= 2 (count hits)))
+    (is (= "first"  (last (first hits))))
+    (is (= "second" (last (second hits))))))
+
+(deftest find-all-by-testid-empty-when-no-match
+  (is (= [] (h/find-all-by-testid [:div] "nope"))))
+
+(deftest find-by-testid-prefix-matches-stem
+  (let [tree (list-view [{:id 1 :label "a"}
+                         {:id 2 :label "b"}
+                         {:id 3 :label "c"}])
+        hits (h/find-by-testid-prefix tree "item-")]
+    (is (= 3 (count hits)))
+    (is (= ["item-1" "item-2" "item-3"]
+           (mapv (comp :data-testid second) hits)))))
+
+;; ---------------------------------------------------------------------------
+;; text-content
+;; ---------------------------------------------------------------------------
+
+(deftest text-content-collects-string-leaves
+  (let [tree [:div [:span "hello "] [:span "world"]]]
+    (is (= "hello world" (h/text-content tree)))))
+
+(deftest text-content-coerces-numbers
+  (is (= "Count: 5" (h/text-content [:span "Count: " 5]))))
+
+(deftest text-content-walks-function-components
+  (let [tree (counter-view {:n 42 :on-inc identity})]
+    (is (= "Count: 42"
+           (h/text-content (h/find-by-testid tree "counter-inc"))))))
+
+(deftest text-content-empty-on-no-strings
+  (is (= "" (h/text-content [:div {:k 1}]))))
+
+;; ---------------------------------------------------------------------------
+;; extract-handler / invoke-handler
+;; ---------------------------------------------------------------------------
+
+(deftest extract-handler-pulls-on-click
+  (let [tree (counter-view {:n 0 :on-inc identity})
+        btn  (h/find-by-testid tree "counter-inc")]
+    (is (fn? (h/extract-handler btn :on-click)))))
+
+(deftest extract-handler-nil-when-missing
+  (let [tree (counter-view {:n 0 :on-inc identity})
+        btn  (h/find-by-testid tree "counter-inc")]
+    (is (nil? (h/extract-handler btn :on-change)))))
+
+(deftest invoke-handler-calls-and-returns
+  (let [fired (atom nil)
+        tree  (counter-view {:n 0 :on-inc #(reset! fired %)})
+        btn   (h/find-by-testid tree "counter-inc")]
+    (h/invoke-handler btn :on-click :evt-arg)
+    (is (= :evt-arg @fired)
+        "invoke-handler did not pass args through to the handler")))
+
+(deftest invoke-handler-returns-handler-result
+  (let [tree [:button {:on-click (fn [_] :returned-value)}]]
+    (is (= :returned-value (h/invoke-handler tree :on-click nil)))))
+
+(deftest invoke-handler-throws-on-missing-handler
+  (let [tree [:div {:k 1}]]
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
+                 (h/invoke-handler tree :on-click)))))
+
+(deftest invoke-handler-throws-on-non-hiccup
+  (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
+               (h/invoke-handler nil :on-click)))
+  (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
+               (h/invoke-handler "string" :on-click))))
+
+;; ---------------------------------------------------------------------------
+;; testid (authoring helper)
+;; ---------------------------------------------------------------------------
+
+(deftest testid-emits-attrs-map
+  (is (= {:data-testid "foo"} (h/testid "foo"))))
+
+(deftest testid-merges-extra-attrs
+  (let [m (h/testid "foo" {:on-click :handler :class "bar"})]
+    (is (= "foo"     (:data-testid m)))
+    (is (= :handler  (:on-click m)))
+    (is (= "bar"     (:class m)))))
+
+(deftest testid-id-wins-over-extra-collision
+  (testing "an :data-testid in extra is overridden by the id arg"
+    (let [m (h/testid "outer" {:data-testid "inner"})]
+      (is (= "outer" (:data-testid m))))))
+
+(deftest testid-round-trips-with-find-by-testid
+  (testing "a view authored with `testid` is reachable by find-by-testid"
+    (let [tree [:button (h/testid "go" {:on-click identity}) "Go"]
+          hit  (h/find-by-testid tree "go")]
+      (is (some? hit))
+      (is (fn? (h/extract-handler hit :on-click))))))

--- a/skills/re-frame2/SKILL.md
+++ b/skills/re-frame2/SKILL.md
@@ -94,6 +94,43 @@ Patterns compose; a screen can use Forms on submit, RemoteData for the request, 
 | Wiring Datadog / Sentry / Honeycomb production listeners that survive `goog.DEBUG=false` | `references/cross-cutting/production-observability.md` |
 | Authoring head/meta (`reg-head` / `render-head` / `active-head`) or a custom `:rf/hydrate` handler dispatching the version + schema-digest check fxs | `references/cross-cutting/ssr-authoring.md` |
 
+## Testing your views
+
+When the user asks how to test a re-frame2 view — "does the screen show the right thing?", "does the button dispatch the right event?" — suggest the **hiccup-walk pattern**, not a browser-mount.
+
+1. Dispatch events via `rf/dispatch-sync` into the test frame (standard re-frame2 testing surface).
+2. Call the view-fn directly. It returns hiccup; that's just data.
+3. Walk the hiccup with `re-frame.test-helpers` (`find-by-testid` / `text-content` / `invoke-handler`).
+
+```clojure
+(:require [re-frame.core :as rf]
+          [re-frame.test-helpers :as h])
+
+(deftest counter-view-shows-and-fires
+  (rf/with-frame [f (rf/make-frame {:on-create [:counter/init]})]
+    (let [tree (counter-view {:n 0})
+          btn  (h/find-by-testid tree "counter-inc")]
+      (h/invoke-handler btn :on-click nil)
+      (is (= 1 (:n (rf/get-frame-db f)))))))
+```
+
+**Single-frame vs. multi-frame.** Application tests use ONE frame — the host frame. Views, events, subs, asserts all reference the same frame. Multi-frame test harnesses exist (e.g. `tools/causa/.../e2e_multi_frame.cljs`) but they are for **observer / tool code** — code that runs in one frame and watches another. Do NOT propose a multi-frame harness for testing a regular application view.
+
+**State alone is not enough.** State-only assertions (`(is (= 2 (:n db)))`) catch handler bugs but miss two classes:
+- *State-correct, view-broken* — handler updated db, view reads wrong path / forgets a branch.
+- *Wrong-frame dispatch* — `:on-click` dispatches into the wrong frame; host-frame state never changes.
+
+The hiccup-walk + invoke-handler pattern catches both, on JVM and Node-CLJS, with no browser. Full pattern walkthrough lives at [`docs/guide/13-testing.md` §Asserting the view shows the right thing](../../docs/guide/13-testing.md).
+
+The `h/testid` authoring helper standardises the attrs fragment at view call sites:
+
+```clojure
+[:button (h/testid "counter-inc" {:on-click #(rf/dispatch [:counter/inc])})
+ "+"]
+```
+
+Use it whenever you write a new view that wants a test handle.
+
 ## Where the depth lives
 
 Load at most two leaves per task. If a task seems to need three, it likely spans patterns and should be broken up.


### PR DESCRIPTION
## Summary
- New `re-frame.test-helpers` ns (`.cljc`, JVM + CLJS): hiccup-walk + invoke-handler for view-assertion tests. Lifts the ad-hoc `find-by-testid` pattern that was duplicated across `tools/causa`, `tools/machines-viz`, etc., generalises it, and ships it as a first-class framework surface so application code can require + use without copy-paste.
- `docs/guide/13-testing.md` gets a new `§Asserting the view shows the right thing` section between the existing `§End-to-end through a frame` and `§Subscriptions` sections. Covers the two motivating bug classes (state-correct/view-broken — Causa rf2-70tkv class; wrong-frame dispatch — Causa rf2-83d4x class), the two patterns (read content; invoke handler), the `testid` authoring helper, the trade-off vs `render-to-string`, and explicitly steers single-app tests away from the multi-frame harness (`tools/causa/.../e2e_multi_frame.cljs`).
- `skills/re-frame2/SKILL.md` gets a `§Testing your views` section so the skill proposes hiccup-walk + invoke-handler when users ask how to test a view, including the single-frame-vs-multi-frame rule.
- Unit tests under `implementation/core/test/re_frame/test_helpers_cljs_test.cljc` (30 deftests / 48 assertions) cover every public fn and the function-component expansion recursion. The file is `_cljs_test.cljc` so it runs under both JVM (`clojure -M:test`) and Node-CLJS (`npm run test:cljs`).

## API shipped
- `find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix`
- `text-content` / `attrs` / `children`
- `extract-handler` / `invoke-handler`
- `testid` (authoring-side attrs builder)
- `expand-tree` (function-component expander; public for callers that need to re-expand a sub-tree mid-walk)

## Acceptance
- [x] `re-frame.test-helpers` ships with its own unit tests (30 deftests, 48 assertions; pass JVM + CLJS)
- [x] `docs/guide/13-testing.md` `§Asserting the view shows the right thing` added; snippets pair with the runnable companion test file in core
- [x] `skills/re-frame2/SKILL.md` `§Testing your views` added, single-frame-vs-multi-frame rule documented
- [x] `mkdocs build --strict` clean
- [x] `npm run test:cljs` clean (3326 tests, baseline + 30 new)

## Gates run
- `npm run test:cljs` from `implementation/` → green (3326 / 9463)
- `clojure -M:test -d test -n re-frame.test-helpers-cljs-test` from `implementation/core/` → green (30 / 48)
- `python -m mkdocs build --strict` → exit 0

## Bead
rf2-irp6j