### PR TITLE
causa: API.md reconcile + first-mount refactor (rf2-te1gu + rf2-y1saa)

### DIFF
--- a/tools/causa/spec/API.md
+++ b/tools/causa/spec/API.md
@@ -135,11 +135,18 @@ bytes after elision.
 
 ## Public CLJS API
 
-Causa exposes a small handful of programmatic entry points. Users
-typically interact via the panel; these are for embedding hosts,
-test harnesses, and Settings UIs.
+Causa's user-facing surface is split into a **canonical entry point**
+(the `day8.re-frame2-causa.core` facade — the surface most hosts ever
+touch) and a **wider public surface** of supporting namespaces (config
+setters, panel components, the keybinding lifecycle escape hatch, the
+preload-installed browser-global API, and the MCP read-and-mutate
+seam). The canonical entry point is the one to reach for by default;
+the wider surface is documented for embedding hosts, test harnesses,
+Settings UIs, and tool integrators that need finer-grained access. Per
+rf2-te1gu (reconcile the previous "small handful" framing with
+implementation reality — ~40 symbols across 6 namespaces).
 
-### `day8.re-frame2-causa.core`
+### Canonical: `day8.re-frame2-causa.core`
 
 ```clojure
 (causa/init!)
@@ -167,7 +174,64 @@ test harnesses, and Settings UIs.
 ;; Programmatically swap the theme (useful for editor-driven palette sync).
 ```
 
-### `day8.re-frame2-causa.panels.*`
+The facade also re-exports the four highest-traffic config setters
+(`configure!`, `set-auto-open!`, `set-editor!`, `set-show-sensitive!`)
+so the common boot-time wiring lands in one require. The full setter
+inventory lives in `day8.re-frame2-causa.config` — see §Wider public
+surface below.
+
+### Wider public surface
+
+Beyond the canonical facade, Causa exposes additional public surfaces
+for embedding hosts, test harnesses, Settings UIs, and tool
+integrators. Each is in scope of the same versioning discipline as
+the facade (no breaking changes within a minor release; deprecations
+announced one minor ahead). The canonical entry point above carries
+the day-to-day surface; this section is the **complete** index so a
+reader scanning for "what's publicly callable?" has a single
+authoritative list.
+
+| Namespace | Source | Public surfaces |
+|---|---|---|
+| `day8.re-frame2-causa.core` | `core.cljs` | The 12 canonical re-exports above (`init!`, `open!`, `open-overlay!`, `close!`, `toggle!`, `popout!`, `status`, `target-frame`, `set-target-frame!`, `load-theme`, plus the four highest-traffic config setters re-exported for boot-time convenience: `configure!`, `set-auto-open!`, `set-editor!`, `set-show-sensitive!`). |
+| `day8.re-frame2-causa.panels.*` | `panels/*.cljs` | The 6 `Panel` reg-views — `event-detail/Panel`, `app-db-diff/Panel`, `views/Panel`, `trace/Panel`, `machine-inspector/Panel`, `issues-ribbon/Panel` (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)). |
+| `day8.re-frame2-causa.config` | `config.cljc` | The `configure!` map dispatcher, the per-key setters (`set-editor!`, `set-project-root!`, `set-layout-host-selector!`, `set-auto-open!`, `set-keybinding-enabled!`, `set-static-mode-enabled!`, `set-show-sensitive!`, `set-filter-seed!`, `set-filters-storage-key!`, `update-setting!`, `reset-settings!`, `reset-suppressed-count!`) and the published constants enumerated in §Published layout-host constants above. The full normative key inventory lives in [`015-Configuration.md`](./015-Configuration.md). |
+| `day8.re-frame2-causa.keybinding` | `keybinding.cljs` | `attach!` / `detach!` — the symmetric, idempotent lifecycle pair for the `Ctrl+Shift+C` global listener. `detach!` is the embed-host escape hatch documented at [`015-Configuration.md`](./015-Configuration.md) §`keybinding/detach!` and [`008-Embedding-Contract.md`](./008-Embedding-Contract.md) §Full-shell embed contract — needed when an embed host's mount lifecycle runs after Causa's preload and wants to take the chord back. |
+| `day8.re-frame2-causa.runtime` | `runtime.cljs` | The Causa ↔ MCP read-and-mutate seam. The accessor surface this namespace exposes is enumerated normatively in §Runtime accessor surface below. Tool clients (`tools/re-frame2-pair-mcp/` today) evaluate forms addressed at this namespace via `eval-cljs`. |
+| `window.day8.re_frame2_causa.*` | `preload.cljs` | The browser-global JS API the preload installs (`interop/debug-enabled?`-gated). The exact Closure-name-mangled spellings: `open_BANG_`, `open_overlay_BANG_`, `close_BANG_`, `toggle_BANG_`, `popout_BANG_`, `status`. Mirrored under `window.day8.re_frame2_causa.core.*` once `core.cljs` has loaded so JS-console users see the canonical facade names. Production builds elide the install entirely via the `interop/debug-enabled?` gate. |
+
+Three surfaces deliberately not re-exported through the canonical
+facade:
+
+- **The per-key setters in `config.cljc`** beyond the four
+  highest-traffic ones (`configure!`, `set-auto-open!`, `set-editor!`,
+  `set-show-sensitive!`). Hosts that want to flip an experimental knob
+  or a less-common setter (`set-project-root!`,
+  `set-keybinding-enabled!`, `set-static-mode-enabled!`,
+  `set-filter-seed!`, etc.) require `day8.re-frame2-causa.config`
+  directly. The split keeps the facade narrow without hiding the
+  setters; reads cleanly from boot code that's already going through
+  `configure!`.
+
+- **`keybinding/attach!` and `keybinding/detach!`.** The lifecycle
+  pair lives in its own namespace because the preload's keybinding
+  install is one of the six side-effects (per §Installation API
+  above) and `detach!` is the embed-host escape hatch — both surfaces
+  are tightly coupled to the preload's listener contract rather than
+  to the mount facade. Re-exporting through `core` would imply
+  symmetry with `open!`/`close!` (mount-side) that the surfaces
+  don't have.
+
+- **`runtime.cljs`.** The Causa ↔ MCP seam is a parallel public
+  surface — public-for-tools, not public-for-host-apps — and the
+  read/mutate accessors are documented under §Runtime accessor
+  surface below as their own contract surface (the same Tool-Pair
+  discipline that governs `:trace-bus` and `epoch-history` per
+  [`Principles.md`](./Principles.md) §Observation only). Re-exporting
+  through `core` would conflate the host-facing facade with the
+  tool-facing read seam.
+
+### Panel reg-views
 
 Each panel namespace exports a single public `Panel` component for
 embedding (per [`008-Embedding-Contract.md`](./008-Embedding-Contract.md)).

