### PR TITLE
test(causa): migrate panel view tests to re-frame.test-helpers (rf2-dzmxs)

### DIFF
--- a/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
@@ -34,6 +34,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.panels.event.event-status-colour :as event-status]
@@ -58,45 +59,15 @@
      :init-fn causa-init!}))
 
 ;; ---- hiccup walker ------------------------------------------------------
+;; Thin aliases over re-frame.test-helpers. The local
+;; `find-by-testid-prefix` returns the FIRST match (vs the framework's
+;; `find-by-testid-prefix` which returns a vector of matches); the
+;; thin wrapper here preserves the existing call-site contract.
 
-(declare expand-tree)
-
-(defn- expand-tree
-  "Same expand-tree the surrounding suites use — invokes fn-headed
-  vectors so the walker descends through reg-view bodies."
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+(def ^:private find-by-testid th/find-by-testid)
 
 (defn- find-by-testid-prefix [tree prefix]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (when-let [tid (:data-testid (second node))]
-                       (= 0 (.indexOf tid prefix))))
-            node))
-        (hiccup-seq tree)))
+  (first (th/find-by-testid-prefix tree prefix)))
 
 ;; ---- fixture builders --------------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
@@ -49,6 +49,7 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
@@ -67,39 +68,12 @@
     {:adapter plain-atom/adapter
      :init-fn causa-init!}))
 
-;; ---- hiccup walkers (mirror machine_inspector_view_cljs_test) -----------
+;; ---- hiccup walkers ----------------------------------------------------
+;; Thin aliases over re-frame.test-helpers so the local call sites read
+;; identically to before.
 
-(declare expand-fn-component)
-
-(defn- expand-children [node]
-  (cond
-    (vector? node) (mapv expand-fn-component node)
-    (seq? node)    (map  expand-fn-component node)
-    :else          node))
-
-(defn- expand-fn-component [node]
-  (if (and (vector? node) (fn? (first node)))
-    (expand-children (apply (first node) (rest node)))
-    (expand-children node)))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filter (fn [node]
-            (and (vector? node)
-                 (map? (second node))
-                 (some-> (:data-testid (second node))
-                         (.startsWith prefix))))
-          (hiccup-seq tree)))
+(def ^:private find-by-testid           th/find-by-testid)
+(def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
 
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)

--- a/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
@@ -19,6 +19,7 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
@@ -38,39 +39,11 @@
      :init-fn causa-init!}))
 
 ;; ---- hiccup walkers -----------------------------------------------------
+;; Thin aliases over re-frame.test-helpers so the local call sites read
+;; identically to before.
 
-(declare expand-fn-component)
-
-(defn- expand-children [node]
-  (cond
-    (vector? node) (mapv expand-fn-component node)
-    (seq? node)    (map  expand-fn-component node)
-    :else          node))
-
-(defn- expand-fn-component [node]
-  (if (and (vector? node) (fn? (first node)))
-    (expand-children (apply (first node) (rest node)))
-    (expand-children node)))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-fn-component tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filter (fn [node]
-            (and (vector? node)
-                 (map? (second node))
-                 (some-> (:data-testid (second node))
-                         (.startsWith prefix))))
-          (hiccup-seq tree)))
+(def ^:private find-by-testid           th/find-by-testid)
+(def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
 
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)

--- a/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
@@ -45,6 +45,7 @@
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.preload :as preload]
             [day8.re-frame2-causa.registry :as registry]
@@ -64,39 +65,18 @@
     {:adapter plain-atom/adapter
      :init-fn causa-init!}))
 
-;; ---- hiccup walkers (mirror machine_inspector_view_cljs_test) ----------
+;; ---- hiccup walkers ----------------------------------------------------
+;; Thin aliases over re-frame.test-helpers so the local call sites read
+;; identically to before.
 
-(declare expand-fn-component)
+(def ^:private find-by-testid           th/find-by-testid)
+(def ^:private find-all-by-testid-prefix th/find-by-testid-prefix)
 
