### PR TITLE
fix/spec(mcp): 6 mcp-base + mcp-conformance follow-ons (rf2-pv7we + vkbzr + xm1fv + ftoca + f3k9f + j6oay)

### DIFF
--- a/tools/mcp-base/spec/elision.md
+++ b/tools/mcp-base/spec/elision.md
@@ -31,12 +31,19 @@ Definition (effectively):
 ```clojure
 (defn count-elided-markers [v]
   (cond
-    (and (map? v) (contains? v :rf.size/large-elided)) 1
-    (coll? v)                                          (reduce + 0 (map count-elided-markers v))
-    :else                                              0))
+    (and (map? v) (contains? v :rf.size/large-elided))   1
+    (map? v)                                             (reduce-kv
+                                                           (fn [n _ c] (+ n (count-elided-markers c)))
+                                                           0 v)
+    (or (vector? v) (set? v) (seq? v))                   (reduce
+                                                           (fn [n c] (+ n (count-elided-markers c)))
+                                                           0 v)
+    :else                                                0))
 ```
 
 The counter is non-negative integer; 0 means nothing was elided. The slot itself rides the response envelope (per [`vocab.md` §Envelope counter slots](vocab.md#envelope-counter-slots)).
+
+**Records are NOT walked.** The walker descends through the explicit collection-type triad (`vector?` / `set?` / `seq?`) plus `map?`, not the broader `coll?` predicate. On CLJS, defrecord instances satisfy `coll?` but neither `map?` nor any of the three sequential predicates, so a record-shaped slot carrying an elision marker is treated as a leaf. This is OK in practice because the wire egress path stamps payloads through `pr-str` / `read-string` so record types are stripped to plain maps before the walker sees them — but JVM-side decoders walking pre-egress data should not rely on record descent.
 
 ## Cousin to `sensitive`
 

--- a/tools/mcp-base/spec/sensitive.md
+++ b/tools/mcp-base/spec/sensitive.md
@@ -50,11 +50,13 @@ Snapshot scrubbing is **stricter** than trace-event filtering — the snapshot p
 
 ## Cross-server arg-vocabulary convention
 
-The opt-in arg name **`:include-sensitive?`** is the fixed, cross-server vocabulary an agent learns once. Every MCP tool that surfaces trace-like data MUST:
+The opt-in arg every MCP tool surfacing trace-like data MUST accept. The semantics are fixed — accept the arg, default it to `false`, feed it to `strip-sensitive` (and any analogous walker that recurses through snapshot slices) — but the **wire-key spelling is in-flight** today:
 
-1. Accept this arg.
-2. Default it to `false`.
-3. Feed it to `strip-sensitive` (and any analogous walker that recurses through snapshot slices).
+- **story-mcp** ships the unqualified `:include-sensitive` (no trailing `?`, per rf2-y710n — the Anthropic tool-input-schema regex `^[a-zA-Z0-9_.-]{1,64}$` rejects `?`).
+- **re-frame2-pair-mcp** still ships `:include-sensitive?` (with `?`) pending rf2-ihq4d.
+- The walker option key inside the framework (`vocab/include-sensitive-opt`) is the namespaced `:rf.size/include-sensitive?` — internal, not a wire-key, so the predicate `?` is retained.
+
+When rf2-ihq4d lands and pair-mcp drops the `?`, this section becomes a single fixed claim again. Until then, treat the cross-server wire-key as a **policy + behaviour** pin, not a literal-spelling pin; the literal each server accepts is documented in its own tool catalogue.
 
 The default-OFF posture aligns with the framework's privacy-by-default stance (per [`../../../spec/Security.md` §Privacy / secret handling](../../../spec/Security.md#privacy--secret-handling) and [`../../../spec/Conventions.md` §Privacy config-knob naming](../../../spec/Conventions.md)).
 

--- a/tools/mcp-base/spec/vocab.md
+++ b/tools/mcp-base/spec/vocab.md
@@ -44,7 +44,7 @@ Unqualified envelope slots — `:dropped-sensitive`, `:elided-large` — are per
 | Var | Key | Role | Source |
 |---|---|---|---|
 | `large-elided-key` | `:rf.size/large-elided` | Substituted for an over-threshold leaf (or declared-large slot). | Spec 009 §Size elision |
-| `redacted-sentinel` | `:rf.size/redacted` | In-place sentinel for a `:sensitive?` leaf when the walker is configured to mask. | Spec 009 §Privacy |
+| `redacted-sentinel` | `:rf/redacted` | In-place **scalar sentinel** (bare keyword, no body) substituted for a `:sensitive?` leaf by `rf/elide-wire-value` / `with-redacted`. Unlike `:rf.size/large-elided`, there is no `:handle` / `:bytes` slot — the value is gone and MUST NOT be re-fetched. Reserved under the `:rf/*` single-root scheme (Conventions §Reserved namespaces). | Spec 009 §Privacy / `tools/mcp-base/src/re_frame/mcp_base/vocab.cljc` `redacted-sentinel` |
 | `elision-handle-key` | First slot in the elision handle vector | Vector-shaped handle for follow-up `get-path` calls. | rf2-9fz64 |
 | `include-large-opt` / `include-sensitive-opt` / `include-digests-opt` / `threshold-bytes-opt` | (framework-side opts) | Knobs `rf/elide-wire-value` honours when the consumer relays a wire request to the walker. | Spec 009 §Size elision |
 

--- a/tools/mcp-base/src/re_frame/mcp_base/args.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/args.cljc
@@ -192,11 +192,12 @@
 
 (defn fresh-keyword
   "Coerce an agent-supplied id into a keyword, INTERNING it. The
-  positive-named primitive for write paths that allocate a new
-  identifier rather than resolve an existing one (e.g.
-  `register-variant`'s `:variant-id` arg, `record-as-variant`'s
-  `:new-variant-id` arg). Strips a leading `:` if present (some agents
-  may serialise EDN-ish). Returns nil for nil / blank input.
+  primitive for paths whose allocation cost is **bounded by some
+  other gate** — either an operator-gated write path that allocates a
+  fresh identifier, or a read path whose universe of acceptable
+  identifiers is constrained by a runtime registry. Strips a leading
+  `:` if present (some agents may serialise EDN-ish). Returns nil for
+  nil / blank input.
 
   Namespaced keywords are supported (`\"ns/name\"` ⇒ `:ns/name`).
 
@@ -204,15 +205,21 @@
 
   JVM keywords are interned in a never-shrinking global table. Every
   `fresh-keyword` call permanently grows that table by one slot for a
-  hitherto-unseen input. Reserve this primitive for sites that have
-  ALREADY bounded the allocation by some other gate:
+  hitherto-unseen input. The policy is **bounded-cost allocation** —
+  reserve this primitive for sites where some other gate caps the
+  number of fresh keywords an attacker can mint:
 
-    - An operator-gated write path (story-mcp's `--allow-writes` flag,
-      re-frame2-pair-mcp's read-side frame-id coercion against a runtime-bounded
-      frame registry).
-    - A registrar that enforces a grammar over the id (e.g.
-      `:story.<path>/<name>` in `assert-id!`) — this constrains the
-      per-id allocation cost.
+    - **Operator-gated write paths** that allocate a NEW identifier —
+      story-mcp's `--allow-writes` flag plus `:story.<path>/<name>`
+      grammar bound; `register-variant`'s `:variant-id`,
+      `record-as-variant`'s `:new-variant-id`.
+    - **Runtime-bounded read paths** that resolve against a FINITE
+      registry — re-frame2-pair-mcp's frame-id coercion. The registry's
+      live size caps the allocation; an agent passing arbitrary
+      strings can mint at most one new keyword per registered frame.
+    - **Grammar-bounded registrars** (e.g. `:story.<path>/<name>` in
+      `assert-id!`) — the grammar constrains the per-id allocation
+      cost regardless of read/write direction.
 
   For finite option sets (mode keywords, slice keywords), use
   `safe-keyword` against a finite allowlist; `fresh-keyword` is the

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -365,13 +365,29 @@
 
   Idempotent on already-full epochs (the marker check returns the
   input unchanged when `:db-after` isn't a diff). Provided for
-  agent-host round-trip parity and for the unit tests."
+  agent-host round-trip parity and for the unit tests.
+
+  ## Decoder-boundary section validation (rf2-j6oay)
+
+  Mirrors the encoder's `validate-sections!` gate. `sections->patches`
+  is a permissive `mapcat :patches` — a section with malformed
+  `:section-path` / `:section-kind` slots, or extra/missing slots,
+  would slip through to `apply-patches` whose own gate only validates
+  the flattened `:patches` list. Validating `sections` here gives
+  encoder/decoder symmetry per the rf2-8e61v argument: the cross-MCP
+  wire convention surfaces drift on the receiving side too, rather
+  than silently passing the cosmetic `:section-kind` / `:section-path`
+  slots through to an agent-host UI that paints them as truth.
+
+  Soft-pass + `goog-define`-elidable by construction — reuses the
+  same `validate-sections!` helper as the encoder."
   [epoch]
   (let [da (when (map? epoch) (:db-after epoch))]
     (if-not (and (map? da)
                  (= :db-before (get da vocab/diff-from-key)))
       epoch
       (let [sections  (:sections da)
+            _         (validate-sections! (or sections []))
             patches   (sg/sections->patches (or sections []))
             db-before (:db-before epoch)
             rebuilt   (apply-patches db-before patches)]

--- a/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
+++ b/tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj
@@ -1122,6 +1122,106 @@
                " — vocabulary-drift bug.")))))
 
 ;; ---------------------------------------------------------------------------
+;; `:rf/redacted` scalar-sentinel gate (rf2-xm1fv).
+;;
+;; Unlike the wrapper-shaped markers in `canonical-markers`, `:rf/redacted`
+;; rides the wire as a **bare keyword scalar** — a literal value
+;; substituted in-place for a sensitive leaf by the framework's
+;; `rf/elide-wire-value` walker and by the `with-redacted` interceptor.
+;; There is no map payload, no `:handle`, no re-fetch affordance; the
+;; value is gone. Per Spec 009 §Privacy and `mcp-base/vocab.cljc`
+;; `redacted-sentinel`.
+;;
+;; Why this scalar needs its own gate
+;;
+;; The `canonical-markers` table validates wrapped-marker-map shapes
+;; (`{<marker-key> <body>}`) with per-marker Malli schemas. A bare
+;; keyword scalar has no body to schema-validate — but it IS a wire-
+;; protocol contract: every agent reading sensitive-leaf data pattern-
+;; matches on the literal `:rf/redacted`. A rename in `vocab.cljc`
+;; (e.g. `:rf.size/redacted` — the historical doc-drift in
+;; rf2-pv7we) or a near-miss spelling that escapes the canonical-marker
+;; gate would slip past silently because the existing near-miss anti-
+;; pin only checks `:rf.mcp/*` / `:rf.size/*` marker keys (the namespace
+;; pattern fixed in `near-miss-variants`).
+;;
+;; The pin shape mirrors `:rf.mcp/cursor-stale` above (the other scalar
+;; reserved value in the cross-MCP vocabulary):
+;;   1. literal-presence pin in the canonical declaration site
+;;      (`mcp-base/vocab.cljc`), AFTER stripping docstrings/comments.
+;;   2. near-miss anti-pin across all conformance-tracked sources.
+;;   3. doc-source mention pin in re-frame2-pair-mcp prose docs (soft —
+;;      raw `str/includes?`).
+;; ---------------------------------------------------------------------------
+
+(def ^:private redacted-sentinel-near-miss-variants
+  "Near-miss spellings of `:rf/redacted`. The default
+  `near-miss-variants` generator targets the marker-key namespace
+  patterns (`:rf.mcp/*` / `:rf.size/*`) — `:rf/redacted` rides the
+  single-segment `:rf/*` namespace and needs bespoke variants.
+
+  Conservative list — false positives here would block legitimate
+  occurrences in surrounding prose.
+
+  - snake_case tail (`:rf/redact_ed`) — irrelevant for `redacted`
+    (no hyphen), included as a guard if a future scalar lands with a
+    multi-segment name.
+  - pluralised (`:rf/redacteds`).
+  - predicate `?` suffix (`:rf/redacted?`).
+  - the historical wrong-namespace forms — the rf2-pv7we doc-drift
+    targeted exactly these.
+  - capitalised name (`:rf/Redacted`) — caught here even though
+    canonical Clojure idiom is all-lowercase."
+  #{":rf/redacteds"
+    ":rf/redacted?"
+    ":rf.size/redacted"        ;; the rf2-pv7we historical doc-drift
+    ":rf.mcp/redacted"
+    ":rf.privacy/redacted"
+    ":rf/Redacted"})
+
+(deftest redacted-sentinel-literal-in-re-frame2-pair-mcp-emit-source
+  ;; The canonical declaration lives in mcp-base/vocab.cljc as
+  ;; `redacted-sentinel` (the single-source-of-truth `def`). Strip
+  ;; comments/docstrings before grep — a rename of the `def` value
+  ;; trips the gate even if old docstrings still mention the prior
+  ;; literal. Mirrors `cursor-stale-literal-in-re-frame2-pair-mcp-emit-source`.
+  (let [literal  ":rf/redacted"
+        rel      "tools/mcp-base/src/re_frame/mcp_base/vocab.cljc"
+        stripped (fx/strip-comments-and-strings (fx/read-source rel))]
+    (is (str/includes? stripped literal)
+        (str literal " missing from " rel
+             " AFTER stripping docstrings/comments. The canonical "
+             "scalar sentinel declaration moved — restore the literal "
+             "or update this test."))))
+
+(deftest redacted-sentinel-literal-in-re-frame2-pair-mcp-doc-sources
+  ;; Doc-source pin — looser, raw `str/includes?` against the prose
+  ;; docs catalogue. Drift here means the docs lag, not that the emit
+  ;; broke.
+  (let [literal ":rf/redacted"
+        files   (get doc-source-files :re-frame2-pair-mcp)]
+    (is (some (fn [rel] (str/includes? (fx/read-source rel) literal)) files)
+        (str literal " missing from re-frame2-pair-mcp doc-sources " files
+             ". The docs may have re-organised the prose; either "
+             "restore the mention or update `doc-source-files`."))))
+
+(deftest redacted-sentinel-no-near-miss-in-any-server-source
+  ;; Defence-in-depth: the bespoke near-miss set above MUST NOT appear
+  ;; anywhere in the conformance-tracked sources. The rf2-pv7we
+  ;; doc-drift (a `:rf.size/redacted` row in `tools/mcp-base/spec/vocab.md`)
+  ;; would surface here if it returned — the anti-pin catches it before
+  ;; the doc ships.
+  (doseq [variant        redacted-sentinel-near-miss-variants
+          [server files] all-source-files
+          rel            files]
+    (testing (str server " — " rel " — near-miss " variant)
+      (is (not (str/includes? (fx/read-source rel) variant))
+          (str "Found near-miss variant " variant
+               " for :rf/redacted scalar sentinel in " server "/" rel
+               " — vocabulary-drift bug. The canonical form is "
+               ":rf/redacted (per mcp-base/vocab.cljc `redacted-sentinel`).")))))
+
+;; ---------------------------------------------------------------------------
 ;; `notifications/progress` streaming gate (rf2-i3ffz F-GAP-1).
 ;;
 ;; re-frame2-pair-mcp's `subscribe` streaming tool emits exactly one


### PR DESCRIPTION
## Summary

Six targeted follow-ons from the rf2-k9k1j / rf2-li7dw audit pair (`ai/findings/2026-05-20-tools-mcp-base-api-review.md` + `ai/findings/2026-05-20-tools-mcp-conformance-api-review.md`). Each bead → one file edit; no cross-cutting refactor.

| Bead | File | Change shape |
|---|---|---|
| **rf2-pv7we** [P2] | `tools/mcp-base/spec/vocab.md` | Fix `redacted-sentinel` table row: `:rf.size/redacted` → `:rf/redacted`; expand the cell to spell out the scalar-sentinel semantics (bare keyword, no body, no re-fetch). |
| **rf2-vkbzr** [P2] | `tools/mcp-base/spec/elision.md` | Tighten the documented walker from `(coll? v)` to the enumerated `(or (vector? v) (set? v) (seq? v))` triad the impl ships; add a paragraph documenting the records-not-walked consequence on CLJS. |
| **rf2-xm1fv** [P2] | `tools/mcp-conformance/wire-vocab/test/re_frame/mcp_conformance/wire_vocab_test.clj` | New `:rf/redacted` scalar-sentinel gate (sibling to `:rf.mcp/cursor-stale`): literal-presence pin against `mcp-base/vocab.cljc` after stripping docstrings/comments + doc-source mention pin + bespoke near-miss anti-pin (explicitly blocks the rf2-pv7we historical `:rf.size/redacted` doc-drift). +3 deftests, +1 near-miss set. |
| **rf2-ftoca** [P3] | `tools/mcp-base/spec/sensitive.md` | Re-frame the cross-server arg-vocabulary section to acknowledge the in-flight `?` transition: story-mcp ships `:include-sensitive` (rf2-y710n); pair-mcp still `:include-sensitive?` pending rf2-ihq4d; the namespaced walker-opt retains `?` as internal. Policy + behaviour pin while wire-key spelling refixes. |
| **rf2-f3k9f** [P3] | `tools/mcp-base/src/re_frame/mcp_base/args.cljc` | `fresh-keyword` docstring: lead with the bounded-cost framing (the actual policy) rather than write-side allocation; the When-to-call section already acknowledged the read-side bounded path (pair-mcp's frame-id coercion). Three explicit bounded-cost categories now in the leading docstring. |
| **rf2-j6oay** [P3] | `tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc` | `decode-db-after`: add symmetric `validate-sections!` call before `sections->patches`. The encoder validates both `patches` and `sections`; the decoder previously validated only the flattened `:patches` list, letting `:section-kind` / `:section-path` slip through. Soft-pass + goog-define-elidable by construction (reuses the existing helper). |

Audit framing: every finding is "documentation drift" or "small gate hole" — no structural changes to factoring or surface count.

## Test plan

- [x] `tools/mcp-base` JVM tests: 129 tests, 326 assertions, 0 failures.
- [x] `tools/mcp-conformance/wire-vocab` JVM tests: 38 tests, 468 assertions, 0 failures (3 new deftests passing).
- [x] `cd implementation && npm run test:cljs`: 3504 tests, 9962 assertions, 0 failures.
- [x] `mkdocs build --strict`: clean (only pre-existing INFO messages about nav-omitted pages and an unrelated `the-mayor-method.md` link).
- [x] Worker worktree guard: passed (worktree under `C:\Users\miket\code\re-frame2-worktrees\mcp-family-fixes`).

Closes rf2-pv7we, rf2-vkbzr, rf2-xm1fv, rf2-ftoca, rf2-f3k9f, rf2-j6oay.