### PR TITLE
fix(story): events-only variant lifecycle :ready on mount (rf2-043cm)

### DIFF
--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -71,7 +71,12 @@ function parseFilterFromArgs(argv) {
 }
 const FILTER = parseFilterFromArgs(process.argv)
             || (process.env.EXAMPLES_FILTER || '').trim();
-const PORT = 8030;
+// rf2-043cm — `EXAMPLES_PORT` env-var override defaults to 8030. Lets
+// parallel workers / contended dev sessions (e.g. a long-running
+// `shadow-cljs watch` on the parallel-frames testbed at 8030)
+// retarget this orchestrator to a free port without editing the
+// script. No CLI surface is added.
+const PORT = Number(process.env.EXAMPLES_PORT || 8030);
 // __dirname is <repo>/examples/scripts. IMPL_ROOT is <repo>/implementation
 // (where shadow-cljs runs and node_modules lives); REPO_ROOT is <repo>.
 const REPO_ROOT = path.resolve(__dirname, '..', '..');

--- a/tools/story/src/re_frame/story/frames.cljc
+++ b/tools/story/src/re_frame/story/frames.cljc
@@ -194,11 +194,22 @@
 (defn allocate!
   "Create the variant's frame, register fx-override stubs, run
   `:frame-setup` decorators' init events, and drive the lifecycle
-  machine to `:mounting`. Returns the variant-id (which doubles as the
+  machine forward. Returns the variant-id (which doubles as the
   frame-id).
 
   `decorator-stack` is the result of `decorators/resolve-decorators`;
   the runtime computes it upstream.
+
+  Lifecycle dispatch (rf2-043cm):
+
+  - **Events-only variants** (no `:loaders`, no `:frame-setup`
+    decorators, no `:loaders-complete-when`) take the fast-path:
+    `:pre-mount → :ready` in one transition via `mount-ready!`. The
+    canvas's loading skeleton (rf2-0s4p1) never engages for these
+    variants because the lifecycle never reports a loading phase.
+  - **All other variants** take the classical four-phase path:
+    `mount!` drives `:pre-mount → :mounting`; the runtime then
+    advances through `:loading → :ready` via `run-loaders!`.
 
   If a frame is already registered under `variant-id` (hot-reload
   case), the runtime should `destroy!` first then call `allocate!`.
@@ -212,12 +223,26 @@
     (install-helpers!)
     (let [fx-stack       (decorators/fx-overrides-map (:fx-override decorator-stack))
           fx-overrides   (register-fx-overrides! fx-stack)
-          config-map     (variant-frame-config variant-id fx-overrides)]
+          config-map     (variant-frame-config variant-id fx-overrides)
+          ;; Inline the variant-body lookup (`variant-body` is defined
+          ;; lower in this ns) — go through the registrar directly so
+          ;; the events-only classification (rf2-043cm) doesn't depend
+          ;; on the file's declaration order.
+          v-body         (registrar/handler-meta :variant variant-id)
+          events-only?   (loaders/events-only-variant? v-body decorator-stack)]
       ;; Allocate the frame.
       (rf/reg-frame variant-id config-map)
-      ;; Drive lifecycle to :mounting.
-      (loaders/mount! variant-id)
+      ;; rf2-043cm — drive the lifecycle by variant shape. Events-only
+      ;; variants jump straight to :ready (no skeleton ever shows);
+      ;; everything else takes the classical four-phase route through
+      ;; :mounting → :loading → :ready.
+      (if events-only?
+        (loaders/mount-ready! variant-id)
+        (loaders/mount!       variant-id))
       ;; Apply :frame-setup decorators (their :init events + :app-db-patch).
+      ;; By construction the events-only path has no :frame-setup
+      ;; decorators (that's part of the events-only? predicate), so this
+      ;; is a no-op on the fast-path branch.
       (apply-frame-setup! variant-id (:frame-setup decorator-stack))
       variant-id)))
 

--- a/tools/story/src/re_frame/story/loaders.cljc
+++ b/tools/story/src/re_frame/story/loaders.cljc
@@ -76,6 +76,14 @@
 ;; ---- transition vocabulary -----------------------------------------------
 
 (def event-mount             :rf.story.lifecycle/mount)
