### PR TITLE
test(causa): wire panel-gallery + workspace-switch smokes into CI (rf2-1w76p)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1043,9 +1043,18 @@ jobs:
       # top-level testbeds/ specs (rf2-fe84r + rf2-ik4io SSR) are
       # exercised here.
       #
+      # RF2_CAUSA_RUN_GALLERY_SMOKES=1 (rf2-1w76p) opts in to the two
+      # panel-gallery stand-alone smokes (_smoke.cjs +
+      # _workspace_switch_smoke.cjs) which boot the gallery testbed
+      # end-to-end and gate the rf2-kgn0c workspace-teardown
+      # regression. They run AFTER the main spec sweep inside the
+      # same orchestrator invocation.
+      #
       # NOT a required check on main initially — mirrors the rollout
       # pattern used for cljs-browser (rf2-zoem).
       - name: Compile adapter smokes + testbeds, serve, and run Playwright specs
+        env:
+          RF2_CAUSA_RUN_GALLERY_SMOKES: "1"
         run: npm run test:examples
 
   story-causa-browser:

--- a/examples/scripts/serve-and-run-examples-tests.cjs
+++ b/examples/scripts/serve-and-run-examples-tests.cjs
@@ -280,6 +280,72 @@ function compileAll() {
   }
 }
 
