### PR TITLE
fix(ssr): error-projector survives production hardening (rf2-fb598)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr.cljc
+++ b/implementation/ssr/src/re_frame/ssr.cljc
@@ -9,8 +9,9 @@
   Façade over eight flat sub-namespaces (`emit`, `hash`, `substrate`,
   `hydrate`, `response`, `error-projector`, `error-listener`,
   `request`). All `reg-fx` / `reg-cofx` / `reg-event-fx` /
-  `reg-error-projector` / `register-trace-cb!` side-effects fire HERE
-  so `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)`
+  `reg-error-projector` / `register-error-emit-listener!` /
+  `register-trace-cb!` side-effects fire HERE so
+  `(require 're-frame.ssr :reload)` after `(registrar/clear-all!)`
   re-installs every registration. Sub-namespaces export pure handler
   fns only.
 
@@ -36,6 +37,7 @@
   ssr/error-known-mapping, ssr/error-sanitisation, ssr/cookie,
   ssr/redirect, ssr/set-status, fx/platforms)."
   (:require [re-frame.cofx :as cofx]
+            [re-frame.error-emit :as error-emit]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
             [re-frame.late-bind :as late-bind]
@@ -263,6 +265,29 @@ Per Spec 011 §Server-only `reg-cofx` for request context."
                      {:doc "Built-in default projector. Spec 011 §Default projector mapping."}
                      default-error-projector-fn)
 
+;; rf2-fb598 — primary install site: the always-on error-emit substrate.
+;; Per Spec 011 §Server error projection / Spec 009 §What IS available in
+;; production §Error-emit listener, this listener survives
+;; `interop/debug-enabled? = false` (production hardening per rf2-vnjfg)
+;; so the SSR `:rf/public-error` projection contract holds even when the
+;; trace surface is gated off. Catches every `:rf.error/*` category that
+;; flows through `re-frame.error-emit/dispatch-on-error!` —
+;; `:rf.error/handler-exception` (router), `:rf.error/fx-handler-
+;; exception` family (fx), `:rf.error/flow-eval-exception` (flows).
+(error-emit/register-error-emit-listener! ::error-projection
+                                          error-listener/error-emit-projection-listener)
+
+;; rf2-fb598 — secondary install site: the dev-only trace surface,
+;; preserved for `:rf.error/*` categories that emit ONLY via
+;; `trace/emit-error!` (no always-on emission path): `:rf.error/no-such-
+;; handler`, `:rf.error/no-such-route`, `:rf.error/schema-validation-
+;; failure`, `:rf.error/sub-exception`, `:rf.error/drain-depth-exceeded`.
+;; These categories DCE under `interop/debug-enabled? = false`; the
+;; substrate-shipping projector relies on the dev gate for them. Both
+;; listeners share id `::error-projection` to keep the contract surface
+;; addressable as one logical projector — `apply-error-projection!`
+;; 1-arity is last-write-wins, so the duplicate buffer entry under dev
+;; is benign.
 (trace-tooling/register-trace-cb! ::error-projection
                                   error-listener/error-projection-listener)
 

--- a/implementation/ssr/src/re_frame/ssr/error_listener.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_listener.cljc
@@ -168,13 +168,80 @@
   frame in the per-frame pending-error-traces buffer. Buffering avoids
   the race where an in-flight handler's `{:db ...}` would clobber an
   inline :rf/response write. Registered in the `re-frame.ssr` façade
