### PR TITLE
feat(machines-viz): drop pulse + visual ergonomics lift (rf2-2sez0 + rf2-gg7ws)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -144,8 +144,10 @@ exist so that coupling never lands.
   from `(rf/machine-meta machine-id)` plus the user's expand/collapse
   state. This plane is **structural**: changing it requires re-laying
   out the graph.
-- **Runtime-highlight plane.** The active-state pulse, transition
-  edge glow, microstep flash, `:after` countdown ring progress,
+- **Runtime-highlight plane.** The active-state affordance (static
+  tint + bolder stroke; pulse retired 2026-05-20 per rf2-2sez0),
+  transition edge glow, microstep flash, `:after` countdown ring
+  progress,
   `:invoke-all` row state, spawn-tray contents, timer state, and
   every other per-trace decoration. Derived from `[:rf/machines <id>]`
   plus the `:rf.machine/*` trace bus. This plane is **decorative**:
@@ -164,8 +166,9 @@ by any `:rf.machine/*` trace event MUST mutate **only**:
 - DOM attributes (`class`, `style.opacity`, `style.transform` on
   decoration layers, SVG `stroke-dasharray` / `stroke-dashoffset`,
   ARIA labels).
-- CSS-driven animations (the heartbeat pulse, the transition glow,
-  the microstep flash, the `prefers-reduced-motion` step animation).
+- CSS-driven animations (the transition glow, the microstep flash,
+  the `prefers-reduced-motion` step animation). The heartbeat pulse
+  was retired 2026-05-20 (rf2-2sez0).
 
 Live updates MUST NOT:
 
@@ -222,9 +225,12 @@ Lock #11.
 
 ### One chart-level, visibility-gated animation clock
 
-`:after` countdown rings, the active-state heartbeat pulse, and any
-other continuous animation in the chart MUST be driven by a
-**single, per-chart-instance animation clock**.
+`:after` countdown rings and any continuous animation in the chart
+MUST be driven by a **single, per-chart-instance animation clock**.
+(The active-state heartbeat pulse was retired 2026-05-20 per
+rf2-2sez0; only the `:after` countdown rings remain on the clock.
+The transition glow is event-driven and resolves to a stable end-
+state, so it does not consume the clock.)
 
 - The clock is **one** `requestAnimationFrame` loop (or equivalent)
   per `MachineChart` instance. It MUST NOT be one loop per ring,
@@ -233,14 +239,13 @@ other continuous animation in the chart MUST be driven by a
   becomes visible (per `IntersectionObserver` and/or
   `document.visibilityState`) and MUST stop when the chart leaves
   the viewport or the document is hidden.
-- The clock drives ring fills and pulse phase by reading the
-  framework's authoritative timer state on each tick; it does not
-  own the timer. The framework's clock keeps running regardless of
-  the chart's visibility (per Lock #8); the chart's clock is purely
+- The clock drives ring fills by reading the framework's
+  authoritative timer state on each tick; it does not own the
+  timer. The framework's clock keeps running regardless of the
+  chart's visibility (per Lock #8); the chart's clock is purely
   presentational.
-- A chart with no scheduled `:after` timers and no active state to
-  pulse MUST stop its clock entirely until the next snapshot or
-  trace tick wakes it.
+- A chart with no scheduled `:after` timers MUST stop its clock
+  entirely until the next snapshot or trace tick wakes it.
 
 Implementations MUST NOT create `setInterval`, `setTimeout`, or
 `requestAnimationFrame` registrations per-node, per-ring, or

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -355,7 +355,8 @@ with `:state` only).**
 ### Why
 
 - **Visual continuity holds** — the recipient sees which state the
-  sharer was in; the pulse / highlight needs the state name only.
+  sharer was in; the static active-state affordance needs the
+  state name only.
   The chart's data display is operator-side chrome (Causa's
   inspector panel), not a `MachineChart` affordance.
 - **Privacy is structural, not prose** — the encoder cannot emit
@@ -680,10 +681,11 @@ from regressing into a full graph recompute?
   nesting, the chart's measured viewbox. Owned by
   `(rf/machine-meta machine-id)` + the user's expand/collapse state +
   the `:show-*` props that affect topology presence.
-- **Runtime-highlight plane** — pulse, edge glow, microstep flash,
-  `:after` ring progress, `:invoke-all` row state, spawn-tray
-  contents, timer state. Owned by `[:rf/machines <id>]` + the
-  `:rf.machine/*` trace bus.
+- **Runtime-highlight plane** — static active-state affordance
+  (tint + bolder stroke; the pulse was retired 2026-05-20 per
+  rf2-2sez0), edge glow, microstep flash, `:after` ring progress,
+  `:invoke-all` row state, spawn-tray contents, timer state. Owned
+  by `[:rf/machines <id>]` + the `:rf.machine/*` trace bus.
 
 The runtime-highlight plane MUST NOT participate in any computation
 whose output reaches the topology plane. The two planes share no

--- a/tools/machines-viz/spec/Principles.md
+++ b/tools/machines-viz/spec/Principles.md
@@ -200,26 +200,66 @@ If a host needs to drive the runtime from a chart click (Causa's
 "jump to source", say), the host wires that through its own
 machinery — Machines-Viz fires the callback and stops there.
 
-## Charts pulse only the active state
+## No continuous animation — static affordance + event-driven glints
 
