### PR TITLE
feat(story): reg-global-decorator primitive (rf2-835ey)

### DIFF
--- a/tools/story/src/re_frame/story.cljc
+++ b/tools/story/src/re_frame/story.cljc
@@ -509,6 +509,78 @@
   of the data."}
   reg-marks rf/reg-marks)
 
+;; ---- reg-global-decorator (rf2-835ey — preview.ts parity, F-1) ----------
+;;
+;; Per ai/findings/2026-05-20-story-tutorial-set.md Finding F-1: Storybook's
+;; canonical "wrap every story in the design system's theme provider"
+;; recipe lives in `preview.ts` as `decorators: [...]`. Story had only
+;; story-level + variant-level decorators; without a global equivalent the
+;; tutorial chapter on decorators cannot offer the canonical recipe, and
+;; large projects end up listing the decorator id on every `reg-story`
+;; manually.
+;;
+;; `reg-global-decorator` registers a decorator body (delegating to
+;; `reg-decorator*`) AND appends a `[<id> & args]` reference to the
+;; per-process global-decorators vector. The decorator resolution layer
+;; prepends that vector to every variant's resolved stack — globals are
+;; the outermost wrap layer, story decorators second, variant decorators
+;; innermost. Re-registering the same id REPLACES in place so hot-
+;; reloading the body does not reshuffle the global stack order.
+;;
+;; Symmetric to `global-args` (Layer 1 of args-resolution) — the host
+;; calls these from `configure!`-adjacent boot code.
+
+(defn reg-global-decorator
+  "Register a decorator AND opt it into the global stack — every
+  variant's resolved decorator chain is prefixed with this entry.
+  Per rf2-835ey + ai/findings/2026-05-20-story-tutorial-set.md Finding
+  F-1 (Storybook `preview.ts` `decorators: [...]` parity).
+
+  Two-arity registration form (the common case):
+
+      (story/reg-global-decorator :app/theme-provider
+        {:kind :hiccup
+         :wrap (fn [body _args] [theme-provider {:theme :light} body])})
+
+  Three-arity form when the decorator takes ref-args (rare):
+
+      (story/reg-global-decorator :app/theme-provider
+        {:kind :hiccup :wrap (fn [body args] ...)}
+        [:dark])              ; ref-args — landed at the :wrap fn under
+                              ; (:decorator/args args-map)
+
+  Order: earliest-registered first. The full per-variant decorator
+  chain is `(concat globals story variant)`; globals are the outermost
+  wrap (e.g. a theme provider at the very top of the rendered tree)
+  with story-level and variant-level decorators composing inside.
+
+  Hot-reload: re-registering the same id REPLACES the entry in place
+  (same position in the global vector) so the body change does not
+  reshuffle the stack order.
+
+  Returns the decorator id."
+  ([id body]
+   (reg-global-decorator id body []))
+  ([id body ref-args]
+   (registrar/reg-decorator* id body)
+   (config/add-global-decorator! (into [id] ref-args))
+   id))
+
+(defn unreg-global-decorator!
+  "Remove `id` from the global-decorators vector. The decorator's
+  registration body is NOT unregistered — call `unregister!` for that.
+  Idempotent."
+  [id]
+  (config/remove-global-decorator! id))
+
+(defn global-decorators
+  "Return the current ordered vector of global-decorator references
+  (`[[decorator-id & args] ...]`). Earliest-registered first; this is
+  the prefix applied to every variant's resolved decorator stack per
+  rf2-835ey."
+  []
+  (config/get-global-decorators))
+
 ;; ---- configure! ---------------------------------------------------------
 
 (defn configure!
@@ -573,9 +645,14 @@
 
 (defn clear-all!
   "Reset every Story registration. Used by test fixtures. Mirrors
-  `re-frame.registrar/clear-all!`."
+  `re-frame.registrar/clear-all!`.
+
+  Also clears the rf2-835ey global-decorators vector so stale ref-by-id
+  entries do not survive a registrar reset and bleed into the next
+  test."
   []
-  (registrar/clear-all!))
+  (registrar/clear-all!)
+  (config/set-global-decorators! []))
 
 (defn clear-kind!
   "Remove every id under `kind`. Used by test fixtures and hot-reload."

--- a/tools/story/src/re_frame/story/config.cljc
+++ b/tools/story/src/re_frame/story/config.cljc
@@ -136,6 +136,87 @@
   []
   @global-args)
 