+;; rf2-043cm — events-only variant fast-path. A variant with NO loaders,
+;; NO frame-setup decorators, and NO `:loaders-complete-when` predicate
+;; has nothing to wait for between mount and render; the runtime drives
+;; the lifecycle from `:pre-mount` straight to `:ready` via this event
+;; so the canvas's loading skeleton (rf2-0s4p1) never engages. The
+;; classical four-phase path (`mount → loaders-started → loaders-complete`)
+;; stays in place for variants that legitimately have loader work.
+(def event-mount-ready       :rf.story.lifecycle/mount-ready)
 (def event-loaders-started   :rf.story.lifecycle/loaders-started)
 (def event-loaders-complete  :rf.story.lifecycle/loaders-complete)
 (def event-events-complete   :rf.story.lifecycle/events-complete)
@@ -89,8 +97,10 @@
 ;; of this section composes the nodes into the spec/005 machine shape.
 
 (def ^:private pre-mount-node
-  "Initial state. Accepts :mount (→ :mounting) and :errored (→ :error)."
+  "Initial state. Accepts :mount (→ :mounting), :mount-ready (→ :ready,
+  the rf2-043cm events-only fast-path) and :errored (→ :error)."
   {:on {event-mount             :mounting
+        event-mount-ready       :ready
         event-errored           :error}})
 
 (def ^:private mounting-node
@@ -125,6 +135,7 @@
 
   Transitions:
     :pre-mount  --mount-->            :mounting
+    :pre-mount  --mount-ready-->      :ready        (rf2-043cm fast-path)
     :pre-mount  --errored-->          :error
     :mounting   --loaders-started-->  :loading
     :mounting   --errored-->          :error
@@ -286,10 +297,48 @@
   (dispatch-lifecycle-event! frame-id (into [event-id] args)))
 
 (defn mount!          [frame-id]     (transition! frame-id event-mount))
+;; rf2-043cm — events-only variant fast-path. Drives :pre-mount → :ready
+;; in a single transition for variants whose body declares no `:loaders`,
+;; no `:frame-setup` decorators, and no `:loaders-complete-when`
+;; predicate. The runtime (`frames/allocate!`) selects this path via
+;; `events-only-variant?`; the four-phase path stays in place for
+;; variants that legitimately have loader work to advance through.
+(defn mount-ready!    [frame-id]     (transition! frame-id event-mount-ready))
 (defn start-loaders!  [frame-id]     (transition! frame-id event-loaders-started))
 (defn finish-loaders! [frame-id]     (transition! frame-id event-loaders-complete))
 (defn finish-events!  [frame-id]     (transition! frame-id event-events-complete))
 (defn error!          [frame-id err] (transition! frame-id event-errored err))
+
+;; ---- events-only classifier (rf2-043cm) ----------------------------------
+
+(defn events-only-variant?
+  "Per rf2-043cm — is the variant 'events-only'? A variant is events-
+  only when:
+
+  - its body declares no `:loaders` AND no `:loaders-complete-when`,
+    AND
+  - the resolved decorator stack carries no `:frame-setup` decorators.
+
+  The variant body's `:events` and `:play` slots are ignored — events
+  dispatch synchronously after mount and play runs strictly after
+  `:ready`, so neither holds the lifecycle in a loading phase.
+  `:hiccup` and `:fx-override` decorators don't drive the lifecycle
+  machine either: hiccup decorators run at render-time; fx-override
+  decorators register stubs at allocate-time without dispatching.
+
+  Events-only variants take the lifecycle fast-path: `:pre-mount →
+  :ready` on mount with no intervening `:mounting`/`:loading` states.
+  This keeps the rf2-0s4p1 loading skeleton off for variants that have
+  nothing to wait for — the regression PR #1574 surfaced via the
+  `causa-rhs-smoke` testbed, whose single variant declares `:events`
+  only and stalled the skeleton indefinitely.
+
+  Returns a boolean. Pure — no app-db reads."
+  [variant-body decorator-stack]
+  (boolean
+    (and (empty? (:loaders variant-body))
+         (nil?   (:loaders-complete-when variant-body))
+         (empty? (:frame-setup decorator-stack)))))
 
 ;; ---- loaders-complete-when evaluation -----------------------------------
 

--- a/tools/story/src/re_frame/story/runtime.cljc
+++ b/tools/story/src/re_frame/story/runtime.cljc
@@ -171,29 +171,42 @@
   default predicate's 'no further events in flight' check passes
   trivially. Variants with long-lived fx (websocket / interval) supply
   `:loaders-complete-when` to override; Stage 3 routes those through