-The only continuous animation in a chart is the active state's
-1.2s heartbeat pulse (lifted from Causa 007-UX-IA §Animation —
-only the active machine's node pulses). Everything else is
-event-driven:
+Charts have **no continuous animation**. The active state is
+signalled **statically**: a cyan tint on the node fill plus a
+bolder stroke than its inactive siblings. The reader's eye lands
+on the current state at-rest, without a heartbeat loop pulling
+attention every two seconds.
 
-- Transition: one ~250ms edge-glow on the matching event.
+This is a deliberate change from the previous lock (rf2-2sez0,
+2026-05-20). The earlier "Charts pulse only the active state"
+principle locked a 1.2s heartbeat pulse as the sole continuous
+animation; Mike rejected it on inspection — the pulse competed
+with the transition-glow for attention, became "look at me I'm
+running" decoration after the chart had been on screen for >5s,
+and diverged from xstate-stately (the
+[`000-Vision.md`](./000-Vision.md) named floor), which uses no
+active-state pulse. The static affordance carries the same
+"currently here" signal without the cost.
+
+Every other animation in the chart is **event-driven** — fires
+once on a discrete event, resolves to a stable end-state, no
+looping:
+
+- Transition: one ~400ms edge-glow on the matching event (the
+  focused edge between FROM-highlight + TO-highlight).
 - Microstep: one 150ms intermediate node flash.
 - `:after` countdown: a fill ring that updates at 60Hz **only**
   when the chart is visible; backgrounded charts pause the fill.
+  This is a *fill-progressing* surface, not a looping animation —
+  the ring drains once per timer and then sits at its end-state.
 - `:invoke-all` join completes: one ~400ms row-collapse animation.
 
-No looping animations except the heartbeat. No "look at me I'm
-running" continuous strobes. Every animation respects
+No looping animations, full stop. No "look at me I'm running"
+continuous strobes. Every animation respects
 `prefers-reduced-motion`; reduced motion clamps durations to 0
 except a 1-frame opacity tween where layout needs to settle.
 
 This is the framework's animation-communicates-not-decorates
 principle, applied to charts.
+
+### How the static active-state affordance is implemented
+
+The chart's `render-node` paints the active state with two
+non-animated emphases:
+
+1. **Cyan fill tint** — via `node-fill` returning the
+   `:cyan @ 0.18` tint when `:highlight?` is true.
+2. **Bolder stroke** — the active node's stroke-width is
+   `:stroke-width-emphasis + 0.75px`; an inactive sibling sits at
+   the baseline `:stroke-width`. The visible delta (~1.75px) reads
+   as "this node is emphasised" without the eye having to track a
+   loop.
+
+Both are static — they shift when the highlight shifts, but they
+do not animate while the highlight is held. The state-node label
+also flips to `font-weight 600 + text-primary` while emphasised
+(it sits at `400 + text-secondary` for inactive siblings) so the
+typography reinforces the visual emphasis. The
+`data-active-affordance` attribute on the node `<g>` lets tests
+and hosts read the emphasis state without inspecting CSS.
 
 ## Colour is never alone
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/elk_layout.cljs
@@ -236,12 +236,19 @@
                      ;; need wider lanes).
                      :labels  [{:text (layout/edge-label e)}]})]
      {:id            "root"
+      ;; rf2-gg7ws — `:edgeRouting` walked from "ORTHOGONAL" (90°
+      ;; dog-legs; below the 000-Vision visual-ergonomics floor per
+      ;; the 2026-05-20 audit) to "SPLINES" (smooth bezier curves)
+      ;; for a polished, organic edge style that reads as competitive
+      ;; with xstate-stately. The `path-from-points` `:case 4` branch
+      ;; in `chart/svg` already emits SVG cubic-bezier `d` strings, so
+      ;; the renderer handles the spline points transparently.
       :layoutOptions {"elk.algorithm"                              "layered"
                       "elk.direction"                              dir-str
                       "elk.spacing.nodeNode"                       "32"
                       "elk.layered.spacing.nodeNodeBetweenLayers"  "60"
                       "elk.layered.crossingMinimization.strategy"  "LAYER_SWEEP"
-                      "elk.edgeRouting"                            "ORTHOGONAL"}
+                      "elk.edgeRouting"                            "SPLINES"}
       :children      (mapv mk-child nodes)
       :edges         (vec (map-indexed mk-edge edges))})))
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart/svg.cljc
@@ -13,13 +13,22 @@
   - **State-space dot-grid background** — rf2-m4nj4. Subtle violet
     dots on a 16px lattice behind every element. Reads as 'state-
     space', distinguishes from Stately/XState's flat canvas.
-  - **Heartbeat pulse + transition glow** — rf2-xfx6l. The active /
-    landing state breathes (2s sine on stroke-width + opacity); the
-    transition edge glows for one beat on event-fire. Both honour
-    `prefers-reduced-motion` via the `--rf-causa-motion-scale` seam.
-  - **Refused-floor typography** — rf2-cd053. State labels 11px,
-    edge labels 9px (spec/007-UX-IA's refused-floor). Node geometry
-    widens to fit.
+  - **Static active-state affordance + transition glow** —
+    rf2-2sez0 / rf2-xfx6l. The active / landing state carries a
+    cyan tint + emphasised stroke (static — no continuous loop);
+    the transition edge glows for one beat on event-fire. The glow
+    honours `prefers-reduced-motion` via the
+    `--rf-causa-motion-scale` seam. The heartbeat-pulse animation
+    was retired 2026-05-20 (rf2-2sez0) per Mike's UX inspection —
+    the static affordance carries the 'currently here' signal
+    without the continuous distraction.
+  - **Chart-appropriate typography (rf2-gg7ws lift)** — state
+    labels 13px, edge labels 11px (lifted from the previous 11/9
+    refused-floor per the 2026-05-20 visual-quality audit). Node
+    geometry widens to fit.
+  - **Edge-label backplates (rf2-gg7ws)** — a small white rect at
+    ~85% opacity sits behind each edge label so overlapping labels
+    on dense charts remain readable.
   - **Caption strip** — rf2-3zdzw. Opt-in `:show-caption?` paints a
     machine-id + current-state header above the chart so PNG/SVG
     exports self-identify.
@@ -61,6 +70,8 @@
 (def ^:private compound-pad-y          (:compound-pad-y vc/chart))
 (def ^:private state-label-px          (:state-label-px vc/chart))
 (def ^:private edge-label-px           (:edge-label-px vc/chart))
+(def ^:private edge-label-backplate-opacity
+  (:edge-label-backplate-opacity vc/chart))
 (def ^:private final-glyph-px          (:final-glyph-px vc/chart))
 (def ^:private compound-title-px       (:compound-title-px vc/chart))
 (def ^:private caption-strip-px        (:caption-strip-px vc/chart))
@@ -81,30 +92,30 @@
   hiccup-walker tests would have to evaluate."
   "ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace")
 
