### PR TITLE
refactor(pair-mcp): :reason vocab + raw-state polarity (rf2-g5ox5 + rf2-p1qli)

### DIFF
--- a/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
+++ b/tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md
@@ -219,6 +219,58 @@ app-db on the second inspect; with the cache it ships ~100
 bytes. Saving the round-trip too needs a server-side hash
 precheck and is filed as a follow-on bead.
 
+## Universal: `:reason` keyword vocabulary (`:ok? false` responses)
+
+Every `{:ok? false ...}` response carries a `:reason` keyword. The
+catalogue uses **three deliberate namespacing dialects** — they look
+similar at a glance but signal different categories of failure. An
+agent host pattern-matching on `:reason` should treat the dialect as
+load-bearing: each carries different recovery semantics.
+
+| Dialect       | Meaning                                                            | Example reasons                                                                              |
+|---------------|--------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| **Bare**      | Per-call validation / runtime failure (the normal tool body ran)   | `:invalid-kind`, `:missing-path`, `:not-an-event-vector`, `:path-not-found`, `:unknown-tool`, `:runtime-not-preloaded`, `:eval-error`, `:<verb>-failed` (e.g. `:snapshot-failed`, `:dispatch-failed`) |
+| `:rf.error/*` | Operator-gated denial — the server refused **without touching nREPL** because a boot-flag / resource cap rejected the call before the tool body ran | `:rf.error/eval-cljs-disabled`, `:rf.error/concurrent-stream-limit`, `:rf.error/stream-abuse-detected` |
+| `:rf.mcp/*`   | Wire-replacement-marker family (otherwise reserved for substitution markers like `:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`, `:rf.mcp/summary`, `:rf.mcp/diff-from`). One carve-out as a `:reason` value: `:rf.mcp/cursor-stale` — cursor-staleness is detected at the wire boundary itself (the cursor envelope), not via tool body or boot gate, so it shares the `:rf.mcp/*` prefix with the rest of the wire-boundary vocabulary | `:rf.mcp/cursor-stale` (the only `:rf.mcp/*` `:reason` value) |
+
+### Rationale for the split
+
+**Why `:rf.error/*` and not bare for operator-gated denials?** The
+`:rf.error/*` namespace carries a distinct recovery shape: the operator
+must add a server-launch flag (`--allow-eval`) or raise an integer cap
+(`--max-concurrent-streams`) before the call will succeed. Bare reasons
+are recoverable by adjusting per-call args; `:rf.error/*` reasons are
+recoverable only by adjusting server configuration. An agent host that
+sees `:rf.error/eval-cljs-disabled` knows to surface a setup hint
+("ask the operator to relaunch with `--allow-eval`") rather than retry
+with different args.
+
+**Why `:rf.mcp/cursor-stale` and not `:rf.error/cursor-stale`?**
+`:rf.mcp/*` is the wire-vocabulary family — every other `:rf.mcp/*`
+keyword (`:rf.mcp/overflow`, `:rf.mcp/dedup-table`, `:rf.mcp/cache-hit`,
+`:rf.mcp/summary`, `:rf.mcp/diff-from`) is a substitution marker that
+replaces a normal payload at the wire boundary. Cursor-staleness is
+detected at the same boundary (the cursor envelope, before the tool
+body runs) and shares the wire-vocabulary lineage even though it
+appears in the `:reason` slot rather than as a payload substitution.
+Migrating it to `:rf.error/*` would break the cross-MCP recognition
+("everything `:rf.mcp/*` is wire-boundary vocabulary, regardless of
+which slot it lives in") that an agent host learns once on a sibling
+server.
+
+**Why bare for per-call validation?** Short, readable, no namespace
+ceremony for the common case. Bare reasons dominate the surface
+(~32 distinct keywords) because per-call validation failures are
+the common path; the dialect cost would tax the common case.
+
+### Recognition rules for agent hosts
+
+- A bare reason ⇒ try different args (path, frame, event vector, …).
+- A `:rf.error/*` reason ⇒ surface a server-config hint; do not retry
+  with different args.
+- `:rf.mcp/cursor-stale` ⇒ drop the cursor; restart pagination from
+  the head (same as cross-MCP cursor-staleness on story-mcp).
+
 ## discover-app
 
 Verify the shadow-cljs nREPL is reachable, confirm the

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/get_path.cljs
@@ -31,9 +31,12 @@
         path      (args/parse-path-arg (wire/arg raw-args :path))
         ;; rf2-c2dtu — when the `--allow-raw-state` boot gate is OFF,
         ;; the per-call `:elision false` arg is overridden so the walker
-        ;; still fires. `force-elision?` is the single arbiter.
-        elision?  (or (args/parse-bool-arg raw-args :elision)
-                      (raw-state/force-elision?))
+        ;; still fires. rf2-p1qli: single intention-naming predicate
+        ;; `raw-state-allowed?` (positive sense — true when operator
+        ;; opted in at launch); the gate-off branch forces elision true.
+        elision?  (if (raw-state/raw-state-allowed?)
+                    (args/parse-bool-arg raw-args :elision)
+                    true)
         ;; rf2-vflrg — `:include-sensitive` threads into the walker's
         ;; `:rf.size/include-sensitive?` opt. Off-box default per
         ;; Tool-Pair §`Direct-read privacy posture for sub-cache and
@@ -44,9 +47,9 @@
         ;; rf2-c2dtu — when the `--allow-raw-state` boot gate is OFF,
         ;; the per-call `:include-sensitive true` arg is dropped before
         ;; reaching the walker.
-        incl?     (if (raw-state/force-redact?)
-                    false
-                    (args/parse-bool-arg raw-args :include-sensitive))]
+        incl?     (if (raw-state/raw-state-allowed?)
+                    (args/parse-bool-arg raw-args :include-sensitive)
+                    false)]
     (cond
       (nil? path)
       (js/Promise.resolve

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/raw_state.cljs
@@ -13,8 +13,7 @@
   published-build default), re-frame2-pair-mcp:
 
   1. FORCES `:include-sensitive false` on every snapshot / get-path /
-     subscribe call, regardless of what the caller passed. The
-     `force-redact?` predicate is the single arbiter.
+     subscribe call, regardless of what the caller passed.
   2. FORCES `:elision true` on every snapshot / get-path call,
      regardless of what the caller passed.
   3. Signals the preload runtime to default-elide its `tap>` emissions
@@ -23,6 +22,30 @@
 
   When `--allow-raw-state` is ON, the per-call args win — the same
   behaviour re-frame2-pair-mcp shipped pre-rf2-c2dtu.
+
+  ## Single intention-naming predicate (rf2-p1qli)
+
+  Call sites consume the gate state through ONE predicate:
+
+      (raw-state/raw-state-allowed?)
+      ; ⇒ true when --allow-raw-state was passed at launch
+      ; ⇒ false otherwise (the published-build default)
+
+  Per-tool bodies branch on this predicate directly — no inversion
+  layer, no `force-*?` predicate-pair gymnastics:
+
+      incl?    (if (raw-state/raw-state-allowed?)
+                 (args/parse-bool-arg raw-args :include-sensitive)
+                 false)
+      elision? (if (raw-state/raw-state-allowed?)
+                 (args/parse-bool-arg raw-args :elision)
+                 true)
+
+  The predicate name asserts the operator's opt-in state directly —
+  the truthy value means \"the operator opted in via --allow-raw-state\".
+  This replaces the prior `force-redact?` / `force-elision?` pair which
+  returned `(not @allow-raw-state?)` and required three negations to
+  trace through (see rf2-p1qli / audit Finding #2).
 
   Symmetric with:
     - rf2-zyoj2 `--allow-eval`  (eval-cljs in re-frame2-pair-mcp; tools/eval-cljs.cljs)
@@ -50,35 +73,31 @@
   []
   @allow-raw-state?)
 
-(defn force-redact?
-  "When the boot gate is OFF, per-call `:include-sensitive true` must
-  not be honoured — return `true` so callers force the walker's
-  `:rf.size/include-sensitive?` to `false`. When the boot gate is ON
-  (operator opted in at server launch), the per-call arg wins; return
-  `false`.
+(defn raw-state-allowed?
+  "Single intention-naming predicate (rf2-p1qli).
 
-  Used by the snapshot / get-path / subscribe tool bodies to wrap the
-  `parse-bool-arg :include-sensitive` value:
+  Returns `true` when the operator opted in via `--allow-raw-state` at
+  server launch; `false` otherwise (the published-build default).
 
-      (let [incl? (args/parse-bool-arg raw-args :include-sensitive)
-            incl? (if (raw-state/force-redact?) false incl?)]
-        ...)"
+  Call sites branch on this predicate directly:
+
+      ;; :include-sensitive — gate-on → caller's arg; gate-off → false
+      incl?    (if (raw-state/raw-state-allowed?)
+                 (args/parse-bool-arg raw-args :include-sensitive)
+                 false)
+
+      ;; :elision — gate-on → caller's arg; gate-off → true (force walker)
+      elision? (if (raw-state/raw-state-allowed?)
+                 (args/parse-bool-arg raw-args :elision)
+                 true)
+
+  Replaces the pre-rf2-p1qli `force-redact?` / `force-elision?`
+  predicate-pair, both of which returned `(not @allow-raw-state?)` and
+  required three negations at the call site to answer \"did the operator
+  opt in?\" The new predicate is positive-sense, single-name, and
+  matches its truth value to the operator's intent."
   []
-  (not @allow-raw-state?))
-
-(defn force-elision?
-  "When the boot gate is OFF, per-call `:elision false` must not be
-  honoured — return `true` so callers force the walker on. When the
-  boot gate is ON, the per-call arg wins; return `false`.
-
-  Used by the snapshot / get-path tool bodies to wrap the
-  `parse-bool-arg :elision` value:
-
-      (let [elision? (args/parse-bool-arg raw-args :elision)
-            elision? (or elision? (raw-state/force-elision?))]
-        ...)"
-  []
-  (not @allow-raw-state?))
+  @allow-raw-state?)
 
 ;; ---------------------------------------------------------------------------
 ;; Preload-runtime signal — default-elide tap> emissions when the gate is OFF.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/snapshot.cljs
@@ -27,10 +27,12 @@
         ;; `:include-sensitive` to false AND `:elision` to true when
         ;; OFF (the default). The per-call args are still parsed (so the
         ;; response envelope reports the effective post-gate value), but
-        ;; the gate wins.
-        incl?       (if (raw-state/force-redact?)
-                      false
-                      (args/parse-bool-arg raw-args :include-sensitive))
+        ;; the gate wins. rf2-p1qli: single intention-naming predicate
+        ;; `raw-state-allowed?` (positive sense — true when operator
+        ;; opted in at launch).
+        incl?       (if (raw-state/raw-state-allowed?)
+                      (args/parse-bool-arg raw-args :include-sensitive)
+                      false)
         path        (args/parse-path-arg (wire/arg raw-args :path))
         mode        (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         ;; Global lazy-summary mode (rf2-u2029): `:summary` (default)
@@ -40,8 +42,9 @@
         slice-mode  (args/parse-mode-arg (wire/arg raw-args :mode))
         slice-modes (args/parse-modes-arg (wire/arg raw-args :modes))
         dedup?      (args/parse-bool-arg raw-args :dedup)
-        elision?    (or (args/parse-bool-arg raw-args :elision)
-                        (raw-state/force-elision?))
+        elision?    (if (raw-state/raw-state-allowed?)
+                      (args/parse-bool-arg raw-args :elision)
+                      true)
         opts        {:frames frames :include include}
         ;; Eval form composition (rf2-urjnc + rf2-e35a5 + rf2-vflrg).
         ;; The snapshot composer returns a per-frame map; we wrap each

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/subscribe.cljs
@@ -449,20 +449,22 @@
         ;; (the published-build default). `sensitive/strip-sensitive`
         ;; below honours the post-gate value, so a caller's
         ;; `:include-sensitive true` arg is dropped before reaching the
-        ;; runtime drain.
-        incl?              (if (raw-state/force-redact?)
-                             false
-                             (args/parse-bool-arg raw-args :include-sensitive))
+        ;; runtime drain. rf2-p1qli: single intention-naming predicate
+        ;; `raw-state-allowed?` (positive sense — true when operator
+        ;; opted in at launch).
+        incl?              (if (raw-state/raw-state-allowed?)
+                             (args/parse-bool-arg raw-args :include-sensitive)
+                             false)
         ;; rf2-vr2hn — the `--allow-raw-state` boot gate forces
         ;; `:elision true` on every streamed event when OFF, mirroring
         ;; the snapshot / get-path gate. Server-side, the drain envelope's
         ;; `:events` flow through `re-frame.core/elide-wire-value` before
         ;; crossing the nREPL wire — declared-large slots elide and
-        ;; declared-sensitive slots redact. `force-elision?` is the
-        ;; single arbiter; a caller's `:elision false` arg is dropped
-        ;; when the gate is OFF.
-        elision?           (or (args/parse-bool-arg raw-args :elision)
-                               (raw-state/force-elision?))
+        ;; declared-sensitive slots redact. A caller's `:elision false`
+        ;; arg is dropped when the gate is OFF.
+        elision?           (if (raw-state/raw-state-allowed?)
+                             (args/parse-bool-arg raw-args :elision)
+                             true)
         dedup?             (args/parse-bool-arg raw-args :dedup)
         {:keys [signal send-note progress-tk]} (parse-mcp-extra extra)]
     (cond

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/trace_window.cljs
@@ -26,10 +26,12 @@
         build-id  (wire/arg-build raw-args)
         frame     (wire/arg-keyword raw-args :frame)
         ;; rf2-c2dtu — the `--allow-raw-state` boot gate forces
-        ;; `:include-sensitive false` when OFF (the default).
-        incl?     (if (raw-state/force-redact?)
-                    false
-                    (args/parse-bool-arg raw-args :include-sensitive))
+        ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:
+        ;; single intention-naming predicate `raw-state-allowed?`
+        ;; (positive sense — true when operator opted in at launch).
+        incl?     (if (raw-state/raw-state-allowed?)
+                    (args/parse-bool-arg raw-args :include-sensitive)
+                    false)
         mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         dedup?    (args/parse-bool-arg raw-args :dedup)
         limit     (cursor/parse-limit-arg (wire/arg raw-args :limit))

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/watch_epochs.cljs
@@ -31,10 +31,12 @@
         frame     (wire/arg-keyword raw-args :frame)
         since-id  (wire/arg raw-args :since-id)
         ;; rf2-c2dtu — the `--allow-raw-state` boot gate forces
-        ;; `:include-sensitive false` when OFF (the default).
-        incl?     (if (raw-state/force-redact?)
-                    false
-                    (args/parse-bool-arg raw-args :include-sensitive))
+        ;; `:include-sensitive false` when OFF (the default). rf2-p1qli:
+        ;; single intention-naming predicate `raw-state-allowed?`
+        ;; (positive sense — true when operator opted in at launch).
+        incl?     (if (raw-state/raw-state-allowed?)
+                    (args/parse-bool-arg raw-args :include-sensitive)
+                    false)
         mode      (dedup/parse-epochs-mode (wire/arg raw-args :epochs-mode))
         dedup?    (args/parse-bool-arg raw-args :dedup)
         limit     (cursor/parse-limit-arg (wire/arg raw-args :limit))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/raw_state_test.cljs
@@ -1,12 +1,13 @@
 (ns re-frame2-pair-mcp.raw-state-test
-  "Unit tests for the `--allow-raw-state` boot gate (rf2-c2dtu).
+  "Unit tests for the `--allow-raw-state` boot gate (rf2-c2dtu) and the
+  single intention-naming predicate `raw-state-allowed?` (rf2-p1qli).
 
   Pins the three behaviours the gate guarantees:
 
-    1. Default state — `allow-raw-state-enabled?` returns false; the two
-       `force-*?` predicates return true so the wire path defaults to
-       redact + elide regardless of per-call args.
-    2. Opt-in state — flipping the gate flips the predicates so the
+    1. Default state — `allow-raw-state-enabled?` and `raw-state-allowed?`
+       both return false; per-tool branches force redact + elide
+       regardless of per-call args.
+    2. Opt-in state — flipping the gate flips the predicate so the
        per-call args win again (pre-rf2-c2dtu posture).
     3. `parse-launch-flags` parses `--allow-raw-state` and stays
        symmetric with `--allow-eval`.
@@ -27,24 +28,44 @@
   ;; `--allow-eval` default (rf2-cxx5s).
   (raw-state/set-allow-raw-state! false)
   (is (false? (raw-state/allow-raw-state-enabled?)))
-  (is (true?  (raw-state/force-redact?))
-      "Gate OFF ⇒ force-redact? true so :include-sensitive collapses to false")
-  (is (true?  (raw-state/force-elision?))
-      "Gate OFF ⇒ force-elision? true so :elision collapses to true"))
+  (is (false? (raw-state/raw-state-allowed?))
+      "Gate OFF ⇒ raw-state-allowed? false; per-tool branches force redact + elide"))
 
 ;; ---------------------------------------------------------------------------
 ;; Opt-in (--allow-raw-state) posture.
 ;; ---------------------------------------------------------------------------
 
-(deftest opt-in-flips-predicates
+(deftest opt-in-flips-predicate
   ;; --allow-raw-state ⇒ per-call args win (pre-rf2-c2dtu posture).
   (raw-state/set-allow-raw-state! true)
   (is (true?  (raw-state/allow-raw-state-enabled?)))
-  (is (false? (raw-state/force-redact?))
-      "Gate ON ⇒ caller's :include-sensitive arg wins")
-  (is (false? (raw-state/force-elision?))
-      "Gate ON ⇒ caller's :elision arg wins")
+  (is (true?  (raw-state/raw-state-allowed?))
+      "Gate ON ⇒ raw-state-allowed? true; caller's :include-sensitive / :elision args win")
   ;; Restore for downstream tests.
+  (raw-state/set-allow-raw-state! false))
+
+;; ---------------------------------------------------------------------------
+;; raw-state-allowed? predicate semantics (rf2-p1qli).
+;; ---------------------------------------------------------------------------
+
+(deftest raw-state-allowed-tracks-gate
+  ;; The single intention-naming predicate (rf2-p1qli) matches its truth
+  ;; value to the operator's opt-in state — positive sense, no inversion.
+  ;; Per-tool bodies branch on this directly:
+  ;;
+  ;;   (if (raw-state/raw-state-allowed?)
+  ;;     (args/parse-bool-arg raw-args :include-sensitive) ; gate ON  → caller wins
+  ;;     false)                                            ; gate OFF → force redact
+  ;;
+  ;;   (if (raw-state/raw-state-allowed?)
+  ;;     (args/parse-bool-arg raw-args :elision)           ; gate ON  → caller wins
+  ;;     true)                                             ; gate OFF → force elide
+  (raw-state/set-allow-raw-state! false)
+  (is (false? (raw-state/raw-state-allowed?))
+      "Gate OFF ⇒ operator did NOT opt in; force redact + elide")
+  (raw-state/set-allow-raw-state! true)
+  (is (true? (raw-state/raw-state-allowed?))
+      "Gate ON ⇒ operator opted in via --allow-raw-state; per-call args win")
   (raw-state/set-allow-raw-state! false))
 
 (deftest set-coerces-to-boolean


### PR DESCRIPTION
## Summary
- :reason 3-dialect split documented in pair-mcp spec (rf2-g5ox5)
- raw-state polarity gymnastics -> single raw-state-allowed? predicate (rf2-p1qli)

## Beads
rf2-g5ox5, rf2-p1qli (both P2)

## Source
ai/findings/2026-05-20-tools-re-frame2-pair-mcp-api-review.md (Findings #1 + #2)

## Changes

### rf2-g5ox5 — `:reason` vocabulary
New "Universal: `:reason` keyword vocabulary" section in `tools/re-frame2-pair-mcp/spec/003-Tool-Catalogue.md`. Documents the three deliberate dialects:
- **Bare** — per-call validation (~32 keywords; the common path)
- **`:rf.error/*`** — operator-gated denial (boot-flag / resource cap rejected before tool body)
- **`:rf.mcp/*`** — wire-vocabulary family; `:rf.mcp/cursor-stale` is the lone `:reason`-slot carve-out (rationale: cursor-staleness is detected at the wire boundary like other `:rf.mcp/*` markers)

Includes recognition rules for agent hosts ("bare ⇒ retry with different args; `:rf.error/*` ⇒ surface server-config hint; `:rf.mcp/cursor-stale` ⇒ drop cursor + restart pagination").

### rf2-p1qli — raw-state polarity
Replaced `force-redact?` / `force-elision?` (both `(not @allow-raw-state?)`, requiring 3 negations to trace) with a single intention-naming predicate `raw-state-allowed?` (positive sense — `true` when operator opted in via `--allow-raw-state`).

Call sites in `snapshot.cljs`, `get_path.cljs`, `trace_window.cljs`, `watch_epochs.cljs`, `subscribe.cljs` now read directly:
```clojure
incl?    (if (raw-state/raw-state-allowed?)
           (args/parse-bool-arg raw-args :include-sensitive)
           false)
elision? (if (raw-state/raw-state-allowed?)
           (args/parse-bool-arg raw-args :elision)
           true)
```

Tests updated; `raw-state-allowed?` predicate added to `raw_state_test.cljs`.

## Acceptance
- test:cljs clean (3566 tests, 10256 assertions, 0 failures, 0 errors)
- mkdocs --strict clean (exit 0)