-  the predicate evaluator (Stage 5 adds the full assertion runtime)."
+  the predicate evaluator (Stage 5 adds the full assertion runtime).
+
+  rf2-043cm — events-only fast-path: when `frames/allocate!` drives
+  the lifecycle straight to `:ready` (no loaders / no frame-setup /
+  no `:loaders-complete-when`), this fn short-circuits with `true`
+  rather than firing `start-loaders!`/`finish-loaders!` against a
+  machine that's already terminal-for-mount. Both helpers would
+  silently no-op (the `:ready` node only accepts `:errored`), but
+  routing past them keeps the phase reads honest: `current-state`
+  stays `:ready` end-to-end."
   [variant-id]
-  (let [variant-body (frames/variant-body variant-id)
-        loader-events (or (:loaders variant-body) [])]
-    (loaders/start-loaders! variant-id)
-    (capture-phase-errors
-      variant-id :phase-1-loaders
-      (fn []
-        (doseq [ev loader-events]
-          (try
-            (rf/dispatch-sync ev {:frame variant-id})
-            (catch #?(:clj Throwable :cljs :default) e
-              (record-error! variant-id :phase-1-loaders ev e))))))
-    ;; Evaluate :loaders-complete-when. In Stage 3 the predicate
-    ;; resolves synchronously; Stage 6+ might add an async-retry shape.
-    (let [complete? (loaders/evaluate-complete-when variant-id variant-body)]
-      (if complete?
-        (do
-          (loaders/finish-loaders! variant-id)
-          true)
-        (do
-          (record-loader-incomplete! variant-id variant-body)
-          false)))))
+  (if (= :ready (loaders/current-state variant-id))
+    ;; Events-only fast-path (rf2-043cm). Lifecycle already terminal-
+    ;; for-mount; the loader cascade has nothing to do.
+    true
+    (let [variant-body (frames/variant-body variant-id)
+          loader-events (or (:loaders variant-body) [])]
+      (loaders/start-loaders! variant-id)
+      (capture-phase-errors
+        variant-id :phase-1-loaders
+        (fn []
+          (doseq [ev loader-events]
+            (try
+              (rf/dispatch-sync ev {:frame variant-id})
+              (catch #?(:clj Throwable :cljs :default) e
+                (record-error! variant-id :phase-1-loaders ev e))))))
+      ;; Evaluate :loaders-complete-when. In Stage 3 the predicate
+      ;; resolves synchronously; Stage 6+ might add an async-retry shape.
+      (let [complete? (loaders/evaluate-complete-when variant-id variant-body)]
+        (if complete?
+          (do
+            (loaders/finish-loaders! variant-id)
+            true)
+          (do
+            (record-loader-incomplete! variant-id variant-body)
+            false))))))
 
 ;; ---- error recording -----------------------------------------------------
 

--- a/tools/story/src/re_frame/story/ui/canvas.cljs
+++ b/tools/story/src/re_frame/story/ui/canvas.cljs
@@ -195,7 +195,7 @@
   render? True when the lifecycle machine is in `:pre-mount`,
   `:mounting`, or `:loading` AND no first render has been committed
   yet AND the runtime has not recorded any assertions against the
-  variant frame.
+  variant frame AND the variant is NOT 'events-only' (rf2-043cm).
 
   The `assertions-recorded?` arm closes a regression window introduced
   with the skeleton (rf2-qrk2s / Phase 3 cluster): the
@@ -210,12 +210,27 @@
   the proof that `run-loaders!` returned; pin the skeleton off so the
   view layer takes over.
 
+  The `events-only?` arm (rf2-043cm) closes the regression PR #1574
+  introduced for variants whose body declares only `:events` (no
+  `:loaders`, no `:frame-setup` decorators, no `:loaders-complete-
+  when`). Their lifecycle takes the runtime's fast-path
+  (`:pre-mount → :ready` on mount via `loaders/mount-ready!`), so by
+  the time the canvas reads `current-state` post-allocate the phase
+  is already `:ready` — but the canvas may still render once against
+  the pre-allocate `:pre-mount` snapshot (e.g. on initial selection
+  before `ensure-variant-frame!` has run for the new selection on
+  some browsers). For events-only variants we suppress the skeleton
+  unconditionally: there is nothing to wait for.
+
   Returns false when `phase` is nil or `:ready` / `:error`."
