### PR TITLE
fix(story): causa-available? compile-time symbol resolution (rf2-ibpwr)

### DIFF
--- a/tools/story/src/re_frame/story/causa_preset.cljc
+++ b/tools/story/src/re_frame/story/causa_preset.cljc
@@ -15,9 +15,11 @@
                :focus    {:event-pos 5}}}     ; pre-focus a cascade pos
 
   Every slot is optional. A missing `:causa` slot is the v0 behaviour
-  (no auto-mount, no tab focus). The runtime is feature-detect for
-  Causa itself AND for the optional filters API (rf2-ak4ms in flight)
-  — when Causa is not on the classpath the preset no-ops silently;
+  (no auto-mount, no tab focus). Causa's mount surface is resolved at
+  compile time via a direct `:require` (rf2-ibpwr, mirroring rf2-senbl
+  for `mount-fn-for`); the optional filters API (rf2-ak4ms in flight)
+  is still runtime feature-detected via the `resolve-fn` lookup. When
+  Causa's mount ns is somehow not bound, the preset no-ops silently;
   when filters is not present, only the filters step is skipped (with
   a console.warn breadcrumb so authors notice).
 
@@ -43,7 +45,23 @@
   (:require [re-frame.story.predicates :as pred]
             [re-frame.story.registrar  :as registrar]
             #?(:cljs [re-frame.core           :as rf])
-            #?(:cljs [re-frame.story.config   :as config])))
+            #?(:cljs [re-frame.story.config   :as config])
+            ;; rf2-ibpwr: direct :require for compile-time symbol
+            ;; resolution of `day8.re-frame2-causa.mount/open!`. The
+            ;; pre-rf2-ibpwr `causa-available?` used a `find-ns-obj` +
+            ;; `aget` walk to feature-detect Causa, which returned a
+            ;; false-negative in node-test (shadow-cljs's namespace
+            ;; organisation does not guarantee top-level def'd fns are
+            ;; surfaced as parent-namespace JS properties — the same
+            ;; bug class as the pre-rf2-senbl `mount-fn-for` walk).
+            ;; Causa is on the same shadow-cljs :source-paths as Story
+            ;; (see `implementation/shadow-cljs.edn`), so the require
+            ;; is a compile-time resolution; bundle-isolation still
+            ;; holds because the gate only forbids `implementation/`
+            ;; → `tools/` requires, not `tools/story` → `tools/causa`
+            ;; (the inverse is explicitly fine — see rf2-senbl PR
+            ;; comment for the dep-arrow analysis).
+            #?(:cljs [day8.re-frame2-causa.mount :as causa-mount])))
 
 ;; ---- pure: preset resolution ---------------------------------------------
 
@@ -103,11 +121,22 @@
 
 #?(:cljs
    (defn causa-available?
-     "True iff the Causa mount surface is loaded — feature-detect
-     `day8.re-frame2-causa.mount/open!`. When false the preset
-     no-ops silently."
+     "True iff the Causa mount surface is loaded — checks that the
+     compile-time-resolved `causa-mount/open!` symbol is bound to a
+     value at runtime.
+
+     rf2-ibpwr: this previously used a runtime `find-ns-obj` + `aget`
+     walk to feature-detect Causa, which returned a false-negative under
+     node-test (same bug class as the pre-rf2-senbl `mount-fn-for`
+     walk). The fix mirrors rf2-senbl's `mount-fn-for`: a direct
+     `:require` of `day8.re-frame2-causa.mount` at the top of this ns
+     means the symbol is resolved at compile time; the runtime call
+     just dereferences the bound value. Causa is on Story's shadow-cljs
+     `:source-paths` so the require always resolves; the `some?` guard
+     is belt-and-braces against a degenerate build that somehow shipped
+     without Causa's mount ns. When false the preset no-ops silently."
      []
-     (some? (resolve-fn 'day8.re-frame2-causa.mount/open!))))
+     (some? causa-mount/open!)))
 
 #?(:cljs
    (defn causa-config-available?
@@ -144,10 +173,13 @@
 
 #?(:cljs
    (defn- apply-open!
-     "Drive the Causa shell open via `day8.re-frame2-causa.mount/open!`."
+     "Drive the Causa shell open via `causa-mount/open!`. The symbol
+     resolves at compile time via the direct `:require` at the top of
+     this ns (rf2-ibpwr — replaces the pre-fix `find-ns-obj` walk that
+     false-negatived under node-test)."
      []
-     (when-let [open-fn (resolve-fn 'day8.re-frame2-causa.mount/open!)]
-       (safe-call! "open!" open-fn))))
+     (when causa-mount/open!
+       (safe-call! "open!" causa-mount/open!))))
 
 ;; ---- :project-root bridge (rf2-r1uod) ------------------------------------
 ;;

--- a/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/causa_preset_cljs_test.cljs
@@ -113,8 +113,12 @@
     ;; `disable-keybinding!` itself so we can assert the wiring without
     ;; depending on the underlying configure! plumbing (covered by the
     ;; shimmed-configure test above). We also stub `detach-keybinding!`
-    ;; and the `resolve-fn` lookup `apply-open!` uses so we don't
-    ;; actually try to mount a shell.
+    ;; and `apply-open!` directly so we don't actually try to mount a
+    ;; shell. (rf2-ibpwr: the pre-fix tests stubbed `resolve-fn` to
+    ;; intercept the `mount/open!` lookup; after rf2-ibpwr `apply-open!`
+    ;; references `causa-mount/open!` directly via compile-time symbol
+    ;; resolution — there is no `resolve-fn` call to intercept, so the
+    ;; cleaner seam is the `apply-open!` var itself.)
     (let [disable-called? (atom false)
           detach-called?  (atom false)
           open-called?    (atom false)]
@@ -124,10 +128,8 @@
                     (fn [] (reset! disable-called? true) true)
                     causa-preset/detach-keybinding!
                     (fn [] (reset! detach-called? true) true)
-                    causa-preset/resolve-fn
-                    (fn [sym]
-                      (when (= sym 'day8.re-frame2-causa.mount/open!)
-                        (fn [] (reset! open-called? true) nil)))]
+                    causa-preset/apply-open!
+                    (fn [] (reset! open-called? true) nil)]
         (causa-preset/ensure-causa-mounted!)
         (is (true? @disable-called?)
             "disable-keybinding! is part of the mount edge")
@@ -150,10 +152,10 @@
                     (fn [] (swap! calls conj :disable) true)
                     causa-preset/detach-keybinding!
                     (fn [] (swap! calls conj :detach) true)
-                    causa-preset/resolve-fn
-                    (fn [sym]
-                      (when (= sym 'day8.re-frame2-causa.mount/open!)
-                        (fn [] (swap! calls conj :open) nil)))]
+                    ;; rf2-ibpwr: shim apply-open! directly — see the
+                    ;; rationale on the disables-keybinding test above.
+                    causa-preset/apply-open!
+                    (fn [] (swap! calls conj :open) nil)]
         (causa-preset/ensure-causa-mounted!)
         (is (= [:disable :detach :open] @calls)
             "slot flip (intent) lands before detach! (runtime removal)
@@ -187,17 +189,15 @@
       ;; `detach-keybinding!` run for real (with-redefs unchanged) and
       ;; their inner `resolve-fn` lookups resolve against Causa's live
       ;; config/keybinding namespaces (both on the test classpath).
-      ;; Capture the original resolve-fn so the with-redefs delegate
-      ;; can fall through for the keybinding/detach! + configure!
-      ;; lookups without recursing on itself.
-      (let [orig-resolve-fn @#'causa-preset/resolve-fn]
-        (with-redefs [causa-preset/causa-available? (fn [] true)
-                      causa-preset/resolve-fn
-                      (fn [sym]
-                        (if (= sym 'day8.re-frame2-causa.mount/open!)
-                          (fn [] nil)
-                          (orig-resolve-fn sym)))]
-          (causa-preset/ensure-causa-mounted!)))
+      ;; rf2-ibpwr: after the fix, `apply-open!` references
+      ;; `causa-mount/open!` directly via compile-time symbol
+      ;; resolution — no `resolve-fn` call to intercept. Shim
+      ;; `apply-open!` itself as the no-op seam so the test's intent
+      ;; (don't actually mount a shell, but DO run the real
+      ;; keybinding bridges) is preserved.
+      (with-redefs [causa-preset/causa-available? (fn [] true)
+                    causa-preset/apply-open!      (fn [] nil)]
+        (causa-preset/ensure-causa-mounted!))
       (is (false? (causa-config/keybinding-attach-enabled?))
           "ensure-causa-mounted! flipped the slot to false")
       (is (false? (causa-keybinding/attached?))

--- a/tools/story/test/re_frame/story/causa_preset_test.cljc
+++ b/tools/story/test/re_frame/story/causa_preset_test.cljc
@@ -108,12 +108,17 @@
           :causa {:open? true :tab :issues}})
        (story/reg-variant :story.no-causa/v
          {:doc "v"})
-       ;; The test build has no Causa namespace loaded, so
-       ;; causa-available? is false and apply-preset! returns nil
-       ;; without dispatching.
-       (is (false? (causa-preset/causa-available?))
-           "this test assumes Causa is NOT on the classpath")
-       (is (nil? (causa-preset/apply-preset! :story.no-causa/v))))))
+       ;; rf2-ibpwr: post-fix `causa-available?` is a compile-time
+       ;; symbol resolution check; Causa IS on the test classpath
+       ;; (Story's `causa-embed.cljs` directly requires
+       ;; `day8.re-frame2-causa.mount`). To exercise the no-Causa
+       ;; no-op path we shim the predicate via `with-redefs` — the
+       ;; production code path is what the predicate naturally
+       ;; reports; the shim is the test surface for the absent-Causa
+       ;; degraded posture.
+       (with-redefs [causa-preset/causa-available? (constantly false)]
+         (is (nil? (causa-preset/apply-preset! :story.no-causa/v))
+             "apply-preset! returns nil when causa-available? is false")))))
 
 #?(:cljs
    (deftest cljs-apply-preset-nil-on-missing-preset

--- a/tools/story/test/re_frame/story/panels_e2e/causa_embed_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/causa_embed_e2e_cljs_test.cljs
@@ -5,12 +5,16 @@
   Story's RHS hosts ONE Causa panel at a time under a chip-row picker
   (rf2-v1ach). Three bug classes drove this coverage:
 
-  - **rf2-senbl** — `mount-fn-for` returning nil because the previous
-    `find-ns-obj` + `aget` walk did not surface top-level def'd fns
-    as parent-namespace JS properties; the fix is a `case` dispatch
-    via direct `:require`. We assert here that every catalogued
-    panel-id resolves to a callable mount-fn so a regression in the
-    require / case shape is caught at unit-test speed.
+  - **rf2-senbl** / **rf2-ibpwr** — `mount-fn-for` returning nil
+    (rf2-senbl) and `causa-available?` returning a false-negative
+    (rf2-ibpwr) because the previous `find-ns-obj` + `aget` walk did
+    not surface top-level def'd fns as parent-namespace JS
+    properties; the fix is a `case` dispatch via direct `:require`
+    (for `mount-fn-for`) and a direct symbol reference via direct
+    `:require` (for `causa-available?`). We assert here that every
+    catalogued panel-id resolves to a callable mount-fn so a
+    regression in the require / case shape is caught at unit-test
+    speed.
   - **rf2-4l7t2** — React 18+ throws \"Attempted to synchronously
     unmount a root while React was already rendering\" whenever a
     Causa-owned React root is torn down inside the outer Story-
@@ -55,28 +59,25 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.story :as story]
-            [re-frame.story.causa-preset :as causa-preset]
             [re-frame.story.ui.causa-embed :as causa-embed]
             [re-frame.story.ui.state :as ui-state]
             [re-frame.story.test-helpers.e2e-multi-frame :as e2e]
             [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as causa-e2e]
             [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
 
-;; rf2-senbl bug class symmetry: `causa-preset/causa-available?` uses
-;; the same `find-ns-obj` + `aget` walk that previously broke
-;; `mount-fn-for`. The classpath HAS Causa loaded (the embed namespace
-;; directly `:require`s `day8.re-frame2-causa.panels`), so the
-;; feature-detection is a false negative in the node-test context. We
-;; stub the predicate so the embed renders its full surface; the
-;; production code path stays untouched.
-
-(defn- with-causa-available [test-fn]
-  (with-redefs [causa-preset/causa-available? (constantly true)]
-    (test-fn)))
+;; rf2-ibpwr: pre-fix, `causa-preset/causa-available?` used a
+;; `find-ns-obj` + `aget` walk that returned a false-negative under
+;; node-test (same bug class as the pre-rf2-senbl `mount-fn-for`
+;; walk). The fixture below used to stub the predicate via
+;; `with-redefs` so the embed rendered its full surface. After
+;; rf2-ibpwr the predicate is a compile-time symbol resolution check
+;; (the direct `:require` of `day8.re-frame2-causa.mount` in
+;; `re-frame.story.causa-preset` makes the symbol bound at compile
+;; time, so the runtime call correctly reports `true` in node-test).
+;; The stub fixture is no longer needed.
 
 (use-fixtures :each
-  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter})
-  with-causa-available)
+  (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
 
 ;; A minimal variant registration the embed-surface tests depend on —
 ;; the embed reads `:selected-variant` off the shell ratom; resolving


### PR DESCRIPTION
## Summary
- Same pattern as rf2-senbl mount-fn-for fix
- with-redefs stub removed from causa_embed_e2e_cljs_test.cljs

## Bead
rf2-ibpwr

## Acceptance
- npm run test:cljs clean
- Embed e2e test passes without the with-redefs stub