### PR TITLE
fix(machines-viz): render guards + actions on edges (rf2-jeim7 critical)

### DIFF
--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
@@ -224,20 +224,17 @@
                      :width  default-node-width
                      :height default-node-height
                      :labels [{:text (:label n)}]})
-         mk-edge  (fn [edge-idx {:keys [from to event] :as e}]
+         mk-edge  (fn [edge-idx {:keys [from to] :as e}]
                     {:id      (str "e" edge-idx "-"
                                    (layout/node-id from) "-"
                                    (layout/node-id to))
                      :sources [(layout/node-id from)]
                      :targets [(layout/node-id to)]
-                     :labels  [{:text (cond
-                                        (:after e)    (str "after(" (:after e) ")")
-                                        (:always? e)  "always"
-                                        (keyword? event)
-                                        (if-let [ns (namespace event)]
-                                          (str ns "/" (name event))
-                                          (name event))
-                                        :else (str event))}]})]
+                     ;; ELK gets the full xstate label so its label-
+                     ;; placement heuristic can reserve enough width
+                     ;; for `event [guard] / action` (longer strings
+                     ;; need wider lanes).
+                     :labels  [{:text (layout/edge-label e)}]})]
      {:id            "root"
       :layoutOptions {"elk.algorithm"                              "layered"
                       "elk.direction"                              dir-str
@@ -251,17 +248,12 @@
 ;; ---- ELK output → chart-layout shape (pure) ----------------------------
 
 (defn- edge-event-label
-  "Build the human-readable event-label string for an edge — same shape
-  the layered fallback produces (so the SVG renderer reads either
-  identically)."
-  [{:keys [event after always?]}]
-  (cond
-    after            (str "after(" after ")")
-    always?          "always"
-    (keyword? event) (if-let [ns (namespace event)]
-                       (str ns "/" (name event))
-                       (name event))
-    :else            (str event)))
+  "Build the human-readable edge label string per the xstate-stately
+  convention: `event [guard] / action`. Delegates to
+  `layout/edge-label` so the layered + ELK paths emit identical
+  labels — the SVG renderer reads either identically."
+  [edge]
+  (layout/edge-label edge))
 
 (defn elk-result->chart-layout
   "Adapter: parsed-definition + ELK layout result map → the same

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/layout.cljc
@@ -26,6 +26,9 @@
        :edges      [{:from <id> :to <id>
                      :label <str>     ;; event id
                      :guard <kw-or-nil>
+                     :action <kw-or-nil>
+                     :event-label <str> ;; xstate convention:
+                                        ;; \"event [guard] / action\"
                      :points [[x y] [x y]]} ...]
        :width      <int>            ;; viewport width
        :height     <int>            ;; viewport height
@@ -314,6 +317,63 @@
   [positioned-nodes]
   (into {} (map (fn [n] [(:path n) n])) positioned-nodes))
 
+(defn- name-of
+  "Render a guard/action symbol-like value as a short string. Keywords
+  use `ns/name` when namespaced, plain `name` otherwise. Non-keywords
+  fall through to `str`."
+  [v]
+  (cond
+    (nil? v)     nil
+    (keyword? v) (if-let [n (namespace v)]
+                   (str n "/" (name v))
+                   (name v))
+    :else        (str v)))
+
+(defn event-segment
+  "Render the leading event segment of an edge label per the
+  xstate-stately convention.
+
+    - regular event keyword → `\"event-id\"` (with namespace when present)
+    - `:after` transition   → `\"after(<delay>)\"`
+    - `:always` transition  → `\"always\"`
+
+  Public so the ELK adapter (and tests) can use the same builder."
+  [{:keys [event after always?]}]
+  (cond
+    after            (str "after(" after ")")
+    always?          "always"
+    (keyword? event) (if-let [n (namespace event)]
+                       (str n "/" (name event))
+                       (name event))
+    :else            (str event)))
+
+(defn edge-label
+  "Compose an xstate-stately-convention edge label from an edge map.
+
+  Shape: `\"event [guard] / action\"`. Brackets and slash are
+  introduced ONLY when their segment is present, so the four legal
+  forms render cleanly:
+
+  | Segments              | Rendered                     |
+  |-----------------------|------------------------------|
+  | event                 | `event`                      |
+  | event + guard         | `event [guard]`              |
+  | event + action        | `event / action`             |
+  | event + guard + action| `event [guard] / action`     |
+
+  `:after` and `:always` substitute for the event segment using the
+  same bracket/slash rules.
+
+  Pure data → string. Public — the ELK adapter and renderer both call
+  this so the layered + ELK paths emit identical labels."
+  [{:keys [guard action] :as edge}]
+  (let [evt   (event-segment edge)
+        g-str (name-of guard)
+        a-str (name-of action)]
+    (cond-> evt
+      g-str (str " [" g-str "]")
+      a-str (str " / " a-str))))
+
 (defn- route-edge
   "Straight-line routing: source-bottom-centre → target-top-centre.
   Self-loops emit a small arc-control flag for the renderer."
@@ -336,14 +396,7 @@
                       [(+ src-x 70) (- tgt-y 30)]
                       [tgt-x tgt-y]]
                      [[src-x src-y] [tgt-x tgt-y]])