-;; ---- inline stylesheet (rf2-xfx6l, rf2-g6cig L3) -----------------------
+;; ---- inline stylesheet (rf2-xfx6l, rf2-2sez0, rf2-g6cig L3) -----------
 
-(def ^:private heartbeat-pulse-css
-  "@keyframes mv-chart-heartbeat-pulse for the active / landing state.
+(def ^:private transition-glow-css
+  "@keyframes mv-chart-transition-glow for the focused edge.
 
-  rf2-xfx6l — the active state breathes: stroke-width + opacity drift
-  from a resting baseline to an emphasised peak on a 2s sine cycle.
-  The seam variable `--rf-causa-motion-scale` (mirrored from Causa's
-  motion seam) drives the duration through `calc(...)`; the
-  `prefers-reduced-motion: reduce` media query below collapses it to
-  ~0 so the keyframes resolve to their `to` state in one frame
-  (matches Causa's 0.001 trick — see Causa theme/global-styles motion
-  docstring)."
+  rf2-xfx6l — the edge that just fired glows for one beat: opacity +
+  stroke-width drift from a resting baseline to an emphasised peak
+  on a short cycle. The seam variable `--rf-causa-motion-scale`
+  (mirrored from Causa's motion seam) drives the duration through
+  `calc(...)`; the `prefers-reduced-motion: reduce` media query
+  below collapses it to ~0 so the keyframes resolve to their `to`
+  state in one frame (matches Causa's 0.001 trick — see Causa
+  theme/global-styles motion docstring).
+
+  rf2-2sez0 — the previous `mv-chart-heartbeat-pulse` keyframes
+  block was retired 2026-05-20 with the heartbeat-pulse animation.
+  The active state's static emphasis (cyan tint + bolder stroke)
+  carries the 'currently here' signal without a continuous loop."
   (str
     ":root {\n"
     "  --rf-causa-motion-scale: 1;\n"
     "}\n"
     "@media (prefers-reduced-motion: reduce) {\n"
     "  :root { --rf-causa-motion-scale: 0.001; }\n"
-    "}\n"
-    "@keyframes mv-chart-heartbeat-pulse {\n"
-    "  0%   { opacity: 0.85; stroke-width: var(--mv-pulse-base, 2.5); }\n"
-    "  50%  { opacity: 1.00; stroke-width: var(--mv-pulse-peak, 3.5); }\n"
-    "  100% { opacity: 0.85; stroke-width: var(--mv-pulse-base, 2.5); }\n"
     "}\n"
     "@keyframes mv-chart-transition-glow {\n"
     "  0%   { opacity: 0.55; stroke-width: var(--mv-glow-base, 2.5); }\n"
@@ -113,15 +124,15 @@
     "}\n"))
 
 (defn- inline-stylesheet
-  "An SVG `<style>` element carrying the chart's `@keyframes` blocks +
+  "An SVG `<style>` element carrying the chart's `@keyframes` block +
   the `prefers-reduced-motion` override. Lives inside the SVG so the
   chart's motion is self-contained: a host that mounts the chart
-  without injecting any global CSS still gets the pulse / glow and
+  without injecting any global CSS still gets the transition glow and
   honours the user's reduced-motion preference.
 
   Pure data → hiccup; JVM-runnable."
   []
-  [:style {:data-testid "rf-mv-chart-stylesheet"} heartbeat-pulse-css])
+  [:style {:data-testid "rf-mv-chart-stylesheet"} transition-glow-css])
 
 ;; ---- helpers ------------------------------------------------------------
 
@@ -343,10 +354,13 @@
   (let [active?         (= node-id highlight-id)
         from-highlight? (= node-id from-highlight-id)
         to-highlight?   (= node-id to-highlight-id)
-        ;; rf2-xfx6l — the active / landing state pulses. The FROM
-        ;; node does NOT pulse (it's the just-left state); only the
-        ;; current state breathes.
-        pulse?          (or active? to-highlight?)
+        ;; rf2-2sez0 — the previous heartbeat-pulse animation was
+        ;; retired 2026-05-20. The active / landing state now carries
+        ;; a STATIC affordance: cyan tint (via node-fill) + emphasised
+        ;; stroke width (via the stroke-w branch below). The
+        ;; `data-active-affordance` attr lets tests / hosts read the
+        ;; node's emphasis state without inspecting CSS.
+        active-affordance? (or active? to-highlight?)
         emphasised?     (or active? from-highlight? to-highlight?)
         styled          (assoc n
                                :highlight?      active?
@@ -355,31 +369,20 @@
                                :sim?            (and active? sim?))
         fill            (node-fill styled)
         stroke          (node-stroke styled)
-        stroke-w        (if emphasised? highlight-stroke-width stroke-width)
-        pulse-base      stroke-w
-        pulse-peak      (+ stroke-w (:pulse-stroke-width-add vc/chart))
-        ;; The rect carries the animation via inline-style so the SVG
-        ;; remains self-contained (no global CSS dependency).
-        rect-style      (when pulse?
-                          {:animation
-                           (str "mv-chart-heartbeat-pulse "
-                                (tokens/duration-css (:pulse-duration-ms tokens/motion))
-                                " ease-in-out infinite")
-                           :transform-box "fill-box"
-                           :transform-origin "center"})
-        rect-extra      (when pulse?
-                          {;; expose pulse stroke-width endpoints via
-                           ;; CSS vars so the keyframes interpolate
-                           ;; them — each pulsing node carries its own
-                           ;; base/peak.
-                           :style (assoc rect-style
-                                    "--mv-pulse-base" (str pulse-base "px")
-                                    "--mv-pulse-peak" (str pulse-peak "px"))})]
+        ;; rf2-2sez0 — the active / landing state takes a slightly
+        ;; bolder stroke than the FROM-highlight so the user's eye
+        ;; reads it as "currently here" without animation. FROM gets
+        ;; emphasis (it just-exited) but stays at the standard
+        ;; emphasised stroke.
+        stroke-w        (cond
+                          active-affordance? (+ highlight-stroke-width 0.75)
+                          emphasised?        highlight-stroke-width
+                          :else              stroke-width)]
     [:g {:data-testid (str "rf-causa-chart-node-" node-id)
          :data-active (str active?)
          :data-from-highlight (str from-highlight?)
          :data-to-highlight (str to-highlight?)
-         :data-pulse (str pulse?)
+         :data-active-affordance (str active-affordance?)
          :data-state-path (pr-str path)
          :on-click (when on-state-click
                      (fn [_ev] (on-state-click path)))
@@ -401,19 +404,20 @@
                :fill "none"
                :stroke (:green tokens/tokens)
                :stroke-width 1}])
-     ;; Main node body — pulse animation applied here when emphasised.
-     [:rect (cond-> {:x x :y y :width width :height height
-                     :rx corner-radius
-                     :fill fill
-                     :stroke stroke
-                     :stroke-width stroke-w
-                     :stroke-dasharray (when (and from-highlight? (not to-highlight?))
-                                         "4 2")}
-              pulse? (merge rect-extra))]
+     ;; Main node body — static affordance for the active state
+     ;; (rf2-2sez0: bolder stroke + cyan tint via stroke-w/fill, no
+     ;; animation).
+     [:rect {:x x :y y :width width :height height
+             :rx corner-radius
+             :fill fill
+             :stroke stroke
+             :stroke-width stroke-w
+             :stroke-dasharray (when (and from-highlight? (not to-highlight?))
+                                 "4 2")}]
      ;; State-tag pills (rf2-m1b88)
      (render-tag-pills n)
-     ;; Label — rf2-cd053 restores typography to the refused-floor
-     ;; (state 11px). Vertical baseline tweak (+4) keeps glyphs
+     ;; Label — rf2-gg7ws lifts typography to a chart-appropriate
+     ;; 13px (was 11). Vertical baseline tweak (+4) keeps glyphs
      ;; visually centred at the larger size.
      [:text {:x (+ x (quot width 2))
              :y (+ y (quot height 2) 4)
@@ -425,7 +429,7 @@
                      (:text-primary tokens/tokens)
                      (:text-secondary tokens/tokens))}
       label]