+// rf2-1w76p — panel-gallery smokes opt-in. The two scripts under
+// tools/causa/testbeds/panel_gallery/_smoke.cjs and
+// _workspace_switch_smoke.cjs are stand-alone (each spawns its own
+// http-server + Playwright) and don't fit the spec.cjs shape the
+// runner walks. They're gated behind RF2_CAUSA_RUN_GALLERY_SMOKES=1
+// (off in the fast PR loop, on in the rigorous browser job). When
+// enabled we compile :testbeds/panel-gallery, stage its index.html
+// next to the bundle, and invoke both smokes in sequence. A failure
+// in either smoke fails the whole `npm run test:examples` run.
+const GALLERY_SMOKES_ENABLED =
+  process.env.RF2_CAUSA_RUN_GALLERY_SMOKES === '1';
+
+function compileAndStagePanelGallery() {
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'npx.cmd' : 'npx';
+  const args = ['shadow-cljs', 'compile', 'testbeds/panel-gallery'];
+  const result = spawnSync(cmd, args, {
+    cwd: IMPL_ROOT,
+    stdio: 'inherit',
+    shell: isWin,
+  });
+  if (result.status !== 0) {
+    console.error(`> ${cmd} ${args.join(' ')}`);
+    throw new Error(
+      `shadow-cljs compile :testbeds/panel-gallery failed (exit ${result.status})`,
+    );
+  }
+  // Stage index.html next to the compiled bundle. The smokes serve
+  // implementation/out/testbeds/panel-gallery/ as the http-server
+  // root and request `/index.html`, so the file must live there.
+  const galleryHtmlSrc = path.join(
+    REPO_ROOT,
+    'tools', 'causa', 'testbeds', 'panel_gallery', 'index.html',
+  );
+  const galleryOutDir = path.join(
+    IMPL_ROOT, 'out', 'testbeds', 'panel-gallery',
+  );
+  if (!fs.existsSync(galleryOutDir)) {
+    throw new Error(`Panel-gallery bundle dir missing: ${galleryOutDir}`);
+  }
+  if (!fs.existsSync(galleryHtmlSrc)) {
+    throw new Error(`Panel-gallery index.html missing: ${galleryHtmlSrc}`);
+  }
+  fs.copyFileSync(galleryHtmlSrc, path.join(galleryOutDir, 'index.html'));
+}
+
+function runPanelGallerySmokes() {
+  const smokes = [
+    path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'panel_gallery', '_smoke.cjs'),
+    path.join(REPO_ROOT, 'tools', 'causa', 'testbeds', 'panel_gallery', '_workspace_switch_smoke.cjs'),
+  ];
+  let anyFailed = false;
+  for (const smoke of smokes) {
+    console.log(`\n=== panel-gallery smoke: ${path.basename(smoke)} ===`);
+    const result = spawnSync(process.execPath, [smoke], {
+      stdio: 'inherit',
+      cwd: REPO_ROOT,
+    });
+    if (result.status !== 0) {
+      console.error(`FAIL panel-gallery smoke ${path.basename(smoke)} (exit ${result.status})`);
+      anyFailed = true;
+    }
+  }
+  return anyFailed ? 1 : 0;
+}
+
 function copyDirRecursive(src, dest) {
   // Minimal recursive copy. Used only for `bundleSrc` — staging a
   // shadow-cljs build whose `:output-dir` lives outside `OUT_ROOT`
@@ -394,7 +460,28 @@ async function main() {
 
   const code = await new Promise((resolve) => runner.on('exit', resolve));
 
-  return code == null ? 1 : code;
+  let finalCode = code == null ? 1 : code;
+
+  // rf2-1w76p — opt-in panel-gallery smokes. Runs AFTER the main
+  // runner so the spec.cjs sweep + smokes share one wall-clock
+  // budget. The smokes spawn their own http-servers on ports
+  // 8766 / 8767 (distinct from the orchestrator's :8030) so there
+  // is no port collision with the still-running EXAMPLES server.
+  // Smoke failures fail the whole run; the orchestrator's server
+  // is still torn down via the cleanup hook in main()'s caller.
+  if (GALLERY_SMOKES_ENABLED) {
+    console.log('\nRF2_CAUSA_RUN_GALLERY_SMOKES=1 — running panel-gallery smokes');
+    try {
+      compileAndStagePanelGallery();
+      const smokeCode = runPanelGallerySmokes();
+      if (smokeCode !== 0) finalCode = smokeCode;
+    } catch (err) {
+      console.error('panel-gallery smokes failed to set up:', err.message);
+      finalCode = 1;
+    }
+  }
+
+  return finalCode;
 }
 
 main().then(async (code) => {

--- a/tools/causa/testbeds/panel_gallery/_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_smoke.cjs
@@ -7,12 +7,20 @@
  *   3. Wait for the workspace gallery  — twelve variant cells render.
  *   4. Snapshot console errors         — none beyond the expected.
  *
- * Not wired into CI. Run manually post-compile to verify the gallery
- * boots end-to-end:
+ * Wired into CI behind the RF2_CAUSA_RUN_GALLERY_SMOKES=1 opt-in
+ * (rf2-1w76p): the examples-browser job sets the flag and the
+ * orchestrator at examples/scripts/serve-and-run-examples-tests.cjs
+ * compiles :testbeds/panel-gallery, stages index.html alongside the
+ * bundle, and invokes this script after the main spec sweep. Run
+ * manually post-compile to verify locally:
  *
  *   shadow-cljs compile testbeds/panel-gallery
  *   cp tools/causa/testbeds/panel_gallery/index.html implementation/out/testbeds/panel-gallery/
  *   node tools/causa/testbeds/panel_gallery/_smoke.cjs
+ *
+ * Or end-to-end via the orchestrator:
+ *
+ *   RF2_CAUSA_RUN_GALLERY_SMOKES=1 npm run test:examples
  */
 
 const { spawn } = require('child_process');

--- a/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+++ b/tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
@@ -16,12 +16,20 @@
  * as the ~22 pageerrors observed in PR #1254's Phase 1b smoke when
  * clicking from `event-detail/all` to `app-db-diff/all`.
  *
- * Not wired into CI (mirrors `_smoke.cjs`'s posture). Run manually
- * post-compile to verify the fix end-to-end:
+ * Wired into CI behind the RF2_CAUSA_RUN_GALLERY_SMOKES=1 opt-in
+ * (rf2-1w76p, mirrors `_smoke.cjs`'s posture): the examples-browser
+ * job sets the flag and the orchestrator at
+ * examples/scripts/serve-and-run-examples-tests.cjs invokes this
+ * script after the main spec sweep. Run manually post-compile to
+ * verify the fix end-to-end:
  *
  *   shadow-cljs compile testbeds/panel-gallery
  *   cp tools/causa/testbeds/panel_gallery/index.html implementation/out/testbeds/panel-gallery/
  *   node tools/causa/testbeds/panel_gallery/_workspace_switch_smoke.cjs
+ *
+ * Or end-to-end via the orchestrator:
+ *
+ *   RF2_CAUSA_RUN_GALLERY_SMOKES=1 npm run test:examples
  */
 
 const { spawn } = require('child_process');


### PR DESCRIPTION
## Summary
- Gate the two stand-alone panel-gallery smokes (`_smoke.cjs` + `_workspace_switch_smoke.cjs`) behind `RF2_CAUSA_RUN_GALLERY_SMOKES=1`. The `examples-browser` CI job opts in.
- Orchestrator (`examples/scripts/serve-and-run-examples-tests.cjs`) compiles `:testbeds/panel-gallery`, stages `index.html` alongside the bundle, and invokes both smokes after the main spec sweep when the flag is set. Smoke failures fail the whole run.
- "Not wired into CI" zombie comments replaced in both smoke files with the env-flag invocation note.
- Audit cite: `ai/findings/2026-05-20-tools-testing-posture-audit.md` Gap-1 + Gap-6

Env-flag name chosen: `RF2_CAUSA_RUN_GALLERY_SMOKES`. Follows the established `RF2_<TOOL>_<RUN>_<SUITE>` convention used by `RF2_TEMPLATE_RUN_EMITTED_TESTS=1`.

CI workflow file updated: `.github/workflows/test.yml` (the `examples-browser` job that runs `npm run test:examples`).

## Bead
rf2-1w76p

## Acceptance
- Local run with flag set: both smokes pass (`smoke OK` + `workspace-switch smoke OK — zero stale subscribe→nil derefs`).
- Local run without flag: smokes silently skipped (no panel-gallery noise).
- The smokes each spawn their own http-server on ports 8766 / 8767, so they don't collide with the orchestrator's 8030.