### PR TITLE
perf(ci): split CLJS browser-test to DOM-dependent (rf2-2hrj8 P1, ~12m cut)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -83,8 +83,8 @@ agent pre-checkin "narrow to the changed surface" workflow.
 
 | Command | Scope |
 |---|---|
-| `npm run test:cljs` | CLJS node-runtime tests via shadow-cljs `node-test` build. The consolidated default gate for CLJS unit coverage. |
-| `npm run test:browser` | Browser CLJS tests (`browser-test` build) served with Playwright + http-server. Headless Chromium harness. |
+| `npm run test:cljs` | CLJS node-runtime tests via shadow-cljs `node-test` build. The consolidated default gate for CLJS unit coverage. Loads every `*_cljs_test.cljs` file (the `cljs-test$` ns-regexp matches both `-cljs-test` and the DOM-tagged `-dom-cljs-test` suffix). |
+| `npm run test:browser` | Browser CLJS tests (`browser-test` build) served with Playwright + http-server. Headless Chromium harness. **Narrowed to DOM-dependent tests only (rf2-2hrj8)**: the `:browser-test` ns-regexp is `-dom-cljs-test$`, matching files named `*_dom_cljs_test.cljs` — these tests mount real React via `react-dom/client`, exercise the React-context tier, or otherwise depend on browser-runtime features Node can't fake. Pure-fn + sub-chain reactivity tests run under `:node-test` only. |
 | `npm run test:browser-prod-elision` | Release-built browser tests proving production elision under the `browser-test-prod-elision` shadow build. |
 | `npm run test:browser-schemas-boundary-prod` | Release-built browser test proving the schemas boundary-warn-once contract in production. |
 | `npm run test:elision` | Production-release elision probe: compiles `elision-probe` + `elision-probe-control` and asserts elision is total. Non-negotiable production invariant. |

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_after_render_dom_cljs_test.cljs
@@ -1,7 +1,7 @@
-(ns re-frame.adapter.uix-after-render-cljs-test
-  "Behavioural coverage for the UIx adapter's `:adapter/after-render`
-  hook (rf2-334d9). Pre-rf2-334d9 the UIx adapter did not publish
-  `:adapter/after-render`, so `(rf/after-render f)` under a UIx-only
+(ns re-frame.adapter.helix-after-render-dom-cljs-test
+  "Behavioural coverage for the Helix adapter's `:adapter/after-render`
+  hook (rf2-334d9). Pre-rf2-334d9 the Helix adapter did not publish
+  `:adapter/after-render`, so `(rf/after-render f)` under a Helix-only
   app was a silent no-op — closed by Mike's rf2-neiqf decision
   2026-05-19 to publish via `React.useLayoutEffect`.
 
@@ -16,11 +16,12 @@
   `r/after-render`. A `queueMicrotask` fallback covers the
   pre-mount / post-unmount call paths.
 
-  Coverage shape. Two assertions:
+  Coverage shape mirrors the UIx parity test
+  (`uix_after_render_cljs_test.cljs`):
     1. The hook is wired at ns-load — calling `interop/after-render`
-       under the UIx adapter returns nil (not a thrown
+       under the Helix adapter returns nil (not a thrown
        'no hook bound' / silent no-op signal).
-    2. Behaviour. Mount a UIx tree; call `(interop/after-render f)`;
+    2. Behaviour. Mount a Helix tree; call `(interop/after-render f)`;
        verify `f` fired after the next commit (asserted via a side-
        channel atom).
 
@@ -31,15 +32,16 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require ["react"            :as React]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [uix.core :as uix :refer-macros [defui $]]
+            [helix.core :refer-macros [$ defnc]]
+            [helix.dom  :as d]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.helix :as helix-adapter]
             [re-frame.interop :as interop]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+    {:adapter helix-adapter/adapter}))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -66,9 +68,9 @@
 
 ;; ---- ns-load smoke -------------------------------------------------------
 
-(deftest after-render-hook-wired-under-uix
+(deftest after-render-hook-wired-under-helix
   (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
-            under the UIx adapter — the hook is wired at ns-load and
+            under the Helix adapter — the hook is wired at ns-load and
             returns nil (the documented swallow shape) rather than
             falling through to nil because no adapter published it."
     ;; Calling with a fn argument should NOT throw and should NOT
@@ -76,20 +78,20 @@
     ;; per the make-after-render-hook contract, and the queueMicrotask
     ;; fallback drain handles the no-mount case asynchronously.
     (is (nil? (interop/after-render (fn [] :ok)))
-        "interop/after-render under the UIx adapter returns nil — the
+        "interop/after-render under the Helix adapter returns nil — the
          spine-built hook is wired through :adapter/after-render via
          substrate-adapter/route-hook!")))
 
 ;; ---- behaviour: mount, schedule, drain after commit ----------------------
 
-(defui Probe []
-  ;; Bare UIx component — the rf2-334d9 sentinel is injected by the
+(defnc Probe []
+  ;; Bare Helix component — the rf2-334d9 sentinel is injected by the
   ;; spine's `make-render`, not by user code.
-  ($ :div "probe"))
+  (d/div "probe"))
 
-(deftest after-render-runs-callback-after-next-commit-uix
+(deftest after-render-runs-callback-after-next-commit-helix
   (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
-            after the next mount/render cycle under the UIx adapter.
+            after the next mount/render cycle under the Helix adapter.
             The sentinel injected by the spine's make-render uses
             React.useLayoutEffect to drain the queue post-commit."
     (if-not (browser?)

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_cross_spec_cljs_test.cljs
@@ -1,6 +1,7 @@
 (ns re-frame.adapter.helix-cross-spec-cljs-test
   "Adapter-parity port of the headless subset of
-  `re-frame.cross-spec-cljs-test` to the Helix adapter (rf2-ta4b5).
+  `re-frame.cross-spec-dom-cljs-test` to the Helix adapter (rf2-ta4b5;
+  renamed rf2-2hrj8).
 
   Each deftest pins a Cross-Spec interaction (spec/Cross-Spec-Interactions.md)
   under a Helix-installed adapter. The subset ported here is the one

--- a/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/helix/test/re_frame/adapter/helix_use_subscribe_dom_cljs_test.cljs
@@ -1,9 +1,9 @@
-(ns re-frame.adapter.uix-use-subscribe-cljs-test
-  "Unit coverage for the UIx adapter's `use-subscribe` hook (rf2-518sp).
+(ns re-frame.adapter.helix-use-subscribe-dom-cljs-test
+  "Unit coverage for the Helix adapter's `use-subscribe` hook (rf2-518sp).
 
-  Pre-rf2-518sp, `use-subscribe` was published as the canonical UIx
-  subscribe surface (rf2-3yij Decision 1) and exercised only through
-  the Playwright `counter_uix` smoke; no node-runtime headless test
+  Pre-rf2-518sp, `use-subscribe` was published as the canonical Helix
+  subscribe surface (rf2-2qit Decision 1) and exercised only through
+  the Playwright `counter_helix` smoke; no node-runtime headless test
   asserted that the React.useSyncExternalStore wiring sees post-
   dispatch values. A regression in `subscribe-fn`'s add-watch keying,
   `get-snap`'s reaction deref, the use-memo deps vec, or the
@@ -20,20 +20,22 @@
   (:require ["react"            :as React]
             ["react-dom/client" :as react-dom-client]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [uix.core :as uix :refer-macros [defui $]]
+            [helix.core :refer-macros [$ defnc]]
+            [helix.dom  :as d]
+            [helix.hooks :as helix-hooks]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.subs :as subs]
-            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.adapter.helix :as helix-adapter]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter uix-adapter/adapter}))
+    {:adapter helix-adapter/adapter}))
 
 ;; ---- side-channel atoms ----------------------------------------------------
-;; Per-test atoms read by the UIx probe components below. The probes
-;; are defui top-levels (uix `defui` defines a Var; it cannot sit
+;; Per-test atoms read by the Helix probe components below. The probes
+;; are defnc top-levels (helix `defnc` defines a Var; it cannot sit
 ;; inside a `let`) and close over these atoms; each deftest `reset!`s
 ;; the atom it cares about at the top of its body.
 
@@ -41,50 +43,51 @@
 (def ^:private probe-fp-observed    (atom []))
 (def ^:private refcount-target      (atom nil))
 
-(defui Probe []
+(defnc Probe []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target
-                                      [:rf.uix-use-subscribe-test/n])]
+        v (helix-adapter/use-subscribe target
+                                       [:rf.helix-use-subscribe-test/n])]
     (swap! probe-observed conj v)
-    ($ :div (str "n=" v))))
+    (d/div (str "n=" v))))
 
-(defui ProbeFp []
-  (let [v (uix-adapter/use-subscribe
-            [:rf.uix-use-subscribe-test/k])]
+(defnc ProbeFp []
+  (let [v (helix-adapter/use-subscribe
+            [:rf.helix-use-subscribe-test/k])]
     (swap! probe-fp-observed conj v)
-    ($ :div (str "k=" v))))
+    (d/div (str "k=" v))))
 
-(defui ProbeRc []
+(defnc ProbeRc []
   (let [target @refcount-target
-        v (uix-adapter/use-subscribe target
-                                      [:rf.uix-use-subscribe-test/m])]
-    ($ :div (str "m=" v))))
+        v (helix-adapter/use-subscribe target
+                                       [:rf.helix-use-subscribe-test/m])]
+    (d/div (str "m=" v))))
 
 ;; ---- rf2-mwft2 regression probes ------------------------------------------
 ;; A parent that owns a tick state (used to force re-renders) plus a child
