### PR TITLE
spec(causa): Sim references post rf2-r4nao rehost (rf2-fr73h)

### DIFF
--- a/tools/causa/spec/003-Machine-Inspector.md
+++ b/tools/causa/spec/003-Machine-Inspector.md
@@ -13,13 +13,15 @@
 > picker chrome, the sub-strip (Topology/Sim/Instances/Cluster), the
 > picker-driven Sim ribbon UI, the multi-instance aggregate (Mode C
 > cluster view), the per-instance arc + mini-scrubber, and the
-> Browse-all entry point. The **Sim engine** (sub/event family at
-> `:rf.causa/sim-*`) and the **browse-all index** remain registered in
-> code so a future Static surface (sibling bead rf2-r4nao) can mount
-> them without re-implementing the algebra. Sections below describing
-> those removed UI ribbons are kept as historical reference for the
-> Static re-host effort; they no longer describe what the Runtime
-> Machines panel renders.
+> Browse-all entry point. The **Sim engine** has since been re-hosted
+> under the Static Machines surface's Sim sub-mode (sibling bead
+> rf2-r4nao landed — sub/event family at
+> `:rf.causa.static.machines/sim-*`, view at
+> `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs`); the
+> **browse-all index** ships as the Static Machines surface's
+> master-detail left pane. Sections below describing those removed UI
+> ribbons are kept as historical design-reference; they no longer
+> describe what the Runtime Machines panel renders.
 
 The Machines tab (tab 5 of 7 in the 4-layer chrome — see
 [`018-Event-Spine.md`](018-Event-Spine.md) §5) renders a Stately-quality
@@ -84,9 +86,12 @@ The header carries:
 - No Mode A/B/C dynamic instance views; no `:rf.causa/forced-machine-
   mode` slot.
 - No Sim toggle / Sim side-rail UI in the Runtime panel header. The
-  `SimSideRail` view is still exported by `panels/machine_inspector_sim.
-  cljs` for the future Static re-host; the `:rf.causa/sim-*` engine
-  events / subs remain registered against the `:rf/causa` frame.
+  `SimRail` view (post-rf2-r4nao rename of the historical
+  `SimSideRail`) ships under
+  `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs` and
+  is mounted by the Static Machines surface; the
+  `:rf.causa.static.machines/sim-*` engine events / subs are
+  registered against the `:rf/causa` frame from that ns.
 - No per-instance arc overlay; no mini-scrubber. The
   `:rf.causa/machine-scrubber-position` SLOT survives (read/write
   events still registered) because the share-URL round-trips it; the
