### PR TITLE
fix(template): pin drift + lockstep + spec sweep (rf2-8v20r P0 + rf2-0kcsu + rf2-22lre)

### DIFF
--- a/tools/template/spec/000-Vision.md
+++ b/tools/template/spec/000-Vision.md
@@ -83,12 +83,23 @@ and recognises the shape. That continuity is deliberate.
   choices materially exceed clj-new's substitution capability
   ([DESIGN-RATIONALE](DESIGN-RATIONALE.md) §clj-new vs CLI).
 
-  **Exception (rf2-t009p):** branching flags are permitted when
-  they enable an *optional shared scaffolding* whose absence would
-  force the user into hand-wiring known idioms — currently
-  `:include-story?` (emits a `counter_with_stories`-shaped story
-  scaffold alongside the live app). Each such flag is justified
-  in DESIGN-RATIONALE alongside the no-other-branching default.
+  **Locked v1 exceptions:** branching flags are permitted when
+  they enable an *optional shared scaffolding* whose absence
+  would force the user into hand-wiring known idioms. The v1
+  set is locked at **three** flags total
+  ([003-DepsNew-Rebuild-Plan.md §5](003-DepsNew-Rebuild-Plan.md)):
+
+  - `:include-story?` (rf2-t009p, shipped today) — emits a
+    `counter_with_stories`-shaped story scaffold alongside the
+    live app. Reagent-only in v1.
+  - `:css :tailwind` (rf2-gthro, deferred until gating bead
+    flips) — Tailwind v4 in place of the default plain-CSS
+    `app.css`.
+  - `:include-ssr?` (rf2-0m5ea, deferred until gating bead
+    flips) — SSR scaffolding per Spec 011.
+
+  Resist further proliferation — every additional flag requires
+  explicit DESIGN-RATIONALE justification.
 - **Bundling Story by default.** [`tools/story/`](../../story/)
   is the Storybook-class playground for re-frame2; the template
   does **not** pre-wire it on the default path. The opt-in

