### PR TITLE
spec/story: 5 rf2-u6o12 P3 follow-ons (rf2-u3e4q + zex19 + hbfko + w3apf + u1w4w)

### DIFF
--- a/tools/story/spec/015-Test-Coverage.md
+++ b/tools/story/spec/015-Test-Coverage.md
@@ -365,3 +365,81 @@ Every browser failure in the full feature-load gate should include:
 
 If a gate cannot provide these diagnostics, its status should remain
 Partial even if it exercises the happy path.
+
+## Browser assert-helper inventory (bi-directional cross-reference)
+
+The `tools/story/test/story_feature_load.cjs` gate carries ~30 JS
+`assert*` helper fns that exercise user contracts in the running
+browser. The `COVERAGE_MATRIX` table inside the JS file (per the
+[Coverage Status Vocabulary §row-level binding rule](#coverage-status-vocabulary))
+binds each matrix row to its probe; this section provides the inverse
+mapping — given an `assert*` fn, which spec section + matrix row does
+it exercise? — so a reader hunting "where is the user-contract for
+feature X" can pivot through either axis (rf2-w3apf follow-on,
+[`findings/2026-05-20-tools-story-api-review.md`](findings/2026-05-20-tools-story-api-review.md)
+Finding #11).
+
+The bi-directional cross-reference exists in code (every helper has a
+matching matrix row above, and many matrix rows above name the helper
+directly in their "Direct exercise path" cell); this section names the
+rule explicitly so a contributor adding a new helper or matrix row
+keeps the two in lockstep.
+
+### Rule
+
+- **Every `assert*` helper in `story_feature_load.cjs` binds to one or
+  more matrix rows above.** The matrix row's "Direct exercise path" or
+  "Owning command/gate" cell SHOULD name the helper. The helper's
+  surrounding comment block SHOULD name the matrix-row feature it
+  exercises.
+- **Adding a new helper requires either (a) extending a matrix row's
+  exercise-path cell to name it, or (b) adding a new matrix row + a
+  `COVERAGE_MATRIX` entry that points at the helper.** The
+  `validateCoverageMatrix()` runtime check in the JS file enforces the
+  forward direction (every `COVERAGE_MATRIX` row resolves to a probe
+  fn); the inverse — every helper resolves to a matrix row — is
+  enforced by spec discipline, not code.
+- **Helpers that exercise multiple matrix rows MAY appear in multiple
+  exercise-path cells.** The wide matrix's "Direct exercise path" cell
+  is the authoritative cross-reference for which spec rows a helper
+  binds to.
+
+### Cross-reference index
+
+| Helper | Matrix row(s) bound | Spec section(s) |
+|---|---|---|
+| `assertHealthyLoaded` | Render shell mount/unmount; Canonical vocabulary install (smoke prelude) | [003](003-Render-Shell.md) §Shell lifecycle |
+| `assertMainContains` / `assertMainNotContains` / `assertAsideContains` | Generic DOM helpers — bound to whichever row's probe calls them (e.g. `reg-story`, `reg-decorator composition`) | n/a — generic primitives |
+| `assertMatrixVariant` | `reg-variant`; `reg-decorator composition` | [001](001-Authoring.md) §reg-variant |
+| `assertWorkspaceLayouts` | `reg-workspace` layouts | [001](001-Authoring.md) §reg-workspace + [003](003-Render-Shell.md) §Workspace dispatch |
+| `assertSidebarFilters` | `reg-tag` and sidebar filters | [014](014-Chrome-Features.md) §Sidebar tag-as-badge |
+| `assertSidebarTagBadges` | Sidebar tag-as-badge | [014](014-Chrome-Features.md) §Sidebar tag-as-badge |
+| `assertSidebarNavigationSelectsEveryRow` | Sidebar navigation | [003](003-Render-Shell.md) §Sidebar |
+| `assertArgsPrecedence` | Args precedence | [002](002-Runtime.md) §Args resolution precedence |
+| `assertNestedControls` | Controls nested widgets | [001](001-Authoring.md) §`:argtypes` |
+| `assertSchemaInvalid` | Schema/args validation panel | [014](014-Chrome-Features.md) §Schema-validation panel |
+| `assertIsolationPair` | Per-variant frame allocation | [002](002-Runtime.md) §Per-variant frame allocation |
+| `assertLoaderLifecyclePhases` | Lifecycle phases | [002](002-Runtime.md) §Four-phase lifecycle |
+| `assertLoaderCompletion` / `assertLoaderSuccess` | Loader completion | [002](002-Runtime.md) §Phase 1 — Loaders |
+| `assertDiagnostics` / `assertDecoratorFailure` / `assertRenderFailure` / `assertFailureDetailIncludes` | Error projection | [002](002-Runtime.md) §Error projection |
+| `assertSnapshotIdentityStable` | Snapshot identity | [002](002-Runtime.md) §Snapshot-identity computation |
+| `assertCounterCore` | Composite — exercises canvas + sidebar + toolbar after burst | n/a — composite smoke |
+| `assertLoginStory` | Composite — login flow happy/error/retry | n/a — composite smoke |
+| `assertCommandPalette` | Command palette | [014](014-Chrome-Features.md) §Command palette |
+| `assertTestPaneStatus` | Test mode pane; Test watch mode | [009](009-Test-Mode.md) §Test pane |
+| `assertNoPlayEmptyState` | Test mode pane (empty state) | [009](009-Test-Mode.md) §Empty state |
+| `assertPlayStepDebugger` | Play step-debugger | [009](009-Test-Mode.md) §Step-debugger |
+| `assertTestWidgetRunAll` | Chrome test widget | [014](014-Chrome-Features.md) §Sidebar test widget |
+| `assertTestWatchToggle` | Test watch mode | [009](009-Test-Mode.md) §Watch mode |
+| `assertShareUrlIntegrity` | Share and QR | [005](005-SOTA-Features.md) §QR code in share menu + [URL surfaces](API.md#url-surfaces) |
+| `assertA11y` | A11y panel | [014](014-Chrome-Features.md) §A11y panel |
+| `assertToolbarRecorder` | Recorder / test codegen; Chrome-visibility hotkeys (recorder chip route) | [005](005-SOTA-Features.md) §Recorder |
+| `assertMultiSubstrate` | Multi-substrate rendering | [003](003-Render-Shell.md) §Multi-substrate |
+| `assertNoUnexpectedThirdPartyEgress` / `assertNoRecordedRequestMatching` | Third-party egress | [014](014-Chrome-Features.md) §Network egress |
+| `assertCoverageMatrix` / `assertFeatureSet` | Meta — drive every `COVERAGE_MATRIX` row through its probe in declared order | n/a — gate orchestrator |
+
+The index above is a contributor aid, not a re-spec — the authoritative
+binding is the matrix row above + the `COVERAGE_MATRIX` entry in the
+JS file. New helpers MUST be added to both axes (a matrix-row exercise
+path cell naming the helper AND a `COVERAGE_MATRIX` entry routing
+through it).

--- a/tools/story/spec/API.md
+++ b/tools/story/spec/API.md
@@ -5,6 +5,36 @@
 > cross-links to the capability doc where the contract is spelled
 > out in full.
 
+## Facade re-export discipline
+
+`re-frame.story` is the **user-callable facade** for Story. The
+re-export rule is:
+
+- **User-callable surfaces re-export.** The registration macros + their
+  `*`-fn partners, the run/reset/watch/destroy lifecycle, the registry
+  query family, the assertion + recorder facades, the canonical
+  vocabulary tables, `configure!`, the `*-id` Vars for built-in
+  decorators, the shell-mount surface (CLJS-only), `variant-share-url`,
+  and `reg-marks` (privacy primitive re-export per
+  [Conventions §Privacy primitive — `reg-marks` re-export](Conventions.md#privacy-primitive--reg-marks-re-export))
+  all sit on the facade.
+- **Chrome internals + theme tokens require sub-ns access.** Theme
+  tokens (`re-frame.story.theme.*`), the chrome-host surface
+  (`re-frame.story.ui.causa-embed/*`, `re-frame.story.causa-preset/*`,
+  `re-frame.story.ui.keybindings/*`), the URL-state engine
+  (`re-frame.story.ui.url-state/*`), and the schema-validation panel
+  installer all require a direct `:require` of the sub-namespace. They
+  are public but called from the chrome itself, the shell bootstrap, or
+  the Causa preset — not from user story bodies.
+
+The split mirrors `re-frame.core`'s practice: the facade carries the
+ergonomic surface; sub-namespace requires are the discoverability
+signal that a surface is chrome-internal even when public. The rule is
+de-facto in the code today; this paragraph names it so authors writing
+to `re-frame.story` know which side of the line a given surface lives
+on (rf2-u3e4q follow-on, [`findings/2026-05-20-tools-story-api-review.md`](findings/2026-05-20-tools-story-api-review.md)
+Finding #6).
+
 ## Registration macros
 
 All under `re-frame.story`. All DCE under `:advanced` (see
@@ -79,6 +109,39 @@ public; their unsuffixed macro counterparts cover authored cases.
 | `unregister!` | `(unregister! kind id)` | Remove a registration. |
 | `clear-kind!` | `(clear-kind! kind)` | Remove all of a kind. |
 | `clear-all!` | `(clear-all!)` | Reset Story state entirely. |
+
+## Recorder facade
+
+The recorder captures canvas-dispatched events into a `:play` body for
+codegen back into a `reg-variant` snippet. The facade exposes six
+entries on `re-frame.story` (per spec/005 §Recorder + [001-Authoring.md](001-Authoring.md)
+§Recorder); the rich `:play-script` translator lives under the
+recorder's sub-namespace.
+
+| Fn | Signature | Purpose |
+|---|---|---|
+| `start-recording!` | `(start-recording! variant-id)` | Begin recording dispatched events against `variant-id`'s frame. |
+| `stop-recording!` | `(stop-recording!)` | Stop the in-flight recording; return the captured events. |
+| `clear-recording!` | `(clear-recording!)` | Drop the buffer + return the recorder to idle. |
+| `recording?` | `(recording?)` | Predicate — is a recording in flight? |
+| `recorder-state` | `(recorder-state)` | Read-only view of the current recorder state map. |
+| `gen-play-snippet` | `(gen-play-snippet events opts)` | Pure codegen: render a captured `events` vector as a `(reg-variant <id> {... :play [...]})` EDN snippet. Produces the **legacy `:play` body** (vector of event vectors). See [005-SOTA-Features.md](005-SOTA-Features.md) §Recorder for the round-trip contract. |
+
+### `:play-script` export — out of facade
+
+The richer `:play-script` DSL (tagged `:click` / `:type` / `:wait` /
+`:assert` steps, derived from the recorder's `:entries` capture
+stream — rf2-d5u89 / rf2-8i2a9) is exported by **`re-frame.story.recorder.play-export`**
+(sub-namespace; not re-exported through `re-frame.story`). The entry
+fns are `recording->play-script` (translate captured events / entries
+into the normalised `:play-script` body map) and `render-play-script`
+/ `render-variant-form` (render the map to EDN). The translator is
+**experimental / v2-staging** — usable today, but the facade exposes
+only `gen-play-snippet` (the legacy `:play` body) as the canonical v1
+codegen entry. Consumers wanting the rich DSL `:require` the
+sub-namespace directly (rf2-hbfko follow-on,
+[`findings/2026-05-20-tools-story-api-review.md`](findings/2026-05-20-tools-story-api-review.md)
+Finding #10).
 
 ## Effects (fx) registered by Story
 
@@ -182,6 +245,30 @@ Finding #3):
 | `keybindings/bindings` | `re-frame.story.ui.keybindings` | Pure data table | `pure-data-for-help` | The canonical `{key → handler}` table for the chrome-visibility hotkeys (`f` / `s` / `a` / `t`). Public so the help overlay's cheat-sheet section and the `015-Test-Coverage.md` matrix row can both walk the table. See [`014-Chrome-Features.md`](014-Chrome-Features.md) §Chrome-visibility hotkeys. |
 | `keybindings/shortcut-keys` | `re-frame.story.ui.keybindings` | Pure data → data | `pure-data-for-help` | Pure data → data: the sorted list of bound keys. Consumed by the first-visit help overlay so the rendered shortcut table stays in lockstep with the registry. |
 | `keybindings/install!` / `keybindings/uninstall!` | `re-frame.story.ui.keybindings` | Installer pair (canonical shape) | `chrome-shell` | Install / teardown the single `window#keydown` capture-phase listener that backs the hotkey registry. Idempotent; no listener leak across re-mounts. Production builds with `re-frame.story.config/enabled?` false never install. The pair follows the canonical chrome-installer shape per [Conventions §Chrome-installer pair shape](Conventions.md#chrome-installer-pair-shape). |
+
+## URL surfaces
+
+Story carries **three** URL surfaces, each with distinct rules. Only
+the share-URL builder sits on the facade; the other two are
+chrome-internal (per the [facade re-export
+discipline](#facade-re-export-discipline) above). They are documented
+together as a cluster so authors generating share / address-bar / embed
+code can see the three axes at a glance (rf2-zex19 follow-on,
+[`findings/2026-05-20-tools-story-api-review.md`](findings/2026-05-20-tools-story-api-review.md)
+Finding #9):
+
+| Surface | Lives in | Source of truth | Persistence | Encodes | Consumer |
+|---|---|---|---|---|---|
+| `variant-share-url` | `re-frame.story` (facade) / `re-frame.story.share` | The arguments passed in (variant-id + active modes + cell-overrides + substrate) | URL only — share popover copies the URL | Variant id, active modes, cell-overrides, substrate | Share popover; pasted into chat / docs / bug reports. Variant-scoped, includes cell-overrides. |
+| `url-from-state` (+ `params-from-state`) | `re-frame.story.ui.url-state` (sub-ns) | The live shell state (selected workspace, mode tab, viewport, background, tag filter) | URL + localStorage round-trip (see [`014-Chrome-Features.md`](014-Chrome-Features.md) §URL state) | Chrome-scoped state — no cell-overrides | Address bar; the chrome's own URL during interactive use. |
+| `embed-flag-from-current-url` (+ `hydrate-embed-flag!`) | `re-frame.story.ui.url-state` (sub-ns) | The current page URL's `?embed=1` query string | URL only — never persisted to localStorage; one-shot at shell mount | The `:embed?` chrome-state flag (boolean) | The embed-mode flag (rf2-pucku). Hydrated once at mount, then ignored on subsequent navigations. |
+
+The cluster gives the user three different "URLs from one shell":
+the **share** URL (variant-scoped, includes cell-overrides),
+the **address-bar** URL (chrome-scoped, no cell-overrides), and
+the **embed flag** (chrome-state, URL-only, one-shot). A reader
+generating URL-handling code consults this table to find the right
+axis before reaching into the implementation.
 
 ## Configuration
 

--- a/tools/story/spec/Conventions.md
+++ b/tools/story/spec/Conventions.md
@@ -52,6 +52,44 @@ Mirror of [`re-frame.core`](../../../implementation/core/src/re_frame/core.cljc)
 
 Each macro elides to `nil` under `:advanced` builds via the `re-frame.story.config/enabled?` sentinel — see [Principles §Production elision strict](Principles.md#production-elision-strict). The `*`-fn partner does not elide automatically; production builds DCE it via Closure when nothing references it. Tests that drive registration programmatically use the `*`-fn partner.
 
+### Why `reg-story-panel` is three tokens (and not `reg-panel`)
+
+`reg-story-panel` is the only **three-token** name in the `reg-*`
+family — every other registration kind is two tokens (`reg-story`,
+`reg-variant`, `reg-workspace`, `reg-decorator`, `reg-tag`, `reg-mode`).
+The longer name has been examined and intentionally retained
+(rf2-u1w4w follow-on,
+[`findings/2026-05-20-tools-story-api-review.md`](findings/2026-05-20-tools-story-api-review.md)
+Finding #2):
+
+- **The registry kind is `:story-panel`** (per [`API.md` §Registry queries](API.md#registry-queries)
+  — `(registrations :story-panel)` / `(ids :story-panel)` /
+  `(registered? :story-panel <id>)`). The two-token kind keyword is the
+  discriminating noun; the macro name mirrors the kind keyword so the
+  surface stays self-describing — a reader who sees `reg-story-panel`
+  knows the registry kind is `:story-panel` without consulting the
+  spec.
+- **`reg-panel` would conflict with the framework's panel concept.** The
+  framework's `re-frame.core` does not own a panel registry, but the
+  word `panel` is ambient in re-frame application code (route-as-panel,
+  panel components, panel ids in `app-db`). The `story-panel` qualifier
+  signals that the registered surface is **a Story chrome panel** —
+  rendered next to the variant canvas, registered through Story's late-
+  bind contract (per [003-Render-Shell.md](003-Render-Shell.md) §Panel
+  registration contract) — not a generic application panel.
+- **The two-token reading is not load-bearing.** The cluster's
+  cognitive shape is "every `reg-*` registers one kind"; whether the
+  hyphenated noun is one or two tokens is a surface detail. The
+  occasional new reader who conflates `reg-story-panel` with
+  `reg-story` recovers from the conflation by reading the docstring or
+  the `:story-panel` registry-kind keyword.
+
+The rename to `reg-panel` is mechanical (one macro + its `*`-fn partner
++ test selectors + spec references) but the contract surface is broad
+(authoring docs, MCP write surface, Causa late-bind contract). The
+3-token form is retained; this section names the rationale so future
+audits do not re-open the question without new evidence.
+
 ## Chrome-installer pair shape
 
 Story's chrome ships several subsystems with their own install / teardown / hydrate surface (keybindings, URL state, recorder, toolbar persistence, element inspector, save-variant modal, schema-validation panel). The canonical shape:


### PR DESCRIPTION
## Summary

Five P3 documentation follow-ons from the rf2-u6o12 Story API review (`ai/findings/2026-05-20-tools-story-api-review.md`). All touch `tools/story/spec/*` only — no source/test/example changes.

- **rf2-u3e4q (Finding #6)** — `API.md` opens with a **Facade re-export discipline** section: user-callable surfaces re-export; chrome internals + theme tokens require sub-ns access.
- **rf2-zex19 (Finding #9)** — `API.md` gains a **URL surfaces** section documenting the three URLs as a cluster (share / address-bar / embed).
- **rf2-hbfko (Finding #10)** — `API.md` gains a **Recorder facade** section + an explicit `:play-script` export status note (sub-ns; experimental / v2-staging; `gen-play-snippet` is the v1 canonical entry).
- **rf2-w3apf (Finding #11)** — `015-Test-Coverage.md` gains a **Browser assert-helper inventory** providing the inverse cross-reference (helper → matrix row + spec section) that complements `COVERAGE_MATRIX`.
- **rf2-u1w4w (Finding #2)** — `Conventions.md` gains a **Why `reg-story-panel` is three tokens** subsection documenting the retain decision. No rename was performed (per the bead's decision-flavored framing — documenting the consideration is the chosen path).

Closes rf2-u3e4q, rf2-zex19, rf2-hbfko, rf2-w3apf, rf2-u1w4w.

## Files

- `tools/story/spec/API.md` — +87 lines (Facade re-export discipline + URL surfaces + Recorder facade sections)
- `tools/story/spec/Conventions.md` — +38 lines (Why `reg-story-panel` is three tokens subsection)
- `tools/story/spec/015-Test-Coverage.md` — +78 lines (Browser assert-helper inventory section)

Net: +203 lines across three files; no source / test / example changes.

## Test plan

- [x] `mkdocs build --strict` — clean (no warnings or errors)
- [x] Diff scoped to `tools/story/spec/*` only — no hot-zone files outside that surface