### PR TITLE
fix(a11y): focus-visible + keyboard-operable rows (rf2-fxde5 + rf2-k3y92 + rf2-6gstp)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -979,8 +979,65 @@
     ;; the row from the earlier 28px / "4px 8px" spec-baseline. Causa is
     ;; info-dense; keeps clickable hit-area while letting ~10 rows fit in
     ;; the same vertical budget the old 8 rows used.
+    ;;
+    ;; rf2-6gstp — keyboard a11y. Rows expose `role="button"` +
+    ;; `tab-index="0"` + `aria-label` so keyboard-only users can Tab
+    ;; into the list and operate it. Enter / Space activates the body
+    ;; (select cascade); Shift+F10 + ContextMenu key open the row's
+    ;; context menu (Mute / Hide event-type) — the same affordance
+    ;; right-click users get. The audit (2026-05-20) flagged this
+    ;; surface as P1 because the menu's actions had no keyboard path.
     [:li (cond-> {:data-testid (str "rf-causa-event-row-" (str id))
+                  :role        "button"
+                  :tab-index   "0"
+                  :aria-label  (cond
+                                 ungrouped?
+                                 ":ungrouped pseudo-cascade — events outside any dispatch"
+
+                                 ev-id
+                                 (str "Event " (str ev-id)
+                                      (when focused? " (focused)")
+                                      (when in-focus? " (in focus set)"))
+
+                                 :else
+                                 "Event row")
+                  :aria-pressed (if focused? "true" "false")
                   :on-click    body-click
+                  :on-key-down (fn [^js e]
+                                 ;; rf2-6gstp — keyboard activation +
+                                 ;; menu fallback. Enter / Space fires
+                                 ;; the body-click selection; Shift+F10
+                                 ;; (Windows / Linux platform standard)
+                                 ;; and the dedicated ContextMenu key
+                                 ;; open the row's context menu so the
+                                 ;; Mute / Hide affordances are reachable
+                                 ;; without right-click. The menu opens
+                                 ;; at the row's bounding-box top-left
+                                 ;; (the click-coords path has no
+                                 ;; equivalent for keyboard activation
+                                 ;; — anchoring on the row itself is
+                                 ;; the standard WAI-ARIA recipe).
+                                 (let [k       (.-key e)
+                                       shift?  (.-shiftKey e)
+                                       target  (.-currentTarget e)]
+                                   (cond
+                                     (or (= k "Enter") (= k " "))
+                                     (do (.preventDefault e)
+                                         (body-click e))
+
+                                     (or (= k "ContextMenu")
+                                         (and shift? (= k "F10")))
+                                     (when ev-id
+                                       (.preventDefault e)
+                                       (let [rect (when target (.getBoundingClientRect target))
+                                             x    (if rect (.-left rect) 0)
+                                             y    (if rect (.-bottom rect) 0)]
+                                         (rf/dispatch
+                                           [:rf.causa/open-row-context-menu
+                                            {:event-id ev-id
+                                             :x        x
+                                             :y        y}]
+                                           {:frame :rf/causa}))))))
                   :on-context-menu (fn [^js e]
                                      ;; rf2-ikuwt — open the row's
                                      ;; floating context menu at the

--- a/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/global_styles.cljs
@@ -443,6 +443,31 @@
     "@keyframes rf-causa-fade-in {\n"
     "  from { opacity: 0; transform: translateY(2px); }\n"
     "  to   { opacity: 1; transform: translateY(0); }\n"
+    "}\n"
+    ;; rf2-fxde5 — global `:focus-visible` focus ring. Causa-wide
+    ;; keyboard-only focus indicator scoped to descendants of the
+    ;; shell roots (`[data-testid="rf-causa-shell"]` for Runtime,
+    ;; `[data-testid="rf-causa-static-shell"]` for Static). Many
+    ;; interactive elements set `:border "none"` and rely on the
+    ;; UA outline, which is suppressed by various theme resets and
+    ;; reads weakly against the dark `#0E0F12` background. The
+    ;; palette input explicitly sets `outline: none` (palette/view
+    ;; line 107). Without this rule keyboard-only users have no
+    ;; reliable focus indicator anywhere in Causa.
+    ;;
+    ;; Token: `:yellow #FBBF24` from `theme/tokens.cljc` — the warm
+    ;; amber matches Causa's design language (sibling to Story's
+    ;; `#F5A524` amber focus ring at `theme/motion.cljc:173`). 2px
+    ;; outline + 2px offset is the documented high-contrast hit
+    ;; threshold. `:focus-visible` (rather than `:focus`) ensures
+    ;; the ring only paints for keyboard navigation, not mouse
+    ;; clicks — matches platform expectations.
+    "[data-testid=\"rf-causa-shell\"] *:focus-visible,\n"
+    "[data-testid=\"rf-causa-static-shell\"] *:focus-visible,\n"
+    "[data-testid=\"rf-causa-palette-backdrop\"] *:focus-visible {\n"
+    "  outline: 2px solid #FBBF24;\n"
+    "  outline-offset: 2px;\n"
+    "  border-radius: 3px;\n"
     "}\n"))
 
 (defn- inject-motion-style!

--- a/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/shell_cljs_test.cljs
@@ -969,6 +969,92 @@
         (is (= "200px" (:height style))
             "list container is ~8 rows × 22px + gaps + padding")))))
 