-     ;; Final-state check glyph — rf2-cd053 final-glyph-px tracks
+     ;; Final-state check glyph — rf2-gg7ws final-glyph-px tracks
      ;; state-label-px so the corner check stays proportional.
      (when final?
        [:text {:x (+ x width -10)
@@ -439,9 +443,12 @@
   "Render an SVG path `d` attribute from a point list.
 
     - 2 points → straight line.
-    - 4 points → cubic bezier (self-loop / hand-routed S-curve).
+    - 4 points → cubic bezier (self-loop / hand-routed S-curve; ELK
+      SPLINES typically returns this 4-tuple per section — start +
+      two control points + end — per rf2-gg7ws).
     - 3 or 5+ points → polyline (ELK orthogonal routing returns
-      multi-segment edges via bend points)."
+      multi-segment edges via bend points; piecewise splines also
+      fall through here for now)."
   [points]
   (case (count points)
     0 ""
@@ -534,22 +541,36 @@
                                             "--mv-glow-base" (str base-w "px")
                                             "--mv-glow-peak" (str (+ base-w 1.5) "px"))))]
      (when (seq full-label)
-       [:g
-        ;; rf2-cd053 — edge-label restored to refused-floor 9px. Pill
-        ;; geometry scales with the larger glyph.
-        [:rect {:x (- lx (long (* 3.5 (count full-label))))
-                :y (- ly 8)
-                :width (long (* 7 (count full-label)))
-                :height 12
-                :rx 3
-                :fill (:bg-2 tokens/tokens)
-                :opacity 0.85}]
-        [:text {:x lx :y ly
-                :text-anchor "middle"
-                :font-family mono-font-stack
-                :font-size edge-label-px
-                :fill (:text-secondary tokens/tokens)}
-         full-label]])]))
+       (let [;; rf2-gg7ws — backplate geometry. Char-width estimate
+             ;; scales with the lifted 11px font; the white backplate
+             ;; with 85% fill-opacity decouples the label from the
+             ;; edges + dot-grid behind it so overlapping labels on
+             ;; dense charts remain readable (collision-avoidance v1).
+             label-len    (count full-label)
+             char-w-half  4
+             char-w-full  8
+             bp-w         (long (* char-w-full label-len))
+             bp-h         14
+             bp-x         (- lx (long (* char-w-half label-len)))
+             bp-y         (- ly 10)]
+         [:g {:data-testid (str "rf-mv-chart-edge-label-" from-id "-to-" to-id)}
+          ;; rf2-gg7ws — light backplate behind the edge label. White
+          ;; at ~85% fill-opacity reads as a small label "card" on
+          ;; both the dark canvas and over edges / dot-grid.
+          [:rect {:data-testid (str "rf-mv-chart-edge-label-backplate-"
+                                    from-id "-to-" to-id)
+                  :x bp-x :y bp-y
+                  :width bp-w :height bp-h
+                  :rx 3
+                  :fill (:white tokens/tokens)
+                  :fill-opacity edge-label-backplate-opacity
+                  :pointer-events "none"}]
+          [:text {:x lx :y ly
+                  :text-anchor "middle"
+                  :font-family mono-font-stack
+                  :font-size edge-label-px
+                  :fill (:bg-0 tokens/tokens)}
+           full-label]]))]))
 
 (defn- format-state-label
   "rf2-3zdzw / rf2-g6cig — render a path-like state-id with namespace

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/theme/tokens.cljc
@@ -26,15 +26,18 @@
 
   ## Motion seam
 
-  rf2-xfx6l — the chart's heartbeat pulse + transition glow
-  interpolate their `animation-duration` through the same
+  rf2-xfx6l / rf2-2sez0 — the chart's transition glow (the sole
+  remaining continuous animation surface, fired one beat on event-
+  fire) interpolates its `animation-duration` through the same
   `--rf-causa-motion-scale` CSS custom property Causa publishes at
   `:root`. The chart's host (Causa today) ensures the variable is
   set; when machines-viz ships standalone the chart's own SVG
   `<style>` block declares the variable + the
   `prefers-reduced-motion` override so the chart honours the user's
   setting without a host-side install. See `chart/svg`
