### PR TITLE
test(causa): Phase 3 panel-control e2e (rf2-w991t)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/density_radio_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/density_radio_e2e_cljs_test.cljs
@@ -17,6 +17,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.settings.effects :as settings-effects]
             [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
             [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
 
@@ -63,3 +64,40 @@
         (e2e/dispatch-host [:counter/inc])
         (is (= :compact (e2e/sub-causa [:rf.causa/density]))
             "density reset on host dispatch — wrong-frame state class")))))
+
+;; ---- rf2-w991t — CSS-var-equivalent (pure fn) mirrors the radio choice ----
+;;
+;; The radio writes `--rf-causa-font-size` via `effects/apply-density-font-
+;; size!` so the whole type scale rescales in lockstep. In node-test there
+;; is no `<html>` to inspect, but the pure CSS-var-equivalent helper
+;; (`effects/density->px`) is the JVM-portable mirror — same lookup table,
+;; same fallback. The original Phase 3 bead (rf2-mpqxn) wanted the test
+;; to assert the CSS-var-equivalent moves with the radio; we read the
+;; helper against the live density sub so a regression that decoupled the
+;; px map from the sub would surface here.
+
+(deftest causa-density-px-tracks-radio
+  (testing "rf2-w991t — density→px helper mirrors the radio's choice"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :compact])
+        (let [d (e2e/sub-causa [:rf.causa/density])]
+          (is (= 12 (settings-effects/density->px d))
+              ":compact density did not resolve to 12px via density->px"))
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :cosy])
+        (let [d (e2e/sub-causa [:rf.causa/density])]
+          (is (= 13 (settings-effects/density->px d))
+              ":cosy density did not resolve to 13px via density->px"))
+        ;; The radio choice's CSS-var value MUST differ between pills
+        ;; — that is the "differently-shaped CSS surface per pill"
+        ;; assertion the original Playwright scenario expressed by
+        ;; comparing computed font-size.
+        (e2e/dispatch-causa [:rf.causa/settings-update :general :density :compact])
+        (let [compact-px (settings-effects/density->px
+                           (e2e/sub-causa [:rf.causa/density]))]
+          (e2e/dispatch-causa [:rf.causa/settings-update :general :density :cosy])
+          (let [cosy-px (settings-effects/density->px
+                          (e2e/sub-causa [:rf.causa/density]))]
+            (is (not= compact-px cosy-px)
+                "compact and cosy resolved to the same px — CSS-var-equivalent collapse")))))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/palette_invoke_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/palette_invoke_e2e_cljs_test.cljs
@@ -19,6 +19,7 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.test-helpers.e2e-multi-frame :as e2e]
             [day8.re-frame2-causa.test-helpers.host-fixtures.counter :as counter]))
 
@@ -68,3 +69,77 @@
         (e2e/dispatch-host [:counter/inc])
         (is (e2e/sub-causa [:rf.causa/palette-open?])
             "palette state cleared on host dispatch — wrong-frame class")))))
