### PR TITLE
fix(causa): 3 P2 a11y improvements — palette/modals ARIA + contrast (rf2-tt7ax + rf2-7389r + rf2-0fr6v)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/filters/edit_popup.cljs
@@ -46,6 +46,7 @@
   and the draft from `:rf.causa/edit-popup-draft` (a working copy the
   user mutates without affecting the live filter slot)."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
 
@@ -274,12 +275,21 @@
            :data-rf-causa-modal-positioning (name (or positioning :fixed))
            :on-click    #(rf/dispatch [:rf.causa/close-edit-popup] {:frame :rf/causa})
            :style       (backdrop-style positioning)}
-     [:div {:data-testid "rf-causa-edit-popup-dialog"
-            :on-click    #(.stopPropagation %)
-            :style       (dialog-style)}
+     [:div (merge
+             ;; rf2-7389r — WAI-ARIA dialog contract. The edit-popup
+             ;; already auto-focuses the pattern input on mount, so a
+             ;; focus-on-mount ref would duplicate the work. The
+             ;; existing auto-focus satisfies "focus captured inside
+             ;; the dialog" without an additional ref pass.
+             (a11y/dialog-attrs {:labelled-by "rf-causa-edit-popup-title"})
+             {:data-testid "rf-causa-edit-popup-dialog"
+              :tab-index   "-1"
+              :on-click    #(.stopPropagation %)
+              :style       (dialog-style)})
       [:div {:style (header-style)}
-       [:span title]
+       [:span {:id "rf-causa-edit-popup-title"} title]
        [:button {:data-testid "rf-causa-edit-popup-close"
+                 :aria-label  "Close filter editor"
                  :on-click    #(rf/dispatch
                                  [:rf.causa/close-edit-popup]
                                  {:frame :rf/causa})

--- a/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/palette/view.cljs
@@ -186,9 +186,26 @@
 
 ;; ---- row ----------------------------------------------------------------
 
+(def ^:private listbox-id
+  "DOM `id` of the palette result list. Stable per-modal (only one
+  palette mounts at a time), so the input's `aria-controls` +
+  `aria-activedescendant` references resolve without per-render id
+  churn. rf2-tt7ax."
+  "rf-causa-palette-listbox")
+
+(defn- row-id
+  "DOM `id` of result row `idx` — referenced by the input's
+  `aria-activedescendant` so screen readers track the cursor highlight
+  as the user arrows up/down. rf2-tt7ax."
+  [idx]
+  (str "rf-causa-palette-option-" idx))
+
 (defn- result-row
   [{:keys [source label hint icon] :as item} active? idx]
   [:li {:key          (str "row-" idx)
+        :id           (row-id idx)
+        :role         "option"
+        :aria-selected (if active? "true" "false")
         :data-testid  (str "rf-causa-palette-row-" idx)
         :data-source  (name source)
         :data-active  (str active?)
@@ -263,15 +280,41 @@
            :style       (backdrop-style)}
      [:div {:data-testid "rf-causa-palette-dialog"
             :data-rf-causa-mode "palette"
+            ;; rf2-tt7ax — modal/listbox ARIA: the dialog wrapper
+            ;; carries `role="dialog"` + `aria-modal="true"` so screen
+            ;; readers announce the surface as a modal and the assistive
+            ;; layer keeps focus inside; `aria-label` provides the
+            ;; accessible name (no visible title bar).
+            :role        "dialog"
+            :aria-modal  "true"
+            :aria-label  "Command palette"
             :on-click    #(.stopPropagation %)
             :style       (dialog-style)}
       [:div {:style (input-row-style)}
-       [:span {:style (icon-style :command)} "⌘"]
+       [:span {:aria-hidden "true"
+               :style (icon-style :command)} "⌘"]
        [:input {:data-testid  "rf-causa-palette-input"
                 :type         "text"
                 :auto-focus   true
                 :value        query
                 :placeholder  "Search panels, events, frames, commands…"
+                ;; rf2-tt7ax — combobox/listbox wiring: `aria-label`
+                ;; names the input (no visible <label>); `aria-controls`
+                ;; + `aria-activedescendant` point at the listbox + the
+                ;; active row id so screen readers track the highlight
+                ;; without focus actually moving off the input.
+                ;; `aria-autocomplete="list"` + `role="combobox"` +
+                ;; `aria-expanded` complete the WAI-ARIA APG combobox
+                ;; pattern.
+                :role         "combobox"
+                :aria-label   "Search palette"
+                :aria-controls listbox-id
+                :aria-autocomplete "list"
+                :aria-expanded (if (seq results) "true" "false")
+                :aria-activedescendant
+                              (when (and (seq results)
+                                         (< cursor (count results)))
+                                (row-id cursor))
                 :on-change    #(rf/dispatch
                                  [:rf.causa/palette-set-query
                                   (.. % -target -value)]
@@ -286,9 +329,16 @@
              (when (seq query) (str " / " (count results))))]]
       (if (empty? results)
         [:ul {:data-testid "rf-causa-palette-list"
+              ;; Empty-state list is presentational — no options to
+              ;; surface as listbox children. Keeping the ul role-less
+              ;; avoids a "listbox, 0 items" announcement.
+              :id          listbox-id
               :style       (list-style)}
          [empty-row]]
         (into [:ul {:data-testid "rf-causa-palette-list"
+                    :id          listbox-id
+                    :role        "listbox"
+                    :aria-label  "Palette results"
                     :style       (list-style)}]
               (map-indexed
                 (fn [idx item]

--- a/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/app_db_segment_inspector.cljs
@@ -49,6 +49,7 @@
   Causa's frame regardless of click-time React context."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.panels.app-db-diff-format :as f]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.data-inspector :as inspector]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
@@ -178,7 +179,8 @@
   inspects the root db; the title says 'app-db (root)' so the user
   isn't left wondering what they're looking at."
   [path]
-  [:span {:data-testid "rf-causa-segment-inspector-title"
+  [:span {:id          "rf-causa-segment-inspector-title"
+          :data-testid "rf-causa-segment-inspector-title"
           :style {:color       (:text-primary tokens)
                   :font-weight 600
                   :font-size   (:body type-scale)
@@ -208,16 +210,25 @@
            :on-key-down handle-keydown
            :tab-index   -1
            :style       (backdrop-style positioning)}
-     [:div {:data-testid "rf-causa-segment-inspector-dialog"
-            :data-rf-causa-mode "segment-inspector"
-            :on-click    #(.stopPropagation %)
-            :on-key-down handle-keydown
-            :tab-index   0
-            :style       (dialog-style)}
+     [:div (merge
+             ;; rf2-7389r — WAI-ARIA dialog contract on the inspector
+             ;; popover. The previous tab-index 0 marker hinted at
+             ;; focus-trap intent but lacked role/aria-modal; this
+             ;; finishes the contract + adds focus-on-mount so keyboard
+             ;; users start inside the dialog (audit findings #3 + #19).
+             (a11y/dialog-attrs {:labelled-by "rf-causa-segment-inspector-title"})
+             {:data-testid "rf-causa-segment-inspector-dialog"
+              :data-rf-causa-mode "segment-inspector"
+              :ref         (a11y/focus-on-mount-ref)
+              :on-click    #(.stopPropagation %)
+              :on-key-down handle-keydown
+              :tab-index   0
+              :style       (dialog-style)})
       ;; Header
       [:div {:style (header-style)}
        (header-title path)
        [:button {:data-testid "rf-causa-segment-inspector-close"
+                 :aria-label  "Close segment inspector"
                  :title       "Close (Esc)"
                  :on-click    (fn [^js e]
                                 (.stopPropagation e)

--- a/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/panels/cancellation_cascade.cljs
@@ -44,6 +44,7 @@
             [day8.re-frame2-causa.panels.cancellation-cascade-events :as events]
             [day8.re-frame2-causa.panels.cancellation-cascade-helpers :as h]
             [day8.re-frame2-causa.panels.cancellation-cascade-subs :as subs]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack type-scale]]))
 
@@ -471,11 +472,20 @@
              :on-key-down handle-popover-keydown
              :tab-index   -1
              :style       (backdrop-style positioning)}
-       [:div {:data-testid "rf-causa-cancellation-cascade-popover-dialog"
-              :on-click    #(.stopPropagation %)
-              :on-key-down handle-popover-keydown
-              :tab-index   0
-              :style       (dialog-style)}
+       [:div (merge
+               ;; rf2-7389r — WAI-ARIA dialog contract on the popover
+               ;; wrapper. The cancellation-cascade popover already
+               ;; carried `tab-index 0` markers hinting at focus-trap
+               ;; intent; this completes the modal contract with
+               ;; role/aria-modal/aria-label + a focus-on-mount ref
+               ;; (audit finding #3 + #19).
+               (a11y/dialog-attrs {:label "Cancellation cascade"})
+               {:data-testid "rf-causa-cancellation-cascade-popover-dialog"
+                :ref         (a11y/focus-on-mount-ref)
+                :on-click    #(.stopPropagation %)
+                :on-key-down handle-popover-keydown
+                :tab-index   0
+                :style       (dialog-style)})
         (render-cascade cascade close)]])))
 
 ;; ---- registration entry --------------------------------------------------

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -34,6 +34,7 @@
   their own beads to keep this PR scoped."
   (:require [re-frame.core :as rf]
             [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens sans-stack mono-stack type-scale]]))
 
@@ -976,19 +977,29 @@
                                       {:frame :rf/causa})
            :on-key-down handle-keydown
            :style       (backdrop-style positioning)}
-     [:div {:data-testid "rf-causa-settings-dialog"
-            :data-rf-causa-mode "settings"
-            :on-click    #(.stopPropagation %)
-            :on-key-down handle-keydown
-            :tab-index   "-1"
-            :style       (dialog-style)}
+     [:div (merge
+             ;; rf2-7389r — WAI-ARIA dialog contract: role/aria-modal/
+             ;; aria-labelledby pointing at the visible title span.
+             ;; `:ref` focuses the first focusable descendant on mount
+             ;; so keyboard users land inside the modal rather than on
+             ;; <body> (audit finding #3 + #8).
+             (a11y/dialog-attrs {:labelled-by "rf-causa-settings-title"})
+             {:data-testid "rf-causa-settings-dialog"
+              :data-rf-causa-mode "settings"
+              :ref         (a11y/focus-on-mount-ref)
+              :on-click    #(.stopPropagation %)
+              :on-key-down handle-keydown
+              :tab-index   "-1"
+              :style       (dialog-style)})
       ;; Header
       [:div {:style (header-style)}
-       [:span {:style {:font-weight 600
+       [:span {:id "rf-causa-settings-title"
+               :style {:font-weight 600
                        :color       (:text-primary tokens)
                        :font-size   (:display type-scale)}}
         "Settings"]
        [:button {:data-testid "rf-causa-settings-close"
+                 :aria-label  "Close settings"
                  :title       "Close settings (Esc)"
                  :on-click    (fn [^js e]
                                 (.stopPropagation e)

--- a/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/share_modal.cljs
@@ -21,6 +21,7 @@
   Every subscribe / dispatch resolves against `:rf/causa` via the
   enclosing frame-provider in `shell.cljs`."
   (:require [re-frame.core :as rf]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens mono-stack sans-stack]]))
 
@@ -64,7 +65,8 @@
   [:div {:style {:display "flex"
                  :align-items "center"
                  :justify-content "space-between"}}
-   [:h2 {:style {:margin 0
+   [:h2 {:id "rf-causa-share-modal-title"
+         :style {:margin 0
                  :font-size "14px"
                  :font-weight 600
                  :color (:text-primary tokens)
@@ -73,6 +75,7 @@
     "Share Causa state"]
    [:button
     {:data-testid "rf-causa-share-modal-close"
+     :aria-label  "Close share dialog"
      :on-click    #(rf/dispatch [:rf.causa/share-modal-close] {:frame :rf/causa})
      :style       {:background "transparent"
                    :border "none"
@@ -231,13 +234,20 @@
   (let [share-state @(rf/subscribe [:rf.causa/share-state])
         share-url   @(rf/subscribe [:rf.causa/share-url])
         copy-status @(rf/subscribe [:rf.causa/share-copy-status])]
-    [:div {:data-testid "rf-causa-share-modal-dialog"
-           :on-click    (fn [e] (.stopPropagation e))
-           :on-key-down (fn [^js e]
-                          (when (= "Escape" (.-key e))
-                            (rf/dispatch [:rf.causa/share-modal-close]
-                                         {:frame :rf/causa})))
-           :style       (dialog-style)}
+    [:div (merge
+            ;; rf2-7389r — WAI-ARIA dialog contract + focus capture on
+            ;; mount so keyboard users land inside the modal (audit
+            ;; finding #3).
+            (a11y/dialog-attrs {:labelled-by "rf-causa-share-modal-title"})
+            {:data-testid "rf-causa-share-modal-dialog"
+             :ref         (a11y/focus-on-mount-ref)
+             :tab-index   "-1"
+             :on-click    (fn [e] (.stopPropagation e))
+             :on-key-down (fn [^js e]
+                            (when (= "Escape" (.-key e))
+                              (rf/dispatch [:rf.causa/share-modal-close]
+                                           {:frame :rf/causa})))
+             :style       (dialog-style)})
      (header)
      (description)
      (state-summary share-state)

--- a/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/spine_filters.cljs
@@ -65,6 +65,7 @@
   (:require [cljs.reader :as reader]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [day8.re-frame2-causa.theme.a11y :as a11y]
             [day8.re-frame2-causa.theme.tokens
              :refer [tokens type-scale sans-stack mono-stack]]))
 
@@ -372,7 +373,8 @@
   [:div {:style {:display "flex"
                  :align-items "center"
                  :justify-content "space-between"}}
-   [:h2 {:style {:margin 0
+   [:h2 {:id "rf-causa-mute-manager-title"
+         :style {:margin 0
                  :font-size "14px"
                  :font-weight 600
                  :color (:text-primary tokens)
@@ -381,6 +383,7 @@
     "Muted events"]
    [:button
     {:data-testid "rf-causa-mute-manager-close"
+     :aria-label  "Close muted-events manager"
      :on-click    #(rf/dispatch [:rf.causa/close-mute-manager] {:frame :rf/causa})
      :style       {:background "transparent"
                    :border "none"
@@ -469,13 +472,19 @@
   "The mute manager dialog body. Pure hiccup."
   []
   (let [muted @(rf/subscribe [:rf.causa/muted-event-ids])]
-    [:div {:data-testid "rf-causa-mute-manager-dialog"
-           :on-click    (fn [^js e] (.stopPropagation e))
-           :on-key-down (fn [^js e]
-                          (when (= "Escape" (.-key e))
-                            (rf/dispatch [:rf.causa/close-mute-manager]
-                                         {:frame :rf/causa})))
-           :style       (dialog-style)}
+    [:div (merge
+            ;; rf2-7389r — WAI-ARIA dialog contract + focus capture on
+            ;; mount (audit finding #3).
+            (a11y/dialog-attrs {:labelled-by "rf-causa-mute-manager-title"})
+            {:data-testid "rf-causa-mute-manager-dialog"
+             :ref         (a11y/focus-on-mount-ref)
+             :tab-index   "-1"
+             :on-click    (fn [^js e] (.stopPropagation e))
+             :on-key-down (fn [^js e]
+                            (when (= "Escape" (.-key e))
+                              (rf/dispatch [:rf.causa/close-mute-manager]
+                                           {:frame :rf/causa})))
+             :style       (dialog-style)})
      (header)
      (if (empty? muted)
        (empty-state)

--- a/tools/causa/src/day8/re_frame2_causa/theme/a11y.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/theme/a11y.cljs
@@ -1,0 +1,125 @@
+(ns day8.re-frame2-causa.theme.a11y
+  "Shared accessibility helpers (rf2-7389r).
+
+  Causa ships six modal surfaces (Settings, Share, Spine-filter mute
+  manager, Filter edit-popup, Cancellation-cascade popover, App-DB
+  segment-inspector popover). The P2 a11y audit (`ai/findings/2026-
+  05-20-causa-story-a11y-audit.md` Finding #3) flagged that none of
+  them carry the WAI-ARIA modal contract end-to-end — `role=\"dialog\"`
+  + `aria-modal=\"true\"` + an accessible name + focus capture on
+  open.
+
+  Rather than copy the contract into every modal (drift risk — the
+  audit observed exactly this drift already, with each modal sliding
+  away from a coherent ARIA story), this ns extracts the small bits
+  the six call sites share.
+
+  ## What lives here
+
+    - `dialog-attrs` — the canonical ARIA attribute map a dialog
+      wrapper merges into its `:div` props. Pure data; one source of
+      truth for the role / aria-modal / accessible-name shape.
+    - `focus-on-mount-ref` — a React `:ref` callback that focuses the
+      first focusable element inside a dialog when it mounts. Handles
+      the common case where the dialog itself needs to be focused
+      (so Esc / arrow-keys / Tab work from a known starting point);
+      falls back to focusing the dialog root if no focusable child
+      is found.
+
+  ## Why a `:ref` callback rather than `useEffect` / lifecycle
+
+  The dialog views in this codebase are plain Reagent fns — no
+  `r/create-class`, no `useEffect`. A `:ref` callback is the smallest
+  surface that hooks into the mount lifecycle without restructuring
+  the call site. React invokes the ref with the DOM node on mount
+  and `nil` on unmount; we only act on the mount call.
+
+  ## What does NOT live here (yet)
+
+    - Focus RESTORE on close — capturing `document.activeElement` on
+      open and re-focusing it on close. Tracked as audit finding #8
+      (P2, separate bead).
+    - Focus TRAP — preventing Tab from leaking to chrome beneath the
+      modal. The current behaviour relies on the modal's backdrop +
+      Esc handler to be the user's primary exit; a full trap is the
+      next rev."
+  (:require [clojure.string :as str]))
+
+;; ---- pure-data attrs ----------------------------------------------------
+
+(defn dialog-attrs
+  "Build the canonical ARIA attribute map a modal dialog merges into
+  its outer `:div` props. `opts` may carry:
+
+      :label        — accessible name (string). Used when there is no
+                      visible heading the dialog can reference by id.
+      :labelled-by  — DOM id of a heading element inside the dialog.
+                      Preferred over `:label` when the dialog has a
+                      visible title (screen readers will read the
+                      heading text).
+      :describedby  — DOM id of a description element (optional).
+
+  Returns a map with `:role`, `:aria-modal`, and one of
+  `:aria-label` / `:aria-labelledby` set. Suitable for `(merge …)`
+  into the caller's existing prop map.
+
+  Pure data → map; JVM-portable so the .cljc-naming pattern can pick
+  up these tests on both runners."
+  [{:keys [label labelled-by describedby]}]
+  (cond-> {:role       "dialog"
+           :aria-modal "true"}
+    labelled-by  (assoc :aria-labelledby labelled-by)
+    (and label
+         (not labelled-by))
+    (assoc :aria-label label)
+    describedby  (assoc :aria-describedby describedby)))
+
+;; ---- focus capture ref --------------------------------------------------
+
+(def ^:private focusable-selector
+  "CSS selector matching elements that can receive keyboard focus by
+  default. Used by `focus-on-mount-ref` to find the first focusable
+  descendant of a freshly-mounted dialog.
+
+  Excludes elements with `disabled` (attribute selector) and matches
+  the WAI-ARIA APG dialog pattern's canonical focusable set."
+  (str/join ","
+            ["a[href]"
+             "button:not([disabled])"
+             "input:not([disabled])"
+             "select:not([disabled])"
+             "textarea:not([disabled])"
+             "[tabindex]:not([tabindex=\"-1\"])"]))
+
+(defn focus-on-mount-ref
+  "Build a React `:ref` callback that focuses the first focusable
+  descendant of the mounted dialog node — or the dialog node itself
+  if none is found.
+
+  Returns a function suitable for use as `:ref` on the dialog's outer
+  `:div`. The callback handles unmount (node `nil`) as a no-op so it
+  never throws after the dialog closes.
+
+  Idempotent on remount — each mount triggers the focus call once.
+
+  ## Why focus the dialog node as a fallback
+
+  WAI-ARIA APG's dialog pattern says focus must land *inside* the
+  dialog on open. When the dialog has no focusable child (e.g. an
+  empty-state mute manager), focusing the dialog root with
+  `tab-index=\"-1\"` keeps Esc / arrow-keys functional and gives
+  screen readers a programmatic focus target.
+
+  Caller must set `:tab-index \"-1\"` on the dialog div so the
+  fallback `.focus()` call succeeds.
+
+  Pre-alpha caveat: this does NOT trap focus — Tab can still leak to
+  chrome beneath. Trap is the next rev (rf2-7389r follow-on)."
+  []
+  (fn [^js node]
+    (when node
+      (let [focusable (.querySelector node focusable-selector)
+            target    (or focusable node)]
+        (try
+          (.focus target)
+          (catch :default _ nil))))))

--- a/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
+++ b/tools/causa/src/day8/re_frame2_causa/theme/tokens.cljc
@@ -67,9 +67,19 @@
    :border-default "#2F3441"
 
    ;; ── text ──
+   ;; `:text-tertiary` was bumped from `#6B7080` to `#8990A0`
+   ;; (rf2-0fr6v, audit finding #7). The old hex landed at ~3.5:1 on
+   ;; `:bg-1` — below WCAG 2.1 AA's 4.5:1 floor for body text. The
+   ;; token is used in ~50 inline-style call sites (relative-time
+   ;; chip, hint text, settings field hints, inactive tab labels,
+   ;; "no events" empty state, palette result-count, etc.) — most
+   ;; at the caption / micro size where the small-text 4.5:1
+   ;; threshold applies. The new hex lands at ~4.7:1 on `:bg-1`
+   ;; (passes AA) without flipping the visual rhythm — still
+   ;; reads as muted/secondary against the dark surfaces.
    :text-primary   "#E8EAF0"
    :text-secondary "#A8AEC0"
-   :text-tertiary  "#6B7080"
+   :text-tertiary  "#8990A0"
 
    ;; ── accents + semantic ──
    :accent-violet  "#7C5CFF"

--- a/tools/causa/test/day8/re_frame2_causa/modals_aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/modals_aria_cljs_test.cljs
@@ -1,0 +1,211 @@
+(ns day8.re-frame2-causa.modals-aria-cljs-test
+  "WAI-ARIA dialog contract tests for the six Causa modal surfaces
+  (rf2-7389r — audit finding #3).
+
+  Each modal must carry:
+    - role=\"dialog\"
+    - aria-modal=\"true\"
+    - an accessible name (either aria-label or aria-labelledby
+      pointing at a heading id rendered inside the dialog)
+
+  The audit caught six modals shipping ZERO modal a11y between them.
+  This file freezes the post-fix contract so the next renderer cannot
+  silently regress.
+
+  ## Surfaces under test
+
+    1. Settings popup  (`settings/view/popup-view`)
+    2. Share modal     (`share-modal/share-dialog`)
+    3. Mute manager    (`spine-filters/dialog`)
+    4. Filter edit-popup (`filters/edit-popup/popup-view`)
+    5. Cancellation-cascade popover — exercised via the Popover
+       reg-view's body (it renders a [:div {:role \"dialog\" ...}])
+    6. App-DB segment-inspector popover — same shape as #5
+
+  Tests render each view function directly (no shadow DOM, no Reagent
+  mount) and walk the returned hiccup, asserting the ARIA attribute
+  map on the dialog element. Mirrors the pattern used by
+  `spine-filters-cljs-test` and `palette/aria-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.filters.edit-popup :as edit-popup]
+            [day8.re-frame2-causa.panels.app-db-segment-inspector
+             :as segment-inspector]
+            [day8.re-frame2-causa.panels.cancellation-cascade
+             :as cancellation-cascade]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.settings.view :as settings-view]
+            [day8.re-frame2-causa.share-modal :as share-modal]
+            [day8.re-frame2-causa.spine-filters :as spine-filters]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- hiccup walk helpers ------------------------------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-by-id [tree id]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= id (:id (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- props [hiccup]
+  (when (and (vector? hiccup) (map? (second hiccup)))
+    (second hiccup)))
+
+(defn- assert-dialog-contract!
+  "Common assertions: the dialog node must carry role + aria-modal,
+  and either aria-label or aria-labelledby resolving to a real id
+  in the same tree."
+  [tree dialog-testid label]
+  (let [dialog (find-by-testid tree dialog-testid)
+        attrs  (props dialog)]
+    (is (some? dialog) (str label ": dialog wrapper renders"))
+    (is (= "dialog" (:role attrs))
+        (str label ": role=\"dialog\""))
+    (is (= "true" (:aria-modal attrs))
+        (str label ": aria-modal=\"true\""))
+    (let [labelled-by (:aria-labelledby attrs)
+          label-attr  (:aria-label attrs)]
+      (is (or (and labelled-by
+                   (some? (find-by-id tree labelled-by)))
+              (and (string? label-attr) (seq label-attr)))
+          (str label ": accessible name set — either aria-labelledby
+                points at a heading id rendered in the same tree, or
+                aria-label carries a non-empty string")))))
+
+;; -------------------------------------------------------------------------
+;; (1) Settings popup
+;; -------------------------------------------------------------------------
+
+(deftest settings-popup-carries-dialog-contract
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/settings-open]))
+  (let [tree (rf/with-frame :rf/causa (settings-view/popup-view))]
+    (assert-dialog-contract! tree "rf-causa-settings-dialog"
+                             "Settings popup")))
+
+(deftest settings-popup-close-button-has-aria-label
+  (testing "rf2-7389r + audit #14 — Settings ✕ button accessibility name"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (let [tree  (rf/with-frame :rf/causa (settings-view/popup-view))
+          close (find-by-testid tree "rf-causa-settings-close")]
+      (is (string? (:aria-label (props close)))
+          "Settings close ✕ carries an aria-label"))))
+
+;; -------------------------------------------------------------------------
+;; (2) Share modal
+;; -------------------------------------------------------------------------
+
+(deftest share-modal-carries-dialog-contract
+  (causa-setup!)
+  (let [tree (rf/with-frame :rf/causa (share-modal/share-dialog))]
+    (assert-dialog-contract! tree "rf-causa-share-modal-dialog"
+                             "Share modal")))
+
+;; -------------------------------------------------------------------------
+;; (3) Mute manager
+;; -------------------------------------------------------------------------
+
+(deftest mute-manager-carries-dialog-contract
+  (causa-setup!)
+  (let [tree (rf/with-frame :rf/causa (spine-filters/dialog))]
+    (assert-dialog-contract! tree "rf-causa-mute-manager-dialog"
+                             "Mute manager")))
+
+;; -------------------------------------------------------------------------
+;; (4) Filter edit-popup
+;; -------------------------------------------------------------------------
+
+(deftest filter-edit-popup-carries-dialog-contract
+  (causa-setup!)
+  (rf/with-frame :rf/causa
+    (rf/dispatch-sync [:rf.causa/open-edit-popup
+                       {:source :add :mode :in :pill {}}]))
+  (let [tree (rf/with-frame :rf/causa (edit-popup/popup-view))]
+    (assert-dialog-contract! tree "rf-causa-edit-popup-dialog"
+                             "Filter edit-popup")))
+
+;; -------------------------------------------------------------------------
+;; (5) + (6) Popovers — cancellation-cascade + segment-inspector
+;; -------------------------------------------------------------------------
+;;
+;; These two use `reg-view` to gate on an `:open?` slot. The reg-view
+;; macro defs the symbol; invoking it directly under `with-frame`
+;; resolves subscribes against `:rf/causa` the same way the shell
+;; mount does.
+
+(deftest cancellation-cascade-popover-carries-dialog-contract
+  (testing "rf2-7389r — the cancellation-cascade popover (audit
+            findings #3 + #19) carries dialog role + aria-modal +
+            accessible name on its inner dialog wrapper"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/cancellation-cascade-open
+                         {:dispatch-id :test-dispatch-id}]))
+    (let [tree (rf/with-frame :rf/causa (cancellation-cascade/Popover))]
+      (is (some? tree) "Popover renders when open")
+      (when tree
+        (assert-dialog-contract!
+          tree
+          "rf-causa-cancellation-cascade-popover-dialog"
+          "Cancellation-cascade popover")))))
+
+(deftest segment-inspector-popover-carries-dialog-contract
+  (testing "rf2-7389r — the App-DB segment-inspector popover carries
+            dialog role + aria-modal + accessible name"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/open-segment-inspector []]))
+    (let [tree (rf/with-frame :rf/causa (segment-inspector/Popup))]
+      (is (some? tree) "Popup renders when open")
+      (when tree
+        (assert-dialog-contract!
+          tree
+          "rf-causa-segment-inspector-dialog"
+          "Segment inspector popover")))))

--- a/tools/causa/test/day8/re_frame2_causa/palette/aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/palette/aria_cljs_test.cljs
@@ -1,0 +1,215 @@
+(ns day8.re-frame2-causa.palette.aria-cljs-test
+  "WAI-ARIA contract tests for the Causa command palette (rf2-tt7ax).
+
+  The audit (`ai/findings/2026-05-20-causa-story-a11y-audit.md`
+  Finding #1) flagged the palette as the most-used keyboard surface
+  with the WORST screen-reader exposure — no role=\"dialog\", no
+  aria-modal, no aria-label on the input, no role=\"listbox\", no
+  role=\"option\", no aria-selected, no aria-activedescendant.
+
+  These tests freeze the post-fix contract so future renderers cannot
+  silently regress:
+
+    1. The dialog wrapper carries role=\"dialog\" + aria-modal=\"true\".
+    2. The input carries role=\"combobox\" + aria-controls pointing at
+       the results list + aria-activedescendant tracking the cursor.
+    3. The results <ul> carries role=\"listbox\" + a stable id.
+    4. Each result <li> carries role=\"option\" + aria-selected +
+       a unique id referenced by aria-activedescendant.
+
+  Hiccup traversal mirrors `spine-filters-cljs-test`'s pattern —
+  expand-tree walks function-in-head-position nodes, then a depth-first
+  search by data-testid / role / attribute resolves each assertion."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.palette.view :as view]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.test-support :as causa-test-support]))
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-by-testid-prefix [tree prefix]
+  (filter (fn [node]
+            (when (and (vector? node)
+                       (map? (second node)))
+              (let [t (:data-testid (second node))]
+                (and (string? t)
+                     (.startsWith t prefix)))))
+          (hiccup-seq tree)))
+
+(defn- props [hiccup]
+  (when (and (vector? hiccup) (map? (second hiccup)))
+    (second hiccup)))
+
+;; ---- (1) dialog wrapper ARIA --------------------------------------------
+
+(deftest dialog-wrapper-has-role-and-aria-modal
+  (testing "rf2-tt7ax / audit #1 — the palette dialog wrapper is
+            announced as a modal dialog (role + aria-modal + aria-label)"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree   (rf/with-frame :rf/causa (view/palette-view))
+          dialog (find-by-testid tree "rf-causa-palette-dialog")]
+      (is (some? dialog) "the dialog wrapper renders")
+      (is (= "dialog" (:role (props dialog))))
+      (is (= "true"   (:aria-modal (props dialog))))
+      (is (string? (:aria-label (props dialog)))
+          "an accessible name is set (no visible title bar)"))))
+
+;; ---- (2) input combobox semantics ---------------------------------------
+
+(deftest input-is-combobox-with-listbox-controls
+  (testing "rf2-tt7ax — the search input is a combobox: role=combobox,
+            aria-label (the visible label is missing), aria-controls
+            pointing at the listbox id, aria-autocomplete=list, and
+            aria-expanded reflecting whether results render"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree  (rf/with-frame :rf/causa (view/palette-view))
+          input (find-by-testid tree "rf-causa-palette-input")
+          attrs (props input)]
+      (is (some? input))
+      (is (= "combobox" (:role attrs)))
+      (is (string? (:aria-label attrs)))
+      (is (string? (:aria-controls attrs))
+          ":aria-controls points at the listbox id")
+      (is (= "list" (:aria-autocomplete attrs)))
+      (is (contains? #{"true" "false"} (:aria-expanded attrs))))))
+
+(deftest input-aria-controls-matches-listbox-id
+  (testing "rf2-tt7ax — the id the input :aria-controls references is
+            the same id the <ul> carries. Without this round-trip the
+            screen reader cannot follow combobox -> listbox."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree    (rf/with-frame :rf/causa (view/palette-view))
+          input   (find-by-testid tree "rf-causa-palette-input")
+          listbox (find-by-testid tree "rf-causa-palette-list")]
+      (is (= (:aria-controls (props input))
+             (:id (props listbox)))
+          "aria-controls round-trips to listbox id"))))
+
+;; ---- (3) listbox semantics ----------------------------------------------
+
+(deftest listbox-has-role-when-results-render
+  (testing "rf2-tt7ax — the <ul> picks up role=listbox when results
+            are present. The empty-state ul stays presentational so
+            the user doesn't get a 'listbox, 0 items' announcement."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree (rf/with-frame :rf/causa (view/palette-view))
+          ul   (find-by-testid tree "rf-causa-palette-list")]
+      (is (some? ul) "the list wrapper renders")
+      ;; Default palette open populates results (>0 commands registered)
+      ;; so the listbox role should be set.
+      (is (= "listbox" (:role (props ul)))
+          "non-empty results carry the listbox role"))))
+
+;; ---- (4) option rows ----------------------------------------------------
+
+(deftest result-rows-carry-option-role-and-aria-selected
+  (testing "rf2-tt7ax — each result <li> is role=option with
+            aria-selected matching whether the cursor is on it"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree (rf/with-frame :rf/causa (view/palette-view))
+          rows (find-all-by-testid-prefix tree "rf-causa-palette-row-")]
+      (is (seq rows) "the palette renders at least one row")
+      (doseq [row rows]
+        (let [attrs (props row)]
+          (is (= "option" (:role attrs))
+              "every result row carries role=option")
+          (is (contains? #{"true" "false"} (:aria-selected attrs))
+              "every result row carries aria-selected (boolean string)")
+          (is (string? (:id attrs))
+              "every result row carries a unique id so
+               aria-activedescendant can reference it"))))))
+
+(deftest result-row-ids-are-unique
+  (testing "rf2-tt7ax — each row id is distinct so
+            aria-activedescendant always points at exactly one row"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open]))
+    (let [tree (rf/with-frame :rf/causa (view/palette-view))
+          rows (find-all-by-testid-prefix tree "rf-causa-palette-row-")
+          ids  (mapv (comp :id props) rows)]
+      (is (= (count ids) (count (set ids)))
+          "every row id is unique within the rendered list"))))
+
+(deftest active-row-aria-selected-true-matches-cursor
+  (testing "rf2-tt7ax — the row at cursor position carries
+            aria-selected=true; siblings carry false"
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open])
+      (rf/dispatch-sync [:rf.causa/palette-cursor-set 0]))
+    (let [tree (rf/with-frame :rf/causa (view/palette-view))
+          rows (find-all-by-testid-prefix tree "rf-causa-palette-row-")
+          selected (filter #(= "true" (:aria-selected (props %))) rows)]
+      (is (= 1 (count selected))
+          "exactly one row carries aria-selected=true"))))
+
+(deftest input-aria-activedescendant-points-at-active-row
+  (testing "rf2-tt7ax — the input's aria-activedescendant points at
+            the active row's id. Screen readers track the highlight
+            without focus moving off the input."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/palette-open])
+      (rf/dispatch-sync [:rf.causa/palette-cursor-set 0]))
+    (let [tree     (rf/with-frame :rf/causa (view/palette-view))
+          input    (find-by-testid tree "rf-causa-palette-input")
+          rows     (find-all-by-testid-prefix tree "rf-causa-palette-row-")
+          active   (some (fn [row]
+                           (when (= "true" (:aria-selected (props row)))
+                             (:id (props row))))
+                         rows)]
+      (is (some? active) "an active row was found")
+      (is (= active (:aria-activedescendant (props input)))
+          "input's aria-activedescendant matches the active row's id"))))

--- a/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/panels/issues_ribbon_helpers_cljs_test.cljc
@@ -24,7 +24,8 @@
     7. **format-time** — renders a stable HH:MM:SS.mmm string."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test    :refer-macros [deftest is testing]])
-            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]))
+            [day8.re-frame2-causa.panels.issues-ribbon-helpers :as h]
+            [day8.re-frame2-causa.theme.tokens :as tokens]))
 
 ;; ---- fixture builders ---------------------------------------------------
 
@@ -86,11 +87,13 @@
     (is (nil? (h/op-type->severity nil)))))
 
 (deftest severity-colour-mapping-honours-tokens
-  (testing "each severity gets the shell.cljs token-equivalent colour"
-    (is (= "#F87171" (h/severity-colour :error)))
-    (is (= "#FBBF24" (h/severity-colour :warning)))
-    (is (= "#43C3D0" (h/severity-colour :advisory)))
-    (is (= "#6B7080" (h/severity-colour :unknown)))))
+  (testing "each severity gets the shell.cljs token-equivalent colour
+            (resolved through `theme/tokens` so the rf2-0fr6v
+            `:text-tertiary` contrast bump round-trips automatically)"
+    (is (= (:red    tokens/tokens) (h/severity-colour :error)))
+    (is (= (:yellow tokens/tokens) (h/severity-colour :warning)))
+    (is (= (:cyan   tokens/tokens) (h/severity-colour :advisory)))
+    (is (= (:text-tertiary tokens/tokens) (h/severity-colour :unknown)))))
 
 (deftest severity-label-stable
   (is (= "error"    (h/severity-label :error)))

--- a/tools/causa/test/day8/re_frame2_causa/theme/a11y_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/theme/a11y_cljs_test.cljs
@@ -1,0 +1,110 @@
+(ns day8.re-frame2-causa.theme.a11y-cljs-test
+  "Pure-data tests for the shared a11y helper (rf2-7389r).
+
+  The helper extracts the WAI-ARIA dialog contract + a focus-on-mount
+  `:ref` callback shared by Causa's six modal surfaces. Tests cover:
+
+    1. `dialog-attrs` shape — role + aria-modal always present;
+       labelled-by preferred over label; describedby attaches when set.
+    2. `focus-on-mount-ref` returns a fn (callback ref) that is a no-op
+       on unmount (`nil` node).
+
+  The interactive `.focus()` behaviour is exercised indirectly via the
+  modal integration tests (see `modals.aria-cljs-test`)."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [day8.re-frame2-causa.theme.a11y :as a11y]))
+
+;; ---- dialog-attrs --------------------------------------------------------
+
+(deftest dialog-attrs-sets-role-and-aria-modal
+  (testing "every dialog gets role=\"dialog\" + aria-modal=\"true\"
+            regardless of which name is used"
+    (let [attrs (a11y/dialog-attrs {:label "Demo"})]
+      (is (= "dialog" (:role attrs)))
+      (is (= "true"   (:aria-modal attrs))))))
+
+(deftest dialog-attrs-prefers-labelledby-over-label
+  (testing "rf2-7389r — when both :labelled-by and :label are
+            supplied, :aria-labelledby wins and :aria-label is dropped
+            so the heading text drives the accessible name (the
+            preferred a11y pattern)"
+    (let [attrs (a11y/dialog-attrs {:label       "fallback"
+                                    :labelled-by "the-heading-id"})]
+      (is (= "the-heading-id" (:aria-labelledby attrs)))
+      (is (nil? (:aria-label attrs))
+          ":aria-label is dropped in favour of :aria-labelledby"))))
+
+(deftest dialog-attrs-falls-back-to-label
+  (testing "without a heading id, :aria-label provides the accessible
+            name. The palette modal uses this path (no visible title)."
+    (let [attrs (a11y/dialog-attrs {:label "Command palette"})]
+      (is (= "Command palette" (:aria-label attrs)))
+      (is (nil? (:aria-labelledby attrs))))))
+
+(deftest dialog-attrs-attaches-describedby
+  (testing "optional :describedby points at a description element id
+            for verbose modals"
+    (let [attrs (a11y/dialog-attrs {:label "Demo"
+                                    :describedby "demo-desc"})]
+      (is (= "demo-desc" (:aria-describedby attrs))))))
+
+(deftest dialog-attrs-without-name-still-yields-role-and-modal
+  (testing "a degenerate {} input still produces a syntactically valid
+            dialog attribute map (caller may add the name separately)"
+    (let [attrs (a11y/dialog-attrs {})]
+      (is (= "dialog" (:role attrs)))
+      (is (= "true"   (:aria-modal attrs)))
+      (is (nil? (:aria-label attrs)))
+      (is (nil? (:aria-labelledby attrs))))))
+
+;; ---- focus-on-mount-ref ---------------------------------------------------
+
+(deftest focus-on-mount-ref-returns-a-function
+  (testing "the factory yields a React :ref callback (a fn)"
+    (let [ref (a11y/focus-on-mount-ref)]
+      (is (fn? ref)))))
+
+(deftest focus-on-mount-ref-tolerates-nil-unmount
+  (testing "rf2-7389r — React invokes the ref with `nil` on unmount;
+            the callback must short-circuit so it never throws after
+            the modal closes (e.g. backdrop click while focus was
+            pending)"
+    (let [ref (a11y/focus-on-mount-ref)]
+      (is (nil? (ref nil))
+          "calling with nil returns nil and does not throw"))))
+
+(deftest focus-on-mount-ref-focuses-first-focusable-child
+  (testing "rf2-7389r — when a real DOM node mounts, the ref focuses
+            the first focusable descendant (matches the WAI-ARIA APG
+            dialog pattern: focus lands inside the dialog)"
+    (when (exists? js/document)
+      (let [host (.createElement js/document "div")
+            input (.createElement js/document "input")
+            btn   (.createElement js/document "button")]
+        (set! (.-tabIndex host) -1)
+        (.appendChild host input)
+        (.appendChild host btn)
+        (.appendChild (.-body js/document) host)
+        (try
+          (let [ref (a11y/focus-on-mount-ref)]
+            (ref host)
+            (is (= input (.-activeElement js/document))
+                "first focusable child receives focus (the <input>)"))
+          (finally
+            (.removeChild (.-body js/document) host)))))))
+
+(deftest focus-on-mount-ref-falls-back-to-root-when-no-focusable
+  (testing "rf2-7389r — when the dialog has no focusable child (e.g.
+            empty-state mute manager), the dialog root itself receives
+            focus via tabindex=-1. Keeps Esc / arrow-keys functional."
+    (when (exists? js/document)
+      (let [host (.createElement js/document "div")]
+        (set! (.-tabIndex host) -1)
+        (.appendChild (.-body js/document) host)
+        (try
+          (let [ref (a11y/focus-on-mount-ref)]
+            (ref host)
+            (is (= host (.-activeElement js/document))
+                "the dialog root receives focus as fallback"))
+          (finally
+            (.removeChild (.-body js/document) host)))))))

--- a/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/perf_tier_cljs_test.cljc
@@ -65,9 +65,11 @@
     (is (= "#FB923C" (perf-tier/tier-colour :slow)))      ; orange
     (is (= "#F87171" (perf-tier/tier-colour :blocking)))) ; red
   (testing "unknown tier falls back to text-tertiary so the dot is
-            never invisible"
-    (is (= "#6B7080" (perf-tier/tier-colour :unknown)))
-    (is (= "#6B7080" (perf-tier/tier-colour nil)))))
+            never invisible. Resolved through `theme/tokens` so the
+            rf2-0fr6v contrast bump for `:text-tertiary` round-trips
+            automatically."
+    (is (= (:text-tertiary tokens/tokens) (perf-tier/tier-colour :unknown)))
+    (is (= (:text-tertiary tokens/tokens) (perf-tier/tier-colour nil)))))
 
 (deftest tier-colour-resolves-through-theme-tokens
   (testing "rf2-5kfxe.4 — `tier-colour` is now a thin wrapper over

--- a/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
+++ b/tools/causa/test/day8/re_frame2_causa/theme/tokens_cljs_test.cljc
@@ -263,3 +263,109 @@
     (doseq [[k mult] t/type-scale-multipliers]
       (is (= (t/font-size-css mult) (get t/type-scale k))
           (str k " is font-size-css of its multiplier")))))
+
+;; ---- rf2-0fr6v — WCAG 2.1 AA contrast for `:text-tertiary` --------------
+;;
+;; The pre-rf2-0fr6v hex `#6B7080` landed at ~3.5:1 on the dark bg-1
+;; surface — fails WCAG 2.1 AA's 4.5:1 floor for small body text. The
+;; token is consumed in ~50 inline-style call sites (relative-time
+;; chip, hint text, settings field hints, inactive tab labels, "no
+;; events" empty state, palette result-count, etc.) — most at the
+;; caption/micro size where the small-text threshold applies. The
+;; new hex `#8990A0` lands at ~4.7:1 on `:bg-1` (passes AA) without
+;; flipping the visual rhythm (still reads as muted/secondary).
+;;
+;; Contrast formula: WCAG 2.1 §1.4.3 relative luminance ratio.
+;; The helpers below are pure data — JVM-portable so the .cljc test
+;; surface validates the relationship on both runners.
+
+(defn- hex->rgb-channels
+  "Parse a `#RRGGBB` hex string into a 3-tuple of channels in the
+  [0, 1] range. Pure data."
+  [hex]
+  (let [s (subs hex 1)
+        ;; subs/parse-int on the JVM cannot pass a radix as a 2nd arg
+        ;; to `subs`; build the 2-char substrings manually.
+        r (subs s 0 2)
+        g (subs s 2 4)
+        b (subs s 4 6)
+        parse #?(:clj  #(/ (Long/parseLong % 16) 255.0)
+                 :cljs #(/ (js/parseInt % 16) 255.0))]
+    [(parse r) (parse g) (parse b)]))
+
+(defn- channel-luminance
+  "WCAG 2.1 §1.4.3 per-channel relative luminance. Input in [0, 1]."
+  [c]
+  (if (<= c 0.03928)
+    (/ c 12.92)
+    (Math/pow (/ (+ c 0.055) 1.055) 2.4)))
+
+(defn- relative-luminance
+  "WCAG 2.1 §1.4.3 relative luminance of a `#RRGGBB` colour."
+  [hex]
+  (let [[r g b] (hex->rgb-channels hex)
+        rl (channel-luminance r)
+        gl (channel-luminance g)
+        bl (channel-luminance b)]
+    (+ (* 0.2126 rl) (* 0.7152 gl) (* 0.0722 bl))))
+
+(defn- contrast-ratio
+  "WCAG 2.1 §1.4.3 contrast ratio between two colours. Returns a
+  number in [1.0, 21.0]. Order-independent — `(contrast-ratio fg bg)`
+  equals `(contrast-ratio bg fg)`."
+  [hex-a hex-b]
+  (let [la (relative-luminance hex-a)
+        lb (relative-luminance hex-b)
+        lighter (max la lb)
+        darker  (min la lb)]
+    (/ (+ lighter 0.05) (+ darker 0.05))))
+
+(deftest text-tertiary-passes-wcag-aa-on-dark-bg-1
+  (testing "rf2-0fr6v + audit finding #7 — `:text-tertiary` on `:bg-1`
+            must clear WCAG 2.1 AA's 4.5:1 floor for small body text.
+            The pre-rf2-0fr6v hex `#6B7080` landed at ~3.5:1 — below
+            the floor. The bumped hex `#8990A0` lands ~4.7:1."
+    (let [ratio (contrast-ratio (:text-tertiary t/tokens)
+                                (:bg-1 t/tokens))]
+      (is (>= ratio 4.5)
+          (str ":text-tertiary " (:text-tertiary t/tokens)
+               " on :bg-1 " (:bg-1 t/tokens)
+               " contrast ratio " ratio
+               " must clear WCAG 2.1 AA 4.5:1")))))
+
+(deftest text-tertiary-passes-wcag-aa-on-dark-bg-2
+  (testing "rf2-0fr6v — same token on `:bg-2` (`#1B1E24`). The bg-2
+            surface is slightly lighter than bg-1, so the contrast
+            ratio is marginally LOWER (the foreground hex sits closer
+            to bg-2 in luminance). Pre-fix hex landed ~3.2:1 — even
+            further below the floor — so the bumped hex must clear AA
+            on this surface too."
+    (let [ratio (contrast-ratio (:text-tertiary t/tokens)
+                                (:bg-2 t/tokens))]
+      (is (>= ratio 4.5)
+          (str ":text-tertiary " (:text-tertiary t/tokens)
+               " on :bg-2 " (:bg-2 t/tokens)
+               " contrast ratio " ratio
+               " must clear WCAG 2.1 AA 4.5:1")))))
+
+(deftest text-tertiary-is-bumped-from-pre-fix-hex
+  (testing "rf2-0fr6v — guard against silent revert. The pre-fix
+            value `#6B7080` was below AA; the new value differs."
+    (is (not= "#6B7080" (:text-tertiary t/tokens))
+        "the audit-flagged pre-fix hex must not regress")))
+
+(deftest text-secondary-still-passes-wcag-aaa
+  (testing "Sanity guard — bumping `:text-tertiary` must not have
+            collateral effect on `:text-secondary`. Per the audit
+            inventory `:text-secondary` lands at ~9:1 on bg-1 (AAA)."
+    (let [ratio (contrast-ratio (:text-secondary t/tokens)
+                                (:bg-1 t/tokens))]
+      (is (>= ratio 7.0)
+          (str ":text-secondary must remain >= 7:1 (AAA), got " ratio)))))
+
+(deftest text-primary-still-passes-wcag-aaa
+  (testing "Sanity guard — `:text-primary` at AAA."
+    (let [ratio (contrast-ratio (:text-primary t/tokens)
+                                (:bg-1 t/tokens))]
+      (is (>= ratio 7.0)
+          (str ":text-primary must remain >= 7:1 (AAA), got " ratio)))))


### PR DESCRIPTION
## Summary

Lands 3 P2 a11y audit findings (rf2-w03x1) in one PR:

- **rf2-tt7ax** — Cmd-K palette ARIA: `role=\"dialog\"` + `aria-modal` on wrapper; `role=\"combobox\"` + `aria-controls` + `aria-activedescendant` on input; `role=\"listbox\"` + stable id on `<ul>`; `role=\"option\"` + `aria-selected` + unique id per row. Screen readers now follow the cursor through the result list.
- **rf2-7389r** — 6 modals (Settings, Share, Spine-filter mute manager, Filter edit-popup, Cancellation-cascade popover, App-DB segment-inspector popover) gain `role=\"dialog\"` + `aria-modal=\"true\"` + accessible name via a shared `theme/a11y` helper (`dialog-attrs` + `focus-on-mount-ref`). Close ✕ buttons gain `aria-label` where missing.
- **rf2-0fr6v** — `:text-tertiary` bumped `#6B7080` → `#8990A0`. Was ~3.5:1 on `:bg-1` (failed WCAG 2.1 AA 4.5:1 floor); now ~4.7:1 (passes AA). ~50 inline-style call sites round-trip automatically through the `tokens` map.

## Files

- New: `tools/causa/src/day8/re_frame2_causa/theme/a11y.cljs` (shared helper)
- Modified: palette/view, settings/view, share_modal, spine_filters, filters/edit_popup, panels/cancellation_cascade, panels/app_db_segment_inspector, theme/tokens
- New tests: `theme/a11y_cljs_test`, `palette/aria_cljs_test`, `modals_aria_cljs_test`; extends `theme/tokens_cljs_test` with WCAG contrast computation
- Two existing tests updated to resolve through `tokens` rather than hard-coded hex (issues_ribbon_helpers, perf_tier)

## Test plan

- [x] `npm run test:cljs` — 3539 tests / 10131 assertions / 0 failures (added ~23 new deftests)
- [x] `mkdocs build --strict` — pass (no new errors)
- [x] WCAG contrast check coded into `tokens_cljs_test` so future palette edits cannot silently regress
- [x] Pure-data ARIA assertions on rendered hiccup (no shadow DOM mount required)

## Closes

- rf2-tt7ax
- rf2-7389r
- rf2-0fr6v