### PR TITLE
fix(causa): rf2-ujra6 — deep-machine substrate name-on-fn regression from #1601

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector.cljs
@@ -57,6 +57,19 @@
 
 ;; ---- guards + actions lists --------------------------------------------
 
+(defn- safe-name
+  "Render `x` to a string suitable for `data-testid` suffixes. Belt-and-
+  braces over the projection layer's `ref-display-id` (which normalises
+  guard/action refs into keywords). If a future trace shape pipes a fn
+  through unprojected the view still won't blow up — `cljs.core/name`
+  on a fn throws `Doesn't support name: function ...` (rf2-ujra6)."
+  [x]
+  (cond
+    (nil? x)                          ""
+    (or (keyword? x) (symbol? x))     (name x)
+    (string? x)                       x
+    :else                             (str x)))
+
 (defn- guards-list
   "Render the per-transition Guards section. Empty list = no surface
   (silent-by-default per rf2-g3ghh)."
@@ -82,7 +95,7 @@
            (for [{:keys [guard-id input outcome]} guards]
              ^{:key (str guard-id)}
              [:li {:data-testid (str "rf-causa-machine-focused-event-guard-"
-                                     (when guard-id (name guard-id)))
+                                     (safe-name guard-id))
                    :style {:display "flex"
                            :align-items "center"
                            :gap "8px"
@@ -122,7 +135,7 @@
            (for [{:keys [action-id input outcome]} actions]
              ^{:key (str action-id)}
              [:li {:data-testid (str "rf-causa-machine-focused-event-action-"
-                                     (when action-id (name action-id)))
+                                     (safe-name action-id))
                    :style {:display "flex"
                            :align-items "center"
                            :gap "8px"

--- a/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/machine_inspector_helpers.cljc
@@ -381,11 +381,24 @@
 ;;   - `:rf.machine.microstep/transition` — `:always`-driven microstep;
 ;;     same tag shape (some tests use `:from`/`:to` tag fallbacks).
 ;;
-;; The substrate does NOT yet emit `:rf.machine/guard-evaluated` or
-;; `:rf.machine/action-ran` per-step traces. The helper looks for those
-;; ops anyway (set in `guard-operations` / `action-operations`) so when
-;; the substrate gains them, the lens lights up without further work.
-;; In the meantime guards/actions render as empty lists per transition.
+;; The substrate emits `:rf.machine/guard-evaluated` /
+;; `:rf.machine/action-ran` per rf2-2nwfd (see spec/009 §Trace event
+;; vocabulary). Before rf2-ko8jb (#1601) those emits carried no
+;; `:frame` tag and were silently dropped by epoch-capture; post-#1601
+;; they reach the focused epoch's `:trace-events` and flow through
+;; this projection.
+;;
+;; The `:guard-id` / `:action-id` slot is the user-declared ref AS-IS
+;; (per spec/Spec-Schemas: "keyword OR inline fn"). When a transition
+;; declares `:guard :user-has-credentials?` the slot is a keyword;
+;; when it inlines `:guard (fn [data ev] ...)` OR the state-node's
+;; `:entry` slot points at a raw fn, the slot is the fn itself. The
+;; view renders the id via `(name ...)` to build a `data-testid`
+;; suffix — and `cljs.core/name` blows up on fn values (`Doesn't
+;; support name: function ...`). `ref-display-id` coerces the
+;; ref into a renderable keyword (named via `:name` meta when
+;; available, `:rf.machine/anonymous-fn` otherwise) so the view
+;; contract stays simple. (rf2-ujra6.)
 ;;
 ;; Per spec/005-StateMachines.md the guard / action functions are
 ;; resolved off the transition object on the machine definition; we
@@ -455,12 +468,47 @@
      :guards       []
      :actions      []}))
 
+(defn- ref-display-id
+  "Coerce a guard/action ref to a renderable id for the per-transition
+  Guards / Actions list.
+
+  Per spec/Spec-Schemas §`:rf.machine/guard-evaluated` and
+  §`:rf.machine/action-ran`, the trace's `:guard-id` / `:action-id` slot
+  carries the user-declared ref AS-IS — a keyword when the transition
+  declared `:guard :foo` / `:action :foo`, or the fn itself when the
+  transition inlined `:guard (fn [...] ...)` / `:action (fn [...] ...)`
+  or pulled a raw fn from a state-node's `:entry` / `:exit` slot. The
+  view renders the id via `(name ...)` to build a stable data-testid
+  suffix, which blows up on fn values (`Doesn't support name:
+  function ...`).
+
+  Coerce to a renderable form here so the view contract is simple:
+
+    - keyword / string / symbol → return as-is (the view's `name`/`str`
+      both work).
+    - fn → return either `:rf.machine/<the fn's :name meta>` when the
+      fn carries `:name` metadata (named `(defn ...)` or `(fn name
+      [...] ...)`) or `:rf.machine/anonymous-fn` for truly anonymous
+      inline fns. The keyword form keeps the view's `(name ...)` call
+      working AND surfaces the fn's declared name when available, which
+      is what a consumer wants to see in the Guards / Actions list."
+  [ref]
+  (cond
+    (nil? ref)                          nil
+    (or (keyword? ref) (symbol? ref))   ref
+    (string? ref)                       ref
+    (fn? ref)
+    (if-let [nm (some-> ref meta :name)]
+      (keyword "rf.machine" (str nm))
+      :rf.machine/anonymous-fn)
+    :else                               ref))
+
 (defn- guard-record
   "Project a guard-evaluated trace event into the record the view
   renders inside the per-transition Guards section."
   [ev]
   (let [tags (get ev :tags {})]
-    {:guard-id (or (:guard-id tags) (:guard tags))
+    {:guard-id (ref-display-id (or (:guard-id tags) (:guard tags)))
      :input    (or (:input tags) (:args tags))
      :outcome  (cond
                  (contains? tags :outcome) (:outcome tags)
@@ -474,7 +522,7 @@
   inside the per-transition Actions section."
   [ev]
   (let [tags (get ev :tags {})]
-    {:action-id (or (:action-id tags) (:action tags))
+    {:action-id (ref-display-id (or (:action-id tags) (:action tags)))
      :input     (or (:input tags) (:args tags))
      :outcome   (cond
                   (contains? tags :outcome)   (:outcome tags)

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_helpers_cljs_test.cljc
@@ -443,6 +443,52 @@
         (is (= :issue-token (-> rec :actions first :action-id)))
         (is (= :ok          (-> rec :actions first :outcome)))))))
 
+(deftest project-focused-event-coerces-fn-refs-to-renderable-ids
+  ;; rf2-ujra6 — per spec/Spec-Schemas `:guard-id` / `:action-id` carry
+  ;; the user-declared ref as-is, which is "keyword OR inline fn". The
+  ;; deep-machine testbed (`testbeds/deep_machine/core.cljs`) declares
+  ;; state-node `:entry` slots as raw fns; when those fire the
+  ;; `:rf.machine/action-ran` trace carries the fn itself in
+  ;; `:action-id`. Before #1601 these traces lacked `:frame` and were
+  ;; dropped by epoch-capture; post-#1601 they flow into
+  ;; `:trace-events` and through this projection. The view renders
+  ;; `:action-id` via `(name ...)` to build a `data-testid` suffix —
+  ;; which throws `Doesn't support name: function ...` on fn values.
+  ;; The projection coerces fn refs to renderable keywords so the view
+  ;; contract stays simple.
+  (testing "anonymous inline fn ref normalises to :rf.machine/anonymous-fn"
+    (let [anon-fn (fn [_data _ev] {:data {}})
+          events  [(t-event 1 :auth/login :idle :authing [:auth/submit])
+                   {:id 2 :time 11 :operation :rf.machine/action-ran
+                    :tags {:machine-id :auth/login
+                           :action-id  anon-fn
+                           :outcome    :ok}}]
+          records (h/project-focused-event-transitions events)
+          a-id    (-> records first :actions first :action-id)]
+      (is (keyword? a-id)
+          "fn ref must be coerced to a keyword so the view's `name` call works")
+      (is (= :rf.machine/anonymous-fn a-id))))
+  (testing "named fn ref via :name metadata normalises to a keyword carrying that name"
+    (let [named-fn (with-meta (fn [_data _ev] {:data {}})
+                              {:name 'action-bump-tick})
+          events   [(t-event 1 :auth/login :idle :authing [:auth/submit])
+                    {:id 2 :time 11 :operation :rf.machine/guard-evaluated
+                     :tags {:machine-id :auth/login
+                            :guard-id   named-fn
+                            :outcome    :pass}}]
+          records  (h/project-focused-event-transitions events)
+          g-id     (-> records first :guards first :guard-id)]
+      (is (keyword? g-id))
+      (is (= :rf.machine/action-bump-tick g-id))))
+  (testing "keyword refs flow through untouched"
+    (let [events  [(t-event 1 :auth/login :idle :authing [:auth/submit])
+                   {:id 2 :time 11 :operation :rf.machine/action-ran
+                    :tags {:machine-id :auth/login
+                           :action-id  :issue-token
+                           :outcome    :ok}}]
+          records (h/project-focused-event-transitions events)]
+      (is (= :issue-token (-> records first :actions first :action-id))))))
+
 ;; ---- (11) focused-epoch-record (rf2-a9cke) ------------------------------
 
 (deftest focused-epoch-record-empty-history


### PR DESCRIPTION
## Summary

Causa's deep-machine inspector substrate scenario failed with
`[pageerror] Doesn't support name: function (data,_ev){...}` after #1601 (rf2-ko8jb) landed.

**Root cause.** Per `spec/Spec-Schemas` `:rf.machine/guard-evaluated` and
`:rf.machine/action-ran` carry the user-declared `:guard-id` / `:action-id`
ref **as-is** — "keyword OR inline fn". The deep-machine testbed declares
state-node `:entry` slots as raw fns (`testbeds/deep_machine/core.cljs` §61
on `helper-tick-machine`), so the runtime emits the fn itself in
`:action-id`. Pre-#1601 these traces lacked the `:frame` tag and
`re-frame.epoch.capture/capture-event!` silently dropped them; post-#1601
they flow into the focused epoch's `:trace-events` and through Causa's
`machine_inspector_helpers/project-focused-event-transitions`. The
inspector view rendered the id via `(name action-id)` to build a
`data-testid` suffix — and `cljs.core/name` throws on fn values.

**Slot at fault.** `:tags :action-id` on `:rf.machine/action-ran` (and
`:tags :guard-id` on `:rf.machine/guard-evaluated`). The emit shape is
correct per spec; the consumer contract was wrong.

**Fix shape.** Minimal, in the consumer:

- `machine_inspector_helpers/ref-display-id` coerces fn refs to a
  renderable keyword (named via the fn's `:name` metadata when present,
  `:rf.machine/anonymous-fn` otherwise). Keyword / string / symbol refs
  flow through untouched. Applied in `guard-record` and `action-record`.
- `machine_inspector/safe-name` belt-and-braces: a non-name-able value
  at the view boundary degrades to `(str x)` rather than throw.

**Regression test.** `project-focused-event-coerces-fn-refs-to-renderable-ids`
covers the anonymous-fn, named-fn-via-meta, and keyword paths.

## Acceptance

- Deep-machine inspector substrate scenario passes (5/5 consecutive local runs)
- `npm run test:causa-feature-gate` — all 16 active scenarios green (15 matrix rows covered)
- `npm run test:cljs` — 3297 tests, 9420 assertions, 0 failures
- `tools/causa: clojure -M:test` — 750 tests, 2268 assertions, 0 failures
- `implementation/machines: clojure -M:test` — 223 tests, 775 assertions, 0 failures

## Bead

rf2-ujra6