--- a/tools/causa/src/day8/re_frame2_causa/core.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/core.cljs
@@ -2,14 +2,24 @@
   "The canonical user-facing facade for Causa.
 
   Per `spec/API.md` §Public CLJS API + the README's `core.cljs` reference,
-  this namespace is the *one* import users reach for. It re-exports the
-  small handful of programmatic entry points enumerated by the spec —
+  this namespace is the *canonical* import users reach for — the day-to-day
+  surface that covers ~90% of host integration needs. It re-exports the
+  canonical entry points enumerated by the spec —
   `init!` / `open!` / `open-overlay!` / `close!` / `toggle!` /
   `popout!` / `status` /
   `target-frame` + `set-target-frame!` / `active-panel` +
-  `set-active-panel!` / `load-theme` — plus the boot-time config knob
-  surface exposed by `config.cljc` (`configure!` / `set-editor!` /
-  `set-auto-open!` / `set-show-sensitive!`).
+  `set-active-panel!` / `load-theme` — plus the four highest-traffic
+  boot-time config knobs exposed by `config.cljc` (`configure!` /
+  `set-editor!` / `set-auto-open!` / `set-show-sensitive!`).
+
+  Per `spec/API.md` §Wider public surface, additional public surfaces
+  live in their own namespaces: the full per-key setter inventory in
+  `day8.re-frame2-causa.config`, the `attach!`/`detach!` lifecycle pair
+  in `day8.re-frame2-causa.keybinding` (the embed-host escape hatch),
+  the panel reg-views under `day8.re-frame2-causa.panels.*`, and the
+  Causa ↔ MCP read-and-mutate seam in `day8.re-frame2-causa.runtime`.
+  Hosts that need the wider surface require those namespaces directly;
+  the facade does not chain-re-export them.
 
   ## Why a thin facade
 
