### PR TITLE
fix(a11y): 4 P3 polish bundles (rf2-plajx + h4mnh + lbutp + vxpq1)

### DIFF
--- a/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/frame_switcher.cljs
@@ -298,7 +298,16 @@
       [:span {:data-testid "rf-causa-ribbon-frame"
               :style (merge label-style {:color (:text-secondary tokens)})}
        (str "Frame: " (or selected-frame (first frames) ":rf/default"))]
+      ;; rf2-lbutp — native `<select>` is keyboard- and screen-
+      ;; reader-accessible by default, but assistive tech needs an
+      ;; accessible NAME to read on focus. The visible "Frame:"
+      ;; prefix lives inside each `<option>`, not as a sibling
+      ;; `<label>`, so the picker arrives "blank, combobox" without
+      ;; this `aria-label`. Matches the convention the audit
+      ;; flagged (#16) — frame-switcher gets an explicit accessible
+      ;; name.
       [:select {:data-testid "rf-causa-ribbon-frame-picker"
+                :aria-label  "Select frame"
                 :value       (str (or selected-frame (first frames)))
                 :on-change   (fn [^js e]
                                (let [v   (.. e -target -value)

--- a/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/resize_handle.cljs
@@ -371,12 +371,27 @@
   [mode]
   (when (and (= mode :inline)
              (not (host-asserts-own-handle?)))
-    (let [current-width @(rf/subscribe [:rf.causa/panel-width-px])]
+    (let [current-width @(rf/subscribe [:rf.causa/panel-width-px])
+          ;; rf2-vxpq1 — WAI-ARIA "separator" with `aria-valuenow`
+          ;; requires both `aria-valuemin` AND `aria-valuemax`. The
+          ;; clamp ceiling is viewport-fraction-based at write time
+          ;; (config/max-panel-width-fraction); for the announced
+          ;; ARIA max we use a stable pixel approximation derived
+          ;; from the window's inner width when available, falling
+          ;; back to a 2000px assumed viewport (the same default the
+          ;; clamp uses when no viewport is supplied). Computing once
+          ;; per render is fine — the value is read on focus, not
+          ;; every paint.
+          viewport-w     (when (exists? js/window)
+                           (.-innerWidth js/window))
+          aria-max       (long (* (or viewport-w 2000)
+                                  config/max-panel-width-fraction))]
       [:div {:data-testid      "rf-causa-resize-handle"
              :role             "separator"
              :aria-orientation "vertical"
              :aria-label       "Resize Causa panel"
              :aria-valuemin    config/min-panel-width-px
+             :aria-valuemax    aria-max
              :aria-valuenow    current-width
              :title            (str "Drag to resize · double-click to reset · "
                                     "arrow keys for fine resize (Shift = coarse) · "

--- a/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/settings/view.cljs
@@ -218,12 +218,37 @@
   load."
   (into {} (for [{:keys [mnemonic id]} tabs] [mnemonic id])))
 
+(defn- settings-tab-button-id
+  "DOM id for a Settings tab button. Public-shaped helper so the
+  tabpanel's `aria-labelledby` can compute the same id without
+  duplicating the literal."
+  [id]
+  (str "rf-causa-settings-tab-button-" (name id)))
+
+(defn- settings-tabpanel-id
+  "DOM id for the Settings tabpanel — referenced by the tab button's
+  `aria-controls` AND set on the body wrapper so the WAI-ARIA APG
+  tabs pattern's id round-trip resolves (rf2-h4mnh)."
+  [id]
+  (str "rf-causa-settings-tabpanel-" (name id)))
+
 (defn- tab-button [{:keys [id label]} active?]
-  [:button {:data-testid (str "rf-causa-settings-tab-" (name id))
-            :data-active (str active?)
-            :on-click    #(rf/dispatch [:rf.causa/settings-select-tab id]
-                                       {:frame :rf/causa})
-            :style       (tab-style active?)}
+  ;; rf2-h4mnh — Settings popup inner tabs now carry the full WAI-
+  ;; ARIA tab role: `role="tab"` + `aria-selected` per state +
+  ;; stable `id` (so the body's `aria-labelledby` resolves) +
+  ;; `aria-controls` pointing at the body's tabpanel id. The same
+  ;; pattern Causa already ships on the L3 Runtime + Static tab
+  ;; strips (shell.cljs/tab-button). Keeps `:data-active` for
+  ;; styling-key parity with existing CSS selectors / tests.
+  [:button {:data-testid    (str "rf-causa-settings-tab-" (name id))
+            :id             (settings-tab-button-id id)
+            :role           "tab"
+            :aria-selected  (if active? "true" "false")
+            :aria-controls  (settings-tabpanel-id id)
+            :data-active    (str active?)
+            :on-click       #(rf/dispatch [:rf.causa/settings-select-tab id]
+                                          {:frame :rf/causa})
+            :style          (tab-style active?)}
    label])
 
 ;; ---- section: General ---------------------------------------------------
@@ -241,10 +266,15 @@
      [:h2 {:style (section-heading-style)} "General"]
 
      ;; ── Text size slider ────────────────────────────────────────
+     ;; rf2-h4mnh — `<label :html-for>` ↔ `<input :id>` association
+     ;; so clicking the label focuses the input AND screen readers
+     ;; pair them (was previously a sibling label with no for/id).
      [:div {:style (field-style)}
-      [:label {:style (label-style)} "Text size"]
+      [:label {:html-for "rf-causa-settings-text-size-input"
+               :style    (label-style)} "Text size"]
       [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
        [:input {:data-testid "rf-causa-settings-text-size-input"
+                :id          "rf-causa-settings-text-size-input"
                 :type        "range"
                 :min         "10"
                 :max         "18"
@@ -265,10 +295,13 @@
         (str (or text-size 13) "px")]]]
 
      ;; ── Panel width (rf2-x8h9y resize handle numeric override) ─
+     ;; rf2-h4mnh — `<label :html-for>` ↔ `<input :id>` association.
      [:div {:style (field-style)}
-      [:label {:style (label-style)} "Panel width (px)"]
+      [:label {:html-for "rf-causa-settings-panel-width-input"
+               :style    (label-style)} "Panel width (px)"]
       [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
        [:input {:data-testid "rf-causa-settings-panel-width-input"
+                :id          "rf-causa-settings-panel-width-input"
                 :type        "number"
                 :min         "320"
                 :step        "10"
@@ -368,10 +401,13 @@
        "Vertical-rhythm knob for Views detail rows and App-db diff rows."]]
 
      ;; ── Long-keyword wrap threshold ─────────────────────────────
+     ;; rf2-h4mnh — `<label :html-for>` ↔ `<input :id>` association.
      [:div {:style (field-style)}
-      [:label {:style (label-style)} "Long-keyword threshold (chars)"]
+      [:label {:html-for "rf-causa-settings-long-keyword-threshold"
+               :style    (label-style)} "Long-keyword threshold (chars)"]
       [:div {:style {:display "flex" :align-items "center" :gap "12px"}}
        [:input {:data-testid "rf-causa-settings-long-keyword-threshold"
+                :id          "rf-causa-settings-long-keyword-threshold"
                 :type        "number"
                 :min         "8"
                 :max         "120"
@@ -735,11 +771,15 @@
 
 (defn- numeric-field
   "Hiccup for a numeric setting input + label + hint. Common shape
-  for the three Buffer-tab knobs."
+  for the three Buffer-tab knobs. rf2-h4mnh — `:html-for` ↔ `:id`
+  associates label with input so clicking the label focuses the
+  input AND screen readers announce them paired."
   [{:keys [testid label value default on-commit min hint]}]
   [:div {:style (field-style)}
-   [:label {:style (label-style)} label]
+   [:label {:html-for testid
+            :style    (label-style)} label]
    [:input {:data-testid testid
+            :id          testid
             :type        "number"
             :min         (str (or min 0))
             :step        "1"
@@ -1007,14 +1047,27 @@
                                              {:frame :rf/causa}))
                  :style       (close-button-style)}
         "✕"]]
-      ;; Tab strip
+      ;; Tab strip — rf2-h4mnh: the strip wrapper is an explicit
+      ;; `role="tablist"` so assistive tech reads the row as a tab
+      ;; group rather than a generic div of buttons. `aria-label`
+      ;; names the group ("Settings sections") for screen readers
+      ;; that announce the landmark on entry.
       (into [:div {:data-testid "rf-causa-settings-tab-strip"
+                   :role        "tablist"
+                   :aria-label  "Settings sections"
                    :style       (tab-strip-style)}]
             (for [tab tabs]
               [tab-button tab (= (:id tab) active-tab)]))
-      ;; Body
-      [:div {:data-testid "rf-causa-settings-body"
-             :style       (body-style)}
+      ;; Body — rf2-h4mnh: closes the tabs/tabpanel loop. The body
+      ;; carries `role="tabpanel"` + an `id` matching the active
+      ;; tab button's `aria-controls`, and `aria-labelledby`
+      ;; pointing back at the tab button so AT announces "<Tab>
+      ;; tabpanel" on focus.
+      [:div {:data-testid     "rf-causa-settings-body"
+             :id              (settings-tabpanel-id active-tab)
+             :role            "tabpanel"
+             :aria-labelledby (settings-tab-button-id active-tab)
+             :style           (body-style)}
        (case active-tab
          :general     (general-section)
          :filters     (filters-section)

--- a/tools/causa/src/day8/re_frame2_causa/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/shell.cljs
@@ -516,7 +516,12 @@
             :style       {:color       (:magenta tokens)
                           :font-weight 600
                           :font-size   (:caption type-scale)}}
-     (str "● REDACTED " redacted-count)]))
+     ;; rf2-vxpq1 — the leading `●` glyph is decorative (the count
+     ;; + "REDACTED" word carry the meaning). `aria-hidden` on the
+     ;; glyph suppresses the unicode-name announcement ("black
+     ;; circle") while keeping the text + title accessible.
+     [:span {:aria-hidden "true"} "● "]
+     (str "REDACTED " redacted-count)]))
 
 (defn- ribbon-focus-chip
   "Focus chip (rf2-a1z3b) — surfaces the active focus-set as
@@ -546,7 +551,12 @@
                            :font-size      (:body type-scale)
                            :color          (:text-primary tokens)
                            :max-width      "240px"}}
-       [:span {:style {:color (:accent-violet tokens)
+       ;; rf2-vxpq1 — `🎯` is a decorative glyph; the chip's
+       ;; "Focus: <label>" tooltip + the label span carry the
+       ;; accessible meaning. `aria-hidden` suppresses the unicode-
+       ;; name announcement ("direct hit").
+       [:span {:aria-hidden "true"
+               :style {:color (:accent-violet tokens)
                        :font-weight 600}}
         "🎯"]                ;; 🎯 (UTF-16 surrogate pair for portability)
        [:span {:data-testid "rf-causa-focus-chip-label"
@@ -1336,11 +1346,17 @@
   rather than generic buttons and reads the selected state correctly;
   `getByRole('tab')` lookups in host integration tests resolve here."
   [{:keys [id label mnem active?]}]
-  (let [glyph (if active? "◉" "○")
-        color (if active? (:text-primary tokens) (:text-secondary tokens))]
+  (let [glyph    (if active? "◉" "○")
+        color    (if active? (:text-primary tokens) (:text-secondary tokens))
+        ;; rf2-plajx — stable per-tab id so the controlled L4 panel's
+        ;; `aria-labelledby` resolves to this button's accessible name.
+        tab-id   (str "rf-causa-tab-button-" (name id))
+        panel-id (str "rf-causa-tabpanel-" (name id))]
     [:button {:data-testid   (str "rf-causa-tab-" (name id))
+              :id            tab-id
               :role          "tab"
               :aria-selected (if active? "true" "false")
+              :aria-controls panel-id
               :on-click      #(rf/dispatch [:rf.causa/select-tab id] {:frame :rf/causa})
               :title         (str label " (" mnem ")")
               :aria-label    (str "Causa " label " tab")
@@ -1356,7 +1372,12 @@
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
                       :white-space   "nowrap"}}
-     [:span {:style {:color (if active?
+     ;; rf2-vxpq1 — the ●/○ glyph is decorative; the visible label
+     ;; carries the tab's accessible name. `aria-hidden="true"`
+     ;; suppresses the unicode-name announcement ("heavy black
+     ;; circle" / "white circle").
+     [:span {:aria-hidden "true"
+             :style {:color (if active?
                               (:accent-violet tokens)
                               (:text-tertiary tokens))
                      :margin-right "4px"}}
@@ -1437,6 +1458,15 @@
   (let [selected (or @(rf/subscribe [:rf.causa/selected-tab])
                      default-tab)]
     [:div {:data-testid (str "rf-causa-detail-panel-" (name selected))
+           ;; rf2-plajx — L4 closes the tab/tabpanel loop. The L3
+           ;; tablist owns `role="tablist"` + per-tab `role="tab"` +
+           ;; `aria-selected`; the panel completes the WAI-ARIA APG
+           ;; tabs pattern with `role="tabpanel"` + `aria-labelledby`
+           ;; pointing at the active tab button (per `tab-button`
+           ;; the id is `rf-causa-tab-button-<tab-id>`).
+           :id              (str "rf-causa-tabpanel-" (name selected))
+           :role            "tabpanel"
+           :aria-labelledby (str "rf-causa-tab-button-" (name selected))
            :style {:flex        "1 1 auto"
                    :min-height  "0"
                    :overflow    "auto"
@@ -1592,6 +1622,18 @@
                         {:frame :rf/causa})))
   [rf/frame-provider {:frame :rf/causa}
    [:div {:data-testid "rf-causa-shell"
+          ;; rf2-plajx — Causa shell root is a landmark. A 40%-
+          ;; viewport overlay rendered as a bare `<div>` is invisible
+          ;; to screen-reader landmark navigation (JAWS R-key /
+          ;; NVDA D-key). `role="region"` + `aria-label` exposes the
+          ;; shell as a labelled landmark so AT users can jump to it.
+          ;; "region" (rather than "complementary" / "aside") matches
+          ;; the audit's Q3 disposition: Causa is a global chrome
+          ;; surface with its own internal landmark structure (L1
+          ;; ribbon = toolbar, L3 = tablist, L4 = tabpanel) rather
+          ;; than content complementary to the host's main.
+          :role        "region"
+          :aria-label  "Causa devtools"
           ;; Per rf2-zkfiz Q1-9 the spec-published mode axis is
           ;; `data-rf-causa-mode` (mount.cljs writes it on both the
           ;; root and the shell node). The previous `data-mode` echo

--- a/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/static/shell.cljs
@@ -226,11 +226,18 @@
   B), the tab carries `role='tab'` + `aria-selected` so assistive
   tech reads it as a tab, not a generic button."
   [{:keys [id label mnem active?]}]
-  (let [glyph (if active? "◉" "○")
-        color (if active? (:text-primary tokens) (:text-secondary tokens))]
+  (let [glyph    (if active? "◉" "○")
+        color    (if active? (:text-primary tokens) (:text-secondary tokens))
+        ;; rf2-plajx — mirror the Runtime tab-button pattern: stable
+        ;; tab-id + matching tabpanel id so the L4 panel's
+        ;; `aria-labelledby` resolves.
+        tab-id   (str "rf-causa-static-tab-button-" (name id))
+        panel-id (str "rf-causa-static-tabpanel-" (name id))]
     [:button {:data-testid   (str "rf-causa-static-tab-" (name id))
+              :id            tab-id
               :role          "tab"
               :aria-selected (if active? "true" "false")
+              :aria-controls panel-id
               :on-click      #(rf/dispatch [:rf.causa.static/select-tab id]
                                            {:frame :rf/causa})
               :title         (str label " (" mnem ")")
@@ -247,7 +254,9 @@
                       :font-size     (:body type-scale)
                       :font-weight   (if active? 600 400)
                       :white-space   "nowrap"}}
-     [:span {:style {:color (if active?
+     ;; rf2-vxpq1 — `aria-hidden` on decorative ●/○ glyph.
+     [:span {:aria-hidden "true"
+             :style {:color (if active?
                               (:cyan tokens)
                               (:text-tertiary tokens))
                      :margin-right "4px"}}
@@ -285,7 +294,10 @@
   "Render a placeholder card for an unfilled Static sub-tab. The card
   surfaces:
 
-    - The tab label as an `<h1>` for screen-reader navigation.
+    - The tab label as an `<h2>` for screen-reader navigation
+      (rf2-vxpq1 — was previously `<h1>` which nested a second top-
+      level heading inside the host document's outline; `<h2>` keeps
+      the placeholder a subheading under the host's `<h1>`).
     - The sibling bead id ('rf2-o5f5f.<N> will fill this').
     - A muted hint paragraph naming the upcoming content.
 
@@ -301,7 +313,7 @@
                      :font-family   sans-stack
                      :font-size     (:body type-scale)
                      :line-height   (:line-height-tight type-scale)}}
-   [:h1 {:style {:font-size     (:display type-scale)
+   [:h2 {:style {:font-size     (:display type-scale)
                  :margin        "0 0 8px 0"
                  :padding-left  "10px"
                  :border-left   (str "3px solid " (:cyan tokens))}}
@@ -347,6 +359,13 @@
                      default-tab)
         tab      (tab-by-id selected)]
     [:div {:data-testid (str "rf-causa-static-detail-panel-" (name selected))
+           ;; rf2-plajx — Static L4 closes the tab/tabpanel loop.
+           ;; Pairs with the per-tab `id` set by `tab-button` so
+           ;; assistive tech reads the panel as "labelled by <tab
+           ;; name>". Same shape as the Runtime detail-panel.
+           :id              (str "rf-causa-static-tabpanel-" (name selected))
+           :role            "tabpanel"
+           :aria-labelledby (str "rf-causa-static-tab-button-" (name selected))
            :style {:flex        "1 1 auto"
                    :min-height  "0"
                    :overflow    "auto"

--- a/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
+++ b/tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs
@@ -1,0 +1,391 @@
+(ns day8.re-frame2-causa.p3-polish-aria-cljs-test
+  "P3 a11y polish contract tests — bundles four audit-derived beads
+  (rf2-w03x1 audit findings #4, #5, #16, #17, #18, #22, #25, #26).
+
+    - rf2-plajx — Causa shell root carries `role=\"region\"` +
+      `aria-label`; L4 detail-panel carries `role=\"tabpanel\"` +
+      `aria-labelledby` linking back to the active L3 tab button.
+      Mirrored on the Static surface's L4 panel.
+
+    - rf2-h4mnh — Settings popup inner tabs render as a WAI-ARIA tab
+      group: tab-strip wrapper has `role=\"tablist\"` +
+      `aria-label`, each tab button has `role=\"tab\"` +
+      `aria-selected` + `id` + `aria-controls`; the body wrapper has
+      `role=\"tabpanel\"` + `id` + `aria-labelledby` pointing at the
+      active tab. Numeric `<label>` ↔ `<input>` pairs in General +
+      Buffer carry `:html-for` ↔ `:id`.
+
+    - rf2-lbutp — Causa frame-switcher native `<select>` carries an
+      explicit `aria-label`. Story multi-substrate grid exposes a
+      labelled `role=\"group\"` with per-cell `role=\"region\"`.
+
+    - rf2-vxpq1 — Causa resize-handle carries `aria-valuemax`;
+      decorative glyphs (●/○ tab markers, ● REDACTED prefix, 🎯
+      focus chip) carry `aria-hidden=\"true\"`; Static placeholder
+      cards drop from `<h1>` to `<h2>`.
+
+  All assertions walk the view's hiccup tree by `data-testid` /
+  attribute presence rather than mounting to a DOM — same approach
+  the existing `modals-aria-cljs-test` / `shell-cljs-test` files
+  use."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [day8.re-frame2-causa.config :as config]
+            [day8.re-frame2-causa.registry :as registry]
+            [day8.re-frame2-causa.resize-handle :as resize-handle]
+            [day8.re-frame2-causa.settings.view :as settings-view]
+            [day8.re-frame2-causa.shell :as shell]
+            [day8.re-frame2-causa.frame-switcher :as frame-switcher]
+            [day8.re-frame2-causa.static.shell :as static-shell]
+            [day8.re-frame2-causa.test-support :as causa-test-support]
+            [day8.re-frame2-causa.trace-bus :as trace-bus]))
+
+;; ---- fixture ------------------------------------------------------------
+
+(defn- causa-init! []
+  (causa-test-support/reset-all!)
+  (trace-bus/clear-buffer!)
+  (config/reset-settings!))
+
+(use-fixtures :each
+  (test-support/reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn causa-init!}))
+
+(defn- causa-setup! []
+  (registry/register-causa-handlers!)
+  (frame/reg-frame :rf/causa {}))
+
+;; ---- hiccup walker (mirrors shell-cljs-test) ----------------------------
+
+(declare expand-tree)
+
+(defn- expand-tree [tree]
+  (cond
+    (and (vector? tree) (fn? (first tree)))
+    (expand-tree (apply (first tree) (rest tree)))
+
+    (vector? tree)
+    (mapv expand-tree tree)
+
+    (seq? tree)
+    (map expand-tree tree)
+
+    :else tree))
+
+(defn- hiccup-seq [tree]
+  (let [expanded (expand-tree tree)]
+    (tree-seq (some-fn vector? seq?) seq expanded)))
+
+(defn- find-by-testid [tree testid]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= testid (:data-testid (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-by-id [tree id]
+  (some (fn [node]
+          (when (and (vector? node)
+                     (map? (second node))
+                     (= id (:id (second node))))
+            node))
+        (hiccup-seq tree)))
+
+(defn- find-all-with-pred [tree pred]
+  (filterv pred (hiccup-seq tree)))
+
+(defn- props [hiccup]
+  (when (and (vector? hiccup) (map? (second hiccup)))
+    (second hiccup)))
+
+;; -------------------------------------------------------------------------
+;; (1) rf2-plajx — shell root landmark
+;; -------------------------------------------------------------------------
+
+(deftest shell-root-is-a-labelled-region-landmark
+  (testing "rf2-plajx — Causa shell root carries role=\"region\" +
+            aria-label so AT users can navigate to it via landmark
+            cycle. The overlay was previously a bare <div>."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree  (shell/shell-view)
+            shell (find-by-testid tree "rf-causa-shell")
+            attrs (props shell)]
+        (is (some? shell) "shell root mounts")
+        (is (= "region" (:role attrs))
+            "shell carries role=\"region\"")
+        (is (and (string? (:aria-label attrs))
+                 (seq (:aria-label attrs)))
+            "shell carries a non-empty aria-label")
+        (is (= "Causa devtools" (:aria-label attrs))
+            "the published accessible name is \"Causa devtools\"")))))
+
+;; -------------------------------------------------------------------------
+;; (2) rf2-plajx — Runtime L3 tabs + L4 tabpanel id round-trip
+;; -------------------------------------------------------------------------
+
+(deftest runtime-tabs-and-panel-close-the-aria-loop
+  (testing "rf2-plajx — Runtime L3 tab buttons carry stable `:id` +
+            `:aria-controls`; the L4 detail-panel carries
+            `:role=\"tabpanel\"` + `:id` + `:aria-labelledby` resolving
+            back to the active tab's id."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree         (shell/shell-view)
+            active-tab   :event ;; default
+            tab-button   (find-by-testid tree (str "rf-causa-tab-" (name active-tab)))
+            tab-attrs    (props tab-button)
+            expected-id  (str "rf-causa-tab-button-" (name active-tab))
+            panel-id     (str "rf-causa-tabpanel-" (name active-tab))
+            panel        (find-by-testid tree (str "rf-causa-detail-panel-" (name active-tab)))
+            panel-attrs  (props panel)]
+        (is (= expected-id (:id tab-attrs))
+            "tab button id matches the documented shape")
+        (is (= panel-id (:aria-controls tab-attrs))
+            "tab button's aria-controls points at the panel id")
+        (is (= "tabpanel" (:role panel-attrs))
+            "L4 detail-panel carries role=\"tabpanel\"")
+        (is (= panel-id (:id panel-attrs))
+            "L4 panel id matches the tab's aria-controls")
+        (is (= expected-id (:aria-labelledby panel-attrs))
+            "L4 panel's aria-labelledby resolves back to the active tab")))))
+
+(deftest static-tabs-and-panel-close-the-aria-loop
+  (testing "rf2-plajx — Static L4 panel mirrors the Runtime pattern."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree        (static-shell/surface)
+            active-tab  :machines ;; the default Static tab
+            tab-button  (find-by-testid tree (str "rf-causa-static-tab-" (name active-tab)))
+            tab-attrs   (props tab-button)
+            expected-id (str "rf-causa-static-tab-button-" (name active-tab))
+            panel-id    (str "rf-causa-static-tabpanel-" (name active-tab))
+            panel       (find-by-testid tree (str "rf-causa-static-detail-panel-" (name active-tab)))
+            panel-attrs (props panel)]
+        (is (= expected-id (:id tab-attrs))
+            "Static tab button id matches the documented shape")
+        (is (= panel-id (:aria-controls tab-attrs))
+            "Static tab button's aria-controls points at the panel id")
+        (is (= "tabpanel" (:role panel-attrs))
+            "Static L4 panel carries role=\"tabpanel\"")
+        (is (= expected-id (:aria-labelledby panel-attrs))
+            "Static L4 panel's aria-labelledby resolves back to the active tab")))))
+
+;; -------------------------------------------------------------------------
+;; (3) rf2-h4mnh — Settings tab strip ARIA + tabpanel
+;; -------------------------------------------------------------------------
+
+(deftest settings-tab-strip-is-a-labelled-tablist
+  (testing "rf2-h4mnh — the Settings tab strip wrapper carries
+            role=\"tablist\" + aria-label."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (let [tree   (rf/with-frame :rf/causa (settings-view/popup-view))
+          strip  (find-by-testid tree "rf-causa-settings-tab-strip")
+          attrs  (props strip)]
+      (is (= "tablist" (:role attrs))
+          "Settings tab strip is a tablist")
+      (is (and (string? (:aria-label attrs)) (seq (:aria-label attrs)))
+          "Settings tab strip has a non-empty aria-label"))))
+
+(deftest settings-tab-buttons-carry-tab-aria
+  (testing "rf2-h4mnh — every Settings tab button has role=\"tab\" +
+            aria-selected reflecting the active tab + stable `:id` +
+            `:aria-controls` pointing at the body's tabpanel id."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (let [tree     (rf/with-frame :rf/causa (settings-view/popup-view))
+          tab-ids  [:general :theme :filters :keybindings :buffer :diff]]
+      (doseq [tid tab-ids]
+        (let [button (find-by-testid tree
+                       (str "rf-causa-settings-tab-" (name tid)))
+              attrs  (props button)]
+          (is (= "tab" (:role attrs))
+              (str "tab " tid " carries role=\"tab\""))
+          (is (contains? #{"true" "false"} (:aria-selected attrs))
+              (str "tab " tid " carries aria-selected as a string"))
+          (is (= (str "rf-causa-settings-tab-button-" (name tid))
+                 (:id attrs))
+              (str "tab " tid " carries the documented id"))
+          (is (= (str "rf-causa-settings-tabpanel-" (name tid))
+                 (:aria-controls attrs))
+              (str "tab " tid " carries aria-controls pointing at "
+                   "its body tabpanel"))))
+      ;; Default active tab is :general; selected reflects that.
+      (let [general (find-by-testid tree "rf-causa-settings-tab-general")
+            theme   (find-by-testid tree "rf-causa-settings-tab-theme")]
+        (is (= "true" (:aria-selected (props general)))
+            "active tab (:general) carries aria-selected=\"true\"")
+        (is (= "false" (:aria-selected (props theme)))
+            "inactive tab (:theme) carries aria-selected=\"false\"")))))
+
+(deftest settings-body-is-a-labelled-tabpanel
+  (testing "rf2-h4mnh — Settings body carries role=\"tabpanel\" + an
+            id matching the active tab's aria-controls + an
+            aria-labelledby resolving back to the active tab button."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (let [tree  (rf/with-frame :rf/causa (settings-view/popup-view))
+          body  (find-by-testid tree "rf-causa-settings-body")
+          attrs (props body)]
+      (is (= "tabpanel" (:role attrs))
+          "body wrapper is a tabpanel")
+      (is (= "rf-causa-settings-tabpanel-general" (:id attrs))
+          "body id matches the active tab's tabpanel id")
+      (is (= "rf-causa-settings-tab-button-general"
+             (:aria-labelledby attrs))
+          "body aria-labelledby resolves back to the active tab"))))
+
+(deftest settings-text-size-label-associates-with-input
+  (testing "rf2-h4mnh — text-size <input :id> matches a <label
+            :html-for> so clicking the label focuses the input."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/settings-open]))
+    (let [tree  (rf/with-frame :rf/causa (settings-view/popup-view))
+          input (find-by-testid tree "rf-causa-settings-text-size-input")
+          ;; The label sits in the same <div> field; find by html-for.
+          label (some (fn [node]
+                        (when (and (vector? node)
+                                   (map? (second node))
+                                   (= "rf-causa-settings-text-size-input"
+                                      (:html-for (second node))))
+                          node))
+                      (hiccup-seq tree))]
+      (is (= "rf-causa-settings-text-size-input" (:id (props input)))
+          "input carries the documented id")
+      (is (some? label)
+          "a <label html-for=...> matches the input's id"))))
+
+;; -------------------------------------------------------------------------
+;; (4) rf2-lbutp — frame-switcher aria-label
+;; -------------------------------------------------------------------------
+
+(defn- seed-trace! [dispatch-id frame-id]
+  ;; Mirrors `frame_switcher_cljs_test/dispatch-trace` — seed the
+  ;; trace-bus directly so the cascades sub composes a list with the
+  ;; right frame ids without dispatching real events.
+  (trace-bus/collect-trace!
+    {:id          dispatch-id
+     :op-type     :event
+     :operation   :event/dispatched
+     :tags        {:event       [:app/touch]
+                   :frame       frame-id
+                   :dispatch-id dispatch-id}}))
+
+(deftest frame-switcher-select-has-aria-label
+  (testing "rf2-lbutp — the native <select> picker has an aria-label
+            so screen readers announce its purpose on focus. The
+            picker only renders when ≥2 frames are present; seed two
+            cascades from distinct frames to surface it."
+    ;; Seed BEFORE causa-setup! so the sub's first compute reads the
+    ;; populated trace-bus atom — mirrors the order frame-switcher's
+    ;; own tests use.
+    (seed-trace! 1 :rf/default)
+    (seed-trace! 2 :app/main)
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree   (frame-switcher/frame-switcher-view nil)
+            picker (find-by-testid tree "rf-causa-ribbon-frame-picker")]
+        (is (some? picker)
+            "the <select> picker renders when ≥2 frames are present")
+        (is (and (string? (:aria-label (props picker)))
+                 (seq (:aria-label (props picker))))
+            "frame-switcher <select> carries a non-empty aria-label")))))
+
+;; -------------------------------------------------------------------------
+;; (5) rf2-vxpq1 — resize-handle aria-valuemax
+;; -------------------------------------------------------------------------
+
+(deftest resize-handle-has-aria-valuemax
+  (testing "rf2-vxpq1 — the resize handle's separator role requires
+            aria-valuemax alongside aria-valuemin and aria-valuenow."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree   (resize-handle/Handle :inline)
+            attrs  (second tree)]
+        (is (some? (:aria-valuemax attrs))
+            "aria-valuemax is set")
+        (is (number? (:aria-valuemax attrs))
+            "aria-valuemax is a number")
+        (is (>= (:aria-valuemax attrs) (:aria-valuemin attrs))
+            "aria-valuemax >= aria-valuemin")
+        (is (some? (:aria-valuemin attrs)) "aria-valuemin is set")
+        (is (some? (:aria-valuenow attrs)) "aria-valuenow is set")))))
+
+;; -------------------------------------------------------------------------
+;; (6) rf2-vxpq1 — decorative glyph aria-hidden
+;; -------------------------------------------------------------------------
+
+(deftest redacted-glyph-is-aria-hidden
+  (testing "rf2-vxpq1 — the leading `●` glyph on the REDACTED
+            indicator carries aria-hidden so AT does not announce the
+            unicode name."
+    (causa-setup!)
+    ;; Force the counter positive so the indicator renders.
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/note-sensitive-suppressed :rf/default]))
+    (rf/with-frame :rf/causa
+      (let [tree      (shell/shell-view)
+            indicator (find-by-testid tree "rf-causa-redacted-indicator")
+            ;; the glyph is the first <span> child carrying aria-hidden
+            glyph     (some (fn [node]
+                              (when (and (vector? node)
+                                         (= :span (first node))
+                                         (map? (second node))
+                                         (= "true" (:aria-hidden (second node))))
+                                node))
+                            (hiccup-seq indicator))]
+        (is (some? indicator) "REDACTED indicator renders when count > 0")
+        (is (some? glyph)
+            "the decorative `●` glyph carries aria-hidden=\"true\"")))))
+
+(deftest runtime-tab-glyph-is-aria-hidden
+  (testing "rf2-vxpq1 — the ●/○ glyph on every L3 tab button carries
+            aria-hidden so AT users hear only the tab label, not the
+            unicode name."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (let [tree     (shell/shell-view)
+            event-tab (find-by-testid tree "rf-causa-tab-event")
+            glyph    (some (fn [node]
+                             (when (and (vector? node)
+                                        (= :span (first node))
+                                        (map? (second node))
+                                        (= "true" (:aria-hidden (second node))))
+                               node))
+                           (hiccup-seq event-tab))]
+        (is (some? glyph)
+            "L3 tab's ●/○ glyph carries aria-hidden=\"true\"")))))
+
+;; -------------------------------------------------------------------------
+;; (7) rf2-vxpq1 — static placeholder uses <h2> not <h1>
+;; -------------------------------------------------------------------------
+
+(deftest static-placeholder-uses-h2-not-h1
+  (testing "rf2-vxpq1 — Static placeholder cards drop <h1> to <h2>
+            so they don't break the host document's heading outline."
+    (causa-setup!)
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa.static/select-tab :events]))
+    (rf/with-frame :rf/causa
+      (let [tree   (static-shell/surface)
+            ;; placeholder is wrapped in a <section> with a known testid
+            ph     (find-by-testid tree "rf-causa-static-placeholder-events")
+            h1s    (find-all-with-pred ph
+                     (fn [n] (and (vector? n) (= :h1 (first n)))))
+            h2s    (find-all-with-pred ph
+                     (fn [n] (and (vector? n) (= :h2 (first n)))))]
+        (is (some? ph) "placeholder card renders for :events tab")
+        (is (empty? h1s)
+            "placeholder card has no <h1> (would break document outline)")
+        (is (seq h2s)
+            "placeholder card uses <h2> for the title")))))

--- a/tools/story/src/re_frame/story/ui/multi_substrate.cljs
+++ b/tools/story/src/re_frame/story/ui/multi_substrate.cljs
@@ -29,7 +29,8 @@
   substrate registry is a runtime atom and the host app populates it
   via `register-substrate!`. Story core consequently does not pull
   UIx / Helix into the classpath."
-  (:require [reagent.core :as r]
+  (:require [clojure.string :as str]
+            [reagent.core :as r]
             [re-frame.core :as rf]
             [re-frame.story.args :as args]
             [re-frame.story.registrar :as registrar]
@@ -233,7 +234,21 @@
                        variant-id
                        {:active-modes   (:active-modes shell)
                         :cell-overrides (get-in shell [:cell-overrides variant-id])})]
-    [:div {:style (:grid styles)}
+    ;; rf2-lbutp — the multi-substrate grid is the canvas's labelled
+    ;; landmark when a variant declares ≥2 substrates. `role="group"`
+    ;; + `aria-label` exposes the substrate-comparison surface as a
+    ;; group of cells; each cell is a `role="region"` with the
+    ;; substrate name as its accessible label (set in
+    ;; `safe-render-cell` below). The audit (#16) flagged the
+    ;; surface as zero-ARIA — the cells now read as labelled regions
+    ;; in landmark navigation.
+    [:div {:style       (:grid styles)
+           :role        "group"
+           :aria-label  (str "Multi-substrate render — "
+                             (str/join ", "
+                               (map name (sort-by name substrates))))}
      (for [substrate (sort-by name substrates)]
-       [:div {:key (name substrate)}
+       [:div {:key         (name substrate)
+              :role        "region"
+              :aria-label  (str (name substrate) " substrate cell")}
         (safe-render-cell variant-id substrate view-id eff-args)])]))

--- a/tools/story/src/re_frame/story/ui/sidebar.cljs
+++ b/tools/story/src/re_frame/story/ui/sidebar.cljs
@@ -598,8 +598,18 @@
                 :aria-label "Stories and workspaces"
                 :tab-index  "0"}
           [:div {:style (:tree styles)}
-           [:div {:style (:header styles)}
-            [:span {:style {:display "inline-flex" :align-items "center"
+           ;; rf2-vxpq1 — sidebar landmarks the two top-level sections
+           ;; ("Stories" / "Workspaces") with `role="heading"` +
+           ;; `aria-level="2"`. The visible `<div>` keeps its existing
+           ;; styling unchanged; the role + level expose the section
+           ;; structure to AT users navigating by heading. Pure
+           ;; visual hiccup: no `<h2>` rewrite (would shift layout
+           ;; via UA stylesheet defaults), no test-id change.
+           [:div {:style       (:header styles)
+                  :role        "heading"
+                  :aria-level  "2"}
+            [:span {:aria-hidden "true"
+                    :style {:display "inline-flex" :align-items "center"
                             :color (:accent-amber colors/tokens)}}
              [glyphs/story-glyph 12]]
             [:span "Stories"]]
@@ -624,8 +634,14 @@
                [story-block entry sel-variant testable-set test-runs query]))
            (when (seq workspaces)
              [:div
-              [:div {:style (:section styles)}
-               [:span {:style {:display "inline-flex" :align-items "center"
+              ;; rf2-vxpq1 — matching heading semantics on the
+              ;; Workspaces section so AT users can land on either
+              ;; section via heading navigation.
+              [:div {:style       (:section styles)
+                     :role        "heading"
+                     :aria-level  "2"}
+               [:span {:aria-hidden "true"
+                       :style {:display "inline-flex" :align-items "center"
                                :color (:info colors/tokens)
                                :margin-right "6px"
                                :vertical-align "-2px"}}

--- a/tools/story/src/re_frame/story/ui/toolbar.cljs
+++ b/tools/story/src/re_frame/story/ui/toolbar.cljs
@@ -316,12 +316,16 @@
 (defn chip
   "Render a single chip for `mode-id`. Pure-hiccup view; click handler
   delegates to `toggle-mode!`. Public so tests can introspect the
-  chip-level hiccup without driving the full strip."
+  chip-level hiccup without driving the full strip.
+
+  rf2-vxpq1 — `role=\"button\"` was redundant on a native `<button>`
+  (the audit flagged this nit; the implicit role already carries).
+  Dropping it removes 14 chars × N-chips noise from the rendered DOM
+  without changing AT behaviour."
   [mode-id body active?]
   [:button
    {:style              (merge (:chip styles)
                                (when active? (:chip-active styles)))
-    :role               "button"
     :aria-pressed       (if active? "true" "false")
     :title              (if-let [d (:doc body)]
                           (str (pr-str mode-id) " — " d)


### PR DESCRIPTION
## Summary

Four P3 a11y polish bundles from the rf2-w03x1 audit, landed in one PR.

- **rf2-plajx** — Causa shell root `role="region"` + L4 `role="tabpanel"` + `aria-labelledby` round-trip (Runtime + Static).
- **rf2-h4mnh** — Settings popup inner tabs become a WAI-ARIA tab group: `role="tablist"` + per-tab `role="tab"` + `aria-selected` + `aria-controls`; body becomes `role="tabpanel"` + `aria-labelledby`. Numeric `<label>` ↔ `<input>` association in General + Buffer.
- **rf2-lbutp** — Causa frame-switcher native `<select>` gains `aria-label`; Story multi-substrate grid exposes labelled `role="group"` + per-cell `role="region"`.
- **rf2-vxpq1** — Polish bundle: resize-handle `aria-valuemax`; decorative glyphs (`●/○` tabs, `● REDACTED`, `🎯`) → `aria-hidden`; Static placeholder `<h1>` → `<h2>`; Story toolbar chip drops redundant `role="button"`; Story sidebar "Stories"/"Workspaces" headers gain `role="heading"` + `aria-level="2"`.

## Test plan

- [x] `npm run test:cljs` — 3551 tests / 10190 assertions / 0 failures (12 new deftests).
- [x] `mkdocs build --strict` — pass.
- [x] 12 new deftests in `tools/causa/test/day8/re_frame2_causa/p3_polish_aria_cljs_test.cljs` cover the new contracts.

Closes rf2-plajx + rf2-h4mnh + rf2-lbutp + rf2-vxpq1.