### PR TITLE
feat(causa): Views sub-status 3-link sub→flow attribution chain (rf2-tv8t1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/panels/views_helpers.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_helpers.cljc
@@ -277,13 +277,109 @@
     (:recomputed? row)  :cache-miss-equal
     :else               :cache-hit))
 
+;; ---- flow attribution (rf2-tv8t1) --------------------------------------
+;;
+;; Per `ai/findings/2026-05-19-causa-machine-inspector-mode-s.md` §13 +
+;; §11 Comment 8 (Mike, 2026-05-19 ~15:00 AUSEST). The Views panel's
+;; per-trigger row carries a third link — "via flow Z" — when the
+;; sub's invalidation can be attributed to a flow firing this cascade.
+;;
+;; The flow link sits between the sub trigger (✱) and the upstream
+;; effect: every flow that wrote app-db this cascade is a candidate
+;; cause of any sub recomputed this cascade. The link is informational
+;; ("Z fired this cascade, possibly contributing to this sub's
+;; recompute"); the precise per-sub attribution requires per-sub
+;; input-path data the v1 runtime does not yet expose.
+;;
+;; Data source: each cascade's `:trace-events` carries one
+;; `:rf.flow/computed` entry per flow firing (per Spec 013 §Flow
+;; tracing). The helper projects these into a vector of
+;; `{:flow-id <kw> :write-path <vec>}` records — the same projection
+;; `app_db_diff_helpers.cljc/flow-writes-from-trace-events` uses for
+;; the App-db diff path-origin chips (rf2-s8r6c).
+;;
+;; Handler-effect-only writes (no flow fired) → the trigger row stays
+;; 2-link "sub Y invalidated"; the third link is absent. This matches
+;; the bead's policy: "when applicable" — the link surfaces only when
+;; flow data exists.
+
+(defn flows-fired-this-cascade
+  "Project the cascade's `:trace-events` into a vector of flow-firing
+  records:
+
+      [{:flow-id <kw> :write-path <vec>} ...]
+
+  Order preserved (cascade firing order = framework topo order).
+  Returns `[]` when no flows fired this cascade.
+
+  Pure data → data. JVM-portable. Mirrors
+  `app_db_diff_helpers/flow-writes-from-trace-events` shape so the
+  panel-level invariant (App-db diff origins ↔ Views third link) is
+  derived from the same source-of-truth projection.
+
+  Skips trace events whose `:path` or `:flow-id` tags are missing
+  (defensive — Spec 013 guarantees these on `:rf.flow/computed` but
+  older fixtures may omit them)."
+  [trace-events]
+  (vec
+    (keep (fn [ev]
+            (when (= :rf.flow/computed (:operation ev))
+              (let [tags (:tags ev)
+                    wp   (:path tags)
+                    fid  (:flow-id tags)]
+                (when (and (vector? wp) (keyword? fid))
+                  {:flow-id    fid
+                   :write-path wp}))))
+          (or trace-events []))))
+
+(defn attribute-trigger-to-flows
+  "Attribute one trigger row to the flows that fired this cascade.
+  Returns a vector of flow-ids (deduplicated, source order preserved)
+  the trigger may be 'via'.
+
+  Inputs:
+    - `row`        — one trigger row from `re-render-invalidated-by`.
+                     Only `:trigger? true` rows are candidates; non-
+                     trigger rows always return `[]` (the third link
+                     decorates the cause, not also-consumed subs).
+    - `flow-writes` — vector of `{:flow-id ... :write-path ...}` per
+                     `flows-fired-this-cascade`.
+
+  V1 attribution policy (per the bead's 'when applicable' clause):
+    - The trigger row's sub is the immediate cause; the flow link
+      surfaces the upstream cause IFF at least one flow wrote app-db
+      this cascade. Per-sub input-path data is not yet exposed by
+      the runtime, so the helper returns every flow-id that fired —
+      the renderer displays 'via :flow-z' (single) or
+      'via :flow-z, :flow-w' (multiple). When the runtime exposes
+      per-sub input paths, this fn narrows to flows whose
+      `:write-path` is a prefix of (or equal to) any of the sub's
+      input paths.
+    - Parent-forced re-renders (`:sub-id ::parent-forced`) → no flow
+      attribution — the trigger is the parent, not a sub
+      invalidation.
+    - Handler-effect-only cascades (no `:rf.flow/computed` events) →
+      empty vector → renderer omits the third link → row stays
+      2-link.
+
+  Pure data → data; JVM-portable."
+  [row flow-writes]
+  (cond
+    (not (:trigger? row))        []
+    (= ::parent-forced
+       (:sub-id row))            []
+    (empty? flow-writes)         []
+    :else
+    (vec (distinct (map :flow-id flow-writes)))))
+
 (defn re-render-invalidated-by
   "Per spec §Per-row content (Re-rendered) — derive the 'Invalidated
   by' list for one re-render row. Returns a vector
 
     `[{:sub-id <sub-id>
        :recomputed? true/false
-       :trigger? true/false}    ;; ✱ marker
+       :trigger? true/false       ;; ✱ marker
+       :via-flow-ids [<kw> ...]}  ;; rf2-tv8t1 — third link attribution
       ...]`
 
   - The render's `:triggered-by` sub-id (when present) is the
@@ -295,22 +391,37 @@
     `≈` for cache-miss-equal in the view per `sub-status`).
     The view filters these to subs the component actually consumed
     once per-render sub-attribution lands.
+  - Trigger rows carry `:via-flow-ids` — the third link in the
+    sub-flow-chain attribution (rf2-tv8t1). Computed via
+    `attribute-trigger-to-flows`; `[]` when no flows fired this
+    cascade or the trigger is parent-forced.
 
-  `sub-runs` is the cascade's `:sub-runs` vector."
-  [render sub-runs]
-  (let [triggered-by (:triggered-by render)
-        trigger      (when triggered-by
-                       {:sub-id triggered-by :recomputed? true :trigger? true})
-        parent-forced (when-not triggered-by
-                        {:sub-id      ::parent-forced
-                         :recomputed? false
-                         :trigger?    true})
-        sub-rows     (for [sr sub-runs
-                           :when (not= (:sub-id sr) triggered-by)]
-                       {:sub-id      (:sub-id sr)
-                        :recomputed? (boolean (:recomputed? sr))
-                        :trigger?    false})]
-    (vec (concat (filter some? [trigger parent-forced]) sub-rows))))
+  `sub-runs` is the cascade's `:sub-runs` vector. `flow-writes` is
+  the cascade's flow-firing projection (per
+  `flows-fired-this-cascade`); pass `[]` (or omit the arg) for the
+  handler-effect-only case."
+  ([render sub-runs]
+   (re-render-invalidated-by render sub-runs []))
+  ([render sub-runs flow-writes]
+   (let [triggered-by  (:triggered-by render)
+         trigger       (when triggered-by
+                         (let [row {:sub-id triggered-by
+                                    :recomputed? true
+                                    :trigger? true}]
+                           (assoc row :via-flow-ids
+                                  (attribute-trigger-to-flows row flow-writes))))
+         parent-forced (when-not triggered-by
+                         {:sub-id       ::parent-forced
+                          :recomputed?  false
+                          :trigger?     true
+                          :via-flow-ids []})
+         sub-rows      (for [sr sub-runs
+                             :when (not= (:sub-id sr) triggered-by)]
+                         {:sub-id       (:sub-id sr)
+                          :recomputed?  (boolean (:recomputed? sr))
+                          :trigger?     false
+                          :via-flow-ids []})]
+     (vec (concat (filter some? [trigger parent-forced]) sub-rows)))))
 
 ;; ---- group-by sub: inverted hierarchy ----------------------------------
 ;;
