### PR TITLE
feat(re-frame2): test-helpers class-3 + find-by-attr (rf2-1c036)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/component.cljs
@@ -500,6 +500,11 @@
           (.create js/Object (.-prototype (.-Component react))))
     (set! (.. klass -prototype -constructor) klass)
     (set! (.-cljsReagentClass klass) true)
+    ;; Stash the user's `:reagent-render` on the class so out-of-band
+    ;; introspection (e.g. `re-frame.test-helpers/expand-tree`) can
+    ;; invoke it without going through React. Mirrors stock Reagent's
+    ;; convention of exposing the user fn alongside the class tag.
+    (set! (.-cljsReagentRender klass) render-fn)
 
     ;; render delegates to wrap-render over the user's :reagent-render.
     ;; make-render-method's body re-stashes argv from props at render

--- a/implementation/core/src/re_frame/test_helpers.cljc
+++ b/implementation/core/src/re_frame/test_helpers.cljc
@@ -62,6 +62,14 @@
   sees the leaf hiccup the user sees. The expansion is recursive
   but terminating: a non-vector / non-fn leaf is a fixed point.
 
+  Form-3 components built via `r/create-class` are detected (the
+  reagent-slim class tag + the stashed `:reagent-render` slot) and
+  expanded by invoking the render fn directly with the hiccup args.
+  The walker does NOT instantiate React or run lifecycle methods —
+  if a Form-3 view's hiccup output depends on lifecycle state, the
+  test sees the initial render only. JVM runs identically: class-3
+  detection is a no-op because the JVM has no JS class instances.
+
   ## Authoring side — the `testid` helper
 
   Tests benefit from views that **carry** a `:data-testid` on the
@@ -74,9 +82,32 @@
   Equivalent to writing `{:data-testid \"counter-inc\" :on-click ...}`
   by hand; pick whichever reads better in your view.
 
+  ## Selector convention — `data-testid` vs `data-test` vs custom
+
+  React conventionally uses `:data-testid`; some codebases (notably
+  Story) standardised on `:data-test` before the rename; framework
+  tools may use their own prefix (Causa uses `:data-rf-causa-*`).
+  This ns ships two layers:
+
+    - [[find-by-attr]] / [[find-all-by-attr]] — the underlying. Match
+      against any attr key the caller supplies. Use these directly
+      when your codebase keys on `:data-test` or a custom attribute.
+
+    - [[find-by-testid]] / [[find-all-by-testid]] — thin wrappers
+      that pre-bind the attr to `:data-testid`. Use these for the
+      common React-convention case.
+
   ## Public API
 
-  ### Walking
+  ### Walking — generic attribute
+  - [[find-by-attr]] — first node whose attrs map carries `attr == val`,
+    or nil.
+  - [[find-all-by-attr]] — all nodes whose attrs map carries
+    `attr == val`.
+  - [[find-by-attr-prefix]] — all nodes whose `attr` value (a string)
+    starts with the given prefix.
+
+  ### Walking — `:data-testid` convenience
   - [[find-by-testid]] — first node with the given testid, or nil.
   - [[find-all-by-testid]] — all nodes with the given testid.
   - [[find-by-testid-prefix]] — all nodes whose testid starts with
@@ -104,22 +135,59 @@
 
 (declare expand-tree)
 