+;; ---- *global-decorators* (rf2-835ey — preview.ts parity, F-1) -----------
+;;
+;; Per ai/findings/2026-05-20-story-tutorial-set.md Finding F-1 (P2) Story
+;; ships story-level + variant-level decorators only; Storybook's canonical
+;; "wrap every story in the design system's theme provider" recipe lives in
+;; `preview.ts` `decorators: [...]` and Story has no equivalent. Without
+;; one, the tutorial chapter on decorators cannot offer the canonical
+;; theme-wrapping recipe, and a large project ends up listing the decorator
+;; id on every `reg-story` manually.
+;;
+;; The global-decorators primitive plugs that gap. It is symmetric to
+;; `global-args` (Layer 1 of args-resolution): a project sets it once at
+;; boot, and every variant's resolved decorator stack is prefixed with
+;; this ordered list. Story-level and variant-level slots still compose
+;; on top — the full stack is `(concat globals story-decorators
+;; variant-decorators)`, with globals as the outermost wrap layer.
+;;
+;; The atom holds an ORDERED VECTOR of `[decorator-id & args]` refs (the
+;; same shape `:decorators` slots take), not just ids — so a global
+;; decorator can carry ref-args exactly like a story-level reference can.
+;; Earliest-registered first; re-registering the same id replaces in-place
+;; (idempotent at the side-table level; same as `reg-decorator`).
+;;
+;; The atom is plain data; production builds with `enabled?` false DCE
+;; the registration call sites so the vector stays empty in release
+;; bundles.
+
+(defonce
+  ^{:doc "Atom holding the ordered vector of global decorator references.
+         Per rf2-835ey — Storybook `preview.ts` `decorators: [...]`
+         parity. Defaults to `[]`; the host calls
+         `re-frame.story/reg-global-decorator` at boot to append.
+         Each entry is a `[decorator-id & args]` vector, same shape as
+         a story-level or variant-level `:decorators` reference. The
+         resolved decorator stack for every variant is prefixed with
+         this vector (earliest-registered = outermost wrap)."}
+  global-decorators
+  (atom []))
+
+(defn set-global-decorators!
+  "Replace the global-decorators ref vector. Accepts a vector of
+  `[decorator-id & args]` refs, or `nil` (clears). Story's
+  `reg-global-decorator` and test fixtures call this."
+  [v]
+  (reset! global-decorators (vec (or v [])))
+  nil)
+
+(defn get-global-decorators
+  "Return the current global-decorators ref vector."
+  []
+  @global-decorators)
+
+(defn add-global-decorator!
+  "Append `ref` to the global-decorators vector. If a ref with the same
+  decorator id already exists, REPLACE it in place (same position) so
+  hot-reloading the body does not reshuffle the global stack order.
+
+  `ref` is `[decorator-id & args]` — same shape as a story-level or
+  variant-level `:decorators` entry.
+
+  Returns the decorator id."
+  [ref]
+  (let [id (first ref)]
+    (swap! global-decorators
+           (fn [v]
+             (let [idx (->> v
+                            (keep-indexed (fn [i r] (when (= id (first r)) i)))
+                            first)]
+               (if idx
+                 (assoc v idx ref)
+                 (conj v ref)))))
+    id))
+
+(defn remove-global-decorator!
+  "Remove every entry whose decorator id is `id` from the
+  global-decorators vector. Idempotent."
+  [id]
+  (swap! global-decorators
+         (fn [v] (vec (remove (fn [r] (= id (first r))) v))))
+  nil)
+
 ;; ---- *editor* (rf2-evgf5 — 'Open in editor' affordance) ----------------
 ;;
 ;; Per Spec 005-SOTA-Features.md §'Open in editor' per variant, every

--- a/tools/story/src/re_frame/story/decorators.cljc
+++ b/tools/story/src/re_frame/story/decorators.cljc
@@ -12,8 +12,11 @@
 
   ## Composition order
 
-  Per IMPL-SPEC §5.3 the runtime walks `(concat story-decorators
-  variant-decorators)` in declared order and groups by `:kind`:
+  Per IMPL-SPEC §5.3 + rf2-835ey the runtime walks
+  `(concat global-decorators story-decorators variant-decorators)` in
+  declared order and groups by `:kind`. Global decorators are the
+  Storybook-`preview.ts`-parity layer (Finding F-1 — every variant
+  inherits the project-wide stack):
 
   - `:hiccup` decorators — outermost wraps innermost. The first
     decorator's `:wrap` is the outermost element in the rendered tree;
@@ -34,6 +37,7 @@
   vector; the runtime then projects those into the variant's
   `:assertions` (per IMPL-SPEC §5.5)."
   (:require [re-frame.story.args      :as args]
+            [re-frame.story.config    :as config]
             [re-frame.story.registrar :as registrar]))
 
 ;; ---- collection -----------------------------------------------------------