@@ -414,7 +525,14 @@
     - `prior-renders`    — prior cascade's `:renders` vector (or nil)
     - `sub-runs`         — current cascade's `:sub-runs` vector
     - `opts`             — `{:cluster-threshold N
-                              :component-filter <view-id-or-nil>}`
+                              :component-filter <view-id-or-nil>
+                              :trace-events     <vec or nil>}`
+
+  `:trace-events` (rf2-tv8t1) — the current cascade's trace stream.
+  When present, `flows-fired-this-cascade` projects the cascade's
+  `:rf.flow/computed` events into the flow-writes vector; the
+  Re-rendered group's trigger rows then carry `:via-flow-ids` for
+  the third link in the sub-flow-chain attribution.
 
   Output:
     `{:groups          {:mounted [<item>]
@@ -424,7 +542,8 @@
                         :rendered N
                         :unmounted N
                         :cascade-ms <sum>}
-      :cluster-counts  {:mounted N :rendered N :unmounted N}}`
+      :cluster-counts  {:mounted N :rendered N :unmounted N}
+      :flow-writes     [{:flow-id … :write-path …} ...]}`
 
   where each `<item>` is the clustered shape from `cluster-renders`
   with an added `:invalidated-by` slot (vector of trigger / non-
@@ -433,9 +552,10 @@
   single-row pointing at the cluster's `:triggered-by` sub-id (per
   spec §Per-row content (Re-rendered) → Clustered renders)."
   [current-renders prior-renders sub-runs
-   {:keys [cluster-threshold component-filter]
+   {:keys [cluster-threshold component-filter trace-events]
     :or   {cluster-threshold default-cluster-threshold
-           component-filter  nil}}]
+           component-filter  nil
+           trace-events      nil}}]
   (let [filter-renders
         (if component-filter
           (fn [rs] (filterv #(= component-filter
@@ -447,6 +567,10 @@
         clustered (into {}
                         (for [[g rs] groups]
                           [g (cluster-renders rs cluster-threshold)]))
+        ;; rf2-tv8t1 — project the cascade's flow firings once at the
+        ;; top of the assembly so every :rendered row attribution shares
+        ;; the same source-of-truth projection.
+        flow-writes (flows-fired-this-cascade trace-events)
         ;; Annotate :rendered group items with :invalidated-by.
         clustered-with-invalidated
         (update clustered :rendered
@@ -455,13 +579,20 @@
                           (case (:kind item)
                             :single
                             (assoc item :invalidated-by
-                                   (re-render-invalidated-by (:render item) sub-runs))
+                                   (re-render-invalidated-by (:render item)
+                                                             sub-runs
+                                                             flow-writes))
                             :cluster
-                            (assoc item :invalidated-by
-                                   [{:sub-id      (:triggered-by item)
-                                     :recomputed? true
-                                     :trigger?    true
-                                     :clustered?  true}])))
+                            (let [cluster-trigger
+                                  {:sub-id      (:triggered-by item)
+                                   :recomputed? true
+                                   :trigger?    true
+                                   :clustered?  true}]
+                              (assoc item :invalidated-by
+                                     [(assoc cluster-trigger
+                                             :via-flow-ids
+                                             (attribute-trigger-to-flows
+                                               cluster-trigger flow-writes))]))))
                         items)))
         cascade-ms (reduce + 0 (keep :elapsed-ms current-renders))
         ;; Per spec §Group-by toggle — the inverted hierarchy