-  `inline-stylesheet`.
+  `inline-stylesheet`. The heartbeat-pulse animation was retired
+  2026-05-20 (rf2-2sez0) — only `:glow-duration-ms` remains in the
+  motion catalogue.
 
   ## Visual constants
 
@@ -147,16 +150,16 @@
   - `:scale-var-name`        — CSS custom property name; consumers
                                interpolate it into their inline
                                `animation-duration: calc(...)`.
-  - `:pulse-duration-ms`     — heartbeat pulse cycle on the active
-                               state node (rf2-xfx6l).
   - `:glow-duration-ms`      — transition-edge glow flash duration
                                (rf2-xfx6l).
 
-  Both durations interpolate through `--rf-causa-motion-scale`
-  (collapsed to 0.001 under `prefers-reduced-motion: reduce`)."
-  {:scale-var-name    "--rf-causa-motion-scale"
-   :pulse-duration-ms 2000
-   :glow-duration-ms  400})
+  The duration interpolates through `--rf-causa-motion-scale`
+  (collapsed to 0.001 under `prefers-reduced-motion: reduce`).
+
+  rf2-2sez0 — `:pulse-duration-ms` retired 2026-05-20 with the
+  heartbeat-pulse animation. Active-state emphasis is now static."
+  {:scale-var-name   "--rf-causa-motion-scale"
+   :glow-duration-ms 400})
 
 (defn duration-css
   "Build the canonical `calc(<ms>ms * var(--rf-causa-motion-scale, 1))`

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/visual_constants.cljc
@@ -8,22 +8,25 @@
   legible at a glance and makes a future density toggle (compact /
   cosy / comfy) a one-knob change.
 
-  rf2-cd053 — state-label + edge-label font sizes restored to the
-  spec/007-UX-IA refused-floor: state labels at 11, edge labels at 9.
-  The previous 9/7 walked under the floor in service of a layout-fit
-  win; typography is load-bearing here, layout adapts via wider nodes
-  (`:node-width-px` here, kept in lockstep with `chart.layout`).
+  rf2-cd053 / rf2-gg7ws — state-label + edge-label font sizes
+  walked up from the previous spec/007-UX-IA refused-floor (11 / 9)
+  to a chart-appropriate 13 / 11 per the 2026-05-20 visual-quality
+  lift. The refused-floor was set for dense data-grid surfaces;
+  applying it to a chart that competes with xstate-stately's
+  typography was a category error (see audit Finding #2). Node
+  geometry adapts via wider nodes (`:node-width-px` in
+  `chart.layout`).
 
   rf2-g6cig — corner-radius locked at 6px. The React Flow default
   (8) reads as 'product chrome'; brutalist (0) reads as 'wireframe';
   6 is the sweet spot — soft enough to feel finished, sharp enough
   to read as 'data, not product'. Locked 2026-05-19.
 
-  rf2-xfx6l — pulse + glow durations live in `:motion` here (the
-  durations); the CSS seam (`--rf-causa-motion-scale`) lives in
-  `theme/tokens/motion` (the surface). Two halves of the same
-  contract: this ns owns the numbers, that ns owns the seam name +
-  the reduced-motion plumbing."
+  rf2-2sez0 — heartbeat-pulse animation removed 2026-05-20. The
+  active state's static affordance (cyan tint + emphasised stroke)
+  carries the 'currently here' signal without a continuous loop;
+  the transition glow on event-fire remains for moment-of-cause
+  cueing. `:pulse-stroke-width-add` retired with the animation."
   {:no-doc true})
 
 (def chart
@@ -40,9 +43,14 @@
                                 leaves room for the title strip)
     :compound-stroke-dash     — dashed pattern for compound borders
     :state-label-px           — state node label font-size
-                                (rf2-cd053 — refused-floor 11)
+                                (rf2-gg7ws lift — 13)
     :edge-label-px            — edge label font-size
-                                (rf2-cd053 — refused-floor 9)
+                                (rf2-gg7ws lift — 11)
+    :edge-label-backplate-opacity
+                              — opacity of the small white rect
+                                painted behind each edge label so
+                                overlapping labels remain legible
+                                (rf2-gg7ws — collision-avoidance v1)
     :final-glyph-px           — final-state ✓ glyph font-size
     :compound-title-px        — compound container title font-size
     :caption-strip-px         — chart-level caption strip height
@@ -58,10 +66,7 @@
     :dot-grid-spacing-px      — dot-grid background pattern spacing
                                 (rf2-m4nj4 — 16px)
     :dot-grid-radius-px       — single dot radius
-    :dot-grid-alpha           — dot opacity (0..1)
-    :pulse-stroke-width-add   — extra stroke width on the pulse-
-                                target node so the eye reads the
-                                animation as a 'breath' (rf2-xfx6l)"
+    :dot-grid-alpha           — dot opacity (0..1)"
   {;; ── geometry ─────────────────────────────────────────────────
    :corner-radius          6
    :stroke-width           1.5
@@ -70,11 +75,12 @@
    :compound-pad-y         24
    :compound-stroke-dash   "4 3"
 
-   ;; ── typography ───────────────────────────────────────────────
-   :state-label-px         11
-   :edge-label-px          9
-   :final-glyph-px         11
-   :compound-title-px      11
+   ;; ── typography (rf2-gg7ws — lifted from 11/9 to 13/11) ───────
+   :state-label-px         13
+   :edge-label-px          11
+   :edge-label-backplate-opacity 0.85
+   :final-glyph-px         13
+   :compound-title-px      13
    :caption-strip-px       28
    :caption-text-px        11
 
@@ -88,7 +94,4 @@
    ;; ── dot-grid background (rf2-m4nj4) ──────────────────────────
    :dot-grid-spacing-px    16
    :dot-grid-radius-px     1.0
-   :dot-grid-alpha         0.06
-
-   ;; ── motion (rf2-xfx6l) — see theme/tokens/motion for the seam ─
-   :pulse-stroke-width-add 1.0})
+   :dot-grid-alpha         0.06})

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/elk_layout_cljs_test.cljs
@@ -56,6 +56,15 @@
     (is (vector? (:children g)))
     (is (vector? (:edges g)))))
 