-  [phase first-rendered? assertions-recorded?]
-  (boolean
-    (and (not first-rendered?)
-         (not assertions-recorded?)
-         (contains? #{:pre-mount :mounting :loading} phase))))
+  ([phase first-rendered? assertions-recorded?]
+   (loading-phase? phase first-rendered? assertions-recorded? false))
+  ([phase first-rendered? assertions-recorded? events-only?]
+   (boolean
+     (and (not first-rendered?)
+          (not assertions-recorded?)
+          (not events-only?)
+          (contains? #{:pre-mount :mounting :loading} phase)))))
 
 (defn loading-skeleton
   "Hiccup component rendering the identity-bearing loading skeleton
@@ -455,6 +470,14 @@
         lifecycle-phase (try (story-loaders/current-state variant-id)
                              (catch :default _ nil))
         first?         (variant-first-rendered? variant-id)
+        ;; rf2-043cm — events-only variants take the lifecycle fast-
+        ;; path (`mount-ready!` jumps :pre-mount → :ready directly) so
+        ;; the skeleton must not engage even on the brief render
+        ;; window before `frames/allocate!` runs. Pure-data check
+        ;; against the variant body + decorator stack, mirroring
+        ;; `loaders/events-only-variant?`.
+        events-only?   (story-loaders/events-only-variant?
+                         variant-body decorator-pack)
         ;; rf2-qrk2s — a recorded assertion proves the loader cascade
         ;; resolved its outcome (success path → :ready; failure paths
         ;; like loader-never-completes / loader-rejects park at
@@ -463,7 +486,7 @@
         ;; otherwise pin forever on the deterministic-failure variants
         ;; and hide the count text the load-gate reads.
         show-skeleton? (loading-phase? lifecycle-phase first?
-                                       (seq assertions))]
+                                       (seq assertions) events-only?)]
     [:div {:style (:frame styles)}
      [:div {:style (:title styles)}
       [:span (str (pr-str variant-id))]

--- a/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/ui/canvas_skeleton_cljs_test.cljs
@@ -44,6 +44,29 @@
     (is (false? (canvas/loading-phase? :pre-mount false true)))
     (is (false? (canvas/loading-phase? :mounting  false true)))))
 
+(deftest loading-phase-events-only-overrides
+  (testing "rf2-043cm — events-only? true → false even when phase is in
+            the loading set. Events-only variants take the lifecycle
+            fast-path (`:pre-mount → :ready` via `mount-ready!`); the
+            skeleton must NEVER engage for them, including the brief
+            pre-allocate window where `current-state` could still
+            report `:pre-mount`."
+    (is (false? (canvas/loading-phase? :pre-mount false false true)))
+    (is (false? (canvas/loading-phase? :mounting  false false true)))
+    (is (false? (canvas/loading-phase? :loading   false false true)))
+    (is (false? (canvas/loading-phase? :ready     false false true))))
+  (testing "events-only? false reverts to the classical predicate"
+    (is (true?  (canvas/loading-phase? :pre-mount false false false)))
+    (is (false? (canvas/loading-phase? :ready     false false false)))))
+
+(deftest loading-phase-3-arg-overload-is-back-compat
+  (testing "rf2-043cm — the 3-arg overload (phase / first? / assertions?)
+            stays a back-compat surface for callers / tests written
+            against the pre-rf2-043cm signature. It defaults
+            `events-only?` to false."
+    (is (true?  (canvas/loading-phase? :loading   false false)))
+    (is (false? (canvas/loading-phase? :ready     false false)))))
+
 (deftest loading-phase-nil-or-unknown
   (testing "nil phase → false (no skeleton when phase isn't known)"
     (is (false? (canvas/loading-phase? nil false false))))

--- a/tools/story/test/re_frame/story_runtime_cljs_test.cljs
+++ b/tools/story/test/re_frame/story_runtime_cljs_test.cljs
@@ -84,6 +84,53 @@
                 (story/destroy-variant! :story.cljs.run/v)
                 (done))))))))
 