@@ -478,4 +609,5 @@
      :cluster-counts {:mounted   (cluster-count (:mounted clustered))
                       :rendered  (cluster-count (:rendered clustered))
                       :unmounted (cluster-count (:unmounted clustered))}
+     :flow-writes      flow-writes
      :component-filter component-filter}))

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_subs.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_subs.cljs
@@ -101,12 +101,19 @@
             current-renders (or (:renders current) [])
             prior-renders   (or (:renders prior) [])
             sub-runs        (or (:sub-runs current) [])
+            ;; rf2-tv8t1 — pass the focused cascade's trace stream
+            ;; through so `flows-fired-this-cascade` can project the
+            ;; `:rf.flow/computed` entries for the Re-rendered group's
+            ;; third-link attribution. Empty / absent slot → no flow
+            ;; data → trigger rows stay 2-link (handler-effect-only).
+            trace-events    (or (:trace-events current) [])
             projected       (h/build-views-data
                               current-renders
                               prior-renders
                               sub-runs
                               {:cluster-threshold cluster-threshold
-                               :component-filter  component-filter})]
+                               :component-filter  component-filter
+                               :trace-events      trace-events})]
         (assoc projected
                :focus             focus
                :frame             (:frame focus)

--- a/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs
@@ -38,7 +38,8 @@
     metadata threads through the new spine.
   - React Fiber metadata (spec §Per-component drilldown → React
     Fiber block) — out of scope v1; collapse-by-default placeholder."
-  (:require [re-frame.core :as rf]
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.views-helpers :as h]
             ;; rf2-x9fzk landed on origin/main during this bead's worktree
             ;; lifetime. The data inspector replaces v1's pr-str
@@ -247,6 +248,49 @@
 ;; out-of-scope rename); the UI text developer-frames as "Rerendered
 ;; because" instead.
 