+(defn- reagent-class-render
+  "When `head` is a reagent-slim Form-3 class constructor (built by
+  `reagent2.impl.component/create-class*`), return its stashed
+  `:reagent-render` fn. Otherwise return nil.
+
+  Detection is property-based — we look for the tag
+  `.-cljsReagentClass` (true) and pluck the render fn from
+  `.-cljsReagentRender`. No `:require` on reagent so this ns stays
+  classpath-clean for callers that don't pull reagent.
+
+  JVM: always nil — JVM has no JS classes and no `.-` property
+  access on plain fns. The reader conditional below makes the
+  body a no-op there."
+  [head]
+  #?(:cljs (when (and (some? head)
+                      (true? (.-cljsReagentClass ^js head)))
+            (.-cljsReagentRender ^js head))
+     :clj  nil))
+
 (defn expand-tree
   "Recursively expand a hiccup tree, invoking any function components
-  with their args. After expansion, every vector's first element is a
-  keyword tag or a non-component value, never a fn.
+  (or Form-3 class components) with their args. After expansion,
+  every vector's first element is a keyword tag or a non-component
+  value, never a fn / class.
 
-  Mirrors what Reagent's renderer does at mount time: a vector whose
-  first element is a fn is treated as `[component-fn & args]` and
-  invoked. Non-vector branches (strings, numbers, maps, nil) are
-  returned unchanged. Lazy sequences are walked through `map`; vectors
-  through `mapv`.
+  Mirrors what Reagent's renderer does at mount time:
+
+    - `[component-fn & args]` — invoke `component-fn` with `args`.
+    - `[reagent-class & args]` — pluck the class's `:reagent-render`
+      slot (stashed at create-class time) and invoke with `args`. The
+      class is NOT instantiated and lifecycle methods do NOT run —
+      this walker is for state/structure assertions, not behaviour
+      that depends on `componentDidMount` etc.
+
+  Non-vector branches (strings, numbers, maps, nil) are returned
+  unchanged. Lazy sequences are walked through `map`; vectors through
+  `mapv`.
 
   Public so test files mid-walk can re-expand a sub-tree if needed."
   [tree]
   (cond
     (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
+    (let [head (first tree)
+          render-fn (reagent-class-render head)]
+      (cond
+        ;; Form-3 reagent class — call its render-fn directly with
+        ;; the hiccup args. Skips React instantiation entirely.
+        (some? render-fn)
+        (expand-tree (apply render-fn (rest tree)))
+
+        ;; Plain function component — invoke as Reagent would.
+        :else
+        (expand-tree (apply head (rest tree)))))
 
     (vector? tree)
     (mapv expand-tree tree)
@@ -188,20 +256,77 @@
   (get (attrs node) event-key))
 
 ;; ---------------------------------------------------------------------------
-;; Finding by testid
+;; Finding by arbitrary attribute (the underlying)
+;;
+;; The `find-by-testid` family below is a thin wrapper around these.
+;; Use `find-by-attr` directly when your codebase keys on `:data-test`
+;; (Story's legacy convention) or a custom prefix (e.g. Causa's
+;; `:data-rf-causa-*`). Cross-framework code that doesn't want to
+;; commit to a single attr convention talks at this layer.
 ;; ---------------------------------------------------------------------------
 
-(defn- testid-of
-  "Return the `:data-testid` value of a hiccup node, or nil."
-  [node]
+(defn- attr-of
+  "Return the value of `attr` on a hiccup node's attrs map, or nil."
+  [node attr]
   (when (vector? node)
     (when-let [a (attrs node)]
-      (:data-testid a))))
+      (get a attr))))
+
+(defn find-by-attr
+  "Walk `tree` (expanding function and class components) and return
+  the FIRST hiccup node whose attrs map carries `attr == val`, or
+  nil if no node matches.
+
+  Generic over the attribute keyword — pick whichever your codebase
+  uses (`:data-testid`, `:data-test`, `:id`, a custom prefix, …):
+
+      (find-by-attr tree :data-testid \"counter-inc\")
+      (find-by-attr tree :data-test    \"submit\")
+      (find-by-attr tree :id           \"root\")"
+  [tree attr val]
+  (some (fn [node]
+          (when (= val (attr-of node attr))
+            node))
+        (hiccup-seq tree)))
+
+(defn find-all-by-attr
+  "Like [[find-by-attr]] but returns a vector of EVERY matching node,
+  in depth-first order. Empty vector when no match."
+  [tree attr val]
+  (filterv (fn [node] (= val (attr-of node attr)))
+           (hiccup-seq tree)))
+
+(defn find-by-attr-prefix
+  "Return a vector of every hiccup node whose `attr` value (a string)
+  STARTS with `prefix`. Useful for view layouts that mint a family of
+  attribute values off a stable stem (e.g. `\"counter-row-1\"`,
+  `\"counter-row-2\"`, …).
+
+  Non-string attr values do not match — only strings respond to
+  prefix comparison."
+  [tree attr prefix]
+  (filterv (fn [node]
+             (when-let [v (attr-of node attr)]
+               (and (string? v) (str/starts-with? v prefix))))
+           (hiccup-seq tree)))
+
+;; ---------------------------------------------------------------------------
+;; Finding by testid — thin wrappers over find-by-attr
+;;
+;; The common case (React's `:data-testid` convention). Authoring side
+;; uses the [[testid]] helper to keep the convention readable at view
+;; call sites. Both layers (these and `find-by-attr` directly) walk the
+;; same underlying tree-seq.
+;; ---------------------------------------------------------------------------
 
 (defn find-by-testid
-  "Walk `tree` (expanding function components) and return the FIRST
-  hiccup node whose attrs map carries `:data-testid == test-id`, or
-  nil if no node matches.
+  "Walk `tree` (expanding function and class components) and return
+  the FIRST hiccup node whose attrs map carries `:data-testid ==
+  test-id`, or nil if no node matches.
+
+  Equivalent to `(find-by-attr tree :data-testid test-id)`. Use the
+  generic [[find-by-attr]] directly when your codebase keys on a
+  different attribute (e.g. `:data-test`).
 
   Use to anchor on a stable element from a view:
 
@@ -209,28 +334,25 @@
             label (find-by-testid tree \"counter-label\")]
         (is (= \"Count: 5\" (text-content label))))"
   [tree test-id]
-  (some (fn [node]
-          (when (= test-id (testid-of node))
-            node))
-        (hiccup-seq tree)))
+  (find-by-attr tree :data-testid test-id))
 
 (defn find-all-by-testid
   "Like [[find-by-testid]] but returns a vector of EVERY matching
-  node, in depth-first order. Empty vector when no match."
+  node, in depth-first order. Empty vector when no match.
+
+  Equivalent to `(find-all-by-attr tree :data-testid test-id)`."
   [tree test-id]
-  (filterv (fn [node] (= test-id (testid-of node)))
-           (hiccup-seq tree)))
+  (find-all-by-attr tree :data-testid test-id))
 
 (defn find-by-testid-prefix
   "Return a vector of every hiccup node whose `:data-testid` STARTS
   with `prefix`. Useful for view layouts that mint a family of testids
   off a stable stem (e.g. `\"counter-row-1\"`, `\"counter-row-2\"`,
-  …)."
+  …).
+
+  Equivalent to `(find-by-attr-prefix tree :data-testid prefix)`."
   [tree prefix]
-  (filterv (fn [node]
-             (when-let [tid (testid-of node)]
-               (str/starts-with? tid prefix)))
-           (hiccup-seq tree)))
+  (find-by-attr-prefix tree :data-testid prefix))
 
 ;; ---------------------------------------------------------------------------
 ;; Driving handlers

--- a/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
+++ b/implementation/core/test/re_frame/test_helpers_cljs_test.cljc
@@ -76,6 +76,76 @@
     (is (= {:a 1}    (h/expand-tree {:a 1})))))
 
 ;; ---------------------------------------------------------------------------
+;; expand-tree — Form-3 reagent class detection (rf2-1c036 gap 1)
+;;
+;; The walker treats a hiccup vector whose head is a reagent-slim
+;; class constructor (built by `reagent2.impl.component/create-class*`)
+;; as a Form-3 component: it plucks the stashed `:reagent-render` slot
+;; off the class and invokes that fn with the hiccup args, instead of
+;; calling the class constructor directly (which would crash without
+;; `new`).
+;;
+;; We fake-stamp a plain fn with the same property tags the reagent-
+;; slim `create-class*` sets — that way the unit test does not have to
+;; depend on reagent and runs identically on JVM (where the class-3
+;; branch is a no-op) and Node-CLJS (where the property access fires).
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (defn- fake-reagent-class
+     "Stamp `f` with the reagent-slim class tags (`cljsReagentClass = true`
+     + `cljsReagentRender = render-fn`) so test-helpers' class-3 branch
+     fires on the wrapped fn. CLJS-only; on JVM there are no JS
+     properties to set so the helper is omitted."
+     [render-fn]
+     (let [klass (fn [& _] (throw (ex-info "do not call" {})))]
+       (set! (.-cljsReagentClass ^js klass) true)
+       (set! (.-cljsReagentRender ^js klass) render-fn)
+       klass)))
+
+#?(:cljs
+   (deftest expand-tree-expands-reagent-class
+     (testing "a hiccup vector headed by a reagent class is expanded via
+              the class's stashed :reagent-render slot, NOT by calling the
+              class as a fn (which would crash)"
+       (let [render-fn (fn [{:keys [n]}] [:button {:data-testid "class3-btn"}
+                                          (str "n=" n)])
+             klass     (fake-reagent-class render-fn)
+             tree      [klass {:n 11}]
+             out       (h/expand-tree tree)]
+         (is (vector? out) "class-3 was expanded into a hiccup vector")
+         (is (= :button (first out)))
+         (is (= "class3-btn" (:data-testid (second out))))
+         (is (= "n=11" (last out)))))))
+
+#?(:cljs
+   (deftest expand-tree-recurses-through-reagent-class
+     (testing "a class-3 whose render-fn returns a nested function component
+              is expanded all the way down"
+       (let [leaf      (fn [s] [:span {:data-testid "leaf"} s])
+             render-fn (fn [{:keys [label]}] [:div {:data-testid "wrap"}
+                                              [leaf label]])
+             klass     (fake-reagent-class render-fn)
+             tree      [klass {:label "hi"}]
+             out       (h/expand-tree tree)]
+         (is (= :div  (first out)))
+         (is (= :span (first (nth out 2)))
+             "the nested function component under the class was expanded")))))
+
+#?(:cljs
+   (deftest find-by-testid-walks-through-reagent-class
+     (testing "find-by-testid resolves a testid that lives inside a Form-3
+              component's render output"
+       (let [render-fn (fn [{:keys [v]}] [:p {:data-testid "inside-class"} v])
+             klass     (fake-reagent-class render-fn)
+             tree      [:section {:data-testid "outer"} [klass {:v "ok"}]]
+             hit       (h/find-by-testid tree "inside-class")]
+         (is (some? hit)
+             "find-by-testid did not walk into the class-3 render output")
+         (is (= :p (first hit)))
+         (is (= "ok" (last hit)))))))
+
+;; ---------------------------------------------------------------------------
 ;; attrs / children
 ;; ---------------------------------------------------------------------------
 