+(deftest ->elk-graph-uses-spline-edge-routing
+  (testing "rf2-gg7ws — edgeRouting is SPLINES (bezier curves), lifted
+            from the previous ORTHOGONAL (90° dog-legs) per the
+            2026-05-20 visual-quality audit. Splines read as polished
+            / organic; orthogonal reads as schematic."
+    (let [g (elk-layout/->elk-graph small-machine :tb)]
+      (is (= "SPLINES"
+             (get-in g [:layoutOptions "elk.edgeRouting"]))))))
+
 (deftest ->elk-graph-direction-switches-on-axis
   (is (= "DOWN"  (get-in (elk-layout/->elk-graph small-machine :tb)
                          [:layoutOptions "elk.direction"])))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/svg_cljs_test.cljc
@@ -327,17 +327,40 @@
             rgba string"
     (is (nil? (tokens/with-alpha :no-such-token 0.5)))))
 
-;; ---- rf2-cd053 — refused-floor typography ------------------------------
+;; ---- rf2-gg7ws — chart-appropriate typography lift ---------------------
 
-(deftest state-label-font-size-meets-refused-floor
-  (testing "rf2-cd053 — state labels render at >= 11px (spec/007-UX-IA
-            refused-floor)"
-    (is (>= (:state-label-px vc/chart) 11))
-    (is (>= (:final-glyph-px vc/chart) 11))))
+(deftest state-label-font-size-meets-chart-floor
+  (testing "rf2-gg7ws — state labels render at >= 13px (lifted from
+            the previous 11px refused-floor per the 2026-05-20
+            visual-quality audit)"
+    (is (>= (:state-label-px vc/chart) 13))
+    (is (>= (:final-glyph-px vc/chart) 13))))
 
-(deftest edge-label-font-size-meets-refused-floor
-  (testing "rf2-cd053 — edge labels render at >= 9px"
-    (is (>= (:edge-label-px vc/chart) 9))))
+(deftest edge-label-font-size-meets-chart-floor
+  (testing "rf2-gg7ws — edge labels render at >= 11px (lifted from
+            the previous 9px refused-floor)"
+    (is (>= (:edge-label-px vc/chart) 11))))
+
+;; ---- rf2-gg7ws — edge-label backplate (collision-avoidance v1) ---------
+
+(deftest edge-labels-carry-backplate
+  (testing "rf2-gg7ws — every edge label is rendered with a light
+            backplate <rect> behind the text so overlapping labels on
+            dense charts remain readable. White fill at <1.0
+            opacity."
+    (let [tree    (chart-svg/render-from-definition small-machine)
+          plates  (find-all-by-testid-prefix
+                    tree "rf-mv-chart-edge-label-backplate-")]
+      (is (= 3 (count plates))
+          "one backplate per labelled edge (3 edges in small-machine)")
+      (doseq [plate plates]
+        (let [attrs (second plate)]
+          (is (= (:white tokens/tokens) (:fill attrs))
+              "backplate fill is the white palette token")
+          (is (number? (:fill-opacity attrs))
+              "backplate carries numeric fill-opacity")
+          (is (< 0.0 (:fill-opacity attrs) 1.0)
+              "backplate opacity is fractional (collision-avoidance)"))))))
 
 ;; ---- rf2-m4nj4 — dot-grid background -----------------------------------
 
@@ -370,45 +393,99 @@
       (is (.startsWith ^String (:fill (second circle)) expected-prefix)
           "dot fill is the accent-violet token tinted via with-alpha"))))
 
-;; ---- rf2-xfx6l — heartbeat pulse + transition-glow ---------------------
+;; ---- rf2-xfx6l + rf2-2sez0 — static active affordance + transition-glow
 
