### PR TITLE
spec(story): Storybook-rejects + machine lifecycle + adapter/after-render cross-refs (rf2-aezbb + rf2-k4mbg + rf2-rqetr)

### DIFF
--- a/tools/story/spec/002-Runtime.md
+++ b/tools/story/spec/002-Runtime.md
@@ -23,6 +23,24 @@ At variant-unmount the runtime calls `(rf/destroy-frame! variant-id)`.
 Hot-reload preserves the side-table; a re-registration of the same
 variant calls `reset-frame!` and re-runs the lifecycle.
 
+### Machine lifecycle on variant unmount
+
+When `destroy-variant!` fires, any
+[spec/005 state machines](../../../spec/005-StateMachines.md) the
+variant's lifecycle spawned receive their `:rf.machine/destroy` event
+as part of frame teardown (per
+[spec/005 §`:rf.machine/destroy`](../../../spec/005-StateMachines.md#raise-rfmachinespawn-and-rfmachinedestroy-are-reserved-fx-ids-inside-fx),
+rf2-rkedz). The destroy event runs the actor's `:exit` action,
+dissociates its snapshot at `[:rf/machines <actor-id>]`, and clears
+its event handler from the frame-local registry — symmetric with the
+`:rf.machine/spawn` that brought the actor into being. Story is a
+passive consumer of this contract; the variant frame's own
+`destroy-frame!` walk drives the destroy emissions, and Story does not
+add a parallel cleanup path. Authors writing `:exit` actions that
+need teardown semantics (close a websocket, cancel a timer, persist
+state) should rely on this contract rather than the variant's own
+unmount hook.
+
 ## Coexistence with hosting application state
 
 Story installs runtime slots into every variant frame's `app-db` under

--- a/tools/story/spec/003-Render-Shell.md
+++ b/tools/story/spec/003-Render-Shell.md
@@ -189,6 +189,29 @@ each substrate **inline** in its own pane.
 The rationale for inline-rendering substrate failures is documented in
 [`DESIGN-RATIONALE.md`](DESIGN-RATIONALE.md) §inline-substrate-failures.
 
+### Substrate-portable post-render hook
+
+DOM-mutating chrome that runs against the rendered output of a variant
+(axe-core a11y scans; the layout-debug overlay trio — measure, outline,
+pseudo) uses the **`:adapter/after-render`** late-bind hook the
+framework publishes from each substrate adapter (Reagent / UIx /
+Helix — rf2-334d9). The hook is `(re-frame.interop/after-render f)`,
+which dispatches through the late-bind directory to whichever
+substrate the active variant runs under; UIx and Helix wire it via
+`useLayoutEffect`, Reagent via its post-render queue. Each adapter
+publishes the hook at startup so panel code stays substrate-agnostic.
+
+At v1 Story's own UI shell is Reagent-only (§UI shell substrate above)
+and the load-bearing post-render work happens inside the chrome's
+Reagent layer, so the hook is not used by the shell itself today.
+**At Stage 8** — when the Story chrome migrates to multi-substrate
+per §Bundle implications and when the a11y / layout-debug panels
+attach against a variant whose substrate is not Reagent — these panels
+attach via `:adapter/after-render` rather than substrate-specific
+escape hatches. The hook is the canonical portable surface; panel
+authors writing for the multi-substrate world should target it
+directly.
+
 ## Workspace persistence (both modes)
 
 Workspace layouts persist **both** ways:

--- a/tools/story/spec/004-Assertions.md
+++ b/tools/story/spec/004-Assertions.md
@@ -20,7 +20,7 @@ into `:assertions` (see below) rather than throwing.
 | `:rf.assert/path-matches` | `[path malli-schema]` | `(m/validate schema (get-in @app-db path))` |
 | `:rf.assert/sub-equals` | `[sub-vec expected]` | `(= @(subscribe sub-vec) expected)` |
 | `:rf.assert/dispatched?` | `[event-vec]` | Was this event dispatched against this frame? |
-| `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. |
+| `:rf.assert/state-is` | `[machine-id state]` | Active state of `reg-machine` machine-id is state. Pairs with the per-variant trace-buffer's `:rf.machine/guard-evaluated` + `:rf.machine/action-ran` ops (rf2-ec52e, per [spec/005-StateMachines.md](../../../spec/005-StateMachines.md) + [spec/009-Instrumentation.md §`:op-type` vocabulary](../../../spec/009-Instrumentation.md)) — failures of this assertion can be diagnosed against the captured guard/action trace via Causa's RHS view. |
 | `:rf.assert/no-warnings` | `[]` | No `:rf.warn/*` events seen during play. |
 | `:rf.assert/effect-emitted` | `[fx-id]` or `[fx-id pred]` | Did the variant's drain emit fx-id? See §`:rf.assert/effect-emitted` payload shape. |
 

--- a/tools/story/spec/DESIGN-RATIONALE.md
+++ b/tools/story/spec/DESIGN-RATIONALE.md
@@ -310,6 +310,22 @@ to the relevant lock. See the rf2-38pb9 audit verdict (warm-slate +
 amber + Plex + motion-as-language >> Storybook's cold-grey + pink +
 Inter + flat) for the comparator pass.
 
+### Storybook commodity patterns (the four-pattern cluster)
+
+The four entries that follow — brand-pink-on-cold-grey, commodity-default
+fonts, addon-per-concern panels, throw-on-first-failure — are the four
+Storybook-comparator rejections recorded under the rf2-aezbb follow-on
+to the rf2-38pb9 audit. Each names the Storybook practice, what Story
+does instead, and the lock the positive contract lives under. These are
+the deliberately-named "do not drift back" markers for future workers;
+they pair with the §record-not-throw + §inline-substrate-failures locks
+above (which are also Storybook-comparator rejections, written as part
+of the original seven §rf2-m6tu §6 decisions rather than as a comparator
+sweep). Treat the cluster's intro paragraph above and the four entries
+below as a single discoverable subsection — proposals to revisit any of
+the four bear the burden of disturbing the comparator-rejection lock,
+not just the individual rationale.
+
 ### Rejected: Brand-pink-on-cold-grey chrome palette — we use amber-on-warm-slate
 
 **Rejected.** Storybook 8 ships a cold-grey chrome (`#1B1C1F` / `#2D3036`


### PR DESCRIPTION
## Summary
- Storybook anti-patterns Story explicitly rejects (rf2-aezbb)
- Machine lifecycle cross-ref — :rf.machine/destroy + trace ops (rf2-k4mbg)
- :adapter/after-render cross-ref for a11y panel + layout overlays (rf2-rqetr)

## Beads
rf2-aezbb, rf2-k4mbg, rf2-rqetr

## Acceptance
- mkdocs --strict clean