### PR TITLE
feat(causa): Static surface Flows + Schemas + Views sub-tabs (rf2-uhsqb + rf2-o5f5f.4 + rf2-o5f5f.5)

### DIFF
--- a/tools/causa/deps.edn
+++ b/tools/causa/deps.edn
@@ -68,6 +68,26 @@
          ;; re-frame2-epoch dep above.
          day8/re-frame2-routing {:local/root "../../implementation/routing"}
 
+         ;; Per rf2-uhsqb — `day8/re-frame2-flows` is a hard dep of
+         ;; Causa. The Static Flows sub-tab reads
+         ;; `re-frame.flows.registry/flows` at view-render time to
+         ;; project the registered-flows catalogue. Same posture as
+         ;; the routing dep above: most real hosts already pull the
+         ;; flows artefact, but the Static Flows sub-tab must work
+         ;; (rendering an empty catalogue when no flows are registered)
+         ;; even for hosts that haven't registered any flows yet.
+         day8/re-frame2-flows {:local/root "../../implementation/flows"}
+
+         ;; Per rf2-o5f5f.4 — `day8/re-frame2-schemas` is a hard dep
+         ;; of Causa. The Static Schemas sub-tab reads
+         ;; `re-frame.schemas.storage/schemas-by-frame` at view-render
+         ;; time to project the registered-schemas catalogue. Same
+         ;; posture as the flows + routing deps above: the Static
+         ;; Schemas sub-tab must work (rendering an empty catalogue
+         ;; when no schemas are registered) even for hosts that
+         ;; haven't registered any schemas yet.
+         day8/re-frame2-schemas {:local/root "../../implementation/schemas"}
+
          ;; Per rf2-o9arp — the MachineChart implementation lives in
          ;; day8/re-frame2-machines-viz. Causa's panel imports
          ;; (`day8.re-frame2-causa.chart.{svg,layout,elk-layout}`)

--- a/tools/causa/src/day8/re_frame2_causa/registry.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/registry.cljs
@@ -43,10 +43,13 @@
             [day8.re-frame2-causa.settings.popup :as settings-popup]
             [day8.re-frame2-causa.spine :as spine]
             [day8.re-frame2-causa.spine-filters :as spine-filters]
+            [day8.re-frame2-causa.static.flows.panel :as static-flows-panel]
             [day8.re-frame2-causa.static.machines.panel :as static-machines-panel]
             [day8.re-frame2-causa.static.persistence :as static-persistence]
             [day8.re-frame2-causa.static.routes.panel :as static-routes-panel]
+            [day8.re-frame2-causa.static.schemas.panel :as static-schemas-panel]
             [day8.re-frame2-causa.static.shell :as static-shell]
+            [day8.re-frame2-causa.static.views.panel :as static-views-panel]
             [day8.re-frame2-causa.trace-bus :as trace-bus]
             [day8.re-frame2-causa.panels.app-db-diff :as app-db-diff]
             [day8.re-frame2-causa.panels.app-db-segment-inspector
@@ -688,6 +691,24 @@
     ;; registered above) — order is cosmetic since re-frame resolves
     ;; `:<-` chains lazily.
     (static-routes-panel/install!)
+    ;; Static Schemas sub-tab (rf2-o5f5f.4) — browse every registered
+    ;; Malli schema across app-db slots + events + subs. Reads
+    ;; `re-frame.schemas.storage/schemas-by-frame` + the registrar's
+    ;; `:event` / `:sub` `:spec` slots. Source-coord chip dispatches
+    ;; `:rf.causa/open-in-editor` (open-in-editor installed above).
+    (static-schemas-panel/install!)
+    ;; Static Views sub-tab (rf2-o5f5f.5) — browse every registered
+    ;; view via the registrar's `:view` slot. Pure-browse verb —
+    ;; event-INDEPENDENT registry catalogue (no Fiber-walker live
+    ;; mount tree at this surface; that's the Runtime Views panel's
+    ;; concern).
+    (static-views-panel/install!)
+    ;; Static Flows sub-tab (rf2-uhsqb) — browse every flow registered
+    ;; via `re-frame.flows/reg-flow`. Reads the per-frame flows atom
+    ;; `re-frame.flows.registry/flows`. Flows are frame-scoped per
+    ;; Spec 013 — the sub flattens the two-level shape into a single
+    ;; row vector for the view.
+    (static-flows-panel/install!)
     (views/install!)
     (trace/install!))
   nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/flows/panel.cljs