+;; -------------------------------------------------------------------------
+;; rf2-6gstp — L2 event-list rows are keyboard-operable buttons + menu
+;; -------------------------------------------------------------------------
+
+(deftest event-row-exposes-keyboard-button-semantics
+  (testing "rf2-6gstp — every L2 event-row exposes `role=\"button\"` +
+            `tab-index=\"0\"` + an `aria-label` so keyboard-only users
+            can Tab into the L2 list and operate it. Without these the
+            j/k chord covers next/prev focus but Tab-into-list / Enter-
+            to-select are absent — keyboard users can't drive L2 at
+            all. The audit (2026-05-20) flagged this as P1."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:cart/add-item]))
+    (rf/with-frame :rf/causa
+      (let [tree  (shell/shell-view)
+            row   (find-by-testid tree "rf-causa-event-row-1")
+            props (second row)]
+        (is (some? row) "row renders")
+        (is (= "button" (:role props))
+            "every event-row exposes role=button")
+        (is (= "0" (:tab-index props))
+            "every event-row exposes tabindex=0 so it joins the
+             sequential focus order")
+        (is (fn? (:on-key-down props))
+            "every event-row carries an on-key-down handler for
+             Enter / Space activation + Shift+F10 / ContextMenu
+             keyboard-menu fallback")
+        (is (string? (:aria-label props))
+            "every event-row carries an aria-label naming the row")
+        (is (re-find #":cart/add-item" (:aria-label props))
+            "the aria-label includes the event-id so screen-reader
+             users hear which event the row represents")))))
+
+(deftest event-row-keyboard-enter-fires-body-click
+  (testing "rf2-6gstp — Enter (and Space) on a focused row fire the
+            same selection path right-click + on-click do. The audit
+            (2026-05-20) flagged the absence of Enter-to-select as a P1
+            keyboard-a11y miss."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:cart/add-item]))
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree    (shell/shell-view)
+                row     (find-by-testid tree "rf-causa-event-row-1")
+                handler (:on-key-down (second row))
+                ;; Synthetic key event — preventDefault is a no-op stub
+                ;; so the test body just records the dispatch effect.
+                evt     #js {:key "Enter"
+                             :preventDefault (fn [])
+                             :currentTarget nil
+                             :shiftKey false}]
+            (is (some? handler))
+            (when handler (handler evt)))))
+      (is (some #(and (= :rf.causa/focus-cascade (first %))
+                      (= 1 (second %))) @dispatches)
+          "Enter on a row fires the same :rf.causa/focus-cascade
+           dispatch as the mouse click"))))
+
+(deftest event-row-keyboard-context-menu-fallback
+  (testing "rf2-6gstp — Shift+F10 (Windows / Linux platform standard)
+            and the dedicated ContextMenu key open the row's context
+            menu so the Mute / Hide affordances are reachable without
+            right-click. The audit flagged the absence of a keyboard
+            path to these actions as a P1 a11y miss."
+    (causa-setup!)
+    (trace-bus/collect-trace! (dispatch-trace-ev 1 [:cart/add-item]))
+    (let [dispatches (atom [])]
+      (with-redefs [rf/dispatch* (fn
+                                   ([ev]       (swap! dispatches conj ev) nil)
+                                   ([ev _opts] (swap! dispatches conj ev) nil))]
+        (rf/with-frame :rf/causa
+          (let [tree    (shell/shell-view)
+                row     (find-by-testid tree "rf-causa-event-row-1")
+                handler (:on-key-down (second row))
+                evt     #js {:key "F10"
+                             :preventDefault (fn [])
+                             :currentTarget nil
+                             :shiftKey true}]
+            (when handler (handler evt)))))
+      (is (some #(= :rf.causa/open-row-context-menu (first %)) @dispatches)
+          "Shift+F10 fires :rf.causa/open-row-context-menu — same
+           handler the right-click path uses"))))
+
 (deftest event-row-renders-event-id-only
   (testing "Round-3 rf2-cmtkw — the default L2 row body renders ONLY
             the bare event-id keyword. Args / payload are NOT inline

--- a/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/global_styles_cljs_test.cljs
@@ -147,6 +147,37 @@
           "the override value is a hair above zero — runs to completion
            in a single frame so the end state is reached immediately"))))
 
+;; ---- rf2-fxde5 — global :focus-visible ring ----------------------------
+
+(deftest motion-css-declares-focus-visible-ring
+  (testing "rf2-fxde5 — Causa ships a global `:focus-visible` focus ring
+            scoped to the shell roots so keyboard-only users get a
+            visible focus indicator. Many interactive elements set
+            `:border \"none\"` and the palette input explicitly sets
+            `outline: none` (palette/view line 107). Without this rule
+            keyboard-only users had no reliable focus indicator anywhere
+            in Causa. Sister-pattern to Story (`theme/motion.cljc:173`)."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"\[data-testid=\"rf-causa-shell\"\][^,]*:focus-visible" css)
+          "focus-visible rule scoped to the Runtime shell root")
+      (is (re-find #"\[data-testid=\"rf-causa-static-shell\"\][^,]*:focus-visible" css)
+          "focus-visible rule scoped to the Static shell root")
+      (is (re-find #"\[data-testid=\"rf-causa-palette-backdrop\"\][^,]*:focus-visible" css)
+          "focus-visible rule scoped to the palette backdrop (palette
+           mounts outside the shell roots so it needs its own scope)"))))
+
+(deftest motion-css-focus-visible-uses-warm-amber-token
+  (testing "rf2-fxde5 — the ring colour is `#FBBF24` (token
+            `:yellow` from `theme/tokens.cljc`) — warm amber matching
+            Causa's design language and Story's amber focus-ring
+            convention. 2px outline + 2px offset is the documented
+            high-contrast hit threshold."
+    (let [css @#'gs/motion-css]
+      (is (re-find #"outline:\s*2px\s+solid\s+#FBBF24" css)
+          "2px solid amber outline")
+      (is (re-find #"outline-offset:\s*2px" css)
+          "2px outline-offset so the ring doesn't graze the element"))))
+
 ;; ---- rf2-5kfxe.6 — light theme CSS variables ---------------------------
 
 (deftest themes-css-publishes-root-defaults

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -205,14 +205,22 @@
   so the user can see the slot is reserved.
 
   Public so the JVM + CLJS test corpus can render it directly without
-  walking a Reagent tree."
+  walking a Reagent tree.
+
+  rf2-k3y92 — uses `role=\"img\"` rather than `role=\"status\"`. The
+  status-dot is a static decoration painted alongside the row label,
+  not an out-of-band update channel. `role=\"status\"` adds an implicit
+  `aria-live=\"polite\"`, which means every mounted dot is announced
+  by assistive tech — with ~50–200 variant rows in a typical Story
+  registry the noise is real. `role=\"img\"` keeps the `aria-label`
+  exposed as the accessible name without the live-region behaviour."
   [status]
   (let [k     (status->dot-style-key status)
         label (dot-aria-label status)]
     [:span {:style       (merge (:dot styles) (k styles))
             :data-test   "story-sidebar-dot"
             :data-status (name (or status :pending))
-            :role        "status"
+            :role        "img"
             :aria-label  label
             :title       label}]))
 
@@ -257,22 +265,54 @@
             ^{:key (str "txt-" i)}
             [:span text]))))))
 
+;; rf2-k3y92 — Enter/Space activation for sidebar rows. The
+;; variant-row + workspace-row + story-block headers render as `<div>`
+;; with `on-click`; without a key handler keyboard-only users can't
+;; activate them even with `role="button"` + `tabindex="0"`. The
+;; pattern mirrors the WAI-ARIA "Button" practice: Enter activates,
+;; Space activates (and we `preventDefault` on Space so the page
+;; doesn't scroll). Returns a handler that wraps the click `(f)` form.
+(defn- on-row-key-down
+  "Build an `:on-key-down` handler that fires `f` for Enter or Space.
+  `f` is a 0-arity fn (the same shape as the row's `on-click` closure
+  but with the event ignored — call sites already discard it). The
+  Space key gets `preventDefault` so the page doesn't scroll."
+  [f]
+  (fn [^js evt]
+    (let [k (.-key evt)]
+      (cond
+        (= k "Enter") (do (.preventDefault evt) (f))
+        (= k " ")     (do (.preventDefault evt) (f))))))
+
 (defn- variant-row
   [variant-id selected? testable? status tags query]
+  (let [activate (fn []
+                   ;; rf2-hscut — symmetric escape from workspace mode.
+                   ;; Selecting a variant clears any previously-selected
+                   ;; workspace so the canvas's ws-id short-circuit
+                   ;; (`shell.cljs` `main-pane`) yields to the variant
+                   ;; branch. Mirror of the workspace-row click below,
+                   ;; which clears `:selected-variant`.
+                   (state/swap-state!
+                     (fn [s] (-> s
+                                 (state/select-variant variant-id)
+                                 (state/select-workspace nil)))))]
   [:div {:style       (merge (:variant-row styles)
                              (when selected? (:variant-row-active styles)))
          :data-test   "story-sidebar-variant-row"
          :data-variant (str variant-id)
-         ;; rf2-hscut — symmetric escape from workspace mode. Selecting a
-         ;; variant clears any previously-selected workspace so the
-         ;; canvas's ws-id short-circuit (`shell.cljs` `main-pane`) yields
-         ;; to the variant branch. Mirror of the workspace-row click
-         ;; below, which clears `:selected-variant`.
-         :on-click    (fn [_]
-                        (state/swap-state!
-                          (fn [s] (-> s
-                                      (state/select-variant variant-id)
-                                      (state/select-workspace nil)))))}
+         ;; rf2-k3y92 — sidebar rows are clickable `<div>`s; expose them
+         ;; as keyboard-operable buttons (role + tabindex + Enter/Space
+         ;; key handler) so keyboard-only users can navigate into and
+         ;; activate them. The visual treatment stays unchanged (the
+         ;; focus ring is the global Story `:focus-visible` 2px amber
+         ;; outline scoped to `[data-rf-story-root]`).
+         :role         "button"
+         :tab-index    "0"
+         :aria-pressed (if selected? "true" "false")
+         :aria-label   (str "Open variant " (name variant-id))
+         :on-key-down  (on-row-key-down activate)
+         :on-click     (fn [_] (activate))}
    ;; rf2-p0wur — per-row glyph affordance. Testable variants keep the
    ;; status dot (it carries pass/fail/running colour); non-testable
    ;; variants get a refined variant glyph so every row carries an
@@ -284,7 +324,7 @@
    ;; rf2-yngai — wrap label so matched substrings render with the
    ;; amber-tint highlight when a search query is in flight.
    (into [:span] (highlighted-label (str "/" (name variant-id)) query))
-   [tag-badges tags]])
+   [tag-badges tags]]))
 
 (defn- story-block
   "Render one story header + its variants. `entry` shape is
@@ -310,18 +350,27 @@
 
 (defn- workspace-row
   [workspace-id selected?]
+  (let [activate (fn []
+                   (state/swap-state!
+                     (fn [s] (-> s
+                                 (state/select-workspace workspace-id)
+                                 (state/select-variant nil)))))]
   [:div {:style    (merge (:workspace-row styles)
                           (when selected? (:workspace-row-active styles)))
          :data-test   "story-sidebar-workspace-row"
          :data-workspace (str workspace-id)
-         :on-click (fn [_]
-                     (state/swap-state!
-                       (fn [s] (-> s
-                                   (state/select-workspace workspace-id)
-                                   (state/select-variant nil)))))}
+         ;; rf2-k3y92 — keyboard-operable button semantics. See
+         ;; `variant-row` for the parallel role/tabindex/key-handler
+         ;; pattern.
+         :role         "button"
+         :tab-index    "0"
+         :aria-pressed (if selected? "true" "false")
+         :aria-label   (str "Open workspace " (name workspace-id))
+         :on-key-down  (on-row-key-down activate)
+         :on-click     (fn [_] (activate))}
    [:span {:style (:workspace-glyph styles)}
     [glyphs/workspace-glyph 12]]
-   [:span (str workspace-id)]])
+   [:span (str workspace-id)]]))
 
 ;; ---- chrome-level test widget (rf2-q0irb) -------------------------------
 

--- a/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/panels_e2e/sidebar_glyphs_e2e_cljs_test.cljs
@@ -247,3 +247,60 @@
                                  (zero? (get roles :variant 0)))))
                         workspace-rows)
                 "no story- or variant-role glyph leaks into a workspace row")))))))