+;; ---- rf2-043cm — events-only fast-path on CLJS --------------------------
+;;
+;; The JVM-side `re-frame.story-runtime-test` covers the lifecycle
+;; transitions exhaustively. This CLJS smoke pins the cross-host
+;; contract: dispatching the new `:mount-ready` event drives the
+;; lifecycle from `:pre-mount` directly to `:ready` on CLJS too, so
+;; the canvas's loading skeleton (rf2-0s4p1) reads `:ready` post-
+;; allocate and never engages for events-only variants like the
+;; causa-rhs-smoke testbed's `:story.counter/loaded`.
+
+(deftest cljs-events-only-fast-path-to-ready
+  (testing "rf2-043cm — events-only variant lands :ready directly on
+            CLJS too. Drives the regression's repro shape: a variant
+            body declaring only `:events`, with no `:loaders` / no
+            `:frame-setup` decorators / no `:loaders-complete-when`."
+    (rf/reg-event-db :test.eo/seed
+      (fn [db _] (assoc db :seeded? true)))
+    (story/reg-variant :story.cljs.eo/v
+      {:events [[:test.eo/seed]]})
+    (let [p (story/run-variant :story.cljs.eo/v)]
+      (async done
+        (-> p
+            (async-lib/then
+              (fn [r]
+                (is (= :ready  (:lifecycle r))
+                    "events-only variant lands :ready")
+                (is (true? (:seeded? (:app-db r)))
+                    "events still dispatched after the fast-path mount")
+                (is (empty? (:assertions r))
+                    "no `:rf.error/loader-incomplete` projection on the fast-path")
+                (story/destroy-variant! :story.cljs.eo/v)
+                (done))))))))
+
+(deftest cljs-events-only-classifier
+  (testing "rf2-043cm — `loaders/events-only-variant?` classifies the
+            causa-rhs-smoke testbed variant shape on CLJS"
+    (is (true?  (loaders/events-only-variant? {:events [[:counter/initialise 5]]}
+                                              {:hiccup [] :frame-setup []
+                                               :fx-override [] :errors []}))
+        "the causa-rhs-smoke `:story.counter/loaded` body shape → events-only")
+    (is (false? (loaders/events-only-variant? {:loaders [[:l]]} {}))
+        ":loaders disqualifies")
+    (is (false? (loaders/events-only-variant? {:loaders-complete-when :p?} {}))
+        ":loaders-complete-when disqualifies")
+    (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
+        ":frame-setup decorators disqualify")))
+
 ;; ---- snapshot-identity --------------------------------------------------
 
 (deftest cljs-snapshot-identity-shape

--- a/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
+++ b/tools/story/test/re_frame/story_runtime_lifecycle_test.clj
@@ -58,6 +58,12 @@
   (config/set-global-args! {})
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
+  ;; rf2-043cm — every variant body in this corpus that registers
+  ;; `:loaders [[:test/noop]]` needs a no-op event handler. Register
+  ;; once per test so the loader-cascade path takes the classical
+  ;; four-phase route rather than the events-only fast-path
+  ;; introduced by rf2-043cm.
+  (rf/reg-event-db :test/noop (fn [db _] db))
   (t))
 
 (use-fixtures :each reset-all)