@@ -50,14 +54,27 @@
         body     (when story-id (registrar/handler-meta :story story-id))]
     (or (:decorators body) [])))
 
+(defn- global-decorator-refs
+  "Return the ordered global-decorators ref vector, or `[]`. Per
+  rf2-835ey — Storybook `preview.ts` `decorators: [...]` parity.
+  Earliest-registered first."
+  []
+  (config/get-global-decorators))
+
 (defn- collect-decorator-refs
   "Build the ordered `[decorator-ref ...]` list for the variant.
 
-  Story decorators come first (outermost when applied as hiccup
-  wrappers), variant decorators second. Active modes contribute no
-  decorators at v1 — per IMPL-SPEC §3.1 modes carry `:args` only."
+  Global decorators come first (outermost when applied as hiccup
+  wrappers), story decorators second, variant decorators last. Active
+  modes contribute no decorators at v1 — per IMPL-SPEC §3.1 modes carry
+  `:args` only.
+
+  Per rf2-835ey the global-decorators layer prepends — symmetric to
+  `global-args` being Layer 1 of args-resolution. The full stack is
+  `(concat globals story variant)`."
   [variant-id]
-  (vec (concat (story-decorator-refs variant-id)
+  (vec (concat (global-decorator-refs)
+               (story-decorator-refs variant-id)
                (variant-decorator-refs variant-id))))
 
 ;; ---- resolution -----------------------------------------------------------
@@ -194,10 +211,12 @@
   their kind-vector — the runtime projects them as `:rf.error/decorator-*`
   assertions per IMPL-SPEC §5.5.
 
-  Composition order (per IMPL-SPEC §5.3):
-  - `:hiccup` — outermost wraps innermost. Story decorators come first
-    (outermost); variant decorators last (innermost).
-  - `:frame-setup` — declared order (story first, variant second).
+  Composition order (per IMPL-SPEC §5.3 + rf2-835ey global decorators):
+  - `:hiccup` — outermost wraps innermost. Global decorators come first
+    (outermost), story decorators second, variant decorators last
+    (innermost).
+  - `:frame-setup` — declared order (global first, then story, then
+    variant).
   - `:fx-override` — declared order; last-wins on a key collision.
 
   `opts` accepts `:active-modes` for forward compatibility — v1 modes

--- a/tools/story/test/re_frame/story_runtime_test.clj
+++ b/tools/story/test/re_frame/story_runtime_test.clj
@@ -225,6 +225,138 @@
              (get-in stack [:overrides :http]))))))
 
 ;; ===========================================================================