-  under `::error-projection`."
+  under `::error-projection`.
+
+  NOTE (rf2-fb598): the production-survivable install site is
+  `error-emit-projection-listener` (below) which rides the always-on
+  `register-error-emit-listener!` substrate. This trace-cb listener
+  is preserved for the dev-only `:rf.error/*` categories that fire
+  only through `trace/emit-error!` — `:rf.error/no-such-handler`,
+  `:rf.error/no-such-route`, `:rf.error/schema-validation-failure`,
+  `:rf.error/sub-exception`, `:rf.error/drain-depth-exceeded`. These
+  do not have an always-on emission path; they elide under
+  `interop/debug-enabled? = false` along with the trace surface they
+  ride. The 500-class errors (`:rf.error/handler-exception`,
+  `:rf.error/fx-handler-exception` family, `:rf.error/flow-eval-
+  exception`) DO have an always-on emission path and reach the
+  projector via `error-emit-projection-listener` regardless of the
+  dev/prod gate. In dev both listeners fire and buffer the same logical
+  error twice — apply-error-projection! 1-arity is last-write-wins and
+  the projector is idempotent, so the duplicate is benign."
   [event]
   (when (= :error (:op-type event))
     (let [op (:operation event)]
       ;; Skip our own sanitisation traces to avoid recursion.
       (when-not (= :rf.error/sanitised-on-projection op)
         (when-let [fid (candidate-frame-for-error event)]
+          (buffer-error-trace! fid event))))))
+
+(defn error-emit-projection-listener
+  "Always-on error-emit-substrate listener (per rf2-fb598 / audit Finding
+  #3) — captures `:rf.error/*` records delivered via
+  `register-error-emit-listener!` and buffers them onto the per-frame
+  pending-error-traces buffer in the same trace-event shape the
+  projector consumes.
+
+  The error-emit record arrives as the tight flat shape
+  `{:error :event :event-id :frame :time :exception :elapsed-ms
+    :source-coord}` (per `re-frame.error-emit/dispatch-on-error!`'s
+  contract). We synthesise the `{:operation :op-type :tags}` envelope
+  the existing projector pipeline expects — symmetric with the trace-cb
+  delivery — so the projector body is substrate-agnostic.
+
+  Registered in the `re-frame.ssr` façade under `::error-projection`.
+  Survives `interop/debug-enabled? = false` — Spec 011 §Server error
+  projection holds under production hardening (rf2-vnjfg)."
+  [record]
+  (let [op (:error record)]
+    ;; Symmetric with the trace-cb guard above — refuse our own
+    ;; sanitisation records to avoid recursion. (As of rf2-fb598
+    ;; `:rf.error/sanitised-on-projection` is not delivered through the
+    ;; error-emit substrate, but keep the guard so a future routing
+    ;; change can't reintroduce a re-entrant projection.)
+    (when-not (= :rf.error/sanitised-on-projection op)
+      (let [;; Frame may be on the flat record directly (`:frame`); fall
+            ;; back to the candidate-frame lookup used on the trace-cb
+            ;; path so a record missing `:frame` still routes to the
+            ;; single active server frame when one exists.
+            direct-fid (:frame record)
+            ;; Synthesise a trace-event-shaped envelope. The projector
+            ;; reads `(:operation event)`; we copy the relevant flat
+            ;; slots onto `:tags` so custom projectors using the tag
+            ;; shape (e.g. `(get-in event [:tags :exception])`) see the
+            ;; same keys they would on the trace path.
+            event {:operation op
+                   :op-type   :error
+                   :tags      {:frame             (:frame      record)
+                               :event-id          (:event-id   record)
+                               :event             (:event      record)
+                               :exception         (:exception  record)
+                               :elapsed-ms        (:elapsed-ms record)
+                               :time              (:time       record)
+                               :source-coord      (:source-coord record)
+                               :recovery          :no-recovery}}]
+        (when-let [fid (if (and direct-fid (error-projector/server-frame? direct-fid))
+                         direct-fid
+                         (candidate-frame-for-error event))]
           (buffer-error-trace! fid event))))))
 
 (defn peek-response

--- a/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj
@@ -1,0 +1,125 @@
+(ns re-frame.ssr-error-projector-substrate-test
+  "Per rf2-fb598: the SSR error-projection pipeline rides the always-on
+  `register-error-emit-listener!` substrate (per Spec 009 §What IS
+  available in production §Error-emit listener) — NOT the dev-only
+  `register-trace-cb!` surface.
+
+  Production-hardening (rf2-vnjfg — `-Dre-frame.debug=false` on the JVM)
+  silences `trace/emit-error!` so any listener installed on
+  `register-trace-cb!` stops firing under that posture. The SSR
+  error-projector is a production-required surface — Spec 011 §Server
+  error projection commits the runtime to stamping the public-error
+  `:status` onto `:rf/response` whenever an exception escapes a server-
+  frame drain — so the listener install MUST survive the JVM dev gate.
+
+  This suite pins that contract: under `with-redefs [interop/debug-
+  enabled? false]` (the same vocabulary jvm_prod_gate_integration_test
+  uses for the same posture), a server-frame handler that throws still
+  results in the projector stamping :status 500 onto :rf/response.
+
+  Companion suites:
+    - `re-frame.ssr-end-to-end-test` — the dev-mode end-to-end coverage
+      (debug-enabled? on; trace surface live).
+    - `re-frame.jvm-prod-gate-integration-test` — the JVM dev-gate
+      contract for the core trace / event-emit / error-emit surfaces.
+    - `re-frame.epoch.jvm-prod-gate-test` — the same posture for the
+      epoch artefact.
+
+  The shape mirrors `jvm_prod_gate_integration_test`'s `always-on-
+  error-emit-still-fires-when-debug-disabled` test: flip the gate,
+  drive a known-throwing handler through the cascade, observe the
+  always-on surface still works. This suite extends that contract one
+  step further — into the SSR-artefact's framework-internal use of the
+  same substrate."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(deftest ssr-error-projector-fires-under-production-hardening-rf2-fb598
+  (testing "Spec 011 §Server error projection holds when
+            `interop/debug-enabled? = false` — the always-on error-emit
+            substrate carries the projector install, not the dev-only
+            trace surface. A server-frame handler that throws still
+            stamps :status 500 onto :rf/response."
+    (rf/reg-event-fx :load/article
+      (fn [_ _]
+        (throw (ex-info "Database connection failed" {}))))
+    (rf/reg-event-fx :rf/server-init
+      (fn [_ _]
+        {:fx [[:dispatch [:load/article]]]}))
+
+    (with-redefs [interop/debug-enabled? false]
+      (let [f (rf/make-frame
+                {:platform  :server
+                 :on-create [:rf/server-init]
+                 :ssr       {:public-error-id   :rf.ssr/default-error-projector
+                             :dev-error-detail? false}})
+            response (ssr/get-response f)]
+        (is (= 500 (:status response))
+            "Spec 011 §Server error projection — the default projector
+             stamps :status 500 on :rf/response even with the dev trace
+             gate disabled (production-hardening posture per rf2-vnjfg).
+             Pre-rf2-fb598 the install was on register-trace-cb!, which
+             elides under this gate; rf2-fb598 moves the install onto
+             the always-on register-error-emit-listener! substrate.")))))
+
+(deftest ssr-error-projector-direct-substrate-install-rf2-fb598
+  (testing "The error-emit listener is registered under
+            `::re-frame.ssr.error-listener/error-projection` (the
+            framework-private id used by both substrate installs). A
+            tight error-record delivered through the substrate routes
+            to the SSR projector buffer and stamps the response."
+    (let [f (rf/make-frame
+              {:platform :server
+               :ssr      {:public-error-id   :rf.ssr/default-error-projector
+                          :dev-error-detail? false}})]
+      ;; Drive the substrate directly via `re-frame.error-emit/dispatch-
+      ;; on-error!` (the same surface `router.cljc` and `fx.cljc` use).
+      ;; This bypasses the cascade so the test isolates the listener-
+      ;; install plumbing — the round-trip through the dispatch loop is
+      ;; covered by the end-to-end suite above and ssr_end_to_end_test.
+      (let [dispatch-on-error!
+            (requiring-resolve 're-frame.error-emit/dispatch-on-error!)
+            ex (ex-info "boom" {})]
+        (with-redefs [interop/debug-enabled? false]
+          (dispatch-on-error!
+            :rf.error/handler-exception
+            [:boom]                            ;; event
+            :boom                              ;; event-id
+            f                                  ;; frame
+            ex                                 ;; exception
+            0                                  ;; elapsed-ms
+            (System/currentTimeMillis)         ;; time
+            {:operation :rf.error/handler-exception
+             :op-type   :error
+             :tags      {:frame f
+                         :event-id :boom
+                         :exception ex
+                         :recovery :no-recovery}})
+          (is (= 500 (:status (ssr/get-response f)))
+              "The framework's own error-emit listener
+               (`::error-projection`) routed the record to the buffer,
+               flush-response! drained it, and the default projector
+               stamped :status 500 on the response accumulator — all
+               under the disabled dev gate."))))))
+
+(deftest ssr-error-projector-listener-installed-on-error-emit-substrate-rf2-fb598
+  (testing "Direct registry-level smoke: the SSR façade installs
+            `::error-projection` on the error-emit substrate at ns-load.
+            Without this install the production-hardening case
+            regresses."
+    ;; Reach into the framework-private listeners atom; an idiomatic
+    ;; check of \"the substrate has the listener\" without depending on
+    ;; the public unregister surface.
+    (let [listeners-var (requiring-resolve 're-frame.error-emit/listeners)
+          registered    (some-> listeners-var deref deref keys set)]
+      (is (contains? registered :re-frame.ssr/error-projection)
+          "The SSR façade registers ::error-projection on the always-on
+           register-error-emit-listener! substrate at ns-load — Spec 011
+           §Server error projection (rf2-fb598). The id matches the one
+           the dev-only register-trace-cb! install also uses, so the
+           two surfaces are addressable as one logical projector."))))

--- a/spec/011-SSR.md
+++ b/spec/011-SSR.md
@@ -704,6 +704,14 @@ The HTML response **is** the public projection — error pages read the public s
 
 If the projector itself throws (or returns a non-conforming shape), the runtime emits `:rf.error/sanitised-on-projection` (per [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue)) and falls back to the locked generic-500 shape `{:status 500 :code :internal-error :message "Something went wrong" :retryable? false}`. The fallback ensures the boundary cannot be bypassed by a bug in the projector.
 
+#### Substrate — projector rides the always-on error-emit listener
+
+Per rf2-fb598 the SSR error-projection pipeline installs onto the **always-on `register-error-emit-listener!` substrate** (per [009 §What IS available in production §Error-emit listener](009-Instrumentation.md#what-is-available-in-production)) — NOT the dev-only `register-trace-cb!` surface. The error-emit substrate is documented as production-survivable; it fires under `:advanced` + `goog.DEBUG=false` builds and under the JVM `-Dre-frame.debug=false` production-hardening gate (per rf2-vnjfg). Server error projection is a production-required surface, not a dev-only one: SSR / webhook receivers / long-running JVMs facing untrusted input MUST set `re-frame.debug=false` per [009 §JVM builds](009-Instrumentation.md), and the projector's status-stamping contract must hold under that posture.
+
+The substrate boundary maps the always-on error-emit record (`{:error :event :event-id :frame :time :exception :elapsed-ms :source-coord}`) onto the projector's trace-event-shaped envelope (`{:operation :op-type :tags}`) before invoking the active projector. Custom projectors that case on `(:operation event)` or read `(get-in event [:tags :exception])` work unchanged across both substrates.
+
+Five `:rf.error/*` categories do NOT have an always-on emission path — they ride the dev-only `trace/emit-error!` and DCE under production hardening: `:rf.error/no-such-handler`, `:rf.error/no-such-route`, `:rf.error/schema-validation-failure`, `:rf.error/sub-exception`, `:rf.error/drain-depth-exceeded`. For dev parity these are also routed through the projector via a secondary `register-trace-cb!` install. Under production hardening these categories silently elide along with the trace surface — apps that need the 404/400 stamping in production deployments must explicitly route them through a `:rf.error/*` category that fires on the always-on substrate (typically by rethrowing inside the failing handler so the cascade lands on `:rf.error/handler-exception`).
+
 #### View-time exceptions
 
 A view that throws during `render-to-string` (e.g., a missing key on an attempted `(get-in db [...])`) flows through the **same projector**. The hiccup walker catches the exception, emits `:rf.error/sub-exception` (or `:rf.error/handler-exception` for view-fn exceptions), invokes the projector, and renders the error page. The user does not write a separate "view exception" path.
@@ -723,7 +731,7 @@ Implementations may key the dev/prod default off the build flag (e.g., `goog.DEB
 
 #### Internal trace events are not leaked
 
-The internal trace stream remains **unchanged** by projection. Monitoring listeners (`register-trace-cb!`) see the full structured trace event with `:exception-message`, `:exception-data`, stack traces, and any other detail the runtime captured. Projection only governs what crosses the **HTTP boundary**.
+The internal trace stream remains **unchanged** by projection. Monitoring listeners (`register-trace-cb!` — dev-only; `register-error-emit-listener!` — always-on; the latter is the production-survivable channel per [009 §What IS available in production](009-Instrumentation.md#what-is-available-in-production)) see the full structured error record with `:exception-message`, `:exception`, stack traces, and any other detail the runtime captured. Projection only governs what crosses the **HTTP boundary**.
 
 This separation is the operational benefit: monitoring stays rich; the wire stays clean.
 


### PR DESCRIPTION
## Summary
- SSR error-projection pipeline moved from register-trace-cb! (dev-only) to register-error-emit-listener! (always-on)
- Production hardening (interop/debug-enabled? = false) no longer disables Spec 011 §Server error projection contract
- Test asserts projector fires under hardened config
- Spec 011 updated to reference new substrate

## Bead
rf2-fb598 (P1)

## Source
ai/findings/2026-05-20-instrumentation-ssr-http-api-review.md Finding #3

## Acceptance
- test:cljs + clojure -M:test clean
- mkdocs --strict clean
- New regression test gates the production-hardening case