@@ -1,0 +1,364 @@
+(ns day8.re-frame2-causa.static.flows.panel
+  "Top-level Flows sub-tab for Causa's Static surface (rf2-uhsqb).
+
+  ## Browse-all verb
+
+  Per Lock #15 (two-verbs-two-homes — browse-all lives in Static) the
+  Flows sub-tab is a flat catalogue of every flow registered via
+  `re-frame.flows/reg-flow`. Each row surfaces the flow-id, its
+  `:inputs` paths, its `:output` `:path`, the owning frame (flows are
+  frame-scoped per Spec 013), and the doc-string (when present).
+
+      ┌───────────────────────────────────────────────────┐
+      │ Flows — header + descriptive prose                │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]            7 flows      │
+      ├───────────────────────────────────────────────────┤
+      │ ▸ :user/full-name   [:user :first] [:user :last]  │
+      │     → [:derived :full-name]    [:rf/default]      │
+      │ ▸ :cart/total       …                             │
+      └───────────────────────────────────────────────────┘
+
+  ## Data source
+
+  Reads the live `re-frame.flows.registry/flows` atom shape
+  `{frame-id {flow-id flow-map}}` via the
+  `:rf.causa.static.flows/registered-flows` sub. The sub flattens the
+  per-frame nesting into a vector of rows so the view never reasons
+  about the registry's two-level shape directly.
+
+  Optional test override slot: `:rf.causa.static.flows/registered-
+  flows-override` lets the CLJS test suite inject deterministic
+  fixtures without poking the live atom.
+
+  ## State slots (all under `:rf.causa.static.flows/*`)
+
+    - `:rf.causa.static.flows/query`    — search input value.
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup, no Reagent / UIx
+  / Helix references. Frame isolation comes from the enclosing
+  `[rf/frame-provider {:frame :rf/causa}]` in `static/shell.cljs`."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.flows.registry :as flows-registry]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn project-rows
+  "Flatten `{frame-id {flow-id flow-map}}` into a flat vector of rows,
+  sorted by flow-id ascending. Pure data so the JVM unit-test target
+  can cover the shape without a CLJS runtime."
+  [registry-snapshot]
+  (->> registry-snapshot
+       (mapcat (fn [[frame-id by-id]]
+                 (map (fn [[flow-id flow-map]]
+                        {:flow-id flow-id
+                         :frame   frame-id
+                         :inputs  (vec (:inputs flow-map))
+                         :path    (vec (:path flow-map))
+                         :doc     (:doc flow-map)})
+                      by-id)))
+       (sort-by (fn [{:keys [flow-id]}] (str flow-id)))
+       vec))
+
+(defn- row-haystack [{:keys [flow-id frame inputs path doc]}]
+  (str/lower-case
+    (str (pr-str flow-id) " "
+         (pr-str frame) " "
+         (pr-str inputs) " "
+         (pr-str path) " "
+         (or doc ""))))
+
+(defn filter-rows
+  "Substring filter against flow-id + frame + inputs + path + doc.
+  Empty / blank query returns rows verbatim."
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+
+(defn project-data
+  "View-facing composite. Folds the registered-flows map + UI controls
+  into the shape `panel/Panel` consumes:
+
+      {:silent?     <bool>
+       :flows       [<row> ...]
+       :total       <pre-filter count>
+       :filtered?   <bool>
+       :query       <string-or-nil>}"
+  [registry-snapshot query]
+  (let [rows     (project-rows registry-snapshot)
+        silent?  (empty? rows)
+        filtered (filter-rows rows query)]
+    {:silent?   silent?
+     :flows     filtered
+     :total     (count rows)
+     :filtered? (not= (count rows) (count filtered))
+     :query     query}))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-flows-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Flows"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every registered flow. Each row carries its "
+    [:strong {:style {:color (:cyan tokens)}} "inputs"]
+    " (the app-db paths it depends on), its "
+    [:strong {:style {:color (:cyan tokens)}} "output path"]
+    " (where its computed value lands), and the owning frame. "
+    "Flows are frame-scoped per Spec 013."]])
+
+;; ---- search box ----------------------------------------------------------
+
+(defn- search-box
+  [query total filtered?]
+  [:div {:data-testid "rf-causa-static-flows-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-flows-search-input"
+            :placeholder "flow-id, path, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.flows/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-flows-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "80px"
+                         :text-align  "right"}}
+    (cond
+      filtered?     "match"
+      (= 1 total)   "1 flow"
+      :else         (str total " flows"))]])
+
+;; ---- row -----------------------------------------------------------------
+
+(defn- flow-row
+  [{:keys [flow-id frame inputs path doc] :as _row}]
+  [:li {:data-testid (str "rf-causa-static-flows-row-"
+                          (subs (pr-str flow-id) 1))
+        :style       {:display       "block"
+                      :padding       "6px 12px"
+                      :font-family   mono-stack
+                      :font-size     "12px"
+                      :color         (:text-primary tokens)
+                      :background    "transparent"
+                      :border-left   "2px solid transparent"
+                      :border-radius "2px"
+                      :line-height   "18px"}}
+   [:div {:style {:display     "flex"
+                  :align-items "baseline"
+                  :gap         "8px"}}
+    [:span {:style {:color       (:accent-violet tokens)
+                    :font-weight 500
+                    :min-width   "180px"}}
+     (pr-str flow-id)]
+    [:span {:data-testid (str "rf-causa-static-flows-frame-"
+                              (subs (pr-str flow-id) 1))
+            :style {:color     (:text-tertiary tokens)
+                    :font-size "10px"}}
+     (pr-str frame)]]
+   [:div {:style {:margin-left  "12px"
+                  :color        (:text-secondary tokens)
+                  :font-size    "11px"
+                  :line-height  1.4}}
+    [:div
+     [:span {:style {:color (:text-tertiary tokens)
+                     :margin-right "6px"}}
+      "inputs:"]
+     (for [[i input-path] (map-indexed vector inputs)]
+       ^{:key (str "in-" i)}
+       [:code {:style {:color (:cyan tokens)
+                       :margin-right "6px"}}
+        (pr-str input-path)])]
+    [:div
+     [:span {:style {:color (:text-tertiary tokens)
+                     :margin-right "6px"}}
+      "output →"]
+     [:code {:style {:color (:yellow tokens)}}
+      (pr-str path)]]
+    (when doc
+      [:div {:style {:margin-top  "4px"
+                     :color       (:text-secondary tokens)
+                     :font-family sans-stack
+                     :font-style  "italic"}}
+       doc])]])
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  []
+  [:div {:data-testid "rf-causa-static-flows-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No flows registered."])
+
+(defn- empty-filtered
+  [query]
+  [:div {:data-testid "rf-causa-static-flows-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No flows match " (pr-str query) ".")])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Flows panel root view. Subscribes to the registered-flows
+  composite + the search-query slot and composes the header + search +
+  flat list.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data @(rf/subscribe [:rf.causa.static.flows/tab-data])
+        {:keys [silent? flows total filtered? query]} data]
+    [:section {:data-testid "rf-causa-static-flows"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (cond
+       silent?
+       (empty-state)
+
+       :else
+       [:<>
+        (search-box query total filtered?)
+        (if (empty? flows)
+          (empty-filtered query)
+          (into [:ul {:data-testid "rf-causa-static-flows-list"
+                      :style       {:list-style     "none"
+                                    :margin         "8px 0 0 0"
+                                    :padding        "0 8px"
+                                    :flex           1
+                                    :overflow       "auto"
+                                    :display        "flex"
+                                    :flex-direction "column"
+                                    :gap            "2px"}}]
+                (for [row flows]
+                  ^{:key (str (:frame row) "/" (:flow-id row))}
+                  [flow-row row])))])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Flows panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.flows/query`            — search input slot.
+    - `:rf.causa.static.flows/set-query`        — search input setter.
+    - `:rf.causa.static.flows/registered-flows-override` — test-only
+                                                  override slot.
+    - `:rf.causa.static.flows/set-registered-flows-override-for-test`
+        — test-only override setter.
+    - `:rf.causa.static.flows/registered-flows` — production data sub
+                                                  reading the live
+                                                  flows registry atom
+                                                  (or override).
+    - `:rf.causa.static.flows/tab-data`         — view-facing composite."
+  []
+
+  ;; ---- UI state ---------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.flows/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.flows/query)
+        (assoc db :rf.causa.static.flows/query q))))
+
+  (rf/reg-sub :rf.causa.static.flows/query
+    (fn [db _]
+      (get db :rf.causa.static.flows/query)))
+
+  ;; ---- test-only override ----------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.flows/set-registered-flows-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rf.causa.static.flows/registered-flows-override)
+        (assoc db :rf.causa.static.flows/registered-flows-override ov))))
+
+  (rf/reg-sub :rf.causa.static.flows/registered-flows-override
+    (fn [db _]
+      (get db :rf.causa.static.flows/registered-flows-override)))
+
+  ;; ---- production data sub ---------------------------------------------
+
+  ;; The flows registry is a top-level atom (per-frame) in the flows
+  ;; artefact; deref it once per sub re-fire. `:<-`-composing against
+  ;; `:rf.causa/trace-buffer` keeps the sub reactive against the same
+  ;; "something changed" pulse the other static-mode subs ride —
+  ;; without it, a fresh `reg-flow!` wouldn't surface until the next
+  ;; subscribe re-render.
+  (rf/reg-sub :rf.causa.static.flows/registered-flows
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa.static.flows/registered-flows-override]
+    (fn [[_buffer override] _query]
+      (or override
+          (try @flows-registry/flows
+               (catch :default _ {})))))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.flows/tab-data
+    :<- [:rf.causa.static.flows/registered-flows]
+    :<- [:rf.causa.static.flows/query]
+    (fn [[registry-snapshot query] _query]
+      (project-data registry-snapshot query)))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/schemas/panel.cljs
@@ -1,0 +1,418 @@
+(ns day8.re-frame2-causa.static.schemas.panel
+  "Top-level Schemas sub-tab for Causa's Static surface (rf2-o5f5f.4).
+
+  ## Browse-all verb
+
+  Per Lock #15 (two-verbs-two-homes — browse-all lives in Static) the
+  Schemas sub-tab is a flat catalogue of every registered schema —
+  app-db slot schemas (via `re-frame.schemas/reg-app-schema`) plus
+  event + sub schemas surfaced through the registrar's `:event` /
+  `:sub` slot metadata `:spec` field.
+
+      ┌───────────────────────────────────────────────────┐
+      │ Schemas — header + descriptive prose              │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]            12 schemas   │
+      ├───────────────────────────────────────────────────┤
+      │ ▸ app-db   [:user]      [:map ...]       [open]   │
+      │ ▸ event    :user/login  [:tuple ...]              │
+      │ ▸ sub      :user/full   [:map ...]                │
+      └───────────────────────────────────────────────────┘
+
+  ## Data sources
+
+  Three input registries:
+
+    - `re-frame.schemas/schemas-by-frame` — per-frame app-db schema
+      entries shaped `{frame-id {path schema-meta}}` where
+      `schema-meta` carries `:schema` (the Malli EDN), `:doc`, and
+      source-coord slots.
+    - `re-frame.registrar/registrations :event` — events whose
+      metadata carries a `:spec` slot.
+    - `re-frame.registrar/registrations :sub` — subs whose metadata
+      carries a `:spec` slot.
+
+  ## Jump-to-source
+
+  Each row carries a source-coord chip (when the registered metadata
+  surfaces `:file` / `:line`). Click dispatches
+  `:rf.causa/open-in-editor` per the rf2-evgf5 / rf2-g5q8d wiring —
+  same affordance the Trace + Issues panels use.
+
+  ## State slots (all under `:rf.causa.static.schemas/*`)
+
+    - `:rf.causa.static.schemas/query`    — search input value.
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup. Frame isolation
+  comes from the enclosing `[rf/frame-provider {:frame :rf/causa}]`
+  in `static/shell.cljs`."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas.storage :as schemas-storage]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn project-app-schema-rows
+  "Flatten `{frame-id {path schema-meta}}` into row maps.
+  `schema-meta` carries `:schema`, `:doc`, plus `:file`/`:line`/`:ns`
+  source-coord slots (Malli EDN + the rf2-5m5n2 source-coord stamp)."
+  [schemas-by-frame]
+  (->> schemas-by-frame
+       (mapcat (fn [[frame-id by-path]]
+                 (map (fn [[path schema-meta]]
+                        {:kind         :app-db
+                         :id           path
+                         :frame        frame-id
+                         :schema       (:schema schema-meta)
+                         :doc          (:doc schema-meta)
+                         :source-coord (select-keys schema-meta [:file :line :ns])})
+                      by-path)))
+       vec))
+
+(defn- meta-row
+  "Project one registrar `:event` / `:sub` entry to a row when it
+  carries a `:spec` slot."
+  [kind id meta]
+  (when-some [spec (:spec meta)]
+    {:kind         kind
+     :id           id
+     :frame        nil
+     :schema       spec
+     :doc          (:doc meta)
+     :source-coord (select-keys meta [:file :line :ns])}))
+
+(defn project-registrar-rows
+  "Walk one kind's `{id meta}` map and return rows for every entry
+  whose `:spec` slot is non-nil."
+  [kind registrations-map]
+  (vec (keep (fn [[id meta]] (meta-row kind id meta)) registrations-map)))
+
+(defn project-rows
+  "Combine app-db schema rows + event-spec rows + sub-spec rows into a
+  single flat vector sorted by `(kind, id)`."
+  [schemas-by-frame events-map subs-map]
+  (let [rows (concat (project-app-schema-rows schemas-by-frame)
+                     (project-registrar-rows :event events-map)
+                     (project-registrar-rows :sub   subs-map))]
+    (->> rows
+         (sort-by (fn [{:keys [kind id]}] [(name kind) (pr-str id)]))
+         vec)))
+
+(defn- row-haystack [{:keys [kind id frame doc schema]}]
+  (str/lower-case
+    (str (name kind) " "
+         (pr-str id) " "
+         (pr-str frame) " "
+         (or doc "") " "
+         (pr-str schema))))
+
+(defn filter-rows
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+
+(defn project-data
+  [schemas-by-frame events-map subs-map query]
+  (let [rows     (project-rows schemas-by-frame events-map subs-map)
+        silent?  (empty? rows)
+        filtered (filter-rows rows query)]
+    {:silent?   silent?
+     :schemas   filtered
+     :total     (count rows)
+     :filtered? (not= (count rows) (count filtered))
+     :query     query}))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-schemas-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Schemas"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every registered Malli schema across app-db slots, events, "
+    "and subscriptions. Click the "
+    [:strong {:style {:color (:cyan tokens)}} "open"]
+    " chip on any row to jump to its registration site."]])
+
+;; ---- search box ----------------------------------------------------------
+
+(defn- search-box
+  [query total filtered?]
+  [:div {:data-testid "rf-causa-static-schemas-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-schemas-search-input"
+            :placeholder "kind, id, frame, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.schemas/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-schemas-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "80px"
+                         :text-align  "right"}}
+    (cond
+      filtered?     "match"
+      (= 1 total)   "1 schema"
+      :else         (str total " schemas"))]])
+
+;; ---- row -----------------------------------------------------------------
+
+(defn- kind-badge
+  [kind]
+  (let [{:keys [letter colour]}
+        (case kind
+          :app-db {:letter "A" :colour (:cyan tokens)}
+          :event  {:letter "E" :colour (:magenta tokens)}
+          :sub    {:letter "S" :colour (:yellow tokens)}
+          {:letter "?" :colour (:text-tertiary tokens)})]
+    [:span {:data-testid (str "rf-causa-static-schemas-badge-" (name kind))
+            :title       (str (name kind) " schema")
+            :style       {:display       "inline-block"
+                          :min-width     "14px"
+                          :height        "14px"
+                          :line-height   "14px"
+                          :padding       "0 3px"
+                          :margin-right  "6px"
+                          :background    (:bg-3 tokens)
+                          :color         colour
+                          :border        (str "1px solid " colour)
+                          :border-radius "3px"
+                          :font-family   mono-stack
+                          :font-size     "9px"
+                          :font-weight   700
+                          :text-align    "center"}}
+     letter]))
+
+(defn- schema-row
+  [{:keys [kind id frame schema doc source-coord] :as _row}]
+  (let [id-text (pr-str id)
+        row-id  (str (name kind) "-" id-text)]
+    [:li {:data-testid (str "rf-causa-static-schemas-row-" row-id)
+          :style       {:display       "block"
+                        :padding       "6px 12px"
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :color         (:text-primary tokens)
+                        :background    "transparent"
+                        :border-left   "2px solid transparent"
+                        :border-radius "2px"
+                        :line-height   "18px"}}
+     [:div {:style {:display     "flex"
+                    :align-items "baseline"
+                    :gap         "8px"}}
+      (kind-badge kind)
+      [:span {:style {:color       (:accent-violet tokens)
+                      :font-weight 500
+                      :min-width   "200px"}}
+       id-text]
+      (when frame
+        [:span {:data-testid (str "rf-causa-static-schemas-frame-" row-id)
+                :style       {:color     (:text-tertiary tokens)
+                              :font-size "10px"}}
+         (pr-str frame)])
+      (when (and source-coord (:file source-coord))
+        [open-in-editor/open-chip source-coord])]
+     [:div {:style {:margin-left "20px"
+                    :margin-top  "2px"
+                    :color       (:text-secondary tokens)
+                    :font-size   "11px"
+                    :white-space "pre-wrap"
+                    :word-break  "break-word"}}
+      [:code (pr-str schema)]]
+     (when doc
+       [:div {:style {:margin-left "20px"
+                      :margin-top  "2px"
+                      :color       (:text-secondary tokens)
+                      :font-family sans-stack
+                      :font-style  "italic"
+                      :font-size   "11px"}}
+        doc])]))
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  []
+  [:div {:data-testid "rf-causa-static-schemas-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No schemas registered."])
+
+(defn- empty-filtered
+  [query]
+  [:div {:data-testid "rf-causa-static-schemas-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No schemas match " (pr-str query) ".")])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Schemas panel root view. Subscribes to the schemas composite
+  + the search-query slot and composes the header + search + flat list.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data @(rf/subscribe [:rf.causa.static.schemas/tab-data])
+        {:keys [silent? schemas total filtered? query]} data]
+    [:section {:data-testid "rf-causa-static-schemas"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (cond
+       silent?
+       (empty-state)
+
+       :else
+       [:<>
+        (search-box query total filtered?)
+        (if (empty? schemas)
+          (empty-filtered query)
+          (into [:ul {:data-testid "rf-causa-static-schemas-list"
+                      :style       {:list-style     "none"
+                                    :margin         "8px 0 0 0"
+                                    :padding        "0 8px"
+                                    :flex           1
+                                    :overflow       "auto"
+                                    :display        "flex"
+                                    :flex-direction "column"
+                                    :gap            "4px"}}]
+                (for [row schemas]
+                  ^{:key (str (name (:kind row)) "/"
+                              (pr-str (:frame row)) "/"
+                              (pr-str (:id row)))}
+                  [schema-row row])))])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Schemas panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.schemas/query`              — search slot.
+    - `:rf.causa.static.schemas/set-query`          — search setter.
+    - `:rf.causa.static.schemas/registry-override`  — test seam.
+    - `:rf.causa.static.schemas/set-registry-override-for-test`
+        — test seam setter; payload shape
+          `{:schemas-by-frame ... :events ... :subs ...}`.
+    - `:rf.causa.static.schemas/registry`           — production data
+                                                      sub reading the
+                                                      three live
+                                                      registries (or
+                                                      override).
+    - `:rf.causa.static.schemas/tab-data`           — view composite."
+  []
+
+  ;; ---- UI state ---------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.schemas/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.schemas/query)
+        (assoc db :rf.causa.static.schemas/query q))))
+
+  (rf/reg-sub :rf.causa.static.schemas/query
+    (fn [db _]
+      (get db :rf.causa.static.schemas/query)))
+
+  ;; ---- test-only override ----------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.schemas/set-registry-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rf.causa.static.schemas/registry-override)
+        (assoc db :rf.causa.static.schemas/registry-override ov))))
+
+  (rf/reg-sub :rf.causa.static.schemas/registry-override
+    (fn [db _]
+      (get db :rf.causa.static.schemas/registry-override)))
+
+  ;; ---- production data sub ---------------------------------------------
+
+  ;; Reads the schemas storage atom + walks the registrar's `:event` /
+  ;; `:sub` slots once per re-fire. `:<-`-composes against the trace
+  ;; buffer so the sub is reactive against the same "something
+  ;; changed" pulse the other Static-mode subs ride.
+  (rf/reg-sub :rf.causa.static.schemas/registry
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa.static.schemas/registry-override]
+    (fn [[_buffer override] _query]
+      (or override
+          {:schemas-by-frame
+           (try @schemas-storage/schemas-by-frame
+                (catch :default _ {}))
+           :events
+           (try (registrar/registrations :event)
+                (catch :default _ {}))
+           :subs
+           (try (registrar/registrations :sub)
+                (catch :default _ {}))})))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.schemas/tab-data
+    :<- [:rf.causa.static.schemas/registry]
+    :<- [:rf.causa.static.schemas/query]
+    (fn [[{:keys [schemas-by-frame events subs]} query] _query]
+      (project-data schemas-by-frame events subs query)))
+
+  nil)

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -84,9 +84,12 @@
     - rf2-o5f5f.5 — Views registry browse (Fiber-walker consumer)
     - rf2-o5f5f.6 — Events registry browse + interceptor stack"
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.static.flows.panel :as flows-panel]
             [day8.re-frame2-causa.static.machines.panel :as static-machines]
             [day8.re-frame2-causa.static.mode-pill :as mode-pill]
             [day8.re-frame2-causa.static.routes.panel :as routes-panel]
+            [day8.re-frame2-causa.static.schemas.panel :as schemas-panel]
+            [day8.re-frame2-causa.static.views.panel :as views-panel]
             [day8.re-frame2-causa.theme.tokens
              :as t
              :refer [tokens type-scale layout sans-stack]]))
@@ -112,6 +115,7 @@
    {:id :routes   :label "Routes"   :mnem "r" :placeholder-bead "rf2-o5f5f.3"}
    {:id :schemas  :label "Schemas"  :mnem "c" :placeholder-bead "rf2-o5f5f.4"}
    {:id :views    :label "Views"    :mnem "v" :placeholder-bead "rf2-o5f5f.5"}
+   {:id :flows    :label "Flows"    :mnem "l" :placeholder-bead "rf2-uhsqb"}
    {:id :events   :label "Events"   :mnem "e" :placeholder-bead "rf2-o5f5f.6"}])
 
 (def default-tab :machines)
@@ -328,9 +332,13 @@
 
   Live mounts:
     :machines → `static.machines.panel/panel` (rf2-o5f5f.2)
+    :routes   → `static.routes.panel/Panel`   (rf2-o5f5f.3)
+    :schemas  → `static.schemas.panel/Panel`  (rf2-o5f5f.4)
+    :views    → `static.views.panel/Panel`    (rf2-o5f5f.5)
+    :flows    → `static.flows.panel/Panel`    (rf2-uhsqb)
 
   Placeholder still-pending (the sibling-bead card):
-    :routes :schemas :views :events
+    :events
 
   Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
   `:rf/causa`."
@@ -350,6 +358,15 @@
 
        (= selected :routes)
        [routes-panel/Panel]
+
+       (= selected :schemas)
+       [schemas-panel/Panel]
+
+       (= selected :views)
+       [views-panel/Panel]
+
+       (= selected :flows)
+       [flows-panel/Panel]
 
        tab
        [placeholder-card tab]

--- a/tools/causa/src/day8/re_frame2_causa/static/views/panel.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/views/panel.cljs
@@ -1,0 +1,342 @@
+(ns day8.re-frame2-causa.static.views.panel
+  "Top-level Views sub-tab for Causa's Static surface (rf2-o5f5f.5).
+
+  ## Pure-browse verb
+
+  Per Lock #15 (two-verbs-two-homes — browse-all lives in Static) the
+  Views sub-tab is a flat catalogue of every view registered via
+  `re-frame.core/reg-view*`. Views are pure-browse per the bead's
+  §Verb taxonomy — there is no simulate-input affordance (component
+  rendering with synthetic props is Storybook territory).
+
+      ┌───────────────────────────────────────────────────┐
+      │ Views — header + descriptive prose                │
+      ├───────────────────────────────────────────────────┤
+      │ Search: [_______________]            42 views     │
+      ├───────────────────────────────────────────────────┤
+      │ ▸ :rf.causa.static.shell/surface  [open]          │
+      │ ▸ :route/link                     [open]          │
+      │ ▸ user.profile/avatar             [open]          │
+      └───────────────────────────────────────────────────┘
+
+  ## Data source
+
+  Reads `(re-frame.registrar/registrations :view)` — every entry
+  registered through `reg-view` / `reg-view*` carries source-coord
+  metadata (`:file` / `:line` / `:ns`) per Spec 004. The
+  Fiber-walker (rf2-mxkq7) is the runtime mount-tree consumer; Static
+  is event-INDEPENDENT, so this sub-tab works off the registry
+  catalogue only — every view that COULD render appears here, not
+  just those currently mounted.
+
+  ## Jump-to-source
+
+  Each row carries an `open` chip (when the metadata surfaces a
+  source-coord). Click dispatches `:rf.causa/open-in-editor` per the
+  rf2-evgf5 / rf2-g5q8d wiring.
+
+  ## State slots (all under `:rf.causa.static.views/*`)
+
+    - `:rf.causa.static.views/query`    — search input value.
+
+  ## Pure hiccup
+
+  Same contract as every Causa view — pure hiccup. Frame isolation
+  comes from the enclosing `[rf/frame-provider {:frame :rf/causa}]`
+  in `static/shell.cljs`.
+
+  ## Distinct from `panels/views.cljs`
+
+  The Runtime-side Views panel (`panels/views.cljs`) is the focused-
+  event mount-tree lens — it consumes the Fiber-walker output for the
+  cascade currently focused on the spine. This Static-side panel is
+  the registry catalogue browser — pure-browse, event-independent."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.registrar :as registrar]
+            [day8.re-frame2-causa.open-in-editor :as open-in-editor]
+            [day8.re-frame2-causa.theme.tokens
+             :as t
+             :refer [tokens type-scale mono-stack sans-stack]]))
+
+;; ---- pure helpers --------------------------------------------------------
+
+(defn project-rows
+  "Project the registrar's `:view` `{id meta}` map into row maps sorted
+  by id ascending. Each row carries `:id`, the source-coord trio
+  (`:file`/`:line`/`:ns`), and the doc-string."
+  [registrations-map]
+  (->> registrations-map
+       (map (fn [[id meta]]
+              {:id           id
+               :ns           (:ns meta)
+               :doc          (:doc meta)
+               :source-coord (select-keys meta [:file :line :ns])}))
+       (sort-by (fn [{:keys [id]}] (pr-str id)))
+       vec))
+
+(defn- row-haystack [{:keys [id ns doc source-coord]}]
+  (str/lower-case
+    (str (pr-str id) " "
+         (or ns "") " "
+         (or doc "") " "
+         (or (:file source-coord) ""))))
+
+(defn filter-rows
+  [rows query]
+  (let [q (some-> query str/trim)]
+    (if (or (nil? q) (= "" q))
+      rows
+      (let [needle (str/lower-case q)]
+        (filterv #(str/includes? (row-haystack %) needle) rows)))))
+
+(defn project-data
+  [registrations-map query]
+  (let [rows     (project-rows registrations-map)
+        silent?  (empty? rows)
+        filtered (filter-rows rows query)]
+    {:silent?   silent?
+     :views     filtered
+     :total     (count rows)
+     :filtered? (not= (count rows) (count filtered))
+     :query     query}))
+
+;; ---- header --------------------------------------------------------------
+
+(defn- header
+  []
+  [:div {:data-testid "rf-causa-static-views-header"
+         :style       {:padding       "12px 16px 8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:h1 {:style {:font-size      "13px"
+                 :margin         "0"
+                 :font-weight    600
+                 :text-transform "uppercase"
+                 :letter-spacing "0.5px"
+                 :color          (:text-primary tokens)
+                 :padding-left   "10px"
+                 :border-left    (str "3px solid " (:cyan tokens))}}
+    "Views"]
+   [:p {:style {:margin    "4px 0 0 10px"
+                :color     (:text-tertiary tokens)
+                :font-size "11px"
+                :line-height 1.4}}
+    "Browse every registered view. The catalogue is "
+    [:strong {:style {:color (:cyan tokens)}} "event-independent"]
+    " — every view that COULD render appears, not just those "
+    "currently mounted. Click the open chip to jump to source."]])
+
+;; ---- search box ----------------------------------------------------------
+
+(defn- search-box
+  [query total filtered?]
+  [:div {:data-testid "rf-causa-static-views-search"
+         :style       {:display       "flex"
+                       :align-items   "center"
+                       :gap           "8px"
+                       :padding       "8px 16px"
+                       :border-bottom (str "1px solid " (:border-subtle tokens))
+                       :font-family   sans-stack}}
+   [:label {:style {:color          (:text-tertiary tokens)
+                    :font-size      "10px"
+                    :text-transform "uppercase"
+                    :letter-spacing "0.5px"
+                    :min-width      "60px"}}
+    "Search"]
+   [:input {:type        "text"
+            :data-testid "rf-causa-static-views-search-input"
+            :placeholder "view-id, ns, file, or doc…"
+            :value       (or query "")
+            :on-change   (fn [e]
+                           (rf/dispatch [:rf.causa.static.views/set-query
+                                         (-> e .-target .-value)]
+                                        {:frame :rf/causa}))
+            :style       {:flex          1
+                          :background    (:bg-3 tokens)
+                          :color         (:text-primary tokens)
+                          :border        (str "1px solid " (:border-default tokens))
+                          :border-radius "3px"
+                          :padding       "4px 8px"
+                          :font-family   mono-stack
+                          :font-size     "12px"}}]
+   [:span {:data-testid "rf-causa-static-views-search-count"
+           :style       {:color       (:text-tertiary tokens)
+                         :font-family mono-stack
+                         :font-size   "11px"
+                         :min-width   "80px"
+                         :text-align  "right"}}
+    (cond
+      filtered?     "match"
+      (= 1 total)   "1 view"
+      :else         (str total " views"))]])
+
+;; ---- row -----------------------------------------------------------------
+
+(defn- view-row
+  [{:keys [id ns doc source-coord] :as _row}]
+  (let [id-text (pr-str id)
+        row-id  (subs id-text 1)]
+    [:li {:data-testid (str "rf-causa-static-views-row-" row-id)
+          :style       {:display       "block"
+                        :padding       "6px 12px"
+                        :font-family   mono-stack
+                        :font-size     "12px"
+                        :color         (:text-primary tokens)
+                        :background    "transparent"
+                        :border-left   "2px solid transparent"
+                        :border-radius "2px"
+                        :line-height   "18px"}}
+     [:div {:style {:display     "flex"
+                    :align-items "baseline"
+                    :gap         "8px"}}
+      [:span {:style {:color       (:accent-violet tokens)
+                      :font-weight 500
+                      :min-width   "260px"}}
+       id-text]
+      (when ns
+        [:span {:data-testid (str "rf-causa-static-views-ns-" row-id)
+                :style       {:color     (:text-tertiary tokens)
+                              :font-size "10px"}}
+         (str ns)])
+      (when (and source-coord (:file source-coord))
+        [open-in-editor/open-chip source-coord])]
+     (when doc
+       [:div {:style {:margin-left "12px"
+                      :margin-top  "2px"
+                      :color       (:text-secondary tokens)
+                      :font-family sans-stack
+                      :font-style  "italic"
+                      :font-size   "11px"}}
+        doc])]))
+
+;; ---- empty states --------------------------------------------------------
+
+(defn- empty-state
+  []
+  [:div {:data-testid "rf-causa-static-views-empty"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   "No views registered."])
+
+(defn- empty-filtered
+  [query]
+  [:div {:data-testid "rf-causa-static-views-empty-filtered"
+         :style       {:padding     "16px"
+                       :color       (:text-tertiary tokens)
+                       :font-family sans-stack
+                       :font-size   "11px"
+                       :font-style  "italic"}}
+   (str "No views match " (pr-str query) ".")])
+
+;; ---- root view -----------------------------------------------------------
+
+(rf/reg-view Panel
+  "Static Views panel root view. Subscribes to the registered-views
+  composite + the search-query slot and composes the header + search +
+  flat list.
+
+  Per rf2-in6l2 `reg-view`-registered so subscribes resolve to
+  `:rf/causa`."
+  []
+  (let [data @(rf/subscribe [:rf.causa.static.views/tab-data])
+        {:keys [silent? views total filtered? query]} data]
+    [:section {:data-testid "rf-causa-static-views"
+               :style       {:height         "100%"
+                             :display        "flex"
+                             :flex-direction "column"
+                             :background     (:bg-2 tokens)
+                             :color          (:text-primary tokens)
+                             :font-family    sans-stack
+                             :font-size      (:body type-scale)}}
+     (header)
+     (cond
+       silent?
+       (empty-state)
+
+       :else
+       [:<>
+        (search-box query total filtered?)
+        (if (empty? views)
+          (empty-filtered query)
+          (into [:ul {:data-testid "rf-causa-static-views-list"
+                      :style       {:list-style     "none"
+                                    :margin         "8px 0 0 0"
+                                    :padding        "0 8px"
+                                    :flex           1
+                                    :overflow       "auto"
+                                    :display        "flex"
+                                    :flex-direction "column"
+                                    :gap            "2px"}}]
+                (for [row views]
+                  ^{:key (pr-str (:id row))}
+                  [view-row row])))])]))
+
+;; ---- registrations -------------------------------------------------------
+
+(defn install!
+  "Idempotent install for the Static Views panel's subs + events.
+
+  Registers:
+
+    - `:rf.causa.static.views/query`             — search input slot.
+    - `:rf.causa.static.views/set-query`         — search input setter.
+    - `:rf.causa.static.views/registry-override` — test seam.
+    - `:rf.causa.static.views/set-registry-override-for-test`
+        — test seam setter.
+    - `:rf.causa.static.views/registry`          — production data sub
+                                                   reading the live
+                                                   `:view` registrations
+                                                   (or override).
+    - `:rf.causa.static.views/tab-data`          — view-facing composite."
+  []
+
+  ;; ---- UI state ---------------------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.views/set-query
+    (fn [db [_ q]]
+      (if (or (nil? q) (= "" q))
+        (dissoc db :rf.causa.static.views/query)
+        (assoc db :rf.causa.static.views/query q))))
+
+  (rf/reg-sub :rf.causa.static.views/query
+    (fn [db _]
+      (get db :rf.causa.static.views/query)))
+
+  ;; ---- test-only override ----------------------------------------------
+
+  (rf/reg-event-db :rf.causa.static.views/set-registry-override-for-test
+    (fn [db [_ ov]]
+      (if (nil? ov)
+        (dissoc db :rf.causa.static.views/registry-override)
+        (assoc db :rf.causa.static.views/registry-override ov))))
+
+  (rf/reg-sub :rf.causa.static.views/registry-override
+    (fn [db _]
+      (get db :rf.causa.static.views/registry-override)))
+
+  ;; ---- production data sub ---------------------------------------------
+
+  ;; Walks the registrar's `:view` slot once per re-fire. `:<-`-composes
+  ;; against the trace buffer so newly-registered views surface as soon
+  ;; as the trace-buffer fires its next reactive pulse.
+  (rf/reg-sub :rf.causa.static.views/registry
+    :<- [:rf.causa/trace-buffer]
+    :<- [:rf.causa.static.views/registry-override]
+    (fn [[_buffer override] _query]
+      (or override
+          (try (registrar/registrations :view)
+               (catch :default _ {})))))
+
+  ;; ---- view-facing composite -------------------------------------------
+
+  (rf/reg-sub :rf.causa.static.views/tab-data
+    :<- [:rf.causa.static.views/registry]
+    :<- [:rf.causa.static.views/query]
+    (fn [[registrations-map query] _query]
+      (project-data registrations-map query)))
+
+  nil)

--- a/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/registry_cljs_test.cljs
@@ -211,6 +211,26 @@
    ;; set + view-facing composite.
    :rf.causa.static.routes/sim-nav-open
    :rf.causa.static.routes/tab-data
+   ;; rf2-o5f5f.4 — Static Schemas sub-tab subs (browse-all over the
+   ;; app-db schemas storage + the registrar's `:event` / `:sub`
+   ;; `:spec` slots + view-facing composite + test seam).
+   :rf.causa.static.schemas/query
+   :rf.causa.static.schemas/registry
+   :rf.causa.static.schemas/registry-override
+   :rf.causa.static.schemas/tab-data
+   ;; rf2-o5f5f.5 — Static Views sub-tab subs (browse-all over the
+   ;; registrar's `:view` slot + view-facing composite + test seam).
+   :rf.causa.static.views/query
+   :rf.causa.static.views/registry
+   :rf.causa.static.views/registry-override
+   :rf.causa.static.views/tab-data
+   ;; rf2-uhsqb — Static Flows sub-tab subs (browse-all over the live
+   ;; `re-frame.flows.registry/flows` atom + view-facing composite +
+   ;; test seam).
+   :rf.causa.static.flows/query
+   :rf.causa.static.flows/registered-flows
+   :rf.causa.static.flows/registered-flows-override
+   :rf.causa.static.flows/tab-data
    :rf.causa/selected-dispatch-frame
    :rf.causa/selected-dispatch-id
    :rf.causa/selected-epoch-annotated-tree
@@ -463,6 +483,15 @@
    :rf.causa.static.routes/toggle-row
    :rf.causa.static.routes/toggle-sim-nav
    :rf.causa.static.routes/jump-to-runtime
+   ;; rf2-o5f5f.4 — Static Schemas sub-tab events.
+   :rf.causa.static.schemas/set-query
+   :rf.causa.static.schemas/set-registry-override-for-test
+   ;; rf2-o5f5f.5 — Static Views sub-tab events.
+   :rf.causa.static.views/set-query
+   :rf.causa.static.views/set-registry-override-for-test
+   ;; rf2-uhsqb — Static Flows sub-tab events.
+   :rf.causa.static.flows/set-query
+   :rf.causa.static.flows/set-registered-flows-override-for-test
    ;; rf2-om6fa — Story-aware modal positioning opt.
    :rf.causa/set-modal-positioning
    ;; rf2-x8h9y — resize-handle live update event.

--- a/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/flows/panel_cljs_test.cljs
@@ -1,0 +1,199 @@
+(ns day8.re-frame2-causa.static.flows.panel-cljs-test
+  "CLJS wiring + view tests for the Static Flows sub-tab (rf2-uhsqb).
+
+  ## Scope
+
+    1. **Registry wires the Static Flows subs + events** under
+       `:rf.causa.static.flows/*`.
+
+    2. **Pure projection** — `project-rows`, `filter-rows`,
+       `project-data` cover the flat-list + filter shape with no
+       runtime / DOM dependency.
+
+    3. **Silent state** — no flows registered → empty body.
+
+    4. **Flat-list rendering** — every registered flow surfaces as a
+       row.
+
+    5. **Search filter** — substring across flow-id + path + doc."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.flows.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- setup-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def sample-flows
+  {:rf/default
+   {:user/full-name
+    {:id     :user/full-name
+     :inputs [[:user :first] [:user :last]]
+     :output (fn [_] "")
+     :path   [:derived :full-name]
+     :doc    "concat first + last"}
+    :cart/total
+    {:id     :cart/total
+     :inputs [[:cart :items]]
+     :output (fn [_] 0)
+     :path   [:cart :total]
+     :doc    "sum of cart items"}}})
+
+;; -------------------------------------------------------------------------
+;; (1) pure helpers
+;; -------------------------------------------------------------------------
+
+(deftest project-rows-flattens-and-sorts
+  (testing "project-rows flattens {frame {id flow}} into a sorted row vec"
+    (let [rows (panel/project-rows sample-flows)]
+      (is (= 2 (count rows)) "two rows")
+      (is (= [:cart/total :user/full-name]
+             (mapv :flow-id rows))
+          "sorted by id ascending")
+      (is (every? #(= :rf/default (:frame %)) rows)
+          ":frame stamped on every row"))))
+
+(deftest project-rows-empty-snapshot
+  (is (= [] (panel/project-rows {}))
+      "empty snapshot → empty rows"))
+
+(deftest filter-rows-substring
+  (let [rows (panel/project-rows sample-flows)]
+    (testing "blank query returns rows verbatim"
+      (is (= rows (panel/filter-rows rows nil)))
+      (is (= rows (panel/filter-rows rows "")))
+      (is (= rows (panel/filter-rows rows "   "))))
+    (testing "case-insensitive substring across id"
+      (is (= 1 (count (panel/filter-rows rows "CART"))))
+      (is (= 1 (count (panel/filter-rows rows "user")))))
+    (testing "matches against doc"
+      (is (= 1 (count (panel/filter-rows rows "concat")))))
+    (testing "no match → empty"
+      (is (= 0 (count (panel/filter-rows rows "no-such-thing")))))))
+
+(deftest project-data-shape
+  (let [data (panel/project-data sample-flows nil)]
+    (testing "silent flag"
+      (is (false? (:silent? data)))
+      (is (true? (:silent? (panel/project-data {} nil)))))
+    (testing "totals + filter flags"
+      (is (= 2 (:total data)))
+      (is (false? (:filtered? data)))
+      (is (true? (:filtered? (panel/project-data sample-flows "cart")))))))
+
+;; -------------------------------------------------------------------------
+;; (2) registry wiring
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs
+  (testing "register-causa-handlers! installs the static-flows subs + events"
+    (setup-causa!)
+    (rf/with-frame :rf/causa
+      (is (nil? @(rf/subscribe [:rf.causa.static.flows/query]))
+          "query slot defaults nil"))))
+
+(deftest set-query-writes-the-slot
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa.static.flows/set-query "cart"])
+    (is (= "cart" @(rf/subscribe [:rf.causa.static.flows/query])))
+    (rf/dispatch-sync [:rf.causa.static.flows/set-query ""])
+    (is (nil? @(rf/subscribe [:rf.causa.static.flows/query]))
+        "blank string dissocs the slot")))
+
+(deftest registered-flows-override-feeds-the-composite
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.flows/set-registered-flows-override-for-test
+       sample-flows])
+    (let [data @(rf/subscribe [:rf.causa.static.flows/tab-data])]
+      (is (= 2 (:total data)) "override surfaces two flows")
+      (is (false? (:silent? data))))
+    (rf/dispatch-sync
+      [:rf.causa.static.flows/set-registered-flows-override-for-test nil])))
+
+;; -------------------------------------------------------------------------
+;; (3) view rendering
+;; -------------------------------------------------------------------------
+
+(deftest panel-renders-empty-state-when-silent
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.flows/set-registered-flows-override-for-test {}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-flows-empty"))
+          "empty-state surface mounts"))))
+
+(deftest panel-renders-rows-from-override
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.flows/set-registered-flows-override-for-test
+       sample-flows])
+    (let [tree (panel/Panel)
+          rows (find-all-by-testid-prefix tree "rf-causa-static-flows-row-")]
+      (is (= 2 (count rows)) "two row surfaces rendered")
+      (is (some? (find-by-testid tree "rf-causa-static-flows-search"))
+          "search box rendered"))))
+
+(deftest panel-renders-filtered-state
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.flows/set-registered-flows-override-for-test
+       sample-flows])
+    (rf/dispatch-sync [:rf.causa.static.flows/set-query "no-such-flow"])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-flows-empty-filtered"))
+          "empty-filtered surface mounts when query removes every row"))))

--- a/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/schemas/panel_cljs_test.cljs
@@ -1,0 +1,191 @@
+(ns day8.re-frame2-causa.static.schemas.panel-cljs-test
+  "CLJS wiring + view tests for the Static Schemas sub-tab
+  (rf2-o5f5f.4)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.schemas.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- setup-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def sample-registry
+  {:schemas-by-frame
+   {:rf/default
+    {[:user]
+     {:schema [:map [:id :int] [:name :string]]
+      :doc    "user shape"
+      :file   "src/user.cljs"
+      :line   12
+      :ns     'user}}}
+   :events
+   {:user/login
+    {:spec [:tuple :keyword :string]
+     :doc  "login event"
+     :file "src/user.cljs"
+     :line 42}
+    :no-spec/event
+    {:doc "no spec — should not surface"}}
+   :subs
+   {:user/full-name
+    {:spec :string
+     :doc  "full name sub"
+     :file "src/user.cljs"
+     :line 88}}})
+
+;; -------------------------------------------------------------------------
+;; (1) pure helpers
+;; -------------------------------------------------------------------------
+
+(deftest project-app-schema-rows-flattens
+  (let [rows (panel/project-app-schema-rows (:schemas-by-frame sample-registry))]
+    (is (= 1 (count rows)))
+    (let [{:keys [kind id frame schema source-coord]} (first rows)]
+      (is (= :app-db kind))
+      (is (= [:user] id))
+      (is (= :rf/default frame))
+      (is (= [:map [:id :int] [:name :string]] schema))
+      (is (= "src/user.cljs" (:file source-coord))))))
+
+(deftest project-registrar-rows-keeps-spec-only
+  (let [event-rows (panel/project-registrar-rows :event (:events sample-registry))]
+    (is (= 1 (count event-rows))
+        "entry without :spec is dropped"))
+  (let [sub-rows (panel/project-registrar-rows :sub (:subs sample-registry))]
+    (is (= 1 (count sub-rows)))
+    (is (= :sub (:kind (first sub-rows))))))
+
+(deftest project-rows-combines-and-sorts
+  (let [rows (panel/project-rows (:schemas-by-frame sample-registry)
+                                 (:events sample-registry)
+                                 (:subs   sample-registry))]
+    (is (= 3 (count rows))
+        "app-db + 1 event + 1 sub = 3 rows")))
+
+(deftest filter-rows-substring
+  (let [rows (panel/project-rows (:schemas-by-frame sample-registry)
+                                 (:events sample-registry)
+                                 (:subs   sample-registry))]
+    (is (= rows (panel/filter-rows rows nil)))
+    (is (= 1 (count (panel/filter-rows rows "login"))))
+    (is (= 0 (count (panel/filter-rows rows "nope"))))))
+
+(deftest project-data-shape
+  (let [data (panel/project-data (:schemas-by-frame sample-registry)
+                                 (:events sample-registry)
+                                 (:subs   sample-registry)
+                                 nil)]
+    (is (= 3 (:total data)))
+    (is (false? (:silent? data)))
+    (is (true? (:silent? (panel/project-data {} {} {} nil))))))
+
+;; -------------------------------------------------------------------------
+;; (2) registry wiring
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa.static.schemas/query]))
+        "query slot defaults nil")))
+
+(deftest set-query-writes-the-slot
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa.static.schemas/set-query "user"])
+    (is (= "user" @(rf/subscribe [:rf.causa.static.schemas/query])))))
+
+(deftest registry-override-feeds-the-composite
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.schemas/set-registry-override-for-test
+       sample-registry])
+    (let [data @(rf/subscribe [:rf.causa.static.schemas/tab-data])]
+      (is (= 3 (:total data)))
+      (is (false? (:silent? data))))))
+
+;; -------------------------------------------------------------------------
+;; (3) view rendering
+;; -------------------------------------------------------------------------
+
+(deftest panel-renders-empty-state-when-silent
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.schemas/set-registry-override-for-test
+       {:schemas-by-frame {} :events {} :subs {}}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-schemas-empty"))))))
+
+(deftest panel-renders-rows-from-override
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.schemas/set-registry-override-for-test
+       sample-registry])
+    (let [tree (panel/Panel)
+          rows (find-all-by-testid-prefix tree "rf-causa-static-schemas-row-")]
+      (is (= 3 (count rows)) "three row surfaces rendered"))))
+
+(deftest panel-renders-jump-to-source-chips
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.schemas/set-registry-override-for-test
+       sample-registry])
+    (let [tree (panel/Panel)
+          chips (find-all-by-testid-prefix tree "causa-open-in-editor")]
+      ;; Every fixture row carries a :file slot, so every row should
+      ;; have an open chip resolved through the editor config.
+      (is (pos? (count chips))
+          "at least one jump-to-source chip rendered"))))

--- a/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/shell_cljs_test.cljs
@@ -253,12 +253,13 @@
 ;; -------------------------------------------------------------------------
 
 (def ^:private expected-static-tab-ids
-  [:machines :routes :schemas :views :events])
+  ;; rf2-uhsqb added :flows as a 6th tab between :views and :events.
+  [:machines :routes :schemas :views :flows :events])
 
 (deftest static-tab-bar-renders-five-tabs
-  (testing "Static L3 tab bar renders 5 sub-tabs per parent-epic
-            rf2-o5f5f sub-bead list (Machines / Routes / Schemas /
-            Views / Events)"
+  (testing "Static L3 tab bar renders 6 sub-tabs per parent-epic
+            rf2-o5f5f sub-bead list + rf2-uhsqb Flows (Machines /
+            Routes / Schemas / Views / Flows / Events)"
     (causa-setup!)
     (rf/with-frame :rf/causa
       (let [tree (static-shell/surface)]
@@ -295,7 +296,10 @@
   off each time they land."
   ;; rf2-o5f5f.2 — :machines mounts the Static Machines panel.
   ;; rf2-o5f5f.3 — :routes   mounts the Static Routes panel.
-  #{:machines :routes})
+  ;; rf2-o5f5f.4 — :schemas  mounts the Static Schemas panel.
+  ;; rf2-o5f5f.5 — :views    mounts the Static Views panel.
+  ;; rf2-uhsqb   — :flows    mounts the Static Flows panel.
+  #{:machines :routes :schemas :views :flows})
 
 (deftest static-placeholder-cards-name-sibling-bead
   (testing "each placeholder card surfaces its sibling-bead id
@@ -490,13 +494,17 @@
 (deftest static-tab-inventory-shape
   (testing "tab inventory carries id/label/mnem/placeholder-bead and
             preserves canonical order"
-    (is (= [:machines :routes :schemas :views :events]
+    (is (= [:machines :routes :schemas :views :flows :events]
            (mapv :id static-shell/tabs))
-        "5 tabs in canonical order")
+        "6 tabs in canonical order (rf2-uhsqb added :flows)")
     (doseq [{:keys [id label mnem placeholder-bead]} static-shell/tabs]
       (is (keyword? id) (str "id is keyword for " id))
       (is (string? label) (str "label is a string for " id))
       (is (and (string? mnem) (= 1 (count mnem)))
           (str "mnem is one character for " id))
-      (is (re-matches #"rf2-o5f5f\.\d" placeholder-bead)
+      ;; Most sub-tabs are sibling beads under the rf2-o5f5f parent epic
+      ;; (rf2-o5f5f.2 / .3 / .4 / .5 / .6). The :flows tab landed under
+      ;; the standalone rf2-uhsqb bead per the parent-epic comment, so
+      ;; the regex accepts either shape.
+      (is (re-matches #"(rf2-o5f5f\.\d|rf2-[a-z0-9]+)" placeholder-bead)
           (str "placeholder-bead names a sibling bead for " id)))))

--- a/tools/causa/test/day8/re_frame2_causa/static/views/panel_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/static/views/panel_cljs_test.cljs
@@ -1,0 +1,160 @@
+(ns day8.re-frame2-causa.static.views.panel-cljs-test
+  "CLJS wiring + view tests for the Static Views sub-tab
+  (rf2-o5f5f.5)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.static.views.panel :as panel]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+;; ---- hiccup walker ------------------------------------------------------
+
+(declare expand-tree)
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+    (vector? tree) (mapv expand-tree tree)
+    (seq? tree)    (map expand-tree tree)
+    :else          tree))
+
+(defn- hiccup-seq [tree]
+  (tree-seq (some-fn vector? seq?) seq (expand-tree tree)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filterv (fn [node]
+             (and (vector? node)
+                  (map? (second node))
+                  (when-let [tid (:data-testid (second node))]
+                    (= 0 (.indexOf tid prefix)))))
+           (hiccup-seq tree)))
+
+(defn- setup-causa! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- fixture data -------------------------------------------------------
+
+(def sample-views
+  {:user/avatar
+   {:doc  "avatar component"
+    :file "src/user/avatar.cljs"
+    :line 12
+    :ns   'user.avatar}
+   :cart/checkout-button
+   {:doc  "checkout button"
+    :file "src/cart/checkout.cljs"
+    :line 88
+    :ns   'cart.checkout}
+   :route/link
+   {:doc nil :file nil :line nil}})
+
+;; -------------------------------------------------------------------------
+;; (1) pure helpers
+;; -------------------------------------------------------------------------
+
+(deftest project-rows-sorts-by-id
+  (let [rows (panel/project-rows sample-views)]
+    (is (= [:cart/checkout-button :route/link :user/avatar]
+           (mapv :id rows))
+        "sorted alphabetically by pr-str of id")))
+
+(deftest project-rows-keeps-doc-and-source-coord
+  (let [rows  (panel/project-rows sample-views)
+        avatar (some #(when (= :user/avatar (:id %)) %) rows)]
+    (is (= "avatar component" (:doc avatar)))
+    (is (= "src/user/avatar.cljs" (-> avatar :source-coord :file)))))
+
+(deftest filter-rows-substring
+  (let [rows (panel/project-rows sample-views)]
+    (is (= rows (panel/filter-rows rows nil)))
+    (is (= 1 (count (panel/filter-rows rows "avatar"))))
+    (is (= 1 (count (panel/filter-rows rows "checkout"))))
+    (is (= 0 (count (panel/filter-rows rows "nope"))))))
+
+(deftest project-data-shape
+  (let [data (panel/project-data sample-views nil)]
+    (is (= 3 (:total data)))
+    (is (false? (:silent? data)))
+    (is (true? (:silent? (panel/project-data {} nil))))))
+
+;; -------------------------------------------------------------------------
+;; (2) registry wiring
+;; -------------------------------------------------------------------------
+
+(deftest install-registers-subs
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (is (nil? @(rf/subscribe [:rf.causa.static.views/query]))
+        "query slot defaults nil")))
+
+(deftest set-query-writes-the-slot
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa.static.views/set-query "avatar"])
+    (is (= "avatar" @(rf/subscribe [:rf.causa.static.views/query])))))
+
+(deftest registry-override-feeds-the-composite
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.views/set-registry-override-for-test
+       sample-views])
+    (let [data @(rf/subscribe [:rf.causa.static.views/tab-data])]
+      (is (= 3 (:total data)))
+      (is (false? (:silent? data))))))
+
+;; -------------------------------------------------------------------------
+;; (3) view rendering
+;; -------------------------------------------------------------------------
+
+(deftest panel-renders-empty-state-when-silent
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.views/set-registry-override-for-test {}])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-views-empty"))))))
+
+(deftest panel-renders-rows-from-override
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.views/set-registry-override-for-test
+       sample-views])
+    (let [tree (panel/Panel)
+          rows (find-all-by-testid-prefix tree "rf-causa-static-views-row-")]
+      (is (= 3 (count rows)) "three row surfaces rendered"))))
+
+(deftest panel-renders-filtered-state-on-no-match
+  (setup-causa!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync
+      [:rf.causa.static.views/set-registry-override-for-test
+       sample-views])
+    (rf/dispatch-sync [:rf.causa.static.views/set-query "no-such-view"])
+    (let [tree (panel/Panel)]
+      (is (some? (find-by-testid tree "rf-causa-static-views-empty-filtered"))))))


### PR DESCRIPTION
## Summary
- Flows sub-tab (rf2-uhsqb) — browse-all over the per-frame flows registry; flat list with inputs / output-path / owning-frame; search across id + frame + paths + doc.
- Schemas sub-tab + jump-to-source (rf2-o5f5f.4) — browse-all over `schemas.storage/schemas-by-frame` + the registrar's `:event` / `:sub` \`:spec\` slots; source-coord chip dispatches `:rf.causa/open-in-editor`.
- Views sub-tab (rf2-o5f5f.5) — browse-all over the registrar's `:view` slot; pure-browse verb (event-INDEPENDENT, no Fiber-walker live mount tree here — the Runtime Views panel owns that lens). Distinct file from the runtime Views panel.

All per Lock #15 (two-verbs-two-homes: browse-all lives in Static). Static tab inventory grows from 5 → 6 tabs; the new \`:flows\` tab (mnemonic \`l\` per Static-findings §7.3) lands between \`:views\` and \`:events\`.

## Beads
rf2-uhsqb, rf2-o5f5f.4, rf2-o5f5f.5

## Acceptance
- test:cljs clean (3461 tests / 9872 assertions / 0 failures / 0 errors)
- mkdocs --strict clean (exit 0)

## Notes
- Each panel installs a test-only override seam (\`:rf.causa.static.<X>/set-registry-override-for-test\`) so the CLJS suite can drive deterministic fixtures without touching live atoms.
- \`tools/causa/deps.edn\` gains hard deps on \`day8/re-frame2-flows\` + \`day8/re-frame2-schemas\` (same posture as the existing \`re-frame2-routing\` dep — registry-empty surfaces still render gracefully for hosts that haven't registered any flows/schemas).
- \`017-Test-Coverage-Matrix.md\` was NOT edited per the dispatch instruction (W8 working there). Follow-on bead \`rf2-sou5c\` filed for the matrix rows.