-(defn- expand-children [node]
-  (cond
-    (vector? node) (mapv expand-fn-component node)
-    (seq? node)    (map  expand-fn-component node)
-    :else          node))
-
-(defn- expand-fn-component [node]
-  (if (and (vector? node) (fn? (first node)))
-    (expand-children (apply (first node) (rest node)))
-    (expand-children node)))
-
-(defn- hiccup-seq [tree]
-  (tree-seq (some-fn vector? seq?) seq (expand-fn-component tree)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
-
-(defn- find-all-by-testid-prefix [tree prefix]
-  (filter (fn [node]
-            (and (vector? node)
-                 (map? (second node))
-                 (some-> (:data-testid (second node))
-                         (.startsWith prefix))))
-          (hiccup-seq tree)))
+(defn- hiccup-seq
+  "Local kept for the orphan-pill text-label helper. Expands fn
+  components via the framework walker, then yields depth-first nodes."
+  [tree]
+  (tree-seq (some-fn vector? seq?) seq (th/expand-tree tree)))
 
 (defn- setup-causa-frame! []
   (registry/register-causa-handlers!)
@@ -672,17 +652,13 @@
       (rf/dispatch-sync [:rf.causa/set-trace-filter :origin :rf/missing-origin])
       (let [tree         (trace/Panel)
             source-pill  (find-by-testid tree "rf-causa-trace-empty-active-source")
-            origin-pill  (find-by-testid tree "rf-causa-trace-empty-active-origin")
-            label-of     (fn [node]
-                           (->> (hiccup-seq node)
-                                (filter string?)
-                                (apply str)))]
+            origin-pill  (find-by-testid tree "rf-causa-trace-empty-active-origin")]
         (is (some? source-pill) "present axis pill renders")
         (is (some? origin-pill)  "orphan axis pill renders")
         (testing "present pill has no orphan marker"
-          (is (not (re-find #"orphaned" (label-of source-pill)))))
+          (is (not (re-find #"orphaned" (th/text-content source-pill)))))
         (testing "orphan pill carries the orphan marker"
-          (is (re-find #"orphaned" (label-of origin-pill))))))))
+          (is (re-find #"orphaned" (th/text-content origin-pill))))))))
 
 ;; ---- (10) incremental projection wiring — rf2-44vzy --------------------
 ;;

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
@@ -8,23 +8,13 @@
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.panels.views :as facade]
             [day8.re-frame2-causa.panels.views-view :as view]))
 
-(defn- expand-fn [node]
-  (if (and (vector? node) (fn? (first node)))
-    (try (apply (first node) (rest node))
-         (catch :default _ node))
-    node))
-
 (defn- has-testid? [tree testid]
-  (some (fn [node]
-          (and (vector? node)
-               (map? (second node))
-               (= testid (:data-testid (second node)))))
-        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
-             (map expand-fn))))
+  (some? (th/find-by-testid tree testid)))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -130,14 +120,7 @@
 ;; cascade to describe.
 ;; ---------------------------------------------------------------------------
 
-(defn- find-by-testid-in [tree testid]
-  (some (fn [node]
-          (and (vector? node)
-               (map? (second node))
-               (= testid (:data-testid (second node)))
-               node))
-        (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
-             (map expand-fn))))
+(def ^:private find-by-testid-in th/find-by-testid)
 
 (deftest header-block-suppresses-cascade-meta-when-no-cascade-focused
   (testing "no focused cascade → cascade-metadata `:p` is absent even
@@ -186,17 +169,16 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- collect-by-pred
-  "Walk the hiccup tree and collect every vector whose attr map (slot 1)
-  satisfies `pred`."
+  "Walk the hiccup tree (expanding function components via
+  `re-frame.test-helpers/expand-tree`) and collect every vector whose
+  attr map satisfies `pred`."
   [tree pred]
-  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn tree))
-       (map expand-fn)
-       (keep (fn [node]
-               (when (and (vector? node)
-                          (map? (second node))
-                          (pred (second node)))
-                 node)))
-       (vec)))
+  (->> (th/expand-tree tree)
+       (tree-seq (some-fn vector? seq?) seq)
+       (filterv (fn [node]
+                  (and (vector? node)
+                       (map? (second node))
+                       (pred (second node)))))))
 
 (deftest rerendered-because-header-text
   (testing "Delta 1 — the right-column section header in a Re-rendered
@@ -209,13 +191,11 @@
                            :elapsed-ms   1.0}
                   :invalidated-by [{:sub-id ::sub :trigger? true}]}
           row    (#'view/single-row item :rendered false)
-          texts  (->> (tree-seq (some-fn vector? seq?) seq (expand-fn row))
-                      (filter string?))]
-      (is (some #(= "Rerendered because" %) texts)
+          text   (th/text-content row)]
+      (is (re-find #"Rerendered because" text)
           (str "expected 'Rerendered because' literal in the row; "
-               "found: " (pr-str (filter #(re-find #"by|because" (or % ""))
-                                         texts))))
-      (is (not-any? #(re-find #"Invalidated by" (or % "")) texts)
+               "got: " (pr-str text)))
+      (is (not (re-find #"Invalidated by" text))
           "no 'Invalidated by' UI text remaining in the rendered row"))))
 
 (deftest rerendered-because-list-marker-tooltips
@@ -268,12 +248,10 @@
                       [{:sub-id ::sub-a :trigger? true  :recomputed? true}
                        {:sub-id ::sub-b :trigger? false :recomputed? true}
                        {:sub-id ::sub-c :trigger? false :recomputed? false}])
-          glyphs    (->> (tree-seq (some-fn vector? seq?) seq
-                                   (expand-fn list-node))
-                         (filter string?))]
-      (is (some #(= "✱" %) glyphs) "the `✱` glyph renders for cache-miss-trigger")
-      (is (some #(= "≈" %) glyphs) "the `≈` glyph renders for cache-miss-equal")
-      (is (some #(= "·" %) glyphs) "the `·` glyph renders for cache-hit"))))
+          text      (th/text-content list-node)]
+      (is (re-find #"✱" text) "the `✱` glyph renders for cache-miss-trigger")
+      (is (re-find #"≈" text) "the `≈` glyph renders for cache-miss-equal")
+      (is (re-find #"·" text) "the `·` glyph renders for cache-hit"))))
 
 (deftest cluster-row-trigger-marker-has-tooltip
   (testing "Delta 2 — the cluster row's single ✱ trigger marker also
@@ -315,13 +293,10 @@
       (is (= #{"trigger" "cache-miss-equal" "cache-hit"}
              (set (keys by-marker)))
           "all three markers ship in the rendered list")
-      (let [glyphs (->> (tree-seq (some-fn vector? seq?) seq
-                                  (expand-fn list-node))
-                        (filter string?)
-                        set)]
-        (is (contains? glyphs "✱") "✱ glyph renders for cache-miss-trigger")
-        (is (contains? glyphs "≈") "≈ glyph renders for cache-miss-equal")
-        (is (contains? glyphs "·") "·  glyph renders for cache-hit"))
+      (let [text (th/text-content list-node)]
+        (is (re-find #"✱" text) "✱ glyph renders for cache-miss-trigger")
+        (is (re-find #"≈" text) "≈ glyph renders for cache-miss-equal")
+        (is (re-find #"·" text) "·  glyph renders for cache-hit"))
       (is (re-find #"value unchanged"
                    (:title (second (get by-marker "cache-miss-equal"))))
           "cache-miss-equal tooltip mentions 'value unchanged'")
@@ -398,18 +373,14 @@
             footer"
     (let [chip (#'view/filter-chip :cart/list)]
       (is (some? chip) "non-nil view-id → chip renders")
-      (is (some #(= (:data-testid (second %))
-                    "rf-causa-views-filter-chip")
-                (filter vector?
-                        (tree-seq (some-fn vector? seq?) seq chip)))
+      (is (some? (th/find-by-testid chip "rf-causa-views-filter-chip"))
           "filter-chip carries the rf-causa-views-filter-chip data-testid")
-      (let [texts (->> (tree-seq (some-fn vector? seq?) seq chip)
-                       (filter string?))]
-        (is (some #(re-find #"Filtered to" %) texts)
+      (let [text (th/text-content chip)]
+        (is (re-find #"Filtered to" text)
             "chip ships the 'Filtered to:' label")
-        (is (some #(re-find #"cart/list" %) texts)
+        (is (re-find #"cart/list" text)
             "chip ships the filtered view-id label")
-        (is (some #(= "×" %) texts)
+        (is (re-find #"×" text)
             "chip ships the × clear glyph")))))
 
 (deftest filter-chip-returns-nil-when-no-filter
@@ -417,18 +388,13 @@
             is active so the panel chrome stays silent-by-default"
     (is (nil? (#'view/filter-chip nil)))))
 
-(defn- expand-pills [tree]
-  "Walk the hiccup tree expanding any inline pill fns (the
-  group-by-toggle uses Reagent component-vectors `[group-by-pill {…}]`
-  rather than direct hiccup). Returns a flat seq of every expanded
-  vector + atom string."
-  (->> (tree-seq (some-fn vector? seq?) seq tree)
-       (mapcat (fn [node]
-                 (if (and (vector? node) (fn? (first node)))
-                   (let [expanded (try (apply (first node) (rest node))
-                                       (catch :default _ node))]
-                     (tree-seq (some-fn vector? seq?) seq expanded))
-                   [node])))))
+(defn- expand-pills
+  "Walk the hiccup tree (expanding fn components via
+  `re-frame.test-helpers/expand-tree`). Returns a flat seq of every
+  expanded vector + atom string."
+  [tree]
+  (->> (th/expand-tree tree)
+       (tree-seq (some-fn vector? seq?) seq)))
 
 (deftest group-by-toggle-renders-both-pills-with-selection-state
   (testing "rf2-r2s2l — bottom-controls group-by-toggle ships both
@@ -495,24 +461,17 @@
                               :render-key [:cart/header :tok-2]
                               :trigger? false :elapsed-ms 0.5}]
                      :view-count 1}]
-          section (#'view/sub-grouped-section sub-rows)
-          testids (->> (tree-seq (some-fn vector? seq?) seq section)
-                       (keep #(when (and (vector? %)
-                                         (map? (second %)))
-                                (:data-testid (second %))))
-                       set)]
-      (is (contains? testids "rf-causa-views-sub-grouped"))
-      (is (contains? testids "rf-causa-views-sub-row"))
-      (is (contains? testids "rf-causa-views-sub-row-consumer")))))
+          section (#'view/sub-grouped-section sub-rows)]
+      (is (some? (th/find-by-testid section "rf-causa-views-sub-grouped")))
+      (is (some? (th/find-by-testid section "rf-causa-views-sub-row")))
+      (is (some? (th/find-by-testid section "rf-causa-views-sub-row-consumer"))))))
 
 (deftest sub-grouped-section-empty-state
   (testing "rf2-r2s2l — empty sub-grouped list renders the empty-state
             teaching message so the user understands the parent-
             forced cascade case"
-    (let [section (#'view/sub-grouped-section [])
-          texts (->> (tree-seq (some-fn vector? seq?) seq section)
-                     (filter string?))]
-      (is (some #(re-find #"No sub invalidations" %) texts)))))
+    (let [section (#'view/sub-grouped-section [])]
+      (is (re-find #"No sub invalidations" (th/text-content section))))))
 
 (deftest no-invalidated-by-ui-text-in-row-rendering
   (testing "Delta 1 — the rendered row tree has zero 'Invalidated by'
@@ -537,14 +496,8 @@
                                           :clustered? true}]}
           single-row  (#'view/single-row single-item :rendered false)
           cluster-row (#'view/cluster-row cluster-item :rendered false)
-          all-texts (concat
-                      (->> (tree-seq (some-fn vector? seq?) seq
-                                     (expand-fn single-row))
-                           (filter string?))
-                      (->> (tree-seq (some-fn vector? seq?) seq
-                                     (expand-fn cluster-row))
-                           (filter string?)))]
-      (is (not-any? #(re-find #"(?i)invalidated by" %) all-texts)
-          (str "no 'Invalidated by' UI text left; offending strings: "
-               (pr-str (filter #(re-find #"(?i)invalidated by" %)
-                               all-texts)))))))
+          all-text    (str (th/text-content single-row)
+                           (th/text-content cluster-row))]
+      (is (not (re-find #"(?i)invalidated by" all-text))
+          (str "no 'Invalidated by' UI text left; got: "
+               (pr-str all-text))))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_dispatch_routing_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_dispatch_routing_cljs_test.cljs
@@ -34,6 +34,7 @@
             [re-frame.frame :as frame]
             [re-frame.substrate.adapter :as substrate-adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.panels.views :as facade]
             [day8.re-frame2-causa.panels.views-view :as view]
@@ -119,15 +120,7 @@
     (rf/with-frame :rf/causa
       (rf/dispatch-sync [:rf.causa/views-set-component-filter :cart/list]))
     (let [chip    (#'view/filter-chip :cart/list)
-          ;; chip is [:div … [:span …] [:button { :data-testid "...-clear" } …]]
-          ;; — find the clear button by walking the tree.
-          clear   (some (fn [node]
-                          (when (and (vector? node)
-                                     (map? (second node))
-                                     (= "rf-causa-views-filter-chip-clear"
-                                        (:data-testid (second node))))
-                            node))
-                        (tree-seq (some-fn vector? seq?) seq chip))
+          clear   (th/find-by-testid chip "rf-causa-views-filter-chip-clear")
           handler (:on-click (second clear))]
       (is (fn? handler) "filter-chip clear exposes an :on-click handler")
       (handler (fake-event))

--- a/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs
@@ -20,6 +20,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-helpers :as th]
             [re-frame.test-support :as test-support]
             [day8.re-frame2-causa.config :as config]
             [day8.re-frame2-causa.registry :as registry]
@@ -44,36 +45,11 @@
   (registry/register-causa-handlers!)
   (frame/reg-frame :rf/causa {}))
 
-;; ---- hiccup walker (copied from shell_cljs_test) -----------------------
+;; ---- hiccup walker -----------------------------------------------------
+;; Thin alias over re-frame.test-helpers so call sites read identically
+;; to before.
 
-(declare expand-tree)
-
-(defn- expand-tree
-  [tree]
-  (cond
-    (and (vector? tree) (fn? (first tree)))
-    (expand-tree (apply (first tree) (rest tree)))
-
-    (vector? tree)
-    (mapv expand-tree tree)
-
-    (seq? tree)
-    (map expand-tree tree)
-
-    :else
-    tree))
-
-(defn- hiccup-seq [tree]
-  (let [expanded (expand-tree tree)]
-    (tree-seq (some-fn vector? seq?) seq expanded)))
-
-(defn- find-by-testid [tree testid]
-  (some (fn [node]
-          (when (and (vector? node)
-                     (map? (second node))
-                     (= testid (:data-testid (second node))))
-            node))
-        (hiccup-seq tree)))
+(def ^:private find-by-testid th/find-by-testid)
 
 ;; ---- Modal short-circuit -----------------------------------------------
 


### PR DESCRIPTION
## Summary
- Replaces ad-hoc hiccup walkers (`expand-fn` / `tree-seq` / local `find-by-testid` / local `has-testid?`) with `re-frame.test-helpers/find-by-testid` + `text-content` + `expand-tree` in 7 of the 8 listed Causa panel view tests.
- The 8th file (`mount_cljs_test.cljs`) had no ad-hoc walkers — out of scope.
- Audit cite: ai/findings/2026-05-20-tools-testing-posture-audit.md Gap-2.

## Bead
rf2-dzmxs

## Files migrated (7 of 8)
- tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/panels/machine_inspector_view_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/panels/trace_view_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_view_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/panels/views_view_dispatch_routing_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/panels/event/event_status_colour_view_cljs_test.cljs
- tools/causa/test/day8/re_frame2_causa/settings/popup_cljs_test.cljs

## Notes
- Two helpers intentionally kept Causa-specific:
  - `machine_inspector_view_cljs_test.cljs/meta-preserving-children` — the rf2-ppzid React-key regression guard walks WITHOUT `mapv`-rebuilding hiccup so Reagent `:key` meta survives the walk. The framework's `expand-tree` would discard it.
  - `trace_view_cljs_test.cljs/row-li-by-id` — insists on `<li>` first-element matching for the rf2-z4fza React-key stability guard.
- `event_status_colour_view_cljs_test.cljs/find-by-testid-prefix` wraps framework's `find-by-testid-prefix` (vector) with `first` to preserve the existing single-node return contract at call sites.

## Acceptance
- `npm run test:cljs` clean — same test count as baseline (3426 tests / 9768 assertions / 0 failures, pure refactor)
- LoC delta: -184 (271 deletions vs 87 insertions)