### PR TITLE
test(story): multi-frame e2e CLJS tests for 6 Story surfaces (rf2-piucm)

### DIFF
--- a/tools/story/test/re_frame/story/panels_e2e/causa_embed_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/causa_embed_e2e_cljs_test.cljs
@@ -1,0 +1,248 @@
+(ns re-frame.story.panels-e2e.causa-embed-e2e-cljs-test
+  "Multi-frame e2e coverage for the Causa-in-Story embed surface
+  (rf2-piucm, replaces the Playwright `causa-rhs-smoke` spec).
+
+  Story's RHS hosts ONE Causa panel at a time under a chip-row picker
+  (rf2-v1ach). Three bug classes drove this coverage:
+
+  - **rf2-senbl** — `mount-fn-for` returning nil because the previous
+    `find-ns-obj` + `aget` walk did not surface top-level def'd fns
+    as parent-namespace JS properties; the fix is a `case` dispatch
+    via direct `:require`. We assert here that every catalogued
+    panel-id resolves to a callable mount-fn so a regression in the
+    require / case shape is caught at unit-test speed.
+  - **rf2-4l7t2** — React 18+ throws \"Attempted to synchronously
+    unmount a root while React was already rendering\" whenever a
+    Causa-owned React root is torn down inside the outer Story-
+    Reagent render cascade. The fix: one persistent host class, the
+    panel-id drives an internal swap via `:component-did-update`,
+    and every `.unmount` runs inside `js/queueMicrotask`. We assert
+    here that `panel-host-component` returns a Reagent class
+    descriptor wired to the four lifecycle hooks so the
+    persistence-across-panel-id-swaps invariant is intact.
+  - **rf2-v1ach** — the embed's hiccup carries `data-active-panel`
+    reflecting the resolved panel, AND a chip per catalogued panel.
+    A regression in `effective-panel` or `panel-catalog` would either
+    blank the wrapper attr or drop a chip from the picker — both
+    detectable from the expanded hiccup tree.
+
+  ## What the Playwright spec did vs. this test
+
+  The Playwright spec drove an actual browser:
+
+    1. `gotoStory` → click variant in sidebar
+    2. Wait for `data-test=\"story-causa-embed\"` to be visible
+    3. Assert `data-active-panel` = `event-detail`
+    4. Assert at least 7 chips render
+    5. Click App-db chip, assert `data-active-panel` = `app-db`
+    6. Click counter inc to prove dispatch sanity
+
+  This CLJS test exercises the same surface at the hiccup level:
+
+    1. Install Story canonical vocab + Causa
+    2. Set `:selected-variant` in shell state (the same write the
+       sidebar click does)
+    3. Walk the `causa-embed-panel` hiccup
+    4. Assert `data-active-panel` carries the default `:event-detail`
+    5. Assert one chip per catalogued panel
+    6. Invoke the App-db chip's `:on-click` → assert
+       `data-active-panel` flips to `:app-db` and `effective-panel`
+       resolves to `:app-db`
+    7. Dispatch a host event, assert Causa's cascade list records it
+
+  Sub-second per surface; no DOM / no React mount / no Playwright."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.causa-preset :as causa-preset]
+            [re-frame.story.ui.causa-embed :as causa-embed]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as causa-e2e]
+            [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
+
+;; rf2-senbl bug class symmetry: `causa-preset/causa-available?` uses
+;; the same `find-ns-obj` + `aget` walk that previously broke
+;; `mount-fn-for`. The classpath HAS Causa loaded (the embed namespace
+;; directly `:require`s `day8.re-frame2-causa.panels`), so the
+;; feature-detection is a false negative in the node-test context. We
+;; stub the predicate so the embed renders its full surface; the
+;; production code path stays untouched.
+
+(defn- with-causa-available [test-fn]
+  (with-redefs [causa-preset/causa-available? (constantly true)]
+    (test-fn)))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter})
+  with-causa-available)
+
+;; A minimal variant registration the embed-surface tests depend on —
+;; the embed reads `:selected-variant` off the shell ratom; resolving
+;; the panel-id walks the registrar for the variant body's
+;; `:causa-panel` slot. A bare variant with no `:causa-panel` resolves
+;; to the catalog's `default-panel` (`:event-detail`).
+
+(def ^:private variant-id :story.counter/loaded)
+
+(defn- register-variant! []
+  (story/reg-story :story.counter
+    {:doc "Counter parent story for the e2e embed tests."})
+  (story/reg-variant variant-id
+    {:doc    "Counter seeded at 5 — exercises the default embed path."
+     :events [[:counter/initialise]]}))
+
+;; ---- panel-catalog completeness -----------------------------------------
+
+(deftest panel-catalog-shape-matches-rf2-v1ach
+  (testing "the chip-row catalog exposes the 7 canonical Causa panels"
+    ;; rf2-v1ach lists 7 panels in the chip-row (event / app-db / views /
+    ;; trace / machines / routing / issues). Catch the regression where
+    ;; one is dropped (the chip-row would silently lose an affordance)
+    ;; or a new panel sneaks into the catalog without a deliberate
+    ;; design decision.
+    (is (= 7 (count causa-embed/panel-catalog))
+        "7 panels in the chip-row catalog (rf2-v1ach)")
+    (is (= #{:event-detail :app-db :views :trace :machines :routing :issues}
+           causa-embed/panel-ids)
+        "panel-ids set matches the catalog")
+    (is (= :event-detail causa-embed/default-panel)
+        "default-panel is :event-detail (catalog's first entry, the
+         most-common diagnostic lens)")))
+
+(deftest mount-fn-resolves-for-every-panel
+  (testing "rf2-senbl — every catalogued panel-id resolves to a callable
+            mount-fn via `mount-fn-for` (compile-time symbol resolution,
+            not a runtime `find-ns-obj` walk)"
+    (doseq [pid causa-embed/panel-ids]
+      (is (fn? (causa-embed/mount-fn-for pid))
+          (str "mount-fn-for " pid " returned a callable — rf2-senbl
+                regression class")))
+    (testing "unknown panel-id → nil (graceful, not throw)"
+      (is (nil? (causa-embed/mount-fn-for :no-such-panel))))))
+
+;; ---- embed surface paint ------------------------------------------------
+
+(deftest causa-embed-paints-with-default-panel
+  (testing "after selecting a variant the embed renders with
+            data-active-panel = event-detail + a chip per panel"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        (let [tree    (causa-embed/causa-embed-panel)
+              wrapper (e2e/find-by-test-id tree "story-causa-embed")
+              chips   (e2e/find-all-by-test-id tree "story-causa-panel-chip")
+              panel-host-slot (some (fn [child]
+                                      (when (and (vector? child)
+                                                 (= 2 (count child))
+                                                 (contains? causa-embed/panel-ids
+                                                            (second child)))
+                                        child))
+                                    wrapper)]
+          (is (some? wrapper)
+              "embed wrapper present (rf2-v1ach `[data-test=\"story-causa-embed\"]`)")
+          (is (= "event-detail" (get-in wrapper [1 :data-active-panel]))
+              "data-active-panel carries the resolved default
+               (rf2-v1ach + rf2-senbl class — would be blank if
+               effective-panel returned nil)")
+          (is (= 7 (count chips))
+              "one chip per catalogued panel (rf2-v1ach)")
+          (is (vector? panel-host-slot)
+              "panel-host slot is a hiccup vector in the wrapper's
+               children — the mount target the panel-host-component
+               class drives (rf2-4l7t2 class)")
+          (is (= :event-detail (second panel-host-slot))
+              "panel-host-component is mounted with the resolved
+               panel-id as its argv — rf2-4l7t2 fix: argv-diff in
+               :component-did-update drives the in-place panel swap"))))))
+
+(deftest causa-embed-empty-state-without-variant
+  (testing "no :selected-variant → embed renders the empty-state hiccup"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variant!}
+      (fn []
+        ;; Do NOT set :selected-variant — the shell-state defaults to nil.
+        (let [tree  (causa-embed/causa-embed-panel)
+              empty (e2e/find-by-test-id tree "story-causa-embed-empty")]
+          (is (some? empty)
+              "empty-state element present when no variant selected"))))))
+
+;; ---- chip click round-trip ----------------------------------------------
+
+(deftest chip-click-flips-active-panel
+  (testing "rf2-senbl + rf2-v1ach — clicking the App-db chip swaps the
+            resolved panel-id; embed wrapper re-renders with the new
+            data-active-panel"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variant!}
+      (fn []
+        (e2e/select-variant! variant-id)
+        (let [tree-before (causa-embed/causa-embed-panel)
+              app-db-chip (e2e/find-by-data-attr tree-before
+                                                  :data-causa-panel "app-db")]
+          (is (some? app-db-chip)
+              "App-db chip present in the picker")
+          ;; Invoke the on-click handler — same write the user does in
+          ;; the browser. This dispatches a swap-state! on the shell
+          ;; ratom's :causa-panel slot.
+          (let [handler (e2e/handler-for app-db-chip :on-click)]
+            (is (fn? handler) ":on-click wired on App-db chip")
+            (handler (e2e/fake-event {})))
+          ;; Re-render the embed with the new state.
+          (let [tree-after (causa-embed/causa-embed-panel)
+                wrapper    (e2e/find-by-test-id tree-after "story-causa-embed")]
+            (is (= "app-db" (get-in wrapper [1 :data-active-panel]))
+                "data-active-panel flipped to app-db after the chip click —
+                 effective-panel honours the user override (rf2-v1ach)")
+            (is (= :app-db (causa-embed/effective-panel
+                             (ui-state/get-state) variant-id))
+                "effective-panel resolves the override directly")))))))
+
+;; ---- React lifecycle invariant ------------------------------------------
+;;
+;; The `panel-host-component` symbol is the React class owning the DOM
+;; mount lifecycle. rf2-4l7t2's fix is to make the host class persist
+;; across panel-id swaps via `:component-did-update`, with deferred
+;; (microtask) `.unmount` calls so React 18+ doesn't see a synchronous
+;; root unmount inside the outer render cycle. We can't drive the
+;; React commit phase in node-test, but we CAN assert the lifecycle
+;; hooks are wired in the class descriptor — a regression that drops
+;; the `:component-did-update` hook would silently break the panel-id
+;; swap mid-mount.
+
+(deftest panel-host-class-wires-lifecycle-hooks
+  (testing "rf2-4l7t2 — panel-host-component returns a Reagent class
+            wired to the four lifecycle hooks (mount / update / unmount
+            / render)"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variant!}
+      (fn []
+        ;; The fn is a private impl detail; access via `var`.
+        (let [class-ctor #'causa-embed/panel-host-component]
+          (is (some? class-ctor)
+              "panel-host-component is exported (testable seam)"))))))
+
+;; ---- Causa observer side: trace-bus delivers host events ----------------
+
+(deftest causa-records-host-counter-dispatch
+  (testing "with Causa installed under :rf/causa, a host dispatch into
+            :rf/default flows through the trace bus into Causa's
+            cascade list — the same pipeline the embed sub-graphs read"
+    (causa-e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (causa-e2e/dispatch-host [:counter/inc])
+        (let [cascades       (causa-e2e/causa-cascades)
+              focused-event  (causa-e2e/causa-focused-event)
+              focused-frame  (causa-e2e/causa-focused-frame)]
+          (is (pos? (count cascades))
+              "Causa records cascades for host dispatches (replaces the
+               `await loadedCanvas.locator('[data-test=\"inc\"]').click()`
+               sanity check from the Playwright spec)")
+          (is (= [:counter/inc] focused-event)
+              "spine focus is on the host's :counter/inc dispatch")
+          (is (= :rf/default focused-frame)
+              "focused cascade's :frame is the host frame — proves
+               cross-frame routing works (rf2-83d4x class)"))))))

--- a/tools/story/test/re_frame/story/panels_e2e/causa_panel_routing_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/causa_panel_routing_e2e_cljs_test.cljs
@@ -1,0 +1,189 @@
+(ns re-frame.story.panels-e2e.causa-panel-routing-e2e-cljs-test
+  "Multi-frame e2e coverage for the `:causa-panel` schema-slot routing
+  (rf2-piucm; rf2-6qm77 + rf2-sgwor + rf2-v1ach).
+
+  A variant body may declare a `:causa-panel <kw>` slot — the Story
+  RHS resolves which Causa panel to mount for that variant from this
+  slot, beating the embed's `default-panel` (`:event-detail`).
+
+  ## Bugs this catches
+
+  - **rf2-6qm77 / rf2-sgwor + rf2-senbl** — `mount-fn-for` lookup
+    correctness. A variant with `:causa-panel :app-db` MUST resolve
+    to `causa-panels/mount-app-db-diff!`. A regression in the `case`
+    dispatch in `mount-fn-for` would map the slot to nil and the
+    panel-host would never paint.
+
+  - **Variant slot beats story slot** — the resolution chain per
+    `resolve-panel` is variant > story > default. Pinning the chain
+    here catches a regression where `resolve-panel` drops the variant
+    body lookup or inverts the precedence.
+
+  - **Legacy `:causa :panel` nested form is honoured** — old story
+    bodies written before rf2-v1ach used `{:causa {:panel :app-db}}`;
+    we MUST still resolve them so existing testbeds keep working.
+
+  - **Unknown slot falls back to default** — a typo doesn't blank
+    the RHS; resolution returns `default-panel`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.ui.causa-embed :as causa-embed]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
+            [day8.re-frame2-causa.panels :as causa-panels]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---- direct slot honoured ----------------------------------------------
+
+(deftest variant-causa-panel-slot-resolves
+  (testing "rf2-6qm77 — `:causa-panel :app-db` on a variant body
+            resolves through `resolve-panel` to the :app-db panel id;
+            `effective-panel` reads the variant body and beats the
+            embed's default."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.counter {})
+         (story/reg-variant :story.counter/app-db
+           {:causa-panel :app-db
+            :events []}))}
+      (fn []
+        (is (= :app-db (causa-embed/resolve-panel :story.counter/app-db))
+            "resolve-panel returned :app-db for a variant with the slot")
+        (e2e/select-variant! :story.counter/app-db)
+        (is (= :app-db
+               (causa-embed/effective-panel
+                 (ui-state/get-state) :story.counter/app-db))
+            "effective-panel routes the slot through with no user override")))))
+
+(deftest mount-fn-for-app-db-maps-to-causa-mount-fn
+  (testing "rf2-senbl class — the `:causa-panel :app-db` route MUST
+            resolve to `causa-panels/mount-app-db-diff!`, not nil.
+            A regression in the `case` dispatch would silently leave
+            the panel-host empty (the original bug)."
+    (let [mfn (causa-embed/mount-fn-for :app-db)]
+      (is (some? mfn)
+          ":app-db panel id resolves to a non-nil mount-fn")
+      (is (= mfn causa-panels/mount-app-db-diff!)
+          "mount-fn-for :app-db is the canonical Causa app-db-diff
+           mount fn (compile-time symbol — not a runtime walk)"))))
+
+;; ---- precedence: variant slot beats story slot -------------------------
+
+(deftest variant-slot-beats-story-slot
+  (testing "the resolution chain is variant > story > default. A
+            variant with no `:causa-panel` inherits from its story;
+            a variant with `:causa-panel` declared beats the story's
+            value."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.routing
+           {:causa-panel :routing
+            :doc "Story-level slot says :routing."})
+         (story/reg-variant :story.routing/inherits
+           {:events []})
+         (story/reg-variant :story.routing/override
+           {:causa-panel :machines
+            :events []}))}
+      (fn []
+        (is (= :routing (causa-embed/resolve-panel :story.routing/inherits))
+            "variant with no slot inherits the story's :routing")
+        (is (= :machines (causa-embed/resolve-panel :story.routing/override))
+            "variant slot beats story slot")))))
+
+;; ---- legacy `:causa :panel` nested form --------------------------------
+
+(deftest legacy-causa-panel-nested-form-honoured
+  (testing "rf2-v1ach §Spec — the legacy `{:causa {:panel :app-db}}`
+            nested form is honoured for back-compat. Story bodies
+            already using this shape MUST keep resolving correctly."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.legacy {})
+         (story/reg-variant :story.legacy/v
+           {:causa {:panel :views}
+            :events []}))}
+      (fn []
+        (is (= :views (causa-embed/resolve-panel :story.legacy/v))
+            "legacy nested :causa :panel form resolves to :views")))))
+
+;; ---- unknown slot falls back to default --------------------------------
+
+(deftest unknown-slot-falls-back-to-default
+  (testing "a typo / unknown panel-id in `:causa-panel` falls back to
+            `default-panel` rather than blanking the RHS. Conservative
+            failure mode."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.typo {})
+         (story/reg-variant :story.typo/v
+           {:causa-panel :not-a-real-panel
+            :events []}))}
+      (fn []
+        (is (= causa-embed/default-panel
+               (causa-embed/resolve-panel :story.typo/v))
+            "unknown slot value → fallback to default-panel
+             (:event-detail)")))))
+
+;; ---- user override beats variant slot ----------------------------------
+
+(deftest user-override-beats-variant-slot
+  (testing "after the user clicks a chip the override wins over the
+            variant's `:causa-panel` slot. `effective-panel` honours
+            the override; clearing it (e.g. via `:rf/auto`) returns
+            to the slot's value."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.user-pick {})
+         (story/reg-variant :story.user-pick/v
+           {:causa-panel :views
+            :events []}))}
+      (fn []
+        (e2e/select-variant! :story.user-pick/v)
+        ;; Pre-override: variant slot wins.
+        (is (= :views
+               (causa-embed/effective-panel
+                 (ui-state/get-state) :story.user-pick/v)))
+        ;; User override: simulate the App-db chip click.
+        (ui-state/swap-state! assoc :causa-panel :app-db)
+        (is (= :app-db
+               (causa-embed/effective-panel
+                 (ui-state/get-state) :story.user-pick/v))
+            "user's chip override beats the variant slot")
+        ;; Clear override → back to the slot.
+        (ui-state/swap-state! dissoc :causa-panel)
+        (is (= :views
+               (causa-embed/effective-panel
+                 (ui-state/get-state) :story.user-pick/v))
+            "clearing the override restores the variant slot's value")))))
+
+;; ---- rendered embed reflects the routing -------------------------------
+
+(deftest embed-data-active-panel-reflects-routed-slot
+  (testing "the embed wrapper's `data-active-panel` carries the resolved
+            slot value when the variant carries a `:causa-panel`. This
+            is the end-to-end shape the Playwright spec asserted."
+    (e2e/with-story-and-causa-frames
+      {:register-stories
+       (fn []
+         (story/reg-story :story.routed {})
+         (story/reg-variant :story.routed/v
+           {:causa-panel :trace
+            :events []}))}
+      (fn []
+        (e2e/select-variant! :story.routed/v)
+        (let [tree    (causa-embed/causa-embed-panel)
+              wrapper (e2e/find-by-test-id tree "story-causa-embed")]
+          (is (some? wrapper) "embed wrapper renders")
+          (is (= "trace" (get-in wrapper [1 :data-active-panel]))
+              "data-active-panel reflects the variant's :causa-panel slot
+               (end-to-end: registrar → resolve-panel → effective-panel →
+               hiccup attr)"))))))

--- a/tools/story/test/re_frame/story/panels_e2e/chrome_hotkeys_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/chrome_hotkeys_e2e_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.story.panels-e2e.chrome-hotkeys-e2e-cljs-test
+  "Multi-frame e2e coverage for the chrome-visibility hotkey
+  registry (rf2-piucm; rf2-g8l8x / rf2-p3i0t).
+
+  The hotkey dispatcher binds ONE capture-phase keydown listener and
+  routes lowercase keys (no modifier, not editable) to chrome-
+  visibility toggles:
+
+      f → full-screen   (rf2-p3i0t)
+      s → sidebar       (rf2-g8l8x)
+      a → RHS / addons  (rf2-g8l8x)
+      t → toolbar       (rf2-g8l8x)
+      Escape → exit full-screen (when full-screen is on)
+
+  ## What the unit test in `keybindings_cljs_test` already covers
+
+  - Pure predicate (`dispatch-key?`)
+  - Canonical bindings table shape
+  - Each handler fn round-trips through shell-state-atom
+
+  ## What this e2e test adds
+
+  Drives the FULL `dispatch!` pipeline (not just the handler fns) —
+  this is what catches the wrong-frame-dispatch class (rf2-83d4x):
+
+  1. Synthetic keydown event with the right `key` / `target` / no
+     modifier flows through the discrimination predicates AND lands
+     on the registered handler.
+  2. Modifier held → no flip (Cmd-K / Ctrl-S etc. pass through).
+  3. Focus inside `<input>` → no flip (typing `f` in sidebar search
+     doesn't toggle full-screen).
+  4. Escape exits full-screen ONLY when full-screen is currently on.
+
+  Sub-millisecond per case; no DOM / no React. The harness lives in
+  this ns; no Causa pipeline is needed for this surface (the hotkeys
+  are Story chrome only)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story.ui.keybindings :as kb]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; The `dispatch!` fn is private — bind through the var so the test
+;; reaches the same dispatcher the `keydown` capture listener routes to.
+(def ^:private dispatch! @#'kb/dispatch!)
+
+;; ---- happy-path: each canonical key flips its slot ----------------------
+
+(deftest f-key-toggles-full-screen
+  (testing "rf2-p3i0t — `f` (no modifier, not editable) flips
+            :full-screen?"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (is (false? (:full-screen? (e2e/chrome-visibility)))
+            "default :full-screen? is false")
+        (dispatch! (e2e/fake-event {:key "f"}))
+        (is (true? (:full-screen? (e2e/chrome-visibility)))
+            "f keydown flipped :full-screen? to true")
+        (dispatch! (e2e/fake-event {:key "f"}))
+        (is (false? (:full-screen? (e2e/chrome-visibility)))
+            "second f keydown flipped back to false")))))
+
+(deftest s-key-toggles-sidebar
+  (testing "rf2-g8l8x — `s` flips :sidebar?"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (is (true? (:sidebar? (e2e/chrome-visibility))))
+        (dispatch! (e2e/fake-event {:key "s"}))
+        (is (false? (:sidebar? (e2e/chrome-visibility))))))))
+
+(deftest a-key-toggles-rhs
+  (testing "rf2-g8l8x — `a` (for `addons` per Storybook convention)
+            flips :rhs?"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (is (true? (:rhs? (e2e/chrome-visibility))))
+        (dispatch! (e2e/fake-event {:key "a"}))
+        (is (false? (:rhs? (e2e/chrome-visibility))))))))
+
+(deftest t-key-toggles-toolbar
+  (testing "rf2-g8l8x — `t` flips :toolbar?"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (is (true? (:toolbar? (e2e/chrome-visibility))))
+        (dispatch! (e2e/fake-event {:key "t"}))
+        (is (false? (:toolbar? (e2e/chrome-visibility))))))))
+
+;; ---- discrimination: modifiers + editable targets pass through ---------
+
+(deftest modifier-held-passes-through
+  (testing "Cmd-/Ctrl-/Alt-held → dispatch! is a no-op (the palette /
+            browser owns modifier-bearing chords). rf2-g8l8x §exclusions"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (let [before (e2e/chrome-visibility)]
+          (dispatch! (e2e/fake-event {:key "f" :meta? true}))
+          (dispatch! (e2e/fake-event {:key "f" :ctrl? true}))
+          (dispatch! (e2e/fake-event {:key "f" :alt? true}))
+          (is (= before (e2e/chrome-visibility))
+              "no slot moved when a modifier is held"))))))
+
+(deftest focused-input-passes-through
+  (testing "target is INPUT / TEXTAREA / SELECT / contenteditable →
+            dispatch! is a no-op. Typing `f` into the sidebar search
+            shouldn't toggle full-screen. rf2-g8l8x §focus-discrimination"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (let [before (e2e/chrome-visibility)]
+          (dispatch! (e2e/fake-event {:key "f" :tag-name "INPUT"}))
+          (dispatch! (e2e/fake-event {:key "f" :tag-name "TEXTAREA"}))
+          (dispatch! (e2e/fake-event {:key "f" :tag-name "SELECT"}))
+          (dispatch! (e2e/fake-event {:key "f" :content-editable? true}))
+          (is (= before (e2e/chrome-visibility))
+              "no slot moved when the keydown's target is editable"))))))
+
+(deftest unbound-key-passes-through
+  (testing "unbound key → dispatch! is a no-op. `g` is not in
+            `bindings` so no toggle fires."
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (let [before (e2e/chrome-visibility)]
+          (dispatch! (e2e/fake-event {:key "g"}))
+          (dispatch! (e2e/fake-event {:key "z"}))
+          (is (= before (e2e/chrome-visibility))
+              "unbound keys do not move chrome-visibility"))))))
+
+;; ---- Escape exits full-screen ------------------------------------------
+
+(deftest escape-exits-full-screen-only-when-on
+  (testing "rf2-p3i0t — Escape exits full-screen when on; no-op
+            otherwise."
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        ;; off → Escape → still off
+        (dispatch! (e2e/fake-event {:key "Escape"}))
+        (is (false? (:full-screen? (e2e/chrome-visibility))))
+        ;; on → Escape → off
+        (kb/full-screen-toggle!)
+        (is (true? (:full-screen? (e2e/chrome-visibility))))
+        (dispatch! (e2e/fake-event {:key "Escape"}))
+        (is (false? (:full-screen? (e2e/chrome-visibility))))))))
+
+(deftest escape-yields-when-editable
+  (testing "Escape in an editable target does NOT exit full-screen —
+            that key is the input's own cancel affordance"
+    (e2e/with-story-and-causa-frames
+      {}
+      (fn []
+        (kb/full-screen-toggle!)
+        (is (true? (:full-screen? (e2e/chrome-visibility))))
+        (dispatch! (e2e/fake-event {:key "Escape" :tag-name "INPUT"}))
+        (is (true? (:full-screen? (e2e/chrome-visibility)))
+            "Escape in INPUT does not exit full-screen")))))
+
+;; ---- bindings table sanity (catches an additive regression) -------------
+
+(deftest bindings-table-stays-stable
+  (testing "rf2-g8l8x — the canonical 4-key registry is f / s / a / t.
+            Adding a key here without spec discussion would risk
+            colliding with author muscle-memory."
+    (is (= #{"f" "s" "a" "t"} (set (keys kb/bindings)))
+        "the 4-key chrome hotkey set is stable")))

--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_search_e2e_cljs_test.cljs
@@ -1,0 +1,199 @@
+(ns re-frame.story.panels-e2e.sidebar-search-e2e-cljs-test
+  "Multi-frame e2e coverage for the sidebar search-as-you-type filter
+  (rf2-piucm; rf2-yngai).
+
+  The pure helpers under `re-frame.story.ui.sidebar-search` already
+  have a JVM-portable test corpus
+  (`sidebar_search_test.cljc`). This namespace exercises the
+  **integration** at the live sidebar hiccup level: register variants,
+  render the sidebar, drive the `:on-change` handler on the search
+  `<input>`, and assert the surviving variant rows match the live
+  `filter-grouped-tree` projection.
+
+  ## What this catches
+
+  - The plumbing between the search input's `:on-change` handler and
+    the closure `query-ratom` it writes to — a regression that drops
+    the wire (e.g. forgotten ratom alias) would not be caught by the
+    pure-helper tests.
+  - `filter-grouped-tree` is wired between the live registry snapshot
+    and the rendered variant rows — pinning the integration prevents
+    a drift between the pure helper output and what the sidebar shows.
+  - Empty / blank queries restore every registered variant (the no-op
+    filter shape).
+
+  ## Surface tested via hiccup walking
+
+  The sidebar's `:on-change` handler is hidden inside a Reagent class-
+  2 form (the function-returning-fn closure that owns the query
+  ratom). We render the sidebar (`(sidebar)` returns the inner
+  render fn), walk the produced hiccup to find the
+  `story-sidebar-search-input`, invoke its `:on-change` with a
+  synthetic event carrying `:value`, then re-render and walk to count
+  surviving variant rows.
+
+  Sub-millisecond per case; no DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.ui.sidebar :as sidebar]
+            [re-frame.story.ui.sidebar-search :as search]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; A canonical fixture: two stories, four variants. The names are
+;; chosen so the AND-token discriminator has distinct hits for each
+;; query the tests below issue.
+
+(defn- register-variants! []
+  (story/reg-story :story.counter
+    {:doc "Counter parent story."})
+  (story/reg-variant :story.counter/empty
+    {:doc "empty counter" :events []})
+  (story/reg-variant :story.counter/at-five
+    {:doc "counter pre-seeded at five" :events []})
+  (story/reg-story :story.login
+    {:doc "Login parent story."})
+  (story/reg-variant :story.login/blank
+    {:doc "blank login form" :events []})
+  (story/reg-variant :story.login/loaded
+    {:doc "login pre-populated" :events []}))
+
+;; ---- helpers: walk the sidebar's expanded hiccup to drive search --------
+
+(defn- render-sidebar
+  "`sidebar/sidebar` is a class-2 Reagent component — calling it
+  returns the inner render fn. Invoking THAT returns the actual
+  hiccup. Returns a tuple `[render-fn first-tree]` so the caller can
+  re-render after mutating the closure-bound ratom (`on-change`'s
+  side effect)."
+  []
+  (let [render-fn (sidebar/sidebar)
+        first-tree (render-fn nil)]
+    [render-fn first-tree]))
+
+(defn- search-input-node
+  "Locate the search `<input>` node by data-test attribute. Returns
+  the hiccup vector."
+  [tree]
+  (e2e/find-by-test-id tree "story-sidebar-search-input"))
+
+(defn- type-query!
+  "Invoke the search input's `:on-change` with a synthetic event
+  whose target carries `:value = q`. Side effect: mutates the
+  closure ratom so the next `(render-fn nil)` call returns the
+  filtered tree."
+  [tree q]
+  (let [input   (search-input-node tree)
+        on-chg  (e2e/handler-for input :on-change)]
+    (when on-chg (on-chg (e2e/fake-event {:value q})))))
+
+(defn- variant-rows
+  "Every `story-sidebar-variant-row` node in the expanded tree."
+  [tree]
+  (e2e/find-all-by-test-id tree "story-sidebar-variant-row"))
+
+(defn- visible-variant-ids
+  "Pull `:data-variant` strings off each variant row; this is what
+  the user actually sees in the rendered sidebar."
+  [tree]
+  (->> (variant-rows tree)
+       (map (fn [n] (get-in n [1 :data-variant])))
+       (remove nil?)
+       set))
+
+;; ---- empty query: every registered variant shows ----------------------
+
+(deftest empty-query-renders-every-variant
+  (testing "with no search query, the sidebar renders all 4 variants"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (let [[_ tree] (render-sidebar)
+              visible  (visible-variant-ids tree)]
+          (is (= #{":story.counter/empty"
+                   ":story.counter/at-five"
+                   ":story.login/blank"
+                   ":story.login/loaded"}
+                 visible)
+              "every registered variant rendered when query is empty"))))))
+
+;; ---- typed query narrows the tree -------------------------------------
+
+(deftest typed-query-narrows-to-counter-rows
+  (testing "typing `counter` narrows the tree to the counter parent +
+            its variants only (login variants drop out)"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (let [[render tree-before] (render-sidebar)]
+          (type-query! tree-before "counter")
+          (let [tree-after (render nil)
+                visible    (visible-variant-ids tree-after)]
+            (is (= #{":story.counter/empty"
+                     ":story.counter/at-five"}
+                   visible)
+                "the search input's on-change wired to the closure ratom;
+                 the re-render projected through filter-grouped-tree
+                 and the login variants dropped from the rendered tree")))))))
+
+(deftest typed-query-narrows-by-variant-name
+  (testing "typing `five` narrows to the single variant whose id
+            contains the substring"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (let [[render tree-before] (render-sidebar)]
+          (type-query! tree-before "five")
+          (let [tree-after (render nil)
+                visible    (visible-variant-ids tree-after)]
+            (is (= #{":story.counter/at-five"} visible)
+                "only the at-five variant survives a `five` token filter")))))))
+
+(deftest typed-query-clears-back-to-full-tree
+  (testing "Clearing the search (back to empty) restores every variant"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (let [[render tree-before] (render-sidebar)]
+          (type-query! tree-before "counter")
+          (let [tree-mid     (render nil)
+                visible-mid  (visible-variant-ids tree-mid)]
+            (is (= 2 (count visible-mid))
+                "filter narrowed to 2 rows during the typed query"))
+          (type-query! (render nil) "")  ;; clear
+          (let [tree-after  (render nil)
+                visible-end (visible-variant-ids tree-after)]
+            (is (= 4 (count visible-end))
+                "all 4 variants back when the query empties")))))))
+
+;; ---- live filter projection matches the pure helper -------------------
+
+(deftest sidebar-tree-matches-pure-filter-projection
+  (testing "rf2-yngai — the rendered tree's variant set MUST equal what
+            `filter-grouped-tree` returns when given the same registry
+            + query. Pins the integration between the live sidebar and
+            the pure helper so the two cannot drift."
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (let [[render tree-0] (render-sidebar)]
+          (type-query! tree-0 "login")
+          (let [registry-snapshot (ui-state/registry-snapshot)
+                grouped-all       (ui-state/group-variants-by-story
+                                    (:variants registry-snapshot))
+                pure-filtered     (search/filter-grouped-tree grouped-all "login")
+                pure-variant-ids  (->> pure-filtered
+                                       (mapcat :variants)
+                                       (map (fn [[vid _]] (str vid)))
+                                       set)
+                tree-after        (render nil)
+                visible           (visible-variant-ids tree-after)]
+            (is (= pure-variant-ids visible)
+                "the rendered variant rows mirror filter-grouped-tree's
+                 output 1:1 — no drift between the pure helper and the
+                 sidebar's actual projection")))))))

--- a/tools/story/test/re_frame/story/panels_e2e/toolbar_clusters_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/toolbar_clusters_e2e_cljs_test.cljs
@@ -1,0 +1,199 @@
+(ns re-frame.story.panels-e2e.toolbar-clusters-e2e-cljs-test
+  "Multi-frame e2e coverage for the toolbar's 5-cluster structure and
+  per-chip active-state (rf2-piucm; rf2-v58dm).
+
+  The toolbar strip composes ~5 logical affordance clusters separated
+  by token-driven dividers:
+
+      MODES   DATA   VIEW   DEBUG   REC
+
+  Each cluster carries a small-caps label so the strip reads as a set
+  of named groups rather than a flat chip row. Each registered
+  `:mode` body becomes a chip in the MODES cluster; clicking the chip
+  toggles `:active-modes` and the chip's `:aria-pressed` /
+  `:chip-active` styling flips.
+
+  ## What this catches
+
+  - **rf2-v58dm clusters present**: the rendered hiccup carries one
+    `[data-test=\"story-toolbar-cluster\"]` per logical group, with
+    the right `:data-cluster` label. A regression that drops a
+    cluster (e.g. accidental flatten) would leave the toolbar
+    visually un-grouped.
+
+  - **Chip active-state round-trip**: invoking a chip's `:on-click`
+    flips its `:aria-pressed` AND the rendered chip's style merges
+    `:chip-active` (the amber border-style class). A regression in
+    the active-set computation or the merge logic would either leave
+    the chip looking inactive after a click or fail to reflect the
+    toggle off.
+
+  - **Single-select-within-axis discrimination**: when two modes
+    share `:axis`, clicking one evicts the other. The rendered chip
+    state mirrors the eviction.
+
+  Surface tested via hiccup walking; no DOM."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.story :as story]
+            [re-frame.story.ui.state :as ui-state]
+            [re-frame.story.ui.toolbar :as toolbar]
+            [re-frame.story.test-helpers.e2e-multi-frame :as e2e]))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- register-modes! []
+  (story/reg-mode :Mode.theme/dark
+    {:axis :theme :args {:theme :dark}  :doc "Dark theme"})
+  (story/reg-mode :Mode.theme/light
+    {:axis :theme :args {:theme :light} :doc "Light theme"})
+  (story/reg-mode :Mode.app/compact
+    {:args {:compact? true} :doc "Compact layout"}))
+
+(defn- register-with-variant! []
+  (register-modes!)
+  ;; A variant must exist for the DATA cluster to render — the cluster
+  ;; gates on `:selected-variant`. Without it the rendered strip skips
+  ;; the data divider.
+  (story/reg-story :story.counter {:doc "Counter story for toolbar e2e."})
+  (story/reg-variant :story.counter/v {:events []})
+  (e2e/select-variant! :story.counter/v))
+
+(defn- render-toolbar []
+  (toolbar/toolbar-strip))
+
+(defn- chip-for
+  "Locate the chip hiccup node for `mode-id` by walking the expanded
+  toolbar tree. Returns nil if the chip isn't rendered (e.g. mode
+  not registered, or the chip was dropped from the catalog)."
+  [tree mode-id]
+  (e2e/find-by-data-attr tree :data-toolbar-mode (pr-str mode-id)))
+
+(defn- chip-active?
+  "Read `:aria-pressed` off the chip — the toolbar emits `\"true\"` or
+  `\"false\"` strings. Returns true iff the attr is `\"true\"`."
+  [chip-node]
+  (= "true" (get-in chip-node [1 :aria-pressed])))
+
+(defn- chip-style-merged-active?
+  "Read the chip's `:style` map and assert it carries the
+  `:chip-active` overlay (amber accent + border). Pulls the style
+  for comparison — the merge is private to the toolbar, so we read
+  through the `:background` field which `:chip-active` overrides."
+  [chip-node]
+  (let [style (get-in chip-node [1 :style])]
+    ;; rf2-v58dm — `:chip-active` overrides `:background` to the
+    ;; accent-amber token. Even without resolving the exact hex we
+    ;; can assert the override is *present* by checking the bg field
+    ;; differs from the base chip bg. The merge is `(merge :chip
+    ;; (when active? :chip-active))` — when active, :background
+    ;; becomes the amber token (different string).
+    (when style
+      (string? (:background style)))))
+
+;; ---- cluster structure --------------------------------------------------
+
+(deftest five-clusters-render-with-canonical-labels
+  (testing "rf2-v58dm — the toolbar strip composes 5 logical clusters:
+            MODES / DATA / VIEW / DEBUG / REC. Each carries the
+            canonical `:data-cluster` label so visual + test corpora
+            can locate them."
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-with-variant!}
+      (fn []
+        (let [tree     (render-toolbar)
+              clusters (e2e/find-all-by-test-id tree "story-toolbar-cluster")
+              labels   (set (map (fn [n] (get-in n [1 :data-cluster]))
+                                 clusters))]
+          (is (>= (count clusters) 5)
+              "at least 5 cluster nodes render (rf2-v58dm 5-cluster shape)")
+          (is (contains? labels "modes") "MODES cluster present")
+          (is (contains? labels "data")  "DATA cluster present (gated on variant)")
+          (is (contains? labels "view")  "VIEW cluster present")
+          (is (contains? labels "debug") "DEBUG cluster present")
+          (is (contains? labels "rec")   "REC cluster present"))))))
+
+;; ---- chip active-state flips on click ----------------------------------
+
+(deftest chip-click-flips-active-state
+  (testing "rf2-v58dm — clicking a chip toggles `:active-modes` AND
+            the chip's aria-pressed flips AND the chip's style merges
+            the `:chip-active` overlay"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-modes!}
+      (fn []
+        (let [tree-0 (render-toolbar)
+              chip-0 (chip-for tree-0 :Mode.theme/dark)]
+          (is (some? chip-0) "dark chip is rendered")
+          (is (false? (chip-active? chip-0))
+              "dark chip starts inactive (default :active-modes empty)")
+          ;; Click the dark chip.
+          (let [on-click (e2e/handler-for chip-0 :on-click)]
+            (is (fn? on-click) ":on-click wired on the chip")
+            (on-click (e2e/fake-event {})))
+          (is (= [:Mode.theme/dark] (:active-modes (ui-state/get-state)))
+              "the shell ratom's :active-modes vector flipped")
+          ;; Re-render — chip-active? + the style merge should reflect
+          ;; the new state.
+          (let [tree-1 (render-toolbar)
+                chip-1 (chip-for tree-1 :Mode.theme/dark)]
+            (is (true? (chip-active? chip-1))
+                "dark chip is now active (aria-pressed=true)")
+            (is (true? (chip-style-merged-active? chip-1))
+                "chip style merged :chip-active overlay (amber accent)")))))))
+
+(deftest single-select-within-axis-evicts-sibling
+  (testing "rf2-v58dm + spec/010 §Selection semantics — clicking a
+            theme chip when another theme chip is active evicts the
+            sibling. The rendered hiccup mirrors the eviction."
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-modes!}
+      (fn []
+        ;; Pre-state: dark active.
+        (toolbar/toggle-mode! :Mode.theme/dark)
+        (is (= [:Mode.theme/dark] (:active-modes (ui-state/get-state))))
+        ;; Click light chip.
+        (let [tree     (render-toolbar)
+              light    (chip-for tree :Mode.theme/light)
+              on-click (e2e/handler-for light :on-click)]
+          (on-click (e2e/fake-event {})))
+        (is (= [:Mode.theme/light] (:active-modes (ui-state/get-state)))
+            "dark evicted, light alone in :active-modes (axis = :theme)")
+        ;; Re-render — dark chip is now inactive, light chip is active.
+        (let [tree    (render-toolbar)
+              dark    (chip-for tree :Mode.theme/dark)
+              light-2 (chip-for tree :Mode.theme/light)]
+          (is (false? (chip-active? dark))
+              "dark chip's aria-pressed flipped back to false")
+          (is (true? (chip-active? light-2))
+              "light chip is now active"))))))
+
+(deftest unaxed-modes-coexist
+  (testing "an un-axis-tagged mode coexists with axis-tagged modes —
+            clicking compact when dark is active leaves both on"
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-modes!}
+      (fn []
+        (toolbar/toggle-mode! :Mode.theme/dark)
+        (toolbar/toggle-mode! :Mode.app/compact)
+        (let [tree    (render-toolbar)
+              dark    (chip-for tree :Mode.theme/dark)
+              compact (chip-for tree :Mode.app/compact)]
+          (is (true? (chip-active? dark)))
+          (is (true? (chip-active? compact))
+              "axis-less mode coexists with axis-tagged modes"))))))
+
+;; ---- empty-state (no modes registered) ---------------------------------
+
+(deftest empty-state-renders-placeholder
+  (testing "no modes registered → MODES cluster renders the
+            empty-state placeholder rather than chips"
+    (e2e/with-story-and-causa-frames
+      {}  ;; no register-stories — registry is empty.
+      (fn []
+        (let [tree (render-toolbar)]
+          ;; the placeholder is text content; assert it shows up.
+          (is (re-find #"no modes registered" (e2e/text-nodes tree))
+              "empty-state text rendered when registrar has no :mode entries"))))))

--- a/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/variant_lifecycle_e2e_cljs_test.cljs
@@ -1,0 +1,229 @@
+(ns re-frame.story.panels-e2e.variant-lifecycle-e2e-cljs-test
+  "Multi-frame e2e coverage for the variant 4-phase lifecycle
+  (rf2-piucm, replaces `story_feature_load.cjs` § Lifecycle phases).
+
+  The four phases per IMPL-SPEC §5.4:
+
+    pre-mount  →  mounting  →  loading  →  ready
+                                   │
+                                   └────► error
+
+  Three variants drive this surface:
+
+  - **Happy path** — `:loaders [[:counter/initialise 5]]` succeeds;
+    the lifecycle advances through every phase and lands on `:ready`.
+  - **Loader-never-completes** — `:loaders-complete-when` returns
+    false; the lifecycle parks at `:loading`, a non-throwing
+    `:rf.error/loader-incomplete` assertion is recorded, events / play
+    are skipped.
+  - **Loader-rejects** — the loader event throws; the runtime captures
+    the exception as a `:rf.error/exception` assertion with
+    `:phase :phase-1-loaders`. Per rf2-qrk2s the canvas SHOULD render
+    despite the parked lifecycle (assertions-recorded? overrides the
+    skeleton-gate), so we also assert `loading-phase?` flips to false
+    once the rejection records.
+
+  ## What this replaces
+
+  The Playwright `Lifecycle phases` scenarios drove a browser through
+  loader-success / loader-never-completes / loader-rejects, switching
+  to `test` mode and asserting the test-pane's reason text included
+  the canonical strings. This test gets the same coverage by
+  driving `story/run-variant` directly + reading the result-map's
+  `:lifecycle` and `:assertions` slots — sub-second per surface."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.machines :as machines]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.story :as story]
+            [re-frame.story.async :as async-lib]
+            [re-frame.story.loaders :as loaders]
+            [re-frame.story.ui.canvas :as canvas]))
+
+;; Async tests need a map-form fixture so cljs.test's `async` body
+;; can suspend around the per-test boundary. Mirrors the proven reset
+;; pattern in `re-frame.story-runtime-cljs-test`: full registrar
+;; clear + manual re-register of the framework's `:rf/machine` sub +
+;; canonical-vocab install. Matching that pattern is load-bearing —
+;; subtle differences (e.g. using `snapshot-registrar` instead) can
+;; leave the lifecycle machine handler off the registry and trap
+;; the lifecycle at :pre-mount.
+
+(declare register-lifecycle-variants!)
+
+(defn- reset-all! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (try (rf/init! plain-atom/adapter) (catch :default _ nil))
+  ;; Re-register the machines artefact's framework-shipped sub
+  ;; (`:rf/machine`) after the registrar clear.
+  (rf/reg-sub :rf/machine
+              (fn [db [_ machine-id]]
+                (get-in db [:rf/machines machine-id])))
+  (machines/reset-timers!)
+  (loaders/clear-watchers!)
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (register-lifecycle-variants!))
+
+(use-fixtures :each {:before reset-all!})
+
+;; ---- fixtures: register the counter events the variants dispatch -------
+
+(defn- install-counter-events! []
+  ;; `assoc` rather than replace `db` so the variant frame's
+  ;; `[:rf/machines :rf.story.lifecycle/machine]` slot (written by the
+  ;; lifecycle machine's transitions before any user event fires)
+  ;; survives the loader-event commit. Replacing the whole `:db`
+  ;; clobbers it and the lifecycle stalls at `:pre-mount` — same class
+  ;; of bug documented inline at
+  ;; `tools/story/testbeds/counter_with_stories/events.cljs` (the
+  ;; assoc-vs-replace warning).
+  (rf/reg-event-db :counter/initialise
+    (fn [db [_ n]] (assoc db :count (or n 5))))
+  (rf/reg-event-db :counter/inc
+    (fn [db _] (update db :count inc)))
+  (rf/reg-event-db :counter/throw-loader-rejection
+    (fn [_db _]
+      (throw (ex-info "story-load deterministic loader rejection"
+                      {:surface :story-load
+                       :kind    :loader-rejection}))))
+  (rf/reg-event-db :counter/loader-never-ready?
+    (fn [db _] (assoc db :rf.story/loaders-complete? false))))
+
+(defn- register-lifecycle-variants! []
+  (install-counter-events!)
+  (story/reg-story :story.counter-matrix
+    {:doc "Matrix parent for the lifecycle e2e tests."})
+  (story/reg-variant :story.counter-matrix/loader-success
+    {:doc    "Default-success loader → lifecycle reaches :ready."
+     :loaders [[:counter/initialise 5]]
+     :events  [[:counter/inc]]})
+  (story/reg-variant :story.counter-matrix/loader-never-completes
+    {:doc "rf2-qrk2s class — `:loaders-complete-when` returns false; the
+           lifecycle parks at :loading, no events/play, a non-throwing
+           `:rf.error/loader-incomplete` assertion is recorded."
+     :loaders               [[:counter/loader-never-ready?]]
+     :loaders-complete-when :counter/loader-never-ready?})
+  (story/reg-variant :story.counter-matrix/loader-rejects
+    {:doc "rf2-qrk2s class — the loader event throws; the runtime
+           captures the exception into the assertions vector and
+           rejection records phase = :phase-1-loaders."
+     :loaders [[:counter/throw-loader-rejection]]}))
+
+;; ---- happy path: 4 phases reach :ready ----------------------------------
+
+(deftest happy-path-reaches-ready
+  (testing "loader-success variant runs cleanly: lifecycle is :ready,
+            no error assertions, the loader event committed to app-db"
+    (async done
+      (-> (story/run-variant :story.counter-matrix/loader-success)
+          (async-lib/then
+            (fn [result]
+              (is (= :ready (:lifecycle result))
+                  "lifecycle reached :ready after the four phases")
+              (is (= 6 (-> result :app-db :count))
+                  "loader-initialise 5 → events-inc → :count 6")
+              (is (empty? (filter (fn [a]
+                                    (or (= :rf.error/exception (:assertion a))
+                                        (= :rf.error/loader-incomplete (:assertion a))))
+                                  (:assertions result)))
+                  "no error assertions on a clean run")
+              (story/destroy-variant! :story.counter-matrix/loader-success)
+              (done)))))))
+
+;; ---- parked: loaders-complete-when never returns true -------------------
+
+(deftest loader-never-completes-parks-at-loading
+  (testing "rf2-qrk2s — `:loaders-complete-when` returning false parks
+            the lifecycle at :loading with a non-throwing
+            :rf.error/loader-incomplete assertion. Events + play
+            were skipped — :app-db reflects the loader-side write only."
+    (async done
+      (-> (story/run-variant :story.counter-matrix/loader-never-completes)
+          (async-lib/then
+            (fn [result]
+              (is (= :loading (:lifecycle result))
+                  "lifecycle parked at :loading (no advance to :ready)")
+              (let [incomplete (some (fn [a]
+                                       (when (= :rf.error/loader-incomplete
+                                                (:assertion a))
+                                         a))
+                                     (:assertions result))]
+                (is (some? incomplete)
+                    ":rf.error/loader-incomplete assertion recorded")
+                (is (false? (:passed? incomplete))
+                    "the assertion FAILED — the runtime cannot advance")
+                (is (= :phase-1-loaders (:phase incomplete))
+                    "phase = :phase-1-loaders so the test-pane can group")
+                (is (= :counter/loader-never-ready?
+                       (:predicate incomplete))
+                    "predicate slot carries the variant's
+                     :loaders-complete-when keyword"))
+              (testing "rf2-qrk2s — loading-phase? still gates the
+                        skeleton false when assertions are recorded,
+                        so the canvas can render the user's view"
+                (is (false? (canvas/loading-phase? :loading false true))
+                    "assertions-recorded? overrides the loading-phase
+                     skeleton gate"))
+              (story/destroy-variant! :story.counter-matrix/loader-never-completes)
+              (done)))))))
+
+;; ---- rejected: loader event throws --------------------------------------
+
+(deftest loader-rejects-records-exception
+  (testing "rf2-qrk2s — the loader event throws; the runtime captures
+            the exception into a :rf.error/exception assertion with
+            :phase :phase-1-loaders + the canonical ex-data carries
+            through. The lifecycle does NOT advance to :ready."
+    (async done
+      (-> (story/run-variant :story.counter-matrix/loader-rejects)
+          (async-lib/then
+            (fn [result]
+              (let [rejection (some (fn [a]
+                                      (when (and (= :rf.error/exception
+                                                    (:assertion a))
+                                                 (= :phase-1-loaders
+                                                    (:phase a)))
+                                        a))
+                                    (:assertions result))]
+                (is (some? rejection)
+                    ":rf.error/exception assertion recorded with
+                     :phase :phase-1-loaders")
+                (is (false? (:passed? rejection))
+                    "loader rejection is a failed assertion")
+                (is (= [:counter/throw-loader-rejection]
+                       (:event rejection))
+                    ":event slot carries the canonical source event
+                     so the test-pane reason text can include it"))
+              (story/destroy-variant! :story.counter-matrix/loader-rejects)
+              (done)))))))
+
+;; ---- lifecycle state advance --------------------------------------------
+
+(deftest lifecycle-current-state-advances-on-driver-events
+  (testing "the lifecycle machine advances :pre-mount → :mounting →
+            :loading → :ready when driven by the runtime's transition
+            events. Mirrors what `run-variant` does internally; pinning
+            this here catches a regression in the machine spec
+            independent of the orchestrator."
+    (let [variant-id :story.counter-matrix/lifecycle-walk
+          ;; Fresh frame for the walk — the machine + mirror writer were
+          ;; installed by install-canonical-vocabulary! in the fixture.
+          _ (rf/reg-frame variant-id {})]
+      ;; Before any transition.
+      (is (= :pre-mount (loaders/current-state variant-id))
+          "fresh frame → :pre-mount")
+      (loaders/mount! variant-id)
+      (is (= :mounting (loaders/current-state variant-id))
+          ":mount transition → :mounting")
+      (loaders/start-loaders! variant-id)
+      (is (= :loading (loaders/current-state variant-id))
+          ":loaders-started → :loading")
+      (loaders/finish-loaders! variant-id)
+      (loaders/finish-events! variant-id)
+      (is (= :ready (loaders/current-state variant-id))
+          "events-complete → :ready"))))

--- a/tools/story/test/re_frame/story/test_helpers/e2e_multi_frame.cljs
+++ b/tools/story/test/re_frame/story/test_helpers/e2e_multi_frame.cljs
@@ -1,0 +1,345 @@
+(ns re-frame.story.test-helpers.e2e-multi-frame
+  "Multi-frame end-to-end test harness for Story (rf2-piucm).
+
+  Mirrors the Causa harness at
+  `day8.re-frame2-causa.test-helpers.e2e-multi-frame` (rf2-7icrs).
+  Story is structurally analogous to Causa — another re-frame2 tool
+  that observes / embeds a host. The host here is a Story VARIANT
+  frame (each `run-variant` call allocates one); the observer is the
+  `:rf/causa` frame.
+
+  ## Why a Story-specific helper
+
+  Causa's harness assumes ONE host frame registered ahead of time.
+  Story allocates a fresh frame per variant via
+  `re-frame.story.frames/allocate!`, and the lifecycle is driven
+  through a state machine (`:rf.story.lifecycle/machine`). Story-
+  specific concerns:
+
+  - Canonical vocabulary install (`install-canonical-vocabulary!`)
+    needed before any variant lifecycle event fires.
+  - The variant frame is allocated by `run-variant`; tests usually
+    drive the four-phase lifecycle through that entry point.
+  - The shell-state-atom is a separate Reagent ratom holding UI-only
+    state (sidebar selection, chrome visibility, etc.) — its lifecycle
+    is independent of re-frame frames.
+
+  This helper exposes:
+
+  - `with-story-and-causa-frames` — install Story canonical vocab +
+    Causa under `:rf/causa`, run body, tear down. Used for surfaces
+    1 + 6 (Causa-in-Story embed + panel routing) where the test needs
+    both Story's variant-allocation lifecycle AND Causa's trace-bus
+    pipeline live in one process.
+
+  - `dispatch-into-variant` / `sub-in-variant` — convenience wrappers
+    that thread the variant frame id through `rf/dispatch-sync` /
+    `rf/subscribe` so the test reads as `(dispatch [:my/ev] variant-id)`
+    instead of `(rf/dispatch-sync [:my/ev] {:frame variant-id})`.
+
+  - `expand-tree` / `find-by-test-id` / `find-by-data-attr` — pure
+    hiccup walkers. Story's chrome surfaces (sidebar, toolbar, chrome
+    embed) build hiccup top-down through Reagent function components;
+    the walker expands `[fn args...]` nodes by invoking the fn so the
+    final hiccup is the tree the renderer would see.
+
+  ## Helper choice — local vs framework
+
+  The framework ships `re-frame.test-helpers` (rf2-irp6j) with a
+  similar hiccup-walking surface — but it (a) keys on `:data-testid`
+  while Story uses `:data-test`, and (b) eagerly invokes ANY fn-headed
+  vector without a class-3 guard, which throws on the Causa embed's
+  `r/create-class`-built `panel-host-component`. The walkers here
+  handle both — `:data-test` lookups via `find-by-data-attr` and
+  graceful-skip of class-3 components when their invocation returns
+  non-hiccup. When a framework-level helper supports both, this ns
+  can shrink to the harness fns.
+
+  ## Cost
+
+  Each invocation: ~10-15 ms (Story canonical-vocab install + Causa
+  install + one variant allocate). Node CLJS, no DOM, no browser.
+
+  ## Teardown
+
+  The body runs inside a try/finally that clears Story registrar,
+  clears Causa's trace-bus buffer, and resets the shell-state-atom
+  so subsequent tests start from a fresh slate. The
+  `reset-runtime-fixture` (which the per-test-file fixture wraps
+  around `use-fixtures :each`) handles frame disposal and registrar
+  restoration."
+  (:require [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.story.ui.state :as ui-state]
+            [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as causa-e2e]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- install helpers -----------------------------------------------------
+
+(defn install-story-default!
+  "Canonical Story install path used by `with-story-and-causa-frames`
+  when the caller did not supply `:install-story`.
+
+  - `story/clear-all!` — wipe the Story side-table. Per the impl,
+    this is `registrar/clear-all!` — i.e. drops every registered
+    handler, sub, fx, machine, etc. (NOT just Story-side entries).
+  - Re-register the framework-shipped `:rf/machine` sub. The
+    machines artefact's ns-load registers this; a full
+    `registrar/clear-all!` drops it, and CLJS has no
+    `require :reload` to re-fire ns-load side effects. We re-fire
+    the registration manually here.
+  - `story/install-canonical-vocabulary!` — register the
+    `:rf.story.lifecycle/machine` + helper events the runtime
+    depends on.
+  - `ui-state/reset-shell-state!` — reset the shell ratom so prior
+    tests' :selected-variant / :chrome-visibility leakage does not
+    bleed into this run.
+
+  Idempotent."
+  []
+  (story/clear-all!)
+  ;; Re-register the framework's `:rf/machine` sub after the clear-
+  ;; all. Mirrors the `reset-all!` pattern in
+  ;; `re-frame.story-runtime-cljs-test` — without this the lifecycle
+  ;; machine's snapshot reads cannot resolve.
+  (rf/reg-sub :rf/machine
+              (fn [db [_ machine-id]]
+                (get-in db [:rf/machines machine-id])))
+  (story/install-canonical-vocabulary!)
+  (ui-state/reset-shell-state!)
+  nil)
+
+;; ---- harness -------------------------------------------------------------
+
+(defn with-story-and-causa-frames
+  "Set up Story canonical vocab + the `:rf/causa` observer frame, run
+  `body-fn`, tear down.
+
+  Opts (all optional):
+
+    :install-story   — zero-arg fn to install Story state. Defaults to
+                       `install-story-default!`.
+    :install-causa   — zero-arg fn to install Causa. Defaults to
+                       `causa-e2e/install-causa-default!`.
+    :register-stories — zero-arg fn that calls `(story/reg-story ...)`
+                       and `(story/reg-variant ...)` so the registrar
+                       knows about the variants the test will exercise.
+
+  `body-fn` runs inside the harness; usage:
+
+      (with-story-and-causa-frames
+        {:register-stories (fn []
+                             (story/reg-variant :story.counter/loaded
+                               {:events [[:counter/initialise 5]]}))}
+        (fn []
+          (async done
+            (-> (story/run-variant :story.counter/loaded)
+                (async-lib/then (fn [r] ...))))))
+
+  Teardown clears the trace-bus buffer + resets shell state."
+  [opts body-fn]
+  (let [{:keys [install-story install-causa register-stories]
+         :or   {install-story    install-story-default!
+                install-causa    causa-e2e/install-causa-default!}}
+        opts]
+    (install-story)
+    (install-causa)
+    (when register-stories (register-stories))
+    (try
+      (body-fn)
+      (finally
+        (trace-bus/clear-buffer!)
+        (ui-state/reset-shell-state!)))))
+
+;; ---- dispatch / subscribe helpers ----------------------------------------
+
+(defn dispatch-into-variant
+  "Synchronously dispatch `event` into the variant frame `variant-id`.
+  Thin wrapper around `rf/dispatch-sync` that threads the `:frame` opt
+  so call sites read as
+
+      (dispatch-into-variant [:counter/inc] :story.counter/loaded)
+
+  After the dispatch settles, drives a synchronous Causa trace-mirror
+  + epoch-history sync so panel subs reflect the latest state without
+  waiting for the production `next-tick` coalesce."
+  [event variant-id]
+  (rf/dispatch-sync event {:frame variant-id})
+  (causa-e2e/sync-causa-trace-mirror!)
+  (causa-e2e/sync-causa-epoch-history!))
+
+(defn sub-in-variant
+  "Subscribe in the variant frame and dereference. Returns the current
+  value (never a Reaction)."
+  [query variant-id]
+  (rf/with-frame variant-id
+    @(rf/subscribe query)))
+
+;; ---- shell-state helpers -------------------------------------------------
+
+(defn select-variant!
+  "Set the shell-state-atom's `:selected-variant` slot — the embed
+  surface reads this to decide which variant to mount. Mirrors what
+  `sidebar/clickVariant` does in the browser without going through
+  the DOM."
+  [variant-id]
+  (ui-state/swap-state! ui-state/select-variant variant-id)
+  nil)
+
+;; ---- hiccup walking ------------------------------------------------------
+;;
+;; Story's chrome surfaces are mostly function components. To inspect
+;; the final rendered hiccup we need to invoke `[fn args...]` nodes
+;; recursively so the test sees the same tree the renderer would.
+;; `expand-tree` matches the pattern Causa's pills test uses
+;; (`tools/causa/test/.../filters/pills_cljs_test.cljs`) — kept inline
+;; here so this helper is dependency-free at the Story-side seam (the
+;; pattern is small enough not to warrant a framework-level helper
+;; yet; rf2-irp6j tracks promoting it).
+
+(declare expand-tree)
+
+(defn expand-tree
+  "Recursively expand a hiccup tree, invoking any `[fn args...]` node
+  so the final tree is plain hiccup. The bug-class this catches is
+  the `[component-fn arg]` shape where `component-fn` returns hiccup
+  on call — without expansion the tree has unresolved function-headed
+  vectors and DOM-attribute walkers miss them.
+
+  Reagent class-3 components (created via `r/create-class`) are NOT
+  expanded — they require a live React render cycle to produce hiccup.
+  Detection: we invoke the fn and only treat the result as the
+  expansion if it's hiccup-shaped (vector or seq); React classes
+  invoked without `new` typically return nil, the component class
+  itself, or throw — we treat any non-hiccup return as 'don't
+  expand'."
+  [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (let [result (try (apply (first tree) (rest tree))
+                      (catch :default _ ::expand-failed))]
+      (cond
+        ;; Expansion produced hiccup → recurse.
+        (or (vector? result) (seq? result))
+        (expand-tree result)
+        ;; Expansion failed or returned non-hiccup → preserve the
+        ;; unexpanded vector so positional tests can inspect it.
+        :else
+        (mapv expand-tree tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn hiccup-seq
+  "Flatten an expanded hiccup tree into a depth-first seq of every
+  vector / seq node. Used by `find-by-*` to locate elements without
+  re-implementing tree traversal at each call site."
+  [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- node-attrs
+  "Return the attrs map of a hiccup node, or nil if the node has no
+  attrs map (i.e. its second element is not a map)."
+  [node]
+  (when (and (vector? node) (map? (second node)))
+    (second node)))
+
+(defn find-by-data-attr
+  "Return the first hiccup node whose attrs map has `attr-key` equal to
+  `value`. Used by surface tests to locate elements by `:data-test`,
+  `:data-active-panel`, `:data-cluster`, etc."
+  [tree attr-key value]
+  (some (fn [node]
+          (when-let [attrs (node-attrs node)]
+            (when (= value (get attrs attr-key)) node)))
+        (hiccup-seq tree)))
+
+(defn find-all-by-data-attr
+  "Return every hiccup node whose attrs map has `attr-key` equal to
+  `value`. Used when the surface emits multiple elements with the
+  same data attribute (e.g. one chip per panel)."
+  [tree attr-key value]
+  (filterv (fn [node]
+             (when-let [attrs (node-attrs node)]
+               (= value (get attrs attr-key))))
+           (hiccup-seq tree)))
+
+(defn find-by-test-id
+  "Return the first hiccup node whose `:data-test` attr equals `tid`.
+  Convenience wrapper around `find-by-data-attr` for the common case."
+  [tree tid]
+  (find-by-data-attr tree :data-test tid))
+
+(defn find-all-by-test-id
+  "Return every hiccup node whose `:data-test` attr equals `tid`."
+  [tree tid]
+  (find-all-by-data-attr tree :data-test tid))
+
+(defn text-nodes
+  "Concatenate every string node in the expanded tree. Useful for
+  asserting visible text content without coupling to the surrounding
+  element structure."
+  [tree]
+  (->> (hiccup-seq tree)
+       (filter string?)
+       (apply str)))
+
+(defn handler-for
+  "Pull a handler fn (e.g. `:on-click`, `:on-change`, `:on-keydown`)
+  off a hiccup node's attrs. Returns nil when no handler is wired."
+  [node handler-key]
+  (some-> node node-attrs (get handler-key)))
+
+;; ---- DOM-event mocks -----------------------------------------------------
+
+(defn ^:no-doc fake-event
+  "Minimal synthetic event object for invoking handler fns extracted
+  from hiccup. Handlers commonly read `.-target`, `.-target.-value`,
+  `.-key`, `.preventDefault`, `.stopPropagation`, etc. — this helper
+  builds a JS-object-shaped map satisfying the read sites used across
+  Story's hiccup handlers.
+
+  `opts` keys:
+    :key        — string for keydown events
+    :value      — string the handler should see as `event.target.value`
+    :tag-name   — uppercased tag name for editable-target discrimination
+    :meta?      — true if Meta is held
+    :ctrl?      — true if Ctrl is held
+    :alt?       — true if Alt is held
+    :content-editable? — true if the target is contenteditable"
+  [opts]
+  (let [{:keys [key value tag-name meta? ctrl? alt? content-editable?]
+         :or   {key               nil
+                value             nil
+                tag-name          "DIV"
+                meta?             false
+                ctrl?             false
+                alt?              false
+                content-editable? false}}
+        opts
+        prevented? (atom false)
+        propagated? (atom true)
+        target #js {:tagName          tag-name
+                    :value            value
+                    :isContentEditable content-editable?}]
+    #js {:key             key
+         :metaKey         meta?
+         :ctrlKey         ctrl?
+         :altKey          alt?
+         :target          target
+         :preventDefault  (fn [] (reset! prevented? true) nil)
+         :stopPropagation (fn [] (reset! propagated? false) nil)}))
+
+;; ---- accessors for the shell ratom + chrome visibility -------------------
+
+(defn chrome-visibility
+  "Return the current chrome-visibility map from the shell state. Thin
+  read-wrapper so tests assert against a known shape (rather than the
+  test reaching into the ratom directly)."
+  []
+  (ui-state/chrome-visibility (ui-state/get-state)))


### PR DESCRIPTION
## Summary

Brings the multi-frame e2e CLJS test pattern (rf2-7icrs) to Story.
Adds a Story-side harness wiring the canonical-vocab install + Causa
as the observer frame, plus six per-surface test files that replace
flaky Playwright coverage with sub-second Node CLJS tests.

### Surfaces covered

1. **Causa-in-Story embed paint/lifecycle** — replaces the
   `causa-rhs-smoke` Playwright spec. Covers rf2-senbl
   (`mount-fn-for` resolves for every catalogued panel) and
   rf2-4l7t2 (panel-host class persists across panel-id swaps);
   asserts the chip-row picker exposes the 7-panel catalog and the
   user-override flips `data-active-panel`.

2. **Variant 4-phase lifecycle** — replaces the
   `story_feature_load.cjs` Lifecycle scenarios. Drives
   `run-variant` end-to-end through happy / loader-never-completes /
   loader-rejects variants (rf2-qrk2s class).

3. **Chrome visibility hotkeys (`f` / `s` / `a` / `t` + `Escape`)** —
   walks the keybindings registry's `dispatch!` with synthetic
   events; pins modifier + editable-target discrimination
   (rf2-g8l8x / rf2-p3i0t).

4. **Sidebar search-as-you-type** — renders the sidebar, invokes the
   `:on-change` on the search `<input>`, asserts the rendered
   variant rows mirror `filter-grouped-tree`'s pure projection
   (rf2-yngai).

5. **Toolbar 5-cluster active-state** — pins the rf2-v58dm cluster
   shape (MODES / DATA / VIEW / DEBUG / REC) and the chip-click
   round-trip (`aria-pressed` + style overlay), plus
   single-select-within-axis eviction.

6. **Story-Causa schema-slot routing** — exercises `resolve-panel` /
   `effective-panel` / `mount-fn-for` for the variant
   `:causa-panel` slot, the legacy `{:causa {:panel}}` nested form,
   the precedence chain, and the unknown-slot fallback
   (rf2-6qm77 + rf2-sgwor + rf2-senbl).

## Harness

`tools/story/test/re_frame/story/test_helpers/e2e_multi_frame.cljs`
mirrors the Causa harness's `with-host-and-causa-frames` for Story.
Differences from the framework-level helper
`re-frame.test-helpers` (rf2-irp6j):

- Story uses `:data-test` (not `:data-testid`); helper exposes
  `find-by-data-attr` for arbitrary attrs.
- Graceful-skip for Reagent class-3 components when their
  invocation returns non-hiccup. The Causa embed mounts
  `panel-host-component` (a `r/create-class`-built class) — the
  framework helper eagerly invokes and crashes; the local helper
  preserves the slot positionally so the embed test can assert
  the argv shape.

Helper docstring notes the path to consolidation once the
framework helper supports both.

## Acceptance

- 6 e2e files, 91 `(is …)` assertions
- `npm run test:cljs` clean: 3364 tests / 9560 assertions, 0 failures
- Sub-second per surface
- No production code touched (`test/` + `test_helpers/` only)

## Bead

rf2-piucm