+
+;; ---- rf2-k3y92 — sidebar rows are keyboard-operable buttons -------------
+
+(deftest variant-rows-expose-keyboard-button-semantics
+  (testing "rf2-k3y92 — variant rows render as clickable `<div>`s; they
+            must expose `role=\"button\"` + `tabindex=\"0\"` + a key
+            handler so keyboard-only users can navigate into and
+            activate them. Without these, the sidebar's `<nav>` landmark
+            is reachable but rows inside it aren't — keyboard users
+            can't select a variant from the sidebar at all."
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (with-redefs [glyphs/story-glyph     story-glyph-stub
+                      glyphs/variant-glyph   variant-glyph-stub
+                      glyphs/workspace-glyph workspace-glyph-stub]
+          (let [tree (render-sidebar-tree)
+                rows (variant-row-nodes tree)]
+            (is (<= 2 (count rows)))
+            (is (every? (fn [row] (= "button" (get (second row) :role)))
+                        rows)
+                "every variant row exposes role=button")
+            (is (every? (fn [row] (= "0" (get (second row) :tab-index)))
+                        rows)
+                "every variant row exposes tabindex=0 so it joins the
+                 sequential focus order")
+            (is (every? (fn [row] (fn? (get (second row) :on-key-down)))
+                        rows)
+                "every variant row carries an on-key-down handler so
+                 Enter / Space can activate it")
+            (is (every? (fn [row]
+                          (let [aria (get (second row) :aria-label)]
+                            (and (string? aria)
+                                 (re-find #"Open variant" aria))))
+                        rows)
+                "every variant row carries an aria-label describing the
+                 action — \"Open variant <id>\"")))))))
+
+(deftest workspace-rows-expose-keyboard-button-semantics
+  (testing "rf2-k3y92 — workspace rows mirror variant rows: clickable
+            `<div>`s that must expose `role=\"button\"` + `tabindex=\"0\"`
+            + a key handler. Without these the workspace section of the
+            sidebar is unreachable from the keyboard."
+    (e2e/with-story-and-causa-frames
+      {:register-stories register-variants!}
+      (fn []
+        (with-redefs [glyphs/story-glyph     story-glyph-stub
+                      glyphs/variant-glyph   variant-glyph-stub
+                      glyphs/workspace-glyph workspace-glyph-stub]
+          (let [tree (render-sidebar-tree)
+                rows (workspace-row-nodes tree)]
+            (is (= 1 (count rows)))
+            (let [props (second (first rows))]
+              (is (= "button" (:role props)))
+              (is (= "0"      (:tab-index props)))
+              (is (fn? (:on-key-down props)))
+              (is (re-find #"Open workspace" (:aria-label props))))))))))

--- a/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/ui/test_widget_cljs_test.cljc
@@ -258,6 +258,26 @@
          ;; aria-label round-trips for screen-reader users.
          (is (= "tests failing" (get (second dot-fail) :aria-label)))))))
 
+;; ---- rf2-k3y92 — status-dot is decorative img (not a live region) -------
+
+#?(:cljs
+   (deftest sidebar-dot-uses-img-role-not-status
+     (testing "rf2-k3y92 — the status-dot is a static decoration painted
+               alongside the row label, not an out-of-band update channel.
+               `role=\"status\"` adds an implicit `aria-live=\"polite\"`
+               which made every mounted dot a live region — with ~50–200
+               variant rows in a typical registry the AT noise was real.
+               `role=\"img\"` keeps the `aria-label` exposed as the
+               accessible name without the live-region announcement."
+       (let [dot-fail (sidebar/status-dot :fail)
+             dot-pass (sidebar/status-dot :pass)]
+         (is (= "img" (get (second dot-fail) :role))
+             "status-dot is exposed as an img with a label")
+         (is (= "img" (get (second dot-pass) :role))
+             "every status produces the same img role")
+         (is (not= "status" (get (second dot-fail) :role))
+             "must NOT use role=status (live-region noise)")))))
+
 #?(:cljs
    (deftest widget-run-all-button-disabled-while-running
      (testing "if any variant is :running the Run all button disables"


### PR DESCRIPTION
## Summary
- Causa: :focus-visible stylesheet injected via chrome (rf2-fxde5 P1 — keyboard-only users now have focus indicator)
- Story: sidebar rows keyboard-operable + status-dot ARIA (rf2-k3y92 P1)
- Causa: L2 event-list rows keyboard-operable + menu fallback (rf2-6gstp P1)

## Beads
rf2-fxde5, rf2-k3y92, rf2-6gstp (all P1)

## Source
ai/findings/2026-05-20-causa-story-a11y-audit.md

## Acceptance
- test:cljs clean
- mkdocs --strict clean