-(deftest inline-stylesheet-defines-pulse-keyframes
-  (testing "rf2-xfx6l — the chart's inline <style> carries the
-            heartbeat + glow keyframes + the reduced-motion seam"
+(deftest inline-stylesheet-defines-transition-glow-keyframes
+  (testing "rf2-xfx6l / rf2-2sez0 — the chart's inline <style> carries
+            the transition-glow keyframes + the reduced-motion seam.
+            The previous heartbeat-pulse keyframes block was retired
+            with rf2-2sez0; only the glow remains."
     (let [tree (chart-svg/render-from-definition small-machine)
           ss   (find-by-testid tree "rf-mv-chart-stylesheet")
           css  (last ss)]
       (is (some? ss))
-      (is (re-find #"@keyframes mv-chart-heartbeat-pulse" css)
-          "heartbeat-pulse keyframes defined")
       (is (re-find #"@keyframes mv-chart-transition-glow" css)
           "transition-glow keyframes defined")
       (is (re-find #"prefers-reduced-motion: reduce" css)
           "reduced-motion media query is wired"))))
 
-(deftest active-state-marked-pulse-target
-  (testing "rf2-xfx6l — the active state node carries data-pulse=true
-            so the keyframes apply"
+(deftest inline-stylesheet-omits-pulse-keyframes
+  (testing "rf2-2sez0 — the heartbeat-pulse animation was retired
+            2026-05-20. The `mv-chart-heartbeat-pulse` keyframes block
+            must NOT appear in the inline stylesheet."
+    (let [tree (chart-svg/render-from-definition small-machine)
+          ss   (find-by-testid tree "rf-mv-chart-stylesheet")
+          css  (last ss)]
+      (is (some? ss))
+      (is (nil? (re-find #"mv-chart-heartbeat-pulse" css))
+          "pulse keyframes must be absent (rf2-2sez0)"))))
+
+(deftest active-state-carries-static-affordance
+  (testing "rf2-2sez0 — the active state node carries
+            data-active-affordance=true (replacement for the retired
+            data-pulse attr). The affordance is STATIC — no
+            continuous animation."
     (let [hid  (layout/highlight-id :loading)
           tree (chart-svg/render-from-definition
                  small-machine {:highlight-id hid})
           node (find-by-testid tree (str "rf-causa-chart-node-" hid))]
-      (is (= "true" (:data-pulse (second node)))))))
+      (is (= "true" (:data-active-affordance (second node)))))))
 
-(deftest non-active-state-not-pulse-target
-  (testing "rf2-xfx6l — non-active states do NOT carry the pulse
-            animation (only one node breathes at a time)"
-    (let [tree  (chart-svg/render-from-definition
-                  small-machine
-                  {:highlight-id (layout/highlight-id :loading)})
-          nodes (find-all-by-testid-prefix tree "rf-causa-chart-node-")
-          pulsing (filter (fn [n] (= "true" (:data-pulse (second n)))) nodes)]
-      (is (= 1 (count pulsing))
-          "exactly one node pulses (the active one)"))))
+(deftest active-state-not-marked-as-pulse-target
+  (testing "rf2-2sez0 — the legacy `data-pulse` attr must be ABSENT;
+            nodes no longer carry pulse animation metadata."
+    (let [hid  (layout/highlight-id :loading)
+          tree (chart-svg/render-from-definition
+                 small-machine {:highlight-id hid})
+          node (find-by-testid tree (str "rf-causa-chart-node-" hid))]
+      (is (nil? (:data-pulse (second node)))
+          "data-pulse attr is gone (rf2-2sez0)"))))
 
-(deftest from-highlight-does-not-pulse
-  (testing "rf2-xfx6l — the FROM node (just-exited state) does NOT
-            pulse; only the active / landing state breathes"
+(deftest active-state-has-bolder-stroke-than-inactive
+  (testing "rf2-2sez0 — the static active-state affordance: the active
+            node's rect carries a thicker stroke than an inactive
+            sibling so the eye reads emphasis without animation"
+    (let [hid    (layout/highlight-id :loading)
+          tree   (chart-svg/render-from-definition
+                   small-machine {:highlight-id hid})
+          active-node   (find-by-testid tree
+                                        (str "rf-causa-chart-node-" hid))
+          inactive-node (find-by-testid tree
+                                        (str "rf-causa-chart-node-"
+                                             (layout/highlight-id :idle)))
+          ;; the main node rect is the LAST :rect descendant of the
+          ;; node <g> that carries a numeric :stroke-width.
+          node-stroke-w (fn [node]
+                          (let [rects (filter (fn [n]
+                                                (and (vector? n)
+                                                     (= :rect (first n))
+                                                     (number?
+                                                       (:stroke-width
+                                                         (second n)))))
+                                              (hiccup-seq node))]
+                            (some-> (last rects) second :stroke-width)))]
+      (is (> (node-stroke-w active-node)
+             (node-stroke-w inactive-node))
+          "active node stroke-width > inactive node stroke-width"))))
+
+(deftest non-active-states-have-no-active-affordance
+  (testing "rf2-2sez0 — only the active / landing state carries the
+            static active affordance (data-active-affordance=true);
+            inactive siblings carry the attr as `false`."
+    (let [tree   (chart-svg/render-from-definition
+                   small-machine
+                   {:highlight-id (layout/highlight-id :loading)})
+          nodes  (find-all-by-testid-prefix tree "rf-causa-chart-node-")
+          active (filter (fn [n]
+                           (= "true"
+                              (:data-active-affordance (second n))))
+                         nodes)]
+      (is (= 1 (count active))
+          "exactly one node carries the active affordance"))))
+
+(deftest from-highlight-not-marked-as-active-affordance
+  (testing "rf2-2sez0 — the FROM node (just-exited state) does NOT
+            carry the active-affordance; only the landing state does."
     (let [from-id (layout/highlight-id :idle)
           to-id   (layout/highlight-id :loading)
           tree    (chart-svg/render-from-definition
@@ -417,10 +494,10 @@
                      :to-highlight-id   to-id})
           from-node (find-by-testid tree (str "rf-causa-chart-node-" from-id))
           to-node   (find-by-testid tree (str "rf-causa-chart-node-" to-id))]
-      (is (= "false" (:data-pulse (second from-node)))
-          "FROM node is NOT a pulse target")
-      (is (= "true"  (:data-pulse (second to-node)))
-          "TO (landing) node IS a pulse target"))))
+      (is (= "false" (:data-active-affordance (second from-node)))
+          "FROM node has no active affordance")
+      (is (= "true"  (:data-active-affordance (second to-node)))
+          "TO (landing) node carries the active affordance"))))
 
 (deftest focused-edge-marked
   (testing "rf2-xfx6l — when both FROM and TO are set, the edge

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/theme/tokens_cljs_test.cljc
@@ -54,7 +54,10 @@
            (tokens/duration-css 2000)))))
 
 (deftest motion-publishes-canonical-durations
-  (testing "motion catalogues the pulse + glow ms so the chart can
-            read them without forking the numbers"
-    (is (pos? (:pulse-duration-ms tokens/motion)))
-    (is (pos? (:glow-duration-ms tokens/motion)))))
+  (testing "motion catalogues the glow ms so the chart can read it
+            without forking the numbers. The `:pulse-duration-ms`
+            entry was retired with rf2-2sez0 (heartbeat-pulse
+            animation removed 2026-05-20)."
+    (is (pos? (:glow-duration-ms tokens/motion)))
+    (is (nil? (:pulse-duration-ms tokens/motion))
+        "pulse-duration-ms removed (rf2-2sez0)")))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/visual_constants_cljs_test.cljc
@@ -36,9 +36,10 @@
     :compound-pad-x
     :compound-pad-y
     :compound-stroke-dash
-    ;; typography
+    ;; typography (rf2-gg7ws — lifted 11/9 → 13/11)
     :state-label-px
     :edge-label-px
+    :edge-label-backplate-opacity
     :final-glyph-px
     :compound-title-px
     :caption-strip-px
@@ -52,9 +53,7 @@
     ;; dot-grid background (rf2-m4nj4)
     :dot-grid-spacing-px
     :dot-grid-radius-px
-    :dot-grid-alpha
-    ;; motion (rf2-xfx6l)
-    :pulse-stroke-width-add})
+    :dot-grid-alpha})
 
 ;; ---- shape pins ---------------------------------------------------------
 