@@ -35,10 +45,14 @@
 
   Per `spec/API.md` §What this doesn't expose, the facade carries no
   plugin-registration API, no middleware injection, no global state
-  mutators beyond the seven listed above. Internal seams
+  mutators beyond the canonical surface above. Internal seams
   (`day8.re-frame2-causa.internal/*`, `day8.re-frame2-causa.shell`,
   `day8.re-frame2-causa.registry`) are not re-exported — callers must
-  not reach for them."
+  not reach for them. The wider public surfaces enumerated in §Wider
+  public surface (config setters beyond the four highest-traffic ones,
+  the keybinding lifecycle pair, the panel reg-views, the MCP runtime
+  seam) live in their own namespaces by design — see the per-namespace
+  documentation for the rationale on each."
   (:require [re-frame.core :as rf]
             [re-frame.trace :as trace]
             [day8.re-frame2-causa.config :as config]

--- a/tools/causa/src/day8/re_frame2_causa/mount.cljs
+++ b/tools/causa/src/day8/re_frame2_causa/mount.cljs
@@ -270,13 +270,76 @@
              :mode     mode})
     @mount-state))
 
+;; ---- first-mount hook table (rf2-y1saa) ---------------------------------
+;;
+;; `ensure-causa-frame!` accreted eight side-effects across eight beads
+;; (rf2-in6l2, rf2-boyc2, rf2-ak4ms, rf2-ikuwt, rf2-o5f5f.1, rf2-9poxq, ...),
+;; each chosen ad-hoc by the bead that added it (some dispatch-sync, some
+;; direct fn call, some conditional on a config flag). The lazy-
+;; registration pattern is correct — the substrate adapter isn't ready at
+;; preload time so each seeding step has to wait until the first
+;; Ctrl+Shift+C keypress — but the implementation density made adding a
+;; Nth side-effect a "modify ensure-causa-frame! the Nth time" task,
+;; which kept the function the hot zone for every first-mount tweak.
+;;
+;; The hook-table refactor introduces an internal `register-first-mount-
+;; hook!` registrar (sentinel-guarded by `:id` so each hook is idempotent
+;; on re-registration via shadow-cljs `:after-load`). `ensure-causa-
+;; frame!` becomes a thin walker: register the frame, then invoke each
+;; hook in insertion order.
+;;
+;; Today the hooks themselves are registered from this namespace's
+;; bottom (one-line `register-first-mount-hook!` per subsystem) so the
+;; refactor lands as a pure structural change without changing the
+;; require graph or touching the registering namespaces. The next
+;; iteration moves each registration into its owning ns (e.g.
+;; `filters/install!` would call `(register-first-mount-hook! ::filters
+;; hydrate!)`), at which point the "modify mount.cljs Nth time" coupling
+;; drops to "add a hook from sub-ns". The mechanism here is the prereq.
+;;
+;; Insertion order is load-bearing: the frame-seed hook MUST run before
+;; the hydrate hooks (the dispatch targets live on `:rf/causa`'s app-
+;; db), and the mode-hydrate hook MUST run before the auto-open watcher
+;; (the watcher's subscribe target depends on the mode-aware ribbon
+;; sub). The hook table preserves vector insertion order so registration
+;; order at this namespace's bottom is the runtime invocation order.
+
+(defonce ^:private first-mount-hooks
+  ;; Ordered vector of `{:id <kw> :handler <0-ary fn>}` entries. The
+  ;; vector shape is load-bearing: `ensure-causa-frame!` walks the
+  ;; hooks in insertion order so subsystems whose seeding depends on
+  ;; a prior hook (e.g. the auto-open watcher depends on the mode
+  ;; slot being present) register after the slot-seeding hook.
+  ;; Sentinel-guarded by `:id` so `register-first-mount-hook!` with
+  ;; an already-registered id replaces in place rather than appending
+  ;; a duplicate (the shadow-cljs `:after-load` cycle re-runs the
+  ;; registrations).
+  (atom []))
+
+(defn- register-first-mount-hook!
+  "Register a 0-ary fn to run on first `ensure-causa-frame!` after the
+  `:rf/causa` frame is registered. Hooks run in insertion order; an
+  already-registered `id` replaces in place (idempotent on `:after-
+  load`). Internal — not part of the public API."
+  [id handler]
+  (swap! first-mount-hooks
+         (fn [hooks]
+           (let [idx (some (fn [[i h]] (when (= id (:id h)) i))
+                           (map-indexed vector hooks))]
+             (if idx
+               (assoc hooks idx {:id id :handler handler})
+               (conj hooks {:id id :handler handler})))))
+  nil)
+
 ;; ---- public API ----------------------------------------------------------
 
 (defn- ensure-causa-frame!
-  "Register the `:rf/causa` frame if not already registered. Idempotent
-  via `reg-frame`'s surgical-update-on-re-register semantics (per Spec
-  002 §reg-frame). Called from `open!` on every keypress — first call
-  creates the frame, subsequent calls are surgical no-ops.
+  "Register the `:rf/causa` frame if not already registered, then run
+  each registered first-mount hook in insertion order. Idempotent via
+  `reg-frame`'s surgical-update-on-re-register semantics (per Spec
+  002 §reg-frame) — first call creates the frame and seeds, subsequent
+  calls are surgical no-ops on the frame side and (per each hook's own
+  idempotency contract) no-ops on the hook side.
 
   ## Why here, not at preload time
 