+
+;; ---- rf2-w991t — Cmd-K palette execute: :toggle-theme + recents ----------
+;;
+;; The original Phase 3 bead (rf2-mpqxn) asked for an end-to-end exercise
+;; of the Cmd-K palette's execute path: invoke the `:toggle-theme` command
+;; item via `:rf.causa/palette-invoke`, assert the theme atom flips, then
+;; re-invoke and assert recents-boost surfaces the just-executed verb.
+;;
+;; The toggle-theme item is built by `palette/sources.cljc`:
+;;
+;;   {:source :command :id :toggle-theme :action [:palette/toggle-theme] …}
+;;
+;; The invoke event reads the current theme via `config/get-setting :theme
+;; nil` (the process-global atom, NOT app-db; the popup-seeded slot is a
+;; mirror) and dispatches `:rf.causa/settings-update :theme nil <next>`
+;; which dual-writes atom + app-db. The recents bump records `:toggle-
+;; theme` at index 0 of `:rf.causa/palette-recents` and persists.
+
+(def toggle-theme-item
+  "Minimal item shape that drives the `:palette/toggle-theme` branch in
+  `:rf.causa/palette-invoke`. The full item carried by the palette UI also
+  has `:label`, `:icon`, `:boost`, etc.; the invoke event reads only
+  `:source`, `:id`, and `:action`."
+  {:source :command
+   :id     :toggle-theme
+   :action [:palette/toggle-theme]})
+
+(deftest causa-palette-invoke-toggle-theme-flips-theme
+  (testing "rf2-w991t — palette-invoke :toggle-theme flips the theme atom"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (let [before (config/get-setting :theme nil)]
+          (e2e/dispatch-causa [:rf.causa/palette-invoke toggle-theme-item])
+          (let [after (config/get-setting :theme nil)]
+            (is (#{:dark :light} after)
+                "post-invoke theme is not :dark or :light")
+            (is (not= before after)
+                "palette-invoke :toggle-theme did not flip the theme atom"))
+          ;; Round-trip — a second invoke restores the prior value.
+          (e2e/dispatch-causa [:rf.causa/palette-invoke toggle-theme-item])
+          (is (= before (config/get-setting :theme nil))
+              "second palette-invoke :toggle-theme did not round-trip"))))))
+
+(deftest causa-palette-invoke-toggle-theme-bumps-recents
+  (testing "rf2-w991t — :toggle-theme invoke records into :rf.causa/palette-recents"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (e2e/dispatch-causa [:rf.causa/palette-invoke toggle-theme-item])
+        (let [recents (e2e/sub-causa [:rf.causa/palette-recents])]
+          (is (vector? recents)
+              ":rf.causa/palette-recents did not resolve to a vector")
+          (is (= :toggle-theme (first recents))
+              ":toggle-theme did not bubble to index 0 of palette-recents"))))))
+
+(deftest causa-palette-invoke-toggle-theme-recents-boost-survives
+  (testing "rf2-w991t — re-invoking same command keeps recents head-stable"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        ;; First invoke records `:toggle-theme` at head.
+        (e2e/dispatch-causa [:rf.causa/palette-invoke toggle-theme-item])
+        (is (= :toggle-theme (first (e2e/sub-causa [:rf.causa/palette-recents])))
+            "first invoke did not record :toggle-theme at head")
+        ;; Re-invoke — the dedup in `recents/record` MUST keep `:toggle-
+        ;; theme` at head without duplicating (the boost surface is what
+        ;; the palette index's recents-aware ranking reads).
+        (e2e/dispatch-causa [:rf.causa/palette-invoke toggle-theme-item])
+        (let [recents (e2e/sub-causa [:rf.causa/palette-recents])]
+          (is (= :toggle-theme (first recents))
+              "second invoke did not keep :toggle-theme at head")
+          (is (= 1 (count (filter #(= :toggle-theme %) recents)))
+              ":toggle-theme appeared twice in recents — dedup regression"))))))

--- a/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/views_group_by_e2e_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/control_axes_e2e/views_group_by_e2e_cljs_test.cljs
@@ -69,3 +69,63 @@
         (e2e/dispatch-host [:counter/inc])
         (is (= :sub (e2e/sub-causa [:rf.causa/views-group-by]))
             "host dispatch reset the views-group-by slot — wrong-frame routing")))))