@@ -78,7 +77,8 @@
 
 (deftest chart-numeric-keys-are-numbers
   (testing "every key that the chart code uses as a numeric (geometry,
-            typography sizes, padding, alpha) resolves to a number"
+            typography sizes, padding, alpha, opacity) resolves to a
+            number"
     (let [numeric-keys (disj expected-chart-keys :compound-stroke-dash)]
       (doseq [k numeric-keys]
         (is (number? (get vc/chart k))
@@ -98,13 +98,26 @@
             future drift fails CI rather than landing silently."
     (is (= 6 (:corner-radius vc/chart)))))
 
-(deftest chart-typography-honours-refused-floor
-  (testing "rf2-cd053 — state-label-px + edge-label-px restored to the
-            spec/007-UX-IA refused-floor (state 11, edge 9). Pin so a
-            future layout-fit win that walks under the floor again
-            (the previous 9/7 regression) fails CI."
-    (is (= 11 (:state-label-px vc/chart)))
-    (is (= 9  (:edge-label-px vc/chart)))))
+(deftest chart-typography-meets-chart-floor
+  (testing "rf2-gg7ws — state-label-px + edge-label-px lifted from the
+            spec/007-UX-IA refused-floor (11 / 9) to a chart-
+            appropriate 13 / 11 per the 2026-05-20 visual-quality
+            audit. The refused-floor was set for dense data-grid
+            surfaces; applying it to a chart that competes with
+            xstate-stately's typography was a category error. Pin so a
+            future layout-fit win that walks back under the chart
+            floor fails CI."
+    (is (= 13 (:state-label-px vc/chart)))
+    (is (= 11 (:edge-label-px vc/chart)))))
+
+(deftest chart-edge-label-backplate-opacity-is-fractional
+  (testing "rf2-gg7ws — edge-label backplate opacity is in (0, 1).
+            At 1 the backplate would be opaque white (overprinted
+            chart canvas); at 0 it would be invisible (no
+            collision-avoidance). ~0.85 is the sweet spot."
+    (let [a (:edge-label-backplate-opacity vc/chart)]
+      (is (pos? a))
+      (is (< a 1.0)))))
 
 (deftest chart-dot-grid-alpha-is-fractional
   (testing "rf2-m4nj4 — dot-grid is a subtle backdrop; alpha must


### PR DESCRIPTION
## Summary
- Drop 1.2s heartbeat-pulse animation; replace with static active-state affordance (bolder fill + thicker stroke) (rf2-2sez0 P1)
- ELK routing: ORTHOGONAL → SPLINES (bezier curves)
- Typography: 11/9px → 13/11px (state/edge labels)
- Edge label backplates (white rect, 85% fill-opacity) for collision-avoidance (rf2-gg7ws P1)
- Principles.md "must pulse" lock removed + static affordance documented

## Beads
rf2-2sez0, rf2-gg7ws (both P1)

## Source
ai/findings/2026-05-20-tools-machines-viz-api-review.md (Findings #1 + #2)

## Acceptance
- test:cljs clean (3496 tests / 9951 assertions; +6 / +16 vs baseline)
- mkdocs --strict clean
- Spec Principles updated