-          :event-label (let [e (:event edge)]
-                         (cond
-                           (:after edge)    (str "after(" (:after edge) ")")
-                           (:always? edge)  "always"
-                           (keyword? e)     (if-let [n (namespace e)]
-                                              (str n "/" (name e))
-                                              (name e))
-                           :else            (str e))))))))
+          :event-label (edge-label edge))))))
 
 ;; ---- public entry -------------------------------------------------------
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
@@ -484,7 +484,7 @@
       [(quot (+ x1 x2) 2) (- (quot (+ y1 y2) 2) 6)])))
 
 (defn- render-edge
-  [{:keys [event-label points guard from-id to-id]
+  [{:keys [event-label points guard action from-id to-id]
     :as _edge}
    {:keys [highlight-id from-highlight-id to-highlight-id]}]
   (let [active?         (or (= from-id highlight-id)
@@ -501,10 +501,11 @@
                   "url(#rf-causa-chart-arrow-highlight)"
                   "url(#rf-causa-chart-arrow)")
         [lx ly] (edge-label-position points)
-        full-label (if guard
-                     (str event-label " [" (if (keyword? guard)
-                                             (name guard) (str guard)) "]")
-                     event-label)
+        ;; rf2-jeim7 — `:event-label` is now the full xstate label
+        ;; `event [guard] / action` built upstream by `layout/edge-label`
+        ;; (both layered + ELK paths). Render it as-is; no per-segment
+        ;; re-stitching here.
+        full-label event-label
         ;; rf2-xfx6l — focused edge glows for one beat on event-fire.
         ;; The animation is `infinite` here so a re-render driven by
         ;; a re-fire restarts the cycle (focused-edge? is per-render
@@ -518,6 +519,10 @@
         base-w (if emphasised? highlight-stroke-width stroke-width)]
     [:g {:data-testid (str "rf-causa-chart-edge-" from-id "-to-" to-id)
          :data-event event-label
+         :data-guard (when guard
+                       (if (keyword? guard) (name guard) (str guard)))
+         :data-action (when action
+                        (if (keyword? action) (name action) (str action)))
          :data-active (str active?)
          :data-focused-edge (str focused-edge?)}
      [:path (cond-> {:d (path-from-points points)

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
@@ -106,6 +106,47 @@
     (is (contains? labels "ok"))
     (is (contains? labels "err"))))
 
+(deftest ->elk-graph-edge-labels-include-guard-and-action
+  (testing "rf2-jeim7 — ELK gets the full xstate label so its label-
+            placement heuristic reserves the right lane width"
+    (let [m  {:initial :idle
+              :states  {:idle    {:on {:submit {:target :loading
+                                                :guard  :authed?
+                                                :action :log-it}
+                                       :reset  {:target :idle
+                                                :action :clear-form}}}
+                        :loading {}}}
+          g  (elk-layout/->elk-graph m :tb)
+          labels (set (mapcat (fn [e] (map :text (:labels e))) (:edges g)))]
+      (is (contains? labels "submit [authed?] / log-it"))
+      (is (contains? labels "reset / clear-form")))))
+
+(deftest elk-result->chart-layout-emits-full-xstate-label
+  (testing "rf2-jeim7 — the ELK adapter's chart-layout output carries
+            the full `event [guard] / action` label on every edge so
+            the SVG renderer consumes the same shape as the layered
+            engine"
+    (let [m  {:initial :idle
+              :states  {:idle    {:on {:submit {:target :loading
+                                                :guard  :authed?
+                                                :action :log-it}}}
+                        :loading {}}}
+          id-idle    (layout/node-id [:idle])
+          id-loading (layout/node-id [:loading])
+          elk-result {:id "root"
+                      :children [{:id id-idle    :x 0 :y 0   :width 140 :height 48}
+                                 {:id id-loading :x 0 :y 100 :width 140 :height 48}]
+                      :edges    [{:id (str "e0-" id-idle "-" id-loading)
+                                  :sources [id-idle]
+                                  :targets [id-loading]
+                                  :sections [{:startPoint {:x 70 :y 48}
+                                              :endPoint   {:x 70 :y 100}}]}]
+                      :width 200
+                      :height 200}
+          chart  (elk-layout/elk-result->chart-layout m elk-result)
+          edge   (first (:edges chart))]
+      (is (= "submit [authed?] / log-it" (:event-label edge))))))
+
 ;; ---- elk-result->chart-layout (pure) -----------------------------------
 
 (deftest elk-result->chart-layout-uses-positions-from-elk

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -173,3 +173,67 @@
 (deftest node-id-distinct-for-distinct-paths
   (is (not= (layout/node-id [:authenticated])
             (layout/node-id [:authenticated :browsing]))))
+
+;; ---- edge-label (rf2-jeim7) xstate-stately convention ------------------
+;;
+;; Shape: `event [guard] / action`. Brackets + slash appear ONLY when
+;; their segment is present, per xstate-stately. Public so the layered
+;; engine + ELK adapter emit identical labels.
+
+(deftest edge-label-event-only
+  (is (= "submit"
+         (layout/edge-label {:event :submit}))))
+
+(deftest edge-label-event-with-guard
+  (is (= "submit [authed?]"
+         (layout/edge-label {:event :submit :guard :authed?}))))
+
+(deftest edge-label-event-with-action
+  (is (= "submit / log-it"
+         (layout/edge-label {:event :submit :action :log-it}))))
+
+(deftest edge-label-event-with-guard-and-action
+  (is (= "submit [authed?] / log-it"
+         (layout/edge-label {:event :submit
+                             :guard :authed?
+                             :action :log-it}))))
+
+(deftest edge-label-after-with-guard-and-action
+  (is (= "after(1500) [timeout?] / cleanup"
+         (layout/edge-label {:event  :after-1500
+                             :after  1500
+                             :guard  :timeout?
+                             :action :cleanup}))))
+
+(deftest edge-label-always-with-guard
+  (is (= "always [ready?]"
+         (layout/edge-label {:event   :always
+                             :always? true
+                             :guard   :ready?}))))
+
+(deftest edge-label-namespaced-event-with-guard
+  (is (= "auth/submit [authed?] / log-it"
+         (layout/edge-label {:event  :auth/submit
+                             :guard  :authed?
+                             :action :log-it}))))
+
+(deftest edge-label-namespaced-guard-renders-ns
+  (testing "guards may be namespaced; the label preserves the namespace"
+    (is (= "submit [auth/authed?]"
+           (layout/edge-label {:event :submit
+                               :guard :auth/authed?})))))
+
+(deftest layout-edges-carry-event-label-with-guard-and-action
+  (testing "layout/layout emits the full xstate label on every edge"
+    (let [m {:initial :idle
+             :states  {:idle {:on {:submit [{:target :loading
+                                             :guard  :authed?
+                                             :action :log-it}
+                                            {:target :failed
+                                             :guard  :anon?}]}}
+                       :loading {}
+                       :failed  {}}}
+          {:keys [edges]} (layout/layout m)
+          labels (set (map :event-label edges))]
+      (is (contains? labels "submit [authed?] / log-it"))
+      (is (contains? labels "submit [anon?]")))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
@@ -539,3 +539,85 @@
       (is (some? title))
       (is (= tokens/sans-stack (:font-family (second title)))
           "compound title uses sans-stack"))))
+
+;; ---- rf2-jeim7 — guards + actions render on edge labels (xstate) -------
+;;
+;; Critical contract per machines-viz spec/API.md + Principles.md:
+;; "Hover an edge for its guard + action functions." Layout walks
+;; guards/actions into edge records; the renderer must paint them.
+;; Convention: `event [guard] / action`.
+
+(def guards-actions-machine
+  "A machine exercising all four edge-label segment combinations
+  plus an :after transition with both guard + action."
+  {:initial :idle
+   :states  {:idle    {:on    {:submit [{:target :loading
+                                         :guard  :authed?
+                                         :action :log-it}
+                                        {:target :failed
+                                         :guard  :anon?}]
+                               :reset  {:target :idle
+                                        :action :clear-form}}
+                       :after {1500 {:target :loading
+                                     :guard  :timeout?
+                                     :action :cleanup}}}
+             :loading {:on {:ok :success}}
+             :success {:final? true}
+             :failed  {:final? true}}})
+
+(defn- edge-label-text
+  "Walk an edge `<g>` and return the rendered label `<text>` body
+  string (the last child of the `:text` form)."
+  [edge-g]
+  (let [text-node (some (fn [n] (and (vector? n)
+                                     (= :text (first n))
+                                     n))
+                        (hiccup-seq edge-g))]
+    (when text-node (last text-node))))
+
+(deftest edge-label-renders-event-with-guard-and-action
+  (testing "rf2-jeim7 — an edge with both guard + action renders the
+            full xstate label `event [guard] / action`"
+    (let [tree   (chart-svg/render-from-definition guards-actions-machine)
+          edges  (find-all-by-testid-prefix tree "rf-causa-chart-edge-")
+          labels (set (keep edge-label-text edges))]
+      (is (contains? labels "submit [authed?] / log-it")
+          "event + guard + action segment shape")
+      (is (contains? labels "submit [anon?]")
+          "event + guard segment shape")
+      (is (contains? labels "reset / clear-form")
+          "event + action segment shape")
+      (is (contains? labels "after(1500) [timeout?] / cleanup")
+          "after + guard + action segment shape")
+      (is (contains? labels "ok")
+          "event-only segment shape"))))
+
+(deftest edge-data-attrs-surface-guard-and-action
+  (testing "rf2-jeim7 — `data-guard` + `data-action` surface on the edge
+            `<g>` so host tests + future click-handlers can target them"
+    (let [tree   (chart-svg/render-from-definition guards-actions-machine)
+          edges  (find-all-by-testid-prefix tree "rf-causa-chart-edge-")
+          attrs  (map (fn [e] (select-keys (second e)
+                                           [:data-event :data-guard :data-action]))
+                      edges)]
+      (is (some (fn [a] (and (= "authed?" (:data-guard a))
+                             (= "log-it"  (:data-action a))))
+                attrs)
+          "guard+action edge carries both data-attrs")
+      (is (some (fn [a] (and (= "anon?" (:data-guard a))
+                             (nil? (:data-action a))))
+                attrs)
+          "guard-only edge surfaces nil :data-action"))))
+
+(deftest edge-label-event-only-omits-brackets-and-slash
+  (testing "rf2-jeim7 — an event-only edge renders as just the event id;
+            no stray brackets or slash leak in"
+    (let [tree   (chart-svg/render-from-definition small-machine)
+          edges  (find-all-by-testid-prefix tree "rf-causa-chart-edge-")
+          labels (keep edge-label-text edges)]
+      (is (seq labels))
+      (doseq [l labels]
+        (is (not (str/includes? l "["))
+            (str "no `[` in event-only label: " l))
+        (is (not (str/includes? l "/"))
+            (str "no `/` in event-only label: " l))))))


### PR DESCRIPTION
## Summary
- Edge labels now render `event [guard] / action` per xstate convention
- Was: only event-id / after(N) / always
- Layered fallback path aligned with ELK path (shared `layout/edge-label` helper)
- `data-guard` + `data-action` now surface on each edge `<g>` for host wiring
- 13 new tests cover all 4 segment combinations + `:after` + `:always` + namespaced ids

## Bead
rf2-jeim7 (P1 critical from rf2-tbcjz audit)

## Source
ai/findings/2026-05-20-tools-machines-viz-api-review.md Finding #3

## Acceptance
- test:cljs clean (3496 tests, 0 failures)
- mkdocs --strict clean