### PR TITLE
perf(ci): narrow Examples (Chromium) gate trigger (rf2-8jz9t P2, 4-5m cut)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -68,12 +68,20 @@ else
         mark_all
         ;;
       implementation/core/*)
+        # rf2-8jz9t — examples_browser NOT fired here. The
+        # examples-browser job exercises the 3 adapter-level smokes
+        # (Reagent/UIx/Helix at implementation/adapters/<name>/testbed/)
+        # which catch adapter-specific bugs (createRoot lifecycle,
+        # hydration, real concurrent scheduling) — not core regressions.
+        # Core renames are caught by node-test (CLJS unit + browser-test)
+        # which exercises every public re-frame.core fn. A core rename
+        # that breaks adapter mount silently is caught by the nightly
+        # cron + post-merge gate (both run the full matrix on main).
         implementation_jvm=true
         adapter_diagnostic=true
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
-        examples_browser=true
         tools_jvm=true
         template_expensive=true
         mcp_conformance=true
@@ -104,11 +112,17 @@ else
         mcp_live=true
         ;;
       implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/epoch/*|implementation/deps.edn)
+        # rf2-8jz9t — examples_browser NOT fired here. Per-feature
+        # artefact changes are covered by their own JVM + CLJS unit
+        # suites (implementation_jvm, cljs_browser, cljs_prod) and by
+        # bundle_isolation; the adapter smokes under examples-browser
+        # only catch adapter-mount-specific bugs (createRoot lifecycle,
+        # hydration, real concurrent scheduling). Nightly + post-merge
+        # gate runs the full matrix.
         implementation_jvm=true
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
-        examples_browser=true
         ;;
       spec/conformance/fixtures/*)
         # rf2-qmiiz — Fixtures under spec/conformance/fixtures/*.edn
@@ -130,11 +144,16 @@ else
         cljs_prod=true
         ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
+        # rf2-8jz9t — examples_browser NOT fired here. The examples-browser
+        # job is now triggered ONLY by direct adapter/example/testbed
+        # surface changes (implementation/adapters/*, examples/*,
+        # testbeds/*). A shadow-cljs.edn or scripts/ change that breaks
+        # the examples-browser build is caught by the nightly cron +
+        # post-merge gate (both run the full matrix on main).
         cljs_browser=true
         cljs_prod=true
         bundle_isolation=true
         reagent_slim_bundle=true
-        examples_browser=true
         story_causa_browser=true
         ;;
       examples/*)

--- a/TESTING.md
+++ b/TESTING.md
@@ -164,7 +164,7 @@ boolean GitHub-Actions outputs per surface:
 | `cljs_prod` | Surface that release-mode probes (`browser-test-prod-elision`, schemas boundary prod) cover changed. |
 | `bundle_isolation` | Surface that can affect bundle boundaries (adapters, build scripts, examples used as probes, package metadata) changed. |
 | `reagent_slim_bundle` | Reagent Slim adapter / its example / its check script changed. |
-| `examples_browser` | Examples surface changed. |
+| `examples_browser` | Direct examples / adapter / top-level testbed surface changed (`implementation/adapters/*`, `examples/*`, `testbeds/*`). Not set by `implementation/core/*`, per-feature artefacts, or build-config changes (rf2-8jz9t — adapter smokes only catch adapter-mount-specific bugs; nightly + post-merge gate runs the full matrix on main). |
 | `tools_jvm` | Story / Causa / Story-MCP / Causa-MCP / Pair2-MCP / MCP-base changed; gates the four per-tool JVM probes (`jvm-tools-{causa,story,story-mcp,mcp-base}`). Not set by `tools/template/*` or `tools/mcp-conformance/*` — those don't share runtime with the per-tool probes. |
 | `template_expensive` | `tools/template/*` changed; gates the template emitted-app smoke. |
 | `mcp_conformance` | Any MCP-server tool, `tools/mcp-base/*`, or `tools/mcp-conformance/*` changed. |
@@ -180,7 +180,14 @@ A few "blast-radius" inputs force the full sweep:
   full matrix).
 - Changes under `implementation/core/*` fan out broadly (they touch
   almost every output) because core regressions can break every
-  downstream substrate, tool, and bundle invariant.
+  downstream substrate, tool, and bundle invariant. Exception:
+  `examples_browser` is **not** fired by `implementation/core/*`
+  changes (rf2-8jz9t). The adapter smokes under examples-browser
+  only catch adapter-mount-specific bugs (createRoot lifecycle,
+  hydration, real concurrent scheduling); core renames are caught
+  by `node-test` (which exercises every public `re-frame.core`
+  fn), and the nightly cron + post-merge gate runs the full matrix
+  on main.
 
 **Adding a new artefact directory**: a new artefact (e.g. a new tool,
 new substrate, new SSR runtime) needs **two** matching changes:
@@ -243,12 +250,12 @@ must re-run the matrix).
 | # | Surface | `implementation_jvm` | `adapter_diagnostic` | `cljs_browser` | `cljs_prod` | `bundle_isolation` | `reagent_slim_bundle` | `examples_browser` | `tools_jvm` | `template_expensive` | `mcp_conformance` | `mcp_live` | `story_causa_browser` | `skills_structural` |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | **S1** | **`.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `report-changed-surfaces.sh`, `TESTING.md` (blast trigger — `mark_all`)** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** | **✓** |
-| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |
+| S2 | `implementation/core/*` | ✓ | ✓ | ✓ | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+| S3 | `implementation/adapters/reagent-slim/*`, `examples/reagent/counter_slim_and_fast/*`, `implementation/scripts/check-reagent-slim-bundle-isolation.cjs` | ✓ | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |   |
 | S4 | `implementation/adapters/*` (other) | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |
-| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   | ✓ |   |   |   |   |   |   |
+| S5 | `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` | ✓ |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | S6 | `spec/conformance/fixtures/*` | ✓ |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |
-| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   | ✓ |   |
+| S7 | `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` |   |   | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   | ✓ |   |
 | S8 | `examples/*` |   |   | ✓ |   |   |   | ✓ |   |   |   |   |   |   |
 | S9 | `testbeds/*` |   |   | ✓ |   |   |   | ✓ |   |   |   |   |   |   |
 | S10 | `tools/template/*` |   |   |   |   |   |   |   |   | ✓ |   |   |   |   |


### PR DESCRIPTION
## Summary
- Examples (Chromium) gate now only triggers on `implementation/adapters/**`, `examples/**`, or `testbeds/**` changes.
- Was: triggered transitively on any `implementation/core/*` change, per-feature artefact change (`schemas/machines/routing/flows/http/ssr/ssr-ring/epoch`), and shadow-cljs.edn / build-config changes.
- The 3 adapter smokes (Reagent/UIx/Helix at `implementation/adapters/<name>/testbed/spec.cjs`) catch adapter-mount-specific bugs (createRoot lifecycle, hydration, real concurrent scheduling); they do not catch core regressions (`node-test` does).

## Bead
rf2-8jz9t (P2)

## CI impact
- Most PRs (core / spec / docs / non-adapter / per-feature artefact / shadow-cljs.edn): skip Examples gate (was 4:55).
- Adapter-touching PRs, example-touching PRs, top-level testbed PRs: still pay 4:55.
- Verified against PR #1648 (core-only refactor): currently ran Examples gate for 4m55s; under the new rule it would skip.

## Surfaces no longer triggering `examples_browser`
- `implementation/core/*` (covered by `node-test` — exercises every public `re-frame.core` fn).
- `implementation/{schemas,machines,routing,flows,http,ssr,ssr-ring,epoch}/*`, `implementation/deps.edn` (covered by per-feature JVM + CLJS unit suites + bundle_isolation).
- `implementation/shadow-cljs.edn`, `implementation/package.json`, `implementation/package-lock.json`, `implementation/scripts/*` (build-config changes — caught by nightly + post-merge).

## Surfaces still triggering `examples_browser`
- `implementation/adapters/*` (real adapter signal).
- `examples/*` (includes `examples/scripts/**` — the Playwright harness).
- `testbeds/*` (top-level testbeds mounted by the same harness — rf2-7vsfm).
- Blast trigger (`mark_all`) — workflow file / classifier script / TESTING.md changes still fire everything.

## Risk
- A core rename that breaks adapter mount could land silently. Mitigations:
  - `node-test` exercises every public `re-frame.core` fn (catches missing exports).
  - Nightly cron + post-merge gate still runs the full matrix on `main` (catches before the next PR).
  - Adapter-touching PRs (which are where adapter-mount regressions usually originate) still pay the 4:55.
- A `shadow-cljs.edn` change that breaks the examples-browser build also won't be caught at PR time; same nightly + post-merge backstop applies.

## Acceptance
- YAML validates (`python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"`).
- `mkdocs build --strict` passes (no new warnings).
- Classifier dry-run verified for core / adapter / example / testbed / per-feature / shadow-cljs.edn scenarios — all correct.
- `--all` blast trigger still fires every output.

## Docs updated
- `TESTING.md` Output table — `examples_browser` row reworded.
- `TESTING.md` Surface→output matrix — S2, S3 (pre-existing inaccuracy), S5, S7 rows updated.
- `TESTING.md` blast-radius paragraph — core fan-out exception documented inline with cross-ref to rf2-8jz9t.