--- a/tools/template/spec/002-Generated-Shape.md
+++ b/tools/template/spec/002-Generated-Shape.md
@@ -37,9 +37,12 @@ my-app/
                               experiments against the running app
 ```
 
-`shadow-cljs.edn` ships `:source-paths ["src" "test"]` so the `:test`
-build (`:target :node-test`, `:ns-regexp "-test$"`) picks the file
-up out of the box.
+`shadow-cljs.edn` ships `:source-paths ["src" "test" "dev"]` so the
+`:test` build (`:target :node-test`, `:ns-regexp "-test$"`) picks
+the emitted test file up out of the box, and `dev/scratch.cljs` +
+`dev/user.clj` (the Q8 dev-ergonomics lock — REPL scratch ns and
+`(user/refresh)` entry) are reachable from `clojure -M:shadow` and
+shadow's nREPL without further classpath plumbing.
 
 The UIx and Helix variants follow the same shape; only `core.cljs`,
 `views.cljs`, `deps.edn`, and the substrate-adapter coord change.

--- a/tools/template/spec/003-DepsNew-Rebuild-Plan.md
+++ b/tools/template/spec/003-DepsNew-Rebuild-Plan.md
@@ -232,9 +232,20 @@ Suggested commit decomposition:
 - `tools/template/spec/API.md` — rewrite the §Invocation surface.
 - `tools/template/spec/001-Substrate-Variants.md` — drop the
   `:edn-args` plumbing language.
+- `tools/template/spec/000-Vision.md` §Non-goals — reconcile
+  the locked-flags enumeration with the post-rebuild invocation
+  form (already enumerates the three flags as of rf2-22lre;
+  drop any residual `:edn-args` language).
+- `tools/template/spec/Principles.md` §P4 — rewrite from
+  "Substrate selection via `:edn-args`" to "Substrate selection
+  via top-level k/v". The axis-name and rationale survive; the
+  plumbing language changes.
 - `tools/template/spec/DESIGN-RATIONALE.md` §1 — flip the clj-new vs
   deps-new decision; archive §2 (`:edn-args`-not-top-level) as a
   retired rationale.
+- `tools/template/spec/DESIGN-RATIONALE.md` §5 — update the
+  `:include-story?` invocation example from
+  `:edn-args '[:include-story? true]'` to top-level k/v.
 
 ## §4 Stage 4 — Docs + migration for existing template users
 
@@ -283,7 +294,7 @@ The locks below are inherited from the template walkthrough (Mike,
 | SSR opt-in: `:include-ssr?` | Q7 lock; gated on rf2-0m5ea | `template-fn` branch on `:include-ssr?` |
 | Story opt-in: `:include-story?` | Q3/Q4 era | `template-fn` branch on `:include-story?` |
 | Causa preload (always-on) | Q9 lock | `_shared/shadow-cljs.edn` :preloads |
-| Skill install stub: `install-skills.sh` | Q9 lean A | `_shared/install-skills.sh` placeholder + README mention |
+| Skill install stub: `install-skills.sh` | Q9 lean A | Deferred — README mention only today (`_shared/README.md` §Future: skill install); placeholder script lands when the Claude Code skill marketplace publishes. |
 | Layout: `src/` + `test/` + `dev/scratch.cljs` + `dev/user.clj` | Q8 lock | Unconditional under `_shared/` |
 
 Three flags total (`:include-story?`, `:css`, `:include-ssr?`). Resist

--- a/tools/template/src/clj/new/re_frame2.clj
+++ b/tools/template/src/clj/new/re_frame2.clj
@@ -162,7 +162,7 @@
                             ;; the smoke-tested combination is what users
                             ;; get.
                             :shadow-version    "3.4.10"
-                            :react-version     "18.3.1"})
+                            :react-version     "19.2.0"})
         ;; Each renderer is scoped to its sub-tree, so the per-substrate
         ;; views.cljs / deps.edn / shadow-cljs.edn / package.json live
         ;; under .../re-frame2/<substrate>/ and substrate-agnostic files

--- a/tools/template/test/clj/new/version_lockstep_test.clj
+++ b/tools/template/test/clj/new/version_lockstep_test.clj
@@ -1,0 +1,194 @@
+(ns clj.new.version-lockstep-test
+  "Pin-lockstep guard for the template's inline version literals
+  (rf2-0kcsu).
+
+  Principle P5 (tools/template/spec/Principles.md) declares that the
+  template's three pin literals — `:rf2-version`, `:shadow-version`,
+  `:react-version` — are bumped in lockstep with their external sources
+  of truth:
+
+    - `:rf2-version`    ↔ repo-root `VERSION`
+    - `:shadow-version` ↔ `implementation/package.json` :devDependencies/shadow-cljs
+    - `:react-version`  ↔ `implementation/package.json` :devDependencies/react (and react-dom)
+
+  History (rf2-8v20r): the template literal `:react-version` drifted to
+  `18.3.1` while `implementation/package.json` had moved to `19.2.0`.
+  Doctrine was right; the literal silently drifted with no automated
+  check. This test reads both sources of truth on disk and asserts the
+  entry-fn literals match, so the next bump can't drift silently.
+
+  The test runs free (JVM, no shadow), under the standard
+  `clojure -M:test` invocation."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clj.new.re-frame2 :as rft]
+            [clj.new.templates :as tmpl]))
+
+;; --- Repo-root discovery (same pattern as template_emission_test) -------
+
+(defn- repo-root
+  "Absolute path of the repo root. The template test JVM is launched
+  from `tools/template/` (clein default), but a manual `clojure -X:test`
+  may launch from the repo root — walk up from `user.dir` until we find
+  a sibling `implementation/package.json`."
+  []
+  (let [cwd (io/file (System/getProperty "user.dir"))]
+    (loop [d cwd]
+      (cond
+        (nil? d)
+        (throw (ex-info "Couldn't locate repo root (no implementation/package.json above cwd)"
+                        {:cwd cwd}))
+
+        (.isFile (io/file d "implementation/package.json"))
+        d
+
+        :else
+        (recur (.getParentFile d))))))
+
+;; --- Source-of-truth readers --------------------------------------------
+
+(defn- read-version-file
+  "Read repo-root `VERSION` and return its trimmed contents (e.g.
+  `\"0.0.1.alpha\"`). Throws if missing."
+  []
+  (let [f (io/file (repo-root) "VERSION")]
+    (when-not (.isFile f)
+      (throw (ex-info "VERSION file missing at repo root" {:file (.getPath f)})))
+    (string/trim (slurp f))))
+
+(defn- read-package-json-pin
+  "Read a pin from `implementation/package.json`. `section` is one of
+  `:devDependencies` / `:dependencies`; `pkg` is the package name string
+  (e.g. `\"react\"`). Returns the pin string (e.g. `\"19.2.0\"`).
+
+  We deliberately use a simple regex parse rather than dragging in a
+  JSON library — the template test artefact has no JSON dep today, and
+  the package.json shape is stable enough that a regex (looking for
+  `\"pkg\": \"value\"` inside the section) reads simply and fails loudly
+  on shape drift."
+  [section pkg]
+  (let [text (slurp (io/file (repo-root) "implementation/package.json"))
+        ;; Find the section (`"devDependencies": { ... }`). The closing
+        ;; brace ends at the first top-level `}` after the section name.
+        section-name (case section
+                       :devDependencies "devDependencies"
+                       :dependencies    "dependencies"
+                       (throw (ex-info "Unknown section" {:section section})))
+        section-re   (re-pattern (str "\"" section-name "\":\\s*\\{([^}]*)\\}"))
+        section-body (some-> (re-find section-re text) second)
+        _            (when-not section-body
+                       (throw (ex-info (str "Couldn't find :" section-name " section in implementation/package.json")
+                                       {:section section-name})))
+        pin-re       (re-pattern (str "\"" pkg "\":\\s*\"([^\"]+)\""))
+        pin          (some-> (re-find pin-re section-body) second)]
+    (when-not pin
+      (throw (ex-info (str "Couldn't find pin for " pkg " in :" section-name)
+                      {:pkg pkg :section section-name})))
+    pin))
+
+;; --- Template literal extraction ----------------------------------------
+;;
+;; The entry fn assembles the substitution data map inside the
+;; `(let [data ...])` binding. The three pin literals are static — they
+;; don't depend on caller args — so we can recover them by emitting a
+;; tmp app and reading the substituted package.json + deps.edn. This
+;; tests the literals as actually-consumed (the same value that flows
+;; into a generated app), not the source string parsed out of the .clj.
+
+(defn- tmp-dir [prefix]
+  (let [f (java.nio.file.Files/createTempDirectory
+            prefix
+            (into-array java.nio.file.attribute.FileAttribute []))]
+    (.toAbsolutePath f)))
+
+(defn- delete-recursively [^java.nio.file.Path path]
+  (when (java.nio.file.Files/exists path (into-array java.nio.file.LinkOption []))
+    (with-open [stream (java.nio.file.Files/walk
+                         path
+                         (into-array java.nio.file.FileVisitOption []))]
+      (->> stream
+           .iterator
+           iterator-seq
+           reverse
+           (run! #(java.nio.file.Files/deleteIfExists ^java.nio.file.Path %))))))
+
+(defn- emit-reagent! [tmp]
+  (let [dir-str  (.toString ^java.nio.file.Path tmp)
+        proj-dir (.getPath (io/file dir-str (tmpl/project-name "acme/my-app")))]
+    (binding [tmpl/*dir* proj-dir]
+      (rft/re-frame2 "acme/my-app" :substrate :reagent))
+    (io/file proj-dir)))
+
+(defn- extract-pin
+  "Pull `\"pkg\": \"value\"` out of the emitted package.json text."
+  [pj-text pkg]
+  (let [pin-re (re-pattern (str "\"" pkg "\":\\s*\"([^\"]+)\""))]
+    (some-> (re-find pin-re pj-text) second)))
+
+(defn- extract-rf2-version
+  "Pull `'day8/re-frame2 {:mvn/version \"...\"}` out of the emitted
+  deps.edn text."
+  [deps-text]
+  (let [m (re-find #"day8/re-frame2\s+\{:mvn/version\s+\"([^\"]+)\"\}" deps-text)]
+    (some-> m second)))
+
+;; --- The lockstep tests -------------------------------------------------
+
+(deftest react-version-lockstep
+  (testing "Template's :react-version literal matches implementation/package.json"
+    (let [pkg-react     (read-package-json-pin :devDependencies "react")
+          pkg-react-dom (read-package-json-pin :devDependencies "react-dom")
+          tmp           (tmp-dir "rf2-template-lockstep-react-")]
+      (try
+        (let [root      (emit-reagent! tmp)
+              pj-text   (slurp (io/file root "package.json"))
+              tpl-react     (extract-pin pj-text "react")
+              tpl-react-dom (extract-pin pj-text "react-dom")]
+          ;; impl tree must keep react / react-dom in lockstep with
+          ;; each other; if they ever diverge, the rationale should
+          ;; be in DESIGN-RATIONALE and this test updates accordingly.
+          (is (= pkg-react pkg-react-dom)
+              "implementation/package.json pins react and react-dom to the same version")
+          (is (= pkg-react tpl-react)
+              (str "Template :react-version (" tpl-react ") must match "
+                   "implementation/package.json :react (" pkg-react ") — "
+                   "P5 lockstep. Bump :react-version in "
+                   "tools/template/src/clj/new/re_frame2.clj."))
+          (is (= pkg-react-dom tpl-react-dom)
+              (str "Template react-dom pin (" tpl-react-dom ") must match "
+                   "implementation/package.json :react-dom (" pkg-react-dom ")")))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest shadow-version-lockstep
+  (testing "Template's :shadow-version literal matches implementation/package.json"
+    (let [pkg-shadow (read-package-json-pin :devDependencies "shadow-cljs")
+          tmp        (tmp-dir "rf2-template-lockstep-shadow-")]
+      (try
+        (let [root       (emit-reagent! tmp)
+              pj-text    (slurp (io/file root "package.json"))
+              tpl-shadow (extract-pin pj-text "shadow-cljs")]
+          (is (= pkg-shadow tpl-shadow)
+              (str "Template :shadow-version (" tpl-shadow ") must match "
+                   "implementation/package.json :shadow-cljs (" pkg-shadow ") — "
+                   "P5 lockstep. Bump :shadow-version in "
+                   "tools/template/src/clj/new/re_frame2.clj.")))
+        (finally
+          (delete-recursively tmp))))))
+
+(deftest rf2-version-lockstep
+  (testing "Template's :rf2-version literal matches repo-root VERSION"
+    (let [version-file (read-version-file)
+          tmp          (tmp-dir "rf2-template-lockstep-rf2-")]
+      (try
+        (let [root        (emit-reagent! tmp)
+              deps-text   (slurp (io/file root "deps.edn"))
+              tpl-rf2     (extract-rf2-version deps-text)]
+          (is (= version-file tpl-rf2)
+              (str "Template :rf2-version (" tpl-rf2 ") must match "
+                   "repo-root VERSION (" version-file ") — P5 lockstep. "
+                   "Bump :rf2-version in "
+                   "tools/template/src/clj/new/re_frame2.clj.")))
+        (finally
+          (delete-recursively tmp))))))


### PR DESCRIPTION
## Summary
- React pin in template literal aligned with implementation/package.json (rf2-8v20r P0)
- New JVM lockstep guard prevents version-pin drift regressions (rf2-0kcsu)
- 4 spec doc reconciliations: :source-paths emit shape, install-skills.sh stub, branching-exception count, doc-sweep coverage (rf2-22lre)

## Beads
rf2-8v20r (P0), rf2-0kcsu (P1), rf2-22lre (P1)

## Source
ai/findings/2026-05-20-tools-template-api-review.md

## Acceptance
- clojure -M:test (template artefact) clean
- npm run test:cljs clean
- mkdocs --strict clean