-;; that reads a fixed query-v via use-subscribe. The literal `[:rf.uix-mwft2/p]`
+;; that reads a fixed query-v via use-subscribe. The literal `[:rf.helix-mwft2/p]`
 ;; vector evaluates to a fresh JS object each render — *exactly* the shape
 ;; the bug-without-fix walks into. The parent stashes its set-tick fn into
 ;; a side-channel atom so the test can drive forced re-renders from outside.
 
 (def ^:private mwft2-set-tick      (atom nil))
 
-(defui ProbeMwft2Child []
-  (let [v (uix-adapter/use-subscribe :rf.uix-mwft2/probe-frame
-                                      [:rf.uix-mwft2/p])]
-    ($ :div (str "p=" v))))
+(defnc ProbeMwft2Child []
+  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame
+                                       [:rf.helix-mwft2/p])]
+    (d/div (str "p=" v))))
 
-(defui ProbeMwft2Parent []
-  (let [[tick set-tick] (uix/use-state 0)]
-    (uix/use-effect
+(defnc ProbeMwft2Parent []
+  (let [[tick set-tick] (helix-hooks/use-state 0)]
+    (helix-hooks/use-effect
       ;; React state-setters have stable identity across renders so an
-      ;; empty deps vec is correct — silences UIx's lint and matches
-      ;; React's "set-state setter is stable" guarantee. The effect runs
-      ;; once on mount to stash the setter for the test driver.
-      (fn [] (reset! mwft2-set-tick set-tick) js/undefined)
-      [])
-    ($ :div {:data-tick tick}
-       ($ ProbeMwft2Child))))
+      ;; empty deps vec is correct — matches React's "set-state setter is
+      ;; stable" guarantee. The effect runs once on mount to stash the
+      ;; setter for the test driver.
+      []
+      (reset! mwft2-set-tick set-tick)
+      (fn cleanup [] nil))
+    (d/div {:data-tick tick}
+           ($ ProbeMwft2Child))))
 
 ;; ---- browser gate ---------------------------------------------------------
 