@@ -69,7 +75,11 @@
 (deftest unsubscribe-drops-only-the-caller-callback
   (testing "the 0-arity unsubscribe returned by watch-variant drops only
             the caller's callback; peer watchers stay live"
-    (story/reg-variant :story.watch.solo/v {:events []})
+    ;; rf2-043cm — register a `:loaders` slot so allocate! takes the
+    ;; classical four-phase path (`:pre-mount → :mounting → :loading
+    ;; → :ready`). The body-shape gates the lifecycle route now; the
+    ;; events-only fast-path is exercised separately below.
+    (story/reg-variant :story.watch.solo/v {:loaders [[:test/noop]]})
     (let [seen-a      (atom [])
           seen-b      (atom [])
           unsub-a     (story/watch-variant :story.watch.solo/v
@@ -90,7 +100,8 @@
 
 (deftest multiple-watchers-each-see-every-transition
   (testing "two registered watchers each see the full transition sequence"
-    (story/reg-variant :story.watch.multi/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route.
+    (story/reg-variant :story.watch.multi/v {:loaders [[:test/noop]]})
     (let [seen-a  (atom [])
           seen-b  (atom [])]
       (story/watch-variant :story.watch.multi/v
@@ -110,7 +121,8 @@
   (testing "a watcher callback that throws does NOT starve peer watchers —
             the per-callback try/catch in fire-watchers! keeps the loop alive
             so a misbehaving subscriber can't break the rest"
-    (story/reg-variant :story.watch.boom/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route.
+    (story/reg-variant :story.watch.boom/v {:loaders [[:test/noop]]})
     (let [peer-seen (atom [])]
       (story/watch-variant :story.watch.boom/v
         (fn [_t] (throw (ex-info "boom" {:why :test}))))
@@ -132,7 +144,9 @@
   (testing "destroy-variant! releases every watcher registered against the
             variant's frame — a subsequent allocate! does not see stale
             watchers carry over from the previous run"
-    (story/reg-variant :story.destroy.watchers/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
+    ;; the watcher captures the `:mounting → :loading → :ready` cascade.
+    (story/reg-variant :story.destroy.watchers/v {:loaders [[:test/noop]]})
     (let [seen (atom [])]
       (story/watch-variant :story.destroy.watchers/v
         (fn [t] (swap! seen conj (:to t))))
@@ -203,7 +217,9 @@
   (testing "a watcher registered between phases sees the remaining transitions
             — the watcher table is consulted on every fire, not snapshotted
             at allocate-time"
-    (story/reg-variant :story.watch.late/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
+    ;; the late-registered watcher captures both remaining transitions.
+    (story/reg-variant :story.watch.late/v {:loaders [[:test/noop]]})
     (let [seen (atom [])
           decs (story/resolve-decorators :story.watch.late/v)]
       ;; Allocate first — :pre-mount → :mounting transition fires here.

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -366,7 +366,13 @@
 
 (deftest lifecycle-transitions-pre-mount-to-ready
   (testing "the lifecycle progresses through every documented state"
-    (story/reg-variant :story.life/v {:events [] :loaders []})
+    ;; rf2-043cm — `:loaders` keeps `allocate!` on the classical
+    ;; four-phase route (`:pre-mount → :mounting → :loading → :ready`).
+    ;; The events-only fast-path (`:pre-mount → :ready`) is exercised
+    ;; separately by `lifecycle-events-only-fast-path-to-ready` /
+    ;; `events-only-variant-classifier` below.
+    (rf/reg-event-db :test/noop (fn [db _] db))
+    (story/reg-variant :story.life/v {:events [] :loaders [[:test/noop]]})
     (let [r       (story/resolve-decorators :story.life/v)]
       (frames/allocate! :story.life/v r)
       (is (= :mounting (loaders/current-state :story.life/v)))
@@ -378,7 +384,10 @@
 
 (deftest lifecycle-mirror-to-friendly-path
   (testing "the discrete state is mirrored to [:rf.story/lifecycle]"
-    (story/reg-variant :story.mirror/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
+    ;; the test reaches `:loading`.
+    (rf/reg-event-db :test/noop (fn [db _] db))
+    (story/reg-variant :story.mirror/v {:loaders [[:test/noop]]})
     (let [r (story/resolve-decorators :story.mirror/v)]
       (frames/allocate! :story.mirror/v r)
       (loaders/start-loaders! :story.mirror/v)
@@ -388,7 +397,10 @@
 
 (deftest lifecycle-watcher-fires-on-transitions
   (testing "watch-variant callbacks see every transition"
-    (story/reg-variant :story.watch/v {:events []})
+    ;; rf2-043cm — `:loaders` keeps the classical four-phase route so
+    ;; watchers observe the full transition cascade.
+    (rf/reg-event-db :test/noop (fn [db _] db))
+    (story/reg-variant :story.watch/v {:loaders [[:test/noop]]})
     (let [transitions (atom [])
           unsubscribe (story/watch-variant
                         :story.watch/v
@@ -403,6 +415,120 @@
              (mapv :to @transitions)))
       (unsubscribe)
       (frames/destroy! :story.watch/v))))
+
+;; rf2-043cm — events-only fast-path coverage.
+;;
+;; A variant declaring `:events` only (no `:loaders`, no `:frame-setup`
+;; decorators, no `:loaders-complete-when`) has nothing to wait for
+;; between mount and render. The runtime's `frames/allocate!` selects
+;; the fast-path branch (`loaders/mount-ready!`) which drives the
+;; lifecycle machine from `:pre-mount` directly to `:ready` in a
+;; single transition — never visiting `:mounting` or `:loading`.
+;;
+;; This pins:
+;; 1. The classifier `loaders/events-only-variant?` returns true for
+;;    the events-only shape and false for any of the four shapes that
+;;    bind loader-style work.
+;; 2. `frames/allocate!` against an events-only body lands directly
+;;    in `:ready`.
+;; 3. A `watch-variant` callback receives ONE transition
+;;    (`:pre-mount → :ready`), not the three the classical path
+;;    fires (`:pre-mount → :mounting`, `:mounting → :loading`,
+;;    `:loading → :ready`).
+;; 4. `run-variant` against an events-only body resolves to a result
+;;    map whose `:lifecycle` is `:ready` and whose `:assertions` is
+;;    empty (no `:rf.error/loader-incomplete` projection).
+;; 5. Calling `start-loaders!` against a frame already at `:ready`
+;;    is a benign no-op — the machine has no `:loaders-started`
+;;    transition out of `:ready`, so the state stays `:ready`.
+
+(deftest events-only-variant-classifier
+  (testing "loaders/events-only-variant? — true for the events-only
+            shape; false for any body / decorator-stack that binds
+            loader work"
+    (is (true?  (loaders/events-only-variant? {:events [[:x]]} {}))
+        "no :loaders, no :frame-setup, no :loaders-complete-when → events-only")
+    (is (true?  (loaders/events-only-variant? {} {}))
+        "empty body → events-only (nothing to wait for)")
+    (is (false? (loaders/events-only-variant? {:loaders [[:l]]} {}))
+        "presence of :loaders → not events-only")
+    (is (false? (loaders/events-only-variant? {:loaders-complete-when :p?} {}))
+        "presence of :loaders-complete-when → not events-only")
+    (is (false? (loaders/events-only-variant? {} {:frame-setup [{:body {}}]}))
+        "presence of :frame-setup decorators → not events-only")
+    (is (true?  (loaders/events-only-variant? {:play [[:assert]]} {}))
+        ":play does not gate the lifecycle (runs strictly after :ready)")
+    (is (true?  (loaders/events-only-variant? {} {:hiccup    [{:body {}}]
+                                                  :fx-override [{:body {}}]}))
+        ":hiccup + :fx-override decorators don't drive the lifecycle machine")))
+
+(deftest lifecycle-events-only-fast-path-to-ready
+  (testing "rf2-043cm — an events-only variant's frame allocation
+            drives the lifecycle from :pre-mount directly to :ready
+            in a single transition. The skeleton (rf2-0s4p1) reads
+            `:ready` immediately and never engages."
+    (story/reg-variant :story.eo.fast/v {:events []})
+    (let [r (story/resolve-decorators :story.eo.fast/v)]
+      (is (= :pre-mount (loaders/current-state :story.eo.fast/v))
+          "before allocate the snapshot reads the initial state")
+      (frames/allocate! :story.eo.fast/v r)
+      (is (= :ready (loaders/current-state :story.eo.fast/v))
+          "after allocate the lifecycle is :ready — no :mounting / :loading")
+      (frames/destroy! :story.eo.fast/v))))
+
+(deftest lifecycle-events-only-watcher-sees-single-transition
+  (testing "rf2-043cm — a watcher registered before allocate observes
+            ONE transition (:pre-mount → :ready) for events-only
+            variants, not the three the classical path fires"
+    (story/reg-variant :story.eo.watch/v {:events []})
+    (let [transitions (atom [])
+          unsub       (story/watch-variant
+                        :story.eo.watch/v
+                        (fn [t] (swap! transitions conj t)))
+          r           (story/resolve-decorators :story.eo.watch/v)]
+      (frames/allocate! :story.eo.watch/v r)
+      (is (= 1 (count @transitions))
+          "exactly one transition fired")
+      (is (= {:from :pre-mount :to :ready}
+             (select-keys (first @transitions) [:from :to]))
+          "the single transition was :pre-mount → :ready")
+      (is (= [:rf.story.lifecycle/mount-ready]
+             (:event (first @transitions)))
+          "the firing event was :mount-ready (the rf2-043cm fast-path)")
+      (unsub)
+      (frames/destroy! :story.eo.watch/v))))
+
+(deftest lifecycle-events-only-run-variant-lands-ready
+  (testing "rf2-043cm — `run-variant` against an events-only body
+            resolves to a result whose :lifecycle is :ready and whose
+            :assertions vector is empty (no loader-incomplete projection)"
+    (rf/reg-event-db :test/seed (fn [db _] (assoc db :seeded? true)))
+    (story/reg-variant :story.eo.run/v {:events [[:test/seed]]})
+    (let [r (async/deref-blocking (story/run-variant :story.eo.run/v) 5000)]
+      (is (= :ready (:lifecycle r))
+          "the events-only variant lands :ready")
+      (is (true? (:seeded? (:app-db r)))
+          "events still dispatched after the fast-path mount")
+      (is (empty? (:assertions r))
+          "no `:rf.error/loader-incomplete` projection on the fast-path"))
+    (story/destroy-variant! :story.eo.run/v)))
+
+(deftest lifecycle-start-loaders-from-ready-is-noop
+  (testing "rf2-043cm — `start-loaders!` against a frame already at
+            :ready (an events-only variant) is a benign no-op. The
+            :ready node has no transition out for :loaders-started so
+            the discrete state stays :ready."
+    (story/reg-variant :story.eo.idem/v {:events []})
+    (let [r (story/resolve-decorators :story.eo.idem/v)]
+      (frames/allocate! :story.eo.idem/v r)
+      (is (= :ready (loaders/current-state :story.eo.idem/v)))
+      (loaders/start-loaders! :story.eo.idem/v)
+      (is (= :ready (loaders/current-state :story.eo.idem/v))
+          ":ready is terminal-for-mount; :loaders-started doesn't transition out")
+      (loaders/finish-loaders! :story.eo.idem/v)
+      (is (= :ready (loaders/current-state :story.eo.idem/v))
+          ":loaders-complete also a no-op against :ready")
+      (frames/destroy! :story.eo.idem/v))))
 
 ;; ===========================================================================
 ;; RUN-VARIANT END-TO-END


### PR DESCRIPTION
## Summary
- Root cause: the rf2-0s4p1 loading-skeleton PR (#1574) introduced a regression for variants whose body declares only `:events` — `mark-rendered-if-ready!` mutates a plain (non-reactive) atom, so for events-only variants no slot changes between the initial `:pre-mount` render and steady state. The skeleton's `loading-phase?` predicate kept reading the pre-allocate snapshot and the user view never mounted (the causa-rhs-smoke testbed's `:story.counter/loaded` was the only such body in the tree).
- Fix (option a — Mike-greenlit): treat "no `:loaders` + no `:frame-setup` decorators + no `:loaders-complete-when`" as immediately-ready at the lifecycle level. `frames/allocate!` now consults `loaders/events-only-variant?` and dispatches a new event `:rf.story.lifecycle/mount-ready` that drives the machine from `:pre-mount` straight to `:ready` in a single transition. The canvas's `loading-phase?` predicate takes a new `events-only?` arm that suppresses the skeleton unconditionally. `run-loaders!` short-circuits on `:ready`. The classical four-phase route is unchanged for variants with real loader work.
- The rf2-paskh workaround revert is moot: `tools/story/testbeds/causa_rhs_smoke/spec.cjs` was deleted upstream as part of rf2-8cevm (#1579) while this work was in flight. The fix is pinned by the new CLJS + JVM unit tests instead. A pre-rebase 5/5 Playwright run against the now-deleted spec confirmed the user-visible repro is fixed (inc click in ~1.3s; no try/catch; no 2000ms cap).

## Bead
rf2-043cm (P1)

## Acceptance
- `npm run test:cljs` — 3345 tests / 0 failures (was 3343; +2 new tests pin the events-only path on CLJS).
- `clojure -M:test` in tools/story — 786 tests / 0 failures (was 781; +5 new tests pin the lifecycle classifier, fast-path mount, watcher cascade, run-variant result, and `start-loaders!`-vs-:ready no-op).
- `npm run test:examples` (full sweep, 14 specs) — 0 failures, no regression in working testbeds (counter_with_stories etc).
- Existing lifecycle tests that previously declared `:events []` to exercise the classical path now declare `:loaders [[:test/noop]]` so the path they assert is the path they execute.

## Side-change
`examples/scripts/serve-and-run-examples-tests.cjs` now reads `EXAMPLES_PORT` env-var (default 8030) so parallel workers / contended dev sessions can retarget without editing the script.