@@ -188,7 +193,7 @@ The Static Machines tab is **tab 1 of 5** in the Static L3 strip (per [`007-UX-I
 │ ─ sort cycle (Name /     │   · 6 states · 2 live (→ Runtime)             │
 │   States / Live)         │                                               │
 │ ─ scrollable rows:       │ ─ 4-mode sub-strip [T][S][I][C]               │
-│   ◉ :checkout    src:42  │ ─ per-mode body (Topology · Sim placeholder · │
+│   ◉ :checkout    src:42  │ ─ per-mode body (Topology · Sim body ·        │
 │   ○ :auth/main   src:18  │   Instances JUMP · Cascade dimmed)            │
 │   ○ :wizard      src:90  │                                               │
 │   …                      │                                               │
@@ -220,7 +225,7 @@ The 4 sub-modes (mnemonic letters `t/s/i/c` surfaced in each pill's `title`) liv
 | Pill | Behaviour in Static | Body renderer |
 |---|---|---|
 | **Topology** (`t`, default) | Static-read of the machine's state graph — the SAME `chart/svg` MachineChart primitive the Runtime panel uses (single implementation), but with **NO `:highlight-id`** because Static is event-INDEPENDENT (there is no active state to spotlight). Click on a state node fires `:rf.causa.static.machines/state-clicked` for a per-state metadata rail (follow-on bead). Carries an "Open chart in pop-out" affordance. | inline SVG chart |
-| **Sim** (`s`) | Sibling bead **rf2-r4nao** — the Sim machinery re-host. v1 ships the strip cell and a placeholder card ("rf2-r4nao will fill this") so the strip stays complete. The Sim engine (`:rf.causa/sim-*` subs/events) remains registered in code; only the Static-side UI re-host is deferred. | placeholder card pointing at rf2-r4nao |
+| **Sim** (`s`) | Hermetic 'what-if' simulator (rf2-r4nao — landed). Clones the registered machine definition into Causa's app-db at `[:rf.causa.static.machines/sim-by-machine <machine-id>]`; production registry is untouched. Event-INDEPENDENT — Sim does NOT read the live snapshot; the seed is the definition's declared `:initial` + `:data`. Engine events/subs live under the `:rf.causa.static.machines/sim-*` namespace (`sim-start`, `sim-step`, `sim-reset`, `sim-stop`, `sim-set-pending-event`, `sim-set-pending-data`). View at `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs` exports `pill` (the strip cell), `body` (the per-machine Sim panel) and `SimRail` (the geometry-coupled side rail). Failed-guard handling + sim-trail described in §UC1 — Sim sub-mode below remain the design reference for v1 mechanics. | Sim body panel (banner + topology highlight + mock-`:data` form + sim-trail) |
 | **Instances** (`i`) | **JUMP to Runtime.** Clicking the pill (or the per-row `→ Runtime` chip in the browse-list) dispatches three events against `:rf/causa`: `:rf.causa/set-mode :runtime` · `:rf.causa/select-tab :machines` · `:rf.causa/select-machine-id <mid>`. The user lands on the Runtime Machines tab with this machine pre-selected. Mode B/C auto-detection (Mode B for 2-8 live, Mode C for ≥8) is the Runtime panel's responsibility — the Static-side JUMP just lands the selection. | no body — the click is the surface |
 | **Cascade** (`c`) | **Dimmed + disabled** with a tooltip: *"Cancellation cascade is a Runtime-only surface. Switch to Runtime mode to view."* The pill renders for muscle-memory consistency with the Runtime sub-strip (same DOM, same letter mnemonic) but is non-interactive — `disabled` + `aria-disabled="true"` + dashed border + 0.5 opacity. The cancellation cascade composes against the trace ring buffer which is event-coupled — there is no spine in Static mode, so the surface has no source data. | no body — the pill IS the surface |
 
@@ -250,20 +255,24 @@ Same discipline as the Runtime Machines panel (per §Tab placement above + [`018
 - [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 — the direction-setting decision behind Two modes (Runtime + Static).
 - [`018-Event-Spine.md`](018-Event-Spine.md) §2.5 Static surface — the architectural spine for the Static mode (3-layer chrome · 4 mode signals · mode-state lifecycle · localStorage `causa.mode` · feature flag · mnemonic mode-scoping).
 - [`007-UX-IA.md`](007-UX-IA.md) §Static mode — the visual-language details (mode pill chrome, edge stripe tokens, motion dampening, sub-tab inventory).
-- §Sim re-host reference (rf2-r4nao — deferred) below — the historical UC1 Sim + UC2 Mode A/B/C prose preserved as design-reference for the Sim re-host effort.
+- §Sim re-host reference (rf2-r4nao — landed) below — the historical UC1 Sim + UC2 Mode A/B/C prose preserved as design-reference. The Sim sub-mode now ships per rf2-r4nao at `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs` with engine events/subs under `:rf.causa.static.machines/sim-*`.
 
 <!-- ============================================================ -->
-<!--  SIM RE-HOST REFERENCE (rf2-r4nao — deferred)                  -->
+<!--  SIM RE-HOST REFERENCE (rf2-r4nao — landed)                    -->
 <!-- ============================================================ -->
 
-## Sim re-host reference (rf2-r4nao — deferred)
+## Sim re-host reference (rf2-r4nao — landed)
 
 > The sections below describe the UC1 Sim engine and UC2 Mode A/B/C
 > dynamic-instance UI as they existed pre-collapse (rf2-y9xmf). They
-> are preserved as design-reference for the **Sim re-host effort
-> (rf2-r4nao)** — the sibling bead that lands the Sim machinery under
-> the Static Machines surface's Sim sub-mode (the Sim pill currently
-> renders a placeholder card pointing at rf2-r4nao).
+> remain preserved as design-reference for the **Sim re-host effort
+> (rf2-r4nao — landed)** — the sibling bead that landed the Sim
+> machinery under the Static Machines surface's Sim sub-mode. The
+> shipped engine + view live at
+> `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs`
+> with events/subs under `:rf.causa.static.machines/sim-*`; the
+> §4-mode sub-strip row above is the normative description of the
+> shipped Sim sub-mode shape.
 >
 > **They DO NOT describe what the Runtime Machines panel renders
 > today** (see the collapse note at the top of this doc and the
@@ -275,7 +284,7 @@ Same discipline as the Runtime Machines panel (per §Tab placement above + [`018
 > Runtime-side responsibility, reached from Static via the JUMP).
 >
 > Read everything below this divider as historical design-reference
-> for the deferred Sim re-host, not as a normative description of any
+> for the Sim re-host effort, not as a normative description of any
 > currently-shipped surface.
 
 ## Definition view — Mode A resting state

--- a/tools/causa/spec/007-UX-IA.md
+++ b/tools/causa/spec/007-UX-IA.md
@@ -358,12 +358,13 @@ shapes based on the focused event's machine activity:
   A/B/C) is no longer emitted; legacy URLs carrying it are silently
   dropped on restore.
 
-**The Sim engine + browse-all index live in code but have no Runtime UI.**
-Sibling bead rf2-r4nao re-hosts the Sim toggle / side-rail + the
-browse-all entry point under a future Static surface; the registered
-`:rf.causa/sim-*` events / subs are unchanged so the re-host doesn't
-re-implement engine algebra. Until that lands, programmatic callers
-can drive Sim against `:rf/causa` directly.
+**The Sim engine + browse-all index have no Runtime UI.**
+Sibling bead rf2-r4nao landed the Sim toggle / side-rail + the
+browse-all entry point under the Static Machines surface; the engine
+events / subs are now namespaced `:rf.causa.static.machines/sim-*` (re-
+hosted from the historical `:rf.causa/sim-*`) and the view lives at
+`tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs`.
+Programmatic callers drive Sim against `:rf/causa` via that ns.
 
 ### Interactive Machines canvas (rf2-y3l8z)
 
@@ -1350,7 +1351,7 @@ along the chart edge.
 | Sub-component | View |
 |---|---|
 | After-rings overlay | `machine-after-rings/AfterRingsOverlay` |
-| Sim side-rail       | `machine-inspector-sim/SimSideRail` |
+| Sim side-rail       | `static.machines.sim/SimRail` |
 
 These render under `machine-inspector/Panel` and are NOT exposed as
 standalone mount fns. Mounting a ring overlay without a chart

--- a/tools/causa/spec/016-Auxiliary-Panels.md
+++ b/tools/causa/spec/016-Auxiliary-Panels.md
@@ -40,7 +40,7 @@ mount paths and L3-tab backing (when applicable) are:
 | 10 | 2 | Cancellation-cascade popover       | `cancellation-cascade/Popover`          | — (overlay) |
 | 11 | 3 | Managed-fx records list            | `panels/ManagedFxList`                  | embedded in Event tab |
 | 12 | 4 | After-rings overlay                | `machine-after-rings/AfterRingsOverlay` | sub of Machines tab |
-| 13 | 4 | Sim side-rail                      | `machine-inspector-sim/SimSideRail`     | sub of Machines tab |
+| 13 | 4 | Sim side-rail                      | `static.machines.sim/SimRail`           | sub of Machines tab |
 
 Panel-by-panel detail (subs / events / interactions) lives in the
 sections below. Tier 4 sub-components are geometry-coupled to

--- a/tools/causa/spec/018-Event-Spine.md
+++ b/tools/causa/spec/018-Event-Spine.md
@@ -162,7 +162,7 @@ Same discipline as the Runtime chrome (per §8 Frame-observation isolation invar
 
 - [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) Lock #14 — the direction-setting decision behind Two modes (Runtime + Static).
 - [`007-UX-IA.md`](007-UX-IA.md) §Static mode — visual-language details (mode pill widget chrome, edge stripe colour tokens, motion dampening durations, sub-tab mnemonics, design language).
-- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface — concrete Static Machines surface description (4-mode sub-strip · Topology · Sim placeholder · Instances JUMP · Cascade dimmed).
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) §Static Machines surface — concrete Static Machines surface description (4-mode sub-strip · Topology · Sim body (rf2-r4nao — landed) · Instances JUMP · Cascade dimmed).
 
 ---
 
@@ -432,7 +432,7 @@ When the user is inspecting a machine in Mode C (4+ instances; see [`003-Machine
 | 2 | **App-db** | `a` | Diff `:db-before` vs `:db-after` — slice-first · clickable path segments (rf2-e9tb0) · path-origin chips (rf2-s8r6c) · full-tree disclosure | [`004-App-DB-Diff.md`](004-App-DB-Diff.md) + this doc §5.2 |
 | 3 | **Views** | `v` | Per-view rows: mounted / re-rendered / unmounted groups; each row lists subs used + sub return values; cluster-large-grids; isolation-scoped to selected frame | [`012-Views.md`](012-Views.md) |
 | 4 | **Trace** | `t` | Raw multi-axis trace stream filtered to `:dispatch-id = <focus>`; trace-type toggle row at top + IN/OUT pills + sensible defaults | this doc §5.3 + [`013-Trace-Bus.md`](013-Trace-Bus.md) |
-| 5 | **Machines** | `m` | **Event-driven Runtime panel** (rf2-y9xmf): BLANK when the focused event has no machine activity; one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it does. UC1 Sim engine + UC2 Mode A/B/C deferred to the Static re-host (rf2-r4nao). | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
+| 5 | **Machines** | `m` | **Event-driven Runtime panel** (rf2-y9xmf): BLANK when the focused event has no machine activity; one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when it does. UC1 Sim engine landed under the Static Machines surface's Sim sub-mode (rf2-r4nao — events/subs at `:rf.causa.static.machines/sim-*`, view at `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs`); UC2 Mode A/B/C remains a Runtime-side concern, reached from Static via the per-row → Runtime JUMP. | [`003-Machine-Inspector.md`](003-Machine-Inspector.md) |
 | 6 | **Routing** | `r` | **FLAT focused-event lens** (rf2-lq0ef): current matched route + params/query/fragment + **Simulate-URL** input ranking every registered route via the 6-rule `:rf.route/rank` tuple with the rank explainer inline; per-focused-event glyphs `◆ HERE` / `◆ FROM` / `◆ TO`. Silent when no routes registered. | this doc §5.6 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Routing tab |
 | 7 | **Issues** | `i` | JS exceptions + schema violations + sensitive-data warnings + hydration mismatches + perf-budget overruns + app console errors/warns | this doc §5.4 + [`016-Auxiliary-Panels.md`](016-Auxiliary-Panels.md) §Issues ribbon |
 
@@ -806,7 +806,7 @@ Default scope = "All issues this session." Toggle to "Spine cascade only" to fil
 
 ### §5.5 Machines tab — see [`003-Machine-Inspector.md`](003-Machine-Inspector.md)
 
-Briefly (rf2-y9xmf): the Runtime panel is **event-driven only**. It is BLANK when the focused event triggered no machine transitions; it renders one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when the focused event did trigger transitions. Per-machine prev/next nav walks the spine's epoch history to the prior/next event that ALSO touched the focused machine. The UC1 Sim engine + UC2 Mode A/B/C dynamic-instance UI are preserved at the code level (`:rf.causa/sim-*` family + `panels/machine_inspector_sim` view) for the future Static surface re-host (rf2-r4nao); they do NOT render in the Runtime tab.
+Briefly (rf2-y9xmf): the Runtime panel is **event-driven only**. It is BLANK when the focused event triggered no machine transitions; it renders one per-machine section (topology + transition highlight + guards + actions + cancellation cascade + `:after` rings) when the focused event did trigger transitions. Per-machine prev/next nav walks the spine's epoch history to the prior/next event that ALSO touched the focused machine. The UC1 Sim engine landed under the Static Machines surface's Sim sub-mode (rf2-r4nao) at `:rf.causa.static.machines/sim-*` (view at `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs`); it does NOT render in the Runtime tab. UC2 Mode A/B/C dynamic-instance UI remains a Runtime-side concern, reached from Static via the per-row → Runtime JUMP.
 
 ### §5.6 Routing tab — parallel to Machines (rf2-nrbs9)
 
@@ -1376,7 +1376,7 @@ Coverage is enumerated in [`017-Test-Coverage-Matrix.md`](017-Test-Coverage-Matr
 | **Spine binding** | `tools/causa/test/.../spine_test.cljs` — asserts `:rf.causa/focus` rebinds atomically when a row is clicked; asserts L2 mode cue (head-row pulse / pinned-row glyph), L3 count badges, L4 detail content all reflect the new focus |
 | **Filter IN/OUT pills round-trip** | `tools/causa/test/.../filter_pills_test.cljs` — asserts pill add/edit/delete via popup; asserts AND-across-modes / OR-within-mode semantics; asserts localStorage persistence; asserts Recommended-filters quick-add |
 | **Event-driven Runtime Machines panel (rf2-y9xmf)** | per-feature in `tools/causa/test/.../machines/runtime_test.cljs` — asserts BLANK state on no-activity; per-machine section rendered on transition; topology highlight + guards + actions + cancellation + `:after` rings; prev/next nav walks spine to other events touching the focused machine |
-| **UC1 Sim engine + UC2 Mode A/B/C (rf2-r4nao — Static re-host, deferred)** | NOT a Runtime test row. The Sim engine subs/events (`:rf.causa/sim-*`) + the `panels/machine_inspector_sim` view are preserved at code level for the future Static re-host; no Runtime test gates them today. |
+| **UC1 Sim engine + UC2 Mode A/B/C (rf2-r4nao — Static re-host, landed)** | NOT a Runtime test row. The Sim engine subs/events (`:rf.causa.static.machines/sim-*`) + the `static/machines/sim.cljs` view ship under the Static Machines surface's Sim sub-mode per [`003-Machine-Inspector.md`](003-Machine-Inspector.md); Static-side tests gate those surfaces. UC2 Mode A/B/C remains Runtime-side (reached via the per-row → Runtime JUMP). |
 | **Data classification rendering** | `tools/causa/test/.../classification_rendering_test.cljs` — asserts `:rf/redacted` opaque (no reveal button); asserts `:rf/large` drillable with size-confirm modal; asserts combination semantics (`:rf/redacted` dominates `:rf/large`); asserts per-surface rendering across L2/L4 |
 | **Frame-isolation invariants** | `tools/causa/test/.../isolation_test.cljs` (NEW; spec §8) — asserts I1 (picker excludes `:rf/causa`) + I3 (Views scoped to selected frame) + I4 (Causa hover doesn't leak into `:rf/default` Views); runs under `npm run test:browser`; **failure blocks merge** |
 | **Sub-graph isolation lint** | `tools/causa/test/.../sub_graph_lint_test.cljs` (NEW; spec §8 I2) — asserts dev-time lint predicate throws on misconfigured Causa-namespaced sub feeding host data |
@@ -1456,7 +1456,7 @@ not Causa.
 
 - [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) — Lock #14 (Two modes — Runtime + Static) is the direction-setting decision behind §2.5 Static surface above.
 - [`000-Vision.md`](000-Vision.md) — 7-tab inventory; philosophy shift to human-only surface.
-- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) — event-driven Runtime Machines panel (rf2-y9xmf) + §Static Machines surface (the shipped Static-mode Machines surface — 4-mode sub-strip with Topology / Sim placeholder / Instances JUMP / Cascade dimmed-with-tooltip). The UC1 Sim engine and UC2 Mode A/B/C historical prose remain below as Sim re-host reference (rf2-r4nao — deferred).
+- [`003-Machine-Inspector.md`](003-Machine-Inspector.md) — event-driven Runtime Machines panel (rf2-y9xmf) + §Static Machines surface (the shipped Static-mode Machines surface — 4-mode sub-strip with Topology / Sim body (rf2-r4nao — landed) / Instances JUMP / Cascade dimmed-with-tooltip). The UC1 Sim engine and UC2 Mode A/B/C historical prose remain below as Sim re-host reference (rf2-r4nao — landed).
 - [`004-App-DB-Diff.md`](004-App-DB-Diff.md) — diff renderer + changed-paths derivation used in L4 App-db tab content.
 - [`007-UX-IA.md`](007-UX-IA.md) — typography, colour tokens, density, keyboard map, editor protocol matrix.
 - [`012-Views.md`](012-Views.md) — Views tab three-group layout (mounted / re-rendered / unmounted); nested subs; cluster-large-grids.


### PR DESCRIPTION
## Summary
- Updates Sim ns + file path references in 003 / 007 / 016 / 018 to the post-rehost shape:
  - Old: `:rf.causa/sim-*` · `panels/machine_inspector_sim.cljs` · `SimSideRail`
  - New: `:rf.causa.static.machines/sim-*` · `tools/causa/src/day8/re_frame2_causa/static/machines/sim.cljs` · `SimRail`
- Flips Sim re-host language from "deferred" to "landed"; the historical UC1 Sim + UC2 Mode A/B/C prose in 003 is preserved as design-reference per Mike's recommendation (no semantic restructure)
- The normative description of the shipped Sim sub-mode now lives in the 4-mode sub-strip row of 003 §Static Machines surface

## Bead
rf2-fr73h

## Acceptance
- mkdocs --strict clean (verified locally; exit 0)