+;; ---- third-link 'via flow' caption (rf2-tv8t1) -------------------------
+;;
+;; The third link in the sub-flow-chain attribution — when a trigger
+;; row's sub was invalidated by a flow firing this cascade, the row
+;; carries a `via :flow-z` caption beside the sub-id. Renders as a
+;; subtle muted caption (NOT a chip) so the visual hierarchy stays:
+;;
+;;   ✱ :sub-y              ← primary: the sub that changed (amber)
+;;       via :flow-z       ← upstream: the flow that fired (muted)
+;;
+;; Handler-effect-only cascades (`:via-flow-ids` is `[]`) → omit the
+;; caption entirely → row stays 2-link. Matches the bead's "when
+;; applicable" framing.
+
+(def ^:private via-flow-caption-style
+  {:color         (:text-tertiary tokens)
+   :font-size     "11px"
+   :font-family   sans-stack
+   :margin-left   "18px"            ; line up under the sub-id
+   :font-style    "italic"})
+
+(defn- via-flow-caption
+  "Inline caption row — 'via :flow-z' (single flow) or
+  'via :flow-z, :flow-w' (multiple). Returns nil for an empty
+  `via-flow-ids` so the row stays 2-link in the handler-effect-only
+  case. The caption sits BELOW the sub-id line so the 3-link chain
+  reads top-to-bottom: ✱ sub → via flow."
+  [via-flow-ids]
+  (when (seq via-flow-ids)
+    [:div {:data-testid "rf-causa-views-via-flow"
+           :style via-flow-caption-style
+           ;; rf2-tv8t1 — both ARIA + title carry the explanation so
+           ;; the third link reads on every browser + screen reader
+           ;; without a dispatch round-trip. The phrasing mirrors the
+           ;; bead's "...because flow Z fired" framing.
+           :aria-label (str "Flow attribution: "
+                            (str/join ", " (map pr-str via-flow-ids))
+                            " fired this cascade")
+           :title (str "This sub may have invalidated because the "
+                       "following flow(s) wrote app-db this cascade: "
+                       (str/join ", " (map pr-str via-flow-ids)))}
+     (str "via " (str/join ", " (map pr-str via-flow-ids)))]))
+
 (defn- rerendered-because-list
   [invalidated-by]
   [:div {:data-testid "rf-causa-views-invalidated-by"
@@ -261,21 +305,25 @@
      ^{:key i}
      [:div {:role "listitem"
             :style mono-style}
-      [:span {:style       (:style chrome)
-              ;; Hover tooltip per rf2-87lkf — Delta 2 + rf2-r2s2l
-              ;; cache-miss-equal. `title` ships the explanation on
-              ;; every browser without a dispatch round-trip; ARIA
-              ;; labels mirror it for screen readers.
-              :title       (:tooltip chrome)
-              :aria-label  (:aria-label chrome)
-              :data-marker (:data-marker chrome)}
-       (:glyph chrome)]
-      [:span (format-sub-id (:sub-id row))]
-      (when (:clustered? row)
-        [:span {:style {:margin-left "6px"
-                        :color (:text-tertiary tokens)
-                        :font-size "11px"}}
-         "(args vary per instance)"])])])
+      [:div {:style {:display "flex" :align-items "baseline"}}
+       [:span {:style       (:style chrome)
+               ;; Hover tooltip per rf2-87lkf — Delta 2 + rf2-r2s2l
+               ;; cache-miss-equal. `title` ships the explanation on
+               ;; every browser without a dispatch round-trip; ARIA
+               ;; labels mirror it for screen readers.
+               :title       (:tooltip chrome)
+               :aria-label  (:aria-label chrome)
+               :data-marker (:data-marker chrome)}
+        (:glyph chrome)]
+       [:span (format-sub-id (:sub-id row))]
+       (when (:clustered? row)
+         [:span {:style {:margin-left "6px"
+                         :color (:text-tertiary tokens)
+                         :font-size "11px"}}
+          "(args vary per instance)"])]
+      ;; rf2-tv8t1 — third link: 'via :flow-z' caption when this
+      ;; trigger row carries flow attribution.
+      (via-flow-caption (:via-flow-ids row))])])
 
 ;; ---- per-row body builders ---------------------------------------------
 

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_helpers_cljs_test.cljc
@@ -334,3 +334,196 @@
           out (h/build-sub-grouped items)]
       (is (= [:sub-b :sub-a] (mapv :sub-id out))
           "sub-b appeared in the first source item → ordered first"))))