@@ -126,10 +129,10 @@
 ;; resolves through the surrounding `frame-provider`.
 
 (deftest use-subscribe-tracks-app-db-changes
-  (testing "UIx use-subscribe sees post-dispatch values via useSyncExternalStore"
+  (testing "Helix use-subscribe sees post-dispatch values via useSyncExternalStore"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/probe-frame
+      (let [target :rf.helix-use-subscribe-test/probe-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -138,15 +141,15 @@
             (reset! probe-observed [])
             (reset! refcount-target target)
             (rf/reg-frame target {:doc "use-subscribe probe frame"})
-            (rf/reg-event-db :seed-uix-us (fn [_ _] {:n 1}))
-            (rf/reg-event-db :inc-uix-us  (fn [db _] (update db :n inc)))
-            (rf/dispatch-sync [:seed-uix-us] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/n
+            (rf/reg-event-db :seed-helix-us (fn [_ _] {:n 1}))
+            (rf/reg-event-db :inc-helix-us  (fn [db _] (update db :n inc)))
+            (rf/dispatch-sync [:seed-helix-us] {:frame target})
+            (rf/reg-sub :rf.helix-use-subscribe-test/n
                         (fn [db _] (:n db)))
             (let [mount-node (make-mount-node!)
                   root       (react-dom-client/createRoot mount-node)]
               (try
-                (act-fn (fn [] (.render root (uix/$ Probe))))
+                (act-fn (fn [] (.render root ($ Probe))))
                 (is (some #{1} @probe-observed)
                     "first render observed the seeded value n=1")
                 ;; Wrap dispatch in act so React commits the forceUpdate
@@ -154,17 +157,17 @@
                 ;; Plain `dispatch-sync` outside act emits the
                 ;; "update was not wrapped in act" warning AND fails to
                 ;; flush the resulting render in the test environment.
-                (act-fn (fn [] (rf/dispatch-sync [:inc-uix-us] {:frame target})))
+                (act-fn (fn [] (rf/dispatch-sync [:inc-helix-us] {:frame target})))
                 (is (some #{2} @probe-observed)
                     "post-dispatch re-render observed the incremented value n=2")
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
 (deftest use-subscribe-frame-provider-resolution
-  (testing "UIx use-subscribe 1-arg form resolves through the surrounding frame-provider"
+  (testing "Helix use-subscribe 1-arg form resolves through the surrounding frame-provider"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/fp-frame
+      (let [target :rf.helix-use-subscribe-test/fp-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -172,9 +175,9 @@
             (enable-react-act-env!)
             (reset! probe-fp-observed [])
             (rf/reg-frame target {:doc "use-subscribe fp probe frame"})
-            (rf/reg-event-db :seed-uix-us-fp (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [:seed-uix-us-fp] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/k
+            (rf/reg-event-db :seed-helix-us-fp (fn [_ _] {:k :wrapped}))
+            (rf/dispatch-sync [:seed-helix-us-fp] {:frame target})
+            (rf/reg-sub :rf.helix-use-subscribe-test/k
                         (fn [db _] (:k db)))
             (let [mount-node (make-mount-node!)
                   root       (react-dom-client/createRoot mount-node)]
@@ -183,77 +186,12 @@
                   (fn []
                     ;; frame-provider is a plain CLJS fn returning a
                     ;; React element (NOT a React-component head), so
-                    ;; invoke it directly rather than via `(uix/$ ...)`.
+                    ;; invoke it directly rather than via `($ ...)`.
                     (.render root
-                      (uix-adapter/frame-provider
-                        {:frame target :children [(uix/$ ProbeFp)]}))))
+                      (helix-adapter/frame-provider
+                        {:frame target :children [($ ProbeFp)]}))))
                 (is (some #{:wrapped} @probe-fp-observed)
                     "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
-;; ---- 2-arg form: explicit frame-id wins over context (rf2-rcgsc) ----------
-;;
-;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
-;; bypass the React-context tier and read from the named frame's
-;; app-db directly. Pre-rf2-rcgsc only the 1-arg context-resolved form
-;; was tested under a frame-provider; the 2-arg explicit-pin shape was
-;; exercised indirectly via the Probe component above but no test
-;; pinned that two different frame-ids in the SAME render tree (no
-;; surrounding provider) see distinct values.
-
-(def ^:private probe-2arg-a-observed (atom []))
-(def ^:private probe-2arg-b-observed (atom []))
-
-(defui Probe2ArgA []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a
-                                     [:rf.uix-rcgsc/n])]
-    (swap! probe-2arg-a-observed conj v)
-    ($ :div (str "a=" v))))
-
-(defui Probe2ArgB []
-  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b
-                                     [:rf.uix-rcgsc/n])]
-    (swap! probe-2arg-b-observed conj v)
-    ($ :div (str "b=" v))))
-
-(deftest use-subscribe-2-arg-pins-explicit-frame
-  (testing "rf2-rcgsc: use-subscribe's 2-arg form
-            `(use-subscribe frame-kw query-v)` reads from the named
-            frame's app-db, bypassing the React-context tier. Two
-            probes pinning two different frames in the same render
-            tree must see each frame's distinct seed value."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-2arg-a-observed [])
-            (reset! probe-2arg-b-observed [])
-            (rf/reg-frame :rf.uix-rcgsc/tenant-a {:doc "tenant-a"})
-            (rf/reg-frame :rf.uix-rcgsc/tenant-b {:doc "tenant-b"})
-            (rf/reg-event-db :rf.uix-rcgsc/seed (fn [_ [_ n]] {:n n}))
-            (rf/dispatch-sync [:rf.uix-rcgsc/seed 10] {:frame :rf.uix-rcgsc/tenant-a})
-            (rf/dispatch-sync [:rf.uix-rcgsc/seed 100] {:frame :rf.uix-rcgsc/tenant-b})
-            (rf/reg-sub :rf.uix-rcgsc/n (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn []
-                          (.render root
-                            (uix/$ :div
-                              (uix/$ Probe2ArgA)
-                              (uix/$ Probe2ArgB)))))
-                (is (some #{10} @probe-2arg-a-observed)
-                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
-                (is (some #{100} @probe-2arg-b-observed)
-                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
-                (is (not (some #{100} @probe-2arg-a-observed))
-                    "tenant-a probe did NOT leak tenant-b's value")
-                (is (not (some #{10} @probe-2arg-b-observed))
-                    "tenant-b probe did NOT leak tenant-a's value")
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
@@ -268,10 +206,10 @@
 ;; period.
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
-  (testing "UIx use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
+  (testing "Helix use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-use-subscribe-test/refcount-frame
+      (let [target :rf.helix-use-subscribe-test/refcount-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -279,16 +217,16 @@
             (enable-react-act-env!)
             (reset! refcount-target target)
             (rf/reg-frame target {:doc "refcount probe frame"})
-            (rf/reg-event-db :seed-uix-us-rc (fn [_ _] {:m 0}))
-            (rf/dispatch-sync [:seed-uix-us-rc] {:frame target})
-            (rf/reg-sub :rf.uix-use-subscribe-test/m
+            (rf/reg-event-db :seed-helix-us-rc (fn [_ _] {:m 0}))
+            (rf/dispatch-sync [:seed-helix-us-rc] {:frame target})
+            (rf/reg-sub :rf.helix-use-subscribe-test/m
                         (fn [db _] (:m db)))
-            (let [cache-key-v [:rf.uix-use-subscribe-test/m]
+            (let [cache-key-v [:rf.helix-use-subscribe-test/m]
                   cache       (:sub-cache (frame/frame target))
                   mount-node  (make-mount-node!)
                   root        (react-dom-client/createRoot mount-node)]
               (try
-                (act-fn (fn [] (.render root (uix/$ ProbeRc))))
+                (act-fn (fn [] (.render root ($ ProbeRc))))
                 (is (pos? (or (get-in @cache [cache-key-v :ref-count])
                               0))
                     "mounted probe pinned a cache entry with ref-count > 0")
@@ -305,6 +243,71 @@
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
+;; ---- 2-arg form: explicit frame-id wins over context (rf2-y0db2) ----------
+;;
+;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
+;; bypass the React-context tier and read from the named frame's
+;; app-db directly. Although the existing Probe defnc above uses the
+;; 2-arg form, no deftest explicitly pinned that two different
+;; frame-ids in the SAME render tree (no surrounding provider) see
+;; distinct values. Parity with UIx's `use-subscribe-2-arg-pins-
+;; explicit-frame` (rf2-rcgsc).
+
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defnc Probe2ArgA []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a
+                                       [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    (d/div (str "a=" v))))
+
+(defnc Probe2ArgB []
+  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b
+                                       [:rf.helix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    (d/div (str "b=" v))))
+
+(deftest use-subscribe-2-arg-pins-explicit-frame
+  (testing "rf2-y0db2 (parity with UIx rf2-rcgsc): use-subscribe's 2-arg
+            form `(use-subscribe frame-kw query-v)` reads from the named
+            frame's app-db, bypassing the React-context tier. Two
+            probes pinning two different frames in the same render
+            tree must see each frame's distinct seed value."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! probe-2arg-a-observed [])
+            (reset! probe-2arg-b-observed [])
+            (rf/reg-frame :rf.helix-rcgsc/tenant-a {:doc "tenant-a"})
+            (rf/reg-frame :rf.helix-rcgsc/tenant-b {:doc "tenant-b"})
+            (rf/reg-event-db :rf.helix-rcgsc/seed (fn [_ [_ n]] {:n n}))
+            (rf/dispatch-sync [:rf.helix-rcgsc/seed 10] {:frame :rf.helix-rcgsc/tenant-a})
+            (rf/dispatch-sync [:rf.helix-rcgsc/seed 100] {:frame :rf.helix-rcgsc/tenant-b})
+            (rf/reg-sub :rf.helix-rcgsc/n (fn [db _] (:n db)))
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                (act-fn (fn []
+                          (.render root
+                            ($ :div
+                              ($ Probe2ArgA)
+                              ($ Probe2ArgB)))))
+                (is (some #{10} @probe-2arg-a-observed)
+                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
+                (is (some #{100} @probe-2arg-b-observed)
+                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
+                (is (not (some #{100} @probe-2arg-a-observed))
+                    "tenant-a probe did NOT leak tenant-b's value")
+                (is (not (some #{10} @probe-2arg-b-observed))
+                    "tenant-b probe did NOT leak tenant-a's value")
+                (finally
+                  (try (.unmount root) (catch :default _ nil)))))))))))
+
 ;; ---- stable structural-equality deps key (rf2-mwft2) ----------------------
 ;;
 ;; Pre-rf2-mwft2, `use-subscribe-2` passed the CLJS query-v vector
@@ -318,28 +321,30 @@
 ;; With the fix the deps element is JS-ref-stable across renders
 ;; (useRef + = compare), so a stable-literal query-v causes exactly
 ;; one subs/subscribe call across N forced re-renders, and the
-;; useEffect cleanup fires only on unmount.
+;; useEffect cleanup fires only on unmount. Parity with UIx's
+;; `use-subscribe-stable-deps-key` (rf2-mwft2).
 
 (deftest use-subscribe-stable-deps-key
-  (testing "rf2-mwft2: stable-literal query-v across N re-renders ⇒ one subs/subscribe call"
+  (testing "rf2-mwft2 (parity with UIx): stable-literal query-v across N
+            re-renders ⇒ one subs/subscribe call"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.uix-mwft2/probe-frame
+      (let [target :rf.helix-mwft2/probe-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
           (do
             (enable-react-act-env!)
             (reset! mwft2-set-tick nil)
-            (rf/reg-frame target {:doc "rf2-mwft2 probe frame"})
-            (rf/reg-event-db :rf.uix-mwft2/seed (fn [_ _] {:p 0}))
-            (rf/dispatch-sync [:rf.uix-mwft2/seed] {:frame target})
-            (rf/reg-sub :rf.uix-mwft2/p (fn [db _] (:p db)))
+            (rf/reg-frame target {:doc "rf2-mwft2 Helix probe frame"})
+            (rf/reg-event-db :rf.helix-mwft2/seed (fn [_ _] {:p 0}))
+            (rf/dispatch-sync [:rf.helix-mwft2/seed] {:frame target})
+            (rf/reg-sub :rf.helix-mwft2/p (fn [db _] (:p db)))
             (let [subscribe-calls   (atom 0)
                   unsubscribe-calls (atom 0)
                   real-subscribe    subs/subscribe
                   real-unsubscribe  subs/unsubscribe
-                  cache-key-v       [:rf.uix-mwft2/p]
+                  cache-key-v       [:rf.helix-mwft2/p]
                   cache             (:sub-cache (frame/frame target))
                   mount-node        (make-mount-node!)
                   root              (react-dom-client/createRoot mount-node)]
@@ -380,7 +385,7 @@
                 (try
                   ;; Mount the probe — one subs/subscribe for the
                   ;; useMemo factory.
-                  (act-fn (fn [] (.render root (uix/$ ProbeMwft2Parent))))
+                  (act-fn (fn [] (.render root ($ ProbeMwft2Parent))))
                   (let [mounted-subs @subscribe-calls]
                     (is (= 1 mounted-subs)
                         "mount triggered exactly one subs/subscribe call")
@@ -389,7 +394,7 @@
                     ;; Force five re-renders by bumping the parent's
                     ;; tick state. Each parent render also re-renders
                     ;; the child probe with a freshly-allocated CLJS
-                    ;; vector for [:rf.uix-mwft2/p] — without the fix
+                    ;; vector for [:rf.helix-mwft2/p] — without the fix
                     ;; the deps mismatch would re-run useMemo (extra
                     ;; subs/subscribe) and useEffect (extra
                     ;; subs/unsubscribe) each render.

--- a/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/cross_spec_dom_cljs_test.cljs
@@ -1,4 +1,4 @@
-(ns re-frame.cross-spec-cljs-test
+(ns re-frame.cross-spec-dom-cljs-test
   "Cross-Spec interaction edge cases. One deftest per documented case in
   spec/Cross-Spec-Interactions.md.
 
@@ -6,9 +6,10 @@
 
   Browser-runner promotion (rf2-o83z): Interactions whose contracts
   require a real React render now run live on the :browser-test target
-  instead of returning a placeholder `(is true)`. The same ns is loaded
-  by :node-test (it matches the `cljs-test$` regex) AND :browser-test
-  (it matches `-cljs-test$`); browser-only branches gate on
+  instead of returning a placeholder `(is true)`. The `-dom-cljs-test$`
+  suffix (rf2-2hrj8) opts this file into the `:browser-test` build; the
+  same ns is also loaded by `:node-test` (its regex `cljs-test$` matches
+  both `-cljs-test` and `-dom-cljs-test`). Browser-only branches gate on
   `(browser?)` and exit early under :node-test.
 
   Coverage audit (rf2-suif): every interaction that previously carried
@@ -33,6 +34,16 @@
             ;; Required here so its load-time hook + reg-sub
             ;; registrations fire before this ns's reg-route calls.
             [re-frame.routing]
+            ;; rf2-2hrj8 — the `:browser-test` build was narrowed to
+            ;; `-dom-cljs-test$` so the full implementation/test corpus no
+            ;; longer fans `re-frame.machines` / `re-frame.flows` /
+            ;; `re-frame.epoch` in via sibling test files. Require them
+            ;; explicitly here so the load-time hook publications
+            ;; (`reg-machine`, `reg-flow`, …) install before the cross-spec
+            ;; tests below reach into the late-bind table at call time.
+            [re-frame.machines]
+            [re-frame.flows]
+            [re-frame.epoch]
             [re-frame.ssr :as ssr]
             [re-frame.subs :as subs]
             [re-frame.substrate.adapter :as adapter]
@@ -310,9 +321,10 @@
    subscribe against the destroyed frame raises :rf.error/frame-destroyed).
 
    Per rf2-o83z this case is promoted from a placeholder to a real
-   browser-runner test. The :node-test target also loads this ns (it
-   matches both the `cljs-test$` and `-cljs-test$` regex), so we gate
-   the DOM-mounting branch on `(browser?)` and exit early under
+   browser-runner test. The :node-test target also loads this ns
+   (its `cljs-test$` regex matches both `-cljs-test` and the
+   `-dom-cljs-test` suffix introduced in rf2-2hrj8), so we gate the
+   DOM-mounting branch on `(browser?)` and exit early under
    :node-test where `js/document` is absent."
   (if-not (browser?)
     (is true ":node-test: no DOM — browser-test runner exercises the assertions")

--- a/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/frame_provider_context_dom_cljs_test.cljs
@@ -1,4 +1,4 @@
-(ns re-frame.frame-provider-context-cljs-test
+(ns re-frame.frame-provider-context-dom-cljs-test
   "Frame-provider runtime React-context test coverage (rf2-22ds).
 
   Per Spec 002 §Reading the frame from React context and Spec 006
@@ -31,11 +31,11 @@
        across re-renders + suspense boundaries (act-wrapped).
 
   Browser-only — every scenario requires a real React render so the
-  React-context tier actually pushes the Provider's value. The same
-  ns is loaded by both :node-test (matches `cljs-test$`) and
-  :browser-test (matches `-cljs-test$`); the DOM-mounting branches
-  gate on `(browser?)` and exit early under :node-test where
-  `js/document` is absent.
+  React-context tier actually pushes the Provider's value. The
+  `-dom-cljs-test$` suffix (rf2-2hrj8) opts this file into the
+  `:browser-test` build; `:node-test` still loads it (matches
+  `cljs-test$`) and the DOM-mounting branches gate on `(browser?)`
+  and exit early under :node-test where `js/document` is absent.
 
   Adapter target: stock Reagent (the artefact on main). The
   reagent-slim track is in flight; once it lands the same scenarios

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_after_render_dom_cljs_test.cljs
@@ -1,7 +1,7 @@
-(ns re-frame.adapter.helix-after-render-cljs-test
-  "Behavioural coverage for the Helix adapter's `:adapter/after-render`
-  hook (rf2-334d9). Pre-rf2-334d9 the Helix adapter did not publish
-  `:adapter/after-render`, so `(rf/after-render f)` under a Helix-only
+(ns re-frame.adapter.uix-after-render-dom-cljs-test
+  "Behavioural coverage for the UIx adapter's `:adapter/after-render`
+  hook (rf2-334d9). Pre-rf2-334d9 the UIx adapter did not publish
+  `:adapter/after-render`, so `(rf/after-render f)` under a UIx-only
   app was a silent no-op — closed by Mike's rf2-neiqf decision
   2026-05-19 to publish via `React.useLayoutEffect`.
 
@@ -16,12 +16,11 @@
   `r/after-render`. A `queueMicrotask` fallback covers the
   pre-mount / post-unmount call paths.
 
-  Coverage shape mirrors the UIx parity test
-  (`uix_after_render_cljs_test.cljs`):
+  Coverage shape. Two assertions:
     1. The hook is wired at ns-load — calling `interop/after-render`
-       under the Helix adapter returns nil (not a thrown
+       under the UIx adapter returns nil (not a thrown
        'no hook bound' / silent no-op signal).
-    2. Behaviour. Mount a Helix tree; call `(interop/after-render f)`;
+    2. Behaviour. Mount a UIx tree; call `(interop/after-render f)`;
        verify `f` fired after the next commit (asserted via a side-
        channel atom).
 
@@ -32,16 +31,15 @@
   ns ends in `-cljs-test` so shadow-cljs `:node-test` picks it up."
   (:require ["react"            :as React]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [helix.core :refer-macros [$ defnc]]
-            [helix.dom  :as d]
+            [uix.core :as uix :refer-macros [defui $]]
             [re-frame.substrate.adapter :as substrate-adapter]
-            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
             [re-frame.interop :as interop]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter helix-adapter/adapter}))
+    {:adapter uix-adapter/adapter}))
 
 (defn- browser? []
   (and (exists? js/document)
@@ -68,9 +66,9 @@
 
 ;; ---- ns-load smoke -------------------------------------------------------
 
-(deftest after-render-hook-wired-under-helix
+(deftest after-render-hook-wired-under-uix
   (testing "rf2-334d9: `interop/after-render` no longer silent-no-ops
-            under the Helix adapter — the hook is wired at ns-load and
+            under the UIx adapter — the hook is wired at ns-load and
             returns nil (the documented swallow shape) rather than
             falling through to nil because no adapter published it."
     ;; Calling with a fn argument should NOT throw and should NOT
@@ -78,20 +76,20 @@
     ;; per the make-after-render-hook contract, and the queueMicrotask
     ;; fallback drain handles the no-mount case asynchronously.
     (is (nil? (interop/after-render (fn [] :ok)))
-        "interop/after-render under the Helix adapter returns nil — the
+        "interop/after-render under the UIx adapter returns nil — the
          spine-built hook is wired through :adapter/after-render via
          substrate-adapter/route-hook!")))
 
 ;; ---- behaviour: mount, schedule, drain after commit ----------------------
 
-(defnc Probe []
-  ;; Bare Helix component — the rf2-334d9 sentinel is injected by the
+(defui Probe []
+  ;; Bare UIx component — the rf2-334d9 sentinel is injected by the
   ;; spine's `make-render`, not by user code.
-  (d/div "probe"))
+  ($ :div "probe"))
 
-(deftest after-render-runs-callback-after-next-commit-helix
+(deftest after-render-runs-callback-after-next-commit-uix
   (testing "rf2-334d9: `(interop/after-render f)` schedules `f` to run
-            after the next mount/render cycle under the Helix adapter.
+            after the next mount/render cycle under the UIx adapter.
             The sentinel injected by the spine's make-render uses
             React.useLayoutEffect to drain the queue post-commit."
     (if-not (browser?)

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_cross_spec_cljs_test.cljs
@@ -1,6 +1,7 @@
 (ns re-frame.adapter.uix-cross-spec-cljs-test
   "Adapter-parity port of the headless subset of
-  `re-frame.cross-spec-cljs-test` to the UIx adapter (rf2-ta4b5).
+  `re-frame.cross-spec-dom-cljs-test` to the UIx adapter (rf2-ta4b5;
+  renamed rf2-2hrj8).
 
   Each deftest pins a Cross-Spec interaction (spec/Cross-Spec-Interactions.md)
   under a UIx-installed adapter. The subset ported here is the one

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -1,9 +1,9 @@
-(ns re-frame.adapter.helix-use-subscribe-cljs-test
-  "Unit coverage for the Helix adapter's `use-subscribe` hook (rf2-518sp).
+(ns re-frame.adapter.uix-use-subscribe-dom-cljs-test
+  "Unit coverage for the UIx adapter's `use-subscribe` hook (rf2-518sp).
 
-  Pre-rf2-518sp, `use-subscribe` was published as the canonical Helix
-  subscribe surface (rf2-2qit Decision 1) and exercised only through
-  the Playwright `counter_helix` smoke; no node-runtime headless test
+  Pre-rf2-518sp, `use-subscribe` was published as the canonical UIx
+  subscribe surface (rf2-3yij Decision 1) and exercised only through
+  the Playwright `counter_uix` smoke; no node-runtime headless test
   asserted that the React.useSyncExternalStore wiring sees post-
   dispatch values. A regression in `subscribe-fn`'s add-watch keying,
   `get-snap`'s reaction deref, the use-memo deps vec, or the
@@ -20,22 +20,20 @@
   (:require ["react"            :as React]
             ["react-dom/client" :as react-dom-client]
             [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [helix.core :refer-macros [$ defnc]]
-            [helix.dom  :as d]
-            [helix.hooks :as helix-hooks]
+            [uix.core :as uix :refer-macros [defui $]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.subs :as subs]
-            [re-frame.adapter.helix :as helix-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/reset-runtime-fixture
-    {:adapter helix-adapter/adapter}))
+    {:adapter uix-adapter/adapter}))
 
 ;; ---- side-channel atoms ----------------------------------------------------
-;; Per-test atoms read by the Helix probe components below. The probes
-;; are defnc top-levels (helix `defnc` defines a Var; it cannot sit
+;; Per-test atoms read by the UIx probe components below. The probes
+;; are defui top-levels (uix `defui` defines a Var; it cannot sit
 ;; inside a `let`) and close over these atoms; each deftest `reset!`s
 ;; the atom it cares about at the top of its body.
 
@@ -43,51 +41,50 @@
 (def ^:private probe-fp-observed    (atom []))
 (def ^:private refcount-target      (atom nil))
 
-(defnc Probe []
+(defui Probe []
   (let [target @refcount-target
-        v (helix-adapter/use-subscribe target
-                                       [:rf.helix-use-subscribe-test/n])]
+        v (uix-adapter/use-subscribe target
+                                      [:rf.uix-use-subscribe-test/n])]
     (swap! probe-observed conj v)
-    (d/div (str "n=" v))))
+    ($ :div (str "n=" v))))
 
-(defnc ProbeFp []
-  (let [v (helix-adapter/use-subscribe
-            [:rf.helix-use-subscribe-test/k])]
+(defui ProbeFp []
+  (let [v (uix-adapter/use-subscribe
+            [:rf.uix-use-subscribe-test/k])]
     (swap! probe-fp-observed conj v)
-    (d/div (str "k=" v))))
+    ($ :div (str "k=" v))))
 
-(defnc ProbeRc []
+(defui ProbeRc []
   (let [target @refcount-target
-        v (helix-adapter/use-subscribe target
-                                       [:rf.helix-use-subscribe-test/m])]
-    (d/div (str "m=" v))))
+        v (uix-adapter/use-subscribe target
+                                      [:rf.uix-use-subscribe-test/m])]
+    ($ :div (str "m=" v))))
 
 ;; ---- rf2-mwft2 regression probes ------------------------------------------
 ;; A parent that owns a tick state (used to force re-renders) plus a child
-;; that reads a fixed query-v via use-subscribe. The literal `[:rf.helix-mwft2/p]`
+;; that reads a fixed query-v via use-subscribe. The literal `[:rf.uix-mwft2/p]`
 ;; vector evaluates to a fresh JS object each render — *exactly* the shape
 ;; the bug-without-fix walks into. The parent stashes its set-tick fn into
 ;; a side-channel atom so the test can drive forced re-renders from outside.
 
 (def ^:private mwft2-set-tick      (atom nil))
 
-(defnc ProbeMwft2Child []
-  (let [v (helix-adapter/use-subscribe :rf.helix-mwft2/probe-frame
-                                       [:rf.helix-mwft2/p])]
-    (d/div (str "p=" v))))
+(defui ProbeMwft2Child []
+  (let [v (uix-adapter/use-subscribe :rf.uix-mwft2/probe-frame
+                                      [:rf.uix-mwft2/p])]
+    ($ :div (str "p=" v))))
 
-(defnc ProbeMwft2Parent []
-  (let [[tick set-tick] (helix-hooks/use-state 0)]
-    (helix-hooks/use-effect
+(defui ProbeMwft2Parent []
+  (let [[tick set-tick] (uix/use-state 0)]
+    (uix/use-effect
       ;; React state-setters have stable identity across renders so an
-      ;; empty deps vec is correct — matches React's "set-state setter is
-      ;; stable" guarantee. The effect runs once on mount to stash the
-      ;; setter for the test driver.
-      []
-      (reset! mwft2-set-tick set-tick)
-      (fn cleanup [] nil))
-    (d/div {:data-tick tick}
-           ($ ProbeMwft2Child))))
+      ;; empty deps vec is correct — silences UIx's lint and matches
+      ;; React's "set-state setter is stable" guarantee. The effect runs
+      ;; once on mount to stash the setter for the test driver.
+      (fn [] (reset! mwft2-set-tick set-tick) js/undefined)
+      [])
+    ($ :div {:data-tick tick}
+       ($ ProbeMwft2Child))))
 
 ;; ---- browser gate ---------------------------------------------------------
 
@@ -129,10 +126,10 @@
 ;; resolves through the surrounding `frame-provider`.
 
 (deftest use-subscribe-tracks-app-db-changes
-  (testing "Helix use-subscribe sees post-dispatch values via useSyncExternalStore"
+  (testing "UIx use-subscribe sees post-dispatch values via useSyncExternalStore"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/probe-frame
+      (let [target :rf.uix-use-subscribe-test/probe-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -141,15 +138,15 @@
             (reset! probe-observed [])
             (reset! refcount-target target)
             (rf/reg-frame target {:doc "use-subscribe probe frame"})
-            (rf/reg-event-db :seed-helix-us (fn [_ _] {:n 1}))
-            (rf/reg-event-db :inc-helix-us  (fn [db _] (update db :n inc)))
-            (rf/dispatch-sync [:seed-helix-us] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/n
+            (rf/reg-event-db :seed-uix-us (fn [_ _] {:n 1}))
+            (rf/reg-event-db :inc-uix-us  (fn [db _] (update db :n inc)))
+            (rf/dispatch-sync [:seed-uix-us] {:frame target})
+            (rf/reg-sub :rf.uix-use-subscribe-test/n
                         (fn [db _] (:n db)))
             (let [mount-node (make-mount-node!)
                   root       (react-dom-client/createRoot mount-node)]
               (try
-                (act-fn (fn [] (.render root ($ Probe))))
+                (act-fn (fn [] (.render root (uix/$ Probe))))
                 (is (some #{1} @probe-observed)
                     "first render observed the seeded value n=1")
                 ;; Wrap dispatch in act so React commits the forceUpdate
@@ -157,17 +154,17 @@
                 ;; Plain `dispatch-sync` outside act emits the
                 ;; "update was not wrapped in act" warning AND fails to
                 ;; flush the resulting render in the test environment.
-                (act-fn (fn [] (rf/dispatch-sync [:inc-helix-us] {:frame target})))
+                (act-fn (fn [] (rf/dispatch-sync [:inc-uix-us] {:frame target})))
                 (is (some #{2} @probe-observed)
                     "post-dispatch re-render observed the incremented value n=2")
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
 (deftest use-subscribe-frame-provider-resolution
-  (testing "Helix use-subscribe 1-arg form resolves through the surrounding frame-provider"
+  (testing "UIx use-subscribe 1-arg form resolves through the surrounding frame-provider"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/fp-frame
+      (let [target :rf.uix-use-subscribe-test/fp-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -175,9 +172,9 @@
             (enable-react-act-env!)
             (reset! probe-fp-observed [])
             (rf/reg-frame target {:doc "use-subscribe fp probe frame"})
-            (rf/reg-event-db :seed-helix-us-fp (fn [_ _] {:k :wrapped}))
-            (rf/dispatch-sync [:seed-helix-us-fp] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/k
+            (rf/reg-event-db :seed-uix-us-fp (fn [_ _] {:k :wrapped}))
+            (rf/dispatch-sync [:seed-uix-us-fp] {:frame target})
+            (rf/reg-sub :rf.uix-use-subscribe-test/k
                         (fn [db _] (:k db)))
             (let [mount-node (make-mount-node!)
                   root       (react-dom-client/createRoot mount-node)]
@@ -186,12 +183,77 @@
                   (fn []
                     ;; frame-provider is a plain CLJS fn returning a
                     ;; React element (NOT a React-component head), so
-                    ;; invoke it directly rather than via `($ ...)`.
+                    ;; invoke it directly rather than via `(uix/$ ...)`.
                     (.render root
-                      (helix-adapter/frame-provider
-                        {:frame target :children [($ ProbeFp)]}))))
+                      (uix-adapter/frame-provider
+                        {:frame target :children [(uix/$ ProbeFp)]}))))
                 (is (some #{:wrapped} @probe-fp-observed)
                     "use-subscribe 1-arg form read from the wrapped frame, not :rf/default")
+                (finally
+                  (try (.unmount root) (catch :default _ nil)))))))))))
+
+;; ---- 2-arg form: explicit frame-id wins over context (rf2-rcgsc) ----------
+;;
+;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
+;; bypass the React-context tier and read from the named frame's
+;; app-db directly. Pre-rf2-rcgsc only the 1-arg context-resolved form
+;; was tested under a frame-provider; the 2-arg explicit-pin shape was
+;; exercised indirectly via the Probe component above but no test
+;; pinned that two different frame-ids in the SAME render tree (no
+;; surrounding provider) see distinct values.
+
+(def ^:private probe-2arg-a-observed (atom []))
+(def ^:private probe-2arg-b-observed (atom []))
+
+(defui Probe2ArgA []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-a
+                                     [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-a-observed conj v)
+    ($ :div (str "a=" v))))
+
+(defui Probe2ArgB []
+  (let [v (uix-adapter/use-subscribe :rf.uix-rcgsc/tenant-b
+                                     [:rf.uix-rcgsc/n])]
+    (swap! probe-2arg-b-observed conj v)
+    ($ :div (str "b=" v))))
+
+(deftest use-subscribe-2-arg-pins-explicit-frame
+  (testing "rf2-rcgsc: use-subscribe's 2-arg form
+            `(use-subscribe frame-kw query-v)` reads from the named
+            frame's app-db, bypassing the React-context tier. Two
+            probes pinning two different frames in the same render
+            tree must see each frame's distinct seed value."
+    (if-not (browser?)
+      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
+      (let [act-fn (get-act)]
+        (if (nil? act-fn)
+          (is true "act() not reachable from this runner; skipping")
+          (do
+            (enable-react-act-env!)
+            (reset! probe-2arg-a-observed [])
+            (reset! probe-2arg-b-observed [])
+            (rf/reg-frame :rf.uix-rcgsc/tenant-a {:doc "tenant-a"})
+            (rf/reg-frame :rf.uix-rcgsc/tenant-b {:doc "tenant-b"})
+            (rf/reg-event-db :rf.uix-rcgsc/seed (fn [_ [_ n]] {:n n}))
+            (rf/dispatch-sync [:rf.uix-rcgsc/seed 10] {:frame :rf.uix-rcgsc/tenant-a})
+            (rf/dispatch-sync [:rf.uix-rcgsc/seed 100] {:frame :rf.uix-rcgsc/tenant-b})
+            (rf/reg-sub :rf.uix-rcgsc/n (fn [db _] (:n db)))
+            (let [mount-node (make-mount-node!)
+                  root       (react-dom-client/createRoot mount-node)]
+              (try
+                (act-fn (fn []
+                          (.render root
+                            (uix/$ :div
+                              (uix/$ Probe2ArgA)
+                              (uix/$ Probe2ArgB)))))
+                (is (some #{10} @probe-2arg-a-observed)
+                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
+                (is (some #{100} @probe-2arg-b-observed)
+                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
+                (is (not (some #{100} @probe-2arg-a-observed))
+                    "tenant-a probe did NOT leak tenant-b's value")
+                (is (not (some #{10} @probe-2arg-b-observed))
+                    "tenant-b probe did NOT leak tenant-a's value")
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
@@ -206,10 +268,10 @@
 ;; period.
 
 (deftest use-subscribe-cleanup-decrements-sub-cache-refcount
-  (testing "Helix use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
+  (testing "UIx use-subscribe pairs subscribe with subs/unsubscribe on unmount (rf2-7g959)"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-use-subscribe-test/refcount-frame
+      (let [target :rf.uix-use-subscribe-test/refcount-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
@@ -217,16 +279,16 @@
             (enable-react-act-env!)
             (reset! refcount-target target)
             (rf/reg-frame target {:doc "refcount probe frame"})
-            (rf/reg-event-db :seed-helix-us-rc (fn [_ _] {:m 0}))
-            (rf/dispatch-sync [:seed-helix-us-rc] {:frame target})
-            (rf/reg-sub :rf.helix-use-subscribe-test/m
+            (rf/reg-event-db :seed-uix-us-rc (fn [_ _] {:m 0}))
+            (rf/dispatch-sync [:seed-uix-us-rc] {:frame target})
+            (rf/reg-sub :rf.uix-use-subscribe-test/m
                         (fn [db _] (:m db)))
-            (let [cache-key-v [:rf.helix-use-subscribe-test/m]
+            (let [cache-key-v [:rf.uix-use-subscribe-test/m]
                   cache       (:sub-cache (frame/frame target))
                   mount-node  (make-mount-node!)
                   root        (react-dom-client/createRoot mount-node)]
               (try
-                (act-fn (fn [] (.render root ($ ProbeRc))))
+                (act-fn (fn [] (.render root (uix/$ ProbeRc))))
                 (is (pos? (or (get-in @cache [cache-key-v :ref-count])
                               0))
                     "mounted probe pinned a cache entry with ref-count > 0")
@@ -243,71 +305,6 @@
                 (finally
                   (try (.unmount root) (catch :default _ nil)))))))))))
 
-;; ---- 2-arg form: explicit frame-id wins over context (rf2-y0db2) ----------
-;;
-;; The 2-arg form `(use-subscribe frame-kw query-v)` is documented to
-;; bypass the React-context tier and read from the named frame's
-;; app-db directly. Although the existing Probe defnc above uses the
-;; 2-arg form, no deftest explicitly pinned that two different
-;; frame-ids in the SAME render tree (no surrounding provider) see
-;; distinct values. Parity with UIx's `use-subscribe-2-arg-pins-
-;; explicit-frame` (rf2-rcgsc).
-
-(def ^:private probe-2arg-a-observed (atom []))
-(def ^:private probe-2arg-b-observed (atom []))
-
-(defnc Probe2ArgA []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-a
-                                       [:rf.helix-rcgsc/n])]
-    (swap! probe-2arg-a-observed conj v)
-    (d/div (str "a=" v))))
-
-(defnc Probe2ArgB []
-  (let [v (helix-adapter/use-subscribe :rf.helix-rcgsc/tenant-b
-                                       [:rf.helix-rcgsc/n])]
-    (swap! probe-2arg-b-observed conj v)
-    (d/div (str "b=" v))))
-
-(deftest use-subscribe-2-arg-pins-explicit-frame
-  (testing "rf2-y0db2 (parity with UIx rf2-rcgsc): use-subscribe's 2-arg
-            form `(use-subscribe frame-kw query-v)` reads from the named
-            frame's app-db, bypassing the React-context tier. Two
-            probes pinning two different frames in the same render
-            tree must see each frame's distinct seed value."
-    (if-not (browser?)
-      (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [act-fn (get-act)]
-        (if (nil? act-fn)
-          (is true "act() not reachable from this runner; skipping")
-          (do
-            (enable-react-act-env!)
-            (reset! probe-2arg-a-observed [])
-            (reset! probe-2arg-b-observed [])
-            (rf/reg-frame :rf.helix-rcgsc/tenant-a {:doc "tenant-a"})
-            (rf/reg-frame :rf.helix-rcgsc/tenant-b {:doc "tenant-b"})
-            (rf/reg-event-db :rf.helix-rcgsc/seed (fn [_ [_ n]] {:n n}))
-            (rf/dispatch-sync [:rf.helix-rcgsc/seed 10] {:frame :rf.helix-rcgsc/tenant-a})
-            (rf/dispatch-sync [:rf.helix-rcgsc/seed 100] {:frame :rf.helix-rcgsc/tenant-b})
-            (rf/reg-sub :rf.helix-rcgsc/n (fn [db _] (:n db)))
-            (let [mount-node (make-mount-node!)
-                  root       (react-dom-client/createRoot mount-node)]
-              (try
-                (act-fn (fn []
-                          (.render root
-                            ($ :div
-                              ($ Probe2ArgA)
-                              ($ Probe2ArgB)))))
-                (is (some #{10} @probe-2arg-a-observed)
-                    "Probe2ArgA observed tenant-a's value (10) via explicit frame-pin")
-                (is (some #{100} @probe-2arg-b-observed)
-                    "Probe2ArgB observed tenant-b's value (100) via explicit frame-pin")
-                (is (not (some #{100} @probe-2arg-a-observed))
-                    "tenant-a probe did NOT leak tenant-b's value")
-                (is (not (some #{10} @probe-2arg-b-observed))
-                    "tenant-b probe did NOT leak tenant-a's value")
-                (finally
-                  (try (.unmount root) (catch :default _ nil)))))))))))
-
 ;; ---- stable structural-equality deps key (rf2-mwft2) ----------------------
 ;;
 ;; Pre-rf2-mwft2, `use-subscribe-2` passed the CLJS query-v vector
@@ -321,30 +318,28 @@
 ;; With the fix the deps element is JS-ref-stable across renders
 ;; (useRef + = compare), so a stable-literal query-v causes exactly
 ;; one subs/subscribe call across N forced re-renders, and the
-;; useEffect cleanup fires only on unmount. Parity with UIx's
-;; `use-subscribe-stable-deps-key` (rf2-mwft2).
+;; useEffect cleanup fires only on unmount.
 
 (deftest use-subscribe-stable-deps-key
-  (testing "rf2-mwft2 (parity with UIx): stable-literal query-v across N
-            re-renders ⇒ one subs/subscribe call"
+  (testing "rf2-mwft2: stable-literal query-v across N re-renders ⇒ one subs/subscribe call"
     (if-not (browser?)
       (is true ":node-test: no DOM — browser-test runner exercises the assertions")
-      (let [target :rf.helix-mwft2/probe-frame
+      (let [target :rf.uix-mwft2/probe-frame
             act-fn (get-act)]
         (if (nil? act-fn)
           (is true "act() not reachable from this runner; skipping")
           (do
             (enable-react-act-env!)
             (reset! mwft2-set-tick nil)
-            (rf/reg-frame target {:doc "rf2-mwft2 Helix probe frame"})
-            (rf/reg-event-db :rf.helix-mwft2/seed (fn [_ _] {:p 0}))
-            (rf/dispatch-sync [:rf.helix-mwft2/seed] {:frame target})
-            (rf/reg-sub :rf.helix-mwft2/p (fn [db _] (:p db)))
+            (rf/reg-frame target {:doc "rf2-mwft2 probe frame"})
+            (rf/reg-event-db :rf.uix-mwft2/seed (fn [_ _] {:p 0}))
+            (rf/dispatch-sync [:rf.uix-mwft2/seed] {:frame target})
+            (rf/reg-sub :rf.uix-mwft2/p (fn [db _] (:p db)))
             (let [subscribe-calls   (atom 0)
                   unsubscribe-calls (atom 0)
                   real-subscribe    subs/subscribe
                   real-unsubscribe  subs/unsubscribe
-                  cache-key-v       [:rf.helix-mwft2/p]
+                  cache-key-v       [:rf.uix-mwft2/p]
                   cache             (:sub-cache (frame/frame target))
                   mount-node        (make-mount-node!)
                   root              (react-dom-client/createRoot mount-node)]
@@ -385,7 +380,7 @@
                 (try
                   ;; Mount the probe — one subs/subscribe for the
                   ;; useMemo factory.
-                  (act-fn (fn [] (.render root ($ ProbeMwft2Parent))))
+                  (act-fn (fn [] (.render root (uix/$ ProbeMwft2Parent))))
                   (let [mounted-subs @subscribe-calls]
                     (is (= 1 mounted-subs)
                         "mount triggered exactly one subs/subscribe call")
@@ -394,7 +389,7 @@
                     ;; Force five re-renders by bumping the parent's
                     ;; tick state. Each parent render also re-renders
                     ;; the child probe with a freshly-allocated CLJS
-                    ;; vector for [:rf.helix-mwft2/p] — without the fix
+                    ;; vector for [:rf.uix-mwft2/p] — without the fix
                     ;; the deps mismatch would re-run useMemo (extra
                     ;; subs/subscribe) and useEffect (extra
                     ;; subs/unsubscribe) each render.

--- a/implementation/core/test/re_frame/dispatch_fallthrough_warn_dom_cljs_test.cljs
+++ b/implementation/core/test/re_frame/dispatch_fallthrough_warn_dom_cljs_test.cljs
@@ -1,4 +1,4 @@
-(ns re-frame.dispatch-fallthrough-warn-cljs-test
+(ns re-frame.dispatch-fallthrough-warn-dom-cljs-test
   "Per rf2-nmusx — CLJS-side integration coverage for the async-escape
   fallthrough warning (`:rf.warning/dispatch-from-async-callback-fell-
   through-to-default`). The JVM test `re-frame.dispatch-fallthrough-
@@ -29,11 +29,12 @@
   string are all pinned (they are the user-facing surface the warning
   exists to deliver).
 
-  Naming convention: the `-cljs-test$` suffix means this file runs
-  under the default `:browser-test` build (Playwright + jsdom-style
-  shell). The async-callback surfaces are real browser APIs; jsdom
-  provides `setTimeout`, `addEventListener`, and `requestAnimationFrame`
-  via a polyfill where needed."
+  Naming convention (rf2-2hrj8): the `-dom-cljs-test$` suffix opts
+  this file into the `:browser-test` build (Playwright + Chromium).
+  `:node-test` still loads it (its regex `cljs-test$` matches both
+  `-cljs-test` and `-dom-cljs-test`), so the cross-runtime assertions
+  below run under both targets. The DOM-mounting branches gate on
+  `(browser?)` and exit early under `:node-test`."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -71,7 +72,8 @@
 ;; ---- browser gate --------------------------------------------------------
 ;;
 ;; This ns is loaded by both :node-test (matches `cljs-test$`) and
-;; :browser-test (matches `-cljs-test$`). Two of the three async-callback
+;; :browser-test (matches `-dom-cljs-test$` per rf2-2hrj8). Two of the
+;; three async-callback
 ;; surfaces (`addEventListener` on a DOM node, `requestAnimationFrame`)
 ;; require a real browser. setTimeout is universal. Each test gates its
 ;; body on `(browser?)` where needed and exits early under :node-test

--- a/implementation/core/test/re_frame/elision_probe.cljs
+++ b/implementation/core/test/re_frame/elision_probe.cljs
@@ -297,7 +297,7 @@
   ;; which is nil at probe time (no Reagent render in flight), so the
   ;; emit-site keyword is DCE'd from BOTH bundles by closure dataflow.
   ;; The browser-runner test
-  ;; (re-frame.cross-spec-cljs-test/plain-fn-under-non-default-frame) is
+  ;; (re-frame.cross-spec-dom-cljs-test/plain-fn-under-non-default-frame) is
   ;; the load-bearing assertion that the gate fires under DEBUG=true;
   ;; production elision rests on the surrounding
   ;; `(when interop/debug-enabled? ...)` constant-folding to false the

--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -272,7 +272,7 @@ const DEV_ONLY_SENTINELS = [
   // dataflow analysis under :advanced determines the inner emit branch
   // is unreachable, so the keyword's literal string is dropped from
   // the control build too. The methodology check would be vacuous.
-  // The browser-test (re-frame.cross-spec-cljs-test/plain-fn-under-
+  // The browser-test (re-frame.cross-spec-dom-cljs-test/plain-fn-under-
   // non-default-frame) is the load-bearing assertion that the gate is
   // wired up under DEBUG=true; under :advanced + goog.DEBUG=false the
   // gate is constant-folded false and the body DCE's regardless.

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -209,9 +209,24 @@
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}
 
+  ;; rf2-2hrj8 — `:browser-test` is narrowed to DOM-dependent tests only.
+  ;; The ns-regexp `-dom-cljs-test$` matches files whose namespace ends in
+  ;; `-dom-cljs-test` (i.e. files named `*_dom_cljs_test.cljs`). The
+  ;; selected files mount real React via `react-dom/client`'s
+  ;; `createRoot`, exercise the React-context tier, or otherwise depend
+  ;; on a live browser-runtime feature that Node can't fake (real DOM,
+  ;; real `requestAnimationFrame`, real `addEventListener` on a Node).
+  ;; Tests written to be cross-runtime (those that stub via `with-redefs`
+  ;; or `(when (browser?) ...)` and provide a node-fallback body) keep
+  ;; the plain `-cljs-test$` suffix and run under `:node-test` only —
+  ;; `:node-test`'s `cljs-test$` regex still matches both suffixes
+  ;; (`-cljs-test` AND `-dom-cljs-test`), so the DOM-tagged files run
+  ;; on BOTH targets and the cross-runtime asserts continue firing in
+  ;; Node. The split eliminates the ~14m of duplicate Chromium compile
+  ;; + run on the ~3500-test bulk that needs no browser signal.
   :browser-test
   {:target    :browser-test
-   :ns-regexp "-cljs-test$"
+   :ns-regexp "-dom-cljs-test$"
    :test-dir  "out/browser-test"
    :runner-ns shadow.test.browser
    :compiler-options


### PR DESCRIPTION
## Summary
- Tag DOM-dependent CLJS tests with a `_dom_cljs_test.cljs` suffix (ns ends in `-dom-cljs-test`).
- Narrow `:browser-test` shadow build's `:ns-regexp` from `-cljs-test$` to `-dom-cljs-test$`.
- `:node-test`'s `cljs-test$` regex still matches both suffixes, so DOM-tagged tests run under BOTH Node and Chromium; cross-runtime tests run under Node only.
- 7 files renamed (every one carries an in-source `(browser?)` gate). One pre-existing file (`source_coord_dom_cljs_test.cljs`, named for its subject) also matches the new regex — verified genuinely DOM-dependent.
- TESTING.md documents the new layering.

## Bead
rf2-2hrj8 (P1)

## CI impact

| Build | Before (CI) | After (CI, projected) | Local (cold) |
|---|---|---|---|
| `:browser-test` | ~14m / 3542 tests | ~2-3m / 64 tests | 32s (was ~41s) |
| `:browser-test-prod-elision` | ~14m / 54 tests | unchanged | unchanged |
| `:node-test` | ~73s / 3551 tests | ~73s / 3551 tests | 36.8s (unchanged) |

`:browser-test-prod-elision` was nominated in the bead for a similar drop but its `-elision-prod-test$` ns-regexp already only matches 13 files / 54 tests pre-change — the 14m CI time is dominated by JDK + Clojure + Playwright setup overhead, not test count. The realistic CI cut is the ~11-12m saved on `:browser-test` per full-matrix PR.

## Tag strategy
Naming convention: `*_dom_cljs_test.cljs` (ns `-dom-cljs-test`). Picked over `^:browser` deftest metadata because shadow-cljs's `:ns-regexp` operates at the namespace level — a file-rename is one git operation per file and shadow's existing regex machinery handles the filtering without touching the test runner.

## Files
- Renamed (7): `dispatch_fallthrough_warn`, `uix_use_subscribe`, `uix_after_render`, `frame_provider_context`, `cross_spec` (reagent), `helix_use_subscribe`, `helix_after_render`.
- Modified: `shadow-cljs.edn` (regex change), `cross_spec_dom_cljs_test.cljs` (added explicit `re-frame.machines` / `re-frame.flows` / `re-frame.epoch` requires — pre-split they loaded transitively via sibling files in the same `:browser-test` build; the narrowed build no longer pulls them in), parity-port docstring updates (`uix_/helix_cross_spec_cljs_test`), cross-reference updates (`elision_probe.cljs`, `check-elision.cjs`), `TESTING.md`.

## Acceptance
- [x] `npm run test:cljs` — 3551 tests, 0 failures (unchanged from baseline).
- [x] `npm run test:browser` — 64 tests, 215 assertions, 0 failures, 32s cold.
- [x] `npm run test:browser-prod-elision` — 54 tests, 151 assertions, 0 failures (unchanged).
- [x] `mkdocs build --strict` — green.
- [x] Coverage parity — DOM-dependent paths gated on `(browser?)` continue to fire under `:browser-test`; everything else continues to run under `:node-test`.

## Surprises
- `:browser-test-prod-elision` was already minimal (54 tests). The bead's claim that it duplicated `:browser-test`'s 3500-test set was a misread; the regex `-elision-prod-test$` only matches 13 files.
- `source_coord_dom_cljs_test.cljs` (pre-existing) happens to match the new regex via natural naming. Verified DOM-dependent — keeps its name unchanged, gets the browser-test inclusion as a side benefit.
- `cross_spec_dom_cljs_test.cljs` needed explicit machine/flow/epoch requires once the test corpus shrank — silent transitive loads in the full build were masking the missing explicit requires.