@@ -150,6 +220,100 @@
     (is (= 3 (count hits)))
     (is (= ["item-1" "item-2" "item-3"]
            (mapv (comp :data-testid second) hits)))))
+
+;; ---------------------------------------------------------------------------
+;; find-by-attr family (rf2-1c036 gap 2)
+;;
+;; Generic over the attribute keyword — `:data-testid` is the React
+;; convention but Story keys on `:data-test` and Causa uses
+;; `:data-rf-causa-*`. The testid wrappers above are thin aliases for
+;; the `:data-testid`-bound case.
+;; ---------------------------------------------------------------------------
+
+(deftest find-by-attr-resolves-data-testid
+  (testing "find-by-attr with :data-testid behaves like find-by-testid"
+    (let [tree (counter-view {:n 0 :on-inc identity})
+          hit  (h/find-by-attr tree :data-testid "counter-inc")]
+      (is (some? hit))
+      (is (= :button (first hit))))))
+
+(deftest find-by-attr-resolves-data-test
+  (testing "Story-style :data-test selectors are matched"
+    (let [tree [:section {:data-test "page-root"}
+                [:button {:data-test "submit"
+                          :on-click identity} "Go"]
+                [:span {:data-test "label"} "hello"]]]
+      (is (= :button (first (h/find-by-attr tree :data-test "submit"))))
+      (is (= "hello" (last (h/find-by-attr tree :data-test "label"))))
+      (is (nil? (h/find-by-attr tree :data-test "missing"))))))
+
+(deftest find-by-attr-resolves-custom-prefix
+  (testing "Causa-style :data-rf-causa-* selectors are matched"
+    (let [tree [:div {:data-rf-causa-id "frame-picker"}
+                [:button {:data-rf-causa-id "btn-1"} "1"]
+                [:button {:data-rf-causa-id "btn-2"} "2"]]]
+      (is (some? (h/find-by-attr tree :data-rf-causa-id "btn-1")))
+      (is (= "2" (last (h/find-by-attr tree :data-rf-causa-id "btn-2")))))))
+
+(deftest find-by-attr-handles-arbitrary-keys
+  (testing "any attribute key — :id, :name, :class — is matchable"
+    (let [tree [:form {:id "login"}
+                [:input {:name "user"}]
+                [:input {:name "pass"}]]]
+      (is (= "login" (-> (h/find-by-attr tree :id "login") second :id)))
+      (is (= "pass"  (-> (h/find-by-attr tree :name "pass") second :name))))))
+
+(deftest find-all-by-attr-collects-every-match
+  (let [tree [:ul
+              [:li {:data-test "row"} "a"]
+              [:li {:data-test "row"} "b"]
+              [:li {:data-test "skip"} "c"]
+              [:li {:data-test "row"} "d"]]
+        hits (h/find-all-by-attr tree :data-test "row")]
+    (is (= 3 (count hits)))
+    (is (= ["a" "b" "d"] (mapv last hits)))))
+
+(deftest find-all-by-attr-empty-when-no-match
+  (is (= [] (h/find-all-by-attr [:div {:data-test "x"}] :data-test "y"))))
+
+(deftest find-by-attr-prefix-matches-stem
+  (let [tree [:ul
+              [:li {:data-test "row-1"} "a"]
+              [:li {:data-test "row-2"} "b"]
+              [:li {:data-test "other"} "c"]
+              [:li {:data-test "row-3"} "d"]]
+        hits (h/find-by-attr-prefix tree :data-test "row-")]
+    (is (= 3 (count hits)))
+    (is (= ["row-1" "row-2" "row-3"]
+           (mapv (comp :data-test second) hits)))))
+
+(deftest find-by-attr-prefix-ignores-non-string-values
+  (testing "an attr whose value is a number/keyword does not match prefix"
+    (let [tree [:div
+                [:span {:data-test "row-1"} "x"]
+                [:span {:data-test 42}     "y"]]
+          hits (h/find-by-attr-prefix tree :data-test "row-")]
+      (is (= 1 (count hits)))
+      (is (= "x" (last (first hits)))))))
+
+;; Back-compat: existing find-by-testid call sites must still work
+;; (Causa tests + every internal caller key on the testid wrapper).
+
+(deftest find-by-testid-still-routes-through-find-by-attr
+  (testing "find-by-testid is a thin wrapper — semantics unchanged"
+    (let [tree (counter-view {:n 0 :on-inc identity})
+          via-testid (h/find-by-testid tree "counter-root")
+          via-attr   (h/find-by-attr tree :data-testid "counter-root")]
+      (is (= via-testid via-attr)
+          "the wrapper and the underlying resolve to the identical node"))))
+
+(deftest find-all-by-testid-still-routes-through-find-all-by-attr
+  (let [tree [:div
+              [:span {:data-testid "dup"} "first"]
+              [:span {:data-testid "dup"} "second"]]
+        via-testid (h/find-all-by-testid tree "dup")
+        via-attr   (h/find-all-by-attr tree :data-testid "dup")]
+    (is (= via-testid via-attr))))
 
 ;; ---------------------------------------------------------------------------
 ;; text-content