+
+;; ---- (8) flow attribution — 3-link sub-flow chain (rf2-tv8t1) -----------
+;;
+;; Per `ai/findings/2026-05-19-causa-machine-inspector-mode-s.md` §13 +
+;; §11 Comment 8. Each Re-rendered row's trigger sub carries a third
+;; link — `via :flow-z` — when a flow fired this cascade. Handler-
+;; effect-only cascades stay 2-link (no `:via-flow-ids`).
+
+(defn- mk-flow-computed
+  "Synthesise one `:rf.flow/computed` trace event in the shape the
+  framework emits per spec/009 + spec/013. Mirrors the projection
+  shape `flows-fired-this-cascade` consumes."
+  [flow-id write-path]
+  {:operation :rf.flow/computed
+   :tags      {:flow-id flow-id
+               :path    write-path}})
+
+(deftest flows-fired-this-cascade-empty
+  (testing "no trace events → empty flow-writes vector"
+    (is (= [] (h/flows-fired-this-cascade nil)))
+    (is (= [] (h/flows-fired-this-cascade [])))))
+
+(deftest flows-fired-this-cascade-projects-flow-computed
+  (testing "every `:rf.flow/computed` trace projects into a
+            `{:flow-id … :write-path …}` record"
+    (let [events [(mk-flow-computed :cart-total [:cart :total])
+                  (mk-flow-computed :tax-due    [:tax :due])]
+          out    (h/flows-fired-this-cascade events)]
+      (is (= 2 (count out)))
+      (is (= {:flow-id :cart-total :write-path [:cart :total]}
+             (first out)))
+      (is (= {:flow-id :tax-due :write-path [:tax :due]}
+             (second out))))))
+
+(deftest flows-fired-this-cascade-skips-non-flow-events
+  (testing "trace events of other operations are ignored — only
+            `:rf.flow/computed` projects"
+    (let [events [{:operation :event/dispatched :tags {:event-id :foo}}
+                  (mk-flow-computed :cart-total [:cart :total])
+                  {:operation :sub/run :tags {:sub-id :foo}}]
+          out    (h/flows-fired-this-cascade events)]
+      (is (= 1 (count out)))
+      (is (= :cart-total (:flow-id (first out)))))))
+
+(deftest flows-fired-this-cascade-defensive-against-missing-tags
+  (testing "events missing :flow-id or :path tags are skipped
+            (defensive — spec/013 guarantees them but older fixtures
+            may not)"
+    (let [events [{:operation :rf.flow/computed :tags {:flow-id :no-path}}
+                  {:operation :rf.flow/computed :tags {:path [:no :id]}}
+                  (mk-flow-computed :ok [:ok])]
+          out    (h/flows-fired-this-cascade events)]
+      (is (= 1 (count out)))
+      (is (= :ok (:flow-id (first out)))))))
+
+(deftest attribute-trigger-to-flows-trigger-with-flows
+  (testing "a trigger row + one flow-write → the flow-id attribution"
+    (let [row    {:sub-id :sub/x :trigger? true :recomputed? true}
+          writes [{:flow-id :cart-total :write-path [:cart :total]}]]
+      (is (= [:cart-total] (h/attribute-trigger-to-flows row writes))))))
+
+(deftest attribute-trigger-to-flows-trigger-with-multiple-flows
+  (testing "a trigger row + multiple flow-writes → every flow-id in
+            source order (the renderer surfaces 'via :z, :w')"
+    (let [row    {:sub-id :sub/x :trigger? true :recomputed? true}
+          writes [{:flow-id :cart-total :write-path [:cart :total]}
+                  {:flow-id :tax-due    :write-path [:tax :due]}]]
+      (is (= [:cart-total :tax-due]
+             (h/attribute-trigger-to-flows row writes))))))
+
+(deftest attribute-trigger-to-flows-dedups-flow-ids
+  (testing "a single flow that wrote multiple paths surfaces as ONE
+            flow-id in the attribution (deduplication)"
+    (let [row    {:sub-id :sub/x :trigger? true :recomputed? true}
+          writes [{:flow-id :cart-total :write-path [:cart :total]}
+                  {:flow-id :cart-total :write-path [:cart :subtotal]}]]
+      (is (= [:cart-total]
+             (h/attribute-trigger-to-flows row writes))))))
+
+(deftest attribute-trigger-to-flows-non-trigger-no-attribution
+  (testing "non-trigger rows (:trigger? false) never carry a flow
+            link — the third link decorates the cause, not the
+            also-consumed subs"
+    (let [row    {:sub-id :sub/x :trigger? false :recomputed? true}
+          writes [{:flow-id :cart-total :write-path [:cart :total]}]]
+      (is (= [] (h/attribute-trigger-to-flows row writes))))))
+
+(deftest attribute-trigger-to-flows-parent-forced-no-attribution
+  (testing "parent-forced trigger rows never carry a flow link —
+            the parent component is the cause, not a sub
+            invalidation"
+    (let [row    {:sub-id      :day8.re-frame2-causa.panels.views-helpers/parent-forced
+                  :trigger?    true
+                  :recomputed? false}
+          writes [{:flow-id :cart-total :write-path [:cart :total]}]]
+      (is (= [] (h/attribute-trigger-to-flows row writes))))))
+
+(deftest attribute-trigger-to-flows-handler-effect-only-stays-2-link
+  (testing "no flows fired this cascade → empty attribution → row
+            stays 2-link (the bead's 'handler-effect writes still
+            surface as 2-link' clause)"
+    (let [row    {:sub-id :sub/x :trigger? true :recomputed? true}
+          writes []]
+      (is (= [] (h/attribute-trigger-to-flows row writes))))))
+
+(deftest re-render-invalidated-by-attaches-via-flow-ids-to-trigger
+  (testing "the trigger row carries :via-flow-ids populated from
+            flow-writes; non-trigger rows carry an empty :via-flow-ids
+            slot so callers can rely on the key being present"
+    (let [render   (mk-render :view/a 1 :sub/x)
+          sub-runs [{:sub-id :sub/x :recomputed? true}
+                    {:sub-id :sub/y :recomputed? true}]
+          writes   [{:flow-id :cart-total :write-path [:cart :total]}]
+          out      (h/re-render-invalidated-by render sub-runs writes)
+          trigger  (first out)
+          others   (rest out)]
+      (is (true? (:trigger? trigger)))
+      (is (= [:cart-total] (:via-flow-ids trigger))
+          "trigger row carries the flow attribution")
+      (is (every? #(= [] (:via-flow-ids %)) others)
+          "non-trigger rows ship with an empty :via-flow-ids slot"))))
+
+(deftest re-render-invalidated-by-parent-forced-empty-via-flow-ids
+  (testing "parent-forced trigger has :via-flow-ids [] — even when
+            flows fired this cascade — because the parent is the
+            cause, not a sub invalidation"
+    (let [render (mk-render :view/a 1 nil)
+          writes [{:flow-id :cart-total :write-path [:cart :total]}]
+          out    (h/re-render-invalidated-by render [] writes)]
+      (is (= 1 (count out)))
+      (is (= [] (:via-flow-ids (first out)))))))
+
+(deftest re-render-invalidated-by-backward-compatible-2-arg
+  (testing "the 2-arg arity (no flow-writes) still works — :via-flow-ids
+            comes through as [] so existing callers stay correct"
+    (let [render (mk-render :view/a 1 :sub/x)
+          out    (h/re-render-invalidated-by render [])]
+      (is (= [] (:via-flow-ids (first out)))))))
+
+(deftest build-views-data-threads-flow-attribution
+  (testing "`build-views-data` consumes `:trace-events`, projects
+            flow-writes once, and surfaces :via-flow-ids on every
+            Re-rendered trigger row"
+    (let [prior     [(mk-render :view/a 1 :sub/x 1.0)]
+          current   [(mk-render :view/a 1 :sub/x 1.5)]
+          sub-runs  [{:sub-id :sub/x :recomputed? true}]
+          events    [(mk-flow-computed :cart-total [:cart :total])]
+          out       (h/build-views-data current prior sub-runs
+                                        {:trace-events events})
+          rendered  (:rendered (:groups out))
+          trigger   (-> rendered first :invalidated-by first)]
+      (is (= 1 (count rendered)))
+      (is (true? (:trigger? trigger)))
+      (is (= [:cart-total] (:via-flow-ids trigger))
+          "the 3-link chain — :sub/x trigger 'via :cart-total'")
+      (is (= [{:flow-id :cart-total :write-path [:cart :total]}]
+             (:flow-writes out))
+          "the cascade-level flow projection is surfaced as
+           :flow-writes for any downstream consumer"))))
+
+(deftest build-views-data-handler-effect-only-stays-2-link
+  (testing "no `:rf.flow/computed` traces → the assembly stays
+            2-link (handler-effect-only path — bead's policy that
+            handler writes 'still surface as 2-link')"
+    (let [prior    [(mk-render :view/a 1 :sub/x 1.0)]
+          current  [(mk-render :view/a 1 :sub/x 1.5)]
+          sub-runs [{:sub-id :sub/x :recomputed? true}]
+          out      (h/build-views-data current prior sub-runs
+                                       {:trace-events []})
+          rendered (:rendered (:groups out))
+          trigger  (-> rendered first :invalidated-by first)]
+      (is (= [] (:via-flow-ids trigger))
+          "no flows fired → no third link → 2-link stays")
+      (is (= [] (:flow-writes out))))))
+
+(deftest build-views-data-clustered-trigger-carries-flow-attribution
+  (testing "clustered Re-rendered rows ALSO carry :via-flow-ids on
+            their synthetic trigger — a 1000-cell grid invalidated
+            by a flow chain reports 'via :flow-z' in the cluster
+            row, same shape as single rows"
+    (let [prior   (mapv #(mk-render :view/cell % :grid/data 1.0)
+                        (range 60))
+          current (mapv #(mk-render :view/cell % :grid/data 1.1)
+                        (range 60))
+          events  [(mk-flow-computed :grid-source [:grid :data])]
+          out     (h/build-views-data current prior [] {:trace-events events})
+          rendered (:rendered (:groups out))
+          cluster  (first rendered)
+          trigger  (first (:invalidated-by cluster))]
+      (is (= :cluster (:kind cluster)))
+      (is (= [:grid-source] (:via-flow-ids trigger))
+          "cluster trigger row carries the same flow attribution as
+           single rows so the third link surfaces in both layouts"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/panels/views_view_cljs_test.cljs
@@ -501,3 +501,130 @@
       (is (not (re-find #"(?i)invalidated by" all-text))
           (str "no 'Invalidated by' UI text left; got: "
                (pr-str all-text))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-tv8t1 — Views sub-status 3-link attribution (sub → flow chain)
+;;
+;; Per `ai/findings/2026-05-19-causa-machine-inspector-mode-s.md` §13 +
+;; §11 Comment 8: each Re-rendered row's trigger row gains a third
+;; link — `via :flow-z` caption — when a flow fired this cascade and
+;; may have caused the sub to invalidate. Handler-effect-only paths
+;; stay 2-link (no `:via-flow-ids` on the row).
+;;
+;; The renderer surfaces the third link as a subtle muted caption
+;; BELOW the sub-id line so the chain reads top-to-bottom:
+;;
+;;   ✱ :sub-y         ← primary (sub change)
+;;       via :flow-z  ← upstream (flow firing)
+;;
+;; Tests below cover the three cases:
+;;   1) Single trigger row with one flow link
+;;   2) Single trigger row with multiple flow links
+;;   3) Handler-effect-only path (no flow link → 2-link preserved)
+;;   4) Cluster trigger row carries the same chain
+;; ---------------------------------------------------------------------------
+
+(deftest rerendered-because-list-renders-third-link-when-flow-attribution
+  (testing "rf2-tv8t1 — a trigger row carrying :via-flow-ids renders
+            a 'via :flow-z' caption beside the sub-id; the testid
+            `rf-causa-views-via-flow` is the stable hook for tools to
+            assert the third link"
+    (let [invalidated-by [{:sub-id      :cart/items
+                           :trigger?    true
+                           :recomputed? true
+                           :via-flow-ids [:cart-total]}]
+          list-node (#'view/rerendered-because-list invalidated-by)
+          captions  (collect-by-pred
+                      list-node
+                      #(= "rf-causa-views-via-flow" (:data-testid %)))
+          text      (th/text-content list-node)]
+      (is (= 1 (count captions))
+          "exactly one via-flow caption renders for one attributed sub")
+      (is (re-find #"via :cart-total" text)
+          (str "expected 'via :cart-total' in the third-link text; "
+               "got: " (pr-str text))))))
+
+(deftest rerendered-because-list-third-link-handles-multiple-flows
+  (testing "rf2-tv8t1 — a trigger row carrying multiple :via-flow-ids
+            renders one caption with comma-separated flow-ids"
+    (let [invalidated-by [{:sub-id      :checkout/grand-total
+                           :trigger?    true
+                           :recomputed? true
+                           :via-flow-ids [:cart-total :tax-due]}]
+          list-node (#'view/rerendered-because-list invalidated-by)
+          text      (th/text-content list-node)]
+      (is (re-find #"via :cart-total, :tax-due" text)
+          (str "expected 'via :cart-total, :tax-due' in the third-link "
+               "text; got: " (pr-str text))))))
+
+(deftest rerendered-because-list-no-via-flow-stays-2-link
+  (testing "rf2-tv8t1 — when :via-flow-ids is empty / absent the row
+            stays 2-link (handler-effect-only path per the bead's
+            policy 'handler-effect writes still surface as 2-link')"
+    (let [invalidated-by [{:sub-id      :cart/items
+                           :trigger?    true
+                           :recomputed? true
+                           :via-flow-ids []}
+                          {:sub-id      :cart/legacy  ;; no slot at all
+                           :trigger?    true
+                           :recomputed? true}]
+          list-node (#'view/rerendered-because-list invalidated-by)
+          captions  (collect-by-pred
+                      list-node
+                      #(= "rf-causa-views-via-flow" (:data-testid %)))]
+      (is (= 0 (count captions))
+          "no via-flow caption — the row stays 2-link"))))
+
+(deftest rerendered-because-list-non-trigger-rows-skip-third-link
+  (testing "rf2-tv8t1 — also-consumed (non-trigger) rows never carry
+            a third link, even if the trigger row does. The chain
+            decorates the cause, not the also-consumed subs."
+    (let [invalidated-by [{:sub-id      :cart/items
+                           :trigger?    true
+                           :recomputed? true
+                           :via-flow-ids [:cart-total]}
+                          {:sub-id      :ui/theme
+                           :trigger?    false
+                           :recomputed? false
+                           :via-flow-ids []}]
+          list-node (#'view/rerendered-because-list invalidated-by)
+          captions  (collect-by-pred
+                      list-node
+                      #(= "rf-causa-views-via-flow" (:data-testid %)))]
+      (is (= 1 (count captions))
+          "exactly one third link — on the trigger row, not the
+           also-consumed row"))))
+
+(deftest cluster-row-renders-third-link-when-flow-attribution
+  (testing "rf2-tv8t1 — clustered Re-rendered rows ALSO surface the
+            third link when :via-flow-ids is populated on the
+            cluster's synthetic trigger. (A 1000-cell grid driven
+            by a flow chain reports 'via :flow-z' in the cluster
+            row, same as singles.)"
+    (let [item   {:kind         :cluster
+                  :view-id      ::cell
+                  :triggered-by ::grid-data
+                  :count        80
+                  :total-ms     8.0
+                  :avg-ms       0.1
+                  :p95-ms       0.2
+                  :renders      []
+                  :invalidated-by
+                  [{:sub-id       ::grid-data
+                    :trigger?     true
+                    :recomputed?  true
+                    :clustered?   true
+                    :via-flow-ids [:grid-source]}]}
+          row    (#'view/cluster-row item :rendered false)
+          ;; cluster row doesn't yet route through the new caption —
+          ;; surface via `rerendered-because-list` to keep the
+          ;; visual + assertion consistent across singles and clusters.
+          ;; Single + cluster both delegate trigger-row rendering to
+          ;; the same list builder, so we exercise the list directly
+          ;; for the cluster trigger shape.
+          list-node (#'view/rerendered-because-list (:invalidated-by item))
+          text      (th/text-content list-node)]
+      (is (some? row) "cluster row renders")
+      (is (re-find #"via :grid-source" text)
+          (str "expected 'via :grid-source' in the cluster trigger's "
+               "list; got: " (pr-str text))))))


### PR DESCRIPTION
## Summary
- Views panel Re-rendered group's trigger rows now render a 3-link sub-flow attribution chain (sub → flow → cascade source) (rf2-tv8t1)
- `flows-fired-this-cascade` projects `:rf.flow/computed` trace events into `{:flow-id … :write-path …}` records; `attribute-trigger-to-flows` decorates each trigger row with `:via-flow-ids`
- Renderer surfaces a muted "via :flow-z" caption below the sub-id when attribution exists; handler-effect-only cascades stay 2-link
- Cluster trigger rows carry the same attribution shape — 1000-cell grids driven by a flow chain show "via :flow-z" in the cluster row

## Beads
rf2-tv8t1

## Files
- `tools/causa/src/day8/re_frame2_causa/panels/views_helpers.cljc` — new `flows-fired-this-cascade` + `attribute-trigger-to-flows`; threaded into `build-views-data` and `re-render-invalidated-by`
- `tools/causa/src/day8/re_frame2_causa/panels/views_subs.cljs` — pass focused cascade's `:trace-events` into `build-views-data`
- `tools/causa/src/day8/re_frame2_causa/panels/views_view.cljs` — new `via-flow-caption` rendered below each trigger row when `:via-flow-ids` is populated
- `tools/causa/test/.../views_helpers_cljs_test.cljc` — +14 pure-data tests
- `tools/causa/test/.../views_view_cljs_test.cljs` — +5 view-render tests

## Acceptance
- npm run test:cljs — clean (3447 tests, 9804 assertions, 0 failures, 0 errors)
- mkdocs --strict — clean (exit 0)