+;; GLOBAL DECORATORS (rf2-835ey — Storybook preview.ts parity, F-1)
+;; ===========================================================================
+
+(deftest reg-global-decorator-appends-to-resolved-stack
+  (testing "a global decorator prefixes the resolved decorator stack for
+            every variant — outermost wrap layer per rf2-835ey"
+    (story/reg-global-decorator :app/theme
+      {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
+    (story/reg-decorator :story-deco
+      {:kind :hiccup :wrap (fn [body _] [:div.story body])})
+    (story/reg-decorator :variant-deco
+      {:kind :hiccup :wrap (fn [body _] [:div.variant body])})
+    (story/reg-story :story.gd
+      {:decorators [[:story-deco]]})
+    (story/reg-variant :story.gd/v
+      {:decorators [[:variant-deco]]
+       :events     []})
+    (let [r       (story/resolve-decorators :story.gd/v)
+          ids     (mapv :id (:hiccup r))
+          wrapped (decorators/apply-hiccup-decorators
+                    (:hiccup r) [:span "leaf"] {})]
+      (is (= [:app/theme :story-deco :variant-deco] ids)
+          "global decorator comes first (outermost), then story, then variant")
+      (is (= [:div.theme [:div.story [:div.variant [:span "leaf"]]]] wrapped)
+          ":app/theme wraps outermost; the leaf is innermost"))))
+
+(deftest reg-global-decorator-applies-to-variants-with-no-story-decorators
+  (testing "a global decorator wraps a variant whose parent story has no
+            :decorators slot and whose own :decorators slot is empty —
+            the global stack still applies"
+    (story/reg-global-decorator :app/wrap
+      {:kind :hiccup :wrap (fn [body _] [:div.wrap body])})
+    (story/reg-story :story.gd2 {})
+    (story/reg-variant :story.gd2/bare {:events []})
+    (let [r   (story/resolve-decorators :story.gd2/bare)
+          ids (mapv :id (:hiccup r))]
+      (is (= [:app/wrap] ids)
+          "bare variant inherits the global stack even with no story
+           / variant decorators"))))
+
+(deftest reg-global-decorator-multiple-earliest-first
+  (testing "two global decorators apply in registration order — earliest
+            first (outermost wrap)"
+    (story/reg-global-decorator :app/g1
+      {:kind :hiccup :wrap (fn [body _] [:div.g1 body])})
+    (story/reg-global-decorator :app/g2
+      {:kind :hiccup :wrap (fn [body _] [:div.g2 body])})
+    (story/reg-variant :story.gd3/v {:events []})
+    (let [r       (story/resolve-decorators :story.gd3/v)
+          ids     (mapv :id (:hiccup r))
+          wrapped (decorators/apply-hiccup-decorators
+                    (:hiccup r) [:span "x"] {})]
+      (is (= [:app/g1 :app/g2] ids)
+          "earliest-registered first")
+      (is (= [:div.g1 [:div.g2 [:span "x"]]] wrapped)
+          ":app/g1 wraps :app/g2 (earliest is outermost)"))))
+
+(deftest reg-global-decorator-replaces-in-place-on-re-registration
+  (testing "re-registering the same global decorator id replaces in place —
+            hot-reloading the body must not reshuffle the order"
+    (story/reg-global-decorator :app/first
+      {:kind :hiccup :wrap (fn [body _] [:div.first.v1 body])})
+    (story/reg-global-decorator :app/second
+      {:kind :hiccup :wrap (fn [body _] [:div.second body])})
+    ;; Re-register :app/first with a new body — its position must stay at 0.
+    (story/reg-global-decorator :app/first
+      {:kind :hiccup :wrap (fn [body _] [:div.first.v2 body])})
+    (let [refs (story/global-decorators)
+          ids  (mapv first refs)]
+      (is (= [:app/first :app/second] ids)
+          ":app/first stays at position 0; re-registration did not push it
+           to the end"))
+    ;; And the new body is the one applied.
+    (story/reg-variant :story.gd4/v {:events []})
+    (let [r       (story/resolve-decorators :story.gd4/v)
+          wrapped (decorators/apply-hiccup-decorators
+                    (:hiccup r) [:span "x"] {})]
+      (is (= [:div.first.v2 [:div.second [:span "x"]]] wrapped)
+          "the replacement body (v2) is the one applied"))))
+
+(deftest reg-global-decorator-mixed-kinds
+  (testing "a global :frame-setup decorator's :init events fire before any
+            story / variant events — the global slot lands in the
+            :frame-setup bucket exactly like a story-level decorator would"
+    (story/reg-global-decorator :app/setup
+      {:kind :frame-setup :init [[:noop]]})
+    (story/reg-global-decorator :app/theme
+      {:kind :hiccup :wrap (fn [body _] [:div.theme body])})
+    (story/reg-global-decorator :app/stub
+      {:kind :fx-override :fx-id :http :response {:ok? true}})
+    (story/reg-variant :story.gd5/v {:events []})
+    (let [r (story/resolve-decorators :story.gd5/v)]
+      (is (= 1 (count (:hiccup r))))
+      (is (= 1 (count (:frame-setup r))))
+      (is (= 1 (count (:fx-override r))))
+      (is (empty? (:errors r))
+          "global decorators classify into all three kind-buckets cleanly")
+      (is (= :app/theme (-> r :hiccup first :id)))
+      (is (= :app/setup (-> r :frame-setup first :id)))
+      (is (= :app/stub  (-> r :fx-override first :id))))))
+
+(deftest unreg-global-decorator-removes-from-stack
+  (testing "unreg-global-decorator! removes the entry from the global
+            vector; subsequent resolutions do not see it"
+    (story/reg-global-decorator :app/keep
+      {:kind :hiccup :wrap (fn [body _] [:div.keep body])})
+    (story/reg-global-decorator :app/drop
+      {:kind :hiccup :wrap (fn [body _] [:div.drop body])})
+    (story/reg-variant :story.gd6/v {:events []})
+    (is (= [:app/keep :app/drop]
+           (mapv :id (:hiccup (story/resolve-decorators :story.gd6/v)))))
+    (story/unreg-global-decorator! :app/drop)
+    (is (= [:app/keep]
+           (mapv :id (:hiccup (story/resolve-decorators :story.gd6/v))))
+        "after unreg, :app/drop is gone from the resolved stack")))
+
+(deftest reg-global-decorator-with-ref-args
+  (testing "reg-global-decorator three-arity form lands ref-args at the
+            :wrap fn under (:decorator/args args-map)"
+    (story/reg-global-decorator :app/wrap-tagged
+      {:kind :hiccup
+       :wrap (fn [body args]
+               [:div.tagged {:tag (-> args :decorator/args first)} body])}
+      [:my-tag])
+    (story/reg-variant :story.gd7/v {:events []})
+    (let [r       (story/resolve-decorators :story.gd7/v)
+          wrapped (decorators/apply-hiccup-decorators
+                    (:hiccup r) [:span "x"] {})]
+      (is (= [:div.tagged {:tag :my-tag} [:span "x"]] wrapped)
+          "ref-args from the global registration land at the :wrap fn"))))
+
+;; ===========================================================================
 ;; SNAPSHOT IDENTITY
 ;; ===========================================================================
 


### PR DESCRIPTION
## Summary

- Adds `re-frame.story/reg-global-decorator` — the Storybook `preview.ts` `decorators: [...]` parity primitive flagged as Finding F-1 (P2) in `ai/findings/2026-05-20-story-tutorial-set.md`. Every variant's resolved decorator chain is now prefixed with an ordered global list, so a project can "wrap every story in the design system's theme provider" without listing the decorator id on every `reg-story`.
- Composition: `(concat globals story variant)`. Globals are the outermost wrap layer, earliest-registered first. Multi-kind support — global decorators classify into all three of `:hiccup` / `:frame-setup` / `:fx-override` exactly like story-level decorators.
- Hot-reload: re-registering the same id REPLACES in place (same position in the global vector) so the body change does not reshuffle the stack.

## Surface added

- `re-frame.story/reg-global-decorator` (2-arity + 3-arity ref-args form)
- `re-frame.story/unreg-global-decorator!`
- `re-frame.story/global-decorators` (query)
- `re-frame.story.config/{global-decorators, add-global-decorator!, remove-global-decorator!, set-global-decorators!, get-global-decorators}`
- `re-frame.story/clear-all!` now also resets the global-decorators vector for test-fixture cleanliness.

## Test plan

- [x] `npm run test:cljs` — 3585 tests / 10307 assertions, 0 failures (was 3578).
- [x] `mkdocs build --strict` — clean.
- [x] 7 new JVM tests in `story_runtime_test.clj`: stack order across global/story/variant; bare-variant inheritance; multi-global earliest-first; in-place hot-reload replacement; multi-kind classification; `unreg-global-decorator!`; ref-args plumbing through the `:wrap` fn.