@@ -287,7 +350,16 @@
   Ctrl+Shift+C keypress fires from the user well after `rf/init!`, so
   `open!` is the canonical lazy-registration point.
 
-  ## App-db seeding
+  ## First-mount hook table (rf2-y1saa)
+
+  The seeding work that used to live inline here is now driven by the
+  `first-mount-hooks` registrar — each subsystem's seed/hydrate step
+  is registered as a `{:id :handler}` entry, and `ensure-causa-frame!`
+  walks the table in insertion order. See the §first-mount hook table
+  block above for the registrar's contract and the registrations at
+  this namespace's bottom for the concrete hooks shipped today.
+
+  ## App-db seeding semantics (preserved from the pre-rf2-y1saa shape)
 
   Two slots seed on first open so the panels render against history
   the user has already produced before opening Causa:
@@ -324,63 +396,93 @@
     `core/set-target-frame!` API."
   []
   (rf/reg-frame :rf/causa {})
+  (doseq [{:keys [handler]} @first-mount-hooks]
+    (handler)))
+
+;; ---- first-mount hook registrations -------------------------------------
+;;
+;; Each registration is a one-line bind from a hook id to a 0-ary fn.
+;; Insertion order is load-bearing: hooks that depend on a prior hook
+;; (e.g. `::auto-open-watcher` depends on the mode slot being present)
+;; appear after their dependencies. The id keywords are mount-internal
+;; (`::seed-trace-and-target-frame`, `::hydrate-filters`, ...) — not
+;; part of the public API.
+
+(register-first-mount-hook!
+  ::seed-trace-and-target-frame
   ;; Seed the frame's app-db with whatever the trace-bus atom + the
   ;; framework's epoch ring buffer have accumulated so far. The host
   ;; may have driven dispatches before the user opened Causa.
-  (let [buffer     (trace-bus/buffer)
-        ;; Project the pre-mount trace buffer through the same pipeline
-        ;; the `:rf.causa/cascades` sub uses — projection + Causa-
-        ;; internal hard-filter — so the seed-frame matches what
-        ;; `compose-focus` will resolve on first paint. Without the
-        ;; internal filter a tool-frame cascade could be chosen as
-        ;; the head, which the user never sees in the L2 list.
-        cascades   (into [] (remove trace-bus/causa-internal-cascade?)
-                         (projection/group-cascades buffer))
-        seed-frame (or (spine/focusable-head-frame-id cascades)
-                       defaults/default-target-frame)]
-    (rf/with-frame :rf/causa
-      (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer])
-      ;; rf2-boyc2 — seed via `:rf.causa/set-target-frame` so
-      ;; `:target-frame` + `:epoch-history` move in lockstep keyed on
-      ;; the frame the user will be observing on first paint (the
-      ;; head focusable cascade's frame). Mirrors the picker-driven
-      ;; `set-frame-reducer` path and `core/set-target-frame!`.
-      (rf/dispatch-sync [:rf.causa/set-target-frame seed-frame])))
+  ;; (rf2-in6l2 :trace-buffer + rf2-boyc2 :epoch-history + :target-frame.)
+  (fn []
+    (let [buffer     (trace-bus/buffer)
+          ;; Project the pre-mount trace buffer through the same
+          ;; pipeline the `:rf.causa/cascades` sub uses — projection +
+          ;; Causa-internal hard-filter — so the seed-frame matches
+          ;; what `compose-focus` will resolve on first paint. Without
+          ;; the internal filter a tool-frame cascade could be chosen
+          ;; as the head, which the user never sees in the L2 list.
+          cascades   (into [] (remove trace-bus/causa-internal-cascade?)
+                           (projection/group-cascades buffer))
+          seed-frame (or (spine/focusable-head-frame-id cascades)
+                         defaults/default-target-frame)]
+      (rf/with-frame :rf/causa
+        (rf/dispatch-sync [:rf.causa/sync-trace-buffer buffer])
+        ;; rf2-boyc2 — seed via `:rf.causa/set-target-frame` so
+        ;; `:target-frame` + `:epoch-history` move in lockstep keyed
+        ;; on the frame the user will be observing on first paint
+        ;; (the head focusable cascade's frame). Mirrors the picker-
+        ;; driven `set-frame-reducer` path and `core/set-target-
+        ;; frame!`.
+        (rf/dispatch-sync [:rf.causa/set-target-frame seed-frame])))))
+
+(register-first-mount-hook!
+  ::hydrate-filters
   ;; Hydrate the auto-filter pills (rf2-ak4ms). The preload-time
   ;; `filters/install!` call ran BEFORE the `:rf/causa` frame was
-  ;; registered, so its hydrate attempt no-op'd; re-running here
-  ;; under the now-registered frame lifts the localStorage / seed
-  ;; value into the slot. Idempotent — re-running with an unchanged
-  ;; source produces the same slot.
-  (filters/hydrate!)
+  ;; registered, so its hydrate attempt no-op'd; re-running here under
+  ;; the now-registered frame lifts the localStorage / seed value into
+  ;; the slot. Idempotent — re-running with an unchanged source
+  ;; produces the same slot.
+  filters/hydrate!)
+
+(register-first-mount-hook!
+  ::hydrate-spine-filters
   ;; Hydrate the muted-event-ids set (rf2-ikuwt). Same rationale as
   ;; `filters/hydrate!` above — the preload-time `spine-filters/
   ;; install!` ran before `:rf/causa` was registered, so re-running
   ;; here under the now-registered frame lifts the localStorage value
   ;; into the slot.
-  (spine-filters/hydrate!)
+  spine-filters/hydrate!)
+
+(register-first-mount-hook!
+  ::hydrate-static-mode
   ;; Hydrate the Runtime ↔ Static mode slot (rf2-o5f5f.1). Same
-  ;; rationale as the filter hydrate above — the persisted mode
-  ;; lives in localStorage under `causa.mode` and the frame must
-  ;; exist before the dispatch can land. `:rf.causa/set-mode`
-  ;; normalises unknown values back to `:runtime` so an absent or
-  ;; malformed slot is harmless. The dispatch carries the persist-
-  ;; mode fx which would re-write the slot; that's intentional —
-  ;; the round-trip canonicalises the stored value (e.g. an
-  ;; old "explorer" pre-rename value would land back as "runtime"
-  ;; without manual intervention).
-  (rf/with-frame :rf/causa
-    (rf/dispatch-sync [:rf.causa/set-mode (static-persistence/load)]))
+  ;; rationale as the filter hydrate above — the persisted mode lives
+  ;; in localStorage under `causa.mode` and the frame must exist
+  ;; before the dispatch can land. `:rf.causa/set-mode` normalises
+  ;; unknown values back to `:runtime` so an absent or malformed slot
+  ;; is harmless. The dispatch carries the persist-mode fx which
+  ;; would re-write the slot; that's intentional — the round-trip
+  ;; canonicalises the stored value (e.g. an old "explorer" pre-
+  ;; rename value would land back as "runtime" without manual
+  ;; intervention).
+  (fn []
+    (rf/with-frame :rf/causa
+      (rf/dispatch-sync [:rf.causa/set-mode (static-persistence/load)]))))
+
+(register-first-mount-hook!
+  ::auto-open-watcher
   ;; Auto-open-on-error watcher (rf2-9poxq) — install lazily here so
-  ;; the persisted-true case picks up as soon as the user opens
-  ;; Causa. The watcher subscribes to `:rf.causa/issues-ribbon`
-  ;; (which lives on `:rf/causa`'s app-db), so it CANNOT install
-  ;; until the frame exists. Install is idempotent + guards against
-  ;; the toggle being off — when the user has never enabled the
-  ;; setting (the default), this is a one-time no-op cost on first
-  ;; mount.
-  (when (config/get-setting :general :auto-open-on-error?)
-    (settings-effects/install-auto-open-watcher!)))
+  ;; the persisted-true case picks up as soon as the user opens Causa.
+  ;; The watcher subscribes to `:rf.causa/issues-ribbon` (which lives
+  ;; on `:rf/causa`'s app-db), so it CANNOT install until the frame
+  ;; exists. Install is idempotent + guards against the toggle being
+  ;; off — when the user has never enabled the setting (the default),
+  ;; this is a one-time no-op cost on first mount.
+  (fn []
+    (when (config/get-setting :general :auto-open-on-error?)
+      (settings-effects/install-auto-open-watcher!))))
 
 (defn open!
   "Mount + show the default Causa shell in the app-provided true-inline


### PR DESCRIPTION
## Summary

Two follow-ons from rf2-6j2lr audit landing in one PR.

### rf2-te1gu — reconcile API.md surface with impl reality (Finding #5)

API.md's "small handful of programmatic entry points" framing
understated the actual ~40-symbol public surface across 6 namespaces.
Reconciles the doc:

- Split §Public CLJS API into **Canonical** (the 12-fn `core.cljs`
  facade most hosts ever touch — `init!`, `open!`, `close!`, `toggle!`,
  `popout!`, `status`, `target-frame`/`set-target-frame!`, `load-theme`,
  plus the 4 highest-traffic config setters re-exported for boot-time
  convenience).
- Add **Wider public surface** enumerating supporting namespaces:
  `config.cljc` per-key setters, `keybinding/attach!`+`detach!` lifecycle
  pair (the embed-host escape hatch), 6 `Panel` reg-views, MCP runtime
  seam, preload-installed `window.day8.re_frame2_causa.*` JS globals.
- Document the 3 "deliberately not re-exported through `core`"
  rationales (granular setters, keybinding lifecycle, MCP read seam) so
  a reader sees both the surface AND the design choice in one place.
- Update `core.cljs`'s docstring to match the canonical/wider split.

Mirrors rf2-bc7dw (`re-frame.core` re-export drift reconciliation,
PR #1642).

### rf2-y1saa — first-mount hook table (Finding #11)

`mount.cljs`'s `ensure-causa-frame!` had accreted 8 side-effects across
8 beads (rf2-in6l2, rf2-boyc2, rf2-ak4ms, rf2-ikuwt, rf2-o5f5f.1,
rf2-9poxq); each chose its own seed mechanism. Adding a 9th compounded
the pile.

- Introduce internal `register-first-mount-hook!` registrar — sentinel-
  guarded by `:id`, idempotent on `:after-load`, ordered-vector storage
  so insertion order is invocation order.
- `ensure-causa-frame!` becomes a thin walker: register the `:rf/causa`
  frame, then `doseq` the registered hooks.
- The 5 existing side-effects (seed trace+target-frame, hydrate
  filters, hydrate spine-filters, hydrate static mode, conditional
  auto-open-watcher) are registered from mount.cljs's bottom as
  one-line `register-first-mount-hook!` bindings — same call sites,
  same ordering, same semantics.
- No public API change.

The next iteration moves each registration into its owning ns so each
panel/subsystem registers its own first-mount hook (the audit's
"add a hook from sub-ns" target). The registrar is the prereq.

## Test plan

- [x] `npm run test:cljs` — 3585 tests, 0 failures.
- [x] `mkdocs build --strict` — clean.
- [ ] Smoke-check: `bd close rf2-te1gu` + `bd close rf2-y1saa` after merge.