### PR DESCRIPTION
## Summary

Closes two gaps in the framework-level `re-frame.test-helpers` (rf2-irp6j PR #1605) caught by the Story-side e2e worker (PR #1611):

- **Gap 1 — Form-3 expansion.** `expand-tree` now detects reagent-slim Form-3 class components and expands via the stashed `:reagent-render` slot, instead of attempting to call the class constructor as a plain fn (which crashed). Detection is property-based (`.-cljsReagentClass` + `.-cljsReagentRender`) so test-helpers keeps zero compile-time dependency on reagent. `reagent-slim`'s `create-class*` now stashes the user's `:reagent-render` on the class — one line, additive.
- **Gap 2 — `find-by-attr` generalisation.** New `find-by-attr` / `find-all-by-attr` / `find-by-attr-prefix` take the attribute keyword as a parameter. `find-by-testid` and friends stay as thin `:data-testid`-bound wrappers for the common React-convention case. Story (`:data-test` legacy) and Causa (`:data-rf-causa-*`) callers now use `find-by-attr` directly. No regression — wrappers preserve identical semantics.

## Bead

rf2-1c036

## API additions

```clojure
(find-by-attr        tree attr val)     ;; first node where attrs[attr] == val
(find-all-by-attr    tree attr val)     ;; every matching node, depth-first
(find-by-attr-prefix tree attr prefix)  ;; every node whose attr value (string) starts-with prefix
```

`find-by-testid` / `find-all-by-testid` / `find-by-testid-prefix` are now thin `:data-testid`-bound wrappers over the above.

## Acceptance

- `npm run test:cljs` clean (3396 tests / 9652 assertions, 0 failures)
- `core/` JVM tests clean (626 / 3052, 0 failures)
- `reagent-slim/` JVM tests clean (11 / 12, 0 failures)
- New unit tests cover both gaps (class-3 expansion, `find-by-attr` with `:data-testid` / `:data-test` / custom prefix, back-compat of testid wrappers)