+
+;; ---- rf2-w991t — canonical event + composite re-projection ----------------
+;;
+;; The original Phase 3 bead (rf2-mpqxn) asked for two things on top of the
+;; raw-slot regression guard above:
+;;
+;;   (a) cycle pills via the registered event surface (not a per-test event)
+;;       so the test exercises the same dispatch path the panel button does;
+;;   (b) the composite Views-data sub re-projects on each pill flip — the
+;;       `:group-by` slot of the projection migrates with the active pill.
+;;
+;; (b) is the "differently-shaped data per pill" assertion the original
+;; Playwright scenario expressed by reading `aria-pressed=true` off the
+;; rendered DOM. In a node-test we read the same migrating value off the
+;; composite sub, which is what the panel's hiccup also reads.
+
+(deftest causa-views-set-group-by-event-cycles-pills
+  (testing "rf2-w991t — :rf.causa/views-set-group-by cycles :component → :sub → :tree → :component"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        (is (= :component (e2e/sub-causa [:rf.causa/views-group-by]))
+            "fresh install did not default to :component")
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :sub])
+        (is (= :sub (e2e/sub-causa [:rf.causa/views-group-by]))
+            "first cycle did not land on :sub")
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :tree])
+        (is (= :tree (e2e/sub-causa [:rf.causa/views-group-by]))
+            "second cycle did not land on :tree")
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :component])
+        (is (= :component (e2e/sub-causa [:rf.causa/views-group-by]))
+            "third cycle did not return to :component")))))
+
+(deftest causa-views-data-group-by-migrates-with-active-pill
+  (testing "rf2-w991t — composite :rf.causa/views-data re-projects per pill"
+    (e2e/with-host-and-causa-frames
+      {:install-host counter/install-and-init!}
+      (fn []
+        ;; Land one cascade so the composite resolves to a real shape rather
+        ;; than the empty-buffer no-op (the `:group-by` slot is on the
+        ;; projection regardless, but `:has-cascade?` flipping on is the
+        ;; signal that the composite ran end-to-end).
+        (e2e/dispatch-host [:counter/inc])
+        (let [d0 (e2e/sub-causa [:rf.causa/views-data])]
+          (is (true? (:has-cascade? d0))
+              "composite did not see the freshly-landed cascade")
+          (is (= :component (:group-by d0))
+              "composite did not start at :component"))
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :sub])
+        (let [d1 (e2e/sub-causa [:rf.causa/views-data])]
+          (is (= :sub (:group-by d1))
+              ":group-by did not migrate to :sub on composite — re-projection drop"))
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :tree])
+        (let [d2 (e2e/sub-causa [:rf.causa/views-data])]
+          (is (= :tree (:group-by d2))
+              ":group-by did not migrate to :tree on composite — re-projection drop"))
+        (e2e/dispatch-causa [:rf.causa/views-set-group-by :component])
+        (let [d3 (e2e/sub-causa [:rf.causa/views-data])]
+          (is (= :component (:group-by d3))
+              ":group-by did not return to :component on composite"))))))


### PR DESCRIPTION
## Summary

Extends three existing control-axes_e2e files (additive — no new files) with the assertions the original Phase 3 bead (rf2-mpqxn) + superseded PR #1607 expressed via Playwright. Authored against the multi-frame e2e helper rf2-7icrs (#1602) at sub-second cost.

- **Views Group-By cycle** — cycles `:component` → `:sub` → `:tree` via the canonical `:rf.causa/views-set-group-by` event and asserts `:rf.causa/views-data`'s `:group-by` slot migrates with the active pill (the differently-shaped composite the Playwright scenario read off `aria-pressed=true`).
- **Density radio cycle** — asserts the CSS-var-equivalent pure fn `effects/density->px` (the JVM-portable mirror of `--rf-causa-font-size`) tracks the radio's `:compact` ↔ `:cosy` choice (12px ↔ 13px).
- **Cmd-K palette execute** — invokes `:toggle-theme` via `:rf.causa/palette-invoke`, asserts the theme atom flips + round-trips, and `:rf.causa/palette-recents` surfaces `:toggle-theme` at index 0 with dedup on re-invoke (the recents-boost surface).

## Bead

- rf2-w991t (closes via PR; supersedes the closed #1607)
- rf2-mpqxn (original Phase 3 ask)
- rf2-7icrs / #1602 (multi-frame e2e helper)

## Acceptance

- +6 tests, +20 assertions across 3 files
- `npm run test:cljs` clean (3410 tests / 9700 assertions / 0 failures / 0 errors)

## Test plan

- [x] `npm run test:cljs` passes
- [x] Each new test exercises the canonical event surface (no per-test event reg)
- [x] No new files — additive extensions to the existing rf2-7icrs files